### PR TITLE
Support typed HTTP queries

### DIFF
--- a/lib/fulminate/src/core/fulminate.Communicable.scala
+++ b/lib/fulminate/src/core/fulminate.Communicable.scala
@@ -43,7 +43,9 @@ object Communicable:
   given Long is Communicable = long => Message(long.toString.tt)
   given Message is Communicable = identity(_)
 
-  given [TypeType] => Quotes => Type[TypeType] is Communicable = tpe => Message(tpe.toString.tt)
+  given [TypeType] => Quotes => Type[TypeType] is Communicable =
+    tpe => Message(quotes.reflect.TypeRepr.of(using tpe).show.tt)
+
   given (quotes: Quotes) => quotes.reflect.TypeRepr is Communicable = tpe => Message(tpe.show)
   given (quotes: Quotes) => quotes.reflect.Term is Communicable = term => Message(term.show)
   given [ExprType] => Quotes => Expr[ExprType] is Communicable = tpe => Message(tpe.show)

--- a/lib/scintillate/src/server/scintillate.RequestParam.scala
+++ b/lib/scintillate/src/server/scintillate.RequestParam.scala
@@ -35,16 +35,16 @@ import gossamer.*
 import telekinesis.*
 import vacuous.*
 
-object RequestParam:
-  given name: ("name" is GenericHtmlAttribute[RequestParam[?]]):
-    def name: Text = t"name"
-    def serialize(value: RequestParam[?]): Text = value.key
+// object RequestParam:
+//   given name: ("name" is GenericHtmlAttribute[RequestParam[?]]):
+//     def name: Text = t"name"
+//     def serialize(value: RequestParam[?]): Text = value.key
 
-case class RequestParam[ParamType](key: Text)(using ParamReader[ParamType]):
-  def opt(using Http.Request): Option[ParamType] =
-    summon[Http.Request].params.get(key).flatMap(summon[ParamReader[ParamType]].read(_).option)
+// case class RequestParam[ParamType](key: Text)(using ParamReader[ParamType]):
+//   def opt(using Http.Request): Option[ParamType] =
+//     summon[Http.Request].params.get(key).flatMap(summon[ParamReader[ParamType]].read(_).option)
 
-  def unapply(req: Http.Request): Option[ParamType] = opt(using req)
+//   def unapply(req: Http.Request): Option[ParamType] = opt(using req)
 
-  def apply()(using Http.Request): ParamType raises ParamError =
-    opt.getOrElse(abort(ParamError(key)))
+//   def apply()(using Http.Request): ParamType raises ParamError =
+//     opt.getOrElse(abort(ParamError(key)))

--- a/lib/scintillate/src/server/soundness+scintillate-server.scala
+++ b/lib/scintillate/src/server/soundness+scintillate-server.scala
@@ -31,5 +31,5 @@ package soundness
 
 export scintillate .
   { cookie, basicAuth, param, request, listen, path, Acceptable, HttpConnection, HttpServer,
-    HttpServerEvent, HttpService, NotFound, ParamError, ParamReader, Redirect, RequestParam,
+    HttpServerEvent, HttpService, NotFound, ParamError, Redirect,
     RequestServable, Responder, Retrievable, ServerError, Unfulfilled }

--- a/lib/telekinesis/src/core/soundness+telekinesis-core.scala
+++ b/lib/telekinesis/src/core/soundness+telekinesis-core.scala
@@ -30,5 +30,5 @@
 package soundness
 
 export telekinesis.
-  { Auth, Cookie, Http, HttpError, HttpEvent, Prefixable, TcpError, Receivable, Fetchable, Params,
+  { Auth, Cookie, Http, HttpError, HttpEvent, Prefixable, TcpError, Receivable, Fetchable, Query,
     HttpClient, Postable, Servable, fetch, submit }

--- a/lib/telekinesis/src/core/telekinesis.Parameter.scala
+++ b/lib/telekinesis/src/core/telekinesis.Parameter.scala
@@ -27,18 +27,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package scintillate
+package telekinesis
 
-import anticipation.*
-import prepositional.*
-import rudiments.*
-import vacuous.*
+import proscenium.*
 
-object ParamReader:
-  given [ParamType](using extractable: Text is Extractable into ParamType): ParamReader[ParamType] =
-    extractable.extract(_)
-
-  given ParamReader[Text] = identity(_)
-
-trait ParamReader[ParamType]:
-  def read(value: Text): Optional[ParamType]
+trait Parameter:
+  type Self <: Label
+  type Subject

--- a/lib/telekinesis/src/core/telekinesis.Query.scala
+++ b/lib/telekinesis/src/core/telekinesis.Query.scala
@@ -31,16 +31,26 @@ package telekinesis
 
 import anticipation.*
 import gossamer.*
+import proscenium.*
 import spectacular.*
 
 import language.dynamics
 
-case class Params(values: List[(Text, Text)]):
-  def append(more: Params): Params = Params(values ++ more.values)
+object Query extends Dynamic:
+
+  given Query is Showable = _.queryString
+
+  inline def applyDynamicNamed(method: "apply")(inline parameters: (Label, Any)*): Query =
+    ${Telekinesis.query('parameters)}
+
+  def of(parameters: List[(Text, Text)]): Query = new Query(parameters)
+
+class Query private (val values: List[(Text, Text)]):
+  def append(more: Query): Query = new Query(values ++ more.values)
   def isEmpty: Boolean = values.isEmpty
 
-  def prefix(str: Text): Params = Params:
-    values.map { (k, v) => if k.length == 0 then str -> v else t"$str.$k" -> v }
+  def prefix(str: Text): Query = Query:
+    values.map { (key, value) => if key.length == 0 then str -> value else t"$str.$key" -> value }
 
   def queryString: Text =
     values.map: (k, v) =>

--- a/lib/telekinesis/src/test/telekinesis.Tests.scala
+++ b/lib/telekinesis/src/test/telekinesis.Tests.scala
@@ -60,6 +60,14 @@ object Tests extends Suite(t"Telekinesis tests"):
 
       . assert()
 
+    suite(t"Response construction tests"):
+      test(t"Construct a Query"):
+        erased given key: ("key" is Parameter of Text) = ###
+        erased given param: ("param" is Parameter of Int) = ###
+        Query(key = t"hello world", param = 24).show
+
+      . assert(_ == t"key=hello+world&param=24")
+
 
     suite(t"Fetching tests"):
 


### PR DESCRIPTION
The `Query` type represents a set of key/value pairs for sending in an HTTP post. You can construct one with,
```scala
Query(key1 = t"some value", key2 = 42)
```
provided `key1` and `key2` have (erased) contextual `Parameter` instances, with appropriate types, and provided those types are `Encodable in Text`.

For the above example, you would need, for example,
```scala
erased given ("key1" is Parameter of Text) = ###
erased given ("key2" is Parameter of Int) = ###
```