### PR TITLE
Run the Abacist tests

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -156,7 +156,7 @@ object abacist extends SoundnessModule {
     def moduleDeps = Seq(quantitative.units)
   }
 
-  object test extends SoundnessSubModule {
+  object test extends ProbablyTestModule {
     def moduleDeps = Seq(probably.cli, core)
   }
 }


### PR DESCRIPTION
There was an error in the build file which made the Abacist tests run without Larceny. That's now fixed, and some `println` output has been removed from the tests.

However, the two compiletime tests are not producing the right results. This is a problem with testing, in particular Larceny, rather than Abacist.