### PR TITLE
Avoid the warning about ambiguous contextual values in Scala 3.7

### DIFF
--- a/lib/coaxial/src/core/coaxial-core.scala
+++ b/lib/coaxial/src/core/coaxial-core.scala
@@ -62,7 +62,7 @@ extension [SocketType: Bindable as bindable](socket: SocketType)
         safely(task.await())
 
 extension [EndpointType: Serviceable as serviceable](endpoint: EndpointType)
-  def request[MessageType: Transmissible](input: MessageType)
+  def transmit[MessageType: Transmissible](input: MessageType)
   :     Stream[Bytes] =
     val connection = serviceable.connect(endpoint)
 

--- a/lib/coaxial/src/core/soundness+coaxial-core.scala
+++ b/lib/coaxial/src/core/soundness+coaxial-core.scala
@@ -34,4 +34,4 @@ package soundness
 
 export coaxial .
    { Addressable, Bindable, BindError, Serviceable, Connection, Control, DomainSocket, Ingressive,
-     SocketService, Transmissible, Packet, UdpResponse, listen, exchange, transmit, request }
+     SocketService, Transmissible, Packet, UdpResponse, listen, exchange, transmit }

--- a/lib/telekinesis/src/core/soundness+telekinesis-core.scala
+++ b/lib/telekinesis/src/core/soundness+telekinesis-core.scala
@@ -34,4 +34,4 @@ package soundness
 
 export telekinesis.
   { Auth, Cookie, Http, HttpError, HttpEvent, Prefixable, ConnectError, Receivable, Fetchable,
-    Query, HttpClient, Postable, Servable, fetch, submit, Parameter }
+    Query, HttpClient, Postable, Servable, fetch, submit, Parameter, query }

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -62,7 +62,7 @@ object HttpClient:
 
     def request(request: Http.Request, socket: DomainSocket): Http.Response logs HttpEvent =
 
-      unsafely(Http.Response.parse(socket.request(request)))
+      unsafely(Http.Response.parse(socket.transmit(request)))
 
   given Tactic[ConnectError] => Online => HttpClient onto Origin["http" | "https"] = new HttpClient:
     type Target = Origin["http" | "https"]


### PR DESCRIPTION
This avoids a warning in user code about certain implicit values conflicting after priorities are changed in Scala 3.7.