### PR TITLE
Eliminate the unnecessary two-parameter variant of `raise`

### DIFF
--- a/lib/ambience/src/core/ambience.Environment.scala
+++ b/lib/ambience/src/core/ambience.Environment.scala
@@ -63,4 +63,4 @@ object Environment extends Dynamic:
   :     VariableType =
 
     environment.variable(reader.defaultName).let(reader.read(_)).or:
-      raise(EnvironmentError(reader.defaultName), reader.read(Text("")))
+      raise(EnvironmentError(reader.defaultName)) yet reader.read(Text(""))

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -125,13 +125,13 @@ object Aviation:
           Date(y.s.toInt, MonthName(m.s.toInt), d.s.toInt)
         catch
           case error: NumberFormatException =>
-            raise(DateError(value), Date(using calendars.gregorian)(2000, MonthName(1), 1))
+            raise(DateError(value)) yet Date(using calendars.gregorian)(2000, MonthName(1), 1)
 
           case error: ju.NoSuchElementException =>
-            raise(DateError(value), Date(using calendars.gregorian)(2000, MonthName(1), 1))
+            raise(DateError(value)) yet Date(using calendars.gregorian)(2000, MonthName(1), 1)
 
       case cnt =>
-        raise(DateError(value), Date(using calendars.gregorian)(2000, MonthName(1), 1))
+        raise(DateError(value)) yet Date(using calendars.gregorian)(2000, MonthName(1), 1)
 
   extension (date: Date)
     def day(using calendar: Calendar): calendar.Day = calendar.getDay(date)

--- a/lib/aviation/src/core/aviation.RomanCalendar.scala
+++ b/lib/aviation/src/core/aviation.RomanCalendar.scala
@@ -81,9 +81,8 @@ abstract class RomanCalendar() extends Calendar:
     date.julianDay - zerothDayOfYear(year).julianDay - month.offset(leapYear(year))
 
   def julianDay(year: Int, month: MonthName, day: Int): Date raises DateError =
-    if day < 1 || day > daysInMonth(month, year)
-    then raise
-     (DateError(t"$year-${month.numerical}-$day"),
-      Date(using calendars.julian)(2000, MonthName(1), 1))
+    if day < 1 || day > daysInMonth(month, year) then
+      raise(DateError(t"$year-${month.numerical}-$day"))
+      Date(using calendars.julian)(2000, MonthName(1), 1)
 
     zerothDayOfYear(year).addDays(month.offset(leapYear(year)) + day)

--- a/lib/aviation/src/core/aviation.Timezone.scala
+++ b/lib/aviation/src/core/aviation.Timezone.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import contextual.*
 import contingency.*
 import fulminate.*
+import rudiments.*
 
 import java.util as ju
 
@@ -48,7 +49,7 @@ object Timezone:
 
   def parse(name: Text)(using Tactic[TimezoneError]): Timezone =
     if ids.contains(name) then new Timezone(name)
-    else raise(TimezoneError(name), new Timezone(ids.head))
+    else raise(TimezoneError(name)) yet new Timezone(ids.head)
 
   object Tz extends Verifier[Timezone]:
     def verify(name: Text): Timezone =

--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -78,12 +78,6 @@ def raise[SuccessType, ErrorType <: Exception: Recoverable into SuccessType]
   tactic.record(error)
   ErrorType.recover(error(using tactic.diagnostics))
 
-def raise[SuccessType, ErrorType <: Exception: Tactic]
-   (error: Diagnostics ?=> ErrorType, ersatz: => SuccessType)
-:     SuccessType =
-  ErrorType.record(error)
-  ersatz
-
 def abort[SuccessType, ErrorType <: Exception: Tactic](error: Diagnostics ?=> ErrorType): Nothing =
   ErrorType.abort(error)
 

--- a/lib/digression/src/core/digression.Fqcn.scala
+++ b/lib/digression/src/core/digression.Fqcn.scala
@@ -48,15 +48,15 @@ object Fqcn:
     val parts = IArray.from(name.s.split("\\.").nn.map(_.nn))
 
     parts.foreach: part =>
-      if part.length == 0 then raise(FqcnError(name, FqcnError.Reason.EmptyName), ())
+      if part.length == 0 then raise(FqcnError(name, FqcnError.Reason.EmptyName))
       if Digression.javaKeywords.has(part)
