### PR TITLE
Rename `haltingly` to `abortive`

### DIFF
--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -130,7 +130,7 @@ def amalgamate[ErrorType <: Exception](using erased Void)[SuccessType]
   boundary: label ?=>
     block(using AmalgamateTactic(label))
 
-def haltingly[ErrorType <: Error](using Quotes, Realm)[SuccessType]
+def abortive[ErrorType <: Error](using Quotes, Realm)[SuccessType]
    (block: Diagnostics ?=> HaltTactic[ErrorType, SuccessType] ?=> SuccessType)
 :     SuccessType =
 

--- a/lib/contingency/src/core/soundness+contingency-core.scala
+++ b/lib/contingency/src/core/soundness+contingency-core.scala
@@ -33,7 +33,7 @@
 package soundness
 
 export contingency.{Tactic, Fatal, Recoverable, raise, abort, safely, unsafely, throwErrors,
-    capture, attempt, haltingly, ExpectationError, raises, Attempt, tend, mend, Unchecked, accrue,
+    capture, attempt, abortive, ExpectationError, raises, Attempt, tend, mend, Unchecked, accrue,
     within, Tracking, Foci, track, focus, lest, dare}
 
 package strategies:

--- a/lib/digression/src/core/digression.Digression.scala
+++ b/lib/digression/src/core/digression.Digression.scala
@@ -56,4 +56,4 @@ object Digression:
       "const", "float", "native", "super", "while")
 
   def fqcn(context: Expr[StringContext])(using Quotes): Expr[Fqcn] =
-    haltingly('{new Fqcn(${Expr(Fqcn(context.valueOrAbort.parts.head.tt).parts)})})
+    abortive('{new Fqcn(${Expr(Fqcn(context.valueOrAbort.parts.head.tt).parts)})})

--- a/lib/inimitable/src/core/inimitable.Inimitable.scala
+++ b/lib/inimitable/src/core/inimitable.Inimitable.scala
@@ -44,5 +44,5 @@ object Inimitable:
   given Realm = realm"inimitable"
 
   def uuid(expr: Expr[StringContext])(using Quotes): Expr[Uuid] =
-    val uuid = haltingly(Uuid.parse(expr.valueOrAbort.parts.head.tt))
+    val uuid = abortive(Uuid.parse(expr.valueOrAbort.parts.head.tt))
     '{Uuid(${Expr(uuid.msb)}, ${Expr(uuid.lsb)})}

--- a/lib/kaleidoscope/src/core/kaleidoscope.Kaleidoscope.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Kaleidoscope.scala
@@ -57,7 +57,7 @@ object Kaleidoscope:
   private def extractor(parts: List[String])(using Quotes): Expr[Any] =
     import quotes.reflect.*
 
-    val regex = haltingly(Regex.parse(parts.map(Text(_))))
+    val regex = abortive(Regex.parse(parts.map(Text(_))))
 
     val types: List[TypeRepr] = regex.captureGroups.map: group =>
       group.quantifier match

--- a/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
+++ b/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
@@ -57,7 +57,7 @@ object EmailAddress:
   given Tactic[EmailAddressError] => EmailAddress is Decodable in Text = EmailAddress.parse(_)
   given EmailAddress is Encodable in Text = _.text
 
-  def expand(context: Expr[StringContext])(using Quotes): Expr[EmailAddress] = haltingly:
+  def expand(context: Expr[StringContext])(using Quotes): Expr[EmailAddress] = abortive:
     val text: Text = context.valueOrAbort.parts.head.tt
     val address = EmailAddress.parse(text)
 

--- a/lib/nettlesome/src/core/nettlesome.Hostname.scala
+++ b/lib/nettlesome/src/core/nettlesome.Hostname.scala
@@ -52,7 +52,7 @@ object Hostname:
 
   given Hostname is Showable = _.dnsLabels.map(_.show).join(t".")
 
-  def expand(context: Expr[StringContext])(using Quotes): Expr[Hostname] = haltingly:
+  def expand(context: Expr[StringContext])(using Quotes): Expr[Hostname] = abortive:
     Expr(Hostname.parse(context.valueOrAbort.parts.head.tt))
 
   given toExpr: ToExpr[Hostname]:

--- a/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
+++ b/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
@@ -203,14 +203,14 @@ object Nettlesome:
 
   def tcpPort(context: Expr[StringContext])(using Quotes): Expr[TcpPort] =
     val portNumber: Int =
-      haltingly(context.valueOrAbort.parts.head.tt.decode[Int])
+      abortive(context.valueOrAbort.parts.head.tt.decode[Int])
 
     if 1 <= portNumber <= 65535 then '{TcpPort.unsafe(${Expr(portNumber)})}
     else halt(m"the TCP port number ${portNumber} is not in the range 1-65535")
 
   def udpPort(context: Expr[StringContext])(using Quotes): Expr[UdpPort] =
     val portNumber: Int =
-      haltingly(context.valueOrAbort.parts.head.tt.decode[Int])
+      abortive(context.valueOrAbort.parts.head.tt.decode[Int])
 
     if 1 <= portNumber <= 65535 then '{UdpPort.unsafe(${Expr(portNumber)})}
     else halt(m"the UDP port number ${portNumber} is not in the range 1-65535")
@@ -218,7 +218,7 @@ object Nettlesome:
   def ip(context: Expr[StringContext])(using Quotes): Expr[Ipv4 | Ipv6] =
     val text = Text(context.valueOrAbort.parts.head)
 
-    haltingly:
+    abortive:
       if text.contains(t".") then
         val ipv4 = Ipv4.parse(text)
         '{Ipv4(${Expr(ipv4.byte0)}, ${Expr(ipv4.byte1)}, ${Expr(ipv4.byte2)}, ${Expr(ipv4.byte3)})}
@@ -227,7 +227,7 @@ object Nettlesome:
         val ipv6 = Ipv6.parse(text)
         '{Ipv6(${Expr(ipv6.highBits)}, ${Expr(ipv6.lowBits)})}
 
-  def mac(context: Expr[StringContext])(using Quotes): Expr[MacAddress] = haltingly:
+  def mac(context: Expr[StringContext])(using Quotes): Expr[MacAddress] = abortive:
     val macAddress = MacAddress.parse(context.valueOrAbort.parts.head.tt)
     '{MacAddress(${Expr(macAddress.long)})}
 


### PR DESCRIPTION
"Haltingly" was never a good choice, since it implies "stopping and starting". Abortive has the disadvantage that it seems to relate to the `abort` method, and doesn't. But on balance, it's a better choice.