### PR TITLE
Switch to `Message` for test/suite names

### DIFF
--- a/lib/abacist/src/test/abacist.Tests.scala
+++ b/lib/abacist/src/test/abacist.Tests.scala
@@ -43,38 +43,38 @@ import language.strictEquality
 
 given decimalizer: Decimalizer = Decimalizer(3)
 
-object Tests extends Suite(t"Quantitative Tests"):
+object Tests extends Suite(m"Quantitative Tests"):
   def run(): Unit =
-    suite(t"Count tests"):
+    suite(m"Count tests"):
 
       type Height = (Feet[1], Inches[1])
 
-      test(t"Access seconds in an HMS time"):
+      test(m"Access seconds in an HMS time"):
         val hmsTime = Count[TimeSeconds](27, 18, 9)
         hmsTime[Seconds]
       .assert(_ == 9)
 
-      test(t"Access minutes in an HMS time"):
+      test(m"Access minutes in an HMS time"):
         val hmsTime = Count[TimeSeconds](27, 18, 9)
         hmsTime[Minutes]
       .assert(_ == 18)
 
-      test(t"Access hours in an HMS time"):
+      test(m"Access hours in an HMS time"):
         val hmsTime = Count[TimeSeconds](27, 18, 9)
         hmsTime[Hours]
       .assert(_ == 27)
 
-      test(t"Access inches in an imperial distance"):
+      test(m"Access inches in an imperial distance"):
         val imperialDistance = Count[(Miles[1], Yards[1], Feet[1], Inches[1])](1800, 4, 2, 11)
         imperialDistance[Feet]
       .assert(_ == 2)
 
-      test(t"Units of different dimensions cannot be mixed"):
+      test(m"Units of different dimensions cannot be mixed"):
         //demilitarize:
           Count[(Miles[1], Yards[1], Seconds[1], Inches[1])](1, 2, 3)
       //.assert(_.nonEmpty)
 
-      test(t"Convert a length to a Count"):
+      test(m"Convert a length to a Count"):
         val length: Quantity[Metres[1]] = (5*Foot + 10*Inch)
         val count = length.count[Height]
         (count[Feet], count[Inches])
@@ -82,115 +82,115 @@ object Tests extends Suite(t"Quantitative Tests"):
 
       type Weight = (Stones[1], Pounds[1], Ounces[1])
 
-      test(t"Convert a mass Quantity to a Count"):
+      test(m"Convert a mass Quantity to a Count"):
         val weight: Quantity[Kilograms[1]] = 20*Kilo(Gram)
         val count = weight.count[Weight]
         (count[Stones], count[Pounds], count[Ounces])
       .assert(_ == (3, 2, 1))
 
-      test(t"Convert a Count to a Quantity"):
+      test(m"Convert a Count to a Quantity"):
         val weight: Count[Weight] = Count(5, 6)
         weight.quantity
       .assert(_ == 2.438057*Kilo(Gram))
 
-      test(t"Convert a Count to a Quantity in pounds"):
+      test(m"Convert a Count to a Quantity in pounds"):
         val weight: Count[Weight] = Count(5, 6)
         weight.quantity.in[Pounds]
       .assert(_ == 5.375*Pound)
 
-      test(t"Add two Counts"):
+      test(m"Add two Counts"):
         val weight: Count[Weight] = Count(12, 9)
         val sum: Count[Weight] = weight + Count[Weight](1)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 12, 10))
 
-      test(t"Add two Counts 2"):
+      test(m"Add two Counts 2"):
         val weight: Count[Weight] = Count(12, 9)
         val sum: Count[Weight] = weight + Count[Weight](2)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 12, 11))
 
-      test(t"Add two Counts 3"):
+      test(m"Add two Counts 3"):
         val weight: Count[Weight] = Count(12, 9)
         val sum: Count[Weight] = weight + Count[Weight](5)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 12, 14))
 
-      test(t"Add two Counts 4"):
+      test(m"Add two Counts 4"):
         val weight: Count[Weight] = Count(12, 9)
         val sum: Count[Weight] = weight + Count[Weight](7)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 13, 0))
 
-      test(t"Add two Counts 5"):
+      test(m"Add two Counts 5"):
         val weight: Count[Weight] = Count(12, 9)
         val sum: Count[Weight] = weight + Count[Weight](8)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 13, 1))
 
-      test(t"Subtract two Counts 1"):
+      test(m"Subtract two Counts 1"):
         val weight: Count[Weight] = Count(12, 9)
         val weight2: Count[Weight] = Count(0, 2)
         val result = weight - weight2
         (result[Stones], result[Pounds], result[Ounces])
       .assert(_ == (0, 12, 7))
 
-      test(t"Subtract two Counts 2"):
+      test(m"Subtract two Counts 2"):
         val weight: Count[Weight] = Count(12, 9)
         val weight2: Count[Weight] = Count(0, 2)
         val result = weight2 - weight
         (result[Stones], result[Pounds], result[Ounces])
       .assert(_ == (0, -12, -7))
 
-      test(t"Multiply a count by a double"):
+      test(m"Multiply a count by a double"):
         val weight: Count[Weight] = Count(12, 9)
         val result = weight*2.5
         (result[Stones], result[Pounds], result[Ounces])
       .assert(_ == (2, 3, 7))
 
-      test(t"Adding with double carry"):
+      test(m"Adding with double carry"):
         val weight: Count[Weight] = Count(100, 13, 15)
         val sum: Count[Weight] = weight + Count[Weight](1)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (101, 0, 0))
 
-      test(t"Collapse a weight value"):
+      test(m"Collapse a weight value"):
         val weight: Count[Weight] = Count(2, 3, 4)
         val weight2 = weight.collapse(1)
         (weight2[Pounds], weight2[Ounces])
       .assert(_ == (31, 4))
 
-      test(t"Collapse a weight value 2"):
+      test(m"Collapse a weight value 2"):
         val weight: Count[Weight] = Count(2, 3, 4)
         val weight2 = weight.collapse(2)
         weight2[Ounces]
       .assert(_ == 500)
 
-      test(t"Cannot collapse beyond last unit"):
+      test(m"Cannot collapse beyond last unit"):
         demilitarize:
           val weight: Count[Weight] = Count(2, 3, 4)
           weight.collapse(3)
       .assert(_.length == 1)
 
-      suite(t"Showing Count values"):
-        test(t"Show a single-unit weight"):
+      suite(m"Showing Count values"):
+        test(m"Show a single-unit weight"):
           Count[Weight](2).show
         .assert(_ == t"2oz")
 
-        test(t"Show a more complex weight"):
+        test(m"Show a more complex weight"):
           Count[Weight](3, 2).show
         .assert(_ == t"3lb 2oz")
 
-        test(t"Show a weight of three parts"):
+        test(m"Show a weight of three parts"):
           Count[Weight](1, 3, 2).show
         .assert(_ == t"1st 3lb 2oz")
 
-        test(t"Show a weight of three parts"):
+        test(m"Show a weight of three parts"):
           Count[Weight](1, 3, 2).show
         .assert(_ == t"1st 3lb 2oz")
 
 
-        test(t"Show with custom unit rendering"):
+        test(m"Show with custom unit rendering"):
           given UnitsNames[Height] = () => List(t"'", t"\"")
           Count[Height](5, 9).show
         .assert(_ == t"5' 9\"")

--- a/lib/acyclicity/src/test/acyclicity.Tests.scala
+++ b/lib/acyclicity/src/test/acyclicity.Tests.scala
@@ -35,6 +35,6 @@ package acyclicity
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Acyclicity Tests"):
+object Tests extends Suite(m"Acyclicity Tests"):
   def run(): Unit =
     ()

--- a/lib/adversaria/src/test/adversaria.Tests.scala
+++ b/lib/adversaria/src/test/adversaria.Tests.scala
@@ -49,59 +49,59 @@ case class Company(name: Text)
 case class Employee(person: Person, @id @unique code: Long)
 case class Letters(@ref(1) alpha: Int, @ref(2) @ref(3) beta: Int, gamma: Int, @ref(4) delta: Int)
 
-object Tests extends Suite(t"Adversaria tests"):
+object Tests extends Suite(m"Adversaria tests"):
 
   def run(): Unit =
 
-    test(t"first field"):
+    test(m"first field"):
       val letters = Letters(5, 6, 7, 8)
       Annotations.firstField[Letters, ref](letters)
     .assert(_ == 5)
 
-    test(t"access field annotations"):
+    test(m"access field annotations"):
       Annotations.field[Employee](_.code)
     .assert(_.contains(unique()))
 
-    test(t"check nonexistant annotations"):
+    test(m"check nonexistant annotations"):
       Annotations.field[Employee](_.person)
     .assert(_ == Nil)
 
-    test(t"get field values"):
+    test(m"get field values"):
       val letters = Letters(5, 6, 7, 8)
       Annotations.fields[Letters, ref].map(_(letters))
     .assert(_ == List(5, 6, 6, 8))
 
-    test(t"get field annotations"):
+    test(m"get field annotations"):
       val letters = Letters(5, 6, 7, 8)
       Annotations.fields[Letters, ref].map(_.annotation)
     .assert(_ == List(ref(1), ref(2), ref(3), ref(4)))
 
-    test(t"get field names"):
+    test(m"get field names"):
       val letters = Letters(5, 6, 7, 8)
       Annotations.fields[Letters, ref].map(_.name)
     .assert(_ == List("alpha", "beta", "beta", "delta"))
 
-    test(t"get annotations on type"):
+    test(m"get annotations on type"):
       summon[Annotations[StaticAnnotation, Company]].annotations
     .assert(_ == List(count(10)))
 
-    test(t"find the field with a particular annotation"):
+    test(m"find the field with a particular annotation"):
       val ann = summon[CaseField[Person, id]]
       val person = Person(t"John Smith", t"test@example.com")
       ann(person)
     .assert(_ == t"test@example.com")
 
-    test(t"check the name of the field found by an annotation"):
+    test(m"check the name of the field found by an annotation"):
       summon[CaseField[Person, id]].name
     .assert(_ == t"email")
 
-    /*test(t"check that given for missing annotation is not resolved"):
+    /*test(m"check that given for missing annotation is not resolved"):
       demilitarize:
         summon[CaseField[Company, id]]
       .map(_.errorId)
     .assert(_ == List(ErrorId.MissingImplicitArgumentID))*/
 
-    test(t"extract annotation value generically"):
+    test(m"extract annotation value generically"):
       def getId[T <: Product](value: T)(using ann: CaseField[T, id]): ann.FieldType = ann(value)
 
       getId(Employee(Person(t"John Smith", t"test@example.com"), 3141592))

--- a/lib/ambience/src/test/ambience.Tests.scala
+++ b/lib/ambience/src/test/ambience.Tests.scala
@@ -35,6 +35,6 @@ package ambience
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Ambience Tests"):
+object Tests extends Suite(m"Ambience Tests"):
   def run(): Unit =
     ()

--- a/lib/anamnesis/src/test/anamnesis.Tests.scala
+++ b/lib/anamnesis/src/test/anamnesis.Tests.scala
@@ -49,7 +49,7 @@ val red = Pencil(t"red")
 val green = Pencil(t"green")
 val blue = Pencil(t"blue")
 
-object Tests extends Suite(t"Anamnesis tests"):
+object Tests extends Suite(m"Anamnesis tests"):
   def run(): Unit =
     given db: Database of (
            Cabinet -< Shelf,
@@ -60,42 +60,42 @@ object Tests extends Suite(t"Anamnesis tests"):
     val alpha: Ref of Box in db.type = Box(t"Alpha").store()
     val beta: Ref of Box in db.type = Box(t"Beta").store()
 
-    test(t"Database is initally empty"):
+    test(m"Database is initally empty"):
       alpha.lookup[Pencil]
 
     . assert(_ == Set())
 
-    test(t"Can add an item"):
+    test(m"Can add an item"):
       red.store()
       alpha.assign(red.ref())
 
     . assert()
 
-    test(t"Table now contains item"):
+    test(m"Table now contains item"):
       alpha.lookup[Pencil].map(_())
 
     . assert(_ == Set(red))
 
-    test(t"Can insert multiple items"):
+    test(m"Can insert multiple items"):
       val greenRef = green.store()
       alpha.assign(greenRef)
       alpha.lookup[Pencil].map(_())
 
     . assert(_ == Set(red, green))
 
-    test(t"Can delete an item"):
+    test(m"Can delete an item"):
       val redRef = red.store()
       alpha.unassign(redRef)
       alpha.lookup[Pencil].map(_())
 
     . assert(_ == Set(green))
 
-    test(t"Other values are unaffected"):
+    test(m"Other values are unaffected"):
       beta.lookup[Pencil]
 
     . assert(_ == Set())
 
-    test(t"Can't insert a pencil onto a shelf"):
+    test(m"Can't insert a pencil onto a shelf"):
       demilitarize:
         top.store().assign(red.ref())
 

--- a/lib/anthology/src/test/anthology.Tests.scala
+++ b/lib/anthology/src/test/anthology.Tests.scala
@@ -34,6 +34,6 @@ package anthology
 
 import soundness.*
 
-object Tests extends Suite(t"Anthology Tests"):
+object Tests extends Suite(m"Anthology Tests"):
   def run(): Unit =
     ()

--- a/lib/anticipation/src/test/anticipation.Tests.scala
+++ b/lib/anticipation/src/test/anticipation.Tests.scala
@@ -34,6 +34,6 @@ package anticipation
 
 import soundness.*
 
-object Tests extends Suite(t"Anticipation Tests"):
+object Tests extends Suite(m"Anticipation Tests"):
   def run(): Unit =
     ()

--- a/lib/austronesian/src/test/austronesian.Example.scala
+++ b/lib/austronesian/src/test/austronesian.Example.scala
@@ -30,39 +30,8 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package gesticulate
+package austronesian
 
-import contingency.*
-import gossamer.*
-import probably.*
-import rudiments.*
-
-import strategies.throwUnsafely
-
-object Tests extends Suite(m"Gesticulate tests"):
-  def run(): Unit =
-    test(m"parse media type's type"):
-      Media.parse(t"application/json").group
-    .assert(_ == Media.Group.Application)
-
-    test(m"parse media type's subtype"):
-      Media.parse(t"application/json").subtype
-    .assert(_ == Media.Subtype.Standard(t"json"))
-
-    test(m"parse media type suffix"):
-      Media.parse(t"application/epub+zip").suffixes
-    .assert(_ == List(Media.Suffix.Zip))
-
-    test(m"parse full media type"):
-      Media.parse(t"application/json")
-    .assert(_ == Medium(Media.Group.Application, Media.Subtype.Standard(t"json")))
-
-    test(m"parse full media type with parameter"):
-      Media.parse(t"application/json; charset=UTF-8")
-    .assert(_ == Medium(Media.Group.Application, Media.Subtype.Standard(t"json"),
-        parameters = List((t"charset", t"UTF-8"))))
-
-    test(m"invalid media type"):
-      capture(Media.parse(t"applicationjson"))
-    .assert(_ == MediumError(t"applicationjson",
-        MediumError.Reason.NotOneSlash))
+object Example:
+  def run(name: Any): Unit =
+    println(s"Hello, $name!")

--- a/lib/austronesian/src/test/austronesian.Tests.scala
+++ b/lib/austronesian/src/test/austronesian.Tests.scala
@@ -41,36 +41,36 @@ case class Group(persons: List[Person], size: Int)
 enum Color:
   case Red, Green, Blue
 
-object Tests extends Suite(t"Austronesian tests"):
+object Tests extends Suite(m"Austronesian tests"):
 
   extension (left: Stdlib) infix def like (right: Array[Any]): Boolean =
     ju.Arrays.deepEquals(left.asInstanceOf[Array[Any]], right)
 
   def run(): Unit =
-    test(t"Serialize a case class")(Person("John", 30).stdlib)
+    test(m"Serialize a case class")(Person("John", 30).stdlib)
     . assert(_ like Array("John", 30))
 
-    test(t"Serialize a list of longs")(List(1L, 99L, 203L).stdlib)
+    test(m"Serialize a list of longs")(List(1L, 99L, 203L).stdlib)
     . assert(_ like Array(1L, 99L, 203L))
 
-    test(t"Serialize a list of case classes")(List(Person("John", 12), Person("Jane", 93)).stdlib)
+    test(m"Serialize a list of case classes")(List(Person("John", 12), Person("Jane", 93)).stdlib)
     . assert(_ like Array(Array("John", 12), Array("Jane", 93)))
 
-    test(t"Serialize a nested case class structure"):
+    test(m"Serialize a nested case class structure"):
       Group(List(Person("John", 30), Person("Jane", 25)), 2).stdlib
     . assert(_ like Array(Array(Array("John", 30), Array("Jane", 25)), 2))
 
     val group = Group(List(Person("John", 30), Person("Jane", 25)), 2)
-    test(t"Roundtrip a nested case class"):
+    test(m"Roundtrip a nested case class"):
       unsafely(group.stdlib.decode[Group])
     . assert(_ == group)
 
-    test(t"Encode an enum"):
+    test(m"Encode an enum"):
       val color: Color = Color.Green
       color.stdlib
     . assert(_ like Array("Green", Array[Any]()))
 
-    test(t"Roundtrip an enum"):
+    test(m"Roundtrip an enum"):
       val color: Color = Color.Green
       unsafely(color.stdlib.decode[Color])
     . assert(_ == Color.Green)

--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -37,248 +37,248 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 
-object Tests extends Suite(t"Aviation Tests"):
+object Tests extends Suite(m"Aviation Tests"):
   def run(): Unit =
-    suite(t"Parsing tests"):
-      test(t"Parse a canonical date"):
+    suite(m"Parsing tests"):
+      test(m"Parse a canonical date"):
         Date.parse(t"2011-12-13")
       .check(_ == 2011-Dec-13)
 
-      test(t"Parse a date with a single-digit month"):
+      test(m"Parse a date with a single-digit month"):
         Date.parse(t"2011-09-13")
       .assert(_ == 2011-Sep-13)
 
-      test(t"Parse a date in the distant past"):
+      test(m"Parse a date in the distant past"):
         Date.parse(t"59-09-13")
       .assert(_ == 59-Sep-13)
 
-      test(t"Month cannot be higher than 12"):
+      test(m"Month cannot be higher than 12"):
         capture(Date.parse(t"59-13-13"))
       .assert(_ == DateError(t"59-13-13"))
 
-      test(t"Month cannot be less than 1"):
+      test(m"Month cannot be less than 1"):
         capture(Date.parse(t"59-0-13"))
       .assert(_ == DateError(t"59-0-13"))
 
-      test(t"Day cannot be over 31"):
+      test(m"Day cannot be over 31"):
         capture(Date.parse(t"59-11-32"))
       .assert(_ == DateError(t"59-11-32"))
 
-      test(t"Day must exist in month"):
+      test(m"Day must exist in month"):
         capture(Date.parse(t"59-11-31"))
       .assert(_ == DateError(t"59-11-31"))
 
 
-    suite(t""):
-      test(t"There are 10 leap seconds for any year before 1972"):
+    suite(m""):
+      test(m"There are 10 leap seconds for any year before 1972"):
         LeapSeconds.during(1900, false)
       .assert(_ == 10)
 
-      test(t"There are 10 leap seconds in the first half of 1972"):
+      test(m"There are 10 leap seconds in the first half of 1972"):
         LeapSeconds.during(1972, false)
       .assert(_ == 10)
 
-      test(t"There are 11 leap seconds in the second half of 1972"):
+      test(m"There are 11 leap seconds in the second half of 1972"):
         LeapSeconds.during(1972, true)
       .assert(_ == 11)
 
-      test(t"There are 12 leap seconds in the first half of 1973"):
+      test(m"There are 12 leap seconds in the first half of 1973"):
         LeapSeconds.during(1973, false)
       .assert(_ == 12)
 
-      test(t"There are 12 leap seconds in the second half of 1973"):
+      test(m"There are 12 leap seconds in the second half of 1973"):
         LeapSeconds.during(1973, true)
       .assert(_ == 12)
 
-      test(t"There are 13 leap seconds in the first half of 1974"):
+      test(m"There are 13 leap seconds in the first half of 1974"):
         LeapSeconds.during(1974, false)
       .assert(_ == 13)
 
-      test(t"There are 13 leap seconds in the second half of 1974"):
+      test(m"There are 13 leap seconds in the second half of 1974"):
         LeapSeconds.during(1974, true)
       .assert(_ == 13)
 
-      test(t"There are 19 leap seconds in the first half of 1980"):
+      test(m"There are 19 leap seconds in the first half of 1980"):
         LeapSeconds.during(1980, false).tap(println)
       .assert(_ == 19)
 
-      test(t"There are 19 leap seconds in the first half of 1981"):
+      test(m"There are 19 leap seconds in the first half of 1981"):
         LeapSeconds.during(1981, false)
       .assert(_ == 19)
 
-      test(t"There are 20 leap seconds in the second half of 1981"):
+      test(m"There are 20 leap seconds in the second half of 1981"):
         LeapSeconds.during(1981, true)
       .assert(_ == 20)
 
-      test(t"There are 19 leap seconds in the first half of 1981"):
+      test(m"There are 19 leap seconds in the first half of 1981"):
         LeapSeconds.during(1981, false)
       .assert(_ == 19)
 
-      test(t"There are 20 leap seconds in the second half of 1981"):
+      test(m"There are 20 leap seconds in the second half of 1981"):
         LeapSeconds.during(1981, true)
       .assert(_ == 20)
 
-      test(t"There are 20 leap seconds in the first half of 1982"):
+      test(m"There are 20 leap seconds in the first half of 1982"):
         LeapSeconds.during(1982, false)
       .assert(_ == 20)
 
-      test(t"There are 21 leap seconds in the second half of 1982"):
+      test(m"There are 21 leap seconds in the second half of 1982"):
         LeapSeconds.during(1982, true)
       .assert(_ == 21)
 
-      test(t"There are 24 leap seconds in the second half of 1988"):
+      test(m"There are 24 leap seconds in the second half of 1988"):
         LeapSeconds.during(1988, true)
       .assert(_ == 24)
 
-      test(t"There are 32 leap seconds in the first half of 2000"):
+      test(m"There are 32 leap seconds in the first half of 2000"):
         LeapSeconds.during(2000, false)
       .assert(_ == 32)
 
-      test(t"There are 37 leap seconds in the first half of 2017"):
+      test(m"There are 37 leap seconds in the first half of 2017"):
         LeapSeconds.during(2017, false)
       .assert(_ == 37)
 
-      test(t"There are 37 leap seconds in the first half of 2100"):
+      test(m"There are 37 leap seconds in the first half of 2100"):
         LeapSeconds.during(2100, false)
       .assert(_ == 37)
 
-    suite(t"Gregorian Calendar Tests"):
-      test(t"2000 is a leap year"):
+    suite(m"Gregorian Calendar Tests"):
+      test(m"2000 is a leap year"):
         calendars.gregorian.leapYear(2000)
       .assert(_ == true)
 
-      test(t"1800, 1900, 2100, 2200 are not leap years"):
+      test(m"1800, 1900, 2100, 2200 are not leap years"):
         List(1800, 1900, 2100, 2200).map(calendars.gregorian.leapYear)
       .assert(_.all(!_))
 
-      test(t"Years not divisble by 4 are never leap years"):
+      test(m"Years not divisble by 4 are never leap years"):
         List(1985, 2001, 2023, 1843).map(calendars.gregorian.leapYear)
       .assert(_.all(!_))
 
-      test(t"Check recent Julian Day"):
+      test(m"Check recent Julian Day"):
         (2022-Dec-16).julianDay
       .assert(_ == 2459930)
 
-      test(t"Check Julian Day in 1950"):
+      test(m"Check Julian Day in 1950"):
         (1950-Mar-10).julianDay
       .assert(_ == 2433351)
 
-      test(t"Check Julian Day in 1650"):
+      test(m"Check Julian Day in 1650"):
         (1650-Mar-10).julianDay
       .assert(_ == 2323779)
 
-      test(t"Check Julian Day in Year 1600"):
+      test(m"Check Julian Day in Year 1600"):
         (1600-Jan-1).julianDay
       .assert(_ == 2305449)
 
-      test(t"Check Julian Day in Year 1"):
+      test(m"Check Julian Day in Year 1"):
         (1-Jan-1).julianDay
       .assert(_ == 1721426)
 
-      test(t"Get zeroth day of year"):
+      test(m"Get zeroth day of year"):
         (2010-Jan-1).julianDay -> (calendars.gregorian.zerothDayOfYear(2010).julianDay + 1)
       .assert(_ == _)
 
-      test(t"Get days in non-leap-year"):
+      test(m"Get days in non-leap-year"):
         calendars.gregorian.daysInYear(1995)
       .assert(_ == 365)
 
-      test(t"Get days in leap-year"):
+      test(m"Get days in leap-year"):
         calendars.gregorian.daysInYear(1996)
       .assert(_ == 366)
 
-      test(t"Get Year from Date"):
+      test(m"Get Year from Date"):
         given calendar: Calendar = calendars.gregorian
         val date = 2016-Jul-11
         calendar.getYear(date)
       .assert(_ == 2016)
 
-      test(t"Check Gregorian date"):
+      test(m"Check Gregorian date"):
         given calendar: Calendar = calendars.gregorian
         2016-Apr-11
       .assert(_ == 2016-Apr-11)
 
-      test(t"Get Gregorian date"):
+      test(m"Get Gregorian date"):
         given calendar: Calendar = calendars.gregorian
         val date = 2016-Jul-11
         (date.year, date.month, date.day)
       .assert(_ == (2016, Jul, 11))
 
-      test(t"Add two periods"):
+      test(m"Add two periods"):
         val period = 1.day + 2.months
         val period2 = 3.days + 1.year
         period + period2
       .assert(_ == 4.days + 2.months + 1.year)
 
-      test(t"Simplify a period"):
+      test(m"Simplify a period"):
         (8.months + 6.months).simplify
       .assert(_ == 1.year + 2.months)
 
-      test(t"Hours do not simplify"):
+      test(m"Hours do not simplify"):
         (1.day + 25.hours).simplify
       .assert(_ == 25.hours + 1.day)
 
-      test(t"Minutes simplify"):
+      test(m"Minutes simplify"):
         123.minutes.simplify
       .assert(_ == 2.hours + 3.minutes)
 
-      test(t"Seconds simplify"):
+      test(m"Seconds simplify"):
         123.seconds.simplify
       .assert(_ == 2.minutes + 3.seconds)
 
-      test(t"Cascading simplification"):
+      test(m"Cascading simplification"):
         (1.hour + 59.minutes + 59.seconds + 2.seconds).simplify
       .assert(_ == 2.hours + 1.second)
 
-      test(t"Simple multiplication"):
+      test(m"Simple multiplication"):
         (1.hour + 5.minutes)*100
       .assert(_ == 100.hours + 500.minutes)
 
-      test(t"Simplified multiplication"):
+      test(m"Simplified multiplication"):
         ((1.hour + 5.seconds)*100).simplify
       .assert(_ == 100.hours + 8.minutes + 20.seconds)
 
-      test(t"Specify times"):
+      test(m"Specify times"):
         2.01.am
       .assert(_ == Clockface(2, 1, 0))
 
-      test(t"Specify times 2"):
+      test(m"Specify times 2"):
         2.59.am
       .assert(_ == Clockface(2, 59, 0))
 
-      test(t"Specify times 3"):
+      test(m"Specify times 3"):
         11.40.am
       .assert(_ == Clockface(11, 40, 0))
 
-      test(t"Specify times 4"):
+      test(m"Specify times 4"):
         7.25.pm
       .assert(_ == Clockface(19, 25, 0))
 
       import calendars.gregorian
-      test(t"Specify datetime"):
+      test(m"Specify datetime"):
         2018-Aug-11 at 5.25.pm
       .assert(_ == Timestamp(Date(2018, Aug, 11), Clockface(17, 25, 0)))
 
-      test(t"Add two months to a date"):
+      test(m"Add two months to a date"):
         2014-Nov-20 + 2.months
       .assert(_ == 2015-Jan-20)
 
-      test(t"Add two days to a date"):
+      test(m"Add two days to a date"):
         2014-Nov-20 + 2.days
       .assert(_ == 2014-Nov-22)
 
-      test(t"Add one year to a date"):
+      test(m"Add one year to a date"):
         2014-Nov-20 + 1.year
       .assert(_ == 2015-Nov-20)
 
-      test(t"Add two years to a date"):
+      test(m"Add two years to a date"):
         2014-Nov-20 + 2.years
       .assert(_ == 2016-Nov-20)
 
-      test(t"Add three years to a date"):
+      test(m"Add three years to a date"):
         2014-Nov-20 + 3.years
       .assert(_ == 2017-Nov-20)
 
-      // test(t"Read TZDB file"):
+      // test(m"Read TZDB file"):
       //   Tzdb.parseFile(t"europe")
       // .assert(_ == List())

--- a/lib/baroque/src/test/baroque.Tests.scala
+++ b/lib/baroque/src/test/baroque.Tests.scala
@@ -40,44 +40,44 @@ import symbolism.*
 
 given Decimalizer = Decimalizer(3)
 
-object Tests extends Suite(t"Baroque tests"):
+object Tests extends Suite(m"Baroque tests"):
   def run(): Unit =
-    test(t"Show a complex number"):
+    test(m"Show a complex number"):
       Complex(1, 3).show
     .assert(_ == t"1 + 3𝒾")
 
-    test(t"Show a quantity complex number"):
+    test(m"Show a quantity complex number"):
       Complex(1*Metre/Second, 9*Metre/Second).show
     .assert(_ == t"1.00 + 9.00𝒾 m·s¯¹")
 
-    test(t"Add two int-complex numbers"):
+    test(m"Add two int-complex numbers"):
       Complex(1, 2) + Complex(8, 2)
     .assert(_ == Complex(9, 4))
 
-    test(t"Add two double-complex numbers"):
+    test(m"Add two double-complex numbers"):
       Complex(0.1, 0.2) + Complex(0.8, 0.2)
     .assert(_ == Complex(0.9, 0.4))
 
-    test(t"Add two quantity-complex numbers"):
+    test(m"Add two quantity-complex numbers"):
       Complex(1*Metre, 3*Metre) + Complex(2*Metre, 8*Metre)
     .assert(_ == Complex(3*Metre, 11*Metre))
 
-    test(t"Add heterogeneous quantity complex numbers"):
+    test(m"Add heterogeneous quantity complex numbers"):
       Complex(1*Inch, 3*Inch) + Complex(2*Foot, 8*Foot)
     .assert(_ == Complex(0.635*Metre, 2.5146*Metre))
 
-    test(t"Multiply complex numbers"):
+    test(m"Multiply complex numbers"):
       Complex(1, 3)*Complex(2, 4)
     .assert(_ == Complex(-10, 10))
 
-    test(t"Divide complex numbers"):
+    test(m"Divide complex numbers"):
       Complex(3.0, 2.0)/Complex(1.0, -4.0)
     .assert { c => c.real == -0.29411764705882354 && c.imaginary == 0.8235294117647058 }
 
-    test(t"Divide complex quantities"):
+    test(m"Divide complex quantities"):
       Complex(3.0*Metre, 2.0*Metre)/Complex(1.0*Foot, -4.0*Foot)
     .assert(_ == Complex(-0.9649529102979775,2.7018681488343375))
 
-    test(t"Multiply complex quantity numbers"):
+    test(m"Multiply complex quantity numbers"):
       Complex(18*Foot, 1.4*Foot)*Complex(4*Kilo(Gram), 2*Kilo(Gram))
     .assert(_ == Complex(69.2*Foot*Kilo(Gram), 41.6*Foot*Kilo(Gram)))

--- a/lib/caesura/src/test/caesura.Tests.scala
+++ b/lib/caesura/src/test/caesura.Tests.scala
@@ -42,167 +42,167 @@ import spectacular.*
 
 given decimalizer: Decimalizer = Decimalizer(1)
 
-object Tests extends Suite(t"Caesura tests"):
+object Tests extends Suite(m"Caesura tests"):
   def run(): Unit =
-    suite(t"Parsing tests"):
+    suite(m"Parsing tests"):
       import dsvFormats.csv
 
-      test(t"simple parse"):
+      test(m"simple parse"):
         Dsv.parse(t"""hello,world""").rows.head
       .assert(_ == Row(t"hello", t"world"))
 
-      test(t"simple parse with quotes"):
+      test(m"simple parse with quotes"):
         Dsv.parse(t""""hello","world"""").rows.head
       .assert(_ == Row(t"hello", t"world"))
 
-      test(t"empty unquoted field at start"):
+      test(m"empty unquoted field at start"):
         Dsv.parse(t",hello,world").rows.head
       .assert(_ == Row(t"", t"hello", t"world"))
 
-      test(t"empty unquoted field at end"):
+      test(m"empty unquoted field at end"):
         Dsv.parse(t"hello,world,").rows.head
       .assert(_ == Row(t"hello", t"world", t""))
 
-      test(t"empty unquoted field in middle"):
+      test(m"empty unquoted field in middle"):
         Dsv.parse(t"hello,,world").rows.head
       .assert(_ == Row(t"hello", t"", t"world"))
 
-      test(t"empty quoted field at start"):
+      test(m"empty quoted field at start"):
         Dsv.parse(t""""","hello","world"""").rows.head
       .assert(_ == Row(t"", t"hello", t"world"))
 
-      test(t"empty quoted field at end"):
+      test(m"empty quoted field at end"):
         Dsv.parse(t""""hello","world",""""").rows.head
       .assert(_ == Row(t"hello", t"world", t""))
 
-      test(t"empty quoted field in middle"):
+      test(m"empty quoted field in middle"):
         Dsv.parse(t""""hello","","world"""").rows.head
       .assert(_ == Row(t"hello", t"", t"world"))
 
-      test(t"quoted comma"):
+      test(m"quoted comma"):
         Dsv.parse(t""""hello,world"""").rows.head
       .assert(_ == Row(t"hello,world"))
 
-      test(t"escaped quotes"):
+      test(m"escaped quotes"):
         Dsv.parse(t""""hello""world"""").rows.head
       .assert(_ == Row(t"""hello"world"""))
 
-      test(t"misplaced quote"):
+      test(m"misplaced quote"):
         capture(Dsv.parse(t"""hello,wo"rld"""))
       .assert(_ == DsvError(summon[DsvFormat], DsvError.Reason.MisplacedQuote))
 
-      test(t"multi-line CSV without trailing newline"):
+      test(m"multi-line CSV without trailing newline"):
         Dsv.parse(t"""foo,bar\nbaz,quux""").rows
       .assert(_ == Stream(Row(t"foo", t"bar"), Row(t"baz", t"quux")))
 
-      test(t"multi-line CSV with trailing newline"):
+      test(m"multi-line CSV with trailing newline"):
         Dsv.parse(t"""foo,bar\nbaz,quux\n""").rows
       .assert(_ == Stream(Row(t"foo", t"bar"), Row(t"baz", t"quux")))
 
-      test(t"multi-line CSV with CR and LF"):
+      test(m"multi-line CSV with CR and LF"):
         Dsv.parse(t"""foo,bar\r\nbaz,quux\r\n""").rows
       .assert(_ == Stream(Row(t"foo", t"bar"), Row(t"baz", t"quux")))
 
-      test(t"multi-line CSV with quoted newlines"):
+      test(m"multi-line CSV with quoted newlines"):
         Dsv.parse(t""""foo","bar"\n"baz","quux"\n""").rows
       .assert(_ == Stream(Row(t"foo", t"bar"), Row(t"baz", t"quux")))
 
-      test(t"multi-line CSV with newlines and quotes in cells"):
+      test(m"multi-line CSV with newlines and quotes in cells"):
         Dsv.parse(t""""f""oo","Hello\nWorld"\nbaz,"1\n2\n3\n"\n""").rows
       .assert(_ == Stream(Row(t"f\"oo", t"Hello\nWorld"), Row(t"baz", t"1\n2\n3\n")))
 
-      test(t"multi-line CSV with quoted quotes adjacent to newlines"):
+      test(m"multi-line CSV with quoted quotes adjacent to newlines"):
         Dsv.parse(t""""f""oo","Hello\nWorld"\nbaz,"1""\n""2\n3\n"\n""").rows
       .assert(_ == Stream(Row(t"f\"oo", t"Hello\nWorld"), Row(t"baz", t"1\"\n\"2\n3\n")))
 
-      test(t"multi-line CSV with quoted quotes adjacent to open/close quotes"):
+      test(m"multi-line CSV with quoted quotes adjacent to open/close quotes"):
         Dsv.parse(t""""f""oo","${"\"\""}Hello\nWorld${t"\"\""}"\n""").rows
       .assert(_ == Stream(Row(t"f\"oo", t"\"Hello\nWorld\"")))
 
-    suite(t"Alternative formats"):
-      test(t"Parse TSV data"):
+    suite(m"Alternative formats"):
+      test(m"Parse TSV data"):
         import dsvFormats.tsv
         Dsv.parse(t"Hello\tWorld\n").rows
       .assert(_ == Stream(Row(t"Hello", t"World")))
 
-      test(t"Parse TSV data"):
+      test(m"Parse TSV data"):
         import dsvFormats.tsvWithHeader
         Dsv.parse(t"Greeting\tAddressee\nHello\tWorld\n")
       .assert(_ == Dsv(Stream(Row(IArray(t"Hello", t"World"), Map(t"Greeting" -> 0, t"Addressee" -> 1))), dsvFormats.tsvWithHeader, IArray(t"Greeting", t"Addressee")))
 
-    suite(t"Dynamic JSON access"):
+    suite(m"Dynamic JSON access"):
       import dynamicDsvAccess.enabled
 
-      test(t"Access field by name"):
+      test(m"Access field by name"):
         import dsvFormats.tsvWithHeader
         import dsvRedesignations.unchanged
         val dsv = Dsv.parse(t"greeting\taddressee\nHello\tWorld\n")
         dsv.rows.head.addressee[Text]
       .assert(_ == t"World")
 
-      test(t"Access field by mapped name"):
+      test(m"Access field by mapped name"):
         import dsvFormats.tsvWithHeader
         import dsvRedesignations.capitalizedWords
         val dsv = Dsv.parse(t"Personal Greeting\tTarget Person\nHello\tWorld\n")
         dsv.rows.head.targetPerson[Text]
       .assert(_ == t"World")
 
-      test(t"Access field by name 2"):
+      test(m"Access field by name 2"):
         import dsvFormats.tsvWithHeader
         import dsvRedesignations.unchanged
         val dsv = Dsv.parse(t"greeting\tnumber\nHello\t23\n")
         dsv.rows.head.number[Int]
       .assert(_ == 23)
 
-    test(t"decode case class"):
+    test(m"decode case class"):
       import dsvFormats.csv
       Dsv.parse(t"""hello,world""").rows.head.as[Foo]
     .assert(_ == Foo(t"hello", t"world"))
 
-    test(t"decode complex case class"):
+    test(m"decode complex case class"):
       import dsvFormats.csv
       Dsv.parse(t"""0.1,two,three,4,five,six""").rows.head.as[Bar]
     .assert(_ == Bar(0.1, Foo(t"two", t"three"), 4, Foo(t"five", t"six")))
 
-    test(t"encode case class"):
+    test(m"encode case class"):
       Foo(t"hello", t"world").dsv
     .assert(_ == Row(t"hello", t"world"))
 
-    test(t"encode complex case class"):
+    test(m"encode complex case class"):
       Bar(0.1, Foo(t"two", t"three"), 4, Foo(t"five", t"six")).dsv
     .assert(_ == Row(t"0.1", t"two", t"three", t"4", t"five", t"six"))
 
-    test(t"convert simple row to string"):
+    test(m"convert simple row to string"):
       import dsvFormats.csv
       Dsv(Stream(Row(t"hello", t"world"))).show
     .assert(_ == t"""hello,world""")
 
-    test(t"convert complex row to string"):
+    test(m"convert complex row to string"):
       import dsvFormats.csv
       Dsv(Stream(Row(t"0.1", t"two", t"three", t"4", t"five", t"six"))).show
     .assert(_ == t"""0.1,two,three,4,five,six""")
 
-    test(t"convert row with escaped quote"):
+    test(m"convert row with escaped quote"):
       import dsvFormats.csv
       Dsv(Stream(Row(t"hello\"world"))).show
     .assert(_ == t""""hello""world"""")
 
-    test(t"simple parse TSV"):
+    test(m"simple parse TSV"):
       import dsvFormats.tsv
       Dsv.parse(t"hello\tworld")
     .assert(_ == Dsv(Stream(Row(t"hello", t"world")), format = dsvFormats.tsv))
 
-    test(t"decode case class from TSV"):
+    test(m"decode case class from TSV"):
       import dsvFormats.tsv
       Dsv.parse(t"hello\tworld").rows.head.as[Foo]
     .assert(_ == Foo(t"hello", t"world"))
 
-    test(t"decode case class from CSV by headings"):
+    test(m"decode case class from CSV by headings"):
       import dsvFormats.csvWithHeader
       Dsv.parse(t"greeting,name\nhello,world").rows.head.as[Quux]
     .assert(_ == Quux(t"world", t"hello"))
 
-    test(t"convert case class to TSV"):
+    test(m"convert case class to TSV"):
       import dsvFormats.tsv
       Seq(Foo(t"hello", t"world")).dsv.show
     .assert(_ == t"hello\tworld")

--- a/lib/camouflage/src/test/camouflage.Tests.scala
+++ b/lib/camouflage/src/test/camouflage.Tests.scala
@@ -36,9 +36,9 @@ import anticipation.*
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Camouflage tests"):
+object Tests extends Suite(m"Camouflage tests"):
   def run(): Unit =
-    test(t"Check first entry is removed"):
+    test(m"Check first entry is removed"):
       val cache = LruCache[Int, Text](4)
       cache(1)(t"one") // should be evicted
       cache(2)(t"two")
@@ -48,7 +48,7 @@ object Tests extends Suite(t"Camouflage tests"):
       cache(1)(t"ein")
     .assert(_ == t"ein")
 
-    test(t"Check that an access stops an element being evicted"):
+    test(m"Check that an access stops an element being evicted"):
       val cache = LruCache[Int, Text](4)
       cache(1)(t"one")
       cache(2)(t"two")
@@ -59,7 +59,7 @@ object Tests extends Suite(t"Camouflage tests"):
       cache(1)(t"un")
     .assert(_ == t"one")
 
-    test(t"Check that an series of accesses causes least-recently-used key to be evicted"):
+    test(m"Check that an series of accesses causes least-recently-used key to be evicted"):
       val cache = LruCache[Int, Text](4)
       cache(1)(t"one")
       cache(2)(t"two")

--- a/lib/capricious/src/test/capricious.Tests.scala
+++ b/lib/capricious/src/test/capricious.Tests.scala
@@ -37,31 +37,31 @@ import soundness.*
 import randomization.seeded
 given Seed = Seed(1L)
 
-object Tests extends Suite(t"Capricious Tests"):
+object Tests extends Suite(m"Capricious Tests"):
   def run(): Unit =
-    suite(t"Distributions"):
-      test(t"Normal distribution mean"):
+    suite(m"Distributions"):
+      test(m"Normal distribution mean"):
         stochastic:
           given Distribution = Gaussian(0.0, 1.0)
           List.fill(10000)(arbitrary[Double]())
 
       . assert(_.mean === 0.0 +/- 0.02)
 
-      test(t"Normal distribution standard deviation"):
+      test(m"Normal distribution standard deviation"):
         stochastic:
           given Distribution = Gaussian(0.0, 2.0)
           List.fill(10000)(arbitrary[Double]())
 
       . assert(_.standardDeviation === 2.0 +/- 0.05)
 
-      test(t"Gamma distribution mean"):
+      test(m"Gamma distribution mean"):
         stochastic:
           given distribution: Gamma = Gamma.approximate(100, 10)
           List.fill(100000)(arbitrary[Double]())
 
       . assert(_.mean === 100.0 +/- 0.1)
 
-      test(t"Gamma distribution standard deviation"):
+      test(m"Gamma distribution standard deviation"):
         stochastic:
           given distribution: Gamma = Gamma.approximate(100, 10)
           List.fill(100000)(arbitrary[Double]())

--- a/lib/cardinality/src/test/cardinality.Tests.scala
+++ b/lib/cardinality/src/test/cardinality.Tests.scala
@@ -38,23 +38,23 @@ import larceny.*
 import probably.*
 import rudiments.*
 
-object Tests extends Suite(t"Cardinality tests"):
+object Tests extends Suite(m"Cardinality tests"):
   def run(): Unit =
-    suite(t"Compile-time tests"):
+    suite(m"Compile-time tests"):
 
-      test(t"Value is less than lower bound"):
+      test(m"Value is less than lower bound"):
         demilitarize:
           val x: -1.0 ~ 1.0 = -1.01
         .map(_.errorId)
       .assert(_ == List(ErrorId.TypeMismatchID))
 
-      test(t"Value is greater than upper bound"):
+      test(m"Value is greater than upper bound"):
         demilitarize:
           val x: -1.0 ~ 1.0 = 1.01
         .map(_.errorId)
       .assert(_ == List(ErrorId.TypeMismatchID))
 
-      test(t"Doubling a number doubles its range"):
+      test(m"Doubling a number doubles its range"):
         demilitarize:
           val x: -1.0 ~ 1.0 = 0.0
           val y: -2.0 ~ 2.0 = x*2.0

--- a/lib/cataclysm/src/test/cataclysm.Tests.scala
+++ b/lib/cataclysm/src/test/cataclysm.Tests.scala
@@ -35,6 +35,6 @@ package cataclysm
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Cataclysm Tests"):
+object Tests extends Suite(m"Cataclysm Tests"):
   def run(): Unit =
     ()

--- a/lib/cellulose/src/test/cellulose.Tests.scala
+++ b/lib/cellulose/src/test/cellulose.Tests.scala
@@ -53,7 +53,7 @@ import strategies.throwUnsafely
 case class User(id: Int, email: Text, privilege: List[Privilege])
 case class Privilege(name: Text, grant: Boolean)
 
-object Tests extends Suite(t"CoDL tests"):
+object Tests extends Suite(m"CoDL tests"):
 
   given Realm = realm"tests"
 
@@ -61,115 +61,115 @@ object Tests extends Suite(t"CoDL tests"):
     import CodlToken.*
     import Arity.*
 
-    suite(t"Reader tests"):
+    suite(m"Reader tests"):
       def interpret(text: Text)(using Log[Text]): PositionReader = PositionReader(Stream(text))
 
-      test(t"Character can store line"):
+      test(m"Character can store line"):
         Character('©', 123, 456).line
       .assert(_ == 123)
 
-      test(t"Character can store column"):
+      test(m"Character can store column"):
         Character('©', 123, 456).column
       .assert(_ == 456)
 
-      test(t"Character can store Char"):
+      test(m"Character can store Char"):
         Character('©', 123, 456).char
       .assert(_ == '©')
 
-      test(t"Initial position is line 0"):
+      test(m"Initial position is line 0"):
         val reader = interpret(t"abc")
         reader.next().line
       .assert(_ == 0)
 
-      test(t"Initial position is column 0"):
+      test(m"Initial position is column 0"):
         val reader = interpret(t"abc")
         reader.next().column
       .assert(_ == 0)
 
-      test(t"Initial character is correct"):
+      test(m"Initial character is correct"):
         val reader = interpret(t"abc")
         reader.next().char
       .assert(_ == 'a')
 
-      test(t"Initial linefeed character is correct"):
+      test(m"Initial linefeed character is correct"):
         val reader = interpret(t"\nabc")
         reader.next().char
       .assert(_ == '\n')
 
-      test(t"Initial carriage return and linefeed gives linefeed"):
+      test(m"Initial carriage return and linefeed gives linefeed"):
         val reader = interpret(t"\r\nabc")
         reader.next().char
       .assert(_ == '\n')
 
-      test(t"Character following CR/LF is correct"):
+      test(m"Character following CR/LF is correct"):
         val reader = interpret(t"\r\nabc")
         reader.next()
         reader.next().char
       .assert(_ == 'a')
 
-      test(t"Read a character gives column 1"):
+      test(m"Read a character gives column 1"):
         val reader = interpret(t"abc")
         reader.next()
         reader.next().column
       .assert(_ == 1)
 
-      test(t"Read a character gives correct line"):
+      test(m"Read a character gives correct line"):
         val reader = interpret(t"abc")
         reader.next()
         reader.next().line
       .assert(_ == 0)
 
-      test(t"Character after newline gives correct line"):
+      test(m"Character after newline gives correct line"):
         val reader = interpret(t"\nabc")
         reader.next()
         reader.next().line
       .assert(_ == 1)
 
-      test(t"Character after newline gives correct column"):
+      test(m"Character after newline gives correct column"):
         val reader = interpret(t"\nabc")
         reader.next()
         reader.next().column
       .assert(_ == 0)
 
-      test(t"Read a CR/LF character gives correct line"):
+      test(m"Read a CR/LF character gives correct line"):
         val reader = interpret(t"\r\nabc")
         reader.next()
         reader.next().line
       .assert(_ == 1)
 
-      test(t"character after CR/LF gives correct column"):
+      test(m"character after CR/LF gives correct column"):
         val reader = interpret(t"\r\nabc")
         reader.next()
         reader.next().column
       .assert(_ == 0)
 
-      test(t"after LF next newline does not fail"):
+      test(m"after LF next newline does not fail"):
         val reader = interpret(t"a\nbc\n")
         for i <- 0 until 4 do reader.next()
         reader.next().char
       .assert(_ == '\n')
 
-      test(t"after LF next newline must not include CR"):
+      test(m"after LF next newline must not include CR"):
         val reader = interpret(t"a\nbc\r\n")
         for i <- 0 until 4 do reader.next()
         capture[CodlError](reader.next().char)
       .matches:
         case CodlError(_, _, _, CodlError.Reason.CarriageReturnMismatch(false)) =>
 
-      test(t"after CR/LF next CR/LF does not fail"):
+      test(m"after CR/LF next CR/LF does not fail"):
         val reader = interpret(t"a\r\nbc\r\n")
         for i <- 0 until 4 do reader.next()
         reader.next().char
       .assert(_ == '\n')
 
-      test(t"after CR/LF next newline must include CR"):
+      test(m"after CR/LF next newline must include CR"):
         val reader = interpret(t"a\r\nbc\n")
         for i <- 0 until 4 do reader.next()
         capture[CodlError](reader.next().char)
       .matches:
         case CodlError(_, _, _, CodlError.Reason.CarriageReturnMismatch(true)) =>
 
-      test(t"can capture start of text"):
+      test(m"can capture start of text"):
         val reader = interpret(t"abcdef")
         reader.put(reader.next())
         reader.put(reader.next())
@@ -177,7 +177,7 @@ object Tests extends Suite(t"CoDL tests"):
         reader.get()
       .assert(_ == t"abc")
 
-      test(t"capture is empty after get"):
+      test(m"capture is empty after get"):
         val reader = interpret(t"abcdef")
         for i <- 0 until 3 do reader.put(reader.next())
         reader.get()
@@ -185,7 +185,7 @@ object Tests extends Suite(t"CoDL tests"):
         reader.get()
       .assert(_ == t"def")
 
-      test(t"capture position is correct"):
+      test(m"capture position is correct"):
         val reader = interpret(t"abcdef")
         for i <- 0 until 3 do reader.put(reader.next())
         reader.get()
@@ -193,103 +193,103 @@ object Tests extends Suite(t"CoDL tests"):
         reader.get()
       .assert(_ == t"def")
 
-      test(t"read end character"):
+      test(m"read end character"):
         val reader = interpret(t"")
         reader.next()
       .matches:
         case Character.End =>
 
-      // test(t"cannot read end twice"):
+      // test(m"cannot read end twice"):
       //   val reader = interpret(t"")
       //   reader.next()
       //   capture(reader.next())
       // .matches:
       //   case _: IllegalStateException =>
 
-    suite(t"Tokenizer tests"):
+    suite(m"Tokenizer tests"):
       def parseText(text: Text)(using Log[Text]): (Int, Stream[CodlToken]) =
         val result = Codl.tokenize(Stream(text))
         result(1).length
         result
 
-      test(t"Parse two words with single space"):
+      test(m"Parse two words with single space"):
         parseText(t"alpha beta")
       .assert(_ == (0, Stream(Item(t"alpha", 0, 0), Item(t"beta", 0, 6))))
 
-      test(t"Parse a completely empty document"):
+      test(m"Parse a completely empty document"):
         parseText(t"")
       .assert(_ == (0, Stream()))
 
-      test(t"Parse two words with trailing spaces"):
+      test(m"Parse two words with trailing spaces"):
         parseText(t"alpha beta   ")
       .assert(_ == (0, Stream(Item(t"alpha", 0, 0), Item(t"beta", 0, 6))))
 
-      test(t"Parse two words with three spaces"):
+      test(m"Parse two words with three spaces"):
         parseText(t"alpha   beta")
       .assert(_ == (0, Stream(Item(t"alpha", 0, 0), Item(t"beta", 0, 8))))
 
-      test(t"Parse two words with newline"):
+      test(m"Parse two words with newline"):
         parseText(t"alpha beta\n")
       .assert(_ == (0, Stream(Item(t"alpha", 0, 0), Item(t"beta", 0, 6))))
 
-      test(t"Parse two words with two lines"):
+      test(m"Parse two words with two lines"):
         parseText(t"alpha\nbeta")
       .assert(_ == (0, Stream(Item(t"alpha", 0, 0), Peer, Item(t"beta", 1, 0))))
 
-      test(t"Parse two words on two lines with indentation"):
+      test(m"Parse two words on two lines with indentation"):
         parseText(t"alpha\n  beta")
       .assert(_ == (0, Stream(Item(t"alpha", 0, 0), Indent, Item(t"beta", 1, 2))))
 
-      test(t"Parse two words on two lines with initial indentation"):
+      test(m"Parse two words on two lines with initial indentation"):
         parseText(t" alpha\n   beta")
       .assert(_ == (1, Stream(Item(t"alpha", 0, 1), Indent, Item(t"beta", 1, 3))))
 
-      test(t"Parse two words on two lines with initial newline"):
+      test(m"Parse two words on two lines with initial newline"):
         parseText(t"\nalpha\n  beta")
       .assert(_ == (0, Stream(Item(t"alpha", 1, 0), Indent, Item(t"beta", 2, 2))))
 
-      test(t"Parse text with whitespace on blank lines"):
+      test(m"Parse text with whitespace on blank lines"):
         parseText(t"root\n  two\n\n \npeer")
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Indent, Item(t"two", 1, 2), Blank, Blank,
           Outdent(1), Item(t"peer", 4, 0))))
 
-      test(t"Parse shebang"):
+      test(m"Parse shebang"):
         parseText(t"""|#!/bin/bash
                       |root
                       |""".s.stripMargin.show)
       .assert(_ == (0, Stream(Comment(t"!/bin/bash", 0, 0), Peer, Item(t"root", 1, 0))))
 
-      test(t"Parse initial comment"):
+      test(m"Parse initial comment"):
         parseText(t"""|# Initial comment
                       |root""".s.stripMargin.show)
       .assert(_ == (0, Stream(Comment(t" Initial comment", 0, 0), Peer, Item(t"root", 1, 0))))
 
-      test(t"Parse two-line comment"):
+      test(m"Parse two-line comment"):
         parseText(t"""|# Line 1
                       |# Line 2
                       |root""".s.stripMargin.show)
       .assert(_ == (0, Stream(Comment(t" Line 1", 0, 0), Peer, Comment(t" Line 2", 1, 0),
           Peer, Item(t"root", 2, 0))))
 
-      test(t"Parse remark"):
+      test(m"Parse remark"):
         parseText(t"""|root # remark""".s.stripMargin.show)
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Comment(t"remark", 0, 6))))
 
-      test(t"Parse non-remark"):
+      test(m"Parse non-remark"):
         parseText(t"""|root #not-a-remark""".s.stripMargin.show)
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"#not-a-remark", 0, 5))))
 
-      test(t"Parse multi-word remark"):
+      test(m"Parse multi-word remark"):
         parseText(t"""|root # remark words""".s.stripMargin.show)
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Comment(t"remark words", 0, 6))))
 
-      test(t"Parse double indentation"):
+      test(m"Parse double indentation"):
         parseText(t"""|root
                       |    child content
                       |""".s.stripMargin.show)
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"child content", 1, 4, true))))
 
-      test(t"Unindented line does not terminate long content"):
+      test(m"Unindented line does not terminate long content"):
         parseText(t"""|root
                       |    one
                       |    two
@@ -298,7 +298,7 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"one\ntwo\n\nthree", 1, 4, true))))
 
 
-      test(t"Parse double indentation then peer"):
+      test(m"Parse double indentation then peer"):
         parseText(t"""|root
                       |    child content
                       |next
@@ -306,7 +306,7 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"child content", 1, 4, true), Peer,
           Item(t"next", 2, 0))))
 
-      test(t"Parse double indentation then peer as children"):
+      test(m"Parse double indentation then peer as children"):
         parseText(t"""|root
                       |  child
                       |      content
@@ -315,7 +315,7 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == List(Item(t"root", 0, 0), Indent, Item(t"child", 1, 2, false),
           Item(t"content", 2, 6, true), Peer, Item(t"next", 3, 2, false)))
 
-      test(t"Parse triple indentation then peer as children"):
+      test(m"Parse triple indentation then peer as children"):
         parseText(t"""|root
                       |  child
                       |    grandchild
@@ -326,7 +326,7 @@ object Tests extends Suite(t"CoDL tests"):
           Item(t"grandchild", 2, 4, false), Item(t"content", 3, 8, true), Peer,
           Item(t"next", 4, 4, false)).to(List))
 
-      test(t"Parse triple indentation then outdent"):
+      test(m"Parse triple indentation then outdent"):
         parseText(t"""|root
                       |  child
                       |    grandchild
@@ -337,7 +337,7 @@ object Tests extends Suite(t"CoDL tests"):
           Item(t"grandchild", 2, 4, false), Item(t"content", 3, 8, true), Outdent(1),
           Item(t"next", 4, 2, false)))
 
-      test(t"Parse triple indentation then double outdent"):
+      test(m"Parse triple indentation then double outdent"):
         parseText(t"""|root
                       |  child
                       |    grandchild
@@ -348,7 +348,7 @@ object Tests extends Suite(t"CoDL tests"):
           Item(t"grandchild", 2, 4, false), Item(t"content", 3, 8, true), Outdent(2),
           Item(t"next", 4, 0, false)))
 
-      test(t"Parse double indentation then peer with margin"):
+      test(m"Parse double indentation then peer with margin"):
         parseText(t"""| root
                       |     child content
                       | next
@@ -356,7 +356,7 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (1, Stream(Item(t"root", 0, 1), Item(t"child content", 1, 5, true), Peer,
           Item(t"next", 2, 1))))
 
-      test(t"Parse double indentation then peer with margin and indent"):
+      test(m"Parse double indentation then peer with margin and indent"):
         parseText(t"""| root
                       |     child content
                       |   next
@@ -364,14 +364,14 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (1, Stream(Item(t"root", 0, 1), Item(t"child content", 1, 5, true), Indent,
           Item(t"next", 2, 3))))
 
-      test(t"Parse multiline content"):
+      test(m"Parse multiline content"):
         parseText(t"""|root
                       |    child content
                       |    more
                       |""".s.stripMargin.show)
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"child content\nmore", 1, 4, true))))
 
-      test(t"Parse multiline content then peer"):
+      test(m"Parse multiline content then peer"):
         parseText(t"""|root
                       |    child content
                       |    more
@@ -380,45 +380,45 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"child content\nmore", 1, 4, true), Peer,
           Item(t"next", 3, 0))))
 
-      test(t"Terminated content"):
+      test(m"Terminated content"):
         parseText(t"""|root child
                       |##
                       |""".s.stripMargin.show)(1)
       .assert(_ == Stream(Item(t"root", 0, 0), Item(t"child", 0, 5), Peer, Body(Stream())))
 
-      test(t"Terminated content 2"):
+      test(m"Terminated content 2"):
         parseText(t"root\n  one two\n##\n")(1)
 
       . assert(_ == Stream(Item(t"root", 0, 0), Indent, Item(t"one", 1, 2), Item(t"two", 1, 6), Outdent(1), Body(Stream())))
 
-      test(t"Terminated content after child"):
+      test(m"Terminated content after child"):
         parseText(t"""|root
                       |  child
                       |##
                       |""".s.stripMargin.show)(1)
       .assert(_ == Stream(Item(t"root", 0, 0), Indent, Item(t"child", 1, 2), Outdent(1), Body(Stream())))
 
-      test(t"Terminated content after long parameter"):
+      test(m"Terminated content after long parameter"):
         parseText(t"""|root
                       |    child
                       |##
                       |""".s.stripMargin.show)(1).to(List)
       .assert(_ == Stream(Item(t"root", 0, 0), Item(t"child", 1, 4, true), Peer, Body(Stream())).to(List))
 
-      test(t"Terminated content with body"):
+      test(m"Terminated content with body"):
         parseText(t"""|root
                       |##
                       | follow""".s.stripMargin.show)(1)
       .assert(_ == Stream(Item(t"root", 0, 0), Peer, Body(Stream(' ', 'f', 'o', 'l', 'l', 'o', 'w'))))
 
-      test(t"Terminated content with body and newline"):
+      test(m"Terminated content with body and newline"):
         parseText(t"""|root
                       |##
                       | follow
                       |""".s.stripMargin.show)(1)
       .assert(_ == Stream(Item(t"root", 0, 0), Peer, Body(Stream(' ', 'f', 'o', 'l', 'l', 'o', 'w', '\n'))))
 
-      test(t"Parse multiline content then indent"):
+      test(m"Parse multiline content then indent"):
         parseText(t"""|root
                       |    child content
                       |    more
@@ -427,7 +427,7 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"child content\nmore", 1, 4, true), Indent,
           Item(t"next", 3, 2))))
 
-      test(t"Parse multiline content then indented comment"):
+      test(m"Parse multiline content then indented comment"):
         parseText(t"""|root
                       |    child content
                       |    more
@@ -436,7 +436,7 @@ object Tests extends Suite(t"CoDL tests"):
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"child content\nmore", 1, 4, true), Indent,
           Comment(t" comment", 3, 2))))
 
-      test(t"Parse multiline content including a hash"):
+      test(m"Parse multiline content including a hash"):
         parseText(t"""|root
                       |    content
                       |    # not a comment
@@ -444,45 +444,45 @@ object Tests extends Suite(t"CoDL tests"):
       .assert: value =>
         value == (0, Stream(Item(t"root", 0, 0), Item(t"content\n# not a comment", 1, 4, true)))
 
-      test(t"Parse multiline content including a additional indentation"):
+      test(m"Parse multiline content including a additional indentation"):
         parseText(t"""|root
                       |    content
                       |     indented
                       |""".s.stripMargin.show)
       .assert(_ == (0, Stream(Item(t"root", 0, 0), Item(t"content\n indented", 1, 4, true))))
 
-      test(t"Surplus indentation"):
+      test(m"Surplus indentation"):
         parseText(t"""|root
                       |     surplus-indented
                       |""".s.stripMargin.show)(1)
       .assert(_ contains CodlToken.Error(CodlError(1, 5, 1, CodlError.Reason.SurplusIndent)))
 
-      test(t"Uneven indentation"):
+      test(m"Uneven indentation"):
         parseText(t"""|root
                       | uneven indented
                       |""".s.stripMargin.show)(1)
       .assert(_ contains CodlToken.Error(CodlError(1, 1, 1, CodlError.Reason.UnevenIndent(0, 1))))
 
-      test(t"Uneven indentation 2"):
+      test(m"Uneven indentation 2"):
         parseText(t"""|root
                       |   uneven indented
                       |""".s.stripMargin.show)(1)
       .assert(_ contains CodlToken.Error(CodlError(1, 3, 1, CodlError.Reason.UnevenIndent(0, 3))))
 
-      test(t"Insufficient indentation"):
+      test(m"Insufficient indentation"):
         parseText(t"""|     root
                       |    uneven indented
                       |""".s.stripMargin.show)(1)
       .assert(_ contains CodlToken.Error(CodlError(1, 4, 1, CodlError.Reason.InsufficientIndent)))
 
-      test(t"Uneven de-indentation"):
+      test(m"Uneven de-indentation"):
         parseText(t"""|root
                       |  child
                       | deindentation
                       |""".s.stripMargin.show)(1)
       .assert(_ contains CodlToken.Error(CodlError(2, 1, 1, CodlError.Reason.UnevenIndent(0, 1))))
 
-    suite(t"Access tests"):
+    suite(m"Access tests"):
       import dynamicCodlAccess.enabled
       val doc = CodlDoc(
         CodlNode(t"term")(
@@ -495,161 +495,161 @@ object Tests extends Suite(t"CoDL tests"):
         CodlNode(t"element")()
       )
 
-      test(t"Access first element"):
+      test(m"Access first element"):
         doc.term().key
       .assert(_ == t"term")
 
-      test(t"Access second element"):
+      test(m"Access second element"):
         doc.element().key
       .assert(_ == t"element")
 
-      test(t"Access nested element"):
+      test(m"Access nested element"):
         doc.term().kind().key
       .assert(_ == t"kind")
 
-      test(t"Access multiple keys"):
+      test(m"Access multiple keys"):
         doc.term().name.length
       .assert(_ == 2)
 
-      test(t"Access deeper nested key"):
+      test(m"Access deeper nested key"):
         doc.term(0).name(1)()
       .assert(_ == CodlNode(Data(t"gamma")))
 
-      test(t"Access deeper nested param"):
+      test(m"Access deeper nested param"):
         doc.term().name()(1)
       .assert(_ == CodlNode(Data(t"beta")))
 
     def read(text: Text)(using Log[Text]): CodlDoc = Codl.parse(text)
 
-    suite(t"Untyped parsing tests"):
-      test(t"Empty document"):
+    suite(m"Untyped parsing tests"):
+      test(m"Empty document"):
         read(t"")
       .assert(_ == CodlDoc())
 
-      test(t"Simplest non-empty document"):
+      test(m"Simplest non-empty document"):
         read(t"root").wiped
       .assert(_ == CodlDoc(CodlNode(Data(t"root"))))
 
-      test(t"Root peers"):
+      test(m"Root peers"):
         read(t"root\nelement\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(), CodlNode(t"element")()))
 
-      test(t"Single child"):
+      test(m"Single child"):
         read(t"root\n  child").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")())))
 
-      test(t"Single child and peer"):
+      test(m"Single child and peer"):
         read(t"root\n  child\npeer").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")()), CodlNode(t"peer")()))
 
-      test(t"Single child and grandchild"):
+      test(m"Single child and grandchild"):
         read(t"root\n  child\n    grandchild").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")(CodlNode(t"grandchild")()))))
 
-      test(t"Single child and grandchild and peer"):
+      test(m"Single child and grandchild and peer"):
         read(t"root\n  child\n    grandchild\npeer").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")(CodlNode(t"grandchild")())), CodlNode(t"peer")()))
 
-      test(t"Peers at multiple levels"):
+      test(m"Peers at multiple levels"):
         read(t"root\n  child\n    grandchild\n  child\n    grandchild\npeer").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")(CodlNode(t"grandchild")()),
           CodlNode(t"child")(CodlNode(t"grandchild")())), CodlNode(t"peer")()))
 
-      test(t"Data with parameter"):
+      test(m"Data with parameter"):
         read(t"root param").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"param")())))
 
-      test(t"Data with remark"):
+      test(m"Data with remark"):
         read(t"root # remark").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root"), Extra(0, Nil, t"remark"))))
 
-      test(t"Data after comment"):
+      test(m"Data after comment"):
         read(t"# comment\nroot").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root"), Extra(0, List(t" comment"), Unset))))
 
-      test(t"Data after two comments"):
+      test(m"Data after two comments"):
         read(t"# comment 1\n# comment 2\nroot").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root"), Extra(0, List(t" comment 1", t" comment 2"), Unset))))
 
-      test(t"Comment on child"):
+      test(m"Comment on child"):
         read(t"root\n  # comment\n  child").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(0, List(t" comment"),
           Unset)))))))
 
-      test(t"Comment and blank line on child"):
+      test(m"Comment and blank line on child"):
         read(t"root\n\n  # comment\n  child").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(1, List(t" comment"),
           Unset)))))))
 
-      test(t"Data with multiple parameters"):
+      test(m"Data with multiple parameters"):
         read(t"root param1 param2").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"param1")(), CodlNode(t"param2")())))
 
-      test(t"Blank line before child"):
+      test(m"Blank line before child"):
         read(t"root\n\n  child").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(1, Nil)))))))
 
-      test(t"Two blank lines before child"):
+      test(m"Two blank lines before child"):
         read(t"root\n\n \n  child").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child", IArray()), Extra(2, Nil, Unset)))))))
 
-      test(t"Data with multiple parameters, remark and comment"):
+      test(m"Data with multiple parameters, remark and comment"):
         read(t"# comment\nroot param1 param2 # remark").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(t"param1")(), CodlNode(t"param2")())), Extra(0,
           List(t" comment"), t"remark"))))
 
-      test(t"Data with multiple parameters, remark, comment and peer"):
+      test(m"Data with multiple parameters, remark, comment and peer"):
         read(t"# comment\nroot param1 param2 # remark\npeer").untyped
       .assert(_ == CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(t"param1")(), CodlNode(t"param2")())), Extra(0,
           List(t" comment"), t"remark")), CodlNode(t"peer")()))
 
-      test(t"Comment on blank node"):
+      test(m"Comment on blank node"):
         read(t"# comment\n\nroot").untyped
       .assert(_ == CodlDoc(CodlNode(Unset, Extra(0, List(t" comment"), Unset)), CodlNode(Data(t"root"), Extra(1,
           Nil, Unset))))
 
-      test(t"Remark after blank line"):
+      test(m"Remark after blank line"):
         read(t"root\n\npeer # remark").untyped
       .assert(_ == CodlDoc(CodlNode(t"root")(), CodlNode(Data(t"peer"), Extra(0, Nil, t"remark"))))
 
-      test(t"Long item"):
+      test(m"Long item"):
         read(t"root\n    one two\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one two")())))
 
-      test(t"Unindented blank line does not terminate long content"):
+      test(m"Unindented blank line does not terminate long content"):
         read(t"root\n    one\n    two\n\n    three").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one\ntwo\n\nthree")())))
 
-      test(t"Multiline item"):
+      test(m"Multiline item"):
         read(t"root\n  child\n    this\n        one two\n        three four\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")(CodlNode(t"this")(CodlNode(t"one two\nthree four")())))))
 
-      test(t"Terminated content"):
+      test(m"Terminated content"):
         read(t"ROOT\n  one two\n##\nfoobar\nbaz").wiped
       .assert(_ == CodlDoc(CodlNode(t"ROOT")(CodlNode(t"one")(CodlNode(t"two")()))))
 
-      test(t"Terminated content without newline"):
+      test(m"Terminated content without newline"):
         read(t"root\n    one two\n##").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one two")())))
 
-      test(t"Terminated content with body"):
+      test(m"Terminated content with body"):
         read(t"root\n    one two\n##\nunparsed").body
       .assert(_ == Stream('u', 'n', 'p', 'a', 'r', 's', 'e', 'd'))
 
-      test(t"Terminated content with newline before body"):
+      test(m"Terminated content with newline before body"):
         read(t"root\n    one two\n##\n\nunparsed").body
       .assert(_ == Stream('\n', 'u', 'n', 'p', 'a', 'r', 's', 'e', 'd'))
 
-      test(t"Terminated content with newline after body"):
+      test(m"Terminated content with newline after body"):
         read(t"root\n    one two\n##\nunparsed\n").body
       .assert(_ == Stream('u', 'n', 'p', 'a', 'r', 's', 'e', 'd', '\n'))
 
-      test(t"Teminator without newline and spurious content"):
+      test(m"Teminator without newline and spurious content"):
         capture(read(t"root\n    one two\n##spurious"))
       .assert(_ == CodlError(2, 2, 1, BadTermination))
 
 
-    suite(t"Schema tests"):
+    suite(m"Schema tests"):
       import dynamicCodlAccess.enabled
       val childSchema = Struct(AtMostOne,
                           t"one" -> Field(AtMostOne),
@@ -674,59 +674,59 @@ object Tests extends Suite(t"CoDL tests"):
 
       val topSchema = Struct(AtMostOne, t"root" -> rootSchema)
 
-      test(t"Root node has correct name"):
+      test(m"Root node has correct name"):
         topSchema.parse(t"root").untyped()
       .assert(_ == CodlNode(Data(t"root")))
 
-      test(t"Root node has correct schema"):
+      test(m"Root node has correct schema"):
         topSchema.parse(t"root").schema
       .assert(_ == topSchema)
 
-      test(t"First child of root param is validated"):
+      test(m"First child of root param is validated"):
         topSchema.parse(t"root\n  child").root()(0).schema
       .assert(_ == childSchema)
 
-      test(t"Third child of root param is validated"):
+      test(m"Third child of root param is validated"):
         val doc = topSchema.parse(t"root\n  child\n  second\n  third value\n")
         doc.root()(2).schema
       .assert(_ == Field(AtMostOne))
 
-      test(t"Second child of root param is validated"):
+      test(m"Second child of root param is validated"):
         val doc = topSchema.parse(t"root\n  child\n  second")
         doc.root()(1).schema
       .assert(_ == childSchema2)
 
-      test(t"Child is validated"):
+      test(m"Child is validated"):
         topSchema.parse(t"root\n  child").root().child().schema
       .assert(_ == childSchema)
 
-      test(t"Different-named child is validated"):
+      test(m"Different-named child is validated"):
         topSchema.parse(t"root\n  second").root().second().schema
       .assert(_ == childSchema2)
 
-      test(t"Grandchild nodes are validated"):
+      test(m"Grandchild nodes are validated"):
         topSchema.parse(t"root\n  second\n    alpha").root().second().alpha().schema
       .assert(_ == grandchildSchema)
 
-      test(t"Invalid top-level node"):
+      test(m"Invalid top-level node"):
         capture[AggregateError[CodlError]](topSchema.parse(t"riot")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(0, 0, 4, InvalidKey(t"riot", t"riot")))
 
-      test(t"Indent after comment forbidden"):
+      test(m"Indent after comment forbidden"):
         capture[AggregateError[CodlError]](Codl.parse(t"root\n  # comment\n    child")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(1, 2, 1, CodlError.Reason.IndentAfterComment))
 
-      test(t"Validate second top-level node"):
+      test(m"Validate second top-level node"):
         rootSchema.parse(t"child\nsecond").second().schema
       .assert(_ == childSchema2)
 
-      test(t"Validate second top-level node out of order"):
+      test(m"Validate second top-level node out of order"):
         rootSchema.parse(t"second\nchild").second().schema
       .assert(_ == childSchema2)
 
-      test(t"Validate second top-level node after child"):
+      test(m"Validate second top-level node after child"):
         rootSchema.parse(t"child\n  one\nsecond").second().schema
       .assert(_ == childSchema2)
 
@@ -736,12 +736,12 @@ object Tests extends Suite(t"CoDL tests"):
                             )
                           )
 
-      test(t"Missing required node throws exception"):
+      test(m"Missing required node throws exception"):
         capture[AggregateError[CodlError]](requiredChild.parse(t"root")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(0, 0, 4, MissingKey(t"root", t"child")))
 
-      test(t"Present required node does not throw exception"):
+      test(m"Present required node does not throw exception"):
         requiredChild.parse(t"root\n  child").untyped.root().child()
       .assert(_ == Data(t"child"))
 
@@ -751,12 +751,12 @@ object Tests extends Suite(t"CoDL tests"):
                               )
                             )
 
-      test(t"Duplicated unique child is forbidden"):
+      test(m"Duplicated unique child is forbidden"):
         capture[AggregateError[CodlError]](requiredChild.parse(t"root\n  child\n  child")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(2, 2, 5, DuplicateKey(t"child", t"child")))
 
-      test(t"Duplicated repeatable child is permitted"):
+      test(m"Duplicated repeatable child is permitted"):
         repeatableChild.parse(t"root\n  child\n  child").untyped.root().child(1)
       .assert(_ == Data(t"child"))
 
@@ -766,15 +766,15 @@ object Tests extends Suite(t"CoDL tests"):
                               )
                             )
 
-      test(t"'At least one' may mean one"):
+      test(m"'At least one' may mean one"):
         atLeastOneChild.parse(t"root\n  child").untyped.root().child()
       .assert(_ == Data(t"child"))
 
-      test(t"'At least one' may mean two"):
+      test(m"'At least one' may mean two"):
         atLeastOneChild.parse(t"root\n  child\n  child").untyped.root().child(1)
       .assert(_ == Data(t"child"))
 
-      test(t"'At least one' may not mean zero"):
+      test(m"'At least one' may not mean zero"):
         capture[AggregateError[CodlError]](requiredChild.parse(t"root")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(0, 0, 4, MissingKey(t"root", t"child")))
@@ -797,100 +797,100 @@ object Tests extends Suite(t"CoDL tests"):
           )
         )
 
-      test(t"Access parameters by name"):
+      test(m"Access parameters by name"):
         childWithTwoParams(One, One).parse(t"root\n  child first second").root().child().beta()
       .assert(_ == Data(t"second", IArray(), schema = Field(One), layout = Layout(0, false, 14)))
 
-      test(t"Surplus parameters"):
+      test(m"Surplus parameters"):
         capture[AggregateError[CodlError]](childWithTwoParams(One, One).parse(t"root\n  child one two three")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(1, 16, 5, SurplusParams(t"three", t"child")))
 
-      test(t"Two surplus parameters"):
+      test(m"Two surplus parameters"):
         capture[AggregateError[CodlError]](childWithTwoParams(One, One).parse(t"root\n  child one two three four")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(1, 16, 5, SurplusParams(t"three", t"child")))
 
-      test(t"Two optional parameters not specified"):
+      test(m"Two optional parameters not specified"):
         childWithTwoParams(AtMostOne, AtMostOne).parse(t"root\n  child").root().child().layout
         . params
       .assert(_ == 0)
 
-      test(t"Two optional parameters with one specified"):
+      test(m"Two optional parameters with one specified"):
         childWithTwoParams(AtMostOne, AtMostOne).parse(t"root\n  child one").root().child().layout.params
       .assert(_ == 1)
 
-      test(t"Two optional parameters with both specified"):
+      test(m"Two optional parameters with both specified"):
         childWithTwoParams(AtMostOne, AtMostOne).parse(t"root\n  child one two").root().child().layout.params
       .assert(_ == 2)
 
-      test(t"Two optional parameters with one surplus"):
+      test(m"Two optional parameters with one surplus"):
         capture[AggregateError[CodlError]](childWithTwoParams(AtMostOne, AtMostOne).parse(t"root\n  child one two three").root().child()) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(1, 16, 5, SurplusParams(t"three", t"child")))
 
-      test(t"Variadic parameters are counted"):
+      test(m"Variadic parameters are counted"):
         childWithTwoParams(One, Many).parse(t"root\n  child one two three four").root().child().layout.params
       .assert(_ == 4)
 
-      test(t"Variadic parameter has right number of values"):
+      test(m"Variadic parameter has right number of values"):
         childWithTwoParams(One, Many).parse(t"root\n  child one two three four").root().child().beta.length
       .assert(_ == 3)
 
-      test(t"Variadic parameters are optional"):
+      test(m"Variadic parameters are optional"):
         childWithTwoParams(One, Many).parse(t"root\n  child one").root().child().layout.params
       .assert(_ == 1)
 
-      test(t"'at least one' parameters are not optional"):
+      test(m"'at least one' parameters are not optional"):
         capture[AggregateError[CodlError]](childWithTwoParams(One, AtLeastOne).parse(t"root\n  child one")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(1, 2, 5, MissingKey(t"child", t"beta")))
 
-      test(t"Variadic first parameters don't count for second"):
+      test(m"Variadic first parameters don't count for second"):
         capture[AggregateError[CodlError]](childWithTwoParams(AtLeastOne, AtLeastOne).parse(t"root\n  child one two three")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(1, 2, 5, MissingKey(t"child", t"beta")))
 
-      test(t"Two optional parameters not specified on root"):
+      test(m"Two optional parameters not specified on root"):
         rootWithTwoParams(AtMostOne, AtMostOne).parse(t"  child").child().layout.params
       .assert(_ == 0)
 
-      test(t"Two optional parameters with one specified on root"):
+      test(m"Two optional parameters with one specified on root"):
         rootWithTwoParams(AtMostOne, AtMostOne).parse(t"  child one").child().layout.params
       .assert(_ == 1)
 
-      test(t"Two optional parameters with both specified on root"):
+      test(m"Two optional parameters with both specified on root"):
         rootWithTwoParams(AtMostOne, AtMostOne).parse(t"  child one two").child().layout.params
       .assert(_ == 2)
 
-      test(t"Two optional parameters with one surplus on root"):
+      test(m"Two optional parameters with one surplus on root"):
         capture[AggregateError[CodlError]](rootWithTwoParams(AtMostOne, AtMostOne).parse(t"  child one two three").child()) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(0, 16, 5, SurplusParams(t"three", t"child")))
 
-      test(t"Variadic parameters are counted on root"):
+      test(m"Variadic parameters are counted on root"):
         rootWithTwoParams(One, Many).parse(t"  child one two three four").child().layout.params
       .assert(_ == 4)
 
-      test(t"Variadic parameter has right number of values on root"):
+      test(m"Variadic parameter has right number of values on root"):
         rootWithTwoParams(One, Many).parse(t"child one two three four").child().beta.length
       .assert(_ == 3)
 
-      test(t"Variadic parameters are optional on root"):
+      test(m"Variadic parameters are optional on root"):
         rootWithTwoParams(One, Many).parse(t"  child one").child().layout.params
       .assert(_ == 1)
 
-      test(t"'at least one' parameters are not optional on root"):
+      test(m"'at least one' parameters are not optional on root"):
         capture[AggregateError[CodlError]](rootWithTwoParams(One, AtLeastOne).parse(t"  child one")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(0, 2, 5, MissingKey(t"child", t"beta")))
 
-      test(t"Variadic first parameters don't count for second on root"):
+      test(m"Variadic first parameters don't count for second on root"):
         capture[AggregateError[CodlError]](rootWithTwoParams(AtLeastOne, AtLeastOne).parse(t"  child one two three")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(0, 2, 5, MissingKey(t"child", t"beta")))
 
-    suite(t"Path tests"):
+    suite(m"Path tests"):
       import dynamicCodlAccess.enabled
       val schema = Struct(AtMostOne,
         t"root" -> Struct(AtMostOne,
@@ -909,23 +909,23 @@ object Tests extends Suite(t"CoDL tests"):
       )
 
 
-      test(t"CodlNode contains reference to an ident param"):
+      test(m"CodlNode contains reference to an ident param"):
         schema.parse(t"""root\n  field apple Braeburn red""").root().ids
       .assert(_ == Set(t"apple"))
 
-      test(t"CodlNode contains reference to an ident param with children"):
+      test(m"CodlNode contains reference to an ident param with children"):
         schema.parse(t"""root\n  field apple Braeburn\n    description red""").root().ids
       .assert(_ == Set(t"apple"))
 
-      test(t"CodlNode contains reference to an ident param as a child"):
+      test(m"CodlNode contains reference to an ident param as a child"):
         schema.parse(t"""root\n  another\n    id jack\n    name Jack\n    color blue\n    size 8""").root().ids
       .assert(_ == Set(t"jack"))
 
-      test(t"CodlNode contains multiple ids"):
+      test(m"CodlNode contains multiple ids"):
         schema.parse(t"""root\n  another jill\n    name Jill\n    color foo\n  another\n    id jack\n    name Jack\n""").root().ids
       .assert(_ == Set(t"jack", t"jill"))
 
-      test(t"CodlNode contains multiple ids (tweaked)"):
+      test(m"CodlNode contains multiple ids (tweaked)"):
         schema.parse(t"""root\n  another jill\n    name Jill\n  another\n    id jack\n    name Jack\n    color blue\n    size 8""").root().ids
       .assert(_ == Set(t"jack", t"jill"))
 
@@ -936,12 +936,12 @@ object Tests extends Suite(t"CoDL tests"):
         )
       )
 
-      test(t"Cannot have duplicate IDs of the same type"):
+      test(m"Cannot have duplicate IDs of the same type"):
         capture[AggregateError[CodlError]](repetitionSchema.parse(t"ABC first One\nABC second Two\nABC first Primary")) match
           case AggregateError[CodlError](errors) => errors.head
       .assert(_ == CodlError(2, 4, 5, CodlError.Reason.DuplicateId(t"first", 0, 4)))
 
-    suite(t"Binary tests"):
+    suite(m"Binary tests"):
 
       val schema = Struct(Arity.AtMostOne,
         t"field" -> Struct(Arity.AtMostOne,
@@ -955,174 +955,174 @@ object Tests extends Suite(t"CoDL tests"):
 
       val doc = schema.parse(t"field")
 
-      test(t"Serialize and deserialize one node"):
+      test(m"Serialize and deserialize one node"):
         roundtrip(doc)
       .assert(_ == doc.uncommented)
 
       val doc2 = schema.parse(t"field\n  child\n")
-      test(t"Serialize and deserialize one node and child"):
+      test(m"Serialize and deserialize one node and child"):
         roundtrip(doc2)
       .assert(_ == doc2.uncommented)
 
       val doc3 = schema.parse(t"field\n  child value")
-      test(t"Serialize and deserialize one node and child/param"):
+      test(m"Serialize and deserialize one node and child/param"):
         roundtrip(doc3)
       .assert(_ == doc3.uncommented)
 
       val doc4 = schema.parse(t"field\n  child value value2 value3")
-      test(t"Serialize and deserialize one node and child with three params"):
+      test(m"Serialize and deserialize one node and child with three params"):
         roundtrip(doc4)
       .assert(_ == doc4.uncommented)
 
       val doc5 = schema.parse(t"field\n  child value value2\nfield2\nfield3")
-      test(t"Serialize and deserialize document with indent, outdent and peer"):
+      test(m"Serialize and deserialize document with indent, outdent and peer"):
         roundtrip(doc5)
       .assert(_ == doc5.uncommented)
 
-    suite(t"Serialization tests"):
+    suite(m"Serialization tests"):
 
-      test(t"Serialize a node"):
+      test(m"Serialize a node"):
         CodlDoc(CodlNode(Data(t"root"))).write
       .assert(_ == t"root\n")
 
-      test(t"Serialize a node and a child"):
+      test(m"Serialize a node and a child"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child")))))).write
       .assert(_ == t"root\n  child\n")
 
-      test(t"Serialize a node and a child with params layout"):
+      test(m"Serialize a node and a child with params layout"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"))), Layout(1, false, 0))))
         . write
       .assert(_ == t"root child\n")
 
-      test(t"Serialize a node and a child with block param"):
+      test(m"Serialize a node and a child with block param"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child")), CodlNode(Data(t"Hello World"))), Layout(2, true, 0)))).write
       .assert(_ == t"root child\n    Hello World\n")
 
-      test(t"Serialize a node and a child with multiline block param"):
+      test(m"Serialize a node and a child with multiline block param"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child")), CodlNode(Data(t"Hello\nWorld"))), Layout(2, true, 0)))).write
       .assert(_ == t"root child\n    Hello\n    World\n")
 
-      test(t"Serialize a node and a child with comment"):
+      test(m"Serialize a node and a child with comment"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(comments = List(t" comment"))))))).write
       .assert(_ == t"root\n  # comment\n  child\n")
 
-      test(t"Serialize a node and a child with multiline comment"):
+      test(m"Serialize a node and a child with multiline comment"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(comments = List(t" line 1", t" line 2"))))))).write
       .assert(_ == t"root\n  # line 1\n  # line 2\n  child\n")
 
-      test(t"Serialize a node and a child with multiline comment and blank lines"):
+      test(m"Serialize a node and a child with multiline comment and blank lines"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(blank = 2, comments = List(t" line 1", t" line 2"))))))).write
       .assert(_ == t"root\n\n\n  # line 1\n  # line 2\n  child\n")
 
-      test(t"Serialize a node and a child with blank lines"):
+      test(m"Serialize a node and a child with blank lines"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(blank = 2)))))).write
       .assert(_ == t"root\n\n\n  child\n")
 
-      test(t"Serialize a node and a child with a remark"):
+      test(m"Serialize a node and a child with a remark"):
         CodlDoc(CodlNode(Data(t"root", IArray(CodlNode(Data(t"child"), Extra(remark = t"some remark")))))).write
       .assert(_ == t"root\n  child # some remark\n")
 
-    suite(t"Double-spacing tests"):
-      test(t"Single-space-separated"):
+    suite(m"Double-spacing tests"):
+      test(m"Single-space-separated"):
         read(t"root one two\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one")(), CodlNode(t"two")())))
 
-      test(t"Double-space-separated"):
+      test(m"Double-space-separated"):
         read(t"root  one  two\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one")(), CodlNode(t"two")())))
 
-      test(t"Short/long spacing"):
+      test(m"Short/long spacing"):
         read(t"root one  two\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one")(), CodlNode(t"two")())))
 
-      test(t"Long/short spacing"):
+      test(m"Long/short spacing"):
         read(t"root  one two\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one two")())))
 
-      test(t"Long/short/long spacing"):
+      test(m"Long/short/long spacing"):
         read(t"root  one two  three\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one two")(), CodlNode(t"three")())))
 
-      test(t"Short/short/long spacing"):
+      test(m"Short/short/long spacing"):
         read(t"root one two  three\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one")(), CodlNode(t"two")(), CodlNode(t"three")())))
 
-      test(t"Short/Long/short spacing"):
+      test(m"Short/Long/short spacing"):
         read(t"root one  two three\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one")(), CodlNode(t"two three")())))
 
-      test(t"Short/Long/short/Long/short spacing"):
+      test(m"Short/Long/short/Long/short spacing"):
         read(t"root one  two three  four five\n").wiped
       .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"one")(), CodlNode(t"two three")(), CodlNode(t"four five")())))
 
 
     def roundtrip[T: CodlEncoder: CodlDecoder](value: T): T = value.codl.as[T]
 
-    suite(t"Generic Derivation tests"):
+    suite(m"Generic Derivation tests"):
 
       case class Person(name: Text, age: Int)
       case class Organisation(name: Text, ceo: Person)
       case class Player(name: Text, rank: Optional[Int])
 
-      test(t"write a simple case class"):
+      test(m"write a simple case class"):
         Person(t"John Smith", 65).codl.untyped
       .assert(_ == CodlDoc(CodlNode(t"name")(CodlNode(t"John Smith")()), CodlNode(t"age")(CodlNode(t"65")())))
 
-      test(t"write a nested case class"):
+      test(m"write a nested case class"):
         val person1 = Person(t"Alpha", 1)
         Organisation(t"Acme", person1).codl.untyped
       .assert(_ == CodlDoc(CodlNode(t"name")(CodlNode(t"Acme")()), CodlNode(t"ceo")(CodlNode(t"name")(CodlNode(t"Alpha")()),
           CodlNode(t"age")(CodlNode(t"1")()))))
 
-      test(t"write a case class with optional field specified"):
+      test(m"write a case class with optional field specified"):
         Player(t"Barry", 1).codl.untyped
       .assert(_ == CodlDoc(CodlNode(t"name")(CodlNode(t"Barry")()), CodlNode(t"rank")(CodlNode(t"1")())))
 
-      test(t"write a case class with optional field unspecified"):
+      test(m"write a case class with optional field unspecified"):
         Player(t"Barry", Unset).codl.untyped
       .assert(_ == CodlDoc(CodlNode(t"name")(CodlNode(t"Barry")())))
 
-      test(t"serialize a List of case classes"):
+      test(m"serialize a List of case classes"):
         List(Person(t"John Smith", 65), Person(t"Jim Calvin", 11)).codl.untyped
       .assert(_ == CodlDoc(
         CodlNode(t"name")(CodlNode(t"John Smith")()), CodlNode(t"age")(CodlNode(t"65")()),
         CodlNode(t"name")(CodlNode(t"Jim Calvin")()), CodlNode(t"age")(CodlNode(t"11")())
       ))
 
-      test(t"serialize a List of integers"):
+      test(m"serialize a List of integers"):
         List(1, 2, 3).codl.untyped
       .assert(_ == CodlDoc(CodlNode(t"1")(), CodlNode(t"2")(), CodlNode(t"3")()))
 
-      test(t"serialize a List of booleans"):
+      test(m"serialize a List of booleans"):
         List(true, false, true).codl.untyped
       .assert(_ == CodlDoc(CodlNode(t"yes")(), CodlNode(t"no")(), CodlNode(t"yes")()))
 
-      test(t"roundtrip a true boolean"):
+      test(m"roundtrip a true boolean"):
         roundtrip[Boolean](true)
       .assert(_ == true)
 
-      test(t"roundtrip a false boolean"):
+      test(m"roundtrip a false boolean"):
         roundtrip[Boolean](false)
       .assert(_ == false)
 
-      test(t"roundtrip an integer"):
+      test(m"roundtrip an integer"):
         roundtrip[Int](42)
       .assert(_ == 42)
 
-      test(t"roundtrip some text"):
+      test(m"roundtrip some text"):
         roundtrip[Text](t"hello world")
       .assert(_ == t"hello world")
 
-      test(t"roundtrip a list of strings"):
+      test(m"roundtrip a list of strings"):
         roundtrip[List[Text]](List(t"hello", t"world"))
       .assert(_ == List(t"hello", t"world"))
 
       case class Foo(alpha: Text, beta: Optional[Text])
-      test(t"roundtrip a case class with an optional parameter"):
+      test(m"roundtrip a case class with an optional parameter"):
         roundtrip(Foo(t"one", t"two"))
       .assert(_ == Foo(t"one", t"two"))
 
-      test(t"roundtrip a case class with an optional parameter, unset"):
+      test(m"roundtrip a case class with an optional parameter, unset"):
         roundtrip(Foo(t"one", Unset))
       .assert(_ == Foo(t"one", Unset))
 
@@ -1132,7 +1132,7 @@ object Tests extends Suite(t"CoDL tests"):
 
       val complex = Bar(List(Baz(t"a", 2, Unset), Baz(t"c", 6, 'e')), Quux(t"e", List(1, 2, 4)))
 
-      test(t"roundtrip a complex case class"):
+      test(m"roundtrip a complex case class"):
         summon[CodlDecoder[Baz]]
         summon[CodlDecoder[List[Baz]]]
         roundtrip(complex)
@@ -1143,28 +1143,28 @@ object Tests extends Suite(t"CoDL tests"):
         Printer.print(writer, value.codl)
         writer.toString().show
 
-      test(t"print a simple case class"):
+      test(m"print a simple case class"):
         print(Foo(t"one", t"two"))
       .assert(_ == t"alpha one\nbeta two\n")
 
-      test(t"print a complex case class"):
+      test(m"print a complex case class"):
         print(complex)
       .assert(_ == t"foo\n  gamma a\n  delta 2\nfoo\n  gamma c\n  delta 6\n  eta e\nquux\n  alpha e\n  beta 1\n  beta 2\n  beta 4\n")
 
-      test(t"roundtrip a complex case class "):
+      test(m"roundtrip a complex case class "):
         read(print(complex)).as[Bar]
       .assert(_ == complex)
 
-      test(t"Print a case class using positional parameters"):
+      test(m"Print a case class using positional parameters"):
         print(User(12, t"user@example.com", List(Privilege(t"read", true), Privilege(t"write", false))))
       .assert(_ == t"")
 
-    suite(t"Extra tests"):
-      test(t"Tabs are recorded"):
+    suite(m"Extra tests"):
+      test(m"Tabs are recorded"):
         read(t"# some comment\nroot   param1    param2\n  child1 param3")().extra
       .assert(_ == Extra())
 
-    // // suite(t"Record tests"):
+    // // suite(m"Record tests"):
 
     // //   val record = GreekRecords(example1)
 
@@ -1172,7 +1172,7 @@ object Tests extends Suite(t"CoDL tests"):
     // //     record.alpha
     // //   .assert(_ == t"one")
 
-    // //   test(t"Test return value"):
+    // //   test(m"Test return value"):
     // //     record.beta
     // //   .assert(_ == t"two")
 
@@ -1184,17 +1184,17 @@ object Tests extends Suite(t"CoDL tests"):
     // //     record.eta
     // //   .assert(_ == t"eight")
 
-    // //   test(t"Test many return value"):
+    // //   test(m"Test many return value"):
     // //     record.gamma
     // //   .assert(_ == List(t"three", t"four", t"five"))
 
-    // //   test(t"Test multiple return value"):
+    // //   test(m"Test multiple return value"):
     // //     record.kappa
     // //   .assert(_ == List(t"nine", t"ten", t"eleven"))
 
-    // suite(t"Interpolation suite"):
+    // suite(m"Interpolation suite"):
 
-    //   test(t"Interpolator with no substitutions"):
+    //   test(m"Interpolator with no substitutions"):
     //     codl"""
     //       root
     //         child value
@@ -1202,7 +1202,7 @@ object Tests extends Suite(t"CoDL tests"):
     //     """.untyped.copy(margin = 0)
     //   .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"child")(CodlNode(t"value")())), CodlNode(t"test")()))
 
-    //   test(t"Interpolator with one substitutions"):
+    //   test(m"Interpolator with one substitutions"):
     //     val bar = t"Hello"
 
     //     codl"""
@@ -1212,7 +1212,7 @@ object Tests extends Suite(t"CoDL tests"):
     //     """.untyped.copy(margin = 0)
     //   .assert(_ == CodlDoc(CodlNode(t"root")(CodlNode(t"Hello")(), CodlNode(t"child")(CodlNode(t"value")())), CodlNode(t"test")()))
 
-    //   test(t"Interpolator with substitution containing space"):
+    //   test(m"Interpolator with substitution containing space"):
     //     val bar = t"Hello World"
 
     //     codl"""

--- a/lib/charisma/src/test/charisma.Tests.scala
+++ b/lib/charisma/src/test/charisma.Tests.scala
@@ -35,6 +35,6 @@ package charisma
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Charisma Tests"):
+object Tests extends Suite(m"Charisma Tests"):
   def run(): Unit =
     ()

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -125,11 +125,14 @@ object Contrastable extends Contrastable2:
       else Juxtaposition.Different(leftMsg, rightMsg)
 
   def compareSeq[ValueType]
-     (left: IArray[Decomposition], right: IArray[Decomposition], leftDebug: Text, rightDebug: Text)
+     (left:       IArray[Decomposition],
+      right:      IArray[Decomposition],
+      leftDebug:  Text,
+      rightDebug: Text)
   :     Juxtaposition =
     if left == right then Juxtaposition.Same(leftDebug) else
       val comparison = IArray.from:
-        diff(left, right).rdiff(_ == _).changes.map:
+        diff(left, right).rdiff(_ == _, 10).changes.map:
           case Par(leftIndex, rightIndex, value) =>
             val label =
               if leftIndex == rightIndex then leftIndex.show

--- a/lib/chiaroscuro/src/test/chiaroscuro.Tests.scala
+++ b/lib/chiaroscuro/src/test/chiaroscuro.Tests.scala
@@ -42,40 +42,40 @@ case class IdName(id: Text, name: Text)
 given Similarity[IdName] = _.id == _.id
 import Juxtaposition.*
 
-object Tests extends Suite(t"Chiaroscuro tests"):
+object Tests extends Suite(m"Chiaroscuro tests"):
   def run(): Unit =
-    suite(t"RDiff tests"):
-      test(t"Two identical, short Vectors"):
+    suite(m"RDiff tests"):
+      test(m"Two identical, short Vectors"):
         Vector(1, 2, 3).contrast(Vector(1, 2, 3))
 
       . assert(_ == Same(t"⟨ 1 2 3 ⟩"))
 
-      test(t"compare two two-parameter case class instances"):
+      test(m"compare two two-parameter case class instances"):
         Person(t"Jack", 12)
 
       . assert(_ == Person(t"Jill", 12))
 
-      test(t"nested comparison"):
+      test(m"nested comparison"):
         Organization(t"Acme Inc", Person(t"Jack", 12), Nil)
 
       . assert(_ == Organization(t"Acme Inc", Person(t"Jill", 12), Nil))
 
-      test(t"nested comparison 2"):
+      test(m"nested comparison 2"):
         Organization(t"Acme Inc.", Person(t"Jack", 12), Nil)
 
       . assert(_ == Organization(t"Acme Inc", Person(t"Jack", 12), Nil))
 
-      test(t"nested comparison 3"):
+      test(m"nested comparison 3"):
         Organization(t"Acme Inc.", Person(t"Jack", 12), List(Person(t"Jerry", 18)))
 
       . assert(_ == Organization(t"Acme Inc.", Person(t"Jack", 12), List(Person(t"Jill", 32), Person(t"Jerry", 18))))
 
-      test(t"nested comparison 4"):
+      test(m"nested comparison 4"):
         Organization(t"Acme Inc.", Person(t"Jack", 12), List(Person(t"Jerry", 18)))
 
       . assert(_ == Organization(t"Acme", Person(t"Jack", 12), List(Person(t"Jerry", 18))))
 
-      test(t"diff list"):
+      test(m"diff list"):
         val xs = List(t"one", t"two", t"three", t"four")
         val ys = List(t"one", t"two", t"three", t"vier")
         diff(xs.to(Vector), ys.to(Vector)).edits
@@ -88,7 +88,7 @@ object Tests extends Suite(t"Chiaroscuro tests"):
                    Del(3, t"four"),
                    Ins(3, t"vier"))
 
-      test(t"recurse on similar list entries"):
+      test(m"recurse on similar list entries"):
         val xs = List(IdName(t"one", t"One"), IdName(t"two", t"Two"),  IdName(t"three", t"Three"), IdName(t"four", t"Four"))
         val ys = List(IdName(t"one", t"Ein"), IdName(t"two", t"Zwei"),  IdName(t"three", t"Three"), IdName(t"vier", t"Vier"))
         val result = xs.contrast(ys)

--- a/lib/coaxial/src/test/coaxial.Tests.scala
+++ b/lib/coaxial/src/test/coaxial.Tests.scala
@@ -46,7 +46,7 @@ import spectacular.*
 import superlunary.*
 import vacuous.*
 
-object Tests extends Suite(t"Coaxial tests"):
+object Tests extends Suite(m"Coaxial tests"):
   def run(): Unit = unsafely:
 
     val u = udp"3876".json.show
@@ -64,12 +64,12 @@ object Tests extends Suite(t"Coaxial tests"):
               promise.await()
         })
 
-        test(t"Test UDP server"):
+        test(m"Test UDP server"):
           udpServer(udp"3962")
         .assert()
 
 
-      test(t"Send UDP messages until port opens"):
+      test(m"Send UDP messages until port opens"):
         Thread.sleep(5000)
         println("transmitting")
         udp"3962".transmit(jvmInstanceId.show)

--- a/lib/contextual/src/test/contextual.Tests.scala
+++ b/lib/contextual/src/test/contextual.Tests.scala
@@ -35,6 +35,6 @@ package contextual
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Contextual Tests"):
+object Tests extends Suite(m"Contextual Tests"):
   def run(): Unit =
     ()

--- a/lib/contingency/src/test/contingency.Tests.scala
+++ b/lib/contingency/src/test/contingency.Tests.scala
@@ -37,12 +37,12 @@ import soundness.*
 case class VarargsError(args: Text*)(using Diagnostics) extends Error(m"Varargs error")
 case class VarargsError2(arg: Text, args: Text*)(using Diagnostics) extends Error(m"Varargs error 2")
 
-object Tests extends Suite(t"Contingency tests"):
+object Tests extends Suite(m"Contingency tests"):
 
   def action(): Unit raises VarargsError = ()
 
   def run(): Unit =
-    test(t"Ensure varargs parameter is handled exhaustively"):
+    test(m"Ensure varargs parameter is handled exhaustively"):
       demilitarize:
         mend:
           case VarargsError(args) => ()
@@ -50,7 +50,7 @@ object Tests extends Suite(t"Contingency tests"):
 
     . assert(_.nonEmpty)
 
-    test(t"Varargs are handled safely"):
+    test(m"Varargs are handled safely"):
       mend:
         case VarargsError(args*) => ()
       . within(action())

--- a/lib/cosmopolite/src/test/cosmopolite.Tests.scala
+++ b/lib/cosmopolite/src/test/cosmopolite.Tests.scala
@@ -40,19 +40,19 @@ import gossamer.*
 
 import unsafeExceptions.canThrowAny
 
-object Tests extends Suite(t"Cosmopolite Tests"):
+object Tests extends Suite(m"Cosmopolite Tests"):
   def run(): Unit =
-    test(t"extract language from string (English)"):
+    test(m"extract language from string (English)"):
       val two = en"two" & fr"deux"
       two[En]
     .assert(_ == t"two")
 
-    test(t"extract language from string (French)"):
+    test(m"extract language from string (French)"):
       val two = en"two" & fr"deux"
       two[Fr]
     .assert(_ == t"deux")
 
-    test(t"extract default language"):
+    test(m"extract default language"):
       val two = en"two" & fr"deux"
       given Language[Fr] = Language[Fr]("fr")
       two()

--- a/lib/dendrology/src/test/dendrology.Tests.scala
+++ b/lib/dendrology/src/test/dendrology.Tests.scala
@@ -41,7 +41,7 @@ import turbulence.*, stdioSources.virtualMachine
 
 import unsafeExceptions.canThrowAny
 
-object Tests extends Suite(t"Dendrology tests"):
+object Tests extends Suite(m"Dendrology tests"):
 
   case class Tree(value: Text, children: List[Tree] = Nil)
 

--- a/lib/digression/src/test/digression.Tests.scala
+++ b/lib/digression/src/test/digression.Tests.scala
@@ -43,10 +43,10 @@ import unsafeExceptions.canThrowAny
 
 case class Person(name: Text, age: Int)
 
-object Tests extends Suite(t"Rudiments Tests"):
+object Tests extends Suite(m"Rudiments Tests"):
   def run(): Unit =
-    suite(t"Exception tests"):
-      test(t"Show exception"):
+    suite(m"Exception tests"):
+      test(m"Show exception"):
         try
           List(1, 2, 3).map(_ / 0)
           ???

--- a/lib/dissonance/src/test/dissonance.Tests.scala
+++ b/lib/dissonance/src/test/dissonance.Tests.scala
@@ -45,213 +45,213 @@ import proximityMeasures.levenshteinDistance
 
 import strategies.throwUnsafely
 
-object Tests extends Suite(t"Dissonance tests"):
+object Tests extends Suite(m"Dissonance tests"):
   given Realm = realm"tests"
 
   def run(): Unit =
-    suite(t"Diff tests"):
-      test(t"Empty lists"):
+    suite(m"Diff tests"):
+      test(m"Empty lists"):
         diff(IArray[Char](), IArray[Char]())
       .assert(_ == Diff())
 
-      test(t"One element, equal"):
+      test(m"One element, equal"):
         diff(IArray('a'), IArray('a'))
       .assert(_ == Diff(Par(0, 0, 'a')))
 
-      test(t"Straight swap"):
+      test(m"Straight swap"):
         diff(IArray('a'), IArray('A'))
       .assert(_ == Diff(Del(0, 'a'), Ins(0, 'A')))
 
-      test(t"Two elements, equal"):
+      test(m"Two elements, equal"):
         diff(IArray('a', 'b'), IArray('a', 'b'))
       .assert(_ == Diff(Par(0, 0, 'a'), Par(1, 1, 'b')))
 
-      test(t"Insertion to empty list"):
+      test(m"Insertion to empty list"):
         diff(IArray[Char](), IArray('a'))
       .assert(_ == Diff(Ins(0, 'a')))
 
-      test(t"Deletion to become empty list"):
+      test(m"Deletion to become empty list"):
         diff(t"a".chars, t"".chars)
       .assert(_ == Diff(Del(0, 'a')))
 
-      test(t"Prefix to short list"):
+      test(m"Prefix to short list"):
         diff(t"BC".chars, t"ABC".chars)
       .assert(_ == Diff(Ins(0, 'A'), Par(0, 1, 'B'), Par(1, 2, 'C')))
 
-      test(t"Suffix to short list"):
+      test(m"Suffix to short list"):
         diff(t"AB".chars, t"ABC".chars)
       .assert(_ == Diff(Par(0, 0, 'A'), Par(1, 1, 'B'), Ins(2, 'C')))
 
-      test(t"Insertion in middle of short list"):
+      test(m"Insertion in middle of short list"):
         diff(t"AC".chars, t"ABC".chars)
       .assert(_ == Diff(Par(0, 0, 'A'), Ins(1, 'B'), Par(1, 2, 'C')))
 
-      test(t"Deletion from middle of short list"):
+      test(m"Deletion from middle of short list"):
         diff(t"ABC".chars, t"AC".chars)
       .assert(_ == Diff(Par(0, 0, 'A'), Del(1, 'B'), Par(2, 1, 'C')))
 
-      test(t"Deletion from start of short list"):
+      test(m"Deletion from start of short list"):
         diff(t"ABC".chars, t"BC".chars).edits.to(List)
       .assert(_ == List(Del(0, 'A'), Par(1, 0, 'B'), Par(2, 1, 'C')))
 
-      test(t"Deletion from end of short list"):
+      test(m"Deletion from end of short list"):
         diff(t"ABC".chars, t"AB".chars)
       .assert(_ == Diff(Par(0, 0, 'A'), Par(1, 1, 'B'), Del(2, 'C')))
 
-      test(t"Multiple inner keeps"):
+      test(m"Multiple inner keeps"):
         diff(t"BCD".chars, t"ABC".chars)
       .assert(_ == Diff(Ins(0, 'A'), Par(0, 1, 'B'), Par(1, 2, 'C'), Del(2, 'D')))
 
-      test(t"Example from blog"):
+      test(m"Example from blog"):
         diff(t"ABCABBA".chars, t"CBABAC".chars).edits.to(List)
       .assert(_ == List(Del(0, 'A'), Del(1, 'B'), Par(2, 0, 'C'), Ins(1, 'B'), Par(3, 2, 'A'),
           Par(4, 3, 'B'), Del(5, 'B'), Par(6, 4, 'A'), Ins(5, 'C')))
 
-      test(t"Reversed example from blog"):
+      test(m"Reversed example from blog"):
         diff(t"CBABAC".chars, t"ABCABBA".chars).edits.to(List)
       .assert(_ == List(Del(0, 'C'), Ins(0, 'A'), Par(1, 1, 'B'), Ins(2, 'C'), Par(2, 3, 'A'),
           Par(3, 4, 'B'), Ins(5, 'B'), Par(4, 6, 'A'), Del(5, 'C')))
 
-      test(t"Item swap"):
+      test(m"Item swap"):
         diff(t"AB".chars, t"BA".chars)
       .assert(_ == Diff(Del(0, 'A'), Par(1, 0, 'B'), Ins(1, 'A')))
 
-      test(t"Item change"):
+      test(m"Item change"):
         diff(t"A".chars, t"C".chars)
       .assert(_ == Diff(Del(0, 'A'), Ins(0, 'C')))
 
-      test(t"Item change between values"):
+      test(m"Item change between values"):
         diff(t"NAN".chars, t"NCN".chars)
       .assert(_ == Diff(Par(0, 0, 'N'), Del(1, 'A'), Ins(1, 'C'), Par(2, 2, 'N')))
 
-      test(t"Item swap between values"):
+      test(m"Item swap between values"):
         diff(t"NABN".chars, t"NBAN".chars)
       .assert(_ == Diff(Par(0, 0, 'N'), Del(1, 'A'), Par(2, 1, 'B'), Ins(2, 'A'), Par(3, 3, 'N')))
 
-      test(t"Item swap interspersed with values"):
+      test(m"Item swap interspersed with values"):
         diff(t"AZB".chars, t"BZA".chars)
       .assert(_ == Diff(Del(0, 'A'), Del(1, 'Z'), Par(2, 0, 'B'), Ins(1, 'Z'), Ins(2, 'A')))
 
-      test(t"real-world example 1"):
+      test(m"real-world example 1"):
         diff(IArray('a', 'b', 'c'), IArray('A', 'b', 'C')).edits.to(List)
       .assert(_ == Diff(Del(0, 'a'), Ins(0, 'A'), Par(1, 1, 'b'), Del(2, 'c'), Ins(2, 'C')).edits.to(List))
 
-      test(t"real-world example 2"):
+      test(m"real-world example 2"):
         diff(IArray(t"A", t"B"), IArray(t"B", t"C", t"D"))
       .assert(_ == Diff(Del(0, t"A"), Par(1, 0, t"B"), Ins(1, t"C"), Ins(2, t"D")))
 
     val start = Vector(t"foo", t"bar", t"baz")
     val end = Vector(t"foo", t"quux", t"bop", t"baz")
 
-    suite(t"Diff parsing tests"):
+    suite(m"Diff parsing tests"):
       val diffStream = Stream(t"2c2,3", t"< bar", t"---", t"> quux", t"> bop")
       val reverseStream = Stream(t"2,3c2", t"< quux", t"< bop", t"---", t"> bar")
 
-      test(t"Parse a simple diff file"):
+      test(m"Parse a simple diff file"):
         Diff.parse(diffStream)
       .assert(_ == Diff(Par(0, 0), Del(1, t"bar"), Ins(1, t"quux"), Ins(2, t"bop")))
 
-      test(t"Apply parsed diff to source to get result"):
+      test(m"Apply parsed diff to source to get result"):
         Diff.parse(diffStream).patch(start)
       .assert(_ == end)
 
-      test(t"Parse reverse diff file"):
+      test(m"Parse reverse diff file"):
         Diff.parse(reverseStream)
       .assert(_ == Diff(Par(0, 0), Del(1, t"quux"), Del(2, t"bop"), Ins(1, t"bar")))
 
-      test(t"Apply parsed diff to source to get result"):
+      test(m"Apply parsed diff to source to get result"):
         Diff.parse(reverseStream).patch(end)
       .assert(_ == start)
 
-    suite(t"Diff serialization tests"):
+    suite(m"Diff serialization tests"):
       val changes = diff(start, end)
       val reverseChanges = diff(end, start)
 
-      test(t"Serialize a trivial diff"):
+      test(m"Serialize a trivial diff"):
         diff(Vector(), Vector(t"a")).serialize.to(List)
       .assert(_ == List(t"0a1", t"> a"))
 
-      test(t"Serialize a trivial deletion diff"):
+      test(m"Serialize a trivial deletion diff"):
         diff(Vector(t"a", t"b", t"c", t"d"), Vector(t"a", t"d")).serialize.to(List)
       .assert(_ == List(t"2,3d1", t"< b", t"< c"))
 
-      test(t"Serialize another trivial diff"):
+      test(m"Serialize another trivial diff"):
         diff(Vector(t"a"), Vector()).serialize.to(List)
       .assert(_ == List(t"1d0", t"< a"))
 
-      test(t"Serialize a simple diff"):
+      test(m"Serialize a simple diff"):
         changes.serialize.to(List)
       .assert(_ == List(t"2c2,3", t"< bar", t"---", t"> quux", t"> bop"))
 
-      test(t"Serialize the reverse diff"):
+      test(m"Serialize the reverse diff"):
         reverseChanges.serialize.to(List)
       .assert(_ == List(t"2,3c2", t"< quux", t"< bop", t"---", t"> bar"))
 
-      test(t"Experimental diff"):
+      test(m"Experimental diff"):
         diff(Vector(t"one"), Vector(t"two")).serialize.to(List)
       .assert(_ == List(t"1c1", t"< one", t"---", t"> two"))
 
-      test(t"Experimental diff 2"):
+      test(m"Experimental diff 2"):
         diff(Vector(t"zero", t"one"), Vector(t"two")).serialize.to(List)
       .assert(_ == List(t"1,2c1", t"< zero", t"< one", t"---", t"> two"))
 
-      test(t"Experimental diff 3"):
+      test(m"Experimental diff 3"):
         diff(Vector(t"zero", t"one"), Vector(t"zero", t"two")).serialize.to(List)
       .assert(_ == List(t"2c2", t"< one", t"---", t"> two"))
 
     val italian = Vector(t"zero", t"uno", t"due", t"tre", t"quattro", t"cinque", t"sei", t"sette")
     val spanish = Vector(t"cero", t"uno", t"dos", t"tres", t"cuatro", t"cinco", t"seis", t"siete")
 
-    suite(t"Rdiff tests"):
-      val italianToSpanish = test(t"Do a normal diff on Italian/Spanish numbers"):
+    suite(m"Rdiff tests"):
+      val italianToSpanish = test(m"Do a normal diff on Italian/Spanish numbers"):
         diff(italian, spanish)
       .check(_ == Diff(Del(0, t"zero"), Ins(0, t"cero"), Par(1,1, t"uno"), Del(2, t"due"),
           Del(3, t"tre"), Del(4, t"quattro"), Del(5, t"cinque"), Del(6, t"sei"), Del(7, t"sette"),
           Ins(2, t"dos"), Ins(3, t"tres"), Ins(4, t"cuatro"), Ins(5, t"cinco"), Ins(6, t"seis"),
           Ins(7, t"siete")))
 
-      test(t"Align on Levenshtein distance < 4"):
+      test(m"Align on Levenshtein distance < 4"):
         italianToSpanish.rdiff(_.proximity(_) < 4)
       .assert(_ == RDiff(Sub(0, 0, t"zero", t"cero"), Par(1, 1, t"uno"), Sub(2, 2, t"due", t"dos"),
           Sub(3, 3, t"tre", t"tres"), Sub(4, 4, t"quattro", t"cuatro"),
           Sub(5, 5, t"cinque", t"cinco"), Sub(6, 6, t"sei", t"seis"),
           Sub(7, 7, t"sette", t"siete")))
 
-      test(t"Align on Levenshtein distance < 3"):
+      test(m"Align on Levenshtein distance < 3"):
         italianToSpanish.rdiff(_.proximity(_) < 3)
       .assert(_ == RDiff(Sub(0, 0, t"zero", t"cero"), Par(1, 1, t"uno"), Sub(2, 2, t"due", t"dos"),
           Sub(3, 3, t"tre", t"tres"), Sub(4, 4, t"quattro", t"cuatro"), Del(5, t"cinque"),
           Ins(5, t"cinco"), Sub(6, 6, t"sei", t"seis"), Sub(7, 7, t"sette", t"siete")))
 
-      test(t"Align on Levenshtein distance < 2"):
+      test(m"Align on Levenshtein distance < 2"):
         italianToSpanish.rdiff(_.proximity(_) < 2)
       .assert(_ == RDiff(Sub(0, 0, t"zero", t"cero"), Par(1, 1, t"uno"), Del(2, t"due"),
           Ins(2, t"dos"), Sub(3, 3, t"tre", t"tres"), Del(4, t"quattro"), Del(5, t"cinque"),
           Ins(4, t"cuatro"), Ins(5, t"cinco"), Sub(6, 6, t"sei", t"seis"),
           Del(7, t"sette"), Ins(7, t"siete")))
 
-    // suite(t"Casual diff tests"):
-    //   test(t"Parse a simple casual diff"):
+    // suite(m"Casual diff tests"):
+    //   test(m"Parse a simple casual diff"):
     //     import unsafeExceptions.canThrowAny
     //     CasualDiff.parse(t"- remove\n+ insert".cut(t"\n").to(Stream))
     //   .assert(_ == CasualDiff(List(Replace(Nil, List(t"remove"), List(t"insert")))))
 
-    //   test(t"Parse a slightly longer casual diff"):
+    //   test(m"Parse a slightly longer casual diff"):
     //     import unsafeExceptions.canThrowAny
     //     CasualDiff.parse(t"- remove\n+ insert\n- removal".cut(t"\n").to(Stream))
     //   .assert(_ == CasualDiff(List(Replace(Nil, List(t"remove"), List(t"insert")), Replace(Nil, List(t"removal"), Nil))))
 
-    //   test(t"Parse a longer casual diff"):
+    //   test(m"Parse a longer casual diff"):
     //     import unsafeExceptions.canThrowAny
     //     CasualDiff.parse(t"- remove 1\n- remove 2\n+ insert 1\n+ insert 2\n- removal".cut(t"\n").to(Stream))
     //   .assert(_ == CasualDiff(List(Replace(Nil, List(t"remove 1", t"remove 2"), List(t"insert 1", t"insert 2")), Replace(Nil, List(t"removal"), Nil))))
 
-    //   test(t"Fail to parse a problematic casual diff"):
+    //   test(m"Fail to parse a problematic casual diff"):
     //     import unsafeExceptions.canThrowAny
     //     capture[CasualDiffError](CasualDiff.parse(t"- remove 1\n- remove 2\n insert 1\n+ insert 2\n- removal".cut(t"\n").to(Stream)))
     //   .assert(_ == CasualDiffError(CasualDiffError.Reason.BadLineStart(t" insert 1"), 3))
 
-    // suite(t"Invariance tests"):
+    // suite(m"Invariance tests"):
     //   val values = List(t"alpha", t"beta", t"gamma")
 
     //   def permutations(n: Int): List[List[Text]] =
@@ -266,6 +266,6 @@ object Tests extends Suite(t"Dissonance tests"):
     //     allPermutations(3).map(_.to(Vector)).each: perm2 =>
     //       import unsafeExceptions.canThrowAny
     //       val d = diff(perm1, perm2).casual
-    //       test(t"Check differences"):
+    //       test(m"Check differences"):
     //         d.patch(perm1).to(Vector)
     //       .assert(_ == perm2)

--- a/lib/distillate/src/test/distillate.Tests.scala
+++ b/lib/distillate/src/test/distillate.Tests.scala
@@ -34,15 +34,15 @@ package distillate
 
 import soundness.*
 
-object Tests extends Suite(t"Distillate Tests"):
+object Tests extends Suite(m"Distillate Tests"):
   def run(): Unit =
-    test(t"Extract an int"):
+    test(m"Extract an int"):
       t"123" match
         case As[Int](n) => n
         case _ => 0
     . assert(_ == 123)
 
-    test(t"Extract three ints from inside a regex"):
+    test(m"Extract three ints from inside a regex"):
       t"12:13:14" match
         case r"${As[Int](first)}(\d+):${As[Int](second)}(\d+):${As[Int](third)}(\d+)" =>
           List(first, second, third)
@@ -50,7 +50,7 @@ object Tests extends Suite(t"Distillate Tests"):
           List(0, 0, 0)
     . assert(_ == List(12, 13, 14))
 
-    test(t"Extract three listed ints"):
+    test(m"Extract three listed ints"):
       List(t"12", t"13", t"14") match
         case As[Int](first) :: As[Int](second) :: As[Int](third) :: Nil =>
           (first, second, third)
@@ -58,14 +58,14 @@ object Tests extends Suite(t"Distillate Tests"):
           (0, 0, 0)
     . assert(_ == (12, 13, 14))
 
-    test(t"Extract an email address"):
+    test(m"Extract an email address"):
       t"foo@bar.com" match
         case As[EmailAddress](email) => email
         case _                       => email"something@else.com"
 
     . assert(_ == email"foo@bar.com")
 
-    test(t"Do not extract an invalid email address"):
+    test(m"Do not extract an invalid email address"):
       t"foobar.com" match
         case As[EmailAddress](email) => email
         case _                       => email"something@else.com"

--- a/lib/diuretic/src/test/diuretic.Tests.scala
+++ b/lib/diuretic/src/test/diuretic.Tests.scala
@@ -35,6 +35,6 @@ package diuretic
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Diuretic Tests"):
+object Tests extends Suite(m"Diuretic Tests"):
   def run(): Unit =
     ()

--- a/lib/enigmatic/src/test/enigmatic.Tests.scala
+++ b/lib/enigmatic/src/test/enigmatic.Tests.scala
@@ -44,7 +44,7 @@ import spectacular.*
 
 import alphabets.hex.upperCase
 
-object Tests extends Suite(t"Gastronomy tests"):
+object Tests extends Suite(m"Gastronomy tests"):
 
   val request: Text = t"""
     |-----BEGIN CERTIFICATE REQUEST-----
@@ -65,36 +65,36 @@ object Tests extends Suite(t"Gastronomy tests"):
   val pangram: Text = t"The quick brown fox jumps over the lazy dog"
 
   def run(): Unit =
-    test(t"Sha256, Hex"):
+    test(m"Sha256, Hex"):
       t"Hello world".digest[Sha2[256]].serialize[Hex]
     .assert(_ == t"64EC88CA00B268E5BA1A35678A1B5316D212F4F366B2477232534A8AECA37F3C")
 
-    test(t"Md5, Base64"):
+    test(m"Md5, Base64"):
       import alphabets.base64.standard
       t"Hello world".digest[Md5].serialize[Base64]
     .assert(_ == t"PiWWCnnbxptnTNTsZ6csYg==")
 
-    test(t"Sha1, Base64Url"):
+    test(m"Sha1, Base64Url"):
       import alphabets.base64.url
       println(t"Hello world".digest[Sha1].serialize[Base64])
       t"Hello world".digest[Sha1].bytes.serialize[Base64]
     .assert(_ == t"e1AsOh9IyGCa4hLN-2Od7jlnP14")
 
-    test(t"Sha384, Base64"):
+    test(m"Sha384, Base64"):
       import alphabets.base64.standard
       t"Hello world".digest[Sha2[384]].serialize[Base64]
     .assert(_ == t"kgOwxEOf0eauWHiGYze3xTKs1tkmAVDIAxjoq4wnzjMBifjflPuJDfHSmP82Bifh")
 
-    test(t"Sha512, Base64"):
+    test(m"Sha512, Base64"):
       import alphabets.base64.standard
       t"Hello world".digest[Sha2[512]].serialize[Base64]
     .assert(_ == t"t/eDuu2Cl/DbkXRiGE/08I5pwtXl95qUJgD5cl9Yzh8pwYE5v4CwbA//K900c4RS7PQMSIwip+PYDN9vnBwNRw==")
 
-    test(t"Encode to Binary"):
+    test(m"Encode to Binary"):
       IArray[Byte](1, 2, 3, 4).serialize[Binary]
     .assert(_ == t"00000001000000100000001100000100")
 
-    test(t"Extract PEM message type"):
+    test(m"Extract PEM message type"):
       val example = t"""
         |-----BEGIN EXAMPLE-----
         |MIIB9TCCAWACAQAwgbgxGTAXBgNVBAoMEFF1b1ZhZGlzIExpbWl0ZWQxHDAaBgNV
@@ -105,59 +105,59 @@ object Tests extends Suite(t"Gastronomy tests"):
       Pem.parse(example).label
     .assert(_ == PemLabel.Proprietary(t"EXAMPLE"))
 
-    test(t"Decode PEM certificate"):
+    test(m"Decode PEM certificate"):
       import alphabets.base64.standard
       Pem.parse(request).data.digest[Md5].serialize[Base64]
     .assert(_ == t"iMwRdyDFStqq08vqjPbzYw==")
 
-    test(t"PEM roundtrip"):
+    test(m"PEM roundtrip"):
       Pem.parse(request).serialize
     .assert(_ == request.trim)
 
-    test(t"RSA roundtrip"):
+    test(m"RSA roundtrip"):
       val privateKey: PrivateKey[Rsa[1024]] = PrivateKey.generate[Rsa[1024]]()
       val message: Bytes = privateKey.public.encrypt(t"Hello world")
       privateKey.decrypt[Text](message)
     .assert(_ == t"Hello world")
 
-    test(t"AES roundtrip"):
+    test(m"AES roundtrip"):
       val key: SymmetricKey[Aes[256]] = SymmetricKey.generate[Aes[256]]()
       val message = key.encrypt(t"Hello world")
       key.decrypt[Text](message)
     .assert(_ == t"Hello world")
 
-    test(t"Sign some data with DSA"):
+    test(m"Sign some data with DSA"):
       val privateKey: PrivateKey[Dsa[1024]] = PrivateKey.generate[Dsa[1024]]()
       val message = t"Hello world"
       val signature = privateKey.sign(message)
       privateKey.public.verify(message, signature)
     .assert(identity)
 
-    test(t"Check bad signature"):
+    test(m"Check bad signature"):
       val privateKey: PrivateKey[Dsa[1024]] = PrivateKey.generate[Dsa[1024]]()
       val message = t"Hello world"
       val signature = privateKey.sign(t"Something else")
       privateKey.public.verify(message, signature)
     .assert(!identity(_))
 
-    test(t"MD5 HMAC"):
+    test(m"MD5 HMAC"):
       pangram.hmac[Md5](t"key".bytes).serialize[Hex]
     .check(_ == t"80070713463E7749B90C2DC24911E275")
 
-    test(t"SHA1 HMAC"):
+    test(m"SHA1 HMAC"):
       pangram.hmac[Sha1](t"key".bytes).serialize[Hex]
     .assert(_ == t"DE7C9B85B8B78AA6BC8A7A36F70A90701C9DB4D9")
 
-    test(t"SHA256 HMAC"):
+    test(m"SHA256 HMAC"):
       pangram.hmac[Sha2[256]](t"key".bytes).serialize[Hex]
     .assert(_ == t"F7BC83F430538424B13298E6AA6FB143EF4D59A14946175997479DBC2D1A3CD8")
 
-    test(t"SHA384 HMAC"):
+    test(m"SHA384 HMAC"):
       import alphabets.base64.standard
       pangram.hmac[Sha2[384]](t"key".bytes).serialize[Base64]
     .assert(_ == t"1/RyfiwLOa4PHkDMlvYCQtW3gBhBzqb8WSxdPhrlBwBYKpbPNeHlVJlf5OAzgcI3")
 
-    test(t"SHA512 HMAC"):
+    test(m"SHA512 HMAC"):
       import alphabets.base64.standard
       pangram.hmac[Sha2[512]](t"key".bytes).serialize[Base64]
     .assert(_ == t"tCrwkFe6weLUFwjkipAuCbX/fxKrQopP6GZTxz3SSPuC+UilSfe3kaW0GRXuTR7Dk1NX5OIxclDQNyr6Lr7rOg==")

--- a/lib/escapade/src/test/escapade.Tests.scala
+++ b/lib/escapade/src/test/escapade.Tests.scala
@@ -43,98 +43,98 @@ import yossarian.*
 
 import escapes.*
 
-object Tests extends Suite(t"Escapade tests"):
+object Tests extends Suite(m"Escapade tests"):
   def run(): Unit =
-    suite(t"Rendering tests"):
-      test(t"normal string"):
+    suite(m"Rendering tests"):
+      test(m"normal string"):
         e"hello world".render
       .assert(_ == t"hello world")
 
-      test(t"simple string substitution"):
+      test(m"simple string substitution"):
         e"hello ${"world"}".render
       .assert(_ == t"hello world")
 
-      test(t"bold text"):
+      test(m"bold text"):
         e"$Bold{bold} text".render
       .assert(_ == t"\e[1mbold\e[22m text")
 
-      test(t"italic text"):
+      test(m"italic text"):
         e"$Italic{italic} text".render
       .assert(_ == t"\e[3mitalic\e[23m text")
 
-      test(t"24-bit colored text"):
+      test(m"24-bit colored text"):
         e"${iridescence.colors.Tan}[text]".render
       .assert(_ == t"\e[38;2;210;180;139mtext\e[39m")
 
-      test(t"non-escape insertion should not parse brackets"):
+      test(m"non-escape insertion should not parse brackets"):
         val notAnEscape = 42
         e"${notAnEscape}[text]".render
       .assert(_ == t"42[text]")
 
-    suite(t"Escaping tests"):
-      test(t"an escaped tab is a tab"):
+    suite(m"Escaping tests"):
+      test(m"an escaped tab is a tab"):
         e"|\t|".plain
       .assert(_.length == 3)
 
-      test(t"a unicode value is converted"):
+      test(m"a unicode value is converted"):
         e"|\u0040|".plain
       .assert(_ == t"|@|")
 
-      test(t"a newline is converted correctly"):
+      test(m"a newline is converted correctly"):
         e"\n".plain
       .assert(_ == t"\n")
 
-    suite(t"Screenbuffer tests"):
+    suite(m"Screenbuffer tests"):
       import strategies.throwUnsafely
       val pty = Pty(80, 1)
       val boldSample = pty.consume(e"This text is $Bold(bold).".render).buffer
       val boldItalicSample = pty.consume(e"start$Bold(bold$Italic(bold-italic)unitalic)end".render).buffer
       val boldItalicSample2 = pty.consume(e"start$Bold($Italic(bold-italic))end".render).buffer
 
-      test(t"bold text is bold"):
+      test(m"bold text is bold"):
         boldSample.find(t"bold").vouch.styles
       .assert(_.all(_.bold))
 
-      test(t"text before bold text is not bold"):
+      test(m"text before bold text is not bold"):
         boldSample.find(t"This text is ").vouch.styles
       .assert(_.all(!_.bold))
 
-      test(t"text after bold text is not bold"):
+      test(m"text after bold text is not bold"):
         boldSample.find(t".").vouch.styles
       .assert(_.all(!_.bold))
 
-      test(t"nested bold/italic is both"):
+      test(m"nested bold/italic is both"):
         boldItalicSample.find(t"bold-italic").vouch.styles
       .assert(_.bi.all(_.bold && _.italic))
 
-      test(t"nested italic is removed but not bold"):
+      test(m"nested italic is removed but not bold"):
         boldItalicSample.find(t"unitalic").vouch.styles
       .assert(_.bi.all(_.bold && !_.italic))
 
-      test(t"nested non-bold, non-italic text is neither"):
+      test(m"nested non-bold, non-italic text is neither"):
         boldItalicSample.find(t"end").vouch.styles
       .assert(_.bi.all(!_.bold && !_.italic))
 
-      test(t"nested non-bold, non-italic text is neither"):
+      test(m"nested non-bold, non-italic text is neither"):
         boldItalicSample.find(t"end").vouch.styles
       .assert(_.bi.all(!_.bold && !_.italic))
 
-      test(t"nested bold/italic (without intermediate characters) is both"):
+      test(m"nested bold/italic (without intermediate characters) is both"):
         boldItalicSample2.find(t"bold-italic").vouch.styles
       .assert(_.bi.all(_.bold && _.italic))
 
-      test(t"normal text following doubly-nested text (without intermediate characters) is normal"):
+      test(m"normal text following doubly-nested text (without intermediate characters) is normal"):
         boldItalicSample2.find(t"end").vouch.styles
       .assert(_.all(_ == Style()))
 
-      test(t"double color change uses latter"):
+      test(m"double color change uses latter"):
         pty.consume(e"$Red($Yellow(yellow))".render).buffer.find(t"yellow").vouch.styles
       .assert(_.all(_.foreground == Yellow))
 
-      test(t"double color change and removal of nested uses former"):
+      test(m"double color change and removal of nested uses former"):
         pty.consume(e"$Red($Yellow(yellow)red)".render).buffer.find(t"red").vouch.styles
       .assert(_.all(_.foreground == Red))
 
-      test(t"double color change and removal uses default"):
+      test(m"double color change and removal uses default"):
         pty.consume(e"$Red($Yellow(yellow)red)default".render).buffer.find(t"default").vouch.styles
       .assert(_.all(_.foreground == Rgb24(255, 255, 255)))

--- a/lib/escritoire/src/test/escritoire.Tests.scala
+++ b/lib/escritoire/src/test/escritoire.Tests.scala
@@ -38,52 +38,52 @@ import probably.*
 
 import textMetrics.uniform
 
-object Tests extends Suite(t"Escritoire tests"):
+object Tests extends Suite(m"Escritoire tests"):
   def run(): Unit =
-    test(t"Constrain to full width plus one is single line"):
+    test(m"Constrain to full width plus one is single line"):
       Column.constrain(t"the quick brown fox", Breaks.Space, 20).left
     .assert(_ == 1)
 
-    test(t"Constrain to full width is still single line"):
+    test(m"Constrain to full width is still single line"):
       Column.constrain(t"the quick brown fox", Breaks.Space, 19).left
     .assert(_ == 1)
 
-    test(t"Constrain to narrow column is two lines"):
+    test(m"Constrain to narrow column is two lines"):
       Column.constrain(t"the quick brown fox", Breaks.Space, 18).left
     .assert(_ == 2)
 
-    test(t"Constrain to narrow column suggests better max"):
+    test(m"Constrain to narrow column suggests better max"):
       Column.constrain(t"the quick brown fox", Breaks.Space, 18).right
     .assert(_ == 15)
 
-    test(t"Constrain to very narrow column needs three lines"):
+    test(m"Constrain to very narrow column needs three lines"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 10).left
     .assert(_ == 3)
 
-    test(t"Constrain to very narrow column can shrink slightly further"):
+    test(m"Constrain to very narrow column can shrink slightly further"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 10).right
     .assert(_ == 9)
 
-    test(t"Constrain to narrowest column cannot do better"):
+    test(m"Constrain to narrowest column cannot do better"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 5).right
     .assert(_ == 5)
 
-    test(t"Constrain to narrowest column needs four lines"):
+    test(m"Constrain to narrowest column needs four lines"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 5).left
     .assert(_ == 4)
 
-    test(t"Slightly wider column does not help"):
+    test(m"Slightly wider column does not help"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 6).left
     .assert(_ == 4)
 
-    test(t"Even wider column does not help"):
+    test(m"Even wider column does not help"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 8).left
     .assert(_ == 4)
 
-    test(t"Even wider column does not help and suggests max"):
+    test(m"Even wider column does not help and suggests max"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 8).right
     .assert(_ == 5)
 
-    test(t"Even wider column still does help"):
+    test(m"Even wider column still does help"):
       Column.constrain(t"the quick brown foxes", Breaks.Space, 9).left
     .assert(_ == 3)

--- a/lib/ethereal/src/test/ethereal.Tests.scala
+++ b/lib/ethereal/src/test/ethereal.Tests.scala
@@ -35,6 +35,6 @@ package ethereal
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Ethereal Tests"):
+object Tests extends Suite(m"Ethereal Tests"):
   def run(): Unit =
     ()

--- a/lib/eucalyptus/src/test/eucalyptus.Tests.scala
+++ b/lib/eucalyptus/src/test/eucalyptus.Tests.scala
@@ -42,7 +42,7 @@ import probably.*
 import spectacular.*
 import turbulence.*, stdioSources.virtualMachine
 
-object Tests extends Suite(t"Eucalyptus tests"):
+object Tests extends Suite(m"Eucalyptus tests"):
   def run(): Unit =
     import Level.*
     given LogFormat[Out.type, Display] = logFormats.standardColor[Out.type]
@@ -54,7 +54,7 @@ object Tests extends Suite(t"Eucalyptus tests"):
         case Fail() => Out
         case _      => Out//Syslog(t"tab")
 
-      test(t"Log something"):
+      test(m"Log something"):
         given realm: Realm = realm"test"
         Log.fine(t"Fine message")
         Log.info(t"Info message")

--- a/lib/exoskeleton/src/test/exoskeleton.Tests.scala
+++ b/lib/exoskeleton/src/test/exoskeleton.Tests.scala
@@ -37,6 +37,6 @@ import probably.*
 
 import unsafeExceptions.canThrowAny
 
-object Tests extends Suite(t"Exoskeleton Tests"):
+object Tests extends Suite(m"Exoskeleton Tests"):
   def run(): Unit =
     ()

--- a/lib/feudalism/src/test/feudalism.Tests.scala
+++ b/lib/feudalism/src/test/feudalism.Tests.scala
@@ -37,9 +37,9 @@ import probably.*
 
 import language.experimental.captureChecking
 
-object Tests extends Suite(t"Feudalism tests"):
+object Tests extends Suite(m"Feudalism tests"):
   def run(): Unit =
-    test(t"read mutex"):
+    test(m"read mutex"):
       val mutex = Mutex[String]("Hello")
 
       val result = mutex.read: ref =>

--- a/lib/fulminate/src/test/fulminate.Tests.scala
+++ b/lib/fulminate/src/test/fulminate.Tests.scala
@@ -35,6 +35,6 @@ package fulminate
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Fulminate Tests"):
+object Tests extends Suite(m"Fulminate Tests"):
   def run(): Unit =
     ()

--- a/lib/gastronomy/src/test/gastronomy.Tests.scala
+++ b/lib/gastronomy/src/test/gastronomy.Tests.scala
@@ -43,7 +43,7 @@ import spectacular.*
 
 import alphabets.hex.upperCase
 
-object Tests extends Suite(t"Gastronomy tests"):
+object Tests extends Suite(m"Gastronomy tests"):
 
   val request: Text = t"""
     |-----BEGIN CERTIFICATE REQUEST-----
@@ -64,31 +64,31 @@ object Tests extends Suite(t"Gastronomy tests"):
   val pangram: Text = t"The quick brown fox jumps over the lazy dog"
 
   def run(): Unit =
-    test(t"Sha256, Hex"):
+    test(m"Sha256, Hex"):
       t"Hello world".digest[Sha2[256]].serialize[Hex]
     .assert(_ == t"64EC88CA00B268E5BA1A35678A1B5316D212F4F366B2477232534A8AECA37F3C")
 
-    test(t"Md5, Base64"):
+    test(m"Md5, Base64"):
       import alphabets.base64.standard
       t"Hello world".digest[Md5].serialize[Base64]
     .assert(_ == t"PiWWCnnbxptnTNTsZ6csYg==")
 
-    test(t"Sha1, Base64Url"):
+    test(m"Sha1, Base64Url"):
       import alphabets.base64.url
       println(t"Hello world".digest[Sha1].serialize[Base64])
       t"Hello world".digest[Sha1].bytes.serialize[Base64]
     .assert(_ == t"e1AsOh9IyGCa4hLN-2Od7jlnP14")
 
-    test(t"Sha384, Base64"):
+    test(m"Sha384, Base64"):
       import alphabets.base64.standard
       t"Hello world".digest[Sha2[384]].serialize[Base64]
     .assert(_ == t"kgOwxEOf0eauWHiGYze3xTKs1tkmAVDIAxjoq4wnzjMBifjflPuJDfHSmP82Bifh")
 
-    test(t"Sha512, Base64"):
+    test(m"Sha512, Base64"):
       import alphabets.base64.standard
       t"Hello world".digest[Sha2[512]].serialize[Base64]
     .assert(_ == t"t/eDuu2Cl/DbkXRiGE/08I5pwtXl95qUJgD5cl9Yzh8pwYE5v4CwbA//K900c4RS7PQMSIwip+PYDN9vnBwNRw==")
 
-    test(t"Encode to Binary"):
+    test(m"Encode to Binary"):
       IArray[Byte](1, 2, 3, 4).serialize[Binary]
     .assert(_ == t"00000001000000100000001100000100")

--- a/lib/geodesy/src/test/geodesy.Tests.scala
+++ b/lib/geodesy/src/test/geodesy.Tests.scala
@@ -36,33 +36,33 @@ import soundness.*
 
 import strategies.throwUnsafely
 
-object Tests extends Suite(t"Geodesy tests"):
+object Tests extends Suite(m"Geodesy tests"):
   def run(): Unit =
-    test(t"render a simple angle"):
+    test(m"render a simple angle"):
       val angle = Angle.degrees(45)
       angle.show
 
     . assert(_ == t"45.0°")
 
-    test(t"render an angle to 1 decimal place"):
+    test(m"render an angle to 1 decimal place"):
       val angle = Angle.degrees(7.25)
       angle.show
 
     . assert(_ == t"7.3°")
 
-    test(t"render zero degrees"):
+    test(m"render zero degrees"):
       val angle = Angle.degrees(0)
       angle.show
 
     . assert(_ == t"0.0°")
 
-    test(t"render principal angle"):
+    test(m"render principal angle"):
       val angle = Angle.degrees(375)
       angle.principal.show
 
     . assert(_ == t"15.0°")
 
-    test(t"render canonical angle"):
+    test(m"render canonical angle"):
       val angle = Angle.degrees(355)
       angle.canonical.show
 

--- a/lib/gossamer/src/bench/gossamer.Benchmarks.scala
+++ b/lib/gossamer/src/bench/gossamer.Benchmarks.scala
@@ -38,17 +38,17 @@ import probably.*
 case class Group(persons: List[Person])
 case class Person(name: String, age: Int)
 
-object Benchmarks extends Suite(t"Gossamer Benchmarks"):
+object Benchmarks extends Suite(m"Gossamer Benchmarks"):
   def run(): Unit =
-    suite(t"Compile performance"):
-      test(t"Resolve a Show instance"):
+    suite(m"Compile performance"):
+      test(m"Resolve a Show instance"):
         deferCompilation:
           import gossamer.*
           Group(List(Person("Jack", 30))).show
 
       . benchmark(warmup = 30000L, duration = 30000L)
 
-      test(t"Resolve a Debug instance"):
+      test(m"Resolve a Debug instance"):
         deferCompilation:
           import gossamer.*
           Group(List(Person("Jack", 30))).inspect

--- a/lib/gossamer/src/test/gossamer.Tests.scala
+++ b/lib/gossamer/src/test/gossamer.Tests.scala
@@ -38,123 +38,123 @@ import textMetrics.uniform
 
 case class Person(name: Text, age: Int)
 
-object Tests extends Suite(t"Gossamer Tests"):
+object Tests extends Suite(m"Gossamer Tests"):
   def run(): Unit =
-    suite(t"Minimum Edit Distance"):
+    suite(m"Minimum Edit Distance"):
       import proximityMeasures.levenshteinDistance
 
-      test(t"equal strings have zero edit distance"):
+      test(m"equal strings have zero edit distance"):
         t"Hello world".proximity(t"Hello world")
 
       . assert(_ == 0)
 
-      test(t"missing character has edit distance of 1"):
+      test(m"missing character has edit distance of 1"):
         t"Hello world".proximity(t"Hello orld")
 
       . assert(_ == 1)
 
-      test(t"missing character from end has edit distance of 1"):
+      test(m"missing character from end has edit distance of 1"):
         t"Hello world".proximity(t"Hello worl")
 
       . assert(_ == 1)
 
-      test(t"missing character from start has edit distance of 1"):
+      test(m"missing character from start has edit distance of 1"):
         t"Hello world".proximity(t"ello world")
 
       . assert(_ == 1)
 
-      test(t"changed character has edit distance of 1"):
+      test(m"changed character has edit distance of 1"):
         t"Hello world".proximity(t"Hellq world")
 
       . assert(_ == 1)
 
-      test(t"switched characters has edit distance of 2"):
+      test(m"switched characters has edit distance of 2"):
         t"Hello world".proximity(t"Hello wrold")
 
       . assert(_ == 2)
 
-      test(t"different strings have large edit distance"):
+      test(m"different strings have large edit distance"):
         t"Hello".proximity(t"world").toLong
 
       . assert(_ == 4)
 
-    suite(t"String functions"):
-      test(t"punycode test"):
+    suite(m"String functions"):
+      test(m"punycode test"):
         t"www.äpfel.com".punycode
 
       . assert(_ == t"www.xn--pfel-koa.com")
 
-      test(t"URL encoding of space"):
+      test(m"URL encoding of space"):
         t"hello world".urlEncode
 
       . assert(_ == t"hello+world")
 
-      test(t"URL encoding of multibyte UTF-8 character"):
+      test(m"URL encoding of multibyte UTF-8 character"):
         t"Café".urlEncode
 
       . assert(_ == t"Caf%C3%A9")
 
-      test(t"URL decoding of UTF-8 string"):
+      test(m"URL decoding of UTF-8 string"):
         t"Na%C3%AFve".urlDecode
 
       . assert(_ == t"Naïve")
 
-      test(t"Lower-case"):
+      test(m"Lower-case"):
         t"InDeCiSiVe".lower
 
       . assert(_ == t"indecisive")
 
-      test(t"Upper-case"):
+      test(m"Upper-case"):
         t"InDeCiSiVe".upper
 
       . assert(_ == t"INDECISIVE")
 
-      test(t"Empty string not populated"):
+      test(m"Empty string not populated"):
         t"".populated
 
       . assert(_ == Unset)
 
-      test(t"Non-empty string populated"):
+      test(m"Non-empty string populated"):
         t"Hello World".populated
 
       . assert(_ == t"Hello World")
 
-    suite(t"Joining strings"):
-      test(t"join with separator"):
+    suite(m"Joining strings"):
+      test(m"join with separator"):
         List(t"one", t"two", t"three").join(t", ")
 
       . assert(_ == t"one, two, three")
 
-      test(t"join with separator; different last"):
+      test(m"join with separator; different last"):
         List(t"one", t"two", t"three", t"four").join(t", ", t" and ")
 
       . assert(_ == t"one, two, three and four")
 
-      test(t"join with separator; different last; two elements"):
+      test(m"join with separator; different last; two elements"):
         List(t"three", t"four").join(t", ", t" and ")
 
       . assert(_ == t"three and four")
 
-      test(t"join with separator, prefix and suffix"):
+      test(m"join with separator, prefix and suffix"):
         List(t"one", t"two").join(t"(", t", ", t")")
 
       . assert(_ == t"(one, two)")
 
-    suite(t"txt interpolator"):
-      test(t"multiline collapses to space-delimited"):
+    suite(m"txt interpolator"):
+      test(m"multiline collapses to space-delimited"):
         txt"""Hello
               world"""
 
       . assert(_ == t"Hello world")
 
-      test(t"double newline becomes single newline"):
+      test(m"double newline becomes single newline"):
         txt"""Hello
 
               world"""
 
       . assert(_ == t"Hello\nworld")
 
-      test(t"paragraphs"):
+      test(m"paragraphs"):
         txt"""Hello
               world
 
@@ -163,690 +163,690 @@ object Tests extends Suite(t"Gossamer Tests"):
 
       . assert(_ == t"Hello world\nBonjour le monde")
 
-    suite(t"Text methods"):
-      test(t"get bytes from text"):
+    suite(m"Text methods"):
+      test(m"get bytes from text"):
         t"hello".sysBytes.to(List)
 
       . assert(_ == List(104, 101, 108, 108, 111))
 
-      test(t"get bytes from empty Text"):
+      test(m"get bytes from empty Text"):
         t"".sysBytes.to(List)
 
       . assert(_.isEmpty)
 
-      test(t"get Text length"):
+      test(m"get Text length"):
         t"hello world".length
 
       . assert(_ == 11)
 
-      test(t"empty Text should not be populated"):
+      test(m"empty Text should not be populated"):
         t"".populated
 
       . assert(_ == Unset)
 
-      test(t"non-empty Text should be populated"):
+      test(m"non-empty Text should be populated"):
         t"Hello".populated
 
       . assert(_ == t"Hello")
 
-      test(t"convert to lower case"):
+      test(m"convert to lower case"):
         t"Hello World".lower
 
       . assert(_ == t"hello world")
 
-      test(t"convert to upper case"):
+      test(m"convert to upper case"):
         t"Hello World".upper
 
       . assert(_ == t"HELLO WORLD")
 
-      test(t"URL encode a space"):
+      test(m"URL encode a space"):
         t" ".urlEncode
 
       . assert(_ == t"+")
 
-      test(t"URL encode a +"):
+      test(m"URL encode a +"):
         t"+".urlEncode
 
       . assert(_ == t"%2B")
 
-      test(t"URL encode an é"):
+      test(m"URL encode an é"):
         t"é".urlEncode
 
       . assert(_ == t"%C3%A9")
 
-      test(t"URL encode a Text"):
+      test(m"URL encode a Text"):
         t"Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu.".urlEncode
 
       . assert(_ == t"Nech%C5%A5+ji%C5%BE+h%C5%99%C3%AD%C5%A1n%C3%A9+saxofony+%C4%8F%C3%A1bl%C5%AF+rozezvu%C4%8D%C3%AD+s%C3%AD%C5%88+%C3%BAd%C4%9Bsn%C3%BDmi+t%C3%B3ny+waltzu%2C+tanga+a+quickstepu.")
 
-      test(t"URL decode a Text"):
+      test(m"URL decode a Text"):
         t"Nech%C5%A5%20ji%C5%BE%20h%C5%99%C3%AD%C5%A1n%C3%A9%20saxofony%20%C4%8F%C3%A1bl%C5%AF%20rozezvu%C4%8D%C3%AD%20s%C3%AD%C5%88%20%C3%BAd%C4%9Bsn%C3%BDmi%20t%C3%B3ny%20waltzu%2C%20tanga%20a%20quickstepu.".urlDecode
 
       . assert(_ == t"Nechť již hříšné saxofony ďáblů rozezvučí síň úděsnými tóny waltzu, tanga a quickstepu.")
 
-      test(t"URL decode a space"):
+      test(m"URL decode a space"):
         t"+".urlDecode
 
       . assert(_ == t" ")
 
-      test(t"URL decode a +"):
+      test(m"URL decode a +"):
         t"%2B".urlDecode
 
       . assert(_ == t"+")
 
-      test(t"drop the first character"):
+      test(m"drop the first character"):
         t"Hello".skip(1)
 
       . assert(_ == t"ello")
 
-      test(t"drop the last character"):
+      test(m"drop the last character"):
         t"Hello".skip(1, Rtl)
 
       . assert(_ == t"Hell")
 
-      test(t"drop more characters than the length of the Text"):
+      test(m"drop more characters than the length of the Text"):
         t"Hello".skip(10)
 
       . assert(_ == t"")
 
-      test(t"drop more characters from the right than the length of the Text"):
+      test(m"drop more characters from the right than the length of the Text"):
         t"Hello".skip(10, Rtl)
 
       . assert(_ == t"")
 
-      test(t"take the first character"):
+      test(m"take the first character"):
         t"Hello".keep(1)
 
       . assert(_ == t"H")
 
-      test(t"take the last character"):
+      test(m"take the last character"):
         t"Hello".keep(1, Rtl)
 
       . assert(_ == t"o")
 
-      test(t"take more characters than the length of the Text"):
+      test(m"take more characters than the length of the Text"):
         t"Hello".keep(10)
 
       . assert(_ == t"Hello")
 
-      test(t"take more characters from the right than the length of the Text"):
+      test(m"take more characters from the right than the length of the Text"):
         t"Hello".keep(10, Rtl)
 
       . assert(_ == t"Hello")
 
-      test(t"snip a Text in two"):
+      test(m"snip a Text in two"):
         t"Hello".snip(2): (Text, Text)
 
       . assert(_ == (t"He", t"llo"))
 
-      test(t"trim spaces from a Text"):
+      test(m"trim spaces from a Text"):
         t"  Hello   ".trim
 
       . assert(_ == t"Hello")
 
-      test(t"trim mixed whitespace from a Text"):
+      test(m"trim mixed whitespace from a Text"):
         t"\n\r\t Hello\n \t\r".trim
 
       . assert(_ == t"Hello")
 
-      test(t"take a slice from a Text"):
+      test(m"take a slice from a Text"):
         t"Hello world".segment(Quin ~ Sept)
 
       . assert(_ == t"o w")
 
-      test(t"take an oversized slice from a Text"):
+      test(m"take an oversized slice from a Text"):
         t"Hello world".segment(Quin ~ Ordinal.zerary(100))
 
       . assert(_ == t"o world")
 
-      test(t"Get characters from a Text"):
+      test(m"Get characters from a Text"):
         t"Hello world".chars.to(List)
 
       . assert(_ == List('H', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd'))
 
-      test(t"Flatmap a text"):
-        t"ABC".flatMap { c => t"${c}." }
+      test(m"Flatmap a text"):
+        t"ABC".bind { c => t"${c}." }
 
       . assert(_ == t"A.B.C.")
 
-      test(t"Map over a text's characters"):
+      test(m"Map over a text's characters"):
         t"ABC".mapChars { char => char.toLower }
       . assert(_ == t"abc")
 
-      test(t"Check an empty Text is empty"):
+      test(m"Check an empty Text is empty"):
         t"".empty
 
       . assert(_ == true)
 
-      test(t"Check a non-empty Text is not empty"):
+      test(m"Check a non-empty Text is not empty"):
         t"abc".empty
 
       . assert(_ == false)
 
-      test(t"Cut a Text"):
+      test(m"Cut a Text"):
         t"one,two,three".cut(t",").to(List)
 
       . assert(_ == List(t"one", t"two", t"three"))
 
-      test(t"Cut a Text with empty Text at start"):
+      test(m"Cut a Text with empty Text at start"):
         t",one,two".cut(t",").to(List)
 
       . assert(_ == List(t"", t"one", t"two"))
 
-      test(t"Cut a Text with empty Text at end"):
+      test(m"Cut a Text with empty Text at end"):
         t"one,two,".cut(t",").to(List)
 
       . assert(_ == List(t"one", t"two", t""))
 
-      test(t"Cut a Text with empty parts at start and end"):
+      test(m"Cut a Text with empty parts at start and end"):
         t",one,two,".cut(t",").to(List)
 
       . assert(_ == List(t"", t"one", t"two", t""))
 
-      test(t"Cut a series of empty Texts"):
+      test(m"Cut a series of empty Texts"):
         t",,,".cut(t",").to(List)
 
       . assert(_ == List(t"", t"", t"", t""))
 
-      test(t"Cut a Text which doesn't contain the separator"):
+      test(m"Cut a Text which doesn't contain the separator"):
         t"one,two,three".cut(t"x").to(List)
 
       . assert(_ == List(t"one,two,three"))
 
-      test(t"Cut a Text on an escaped character"):
+      test(m"Cut a Text on an escaped character"):
         t"one\ntwo\nthree".cut(t"\n").to(List)
 
       . assert(_ == List(t"one", t"two", t"three"))
 
-      test(t"Substitute characters"):
+      test(m"Substitute characters"):
         t"one,two,three".tr(',', ';')
 
       . assert(_ == t"one;two;three")
 
-      test(t"Replace substring"):
+      test(m"Replace substring"):
         t"naive".sub(t"i", t"ï")
 
       . assert(_ == t"naïve")
 
-      test(t"Replace different-length substring"):
+      test(m"Replace different-length substring"):
         t"Once upon a time".sub(t"Once", t"Twice")
 
       . assert(_ == t"Twice upon a time")
 
-      test(t"Several substitutions"):
+      test(m"Several substitutions"):
         t"foo bar baz".sub(t"ba", t"ma")
 
       . assert(_ == t"foo mar maz")
 
-      test(t"Overlapping substitutions"):
+      test(m"Overlapping substitutions"):
         t"fofofoo".sub(t"fofo", t"momo")
 
       . assert(_ == t"momofoo")
 
-      test(t"Get camel-case words"):
+      test(m"Get camel-case words"):
         t"oneTwoThree".uncamel
 
       . assert(_ == Seq(t"one", "two", "three"))
 
-      test(t"Camel-case to dashed words"):
+      test(m"Camel-case to dashed words"):
         t"oneTwoThree".uncamel.kebab
 
       . assert(_ == t"one-two-three")
 
-      test(t"Fit short text into fixed width"):
+      test(m"Fit short text into fixed width"):
         t"123".fit(5)
 
       . assert(_ == t"123  ")
 
-      test(t"Fit long text into fixed width"):
+      test(m"Fit long text into fixed width"):
         t"12345".fit(3)
 
       . assert(_ == t"123")
 
-      test(t"Right-fit long text into fixed width"):
+      test(m"Right-fit long text into fixed width"):
         t"12345".fit(3, Rtl)
 
       . assert(_ == t"345")
 
-      test(t"Right-fit short text into fixed width"):
+      test(m"Right-fit short text into fixed width"):
         t"123".fit(5, Rtl)
 
       . assert(_ == t"  123")
 
-      test(t"Right-fit short text with different padding character"):
+      test(m"Right-fit short text with different padding character"):
         t"123".fit(5, Rtl, '.')
 
       . assert(_ == t"..123")
 
-      test(t"Fit short text with different padding character"):
+      test(m"Fit short text with different padding character"):
         t"123".fit(5, Ltr, '.')
 
       . assert(_ == t"123..")
 
-      test(t"duplicate text several times"):
+      test(m"duplicate text several times"):
         t"123"*3
 
       . assert(_ == t"123123123")
 
-      test(t"duplicate text zero times"):
+      test(m"duplicate text zero times"):
         t"123"*0
 
       . assert(_ == t"")
 
-      test(t"Random access of character"):
+      test(m"Random access of character"):
         t"123".at(Prim)
 
       . assert(_ == '1')
 
-      // test(t"Random access of out-of-range character"):
+      // test(m"Random access of out-of-range character"):
       //   capture[RangeError](t"123".at(Sen))
       //
       //. assert(_ == RangeError(5, 0, 3))
 
-      test(t"Random access of out-of-range character"):
+      test(m"Random access of out-of-range character"):
         t"123".at(Sen)
 
       . assert(_ == Unset)
 
-      test(t"Pad-right with space"):
+      test(m"Pad-right with space"):
         t"123".pad(5, Rtl)
 
       . assert(_ == t"  123")
 
-      test(t"Pad-left with space"):
+      test(m"Pad-left with space"):
         t"123".pad(5, Ltr)
 
       . assert(_ == t"123  ")
 
-      test(t"Pad-right with smaller value does not change text"):
+      test(m"Pad-right with smaller value does not change text"):
         t"12345".pad(3, Rtl)
 
       . assert(_ == t"12345")
 
-      test(t"Pad-left with smaller value does not change text"):
+      test(m"Pad-left with smaller value does not change text"):
         t"12345".pad(3, Ltr)
 
       . assert(_ == t"12345")
 
-      test(t"Text does contain value"):
+      test(m"Text does contain value"):
         t"hello world".contains(t"ello")
 
       . assert(_ == true)
 
-      test(t"Text does not contain value"):
+      test(m"Text does not contain value"):
         t"hello world".contains(t"goodbye")
 
       . assert(_ == false)
 
-      test(t"Text contains itself"):
+      test(m"Text contains itself"):
         t"hello world".contains(t"hello world")
 
       . assert(_ == true)
 
-      test(t"Text contains empty text"):
+      test(m"Text contains empty text"):
         t"hello world".contains(t"")
 
       . assert(_ == true)
 
-      test(t"Empty text contains empty text"):
+      test(m"Empty text contains empty text"):
         t"".contains(t"")
 
       . assert(_ == true)
 
-      test(t"Index of character satisfying predicate"):
+      test(m"Index of character satisfying predicate"):
         t"oh, Hello World".where(_.isUpper)
 
       . assert(_ == Quin)
 
-      test(t"Index of character satisfying predicate with start point at result index"):
+      test(m"Index of character satisfying predicate with start point at result index"):
         t"oh, Hello World".where(_.isUpper, Quin)
 
       . assert(_ == Quin)
 
-      test(t"Index of character satisfying predicate with start point after first result"):
+      test(m"Index of character satisfying predicate with start point after first result"):
         t"oh, Hello World".where(_.isUpper, Sen)
 
       . assert(_ == Ordinal.zerary(10))
 
-      test(t"Take characters while predicate is true"):
+      test(m"Take characters while predicate is true"):
         t"HELLOworld".whilst(_.isUpper)
 
       . assert(_ == t"HELLO")
 
-      test(t"Take characters when predicate is never true returns empty text"):
+      test(m"Take characters when predicate is never true returns empty text"):
         t"hello world".whilst(_.isUpper)
 
       . assert(_ == t"")
 
-      test(t"Take characters when predicate isn't initially true returns empty text"):
+      test(m"Take characters when predicate isn't initially true returns empty text"):
         t"Helloworld".whilst(_.isLower)
 
       . assert(_ == t"")
 
-      test(t"Capitalize a lowercase word"):
+      test(m"Capitalize a lowercase word"):
         t"hello".capitalize
 
       . assert(_ == t"Hello")
 
-      test(t"Capitalize a mixed-case word"):
+      test(m"Capitalize a mixed-case word"):
         t"fooBar".capitalize
 
       . assert(_ == t"FooBar")
 
-      test(t"Capitalize an uppercase word does not change it"):
+      test(m"Capitalize an uppercase word does not change it"):
         t"HELLO".capitalize
 
       . assert(_ == t"HELLO")
 
-    suite(t"Compile errors"):
-      test(t"Check that Text and String are incompatible"):
+    suite(m"Compile errors"):
+      test(m"Check that Text and String are incompatible"):
         demilitarize:
           val x: String = Text("text")
 
       . assert(!_.isEmpty)
 
-    suite(t"Decimalization tests"):
-      test(t"Write negative pi"):
+    suite(m"Decimalization tests"):
+      test(m"Write negative pi"):
         Decimalizer(1).decimalize(-math.Pi)
 
       . assert(_ == t"-3")
 
-      test(t"Write negative pi to 2 s.f."):
+      test(m"Write negative pi to 2 s.f."):
         Decimalizer(2).decimalize(-math.Pi)
 
       . assert(_ == t"-3.1")
 
-      test(t"Write negative pi to 3 s.f."):
+      test(m"Write negative pi to 3 s.f."):
         Decimalizer(3).decimalize(-math.Pi)
 
       . assert(_ == t"-3.14")
 
-      test(t"Write 1 s.f. pi"):
+      test(m"Write 1 s.f. pi"):
         Decimalizer(1).decimalize(math.Pi)
 
       . assert(_ == t"3")
 
-      test(t"Write 2 s.f. pi"):
+      test(m"Write 2 s.f. pi"):
         Decimalizer(2).decimalize(math.Pi)
 
       . assert(_ == t"3.1")
 
-      test(t"Write 3 s.f. pi"):
+      test(m"Write 3 s.f. pi"):
         Decimalizer(3).decimalize(math.Pi)
 
       . assert(_ == t"3.14")
 
-      test(t"Write 4 s.f. pi"):
+      test(m"Write 4 s.f. pi"):
         Decimalizer(4).decimalize(math.Pi)
 
       . assert(_ == t"3.142")
 
-      test(t"Write 5 s.f. pi"):
+      test(m"Write 5 s.f. pi"):
         Decimalizer(5).decimalize(math.Pi)
 
       . assert(_ == t"3.1416")
 
-      test(t"Write 6 s.f. pi"):
+      test(m"Write 6 s.f. pi"):
         Decimalizer(6).decimalize(math.Pi)
 
       . assert(_ == t"3.14159")
 
-      test(t"Write 7 s.f. pi"):
+      test(m"Write 7 s.f. pi"):
         Decimalizer(7).decimalize(math.Pi)
 
       . assert(_ == t"3.141593")
 
-      test(t"Write 8 s.f. pi"):
+      test(m"Write 8 s.f. pi"):
         Decimalizer(8).decimalize(math.Pi)
 
       . assert(_ == t"3.1415927")
 
-      test(t"Write 1 s.f. 10*pi"):
+      test(m"Write 1 s.f. 10*pi"):
         Decimalizer(1).decimalize(10*math.Pi)
 
       . assert(_ == t"30")
 
-      test(t"Write 2 s.f. 10*pi"):
+      test(m"Write 2 s.f. 10*pi"):
         Decimalizer(2).decimalize(10*math.Pi)
 
       . assert(_ == t"31")
 
-      test(t"Write 3 s.f. 10*pi"):
+      test(m"Write 3 s.f. 10*pi"):
         Decimalizer(3).decimalize(10*math.Pi)
 
       . assert(_ == t"31.4")
 
-      test(t"Write 4 s.f. 10*pi"):
+      test(m"Write 4 s.f. 10*pi"):
         Decimalizer(4).decimalize(10*math.Pi)
 
       . assert(_ == t"31.42")
 
-      test(t"Write 5 s.f. 10*pi"):
+      test(m"Write 5 s.f. 10*pi"):
         Decimalizer(5).decimalize(10*math.Pi)
 
       . assert(_ == t"31.416")
 
-      test(t"Write 6 s.f. 10*pi"):
+      test(m"Write 6 s.f. 10*pi"):
         Decimalizer(6).decimalize(10*math.Pi)
 
       . assert(_ == t"31.4159")
 
-      test(t"Write 7 s.f. 10*pi"):
+      test(m"Write 7 s.f. 10*pi"):
         Decimalizer(7).decimalize(10*math.Pi)
 
       . assert(_ == t"31.41593")
 
-      test(t"Write 8 s.f. 10*pi"):
+      test(m"Write 8 s.f. 10*pi"):
         Decimalizer(8).decimalize(10*math.Pi)
 
       . assert(_ == t"31.415927")
 
-      test(t"Write 1 s.f. 100*pi"):
+      test(m"Write 1 s.f. 100*pi"):
         Decimalizer(1).decimalize(100*math.Pi)
 
       . assert(_ == t"300")
 
-      test(t"Write 2 s.f. 100*pi"):
+      test(m"Write 2 s.f. 100*pi"):
         Decimalizer(2).decimalize(100*math.Pi)
 
       . assert(_ == t"310")
 
-      test(t"Write 3 s.f. 100*pi"):
+      test(m"Write 3 s.f. 100*pi"):
         Decimalizer(3).decimalize(100*math.Pi)
 
       . assert(_ == t"314")
 
-      test(t"Write 4 s.f. 100*pi"):
+      test(m"Write 4 s.f. 100*pi"):
         Decimalizer(4).decimalize(100*math.Pi)
 
       . assert(_ == t"314.2")
 
-      test(t"Write 5 s.f. 100*pi"):
+      test(m"Write 5 s.f. 100*pi"):
         Decimalizer(5).decimalize(100*math.Pi)
 
       . assert(_ == t"314.16")
 
-      test(t"Write 6 s.f. 100*pi"):
+      test(m"Write 6 s.f. 100*pi"):
         Decimalizer(6).decimalize(100*math.Pi)
 
       . assert(_ == t"314.159")
 
-      test(t"Write 7 s.f. 100*pi"):
+      test(m"Write 7 s.f. 100*pi"):
         Decimalizer(7).decimalize(100*math.Pi)
 
       . assert(_ == t"314.1593")
 
-      test(t"Write 8 s.f. 100*pi"):
+      test(m"Write 8 s.f. 100*pi"):
         Decimalizer(8).decimalize(100*math.Pi)
 
       . assert(_ == t"314.15927")
 
-      test(t"Write 1 s.f. pi/10"):
+      test(m"Write 1 s.f. pi/10"):
         Decimalizer(1).decimalize(math.Pi/10)
 
       . assert(_ == t"0.3")
 
-      test(t"Write 2 s.f. pi/10"):
+      test(m"Write 2 s.f. pi/10"):
         Decimalizer(2).decimalize(math.Pi/10)
 
       . assert(_ == t"0.31")
 
-      test(t"Write 3 s.f. pi/10"):
+      test(m"Write 3 s.f. pi/10"):
         Decimalizer(3).decimalize(math.Pi/10)
 
       . assert(_ == t"0.314")
 
-      test(t"Write 4 s.f. pi/10"):
+      test(m"Write 4 s.f. pi/10"):
         Decimalizer(4).decimalize(math.Pi/10)
 
       . assert(_ == t"0.3142")
 
-      test(t"Write 5 s.f. pi/10"):
+      test(m"Write 5 s.f. pi/10"):
         Decimalizer(5).decimalize(math.Pi/10)
 
       . assert(_ == t"0.31416")
 
-      test(t"Write 6 s.f. pi/10"):
+      test(m"Write 6 s.f. pi/10"):
         Decimalizer(6).decimalize(math.Pi/10)
 
       . assert(_ == t"0.314159")
 
-      test(t"Write 7 s.f. pi/10"):
+      test(m"Write 7 s.f. pi/10"):
         Decimalizer(7).decimalize(math.Pi/10)
 
       . assert(_ == t"0.3141593")
 
-      test(t"Write 8 s.f. pi/10"):
+      test(m"Write 8 s.f. pi/10"):
         Decimalizer(8).decimalize(math.Pi/10)
 
       . assert(_ == t"0.31415927")
 
-      test(t"Write 1 s.f. pi/100"):
+      test(m"Write 1 s.f. pi/100"):
         Decimalizer(1).decimalize(math.Pi/100)
 
       . assert(_ == t"0.03")
 
-      test(t"Write 2 s.f. pi/100"):
+      test(m"Write 2 s.f. pi/100"):
         Decimalizer(2).decimalize(math.Pi/100)
 
       . assert(_ == t"0.031")
 
-      test(t"Write 3 s.f. pi/100"):
+      test(m"Write 3 s.f. pi/100"):
         Decimalizer(3).decimalize(math.Pi/100)
 
       . assert(_ == t"0.0314")
 
-      test(t"Write 4 s.f. pi/100"):
+      test(m"Write 4 s.f. pi/100"):
         Decimalizer(4).decimalize(math.Pi/100)
 
       . assert(_ == t"0.03142")
 
-      test(t"Write 5 s.f. pi/100"):
+      test(m"Write 5 s.f. pi/100"):
         Decimalizer(5).decimalize(math.Pi/100)
 
       . assert(_ == t"0.031416")
 
-      test(t"Write 6 s.f. pi/100"):
+      test(m"Write 6 s.f. pi/100"):
         Decimalizer(6).decimalize(math.Pi/100)
 
       . assert(_ == t"0.0314159")
 
-      test(t"Write 7 s.f. pi/100"):
+      test(m"Write 7 s.f. pi/100"):
         Decimalizer(7).decimalize(math.Pi/100)
 
       . assert(_ == t"0.03141593")
 
-      test(t"Write 8 s.f. pi/100"):
+      test(m"Write 8 s.f. pi/100"):
         Decimalizer(8).decimalize(math.Pi/100)
 
       . assert(_ == t"0.031415927")
 
-      test(t"Write 1 s.f. pi/1000"):
+      test(m"Write 1 s.f. pi/1000"):
         Decimalizer(1).decimalize(math.Pi/1000)
 
       . assert(_ == t"3×10¯³")
 
-      test(t"Write 2 s.f. pi/1000"):
+      test(m"Write 2 s.f. pi/1000"):
         Decimalizer(2).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.1×10¯³")
 
-      test(t"Write 3 s.f. pi/1000"):
+      test(m"Write 3 s.f. pi/1000"):
         Decimalizer(3).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.14×10¯³")
 
-      test(t"Write 4 s.f. pi/1000"):
+      test(m"Write 4 s.f. pi/1000"):
         Decimalizer(4).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.142×10¯³")
 
-      test(t"Write 5 s.f. pi/1000"):
+      test(m"Write 5 s.f. pi/1000"):
         Decimalizer(5).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.1416×10¯³")
 
-      test(t"Write 6 s.f. pi/1000"):
+      test(m"Write 6 s.f. pi/1000"):
         Decimalizer(6).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.14159×10¯³")
 
-      test(t"Write 7 s.f. pi/1000"):
+      test(m"Write 7 s.f. pi/1000"):
         Decimalizer(7).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.141593×10¯³")
 
-      test(t"Show Avogadro's number"):
+      test(m"Show Avogadro's number"):
         Decimalizer(5).decimalize(6.0221408e23)
 
       . assert(_ == t"6.0221×10²³")
 
-      test(t"Write 8 s.f. pi/1000"):
+      test(m"Write 8 s.f. pi/1000"):
         Decimalizer(8).decimalize(math.Pi/1000)
 
       . assert(_ == t"3.1415927×10¯³")
 
-      test(t"Show Avogadro's number to 7 s.f."):
+      test(m"Show Avogadro's number to 7 s.f."):
         Decimalizer(7).decimalize(6.0221408e23)
 
       . assert(_ == t"6.022141×10²³")
 
-      test(t"Show Planck's constant to 7 s.f."):
+      test(m"Show Planck's constant to 7 s.f."):
         Decimalizer(7, decimalPoint = '·').decimalize(6.626070e-34)
 
       . assert(_ == t"6·626070×10¯³⁴")
 
-      test(t"Show Avogadro's numer with decimal multiplier"):
+      test(m"Show Avogadro's numer with decimal multiplier"):
         Decimalizer(7, exponentMultiple = 3).decimalize(6.0221408e23)
 
       . assert(_ == t"602.2141×10²¹")
 
-      test(t"Show Planck's constant with decimal multiplier"):
+      test(m"Show Planck's constant with decimal multiplier"):
         Decimalizer(7, decimalPoint = '·', exponentMultiple = 3).decimalize(6.626070e-34)
 
       . assert(_ == t"0·6626070×10¯³³")
 
-      test(t"Show positive infinity"):
+      test(m"Show positive infinity"):
         Decimalizer(7, decimalPoint = '·', exponentMultiple = 3).decimalize(1.0/0.0)
 
       . assert(_ == t"∞")
 
-      test(t"Show negative infinity"):
+      test(m"Show negative infinity"):
         Decimalizer(7, decimalPoint = '·', exponentMultiple = 3).decimalize(-1.0/0.0)
 
       . assert(_ == t"-∞")
 
-      test(t"Show not-a-number"):
+      test(m"Show not-a-number"):
         Decimalizer(7, decimalPoint = '·', exponentMultiple = 3).decimalize(0.0/0.0)
 
       . assert(_ == t"∉ℝ")
 
-      test(t"Show 100.0"):
+      test(m"Show 100.0"):
         Decimalizer(decimalPlaces = 1).decimalize(100.0)
 
       . assert(_ == t"100.0")
 
-      test(t"Show 0.0"):
+      test(m"Show 0.0"):
         Decimalizer(decimalPlaces = 1).decimalize(0.0)
 
       . assert(_ == t"0.0")

--- a/lib/guillotine/src/test/guillotine.Tests.scala
+++ b/lib/guillotine/src/test/guillotine.Tests.scala
@@ -50,219 +50,219 @@ import unsafeExceptions.canThrowAny
 
 given SimpleLogger = logging.silent
 
-object Tests extends Suite(t"Guillotine tests"):
+object Tests extends Suite(m"Guillotine tests"):
   def run(): Unit =
-    suite(t"Parsing tests"):
-      test(t"parse simple command"):
+    suite(m"Parsing tests"):
+      test(m"parse simple command"):
         sh"ls -la"
       .assert(_ == Command(t"ls", t"-la"))
 
-      test(t"parse a substitution"):
+      test(m"parse a substitution"):
         val flags = t"-la"
         val file = t"filename"
         sh"ls $flags"
       .assert(_ == Command(t"ls", t"-la"))
 
-      test(t"parse two substitutions"):
+      test(m"parse two substitutions"):
         val flags = t"-la"
         val file = t"filename"
         sh"ls $flags $file"
       .assert(_ == Command(t"ls", t"-la", t"filename"))
 
-      test(t"parse irregular spacing"):
+      test(m"parse irregular spacing"):
         val flags = t"-la"
         val file = t"filename"
         sh"ls  $flags     $file"
       .assert(_ == Command(t"ls", t"-la", t"filename"))
 
-      test(t"parse irregular spacing 2"):
+      test(m"parse irregular spacing 2"):
         val flags = t"-la"
         val file = t"filename"
         sh"ls  $flags $file"
       .assert(_ == Command(t"ls", t"-la", t"filename"))
 
-      test(t"adjacent substitutions"):
+      test(m"adjacent substitutions"):
         val a = t"a"
         val b = t"b"
         sh"ls $a$b"
       .assert(_ == Command(t"ls", t"ab"))
 
-      test(t"substitute a list"):
+      test(m"substitute a list"):
         val a = List(t"a", t"b")
         sh"ls $a"
       .assert(_ == Command(t"ls", t"a", t"b"))
 
-      test(t"substitute a single-quoted list"):
+      test(m"substitute a single-quoted list"):
         val a = List(t"a", t"b")
         sh"ls '$a'"
       .assert(_ == Command(t"ls", t"a b"))
 
-      test(t"substitute in a double-quoted list"):
+      test(m"substitute in a double-quoted list"):
         val a = List(t"a", t"b")
         sh"""ls "$a""""
       .assert(_ == Command(t"ls", t"a b"))
 
-      test(t"insertion after arg"):
+      test(m"insertion after arg"):
         val a = List(t"a", t"b")
         sh"""ls ${a}x"""
       .assert(_ == Command(t"ls", t"a", t"bx"))
 
-      test(t"insertion before arg"):
+      test(m"insertion before arg"):
         val a = List(t"a", t"b")
         sh"""ls x${a}"""
       .assert(_ == Command(t"ls", t"xa", t"b"))
 
-      test(t"insertion before quoted arg"):
+      test(m"insertion before quoted arg"):
         val a = List(t"a", t"b")
         sh"""ls ${a}'x'"""
       .assert(_ == Command(t"ls", t"a", t"bx"))
 
-      test(t"insertion after quoted arg"):
+      test(m"insertion after quoted arg"):
         val a = List(t"a", t"b")
         sh"""ls 'x'${a}"""
       .assert(_ == Command(t"ls", t"xa", t"b"))
 
-      test(t"empty list insertion"):
+      test(m"empty list insertion"):
         val a = List()
         sh"""ls ${a}"""
       .assert(_ == Command(t"ls"))
 
-      test(t"empty list insertion"):
+      test(m"empty list insertion"):
         val a = List()
         sh"""ls '${a}'"""
       .assert(_ == Command(t"ls", t""))
 
-      test(t"empty parameters"):
+      test(m"empty parameters"):
         sh"""ls '' ''"""
       .assert(_ == Command(t"ls", t"", t""))
 
-      test(t"one empty parameter, specified twice"):
+      test(m"one empty parameter, specified twice"):
         sh"""ls ''''"""
       .assert(_ == Command(t"ls", t""))
 
-      test(t"single quote inside double quotes"):
+      test(m"single quote inside double quotes"):
         sh"""ls "'" """
       .assert(_ == Command(t"ls", t"'"))
 
-      test(t"double quote inside single quotes"):
+      test(m"double quote inside single quotes"):
         sh"""ls '"' """
       .assert(_ == Command(t"ls", t"\""))
 
-      test(t"escaped double quote"):
+      test(m"escaped double quote"):
         sh"""ls \" """
       .assert(_ == Command(t"ls", t"\""))
 
-      test(t"escaped single quote"):
+      test(m"escaped single quote"):
         sh"""ls \' """
       .assert(_ == Command(t"ls", t"'"))
 
-    suite(t"rendering Debug")
-      test(t"simple command"):
+    suite(m"rendering Debug")
+      test(m"simple command"):
         sh"echo Hello World".inspect
       .check(_ == t"""sh"echo Hello World"""")
 
       println(sh"echo 'Hello World'".inspect)
-      test(t"simple command with space"):
+      test(m"simple command with space"):
         sh"echo 'Hello World'".inspect
       .check(_ == t"""sh"echo 'Hello World'"""")
 
-      test(t"simple command with quote and space"):
+      test(m"simple command with quote and space"):
         Command(t"echo", t"Don't stop").inspect
       .check(_ == t"sh\"\"\"echo \"Don't stop\"\"\"\"")
 
-      test(t"simple command with single and double quote"):
+      test(m"simple command with single and double quote"):
         Command(t"echo", t"single ' and double \" quotes").inspect
       .check(_ == t"sh\"\"\"echo \"single ' and double \\\" quotes\"\"\"\"")
 
-      test(t"render pipeline of commands"):
+      test(m"render pipeline of commands"):
         (sh"echo Hello" | sh"sed s/e/a/g").inspect
       .check(_ == t"""sh"echo Hello" | sh"sed s/e/a/g"""")
 
-    suite(t"equality tests"):
-      test(t"check that two commands written differently are equivalent"):
+    suite(m"equality tests"):
+      test(m"check that two commands written differently are equivalent"):
         sh"echo 'hello world'"
       .assert(_ == sh"""echo "hello world"""")
 
-      test(t"check that two commands written with different whitespace are equivalent"):
+      test(m"check that two commands written with different whitespace are equivalent"):
         sh"one two   three"
       .assert(_ == sh"one   two three")
 
-    suite(t"Execution tests"):
+    suite(m"Execution tests"):
 
       given Environment = environments.virtualMachine
 
-      test(t"Echo string"):
+      test(m"Echo string"):
         sh"echo hello".exec[Text]()
       .check(_ == t"hello")
 
-      test(t"substitute string into echo"):
+      test(m"substitute string into echo"):
         val text = t"Hello world!"
         sh"echo $text".exec[Text]()
       .check(_ == t"Hello world!")
 
-      test(t"pipe output through two commands"):
+      test(m"pipe output through two commands"):
         (sh"echo 'Hello world'" | sh"sed s/e/a/g").exec[Text]()
       .check(_ == t"Hallo world")
 
-      test(t"read stream of strings"):
+      test(m"read stream of strings"):
         sh"echo 'Hello world'".exec[Stream[Text]]().to(List)
       .assert(_ == List("Hello world"))
 
-      test(t"read stream of bytes"):
+      test(m"read stream of bytes"):
         sh"echo 'Hello world'".exec[Stream[Bytes]]().read[Bytes].to(List)
       .assert(_ == Bytes(72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 10).to(List))
 
-      test(t"fork sleeping process"):
+      test(m"fork sleeping process"):
         val t0 = System.currentTimeMillis
         sh"sleep 0.2".fork[Unit]()
         System.currentTimeMillis - t0
       .assert(_ <= 100L)
 
-      test(t"exec sleeping process"):
+      test(m"exec sleeping process"):
         val t0 = System.currentTimeMillis
         sh"sleep 0.2".exec[Unit]()
         System.currentTimeMillis - t0
       .assert(_ >= 200L)
 
-      test(t"fork and await sleeping process"):
+      test(m"fork and await sleeping process"):
         val t0 = System.currentTimeMillis
         val proc = sh"sleep 0.2".fork[Unit]()
         proc.await()
         System.currentTimeMillis - t0
       .assert(_ >= 200L)
 
-      test(t"fork and abort sleeping process"):
+      test(m"fork and abort sleeping process"):
         val t0 = System.currentTimeMillis
         val proc = sh"sleep 0.2".fork[Unit]()
         proc.abort()
         System.currentTimeMillis - t0
       .assert(_ <= 100L)
 
-      test(t"fork and kill sleeping process"):
+      test(m"fork and kill sleeping process"):
         val t0 = System.currentTimeMillis
         val proc = sh"sleep 0.2".fork[Unit]()
         proc.kill()
         System.currentTimeMillis - t0
       .assert(_ <= 100L)
 
-      test(t"successful exit status"):
+      test(m"successful exit status"):
         sh"echo hello".exec[Exit]()
       .assert(_ == Exit.Ok)
 
-      test(t"failed exit status"):
+      test(m"failed exit status"):
         sh"false".exec[Exit]()
       .assert(_ == Exit.Fail(1))
 
-      test(t"nested command"):
+      test(m"nested command"):
         val cmd = sh"echo 'Hello world'"
         sh"sh -c '$cmd'".exec[Text]()
       .check(_ == t"Hello world")
 
-      test(t"implied return type"):
+      test(m"implied return type"):
         sh"echo 'Hello world'"()
       .assert(_ == t"Hello world")
 
-      test(t"implied return type for `which`"):
+      test(m"implied return type for `which`"):
         import filesystemApi.galileiPath
         sh"which cat"()
       .assert(_ == Unix / p"bin" / p"cat")

--- a/lib/hallucination/src/test/hallucination.Tests.scala
+++ b/lib/hallucination/src/test/hallucination.Tests.scala
@@ -35,6 +35,6 @@ package hallucination
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Hallucination Tests"):
+object Tests extends Suite(m"Hallucination Tests"):
   def run(): Unit =
     ()

--- a/lib/harlequin/src/test/harlequin.Tests.scala
+++ b/lib/harlequin/src/test/harlequin.Tests.scala
@@ -35,6 +35,6 @@ package harlequin
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Harlequin Tests"):
+object Tests extends Suite(m"Harlequin Tests"):
   def run(): Unit =
     ()

--- a/lib/hieroglyph/src/test/hieroglyph.Tests.scala
+++ b/lib/hieroglyph/src/test/hieroglyph.Tests.scala
@@ -42,77 +42,77 @@ import vacuous.*
 
 import textMetrics.eastAsianScripts
 
-object Tests extends Suite(t"Hieroglyph tests"):
+object Tests extends Suite(m"Hieroglyph tests"):
   def run(): Unit =
     val japanese = t"平ぱ記動テ使村方島おゃぎむ万離ワ学つス携"
     val japaneseBytes = japanese.s.getBytes("UTF-8").nn.immutable(using Unsafe)
 
-    suite(t"Character widths"):
-      test(t"Check narrow character width"):
+    suite(m"Character widths"):
+      test(m"Check narrow character width"):
         'a'.displayWidth
       .assert(_ == 1)
 
-      test(t"Check Japanese character width"):
+      test(m"Check Japanese character width"):
         '身'.displayWidth
       .assert(_ == 2)
 
-      test(t"Check displayWidth of string of Japanese text: \"平ぱ記...つス携\""):
+      test(m"Check displayWidth of string of Japanese text: \"平ぱ記...つス携\""):
         import gossamer.displayWidth
         japanese.displayWidth
       .assert(_ == 40)
 
-    suite(t"Roundtrip decoding"):
+    suite(m"Roundtrip decoding"):
 
-      test(t"Decode Japanese from UTF-8"):
+      test(m"Decode Japanese from UTF-8"):
         import textSanitizers.skip
         charDecoders.utf8.decode(japaneseBytes)
       .assert(_ == japanese)
 
       for chunk <- 1 to 25 do
-        test(t"Decode Japanese text in chunks of size $chunk"):
+        test(m"Decode Japanese text in chunks of size $chunk"):
           import textSanitizers.skip
           charDecoders.utf8.decode(japaneseBytes.grouped(chunk).to(Stream)).join
         .assert(_ == japanese)
 
       val badUtf8 = Bytes(45, -62, 49, 48)
 
-      test(t"Decode invalid UTF-8 sequence, skipping errors"):
+      test(m"Decode invalid UTF-8 sequence, skipping errors"):
         import textSanitizers.skip
         charDecoders.utf8.decode(badUtf8)
       .assert(_ == t"-10")
 
-      test(t"Decode invalid UTF-8 sequence, substituting for a question mark"):
+      test(m"Decode invalid UTF-8 sequence, substituting for a question mark"):
         import textSanitizers.substitute
         charDecoders.utf8.decode(badUtf8)
       .assert(_ == t"-?10")
 
-      test(t"Decode invalid UTF-8 sequence, throwing exception"):
+      test(m"Decode invalid UTF-8 sequence, throwing exception"):
         import unsafeExceptions.canThrowAny
         import textSanitizers.strict
         capture[UndecodableCharError](charDecoders.utf8.decode(badUtf8))
       .assert(_ == UndecodableCharError(1, enc"UTF-8"))
 
-      test(t"Ensure that decoding is finished"):
+      test(m"Ensure that decoding is finished"):
         import unsafeExceptions.canThrowAny
         import textSanitizers.strict
         given CharEncoder = enc"UTF-8".encoder
         capture[UndecodableCharError](charDecoders.utf8.decode(t"café".bytes.dropRight(1)))
       .assert(_ == UndecodableCharError(4, enc"UTF-8"))
 
-    suite(t"Compile-time tests"):
-      test(t"Check that an invalid encoding produces an error"):
+    suite(m"Compile-time tests"):
+      test(m"Check that an invalid encoding produces an error"):
         demilitarize(enc"ABCDEF").map(_.message)
       .assert(_ == List(t"hieroglyph: the encoding ABCDEF was not available"))
 
-      test(t"Check that a non-encoding encoding does have a `decoder` method"):
+      test(m"Check that a non-encoding encoding does have a `decoder` method"):
         import textSanitizers.skip
         demilitarize(enc"ISO-2022-CN".decoder)
       .assert(_ == List())
 
-      test(t"Check that a non-encoding encoding has no encoder method"):
+      test(m"Check that a non-encoding encoding has no encoder method"):
         demilitarize(enc"ISO-2022-CN".encoder)
       .assert(_.length == 1)
 
-      test(t"Check that an encoding which can encode has an encoder method"):
+      test(m"Check that an encoding which can encode has an encoder method"):
         demilitarize(enc"ISO-8859-1".encoder)
       .assert(_ == List())

--- a/lib/honeycomb/src/test/honeycomb.Tests.scala
+++ b/lib/honeycomb/src/test/honeycomb.Tests.scala
@@ -39,49 +39,49 @@ import spectacular.*
 
 import html5.*
 
-object Tests extends Suite(t"Honeycomb Tests"):
+object Tests extends Suite(m"Honeycomb Tests"):
   def run(): Unit =
-    suite(t"Showing HTML"):
-      test(t"empty normal tag"):
+    suite(m"Showing HTML"):
+      test(m"empty normal tag"):
         Div.show
       .check(_ == t"<div/>")
 
-      test(t"empty unclosed tag"):
+      test(m"empty unclosed tag"):
         Br.show
       .check(_ == t"<br>")
 
-      test(t"tag with one attribute"):
+      test(m"tag with one attribute"):
         P(id = id"abc").show
       .check(_ == t"""<p id="abc"/>""")
 
-      test(t"tag with two attributes"):
+      test(m"tag with two attributes"):
         P(id = id"abc", style = t"def").show
       .check(_ == t"""<p id="abc" style="def"/>""")
 
-      test(t"unclosed tag with one attribute"):
+      test(m"unclosed tag with one attribute"):
         Hr(id = id"foo").show
       .check(_ == t"""<hr id="foo">""")
 
-      test(t"unclosed tag with two attributes"):
+      test(m"unclosed tag with two attributes"):
         Hr(id = id"foo", style = t"bar").show
       .check(_ == t"""<hr id="foo" style="bar">""")
 
-      test(t"non-self-closing tag"):
+      test(m"non-self-closing tag"):
         Script.show
       .check(_ == t"""<script></script>""")
 
-      test(t"tag with no attributes and children"):
+      test(m"tag with no attributes and children"):
         Div(Hr, Br).show
       .check(_ == t"""<div><hr><br></div>""")
 
-      test(t"tag with text child"):
+      test(m"tag with text child"):
         P(t"hello world").show
       .check(_ == t"<p>hello world</p>")
 
-      test(t"tag with mixed children"):
+      test(m"tag with mixed children"):
         P(t"hello ", Em(t"world"), t"!").show
       .check(_ == t"<p>hello <em>world</em>!</p>")
 
-      test(t"deeper-nested elements"):
+      test(m"deeper-nested elements"):
         Table(Tbody(Tr(Td(t"A")))).show
       .check(_ == t"<table><tbody><tr><td>A</td></tr></tbody></table>")

--- a/lib/hypotenuse/src/test/hypotenuse.Tests.scala
+++ b/lib/hypotenuse/src/test/hypotenuse.Tests.scala
@@ -37,264 +37,264 @@ import denominative.*
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Hypotenuse tests"):
+object Tests extends Suite(m"Hypotenuse tests"):
   def run(): Unit =
-    suite(t"Addition tests"):
-      test(t"Construct an unsigned integer"):
+    suite(m"Addition tests"):
+      test(m"Construct an unsigned integer"):
         val left: U64 = 123
 
-    suite(t"Bitmap tests"):
-      test(t"Check first bit of 10"):
+    suite(m"Bitmap tests"):
+      test(m"Check first bit of 10"):
         B64(Bytes(10))(Prim)
       .assert(_ == false)
 
-      test(t"Check second bit of 6"):
+      test(m"Check second bit of 6"):
         B64(Bytes(6))(Sec)
       .assert(_ == true)
 
-      test(t"Check third bit of 6"):
+      test(m"Check third bit of 6"):
         B64(Bytes(6))(Ter)
       .assert(_ == true)
 
-      test(t"Check fourth bit of 6"):
+      test(m"Check fourth bit of 6"):
         B64(Bytes(6))(Quat)
       .assert(_ == false)
 
-      test(t"Check first two bits of 6")(B64(Bytes(6))(Prim ~ Sec)).assert(_ == B64(2))
-      test(t"Check first three bits of 6")(B64(Bytes(6))(Prim ~ Ter)).assert(_ == B64(6))
-      test(t"Check first four bits of 6")(B64(Bytes(6))(Prim ~ Quat)).assert(_ == B64(6))
-      test(t"Check middle two bits of 6")(B64(Bytes(6))(Sec ~ Ter)).assert(_ == B64(3))
+      test(m"Check first two bits of 6")(B64(Bytes(6))(Prim ~ Sec)).assert(_ == B64(2))
+      test(m"Check first three bits of 6")(B64(Bytes(6))(Prim ~ Ter)).assert(_ == B64(6))
+      test(m"Check first four bits of 6")(B64(Bytes(6))(Prim ~ Quat)).assert(_ == B64(6))
+      test(m"Check middle two bits of 6")(B64(Bytes(6))(Sec ~ Ter)).assert(_ == B64(3))
 
-      test(t"Check middle two bits as subsequent")(B64(Bytes(6))(Prim.subsequent(2)))
+      test(m"Check middle two bits as subsequent")(B64(Bytes(6))(Prim.subsequent(2)))
       . assert(_ == B64(3))
 
-      test(t"Check first two bits as preceding")(B64(Bytes(6))(Ter.preceding(2)))
+      test(m"Check first two bits as preceding")(B64(Bytes(6))(Ter.preceding(2)))
       . assert(_ == B64(2))
 
 
-    suite(t"Inequality tests"):
-      test(t"1.2 < x < 1.4"):
+    suite(m"Inequality tests"):
+      test(m"1.2 < x < 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ < 1.4)
       .assert(_ == List(1.3))
 
-      test(t"1.2 < x <= 1.4"):
+      test(m"1.2 < x <= 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 < _ <= 1.4)
       .assert(_ == List(1.3, 1.4))
 
-      test(t"1.2 <= x < 1.4"):
+      test(m"1.2 <= x < 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 <= _ < 1.4)
       .assert(_ == List(1.2, 1.3))
 
-      test(t"1.2 <= x <= 1.4"):
+      test(m"1.2 <= x <= 1.4"):
         List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.2 <= _ <= 1.4)
       .assert(_ == List(1.2, 1.3, 1.4))
 
-      test(t"2 < x < 4"):
+      test(m"2 < x < 4"):
         List(1, 2, 3, 4, 5).filter(2 < _ < 4)
       .assert(_ == List(3))
 
-      test(t"2 < x <= 4"):
+      test(m"2 < x <= 4"):
         List(1, 2, 3, 4, 5).filter(2 < _ <= 4)
       .assert(_ == List(3, 4))
 
-      test(t"2 <= x < 4"):
+      test(m"2 <= x < 4"):
         List(1, 2, 3, 4, 5).filter(2 <= _ < 4)
       .assert(_ == List(2, 3))
 
-      test(t"2 <= x <= 4"):
+      test(m"2 <= x <= 4"):
         List(1, 2, 3, 4, 5).filter(2 <= _ <= 4)
       .assert(_ == List(2, 3, 4))
 
-      test(t"2L < x < 4L"):
+      test(m"2L < x < 4L"):
         List(1L, 2L, 3L, 4L, 5L).filter(2L < _ < 4L)
       .assert(_ == List(3L))
 
-      test(t"2L < x <= 4L"):
+      test(m"2L < x <= 4L"):
         List(1L, 2L, 3L, 4L, 5L).filter(2L < _ <= 4L)
       .assert(_ == List(3L, 4L))
 
-      test(t"2L <= x < 4L"):
+      test(m"2L <= x < 4L"):
         List(1L, 2L, 3L, 4L, 5L).filter(2L <= _ < 4L)
       .assert(_ == List(2L, 3L))
 
-      test(t"2L <= x <= 4L"):
+      test(m"2L <= x <= 4L"):
         List(1L, 2L, 3L, 4L, 5L).filter(2L <= _ <= 4L)
       .assert(_ == List(2L, 3L, 4L))
 
-      test(t"2F < x < 4F"):
+      test(m"2F < x < 4F"):
         List(1F, 2F, 3F, 4F, 5F).filter(2F < _ < 4F)
       .assert(_ == List(3F))
 
-      test(t"2F < x <= 4F"):
+      test(m"2F < x <= 4F"):
         List(1F, 2F, 3F, 4F, 5F).filter(2F < _ <= 4F)
       .assert(_ == List(3F, 4F))
 
-      test(t"2F <= x < 4F"):
+      test(m"2F <= x < 4F"):
         List(1F, 2F, 3F, 4F, 5F).filter(2F <= _ < 4F)
       .assert(_ == List(2F, 3F))
 
-      test(t"2F <= x <= 4F"):
+      test(m"2F <= x <= 4F"):
         List(1F, 2F, 3F, 4F, 5F).filter(2F <= _ <= 4F)
       .assert(_ == List(2F, 3F, 4F))
 
-      test(t"'2' < x < '4'"):
+      test(m"'2' < x < '4'"):
         List('1', '2', '3', '4', '5').filter('2' < _ < '4')
       .assert(_ == List('3'))
 
-      test(t"'2' < x <= '4'"):
+      test(m"'2' < x <= '4'"):
         List('1', '2', '3', '4', '5').filter('2' < _ <= '4')
       .assert(_ == List('3', '4'))
 
-      test(t"'2' <= x < '4'"):
+      test(m"'2' <= x < '4'"):
         List('1', '2', '3', '4', '5').filter('2' <= _ < '4')
       .assert(_ == List('2', '3'))
 
-      test(t"'2' <= x <= '4'"):
+      test(m"'2' <= x <= '4'"):
         List('1', '2', '3', '4', '5').filter('2' <= _ <= '4')
       .assert(_ == List('2', '3', '4'))
 
-      test(t"2.toByte < x < 4.toByte"):
+      test(m"2.toByte < x < 4.toByte"):
         List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(2.toByte < _ < 4.toByte)
       .assert(_ == List(3.toByte))
 
-      test(t"2.toByte < x <= 4.toByte"):
+      test(m"2.toByte < x <= 4.toByte"):
         List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(2.toByte < _ <= 4.toByte)
       .assert(_ == List(3.toByte, 4.toByte))
 
-      test(t"2.toByte <= x < 4.toByte"):
+      test(m"2.toByte <= x < 4.toByte"):
         List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(2.toByte <= _ < 4.toByte)
       .assert(_ == List(2.toByte, 3.toByte))
 
-      test(t"2.toByte <= x <= 4.toByte"):
+      test(m"2.toByte <= x <= 4.toByte"):
         List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(2.toByte <= _ <= 4.toByte)
       .assert(_ == List(2.toByte, 3.toByte, 4.toByte))
 
-      test(t"2.toShort < x < 4.toShort"):
+      test(m"2.toShort < x < 4.toShort"):
         List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(2.toShort < _ < 4.toShort)
       .assert(_ == List(3.toShort))
 
-      test(t"2.toShort < x <= 4.toShort"):
+      test(m"2.toShort < x <= 4.toShort"):
         List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(2.toShort < _ <= 4.toShort)
       .assert(_ == List(3.toShort, 4.toShort))
 
-      test(t"2.toShort <= x < 4.toShort"):
+      test(m"2.toShort <= x < 4.toShort"):
         List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(2.toShort <= _ < 4.toShort)
       .assert(_ == List(2.toShort, 3.toShort))
 
-      test(t"2.toShort <= x <= 4.toShort"):
+      test(m"2.toShort <= x <= 4.toShort"):
         List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(2.toShort <= _ <= 4.toShort)
       .assert(_ == List(2.toShort, 3.toShort, 4.toShort))
 
 
 
-    //   test(t"1.2 > x > 1.4"):
+    //   test(m"1.2 > x > 1.4"):
     //     List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.4 > _ > 1.2)
     //   .assert(_ == List(1.3))
 
-    //   test(t"1.2 >= x > 1.4"):
+    //   test(m"1.2 >= x > 1.4"):
     //     List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.4 >= _ > 1.2)
     //   .assert(_ == List(1.3, 1.4))
 
-    //   test(t"1.2 > x >= 1.4"):
+    //   test(m"1.2 > x >= 1.4"):
     //     List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.4 > _ >= 1.2)
     //   .assert(_ == List(1.2, 1.3))
 
-    //   test(t"1.2 >= x >= 1.4"):
+    //   test(m"1.2 >= x >= 1.4"):
     //     List(1.1, 1.2, 1.3, 1.4, 1.5).filter(1.4 >= _ >= 1.2)
     //   .assert(_ == List(1.2, 1.3, 1.4))
 
-    //   test(t"2 > x > 4"):
+    //   test(m"2 > x > 4"):
     //     List(1, 2, 3, 4, 5).filter(4 > _ > 2)
     //   .assert(_ == List(3))
 
-    //   test(t"2 >= x > 4"):
+    //   test(m"2 >= x > 4"):
     //     List(1, 2, 3, 4, 5).filter(4 >= _ > 2)
     //   .assert(_ == List(3, 4))
 
-    //   test(t"2 > x >= 4"):
+    //   test(m"2 > x >= 4"):
     //     List(1, 2, 3, 4, 5).filter(4 > _ >= 2)
     //   .assert(_ == List(2, 3))
 
-    //   test(t"2 >= x >= 4"):
+    //   test(m"2 >= x >= 4"):
     //     List(1, 2, 3, 4, 5).filter(4 >= _ >= 2)
     //   .assert(_ == List(2, 3, 4))
 
-    //   test(t"2L > x > 4L"):
+    //   test(m"2L > x > 4L"):
     //     List(1L, 2L, 3L, 4L, 5L).filter(4L > _ > 2L)
     //   .assert(_ == List(3L))
 
-    //   test(t"2L >= x > 4L"):
+    //   test(m"2L >= x > 4L"):
     //     List(1L, 2L, 3L, 4L, 5L).filter(4L >= _ > 2L)
     //   .assert(_ == List(3L, 4L))
 
-    //   test(t"2L > x >= 4L"):
+    //   test(m"2L > x >= 4L"):
     //     List(1L, 2L, 3L, 4L, 5L).filter(4L > _ >= 2L)
     //   .assert(_ == List(2L, 3L))
 
-    //   test(t"2L >= x >= 4L"):
+    //   test(m"2L >= x >= 4L"):
     //     List(1L, 2L, 3L, 4L, 5L).filter(4L >= _ >= 2L)
     //   .assert(_ == List(2L, 3L, 4L))
 
-    //   test(t"2F > x > 4F"):
+    //   test(m"2F > x > 4F"):
     //     List(1F, 2F, 3F, 4F, 5F).filter(4F > _ > 2F)
     //   .assert(_ == List(3F))
 
-    //   test(t"2F >= x > 4F"):
+    //   test(m"2F >= x > 4F"):
     //     List(1F, 2F, 3F, 4F, 5F).filter(4F >= _ > 2F)
     //   .assert(_ == List(3F, 4F))
 
-    //   test(t"2F > x >= 4F"):
+    //   test(m"2F > x >= 4F"):
     //     List(1F, 2F, 3F, 4F, 5F).filter(4F > _ >= 2F)
     //   .assert(_ == List(2F, 3F))
 
-    //   test(t"2F >= x >= 4F"):
+    //   test(m"2F >= x >= 4F"):
     //     List(1F, 2F, 3F, 4F, 5F).filter(4F >= _ >= 2F)
     //   .assert(_ == List(2F, 3F, 4F))
 
-    //   test(t"'2' > x > '4'"):
+    //   test(m"'2' > x > '4'"):
     //     List('1', '2', '3', '4', '5').filter('4' > _ > '2')
     //   .assert(_ == List('3'))
 
-    //   test(t"'2' >= x > '4'"):
+    //   test(m"'2' >= x > '4'"):
     //     List('1', '2', '3', '4', '5').filter('4' >=_ > '2')
     //   .assert(_ == List('3', '4'))
 
-    //   test(t"'2' > x >= '4'"):
+    //   test(m"'2' > x >= '4'"):
     //     List('1', '2', '3', '4', '5').filter('4' > _ >= '2')
     //   .assert(_ == List('2', '3'))
 
-    //   test(t"'2' >= x >= '4'"):
+    //   test(m"'2' >= x >= '4'"):
     //     List('1', '2', '3', '4', '5').filter('4' >= _ >= '2')
     //   .assert(_ == List('2', '3', '4'))
 
-    //   test(t"2.toByte > x > 4.toByte"):
+    //   test(m"2.toByte > x > 4.toByte"):
     //     List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(4.toByte > _ > 2.toByte)
     //   .assert(_ == List(3.toByte))
 
-    //   test(t"2.toByte >= x > 4.toByte"):
+    //   test(m"2.toByte >= x > 4.toByte"):
     //     List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(4.toByte >= _ > 2.toByte)
     //   .assert(_ == List(3.toByte, 4.toByte))
 
-    //   test(t"2.toByte > x >= 4.toByte"):
+    //   test(m"2.toByte > x >= 4.toByte"):
     //     List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(4.toByte > _ >= 2.toByte)
     //   .assert(_ == List(2.toByte, 3.toByte))
 
-    //   test(t"2.toByte >= x >= 4.toByte"):
+    //   test(m"2.toByte >= x >= 4.toByte"):
     //     List(1.toByte, 2.toByte, 3.toByte, 4.toByte, 5.toByte).filter(4.toByte >= _ >= 2.toByte)
     //   .assert(_ == List(2.toByte, 3.toByte, 4.toByte))
 
-    //   test(t"2.toShort > x > 4.toShort"):
+    //   test(m"2.toShort > x > 4.toShort"):
     //     List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(4.toShort > _ > 2.toShort)
     //   .assert(_ == List(3.toShort))
 
-    //   test(t"2.toShort >= x > 4.toShort"):
+    //   test(m"2.toShort >= x > 4.toShort"):
     //     List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(4.toShort >= _ > 2.toShort)
     //   .assert(_ == List(3.toShort, 4.toShort))
 
-    //   test(t"2.toShort > x >= 4.toShort"):
+    //   test(m"2.toShort > x >= 4.toShort"):
     //     List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(4.toShort > _ >= 2.toShort)
     //   .assert(_ == List(2.toShort, 3.toShort))
 
-    //   test(t"2.toShort >= x >= 4.toShort"):
+    //   test(m"2.toShort >= x >= 4.toShort"):
     //     List(1.toShort, 2.toShort, 3.toShort, 4.toShort, 5.toShort).filter(4.toShort >= _ >= 2.toShort)
     //   .assert(_ == List(2.toShort, 3.toShort, 4.toShort))

--- a/lib/imperial/src/test/imperial.Tests.scala
+++ b/lib/imperial/src/test/imperial.Tests.scala
@@ -52,73 +52,73 @@ given SystemProperties =
 
 given Text is SpecificPath = identity(_)
 
-object Tests extends Suite(t"Imperial tests"):
+object Tests extends Suite(m"Imperial tests"):
   def run(): Unit =
 
-    test(t"Home directory"):
+    test(m"Home directory"):
       Home()
     .assert(_ == t"/home/work")
 
-    test(t"Cache directory"):
+    test(m"Cache directory"):
       Home.Cache()
     .assert(_ == t"/home/work/.cache")
 
-    test(t"~/.local/bin path"):
+    test(m"~/.local/bin path"):
       Home.Local.Bin()
     .assert(_ == t"/home/work/.local/bin")
 
-    test(t"/ path"):
+    test(m"/ path"):
       Base()
     .assert(_ == t"/")
 
-    test(t"/boot path"):
+    test(m"/boot path"):
       Base.Boot()
     .assert(_ == t"/boot")
 
-    test(t"/efi path"):
+    test(m"/efi path"):
       Base.Efi()
     .assert(_ == t"/efi")
 
-    test(t"/etc path"):
+    test(m"/etc path"):
       Base.Etc()
     .assert(_ == t"/etc")
 
-    test(t"/home path"):
+    test(m"/home path"):
       Base.Home()
     .assert(_ == t"/home")
 
-    test(t"/root path"):
+    test(m"/root path"):
       Base.Root()
     .assert(_ == t"/root")
 
-    test(t"/srv path"):
+    test(m"/srv path"):
       Base.Srv()
     .assert(_ == t"/srv")
 
-    test(t"/tmp path"):
+    test(m"/tmp path"):
       Base.Tmp()
     .assert(_ == t"/tmp")
 
-    test(t"/usr path"):
+    test(m"/usr path"):
       Base.Usr()
     .assert(_ == t"/usr")
 
-    test(t"/usr/share path"):
+    test(m"/usr/share path"):
       Base.Usr.Share()
     .assert(_ == t"/usr/share")
 
-    test(t"/usr/bin path"):
+    test(m"/usr/bin path"):
       Base.Usr.Bin()
     .assert(_ == t"/usr/bin")
 
-    test(t"/usr/share/doc path"):
+    test(m"/usr/share/doc path"):
       Base.Usr.Share.Doc()
     .assert(_ == t"/usr/share/doc")
 
-    test(t"/usr/share/factory/etc path"):
+    test(m"/usr/share/factory/etc path"):
       Base.Usr.Share.Factory.Etc()
     .assert(_ == t"/usr/share/factory/etc")
 
-    test(t"/proc PID path"):
+    test(m"/proc PID path"):
       Base.Proc(Pid(2000))()
     .assert(_ == t"/proc/2000")

--- a/lib/inimitable/src/test/inimitable.Tests.scala
+++ b/lib/inimitable/src/test/inimitable.Tests.scala
@@ -40,62 +40,62 @@ import larceny.*
 import probably.*
 import rudiments.*
 
-object Tests extends Suite(t"Inimitable Tests"):
+object Tests extends Suite(m"Inimitable Tests"):
   def run(): Unit =
-    suite(t"UUID tests"):
-      test(t"Construct a new UUID"):
+    suite(m"UUID tests"):
+      test(m"Construct a new UUID"):
         Uuid()
       .matches:
         case Uuid(a, b) => (a, b)
 
-      test(t"Get bytes from UUID"):
+      test(m"Get bytes from UUID"):
         Uuid().bytes
       .assert(_.length == 16)
 
-      test(t"Parse a UUID at compiletime"):
+      test(m"Parse a UUID at compiletime"):
         uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c"
       .assert()
 
-      test(t"Get the most significant bits from a UUID"):
+      test(m"Get the most significant bits from a UUID"):
         uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".msb
       .assert(_ == -6860364383762101208L)
 
-      test(t"Get the least significant bits from a UUID"):
+      test(m"Get the least significant bits from a UUID"):
         uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".lsb
       .assert(_ == -8777588922722300788L)
 
-      test(t"Get the Java UUID"):
+      test(m"Get the Java UUID"):
         uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".java
       .assert(_ == java.util.UUID.fromString("a0cb16f0-d41e-4c28-862f-bd6164bbcc8c"))
 
-      test(t"Get the bytes from a UUID"):
+      test(m"Get the bytes from a UUID"):
         uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".bytes.to(List)
       .assert(_ == List[Byte](-96, -53, 22, -16, -44, 30, 76, 40, -122, 47, -67, 97, 100, -69, -52, -116))
 
-      test(t"Convert a UUID to Text"):
+      test(m"Convert a UUID to Text"):
         uuid"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c".text
       .assert(_ == t"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c")
 
-      test(t"Parse a UUID at runtime"):
+      test(m"Parse a UUID at runtime"):
         unsafely(Uuid.parse(t"a0cb16f0-d41e-4c28-862f-bd6164bbcc8c"))
       .assert(_ == Uuid(-6860364383762101208L, -8777588922722300788L))
 
-      test(t"Parse a bad UUID at runtime"):
+      test(m"Parse a bad UUID at runtime"):
         unsafely(capture[UuidError](Uuid.parse(t"not-a-uuid")))
       .assert(_ == UuidError(t"not-a-uuid"))
 
       val uuid1 = Uuid()
       val uuid2 = Uuid()
 
-      test(t"XOR two UUIDs"):
+      test(m"XOR two UUIDs"):
         uuid1 ^ uuid2
       .assert { uuid => uuid != uuid1 && uuid != uuid2 }
 
-      test(t"Invert a UUID"):
+      test(m"Invert a UUID"):
         ~uuid1
       .assert(_ != uuid1)
 
-      test(t"Parse a bad UUID at compiletime"):
+      test(m"Parse a bad UUID at compiletime"):
         demilitarize:
           uuid"not-a-uuid"
         .map(_.message)

--- a/lib/iridescence/src/test/iridescence.Tests.scala
+++ b/lib/iridescence/src/test/iridescence.Tests.scala
@@ -37,47 +37,47 @@ import probably.*
 
 given ColorProfile = colorProfiles.daylight
 
-object Tests extends Suite(t"Iridescence tests"):
+object Tests extends Suite(m"Iridescence tests"):
   def run(): Unit =
-    // suite(t"Roundtrip tests"):
+    // suite(m"Roundtrip tests"):
     //   for color <- colors.all.reverse do
-    //     test(t"sRGB to L*a*b*"):
+    //     test(m"sRGB to L*a*b*"):
     //       color.srgb.cielab.srgb
     //     .assert(_ ~~ color.srgb)
 
-    //     test(t"HSV to sRGB and back"):
+    //     test(m"HSV to sRGB and back"):
     //       color.srgb.hsv.srgb.hsv
     //     .assert(_ ~~ color.srgb.hsv)
 
-    //     test(t"sRGB to CMY and back"):
+    //     test(m"sRGB to CMY and back"):
     //       color.srgb.cmy.srgb
     //     .assert(_ ~~ color.srgb)
 
-    //     test(t"sRGB to CMYK and back"):
+    //     test(m"sRGB to CMYK and back"):
     //       color.srgb.cmyk.srgb
     //     .assert(_ ~~ color.srgb)
 
-    //     test(t"sRGB to XYZ and back"):
+    //     test(m"sRGB to XYZ and back"):
     //       color.srgb.xyz.srgb
     //     .assert(_ ~~ color.srgb)
 
-    //     test(t"sRGB to HSL and back"):
+    //     test(m"sRGB to HSL and back"):
     //       color.srgb.hsl.srgb
     //     .assert(_ ~~ color.srgb)
 
-    suite(t"Interpolator tests"):
-      test(t"Read a hex value with a leading hash"):
+    suite(m"Interpolator tests"):
+      test(m"Read a hex value with a leading hash"):
         rgb"#abcdef"
       .assert(_ == Rgb24(171, 205, 239))
 
-      test(t"Read a hex value without a leading hash"):
+      test(m"Read a hex value without a leading hash"):
         rgb"abcdef"
       .assert(_ == Rgb24(171, 205, 239))
 
-      test(t"Read black"):
+      test(m"Read black"):
         rgb"#000000"
       .assert(_ == Rgb24(0, 0, 0))
 
-      test(t"Read white"):
+      test(m"Read white"):
         rgb"#ffffff"
       .assert(_ == Rgb24(255, 255, 255))

--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -40,34 +40,34 @@ import turbulence.*
 
 import unsafeExceptions.canThrowAny
 
-object Bench extends Suite(t"Jacinta benchmarks"):
+object Bench extends Suite(m"Jacinta benchmarks"):
   def run(): Unit =
-    test(t"Parse a simple object with one string value"):
+    test(m"Parse a simple object with one string value"):
       Json.parse(t"""{"foo": "bar"}""")
 
     . benchmark(duration = 3000L, warmup = 3000L)
 
-    test(t"Parse a simple object with one numerical value"):
+    test(m"Parse a simple object with one numerical value"):
       Json.parse(t"""{"foo": 3.1415926 }""")
 
     . benchmark(duration = 3000L, warmup = 3000L)
 
-    test(t"Parse true value"):
+    test(m"Parse true value"):
       Json.parse(t"""{"foo": true }""")
 
     . benchmark(duration = 3000L, warmup = 3000L)
 
-    test(t"Parse false value"):
+    test(m"Parse false value"):
       Json.parse(t"""{"foo": false }""")
 
     . benchmark(duration = 3000L, warmup = 3000L)
 
-    test(t"Parse array of strings"):
+    test(m"Parse array of strings"):
       Json.parse(t"""["foo", "bar", "baz", "quux", "abcd", "defg", "hijk"]""")
 
     . benchmark(duration = 3000L, warmup = 3000L)
 
-    test(t"Parse array of numbers"):
+    test(m"Parse array of numbers"):
       Json.parse(t"""[12345.6789, 98765.4321, 142536.475869]""")
 
     . benchmark(duration = 3000L, warmup = 3000L)

--- a/lib/jacinta/src/test/jacinta.Tests.scala
+++ b/lib/jacinta/src/test/jacinta.Tests.scala
@@ -51,115 +51,115 @@ case class Foo(x: Int, y: Text) derives CanEqual
 
 case class InvalidState(name: String) extends Exception("Not a valid state: "+name)
 
-object Tests extends Suite(t"Jacinta Tests"):
+object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
-    suite(t"Parsing tests"):
-      test(t"Parse a number"):
+    suite(m"Parsing tests"):
+      test(m"Parse a number"):
         Json.parse(t"42").as[Int]
       .assert(_ == 42)
 
-      test(t"Parse a string"):
+      test(m"Parse a string"):
         val s = Json.parse(t"\"string\"")
         s.as[Text]
       .assert(_ == t"string")
 
-      test(t"Parse true"):
+      test(m"Parse true"):
         Json.parse(t"true").as[Boolean]
       .assert(identity)
 
-      test(t"Parse false"):
+      test(m"Parse false"):
         Json.parse(t"false").as[Boolean]
       .assert(!_)
 
-      test(t"Parse float"):
+      test(m"Parse float"):
         Json.parse(t"3.1415").as[Float]
       .assert(_ == 3.1415f)
 
-      test(t"Parse double"):
+      test(m"Parse double"):
         Json.parse(t"3.1415926").as[Double]
       .assert(_ == 3.1415926)
 
-    suite(t"Serialization"):
-      test(t"Serialize string"):
+    suite(m"Serialization"):
+      test(m"Serialize string"):
         t"foo".json.show
       .assert(_ == t""""foo"""")
 
-      test(t"Serialize double"):
+      test(m"Serialize double"):
         3.14159.json.show
       .assert(_ == t"3.14159")
 
-      test(t"Serialize true"):
+      test(m"Serialize true"):
         true.json.show
       .assert(_ == t"true")
 
-      test(t"Serialize false"):
+      test(m"Serialize false"):
         false.json.show
       .assert(_ == t"false")
 
-      test(t"Serialize case class with Option as None"):
+      test(m"Serialize case class with Option as None"):
         case class Foo(x: Int, y: Option[Int])
         Foo(1, None).json.show
       .assert(_ == t"""{"x":1}""")
 
-      test(t"Serialize case class with Option as Some"):
+      test(m"Serialize case class with Option as Some"):
         case class Foo(x: Int, y: Option[Int])
         Foo(1, Some(2)).json.show
       .assert(_ == t"""{"x":1,"y":2}""")
 
-      test(t"Serialize case class with Optional as Unset"):
+      test(m"Serialize case class with Optional as Unset"):
         case class Foo(x: Int, y: Optional[Int])
         Foo(1, Unset).json.show
       .assert(_ == t"""{"x":1}""")
 
-      test(t"Serialize case class with present Optional"):
+      test(m"Serialize case class with present Optional"):
         case class Foo(x: Int, y: Optional[Int])
         Foo(1, 2).json.show
       .assert(_ == t"""{"x":1,"y":2}""")
 
-    suite(t"Misc tests"):
-      test(t"Serialize to Json"):
+    suite(m"Misc tests"):
+      test(m"Serialize to Json"):
         Foo(1, t"two").json
       .assert(_ == Json.of(x = 1.json, y = t"two".json))
 
-      test(t"Parse from JSON"):
+      test(m"Parse from JSON"):
         Json.parse(t"""{"x": 1}""")
       .assert(_ == Json.of(x = 1.json))
 
-      test(t"Read case class"):
+      test(m"Read case class"):
         Json.parse(t"""{"x": 1, "y": "two"}""").as[Foo]
       .assert(_ == Foo(1, t"two"))
 
-      test(t"Extract an absent Option"):
+      test(m"Extract an absent Option"):
         case class OptFoo(x: Option[Int])
         Json.parse(t"""{"y": 1}""").as[OptFoo].x
       .assert(_ == None)
 
-      test(t"Extract an option"):
+      test(m"Extract an option"):
         case class OptFoo(x: Option[Int])
         Json.parse(t"""{"x": 1}""").as[OptFoo].x
       .assert(_ == Some(1))
 
-      test(t"Extract a present Optional"):
+      test(m"Extract a present Optional"):
         case class OptionalFoo(x: Optional[Int])
         Json.parse(t"""{"x": 1}""").as[OptionalFoo].x
       .assert(_ == 1)
 
-      test(t"Extract an absent Optional"):
+      test(m"Extract an absent Optional"):
         case class OptionalFoo(x: Optional[Int])
         Json.parse(t"""{"y": 1}""").as[OptionalFoo].x
       .assert(_ == Unset)
 
-      test(t"Extract a None"):
+      test(m"Extract a None"):
         case class OptFoo(x: Option[Int])
         Json.parse(t"""{"y": 1}""").as[OptFoo].x
       .assert(_ == None)
 
-    suite(t"Generic derivation tests"):
+    suite(m"Generic derivation tests"):
       case class Person(name: Text, age: Int)
       case class Band(guitarists: List[Person], drummer: Person, bassist: Option[Person])
 
       val paul =
-        test(t"Serialize a simple case class"):
+        test(m"Serialize a simple case class"):
           Person(t"Paul", 81).json.show
         .check(_ == t"""{"name":"Paul","age":81}""")
 
@@ -169,15 +169,15 @@ object Tests extends Suite(t"Jacinta Tests"):
 
       val beatles = t"""{"guitarists": [$john, $george], "drummer": $ringo, "bassist": $paul}"""
 
-      val paulObj = test(t"Extract a Person"):
+      val paulObj = test(m"Extract a Person"):
         Json.parse(paul).as[Person]
       .check(_ == Person(t"Paul", 81))
 
-      val ringoObj = test(t"Extract a different person"):
+      val ringoObj = test(m"Extract a different person"):
         Json.parse(ringo).as[Person]
       .check(_ == Person(t"Ringo", 82))
 
-      test(t"Extract a band"):
+      test(m"Extract a band"):
         Json.parse(beatles).as[Band]
       .assert(_ == Band(List(Person(t"John", 40), Person(t"George", 58)), ringoObj, Some(paulObj)))
 
@@ -186,17 +186,17 @@ object Tests extends Suite(t"Jacinta Tests"):
         case Drummer(person: Person)
         case Bassist(person: Person)
 
-      val paulCoproduct = test(t"Serialize a coproduct"):
+      val paulCoproduct = test(m"Serialize a coproduct"):
         val paul: Player = Player.Bassist(paulObj)
         paul.json.show
       .check(_ == t"""{"_type":"Bassist","person":{"name":"Paul","age":81}}""")
 
-      test(t"Decode a coproduct"):
+      test(m"Decode a coproduct"):
         summon[Int is Decodable in Json]
         Json.parse(paulCoproduct).as[Player]
       .assert(_ == Player.Bassist(paulObj))
 
-      test(t"Decode a coproduct as a precise subtype"):
+      test(m"Decode a coproduct as a precise subtype"):
         Json.parse(paulCoproduct).as[Player.Bassist]
       .assert(_ == Player.Bassist(paulObj))
 
@@ -206,10 +206,10 @@ object Tests extends Suite(t"Jacinta Tests"):
       val newBand = NewBand(Set(Bassist(paulObj), Drummer(ringoObj), Guitarist(Person(t"John", 40)),
           Guitarist(Person(t"George", 58))))
 
-      val newBandText = test(t"Serialize NewBand"):
+      val newBandText = test(m"Serialize NewBand"):
         newBand.json.show
       .check(_ == t"""{"members":[{"_type":"Bassist","person":{"name":"Paul","age":81}},{"_type":"Drummer","person":{"name":"Ringo","age":82}},{"_type":"Guitarist","person":{"name":"John","age":40}},{"_type":"Guitarist","person":{"name":"George","age":58}}]}""")
 
-      test(t"Decode a NewBand"):
+      test(m"Decode a NewBand"):
         Json.parse(newBandText).as[NewBand]
       .assert(_ == newBand)

--- a/lib/kaleidoscope/src/test/kaleidoscope.Tests.scala
+++ b/lib/kaleidoscope/src/test/kaleidoscope.Tests.scala
@@ -37,290 +37,290 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 
-object Tests extends Suite(t"Kaleidoscope tests"):
+object Tests extends Suite(m"Kaleidoscope tests"):
   def run(): Unit =
-    suite(t"Regex tests"):
+    suite(m"Regex tests"):
       import Regex.Group, Regex.Quantifier.*, Regex.Greed.*
 
-      suite(t"Standard parsing"):
-        test(t"Parse aaa")(Regex.parse(List(t"aaa")))
+      suite(m"Standard parsing"):
+        test(m"Parse aaa")(Regex.parse(List(t"aaa")))
         . assert(_ == Regex(t"aaa", Nil))
 
-        test(t"Parse (aaa)")(Regex.parse(List(t"(aaa)")))
+        test(m"Parse (aaa)")(Regex.parse(List(t"(aaa)")))
         . assert:
           _ == Regex(t"(aaa)", List(Group(1, 4, 5)))
 
-        test(t"Parse (aa)bb")(Regex.parse(List(t"(aa)bb")))
+        test(m"Parse (aa)bb")(Regex.parse(List(t"(aa)bb")))
         . assert:
           _ == Regex(t"(aa)bb", List(Group(1, 3, 4)))
 
-        test(t"Parse aa(bb)")(Regex.parse(List(t"aa(bb)")))
+        test(m"Parse aa(bb)")(Regex.parse(List(t"aa(bb)")))
         . assert(_ == Regex(t"aa(bb)", List(Group(3, 5, 6))))
 
-        test(t"Parse aa(bb)cc")(Regex.parse(List(t"aa(bb)cc")))
+        test(m"Parse aa(bb)cc")(Regex.parse(List(t"aa(bb)cc")))
         . assert(_ == Regex(t"aa(bb)cc", List(Group(3, 5, 6))))
 
-        test(t"Parse aa(bb)+?cc")(Regex.parse(List(t"aa(bb)+?cc")))
+        test(m"Parse aa(bb)+?cc")(Regex.parse(List(t"aa(bb)+?cc")))
         . assert(_ == Regex(t"aa(bb)+?cc", List(Group(3, 5, 8, Nil, AtLeast(1), Reluctant))))
 
-        test(t"Parse aa(bb)++cc")(Regex.parse(List(t"aa(bb)++cc")))
+        test(m"Parse aa(bb)++cc")(Regex.parse(List(t"aa(bb)++cc")))
         . assert(_ == Regex(t"aa(bb)++cc", List(Group(3, 5, 8, Nil, AtLeast(1), Possessive))))
 
-        test(t"Parse aa(bb)cc(dd)ee")(Regex.parse(List(t"aa(bb)cc(dd)ee")))
+        test(m"Parse aa(bb)cc(dd)ee")(Regex.parse(List(t"aa(bb)cc(dd)ee")))
         . assert(_ == Regex(t"aa(bb)cc(dd)ee", List(Group(3, 5, 6), Group(9, 11, 12))))
 
-        test(t"Parse aa(bb(cc)dd)ee")(Regex.parse(List(t"aa(bb(cc)dd)ee")))
+        test(m"Parse aa(bb(cc)dd)ee")(Regex.parse(List(t"aa(bb(cc)dd)ee")))
         . assert(_ == Regex(t"aa(bb(cc)dd)ee", List(Group(3, 11, 12, List(Group(6, 8, 9))))))
 
-        test(t"Parse aa(bb)*cc(dd)ee")(Regex.parse(List(t"aa(bb)*cc(dd)ee")))
+        test(m"Parse aa(bb)*cc(dd)ee")(Regex.parse(List(t"aa(bb)*cc(dd)ee")))
         . assert(_ == Regex(t"aa(bb)*cc(dd)ee", List(Group(3, 5, 7, Nil, AtLeast(0)), Group(10, 12, 13))))
 
-        test(t"Parse aa(bb(cc)*dd)ee"):
+        test(m"Parse aa(bb(cc)*dd)ee"):
           Regex.parse(List(t"aa(bb(cc)*dd)ee"))
 
         . assert:
           _ == Regex(t"aa(bb(cc)*dd)ee", List(Group(3, 12, 13, List(Group(6, 8, 10, Nil, AtLeast(0))))))
 
-        test(t"Parse aa(bb)+cc(dd)ee"):
+        test(m"Parse aa(bb)+cc(dd)ee"):
           Regex.parse(List(t"aa(bb)+cc(dd)ee"))
 
         . assert:
           _ == Regex(t"aa(bb)+cc(dd)ee", List(Group(3, 5, 7, Nil, AtLeast(1)), Group(10, 12, 13)))
 
-        test(t"Parse aa(bb){4}cc(dd)ee"):
+        test(m"Parse aa(bb){4}cc(dd)ee"):
           Regex.parse(List(t"aa(bb){4}cc(dd)ee"))
 
         . assert:
           _ == Regex(t"aa(bb){4}cc(dd)ee", List(Group(3, 5, 9, Nil, Exactly(4)), Group(12, 14, 15)))
 
-        test(t"Parse aa(bb){4,}cc(dd)ee"):
+        test(m"Parse aa(bb){4,}cc(dd)ee"):
           Regex.parse(List(t"aa(bb){4,}cc(dd)ee"))
 
         . assert:
           _ == Regex(t"aa(bb){4,}cc(dd)ee", List(Group(3, 5, 10, Nil, AtLeast(4)), Group(13, 15, 16)))
 
-        test(t"Parse aa(bb){4,6}cc(dd)ee"):
+        test(m"Parse aa(bb){4,6}cc(dd)ee"):
           Regex.parse(List(t"aa(bb){4,6}cc(dd)ee"))
 
         . assert:
           _ == Regex(t"aa(bb){4,6}cc(dd)ee", List(Group(3, 5, 11, Nil, Between(4, 6)), Group(14, 16, 17)))
 
-        test(t"Parse aa(bb){14,16}ccddee"):
+        test(m"Parse aa(bb){14,16}ccddee"):
           Regex.parse(List(t"aa(bb){14,16}ccddee"))
 
         . assert(_ == Regex(t"aa(bb){14,16}ccddee", List(Group(3, 5, 13, Nil, Between(14, 16)))))
 
-        test(t"Capture character class"):
+        test(m"Capture character class"):
           Regex.parse(List(t"w[aeiou]rld")).tap: result =>
             println(result)
 
         .assert(_ == Regex(t"w[aeiou]rld", List(Group(2, 7, 8, Nil, Exactly(1), Greedy, false, true))))
 
-      suite(t"Parsing failures"):
-        test(t"Fail to parse aa(bb){14,16ccddee"):
+      suite(m"Parsing failures"):
+        test(m"Fail to parse aa(bb){14,16ccddee"):
           capture(Regex.parse(List(t"aa(bb){14,16ccddee")))
 
         . assert(_ == RegexError(12, RegexError.Reason.UnexpectedChar))
 
-        test(t"Fail to parse aa(bb){14!}ccddee"):
+        test(m"Fail to parse aa(bb){14!}ccddee"):
           capture(Regex.parse(List(t"aa(bb){14!}ccddee")))
 
         . assert(_ == RegexError(9, RegexError.Reason.UnexpectedChar))
 
-        test(t"Fail to parse aa(bb{14}ccddee"):
+        test(m"Fail to parse aa(bb{14}ccddee"):
           capture(Regex.parse(List(t"aa(bb{14}ccddee")))
 
         . assert(_ == RegexError(15, RegexError.Reason.UnclosedGroup))
 
-        test(t"Fail to parse aa(bb){2,1}c"):
+        test(m"Fail to parse aa(bb){2,1}c"):
           capture(Regex.parse(List(t"aa(bb){2,1}c")))
 
         . assert(_ == RegexError(9, RegexError.Reason.BadRepetition))
 
-        test(t"Fail to parse aabb){2,1}c"):
+        test(m"Fail to parse aabb){2,1}c"):
           capture(Regex.parse(List(t"aabb){2,1}c")))
 
         . assert(_ == RegexError(4, RegexError.Reason.NotInGroup))
 
-        test(t"Fail to parse aa(bb){2,,1}c"):
+        test(m"Fail to parse aa(bb){2,,1}c"):
           capture(Regex.parse(List(t"aabb){2,,1}c")))
 
         . assert(_ == RegexError(4, RegexError.Reason.NotInGroup))
 
-        test(t"Fail to parse aabb){2,,1}c"):
+        test(m"Fail to parse aabb){2,,1}c"):
           capture(Regex.parse(List(t"aabb){2,,1}c")))
 
         . assert(_ == RegexError(4, RegexError.Reason.NotInGroup))
 
-        test(t"Fail to parse aabb){,2}c"):
+        test(m"Fail to parse aabb){,2}c"):
           capture(Regex.parse(List(t"aabb){,2}c")))
 
         . assert(_ == RegexError(4, RegexError.Reason.NotInGroup))
 
-        test(t"Fail to parse aa(bb){2,,1}c"):
+        test(m"Fail to parse aa(bb){2,,1}c"):
           capture(Regex.parse(List(t"aa(bb){2,,1}c")))
 
         . assert(_ == RegexError(9, RegexError.Reason.UnexpectedChar))
 
-        test(t"Fail to parse aa(bb){"):
+        test(m"Fail to parse aa(bb){"):
           capture(Regex.parse(List(t"aa(bb){")))
 
         . assert(_ == RegexError(7, RegexError.Reason.IncompleteRepetition))
 
-      suite(t"Test captures"):
-        test(t"Capture without parens should fail"):
+      suite(m"Test captures"):
+        test(m"Capture without parens should fail"):
           capture(Regex.parse(List(t"a", t"a(bb)")))
 
         . assert(_ == RegexError(0, RegexError.Reason.ExpectedGroup))
 
-        test(t"Check simple group is captured"):
+        test(m"Check simple group is captured"):
           Regex.parse(List(t"aa", t"(bb)cc"))
 
         . assert(_ == Regex(t"aa(bb)cc", List(Group(3, 5, 6, Nil, Exactly(1), Greedy, true))))
 
-        test(t"Check simple group at start is captured"):
+        test(m"Check simple group at start is captured"):
           Regex.parse(List(t"", t"(bb)cc"))
 
         . assert(_ == Regex(t"(bb)cc", List(Group(1, 3, 4, Nil, Exactly(1), Greedy, true))))
 
-        test(t"Check nested group is captured"):
+        test(m"Check nested group is captured"):
           Regex.parse(List(t"a(a", t"(bb)c)c"))
 
         . assert(_ == Regex(t"a(a(bb)c)c", List(Group(2, 8, 9, List(Group(4, 6, 7, Nil, Exactly(1), Greedy, true))))))
 
-        test(t"Check that capture in repeated group is forbidden"):
+        test(m"Check that capture in repeated group is forbidden"):
           capture(Regex.parse(List(t"a(a", t"(bb)c)*c")))
 
         . assert(_ == RegexError(3, RegexError.Reason.Uncapturable))
 
-        test(t"Check that capture in another repeated group is forbidden"):
+        test(m"Check that capture in another repeated group is forbidden"):
           capture(Regex.parse(List(t"a(a", t"(bb)c){2}c")))
 
         . assert(_ == RegexError(3, RegexError.Reason.Uncapturable))
 
-      suite(t"Capturing patterns"):
-        test(t"Show plain capturing pattern"):
+      suite(m"Capturing patterns"):
+        test(m"Show plain capturing pattern"):
           Regex.parse(List(t"abc")).capturePattern
 
         . assert(_ == t"abc")
 
-        test(t"Show simple capturing pattern"):
+        test(m"Show simple capturing pattern"):
           Regex.parse(List(t"a", t"(bc)")).capturePattern
 
         . assert(_ == t"a(?<g0>bc)")
 
-        test(t"Capturing groups are numbered correctly"):
+        test(m"Capturing groups are numbered correctly"):
           Regex.parse(List(t"(hello) ", t"(world)")).capturePattern
 
         . assert(_ == t"(hello) (?<g0>world)")
 
-        test(t"Show double capturing pattern"):
+        test(m"Show double capturing pattern"):
           Regex.parse(List(t"a", t"(bc)d", t"(ef)")).capturePattern
 
         . assert(_ == t"a(?<g0>bc)d(?<g1>ef)")
 
-        test(t"Show repeating capturing pattern"):
+        test(m"Show repeating capturing pattern"):
           Regex.parse(List(t"a", t"(bc)*")).capturePattern
 
         . assert(_ == t"a(?<g0>(bc)*)")
 
-        test(t"Show exact repeating capturing pattern"):
+        test(m"Show exact repeating capturing pattern"):
           Regex.parse(List(t"a", t"(bc){3}")).capturePattern
 
         . assert(_ == t"a(?<g0>(bc){3})")
 
-      suite(t"Scanner patterns"):
-        test(t"Simple capture"):
+      suite(m"Scanner patterns"):
+        test(m"Simple capture"):
           Regex.parse(List(t"foo", t"(bar)")).matchGroups(t"foobar")
           . map(_.to(List))
 
         . assert(_ == Some(List(t"bar")))
 
-        test(t"Two captures"):
+        test(m"Two captures"):
           Regex.parse(List(t"foo", t"(bar)", t"(baz)")).matchGroups(t"foobarbaz")
           . map(_.to(List))
 
         . assert(_ == Some(List(t"bar", t"baz")))
 
-        test(t"Two captures, one repeating"):
+        test(m"Two captures, one repeating"):
           Regex.parse(List(t"foo", t"(bar)", t"(baz)*")).matchGroups(t"foobarbazbaz")
           . map(_.to(List))
 
         . assert(_ == Some(List(t"bar", List(t"baz", t"baz"))))
 
-        test(t"Two captures, both repeating"):
+        test(m"Two captures, both repeating"):
           Regex.parse(List(t"foo", t"(bar){4}", t"(baz)*")).matchGroups(t"foobarbarbarbarbazbaz")
           . map(_.to(List))
 
         . assert(_ == Some(List(List(t"bar", t"bar", t"bar", t"bar"), List(t"baz", t"baz"))))
 
-        test(t"Two captures, one optional and absent, one repeating"):
+        test(m"Two captures, one optional and absent, one repeating"):
           Regex.parse(List(t"foo", t"(bar)+", t"(baz)?")).matchGroups(t"foobarbar")
           . map(_.to(List))
 
         . assert(_ == Some(List(List(t"bar", t"bar"), Unset)))
 
-        test(t"Two captures, one optional and present, one repeating"):
+        test(m"Two captures, one optional and present, one repeating"):
           Regex.parse(List(t"foo", t"(b.r)+", t"(baz)?")).matchGroups(t"fooberbirbaz")
           . map(_.to(List))
 
         . assert(_ == Some(List(List(t"ber", t"bir"), t"baz")))
 
-        test(t"Nested captures, one optional and present, one repeating"):
+        test(m"Nested captures, one optional and present, one repeating"):
           Regex.parse(List(t"f(oo", t"(b.r)+", t"(baz)?)")).matchGroups(t"fooberbirbaz")
           . map(_.to(List))
 
         . assert(_ == Some(List(List(t"ber", t"bir"), t"baz")))
 
-    suite(t"Match tests"):
-      test(t"simple match"):
+    suite(m"Match tests"):
+      test(m"simple match"):
         t"hello world".absolve match
           case r"hello world" => 1
 
       . assert(_ == 1)
 
-      test(t"basic extractor"):
+      test(m"basic extractor"):
         t"hello world".absolve match
           case r"(hello world)" => 2
 
       . assert(_ == 2)
 
-      test(t"extract one word"):
+      test(m"extract one word"):
         t"hello world".absolve match
           case r"$first(hello) world" => first.show
 
       . check(_ == t"hello")
 
-      test(t"extract a nested capture group"):
+      test(m"extract a nested capture group"):
         t"hello world".absolve match
           case r"(($first(hello)) world)" => first.show
 
       . assert(_ == t"hello")
 
-      test(t"extract words"):
+      test(m"extract words"):
         t"hello world".absolve match
           case r"$first(hello) $second(world)" => List(first, second)
 
       . assert(_ == List(t"hello", t"world"))
 
-      test(t"skipped capture group"):
+      test(m"skipped capture group"):
         t"hello world".absolve match
           case r"(hello) $second(world)" => second.show
 
       . assert(_ == t"world")
 
-      test(t"skipped capture group 2"):
+      test(m"skipped capture group 2"):
         t"1 2 3 4 5".absolve match
           case r"1 $two(2) 3 4 5" => two.show
 
       . assert(_ == t"2")
 
-      test(t"nested unbound capture group"):
+      test(m"nested unbound capture group"):
         t"anyval".absolve match
           case r"$x(any(val))" => x.show
       . assert(_ == t"anyval")
 
-      test(t"email regex"):
+      test(m"email regex"):
         val r"^$prefix([a-z0-9._%+-]+)@$domain([a-z0-9.-]+)\.$tld([a-z]{2,6})$$" =
             t"test@example.com": @unchecked
 
@@ -328,123 +328,123 @@ object Tests extends Suite(t"Kaleidoscope tests"):
 
       . assert(_ == List(t"test", t"example", t"com"))
 
-      suite(t"Character match tests"):
-        test(t"Match a character"):
+      suite(m"Character match tests"):
+        test(m"Match a character"):
           t"hello" match
             case r"h$vowel[aeiou]llo" => vowel
 
         . assert(_ == 'e')
 
-        test(t"Match several characters"):
+        test(m"Match several characters"):
           t"favourite" match
             case r"fav$vowels[aeiou]+rite" => vowels
 
         . assert(_ == List('o', 'u'))
 
-        test(t"Match zero characters"):
+        test(m"Match zero characters"):
           t"favourite" match
             case r"favou$misc[cxm]*rite" => misc
 
         . assert(_ == Nil)
 
-        test(t"Match maybe one character; preset"):
+        test(m"Match maybe one character; preset"):
           t"favourite" match
             case r"favo$vowel[aeiou]?rite" => vowel
 
         . assert(_ == 'u')
 
-        test(t"Match maybe one character; absent"):
+        test(m"Match maybe one character; absent"):
           t"favourite" match
             case r"favou$vowel[aeiou]?rite" => vowel
 
         . assert(_ == Unset)
 
-        test(t"Match characters in subgroup"):
+        test(m"Match characters in subgroup"):
           t"favourite" match
             case r"fav($vowels[ou]*)rite" => vowels
 
         . assert(_ == List('o', 'u'))
 
 
-        test(t"Match characters in subgroup"):
+        test(m"Match characters in subgroup"):
           t"favourite" match
             case r"fav($vowels[ou]*)rite" => vowels.tap(println(_))
 
         . assert(_ == List('o', 'u'))
 
-    suite(t"Glob tests"):
-      test(t"Parse a plain glob"):
+    suite(m"Glob tests"):
+      test(m"Parse a plain glob"):
         Glob.parse(t"hello world").regex
 
       . assert(_ == t"hello world")
 
-      test(t"Parse a plain glob with some symbols"):
+      test(m"Parse a plain glob with some symbols"):
         Glob.parse(t"hello-world!").regex
 
       . assert(_ == t"hello\\-world\\!")
 
-      test(t"Parse a glob with a star"):
+      test(m"Parse a glob with a star"):
         Glob.parse(t"hello*world").regex
 
       . assert(_ == t"hello[^/\\\\]*world")
 
-      test(t"Parse a glob with a question mark"):
+      test(m"Parse a glob with a question mark"):
         Glob.parse(t"hello?world").regex
 
       . assert(_ == t"hello[^/\\\\]world")
 
-      test(t"Parse a glob with a range"):
+      test(m"Parse a glob with a range"):
         Glob.parse(t"hello[a-z]world").regex
 
       . assert(_ == t"hello[a-z]world")
 
-      test(t"Parse a glob with a specific set of characters"):
+      test(m"Parse a glob with a specific set of characters"):
         Glob.parse(t"hello[aeiou]world").regex
 
       . assert(_ == t"hello[aeiou]world")
 
-      test(t"Parse a glob excluding a specific set of characters"):
+      test(m"Parse a glob excluding a specific set of characters"):
         Glob.parse(t"hello[!aeiou]world").regex
 
       . assert(_ == t"hello[^aeiou]world")
 
-      test(t"Parse a glob excluding a range of characters"):
+      test(m"Parse a glob excluding a range of characters"):
         Glob.parse(t"hello[!a-z]world").regex
 
       . assert(_ == t"hello[^a-z]world")
 
-      test(t"Extract from a glob"):
+      test(m"Extract from a glob"):
         t"/home/work/docs" match
           case g"/$home/work/docs" => home
 
       . assert(_ == t"home")
 
-      test(t"Extract from a glob with a star"):
+      test(m"Extract from a glob with a star"):
         t"/home/work/docs" match
           case g"/$home/*/docs" => home
 
       . assert(_ == t"home")
 
-      test(t"Extract from a glob with question marks"):
+      test(m"Extract from a glob with question marks"):
         t"/home/work/docs" match
           case g"/$home/????/docs" => home
 
       . assert(_ == t"home")
 
-      test(t"Extract from a glob with two extractions"):
+      test(m"Extract from a glob with two extractions"):
         t"/home/work/docs" match
           case g"/$home/$work/docs" => (home, work)
 
       . assert(_ == (t"home", t"work"))
 
-      test(t"Extract from a glob with globstar"):
+      test(m"Extract from a glob with globstar"):
         t"/home/work/docs" match
           case g"/$home/**" => home
 
       . assert(_ == t"home")
 
-    suite(t"Compilation tests"):
-      test(t"brackets must be matched"):
+    suite(m"Compilation tests"):
+      test(m"brackets must be matched"):
         demilitarize:
           t"" match
             case r"hello(world" =>
@@ -455,7 +455,7 @@ object Tests extends Suite(t"Kaleidoscope tests"):
 
       . assert(_.contains("kaleidoscope:  the regular expression could not be parsed because a capturing group was not closed at 11"))
 
-      test(t"variable must be bound"):
+      test(m"variable must be bound"):
         demilitarize:
           t"" match
             case r"hello${space}world" =>

--- a/lib/larceny/.github/readme.md
+++ b/lib/larceny/.github/readme.md
@@ -156,7 +156,7 @@ Larceny should work with any Scala unit testing framework or library. For
 example, with [Probably](https://github.com/propensive/probably/), we could
 write a compile error test with:
 ```scala
-test(t"cannot sort data without an Ordering"):
+test(m"cannot sort data without an Ordering"):
   demilitarize(data.sorted).head.message
 .assert(_.startsWith("No implicit Ordering"))
 ```
@@ -189,7 +189,7 @@ experimentation. They are provided only for the necessity of providing _some_
 answer to the question, "how can I try Larceny?".
 
 1. *Copy the sources into your own project*
-   
+
    Read the `fury` file in the repository root to understand Larceny's build
    structure, dependencies and source location; the file format should be short
    and quite intuitive. Copy the sources into a source directory in your own
@@ -206,7 +206,7 @@ answer to the question, "how can I try Larceny?".
    file in the project directory, and produce a collection of JAR files which can
    be added to a classpath, by compiling the project and all of its dependencies,
    including the Scala compiler itself.
-   
+
    Download the latest version of
    [`wrath`](https://github.com/propensive/wrath/releases/latest), make it
    executable, and add it to your path, for example by copying it to
@@ -266,4 +266,3 @@ The logo shows a shape of a medieval fortification, alluding to a "demilitarized
 
 Larceny is copyright &copy; 2025 Jon Pretty & Propensive O&Uuml;, and
 is made available under the [Apache 2.0 License](/license.md).
-

--- a/lib/larceny/doc/basics.md
+++ b/lib/larceny/doc/basics.md
@@ -120,7 +120,7 @@ Larceny should work with any Scala unit testing framework or library. For
 example, with [Probably](https://github.com/propensive/probably/), we could
 write a compile error test with:
 ```scala
-test(t"cannot sort data without an Ordering"):
+test(m"cannot sort data without an Ordering"):
   demilitarize(data.sorted).head.message
 .assert(_.startsWith("No implicit Ordering"))
 ```

--- a/lib/mercator/src/test/mercator.Tests.scala
+++ b/lib/mercator/src/test/mercator.Tests.scala
@@ -38,106 +38,106 @@ import probably.*
 
 import scala.util.{Try, Success}
 
-object Tests extends Suite(t"Mercator tests"):
+object Tests extends Suite(m"Mercator tests"):
   def run(): Unit =
-    test(t"Identity for Option"):
+    test(m"Identity for Option"):
       val point = summon[Identity[Option]]
       point.point(1)
     .assert(_ == Some(1))
 
-    test(t"Identity for List"):
+    test(m"Identity for List"):
       summon[Identity[List]].point(1)
     .assert(_ == List(1))
 
-    test(t"Identity for Set"):
+    test(m"Identity for Set"):
       summon[Identity[Set]].point(1)
     .assert(_ == Set(1))
 
-    test(t"Identity for Vector"):
+    test(m"Identity for Vector"):
       summon[Identity[Vector]].point(1)
     .assert(_ == Vector(1))
 
-    test(t"Identity for Try"):
+    test(m"Identity for Try"):
       summon[Identity[scala.util.Try]].point(1)
     .assert(_ == scala.util.Success(1))
 
-    test(t"Identity for Either"):
+    test(m"Identity for Either"):
       summon[Identity[[T] =>> Either[Any, T]]].point(1)
     .assert(_ == Right(1))
 
-    test(t"Functor for Option"):
+    test(m"Functor for Option"):
       val functor = summon[Functor[Option]]
       functor.map(Some(1))(_ + 1)
     .assert(_ == Some(2))
 
-    test(t"Functor for List"):
+    test(m"Functor for List"):
       val functor = summon[Functor[List]]
       functor.map(List(1, 2, 3))(_ + 1)
     .assert(_ == List(2, 3, 4))
 
-    test(t"Functor for Set"):
+    test(m"Functor for Set"):
       val functor = summon[Functor[Set]]
       functor.map(Set(1, 3, 5))(_ + 1)
     .assert(_ == Set(2, 4, 6))
 
-    test(t"Functor for Vector"):
+    test(m"Functor for Vector"):
       val functor = summon[Functor[Vector]]
       functor.map(Vector(1, 2, 3))(_ + 1)
     .assert(_ == Vector(2, 3, 4))
 
-    test(t"Functor for Try"):
+    test(m"Functor for Try"):
       val functor = summon[Functor[scala.util.Try]]
       functor.map(scala.util.Success(1))(_ + 1)
     .assert(_ == scala.util.Success(2))
 
-    test(t"Functor for Either"):
+    test(m"Functor for Either"):
       val functor = summon[Functor[[T] =>> Either[Any, T]]]
       functor.map(Right(1))(_ + 1)
     .assert(_ == Right(2))
 
-    test(t"Monad for Option"):
+    test(m"Monad for Option"):
       val monad = summon[Monad[Option]]
       monad.flatMap(Some(1)) { v => Some(v + 1) }
     .assert(_ == Some(2))
 
-    test(t"Monad for List"):
+    test(m"Monad for List"):
       val monad = summon[Monad[List]]
       monad.flatMap(List(1, 2, 3)) { v => if v > 1 then List(v + 1) else Nil }
     .assert(_ == List(3, 4))
 
-    test(t"Monad for Set"):
+    test(m"Monad for Set"):
       val monad = summon[Monad[Set]]
       monad.flatMap(Set(1, 3, 5)) { v => Set(v + 1) }
     .assert(_ == Set(2, 4, 6))
 
-    test(t"Monad for Vector"):
+    test(m"Monad for Vector"):
       val monad = summon[Monad[Vector]]
       monad.flatMap(Vector(1, 2, 3)) { v => Vector(v + 1, v + 1) }
     .assert(_ == Vector(2, 2, 3, 3, 4, 4))
 
-    test(t"Monad for Try"):
+    test(m"Monad for Try"):
       val monad = summon[Monad[scala.util.Try]]
       monad.flatMap(scala.util.Success(1)) { v => scala.util.Try(v + 1) }
     .assert(_ == scala.util.Success(2))
 
-    test(t"Sequence on List/Try"):
+    test(m"Sequence on List/Try"):
       List(Try(1), Try(2), Try(3)).sequence
     .assert(_ == Success(List(1, 2, 3)))
 
-    // test(t"Sequence on Vector/Try"):
+    // test(m"Sequence on Vector/Try"):
     //   Vector(Try(1), Try(2), Try(3)).sequence
     // .assert(_ == Success(Vector(1, 2, 3)))
 
-    test(t"Sequence on List/Set"):
+    test(m"Sequence on List/Set"):
       List(Set(1), Set(2), Set(3)).sequence
     .assert(_ == Set(List(1, 2, 3)))
 
-    // test(t"Monad for Either"):
+    // test(m"Monad for Either"):
     //   val monad = summon[Monad[[T] =>> Either[Any, T]]]
     //   monad.flatMap(Right(1)) { v => Right(v + 1) }
     // .assert(_ == Right(2))
 
-    test(t"Identity for Ordering does not exist"):
+    test(m"Identity for Ordering does not exist"):
       demilitarize:
         summon[Identity[Ordering]].point(1)
       .map(_.message)

--- a/lib/merino/src/bench/merino.Benchmarks.scala
+++ b/lib/merino/src/bench/merino.Benchmarks.scala
@@ -48,43 +48,43 @@ import LogFormat.standardAnsi
 val OutSink = Out.sink
 given Log({ case _ => OutSink })
 
-object Benchmarks extends Suite(t"Merino tests"):
+object Benchmarks extends Suite(m"Merino tests"):
   def run(): Unit =
-    suite(t"Parse example 1"):
-      test(t"Parse file with Jawn"):
+    suite(m"Parse example 1"):
+      test(m"Parse file with Jawn"):
         import org.typelevel.jawn.*, ast.*
         JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(jsonExample1).nn)
 
       . benchmark
          (warmup = 1000L, duration = 1000L, baseline = Baseline(compare = Min), confidence = 99)
 
-      test(t"Parse file with Merino"):
+      test(m"Parse file with Merino"):
         JsonAst.parse(jsonExample1.nn.immutable(using Unsafe))
 
       . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)
 
-    suite(t"Parse example 2"):
-      test(t"Parse file with Jawn"):
+    suite(m"Parse example 2"):
+      test(m"Parse file with Jawn"):
         import org.typelevel.jawn.*, ast.*
         JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(jsonExample2).nn)
 
       . benchmark
          (warmup = 1000L, duration = 1000L, baseline = Baseline(compare = Min), confidence = 99)
 
-      test(t"Parse file with Merino"):
+      test(m"Parse file with Merino"):
         JsonAst.parse(jsonExample2.nn.immutable(using Unsafe))
 
       . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)
 
-    suite(t"Parse example 3"):
-      test(t"Parse file with Jawn"):
+    suite(m"Parse example 3"):
+      test(m"Parse file with Jawn"):
         import org.typelevel.jawn.*, ast.*
         JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(jsonExample3).nn)
 
       . benchmark
          (warmup = 1000L, duration = 1000L, baseline = Baseline(compare = Min), confidence = 99)
 
-      test(t"Parse file with Merino"):
+      test(m"Parse file with Merino"):
         JsonAst.parse(jsonExample3.nn.immutable(using Unsafe))
 
       . benchmark(warmup = 1000L, duration = 1000L, confidence = 99)

--- a/lib/merino/src/test/merino.Tests.scala
+++ b/lib/merino/src/test/merino.Tests.scala
@@ -46,18 +46,18 @@ import java.io as ji
 
 //import unsafeExceptions.canThrowAny
 
-object Tests extends Suite(t"Merino tests"):
+object Tests extends Suite(m"Merino tests"):
   def run(): Unit =
     val tests = ji.File(ji.File(workingDirectory, "tests"), "test_parsing")
     val tests2 = ji.File(ji.File(workingDirectory, "tests"), "test_transform")
 
-    suite(t"Positive tests"):
+    suite(m"Positive tests"):
       (tests.listFiles.nn.map(_.nn).to(List).filter(_.getName.nn.startsWith("y_")) ++ tests2.listFiles.nn.map(_.nn).to(List)).each: file =>
         test(Text(file.getName.nn.dropRight(5))):
           JsonAst.parse(ji.BufferedInputStream(ji.FileInputStream(file)))
         .check()
 
-    suite(t"Negative tests"):
+    suite(m"Negative tests"):
       tests.listFiles.nn.map(_.nn).filter(_.getName.nn.startsWith("n_")).each: file =>
         test(Text(file.getName.nn.dropRight(5))):
           capture(JsonAst.parse(ji.BufferedInputStream(ji.FileInputStream(file))))
@@ -67,111 +67,111 @@ object Tests extends Suite(t"Merino tests"):
 
     val testDir = ji.File(workingDirectory, "data")
 
-    suite(t"Parse large files"):
-      val file: Bytes = test(t"Read file"):
+    suite(m"Parse large files"):
+      val file: Bytes = test(m"Read file"):
         ji.BufferedInputStream(ji.FileInputStream(ji.File(testDir, "huge.json"))).read[Bytes]
       .check()
 
-      val file2: Bytes = test(t"Read file 2"):
+      val file2: Bytes = test(m"Read file 2"):
         ji.BufferedInputStream(ji.FileInputStream(ji.File(testDir, "huge2.json"))).read[Bytes]
       .check()
 
-      // test(t"Parse huge file with Jawn"):
+      // test(m"Parse huge file with Jawn"):
       //   import org.typelevel.jawn.*, ast.*
       //   JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(file.mutable(using Unsafe)).nn)
       // .benchmark()
 
-      // test(t"Parse huge file with Merino"):
+      // test(m"Parse huge file with Merino"):
       //   JsonAst.parse(file)
       // .benchmark()
 
-      // test(t"Parse big file with Jawn"):
+      // test(m"Parse big file with Jawn"):
       //   import org.typelevel.jawn.*, ast.*
       //   JParser.parseFromByteBuffer(java.nio.ByteBuffer.wrap(file2.mutable(using Unsafe)).nn)
       // .benchmark()
 
-      test(t"Parse big file with Merino"):
+      test(m"Parse big file with Merino"):
         JsonAst.parse(file2)
       .benchmark()
 
-    suite(t"Number tests"):
-      test(t"Parse 0e+1"):
+    suite(m"Number tests"):
+      test(m"Parse 0e+1"):
         JsonAst.parse(t"0e+1")
       .assert(_ == JsonAst(0L))
 
-      test(t"Parse 0e1"):
+      test(m"Parse 0e1"):
         JsonAst.parse(t"0e1")
       .assert(_ == JsonAst(0L))
 
-      test(t"Parse ' 4'"):
+      test(m"Parse ' 4'"):
         JsonAst.parse(t" 4")
       .assert(_ == JsonAst(4L))
 
-      test(t"Parse small negative number"):
+      test(m"Parse small negative number"):
         JsonAst.parse(t"-0.000000000000000000000000000000000000000000000000000000000000000000000000000001")
       .assert(_ == JsonAst(-1.0e-78))
 
-      test(t"Parse 20e1"):
+      test(m"Parse 20e1"):
         JsonAst.parse(t"20e1")
       .assert(_ == JsonAst(200L))
 
-      test(t"Parse 123e65"):
+      test(m"Parse 123e65"):
         JsonAst.parse(t"123e65")
       .assert(_ == JsonAst(1.23e67))
 
-      test(t"Parse -0"):
+      test(m"Parse -0"):
         JsonAst.parse(t"-0")
       .assert(_ == JsonAst(-0.0))
 
-      test(t"Parse -123"):
+      test(m"Parse -123"):
         JsonAst.parse(t"-123")
       .assert(_ == JsonAst(-123L))
 
-      test(t"Parse -1"):
+      test(m"Parse -1"):
         JsonAst.parse(t"-1")
       .assert(_ == JsonAst(-1L))
 
-      test(t"Parse 1E22"):
+      test(m"Parse 1E22"):
         JsonAst.parse(t"1E22")
       .assert(_ == JsonAst(1.0E22))
 
-      test(t"Parse 1E-2"):
+      test(m"Parse 1E-2"):
         JsonAst.parse(t"1E-2")
       .assert(_ == JsonAst(1.0E-2))
 
-      test(t"Parse 1E+2"):
+      test(m"Parse 1E+2"):
         JsonAst.parse(t"1E+2")
       .assert(_ == JsonAst(1.0E2))
 
-      test(t"Parse 123e45"):
+      test(m"Parse 123e45"):
         JsonAst.parse(t"123e45")
       .assert(_ == JsonAst(1.23E47))
 
-      test(t"Parse 123.456e78"):
+      test(m"Parse 123.456e78"):
         JsonAst.parse(t"123.456e78")
       .assert(_ == JsonAst(1.23456E80))
 
-      test(t"Parse 1e-2"):
+      test(m"Parse 1e-2"):
         JsonAst.parse(t"1e-2")
       .assert(_ == JsonAst(1.0E-2))
 
-      test(t"Parse 1e+2"):
+      test(m"Parse 1e+2"):
         JsonAst.parse(t"1e+2")
       .assert(_ == JsonAst(1.0E2))
 
-      test(t"Parse 123"):
+      test(m"Parse 123"):
         JsonAst.parse(t"123")
       .assert(_ == JsonAst(123L))
 
-      test(t"Parse 123.456789"):
+      test(m"Parse 123.456789"):
         JsonAst.parse(t"123.456789")
       .assert(_ == JsonAst(123.456789))
 
-      test(t"Parse \"Hello World\""):
+      test(m"Parse \"Hello World\""):
         JsonAst.parse(t"\"Hello World\"")
       .assert(_ == JsonAst("Hello World"))
 
-      test(t"Parse \"\""):
+      test(m"Parse \"\""):
         JsonAst.parse(t"\"\"")
       .assert(_ == JsonAst(""))
 

--- a/lib/metamorphose/src/test/metamorphose.Tests.scala
+++ b/lib/metamorphose/src/test/metamorphose.Tests.scala
@@ -38,107 +38,107 @@ import language.experimental.genericNumberLiterals
 import probably.*
 import rudiments.*
 
-object Tests extends Suite(t"Metamorphose tests"):
+object Tests extends Suite(m"Metamorphose tests"):
   def run(): Unit =
-    suite(t"Factorial tests"):
-      test(t"Calculate 0!")(Factorial(0)).assert(_ == 1)
-      test(t"Calculate 1!")(Factorial(1)).assert(_ == 1)
-      test(t"Calculate 2!")(Factorial(2)).assert(_ == 2)
-      test(t"Calculate 3!")(Factorial(3)).assert(_ == 6)
-      test(t"Calculate 4!")(Factorial(4)).assert(_ == 24)
+    suite(m"Factorial tests"):
+      test(m"Calculate 0!")(Factorial(0)).assert(_ == 1)
+      test(m"Calculate 1!")(Factorial(1)).assert(_ == 1)
+      test(m"Calculate 2!")(Factorial(2)).assert(_ == 2)
+      test(m"Calculate 3!")(Factorial(3)).assert(_ == 6)
+      test(m"Calculate 4!")(Factorial(4)).assert(_ == 24)
 
       val factorial21: BigInt = 51090942171709440000
-      test(t"Calculate 21!")(Factorial(21)).assert(_ == factorial21)
+      test(m"Calculate 21!")(Factorial(21)).assert(_ == factorial21)
 
       val factorial42: BigInt = 1405006117752879898543142606244511569936384000000000
-      test(t"Calculate 42!")(Factorial(42)).assert(_ == factorial42)
+      test(m"Calculate 42!")(Factorial(42)).assert(_ == factorial42)
 
-    suite(t"Factoradic encoding tests"):
-      test(t"2-element identity permutation")(Factoradic(List(0, 0))).assert(_ == Factoradic(0))
-      test(t"4-element identity permutation")(Factoradic(List(0, 0, 0, 0))).assert(_ == Factoradic(0))
-      test(t"(1, 0, 0, 0) permutation")(Factoradic(List(1, 0, 0, 0))).assert(_ == Factoradic(6))
-      test(t"(2, 0, 0, 0) permutation")(Factoradic(List(2, 0, 0, 0))).assert(_ == Factoradic(12))
-      test(t"(3, 0, 0, 0) permutation")(Factoradic(List(3, 0, 0, 0))).assert(_ == Factoradic(18))
-      test(t"(0, 1, 0, 0) permutation")(Factoradic(List(0, 1, 0, 0))).assert(_ == Factoradic(2))
-      test(t"(1, 1, 0, 0) permutation")(Factoradic(List(1, 1, 0, 0))).assert(_ == Factoradic(8))
-      test(t"(2, 1, 0, 0) permutation")(Factoradic(List(2, 1, 0, 0))).assert(_ == Factoradic(14))
-      test(t"(3, 1, 0, 0) permutation")(Factoradic(List(3, 1, 0, 0))).assert(_ == Factoradic(20))
-      test(t"(0, 2, 0, 0) permutation")(Factoradic(List(0, 2, 0, 0))).assert(_ == Factoradic(4))
-      test(t"(1, 2, 0, 0) permutation")(Factoradic(List(1, 2, 0, 0))).assert(_ == Factoradic(10))
-      test(t"(2, 2, 0, 0) permutation")(Factoradic(List(2, 2, 0, 0))).assert(_ == Factoradic(16))
-      test(t"(3, 2, 0, 0) permutation")(Factoradic(List(3, 2, 0, 0))).assert(_ == Factoradic(22))
+    suite(m"Factoradic encoding tests"):
+      test(m"2-element identity permutation")(Factoradic(List(0, 0))).assert(_ == Factoradic(0))
+      test(m"4-element identity permutation")(Factoradic(List(0, 0, 0, 0))).assert(_ == Factoradic(0))
+      test(m"(1, 0, 0, 0) permutation")(Factoradic(List(1, 0, 0, 0))).assert(_ == Factoradic(6))
+      test(m"(2, 0, 0, 0) permutation")(Factoradic(List(2, 0, 0, 0))).assert(_ == Factoradic(12))
+      test(m"(3, 0, 0, 0) permutation")(Factoradic(List(3, 0, 0, 0))).assert(_ == Factoradic(18))
+      test(m"(0, 1, 0, 0) permutation")(Factoradic(List(0, 1, 0, 0))).assert(_ == Factoradic(2))
+      test(m"(1, 1, 0, 0) permutation")(Factoradic(List(1, 1, 0, 0))).assert(_ == Factoradic(8))
+      test(m"(2, 1, 0, 0) permutation")(Factoradic(List(2, 1, 0, 0))).assert(_ == Factoradic(14))
+      test(m"(3, 1, 0, 0) permutation")(Factoradic(List(3, 1, 0, 0))).assert(_ == Factoradic(20))
+      test(m"(0, 2, 0, 0) permutation")(Factoradic(List(0, 2, 0, 0))).assert(_ == Factoradic(4))
+      test(m"(1, 2, 0, 0) permutation")(Factoradic(List(1, 2, 0, 0))).assert(_ == Factoradic(10))
+      test(m"(2, 2, 0, 0) permutation")(Factoradic(List(2, 2, 0, 0))).assert(_ == Factoradic(16))
+      test(m"(3, 2, 0, 0) permutation")(Factoradic(List(3, 2, 0, 0))).assert(_ == Factoradic(22))
 
-      test(t"(0, 0, 1, 0) permutation")(Factoradic(List(0, 0, 1, 0))).assert(_ == Factoradic(1))
-      test(t"(1, 0, 1, 0) permutation")(Factoradic(List(1, 0, 1, 0))).assert(_ == Factoradic(7))
-      test(t"(2, 0, 1, 0) permutation")(Factoradic(List(2, 0, 1, 0))).assert(_ == Factoradic(13))
-      test(t"(3, 0, 1, 0) permutation")(Factoradic(List(3, 0, 1, 0))).assert(_ == Factoradic(19))
-      test(t"(0, 1, 1, 0) permutation")(Factoradic(List(0, 1, 1, 0))).assert(_ == Factoradic(3))
-      test(t"(1, 1, 1, 0) permutation")(Factoradic(List(1, 1, 1, 0))).assert(_ == Factoradic(9))
-      test(t"(2, 1, 1, 0) permutation")(Factoradic(List(2, 1, 1, 0))).assert(_ == Factoradic(15))
-      test(t"(3, 1, 1, 0) permutation")(Factoradic(List(3, 1, 1, 0))).assert(_ == Factoradic(21))
-      test(t"(0, 2, 1, 0) permutation")(Factoradic(List(0, 2, 1, 0))).assert(_ == Factoradic(5))
-      test(t"(1, 2, 1, 0) permutation")(Factoradic(List(1, 2, 1, 0))).assert(_ == Factoradic(11))
-      test(t"(2, 2, 1, 0) permutation")(Factoradic(List(2, 2, 1, 0))).assert(_ == Factoradic(17))
-      test(t"(3, 2, 1, 0) permutation")(Factoradic(List(3, 2, 1, 0))).assert(_ == Factoradic(23))
+      test(m"(0, 0, 1, 0) permutation")(Factoradic(List(0, 0, 1, 0))).assert(_ == Factoradic(1))
+      test(m"(1, 0, 1, 0) permutation")(Factoradic(List(1, 0, 1, 0))).assert(_ == Factoradic(7))
+      test(m"(2, 0, 1, 0) permutation")(Factoradic(List(2, 0, 1, 0))).assert(_ == Factoradic(13))
+      test(m"(3, 0, 1, 0) permutation")(Factoradic(List(3, 0, 1, 0))).assert(_ == Factoradic(19))
+      test(m"(0, 1, 1, 0) permutation")(Factoradic(List(0, 1, 1, 0))).assert(_ == Factoradic(3))
+      test(m"(1, 1, 1, 0) permutation")(Factoradic(List(1, 1, 1, 0))).assert(_ == Factoradic(9))
+      test(m"(2, 1, 1, 0) permutation")(Factoradic(List(2, 1, 1, 0))).assert(_ == Factoradic(15))
+      test(m"(3, 1, 1, 0) permutation")(Factoradic(List(3, 1, 1, 0))).assert(_ == Factoradic(21))
+      test(m"(0, 2, 1, 0) permutation")(Factoradic(List(0, 2, 1, 0))).assert(_ == Factoradic(5))
+      test(m"(1, 2, 1, 0) permutation")(Factoradic(List(1, 2, 1, 0))).assert(_ == Factoradic(11))
+      test(m"(2, 2, 1, 0) permutation")(Factoradic(List(2, 2, 1, 0))).assert(_ == Factoradic(17))
+      test(m"(3, 2, 1, 0) permutation")(Factoradic(List(3, 2, 1, 0))).assert(_ == Factoradic(23))
 
-      test(t"six-element reversal permutation")(Factoradic(List(5, 4, 3, 2, 1, 0)))
+      test(m"six-element reversal permutation")(Factoradic(List(5, 4, 3, 2, 1, 0)))
        .assert(_ == Factoradic(719))
 
-      test(t"ensure that an error occurs for out-of-range bases"):
+      test(m"ensure that an error occurs for out-of-range bases"):
         capture[PermutationError](Factoradic(List(2, 1)))
       .assert(_ == PermutationError(PermutationError.Reason.BaseRange(2, 2)))
 
-      test(t"ensure that an error occurs for more complex out-of-range base"):
+      test(m"ensure that an error occurs for more complex out-of-range base"):
         capture[PermutationError](Factoradic(List(0, 0, 8, 3, 0, 1, 0)))
       .assert(_ == PermutationError(PermutationError.Reason.BaseRange(8, 5)))
 
-    suite(t"Factoradic decoding"):
-      test(t"Check distinctness of factoradic expansions"):
+    suite(m"Factoradic decoding"):
+      test(m"Check distinctness of factoradic expansions"):
         (0 to 1000).map(Factoradic(_).expand).to(Set).size
       .assert(_ == 1001)
 
-    suite(t"Permutations"):
-      test(t"Construct an identity permutation"):
+    suite(m"Permutations"):
+      test(m"Construct an identity permutation"):
         Permutation(Vector(0, 1, 2, 3, 4, 5))
       .assert(_ == Permutation(Factoradic(0)))
 
-      test(t"Construct a reversal permutation"):
+      test(m"Construct a reversal permutation"):
         Permutation(Vector(5, 4, 3, 2, 1, 0))
       .assert(_ == Permutation(Factoradic(719)))
 
-      test(t"Reverse a list of numbers"):
+      test(m"Reverse a list of numbers"):
         Permutation(Vector(5, 4, 3, 2, 1, 0))(List("one", "two", "three", "four", "five", "six"))
       .assert(_ == List("six", "five", "four", "three", "two", "one"))
 
-      test(t"Reorder a list of numbers"):
+      test(m"Reorder a list of numbers"):
         Permutation(Vector(3, 1, 4, 2, 0, 5))(List("zero", "one", "two", "three", "four", "five"))
       .assert(_ == List("three", "one", "four", "two", "zero", "five"))
 
-      test(t"Check duplicate indexes are caught"):
+      test(m"Check duplicate indexes are caught"):
         capture[PermutationError](Permutation(Vector(3, 1, 4, 2, 3, 5)))
       .assert(_ == PermutationError(PermutationError.Reason.DuplicateIndex(3, 4)))
 
-      test(t"Check negative indexes are caught"):
+      test(m"Check negative indexes are caught"):
         capture[PermutationError](Permutation(Vector(3, 1, 4, 2, -3, 5)))
       .assert(_ == PermutationError(PermutationError.Reason.InvalidIndex(-3, 5)))
 
-      test(t"Check high indexes are caught"):
+      test(m"Check high indexes are caught"):
         capture[PermutationError](Permutation(Vector(3, 1, 4, 6, 0, 5)))
       .assert(_ == PermutationError(PermutationError.Reason.InvalidIndex(6, 5)))
 
-      test(t"Check input is long enough"):
+      test(m"Check input is long enough"):
         val permutation = Permutation(Vector(3, 1, 4, 2, 0, 5))
         capture[PermutationError](permutation(List(1, 2, 3)))
       .assert(_ == PermutationError(PermutationError.Reason.TooShort(3, 6)))
 
-      test(t"Check uniqueness of permutations"):
+      test(m"Check uniqueness of permutations"):
         val list = List("one", "two", "three", "four", "five", "six", "seven")
         Permutation.bySize(7).map(_(list)).to(Set).size
       .assert(_ == 5040)
 
       Permutation.bySize(6).each: permutation =>
         val list = List("one", "two", "three", "four", "five", "six")
-        test(t"Inversion"):
+        test(m"Inversion"):
           val applied = permutation(list)
           val inversion = permutation.inverse
           inversion(applied)
@@ -148,6 +148,6 @@ object Tests extends Suite(t"Metamorphose tests"):
       val indices = Vector(6, 2, 1, 0, 3, 5, 4)
       val permutation = Permutation(indices)
       for i <- 0 to 6 do
-        test(t"Apply permutation indexwise"):
+        test(m"Apply permutation indexwise"):
           permutation(i)
         .assert(_ == indices(i))

--- a/lib/monotonous/src/test/monotonous.Tests.scala
+++ b/lib/monotonous/src/test/monotonous.Tests.scala
@@ -43,7 +43,7 @@ import alphabets.hex.lowerCase
 
 given Seed = Seed(1L)
 
-object Tests extends Suite(t"Monotonous tests"):
+object Tests extends Suite(m"Monotonous tests"):
 
   val numbers = IArray[Byte](0, 1, 2, 3, -125, -126, -127, -128, -4, -3, -2, -1)
   val numberList = numbers.to(List)
@@ -55,8 +55,8 @@ object Tests extends Suite(t"Monotonous tests"):
 
   def run(): Unit = stochastic:
 
-    suite(t"Streaming tests"):
-      test(t"Streaming BASE32"):
+    suite(m"Streaming tests"):
+      test(m"Streaming BASE32"):
         val text: Text = allNumbers.serialize
         val shredded = Stream(text.bytes).shred(6, 9).map(_.utf8)
         println(shredded.to(List).inspect)
@@ -65,75 +65,75 @@ object Tests extends Suite(t"Monotonous tests"):
         result.reduce(_ ++ _).to(List)
       .assert(_ == allNumbers.to(List))
 
-      // test(t"Streaming BASE64"):
+      // test(m"Streaming BASE64"):
       //   import strategies.throwUnsafely
       //   import alphabets.base64.standard
       //   stream.
 
-    // test(t"Serialize to Binary"):
+    // test(m"Serialize to Binary"):
     //   import alphabets.binary.standard
     //   numbers.serialize[Binary]
     // .assert(_ == t"000000000000000100000010000000111000001110000010100000011000000011111100111111011111111011111111")
 
-    // test(t"Serialize to Octal"):
+    // test(m"Serialize to Octal"):
     //   import alphabets.octal.standard
     //   numbers.serialize[Octal]
     // .assert(_ == t"00000402007016024030037477377377")
 
-    // test(t"Serialize to Hex"):
+    // test(m"Serialize to Hex"):
     //   import alphabets.hex.lowerCase
     //   numbers.serialize[Hex]
     // .assert(_ == t"0001020383828180fcfdfeff")
 
-    // test(t"Serialize to BASE32"):
+    // test(m"Serialize to BASE32"):
     //   import alphabets.base32.upperCase
     //   numbers.serialize[Base32]
     // .assert(_ == t"AAAQEA4DQKAYB7H5737Q====")
 
-    // test(t"Serialize to BASE64"):
+    // test(m"Serialize to BASE64"):
     //   import alphabets.base64.standard
     //   numbers.serialize[Base64]
     // .assert(_ == t"AAECA4OCgYD8/f7/")
 
     // import strategies.throwUnsafely
 
-    // test(t"Deserialize from Binary"):
+    // test(m"Deserialize from Binary"):
     //   import alphabets.binary.standard
     //   t"000000000000000100000010000000111000001110000010100000011000000011111100111111011111111011111111".deserialize[Binary].to(List)
     // .assert(_ == numberList)
 
-    // test(t"Deserialize from Octal"):
+    // test(m"Deserialize from Octal"):
     //   import alphabets.octal.standard
     //   t"00000402007016024030037477377377".deserialize[Octal].to(List)
     // .assert(_ == numberList)
 
-    // test(t"Deserialize from Hex"):
+    // test(m"Deserialize from Hex"):
     //   import alphabets.hex.lowerCase
     //   t"0001020383828180fcfdfeff".deserialize[Hex].to(List)
     // .assert(_ == numberList)
 
-    // test(t"Deserialize from BASE32"):
+    // test(m"Deserialize from BASE32"):
     //   import alphabets.base32.upperCase
     //   t"AAAQEA4DQKAYB7H5737Q====".deserialize[Base32].to(List)
     // .assert(_ == numberList)
 
-    // test(t"Deserialize from BASE64"):
+    // test(m"Deserialize from BASE64"):
     //   import alphabets.base64.standard
     //   t"AAECA4OCgYD8/f7/".deserialize[Base64].to(List)
     // .assert(_ == numberList)
 
-    // test(t"Tolerant BASE32"):
+    // test(m"Tolerant BASE32"):
     //   import alphabets.base32.lowerCase
     //   t"AAAQEA4DQKAYB7H5737Q====".deserialize[Base32].to(List)
     // .assert(_ == numberList)
 
-    // test(t"Intolerant BASE32"):
+    // test(m"Intolerant BASE32"):
     //   capture[SerializationError]:
     //     import alphabets.base32.strictLowerCase
     //     t"AAAQEA4DQKAYB7H5737Q====".deserialize[Base32].to(List)
     // .assert(_ == SerializationError(0, 'A'))
 
-    // test(t"Bad character offset"):
+    // test(m"Bad character offset"):
     //   capture[SerializationError]:
     //     import alphabets.base32.lowerCase
     //     t"AAAQEA4?DQKAYB7H5737Q====".deserialize[Base32].to(List)
@@ -150,7 +150,7 @@ object Tests extends Suite(t"Monotonous tests"):
     //       import alphabets.base64
     //       for alphabet <- List(base64.standard, base64.unpadded, base64.url, base64.xml,
     //           base64.imap, base64.yui, base64.radix64, base64.bcrypt, base64.sasl) do
-    //         test(t"Roundtrip BASE64 tests"):
+    //         test(m"Roundtrip BASE64 tests"):
     //           given Alphabet[Base64] = alphabet
     //           arb.serialize[Base64].deserialize[Base64].to(List)
     //         .assert(_ == arbList)
@@ -161,7 +161,7 @@ object Tests extends Suite(t"Monotonous tests"):
     //           base32.lowerCase, base32.extendedHexUpperCase, base32.extendedHexLowerCase,
     //           base32.zBase32, base32.zBase32Unpadded, base32.geohash, base32.wordSafe,
     //           base32.crockford) do
-    //         test(t"Roundtrip BASE32 tests"):
+    //         test(m"Roundtrip BASE32 tests"):
     //           given Alphabet[Base32] = alphabet
     //           arb.serialize[Base32].deserialize[Base32].to(List)
     //         .assert(_ == arbList)
@@ -170,22 +170,22 @@ object Tests extends Suite(t"Monotonous tests"):
     //       import alphabets.hex
     //       for alphabet <- List(hex.strictUpperCase, hex.strictLowerCase, hex.upperCase,
     //           hex.lowerCase, hex.bioctal) do
-    //         test(t"Roundtrip Hex tests"):
+    //         test(m"Roundtrip Hex tests"):
     //           given Alphabet[Hex] = alphabet
     //           arb.serialize[Hex].deserialize[Hex].to(List)
     //         .assert(_ == arbList)
 
-    //     test(t"Roundtrip Octal tests"):
+    //     test(m"Roundtrip Octal tests"):
     //       import alphabets.octal.standard
     //       arb.serialize[Octal].deserialize[Octal].to(List)
     //     .assert(_ == arbList)
 
-    //     test(t"Roundtrip Quaternary tests"):
+    //     test(m"Roundtrip Quaternary tests"):
     //       import alphabets.quaternary.dnaNucleotide
     //       arb.serialize[Quaternary].deserialize[Quaternary].to(List)
     //     .assert(_ == arbList)
 
-    //     test(t"Roundtrip Binary tests"):
+    //     test(m"Roundtrip Binary tests"):
     //       import alphabets.binary.standard
     //       arb.serialize[Binary].deserialize[Binary].to(List)
     //     .assert(_ == arbList)

--- a/lib/mosquito/src/test/mosquito.Tests.scala
+++ b/lib/mosquito/src/test/mosquito.Tests.scala
@@ -40,89 +40,89 @@ import quantitative.*
 import rudiments.*
 import spectacular.*
 
-object Tests extends Suite(t"Mosquito tests"):
+object Tests extends Suite(m"Mosquito tests"):
   def run(): Unit =
-    test(t"Create a Vector of Ints"):
+    test(m"Create a Vector of Ints"):
       Vector(1, 2, 3)
     .assert(_ == Vector(1, 2, 3))
 
-    test(t"A Vector of Ints infers the correct size"):
+    test(m"A Vector of Ints infers the correct size"):
       demilitarize:
         val vector: Vector[Int, 3] = Vector(1, 3, 4)
       .map(_.message)
     .assert(_ == Nil)
 
-    test(t"Type error if size is incorrect"):
+    test(m"Type error if size is incorrect"):
       demilitarize:
         val vector: Vector[Int, 2] = Vector(1, 3, 4)
     .assert(_.nonEmpty)
 
-    test(t"Type error if type is incorrect"):
+    test(m"Type error if type is incorrect"):
       demilitarize:
         val vector: Vector[String, 3] = Vector(1, 3, 4)
     .assert(_.nonEmpty)
 
-    test(t"Calculate integer dot-product"):
+    test(m"Calculate integer dot-product"):
       Vector(1, 2, 3).dot(Vector(4, 3, 7))
     .assert(_ == 31)
 
-    test(t"Calculate Double dot-product"):
+    test(m"Calculate Double dot-product"):
       Vector(0.1, 0.2, 0.3).dot(Vector(0.4, 0.3, 0.7))
     .assert(_ === 0.31 +/- 0.000001)
 
-    test(t"Calculate integer cross-product"):
+    test(m"Calculate integer cross-product"):
       Vector(1, 2, 3).cross(Vector(4, 3, 7))
     .assert(_ == Vector(5, 5, -5))
 
-    test(t"Calculate Double cross-product"):
+    test(m"Calculate Double cross-product"):
       Vector(1.4, 2.4, 3.8).cross(Vector(4.9, 3.6, 0.7))
     .assert(_ == Vector(-12.0, 17.64, -6.72))
 
-    test(t"Show Vector 3-vector"):
+    test(m"Show Vector 3-vector"):
       Vector(1, 3, 6).show
     .assert(_ == t"\u239b 1 \u239e\n\u239c 3 \u239f\n\u239d 6 \u23a0")
 
-    test(t"Add two vectors"):
+    test(m"Add two vectors"):
       Vector(1, 2, 3) + Vector(3, 4, 5)
     .assert(_ == Vector(4, 6, 8))
 
-    suite(t"Quantity operations"):
-      test(t"Add two quantity vectors"):
+    suite(m"Quantity operations"):
+      test(m"Add two quantity vectors"):
         Vector(1*Metre, 2*Metre, 3*Metre) + Vector(3*Metre, 4*Metre, 5*Metre)
       .assert(_ == Vector(4*Metre, 6*Metre, 8*Metre))
 
-      test(t"Add two mixed-quantity vectors"):
+      test(m"Add two mixed-quantity vectors"):
         Vector(1*Foot, 1*Foot, 1*Foot) + Vector(3*Metre, 4*Metre, 5*Metre)
       .assert(_ == Vector(3.3048*Metre, 4.3048*Metre, 5.3048*Metre))
 
-      test(t"Map from m to m²"):
+      test(m"Map from m to m²"):
         Vector(1*Metre, 2*Metre, 3*Metre, 4*Metre).map(_*Metre)
       .assert(_ == Vector(1*Metre*Metre, 2*Metre*Metre, 3*Metre*Metre, 4*Metre*Metre))
 
-    suite(t"Matrix tests"):
+    suite(m"Matrix tests"):
       val m1 = Matrix[2, 3]((1, 2, 3), (4, 5, 6))
       val m2 = Matrix[3, 2]((7, 8), (9, 10), (11, 12))
 
-      test(t"Access matrix elements"):
+      test(m"Access matrix elements"):
         m1(0, 0)
       .assert(_ == 1)
 
-      test(t"Access matrix elements2"):
+      test(m"Access matrix elements2"):
         m1(1, 1)
       .assert(_ == 5)
 
-      test(t"Access matrix elements 3"):
+      test(m"Access matrix elements 3"):
         m1(1, 2)
       .assert(_ == 6)
 
-      test(t"Multiply matrices"):
+      test(m"Multiply matrices"):
         m1*m2
       .assert(_ == Matrix[2, 2]((58, 139), (64, 154)))
 
-      test(t"Scalar multiply matrices"):
+      test(m"Scalar multiply matrices"):
         m1*10
       .assert(_ == Matrix[2, 3]((10, 20, 30), (40, 50, 60)))
 
-      test(t"Scalar divide matrices"):
+      test(m"Scalar divide matrices"):
         m1/2
       .assert(_ == Matrix[2, 3]((0, 1, 1), (2, 2, 3)))

--- a/lib/nettlesome/src/test/nettlesome.Tests.scala
+++ b/lib/nettlesome/src/test/nettlesome.Tests.scala
@@ -36,18 +36,18 @@ import soundness.*
 import fulminate.errorDiagnostics.stackTraces
 import strategies.throwUnsafely
 
-object Tests extends Suite(t"Nettlesome tests"):
+object Tests extends Suite(m"Nettlesome tests"):
   def run(): Unit =
-    suite(t"Internet tests"):
+    suite(m"Internet tests"):
       def remoteCall()(using Internet): Unit = ()
 
-      test(t"Check remote call is callable with `Internet`"):
+      test(m"Check remote call is callable with `Internet`"):
         internet(true):
           remoteCall()
       .assert()
 
       // TODO: fix
-      // test(t"Check remote call is not callable without `Internet`"):
+      // test(m"Check remote call is not callable without `Internet`"):
       //   val result = demilitarize:
       //     remoteCall()
       //   .map(_.id)
@@ -56,454 +56,454 @@ object Tests extends Suite(t"Nettlesome tests"):
       // .assert(_ == List(CompileErrorId.MissingImplicitArgument))
 
 
-    suite(t"IPv4 tests"):
-      test(t"Parse in IPv4 address"):
+    suite(m"IPv4 tests"):
+      test(m"Parse in IPv4 address"):
         Ipv4.parse(t"1.2.3.4")
       .assert(_ == Ipv4(1, 2, 3, 4))
 
-      test(t"Show an Ipv4 address"):
+      test(m"Show an Ipv4 address"):
         Ipv4(127, 244, 197, 0).show
       .assert(_ == t"127.244.197.0")
 
-      test(t"Show a zero Ipv4 address"):
+      test(m"Show a zero Ipv4 address"):
         Ipv4(0, 0, 0, 0).show
       .assert(_ == t"0.0.0.0")
 
-      test(t"Show a 'maximum' Ipv4 address"):
+      test(m"Show a 'maximum' Ipv4 address"):
         Ipv4(255, 255, 255, 255).show
       .assert(_ == t"255.255.255.255")
 
-      test(t"Get an IP address as an integer"):
+      test(m"Get an IP address as an integer"):
         Ipv4(192, 168, 0, 1).int
       .assert(_ == bin"11000000 10101000 00000000 00000001")
 
-    suite(t"IPv6 tests"):
-      test(t"Parse an IPv6 address"):
+    suite(m"IPv6 tests"):
+      test(m"Parse an IPv6 address"):
         Ipv6.parse(t"2001:db8:0000:1:1:1:1:1")
       .assert(_ == Ipv6(0x2001, 0xdb8, 0, 0x1, 0x1, 0x1, 0x1, 0x1))
 
-      test(t"Render an IPv6 address"):
+      test(m"Render an IPv6 address"):
         Ipv6.parse(t"2001:db8:0000:1:1:1:1:1").show
       .assert(_ == t"2001:db8:0:1:1:1:1:1")
 
-      test(t"Parse zero IPv6 address"):
+      test(m"Parse zero IPv6 address"):
         Ipv6.parse(t"::")
       .assert(_ == Ipv6(0, 0, 0, 0, 0, 0, 0, 0))
 
-      test(t"Parse zero-leading IPv6 address"):
+      test(m"Parse zero-leading IPv6 address"):
         Ipv6.parse(t"::2")
       .assert(_ == Ipv6(0, 0, 0, 0, 0, 0, 0, 2))
 
-      test(t"Parse zeroes-trailing IPv6 address"):
+      test(m"Parse zeroes-trailing IPv6 address"):
         Ipv6.parse(t"8::")
       .assert(_ == Ipv6(8, 0, 0, 0, 0, 0, 0, 0))
 
-      test(t"Show zero IPv6 address"):
+      test(m"Show zero IPv6 address"):
         Ipv6(0, 0, 0, 0, 0, 0, 0, 0).show
       .assert(_ == t"::")
 
-      test(t"Show zero-leading IPv6 address"):
+      test(m"Show zero-leading IPv6 address"):
         Ipv6(0, 0, 0, 0, 0, 0, 0, 1).show
       .assert(_ == t"::1")
 
-      test(t"Show zeroes-trailing IPv6 address"):
+      test(m"Show zeroes-trailing IPv6 address"):
         Ipv6(8, 0, 0, 0, 0, 0, 0, 0).show
       .assert(_ == t"8::")
 
-      test(t"Parse IPv4 address at compiletime"):
+      test(m"Parse IPv4 address at compiletime"):
         ip"122.0.0.1"
       .assert(_ == Ipv4(122, 0, 0, 1))
 
-      test(t"Parse an IPv6 address at compiletime"):
+      test(m"Parse an IPv6 address at compiletime"):
         ip"2001:db8::1:1:1:1"
       .assert(_ == Ipv6(0x2001, 0xdb8, 0, 0, 0x1, 0x1, 0x1, 0x1))
 
-      test(t"Create and show a subnet"):
+      test(m"Create and show a subnet"):
         (ip"255.123.143.0".subnet(12)).show
       .assert(_ == t"255.112.0.0/12")
 
-      test(t"Parse an IPv6 containing capital letters"):
+      test(m"Parse an IPv6 containing capital letters"):
         Ipv6.parse(t"2001:DB8::1:1:1:1:1")
       .assert(_ == Ipv6(0x2001, 0xdb8, 0, 0x1, 0x1, 0x1, 0x1, 0x1))
 
-      test(t"Invalid IP address is compile error"):
+      test(m"Invalid IP address is compile error"):
         demilitarize(ip"192.168.0.0.0.1").map(_.message)
       .assert(_ == List(t"nettlesome: the IP address is not valid because the address contains 6 period-separated groups instead of 4"))
 
-      test(t"IP address byte out of range"):
+      test(m"IP address byte out of range"):
         capture(Ipv4.parse(t"100.300.200.0"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv4ByteOutOfRange(300)))
 
-      test(t"IPv4 address wrong number of bytes"):
+      test(m"IPv4 address wrong number of bytes"):
         capture(Ipv4.parse(t"10.3.20.0.8"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv4WrongNumberOfGroups(5)))
 
-      test(t"IPv6 address non-hex value"):
+      test(m"IPv6 address non-hex value"):
         capture(Ipv6.parse(t"::8:abcg:abc:1234"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv6GroupNotHex(t"abcg")))
 
-      test(t"IPv6 address too many groups"):
+      test(m"IPv6 address too many groups"):
         capture(Ipv6.parse(t"1:2:3:4::5:6:7:8"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv6TooManyNonzeroGroups(8)))
 
-      test(t"IPv6 address wrong number of groups"):
+      test(m"IPv6 address wrong number of groups"):
         capture(Ipv6.parse(t"1:2:3:4:5:6:7:8:9"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv6WrongNumberOfGroups(9)))
 
-      test(t"IPv6 address wrong number of groups"):
+      test(m"IPv6 address wrong number of groups"):
         capture(Ipv6.parse(t"1:2:3:4:5:6:7:8:9"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv6WrongNumberOfGroups(9)))
 
-      test(t"IPv6 duplicate double-colon"):
+      test(m"IPv6 duplicate double-colon"):
         capture(Ipv6.parse(t"1::3:7::9"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv6MultipleDoubleColons))
 
-      test(t"IPv6 address wrong-length group"):
+      test(m"IPv6 address wrong-length group"):
         capture(Ipv6.parse(t"::8:abcde:abc:1234"))
       .assert(_ == IpAddressError(IpAddressError.Reason.Ipv6GroupWrongLength(t"abcde")))
 
-    suite(t"Email address tests"):
+    suite(m"Email address tests"):
       import EmailAddressError.Reason.*
 
-      test(t"simple@example.com"):
+      test(m"simple@example.com"):
         EmailAddress.parse(t"simple@example.com")
       .assert()
 
-      test(t"very.common@example.com"):
+      test(m"very.common@example.com"):
         EmailAddress.parse(t"very.common@example.com")
       .assert()
 
-      test(t"x@example.com"):
+      test(m"x@example.com"):
         EmailAddress.parse(t"x@example.com")
       .assert()
 
-      test(t"long.email-address-with-hyphens@and.subdomains.example.com"):
+      test(m"long.email-address-with-hyphens@and.subdomains.example.com"):
         EmailAddress.parse(t"long.email-address-with-hyphens@and.subdomains.example.com")
       .assert()
 
-      test(t"user.name+tag+sorting@example.com"):
+      test(m"user.name+tag+sorting@example.com"):
         EmailAddress.parse(t"user.name+tag+sorting@example.com")
       .assert()
 
-      test(t"name/surname@example.com"):
+      test(m"name/surname@example.com"):
         EmailAddress.parse(t"name/surname@example.com")
       .assert()
 
-      test(t"admin@example"):
+      test(m"admin@example"):
         EmailAddress.parse(t"admin@example")
       .assert()
 
-      test(t"example@s.example"):
+      test(m"example@s.example"):
         EmailAddress.parse(t"example@s.example")
       .assert()
 
-      test(t"\" \"@example.org"):
+      test(m"\" \"@example.org"):
         EmailAddress.parse(t"\" \"@example.org")
       .assert()
 
-      test(t"\"john..doe\"@example.org"):
+      test(m"\"john..doe\"@example.org"):
         EmailAddress.parse(t"\"john..doe\"@example.org")
       .assert()
 
-      test(t"mailhost!username@example.org"):
+      test(m"mailhost!username@example.org"):
         EmailAddress.parse(t"mailhost!username@example.org")
       .assert()
 
-      test(t"\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com"):
+      test(m"\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com"):
         EmailAddress.parse(t"\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com")
       .assert()
 
-      test(t"user%example.com@example.org"):
+      test(m"user%example.com@example.org"):
         EmailAddress.parse(t"user%example.com@example.org")
       .assert()
 
-      test(t"user-@example.org"):
+      test(m"user-@example.org"):
         EmailAddress.parse(t"user-@example.org")
       .assert()
 
-      test(t"postmaster@[123.123.123.123]"):
+      test(m"postmaster@[123.123.123.123]"):
         EmailAddress.parse(t"postmaster@[123.123.123.123]")
       .assert()
 
-      test(t"postmaster@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]"):
+      test(m"postmaster@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]"):
         EmailAddress.parse(t"postmaster@[IPv6:2001:0db8:85a3:0000:0000:8a2e:0370:7334]")
       .assert()
 
-      test(t"Empty email address"):
+      test(m"Empty email address"):
         capture(EmailAddress.parse(t""))
       .assert(_ == EmailAddressError(Empty))
 
-      test(t"abc.example.com"):
+      test(m"abc.example.com"):
         capture(EmailAddress.parse(t"abc.example.com"))
       .assert(_ == EmailAddressError(MissingAtSymbol))
 
-      test(t"a@b@c@example.com"):
+      test(m"a@b@c@example.com"):
         capture(EmailAddress.parse(t"a@b@c@example.com"))
       .assert(_ == EmailAddressError(InvalidDomain(HostnameError(t"b@c@example.com", HostnameError.Reason.InvalidChar('@')))))
 
-      test(t"a\\\"b(c)d,e:f;g<h>i[j\\k]l@example.com"):
+      test(m"a\\\"b(c)d,e:f;g<h>i[j\\k]l@example.com"):
         capture(EmailAddress.parse(t"a\\\"b(c)d,e:f;g<h>i[j\\k]l@example.com"))
       .assert(_ == EmailAddressError(InvalidChar('\\')))
 
-      test(t"just\"not\"right@example.com"):
+      test(m"just\"not\"right@example.com"):
         capture(EmailAddress.parse(t"just\"not\"right@example.com"))
       .assert(_ == EmailAddressError(InvalidChar('\"')))
 
-      test(t"this is\\\"not\\allowed@example.com"):
+      test(m"this is\\\"not\\allowed@example.com"):
         capture(EmailAddress.parse(t"this is\\\"not\\allowed@example.com"))
       .assert(_ == EmailAddressError(InvalidChar(' ')))
 
-      test(t"this\\ still\\\"not\\\\allowed@example.com"):
+      test(m"this\\ still\\\"not\\\\allowed@example.com"):
         capture(EmailAddress.parse(t"this\\ still\\\"not\\\\allowed@example.com"))
       .assert(_ == EmailAddressError(InvalidChar('\\')))
 
-      test(t"1234567890123456789012345678901234567890123456789012345678901234+x@example.com"):
+      test(m"1234567890123456789012345678901234567890123456789012345678901234+x@example.com"):
         capture(EmailAddress.parse(t"1234567890123456789012345678901234567890123456789012345678901234+x@example.com"))
       .assert(_ == EmailAddressError(LongLocalPart))
 
-      test(t"user@[not-an-ip]"):
+      test(m"user@[not-an-ip]"):
         capture(EmailAddress.parse(t"user@[not-an-ip]"))
       .assert(_ == EmailAddressError(InvalidDomain(IpAddressError(IpAddressError.Reason.Ipv4WrongNumberOfGroups(1)))))
 
-      test(t"i.like.underscores@but_they_are_not_allowed_in_this_part"):
+      test(m"i.like.underscores@but_they_are_not_allowed_in_this_part"):
         capture(EmailAddress.parse(t"i.like.underscores@but_they_are_not_allowed_in_this_part"))
       .assert(_ == EmailAddressError(InvalidDomain(HostnameError(t"but_they_are_not_allowed_in_this_part", HostnameError.Reason.InvalidChar('_')))))
 
-      test(t"I❤️CHOCOLATE🍫@example.com"):
+      test(m"I❤️CHOCOLATE🍫@example.com"):
         capture(EmailAddress.parse(t"I❤️CHOCOLATE🍫@example.com"))
       .matches:
         case EmailAddressError(InvalidChar(_)) =>
 
-      test(t"Create an email address at compiletime"):
+      test(m"Create an email address at compiletime"):
         email"test@example.com"
       .assert(_ == EmailAddress.parse(t"test@example.com"))
 
-      test(t"Create an IPv4 email address at compiletime"):
+      test(m"Create an IPv4 email address at compiletime"):
         email"test@[192.168.0.1]"
       .assert(_ == EmailAddress.parse(t"test@[192.168.0.1]"))
 
-      test(t"Create an IPv6 email address at compiletime"):
+      test(m"Create an IPv6 email address at compiletime"):
         email"test@[IPv6:1234::6789]"
       .assert(_ == EmailAddress.parse(t"test@[IPv6:1234::6789]"))
 
-      test(t"Create a quoted email address at compiletime"):
+      test(m"Create a quoted email address at compiletime"):
         email""""test user"@example.com"""
       .assert(_ == EmailAddress.parse(t""""test user"@example.com"""))
 
-      test(t"forbidden.@example.com"):
+      test(m"forbidden.@example.com"):
         capture(EmailAddress.parse(t"forbidden.@example.com"))
       .assert(_ == EmailAddressError(TerminalPeriod))
 
-      test(t".forbidden@example.com"):
+      test(m".forbidden@example.com"):
         capture(EmailAddress.parse(t".forbidden@example.com"))
       .assert(_ == EmailAddressError(InitialPeriod))
 
-      test(t"not..allowed@example.com"):
+      test(m"not..allowed@example.com"):
         capture(EmailAddress.parse(t"not..allowed@example.com"))
       .assert(_ == EmailAddressError(SuccessivePeriods))
 
-      test(t""""unescaped quote " is forbidden"@example.com"""):
+      test(m""""unescaped quote " is forbidden"@example.com"""):
         capture(EmailAddress.parse(t""""unescaped quote " is forbidden"@example.com"""))
       .assert(_ == EmailAddressError(UnescapedQuote))
 
-      test(t""""unclosed.quote@example.com"""):
+      test(m""""unclosed.quote@example.com"""):
         capture(EmailAddress.parse(t""""unclosed.quote@example.com"""))
       .assert(_ == EmailAddressError(UnclosedQuote))
 
-      test(t"""missing.domain@"""):
+      test(m"""missing.domain@"""):
         capture(EmailAddress.parse(t"""missing.domain@"""))
       .assert(_ == EmailAddressError(MissingDomain))
 
-      test(t"""unclosed IP address domain"""):
+      test(m"""unclosed IP address domain"""):
         capture(EmailAddress.parse(t"""user@[192.168.0.1"""))
       .assert(_ == EmailAddressError(UnclosedIpAddress))
 
-    suite(t"URL tests"):
-      test(t"parse Authority with username and password"):
+    suite(m"URL tests"):
+      test(m"parse Authority with username and password"):
         Authority.parse(t"username:password@example.com")
       .assert(_ == Authority(example.com, t"username:password"))
 
-      test(t"parse Authority with username but not password"):
+      test(m"parse Authority with username but not password"):
         Authority.parse(t"username@example.com")
       .assert(_ == Authority(example.com, t"username"))
 
-      test(t"parse Authority with username, password and port"):
+      test(m"parse Authority with username, password and port"):
         Authority.parse(t"username:password@example.com:8080")
       .assert(_ == Authority(example.com, t"username:password", 8080))
 
-      test(t"parse Authority with username and port"):
+      test(m"parse Authority with username and port"):
         Authority.parse(t"username@example.com:8080")
       .assert(_ == Authority(example.com, t"username", 8080))
 
-      test(t"parse Authority with username, numerical password and port"):
+      test(m"parse Authority with username, numerical password and port"):
         Authority.parse(t"username:1234@example.com:8080")
       .assert(_ == Authority(example.com, t"username:1234", 8080))
 
-      test(t"Authority with invalid port fails"):
+      test(m"Authority with invalid port fails"):
         capture(Authority.parse(t"username@example.com:no"))
       .matches:
         case UrlError(_, position, UrlError.Reason.Expected(UrlError.Expectation.Number)) if position == 21.z =>
 
-      test(t"Parse full URL"):
+      test(m"Parse full URL"):
         Url.parse(t"http://user:pw@example.com:8080/path/to/location?query=1#ref")
       .assert(_ == Url(Origin(Scheme.Http, Authority(example.com, t"user:pw", 8080)),
           t"/path/to/location", t"query=1", t"ref"))
 
-      test(t"Parse simple URL"):
+      test(m"Parse simple URL"):
         Url.parse(t"https://example.com/foo")
       .assert(_ == Url(Origin(Scheme.Https, Authority(example.com)), t"/foo"))
 
-      test(t"Parse url with fragment"):
+      test(m"Parse url with fragment"):
         Url.parse(t"https://example.com/#id")
       .assert(_ == Url(Origin(Scheme.Https, Authority(example.com)), t"/", Unset, t"id"))
 
-      test(t"Show simple URL"):
+      test(m"Show simple URL"):
         Url.parse(t"http://example.com/foo").show
       .assert(_ == t"http://example.com/foo")
 
-      test(t"show url with fragment"):
+      test(m"show url with fragment"):
         Url.parse(t"https://example.com/#id").show
       .assert(_ == t"https://example.com/#id")
 
-      test(t"Parse full URL at compiletime"):
+      test(m"Parse full URL at compiletime"):
         url"http://user:pw@example.com:8080/path/to/location?query=1#ref"
       .assert(_ == Url(Origin(Scheme.Http, Authority(example.com, t"user:pw", 8080)),
           t"/path/to/location", t"query=1", t"ref"))
 
-      test(t"Parse FTP URL at compiletime"):
+      test(m"Parse FTP URL at compiletime"):
         url"ftp://user:pw@example.com:8080/path/to/location"
       .assert(_ == Url(Origin(Scheme(t"ftp"), Authority(example.com, t"user:pw", 8080)),
           t"/path/to/location"))
 
-      test(t"Parse URL at compiletime with substitution"):
+      test(m"Parse URL at compiletime with substitution"):
         val port = 1234
         url"http://user:pw@example.com:$port/path/to/location"
       .assert(_ == Url(Origin(Scheme(t"http"), Authority(example.com, t"user:pw", 1234)),
           t"/path/to/location"))
 
-      test(t"Parse URL at compiletime with escaped substitution"):
+      test(m"Parse URL at compiletime with escaped substitution"):
         val message: Text = t"Hello world!"
         url"http://user:pw@example.com/$message"
       .assert(_ == Url(Origin(Scheme(t"http"), Authority(example.com, t"user:pw")), t"/Hello+world%21"))
 
-      test(t"Parse URL at compiletime with unescaped substitution"):
+      test(m"Parse URL at compiletime with unescaped substitution"):
         val message = Raw(t"Hello world!")
         url"http://user:pw@example.com/$message"
       .assert(_ == Url(Origin(Scheme(t"http"), Authority(example.com, t"user:pw")), t"/Hello world!"))
 
       // TODO: fix
-      // test(t"Relative path is unescaped"):
+      // test(m"Relative path is unescaped"):
       //   val message: Text = t"Hello world!"
       //   url"http://user:pw@example.com/$message/foo".path
       // .assert(_ == (? / n"Hello world!" / n"foo").descent)
 
-      // test(t"Relative path with raw substitution is unescaped"):
+      // test(m"Relative path with raw substitution is unescaped"):
       //   val message: Raw = Raw(t"Hello+world%21")
       //   url"http://user:pw@example.com/$message/foo".path
       // .assert(_ == (? / n"Hello world!" / n"foo").descent)
 
-    suite(t"Hostname tests"):
-      test(t"Parse a simple hostname"):
+    suite(m"Hostname tests"):
+      test(m"Parse a simple hostname"):
         Hostname.parse(t"www.example.com")
       .assert(_ == Hostname(DnsLabel(t"www"), DnsLabel(t"example"), DnsLabel(t"com")))
 
-      test(t"A hostname cannot end in a period"):
+      test(m"A hostname cannot end in a period"):
         capture[HostnameError](Hostname.parse(t"www.example."))
       .assert(_ == HostnameError(t"www.example.", HostnameError.Reason.EmptyDnsLabel(2)))
 
-      test(t"A hostname cannot start with a period"):
+      test(m"A hostname cannot start with a period"):
         capture[HostnameError](Hostname.parse(t".example.com"))
       .assert(_ == HostnameError(t".example.com", HostnameError.Reason.EmptyDnsLabel(0)))
 
-      test(t"A hostname cannot have adjacent periods"):
+      test(m"A hostname cannot have adjacent periods"):
         capture[HostnameError](Hostname.parse(t"www..com"))
       .assert(_ == HostnameError(t"www..com", HostnameError.Reason.EmptyDnsLabel(1)))
 
-      test(t"A hostname cannot contain symbols"):
+      test(m"A hostname cannot contain symbols"):
         capture[HostnameError](Hostname.parse(t"www.maybe?.com"))
       .assert(_ == HostnameError(t"www.maybe?.com", HostnameError.Reason.InvalidChar('?')))
 
-      test(t"A DNS Label cannot begin with a dash"):
+      test(m"A DNS Label cannot begin with a dash"):
         capture[HostnameError](Hostname.parse(t"www.-maybe.com"))
       .assert(_ == HostnameError(t"www.-maybe.com", HostnameError.Reason.InitialDash(t"-maybe")))
 
-      test(t"A hostname can contain two consecutive dashes"):
+      test(m"A hostname can contain two consecutive dashes"):
         Hostname.parse(t"www.exam--ple.com")
       .assert(_ == Hostname(DnsLabel(t"www"), DnsLabel(t"exam--ple"), DnsLabel(t"com")))
 
-      test(t"A DNS label cannot be longer than 63 characters"):
+      test(m"A DNS label cannot be longer than 63 characters"):
         capture[HostnameError](Hostname.parse(t"www.abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghij.com"))
       .assert(_ == HostnameError(
         t"www.abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghij.com",
         HostnameError.Reason.LongDnsLabel(t"abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghij")
       ))
 
-      test(t"A DNS label may be 63 characters long"):
+      test(m"A DNS label may be 63 characters long"):
         Hostname.parse(t"www.abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghi.com")
       .assert(_ == Hostname(DnsLabel(t"www"), DnsLabel(t"abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz-abcdefghi"), DnsLabel(t"com")))
 
-      test(t"A DNS label may be 253 characters long"):
+      test(m"A DNS label may be 253 characters long"):
         Hostname.parse(t"www.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.com")
       .assert()
 
-      test(t"A DNS label may not be longer than 253 characters"):
+      test(m"A DNS label may not be longer than 253 characters"):
         capture[HostnameError](Hostname.parse(t"www.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxy.com"))
       .assert(_.reason == HostnameError.Reason.LongHostname)
 
-      test(t"Parse hostname at compiletime"):
+      test(m"Parse hostname at compiletime"):
         host"www.altavista.com"
       .assert()
 
-      test(t"Parse bad hostname at compiletime"):
+      test(m"Parse bad hostname at compiletime"):
         demilitarize(host"www..com").map(_.message)
       .assert(_ == List(t"nettlesome: the hostname is not valid because a DNS label cannot be empty"))
 
-    suite(t"MAC Address tests"):
+    suite(m"MAC Address tests"):
       import MacAddressError.Reason.*
 
-      test(t"Test simple MAC address"):
+      test(m"Test simple MAC address"):
         MacAddress.parse(t"01-23-45-ab-cd-ef")
       .assert(_ == MacAddress(1251004370415L))
 
-      test(t"Check MAC address with too few groups"):
+      test(m"Check MAC address with too few groups"):
         capture[MacAddressError](MacAddress.parse(t"01-23-ab-cd-ef"))
       .assert(_ == MacAddressError(WrongGroupCount(5)))
 
-      test(t"Check MAC address with too few groups"):
+      test(m"Check MAC address with too few groups"):
         capture[MacAddressError](MacAddress.parse(t"01-23-45-67-ab-cd-ef"))
       .assert(_ == MacAddressError(WrongGroupCount(7)))
 
-      test(t"Check MAC address with short group"):
+      test(m"Check MAC address with short group"):
         capture[MacAddressError](MacAddress.parse(t"01-23-45-6-ab-cd"))
       .assert(_ == MacAddressError(WrongGroupLength(3, 1)))
 
-      test(t"Check MAC address with long group"):
+      test(m"Check MAC address with long group"):
         capture[MacAddressError](MacAddress.parse(t"01-23-45-67-ab-cde"))
       .assert(_ == MacAddressError(WrongGroupLength(5, 3)))
 
-      test(t"Check MAC address with empty group"):
+      test(m"Check MAC address with empty group"):
         capture[MacAddressError](MacAddress.parse(t"01-23-45--ab-cd"))
       .assert(_ == MacAddressError(WrongGroupLength(3, 0)))
 
-      test(t"Check MAC address with non-hex character"):
+      test(m"Check MAC address with non-hex character"):
         capture[MacAddressError](MacAddress.parse(t"01-23-45-6g-ab-cd"))
       .assert(_ == MacAddressError(NotHex(3, t"6g")))
 
-      test(t"Show a MAC address"):
+      test(m"Show a MAC address"):
         MacAddress.parse(t"01-23-45-ab-cd-ef").show
       .assert(_ == t"01-23-45-ab-cd-ef")
 
-      test(t"Create a MAC address statically (and show it)"):
+      test(m"Create a MAC address statically (and show it)"):
         mac"01-23-45-ab-cd-ef".show
       .assert(_ == t"01-23-45-ab-cd-ef")
 
-      test(t"Check that a bad MAC address fails at compiletime"):
+      test(m"Check that a bad MAC address fails at compiletime"):
         demilitarize:
           mac"01-23-45-ab-cd-e"
         .map(_.message)
       .assert(_ == List(t"nettlesome: the MAC address is not valid because group 5 should be two hex digits, but its length is 1"))
 
-      test(t"Create a MAC address from bytes"):
+      test(m"Create a MAC address from bytes"):
         MacAddress(1, 2, 3, 4, 5, 6).show
       .assert(_ == t"01-02-03-04-05-06")
 

--- a/lib/nomenclature/src/test/nomenclature.Tests.scala
+++ b/lib/nomenclature/src/test/nomenclature.Tests.scala
@@ -42,42 +42,42 @@ import spectacular.*
 erased trait Id
 erased trait Id2
 
-object Tests extends Suite(t"Nomenclature tests"):
+object Tests extends Suite(m"Nomenclature tests"):
   def run(): Unit =
     given Id is Nominative under MustEnd["!"] & MustNotStart["0"] & MustNotContain["."] as id =
       Nominative()
 
     given Id2 is Nominative under MustNotEqual["."] & MustNotEqual[".."] as id2 = Nominative()
 
-    test(t"Create a successful new name"):
+    test(m"Create a successful new name"):
       Name[Id](t"hello!")
     .assert(_.text == t"hello!")
 
-    test(t"Create a successful new name with inference"):
+    test(m"Create a successful new name with inference"):
       val name: Name[Id] = Name(t"hello!")
       name
     .assert(_.text == t"hello!")
 
-    test(t"Name must not start with 0"):
+    test(m"Name must not start with 0"):
       capture[NameError](Name[Id](t"0hello!")).message.show
     .assert(_ == t"the name 0hello! is not valid because it must not start with 0")
 
-    test(t"Name must end with !"):
+    test(m"Name must end with !"):
       capture[NameError](Name[Id](t"hello!9")).message.show
     .assert(_ == t"the name hello!9 is not valid because it must end with !")
 
-    test(t"Name must not contain ."):
+    test(m"Name must not contain ."):
       capture[NameError](Name[Id](t"hello.world!")).message.show
     .assert(_ == t"the name hello.world! is not valid because it must not contain .")
 
-    test(t"Name must not equal ."):
+    test(m"Name must not equal ."):
       capture[NameError](Name[Id2](t".")).message.show
     .assert(_ == t"the name . is not valid because it must not equal .")
 
-    test(t"Name must not equal .."):
+    test(m"Name must not equal .."):
       capture[NameError](Name[Id2](t"..")).message.show
     .assert(_ == t"the name .. is not valid because it must not equal ..")
 
-    test(t"Construct a new name at compiletime"):
+    test(m"Construct a new name at compiletime"):
       n"hello": Name[Id2]
     .assert(_.text == t"hello")

--- a/lib/panopticon/src/test/panopticon.Tests.scala
+++ b/lib/panopticon/src/test/panopticon.Tests.scala
@@ -38,31 +38,31 @@ case class Organization(name: String, leader: Person)
 case class Person(name: String, age: Int, role: Role)
 case class Role(name: String, salary: Int)
 
-object Tests extends Suite(t"Panopticon tests"):
+object Tests extends Suite(m"Panopticon tests"):
   def run(): Unit =
-    test(t"Check that correct type is inferred"):
+    test(m"Check that correct type is inferred"):
       val salary = Lens[Organization](_.leader.role.salary)
       salary: Lens[Organization, ("salary", "role", "leader"), Int]
     .assert()
 
-    test(t"Check that non-existant fields are inaccessible"):
+    test(m"Check that non-existant fields are inaccessible"):
       demilitarize:
         Lens[Organization](_.age)
       . map(_.message)
     .assert(_ == List("panopticon: the field age is not a member of panopticon.Organization"))
 
-    test(t"Check that indirect non-existant fields are inaccessible"):
+    test(m"Check that indirect non-existant fields are inaccessible"):
       demilitarize(Lens[Organization](_.leader.size)).map(_.message)
 
     . assert(_ == List("panopticon: the field size is not a member of panopticon.Person"))
 
-    test(t"Check that two compatible lenses can be added"):
+    test(m"Check that two compatible lenses can be added"):
       val orgLeader = Lens[Organization](_.leader)
       val personName = Lens[Person](_.name)
       orgLeader ++ personName
     .assert()
 
-    test(t"Check that two incompatible lenses can be added"):
+    test(m"Check that two incompatible lenses can be added"):
       demilitarize:
         val orgLeader = Lens[Organization](_.leader)
         val roleName = Lens[Role](_.name)
@@ -74,26 +74,26 @@ object Tests extends Suite(t"Panopticon tests"):
     val leader = Person("Jack Smith", 59, ceo)
     val org = Organization("Acme Inc", leader)
 
-    test(t"Can apply a simple lens to get a value"):
+    test(m"Can apply a simple lens to get a value"):
       val lens = Lens[Organization](_.leader)
       lens.get(org)
     .assert(_ == leader)
 
-    test(t"Can apply a lens to get a value"):
+    test(m"Can apply a lens to get a value"):
       val lens = Lens[Organization](_.leader.role.salary)
       lens.get(org)
     .assert(_ == 120000)
 
-    test(t"Can updatea value with a simple lens"):
+    test(m"Can updatea value with a simple lens"):
       val lens = Lens[Role](_.salary)
       val newRole: Role = lens.set(ceo, 100)
       newRole.salary
     .assert(_ == 100)
 
-    test(t"Get a value with a deep lens"):
+    test(m"Get a value with a deep lens"):
       val lens = Lens[Organization](_.leader.role.salary)
 
-    test(t"Can update a value with a deep lens"):
+    test(m"Can update a value with a deep lens"):
       val lens = Lens[Organization](_.leader.role.salary)
       val newOrganization: Organization = lens.set(org, 1000)
       newOrganization.leader.role.salary
@@ -108,17 +108,17 @@ object Tests extends Suite(t"Panopticon tests"):
 
     val date = new Date(1, 3, 2000)
 
-    test(t"Test non-case-class get"):
+    test(m"Test non-case-class get"):
       val lens = Lens[Date](_.month)
       lens.get(date)
     .assert(_ == 3)
 
     // val orgName = Lens[Organization, Mono["name"], String](_.name, (org, name) => org.copy(name = name))
 
-    // test(t"Manual lens can access field"):
+    // test(m"Manual lens can access field"):
     //   orgName(org)
     // .assert(_ == "Acme Inc")
 
-    // test(t"Manual lens can update field"):
+    // test(m"Manual lens can update field"):
     //   orgName(org) = "Emca Inc"
     // .assert(_.name == "Emca Inc")

--- a/lib/parasite/src/test/parasite.Tests.scala
+++ b/lib/parasite/src/test/parasite.Tests.scala
@@ -54,7 +54,7 @@ import errorDiagnostics.stackTraces
 //   error.printStackTrace()
 //   Mitigation.Escalate
 
-object Tests extends Suite(t"Parasite tests"):
+object Tests extends Suite(m"Parasite tests"):
 
   def thread(block: => Unit): () => Unit =
     val thread = new Thread:
@@ -68,14 +68,14 @@ object Tests extends Suite(t"Parasite tests"):
     supervise:
 
 
-      suite(t"Convoluted test tests"):
+      suite(m"Convoluted test tests"):
         case class Bus():
           val spool: Spool[Text] = Spool()
           val stream = spool.stream
           def put(message: Text): Unit = spool.put(message)
           def waitFor(value: Text): Unit = stream.find(_ == value)
 
-        test(t"Ordered messages"):
+        test(m"Ordered messages"):
           val bus = Bus()
 
           val alpha = async:
@@ -110,7 +110,7 @@ object Tests extends Suite(t"Parasite tests"):
           Set(alpha.await(), beta.await(), gamma.await(), delta.await())
         .assert(_ == Set(t"ALPHA", t"BETA", t"GAMMA", t"DELTA"))
 
-        test(t"Race test"):
+        test(m"Race test"):
           val bus = Bus()
           val task1 = async:
             bus.waitFor(t"task1")
@@ -129,26 +129,26 @@ object Tests extends Suite(t"Parasite tests"):
 
         .assert(_ == t"TASK2")
 
-      suite(t"Promises"):
-        test(t"New promise is incomplete"):
+      suite(m"Promises"):
+        test(m"New promise is incomplete"):
           val promise = Promise[Int]()
           promise.ready
 
         . assert(_ == false)
 
-        test(t"Completed promise is ready"):
+        test(m"Completed promise is ready"):
           val promise = Promise[Int]()
           promise.fulfill(42)
           promise.ready
         .assert(_ == true)
 
-        test(t"Completed promise has correct value"):
+        test(m"Completed promise has correct value"):
           val promise = Promise[Int]()
           promise.fulfill(42)
           promise.await()
         .assert(_ == 42)
 
-        test(t"Promise result can be awaited"):
+        test(m"Promise result can be awaited"):
           val promise = Promise[Int]()
           thread:
             snooze(100L)
@@ -156,36 +156,36 @@ object Tests extends Suite(t"Parasite tests"):
           promise.await()
         .assert(_ == 42)
 
-        test(t"Canceled promise contains exception"):
+        test(m"Canceled promise contains exception"):
           val promise = Promise[Int]()
           promise.cancel()
           capture(promise.await())
         .assert(_ == AsyncError(AsyncError.Reason.Cancelled))
 
-      suite(t"Asyncs"):
-        test(t"Simple task produces a result"):
+      suite(m"Asyncs"):
+        test(m"Simple task produces a result"):
           val task = async(100)
           task.await()
         .assert(_ == 100)
 
-        test(t"Mapped task"):
+        test(m"Mapped task"):
           val task = async(100)
           task.map(_ + 1).await()
         .assert(_ == 101)
 
-        test(t"FlatMapped task"):
+        test(m"FlatMapped task"):
           val task = async(100)
           task.flatMap: x =>
             async(x + 1)
           .await()
         .assert(_ == 101)
 
-        // test(t"Async name"):
+        // test(m"Async name"):
         //   val task = Task(100)
         //   task.id
         // .assert(_ == t"/simple")
 
-      //   // test(t"Subtask name"):
+      //   // test(m"Subtask name"):
       //   //   var name: Option[Text] = None
       //   //   val task = async:
       //   //     val inner = async(100)
@@ -196,7 +196,7 @@ object Tests extends Suite(t"Parasite tests"):
       //   //   name
       //   // .assert(_ == Some(t"/simple/inner"))
 
-        test(t"Async creates one new thread"):
+        test(m"Async creates one new thread"):
           val threads = Thread.activeCount
           var insideThreads = 0
 
@@ -208,7 +208,7 @@ object Tests extends Suite(t"Parasite tests"):
 
         . assert(_ == 1)
 
-        test(t"Threads do not persist"):
+        test(m"Threads do not persist"):
           val threads = Thread.activeCount
           val task = async:
             sleep(10L)
@@ -216,11 +216,11 @@ object Tests extends Suite(t"Parasite tests"):
           threads - Thread.activeCount
         .assert(_ == 0)
 
-        test(t"Sequencing tasks"):
+        test(m"Sequencing tasks"):
           Seq(async(3), async(5), async(7)).sequence.await()
         .assert(_ == Seq(3, 5, 7))
 
-        test(t"Sequencing tasks run in parallel"):
+        test(m"Sequencing tasks run in parallel"):
           var acc: List[Int] = Nil
           val t1 = async(snooze(40L).also((acc ::= 2)))
           val t2 = async(snooze(60L).also((acc ::= 3)))
@@ -229,7 +229,7 @@ object Tests extends Suite(t"Parasite tests"):
           acc
         .assert(_ == List(3, 2, 1))
 
-        // test(t"Async can be canceled"):
+        // test(m"Async can be canceled"):
         //   var value: Boolean = false
 
         //   val task = async:
@@ -247,19 +247,19 @@ object Tests extends Suite(t"Parasite tests"):
         //   relent()
         //   if a < 2 then 1 else fibonacci(a - 1) + fibonacci(a - 2)
 
-        // test(t"Affirmed calculation without interruption does not cancel it"):
+        // test(m"Affirmed calculation without interruption does not cancel it"):
         //   val task = async(fibonacci(30))
         //   task.cancel()
         //   try task.await() catch case e: CancelError => -1
         // .assert(_ == 1346269)
 
-        // test(t"Affirmed calculation with interruption cancels it"):
+        // test(m"Affirmed calculation with interruption cancels it"):
         //   val task = async(fibonacci(40))
         //   task.cancel()
         //   capture(task.await())
         // .assert(_ == CancelError())
 
-        // test(t"Canceled task cancels child"):
+        // test(m"Canceled task cancels child"):
         //   println("a")
         //   var value = 1
         //   println("b")
@@ -287,7 +287,7 @@ object Tests extends Suite(t"Parasite tests"):
         //   value
         // .assert(_ == 2)
 
-      //   test(t"Incomplete child is awaited"):
+      //   test(m"Incomplete child is awaited"):
       //     import asyncTermination.await
       //     var value = 1
       //     val task = async:
@@ -301,7 +301,7 @@ object Tests extends Suite(t"Parasite tests"):
       //   .assert(_ == 3)
       //   println("C")
 
-      //   test(t"Incomplete child is cancelled"):
+      //   test(m"Incomplete child is cancelled"):
       //     import asyncTermination.cancel
       //     var value = 1
       //     val task = async:
@@ -314,7 +314,7 @@ object Tests extends Suite(t"Parasite tests"):
       //     value
       //   .assert(_ == 2)
 
-        test(t"Cancel read on slow Stream"):
+        test(m"Cancel read on slow Stream"):
           var count = 0
           val task = async:
             Stream.continually:
@@ -332,7 +332,7 @@ object Tests extends Suite(t"Parasite tests"):
           count
         .assert(_ == 2)
 
-      //   test(t"Check that asynchronous exceptions are handled"):
+      //   test(m"Check that asynchronous exceptions are handled"):
       //     async:
       //       sleep(10L)
       //       async:

--- a/lib/plutocrat/src/test/plutocrat.Tests.scala
+++ b/lib/plutocrat/src/test/plutocrat.Tests.scala
@@ -38,87 +38,87 @@ import probably.*
 
 import currencies.*
 
-object Tests extends Suite(t"Plutocrat tests"):
+object Tests extends Suite(m"Plutocrat tests"):
   def run(): Unit =
-    suite(t"Money tests"):
-      test(t"Show a local monetary value"):
+    suite(m"Money tests"):
+      test(m"Show a local monetary value"):
         import currencyStyles.local
         val amount: Money[Eur] = Eur(3.01)
         t"Received $amount"
 
       . assert(_ == t"Received €3.01")
 
-      test(t"Show a monetary value"):
+      test(m"Show a monetary value"):
         import currencyStyles.generic
         val amount = Eur(3.01)
         t"Received $amount"
 
       . assert(_ == t"Received 3.01 EUR")
 
-      test(t"Add two amounts"):
+      test(m"Add two amounts"):
         Eur(3.01) + Eur(0.02)
 
       . assert(_ == Eur(3.03))
 
-      test(t"Subtract an amounts"):
+      test(m"Subtract an amounts"):
         Eur(3.01) - Eur(0.02)
 
       . assert(_ == Eur(2.99))
 
-      test(t"Multiply an amount"):
+      test(m"Multiply an amount"):
         Eur(3.01)*3
 
       . assert(_ == Eur(9.03))
 
-      test(t"Divide an amount"):
+      test(m"Divide an amount"):
         Eur(3.01)/3
 
       . assert(_ == Eur(1.00))
 
-      test(t"Split an amount"):
+      test(m"Split an amount"):
         Eur(3.01).split(3).total
 
       . assert(_ == Eur(3.01))
 
-      /*test(t"Different currencies cannot be combined"):
+      /*test(m"Different currencies cannot be combined"):
         demilitarize:
           Eur(1.00) + Gbp(1.00)
         .map(_.id)
 
       . assert(_ == List(CompileErrorId.MissingImplicitArgument))*/
 
-      test(t"Monetary values can be negated"):
+      test(m"Monetary values can be negated"):
         -Eur(1.99)
 
       . assert(_ == Eur(-1.99))
 
-      test(t"Compare amounts"):
+      test(m"Compare amounts"):
         Eur(1.01) > Eur(2.10)
 
       . assert(_ == false)
 
-      test(t"Compare equal amounts"):
+      test(m"Compare equal amounts"):
         Eur(1.01) > Eur(1.01)
 
       . assert(_ == false)
 
-      test(t"Compare equal amounts"):
+      test(m"Compare equal amounts"):
         Eur(1.01) >= Eur(1.01)
 
       . assert(_ == true)
 
-    suite(t"Price tests"):
-      test(t"Construct new price"):
+    suite(m"Price tests"):
+      test(m"Construct new price"):
         Gbp(2.30).tax(0.2)
 
       . assert(_ == Price(Gbp(2.30), Gbp(0.46)))
 
-      test(t"Tax amount is rounded up correctly"):
+      test(m"Tax amount is rounded up correctly"):
         Gbp(2.94).tax(0.2)
 
       . assert(_ == Price(Gbp(2.94), Gbp(0.59)))
 
-      test(t"Prices in different currencies cannot be combined"):
+      test(m"Prices in different currencies cannot be combined"):
         demilitarize(Eur(1.00).tax(0.175) + Gbp(1.00).tax(0.2)).map(_.message)
 
       . assert(_ == List(t"Found:    plutocrat.Price[plutocrat.currencies.Gbp.type]\nRequired: plutocrat.Price[plutocrat.currencies.Eur.type]"))

--- a/lib/polyvinyl/src/test/polyvinyl.Tests.scala
+++ b/lib/polyvinyl/src/test/polyvinyl.Tests.scala
@@ -35,5 +35,5 @@ package polyvinyl
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Polyvinyl tests"):
+object Tests extends Suite(m"Polyvinyl tests"):
   def run(): Unit = ()

--- a/lib/probably/.github/readme.md
+++ b/lib/probably/.github/readme.md
@@ -39,7 +39,7 @@ is simple. For example,
 ```scala
 import probably.*
 
-test(t"the sum of two identical integers is divisible by two"):
+test(m"the sum of two identical integers is divisible by two"):
   val x: Int = 7
   x + x
 .assert(_%2 == 0)
@@ -74,7 +74,7 @@ It is important to note that a test can be defined anywhere, such as,
 Regardless of where the test is defined, the behavior is always the same: it will be evaluated, checked, and the
 result will be recorded in the `Runner`, as a side-effect. Tests may be run more than once (in which case they
 are recorded more than once, and aggregated) or not at all if, by virtue of some runtime criterion, they are
-simply not executed. The question of whether the test is executed is the same for 
+simply not executed. The question of whether the test is executed is the same for
 
 The decision to make the `Runner` mutable reflects the power of Scala's hybrid nature. The state of the `Runner`
 is write-only while the tests are being run, so many of the common concurrency problems which arise with mutable
@@ -91,7 +91,7 @@ so,
 import probably.*
 
 def runTest(x: Int): Unit =
-  test(t"the sum of three identical integers is divisible by 3"):
+  test(m"the sum of three identical integers is divisible by 3"):
     x + x + x
   .assert(_%3 == 0)
 
@@ -106,7 +106,7 @@ can be logged by including them as additional named parameters after the test na
 import probably.*
 
 def runTest(x: Int): Unit =
-  test(t"the sum of three identical integers is divisible by 3", input = x):
+  test(m"the sum of three identical integers is divisible by 3", input = x):
     x + x + x
   .assert(_%3 == 0)
 ```
@@ -129,7 +129,7 @@ import probably.*
 case class Person(name: Text, age: Int)
 
 Generate.stream[Person](1000).foreach { person =>
-  test(t"all persons have realistic ages", v = person):
+  test(m"all persons have realistic ages", v = person):
     person.age
   .assert { a => a >= 0 && a < 100 }
 }
@@ -146,7 +146,7 @@ the tests, in order, like so:
 ```scala
 object ProjectTests extends Suite("Project tests"):
   def run(using Runner): Unit =
-    test(t"first test"):
+    test(m"first test"):
       // test body
     .assert(/* predicate */)
 ```
@@ -161,7 +161,7 @@ _Probably_ provides a second way of defining a test: as an expression. For examp
 import probably.*
 import java.io.*
 
-test(t"check the backup exists"):
+test(m"check the backup exists"):
   File("data.bak")
 .check(_.exists).setReadOnly()
 ```
@@ -181,7 +181,7 @@ A test suite is a convenient grouping of related tests, and can be launched from
 the following example) like so:
 ```scala
 test.suite("integration tests") { test =>
-  test(t"end-to-end process"):
+  test(m"end-to-end process"):
     System.process()
   .assert(_.isSuccess)
 }
@@ -229,7 +229,7 @@ experimentation. They are provided only for the necessity of providing _some_
 answer to the question, "how can I try Probably?".
 
 1. *Copy the sources into your own project*
-   
+
    Read the `fury` file in the repository root to understand Probably's build
    structure, dependencies and source location; the file format should be short
    and quite intuitive. Copy the sources into a source directory in your own
@@ -246,7 +246,7 @@ answer to the question, "how can I try Probably?".
    file in the project directory, and produce a collection of JAR files which can
    be added to a classpath, by compiling the project and all of its dependencies,
    including the Scala compiler itself.
-   
+
    Download the latest version of
    [`wrath`](https://github.com/propensive/wrath/releases/latest), make it
    executable, and add it to your path, for example by copying it to
@@ -306,4 +306,3 @@ The logo shows a twenty-sided die, an icosahedron, alluding to probabilistic cha
 
 Probably is copyright &copy; 2025 Jon Pretty & Propensive O&Uuml;, and
 is made available under the [Apache 2.0 License](/license.md).
-

--- a/lib/probably/doc/basics.md
+++ b/lib/probably/doc/basics.md
@@ -7,7 +7,7 @@ is simple. For example,
 ```scala
 import probably.*
 
-test(t"the sum of two identical integers is divisible by two"):
+test(m"the sum of two identical integers is divisible by two"):
   val x: Int = 7
   x + x
 .assert(_%2 == 0)
@@ -42,7 +42,7 @@ It is important to note that a test can be defined anywhere, such as,
 Regardless of where the test is defined, the behavior is always the same: it will be evaluated, checked, and the
 result will be recorded in the `Runner`, as a side-effect. Tests may be run more than once (in which case they
 are recorded more than once, and aggregated) or not at all if, by virtue of some runtime criterion, they are
-simply not executed. The question of whether the test is executed is the same for 
+simply not executed. The question of whether the test is executed is the same for
 
 The decision to make the `Runner` mutable reflects the power of Scala's hybrid nature. The state of the `Runner`
 is write-only while the tests are being run, so many of the common concurrency problems which arise with mutable
@@ -59,7 +59,7 @@ so,
 import probably.*
 
 def runTest(x: Int): Unit =
-  test(t"the sum of three identical integers is divisible by 3"):
+  test(m"the sum of three identical integers is divisible by 3"):
     x + x + x
   .assert(_%3 == 0)
 
@@ -74,7 +74,7 @@ can be logged by including them as additional named parameters after the test na
 import probably.*
 
 def runTest(x: Int): Unit =
-  test(t"the sum of three identical integers is divisible by 3", input = x):
+  test(m"the sum of three identical integers is divisible by 3", input = x):
     x + x + x
   .assert(_%3 == 0)
 ```
@@ -97,7 +97,7 @@ import probably.*
 case class Person(name: Text, age: Int)
 
 Generate.stream[Person](1000).foreach { person =>
-  test(t"all persons have realistic ages", v = person):
+  test(m"all persons have realistic ages", v = person):
     person.age
   .assert { a => a >= 0 && a < 100 }
 }
@@ -114,7 +114,7 @@ the tests, in order, like so:
 ```scala
 object ProjectTests extends Suite("Project tests"):
   def run(using Runner): Unit =
-    test(t"first test"):
+    test(m"first test"):
       // test body
     .assert(/* predicate */)
 ```
@@ -129,7 +129,7 @@ _Probably_ provides a second way of defining a test: as an expression. For examp
 import probably.*
 import java.io.*
 
-test(t"check the backup exists"):
+test(m"check the backup exists"):
   File("data.bak")
 .check(_.exists).setReadOnly()
 ```
@@ -149,7 +149,7 @@ A test suite is a convenient grouping of related tests, and can be launched from
 the following example) like so:
 ```scala
 test.suite("integration tests") { test =>
-  test(t"end-to-end process"):
+  test(m"end-to-end process"):
     System.process()
   .assert(_.isSuccess)
 }
@@ -165,6 +165,3 @@ launched it using the CLI, the table of results will show the nested tests inden
 
 The `Runner` introduced by the `suite` method is the same as any other `Runner`, so further test suites can be
 defined inside other test suites, making it possible to organise tests into a hierarchy.
-
-
-

--- a/lib/probably/src/cli/probably.Suite.scala
+++ b/lib/probably/src/cli/probably.Suite.scala
@@ -37,13 +37,14 @@ import anticipation.*
 import contingency.*
 import digression.*
 import escapade.*
+import fulminate.*
 import hieroglyph.*, textMetrics.uniform
 import turbulence.*
 import vacuous.*
 
 import language.adhocExtensions
 
-abstract class Suite(suiteName: Text) extends Testable(suiteName):
+abstract class Suite(suiteName: Message) extends Testable(suiteName):
   val suiteIo = safely(stdioSources.virtualMachine.ansi).vouch
 
   given runner: Runner[Report] =

--- a/lib/probably/src/core/probably-core.scala
+++ b/lib/probably/src/core/probably-core.scala
@@ -64,10 +64,10 @@ extension (value: Double)
   @targetName("plusOrMinus")
   infix def +/- (tolerance: Double): Tolerance = Tolerance(value, tolerance)
 
-def test[ReportType](name: Text)(using suite: Testable, codepoint: Codepoint): TestId =
+def test[ReportType](name: Message)(using suite: Testable, codepoint: Codepoint): TestId =
   TestId(name, suite, codepoint)
 
-def suite[ReportType](name: Text)(using suite: Testable, runner: Runner[ReportType])
+def suite[ReportType](name: Message)(using suite: Testable, runner: Runner[ReportType])
    (block: Testable ?=> Unit)
 :     Unit =
 

--- a/lib/probably/src/core/probably.Probably.scala
+++ b/lib/probably/src/core/probably.Probably.scala
@@ -75,7 +75,7 @@ object Probably:
           Expr.summon[testType is Decomposable].getOrElse('{Decomposable.primitive[testType]})
 
         val contrast = Expr.summon[testType is Contrastable].getOrElse:
-          halt(m"Can't contrast ${Type.of[testType]}")
+          halt(m"Can't find a `Contrastable` instance for ${Type.of[testType]}")
 
         '{
           assertion[testType, TestType, ReportType, ResultType]

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -360,7 +360,8 @@ class Report(using Environment):
         Ribbon(DarkGreen.srgb, MediumSeaGreen.srgb, PaleGreen.srgb)
 
       Out.println:
-        ribbon.fill(e"${suite.lay(t"")(_.id.id)}", e"Benchmarks", e"${suite.lay(t"")(_.name)}")
+        val suiteName = suite.let(_.name.teletype).or(e"")
+        ribbon.fill(e"${suite.lay(t"")(_.id.id)}", e"Benchmarks", suiteName)
 
       val comparisons: List[ReportLine.Bench] =
         benchmarks.filter(!_.benchmark.baseline.absent).to(List)

--- a/lib/probably/src/core/probably.TestId.scala
+++ b/lib/probably/src/core/probably.TestId.scala
@@ -34,6 +34,7 @@ package probably
 
 import anticipation.*
 import digression.*
+import fulminate.*
 import gossamer.*
 import hieroglyph.*
 import hypotenuse.*
@@ -42,7 +43,7 @@ import vacuous.*
 object TestId:
   given Ordering[TestId] = math.Ordering.Implicits.seqOrdering[List, Text].on(_.ids.reverse)
 
-case class TestId(name: Text, suite: Optional[Testable], codepoint: Codepoint):
+case class TestId(name: Message, suite: Optional[Testable], codepoint: Codepoint):
   val timestamp: Long = System.currentTimeMillis
   import textMetrics.uniform
   lazy val id: Text = (suite.hashCode ^ name.hashCode).hex.pad(6, Rtl, '0').keep(6, Rtl)

--- a/lib/probably/src/core/probably.Testable.scala
+++ b/lib/probably/src/core/probably.Testable.scala
@@ -34,10 +34,11 @@ package probably
 
 import anticipation.*
 import digression.*
+import fulminate.*
 import rudiments.*
 import vacuous.*
 
-class Testable(val name: Text, val parent: Optional[Testable] = Unset)
+class Testable(val name: Message, val parent: Optional[Testable] = Unset)
    (using codepoint: Codepoint):
 
   override def equals(that: Any): Boolean = that.matchable(using Unsafe) match

--- a/lib/probably/src/test/probably.Tests.scala
+++ b/lib/probably/src/test/probably.Tests.scala
@@ -34,6 +34,6 @@ package probably
 
 import gossamer.*
 
-object Tests extends Suite(t"Probably Tests"):
+object Tests extends Suite(m"Probably Tests"):
   def run(): Unit =
     ()

--- a/lib/profanity/src/test/profanity.Tests.scala
+++ b/lib/profanity/src/test/profanity.Tests.scala
@@ -35,6 +35,6 @@ package profanity
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Profanity Tests"):
+object Tests extends Suite(m"Profanity Tests"):
   def run(): Unit =
     ()

--- a/lib/punctuation/src/test/punctuation.Tests.scala
+++ b/lib/punctuation/src/test/punctuation.Tests.scala
@@ -45,100 +45,100 @@ import strategies.throwUnsafely
 
 case class Example(str: Text, int: Int)
 
-object Tests extends Suite(t"Punctuation tests"):
+object Tests extends Suite(m"Punctuation tests"):
 
   import Markdown.Ast.Block.*, Markdown.Ast.Inline.*, Markdown.Ast.ListItem
 
   def run(): Unit =
-    test(t"get a heading"):
+    test(m"get a heading"):
       Markdown.parse(t"# Heading 1") match
         case Markdown(Heading(1, Copy(str))) => str
         case _                                  => t""
     .check(_ == t"Heading 1")
 
-    test(t"get a level 2 heading"):
+    test(m"get a level 2 heading"):
       Markdown.parse(t"## Heading 2")
     .assert(_ == Markdown(Heading(2, Copy(t"Heading 2"))))
 
-    test(t"get a bullet list"):
+    test(m"get a bullet list"):
       Markdown.parse(t" - Item 1\n - Item 2")
     .assert(_ == Markdown(BulletList(Unset, false, ListItem(Paragraph(Copy(t"Item 1"))),
         ListItem(Paragraph(Copy(t"Item 2"))))))
 
-    test(t"get an ordered list"):
+    test(m"get an ordered list"):
       Markdown.parse(t" 1. Item 1\n 2. Item 2")
     .assert(_ == Markdown(BulletList(1, false, ListItem(Paragraph(Copy(t"Item 1"))),
         ListItem(Paragraph(Copy(t"Item 2"))))))
 
-    test(t"plain paragraph"):
+    test(m"plain paragraph"):
       Markdown.parseInline(t"Here is some content in\na paragraph.")
     .assert(_ == Markdown(Copy(t"Here is some content in\na paragraph.")))
 
-    test(t"directional apostrophe"):
+    test(m"directional apostrophe"):
       Markdown.parseInline(t"It's great.")
     .assert(_ == Markdown(Copy(t"It’s great.")))
 
-    test(t"directional double-quotes"):
+    test(m"directional double-quotes"):
       Markdown.parseInline(t"""Some "quoted" text.""")
     .assert(_ == Markdown(Copy(t"Some “quoted” text.")))
 
-    test(t"directional single-quotes"):
+    test(m"directional single-quotes"):
       Markdown.parseInline(t"""Some 'quoted' text.""")
     .assert(_ == Markdown(Copy(t"Some ‘quoted’ text.")))
 
-    test(t"conversion of emdashes"):
+    test(m"conversion of emdashes"):
       Markdown.parse(t"""An em-dash--so elegant!""")
     .assert(_ == Markdown(Paragraph(Copy(t"An em-dash—so elegant!"))))
 
-    test(t"strongly emphasised text"):
+    test(m"strongly emphasised text"):
       Markdown.parseInline(t"Here is some __strongly emphasised text__.")
     .assert(_ == Markdown(Copy(t"Here is some "),
         Strong(Copy(t"strongly emphasised text")), Copy(t".")))
 
-    test(t"emphasised text"):
+    test(m"emphasised text"):
       Markdown.parseInline(t"Here is some *emphasised text*.")
     .assert(_ == Markdown(Copy(t"Here is some "), Emphasis(Copy(t"emphasised text")),
         Copy(t".")))
 
-    test(t"some code"):
+    test(m"some code"):
       Markdown.parseInline(t"Here is some `source code`.")
     .assert(_ == Markdown(Copy(t"Here is some "), SourceCode(t"source code"), Copy(t".")))
 
-    test(t"a code block"):
+    test(m"a code block"):
       Markdown.parse(t"""```
                           |echo Hello World
                           |```""".s.stripMargin.show)
     .assert(_ == Markdown(FencedCode(Unset, Unset, t"echo Hello World\n")))
 
-    test(t"a syntax-aware code block"):
+    test(m"a syntax-aware code block"):
       Markdown.parse(t"""```scala
                           |echo Hello World
                           |```""".s.stripMargin.show)
     .assert(_ == Markdown(FencedCode(t"scala", Unset, t"echo Hello World\n")))
 
-    test(t"a link"):
+    test(m"a link"):
       Markdown.parse(t"Take a look [here](http://example.com/)")
     .assert(_ == Markdown(Paragraph(Copy(t"Take a look "), Weblink(t"http://example.com/",
         Copy(t"here")))))
 
-    test(t"an image"):
+    test(m"an image"):
       Markdown.parse(t"Take a look ![alt text](http://example.com/image.jpg)")
     .assert(_ == Markdown(Paragraph(Copy(t"Take a look "), Image(t"alt text",
         t"http://example.com/image.jpg"))))
 
-    test(t"a block quote"):
+    test(m"a block quote"):
       Markdown.parse(t"> This paragraph is\n> indented.")
     .assert(_ == Markdown(Blockquote(Paragraph(Copy(t"This paragraph is\nindented.")))))
 
-    test(t"indented content"):
+    test(m"indented content"):
       Markdown.parse(t"    This paragraph is\n    indented.\n")
     .assert(_ == Markdown(FencedCode(Unset, Unset, t"This paragraph is\nindented.\n")))
 
-    test(t"hard linebreak"):
+    test(m"hard linebreak"):
       Markdown.parse(t"Line 1  \nLine 2\n")
     .assert(_ == Markdown(Paragraph(Copy(t"Line 1"), LineBreak, Copy(t"Line 2"))))
 
-    test(t"referenced images"):
+    test(m"referenced images"):
       Markdown.parse(t"""![images reference][ref]
                        |
                        |[ref]: http://example.com/image.jpg
@@ -146,7 +146,7 @@ object Tests extends Suite(t"Punctuation tests"):
     .assert(_ == Markdown(Paragraph(Image(t"images reference", t"http://example.com/image.jpg")),
         Reference(t"ref", t"http://example.com/image.jpg")))
 
-    test(t"referenced link"):
+    test(m"referenced link"):
       Markdown.parse(t"""[link reference][ref]
                        |
                        |[ref]: http://example.com/
@@ -154,22 +154,22 @@ object Tests extends Suite(t"Punctuation tests"):
     .assert(_ == Markdown(Paragraph(Weblink(t"http://example.com/", Copy(t"link reference"))),
         Reference(t"ref", t"http://example.com/")))
 
-    test(t"thematic break"):
+    test(m"thematic break"):
       Markdown.parse(t"""Paragraph 1
                        |***
                        |Paragraph 2""".s.stripMargin.show)
     .assert(_ == Markdown(Paragraph(Copy(t"Paragraph 1")), ThematicBreak(),
         Paragraph(Copy(t"Paragraph 2"))))
 
-    test(t"email link"):
+    test(m"email link"):
       Markdown.parse(t"Email me <nobody@example.com>!")
     .assert(_ == Markdown(Paragraph(Copy(t"Email me "), Weblink(t"nobody@example.com",
         Copy(t"mailto:nobody@example.com")), Copy(t"!"))))
 
-    test(t"interpolator"):
+    test(m"interpolator"):
       md"Hello *World*"
     .assert(_ == Markdown(Copy(t"Hello "), Emphasis(Copy(t"World"))))
 
-    // test(t"interpolator produces inline markdown"):
+    // test(m"interpolator produces inline markdown"):
     //   md"Hello *world*!".hasType[InlineMd]
     // .assert(identity)

--- a/lib/quantitative/src/test/quantitative.Tests.scala
+++ b/lib/quantitative/src/test/quantitative.Tests.scala
@@ -43,310 +43,310 @@ import language.experimental.into
 
 given decimalizer: Decimalizer = Decimalizer(3)
 
-object Tests extends Suite(t"Quantitative Tests"):
+object Tests extends Suite(m"Quantitative Tests"):
   def run(): Unit =
-    suite(t"Arithmetic tests"):
-      test(t"Add two distances"):
+    suite(m"Arithmetic tests"):
+      test(m"Add two distances"):
         Metre + Metre*2
       .assert(_ == Metre*3)
 
-      test(t"Multiply two different units"):
+      test(m"Multiply two different units"):
         2*Second * 3*Metre
       .assert(_ == 6*Metre*Second)
 
-      test(t"Invert a quantity"):
+      test(m"Invert a quantity"):
         (2*Metre/Second).invert
       .assert(_ == 0.5*Second/Metre)
 
-      test(t"Divide a double by a quantity"):
+      test(m"Divide a double by a quantity"):
         Quantity(1.0)/(2.0*Metre/Second)
       .assert(_ == 0.5*Second/Metre)
 
-    suite(t"Compile errors"):
-      test(t"Cannot add quantities of different units"):
+    suite(m"Compile errors"):
+      test(m"Cannot add quantities of different units"):
         demilitarize:
           Metre + 2*Second
       .assert(_.nonEmpty)
 
-      test(t"Cannot specify a quantity with a double value"):
+      test(m"Cannot specify a quantity with a double value"):
         demilitarize:
           val x: Quantity[Metres[1]] = 10.0
       . assert(_.nonEmpty)
 
-      test(t"Specify a quantity"):
+      test(m"Specify a quantity"):
         case class Speed(value: Quantity[Metres[1] & Hours[-1]])
         Speed(10.0*Kilo(Metre)/Hour)
 
       . assert()
 
-      test(t"Specify a quantity"):
+      test(m"Specify a quantity"):
         case class Speed(value: Quantity[Metres[1] & Hours[-1]])
         Speed(10.0*Kilo(Metre)/Hour)
 
       . assert()
 
-      test(t"Cannot subtract quantities of different units"):
+      test(m"Cannot subtract quantities of different units"):
         demilitarize:
           Metre - 2*Second
         .map(_.message)
       .assert(_.contains(t"quantitative: the left operand represents distance, but the right operand represents time; these are incompatible physical quantities"))
 
-      test(t"Add two different units"):
+      test(m"Add two different units"):
         demilitarize:
           Second*2 + Metre*3
         .map(_.message)
       .assert(_.contains(t"quantitative: the left operand represents time, but the right operand represents distance; these are incompatible physical quantities"))
 
-      test(t"Units cancel out"):
+      test(m"Units cancel out"):
         demilitarize:
           (20*Metre*Second)/(Metre*Second): Double
         .map(_.message)
       .assert(_.isEmpty)
 
-      test(t"Principal units are preferred"):
+      test(m"Principal units are preferred"):
         demilitarize:
           val x = 2*Metre
           val y = 3*Foot
           val z: Quantity[Metres[2]] = x*y
       .assert(_.isEmpty)
 
-      test(t"Non-principal units are not preferred"):
+      test(m"Non-principal units are not preferred"):
         demilitarize:
           val x = 2*Metre
           val y = 3*Foot
           val z: Quantity[Feet[2]] = x*y
       .assert(_.nonEmpty)
 
-      test(t"Units of different dimension cannot be added"):
+      test(m"Units of different dimension cannot be added"):
         demilitarize:
           2*Metre + 2*Joule
         .map(_.message)
       .assert(_ == List("quantitative: the left operand represents distance, but the right operand represents energy; these are incompatible physical quantities"))
 
-      test(t"Different dimensions are incomparable"):
+      test(m"Different dimensions are incomparable"):
         demilitarize:
           7*Metre >= 2*Kilo(Gram)
         .map(_.message)
       .assert(_ == List("quantitative: the left operand represents distance, but the right operand represents mass; these are incompatible physical quantities"))
 
-      test(t"Different powers of the same dimension are incomparable"):
+      test(m"Different powers of the same dimension are incomparable"):
         demilitarize:
           7*Metre >= 2*Metre*Metre
         .map(_.message)
       .assert(_ == List("quantitative: the left operand represents distance, but the right operand represents area; these are incompatible physical quantities"))
 
-    suite(t"Automatic conversions"):
-      test(t"Conversions are applied automatically to RHS in multiplication"):
+    suite(m"Automatic conversions"):
+      test(m"Conversions are applied automatically to RHS in multiplication"):
         val x = 2*Metre
         val y = 3*Foot
         x*y
       .assert(_ == 1.8288000000000002*Metre*Metre)
 
-      test(t"Conversions are applied automatically to LHS in multiplication"):
+      test(m"Conversions are applied automatically to LHS in multiplication"):
         val x = 2*Metre
         val y = 3*Foot
         y*x
       .assert(_ == 1.8288000000000002*Metre*Metre)
 
-      test(t"Conversions are applied automatically in division"):
+      test(m"Conversions are applied automatically in division"):
         val x = 2*Metre*Metre
         val y = 3*Foot
         x/y
       .assert(_ == 2.187226596675415*Metre)
 
-      test(t"Conversions are applied automatically to LHS in division"):
+      test(m"Conversions are applied automatically to LHS in division"):
         val x = 2*Metre
         val y = 3*Foot*Foot
         y/x
       .assert(_ == 0.13935456000000002*Metre)
 
-      test(t"Mixed units of the same dimension can be added"):
+      test(m"Mixed units of the same dimension can be added"):
         2*Metre + 2*Foot
       .assert(_ == 2.6096*Metre)
 
-      test(t"Mixed units of the same dimension can be subtracted"):
+      test(m"Mixed units of the same dimension can be subtracted"):
         2*Metre - 2*Foot
       .assert(_ == 1.3904*Metre)
 
-      test(t"Mixed units of the same type can be added (reverse order)"):
+      test(m"Mixed units of the same type can be added (reverse order)"):
         2*Foot + 2*Metre
       .assert(_ == 2.6096*Metre)
 
 
-    suite(t"Metric prefixes"):
-      test(t"Metric kilo prefix multiplies by 10^3"):
+    suite(m"Metric prefixes"):
+      test(m"Metric kilo prefix multiplies by 10^3"):
         15.0*Kilo(Metre)
       .assert(_ == 15000.0*Metre)
 
-      test(t"Metric mega prefix multiplies by 10^6"):
+      test(m"Metric mega prefix multiplies by 10^6"):
         15.0*Mega(Metre)
       .assert(_ == 15000000.0*Metre)
 
-      test(t"Metric giga prefix multiplies by 10^9"):
+      test(m"Metric giga prefix multiplies by 10^9"):
         15.0*Giga(Metre)
       .assert(_ == 15000000000.0*Metre)
 
-      test(t"Metric kibi prefix multiplies by 2^10"):
+      test(m"Metric kibi prefix multiplies by 2^10"):
         10*Kibi(Metre)
       .assert(_ == 10240*Metre)
 
-      test(t"Metric mebi prefix multiplies by 2^20"):
+      test(m"Metric mebi prefix multiplies by 2^20"):
         10*Mebi(Metre)
       .assert(_ == (1024*1024*10)*Metre)
 
-      test(t"Metric milli prefix multiplies by 10^-3"):
+      test(m"Metric milli prefix multiplies by 10^-3"):
         1.5*Milli(Metre)
       .assert(_ == 0.0015*Metre)
 
-      test(t"Metric micro prefix multiplies by 10^-6"):
+      test(m"Metric micro prefix multiplies by 10^-6"):
         1.5*Micro(Metre)
       .assert(_ == 0.0000015*Metre)
 
-      test(t"Metric nano prefix multiplies by 10^-9"):
+      test(m"Metric nano prefix multiplies by 10^-9"):
         2.5*Nano(Metre)
       .assert(_ == 0.0000000025*Metre)
 
-    suite(t"Explicit conversion tests"):
-      test(t"Convert feet to metres"):
+    suite(m"Explicit conversion tests"):
+      test(m"Convert feet to metres"):
         (3.0*Foot).in[Metres]
       .assert(_ == 0.9144000000000001*Metre)
 
-      test(t"Convert metres to feet"):
+      test(m"Convert metres to feet"):
         (3.0*Metre).in[Feet]
       .assert(_ == 9.842519685039369*Foot)
 
-      test(t"Convert m² to ft²"):
+      test(m"Convert m² to ft²"):
         (Metre*Metre).in[Feet]
       .assert(_ == 10.76391041670972*Foot*Foot)
 
-      test(t"Conversion to seconds does nothing"):
+      test(m"Conversion to seconds does nothing"):
         (3.0*Metre).in[Seconds]
       .assert(_ == 3.0*Metre)
 
-    suite(t"Inequalities"):
-      test(t"6ft < 2m"):
+    suite(m"Inequalities"):
+      test(m"6ft < 2m"):
         6*Foot < 2*Metre
       .assert(_ == true)
 
-      test(t"6ft <= 2m"):
+      test(m"6ft <= 2m"):
         6*Foot < 2*Metre
       .assert(_ == true)
 
-      test(t"7ft > 2m"):
+      test(m"7ft > 2m"):
         7*Foot > 2*Metre
       .assert(_ == true)
 
-      test(t"7ft >= 2m"):
+      test(m"7ft >= 2m"):
         7*Foot >= 2*Metre
       .assert(_ == true)
 
-      test(t"9ft² < 1m²"):
+      test(m"9ft² < 1m²"):
         9*Foot*Foot < Metre*Metre
       .assert(_ == true)
 
-      test(t"10ft² < 1m²"):
+      test(m"10ft² < 1m²"):
         10*Foot*Foot < Metre*Metre
       .assert(_ == true)
 
-      test(t"11ft² > 1m²"):
+      test(m"11ft² > 1m²"):
         11*Foot*Foot > Metre*Metre
       .assert(_ == true)
 
-    suite(t"Rendering tests"):
-      test(t"Show a value in metres"):
+    suite(m"Rendering tests"):
+      test(m"Show a value in metres"):
         (7.567*Metre).show
       .assert(_ == t"7.57 m")
 
-      test(t"Show a value in square metres"):
+      test(m"Show a value in square metres"):
         (1.4*Metre*Metre).show
       .assert(_ == t"1.40 m²")
 
-      test(t"Show a value in metres per second"):
+      test(m"Show a value in metres per second"):
         (8.54*Metre/Second).show
       .assert(_ == t"8.54 m·s¯¹")
 
-      test(t"Show a value in kilometres per second"):
+      test(m"Show a value in kilometres per second"):
         (8.54*Kilo(Metre)/Second).show
       .assert(_ == t"8.54×10³ m·s¯¹")
 
-      test(t"Show a value in kilograms"):
+      test(m"Show a value in kilograms"):
         (10.4*Kilo(Gram)/Second).show
       .assert(_ == t"10.4 kg·s¯¹")
 
-      test(t"Show the speed of light"):
+      test(m"Show the speed of light"):
         constants.SpeedOfLightInVacuum.show
       .assert(_ == t"3.00×10⁸ m·s¯¹")
 
-      test(t"Show Planck's constant"):
+      test(m"Show Planck's constant"):
         constants.PlanckConstant.show
       .assert(_ == t"6.63×10¯³⁴ m²·kg·s¯¹")
 
-      test(t"Show an energy using custom units"):
+      test(m"Show an energy using custom units"):
         (45*Joule).show
       .assert(_ == t"45.0 J")
 
-      test(t"Show a force in Newtons"):
+      test(m"Show a force in Newtons"):
         (100*Newton).show
       .assert(_ == t"100 N")
 
-    suite(t"Quantity descriptions"):
-      test(t"describe a base dimension"):
+    suite(m"Quantity descriptions"):
+      test(m"describe a base dimension"):
         Metre.dimension
       .assert(_ == t"distance")
 
-      test(t"describe a compound dimension"):
+      test(m"describe a compound dimension"):
         (Metre/Second).dimension
       .assert(_ == t"velocity")
 
-      test(t"describe a complex compound dimension"):
+      test(m"describe a complex compound dimension"):
         (Foot*Foot*Kilo(Gram)/(Second*Second*Mole)).dimension
       .assert(_ == t"chemical potential")
 
-    suite(t"Quantifiability tests"):
+    suite(m"Quantifiability tests"):
       case class Pts(value: Double)
       given Quantifiable[Pts, Inches[1]] = pts => (Inch*pts.value)/72
 
-      test(t"quantify a distance"):
+      test(m"quantify a distance"):
         Pts(71).quantify < Inch
       .assert(_ == true)
 
-      test(t"quantify a distance"):
+      test(m"quantify a distance"):
         Pts(73).quantify > Inch
       .assert(_ == true)
 
-    suite(t"Offset quantities"):
-      test(t"Get Celsius value"):
+    suite(m"Offset quantities"):
+      test(m"Get Celsius value"):
         (300*Kelvin).in[Celsius].show
       .assert(_ == t"26.9 °C")
 
-      test(t"Get Fahrenheit value"):
+      test(m"Get Fahrenheit value"):
         (300*Kelvin).in[Fahrenheit].show
       .assert(_ == t"80.3 °F")
 
-      test(t"Create Celsius value"):
+      test(m"Create Celsius value"):
         Celsius(30.0).show
       .assert(_ == t"30.0 °C")
 
-      test(t"Create Fahrenheit value"):
+      test(m"Create Fahrenheit value"):
         Fahrenheit(30.0).show
       .assert(_ == t"30.0 °F")
 
-      test(t"Check stored Celsius value"):
+      test(m"Check stored Celsius value"):
         Celsius(30.0).toString.show
       .assert(_ == t"303.15")
 
-      test(t"Check stored Fahrenheit value"):
+      test(m"Check stored Fahrenheit value"):
         Fahrenheit(30.0).toString.show
       .assert(_ == t"489.67")
 
-      test(t"Convert Fahrenheit value to Kelvin"):
+      test(m"Convert Fahrenheit value to Kelvin"):
         Fahrenheit(0.0).in[Kelvins].show
       .assert(_ == t"255 K")
 
-      test(t"Convert Fahrenheit value to Celsius via Kelvin"):
+      test(m"Convert Fahrenheit value to Celsius via Kelvin"):
         Fahrenheit(100.0).in[Kelvins].in[Celsius].show
       .assert(_ == t"37.8 °C")
 
-      test(t"Convert Fahrenheit directly to Celsius"):
+      test(m"Convert Fahrenheit directly to Celsius"):
         Fahrenheit(100.0).in[Celsius].show
       .assert(_ == t"37.8 °C")

--- a/lib/rudiments/src/test/rudiments.Tests.scala
+++ b/lib/rudiments/src/test/rudiments.Tests.scala
@@ -38,10 +38,10 @@ import language.experimental.captureChecking
 
 case class Person(name: Text, age: Int)
 
-object Tests extends Suite(t"Rudiments Tests"):
+object Tests extends Suite(m"Rudiments Tests"):
   def run(): Unit =
 
-    test(t"Dual extraction"):
+    test(m"Dual extraction"):
       object AsInt:
         def unapply(x: String): Option[Char] = Some('I')
 
@@ -53,32 +53,32 @@ object Tests extends Suite(t"Rudiments Tests"):
         case _                    => ('X', 'X')
     .assert(_ == ('I', 'J'))
 
-    // test(t"Display a PID"):
+    // test(m"Display a PID"):
     //   Pid(2999).toString
     // .assert(_ == "↯2999")
 
-    suite(t"bin tests"):
-      test(t"Specify a byte"):
+    suite(m"bin tests"):
+      test(m"Specify a byte"):
         val x: Byte = bin"10101010"
         x
       .assert(_ == -86)
 
-      test(t"Specify a short"):
+      test(m"Specify a short"):
         val x: Short = bin"01111111 11111111"
         x
       .assert(_ == 32767)
 
-      test(t"Specify an integer"):
+      test(m"Specify an integer"):
         val x: Int = bin"00000000 11111111 11111111 11111111"
         x
       .assert(_ == 16777215)
 
-      test(t"Specify a long"):
+      test(m"Specify a long"):
         val x: Long = bin"10101010 10101010 10101010 10101010 00000000 11111111 11111111 11111111"
         x
       .assert(_ == -6148914694083051521L)
 
-      test(t"Too many bits"):
+      test(m"Too many bits"):
         demilitarize:
           val long: Long =
             bin"010101010 10101010 10101010 10101010 00000000 11111111 11111111 11111111"
@@ -87,103 +87,103 @@ object Tests extends Suite(t"Rudiments Tests"):
         .map(_.id)
       .assert(_ == List(CompileErrorId.NoExplanation))
 
-      test(t"Incorrect bit count"):
+      test(m"Incorrect bit count"):
         demilitarize:
           val x: Long = bin"0101010 10101010 10101010 10101010 00000000 11111111 11111111 11111111"
           x
         .map(_.id)
       .assert(_ == List(CompileErrorId.NoExplanation))
 
-      test(t"Too many bits for type"):
+      test(m"Too many bits for type"):
         demilitarize:
           val x: Byte = bin"00011111 11111111"
           x
         .map(_.id)
       .assert(_ == List(CompileErrorId.TypeMismatch))
 
-      test(t"Non-binary content"):
+      test(m"Non-binary content"):
         demilitarize:
           bin"00011112 11111111"
         .map(_.id)
       .assert(_ == List(CompileErrorId.NoExplanation))
 
-    suite(t"hex tests"):
-      test(t"Specify some bytes"):
+    suite(m"hex tests"):
+      test(m"Specify some bytes"):
         hex"bacdf1e9".to(List)
       .assert(_ == Bytes(-70, -51, -15, -23).to(List))
 
-      test(t"Specify some bytes in uppercase with a space"):
+      test(m"Specify some bytes in uppercase with a space"):
         hex"BACD F1E9".to(List)
       .assert(_ == Bytes(-70, -51, -15, -23).to(List))
 
-      test(t"Non-even number of bytes"):
+      test(m"Non-even number of bytes"):
         demilitarize:
           hex"bacdf1e"
         .map(_.message)
       .assert(_ == List(t"rudiments: a hexadecimal value must have an even number of digits"))
 
-      test(t"Non-hex content"):
+      test(m"Non-hex content"):
         demilitarize:
           hex"bacdf1eg"
         .map(_.message)
       .assert(_ == List(t"rudiments: g is not a valid hexadecimal character"))
 
-      /*test(t"Convert a byte to hex"):
+      /*test(m"Convert a byte to hex"):
         126.toByte.hex
       .assert(_ == t"7e")
 
-      test(t"Convert a short to hex"):
+      test(m"Convert a short to hex"):
         32767.toShort.hex
       .assert(_ == t"7fff")
 
-      test(t"Convert an integer to hex"):
+      test(m"Convert an integer to hex"):
         123456789.hex
       .assert(_ == t"75bcd15")
 
-      test(t"Convert a long to hex"):
+      test(m"Convert a long to hex"):
         654321123456789L.hex
       .assert(_ == t"2531a0221f715")*/
 
-      test(t"Pattern match hex"):
+      test(m"Pattern match hex"):
         t"1234" match
           case Hex(value) => value
           case _          => 0
       .assert(_ == 4660)
 
-    suite(t"Collections tests"):
+    suite(m"Collections tests"):
       val numbers = List(t"one", t"two", t"four", t"six", t"eight", t"nine")
 
-      test(t"Index unique numbers by their first letter"):
+      test(m"Index unique numbers by their first letter"):
         safely:
           numbers.indexBy(_.prim)
       .assert(_ == Map('o' -> t"one", 't' -> t"two", 'f' -> t"four", 's' -> t"six", 'e' -> t"eight", 'n' -> t"nine"))
 
-      //test(t"Index unique numbers by their length"):
+      //test(m"Index unique numbers by their length"):
       //  capture[DuplicateIndexError]:
       //    numbers.indexBy(_.length)
       //.assert(_ == DuplicateIndexError())
 
-      test(t"Sift some options"):
+      test(m"Sift some options"):
         List(None, Some(1), Some(2), None).sift[Some[Int]]
       .assert(_ == List(Some(1), Some(2)))
 
-      test(t"Sift on singleton type"):
+      test(m"Sift on singleton type"):
         List.range(0, 10).sift[5]
       .assert(_ == List(5))
 
-      test(t"Sift on a union of singleton types"):
+      test(m"Sift on a union of singleton types"):
         List.range(0, 10).sift[5 | 7]
       .assert(_ == List(5, 7))
 
-      test(t"Map a List to twins"):
+      test(m"Map a List to twins"):
         List(1, 2, 3).bi
       .assert(_ == List((1, 1), (2, 2), (3, 3)))
 
-      test(t"Map a Set to triples"):
+      test(m"Map a Set to triples"):
         Set(1, 2, 3).tri
       .assert(_ == Set((1, 1, 1), (2, 2, 2), (3, 3, 3)))
 
-      test(t"Take a snapshot of an array"):
+      test(m"Take a snapshot of an array"):
         val array = Array[Int](1, 2, 3, 4, 5)
         array(1) = 17
         val snapshot: IArray[Int] = array.snapshot
@@ -191,187 +191,187 @@ object Tests extends Suite(t"Rudiments Tests"):
         snapshot.to(List)
       .assert(_ == List(1, 17, 3, 4, 5))
 
-      test(t"Take Map#upsert as an insertion"):
+      test(m"Take Map#upsert as an insertion"):
         val map = Map(1 -> "one", 2 -> "two")
         map.upsert(3, _.or("three"))
       .assert(_ == Map(1 -> "one", 2 -> "two", 3 -> "three"))
 
-      test(t"Take Map#upsert as an update"):
+      test(m"Take Map#upsert as an update"):
         val map = Map(1 -> "one", 2 -> "two")
         map.upsert(2, _.or("")+"!")
       .assert(_ == Map(1 -> "one", 2 -> "two!"))
 
-      test(t"Collation"):
+      test(m"Collation"):
         val map1 = Map(1 -> List("one"), 2 -> List("two"))
         val map2 = Map(2 -> List("deux"), 3 -> List("trois"))
         map1.collate(map2): (left, right) =>
           left ::: right
       .assert(_ == Map(1 -> List("one"), 2 -> List("two", "deux"), 3 -> List("trois")))
 
-      test(t"runs"):
+      test(m"runs"):
         List(1, 2, 2, 1, 1, 1, 4, 4).runs
       .assert(_ == List(List(1), List(2, 2), List(1, 1, 1), List(4, 4)))
 
-      test(t"runsBy"):
+      test(m"runsBy"):
         List(1, 2, 2, 1, 1, 1, 4, 4).runsBy(_%3)
       .assert(_ == List(List(1), List(2, 2), List(1, 1, 1, 4, 4)))
 
-    suite(t"Longest train tests"):
-      test(t"Find longest train of zeros in middle"):
+    suite(m"Longest train tests"):
+      test(m"Find longest train of zeros in middle"):
         List(1, 0, 0, 2, 3, 4, 0, 0, 0, 5, 6, 0, 7).longestTrain(_ == 0)
       .assert(_ == (6, 3))
 
-      test(t"Find longest train of zeros at start"):
+      test(m"Find longest train of zeros at start"):
         List(0, 0, 0, 2, 3, 4, 0, 0, 1, 5, 6, 0, 7).longestTrain(_ == 0)
       .assert(_ == (0, 3))
 
-      test(t"Find longest train of zeros at end"):
+      test(m"Find longest train of zeros at end"):
         List(0, 0, 1, 2, 3, 4, 0, 0, 1, 5, 6, 0, 0, 0, 0).longestTrain(_ == 0)
       .assert(_ == (11, 4))
 
-    suite(t"Optional tests"):
+    suite(m"Optional tests"):
       val absentInt: Optional[Int] = Unset
       val setInt: Optional[Int] = 42
 
-      test(t"Check whether absent value is absent"):
+      test(m"Check whether absent value is absent"):
         absentInt.absent
       .assert(_ == true)
 
-      test(t"Check thet set value is not absent"):
+      test(m"Check thet set value is not absent"):
         setInt.absent
       .assert(_ == false)
 
-      test(t"Unsafely vouch a set value"):
+      test(m"Unsafely vouch a set value"):
         val x: Int = setInt.vouch
         x
       .assert(_ == 42)
 
-      test(t"Provide an alternative for an absent value"):
+      test(m"Provide an alternative for an absent value"):
         absentInt.or(1)
       .assert(_ == 1)
 
-      test(t"Provide an alternative for a set value"):
+      test(m"Provide an alternative for a set value"):
         setInt.or(1)
       .assert(_ == 42)
 
-      test(t"Presume a default value for an absent value"):
+      test(m"Presume a default value for an absent value"):
         absentInt.presume
       .assert(_ == 0)
 
-      test(t"Convert an absent value to an Option"):
+      test(m"Convert an absent value to an Option"):
         absentInt.option
       .assert(_ == None)
 
-      test(t"Convert a set value to an Option"):
+      test(m"Convert a set value to an Option"):
         setInt.option
       .assert(_ == Some(42))
 
-      test(t"Fold over a Optional"):
+      test(m"Fold over a Optional"):
         absentInt.lay(0)(_ + 1)
       .assert(_ == 0)
 
-      test(t"Fold over a set Optional"):
+      test(m"Fold over a set Optional"):
         setInt.lay(0)(_ + 1)
       .assert(_ == 43)
 
-      test(t"Map over an absent Optional"):
+      test(m"Map over an absent Optional"):
         absentInt.let(_ + 1)
       .assert(_ == Unset)
 
-      test(t"Map over a set Optional"):
+      test(m"Map over a set Optional"):
         setInt.let(_ + 1)
       .assert(_ == 43)
 
-      test(t"Construct a new Optional from a null value"):
+      test(m"Construct a new Optional from a null value"):
         val x: String | Null = null
         Optional(x)
       .assert(_ == Unset)
 
-      test(t"Construct a new Optional from a possibly-null value"):
+      test(m"Construct a new Optional from a possibly-null value"):
         val x: String | Null = ""
         Optional(x)
       .assert(_ == "")
 
-      test(t"Convert an option to an optional"):
+      test(m"Convert an option to an optional"):
         val x: Option[Int] = Some(42)
         x.optional
       .assert(_ == 42)
 
-      test(t"Convert an empty Option to an optional"):
+      test(m"Convert an empty Option to an optional"):
         val x: Option[Int] = None
         x.optional
       .assert(_ == Unset)
 
-      test(t"Presume a value for an empty Option"):
+      test(m"Presume a value for an empty Option"):
         val x: Option[List[Int]] = None
         x.presume
       .assert(_ == Nil)
 
-    suite(t"PID & exit status tests"):
-      test(t"Zero exit-status is OK"):
+    suite(m"PID & exit status tests"):
+      test(m"Zero exit-status is OK"):
         Exit(0)
       .assert(_ == Exit.Ok)
 
-      test(t"Positive exit-status is a failure"):
+      test(m"Positive exit-status is a failure"):
         Exit(1)
       .assert(_ == Exit.Fail(1))
 
-      test(t"Ok has exit status 0"):
+      test(m"Ok has exit status 0"):
         Exit.Ok
       .assert(_() == 0)
 
-      test(t"Failure has non-zero exit status"):
+      test(m"Failure has non-zero exit status"):
         Exit.Fail(3)
       .assert(_() == 3)
 
-    suite(t"Bytes tests"):
-      test(t"Construct a `Bytes` literal"):
+    suite(m"Bytes tests"):
+      test(m"Construct a `Bytes` literal"):
         Bytes(1, 2, 3)
       .assert(_.length == 3)
 
-      test(t"Construct a `Bytes` value from a Long"):
+      test(m"Construct a `Bytes` value from a Long"):
         Bytes(Long.MaxValue)
       .assert(_.length == 8)
 
-      test(t"Construct an empty `Bytes`"):
+      test(m"Construct an empty `Bytes`"):
         Bytes()
       .assert(_.length == 0)
 
-    suite(t"Byte Size tests"):
-      test(t"Construct a simple Memory"):
+    suite(m"Byte Size tests"):
+      test(m"Construct a simple Memory"):
         4.b: Memory
       .assert(_ == Memory(4))
 
-      test(t"Construct a simple Memory in kB"):
+      test(m"Construct a simple Memory in kB"):
         4.kb: Memory
       .assert(_ == Memory(4096))
 
-      test(t"Construct a simple Memory in MB"):
+      test(m"Construct a simple Memory in MB"):
         4.mb: Memory
       .assert(_ == Memory(4096*1024L))
 
-      test(t"Construct a simple Memory in GB"):
+      test(m"Construct a simple Memory in GB"):
         4.gb: Memory
       .assert(_ == Memory(4096*1024L*1024L))
 
-      test(t"Construct a simple Memory in TB"):
+      test(m"Construct a simple Memory in TB"):
         4.tb: Memory
       .assert(_ == Memory(4096*1024L*1024L*1024L))
 
-      /*test(t"Compare bytes with >"):
+      /*test(m"Compare bytes with >"):
         4.gb > 4.mb
       .assert(_ == true)
 
-      test(t"Compare bytes with >="):
+      test(m"Compare bytes with >="):
         4.gb >= 4.mb*1024
       .assert(_ == true)*/
 
-      test(t"Sort some byte sizes"):
+      test(m"Sort some byte sizes"):
         List(1.b, 1.mb, 1.kb).sorted
       .assert(_ == List(1.b, 1.kb, 1.mb))
 
-    suite(t"Y-combinator test"):
-      test(t"Check factorial implementation"):
+    suite(m"Y-combinator test"):
+      test(m"Check factorial implementation"):
         def factorial(n: Int): Int = fix[Int] { i => if i <= 0 then 1 else i*recur(i - 1) } (n)
         factorial(4)
       .assert(_ == 24)

--- a/lib/satirical/src/test/satirical.Tests.scala
+++ b/lib/satirical/src/test/satirical.Tests.scala
@@ -36,24 +36,24 @@ import soundness.*
 
 import charEncoders.utf8
 
-object Tests extends Suite(t"Satirical tests"):
+object Tests extends Suite(m"Satirical tests"):
   def run(): Unit =
-    test(t"Parse empty world"):
+    test(m"Parse empty world"):
       t"world example-world {   }".read[Wit]
     . assert(_ == Wit(World(w"example-world", Nil)))
 
-    test(t"Parse empty interface"):
+    test(m"Parse empty interface"):
       t"interface example-interface {   }".read[Wit]
     . assert(_ == Wit(Interface(w"example-interface", Nil)))
 
-    test(t"Parse empty interface ignoring comment"):
+    test(m"Parse empty interface ignoring comment"):
       t"// a comment\n // another\ninterface example-interface {   } ".read[Wit].tap(println)
     . assert(_ == Wit(Interface(w"example-interface", Nil)))
 
-    test(t"Parse empty world and interface"):
+    test(m"Parse empty world and interface"):
       t"interface eg-int {   }\nworld eg-world {}".read[Wit]
     . assert(_ == Wit(Interface(w"eg-int", Nil), World(w"eg-world", Nil)))
 
-    test(t"Parse package"):
+    test(m"Parse package"):
       t"package namespace:name;\ninterface eg-int {   }\nworld eg-world {}".read[Wit]
     . assert(_ == Wit(Interface(w"eg-int", Nil), World(w"eg-world", Nil)))

--- a/lib/savagery/src/test/tests.scala
+++ b/lib/savagery/src/test/tests.scala
@@ -36,9 +36,9 @@ import gossamer.*
 import probably.*
 import spectacular.*
 
-object Tests extends Suite(t"Savagery tests"):
+object Tests extends Suite(m"Savagery tests"):
   def run(): Unit =
-    test(t"Simple plus sign path"):
+    test(m"Simple plus sign path"):
       Path().moveTo(0!0).lineUp(2).lineLeft(2).lineUp(1).lineRight(2).lineUp(2).lineRight(1)
           .lineDown(2).lineRight(2).lineDown(1).lineLeft(2).lineDown(2).closed.xml.show
     .assert(_ == t"")

--- a/lib/scintillate/src/test/scintillate.Tests.scala
+++ b/lib/scintillate/src/test/scintillate.Tests.scala
@@ -35,5 +35,5 @@ package scintillate
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Scintillate tests"):
+object Tests extends Suite(m"Scintillate tests"):
   def run(): Unit = ()

--- a/lib/serpentine/src/bench/serpentine.Benchmarks.scala
+++ b/lib/serpentine/src/bench/serpentine.Benchmarks.scala
@@ -37,10 +37,10 @@ import gossamer.*
 import probably.*
 import rudiments.*
 
-object Benchmarks extends Suite(t"Serpentine Benchmarks"):
+object Benchmarks extends Suite(m"Serpentine Benchmarks"):
   def run(): Unit =
-    suite(t"Conjunctions"):
-      test(t"Find conjunction of 2-element paths"):
+    suite(m"Conjunctions"):
+      test(m"Find conjunction of 2-element paths"):
         val p1 = ^ / p"foo" / p"bar"
         val p2 = ^ / p"foo" / p"baz"
         p1.conjunction(p2)
@@ -50,35 +50,35 @@ object Benchmarks extends Suite(t"Serpentine Benchmarks"):
           duration = 500L,
           baseline = Baseline(ratio = Ratio.Time, compare = Compare.Min))
 
-      test(t"Find conjunction of 3-element paths"):
+      test(m"Find conjunction of 3-element paths"):
         val p1 = ^ / p"foo" / p"bar" / p"quux"
         val p2 = ^ / p"foo" / p"baz" / p"quux"
         p1.conjunction(p2)
 
       . benchmark(warmup = 500L, duration = 500L)
 
-      test(t"Find conjunction of 4-element paths"):
+      test(m"Find conjunction of 4-element paths"):
         val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy"
         val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop"
         p1.conjunction(p2)
 
       . benchmark(warmup = 500L, duration = 500L)
 
-      test(t"Find conjunction of 5-element paths"):
+      test(m"Find conjunction of 5-element paths"):
         val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy" / p"abc"
         val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop" / p"def"
         p1.conjunction(p2)
 
       . benchmark(warmup = 500L, duration = 500L)
 
-      test(t"Find conjunction of 6-element paths"):
+      test(m"Find conjunction of 6-element paths"):
         val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy" / p"abc" / p"ghi"
         val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop" / p"def" / p"jkl"
         p1.conjunction(p2)
 
       . benchmark(warmup = 500L, duration = 500L)
 
-      test(t"Find conjunction of 7-element paths"):
+      test(m"Find conjunction of 7-element paths"):
         val p1 = ^ / p"foo" / p"bar" / p"quux" / p"bippy" / p"abc" / p"ghi" / p"mno"
         val p2 = ^ / p"foo" / p"baz" / p"quux" / p"bop" / p"def" / p"jkl" / p"pqr"
         p1.conjunction(p2)

--- a/lib/spectacular/src/test/spectacular.Tests.scala
+++ b/lib/spectacular/src/test/spectacular.Tests.scala
@@ -40,197 +40,197 @@ import spectacular.*
 
 case class Person(name: Text, age: Int)
 
-object Tests extends Suite(t"Spectacular Tests"):
+object Tests extends Suite(m"Spectacular Tests"):
   def run(): Unit =
-    suite(t"Debug tests"):
-      test(t"serialize boring string"):
+    suite(m"Debug tests"):
+      test(m"serialize boring string"):
         t"Hello world!".inspect
       .assert(_ == t"t\"Hello world!\"")
 
-      test(t"serialize string with newline"):
+      test(m"serialize string with newline"):
         t"Hello\nworld".inspect
       .assert(_ == t"t\"Hello\\nworld\"")
 
-      test(t"serialize string with tab"):
+      test(m"serialize string with tab"):
         t"Hello\tworld".inspect
       .assert(_ == t"t\"Hello\\tworld\"")
 
-      test(t"serialize string with apostrophe"):
+      test(m"serialize string with apostrophe"):
         t"Hell' world".inspect
       .assert(_ == t"t\"Hell\\' world\"")
 
-      test(t"serialize string with quote"):
+      test(m"serialize string with quote"):
         t"Hello \"world\"".inspect
       .assert(_ == t"t\"Hello \\\"world\\\"\"")
 
-      test(t"serialize string with backslash"):
+      test(m"serialize string with backslash"):
         t"Hello\\world".inspect
       .assert(_ == t"t\"Hello\\\\world\"")
 
-      test(t"serialize string with linefeed"):
+      test(m"serialize string with linefeed"):
         t"Hello world\r".inspect
       .assert(_ == t"t\"Hello world\\r\"")
 
-      test(t"serialize string with unicode escapes"):
+      test(m"serialize string with unicode escapes"):
         t"Hello мир".inspect
       .assert(_ == t"t\"Hello \\u043c\\u0438\\u0440\"")
 
-      test(t"pattern match on Text"):
+      test(m"pattern match on Text"):
         var text = t"Hello"
         text match
           case t"Hello" => true
           case _        => false
       .assert(_ == true)
 
-      test(t"pattern non-match on Text"):
+      test(m"pattern non-match on Text"):
         var text = t"Hello"
         text match
           case t"World" => true
           case _        => false
       .assert(_ == false)
 
-      test(t"serialize double"):
+      test(m"serialize double"):
         3.1.inspect
       .assert(_ == t"3.1")
 
-      test(t"serialize float"):
+      test(m"serialize float"):
         3.1f.inspect
       .assert(_ == t"3.1F")
 
-      test(t"serialize long"):
+      test(m"serialize long"):
         3L.inspect
       .assert(_ == t"3L")
 
-      test(t"serialize int"):
+      test(m"serialize int"):
         3.inspect
       .assert(_ == t"3")
 
-      test(t"serialize short"):
+      test(m"serialize short"):
         3.toShort.inspect
       .assert(_ == t"3.toShort")
 
-      test(t"serialize +infinity"):
+      test(m"serialize +infinity"):
         (1.0/0.0).inspect
       .assert(_ == t"Double.PositiveInfinity")
 
-      test(t"serialize -infinity"):
+      test(m"serialize -infinity"):
         (-1.0/0.0).inspect
       .assert(_ == t"Double.NegativeInfinity")
 
-      test(t"serialize NaN"):
+      test(m"serialize NaN"):
         (0.0/0.0).inspect
       .assert(_ == t"Double.NaN")
 
-      test(t"serialize float +infinity"):
+      test(m"serialize float +infinity"):
         (1.0F/0.0F).inspect
       .assert(_ == t"Float.PositiveInfinity")
 
-      test(t"serialize float -infinity"):
+      test(m"serialize float -infinity"):
         (-1.0F/0.0F).inspect
       .assert(_ == t"Float.NegativeInfinity")
 
-      test(t"serialize float NaN"):
+      test(m"serialize float NaN"):
         (0.0F/0.0F).inspect
       .assert(_ == t"Float.NaN")
 
-      test(t"serialize tab char"):
+      test(m"serialize tab char"):
         '\t'.inspect
       .assert(_ == t"'\\t'")
 
-      test(t"serialize backslash char"):
+      test(m"serialize backslash char"):
         '\\'.inspect
       .assert(_ == t"'\\\\'")
 
-      test(t"serialize newline char"):
+      test(m"serialize newline char"):
         '\n'.inspect
       .assert(_ == t"'\\n'")
 
-      test(t"serialize backspace char"):
+      test(m"serialize backspace char"):
         '\b'.inspect
       .assert(_ == t"'\\b'")
 
-      test(t"serialize unicode char"):
+      test(m"serialize unicode char"):
         '«'.inspect
       .assert(_ == t"'\\u00ab'")
 
-      test(t"serialize apostrophe char"):
+      test(m"serialize apostrophe char"):
         '\''.inspect
       .assert(_ == t"'\\''")
 
-      test(t"serialize quote char"):
+      test(m"serialize quote char"):
         '\"'.inspect
       .assert(_ == t"'\\\"'")
 
-      test(t"serialize case class"):
+      test(m"serialize case class"):
         Person(t"Simon", 72).inspect
       .assert(_ == t"Person(name:t\"Simon\" ╱ age:72)")
 
-      test(t"serialize tuple"):
+      test(m"serialize tuple"):
         (t"Simon", 72).inspect
       .assert(_ == t"(t\"Simon\" ╱ 72)")
 
-      test(t"serialize list of strings"):
+      test(m"serialize list of strings"):
         List(t"one", t"two", t"three").inspect
       .assert(_ == t"""[t"one", t"two", t"three"]""")
 
-      test(t"serialize set of strings"):
+      test(m"serialize set of strings"):
         Set(t"one", t"two", t"three").inspect
       .assert(_ == t"""{t"one", t"two", t"three"}""")
 
-      test(t"serialize Array of strings"):
+      test(m"serialize Array of strings"):
         Array(t"one", t"two", t"three").inspect
       .assert(_ == t"""⦋🅻₀t"one"∣₁t"two"∣₂t"three"⦌""")
 
-      test(t"serialize Array of ints"):
+      test(m"serialize Array of ints"):
         Array(1, 2, 3).inspect
       .assert(_ == t"""⦋🅸₀1∣₁2∣₂3⦌""")
 
-      test(t"serialize Vector of shorts"):
+      test(m"serialize Vector of shorts"):
         Vector(1.toShort, 2.toShort, 3.toShort).inspect
       .assert(_ == t"""⟨ 1.toShort 2.toShort 3.toShort ⟩""")
 
-      test(t"serialize Array of Longs"):
+      test(m"serialize Array of Longs"):
         Array(1L, 2L, 3L).inspect
       .assert(_ == t"""⦋🅹₀1L∣₁2L∣₂3L⦌""")
 
-      test(t"serialize IArray of booleans"):
+      test(m"serialize IArray of booleans"):
         IArray(true, false, true).inspect
       .assert(_ == t"""🆉⁅₀true╱₁false╱₂true⁆""")
 
-      test(t"serialize IArray of strings"):
+      test(m"serialize IArray of strings"):
         IArray(t"one", t"two", t"three").inspect
       .assert(_ == t"""🅻⁅₀t"one"╱₁t"two"╱₂t"three"⁆""")
 
-    suite(t"Show tests"):
-      test(t"Show a string"):
+    suite(m"Show tests"):
+      test(m"Show a string"):
         t"Hello world".show
       .assert(_ == t"Hello world")
 
-      test(t"Show an Int"):
+      test(m"Show an Int"):
         43.show
       .assert(_ == t"43")
 
-      test(t"Show yes/no booleans"):
+      test(m"Show yes/no booleans"):
         import booleanStyles.yesNo
         t"${true} ${false}"
       .assert(_ == t"yes no")
 
-      test(t"Show true/false booleans"):
+      test(m"Show true/false booleans"):
         import booleanStyles.trueFalse
         t"${true} ${false}"
       .assert(_ == t"true false")
 
-      test(t"Show on/off booleans"):
+      test(m"Show on/off booleans"):
         import booleanStyles.onOff
         t"${true} ${false}"
       .assert(_ == t"on off")
 
-      test(t"Show 1/0 booleans"):
+      test(m"Show 1/0 booleans"):
         import booleanStyles.oneZero
         t"${true} ${false}"
       .assert(_ == t"1 0")
 
-      test(t"Show a locally-declared showable"):
+      test(m"Show a locally-declared showable"):
         given Exception is Showable = e => txt"<exception>"
         Exception("error message").inspect
       .assert(_ == t"<exception>")

--- a/lib/superlunary/src/test/superlunary.Tests.scala
+++ b/lib/superlunary/src/test/superlunary.Tests.scala
@@ -35,6 +35,6 @@ package superlunary
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Superlunary Tests"):
+object Tests extends Suite(m"Superlunary Tests"):
   def run(): Unit =
     ()

--- a/lib/surveillance/src/test/surveillance.Tests.scala
+++ b/lib/surveillance/src/test/surveillance.Tests.scala
@@ -35,5 +35,5 @@ package surveillance
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Surveillance tests"):
+object Tests extends Suite(m"Surveillance tests"):
   def run(): Unit = ()

--- a/lib/symbolism/src/test/symbolism.Tests.scala
+++ b/lib/symbolism/src/test/symbolism.Tests.scala
@@ -35,6 +35,6 @@ package symbolism
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Symbolism Tests"):
+object Tests extends Suite(m"Symbolism Tests"):
   def run(): Unit =
     ()

--- a/lib/tarantula/src/test/tarantula.Tests.scala
+++ b/lib/tarantula/src/test/tarantula.Tests.scala
@@ -35,6 +35,6 @@ package tarantula
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Tarantula Tests"):
+object Tests extends Suite(m"Tarantula Tests"):
   def run(): Unit =
     ()

--- a/lib/turbulence/src/test/turbulence.Tests.scala
+++ b/lib/turbulence/src/test/turbulence.Tests.scala
@@ -40,10 +40,10 @@ import strategies.throwUnsafely
 
 import scala.collection.mutable as scm
 
-object Tests extends Suite(t"Turbulence tests"):
+object Tests extends Suite(m"Turbulence tests"):
   def run(): Unit =
 
-    suite(t"Shredding"):
+    suite(m"Shredding"):
       given Seed = Seed(1L)
       import randomization.seeded
       val bytes: Bytes = Bytes.fill(1000)(_.toByte)
@@ -53,15 +53,15 @@ object Tests extends Suite(t"Turbulence tests"):
           stream.shred(20.0, 10.0)
 
       shredded.each: stream =>
-        test(t"correct length after shredding"):
+        test(m"correct length after shredding"):
           stream.map(_.length).total
         . assert(_ == 1000)
 
-        test(t"correct content after shredding"):
+        test(m"correct content after shredding"):
           stream.reduce(_ ++ _)
         . assert(_ === bytes)
 
-    suite(t"Streaming Unicode tests"):
+    suite(m"Streaming Unicode tests"):
       val ascii = IArray(t"", t"a", t"ab", t"abc", t"abcd")
 
       val strings = for
@@ -78,13 +78,13 @@ object Tests extends Suite(t"Turbulence tests"):
         string <- strings
         bs     <- 1 to 8
       do
-        test(t"length tests"):
+        test(m"length tests"):
           val stream = string.bytes.grouped(bs).to(Stream)
           val result = stream.read[Text]
           result.bytes.length
         .assert(_ == string.bytes.length)
 
-        test(t"roundtrip tests"):
+        test(m"roundtrip tests"):
           val stream = string.bytes.grouped(bs).to(Stream)
           val result = stream.read[Text]
 
@@ -110,80 +110,80 @@ object Tests extends Suite(t"Turbulence tests"):
 
     case class Ref3()
 
-    suite(t"Reading tests"):
-      test(t"Stream Text"):
+    suite(m"Reading tests"):
+      test(m"Stream Text"):
         qbf.stream[Text].join
       .assert(_ == qbf)
 
-      test(t"Stream Bytes"):
+      test(m"Stream Bytes"):
         qbf.stream[Bytes].reduce(_ ++ _).to(List)
       .assert(_ == qbfBytes.to(List))
 
-      test(t"Read Text as Text"):
+      test(m"Read Text as Text"):
         qbf.read[Text]
       .assert(_ == qbf)
 
-      test(t"Read some type as Text with Text and Byte Readable instance"):
+      test(m"Read some type as Text with Text and Byte Readable instance"):
         Ref().read[Text]
       .assert(_ == t"abcdef")
 
-      test(t"Read some type as Bytes with Text and Byte Readable instance"):
+      test(m"Read some type as Bytes with Text and Byte Readable instance"):
         Ref().read[Bytes].to(List)
       .assert(_ == t"abcdef".bytes.to(List))
 
-      test(t"Read some type as Text with only Text Readable instance"):
+      test(m"Read some type as Text with only Text Readable instance"):
         Ref2().read[Text]
       .assert(_ == t"abcdef")
 
-      test(t"Read some type as Bytes with only Text Readable instance"):
+      test(m"Read some type as Bytes with only Text Readable instance"):
         Ref2().read[Bytes].to(List)
       .assert(_ == t"abcdef".bytes.to(List))
 
-      test(t"Read some type as Text with only Bytes Readable instance"):
+      test(m"Read some type as Text with only Bytes Readable instance"):
         Ref3().read[Text]
       .assert(_ == t"abcdef")
 
-      test(t"Read some type as Bytes with only Bytes Readable instance"):
+      test(m"Read some type as Bytes with only Bytes Readable instance"):
         Ref3().read[Bytes].to(List)
       .assert(_ == t"abcdef".bytes.to(List))
 
-      test(t"Read Text as Stream[Text]"):
+      test(m"Read Text as Stream[Text]"):
         qbf.read[Stream[Text]].join
       .assert(_ == qbf)
 
-      test(t"Read Text as Bytes"):
+      test(m"Read Text as Bytes"):
         qbf.read[Bytes]
       .assert(_.to(List) == qbfBytes.to(List))
 
-      test(t"Read Text as Stream[Bytes]"):
+      test(m"Read Text as Stream[Bytes]"):
         qbf.read[Stream[Bytes]]
       .assert(_.reduce(_ ++ _).to(List) == qbfBytes.to(List))
 
-      test(t"Read Bytes as Text"):
+      test(m"Read Bytes as Text"):
         qbfBytes.read[Text]
       .assert(_ == qbf)
 
-      test(t"Read Bytes as Stream[Text]"):
+      test(m"Read Bytes as Stream[Text]"):
         qbfBytes.read[Stream[Text]].join
       .assert(_ == qbf)
 
-      test(t"Read Bytes as Bytes"):
+      test(m"Read Bytes as Bytes"):
         qbfBytes.read[Bytes]
       .assert(_.to(List) == qbfBytes.to(List))
 
-      test(t"Read Bytes as Stream[Bytes]"):
+      test(m"Read Bytes as Stream[Bytes]"):
         qbfBytes.read[Stream[Bytes]]
       .assert(_.reduce(_ ++ _).to(List) == qbfBytes.to(List))
 
-      // test(t"Read Text as Lines"):
+      // test(m"Read Text as Lines"):
       //   qbf.read[Stream[Line]]
       // .assert(_ == Stream(Line(t"The quick brown fox"), Line(t"jumps over the lazy dog")))
 
-      // test(t"Read Bytes as Lines"):
+      // test(m"Read Bytes as Lines"):
       //   qbfBytes.read[Stream[Line]]
       // .assert(_ == Stream(Line(t"The quick brown fox"), Line(t"jumps over the lazy dog")))
 
-    suite(t"Writing tests"):
+    suite(m"Writing tests"):
 
       class GeneralStore():
         val arrayBuffer: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
@@ -215,79 +215,79 @@ object Tests extends Suite(t"Turbulence tests"):
         given TextStore is Writable by Text = (store, texts) => texts.each: text =>
           store.text = store.text + text
 
-      test(t"Write Text to some reference with Text and Bytes instances"):
+      test(m"Write Text to some reference with Text and Bytes instances"):
         val store = GeneralStore()
         qbf.writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Bytes to some reference with Text and Bytes instances"):
+      test(m"Write Bytes to some reference with Text and Bytes instances"):
         val store = GeneralStore()
         qbfBytes.writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Stream[Text] to some reference with Text and Bytes instances"):
+      test(m"Write Stream[Text] to some reference with Text and Bytes instances"):
         val store = GeneralStore()
         Stream(qbf).writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Stream[Bytes] to some reference with Text and Bytes instances"):
+      test(m"Write Stream[Bytes] to some reference with Text and Bytes instances"):
         val store = GeneralStore()
         Stream(qbfBytes).writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Text to some reference with only a Bytes instance"):
+      test(m"Write Text to some reference with only a Bytes instance"):
         val store = ByteStore()
         qbf.writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Bytes to some reference with only a Bytes instance"):
+      test(m"Write Bytes to some reference with only a Bytes instance"):
         val store = ByteStore()
         qbfBytes.writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Stream[Text] to some reference with only a Bytes instance"):
+      test(m"Write Stream[Text] to some reference with only a Bytes instance"):
         val store = ByteStore()
         Stream(qbf).writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Stream[Bytes] to some reference with only a Bytes instance"):
+      test(m"Write Stream[Bytes] to some reference with only a Bytes instance"):
         val store = ByteStore()
         Stream(qbfBytes).writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Text to some reference with only a Text instance"):
+      test(m"Write Text to some reference with only a Text instance"):
         val store = TextStore()
         qbf.writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Bytes to some reference with only a Text instance"):
+      test(m"Write Bytes to some reference with only a Text instance"):
         val store = TextStore()
         qbfBytes.writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Stream[Text] to some reference with only a Text instance"):
+      test(m"Write Stream[Text] to some reference with only a Text instance"):
         val store = TextStore()
         Stream(qbf).writeTo(store)
         store()
       .assert(_ == qbf)
 
-      test(t"Write Stream[Bytes] to some reference with only a Text instance"):
+      test(m"Write Stream[Bytes] to some reference with only a Text instance"):
         val store = TextStore()
         Stream(qbfBytes).writeTo(store)
         store()
       .assert(_ == qbf)
 
-    // suite(t"Appending tests"):
+    // suite(m"Appending tests"):
 
     //   class GeneralStore():
     //     val arrayBuffer: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
@@ -319,90 +319,90 @@ object Tests extends Suite(t"Turbulence tests"):
     //     given TextStore is Writable by Text = (store, texts) => texts.each: text =>
     //       store.text = store.text + text
 
-      // test(t"Append Text to some reference with Text and Bytes instances"):
+      // test(m"Append Text to some reference with Text and Bytes instances"):
       //   val store = GeneralStore()
       //   qbf.appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Bytes to some reference with Text and Bytes instances"):
+      // test(m"Append Bytes to some reference with Text and Bytes instances"):
       //   val store = GeneralStore()
       //   qbfBytes.appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Stream[Text] to some reference with Text and Bytes instances"):
+      // test(m"Append Stream[Text] to some reference with Text and Bytes instances"):
       //   val store = GeneralStore()
       //   Stream(qbf).appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Stream[Bytes] to some reference with Text and Bytes instances"):
+      // test(m"Append Stream[Bytes] to some reference with Text and Bytes instances"):
       //   val store = GeneralStore()
       //   Stream(qbfBytes).appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Text to some reference with only a Bytes instance"):
+      // test(m"Append Text to some reference with only a Bytes instance"):
       //   val store = ByteStore()
       //   qbf.appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Bytes to some reference with only a Bytes instance"):
+      // test(m"Append Bytes to some reference with only a Bytes instance"):
       //   val store = ByteStore()
       //   qbfBytes.appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Stream[Text] to some reference with only a Bytes instance"):
+      // test(m"Append Stream[Text] to some reference with only a Bytes instance"):
       //   val store = ByteStore()
       //   Stream(qbf).appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Stream[Bytes] to some reference with only a Bytes instance"):
+      // test(m"Append Stream[Bytes] to some reference with only a Bytes instance"):
       //   val store = ByteStore()
       //   Stream(qbfBytes).appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Text to some reference with only a Text instance"):
+      // test(m"Append Text to some reference with only a Text instance"):
       //   val store = TextStore()
       //   qbf.appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Bytes to some reference with only a Text instance"):
+      // test(m"Append Bytes to some reference with only a Text instance"):
       //   val store = TextStore()
       //   qbfBytes.appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Stream[Text] to some reference with only a Text instance"):
+      // test(m"Append Stream[Text] to some reference with only a Text instance"):
       //   val store = TextStore()
       //   Stream(qbf).appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-      // test(t"Append Stream[Bytes] to some reference with only a Text instance"):
+      // test(m"Append Stream[Bytes] to some reference with only a Text instance"):
       //   val store = TextStore()
       //   Stream(qbfBytes).appendTo(store)
       //   store()
       // .assert(_ == qbf)
 
-    suite(t"Multiplexer tests"):
+    suite(m"Multiplexer tests"):
       val l1 = Stream(2, 4, 6, 8, 10)
       val l2 = Stream(1, 3, 5, 7, 9)
 
-      test(t"Check that two multiplexed streams contain all elements"):
+      test(m"Check that two multiplexed streams contain all elements"):
         supervise(l1.multiplexWith(l2).to(Set))
       .assert(_ == Set.range(1, 11))
 
-      test(t"Check that two multiplexed streams contain elements from the first stream in order"):
+      test(m"Check that two multiplexed streams contain elements from the first stream in order"):
         supervise(l1.multiplexWith(l2).filter(_%2 == 0))
       .assert(_ == l1)
 
-      test(t"Check that two multiplexed streams contain elements from the second stream in order"):
+      test(m"Check that two multiplexed streams contain elements from the second stream in order"):
         supervise(l1.multiplexWith(l2).filter(_%2 == 1))
       .assert(_ == l2)

--- a/lib/typonym/src/test/typonym.Tests.scala
+++ b/lib/typonym/src/test/typonym.Tests.scala
@@ -34,16 +34,16 @@ package typonym
 
 import soundness.*
 
-object Tests extends Suite(t"Typonym tests"):
+object Tests extends Suite(m"Typonym tests"):
   def run(): Unit =
-    test(t"Get a list of strings"):
+    test(m"Get a list of strings"):
       reify[TypeList[("one", "two", "three")]]
     .assert(_ == List("one", "two", "three"))
 
-    test(t"Get a map of strings"):
+    test(m"Get a map of strings"):
       reify[TypeMap[((1, "one"), (2, "two"), (3, "three"))]]
     .assert(_ == Map(1 -> "one", 2 -> "two", 3 -> "three"))
 
-    test(t"Get a multimap of strings"):
+    test(m"Get a multimap of strings"):
       reify[TypeMap[((1, TypeList[("one", "un", "ein")]), (2, TypeList[("two", "zwei", "deux")]))]]
     .assert(_ == Map(1 -> List("one", "un", "ein"), 2 -> List("two", "zwei", "deux")))

--- a/lib/ulysses/src/test/ulysses.Tests.scala
+++ b/lib/ulysses/src/test/ulysses.Tests.scala
@@ -39,31 +39,31 @@ import probably.*
 
 import language.experimental.genericNumberLiterals
 
-object Tests extends Suite(t"Ulysses tests"):
+object Tests extends Suite(m"Ulysses tests"):
   def run(): Unit =
-    test(t"Check how many bits are required for a bloom filter"):
+    test(m"Check how many bits are required for a bloom filter"):
       val bloom = BloomFilter[Text](100, 0.01)
       bloom.bitSize
     .assert(_ == 663)
 
-    test(t"Check that more bits are required to store more elements"):
+    test(m"Check that more bits are required to store more elements"):
       val bloom = BloomFilter[Text](1000, 0.01)
       bloom.bitSize
     .assert(_ == 6631)
 
-    test(t"Check that more bits are required to store with more certainty"):
+    test(m"Check that more bits are required to store with more certainty"):
       val bloom = BloomFilter[Text](100, 0.001)
       bloom.bitSize
     .assert(_ == 994)
 
-    val bloom = test(t"Add an element to a Bloom filter"):
+    val bloom = test(m"Add an element to a Bloom filter"):
       BloomFilter[Text](100, 0.001) + t"Hello world"
     .check(_.mayContain(t"Hello world"))
 
-    test(t"Check that Bloom filter does not contain other strings"):
+    test(m"Check that Bloom filter does not contain other strings"):
       !bloom.mayContain(t"hello")
     .check(identity(_))
 
-    val bloom2 = test(t"Add multiple elements to a Bloom filter"):
+    val bloom2 = test(m"Add multiple elements to a Bloom filter"):
       bloom ++ List(t"hello", t"world")
     .assert { b => b.mayContain(t"hello") && b.mayContain(t"world") }

--- a/lib/vexillology/src/test/vexillology.Tests.scala
+++ b/lib/vexillology/src/test/vexillology.Tests.scala
@@ -34,7 +34,7 @@ package vexillology
 
 import soundness.*
 
-object Tests extends Suite(t"Vexillology tests"):
+object Tests extends Suite(m"Vexillology tests"):
   def run(): Unit =
 
     enum Color:
@@ -42,36 +42,36 @@ object Tests extends Suite(t"Vexillology tests"):
 
     import Color.*
 
-    test(t"Empty flags"):
+    test(m"Empty flags"):
       val flags = Flags[Color]()
       flags.set
 
     . assert(_.isEmpty)
 
-    test(t"Value is initially unset"):
+    test(m"Value is initially unset"):
       val flags = Flags[Color]()
       flags(Orange)
     . assert(_ == false)
 
-    test(t"Value can be set"):
+    test(m"Value can be set"):
       var flags = Flags[Color]()
       flags = flags(Orange) = true
       flags(Orange)
     . assert(_ == true)
 
-    test(t"Setting one value does not set others"):
+    test(m"Setting one value does not set others"):
       var flags = Flags[Color]()
       flags = flags(Orange) = true
       flags(Red) || flags(Yellow) || flags(Green) || flags(Blue) || flags(Indigo) || flags(Violet)
     . assert(_ == false)
 
-    test(t"Single value"):
+    test(m"Single value"):
       var flags = Flags[Color]()
       flags = flags(Orange) = true
       flags.set
     . assert(_ == Set(Orange))
 
-    test(t"Multiple values"):
+    test(m"Multiple values"):
       var flags = Flags[Color]()
       flags = flags(Orange) = true
       flags = flags(Green) = true
@@ -79,7 +79,7 @@ object Tests extends Suite(t"Vexillology tests"):
       flags.set
     . assert(_ == Set(Orange, Green, Violet))
 
-    test(t"Unset a value"):
+    test(m"Unset a value"):
       var flags = Flags[Color]()
       flags = flags(Orange) = true
       flags = flags(Green) = true

--- a/lib/wisteria/src/test/wisteria.Tests.scala
+++ b/lib/wisteria/src/test/wisteria.Tests.scala
@@ -213,7 +213,7 @@ object Producer extends Derivation[Producer]:
   inline def split[DerivationType: SumOf]: Producer[DerivationType] = input =>
     inline if choice then Some(singleton(input)) else compiletime.error("not a choice")
 
-object Tests extends Suite(t"Wisteria tests"):
+object Tests extends Suite(m"Wisteria tests"):
   def run(): Unit =
     val george = Person("George Washington".tt, 61, true)
     val ronald = User(Person("Ronald Reagan".tt, 51, true), "ronald@whitehouse.gov".tt)

--- a/lib/xylophone/src/test/xylophone.Tests.scala
+++ b/lib/xylophone/src/test/xylophone.Tests.scala
@@ -57,101 +57,101 @@ enum ColorVal:
 
 case class Pixel(x: Int, y: Int, color: ColorVal)
 
-object Tests extends Suite(t"Xylophone tests"):
+object Tests extends Suite(m"Xylophone tests"):
   def run(): Unit =
-    test(t"extract integer"):
+    test(m"extract integer"):
       Xml.parse(t"""<message>1</message>""").as[Int]
     .assert(_ == 1)
 
-    test(t"extract string"):
+    test(m"extract string"):
       Xml.parse(t"""<message>Hello world</message>""").as[Text]
     .assert(_ == t"Hello world")
 
-    test(t"extract string from fragment"):
+    test(m"extract string from fragment"):
       val xml = Xml.parse(t"""<message><info>Hello world</info></message>""")
       xml.info.as[Text]
     .assert(_ == t"Hello world")
 
-    test(t"extract string from node"):
+    test(m"extract string from node"):
       val xml = Xml.parse(t"""<message><info>Hello world</info></message>""")
       xml.info().as[Text]
     .assert(_ == t"Hello world")
 
-    test(t"serialize simple case class"):
+    test(m"serialize simple case class"):
       val person = Worker(t"Jack", 50)
       person.xml.string
     .assert(_ == t"<Worker><name>Jack</name><age>50</age></Worker>")
 
-    test(t"serialize nested case class"):
+    test(m"serialize nested case class"):
       val person = Worker(t"Jack", 50)
       val company = Firm(t"Acme Inc", person)
       company.xml.string
     .assert(_ == t"<Firm><name>Acme Inc</name><ceo><name>Jack</name><age>50</age></ceo></Firm>")
 
-    test(t"access second element"):
+    test(m"access second element"):
       val xml = Xml.parse(t"""<events><eventId>1</eventId><eventId>2</eventId></events>""")
       xml.eventId(1).as[Int]
     .assert(_ == 2)
 
-    test(t"extract to simple case class"):
+    test(m"extract to simple case class"):
       val string = t"<jack><name>Jack</name><age>50</age></jack>"
       val xml = Xml.parse(string)
       xml.as[Worker]
     .assert(_ == Worker(t"Jack", 50))
 
-    test(t"extract to nested case class"):
+    test(m"extract to nested case class"):
       val string = t"<Firm><name>Acme Inc</name><ceo><name>Jack</name><age>50</age></ceo></Firm>"
       val xml = Xml.parse(string)
       xml.as[Firm]
     .assert(_ == Firm(t"Acme Inc", Worker(t"Jack", 50)))
 
-    test(t"serialize with attribute"):
+    test(m"serialize with attribute"):
       val book = Book(t"Lord of the Flies", t"9780399529207")
       book.xml.string
     .assert(_ == t"<Book isbn=\"9780399529207\"><title>Lord of the Flies</title></Book>")
 
-    test(t"serialize nested type with attribute"):
+    test(m"serialize nested type with attribute"):
       val bibliography = Bibliography(t"William Golding", Book(t"Lord of the Flies", t"9780399529207"))
       bibliography.xml.string
     .assert(_ == t"<Bibliography><author>William Golding</author><book isbn=\"9780399529207\"><title>Lord of the Flies</title></book></Bibliography>")
 
-    test(t"serialize coproduct"):
+    test(m"serialize coproduct"):
       val color: ColorVal = ColorVal.Rgb(5, 10, 15)
       color.xml.string
 
     . assert: value =>
       value == t"""<ColorVal type="Rgb"><red>5</red><green>10</green><blue>15</blue></ColorVal>""")
 
-    test(t"serialize nested coproduct"):
+    test(m"serialize nested coproduct"):
       val pixel: Pixel = Pixel(100, 200, ColorVal.Cmyk(1, 2, 3, 4))
       pixel.xml.string
     .assert(_ == t"""<Pixel><x>100</x><y>200</y><color type="Cmyk"><cyan>1</cyan><magenta>2</magenta><yellow>3</yellow><key>4</key></color></Pixel>""")
 
-    test(t"read coproduct"):
+    test(m"read coproduct"):
       val string = t"""<ColorVal type="Cmyk"><cyan>1</cyan><magenta>2</magenta><yellow>3</yellow><key>4</key></ColorVal>"""
       val xml = Xml.parse(string)
       xml.as[ColorVal]
     .assert(_ == ColorVal.Cmyk(1, 2, 3, 4))
 
-    test(t"read nested coproduct"):
+    test(m"read nested coproduct"):
       val string = t"""<Pixel><x>100</x><y>200</y><color type="Cmyk"><cyan>1</cyan><magenta>2</magenta><yellow>3</yellow><key>4</key></color></Pixel>"""
       val xml = Xml.parse(string)
       xml.as[Pixel]
     .assert(_ == Pixel(100, 200, ColorVal.Cmyk(1, 2, 3, 4)))
 
-    test(t"read attribute value from fragment"):
+    test(m"read attribute value from fragment"):
       val string = t"""<node><content key="value"/></node>"""
       val xml = Xml.parse(string)
       xml.content.attribute(t"key").as[Text]
     .assert(_ == t"value")
 
-    test(t"read attribute value from node"):
+    test(m"read attribute value from node"):
       val string = t"""<node><content key="value"/></node>"""
       val xml = Xml.parse(string)
       xml.content().attribute(t"key").as[Text]
     .assert(_ == t"value")
 
-    test(t"read with namespace"):
+    test(m"read with namespace"):
       val string = t"""<?xml version="1.0"?>
                         |<root>
                         |<h:table xmlns:h="http://www.w3.org/TR/html4/">
@@ -166,59 +166,59 @@ object Tests extends Suite(t"Xylophone tests"):
       xml.table.tr.td().as[Text]
     .assert(_ == t"Apples")
 
-    test(t"serialize list of strings"):
+    test(m"serialize list of strings"):
       val xs = List(t"one", t"two", t"three")
       Xml.print(xs.xml)
     .assert(_ == t"<Seq><Text>one</Text><Text>two</Text><Text>three</Text></Seq>")
 
-    test(t"serialize list of complex objects"):
+    test(m"serialize list of complex objects"):
       val book1 = Book(t"Lord of the Flies", t"9780399529207")
       val book2 = Book(t"Brave New World", t"9781907704345")
       val books = List(book1, book2)
       Xml.print(books.xml)
     .assert(_ == t"""<Seq><Book isbn="9780399529207"><title>Lord of the Flies</title></Book><Book isbn="9781907704345"><title>Brave New World</title></Book></Seq>""")
 
-    test(t"serialize empty node"):
+    test(m"serialize empty node"):
       Xml.print(List[Text]().xml)
     .assert(_ == t"<Seq/>")
 
-    test(t"serialize case object"):
+    test(m"serialize case object"):
       case object Foo
       Xml.print(Foo.xml)
     .assert(_ == t"<Foo/>")
 
-    test(t"parse error: unclosed tag"):
+    test(m"parse error: unclosed tag"):
       capture(Xml.parse(t"""<foo key="value"><bar></foo>"""))
     .assert(_ == XmlParseError(0, 24))
 
-    test(t"parse error: unclosed string"):
+    test(m"parse error: unclosed string"):
       capture(Xml.parse(t"""<foo key="value><bar/></foo>"""))
     .assert(_ == XmlParseError(0, 16))
 
-    test(t"read error: not an integer"):
+    test(m"read error: not an integer"):
       val xml = Xml.parse(t"""<foo>not an integer</foo>""")
       capture(xml.as[Int])
     .assert(NumberError(t"not an integer", Int) == _)
 
-    test(t"access error; proactively resolving head nodes"):
+    test(m"access error; proactively resolving head nodes"):
       val xml = Xml.parse(t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""")
       capture(xml.company().staff().cto().name().as[Text])
     .assert(_ == XmlAccessError(0, List(t"company", 0, t"staff", 0, t"cto")))
 
-    test(t"access error; taking all children"):
+    test(m"access error; taking all children"):
       val xml = Xml.parse(t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""")
       capture(xml.company.staff.cto.name().as[Text])
     .assert(_ == XmlAccessError(0, List(t"company", t"staff", t"cto", t"name")))
 
-    test(t"access non-zero node"):
+    test(m"access non-zero node"):
       val xml = Xml.parse(t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""")
       capture(xml.company(1).staff().cto.name().as[Text])
     .assert(_ == XmlAccessError(1, List(t"company")))
 
-    // test(t"simple literal content is as expected"):
+    // test(m"simple literal content is as expected"):
     //   x"""<root attribute=""/>""".show
     // .assert(_ == t"""<root attribute=""/>""")
 
-    // test(t"literal content is as expected"):
+    // test(m"literal content is as expected"):
     //   x"<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>"
     // .assert(_ == t"""<root><company><staff><ceo><name>Xyz</name></ceo></staff></company></root>""")

--- a/lib/yossarian/src/test/yossarian.tests.scala
+++ b/lib/yossarian/src/test/yossarian.tests.scala
@@ -35,6 +35,6 @@ package yossarian
 import gossamer.*
 import probably.*
 
-object Tests extends Suite(t"Yossarian Tests"):
+object Tests extends Suite(m"Yossarian Tests"):
   def run(): Unit =
     ()

--- a/lib/zephyrine/src/test/zephyrine.Tests.scala
+++ b/lib/zephyrine/src/test/zephyrine.Tests.scala
@@ -36,45 +36,45 @@ import soundness.*
 
 import randomization.unseeded
 
-object Tests extends Suite(t"Zephyrine tests"):
+object Tests extends Suite(m"Zephyrine tests"):
   val bytes = Bytes.fill(1000)(_.toByte)
   def run(): Unit = stochastic:
     for i <- 1 to 100 do
       val stream = Stream(bytes).shred(10.0, 10.0)//.filter(!_.isEmpty)
-      test(t"Conduit always starts at first byte"):
+      test(m"Conduit always starts at first byte"):
         val conduit = Conduit(stream)
         conduit.datum
 
       . assert(_ == 0.toByte)
 
-      test(t"Conduit second byte is always 1"):
+      test(m"Conduit second byte is always 1"):
         val conduit = Conduit(stream)
         conduit.next()
         conduit.datum
 
       . assert(_ == 1.toByte)
 
-      test(t"Can capture first ten bytes"):
+      test(m"Can capture first ten bytes"):
         val conduit = Conduit(stream)
         conduit.take(10)
 
       . assert(_ === Bytes(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
-      test(t"Can capture second ten bytes"):
+      test(m"Can capture second ten bytes"):
         val conduit = Conduit(stream)
         conduit.skip(10)
         conduit.take(10)
 
       . assert(_ === Bytes(10, 11, 12, 13, 14, 15, 16, 17, 18, 19))
 
-      test(t"Next ten times reaches same datum"):
+      test(m"Next ten times reaches same datum"):
         val conduit = Conduit(stream)
         for i <- 1 to 10 do conduit.next()
         conduit.datum
 
       . assert(_ == 10.toByte)
 
-      test(t"Position on next after save"):
+      test(m"Position on next after save"):
         val conduit = Conduit(stream)
 
         conduit.skip(15)
@@ -84,7 +84,7 @@ object Tests extends Suite(t"Zephyrine tests"):
 
       . assert(_ == (24.toByte, 25.toByte))
 
-      test(t"Position on next after take"):
+      test(m"Position on next after take"):
         val conduit = Conduit(stream)
 
         conduit.skip(15)
@@ -92,7 +92,7 @@ object Tests extends Suite(t"Zephyrine tests"):
 
       . assert(_ == (24.toByte, 25.toByte))
 
-      test(t"Breaking before starts on consistent datum"):
+      test(m"Breaking before starts on consistent datum"):
         val conduit = Conduit(stream)
 
         conduit.skip(15)
@@ -101,7 +101,7 @@ object Tests extends Suite(t"Zephyrine tests"):
 
       . assert(_ == 15.toByte)
 
-      test(t"Breaking after starts on consistent datum"):
+      test(m"Breaking after starts on consistent datum"):
         val conduit = Conduit(stream)
 
         conduit.skip(15)

--- a/lib/zeppelin/src/test/zeppelin.Tests.scala
+++ b/lib/zeppelin/src/test/zeppelin.Tests.scala
@@ -46,20 +46,20 @@ import turbulence.*
 
 import java.io.File
 
-object Tests extends Suite(t"Zeppelin tests"):
+object Tests extends Suite(m"Zeppelin tests"):
   def run(): Unit =
 
     val root: File = Base.Var.Tmp()
     root.mkdirs()
 
-    test(t"Create an empty ZIP file"):
+    test(m"Create an empty ZIP file"):
       val file = File(root, "empty.zip")
       if file.exists() then file.delete()
       ZipFile.create(file)
       file
     .assert(_.length > 0)
 
-    val simpleFile: File = test(t"Create a simple ZIP file"):
+    val simpleFile: File = test(m"Create a simple ZIP file"):
       val path = File.createTempFile("tmp", ".zip").nn
       val entry = ZipEntry(ZipRef / p"hello.txt", t"Hello world")
       val zip = ZipFile.create(path)
@@ -67,15 +67,15 @@ object Tests extends Suite(t"Zeppelin tests"):
       path
     .check(_.length > 0)
 
-    test(t"Check zip file contains one entry"):
+    test(m"Check zip file contains one entry"):
       ZipFile(simpleFile).entries()
     .assert(_.length == 1)
 
-    test(t"Check ZIP file's entry has correct content"):
+    test(m"Check ZIP file's entry has correct content"):
       ZipFile(simpleFile).entries().head.read[Text]
     .assert(_ == t"Hello world")
 
-    val twoEntryFile: File = test(t"Append a file to a ZIP archive"):
+    val twoEntryFile: File = test(m"Append a file to a ZIP archive"):
       val entry = ZipEntry(ZipRef / p"fox.txt", t"The quick brown fox jumps over the lazy dog.")
       val newFile: File  = File.createTempFile("tmp", ".zip").nn
       newFile.delete()
@@ -85,19 +85,19 @@ object Tests extends Suite(t"Zeppelin tests"):
       newFile
     .check(_.length > 0)
 
-    test(t"Check zip file based on another has two entries"):
+    test(m"Check zip file based on another has two entries"):
       ZipFile(twoEntryFile).entries()
     .assert(_.length == 2)
 
-    test(t"Check ZIP file's first entry has correct content after update"):
+    test(m"Check ZIP file's first entry has correct content after update"):
       ZipFile(twoEntryFile).entries().head.read[Text]
     .assert(_ == t"Hello world")
 
-    test(t"Check ZIP file's second entry has correct content"):
+    test(m"Check ZIP file's second entry has correct content"):
       ZipFile(twoEntryFile).entries().tail.head.read[Text]
     .assert(_ == t"The quick brown fox jumps over the lazy dog.")
 
-    test(t"Access ZIP file content by path"):
+    test(m"Access ZIP file content by path"):
       (ZipFile(twoEntryFile) / p"fox.txt").read[Text]
     .assert(_ == t"The quick brown fox jumps over the lazy dog.")
 


### PR DESCRIPTION
We will start using the `Message` type for the names of tests and suites. This has the advantage that parameters appearing in test names can be highlighted and and/or grouped, and particular failing parameters can be highlighted.