-      then raise(FqcnError(name, FqcnError.Reason.JavaKeyword(part.tt)), ())
+      then raise(FqcnError(name, FqcnError.Reason.JavaKeyword(part.tt)))
 
       part.foreach: char =>
-        if !valid(char) then raise(FqcnError(name, FqcnError.Reason.InvalidChar(char)), ())
+        if !valid(char) then raise(FqcnError(name, FqcnError.Reason.InvalidChar(char)))
 
       if part.head >= '0' && part.head <= '9'
-      then raise(FqcnError(name, FqcnError.Reason.InvalidStart(part.head)), ())
+      then raise(FqcnError(name, FqcnError.Reason.InvalidStart(part.head)))
 
     new Fqcn(parts.map(_.tt))
 

--- a/lib/dissonance/src/core/dissonance.Diff.scala
+++ b/lib/dissonance/src/core/dissonance.Diff.scala
@@ -58,8 +58,8 @@ object Diff:
               try string.split(",").nn.to(List) match
                 case List(start, end) => (start.nn.toInt - 1, end.nn.toInt)
                 case List(start)      => (start.nn.toInt - 1, start.nn.toInt)
-                case _                => raise(DiffError(line, head), (0, 0))
-              catch case err: NumberFormatException => raise(DiffError(line, head), (0, 0))
+                case _                => raise(DiffError(line, head)) yet (0, 0)
+              catch case err: NumberFormatException => raise(DiffError(line, head)) yet (0, 0)
 
             val pairs =
               head.s.split("[acd]").nn.to(List) match
@@ -71,7 +71,7 @@ object Diff:
                 recur(tail, line + 1, edits, pos, rpos, leftStart)
 
               case None =>
-                raise(DiffError(line, head), recur(tail, line + 1, edits, pos, rpos, 0))
+                raise(DiffError(line, head)) yet recur(tail, line + 1, edits, pos, rpos, 0)
 
         case _ =>
           Diff(edits.reverse*)

--- a/lib/distillate/src/core/distillate.Decodable.scala
+++ b/lib/distillate/src/core/distillate.Decodable.scala
@@ -38,6 +38,7 @@ import denominative.*
 import digression.*
 import inimitable.*
 import prepositional.*
+import rudiments.*
 import wisteria.*
 import vacuous.*
 
@@ -46,36 +47,37 @@ object Decodable:
 
   given int: (number: Tactic[NumberError]) => Int is Decodable in Text = text =>
     try Integer.parseInt(text.s) catch case _: NumberFormatException =>
-      raise(NumberError(text, Int), 0)
+      raise(NumberError(text, Int)) yet 0
 
   given fqcn: Tactic[FqcnError] => Fqcn is Decodable in Text = Fqcn(_)
   given uuid: Tactic[UuidError] => Uuid is Decodable in Text = Uuid.parse(_)
 
   given byte: Tactic[NumberError] => Byte is Decodable in Text = text =>
     val int = try Integer.parseInt(text.s) catch case _: NumberFormatException =>
-      raise(NumberError(text, Byte), 0)
+      raise(NumberError(text, Byte)) yet 0
 
-    if int < Byte.MinValue || int > Byte.MaxValue then raise(NumberError(text, Byte), 0.toByte)
+    if int < Byte.MinValue || int > Byte.MaxValue then raise(NumberError(text, Byte)) yet 0.toByte
     else int.toByte
 
   given short: Tactic[NumberError] => Short is Decodable in Text = text =>
     val int = try Integer.parseInt(text.s) catch case _: NumberFormatException =>
-      raise(NumberError(text, Short), 0)
+      raise(NumberError(text, Short)) yet 0
 
-    if int < Short.MinValue || int > Short.MaxValue then raise(NumberError(text, Short), 0.toShort)
+    if int < Short.MinValue || int > Short.MaxValue
+    then raise(NumberError(text, Short)) yet 0.toShort
     else int.toShort
 
   given long: Tactic[NumberError] => Long is Decodable in Text = text =>
     try java.lang.Long.parseLong(text.s) catch case _: NumberFormatException =>
