### PR TITLE
Add GCP logging

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -123,7 +123,7 @@ object soundness extends ScalaModule {
     def moduleDeps = Seq(cataclysm.core, coaxial.core, cosmopolite.core, gesticulate.core,
         honeycomb.core, nettlesome.core, nettlesome.url, hallucination.core, phoenicia.core,
         punctuation.core, savagery.core, scintillate.server, scintillate.servlet,
-        telekinesis.core, plutocrat.core)
+        telekinesis.core, plutocrat.core, eucalyptus.gcp)
     def scalaVersion = settings.scalaVersion
   }
 
@@ -500,6 +500,10 @@ object eucalyptus extends SoundnessModule {
   }
   object syslog extends SoundnessSubModule {
     def moduleDeps = Seq(guillotine.core, core)
+  }
+
+  object gcp extends SoundnessSubModule {
+    def moduleDeps = Seq(jacinta.core, core)
   }
 
   object ansi extends SoundnessSubModule {


### PR DESCRIPTION
This adds a new format for log output customised for Google Cloud Platform, which consumes logs in JSON. To use it,
```scala
import eucalyptus.logFormats.googleCloudPlatform
```