### PR TITLE
Add a module for working with bit flags

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1244,6 +1244,15 @@ object vacuous extends SoundnessModule {
   }
 }
 
+object vexillology extends SoundnessModule {
+  object core extends SoundnessSubModule {
+    def moduleDeps = Seq(hypotenuse.core, distillate.core)
+  }
+  object test extends ProbablyTestModule {
+    def moduleDeps = Seq(probably.cli, core)
+  }
+}
+
 object vicarious extends SoundnessModule {
   object core extends SoundnessSubModule {
     def moduleDeps = Seq(rudiments.core)

--- a/lib/vexillology/src/core/vexillology.Flags.scala
+++ b/lib/vexillology/src/core/vexillology.Flags.scala
@@ -1,0 +1,32 @@
+package vexillology
+
+import java.lang as jl
+
+import distillate.*
+
+object Vexillology:
+  opaque type Flags[EnumType] = Long
+
+  object Flags:
+    def apply[EnumType](): Flags[EnumType] = 0L
+
+  extension [EnumType: Enumerable](flags: Flags[EnumType])
+    def apply(value: EnumType & Singleton): Boolean =
+      (flags & (1L << EnumType.index(value))) > 0
+
+    def update(value: EnumType & Singleton, enabled: Boolean): Flags[EnumType] =
+      if enabled then flags | (1L << EnumType.index(value))
+      else flags & ~(1L << EnumType.index(value))
+
+    def set(using enumerable: EnumType is Enumerable): Set[EnumType] =
+      var value: Long = flags
+      var set: Set[EnumType] = Set()
+
+      while (value != 0) do
+        val position = jl.Long.numberOfTrailingZeros(value)
+        set += enumerable.values(position)
+        value &= value - 1
+
+      set
+
+export Vexillology.Flags

--- a/lib/vexillology/src/test/vexillology.Tests.scala
+++ b/lib/vexillology/src/test/vexillology.Tests.scala
@@ -1,0 +1,57 @@
+package vexillology
+
+import soundness.*
+
+object Tests extends Suite(t"Vexillology tests"):
+  def run(): Unit =
+
+    enum Color:
+      case Red, Orange, Yellow, Green, Blue, Indigo, Violet
+
+    import Color.*
+
+    test(t"Empty flags"):
+      val flags = Flags[Color]()
+      flags.set
+
+    . assert(_.isEmpty)
+
+    test(t"Value is initially unset"):
+      val flags = Flags[Color]()
+      flags(Orange)
+    . assert(_ == false)
+
+    test(t"Value can be set"):
+      var flags = Flags[Color]()
+      flags = flags(Orange) = true
+      flags(Orange)
+    . assert(_ == true)
+
+    test(t"Setting one value does not set others"):
+      var flags = Flags[Color]()
+      flags = flags(Orange) = true
+      flags(Red) || flags(Yellow) || flags(Green) || flags(Blue) || flags(Indigo) || flags(Violet)
+    . assert(_ == false)
+
+    test(t"Single value"):
+      var flags = Flags[Color]()
+      flags = flags(Orange) = true
+      flags.set
+    . assert(_ == Set(Orange))
+
+    test(t"Multiple values"):
+      var flags = Flags[Color]()
+      flags = flags(Orange) = true
+      flags = flags(Green) = true
+      flags = flags(Violet) = true
+      flags.set
+    . assert(_ == Set(Orange, Green, Violet))
+
+    test(t"Unset a value"):
+      var flags = Flags[Color]()
+      flags = flags(Orange) = true
+      flags = flags(Green) = true
+      flags = flags(Violet) = true
+      flags = flags(Green) = false
+      flags.set
+    . assert(_ == Set(Orange, Violet))


### PR DESCRIPTION
This introduces an opaque `Flags[E]` type, where `E` is an `Enumerable` value, based on an underlying `Long` value. It can be used to store a set of bits corresponding to each of the enumerable values.