### PR TITLE
Fix a serious breakage in `Promise` fulfillment

### DIFF
--- a/lib/parasite/src/core/parasite.Promise.scala
+++ b/lib/parasite/src/core/parasite.Promise.scala
@@ -80,7 +80,7 @@ final case class Promise[ValueType]():
       case current             => current
 
   def fulfill(supplied: => ValueType): Unit raises AsyncError =
-    state.updateAndGet(completeIncomplete(supplied)).nn match
+    state.getAndUpdate(completeIncomplete(supplied)).nn match
       case Cancelled           => raise(AsyncError(AsyncError.Reason.Cancelled))
       case Complete(_)         => raise(AsyncError(AsyncError.Reason.AlreadyComplete))
       case Incomplete(waiting) => ()

--- a/lib/parasite/src/test/parasite.Tests.scala
+++ b/lib/parasite/src/test/parasite.Tests.scala
@@ -32,9 +32,10 @@
                                                                                                   */
 package parasite
 
-import anticipation.*, timeInterfaces.long
+import anticipation.*
 import contingency.*
 import digression.*
+import fulminate.*
 import gossamer.*
 import probably.*
 import proscenium.*
@@ -46,10 +47,12 @@ import strategies.throwUnsafely
 import threadModels.platform
 import asyncTermination.cancel
 
-given Interceptor = (path, error) =>
-  println(s"An async exception occurred in ${path.stack}:")
-  error.printStackTrace()
-  Mitigation.Escalate
+import errorDiagnostics.stackTraces
+
+// given Interceptor = (path, error) =>
+//   println(s"An async exception occurred in ${path.stack}:")
+//   error.printStackTrace()
+//   Mitigation.Escalate
 
 object Tests extends Suite(t"Parasite tests"):
 


### PR DESCRIPTION
A misuse of `updateAndGet` when `getAndUpdate` should have been used was causing `Promise`s to simply not work. This is been fixed, but much more testing is required.