### PR TITLE
Make shredding random

### DIFF
--- a/lib/perihelion/src/core/perihelion-core.scala
+++ b/lib/perihelion/src/core/perihelion-core.scala
@@ -30,26 +30,125 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package anticipation
+package perihelion
 
+import anticipation.*
+import denominative.*
+import fulminate.*
+import gastronomy.*
+import gossamer.*
+import hieroglyph.*
+import hypotenuse.*
+import monotonous.*
+import parasite.*
 import prepositional.*
+import rudiments.*
+import scintillate.*
+import telekinesis.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
 
-type Bytes = IArray[Byte]
+import alphabets.base64.standard
+import charEncoders.utf8
 
-object Bytes:
-  def apply(xs: Byte*): Bytes = IArray(xs*)
-  def empty: Bytes = IArray()
+def websocket(using request: HttpConnection): Http.Response =
+  Websocket(request).response
 
-  def construct(count: Int)(lambda: Array[Byte] => Unit): Bytes =
-    val array: Array[Byte] = new Array[Byte](count)
-    lambda(array)
-    array.asInstanceOf[IArray[Byte]]
 
-  def fill(count: Int)(lambda: Int => Byte): Bytes = construct(count): array =>
-    for index <- 0 until count do array(index) = lambda(index)
+object Frame:
+  def apply(bytes: Bytes, offset: Int = 0): Frame = ???
 
-extension [ValueType: Encodable in Bytes](value: ValueType)
-  def bytestream: Bytes = ValueType.encode(value)
 
-extension (long: Long)
-  def bytes: Bytes = IArray((56 to 0 by -8).map(long >> _).map(_.toByte)*)
+
+enum Frame(payload: Bytes):
+  case Continuation(fin: Boolean, payload: Bytes) extends Frame(payload)
+  case Text(fin: Boolean, payload: Bytes) extends Frame(payload)
+  case Binary(fin: Boolean, payload: Bytes) extends Frame(payload)
+  case Ping(payload: Bytes) extends Frame(payload)
+  case Pong(payload: Bytes) extends Frame(payload)
+  case Close(code: Int) extends Frame(Bytes())
+
+  def mask: Optional[Bytes] = Unset
+
+  val length = payload.length
+
+  val byte0: Byte = this match
+    case Continuation(fin, _) => if fin then bin"10000000" else bin"00000000"
+    case Text(fin, _)         => if fin then bin"10000001" else bin"00000001"
+    case Binary(fin, _)       => if fin then bin"10000010" else bin"00000010"
+    case Close(_)             => bin"00001000"
+    case Ping(_)              => bin"00001001"
+    case Pong(_)              => bin"00001010"
+
+  val lengthByte: Byte = payload.length match
+    case length if length <= 125   => length.toByte
+    case length if length <= 65535 => 126
+    case _                         => 127
+
+  val headerLength = lengthByte match
+    case 126 => 4
+    case 127 => 10
+    case _   => 2
+
+  val byte1: Byte = ((if mask.present then bin"10000000" else bin"00000000") | lengthByte).toByte
+
+  val header: Bytes = headerLength match
+    case 2  => Bytes(byte0, byte1)
+    case 4  => Bytes(byte0, byte1, (length >> 8).toByte, length.toByte)
+    case 10 => val byte6 = (length >> 24).toByte
+               val byte7 = (length >> 16).toByte
+               val byte8 = (length >> 8).toByte
+               val byte9 = length.toByte
+               Bytes(byte0, byte1, 0, 0, 0, 0, byte6, byte7, byte8, byte9)
+
+object Websocket:
+  val magic: Text = t"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+  enum Opcode:
+    case Continuation, Text, Binary, Reserved0, Reserved1, Reserved2, Reserved3, Reserved4, Close,
+         Ping, Pong
+
+class Websocket(request: Http.Request):
+  private given prefix: ("secWebsocketAccept" is Prefixable of Text) = identity(_)
+  private given prefix2: ("secWebsocketKey" is Prefixable of Text) = identity(_)
+  private val key: Text = request.headers.secWebsocketKey.prim.or(panic(m"Missing header"))
+  private val spool: Spool[Frame] = Spool()
+  private val conduit: Conduit = Conduit(request.body)
+
+  def unmask(bytes: Bytes, mask: Bytes): Bytes =
+    Bytes.fill(bytes.length): index =>
+      array
+
+  def start()(using Monitor, Codicil): Task[Unit] = async:
+    var continue = true
+
+    while continue do
+      val head1 = conduit.datum
+      val fin = (head1 & 128) == 128
+      val opcode = Websocket.Opcode.fromOrdinal(head1 & 16)
+      conduit.next()
+
+      val length = conduit.datum match
+        case 127   => S64(conduit.take(8)).long.toInt
+        case 126   => S16(conduit.take(2)).int
+        case count => count
+
+      val payload = conduit.take(length)
+
+      val frame = opcode match
+        case Websocket.Opcode.Continuation =>
+        case Websocket.Opcode.Text         =>
+        case Websocket.Opcode.Binary       =>
+        case Websocket.Opcode.Ping         =>
+          spool.put(Frame.Pong(payload))
+        case Websocket.Opcode.Pong         =>
+        case Websocket.Opcode.Close        =>
+          continue = false
+
+  def response: Http.Response =
+    Http.Response
+     (Http.SwitchingProtocols,
+      secWebsocketAccept = (key+Websocket.magic).digest[Sha1].serialize[Base64],
+      connection         = t"Upgrade",
+      upgrade            = t"websocket")
+     (spool.stream.map(_.pack()))

--- a/lib/turbulence/src/test/turbulence.Tests.scala
+++ b/lib/turbulence/src/test/turbulence.Tests.scala
@@ -48,12 +48,13 @@ object Tests extends Suite(t"Turbulence tests"):
       import randomization.seeded
       val bytes: Bytes = Bytes.fill(1000)(_.toByte)
       val stream: Stream[Bytes] = Stream(bytes)
-      val shredded: Iterable[Stream[Bytes]] = (0 until 100).map: index =>
-        stream.shred(10.0, 10.0)
+      val shredded: Iterable[Stream[Bytes]] = stochastic:
+        (0 until 100).map: index =>
+          stream.shred(20.0, 10.0)
 
       shredded.each: stream =>
         test(t"correct length after shredding"):
-          stream.reduce(_ ++ _).length
+          stream.map(_.length).total
         . assert(_ == 1000)
 
         test(t"correct content after shredding"):

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -142,6 +142,11 @@ class Conduit(input: Stream[Bytes]):
     done = done0
     clutch = clutch0
 
+  def take(count: Int): Bytes =
+    mark()
+    skip(count)
+    save()
+
   inline def lookahead[ResultType](inline action: => ResultType): ResultType =
     mark()
     try action finally revert()

--- a/lib/zephyrine/src/test/zephyrine.Tests.scala
+++ b/lib/zephyrine/src/test/zephyrine.Tests.scala
@@ -1,0 +1,15 @@
+package zephyrine
+
+import soundness.*
+
+import randomization.unseeded
+
+object Tests extends Suite(t"Zephyrine tests"):
+  val bytes = Bytes.fill(1000)(_.toByte)
+  def run(): Unit =
+    for i <- 1 to 100 do
+      val stream = Stream(bytes).shred(1.0, 1.0)
+      println(stream.toList.length)
+      test(t"check the stream"):
+        ()
+      .assert()


### PR DESCRIPTION
Make sure that the `shred` method is not only random, but different every time it runs. Previously, the implementation would reuse the same random seed and produce the same sequence every time.