### PR TITLE
Make `Http` servable

### DIFF
--- a/lib/nettlesome/src/core/nettlesome.Service.scala
+++ b/lib/nettlesome/src/core/nettlesome.Service.scala
@@ -30,8 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package scintillate
+package nettlesome
 
-import parasite.*
-
-case class HttpService(port: Int, async: Task[Unit], cancel: () => Unit)
+case class Service(cancel: () => Unit)

--- a/lib/nettlesome/src/core/soundness+nettlesome-core.scala
+++ b/lib/nettlesome/src/core/soundness+nettlesome-core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export nettlesome.{ip, mac, tcp, udp, on, internet, online, EmailAddress, EmailAddressError,
     Endpoint, Hostname, HostnameError, Internet, IpAddressError, LocalPart, MacAddressError,
-    OfflineError, Online, Port, PortError, Connectable, serve}
+    OfflineError, Online, Port, PortError, Connectable, serve, Service}
 
 package internetAccess:
   export nettlesome.internetAccess.{enabled, disabled}

--- a/lib/scintillate/src/server/scintillate-core.scala
+++ b/lib/scintillate/src/server/scintillate-core.scala
@@ -46,6 +46,20 @@ import spectacular.*
 import telekinesis.*
 import vacuous.*
 
+package httpServers:
+  given stdlib: (Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable)
+  =>    Http is Protocolic:
+
+    type Carrier = TcpPort
+    type Self = Http
+    type Server = Service
+    type Request = HttpConnection
+    type Response = Http.Response
+
+    def server(port: TcpPort)(lambda: Request ?=> Response): Service =
+      HttpServer(port.number).listen(lambda)
+
+
 def cookie(using request: Http.Request)(key: Text): Optional[Text] = request.textCookies.at(key)
 
 def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.Response)
@@ -67,7 +81,7 @@ given realm: Realm = realm"scintillate"
 extension (value: Http.type)
   def listen(handle: (connection: HttpConnection) ?=> Http.Response)
      (using RequestServable, Monitor, Codicil)
-  :     HttpService logs HttpServerEvent =
+  :     Service logs HttpServerEvent raises ServerError =
     summon[RequestServable].listen(handle)
 
 extension (request: Http.Request)

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -37,6 +37,7 @@ import contingency.*
 import digression.*
 import parasite.*
 import proscenium.*
+import nettlesome.*
 import rudiments.*
 import telekinesis.*
 import turbulence.*
@@ -47,10 +48,10 @@ import scala.compiletime.*
 import java.net as jn
 import com.sun.net.httpserver as csnh
 
-case class HttpServer(port: Int)(using Tactic[ServerError]) extends RequestServable:
+case class HttpServer(port: Int) extends RequestServable:
   def listen(handler: (connection: HttpConnection) ?=> Http.Response)
      (using Monitor, Codicil)
-  :     HttpService logs HttpServerEvent =
+  :     Service logs HttpServerEvent raises ServerError =
 
     def handle(exchange: csnh.HttpExchange | Null) =
       try
@@ -96,7 +97,7 @@ case class HttpServer(port: Int)(using Tactic[ServerError]) extends RequestServa
 
     val asyncTask = async(cancel.attend() yet server.stop(1))
 
-    HttpService(port, asyncTask, () => safely(cancel.fulfill(())))
+    Service(() => safely(cancel.fulfill(())))
 
   private def streamBody(exchange: csnh.HttpExchange): Stream[Bytes] =
     val in = exchange.getRequestBody.nn

--- a/lib/scintillate/src/server/scintillate.RequestServable.scala
+++ b/lib/scintillate/src/server/scintillate.RequestServable.scala
@@ -33,9 +33,11 @@
 package scintillate
 
 import anticipation.*
+import contingency.*
+import nettlesome.*
 import parasite.*
 import telekinesis.*
 
 trait RequestServable:
   def listen(handle: (connection: HttpConnection) ?=> Http.Response)(using Monitor, Codicil)
-  :     HttpService logs HttpServerEvent
+  :     Service logs HttpServerEvent raises ServerError

--- a/lib/scintillate/src/server/soundness+scintillate-server.scala
+++ b/lib/scintillate/src/server/soundness+scintillate-server.scala
@@ -34,5 +34,8 @@ package soundness
 
 export scintillate .
   { cookie, basicAuth, request, listen, path, Acceptable, HttpConnection, HttpServer,
-    HttpServerEvent, HttpService, NotFound, Redirect, RequestServable, Responder, Retrievable,
+    HttpServerEvent, NotFound, Redirect, RequestServable, Responder, Retrievable,
     ServerError, Unfulfilled }
+
+package httpServers:
+  export scintillate.httpServers.stdlib


### PR DESCRIPTION
The `Protocolic` typeclass existed, but had no instances, despite being intended for use (at least) with `Http`. An instance has now been created, so it's possible to write:
```scala
tcp"80".serve[Http]:
  // handle requests
```