### PR TITLE
Avoid `HostnameError`s when parsing `UrlError`s

### DIFF
--- a/lib/nettlesome/src/url/nettlesome.Authority.scala
+++ b/lib/nettlesome/src/url/nettlesome.Authority.scala
@@ -49,7 +49,7 @@ object Authority:
     t"${auth.userInfo.lay(t"")(_+t"@")}${auth.host}${auth.port.let(_.show).lay(t"")(t":"+_)}"
 
   def parse(value: Text): Authority raises HostnameError raises UrlError =
-    import UrlError.Expectation.*
+    import UrlError.{Expectation, Reason}, Expectation.*, Reason.*
 
     safely(value.where(_ == '@')).asMatchable match
       case Zerary(arobase) => safely(value.where(_ == ':', arobase + 1)).asMatchable match
@@ -58,10 +58,10 @@ object Authority:
             case port: Int if port >= 0 && port <= 65535 => port
 
             case port: Int =>
-              raise(UrlError(value, colon + 1, PortRange)) yet 0
+              raise(UrlError(value, colon + 1, Expected(PortRange))) yet 0
 
             case _ =>
-              raise(UrlError(value, colon + 1, Number)) yet 0
+              raise(UrlError(value, colon + 1, Expected(Number))) yet 0
 
           . pipe:
             Authority
@@ -76,10 +76,10 @@ object Authority:
             case port: Int if port >= 0 && port <= 65535 => port
 
             case port: Int =>
-              raise(UrlError(value, colon + 1, PortRange)) yet 0
+              raise(UrlError(value, colon + 1, Expected(PortRange))) yet 0
 
             case _ =>
-              raise(UrlError(value, colon + 1, Number)) yet 0
+              raise(UrlError(value, colon + 1, Expected(Number))) yet 0
 
           . pipe(Authority(Hostname.parse(value.before(colon)), Unset, _))
 

--- a/lib/nettlesome/src/url/nettlesome.UrlError.scala
+++ b/lib/nettlesome/src/url/nettlesome.UrlError.scala
@@ -36,10 +36,18 @@ import anticipation.*
 import denominative.*
 import fulminate.*
 
-case class UrlError(text: Text, offset: Ordinal, expected: UrlError.Expectation)(using Diagnostics)
-extends Error(m"the URL $text is not valid: expected $expected at ${offset.n0}")
+case class UrlError(text: Text, offset: Ordinal, reason: UrlError.Reason)(using Diagnostics)
+extends Error(m"the URL $text is not valid: $reason at ${offset.n0}")
 
 object UrlError:
+  given Reason is Communicable =
+    case Reason.Expected(expectation)         => m"$expectation was expected"
+    case Reason.BadHostname(hostname, reason) => m"$hostname was not valid because $reason"
+
+  enum Reason:
+    case Expected(expectation: Expectation)
+    case BadHostname(hostname: Text, reason: HostnameError.Reason)
+
   enum Expectation:
     case Colon, More, LowerCaseLetter, PortRange, Number
 

--- a/lib/nettlesome/src/url/nettlesome.UrlInterpolator.scala
+++ b/lib/nettlesome/src/url/nettlesome.UrlInterpolator.scala
@@ -59,7 +59,6 @@ object UrlInterpolator extends contextual.Interpolator[UrlFragment, Text, Url[La
   def complete(value: Text): Url[Label] =
     try throwErrors(Url.parse(value)) catch
       case error: UrlError      => throw InterpolationError(error.message)
-      case error: HostnameError => throw InterpolationError(error.message)
 
   def initial: Text = t""
 
@@ -70,7 +69,6 @@ object UrlInterpolator extends contextual.Interpolator[UrlFragment, Text, Url[La
 
       try throwErrors(Url.parse(state+port.show)) catch
         case err: UrlError      => throw InterpolationError(Message(err.message.text))
-        case err: HostnameError => throw InterpolationError(Message(err.message.text))
 
       state+port.show
 
@@ -80,7 +78,6 @@ object UrlInterpolator extends contextual.Interpolator[UrlFragment, Text, Url[La
 
       try throwErrors(Url.parse(state+text.urlEncode)) catch
         case err: UrlError      => throw InterpolationError(Message(err.message.text))
-        case err: HostnameError => throw InterpolationError(Message(err.message.text))
 
       state+text.urlEncode
 
@@ -90,7 +87,6 @@ object UrlInterpolator extends contextual.Interpolator[UrlFragment, Text, Url[La
 
       try throwErrors(Url.parse(state+text.urlEncode)) catch
         case err: UrlError      => throw InterpolationError(Message(err.message.text))
-        case err: HostnameError => throw InterpolationError(Message(err.message.text))
 
       state+text
 


### PR DESCRIPTION
Parsing an HTTP URL can raise either a `UrlError` (to be expected) or a `HostnameError`. This doubles the work required to handle them.

So hereafter, hostname-related errors arising during URL parsing will be encoded in the `UrlError` itself.