### PR TITLE
Interpret integers as microdegrees, not millidegrees

### DIFF
--- a/lib/geodesy/src/core/geodesy.Geodesy.scala
+++ b/lib/geodesy/src/core/geodesy.Geodesy.scala
@@ -62,7 +62,7 @@ object Geodesy:
     def apply(latitude: Radians, longitude: Radians): Location = fromRadians(latitude, longitude)
 
     def apply(north: Int, east: Int): Location =
-      fromRadians(Degrees(north/1000.0).radians, Degrees(east/1000.0).radians)
+      fromRadians(Degrees(north/1000000.0).radians, Degrees(east/1000000.0).radians)
 
     @targetName("applyDegrees")
     def apply(latitude: Degrees, longitude: Degrees): Location =


### PR DESCRIPTION
The new `Location.apply` method interpreted a latitude and longitude integer as millidegrees. But actually, by convention, they're _microdegrees_. So the result is a factor of 1000 off, or for most inputs, is limited by the range of values.