### PR TITLE
Safely convert `Double`s to `Quantity`s without breaking units

### DIFF
--- a/lib/quantitative/src/core/quantitative.Quantitative.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative.scala
@@ -134,11 +134,8 @@ object Quantitative extends Quantitative2:
 
     inline def apply[UnitsType <: Measure](value: Double): Quantity[UnitsType] = value
 
-    given convertDouble: [UnitsType <: Measure] => Conversion[Double, Quantity[UnitsType]] =
-      Quantity(_)
-
-    given convertInt: [UnitsType <: Measure] => Conversion[Int, Quantity[UnitsType]] =
-      int => Quantity(int.toDouble)
+    given convertDouble: Conversion[Double, Quantity[Measure]] = Quantity[Measure](_)
+    given convertInt: Conversion[Int, Quantity[Measure]] = int => Quantity[Measure](int.toDouble)
 
     given commensurable: [UnitsType <: Measure, UnitsType2 <: Measure]
     =>    Quantity[UnitsType] is Commensurable:

--- a/lib/quantitative/src/test/quantitative.Tests.scala
+++ b/lib/quantitative/src/test/quantitative.Tests.scala
@@ -59,7 +59,7 @@ object Tests extends Suite(t"Quantitative Tests"):
       .assert(_ == 0.5*Second/Metre)
 
       test(t"Divide a double by a quantity"):
-        1.0/(2.0*Metre/Second)
+        Quantity(1.0)/(2.0*Metre/Second)
       .assert(_ == 0.5*Second/Metre)
 
     suite(t"Compile errors"):
@@ -67,6 +67,23 @@ object Tests extends Suite(t"Quantitative Tests"):
         demilitarize:
           Metre + 2*Second
       .assert(_.nonEmpty)
+
+      test(t"Cannot specify a quantity with a double value"):
+        demilitarize:
+          val x: Quantity[Metres[1]] = 10.0
+      . assert(_.nonEmpty)
+
+      test(t"Specify a quantity"):
+        case class Speed(value: Quantity[Metres[1] & Hours[-1]])
+        Speed(10.0*Kilo(Metre)/Hour)
+
+      . assert()
+
+      test(t"Specify a quantity"):
+        case class Speed(value: Quantity[Metres[1] & Hours[-1]])
+        Speed(10.0*Kilo(Metre)/Hour)
+
+      . assert()
 
       test(t"Cannot subtract quantities of different units"):
         demilitarize:

--- a/lib/quantitative/src/units/quantitative.unitDefinitions.scala
+++ b/lib/quantitative/src/units/quantitative.unitDefinitions.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package quantitative
 
-import language.experimental.captureChecking
-
 import anticipation.*
 import hypotenuse.*
 
@@ -54,9 +52,9 @@ val Emu = MetricUnit(10e-3*Ampere/(Metre*Metre))
 val Oersted = MetricUnit(79.577*Ampere/Metre)
 val Gilbert = MetricUnit(0.796*Ampere)
 val Darcy = MetricUnit(0.987e-12*Metre*Metre)
-val Kayser = MetricUnit(100/Second)
+val Kayser = MetricUnit(Quantity[Measure](100)/Second)
 
-val Hertz = MetricUnit(1.0/Second)
+val Hertz = MetricUnit(Quantity[Measure](1.0)/Second)
 val Newton = MetricUnit(Metre*Kilo(Gram)/(Second*Second))
 val Dyne = MetricUnit(10e-5*Newton)
 val Pascal = MetricUnit(Newton/(Metre*Metre))
@@ -81,7 +79,7 @@ val Gauss = MetricUnit(10e-4*Tesla)
 val Henry = MetricUnit(Weber/Ampere)
 val Lux = MetricUnit(Candela/(Metre*Metre))
 val Phot = MetricUnit(10e4*Lux)
-val Becquerel = MetricUnit(1.0/Second)
+val Becquerel = MetricUnit(Quantity[Measure](1.0)/Second)
 val Gray = MetricUnit(Joule/Kilo(Gram))
 val Sievert = MetricUnit(Joule/Kilo(Gram))
 val Katal = MetricUnit(Mole/Second)
@@ -127,5 +125,5 @@ package constants:
   val PlanckConstant = 6.62607015e-34*Metre*Metre*Kilo(Gram)/Second
   val GravitationalConstant = 6.67430e-11*Newton/Metre*Metre/Kilo(Gram)/Kilo(Gram)
   val ElementaryCharge = 1.602176634e-19*Coulomb
-  val AvogadroConstant = 6.02214076e23/Mole
+  val AvogadroConstant = Quantity[Measure](6.02214076e23)/Mole
   val BoltzmannConstant = 1.380649e-13*Joule/Kelvin


### PR DESCRIPTION
When auto-converting a `Double` to a `Quantity`, we were adapting the `Quantity`'s arguments to be whatever we wanted. But we only want to do the conversion from a double to a unitless `Quantity`, i.e. a `Quantity[Measure]`. The contextual instances of `Conversion[Double, Quantity[UnitsType]]` have been constrained now.