### PR TITLE
Remove `Radians` in Quantitative

### DIFF
--- a/lib/quantitative/src/core/quantitative.PrincipalUnit.scala
+++ b/lib/quantitative/src/core/quantitative.PrincipalUnit.scala
@@ -46,5 +46,3 @@ object PrincipalUnit:
   given luminosity: PrincipalUnit[Luminosity, Candelas]()
   given temperature: PrincipalUnit[Temperature, Kelvins]()
   given amountOfSubstance: PrincipalUnit[AmountOfSubstance, Moles]()
-
-  given angle: PrincipalUnit[Angle, Radians]()

--- a/lib/quantitative/src/core/quantitative.UnitName.scala
+++ b/lib/quantitative/src/core/quantitative.UnitName.scala
@@ -52,8 +52,6 @@ object UnitName:
   given UnitName[Kelvins[1]] = () => t"K"
   given UnitName[Seconds[1]] = () => t"s"
 
-  given UnitName[Radians[1]] = () => t"rad"
-
   given UnitName[Kilograms[1]] with
     override def siPrefix: MetricPrefix = Kilo
     def name(): Text = t"g"

--- a/lib/quantitative/src/core/quantitative.Units.scala
+++ b/lib/quantitative/src/core/quantitative.Units.scala
@@ -43,5 +43,3 @@ erased trait Moles[Power <: Nat] extends Units[Power, AmountOfSubstance]
 erased trait Amperes[Power <: Nat] extends Units[Power, Current]
 erased trait Kelvins[Power <: Nat] extends Units[Power, Temperature]
 erased trait Seconds[Power <: Nat] extends Units[Power, Time]
-
-erased trait Radians[Power <: Nat] extends Units[Power, Angle]

