### PR TITLE
Improved text comparisons

### DIFF
--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -139,11 +139,11 @@ object Contrastable extends Contrastable2:
 
           case Ins(rightIndex, value) =>
             t" ⧸${rightIndex.show.subscripts}"
-            -> Juxtaposition.Different(t"—", value.short)
+            -> Juxtaposition.Different(t"", value.short)
 
           case Del(leftIndex, value) =>
             t"${leftIndex.show.superscripts}╱ "
-            -> Juxtaposition.Different(value.let(_.short).or(t"?"), t"—")
+            -> Juxtaposition.Different(value.let(_.short).or(t"?"), t"")
 
           case Sub(leftIndex, rightIndex, leftValue, rightValue) =>
             val label = t"${leftIndex.show.superscripts}╱${rightIndex.show.subscripts}"

--- a/lib/chiaroscuro/src/core/chiaroscuro.Juxtaposition.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Juxtaposition.scala
@@ -34,11 +34,13 @@ package chiaroscuro
 
 import anticipation.*
 import dendrology.*
+import denominative.*
 import escapade.*
 import escritoire.*, columnAttenuation.ignore
 import gossamer.*
 import hieroglyph.*
 import iridescence.*
+import rudiments.*
 import spectacular.*
 import vacuous.*
 
@@ -47,43 +49,100 @@ enum Juxtaposition:
   case Different(left: Text, right: Text, difference: Optional[Text] = Unset)
   case Collation(comparison: IArray[(Text, Juxtaposition)], left: Text, right: Text)
 
+  def singleChar: Boolean = this match
+    case Same(value)                        => value.length == 1
+    case Different(left, right, difference) => left.length <= 1 && right.length <= 1
+    case Collation(_, _, _)                 => false
+
+  def leftWidth: Int = this match
+    case Same(value)                 => value.length
+    case Different(left, _, _)       => left.length
+    case Collation(comparison, _, _) => comparison.sumBy(_(1).leftWidth)
+
+  def rightWidth: Int = this match
+    case Same(value)                 => value.length
+    case Different(_, right, _)      => right.length
+    case Collation(comparison, _, _) => comparison.sumBy(_(1).rightWidth)
+
 object Juxtaposition:
   given (measurable: Text is Measurable) => Juxtaposition is Teletypeable =
-    case Juxtaposition.Collation(cmp, l, r) =>
+    case Juxtaposition.Collation(comparison, _, _) =>
       import tableStyles.default
+      import webColors.{Black, Gray}
 
-      def children(comp: (Text, Juxtaposition)): List[(Text, Juxtaposition)] = comp(1) match
-        case Same(value)                        => Nil
-        case Different(left, right, difference) => Nil
-        case Collation(comparison, left, right) => comparison.to(List)
+      val columns = 110
+      val length = comparison.length
+      val topRule = e"\n$Gray(    ┬${(t"─"*(length.min(columns)))}┬)\n"
+      val midRule = e"$Gray(    ┼${(t"─"*(length.min(columns)))}┼)\n"
+      val bottomRule = e"$Gray(    ┴${(t"─"*(length%columns))}┴)\n"
 
-      case class Row(treeLine: Text, left: Teletype, right: Teletype, difference: Teletype)
+      val penultimateRule = if length%columns == 0 then midRule else
+        e"$Gray(    ┴${(t"─"*(length%columns))}┬${(t"─"*(columns - length%columns))}┴)\n"
 
-      given (Text is Textual) => TreeStyle[Row] = (tiles, row) =>
-        row.copy(treeLine = tiles.map(treeStyles.default.text(_)).join+row.treeLine)
+      if comparison.all(_(1).singleChar) then
+        var topSum = 0
+        var bottomSum = 0
+        def pad(value: Text): Char = Unicode.visible(value.at(Prim).or(' '))
 
-      def mkLine(data: (Text, Juxtaposition)) =
-        def line(bullet: Text): Text = t"$bullet ${data(0)}"
+        comparison.grouped(columns).map: comparison =>
+          val observed = comparison.map:
+            case (_, Same(char))            => e"${Bg(rgb"#003399")}(${pad(char)})"
+            case (_, Different(char, _, _)) => e"${Bg(rgb"#003300")}(${pad(char)})"
+            case _                          => e""
+          . join
 
