### PR TITLE
Alias `EmptyTuple` as `Zero`; `T *: EmtyTuple` as `Mono[T]`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1217,7 +1217,7 @@ object turbulence extends SoundnessModule {
 
 object typonym extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq()
+    def moduleDeps = Seq(proscenium.core)
   }
 
   object test extends ProbablyTestModule {

--- a/lib/fulminate/src/core/fulminate-core.scala
+++ b/lib/fulminate/src/core/fulminate-core.scala
@@ -38,6 +38,7 @@ import scala.compiletime.*
 import scala.quoted.*
 
 import anticipation.*
+import proscenium.*
 
 export Fulminate.Diagnostics
 
@@ -89,7 +90,7 @@ def warn(using Quotes)(message: Message, pos: quotes.reflect.Position | Null = n
   if pos == null then report.warning(text) else report.warning(text, pos)
 
 extension (inline context: StringContext)
-  transparent inline def m[ParamType](inline subs: ParamType = EmptyTuple): Message =
+  transparent inline def m[ParamType](inline subs: ParamType = Zero): Message =
     inline subs.asMatchable match
       case tuple: Tuple =>
         import unsafeExceptions.canThrowAny

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -129,7 +129,7 @@ object Matrix:
      (using Tuple.Union
              [Tuple.Fold
                [rows.type,
-                EmptyTuple,
+                Zero,
                 [left, right] =>>
                   Tuple.Concat[left & Tuple, right & Tuple]] & Tuple] <:< ElementType,
             Columns =:= Tuple.Union[Tuple.Map[rows.type, [tuple] =>> Tuple.Size[tuple & Tuple]]],

--- a/lib/mosquito/src/core/mosquito.Mosquito.scala
+++ b/lib/mosquito/src/core/mosquito.Mosquito.scala
@@ -49,7 +49,7 @@ object Mosquito:
 
     def take[ElementType](list: List[ElementType], size: Int)
     :     Optional[Vector[ElementType, size.type]] =
-      if size == 0 then EmptyTuple else list match
+      if size == 0 then Zero else list match
         case Nil          => Unset
         case head :: tail => take(tail, size - 1).let(head *: _)
 
@@ -80,7 +80,7 @@ object Mosquito:
       (left(1)*right(2) - left(2)*right(1)) *:
           (left(2)*right(0) - left(0)*right(2)) *:
           (left(0)*right(1) - left(1)*right(0)) *:
-          EmptyTuple
+          Zero
 
   extension [SizeType <: Int, LeftType](left: Vector[LeftType, SizeType])
     def apply(index: Int): LeftType = left.toArray(index).asInstanceOf[LeftType]
@@ -102,7 +102,7 @@ object Mosquito:
     def map[LeftType2](fn: LeftType => LeftType2): Vector[LeftType2, SizeType] =
       def recur(tuple: Tuple): Tuple = tuple match
         case head *: tail => fn(head.asInstanceOf[LeftType]) *: recur(tail)
-        case _            => EmptyTuple
+        case _            => Zero
 
       recur(left)
 
@@ -117,7 +117,7 @@ object Mosquito:
 
       def recur(tuple: Tuple): Tuple = tuple match
         case head *: tail => (head.asInstanceOf[LeftType]/magnitude) *: recur(tail)
-        case _            => EmptyTuple
+        case _            => Zero
 
       recur(left)
 
@@ -133,10 +133,10 @@ object Mosquito:
             *: recur(leftTail, rightTail)
 
           case _ =>
-            EmptyTuple
+            Zero
 
         case _ =>
-          EmptyTuple
+          Zero
 
       recur(left, right)
 
@@ -151,9 +151,10 @@ object Mosquito:
             (leftHead.asInstanceOf[LeftType] - rightHead.asInstanceOf[RightType])
             *: recur(leftTail, rightTail)
           case _ =>
-            EmptyTuple
+            Zero
+
         case _ =>
-          EmptyTuple
+          Zero
 
       recur(left, right)
 

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
@@ -58,7 +58,7 @@ object Nomenclature:
 
     private inline def check[CheckType <: Matchable](name: Text): Unit raises NameError =
       inline erasedValue[CheckType] match
-        case _: EmptyTuple     => ()
+        case _: Zero           => ()
         case _: (head *: tail) => inline erasedValue[head & Matchable] match
           case _: Check[param] =>
             inline staticCompanion[head] match

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -47,7 +47,7 @@ object Nomenclature2:
     import quotes.reflect.*
 
     todo match
-      case Nil          => TypeRepr.of[EmptyTuple]
+      case Nil          => TypeRepr.of[Zero]
       case next :: todo => next.asType.absolve match
         case '[next] => build(todo).asType.absolve match
           case '[type tupleType <: Tuple; tupleType] => TypeRepr.of[next *: tupleType]

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -52,7 +52,7 @@ object Panopticon:
 
   extension [FromType](initLens: InitLens[FromType])
     def apply[PathType <: Tuple, ToType]
-       (lambda: Target[FromType, EmptyTuple] => Target[ToType, PathType])
+       (lambda: Target[FromType, Zero] => Target[ToType, PathType])
     :     Lens[FromType, PathType, ToType] =
       0
 

--- a/lib/panopticon/src/test/panopticon.Tests.scala
+++ b/lib/panopticon/src/test/panopticon.Tests.scala
@@ -115,7 +115,7 @@ object Tests extends Suite(t"Panopticon tests"):
       lens.get(date)
     .assert(_ == 3)
 
-    // val orgName = new Lens[Organization, "name" *: EmptyTuple, String](_.name, (org, name) => org.copy(name = name))
+    // val orgName = new Lens[Organization, "name" *: Zero, String](_.name, (org, name) => org.copy(name = name))
 
     // test(t"Manual lens can access field"):
     //   orgName(org)

--- a/lib/proscenium/src/core/proscenium-core.scala
+++ b/lib/proscenium/src/core/proscenium-core.scala
@@ -65,3 +65,10 @@ type Label = String & Singleton
 
 @targetName("partialFn")
 infix type ~> [-DomainType, +RangeType] = PartialFunction[DomainType, RangeType]
+
+export scala.EmptyTuple as Zero
+
+type Mono[ValueType] = ValueType *: Zero
+
+object Mono:
+  inline def apply[ValueType](value: ValueType): Mono[ValueType] = value *: Zero

--- a/lib/proscenium/src/core/soundness+proscenium-core.scala
+++ b/lib/proscenium/src/core/soundness+proscenium-core.scala
@@ -60,4 +60,4 @@ export scala.annotation.unchecked.{uncheckedVariance, uncheckedCaptures, uncheck
 export scala.LazyList as Stream
 export scala.DummyImplicit as Void
 
-export proscenium.{Nat, Label, `~>`}
+export proscenium.{Nat, Label, `~>`, Zero, Mono}

--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -379,19 +379,19 @@ extension (erased tuple: Tuple)
   inline def indexOf[ElementType]: Int = recurIndex[tuple.type, ElementType](0)
 
   transparent inline def subtypes[Supertype]: Tuple =
-    recurSubtypes[tuple.type, Supertype, EmptyTuple]
+    recurSubtypes[tuple.type, Supertype, Zero]
 
   private transparent inline def recurSubtypes[TupleType <: Tuple, Supertype, DoneType <: Tuple]
   :     Tuple =
 
     inline !![TupleType] match
-      case _: EmptyTuple            => !![Tuple.Reverse[DoneType]]
+      case _: Zero                  => !![Tuple.Reverse[DoneType]]
       case _: (head *: tail)        => inline !![head] match
         case _: Supertype             => recurSubtypes[tail, Supertype, head *: DoneType]
         case _                        => recurSubtypes[tail, Supertype, DoneType]
 
   private inline def recurIndex[TupleType <: Tuple, ElementType](index: Int): Int =
     inline !![TupleType] match
-      case _: EmptyTuple            => -1
+      case _: Zero                  => -1
       case _: (ElementType *: tail) => index
       case _: (other *: tail)       => recurIndex[tail, ElementType](index + 1)

--- a/lib/rudiments/src/core/soundness+rudiments-core.scala
+++ b/lib/rudiments/src/core/soundness+rudiments-core.scala
@@ -33,15 +33,14 @@
 package soundness
 
 export rudiments
-. { Memory, bin, hex, Hex, b, kib, mib, gib, tib, memory, sift, has,
-    interleave, each, all, sumBy, bi, tri, indexBy, longestTrain, mutable, immutable, snapshot,
-    place, upsert, collate, establish, plus, runs, runsBy, Cursor, cursor, precursor, postcursor,
-    cursorIndex, cursorOffset, curse, ult, create, javaInputStream, DecimalConverter, !!,
-    Exit, unit, waive, twin, triple, is, matchable, give, pipe, fuse,
-    tap, also, Counter, loop, Loop, &, tuple, to, WorkingDirectoryError, HomeDirectoryError,
-    WorkingDirectory, HomeDirectory, workingDirectory, homeDirectory, prim, sec,
-    ter, unwind, at, Indexable, yet, Bijection, bijection, segment, Segmentable, Digit,
-    temporaryDirectory }
+. { Memory, bin, hex, Hex, b, kib, mib, gib, tib, memory, sift, has, interleave, each, all, sumBy,
+    bi, tri, indexBy, longestTrain, mutable, immutable, snapshot, place, upsert, collate, establish,
+    plus, runs, runsBy, Cursor, cursor, precursor, postcursor, cursorIndex, cursorOffset, curse,
+    ult, create, javaInputStream, DecimalConverter, !!, Exit, unit, waive, twin, triple, is,
+    matchable, give, pipe, fuse, tap, also, Counter, loop, Loop, &, tuple, to,
+    WorkingDirectoryError, HomeDirectoryError, WorkingDirectory, HomeDirectory, workingDirectory,
+    homeDirectory, prim, sec, ter, unwind, at, Indexable, yet, Bijection, bijection, segment,
+    Segmentable, Digit, temporaryDirectory }
 
 package workingDirectories:
   export rudiments.workingDirectories.{systemProperty, default}

--- a/lib/typonym/src/core/typonym.Typonym.scala
+++ b/lib/typonym/src/core/typonym.Typonym.scala
@@ -34,6 +34,8 @@ package typonym
 
 import scala.quoted.*
 
+import proscenium.*
+
 object Typonym:
   private def untuple[TupleType <: Tuple: Type](using Quotes): List[quotes.reflect.TypeRepr] =
     import quotes.reflect.*
@@ -89,7 +91,7 @@ object Typonym:
       case boolean: Boolean => ConstantType(BooleanConstant(boolean))
 
       case list: List[?] =>
-        val tuple = list.map(reflect).reverse.foldLeft(TypeRepr.of[EmptyTuple]): (tuple, next) =>
+        val tuple = list.map(reflect).reverse.foldLeft(TypeRepr.of[Zero]): (tuple, next) =>
           tuple.asType.runtimeChecked match
             case '[type tupleType <: Tuple; tupleType] => next.asType.runtimeChecked match
               case '[nextType] => TypeRepr.of[nextType *: tupleType]

--- a/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
@@ -55,7 +55,7 @@ trait ProductDerivationMethods[TypeclassType[_]]:
     type Labels = reflection.MirroredElemLabels
 
     reflection.fromProduct:
-      fold[DerivationType, Fields, Labels, Tuple](EmptyTuple, 0): accumulator =>
+      fold[DerivationType, Fields, Labels, Tuple](Zero, 0): accumulator =>
         [FieldType] => context ?=> lambda[FieldType](context) *: accumulator
 
       . reverse
@@ -80,7 +80,7 @@ trait ProductDerivationMethods[TypeclassType[_]]:
     type Labels = reflection.MirroredElemLabels
 
     val tuple: ConstructorType[Tuple] =
-      fold[DerivationType, Fields, Labels, ConstructorType[Tuple]](pure(EmptyTuple), 0):
+      fold[DerivationType, Fields, Labels, ConstructorType[Tuple]](pure(Zero), 0):
         accumulator =>
           [FieldType] => context ?=>
             bind(accumulator): accumulator2 =>
@@ -185,7 +185,7 @@ trait ProductDerivationMethods[TypeclassType[_]]:
   :     ResultType =
 
     inline tuple match
-      case EmptyTuple => accumulator
+      case Zero => accumulator
 
       case tuple: (fieldType *: moreFieldsType) => tuple match
         case field *: moreFields => inline erasedValue[LabelsType] match
@@ -221,7 +221,7 @@ trait ProductDerivationMethods[TypeclassType[_]]:
   :     ResultType =
 
     inline erasedValue[FieldsType] match
-      case _: EmptyTuple => accumulator
+      case _: Zero => accumulator
 
       case _: (fieldType *: moreFieldsType) => inline erasedValue[LabelsType] match
         case _: (labelType *: moreLabelsType) => inline valueOf[labelType].asMatchable match

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -54,7 +54,7 @@ trait SumDerivationMethods[TypeclassType[_]]:
 
   private transparent inline def all[VariantType, VariantTypes <: Tuple]: Boolean = summonFrom:
     case given (VariantType <:< Singleton) => inline erasedValue[VariantTypes] match
-      case _: EmptyTuple                     => true
+      case _: Zero                           => true
       case _: (variantType *: variantsType)  => all[variantType, variantsType]
     case _                                 => false
 
@@ -100,7 +100,7 @@ trait SumDerivationMethods[TypeclassType[_]]:
           type VariantType = variantType & DerivationType
 
           if predicate(valueOf[labelType & String].tt)
-          then summonInline[Mirror.ProductOf[VariantType]].fromProduct(EmptyTuple)
+          then summonInline[Mirror.ProductOf[VariantType]].fromProduct(Zero)
           else singletonFold[DerivationType, variantsType, labelsType](predicate)
 
       case _  =>


### PR DESCRIPTION
While constructing a two-tuple is possible with just `(A, B)`, a one-tuple has to be written, `A *: EmptyTuple` and an empty tuple is `EmptyTuple`. We can improve on this with `Mono[A]` and `Zero` respectively.