--- a/lib/quantitative/src/core/soundness+quantitative-core.scala
+++ b/lib/quantitative/src/core/soundness+quantitative-core.scala
@@ -35,7 +35,7 @@ package soundness
 export quantitative .
   { Distance, Mass, Time, Current, Luminosity, Temperature, AmountOfSubstance, Angle,
     PhysicalQuantity, Measure, Units, Metres, Kilograms, Candelas, Moles, Amperes, Kelvins, Seconds,
-    Radians, UnitName, PrincipalUnit, SubstituteUnits, UnitsOffset, Quantity, MetricUnit,
+    UnitName, PrincipalUnit, SubstituteUnits, UnitsOffset, Quantity, MetricUnit,
     Quantifiable, invert, in, sqrt, cbrt, units, render, dimension, MetricPrefix, NoPrefix, Deka,
     Hecto, Kilo, Mega, Giga, Tera, Peta, Exa, Zetta, Yotta, Ronna, Quetta, Deci, Centi, Milli,
     Micro, Nano, Pico, Femto, Atto, Zepto, Yocto, Ronto, Quecto, Kibi, Mebi, Gibi, Tebi, Pebi, Exbi,

--- a/lib/quantitative/src/units/quantitative.ArcMinutes.scala
+++ b/lib/quantitative/src/units/quantitative.ArcMinutes.scala
@@ -42,4 +42,4 @@ trait ArcMinutes[Power <: Nat] extends Units[Power, Angle]
 
 object ArcMinutes:
   given UnitName[ArcMinutes[1]] = () => "'".tt
-  erased given degreesPerRadian: Ratio[ArcMinutes[1] & Radians[-1], 3437.74677078] = ###
+  erased given degreesPerRadian: Ratio[ArcMinutes[1], 3437.74677078] = ###

--- a/lib/quantitative/src/units/quantitative.ArcSeconds.scala
+++ b/lib/quantitative/src/units/quantitative.ArcSeconds.scala
@@ -42,4 +42,4 @@ trait ArcSeconds[Power <: Nat] extends Units[Power, Angle]
 
 object ArcSeconds:
   given UnitName[ArcSeconds[1]] = () => "\"".tt
-  erased given degreesPerRadian: Ratio[ArcSeconds[1] & Radians[-1], 206264.806247] = ###
+  erased given degreesPerRadian: Ratio[ArcSeconds[1], 206264.806247] = ###

--- a/lib/quantitative/src/units/quantitative.Degrees.scala
+++ b/lib/quantitative/src/units/quantitative.Degrees.scala
@@ -42,4 +42,4 @@ trait Degrees[Power <: Nat] extends Units[Power, Angle]
 
 object Degrees:
   given UnitName[Degrees[1]] = () => "°".tt
-  erased given degreesPerRadian: Ratio[Degrees[1] & Radians[-1], 57.2957795131] = ###
+  erased given degreesPerRadian: Ratio[Degrees[1], 57.2957795131] = ###

--- a/lib/quantitative/src/units/quantitative.unitDefinitions.scala
+++ b/lib/quantitative/src/units/quantitative.unitDefinitions.scala
@@ -42,7 +42,6 @@ val Mole: MetricUnit[Moles[1]] = MetricUnit(1)
 val Ampere: MetricUnit[Amperes[1]] = MetricUnit(1)
 val Kelvin: MetricUnit[Kelvins[1]] = MetricUnit(1)
 val Second: MetricUnit[Seconds[1]] = MetricUnit(1)
-val Radian: MetricUnit[Radians[1]] = MetricUnit(1)
 
 val Galileo = MetricUnit(0.01*Metre/(Second*Second))
 val Biot = MetricUnit(10*Ampere)

--- a/lib/quantitative/src/units/soundness+quantitative-units.scala
+++ b/lib/quantitative/src/units/soundness+quantitative-units.scala
@@ -32,17 +32,18 @@
                                                                                                   */
 package soundness
 
-export quantitative.{Galileo, Poise, Franklin, Biot, Debye, Erg, Dyne, Calorie, Langley, Phot,
-    Stokes, Lambert, Emu, Oersted, Maxwell, Gauss, Gilbert, Darcy, Barye, Kayser, Hertz, Newton,
-    Pascal, Joule, Watt, Coulomb, Volt, Farad, Ohm, Siemens, Weber, Tesla, Henry, Lux, Becquerel,
-    Gray, Sievert, Katal, Metre, Gram, Candela, Mole, Ampere, Kelvin, Second, Radian, Inch, Foot,
-    Yard, Mile, Lightyear, NauticalMile, Furlong, Chain, Grain, Ounce, Pound, Stone, Hundredweight,
-    Ton, Day, Hour, Minute, Are, Acre, Litre, FluidOunce, Pint, Quart, Gallon, ArcMinutes,
-    ArcSeconds, Celsius, Chains, Days, Degrees, Drams, Fahrenheit, Feet, Furlongs, Grains, Hours,
-    Hundredweights, Inches, Lightyears, Miles, Minutes, NauticalMiles, Ounces, Picas, Points,
-    Pounds, Quarters, Rankines, SiderealDays, Stones, Tons, Yards}
+export quantitative .
+  { Galileo, Poise, Franklin, Biot, Debye, Erg, Dyne, Calorie, Langley, Phot, Stokes, Lambert, Emu,
+    Oersted, Maxwell, Gauss, Gilbert, Darcy, Barye, Kayser, Hertz, Newton, Pascal, Joule, Watt,
+    Coulomb, Volt, Farad, Ohm, Siemens, Weber, Tesla, Henry, Lux, Becquerel, Gray, Sievert, Katal,
+    Metre, Gram, Candela, Mole, Ampere, Kelvin, Second, Inch, Foot, Yard, Mile, Lightyear,
+    NauticalMile, Furlong, Chain, Grain, Ounce, Pound, Stone, Hundredweight, Ton, Day, Hour, Minute,
+    Are, Acre, Litre, FluidOunce, Pint, Quart, Gallon, ArcMinutes, ArcSeconds, Celsius, Chains,
+    Days, Degrees, Drams, Fahrenheit, Feet, Furlongs, Grains, Hours, Hundredweights, Inches,
+    Lightyears, Miles, Minutes, NauticalMiles, Ounces, Picas, Points, Pounds, Quarters, Rankines,
+    SiderealDays, Stones, Tons, Yards }
 
 package constants:
-  export quantitative.constants.{SpeedOfLightInVacuum, MagneticConstant, ElectricConstant,
-      CharacteristicImpedanceOfVacuum, PlanckConstant, GravitationalConstant, ElementaryCharge,
-      AvogadroConstant, BoltzmannConstant}
+  export quantitative.constants .
+    { SpeedOfLightInVacuum, MagneticConstant, ElectricConstant, CharacteristicImpedanceOfVacuum,
+      PlanckConstant, GravitationalConstant, ElementaryCharge, AvogadroConstant, BoltzmannConstant }


### PR DESCRIPTION
`Radians` were defined in both Geodesy and Quantitative, leading to a conflict when both were exported to `soundness`. This removes the definition in Quantitative, since radians are not "units" in the same sense as other quantities have units.