### PR TITLE
Rename `MediaType` to `Medium`

### DIFF
--- a/lib/anticipation/.github/readme.md
+++ b/lib/anticipation/.github/readme.md
@@ -134,7 +134,7 @@ for the given attribute. The `GenericHtmlAttribute` typeclass, parameterised on
 the singleton literal type of the attribute name, and the value type, allows
 libraries to make their types usable in such HTML libraries.
 [Gesticulate](https://github.com/propensive/gesticulate/) makes
-`gesticulate.MediaType`s usable for `formenctype`, `enctype`, `media` and
+`gesticulate.Medium`s usable for `formenctype`, `enctype`, `media` and
 `type` attributes. [Scintillate](https://github.com/propensive/scintillate/)
 allows `scintillate.RequestParam` instances to be used for the `name` parameter
 of inputs in a form. [Cataclysm](https://github.com/propensive/cataclysm/)
@@ -214,7 +214,7 @@ experimentation. They are provided only for the necessity of providing _some_
 answer to the question, "how can I try Anticipation?".
 
 1. *Copy the sources into your own project*
-   
+
    Read the `fury` file in the repository root to understand Anticipation's build
    structure, dependencies and source location; the file format should be short
    and quite intuitive. Copy the sources into a source directory in your own
@@ -231,7 +231,7 @@ answer to the question, "how can I try Anticipation?".
    file in the project directory, and produce a collection of JAR files which can
    be added to a classpath, by compiling the project and all of its dependencies,
    including the Scala compiler itself.
-   
+
    Download the latest version of
    [`wrath`](https://github.com/propensive/wrath/releases/latest), make it
    executable, and add it to your path, for example by copying it to
@@ -292,4 +292,3 @@ The logo shows a simple floral pattern.
 
 Anticipation is copyright &copy; 2025 Jon Pretty & Propensive O&Uuml;, and
 is made available under the [Apache 2.0 License](/license.md).
-

--- a/lib/anticipation/doc/basics.md
+++ b/lib/anticipation/doc/basics.md
@@ -96,7 +96,7 @@ for the given attribute. The `GenericHtmlAttribute` typeclass, parameterised on
 the singleton literal type of the attribute name, and the value type, allows
 libraries to make their types usable in such HTML libraries.
 [Gesticulate](https://github.com/propensive/gesticulate/) makes
-`gesticulate.MediaType`s usable for `formenctype`, `enctype`, `media` and
+`gesticulate.Medium`s usable for `formenctype`, `enctype`, `media` and
 `type` attributes. [Scintillate](https://github.com/propensive/scintillate/)
 allows `scintillate.RequestParam` instances to be used for the `name` parameter
 of inputs in a form. [Cataclysm](https://github.com/propensive/cataclysm/)
@@ -143,7 +143,3 @@ and [Telekinesis](https://github.com/propensive/telekinesis/).
 [Diuretic](https://github.com/propensive/diuretic/) provides instances for
 `java.net.URL` and Telekinesis provides an instance for its own
 `telekinesis.Url` type.
-
-
-
-

--- a/lib/gesticulate/.github/readme.md
+++ b/lib/gesticulate/.github/readme.md
@@ -31,14 +31,14 @@ unrepresentable, which is contravened when media types are represented by string
 
 ## Getting Started
 
-### `MediaType`
+### `Medium`
 
 All terms and types are defined in the `gesticulate` package:
 ```scala
 import gesticulate.*
 ```
 
-Gesticulate primarily provides the `MediaType` type, consisting of:
+Gesticulate primarily provides the `Medium` type, consisting of:
  - a main "type" (called `group` to avoid a conflict with Scala's `type` keyword)
  - a subtype
  - a list of suffixes
@@ -66,7 +66,7 @@ The media type for XHTML, encoded as `UTF-8`, which would normally be written as
 ```scala
 import gossamer.t
 
-val mediaType = MediaType(
+val medium = Medium(
   group = Media.Group.Application,
   subtype = Media.Subtype.Standard(t"xhtml"),
   suffixes = List(Media.Suffix.Xml),
@@ -75,9 +75,9 @@ val mediaType = MediaType(
 ```
 
 However, this may be expressed as, `media"application/xhtml+xml; charset=UTF-8"`, and Gesticulate
-will statically parse, check and destructure the type into the `MediaType` instance above.
+will statically parse, check and destructure the type into the `Medium` instance above.
 
-`MediaType` reimplements `toString` to render a media type as a `String`, and additionally provides
+`Medium` reimplements `toString` to render a media type as a `String`, and additionally provides
 the method `basic` to provide the media type with any parameters removed. This may be useful in
 some comparisons.
 
@@ -92,8 +92,8 @@ parameters.
 
 ### Parsing
 
-Media types may be parsed using `MediaType.parse(string)` which returns a `MediaType` or throws an
-`InvalidMediaTypeError`. The `InvalidMediaTypeError.Nature` type encodes different varieties of
+Media types may be parsed using `Medium.parse(string)` which returns a `Medium` or throws an
+`InvalidMediumError`. The `InvalidMediumError.Nature` type encodes different varieties of
 parsing failure, should it be useful to distinguish between these.
 
 
@@ -127,7 +127,7 @@ experimentation. They are provided only for the necessity of providing _some_
 answer to the question, "how can I try Gesticulate?".
 
 1. *Copy the sources into your own project*
-   
+
    Read the `fury` file in the repository root to understand Gesticulate's build
    structure, dependencies and source location; the file format should be short
    and quite intuitive. Copy the sources into a source directory in your own
@@ -144,7 +144,7 @@ answer to the question, "how can I try Gesticulate?".
    file in the project directory, and produce a collection of JAR files which can
    be added to a classpath, by compiling the project and all of its dependencies,
    including the Scala compiler itself.
-   
+
    Download the latest version of
    [`wrath`](https://github.com/propensive/wrath/releases/latest), make it
    executable, and add it to your path, for example by copying it to
@@ -204,4 +204,3 @@ The logo shows a simple fast-forward symbol, familiar from playing many kinds of
 
 Gesticulate is copyright &copy; 2025 Jon Pretty & Propensive O&Uuml;, and
 is made available under the [Apache 2.0 License](/license.md).
-

--- a/lib/gesticulate/doc/api/gesticulate/Media/Prefix/complete.md
+++ b/lib/gesticulate/doc/api/gesticulate/Media/Prefix/complete.md
@@ -1,1 +1,1 @@
-finalizes the interpolator's interpretation and constructs a new `:MediaType`
+finalizes the interpolator's interpretation and constructs a new `:Medium`

--- a/lib/gesticulate/doc/api/gesticulate/Media/parse.md
+++ b/lib/gesticulate/doc/api/gesticulate/Media/parse.md
@@ -1,1 +1,1 @@
-attempts to parse a `:Text` value as a `:MediaType`
+attempts to parse a `:Text` value as a `:Medium`

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/enctype.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/enctype.md
@@ -1,1 +1,1 @@
-contextual evidence to allow `:MediaType` instances to be used as the `enctype` parameter in HTML
+contextual evidence to allow `:Medium` instances to be used as the `enctype` parameter in HTML

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/formenctype.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/formenctype.md
@@ -1,1 +1,1 @@
-contextual evidence to allow `:MediaType` instances to be used as the `formenctype` parameter in HTML
+contextual evidence to allow `:Medium` instances to be used as the `formenctype` parameter in HTML

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/given_DebugString_MediaType.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/given_DebugString_MediaType.md
@@ -1,1 +1,1 @@
-a `:DebugString` instance for displaying a `:MediaType` as a string that could be interpreted as source code
+a `:DebugString` instance for displaying a `:Medium` as a string that could be interpreted as source code

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/given_Show_MediaType.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/given_Show_MediaType.md
@@ -1,1 +1,1 @@
-`:Show` typeclass for displaying a `:MediaType` instance as a `:Text`
+`:Show` typeclass for displaying a `:Medium` instance as a `:Text`

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/htype.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/htype.md
@@ -1,2 +1,2 @@
-contextual value to allow `:MediaType` instances to be used in HTML `type` attributes, which are written as
+contextual value to allow `:Medium` instances to be used in HTML `type` attributes, which are written as
 `htype` here to avoid conflict with the Scala keyword, `type`

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/media.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/media.md
@@ -1,1 +1,1 @@
-contextual evidence to allow `:MediaType` instances to be used as the `media` parameter in HTML
+contextual evidence to allow `:Medium` instances to be used as the `media` parameter in HTML

--- a/lib/gesticulate/doc/api/gesticulate/MediaType/unapply.md
+++ b/lib/gesticulate/doc/api/gesticulate/MediaType/unapply.md
@@ -1,1 +1,1 @@
-method for pattern matching a `:Text` value as a `:MediaType`
+method for pattern matching a `:Text` value as a `:Medium`

--- a/lib/gesticulate/doc/basics.md
+++ b/lib/gesticulate/doc/basics.md
@@ -1,11 +1,11 @@
-### `MediaType`
+### `Medium`
 
 All terms and types are defined in the `gesticulate` package:
 ```scala
 import gesticulate.*
 ```
 
-Gesticulate primarily provides the `MediaType` type, consisting of:
+Gesticulate primarily provides the `Medium` type, consisting of:
  - a main "type" (called `group` to avoid a conflict with Scala's `type` keyword)
  - a subtype
  - a list of suffixes
@@ -33,7 +33,7 @@ The media type for XHTML, encoded as `UTF-8`, which would normally be written as
 ```scala
 import gossamer.t
 
-val mediaType = MediaType(
+val medium = Medium(
   group = Media.Group.Application,
   subtype = Media.Subtype.Standard(t"xhtml"),
   suffixes = List(Media.Suffix.Xml),
@@ -42,9 +42,9 @@ val mediaType = MediaType(
 ```
 
 However, this may be expressed as, `media"application/xhtml+xml; charset=UTF-8"`, and Gesticulate
-will statically parse, check and destructure the type into the `MediaType` instance above.
+will statically parse, check and destructure the type into the `Medium` instance above.
 
-`MediaType` reimplements `toString` to render a media type as a `String`, and additionally provides
+`Medium` reimplements `toString` to render a media type as a `String`, and additionally provides
 the method `basic` to provide the media type with any parameters removed. This may be useful in
 some comparisons.
 
@@ -59,9 +59,6 @@ parameters.
 
 ### Parsing
 
-Media types may be parsed using `MediaType.parse(string)` which returns a `MediaType` or throws an
-`InvalidMediaTypeError`. The `InvalidMediaTypeError.Nature` type encodes different varieties of
+Media types may be parsed using `Medium.parse(string)` which returns a `Medium` or throws an
+`InvalidMediumError`. The `InvalidMediumError.Nature` type encodes different varieties of
 parsing failure, should it be useful to distinguish between these.
-
-
-

--- a/lib/gesticulate/src/core/gesticulate-core.scala
+++ b/lib/gesticulate/src/core/gesticulate-core.scala
@@ -35,5 +35,5 @@ package gesticulate
 import language.experimental.captureChecking
 
 extension (inline ctx: StringContext)
-  transparent inline def media(inline parts: String*): MediaType =
+  transparent inline def media(inline parts: String*): Medium =
     ${Media.Prefix.expand('ctx, 'parts)}

--- a/lib/gesticulate/src/core/gesticulate.Content.scala
+++ b/lib/gesticulate/src/core/gesticulate.Content.scala
@@ -35,4 +35,4 @@ package gesticulate
 import anticipation.*
 import proscenium.*
 
-case class Content(media: MediaType, stream: Stream[Bytes])
+case class Content(media: Medium, stream: Stream[Bytes])

--- a/lib/gesticulate/src/core/gesticulate.Extensions.scala
+++ b/lib/gesticulate/src/core/gesticulate.Extensions.scala
@@ -38,9 +38,9 @@ import gossamer.*
 import language.experimental.captureChecking
 
 object Extensions:
-  def guess(ext: Text): MediaType = mediaTypes.getOrElse(ext, media"application/octet-stream")
+  def guess(ext: Text): Medium = mediums.getOrElse(ext, media"application/octet-stream")
 
-  val mediaTypes: Map[Text, MediaType] = Map
+  val mediums: Map[Text, Medium] = Map
    (t"aac"    -> media"audio/aac",
     t"abw"    -> media"application/x-abiword",
     t"arc"    -> media"application/x-freearc",

--- a/lib/gesticulate/src/core/gesticulate.Media.scala
+++ b/lib/gesticulate/src/core/gesticulate.Media.scala
@@ -51,11 +51,11 @@ import proximityMeasures.levenshteinDistance
 
 object Media:
   given Text is Media:
-    extension (value: Text) def mediaType = MediaType(Group.Text, Subtype.Standard(t"plain"))
+    extension (value: Text) def medium: Medium = Medium(Group.Text, Subtype.Standard(t"plain"))
 
   given [ValueType: Nominable] => ValueType is Media:
     extension (value: ValueType)
-      def mediaType = Extensions.guess(ValueType.name(value).cut(t".").last)
+      def medium: Medium = Extensions.guess(ValueType.name(value).cut(t".").last)
 
   object Group:
     given Group is Inspectable = _.name
@@ -93,7 +93,7 @@ object Media:
       case CborSeq => t"cbor-seq"
       case other   => other.toString.tt.uncamel.kebab
 
-  lazy val systemMediaTypes: Set[Text] =
+  lazy val systemMediums: Set[Text] =
     try
       val stream = Optional(getClass.getResourceAsStream("/gesticulate/media.types")).or:
         throw InterpolationError(m"could not find 'gesticulate/media.types' on the classpath")
@@ -105,7 +105,7 @@ object Media:
 
     catch case err: InterpolationError => Set()
 
-  object Prefix extends Interpolator[Unit, Text, MediaType]:
+  object Prefix extends Interpolator[Unit, Text, Medium]:
     def parse(state: Text, next: Text): Text = next
 
     def insert(state: Text, value: Unit): Text =
@@ -114,16 +114,16 @@ object Media:
     def skip(value: Text): Text = value
     def initial: Text = t""
 
-    def complete(value: Text): MediaType =
+    def complete(value: Text): Medium =
       val parsed = try throwErrors(Media.parse(value)) catch
-        case err: MediaTypeError =>
+        case err: MediumError =>
           throw InterpolationError(m"${err.value} is not a valid media type; ${err.reason.message}")
 
       parsed.subtype match
         case Subtype.Standard(_) =>
-          if !systemMediaTypes.isEmpty then
-            if !systemMediaTypes.contains(parsed.basic) then
-              val suggestion = systemMediaTypes.minBy(_.proximity(parsed.basic))
+          if !systemMediums.isEmpty then
+            if !systemMediums.contains(parsed.basic) then
+              val suggestion = systemMediums.minBy(_.proximity(parsed.basic))
               throw InterpolationError(m"""
                 ${parsed.basic} is not a registered media type; did you mean $suggestion or
                 ${parsed.basic.sub(t"/", t"/x-")}?
@@ -134,16 +134,16 @@ object Media:
 
       parsed
 
-  def parse(string: Text)(using Tactic[MediaTypeError]): MediaType =
+  def parse(string: Text)(using Tactic[MediumError]): Medium =
     def parseParams(ps: List[Text]): List[(Text, Text)] =
       if ps == List("")
-      then raise(MediaTypeError(string, MediaTypeError.Reason.MissingParam))
+      then raise(MediumError(string, MediumError.Reason.MissingParam))
       ps.map(_.cut(t"=", 2).to(List)).map { p => p(0).show -> p(1).show }
 
     def parseSuffixes(suffixes: List[Text]): List[Suffix] =
       suffixes.map(_.lower.capitalize).flatMap: suffix =>
         try List(Suffix.valueOf(suffix.s)) catch IllegalArgumentException =>
-          raise(MediaTypeError(string, MediaTypeError.Reason.InvalidSuffix(suffix))) yet Nil
+          raise(MediumError(string, MediumError.Reason.InvalidSuffix(suffix))) yet Nil
 
     def parseInit(str: Text): (Subtype, List[Suffix]) =
       val xs: List[Text] = str.cut(t"+").to(List)
@@ -155,19 +155,19 @@ object Media:
       case List(group, subtype) => parseGroup(group) *: parseInit(subtype)
 
       case _ =>
-        raise(MediaTypeError(string, MediaTypeError.Reason.NotOneSlash))
+        raise(MediumError(string, MediumError.Reason.NotOneSlash))
         Group.Text *: parseInit(string)
 
     def parseGroup(str: Text): Group =
       try Group.valueOf(str.lower.capitalize.s) catch IllegalArgumentException =>
-        raise(MediaTypeError(string, MediaTypeError.Reason.InvalidGroup)) yet Group.Text
+        raise(MediumError(string, MediumError.Reason.InvalidGroup)) yet Group.Text
 
     def parseSubtype(str: Text): Subtype =
       def notAllowed(char: Char): Boolean =
         char.isWhitespace || char.isControl || specials.contains(char)
 
       str.chars.find(notAllowed(_)).map: char =>
-        raise(MediaTypeError(string, MediaTypeError.Reason.InvalidChar(char)))
+        raise(MediumError(string, MediumError.Reason.InvalidChar(char)))
         Subtype.X(str.chars.filter(!notAllowed(_)).text)
 
       . getOrElse:
@@ -181,11 +181,11 @@ object Media:
     xs.absolve match
       case (h: Text) :: _ =>
         val basic = parseBasic(h)
-        MediaType(basic(0), basic(1), basic(2), parseParams(xs.tail))
+        Medium(basic(0), basic(1), basic(2), parseParams(xs.tail))
 
   final private val specials: Set[Char] =
     Set('(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '+')
 
 trait Media:
   type Self
-  extension (value: Self) def mediaType: MediaType
+  extension (value: Self) def medium: Medium

--- a/lib/gesticulate/src/core/gesticulate.MediaType.scala
+++ b/lib/gesticulate/src/core/gesticulate.MediaType.scala
@@ -45,7 +45,7 @@ import vacuous.*
 import language.dynamics
 //import language.experimental.captureChecking
 
-case class MediaType
+case class Medium
    (group:     Media.Group,
     subtype:    Media.Subtype,
     suffixes:   List[Media.Suffix] = Nil,
@@ -54,36 +54,36 @@ extends Dynamic:
 
   private def suffixString: Text = suffixes.map { s => t"+${s.name}" }.join
   def basic: Text = t"${group.name}/${subtype.name}$suffixString"
-  def base: MediaType = MediaType(group, subtype, suffixes)
+  def base: Medium = Medium(group, subtype, suffixes)
 
   def at(name: Text): Optional[Text] = parameters.where(_(0) == name).let(_(1))
 
-  def applyDynamicNamed(apply: "apply")(kvs: (String, Text)*): MediaType =
+  def applyDynamicNamed(apply: "apply")(kvs: (String, Text)*): Medium =
     copy(parameters = parameters ::: kvs.map(_.show -> _).to(List))
 
-object MediaType:
-  given MediaType is Inspectable = mt => t"""media"${mt}""""
+object Medium:
+  given Medium is Inspectable = mt => t"""media"${mt}""""
 
-  given showable: MediaType is Showable =
+  given showable: Medium is Showable =
     mt => t"${mt.basic}${mt.parameters.map { p => t"; ${p(0)}=${p(1)}" }.join}"
 
-  given MediaType is Encodable in Text = _.show
-  given Tactic[MediaTypeError] => MediaType is Decodable in Text = Media.parse(_)
+  given Medium is Encodable in Text = _.show
+  given Tactic[MediumError] => Medium is Decodable in Text = Media.parse(_)
 
-  given formenctype: ("formenctype" is GenericHtmlAttribute[MediaType]):
+  given formenctype: ("formenctype" is GenericHtmlAttribute[Medium]):
     def name: Text = t"formenctype"
-    def serialize(mediaType: MediaType): Text = mediaType.show
+    def serialize(medium: Medium): Text = medium.show
 
-  given media: ("media" is GenericHtmlAttribute[MediaType]):
+  given media: ("media" is GenericHtmlAttribute[Medium]):
     def name: Text = t"media"
-    def serialize(mediaType: MediaType): Text = mediaType.show
+    def serialize(medium: Medium): Text = medium.show
 
-  given enctype: ("enctype" is GenericHtmlAttribute[MediaType]):
+  given enctype: ("enctype" is GenericHtmlAttribute[Medium]):
     def name: Text = t"enctype"
-    def serialize(mediaType: MediaType): Text = mediaType.show
+    def serialize(medium: Medium): Text = medium.show
 
-  given htype: ("htype" is GenericHtmlAttribute[MediaType]):
+  given htype: ("htype" is GenericHtmlAttribute[Medium]):
     def name: Text = t"type"
-    def serialize(mediaType: MediaType): Text = mediaType.show
+    def serialize(medium: Medium): Text = medium.show
 
-  def unapply(value: Text): Option[MediaType] = safely(Some(Media.parse(value))).or(None)
+  def unapply(value: Text): Option[Medium] = safely(Some(Media.parse(value))).or(None)

--- a/lib/gesticulate/src/core/gesticulate.MediaTypeError.scala
+++ b/lib/gesticulate/src/core/gesticulate.MediaTypeError.scala
@@ -43,7 +43,7 @@ import vacuous.*
 import language.dynamics
 //import language.experimental.captureChecking
 
-object MediaTypeError:
+object MediumError:
   enum Reason:
     case NotOneSlash, MissingParam, InvalidGroup
     case InvalidChar(char: Char)
@@ -57,5 +57,5 @@ object MediaTypeError:
       case InvalidChar(c)   => txt"the character '$c' is not allowed"
       case InvalidSuffix(s) => txt"the suffix '$s' is not recognized"
 
-case class MediaTypeError(value: Text, reason: MediaTypeError.Reason)(using Diagnostics)
+case class MediumError(value: Text, reason: MediumError.Reason)(using Diagnostics)
 extends Error(m"the value $value is not a valid media type; ${reason.message}")

--- a/lib/gesticulate/src/core/gesticulate.MultipartError.scala
+++ b/lib/gesticulate/src/core/gesticulate.MultipartError.scala
@@ -40,13 +40,13 @@ import scala.reflect.*
 object MultipartError:
   enum Reason:
     case Expected(char: Char)
-    case StreamContinues, BadBoundaryEnding, MediaType, BadDisposition
+    case StreamContinues, BadBoundaryEnding, Medium, BadDisposition
 
   given Reason is Communicable =
     case Reason.Expected(char)    => m"the character '$char' was expected"
     case Reason.StreamContinues   => m"the stream continues beyond the last part"
     case Reason.BadBoundaryEnding => m"unexpected content followed the boundary"
-    case Reason.MediaType         => m"the media type is invalid"
+    case Reason.Medium            => m"the media type is invalid"
     case Reason.BadDisposition    => m"the `Content-Disposition` header has the wrong format"
 
 import MultipartError.Reason

--- a/lib/gesticulate/src/core/soundness+gesticulate-core.scala
+++ b/lib/gesticulate/src/core/soundness+gesticulate-core.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export gesticulate .
-  { Extensions, Media, MediaType, MediaTypeError, media, Multipart, MultipartError, Part, Content }
+  { Extensions, Media, Medium, MediumError, media, Multipart, MultipartError, Part, Content }

--- a/lib/gesticulate/src/test/gesticulate.Tests.scala
+++ b/lib/gesticulate/src/test/gesticulate.Tests.scala
@@ -55,14 +55,14 @@ object Tests extends Suite(t"Gesticulate tests"):
 
     test(t"parse full media type"):
       Media.parse(t"application/json")
-    .assert(_ == MediaType(Media.Group.Application, Media.Subtype.Standard(t"json")))
+    .assert(_ == Medium(Media.Group.Application, Media.Subtype.Standard(t"json")))
 
     test(t"parse full media type with parameter"):
       Media.parse(t"application/json; charset=UTF-8")
-    .assert(_ == MediaType(Media.Group.Application, Media.Subtype.Standard(t"json"),
+    .assert(_ == Medium(Media.Group.Application, Media.Subtype.Standard(t"json"),
         parameters = List((t"charset", t"UTF-8"))))
 
     test(t"invalid media type"):
       capture(Media.parse(t"applicationjson"))
-    .assert(_ == MediaTypeError(t"applicationjson",
-        MediaTypeError.Reason.NotOneSlash))
+    .assert(_ == MediumError(t"applicationjson",
+        MediumError.Reason.NotOneSlash))

--- a/lib/hallucination/src/core/hallucination.Bmp.scala
+++ b/lib/hallucination/src/core/hallucination.Bmp.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Bmp extends ImageFormat
 
 object Bmp extends ImageCodec[Bmp]("BMP".tt):
-  def mediaType = media"image/bmp"
+  def medium = media"image/bmp"

--- a/lib/hallucination/src/core/hallucination.Gif.scala
+++ b/lib/hallucination/src/core/hallucination.Gif.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Gif extends ImageFormat
 
 object Gif extends ImageCodec[Gif]("GIF".tt):
-  def mediaType = media"image/gif"
+  def medium = media"image/gif"

--- a/lib/hallucination/src/core/hallucination.ImageCodec.scala
+++ b/lib/hallucination/src/core/hallucination.ImageCodec.scala
@@ -44,7 +44,7 @@ import javax.imageio as ji
 
 abstract class ImageCodec[ImageFormatType <: ImageFormat](name: Text):
   inline def codec: ImageCodec[ImageFormatType] = this
-  protected def mediaType: MediaType
+  protected def medium: Medium
   protected lazy val reader: ji.ImageReader = ji.ImageIO.getImageReaders(name.s).nn.next().nn
   protected lazy val writer: ji.ImageWriter = ji.ImageIO.getImageWriter(reader).nn
 
@@ -56,7 +56,7 @@ abstract class ImageCodec[ImageFormatType <: ImageFormat](name: Text):
       type Result = HttpStreams.Content
 
       def genericize(image: Image in ImageFormatType): HttpStreams.Content =
-        (mediaType.show, image.serialize(using codec))
+        (medium.show, image.serialize(using codec))
 
   def read[InputType: Readable by Bytes](inputType: InputType): Image in ImageFormatType =
     reader.synchronized:

--- a/lib/hallucination/src/core/hallucination.Jpeg.scala
+++ b/lib/hallucination/src/core/hallucination.Jpeg.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Jpeg extends ImageFormat
 
 object Jpeg extends ImageCodec[Jpeg]("JPEG".tt):
-  def mediaType = media"image/jpeg"
+  def medium = media"image/jpeg"

--- a/lib/hallucination/src/core/hallucination.Png.scala
+++ b/lib/hallucination/src/core/hallucination.Png.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Png extends ImageFormat
 
 object Png extends ImageCodec[Png]("PNG".tt):
-  def mediaType = media"image/png"
+  def medium = media"image/png"

--- a/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
@@ -130,7 +130,7 @@ object HtmlAttribute:
   given download: ("download" is HtmlAttribute[Text]) = identity(_)
 
   given draggable: ("draggable" is HtmlAttribute[Boolean]) = if _ then Unset else NotShown
-  given enctype: ("enctype" is HtmlAttribute[MediaType]) = _.show
+  given enctype: ("enctype" is HtmlAttribute[Medium]) = _.show
 
   given hfor: ("hfor" is HtmlAttribute[DomId]):
     override def rename: Optional[Text] = t"for"
@@ -257,7 +257,7 @@ object HtmlAttribute:
   given target: ("target" is HtmlAttribute[Target]) = _.show
   given title: ("title" is HtmlAttribute[Text]) = identity(_)
   given translate: ("translate" is HtmlAttribute[Boolean]) = if _ then Unset else NotShown
-  given linkType: ("type" is HtmlAttribute[MediaType] onto "link") = _.show
+  given linkType: ("type" is HtmlAttribute[Medium] onto "link") = _.show
   given capture: ("capture" is HtmlAttribute[Capture]) = _.show
 
   // This needs a representation of HTML names

--- a/lib/scintillate/src/server/scintillate.Acceptable.scala
+++ b/lib/scintillate/src/server/scintillate.Acceptable.scala
@@ -48,18 +48,18 @@ import errorDiagnostics.stackTraces
 object Acceptable:
   given Tactic[MultipartError] => Multipart is Acceptable = request =>
     tend:
-      case _: MediaTypeError => MultipartError(MultipartError.Reason.MediaType)
+      case _: MediumError => MultipartError(MultipartError.Reason.Medium)
 
     . within:
         val contentType = request.headers.contentType.prim.or:
-          abort(MultipartError(MultipartError.Reason.MediaType))
+          abort(MultipartError(MultipartError.Reason.Medium))
 
         if contentType.base == media"multipart/form-data" then
           val boundary = contentType.at(t"boundary").or:
-            abort(MultipartError(MultipartError.Reason.MediaType))
+            abort(MultipartError(MultipartError.Reason.Medium))
 
           Multipart.parse(request.body, boundary)
-        else abort(MultipartError(MultipartError.Reason.MediaType))
+        else abort(MultipartError(MultipartError.Reason.Medium))
 
 trait Acceptable:
   type Self

--- a/lib/scintillate/src/server/scintillate.Retrievable.scala
+++ b/lib/scintillate/src/server/scintillate.Retrievable.scala
@@ -40,7 +40,7 @@ import rudiments.*
 import spectacular.*
 import telekinesis.*
 
-trait Retrievable(val mediaType: MediaType) extends Servable:
+trait Retrievable(val medium: Medium) extends Servable:
   type Self
 
   def stream(response: Self): Stream[Bytes]
@@ -48,6 +48,6 @@ trait Retrievable(val mediaType: MediaType) extends Servable:
   final def process(content: Self, status: Int, headers: Map[Text, Text], responder: Responder)
   :     Unit =
 
-    responder.addHeader(t"content-type", mediaType.show)
+    responder.addHeader(t"content-type", medium.show)
     headers.each(responder.addHeader)
     responder.sendBody(status, stream(content))

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -159,7 +159,7 @@ object Http:
     case PreconditionFailed            extends Status(412, t"Precondition Failed")
     case PayloadTooLarge               extends Status(413, t"Payload Too Large")
     case UriTooLong                    extends Status(414, t"URI Too Long")
-    case UnsupportedMediaType          extends Status(415, t"Unsupported Media Type")
+    case UnsupportedMedium             extends Status(415, t"Unsupported Media Type")
     case RangeNotSatisfiable           extends Status(416, t"Range Not Satisfiable")
     case ExpectationFailed             extends Status(417, t"Expectation Failed")
     case UnprocessableEntity           extends Status(422, t"Unprocessable Entity")
@@ -289,7 +289,7 @@ object Http:
         val name2 = name.tt.uncamel.kebab.lower
         textHeaders.filter(_.key.lower == name2).map(_.value.decode)
 
-    lazy val contentType: Optional[MediaType] = safely(headers.contentType.prim)
+    lazy val contentType: Optional[Medium] = safely(headers.contentType.prim)
 
     lazy val textCookies: Map[Text, Text] =
       headers.cookie.flatMap: cookie =>

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -49,11 +49,11 @@ import vacuous.*
 import language.dynamics
 
 object Postable:
-  def apply[ResponseType](mediaType0: MediaType, stream0: ResponseType => Stream[Bytes])
+  def apply[ResponseType](medium0: Medium, stream0: ResponseType => Stream[Bytes])
   :     ResponseType is Postable =
     new Postable:
       type Self = ResponseType
-      def mediaType(response: ResponseType): MediaType = mediaType0
+      def medium(response: ResponseType): Medium = medium0
       def stream(response: ResponseType): Stream[Bytes] = stream0(response)
 
   given text: (encoder: CharEncoder) => Text is Postable =
@@ -72,18 +72,18 @@ object Postable:
     Postable(media"application/x-www-form-urlencoded", query => Stream(query.queryString.bytes))
 
   given dataStream: [ResponseType: Abstractable across HttpStreams into HttpStreams.Content]
-  =>    Tactic[MediaTypeError]
+  =>    Tactic[MediumError]
   =>    ResponseType is Postable =
 
     new Postable:
       type Self = ResponseType
 
-      def mediaType(content: ResponseType): MediaType = content.generic(0).decode[MediaType]
+      def medium(content: ResponseType): Medium = content.generic(0).decode[Medium]
       def stream(content: ResponseType): Stream[Bytes] = content.generic(1)
 
 trait Postable:
   type Self
-  def mediaType(content: Self): MediaType
+  def medium(content: Self): Medium
   def stream(content: Self): Stream[Bytes]
 
   def preview(value: Self): Text = stream(value).prim.lay(t""): bytes =>

--- a/lib/telekinesis/src/core/telekinesis.Prefixable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Prefixable.scala
@@ -48,14 +48,14 @@ object Prefixable:
   given contentEncoding: [EncodingType <: Encoding]
   =>    ("contentEncoding" is Prefixable of EncodingType) = _.name
 
-  given accept: ("accept" is Prefixable of MediaType) = _.show
-  given accept2: ("accept" is Prefixable of List[MediaType]) = _.map(_.show).join(t",")
+  given accept: ("accept" is Prefixable of Medium) = _.show
+  given accept2: ("accept" is Prefixable of List[Medium]) = _.map(_.show).join(t",")
 
   given authorization: ("authorization" is Prefixable of Auth) = _.show
   given cacheControl: ("cacheControl" is Prefixable of Text) = identity(_)
   given connection: ("connection" is Prefixable of Text) = identity(_)
   given contentMd5: ("contentMd5" is Prefixable of Text) = identity(_)
-  given contentType: ("contentType" is Prefixable of MediaType) = _.basic
+  given contentType: ("contentType" is Prefixable of Medium) = _.basic
   given contentLength: ("contentLength" is Prefixable of Memory) = _.long.toString.tt
   given cookie: ("cookie" is Prefixable of List[Cookie.Value]) = _.map(_.show).join(t"; ")
   given date: ("date" is Prefixable of Text) = identity(_)

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -42,11 +42,11 @@ import spectacular.*
 import turbulence.*
 
 object Servable:
-  def apply[ResponseType](mediaType: ResponseType => MediaType)
+  def apply[ResponseType](medium: ResponseType => Medium)
      (lambda: ResponseType => Stream[Bytes])
   :     ResponseType is Servable = response =>
 
-    val headers = List(Http.Header(t"content-type", mediaType(response).show))
+    val headers = List(Http.Header(t"content-type", medium(response).show))
     Http.Response.make(Http.Ok, headers, lambda(response))
 
   given content: Content is Servable:
@@ -67,12 +67,12 @@ object Servable:
     scala.compiletime.summonFrom:
       case encodable: (ValueType is Encodable in Bytes) => value =>
         val headers =
-          List(Http.Header(t"content-type", ValueType.mediaType(value).show))
+          List(Http.Header(t"content-type", ValueType.medium(value).show))
 
         Http.Response.make(Http.Ok, headers, Stream(encodable.encode(value)))
       case given (ValueType is Readable by Bytes)       => value =>
         val headers =
-          List(Http.Header(t"content-type", ValueType.mediaType(value).show))
+          List(Http.Header(t"content-type", ValueType.medium(value).show))
 
         Http.Response.make(Http.Ok, headers, value.stream[Bytes])
 

--- a/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
+++ b/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
@@ -129,7 +129,7 @@ object Telekinesis:
             val host: Hostname = $submit.host
             val body = $postable.stream($payload)
             val path = $submit.originForm
-            val contentType = Http.Header("content-type".tt, $postable.mediaType($payload).show)
+            val contentType = Http.Header("content-type".tt, $postable.medium($payload).show)
 
             val request =
               Http.Request($method, 1.1, host, path, contentType :: $headers.to(List), body)


### PR DESCRIPTION
The name `MediaType` _looks_ like a type parameter because it ends in `Type`. Changing it to `Medium` avoids this.