### PR TITLE
Erase usage of `Parametric`

### DIFF
--- a/lib/telekinesis/src/core/telekinesis.Query.scala
+++ b/lib/telekinesis/src/core/telekinesis.Query.scala
@@ -115,8 +115,8 @@ case class Query private (values: List[(Text, Text)]) extends Dynamic:
   infix def ++ (query: Query) = Query(values ++ query.values)
 
   def selectDynamic[ResultType](label: String)
-     (using parametric: label.type is Parametric into ResultType,
-            decodable:  ResultType is Decodable in Query)
+     (using erased (label.type is Parametric into ResultType))
+     (using decodable: ResultType is Decodable in Query)
   :     ResultType =
     decodable.decoded(apply(label.tt))
 


### PR DESCRIPTION
A `Parametric` value should never need to be instantiated, so every contextual instance should be erased. But it was being used as a non-erased parameter, which made this impossible. That parameter has now been erased, and it is possible.