### PR TITLE
Fix a couple of problems with Larceny

### DIFF
--- a/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
+++ b/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
@@ -49,6 +49,7 @@ class LarcenyTransformer() extends PluginPhase:
   override def transformUnit(tree: Tree)(using Context): Tree =
     import ast.untpd.*
     val classpath = ctx.settings.classpath.value
+    val language = ctx.settings.language.value
 
     object collector extends UntypedTreeMap:
       val regions: scm.ListBuffer[(Int, Int)] = scm.ListBuffer()
@@ -66,7 +67,7 @@ class LarcenyTransformer() extends PluginPhase:
     val source = String(ctx.compilationUnit.source.content)
 
     val errors: List[CompileError] =
-      Subcompiler.compile(ctx.settings.classpath.value, source, regions)
+      Subcompiler.compile(language, classpath, source, regions)
 
     object transformer extends UntypedTreeMap:
 


### PR DESCRIPTION
Larceny was sometimes failing to capture certain errors, and code which would clearly not compile was appearing to have no errors. That turned out to have two causes.

Firstly, the error position being reported was not the "primary" error position in the problematic file. The `Diagnostic` from the compiler needed to be "dereferenced" to reach the outermost error.

Secondly, subcompilations were being done with different settings from those used for the main compilation. These caused errors elsewhere in the file under compilation which shadowed the desired error.

Both these issues are now fixed.