-      raise(NumberError(text, Long), 0L)
+      raise(NumberError(text, Long)) yet 0L
 
   given double: Tactic[NumberError] => Double is Decodable in Text = text =>
     try java.lang.Double.parseDouble(text.s) catch case _: NumberFormatException =>
-      raise(NumberError(text, Double), 0.0)
+      raise(NumberError(text, Double)) yet 0.0
 
   given float: Tactic[NumberError] => Float is Decodable in Text = text =>
     try java.lang.Float.parseFloat(text.s) catch case _: NumberFormatException =>
-      raise(NumberError(text, Float), 0.0F)
+      raise(NumberError(text, Float)) yet 0.0F
 
   given char: Char is Decodable in Text = _.s(0)
 
@@ -85,7 +87,7 @@ object Decodable:
 
     EnumType.value(identifiable.decode(value)).or:
       val names = EnumType.values.to(List).map(EnumType.name(_)).map(EnumType.encode(_))
-      raise(VariantError(value, EnumType.name, names), EnumType.value(Prim).vouch)
+      raise(VariantError(value, EnumType.name, names)) yet EnumType.value(Prim).vouch
 
 trait Decodable:
   inline def decodable: this.type = this

--- a/lib/escritoire/src/core/escritoire-core.scala
+++ b/lib/escritoire/src/core/escritoire-core.scala
@@ -52,7 +52,7 @@ extension [ValueType](value: ValueType)
 
 package columnAttenuation:
   given fail: Tactic[TableError] => Attenuation =
-    (minimum, available) => raise(TableError(minimum, available), ())
+    (minimum, available) => raise(TableError(minimum, available))
 
   given ignore: Attenuation = (minimum, available) => ()
 

--- a/lib/galilei/src/core/galilei-core.scala
+++ b/lib/galilei/src/core/galilei-core.scala
@@ -270,7 +270,7 @@ extension [PlatformType <: Posix](path: Path on PlatformType)
     path.protect(Operation.Metadata):
       jnf.Files.getAttribute(path.javaPath, "unix:nlink", dereferenceSymlinks.options()*) match
         case count: Int => count
-        case _          => raise(IoError(path, Operation.Metadata, Reason.Unsupported), 1)
+        case _          => raise(IoError(path, Operation.Metadata, Reason.Unsupported)) yet 1
 
 package filesystemOptions:
   object readAccess:

--- a/lib/gesticulate/src/core/gesticulate.Media.scala
+++ b/lib/gesticulate/src/core/gesticulate.Media.scala
@@ -143,7 +143,7 @@ object Media:
     def parseSuffixes(suffixes: List[Text]): List[Suffix] =
       suffixes.map(_.lower.capitalize).flatMap: suffix =>
         try List(Suffix.valueOf(suffix.s)) catch IllegalArgumentException =>
-          raise(MediaTypeError(string, MediaTypeError.Reason.InvalidSuffix(suffix)), Nil)
+          raise(MediaTypeError(string, MediaTypeError.Reason.InvalidSuffix(suffix))) yet Nil
 
     def parseInit(str: Text): (Subtype, List[Suffix]) =
       val xs: List[Text] = str.cut(t"+").to(List)
@@ -155,22 +155,20 @@ object Media:
       case List(group, subtype) => parseGroup(group) *: parseInit(subtype)
 
       case _ =>
-        raise
-         (MediaTypeError(string, MediaTypeError.Reason.NotOneSlash),
-          Group.Text *: parseInit(string))
+        raise(MediaTypeError(string, MediaTypeError.Reason.NotOneSlash))
+        Group.Text *: parseInit(string)
 
     def parseGroup(str: Text): Group =
       try Group.valueOf(str.lower.capitalize.s) catch IllegalArgumentException =>
-        raise(MediaTypeError(string, MediaTypeError.Reason.InvalidGroup), Group.Text)
+        raise(MediaTypeError(string, MediaTypeError.Reason.InvalidGroup)) yet Group.Text
 
     def parseSubtype(str: Text): Subtype =
       def notAllowed(char: Char): Boolean =
         char.isWhitespace || char.isControl || specials.contains(char)
 
       str.chars.find(notAllowed(_)).map: char =>
