### PR TITLE
Iterate using the `iterator` from an `Iterable` in `each` implementation

### DIFF
--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -129,7 +129,7 @@ extension [ValueType](iterator: Iterator[ValueType])
 extension [ValueType](iterable: Iterable[ValueType])
   transparent inline def each(lambda: (ordinal: Ordinal) ?=> ValueType => Unit): Unit =
     var ordinal: Ordinal = Prim
-    iterable.foreach: value =>
+    iterable.iterator.foreach: value =>
       lambda(using ordinal)(value)
       ordinal += 1
 


### PR DESCRIPTION
Calling `each` on a `Stream` (i.e. a `LazyList`) would do nothing due to its laziness. This is fixed by operating on the `iterator` of the `Iterable` instead.