### PR TITLE
Provide methods to get adjacent floating-point values

### DIFF
--- a/lib/hypotenuse/src/core/hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse-core.scala
@@ -98,6 +98,12 @@ extension (float: Float)
   @targetName("nanFloat")
   inline def nan: Boolean = float.isNaN
 
+  @targetName("successorFloat")
+  inline def successor: Float = Math.nextUp(float)
+
+  @targetName("predecessorFloat")
+  inline def predecessor: Float = Math.nextDown(float)
+
   @targetName("powerFloat")
   inline infix def ** (exponent: Double): Float = math.pow(float, exponent).toFloat
 
@@ -149,6 +155,12 @@ extension (double: Double)
 
   @targetName("nanDouble")
   inline def nan: Boolean = double.isNaN
+
+  @targetName("successorDouble")
+  inline def successor: Double = Math.nextUp(double)
+
+  @targetName("predecessorDouble")
+  inline def predecessor: Double = Math.nextDown(double)
 
   @targetName("powerDouble")
   inline infix def ** (exponent: Double): Double = math.pow(double, exponent)

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -1151,6 +1151,12 @@ object Hypotenuse:
     @targetName("nanF64")
     inline def nan: Boolean = double.isNaN
 
+    @targetName("successorF64")
+    inline def successor: F64 = Math.nextUp(double)
+
+    @targetName("predecessorF64")
+    inline def predecessor: F64 = Math.nextDown(double)
+
   extension (f32: F32)
     @targetName("floatF32")
     inline def float: Float = f32
@@ -1227,6 +1233,11 @@ object Hypotenuse:
     @targetName("nanF32")
     inline def nan: Boolean = float.isNaN
 
+    @targetName("successorF32")
+    inline def successor: F32 = Math.nextUp(float)
+
+    @targetName("predecessorF32")
+    inline def predecessor: F32 = Math.nextDown(float)
 
   extension (u64: U64)
     @targetName("bitsU64")


### PR DESCRIPTION
The methods `successor` and `predecessor` and provided on all floating point types (`Float`, `Double`, `F32` and `F64`) to provide the next and previous values representable by that type, in order. Amongst other things, these will be useful in converting between closed and open intervals on these types.