-        raise
-         (MediaTypeError(string, MediaTypeError.Reason.InvalidChar(char)),
-          Subtype.X(str.chars.filter(!notAllowed(_)).text))
+        raise(MediaTypeError(string, MediaTypeError.Reason.InvalidChar(char)))
+        Subtype.X(str.chars.filter(!notAllowed(_)).text)
 
       . getOrElse:
           if str.starts(t"vnd.") then Subtype.Vendor(str.skip(4))

--- a/lib/hieroglyph/src/core/hieroglyph-core.scala
+++ b/lib/hieroglyph/src/core/hieroglyph-core.scala
@@ -34,6 +34,7 @@ package hieroglyph
 
 import anticipation.*
 import contingency.*
+import rudiments.*
 import vacuous.*
 
 import language.experimental.pureFunctions
@@ -66,7 +67,7 @@ package charEncoders:
 
 package textSanitizers:
   given strict: Tactic[CharDecodeError] => TextSanitizer = (pos, encoding) =>
-    raise(CharDecodeError(pos, encoding), '?')
+    raise(CharDecodeError(pos, encoding)) yet '?'
 
   given skip: TextSanitizer = (pos, encoding) => Unset
   given substitute: TextSanitizer = (pos, encoding) => '?'

--- a/lib/hypotenuse/src/core/hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse-core.scala
@@ -42,6 +42,7 @@ import scala.annotation.*
 import anticipation.*
 import contingency.*
 import prepositional.*
+import rudiments.*
 
 export Hypotenuse.{B8, B16, B32, B64, S8, S16, S32, S64, U8, U16, U32, U64, F32, F64}
 
@@ -447,35 +448,35 @@ package arithmeticOptions:
       type Wrap[ResultType] = ResultType raises DivisionError
 
       inline def divideU64(left: U64, right: U64): U64 raises DivisionError =
-        if Long(right.bits) == 0 then raise(DivisionError(), U64(0.bits))
+        if Long(right.bits) == 0 then raise(DivisionError()) yet U64(0.bits)
         else U64((Long(left.bits)/Long(right.bits)).bits)
 
       inline def divideS64(left: S64, right: S64): S64 raises DivisionError =
-        if right.long == 0 then raise(DivisionError(), S64(0.bits))
+        if right.long == 0 then raise(DivisionError()) yet S64(0.bits)
         else S64((left.long/right.long).bits)
 
       inline def divideU32(left: U32, right: U32): U32 raises DivisionError =
-        if right.long == 0 then raise(DivisionError(), U32(0.bits))
+        if right.long == 0 then raise(DivisionError()) yet U32(0.bits)
         else U32((Int(left.bits)/Int(right.bits)).bits)
 
       inline def divideS32(left: S32, right: S32): S32 raises DivisionError =
-        if right.int == 0 then raise(DivisionError(), S32(0.bits))
+        if right.int == 0 then raise(DivisionError()) yet S32(0.bits)
         else S32((left.int/right.int).bits)
 
       inline def divideU16(left: U16, right: U16): U16 raises DivisionError =
-        if right.int == 0 then raise(DivisionError(), U16(0.bits))
+        if right.int == 0 then raise(DivisionError()) yet U16(0.bits)
         else U16((Short(left.bits)/Short(right.bits)).toShort.bits)
 
       inline def divideS16(left: S16, right: S16): S16 raises DivisionError =
-        if right.int == 0 then raise(DivisionError(), S16(0.bits))
+        if right.int == 0 then raise(DivisionError()) yet S16(0.bits)
         else S16((left.short/right.short).toShort.bits)
 
       inline def divideU8(left: U8, right: U8): U8 raises DivisionError =
-        if right.int == 0 then raise(DivisionError(), U8(0.bits))
+        if right.int == 0 then raise(DivisionError()) yet U8(0.bits)
         else U8((left.byte/right.byte).toByte.bits)
 
       inline def divideS8(left: S8, right: S8): S8 raises DivisionError =
-        if right.int == 0 then raise(DivisionError(), S8(0.bits))
+        if right.int == 0 then raise(DivisionError()) yet S8(0.bits)
         else S8((left.byte/right.byte).toByte.bits)
 
   object overflow:
@@ -500,38 +501,38 @@ package arithmeticOptions:
         val result: B64 = (Long(left.bits) + Long(right.bits)).bits
 
         if U64((left.bits^result) & (right.bits^result)) < U64(0.bits)
