### PR TITLE
Introduce Austronesian

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -291,6 +291,16 @@ object anticipation extends SoundnessModule {
   object test extends ProbablyTestModule
 }
 
+object austronesian extends SoundnessModule {
+  object core extends SoundnessSubModule {
+    def moduleDeps = Seq(wisteria.core, distillate.core)
+  }
+
+  object test extends ProbablyTestModule {
+    def moduleDeps = Seq(probably.cli, core)
+  }
+}
+
 object aviation extends SoundnessModule {
   object core extends SoundnessSubModule {
     def moduleDeps = Seq(quantitative.core)

--- a/lib/austronesian/src/core/austronesian-core.JavaError.scala
+++ b/lib/austronesian/src/core/austronesian-core.JavaError.scala
@@ -1,6 +1,0 @@
-package austronesian
-
-import anticipation.*
-import fulminate.*
-
-case class JavaError()(using Diagnostics) extends Error(m"JavaError")

--- a/lib/austronesian/src/core/austronesian-core.JavaError.scala
+++ b/lib/austronesian/src/core/austronesian-core.JavaError.scala
@@ -1,0 +1,6 @@
+package austronesian
+
+import anticipation.*
+import fulminate.*
+
+case class JavaError()(using Diagnostics) extends Error(m"JavaError")

--- a/lib/austronesian/src/core/austronesian-core.scala
+++ b/lib/austronesian/src/core/austronesian-core.scala
@@ -3,6 +3,7 @@ package austronesian
 import anticipation.*
 import prepositional.*
 
-export Austronesian.Java
+export Austronesian.Stdlib
 
-extension [ValueType: Encodable in Java](value: ValueType) def java = ValueType.encoded(value)
+extension [ValueType: Encodable in Stdlib](value: ValueType)
+  def stdlib: Stdlib = ValueType.encoded(value)

--- a/lib/austronesian/src/core/austronesian-core.scala
+++ b/lib/austronesian/src/core/austronesian-core.scala
@@ -1,0 +1,8 @@
+package austronesian
+
+import anticipation.*
+import prepositional.*
+
+export Austronesian.Java
+
+extension [ValueType: Encodable in Java](value: ValueType) def java = ValueType.encoded(value)

--- a/lib/austronesian/src/core/austronesian.Austronesian.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian.scala
@@ -1,0 +1,81 @@
+package austronesian
+
+import scala.collection.Factory
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import prepositional.*
+import rudiments.*
+import wisteria.*
+
+object Austronesian:
+  opaque type Java =
+  IArray[Any] | String | Boolean | Byte | Char | Short | Int | Long | Float | Double
+
+  object Java extends Java2:
+    given text: Text is Encodable in Java = _.s
+    given string: String is Encodable in Java = identity(_)
+    given int: Int is Encodable in Java = identity(_)
+    given long: Long is Encodable in Java = identity(_)
+    given float: Float is Encodable in Java = identity(_)
+    given double: Double is Encodable in Java = identity(_)
+    given char: Char is Encodable in Java = identity(_)
+    given boolean: Boolean is Encodable in Java = identity(_)
+    given byte: Byte is Encodable in Java = identity(_)
+
+    given list: [CollectionType <: Iterable, ElementType: Encodable in Java]
+    =>     CollectionType[ElementType] is Encodable in Java =
+      iterable => IArray.from(iterable.map(_.encode))
+
+    given text2: Tactic[JavaError] => Text is Decodable in Java =
+      case string: String => string.tt
+      case _              => raise(JavaError()) yet "".tt
+
+    given string2: Tactic[JavaError] => String is Decodable in Java =
+      case string: String => string
+      case _              => raise(JavaError()) yet ""
+
+    given int2: Tactic[JavaError] => Int is Decodable in Java =
+      case int: Int => int
+      case _        => raise(JavaError()) yet 0
+
+    given long2: Tactic[JavaError] => Long is Decodable in Java =
+      case long: Long => long
+      case _          => raise(JavaError()) yet 0L
+
+    given float2: Tactic[JavaError] => Float is Decodable in Java =
+      case float: Float => float
+      case _            => raise(JavaError()) yet 0.0f
+
+    given double2: Tactic[JavaError] => Double is Decodable in Java =
+      case double: Double => double
+      case _              => raise(JavaError()) yet 0.0
+
+    given char2: Tactic[JavaError] => Char is Decodable in Java =
+      case char: Char => char
+      case _          => raise(JavaError()) yet '\u0000'
+
+    given boolean2: Tactic[JavaError] => Boolean is Decodable in Java =
+      case boolean: Boolean => boolean
+      case _                => raise(JavaError()) yet false
+
+    given collection: [CollectionType <: Iterable, ElementType: Decodable in Java]
+    =>    Tactic[JavaError]
+    =>    (factory: Factory[ElementType, CollectionType[ElementType]])
+    =>    CollectionType[ElementType] is Decodable in Java =
+
+      case array: Array[Java] =>
+        factory.newBuilder.pipe: builder =>
+          array.each(builder += _.decode)
+          builder.result()
+
+      case other =>
+        raise(JavaError()) yet factory.newBuilder.result()
+
+  trait Java2:
+    inline given encodable: [ValueType: Reflection] => ValueType is Encodable in Java =
+      Austronesian2.EncodableDerivation.derived
+
+    inline given decodable: [ValueType: Reflection] => ValueType is Decodable in Java =
+      Austronesian2.DecodableDerivation.derived

--- a/lib/austronesian/src/core/austronesian.Austronesian.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian.scala
@@ -10,72 +10,72 @@ import rudiments.*
 import wisteria.*
 
 object Austronesian:
-  opaque type Java =
-  IArray[Any] | String | Boolean | Byte | Char | Short | Int | Long | Float | Double
+  opaque type Stdlib =
+    IArray[Any] | String | Boolean | Byte | Char | Short | Int | Long | Float | Double
 
-  object Java extends Java2:
-    given text: Text is Encodable in Java = _.s
-    given string: String is Encodable in Java = identity(_)
-    given int: Int is Encodable in Java = identity(_)
-    given long: Long is Encodable in Java = identity(_)
-    given float: Float is Encodable in Java = identity(_)
-    given double: Double is Encodable in Java = identity(_)
-    given char: Char is Encodable in Java = identity(_)
-    given boolean: Boolean is Encodable in Java = identity(_)
-    given byte: Byte is Encodable in Java = identity(_)
+  object Stdlib extends Stdlib2:
+    given text: Text is Encodable in Stdlib = _.s
+    given string: String is Encodable in Stdlib = identity(_)
+    given int: Int is Encodable in Stdlib = identity(_)
+    given long: Long is Encodable in Stdlib = identity(_)
+    given float: Float is Encodable in Stdlib = identity(_)
+    given double: Double is Encodable in Stdlib = identity(_)
+    given char: Char is Encodable in Stdlib = identity(_)
+    given boolean: Boolean is Encodable in Stdlib = identity(_)
+    given byte: Byte is Encodable in Stdlib = identity(_)
 
-    given list: [CollectionType <: Iterable, ElementType: Encodable in Java]
-    =>     CollectionType[ElementType] is Encodable in Java =
+    given list: [CollectionType <: Iterable, ElementType: Encodable in Stdlib]
+    =>     CollectionType[ElementType] is Encodable in Stdlib =
       iterable => IArray.from(iterable.map(_.encode))
 
-    given text2: Tactic[JavaError] => Text is Decodable in Java =
+    given text2: Tactic[StdlibError] => Text is Decodable in Stdlib =
       case string: String => string.tt
-      case _              => raise(JavaError()) yet "".tt
+      case _              => raise(StdlibError()) yet "".tt
 
-    given string2: Tactic[JavaError] => String is Decodable in Java =
+    given string2: Tactic[StdlibError] => String is Decodable in Stdlib =
       case string: String => string
-      case _              => raise(JavaError()) yet ""
+      case _              => raise(StdlibError()) yet ""
 
-    given int2: Tactic[JavaError] => Int is Decodable in Java =
+    given int2: Tactic[StdlibError] => Int is Decodable in Stdlib =
       case int: Int => int
-      case _        => raise(JavaError()) yet 0
+      case _        => raise(StdlibError()) yet 0
 
-    given long2: Tactic[JavaError] => Long is Decodable in Java =
+    given long2: Tactic[StdlibError] => Long is Decodable in Stdlib =
       case long: Long => long
-      case _          => raise(JavaError()) yet 0L
+      case _          => raise(StdlibError()) yet 0L
 
-    given float2: Tactic[JavaError] => Float is Decodable in Java =
+    given float2: Tactic[StdlibError] => Float is Decodable in Stdlib =
       case float: Float => float
-      case _            => raise(JavaError()) yet 0.0f
+      case _            => raise(StdlibError()) yet 0.0f
 
-    given double2: Tactic[JavaError] => Double is Decodable in Java =
+    given double2: Tactic[StdlibError] => Double is Decodable in Stdlib =
       case double: Double => double
-      case _              => raise(JavaError()) yet 0.0
+      case _              => raise(StdlibError()) yet 0.0
 
-    given char2: Tactic[JavaError] => Char is Decodable in Java =
+    given char2: Tactic[StdlibError] => Char is Decodable in Stdlib =
       case char: Char => char
-      case _          => raise(JavaError()) yet '\u0000'
+      case _          => raise(StdlibError()) yet '\u0000'
 
-    given boolean2: Tactic[JavaError] => Boolean is Decodable in Java =
+    given boolean2: Tactic[StdlibError] => Boolean is Decodable in Stdlib =
       case boolean: Boolean => boolean
-      case _                => raise(JavaError()) yet false
+      case _                => raise(StdlibError()) yet false
 
-    given collection: [CollectionType <: Iterable, ElementType: Decodable in Java]
-    =>    Tactic[JavaError]
+    given collection: [CollectionType <: Iterable, ElementType: Decodable in Stdlib]
+    =>    Tactic[StdlibError]
     =>    (factory: Factory[ElementType, CollectionType[ElementType]])
-    =>    CollectionType[ElementType] is Decodable in Java =
+    =>    CollectionType[ElementType] is Decodable in Stdlib =
 
-      case array: Array[Java] =>
+      case array: Array[Stdlib] =>
         factory.newBuilder.pipe: builder =>
           array.each(builder += _.decode)
           builder.result()
 
       case other =>
-        raise(JavaError()) yet factory.newBuilder.result()
+        raise(StdlibError()) yet factory.newBuilder.result()
 
-  trait Java2:
-    inline given encodable: [ValueType: Reflection] => ValueType is Encodable in Java =
+  trait Stdlib2:
+    inline given encodable: [ValueType: Reflection] => ValueType is Encodable in Stdlib =
       Austronesian2.EncodableDerivation.derived
 
-    inline given decodable: [ValueType: Reflection] => ValueType is Decodable in Java =
+    inline given decodable: [ValueType: Reflection] => ValueType is Decodable in Stdlib =
       Austronesian2.DecodableDerivation.derived

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -1,0 +1,48 @@
+package austronesian
+
+import scala.compiletime.*
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import prepositional.*
+import rudiments.*
+import wisteria.*
+
+object Austronesian2:
+  object EncodableDerivation extends Derivation[[Type] =>> Type is Encodable in Java]:
+
+    inline def join[DerivationType <: Product: ProductReflection]
+    :     DerivationType is Encodable in _root_.austronesian.Austronesian.Java =
+
+      fields(_):
+        [FieldType] => _.encode
+      .asInstanceOf[Java]
+
+    inline def split[DerivationType: SumReflection]: DerivationType is Encodable in Java =
+      variant(_):
+        [VariantType <: DerivationType] => value =>
+          IArray.create[Java](2): array =>
+            array(0) = label.s.asInstanceOf[Java]
+            array(1) = value.encode
+
+          . asInstanceOf[Java]
+
+  object DecodableDerivation extends Derivable[Decodable in Java]:
+    inline def join[DerivationType <: Product: ProductReflection]
+    :     DerivationType is Decodable in Java =
+
+      case array: Array[Java] =>
+        construct: [FieldType] =>
+          _.decoded(array(index))
+
+      case other =>
+        summonInline[Tactic[JavaError]].give(abort(JavaError()))
+
+    inline def split[DerivationType: SumReflection]: DerivationType is Decodable in Java =
+      case Array(label: String, java: Java) =>
+        delegate(label): [VariantType <: DerivationType] =>
+          _.decoded(java)
+
+      case other =>
+        summonInline[Tactic[JavaError]].give(abort(JavaError()))

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -10,39 +10,39 @@ import rudiments.*
 import wisteria.*
 
 object Austronesian2:
-  object EncodableDerivation extends Derivation[[Type] =>> Type is Encodable in Java]:
+  object EncodableDerivation extends Derivation[[Type] =>> Type is Encodable in Stdlib]:
 
     inline def join[DerivationType <: Product: ProductReflection]
-    :     DerivationType is Encodable in _root_.austronesian.Austronesian.Java =
+    :     DerivationType is Encodable in _root_.austronesian.Austronesian.Stdlib =
 
       fields(_):
         [FieldType] => _.encode
-      .asInstanceOf[Java]
+      .asInstanceOf[Stdlib]
 
-    inline def split[DerivationType: SumReflection]: DerivationType is Encodable in Java =
+    inline def split[DerivationType: SumReflection]: DerivationType is Encodable in Stdlib =
       variant(_):
         [VariantType <: DerivationType] => value =>
-          IArray.create[Java](2): array =>
-            array(0) = label.s.asInstanceOf[Java]
+          IArray.create[Stdlib](2): array =>
+            array(0) = label.s.asInstanceOf[Stdlib]
             array(1) = value.encode
 
-          . asInstanceOf[Java]
+          . asInstanceOf[Stdlib]
 
-  object DecodableDerivation extends Derivable[Decodable in Java]:
+  object DecodableDerivation extends Derivable[Decodable in Stdlib]:
     inline def join[DerivationType <: Product: ProductReflection]
-    :     DerivationType is Decodable in Java =
+    :     DerivationType is Decodable in Stdlib =
 
-      case array: Array[Java] =>
+      case array: Array[Stdlib] =>
         construct: [FieldType] =>
           _.decoded(array(index))
 
       case other =>
-        summonInline[Tactic[JavaError]].give(abort(JavaError()))
+        summonInline[Tactic[StdlibError]].give(abort(StdlibError()))
 
-    inline def split[DerivationType: SumReflection]: DerivationType is Decodable in Java =
-      case Array(label: String, java: Java) =>
+    inline def split[DerivationType: SumReflection]: DerivationType is Decodable in Stdlib =
+      case Array(label: String, stdlib: Stdlib) =>
         delegate(label): [VariantType <: DerivationType] =>
-          _.decoded(java)
+          _.decoded(stdlib)
 
       case other =>
-        summonInline[Tactic[JavaError]].give(abort(JavaError()))
+        summonInline[Tactic[StdlibError]].give(abort(StdlibError()))

--- a/lib/austronesian/src/core/austronesian.StdlibError.scala
+++ b/lib/austronesian/src/core/austronesian.StdlibError.scala
@@ -1,0 +1,6 @@
+package austronesian
+
+import anticipation.*
+import fulminate.*
+
+case class StdlibError()(using Diagnostics) extends Error(m"JavaError")

--- a/lib/austronesian/src/test/austronesian.Tests.scala
+++ b/lib/austronesian/src/test/austronesian.Tests.scala
@@ -1,0 +1,33 @@
+package austronesian
+
+import _root_.java.util as ju
+import soundness.*
+
+case class Person(name: Text, age: Int)
+case class Group(persons: List[Person], size: Int)
+
+import Austronesian.Java
+
+object Tests extends Suite(t"Austronesian tests"):
+
+  extension (left: Java) infix def like (right: Array[Any]): Boolean =
+    ju.Arrays.deepEquals(left.asInstanceOf[Array[Any]], right)
+
+  def run(): Unit =
+    test(t"Serialize a case class")(Person("John", 30).java)
+    . assert(_ like Array("John", 30))
+
+    test(t"Serialize a list of longs")(List(1L, 99L, 203L).java)
+    . assert(_ like Array(1L, 99L, 203L))
+
+    test(t"Serialize a list of case classes")(List(Person("John", 12), Person("Jane", 93)).java)
+    . assert(_ like Array(Array("John", 12), Array("Jane", 93)))
+
+    test(t"Serialize a nested case class structure"):
+      Group(List(Person("John", 30), Person("Jane", 25)), 2).java
+    . assert(_ like Array(Array(Array("John", 30), Array("Jane", 25)), 2))
+
+    val group = Group(List(Person("John", 30), Person("Jane", 25)), 2)
+    test(t"Roundtrip a nested case class"):
+      unsafely(group.java.decode[Group])
+    . assert(_ == group)

--- a/lib/austronesian/src/test/austronesian.Tests.scala
+++ b/lib/austronesian/src/test/austronesian.Tests.scala
@@ -1,33 +1,44 @@
 package austronesian
 
-import _root_.java.util as ju
+import java.util as ju
 import soundness.*
 
 case class Person(name: Text, age: Int)
 case class Group(persons: List[Person], size: Int)
 
-import Austronesian.Java
+enum Color:
+  case Red, Green, Blue
 
 object Tests extends Suite(t"Austronesian tests"):
 
-  extension (left: Java) infix def like (right: Array[Any]): Boolean =
+  extension (left: Stdlib) infix def like (right: Array[Any]): Boolean =
     ju.Arrays.deepEquals(left.asInstanceOf[Array[Any]], right)
 
   def run(): Unit =
-    test(t"Serialize a case class")(Person("John", 30).java)
+    test(t"Serialize a case class")(Person("John", 30).stdlib)
     . assert(_ like Array("John", 30))
 
-    test(t"Serialize a list of longs")(List(1L, 99L, 203L).java)
+    test(t"Serialize a list of longs")(List(1L, 99L, 203L).stdlib)
     . assert(_ like Array(1L, 99L, 203L))
 
-    test(t"Serialize a list of case classes")(List(Person("John", 12), Person("Jane", 93)).java)
+    test(t"Serialize a list of case classes")(List(Person("John", 12), Person("Jane", 93)).stdlib)
     . assert(_ like Array(Array("John", 12), Array("Jane", 93)))
 
     test(t"Serialize a nested case class structure"):
-      Group(List(Person("John", 30), Person("Jane", 25)), 2).java
+      Group(List(Person("John", 30), Person("Jane", 25)), 2).stdlib
     . assert(_ like Array(Array(Array("John", 30), Array("Jane", 25)), 2))
 
     val group = Group(List(Person("John", 30), Person("Jane", 25)), 2)
     test(t"Roundtrip a nested case class"):
-      unsafely(group.java.decode[Group])
+      unsafely(group.stdlib.decode[Group])
     . assert(_ == group)
+
+    test(t"Encode an enum"):
+      val color: Color = Color.Green
+      color.stdlib
+    . assert(_ like Array("Green", Array[Any]()))
+
+    test(t"Roundtrip an enum"):
+      val color: Color = Color.Green
+      unsafely(color.stdlib.decode[Color])
+    . assert(_ == Color.Green)

--- a/lib/vacuous/src/core/soundness+vacuous-core.scala
+++ b/lib/vacuous/src/core/soundness+vacuous-core.scala
@@ -33,5 +33,5 @@
 package soundness
 
 export vacuous.{Default, default, Unset, Optional, UnsetError, or, absent, present, vouch, mask,
-    stdlib, presume, option, assume, lay, layGiven, let, letGiven, compact, optional, puncture,
+    javaOptional, presume, option, assume, lay, layGiven, let, letGiven, compact, optional, puncture,
     only, unless, provided, Unsafe, Extractor}

--- a/lib/vacuous/src/core/vacuous.Optional.scala
+++ b/lib/vacuous/src/core/vacuous.Optional.scala
@@ -60,7 +60,7 @@ extension [ValueType](optional: Optional[ValueType])(using Optionality[optional.
   inline def mask(predicate: ValueType => Boolean): Optional[ValueType] =
     optional.let { value => if predicate(value) then Unset else value }
 
-  def stdlib: ju.Optional[ValueType] =
+  def javaOptional: ju.Optional[ValueType] =
     optional.lay(ju.Optional.empty[ValueType].nn)(ju.Optional.of(_).nn)
 
   def presume(using default: Default[ValueType]): ValueType = optional.or(default())


### PR DESCRIPTION
Sometimes we need datatypes to be portable across domains with subtly different representations, even within the same JVM. A particular example regards passing data between different versions of the same code running in different classloaders, for example, when invoking a different version of the same library or compiled for a different version of Scala.

Austronesian provides a means of conversion of primitives, collections, products and sum types to the "lowest common denominator" representation: JVM primitives.