### PR TITLE
Fix off-by-one error when rendering ribbons

### DIFF
--- a/lib/escapade/src/core/escapade.Ribbon.scala
+++ b/lib/escapade/src/core/escapade.Ribbon.scala
@@ -45,7 +45,7 @@ case class Ribbon(colors: Bg*):
     array.indices.map: index =>
       val (background, text) = array(index)
 
-      val arrow = if index >= array.length then e"$Reset${background.fg}()" else
+      val arrow = if index >= (array.length - 1) then e"$Reset${background.fg}()" else
         e"${background.fg}(${array(index + 1)(0)}())"
 
       e"$background( ${background.highContrast}($text) )$arrow"


### PR DESCRIPTION
There was an off-by-one error when rendering a `Ribbon` after refactoring away the use of `curse` (which was removed). The `curse` method was genuinely useful, so a better long-term solution would be helpful.