-        then raise(OverflowError(), U64(result)) else U64(result)
+        then raise(OverflowError()) yet U64(result) else U64(result)
 
       inline def addS64(left: S64, right: S64): S64 raises OverflowError =
         val result: S64 = S64((left.long + right.long).bits)
-        if result < left || result < right then raise(OverflowError(), result) else result
+        if result < left || result < right then raise(OverflowError()) yet result else result
 
       inline def addU32(left: U32, right: U32): U32 raises OverflowError =
         val result: B32 = (Int(left.bits) + Int(right.bits)).bits
 
         if U32((left.bits^result) & (right.bits^result)) < U32(0.bits)
-        then raise(OverflowError(), U32(result)) else U32(result)
+        then raise(OverflowError()) yet U32(result) else U32(result)
 
       inline def addS32(left: S32, right: S32): S32 raises OverflowError =
         val result: S32 = S32((left.int + right.int).bits)
-        if result < left || result < right then raise(OverflowError(), result) else result
+        if result < left || result < right then raise(OverflowError()) yet result else result
 
       inline def addU16(left: U16, right: U16): U16 raises OverflowError =
         val result: B16 = (Short(left.bits) + Short(right.bits)).toShort.bits
 
         if U16((left.bits^result) & (right.bits^result)) < U16(0.toShort.bits)
-        then U16(raise(OverflowError(), result)) else U16(result)
+        then U16(raise(OverflowError()) yet result) else U16(result)
 
       inline def addS16(left: S16, right: S16): S16 raises OverflowError =
         val result: S16 = S16((left.short + right.short).toShort.bits)
-        if result < left || result < right then raise(OverflowError(), result) else result
+        if result < left || result < right then raise(OverflowError()) yet result else result
 
       inline def addU8(left: U8, right: U8): U8 raises OverflowError =
         val result: B8 = (left.short + right.short).toByte.bits
 
         if U8((left.bits^result) & (right.bits^result)) < U8(0.toByte.bits)
-        then U8(raise(OverflowError(), result)) else U8(result)
+        then U8(raise(OverflowError()) yet result) else U8(result)
 
       inline def addS8(left: S8, right: S8): S8 raises OverflowError =
         val result: S8 = S8((left.short + right.short).toByte.bits)
-        if result < left || result < right then raise(OverflowError(), result) else result
+        if result < left || result < right then raise(OverflowError()) yet result else result

--- a/lib/inimitable/src/core/inimitable.Uuid.scala
+++ b/lib/inimitable/src/core/inimitable.Uuid.scala
@@ -46,7 +46,7 @@ import vacuous.*
 
 object Uuid extends Extractor[Text, Uuid]:
   def parse(text: Text): Uuid raises UuidError =
-    extract(text).or(raise(UuidError(text), Uuid(0L, 0L)))
+    extract(text).or(raise(UuidError(text)) yet Uuid(0L, 0L))
 
   def extract(text: Text): Optional[Uuid] = safely:
     ju.UUID.fromString(text.s).nn.pipe: uuid =>

--- a/lib/monotonous/src/core/monotonous.Alphabet.scala
+++ b/lib/monotonous/src/core/monotonous.Alphabet.scala
@@ -35,6 +35,7 @@ package monotonous
 import anticipation.*
 import contingency.*
 import gossamer.*
+import rudiments.*
 
 case class Alphabet[EncodingType <: Serialization]
    (chars: Text, padding: Boolean, tolerance: Map[Char, Int] = Map()):
@@ -42,6 +43,6 @@ case class Alphabet[EncodingType <: Serialization]
   def apply(index: Int): Char = chars.s.charAt(index)
 
   def invert(position: Int, char: Char): Int raises SerializationError =
-    inverse.getOrElse(char, raise(SerializationError(position, char), 0))
+    inverse.getOrElse(char, raise(SerializationError(position, char)) yet 0)
 
   lazy val inverse: Map[Char, Int] = tolerance ++ chars.chars.zipWithIndex.to(Map)

--- a/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
+++ b/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
@@ -93,7 +93,7 @@ object EmailAddress:
         quoted(index + 1, false)
 
       case Unset =>
