### PR TITLE
Rename `get` and `set` to `apply` and `update`

### DIFF
--- a/lib/panopticon/src/core/panopticon-core.scala
+++ b/lib/panopticon/src/core/panopticon-core.scala
@@ -45,7 +45,7 @@ extension [FromType, PathType <: Tuple, ToType](lens: Lens[FromType, PathType, T
 
     Lens.make()
 
-  inline def get(aim: FromType): ToType = ${Panopticon.get[FromType, PathType, ToType]('aim)}
+  inline def apply(aim: FromType): ToType = ${Panopticon.get[FromType, PathType, ToType]('aim)}
 
-  inline def set(aim: FromType, newValue: ToType): FromType =
+  inline def update(aim: FromType, newValue: ToType): FromType =
     ${Panopticon.set[FromType, PathType, ToType]('aim, 'newValue)}

--- a/lib/panopticon/src/core/panopticon-core.scala
+++ b/lib/panopticon/src/core/panopticon-core.scala
@@ -37,15 +37,3 @@ import proscenium.*
 import scala.quoted.*
 
 export Panopticon.Lens
-
-extension [FromType, PathType <: Tuple, ToType](lens: Lens[FromType, PathType, ToType])
-  @targetName("append")
-  infix def ++ [ToType2, PathType2 <: Tuple](right: Lens[ToType, PathType2, ToType2])
-  :     Lens[FromType, Tuple.Concat[PathType, PathType2], ToType2] =
-
-    Lens.make()
-
-  inline def apply(aim: FromType): ToType = ${Panopticon.get[FromType, PathType, ToType]('aim)}
-
-  inline def update(aim: FromType, newValue: ToType): FromType =
-    ${Panopticon.set[FromType, PathType, ToType]('aim, 'newValue)}

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -56,6 +56,18 @@ object Panopticon:
     :     Lens[FromType, PathType, ToType] =
       0
 
+  extension [FromType, PathType <: Tuple, ToType](lens: Lens[FromType, PathType, ToType])
+    @targetName("append")
+    infix def ++ [ToType2, PathType2 <: Tuple](right: Lens[ToType, PathType2, ToType2])
+    :     Lens[FromType, Tuple.Concat[PathType, PathType2], ToType2] =
+
+      Lens.make()
+
+    inline def apply(aim: FromType): ToType = ${Panopticon.get[FromType, PathType, ToType]('aim)}
+
+    inline def update(aim: FromType, newValue: ToType): FromType =
+      ${Panopticon.set[FromType, PathType, ToType]('aim, 'newValue)}
+
   private def getPath[TupleType <: Tuple: Type](path: List[String] = Nil)(using Quotes)
   :     List[String] =
     import quotes.reflect.*

--- a/lib/panopticon/src/core/soundness+panopticon-core.scala
+++ b/lib/panopticon/src/core/soundness+panopticon-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export panopticon.{Dereferencer, Aim, Lens, ++}
+export panopticon.{Dereferencer, Aim, Lens}


### PR DESCRIPTION
The `get` and `set` methods on a lens don't take advantage of Scala's syntactic sugar for access and updates. By renaming them to `apply` and `update`, we do.