### PR TITLE
Avoid possible occurrences of infinite recursion

### DIFF
--- a/lib/telekinesis/src/core/telekinesis.Query.scala
+++ b/lib/telekinesis/src/core/telekinesis.Query.scala
@@ -89,13 +89,13 @@ object Query extends Dynamic:
   inline given decodable: [ValueType] => ValueType is Decodable in Query =
     summonFrom:
       case given (ValueType is Decodable in Text) =>
-        given Tactic[QueryError] = summonInline[Tactic[QueryError]]
-        summonFrom:
-          case given Default[ValueType] =>
-            _().let(_.decode).or(raise(QueryError()) yet default[ValueType])
+        summonInline[Tactic[QueryError]].give:
+          summonFrom:
+            case given Default[ValueType] =>
+              _().let(_.decode).or(raise(QueryError()) yet default[ValueType])
 
-          case _ =>
-            _().lest(QueryError()).decode
+            case _ =>
+              _().lest(QueryError()).decode
 
       case given ProductReflection[ValueType & Product] =>
         DecodableDerivation.join[ValueType & Product].asInstanceOf[ValueType is Decodable in Query]

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -186,8 +186,7 @@ trait SumDerivationMethods[TypeclassType[_]]:
 
       case _ =>
         inline if fallible
-        then
-          given Tactic[VariantError] = summonInline[Tactic[VariantError]]
+        then summonInline[Tactic[VariantError]].give:
           raise(VariantError[DerivationType](inputLabel)) yet Unset
         else panic(m"Should be unreachable")
 
@@ -228,8 +227,7 @@ trait SumDerivationMethods[TypeclassType[_]]:
 
       case _ =>
         inline if fallible
-        then
-          given Tactic[VariantError] = summonInline[Tactic[VariantError]]
+        then summonInline[Tactic[VariantError]].give:
           raise(VariantError[DerivationType]("".tt)) yet Unset
         else panic(m"Should be unreachable")
 


### PR DESCRIPTION
A warning in some inlined code suggested that an infinitely recursive `given` had been defined, of the form,
```
given Foo = summonInline[Foo]
```

I didn't check whether this and a couple more examples actually resulted in an infinite recursion, but I replaced them anyway.