-        raise(EmailAddressError(UnclosedQuote), (LocalPart.Quoted(buffer.text), index))
+        raise(EmailAddressError(UnclosedQuote)) yet (LocalPart.Quoted(buffer.text), index)
 
     def unquoted(index: Ordinal, dot: Boolean): (LocalPart, Ordinal) =
       text.at(index) match
@@ -118,7 +118,7 @@ object EmailAddress:
           unquoted(index + 1, false)
 
         case Unset =>
-          raise(EmailAddressError(MissingAtSymbol), (LocalPart.Unquoted(buffer.text), index))
+          raise(EmailAddressError(MissingAtSymbol)) yet (LocalPart.Unquoted(buffer.text), index)
 
     val (localPart, index) =
       if text.starts(t"\"") then quoted(Sec, false) else unquoted(Prim, false)

--- a/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
+++ b/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
@@ -94,11 +94,11 @@ object Nettlesome:
               bytes.map(_.decode[Int]).pipe: bytes =>
                 for byte <- bytes do
                   if !(0 <= byte <= 255)
-                  then raise(IpAddressError(Ipv4ByteOutOfRange(byte)), 0.toByte)
+                  then raise(IpAddressError(Ipv4ByteOutOfRange(byte))) yet 0.toByte
 
                 Ipv4(bytes(0).toByte, bytes(1).toByte, bytes(2).toByte, bytes(3).toByte)
 
-        else raise(IpAddressError(Ipv4WrongNumberOfGroups(bytes.length)), 0)
+        else raise(IpAddressError(Ipv4WrongNumberOfGroups(bytes.length))) yet 0
 
     object MacAddress:
       import MacAddressError.Reason.*
@@ -124,7 +124,7 @@ object Nettlesome:
             then raise(MacAddressError(WrongGroupLength(index, head.length)))
 
             val value = try Integer.parseInt(head.s, 16) catch case error: NumberFormatException =>
-              raise(MacAddressError(NotHex(index, head)), 0)
+              raise(MacAddressError(NotHex(index, head))) yet 0
 
             recur(tail, index + 1, (acc << 8) + value)
 
@@ -150,7 +150,8 @@ object Nettlesome:
       def unsafe(value: Int): TcpPort = value.asInstanceOf[TcpPort]
 
       def apply(value: Int): TcpPort raises PortError =
-        if 1 <= value <= 65535 then value.asInstanceOf[TcpPort] else raise(PortError(), unsafe(1))
+        if 1 <= value <= 65535 then value.asInstanceOf[TcpPort]
+        else raise(PortError()) yet unsafe(1)
 
     object UdpPort:
       erased given underlying: Underlying[UdpPort, Int] = ###
@@ -163,7 +164,8 @@ object Nettlesome:
       def unsafe(value: Int): UdpPort = value.asInstanceOf[UdpPort]
 
       def apply(value: Int): UdpPort raises PortError =
-        if 1 <= value <= 65535 then value.asInstanceOf[UdpPort] else raise(PortError(), unsafe(1))
+        if 1 <= value <= 65535 then value.asInstanceOf[UdpPort]
+        else raise(PortError()) yet unsafe(1)
 
     extension (port: TcpPort | UdpPort)
       def number: Int = port
@@ -283,10 +285,10 @@ object Nettlesome:
           val groups = whole.cut(t":")
 
           if groups.length != 8
-          then raise(IpAddressError(Ipv6WrongNumberOfGroups(groups.length)), zeroes)
+          then raise(IpAddressError(Ipv6WrongNumberOfGroups(groups.length))) yet zeroes
           else groups.to(List)
 
         case _ =>
-          raise(IpAddressError(Ipv6MultipleDoubleColons), zeroes)
+          raise(IpAddressError(Ipv6MultipleDoubleColons)) yet zeroes
 
       Ipv6(pack(groups.take(4).map(parseGroup)), pack(groups.drop(4).map(parseGroup)))

--- a/lib/nettlesome/src/url/nettlesome.Authority.scala
+++ b/lib/nettlesome/src/url/nettlesome.Authority.scala
@@ -58,10 +58,10 @@ object Authority:
             case port: Int if port >= 0 && port <= 65535 => port
 
             case port: Int =>
