### PR TITLE
Generalize equivalence of values

### DIFF
--- a/lib/prepositional/src/core/prepositional-core.scala
+++ b/lib/prepositional/src/core/prepositional-core.scala
@@ -41,6 +41,7 @@ infix type of [Type <: { type Subject }, SubjectType] = Type { type Subject = Su
 infix type on [Type <: { type Platform }, PlatformType] = Type { type Platform = PlatformType }
 infix type onto [Type <: { type Target }, TargetType] = Type { type Target = TargetType }
 infix type over [Type <: { type Carrier }, CarrierType] = Type { type Carrier = CarrierType }
+infix type against [Type <: { type Contrast }, ContrastType] = Type { type Contrast = ContrastType }
 
 infix type under [Type <: { type Constraint }, ConstraintType] =
   Type { type Constraint = ConstraintType }

--- a/lib/probably/src/core/probably-core.scala
+++ b/lib/probably/src/core/probably-core.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import digression.*
 import fulminate.*
 import gossamer.*
+import prepositional.*
 import proscenium.*
 import spectacular.*
 
@@ -47,10 +48,15 @@ export Baseline.Compare.{Min, Mean, Max}
 export Baseline.Metric.{BySpeed, ByTime}
 export Baseline.Mode.{Arithmetic, Geometric}
 
+extension [LeftType](left: LeftType)
+  infix def === [RightType](right: RightType)
+     (using checkable: LeftType is Checkable against RightType)
+  :     Boolean =
+    checkable.check(left, right)
+
 extension (value: Double)
   @targetName("plusOrMinus")
   infix def +/- (tolerance: Double): Tolerance = Tolerance(value, tolerance)
-  infix def meets (tolerance: Tolerance): Boolean = tolerance.covers(value)
 
 def test[ReportType](name: Text)(using suite: Testable, codepoint: Codepoint): TestId =
   TestId(name, suite, codepoint)

--- a/lib/probably/src/core/probably.Checkable.scala
+++ b/lib/probably/src/core/probably.Checkable.scala
@@ -30,6 +30,18 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package probably
 
-export prepositional.{by, from, in, into, of, on, onto, over, under, against}
+import prepositional.*
+
+object Checkable:
+  given [LeftType, RightType] => IArray[LeftType] is Checkable against IArray[RightType] =
+    _.sameElements(_)
+
+  given Double is Checkable against Tolerance = (double, tolerance) => tolerance.covers(double)
+
+trait Checkable:
+  type Self
+  type Contrast
+
+  def check(left: Self, right: Contrast): Boolean

--- a/lib/probably/src/core/soundness+probably-core.scala
+++ b/lib/probably/src/core/soundness+probably-core.scala
@@ -32,9 +32,10 @@
                                                                                                   */
 package soundness
 
-export probably.{Baseline, Benchmark, Details, Inclusion, Outcome, Runner, Test, Harness,
-    TestId, Report, Reporter, Trial, Testable, Tolerance, Min, Mean, Max, BySpeed,
-    ByTime, Geometric, Arithmetic, `+/-`, meets, test, suite, aspire, assert, check, matches, debug}
+export probably .
+  { Baseline, Benchmark, Details, Inclusion, Outcome, Runner, Test, Harness, TestId, Report,
+    Reporter, Trial, Testable, Tolerance, Min, Mean, Max, BySpeed, ===, ByTime, Geometric,
+    Arithmetic, `+/-`, test, suite, aspire, assert, check, matches, debug, Checkable }
 
 package testContexts:
-  export probably.harnesses.{threadLocal}
+  export probably.harnesses.threadLocal

--- a/lib/turbulence/src/test/turbulence.Tests.scala
+++ b/lib/turbulence/src/test/turbulence.Tests.scala
@@ -42,6 +42,24 @@ import scala.collection.mutable as scm
 
 object Tests extends Suite(t"Turbulence tests"):
   def run(): Unit =
+
+    suite(t"Shredding"):
+      given Seed = Seed(1L)
+      import randomization.seeded
+      val bytes: Bytes = Bytes.fill(1000)(_.toByte)
+      val stream: Stream[Bytes] = Stream(bytes)
+      val shredded: Iterable[Stream[Bytes]] = (0 until 100).map: index =>
+        stream.shred(10.0, 10.0)
+
+      shredded.each: stream =>
+        test(t"correct length after shredding"):
+          stream.reduce(_ ++ _).length
+        . assert(_ == 1000)
+
+        test(t"correct content after shredding"):
+          stream.reduce(_ ++ _)
+        . assert(_ === bytes)
+
     suite(t"Streaming Unicode tests"):
       val ascii = IArray(t"", t"a", t"ab", t"abc", t"abcd")
 


### PR DESCRIPTION
This provides a generalized way of comparing values in tests, using `===`. The motivation is to support better syntax for comparing `IArray` elements, but the same mechanism works well for defining tolerance of values. We can now write,
```scala
. assert(_ === array)
```
and it will return true if the elements of the two arrays are the same. And,
```scala
. assert(_ === 100.0 +/- 0.5)
```
to return true for a value that's somewhere between `99.5` and `100.5`.

The latter example could potentially be generalized further to support tolerance of non-`Double` types.