### PR TITLE
Make changes necessary to work on Scala 3.7; but still use 3.6.4

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -8,14 +8,14 @@ import os.Path
 
 object settings {
   val scalaVersion = "3.6.4"
-  //val scalaVersion = "3.7.0-RC1-bin-20250121-3f2365d-NIGHTLY"
+  //val scalaVersion = "3.7.0-RC1-bin-20250309-2f639e2-NIGHTLY"
   val scalaOptions = Seq(
     "-experimental",
     "-new-syntax",
     "-feature",
     //"-explain",
     "-deprecation",
-    "-Wunused:imports",
+    //"-Wunused:imports",
     "-Wimplausible-patterns",
     "-Wsafe-init",
     "-Xmax-inlines", "100",
@@ -24,10 +24,8 @@ object settings {
     "-Yexplicit-nulls",
     "-Ycheck-all-patmat",
     "-explain-cyclic",
-    "-language:experimental.clauseInterleaving",
     "-language:experimental.modularity",
     "-language:experimental.genericNumberLiterals",
-    "-language:experimental.fewerBraces",
     "-language:experimental.into",
     "-language:experimental.erasedDefinitions",
     "-language:experimental.saferExceptions",

--- a/lib/abacist/src/core/abacist.Abacist2.scala
+++ b/lib/abacist/src/core/abacist.Abacist2.scala
@@ -39,7 +39,6 @@ import rudiments.*
 import spectacular.*
 import symbolism.*
 
-import scala.quoted.*
 import scala.compiletime.*, ops.int.*
 
 object Abacist2:

--- a/lib/anthology/src/java/anthology.Javac.scala
+++ b/lib/anthology/src/java/anthology.Javac.scala
@@ -69,25 +69,26 @@ case class Javac(options: List[JavacOption]):
 
     val diagnostics = new jt.DiagnosticListener[jt.JavaFileObject]:
 
-      def report(diagnostic: jt.Diagnostic[? <: jt.JavaFileObject]): Unit =
-        val importance = diagnostic.getKind match
-          case jt.Diagnostic.Kind.ERROR             => Importance.Error
-          case jt.Diagnostic.Kind.WARNING           => Importance.Warning
-          case jt.Diagnostic.Kind.MANDATORY_WARNING => Importance.Warning
-          case _                                    => Importance.Info
+      def report(diagnostic: jt.Diagnostic[? <: jt.JavaFileObject] | Null): Unit =
+        if diagnostic != null then
+          val importance = diagnostic.getKind match
+            case jt.Diagnostic.Kind.ERROR             => Importance.Error
+            case jt.Diagnostic.Kind.WARNING           => Importance.Warning
+            case jt.Diagnostic.Kind.MANDATORY_WARNING => Importance.Warning
+            case _                                    => Importance.Info
 
-        val codeRange: Optional[CodeRange] =
-          if diagnostic.getPosition == jt.Diagnostic.NOPOS then Unset else
-            CodeRange
-             (diagnostic.getLineNumber.toInt,
-              diagnostic.getColumnNumber.toInt,
-              diagnostic.getLineNumber.toInt,
-              (diagnostic.getColumnNumber + diagnostic.getEndPosition
-               - diagnostic.getPosition).toInt)
+          val codeRange: Optional[CodeRange] =
+            if diagnostic.getPosition == jt.Diagnostic.NOPOS then Unset else
+              CodeRange
+               (diagnostic.getLineNumber.toInt,
+                diagnostic.getColumnNumber.toInt,
+                diagnostic.getLineNumber.toInt,
+                (diagnostic.getColumnNumber + diagnostic.getEndPosition
+                 - diagnostic.getPosition).toInt)
 
-        process.put:
-          Notice
-           (importance, "name".tt, diagnostic.getMessage(ju.Locale.getDefault()).nn.tt, codeRange)
+          process.put:
+            Notice
+             (importance, "name".tt, diagnostic.getMessage(ju.Locale.getDefault()).nn.tt, codeRange)
 
     val options = List(t"-classpath", classpath(), t"-d", out.generic)
     val javaSources = sources.map(JavaSource(_, _)).asJava

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -79,16 +79,24 @@ case class Scalac[VersionType <: Scalac.All](options: List[ScalacOption[VersionT
 
     object ProgressApi extends dtdsi.ProgressCallback:
       private var last: Int = -1
-      override def informUnitStarting(stage: String, unit: dtd.CompilationUnit): Unit = ()
+      override def informUnitStarting
+         (stage: String | Null, unit: dtd.CompilationUnit | Null)
+      :     Unit =
+        ()
 
-      override def progress(current: Int, total: Int, currentStage: String, nextStage: String)
+      override def progress
+         (current:      Int,
+          total:        Int,
+          currentStage: String | Null,
+          nextStage:    String | Null)
       :     Boolean =
 
         val int = (100.0*current/total).toInt
 
         if int > last then
           last = int
-          scalacProcess.put(CompileProgress(last/100.0, currentStage.tt))
+          scalacProcess.put
+           (CompileProgress(last/100.0, if currentStage == null then t"null" else currentStage.tt))
 
         scalacProcess.continue
 

--- a/lib/cellulose/src/core/cellulose.Character.scala
+++ b/lib/cellulose/src/core/cellulose.Character.scala
@@ -40,7 +40,6 @@ import kaleidoscope.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
-import spectacular.*
 import vacuous.*
 
 opaque type Character = Long

--- a/lib/cellulose/src/core/cellulose.CodlEncoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoder.scala
@@ -39,8 +39,6 @@ import spectacular.*
 import vacuous.*
 import wisteria.*
 
-import scala.deriving.*
-
 trait CodlEncoder[ValueType]:
   def encode(value: ValueType): List[IArray[CodlNode]]
   def schema: CodlSchema

--- a/lib/cellulose/src/core/cellulose.CodlEncoderDerivation.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoderDerivation.scala
@@ -37,8 +37,6 @@ import rudiments.*
 import vacuous.*
 import wisteria.*
 
-import scala.deriving.*
-
 object CodlEncoderDerivation extends ProductDerivation[CodlEncoder]:
   inline def join[DerivationType <: Product: ProductReflection]: CodlEncoder[DerivationType] =
     val mapping: Map[Text, Text] = compiletime.summonFrom:

--- a/lib/cellulose/src/core/cellulose.CodlFieldReader.scala
+++ b/lib/cellulose/src/core/cellulose.CodlFieldReader.scala
@@ -35,7 +35,6 @@ package cellulose
 import anticipation.*
 import contingency.*
 import rudiments.*
-import vacuous.*
 
 class CodlFieldReader[ValueType](lambda: Text => ValueType)
 extends CodlDecoder[ValueType]:

--- a/lib/distillate/src/core/distillate.Extractable.scala
+++ b/lib/distillate/src/core/distillate.Extractable.scala
@@ -75,58 +75,58 @@ object Extractable:
     if v.s == "true" then true else if v.s == "false" then false else Unset
 
   given shortByte: [ShortType <: Short] => ShortType is Extractable into Byte =
-    short => short.toByte.unless(_.toInt != short)
+    short => short.toByte.unless(value.toInt != short)
 
   given intByte: [IntType <: Int] => IntType is Extractable into Byte =
-    int => int.toByte.unless(_.toInt != int)
+    int => int.toByte.unless(value.toInt != int)
 
   given intShort: [IntType <: Int] => IntType is Extractable into Short =
-    int => int.toShort.unless(_.toInt != int)
+    int => int.toShort.unless(value.toInt != int)
 
   given intFloat: [IntType <: Int] => IntType is Extractable into Float =
-    int => int.toFloat.unless(_.toInt != int)
+    int => int.toFloat.unless(value.toInt != int)
 
   given longByte: [LongType <: Long] => LongType is Extractable into Byte =
-    long => long.toByte.unless(_.toLong != long)
+    long => long.toByte.unless(value.toLong != long)
 
   given longShort: [LongType <: Long] => LongType is Extractable into Short =
-    long => long.toShort.unless(_.toLong != long)
+    long => long.toShort.unless(value.toLong != long)
 
   given longInt: [LongType <: Long] => LongType is Extractable into Int =
-    long => long.toInt.unless(_.toLong != long)
+    long => long.toInt.unless(value.toLong != long)
 
   given longFloat: [LongType <: Long] => LongType is Extractable into Float =
-    long => long.toFloat.unless(_.toLong != long)
+    long => long.toFloat.unless(value.toLong != long)
 
   given longDouble: [LongType <: Long] => LongType is Extractable into Double =
-    long => long.toDouble.unless(_.toLong != long)
+    long => long.toDouble.unless(value.toLong != long)
 
   given floatByte: [FloatType <: Float] => FloatType is Extractable into Byte =
-    float => float.toByte.unless(_.toFloat != float)
+    float => float.toByte.unless(value.toFloat != float)
 
   given floatShort: [FloatType <: Float] => FloatType is Extractable into Short =
-    float => float.toShort.unless(_.toFloat != float)
+    float => float.toShort.unless(value.toFloat != float)
 
   given floatInt: [FloatType <: Float] => FloatType is Extractable into Int =
-    float => float.toInt.unless(_.toFloat != float)
+    float => float.toInt.unless(value.toFloat != float)
 
   given floatLong: [FloatType <: Float] => FloatType is Extractable into Long =
-    float => float.toLong.unless(_.toFloat != float)
+    float => float.toLong.unless(value.toFloat != float)
 
   given doubleByte: [DoubleType <: Double] => DoubleType is Extractable into Byte =
-    double => double.toByte.unless(_.toDouble != double)
+    double => double.toByte.unless(value.toDouble != double)
 
   given doubleShort: [DoubleType <: Double] => DoubleType is Extractable into Short =
-    double => double.toShort.unless(_.toDouble != double)
+    double => double.toShort.unless(value.toDouble != double)
 
   given doubleInt: [DoubleType <: Double] => DoubleType is Extractable into Int =
-    double => double.toInt.unless(_.toDouble != double)
+    double => double.toInt.unless(value.toDouble != double)
 
   given doubleLong: [DoubleType <: Double] => DoubleType is Extractable into Long =
-    double => double.toLong.unless(_.toDouble != double)
+    double => double.toLong.unless(value.toDouble != double)
 
   given doubleFloat: [DoubleType <: Double] => DoubleType is Extractable into Float =
-    double => double.toFloat.unless(_.toDouble != double)
+    double => double.toFloat.unless(value.toDouble != double)
 
   given valueOf: [EnumType <: Enum: Mirror.SumOf as mirror, TextType <: Text]
   =>    TextType is Extractable into EnumType =

--- a/lib/ethereal/src/core/ethereal-core.scala
+++ b/lib/ethereal/src/core/ethereal-core.scala
@@ -238,9 +238,9 @@ def cli[BusType <: Matchable](using executive: Executive)
             else new ji.OutputStream():
               private lazy val wrapped = connection.stderr.await()
               def write(i: Int): Unit = wrapped.write(i)
-              override def write(bytes: Array[Byte]): Unit = wrapped.write(bytes)
+              override def write(bytes: Array[Byte] | Null): Unit = wrapped.write(bytes)
 
-              override def write(bytes: Array[Byte], offset: Int, length: Int): Unit =
+              override def write(bytes: Array[Byte] | Null, offset: Int, length: Int): Unit =
                 wrapped.write(bytes, offset, length)
 
           given environment: Environment = LazyEnvironment(env)

--- a/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
+++ b/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
@@ -37,7 +37,6 @@ import contingency.*
 import guillotine.*
 import parasite.*
 import prepositional.*
-import proscenium.*
 import rudiments.*
 import turbulence.*
 import vacuous.*

--- a/lib/hallucination/src/core/hallucination.Image.scala
+++ b/lib/hallucination/src/core/hallucination.Image.scala
@@ -39,7 +39,6 @@ import iridescence.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
-import spectacular.*
 import turbulence.*
 
 import java.awt.image as jai

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -100,8 +100,10 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
       val connection = makeConnection(request, response)
       connection.respond(handle(using connection))
 
-  override def service(request: jsh.HttpServletRequest, response: jsh.HttpServletResponse): Unit =
-    try handle(request, response) catch
+  override def service
+     (request: jsh.HttpServletRequest | Null, response: jsh.HttpServletResponse | Null)
+  :     Unit =
+    if request != null && response != null then try handle(request, response) catch
       case error: Throwable =>
         println("An error occurred while processing a request: "+error)
         error.printStackTrace(System.out)

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -182,7 +182,7 @@ object Http:
     case NotExtended                   extends Status(510, t"Not Extended")
     case NetworkAuthenticationRequired extends Status(511, t"Network Authentication Required")
 
-    def category: Category = (code/100).absolve match
+    def category: Status.Category = (code/100).absolve match
       case 1 => Http.Category.Informational
       case 2 => Http.Category.Successful
       case 3 => Http.Category.Redirection
@@ -414,7 +414,7 @@ object Http:
       body:        Stream[Bytes]):
 
     def successBody: Optional[Stream[Bytes]] =
-      body.provided(status.category == Http.Status.Category.Successful)
+      body.unless(status.category != Http.Status.Category.Successful)
 
     def receive[BodyType: Receivable as receivable]: BodyType = receivable.read(this)
 

--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -45,7 +45,6 @@ import parasite.*, asyncTermination.await
 import prepositional.*
 import proscenium.*
 import rudiments.*
-import symbolism.*
 import vacuous.*
 
 extension [ValueType](value: ValueType)
@@ -362,7 +361,7 @@ extension (stream: Stream[Bytes])
 
     def read(): Int = if available() == 0 then -1 else (focus(offset) & 0xff).also(offset += 1)
 
-    override def read(array: Array[Byte], arrayOffset: Int, length: Int): Int =
+    override def read(array: Array[Byte] | Null, arrayOffset: Int, length: Int): Int =
       if length == 0 then 0 else
         val count = length.min(available())
 

--- a/lib/turbulence/src/core/turbulence.Readable.scala
+++ b/lib/turbulence/src/core/turbulence.Readable.scala
@@ -41,7 +41,6 @@ import hieroglyph.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
-import symbolism.*
 import vacuous.*
 
 object Readable:

--- a/lib/turbulence/src/core/turbulence.Stdio.scala
+++ b/lib/turbulence/src/core/turbulence.Stdio.scala
@@ -61,16 +61,16 @@ object Stdio:
 
   object MuteOutputStream extends ji.OutputStream:
     def write(byte: Int): Unit = ()
-    override def write(array: Array[Byte]): Unit = ()
-    override def write(array: Array[Byte], offset: Int, length: Int): Unit = ()
+    override def write(array: Array[Byte] | Null): Unit = ()
+    override def write(array: Array[Byte] | Null, offset: Int, length: Int): Unit = ()
     override def close(): Unit = ()
 
   lazy val MutePrintStream = ji.PrintStream(MuteOutputStream)
 
   object MuteInputStream extends ji.InputStream:
     def read(): Int = -1
-    override def read(array: Array[Byte]): Int = 0
-    override def read(array: Array[Byte], offset: Int, length: Int): Int = 0
+    override def read(array: Array[Byte] | Null): Int = 0
+    override def read(array: Array[Byte] | Null, offset: Int, length: Int): Int = 0
     override def reset(): Unit = ()
     override def close(): Unit = ()
     override def available(): Int = 0

--- a/lib/turbulence/src/core/turbulence.StreamOutputStream.scala
+++ b/lib/turbulence/src/core/turbulence.StreamOutputStream.scala
@@ -52,11 +52,13 @@ class StreamOutputStream() extends ji.OutputStream:
 
   override def close(): Unit = flush().also(chunks.stop())
 
-  override def write(bytes: Array[Byte]): Unit =
-    flush() yet chunks.put(bytes.immutable(using Unsafe))
+  override def write(bytes: Array[Byte] | Null): Unit =
+    flush()
+    if bytes != null then chunks.put(bytes.immutable(using Unsafe))
 
-  override def write(bytes: Array[Byte], offset: Int, length: Int): Unit =
-    flush() yet chunks.put(bytes.slice(offset, offset + length).immutable(using Unsafe))
+  override def write(bytes: Array[Byte] | Null, offset: Int, length: Int): Unit =
+    flush()
+    if bytes != null then chunks.put(bytes.slice(offset, offset + length).immutable(using Unsafe))
 
   override def flush(): Unit = if !buffer.isEmpty then
     chunks.put(buffer.toArray.immutable(using Unsafe))

--- a/lib/turbulence/src/core/turbulence.Tap.scala
+++ b/lib/turbulence/src/core/turbulence.Tap.scala
@@ -35,7 +35,6 @@ package turbulence
 import language.experimental.captureChecking
 
 import java.util.concurrent.atomic as juca
-import java.util.concurrent as juc
 
 import proscenium.*
 

--- a/lib/vacuous/src/core/soundness+vacuous-core.scala
+++ b/lib/vacuous/src/core/soundness+vacuous-core.scala
@@ -34,4 +34,4 @@ package soundness
 
 export vacuous.{Default, default, Unset, Optional, UnsetError, or, absent, present, vouch, mask,
     javaOptional, presume, option, assume, lay, layGiven, let, letGiven, compact, optional, puncture,
-    only, unless, provided, Unsafe, Extractor}
+    only, unless, Unsafe, Extractor}

--- a/lib/vacuous/src/core/vacuous-core.scala
+++ b/lib/vacuous/src/core/vacuous-core.scala
@@ -58,11 +58,8 @@ extension [ValueType](value: ValueType)
   def only[ValueType2](partial: PartialFunction[ValueType, ValueType2]): Optional[ValueType2] =
     (partial.orElse { _ => Unset })(value)
 
-  def unless(predicate: => Boolean) = if predicate then Unset else value
-  def unless(predicate: ValueType => Boolean) = if predicate(value) then Unset else value
-
-  def provided(predicate: => Boolean) = if predicate then value else Unset
-  def provided(predicate: ValueType => Boolean) = if predicate(value) then value else Unset
+  def unless(predicate: (value: ValueType) ?=> Boolean) =
+    if predicate(using value) then Unset else value
 
 extension [ValueType](java: ju.Optional[ValueType])
   def optional: Optional[ValueType] = if java.isEmpty then Unset else java.get.nn


### PR DESCRIPTION
Several changes were required to get Soundness compiling on the nightly release of Scala 3.7. The most significant was the (hopefully temporary) removal of unused import checking, which crashes the compiler in Serpentine.