### PR TITLE
The `Parameter` value for `parameters.<param>` should be `erased`

### DIFF
--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -285,7 +285,7 @@ object Http:
           case _ =>
             request.query
 
-      def selectDynamic(label: Label)(using parameter: label.type is Parameter)
+      def selectDynamic(label: Label)(using erased parameter: label.type is Parameter)
          (using parameter.Subject is Decodable in Text)
       :     Optional[parameter.Subject] =
         query.at(label.tt).let: value =>


### PR DESCRIPTION
When using `request.parameters.<paramName>`, we check for a contextual `<paramName> is Parameter`. Its value isn't actually used, though it's not marked as `erased`. But this means that an `erased` instance of `Parameter` is not suitable for use.

This makes the `using` value `erased` so that we can make instances of `Parameter` `erased`.