### PR TITLE
Allow construction of `Location` in millidegrees

### DIFF
--- a/lib/geodesy/src/core/geodesy.Geodesy.scala
+++ b/lib/geodesy/src/core/geodesy.Geodesy.scala
@@ -61,6 +61,9 @@ object Geodesy:
 
     def apply(latitude: Radians, longitude: Radians): Location = fromRadians(latitude, longitude)
 
+    def apply(north: Int, east: Int): Location =
+      fromRadians(Degrees(north/1000.0).radians, Degrees(east/1000.0).radians)
+
     @targetName("applyDegrees")
     def apply(latitude: Degrees, longitude: Degrees): Location =
       fromRadians(latitude.radians, longitude.radians)

--- a/lib/geodesy/src/core/geodesy.Geolocation.scala
+++ b/lib/geodesy/src/core/geodesy.Geolocation.scala
@@ -114,6 +114,6 @@ object Geolocation:
 case class Geolocation
    (location:    Location,
     altitude:    Optional[Double] = Unset,
-    crs:      Optional[Text]   = Unset,
+    crs:         Optional[Text]   = Unset,
     uncertainty: Optional[Double] = Unset,
     parameters:  Map[Text, Text]  = Map())


### PR DESCRIPTION
Some systems use integer values of millidegrees to represent locations. This is now supported with a new `apply` method on `Location`.