### PR TITLE
Rename `Copy` to `Prose`

### DIFF
--- a/lib/punctuation/src/ansi/punctuation.TextConverter.scala
+++ b/lib/punctuation/src/ansi/punctuation.TextConverter.scala
@@ -146,7 +146,7 @@ open class TextConverter():
       case Emphasis(children*)     => e"$Italic(${text(children)})"
       case Strong(children*)       => e"$Bold(${text(children)})"
       case SourceCode(code)        => e"${webColors.YellowGreen}(${Bg(Srgb(0, 0.1, 0))}($code))"
-      case Copy(text)              => e"$text"
+      case Prose(text)             => e"$text"
       case BulletList(_, _, _, _*) => e""
       case Reference(_, _)         => e""
       case ThematicBreak()         => e""
@@ -172,7 +172,7 @@ open class TextConverter():
     case Markdown.Ast.Inline.LineBreak                => e"\n"
     case Markdown.Ast.Inline.Emphasis(children*)      => e"$Italic(${children.map(phrasing).join})"
     case Markdown.Ast.Inline.Strong(children*)        => e"$Bold(${children.map(phrasing).join})"
-    case Markdown.Ast.Inline.Copy(str)                => e"${str.sub(t"\n", t" ")}"
+    case Markdown.Ast.Inline.Prose(str)               => e"${str.sub(t"\n", t" ")}"
 
     case Markdown.Ast.Inline.SourceCode(code) =>
       e"${webColors.YellowGreen}(${Bg(Srgb(0, 0.1, 0))}($code))"

--- a/lib/punctuation/src/html/punctuation.HtmlConverter.scala
+++ b/lib/punctuation/src/html/punctuation.HtmlConverter.scala
@@ -117,7 +117,7 @@ open class HtmlConverter(renderers: Renderer*):
     case Markdown.Ast.Block.Heading(_, children*)   => text(children)
     case Markdown.Ast.Block.Blockquote(children*)   => text(children)
     case Markdown.Ast.Block.FencedCode(_, _, code)  => code
-    case Markdown.Ast.Inline.Copy(text)             => text
+    case Markdown.Ast.Inline.Prose(text)            => text
     case Markdown.Ast.Block.Cell(content*)          => text(content)
 
     case Markdown.Ast.Inline.SourceCode(code) =>
@@ -131,7 +131,7 @@ open class HtmlConverter(renderers: Renderer*):
     case Markdown.Ast.Inline.LineBreak                => List(Br)
     case Markdown.Ast.Inline.Emphasis(children*)      => List(Em(children.flatMap(phrasing)))
     case Markdown.Ast.Inline.Strong(children*)        => List(Strong(children.flatMap(phrasing)))
-    case Markdown.Ast.Inline.Copy(str)                => List(escape(str))
+    case Markdown.Ast.Inline.Prose(str)               => List(escape(str))
 
     case Markdown.Ast.Inline.SourceCode(code) =>
       List(html5.Code(code.broken(_.isLetterOrDigit != _.isLetterOrDigit)))


### PR DESCRIPTION
I always found the term `Copy` an ambiguous name for _text_, especially in a programming context. This renames it to `Prose` which is more appropriate and unique.