-              raise(UrlError(value, colon + 1, PortRange), 0)
+              raise(UrlError(value, colon + 1, PortRange)) yet 0
 
             case _ =>
-              raise(UrlError(value, colon + 1, Number), 0)
+              raise(UrlError(value, colon + 1, Number)) yet 0
 
           . pipe:
             Authority
@@ -76,10 +76,10 @@ object Authority:
             case port: Int if port >= 0 && port <= 65535 => port
 
             case port: Int =>
-              raise(UrlError(value, colon + 1, PortRange), 0)
+              raise(UrlError(value, colon + 1, PortRange)) yet 0
 
             case _ =>
-              raise(UrlError(value, colon + 1, Number), 0)
+              raise(UrlError(value, colon + 1, Number)) yet 0
 
           . pipe(Authority(Hostname.parse(value.before(colon)), Unset, _))
 

--- a/lib/octogenarian/src/core/octogenarian.Octogenarian.scala
+++ b/lib/octogenarian/src/core/octogenarian.Octogenarian.scala
@@ -55,14 +55,14 @@ object Octogenarian:
 
     def parse(text: Text)(using Tactic[GitRefError]): Text =
       text.cut(t"/").each: part =>
-        if part.starts(t".") || part.ends(t".") then raise(GitRefError(text), text)
-        if part.ends(t".lock") then raise(GitRefError(text), text)
-        if part.contains(t"@{") then raise(GitRefError(text), text)
-        if part.contains(t"..") then raise(GitRefError(text), text)
-        if part.length == 0 then raise(GitRefError(text), text)
+        if part.starts(t".") || part.ends(t".") then raise(GitRefError(text)) yet text
+        if part.ends(t".lock") then raise(GitRefError(text)) yet text
+        if part.contains(t"@{") then raise(GitRefError(text)) yet text
+        if part.contains(t"..") then raise(GitRefError(text)) yet text
+        if part.length == 0 then raise(GitRefError(text)) yet text
 
         for char <- List('*', '[', '\\', ' ', '^', '~', ':', '?')
-        do if part.contains(char) then raise(GitRefError(text), text)
+        do if part.contains(char) then raise(GitRefError(text)) yet text
 
       text
 
@@ -84,7 +84,7 @@ object Octogenarian:
   object CommitHash:
     def apply(text: Text)(using Tactic[GitRefError]): CommitHash = text match
       case r"[a-f0-9]{40}" => text
-      case _               => raise(GitRefError(text), text)
+      case _               => raise(GitRefError(text)) yet text
 
     def unsafe(text: Text): CommitHash = text
 

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -160,7 +160,8 @@ object Markdown:
       Markdown[Markdown.Ast.Inline](xs*)
 
     case other =>
-      raise(MarkdownError(MarkdownError.Reason.BlockInsideInline), Markdown[Markdown.Ast.Inline]())
+      raise(MarkdownError(MarkdownError.Reason.BlockInsideInline))
+      Markdown[Markdown.Ast.Inline]()
 
   @tailrec
   private def coalesce[MdType >: Copy <: Markdown.Ast.Inline]
@@ -187,7 +188,7 @@ object Markdown:
   :     Text raises MarkdownError =
 
     Optional(node.getReferenceNode(root)).let(_.nn.getUrl.toString.show).or:
-      raise(MarkdownError(MarkdownError.Reason.BrokenImageRef), t"https://example.com/")
+      raise(MarkdownError(MarkdownError.Reason.BrokenImageRef)) yet t"https://example.com/"
 
   type PhrasingInput =
     cvfa.Emphasis | cvfa.StrongEmphasis | cvfa.Code | cvfa.HardLineBreak | cvfa.Image
@@ -260,9 +261,8 @@ object Markdown:
         case lvl@(1 | 2 | 3 | 4 | 5 | 6) => Heading(lvl, phraseChildren(root, node)*)
 
         case _ =>
-          raise
-           (MarkdownError(MarkdownError.Reason.BadHeadingLevel),
-            Heading(6, phraseChildren(root, node)*))
+          raise(MarkdownError(MarkdownError.Reason.BadHeadingLevel))
+          Heading(6, phraseChildren(root, node)*)
 
   def convert(root: cvfua.Document, node: cvfua.Node, noFormat: Boolean = false)
   :     Markdown.Ast.Node raises MarkdownError =