-        data(1) match
-          case Same(v) =>
-            Row(line(t"▪"), e"${rgb"#667799"}($v)", e"${rgb"#667799"}($v)", e"")
+          val expected = comparison.map:
+            case (_, Same(char))            => e"${Bg(rgb"#003399")}(${pad(char)})"
+            case (_, Different(_, char, _)) => e"${Bg(rgb"#660000")}(${pad(char)})"
+            case _                          => e""
+          . join
 
-          case Different(left, right, difference) =>
-            Row(line(t"▪"), e"${webColors.YellowGreen}($left)", e"${webColors.Crimson}($right)",
-                e"${rgb"#40bbcb"}(${difference.or(t"")})")
+          val margin1 = topSum.show.superscripts.pad(4, Rtl, ' ')
+          val margin2 = bottomSum.show.subscripts.pad(4, Rtl, ' ')
+          topSum += comparison.sumBy(_(1).leftWidth)
+          bottomSum += comparison.sumBy(_(1).rightWidth)
+          val margin3 = topSum.show.superscripts.pad(4, Ltr, ' ')
+          val margin4 = bottomSum.show.subscripts.pad(4, Ltr, ' ')
 
-          case Collation(cmp, left, right) =>
-            Row(line(t"■"), e"$left", e"$right", e"")
+          e"$Gray($margin1│)$observed$Gray(│$margin3)\n$Gray($margin2│)$expected$Gray(│$margin4)\n"
 
-      val table = Table[Row](
-        Column(e"")(_.treeLine),
-        Column(e"Expected", textAlign = TextAlignment.Left)(_.left),
-        Column(e"Found")(_.right),
-        Column(e"Difference")(_.difference)
-      )
+        . to(Iterable)
+        . join(topRule, midRule, penultimateRule, bottomRule)
 
-      table.tabulate(TreeDiagram.by(children(_))(cmp*).render(mkLine)).grid(200).render.join(e"\n")
+      else
+        def children(comp: (Text, Juxtaposition)): List[(Text, Juxtaposition)] = comp(1) match
+          case Same(value)                        => Nil
+          case Different(left, right, difference) => Nil
+          case Collation(comparison, left, right) => comparison.to(List)
+
+        case class Row(treeLine: Text, left: Teletype, right: Teletype)
+
+        given (Text is Textual) => TreeStyle[Row] = (tiles, row) =>
+          row.copy(treeLine = tiles.map(treeStyles.default.text(_)).join+row.treeLine)
+
+        def line(data: (Text, Juxtaposition)): Row =
+          def line(bullet: Text): Text = t"$bullet ${data(0)}"
+
+          data(1) match
+            case Same(v) =>
+              Row(line(t"▪"), e"${rgb"#667799"}($v)", e"${rgb"#667799"}($v)")
+
+            case Different(left, right, difference) =>
+              Row(line(t"▪"), e"${rgb"#bb0000"}($left)", e"${rgb"#00aa00"}($right)")
+
+            case Collation(comparison, left, right) =>
+              Row(line(t"■"), e"$left", e"$right")
+
+        val table = Table[Row]
+                     (Column(e"")(_.treeLine),
+                      Column(e"Expected", textAlign = TextAlignment.Left)(_.left),
+                      Column(e"Observed")(_.right))
+
+        table
+        . tabulate(TreeDiagram.by(children(_))(comparison*).render(line))
+        . grid(200)
+        . render
+        . join(e"\n")
 
     case Different(left, right, difference) =>
       val ws = if right.contains('\n') then e"\n" else e" "

--- a/lib/hieroglyph/src/core/hieroglyph.Unicode.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.Unicode.scala
@@ -82,6 +82,12 @@ object Unicode:
   def eastAsianWidth(char: Char): Optional[EaWidth] =
     eastAsianWidths.minAfter(CharRange(char.toInt, char.toInt)).optional.let(_(1))
 
+  def visible(char: Char): Char = char match
+    case '\u007f'            => '␥'
+    case ' '                 => '␣'
+    case char if char <= ' ' => ('\u2400' + char).toChar
+    case char                => char
+
   def apply(name: Text): Optional[Char | Text] = unicodeData.at(name)
   def name(char: Char): Optional[Text] = unicodeNames.at(char)
 


### PR DESCRIPTION
When Chiaroscuro was used to render a comparison of two strings, previously it would draw a large table showing the diff of the characters, one character per line. This was difficult to read.

Now, the text is printed in rows, highlighted in green and red if there's a difference, or blue if the characters are the same. Nonprinting characters, which may be responsible for a difference, are rendered as printable characters.