### PR TITLE
Remember to export `orchestrate`

### DIFF
--- a/lib/telekinesis/src/core/soundness+telekinesis-core.scala
+++ b/lib/telekinesis/src/core/soundness+telekinesis-core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export telekinesis
 . { Auth, Cookie, Http, HttpError, HttpEvent, Prefixable, ConnectError, Receivable, Fetchable,
-    HttpClient, Postable, Servable, fetch, submit, Parameter, query }
+    HttpClient, Postable, Servable, fetch, submit, Parameter, query, orchestrate }
 
 package queryParameters:
   export telekinesis.queryParameters.arbitrary


### PR DESCRIPTION
This new method in Telekinesis was not previously exported to `soundness`.