@@ -275,7 +275,7 @@ object Markdown:
       case node: PhrasingInput      => phrasing(root, node)
 
       case node: cvfua.Node =>
-        raise(MarkdownError(MarkdownError.Reason.UnexpectedNode), Copy(t"?"))
+        raise(MarkdownError(MarkdownError.Reason.UnexpectedNode)) yet Copy(t"?")
 
       case node: cvfa.Reference =>
         Reference(node.getReference.toString.show, node.getUrl.toString.show)

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -346,7 +346,7 @@ object Http:
         case Http.Status.Category.Successful => response.body
 
         case _ =>
-          raise(HttpError(response.status, response.textHeaders), response.body)
+          raise(HttpError(response.status, response.textHeaders)) yet response.body
 
       body.stream
 

--- a/lib/turbulence/src/core/turbulence.Readable.scala
+++ b/lib/turbulence/src/core/turbulence.Readable.scala
@@ -84,7 +84,7 @@ object Readable:
         case int => int.toChar #:: recur(count + 1.b)
       catch case err: ji.IOException =>
         reader.close()
-        raise(StreamError(count), Stream())
+        raise(StreamError(count)) yet Stream()
 
     Stream.defer(recur(0L.b))
 
@@ -98,7 +98,7 @@ object Readable:
           case line: String => Line(Text(line)) #:: recur(count + line.length.b + 1.b)
         catch case err: ji.IOException =>
           reader.close()
-          raise(StreamError(count), Stream())
+          raise(StreamError(count)) yet Stream()
 
       Stream.defer(recur(0L.b))
 
@@ -125,7 +125,7 @@ object Readable:
 
             array.immutable(using Unsafe) #:: recur(total + count)
 
-        catch case e: Exception => Stream(raise(StreamError(total.b), Bytes()))
+        catch case e: Exception => Stream(raise(StreamError(total.b)) yet Bytes())
 
       Stream.defer(recur(0))
 

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -186,8 +186,9 @@ trait SumDerivationMethods[TypeclassType[_]]:
 
       case _ =>
         inline if fallible
-        then raise(VariantError[DerivationType](inputLabel), Unset)
-              (using summonInline[Tactic[VariantError]])
+        then
+          given Tactic[VariantError] = summonInline[Tactic[VariantError]]
+          raise(VariantError[DerivationType](inputLabel)) yet Unset
         else panic(m"Should be unreachable")
 
   private transparent inline def fold[DerivationType, VariantsType <: Tuple, LabelsType <: Tuple]
@@ -227,8 +228,9 @@ trait SumDerivationMethods[TypeclassType[_]]:
 
       case _ =>
         inline if fallible
-        then raise(VariantError[DerivationType]("".tt), Unset)
-              (using summonInline[Tactic[VariantError]])
+        then
+          given Tactic[VariantError] = summonInline[Tactic[VariantError]]
+          raise(VariantError[DerivationType]("".tt)) yet Unset
         else panic(m"Should be unreachable")
 
   inline def split[DerivationType: SumReflection]: TypeclassType[DerivationType]

--- a/lib/xylophone/src/core/xylophone.XmlDecoder.scala
+++ b/lib/xylophone/src/core/xylophone.XmlDecoder.scala
@@ -37,6 +37,7 @@ import contingency.*
 import distillate.*
 import prepositional.*
 import proscenium.*
+import rudiments.*
 import wisteria.*
 
 trait XmlDecoder[ValueType]:
@@ -48,7 +49,7 @@ trait XmlDecoder[ValueType]:
 object XmlDecoder extends Derivation[XmlDecoder]:
   given text(using Tactic[XmlReadError]): XmlDecoder[Text] = list =>
     val elements = childElements(list).collect { case XmlAst.Textual(text) => text }
-    if elements.length == 0 then raise(XmlReadError(), "".tt) else elements.head
+    if elements.length == 0 then raise(XmlReadError()) yet "".tt else elements.head
 
   given [ValueType: Decodable in Text]: XmlDecoder[ValueType] = value =>
     value.absolve match


### PR DESCRIPTION
Replaces every occurrence of `raise(error, ersatz)` with `raise(error) yet ersatz`. This obviates the two-parameter variant of `raise.