### PR TITLE
Prefer method signatures on single lines

### DIFF
--- a/lib/abacist/src/core/abacist.Abacist.scala
+++ b/lib/abacist/src/core/abacist.Abacist.scala
@@ -100,8 +100,7 @@ object Abacist:
     recur(multipliers[CountUnits], '{ListMap()})
 
   def multiplyCount[countUnits <: Tuple: Type]
-     (count: Expr[Count[countUnits]], multiplier: Expr[Double], division: Boolean)
-     (using Quotes)
+     (count: Expr[Count[countUnits]], multiplier: Expr[Double], division: Boolean)(using Quotes)
   :     Expr[Any] =
 
     if division then '{Count.fromLong[countUnits](($count.longValue/$multiplier + 0.5).toLong)}
@@ -130,8 +129,7 @@ object Abacist:
 
     '{($quantity.value*$ratioExpr + 0.5).toLong.asInstanceOf[Count[countUnits]]}
 
-  def get[units <: Tuple: Type, unit <: Units[1, ? <: Dimension]: Type]
-     (value: Expr[Count[units]])
+  def get[units <: Tuple: Type, unit <: Units[1, ? <: Dimension]: Type](value: Expr[Count[units]])
      (using Quotes)
   :     Expr[Int] =
 

--- a/lib/acyclicity/src/core/acyclicity.Dag.scala
+++ b/lib/acyclicity/src/core/acyclicity.Dag.scala
@@ -44,8 +44,7 @@ object Dag:
 
   def create[node](start: node)(dependencies: node => Set[node]): Dag[node] =
     @tailrec
-    def recur(map: Map[node, Set[node]], todo: Set[node], done: Set[node])
-    :     Dag[node] =
+    def recur(map: Map[node, Set[node]], todo: Set[node], done: Set[node]): Dag[node] =
 
       if todo.isEmpty then new Dag(map) else
         val key = todo.head
@@ -88,8 +87,7 @@ case class Dag[node] private(edgeMap: Map[node, Set[node]] = Map()):
 
   def has(key: node): Boolean = edgeMap.contains(key)
 
-  def traversal[node2](lambda: (Set[node2], node) => node2)
-  :     Map[node, node2] =
+  def traversal[node2](lambda: (Set[node2], node) => node2): Map[node, node2] =
 
     sorted.fuse(Map[node, node2]()):
       state.updated(next, lambda(apply(next).map(state), next))
@@ -147,8 +145,7 @@ case class Dag[node] private(edgeMap: Map[node, Set[node]] = Map()):
 
   private def findCycle(start: node): Option[List[node]] =
     @tailrec
-    def recur(queue: List[(node, List[node])], finished: Set[node])
-    :     Option[List[node]] =
+    def recur(queue: List[(node, List[node])], finished: Set[node]): Option[List[node]] =
 
       queue match
         case Nil => None

--- a/lib/adversaria/src/core/adversaria.Annotations.scala
+++ b/lib/adversaria/src/core/adversaria.Annotations.scala
@@ -41,13 +41,11 @@ import language.experimental.captureChecking
 case class Annotations[annotation <: StaticAnnotation, target](annotations: annotation*)
 
 object Annotations:
-  inline given[annotation <: StaticAnnotation, target]
-  :     Annotations[annotation, target] =
+  inline given[annotation <: StaticAnnotation, target]: Annotations[annotation, target] =
 
     ${Adversaria.typeAnnotations[annotation, target]}
 
-  transparent inline def field[target](inline lambda: target => Any)
-  :     List[StaticAnnotation] =
+  transparent inline def field[target](inline lambda: target => Any): List[StaticAnnotation] =
     ${Adversaria.fieldAnnotations[target]('lambda)}
 
   transparent inline def fields[target <: Product, annotation <: StaticAnnotation]

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -79,8 +79,7 @@ case class Scalac[version <: Scalac.All](options: List[ScalacOption[version]]):
 
     object ProgressApi extends dtdsi.ProgressCallback:
       private var last: Int = -1
-      override def informUnitStarting
-         (stage: String | Null, unit: dtd.CompilationUnit | Null)
+      override def informUnitStarting(stage: String | Null, unit: dtd.CompilationUnit | Null)
       :     Unit =
         ()
 

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -61,8 +61,7 @@ object Austronesian2:
           . asInstanceOf[Stdlib]
 
   object DecodableDerivation extends Derivable[Decodable in Stdlib]:
-    inline def join[derivation <: Product: ProductReflection]
-    :     derivation is Decodable in Stdlib =
+    inline def join[derivation <: Product: ProductReflection]: derivation is Decodable in Stdlib =
 
       case array: Array[Stdlib] =>
         construct: [field] =>

--- a/lib/cardinality/src/core/cardinality.Cardinality.scala
+++ b/lib/cardinality/src/core/cardinality.Cardinality.scala
@@ -55,8 +55,7 @@ object Cardinality:
 
   given realm: Realm = realm"cardinality"
 
-  def apply[left <: Double: Type, right <: Double: Type](digits: Expr[String])
-     (using Quotes)
+  def apply[left <: Double: Type, right <: Double: Type](digits: Expr[String])(using Quotes)
   :     Expr[left ~ right] =
 
     import quotes.reflect.*

--- a/lib/cardinality/src/core/cardinality.NumericRange.scala
+++ b/lib/cardinality/src/core/cardinality.NumericRange.scala
@@ -44,15 +44,14 @@ object NumericRange:
   @annotation.targetName("Range")
   opaque infix type ~ [min <: Double, max <: Double] = Double
 
-  def apply[min <: Double, max <: Double](value: Double)
-  :     min ~ max =
+  def apply[min <: Double, max <: Double](value: Double): min ~ max =
     value
 
   @annotation.targetName("Range")
   object `~`:
-    given comparable[min <: Double & Singleton, max <: Double & Singleton]
-       (using min: ValueOf[min], max: ValueOf[max])
-    :     TypeTest[Double, min ~ max] =
+    given comparable: [min <: Double & Singleton, max <: Double & Singleton]
+          => (min: ValueOf[min], max: ValueOf[max])
+          =>  TypeTest[Double, min ~ max] =
 
       value =>
         if value >= min.value && value <= max.value
@@ -63,8 +62,7 @@ object NumericRange:
     extends FromDigits.Decimal[min ~ max]:
       def fromDigits(digits: String): Double = apply(digits.toDouble)
 
-    given cardinality[min <: Double, max <: Double]
-    :     RangeParser[min, max] with
+    given cardinality: [min <: Double, max <: Double] => RangeParser[min, max]:
       override inline def fromDigits(digits: String): min ~ max =
         ${Cardinality('digits)}
 
@@ -72,8 +70,7 @@ object NumericRange:
       def double: Double = left
 
       @annotation.targetName("add")
-      infix def + [rightMin <: Double, rightMax <: Double]
-         (right: rightMin ~ rightMax)
+      infix def + [rightMin <: Double, rightMax <: Double](right: rightMin ~ rightMax)
       :     (leftMin + rightMin) ~ (leftMax + rightMax) =
         left + right
 
@@ -86,8 +83,7 @@ object NumericRange:
       infix def + (right: Double): Double = left + right
 
       @annotation.targetName("times")
-      infix def * [rightMin <: Double, rightMax <: Double]
-         (right: rightMin ~ rightMax)
+      infix def * [rightMin <: Double, rightMax <: Double](right: rightMin ~ rightMax)
       :     (Min4
               [leftMin*rightMin,
                leftMin*rightMax,
@@ -102,11 +98,7 @@ object NumericRange:
 
       @annotation.targetName("times2")
       infix def * [right <: Double & Singleton](right: right)
-      :     Min
-             [leftMin*right,
-              leftMax*right] ~ Max
-                                        [leftMin*right,
-                                         leftMax*right] =
+      :     Min[leftMin*right, leftMax*right] ~ Max[leftMin*right, leftMax*right] =
 
         left*right
 
@@ -114,22 +106,14 @@ object NumericRange:
       infix def * (right: Double): Double = left*right
 
       @annotation.targetName("minus")
-      infix def - [rightMin <: Double, rightMax <: Double]
-         (right: rightMin ~ rightMax)
-      :     Min
-             [leftMin - rightMin,
-              leftMin - rightMax] ~ Max
-                                             [leftMax - rightMin,
-                                              leftMax - rightMax] =
+      infix def - [rightMin <: Double, rightMax <: Double](right: rightMin ~ rightMax)
+      :     Min[leftMin - rightMin, leftMin - rightMax] ~ Max[leftMax - rightMin, leftMax -
+             rightMax] =
         left - right
 
       @annotation.targetName("minus2")
       infix def - [right <: Double & Singleton](right: right)
-      :     Min
-             [leftMin - right,
-              leftMax - right] ~ Max
-                                          [leftMin - right,
-                                           leftMax - right] =
+      :     Min[leftMin - right, leftMax - right] ~ Max[leftMin - right, leftMax - right] =
 
         left - right
 
@@ -138,11 +122,7 @@ object NumericRange:
 
       @annotation.targetName("divide")
       infix def / [right <: Double & Singleton](right: right)
-      :     Min
-             [leftMin/right,
-              leftMax/right] ~ Max
-                                        [leftMin/right,
-                                         leftMax/right] =
+      :     Min[leftMin/right, leftMax/right] ~ Max[leftMin/right, leftMax/right] =
 
         left/right
 

--- a/lib/cellulose/src/core/cellulose.CodlNode.scala
+++ b/lib/cellulose/src/core/cellulose.CodlNode.scala
@@ -87,13 +87,11 @@ case class CodlNode(data: Optional[Data] = Unset, extra: Optional[Extra] = Unset
     case data: Data => data
 
   def selectDynamic(key: String)(using erased DynamicCodlEnabler)
-     (using Tactic[MissingValueError])
-  :     List[Data] =
+  :     List[Data] raises MissingValueError =
     data.lest(MissingValueError(key.show)).selectDynamic(key)
 
   def applyDynamic(key: String)(idx: Int = 0)(using erased DynamicCodlEnabler)
-     (using Tactic[MissingValueError])
-  :     Data =
+  :     Data raises MissingValueError =
     selectDynamic(key)(idx)
 
   def untyped: CodlNode =

--- a/lib/cellulose/src/core/cellulose.CodlSchema.scala
+++ b/lib/cellulose/src/core/cellulose.CodlSchema.scala
@@ -76,9 +76,8 @@ extends Dynamic:
   def optional: CodlSchema
   def entry(n: Int): Entry = subschemas(n)
 
-  def parse[source](source: source)
-     (using aggregate: Tactic[CodlError], readable: source is Readable by Text)
-  :     CodlDoc =
+  def parse[source](source: source)(using readable: source is Readable by Text)
+  :     CodlDoc raises CodlError =
     Codl.parse(source, this)
 
   def apply(key: Text): Optional[CodlSchema] = dictionary.at(key).or(dictionary.at(Unset)).or(Unset)

--- a/lib/cellulose/src/core/cellulose.Indexed.scala
+++ b/lib/cellulose/src/core/cellulose.Indexed.scala
@@ -80,13 +80,12 @@ trait Indexed extends Dynamic:
         List.range(idx, layout.params).map: idx =>
           Data(key, IArray(unsafely(children(idx))), Layout.empty, CodlSchema.Free)
 
-  def selectDynamic(key: String)(using erased DynamicCodlEnabler)(using Tactic[MissingValueError])
-  :     List[Data] =
+  def selectDynamic(key: String)(using erased DynamicCodlEnabler)
+  :     List[Data] raises MissingValueError =
     index(key.show).map(children(_).data).collect:
       case data: Data => data
 
   def applyDynamic(key: String)(idx: Int = 0)(using erased DynamicCodlEnabler)
-     (using Tactic[MissingValueError])
-  :     Data =
+  :     Data raises MissingValueError =
 
     selectDynamic(key)(idx)

--- a/lib/coaxial/src/core/coaxial-core.scala
+++ b/lib/coaxial/src/core/coaxial-core.scala
@@ -43,8 +43,7 @@ import vacuous.*
 import Control.*
 
 extension [bindable: Bindable](socket: bindable)
-  def listen[input](using Monitor, Codicil)[result]
-     (lambda: bindable.Input => bindable.Output)
+  def listen[input](using Monitor, Codicil)[result](lambda: bindable.Input => bindable.Output)
   :     SocketService raises BindError =
 
     val binding = bindable.bind(socket)
@@ -62,15 +61,13 @@ extension [bindable: Bindable](socket: bindable)
         safely(task.await())
 
 extension [endpoint: Serviceable as serviceable](endpoint: endpoint)
-  def transmit[message: Transmissible](input: message)
-  :     Stream[Bytes] =
+  def transmit[message: Transmissible](input: message): Stream[Bytes] =
     val connection = serviceable.connect(endpoint)
 
     serviceable.transmit(connection, message.serialize(input))
     serviceable.receive(connection)
 
-  def exchange[state](initialState: state)[message: Ingressive]
-     (initialMessage: message = Bytes())
+  def exchange[state](initialState: state)[message: Ingressive](initialMessage: message = Bytes())
      (handle: (state: state) ?=> message => Control[state])
   :     state =
 

--- a/lib/contingency/src/core/contingency.Attempt.scala
+++ b/lib/contingency/src/core/contingency.Attempt.scala
@@ -67,8 +67,7 @@ enum Attempt[+success, +error <: Exception]:
     case Success(value) => value
     case Failure(error) => abort(error)
 
-  def recover[success2 >: success](block: error ~> success2)
-  :     success2 =
+  def recover[success2 >: success](block: error ~> success2): success2 =
 
     this match
       case Success(value) => value

--- a/lib/contingency/src/core/contingency.Contingency.scala
+++ b/lib/contingency/src/core/contingency.Contingency.scala
@@ -65,8 +65,7 @@ object Contingency:
       case other =>
         halt(m"unexpected AST: ${other.toString}")
 
-  private def mapping[error <: Exception: Type](using Quotes)
-     (handler: quotes.reflect.Term)
+  private def mapping[error <: Exception: Type](using Quotes)(handler: quotes.reflect.Term)
   :     Map[quotes.reflect.Symbol, quotes.reflect.Symbol] =
 
     import quotes.reflect.*
@@ -166,8 +165,7 @@ object Contingency:
       case '[type typeLambda[_]; typeLambda] => '{Tend[typeLambda]($handler)}
 
   def track[accrual <: Exception: Type, focus: Type]
-     (accrual: Expr[accrual],
-      handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
+     (accrual: Expr[accrual], handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
      (using Quotes)
   :     Expr[Any] =
 
@@ -189,8 +187,7 @@ object Contingency:
             focus, accrual))}
 
   def validate[accrual: Type, focus: Type]
-     (accrual: Expr[accrual],
-      handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
+     (accrual: Expr[accrual], handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
      (using Quotes)
   :     Expr[Any] =
 
@@ -212,8 +209,7 @@ object Contingency:
             focus, accrual))}
 
   def accrue[accrual <: Exception: Type]
-     (accrual: Expr[accrual],
-      handler: Expr[accrual ?=> Exception ~> accrual])
+     (accrual: Expr[accrual], handler: Expr[accrual ?=> Exception ~> accrual])
      (using Quotes)
   :     Expr[Any] =
 
@@ -233,9 +229,7 @@ object Contingency:
       case '[type typeLambda[_]; typeLambda] =>
         '{Accrue[accrual, typeLambda]($accrual, accrual ?=> $handler(using accrual))}
 
-  def mend[result: Type](handler: Expr[Exception ~> result])(using Quotes)
-  :     Expr[Any] =
-
+  def mend[result: Type](handler: Expr[Exception ~> result])(using Quotes): Expr[Any] =
     import quotes.reflect.*
 
     val errors = mapping(handler.asTerm)

--- a/lib/contingency/src/core/contingency.Foci.scala
+++ b/lib/contingency/src/core/contingency.Foci.scala
@@ -44,8 +44,7 @@ object Foci:
     def success: Boolean = false
     def register(error: Exception): Unit = ()
 
-    def fold[accrual](initial: accrual)
-       (lambda: (Optional[focus], accrual) => Exception ~> accrual)
+    def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
     :     accrual =
       initial
 
@@ -56,8 +55,7 @@ trait Foci[focus]:
   def success: Boolean
   def register(error: Exception): Unit
 
-  def fold[accrual](initial: accrual)
-     (lambda: (Optional[focus], accrual) => Exception ~> accrual)
+  def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
   :     accrual
 
   def supplement(count: Int, transform: Optional[focus] => focus): Unit
@@ -73,8 +71,7 @@ class TrackFoci[focus]() extends Foci[focus]:
     errors.append(error)
     focuses.append(Unset)
 
-  def fold[accrual](initial: accrual)
-     (lambda: (Optional[focus], accrual) => Exception ~> accrual)
+  def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
   :     accrual =
     (0 until errors.length).fuse(initial)(lambda(focuses(next), state)(errors(next)))
 

--- a/lib/cosmopolite/src/core/cosmopolite.Polyglot.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.Polyglot.scala
@@ -36,8 +36,7 @@ import proscenium.*
 
 case class Polyglot[+value, language](values: Map[Language, value]):
   @targetName("or")
-  transparent inline infix def | [value2 >: value, language2]
-    (polyglot: Polyglot[value2, language2])
+  transparent inline infix def | [value2 >: value, language2](polyglot: Polyglot[value2, language2])
   :     Polyglot[value2, language & language2] | value2 =
     compiletime.summonFrom:
       case locale: Locale[language & language2] =>

--- a/lib/cosmopolite/src/core/cosmopolite.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.scala
@@ -49,13 +49,11 @@ case class Polyglot[+value, +localization <: Localization](value: Map[String, va
 
   def ap(polyglotFn: Polyglot[value => value2, localization])
 
-  infix def & [value2 >: value, localization2]
-     (other: Polyglot[value2, localization2])
+  infix def & [value2 >: value, localization2](other: Polyglot[value2, localization2])
   :     Polyglot[value2, localization2]
 
 object Cosmopolite:
-  def access[value: Type, localization <: Localization: Type]
-     (value: Expr[Map[String, value]])
+  def access[value: Type, localization <: Localization: Type](value: Expr[Map[String, value]])
      (using Quotes)
   :     Expr[value] =
 

--- a/lib/dendrology/src/tree/dendrology.TreeDiagram.scala
+++ b/lib/dendrology/src/tree/dendrology.TreeDiagram.scala
@@ -49,8 +49,7 @@ object TreeDiagram:
     (diagram, termcap) =>
       (diagram.render[Text] { node => t"▪ $node" }).join(t"\n")
 
-  def by[node](getChildren: node => Seq[node])(roots: node*)
-  :     TreeDiagram[node] =
+  def by[node](getChildren: node => Seq[node])(roots: node*): TreeDiagram[node] =
     def recur(level: List[TreeTile], input: Seq[node]): Stream[(List[TreeTile], node)] =
       val last = input.size - 1
       input.zipWithIndex.to(Stream).flatMap: (item, idx) =>

--- a/lib/enigmatic/src/core/enigmatic.PublicKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PublicKey.scala
@@ -46,8 +46,7 @@ object PublicKey:
   given encodable: [cipher <: Cipher] => PublicKey[cipher] is Encodable in Bytes = _.bytes
 
 case class PublicKey[cipher <: Cipher](bytes: Bytes):
-  def encrypt[value: Encodable in Bytes](value: value)
-     (using algorithm: cipher & Encryption)
+  def encrypt[value: Encodable in Bytes](value: value)(using algorithm: cipher & Encryption)
   :     Bytes =
 
     algorithm.encrypt(value.bytestream, bytes)

--- a/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
@@ -37,15 +37,13 @@ import prepositional.*
 
 object SymmetricKey:
   given encodable: [cipher <: Cipher] => SymmetricKey[cipher] is Encodable in Bytes = _.bytes
-  def generate[cipher <: Cipher & Symmetric]()(using cipher: cipher)
-  :     SymmetricKey[cipher] =
 
+  def generate[cipher <: Cipher & Symmetric]()(using cipher: cipher): SymmetricKey[cipher] =
     SymmetricKey(cipher.genKey())
 
 class SymmetricKey[cipher <: Cipher](private[enigmatic] val bytes: Bytes)
 extends PrivateKey[cipher](bytes):
-  def encrypt[value: Encodable in Bytes](value: value)(using cipher & Encryption)
-  :     Bytes =
+  def encrypt[value: Encodable in Bytes](value: value)(using cipher & Encryption): Bytes =
     public.encrypt(value)
 
   def verify[value: Encodable in Bytes](value: value, signature: Signature[cipher])

--- a/lib/escapade/src/core/escapade.Colorable.scala
+++ b/lib/escapade/src/core/escapade.Colorable.scala
@@ -42,8 +42,7 @@ object Colorable:
       type Self = value
       extension (value: value) def color: Fg = Fg(color0.asRgb24Int)
 
-  def apply[value](using erased Void)[color: Chromatic]
-     (chooseColor: value -> color)
+  def apply[value](using erased Void)[color: Chromatic](chooseColor: value -> color)
   :     value is Colorable =
     new Colorable:
       type Self = value

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -177,10 +177,10 @@ case class Teletype
 
     @tailrec
     def recur
-       (spans:     TreeMap[CharSpan, Ansi.Transform],
-        pos:     Int                               = 0,
-        style:     TextStyle                         = TextStyle(),
-        stack:     List[(CharSpan, TextStyle)]       = Nil,
+       (spans:      TreeMap[CharSpan, Ansi.Transform],
+        pos:        Int                               = 0,
+        style:      TextStyle                         = TextStyle(),
+        stack:      List[(CharSpan, TextStyle)]       = Nil,
         insertions: TreeMap[Int, Text]                = TreeMap())
     :     Text =
 

--- a/lib/escritoire/src/core/escritoire-core.scala
+++ b/lib/escritoire/src/core/escritoire-core.scala
@@ -40,8 +40,7 @@ import rudiments.*
 import vacuous.*
 
 extension [row](data: Seq[row])
-  def table[text: Textual](using tabulable: row is Tabulable[text])
-  :     Tabulation[text] =
+  def table[text: Textual](using tabulable: row is Tabulable[text]): Tabulation[text] =
 
     tabulable.tabulate(data)
 
@@ -104,8 +103,7 @@ package columnar:
       lines.to(IndexedSeq).flatMap(format(_, 0, 0, 0, Nil).reverse)
 
   case class Fixed(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
-    :     Optional[Int] =
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
       fixedWidth
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
@@ -115,8 +113,7 @@ package columnar:
         if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
 
   case class Shortened(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
-    :     Optional[Int] =
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
       val naturalWidth = lines.map(_.length).max
       (maxWidth*slack).toInt.min(naturalWidth)
 
@@ -127,8 +124,7 @@ package columnar:
         if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
 
   case class Collapsible(threshold: Double) extends Columnar:
-    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)
-    :     Optional[Int] =
+    def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
       if slack > threshold then lines.map(_.length).max else Unset
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)

--- a/lib/escritoire/src/core/escritoire.Table.scala
+++ b/lib/escritoire/src/core/escritoire.Table.scala
@@ -40,8 +40,7 @@ import scala.collection.immutable as sci
 
 object Table:
   @targetName("make")
-  def apply[row](using erased Void)[text: ClassTag: Textual]
-     (columns0: Column[row, text]*)
+  def apply[row](using erased Void)[text: ClassTag: Textual](columns0: Column[row, text]*)
   :     Table[row, text] =
 
     new Table(columns0*)

--- a/lib/escritoire/src/core/escritoire.TextAlignment.scala
+++ b/lib/escritoire/src/core/escritoire.TextAlignment.scala
@@ -39,18 +39,15 @@ import rudiments.*
 
 object TextAlignment:
   object Right extends TextAlignment:
-    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable)
-    :     text =
+    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable): text =
       Textual(t" "*(width - text.plain.metrics))+text
 
   object Left extends TextAlignment:
-    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable)
-    :     text =
+    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable): text =
       text+Textual(t" "*(width - text.plain.metrics))
 
   object Center extends TextAlignment:
-    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable)
-    :     text =
+    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable): text =
       val space = width - text.plain.metrics
       val before = Textual(t" "*(space/2))
       val after = Textual(t" "*(space - space/2))
@@ -58,8 +55,7 @@ object TextAlignment:
       before+text+after
 
   object Justify extends TextAlignment:
-    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable)
-    :     text =
+    def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable): text =
       if last then text+Textual(t" "*(width - text.plain.metrics))
       else
         val words = text.cut(t" ")
@@ -74,5 +70,4 @@ object TextAlignment:
         recur(spare, wordCount - 1, words.head)
 
 trait TextAlignment:
-  def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable)
-  :     text
+  def pad[text: Textual](text: text, width: Int, last: Boolean)(using Text is Measurable): text

--- a/lib/ethereal/src/core/ethereal-core.scala
+++ b/lib/ethereal/src/core/ethereal-core.scala
@@ -157,8 +157,7 @@ def cli[bus <: Matchable](using executive: Executive)
     Log.warn(DaemonLogEvent.Shutdown)
     pid.let(terminatePid.fulfill(_)).or(termination)
 
-  def makeClient(socket: jn.Socket)
-     (using Monitor, Stdio, Codicil)
+  def makeClient(socket: jn.Socket)(using Monitor, Stdio, Codicil)
   :     Unit logs DaemonLogEvent raises StreamError raises CharDecodeError raises NumberError =
 
     async:

--- a/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
@@ -37,8 +37,7 @@ import vacuous.*
 import language.experimental.captureChecking
 
 case class Arguments(sequence: Argument*) extends FlagParameters:
-  def read[operand](flag: Flag)
-     (using Cli, FlagInterpreter[operand], Suggestions[operand])
+  def read[operand](flag: Flag)(using Cli, FlagInterpreter[operand], Suggestions[operand])
   :     Optional[operand] =
     Unset // FIXME
 

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -54,8 +54,7 @@ trait Cli extends ProcessContext:
   def environment: Environment
   def workingDirectory: WorkingDirectory
 
-  def readParameter[operand](flag: Flag)
-     (using FlagInterpreter[operand], Suggestions[operand])
+  def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
   :     Optional[operand]
 
   def register(flag: Flag, suggestions: Suggestions[?]): Unit = ()

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -59,8 +59,7 @@ case class Flag
     description: Optional[Text] = Unset,
     secret: Boolean             = false):
 
-  def suggest[operand: FlagInterpreter](suggestions: Suggestions[operand])(using cli: Cli)
-  :     Unit =
+  def suggest[operand: FlagInterpreter](suggestions: Suggestions[operand])(using cli: Cli): Unit =
     cli.register(this, suggestions)
 
   def matches(key: Argument): Boolean =

--- a/lib/exoskeleton/src/args/exoskeleton.FlagParameters.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.FlagParameters.scala
@@ -37,8 +37,7 @@ import vacuous.*
 import language.experimental.captureChecking
 
 trait FlagParameters:
-  def read[operand](flag: Flag)
-     (using Cli, FlagInterpreter[operand], Suggestions[operand])
+  def read[operand](flag: Flag)(using Cli, FlagInterpreter[operand], Suggestions[operand])
   :     Optional[operand]
 
   def focusFlag: Optional[Argument]

--- a/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
@@ -66,8 +66,7 @@ extends Cli:
   var explanation: Optional[Text] = Unset
   var cursorSuggestions: List[Suggestion] = Nil
 
-  def readParameter[operand](flag: Flag)
-     (using FlagInterpreter[operand], Suggestions[operand])
+  def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
   :     Optional[operand] =
 
     given cli: Cli = this

--- a/lib/fulminate/src/core/fulminate.TextEscapes.scala
+++ b/lib/fulminate/src/core/fulminate.TextEscapes.scala
@@ -40,8 +40,7 @@ import anticipation.*
 
 object TextEscapes:
   import errorDiagnostics.stackTraces
-  def standardEscape
-     (text: into Text, cur: Int, esc: Boolean)
+  def standardEscape(text: into Text, cur: Int, esc: Boolean)
   :     (Int, Int, Boolean) throws EscapeError =
     text.s.charAt(cur) match
       case '\\' if !esc => (-1, cur + 1, true)

--- a/lib/galilei/src/core/galilei-core.scala
+++ b/lib/galilei/src/core/galilei-core.scala
@@ -215,7 +215,7 @@ extension [platform <: Filesystem](path: Path on platform)
     moveTo(unsafely(destination.child(path.textDescent.head)))
 
   def symlinkTo(destination: Path on platform)
-     (using overwritePreexisting:    OverwritePreexisting on platform,
+     (using overwritePreexisting:     OverwritePreexisting on platform,
             createNonexistentParents: CreateNonexistentParents on platform)
   :     Path on platform raises IoError =
 

--- a/lib/galilei/src/core/galilei.Openable.scala
+++ b/lib/galilei/src/core/galilei.Openable.scala
@@ -101,8 +101,7 @@ trait Openable:
   def init(value: Self, options: List[Operand]): Carrier
   def handle(carrier: Carrier): Result
 
-  def open[result](value: Self, lambda: Result => result, options: List[Operand])
-  :     result =
+  def open[result](value: Self, lambda: Result => result, options: List[Operand]): result =
     val carrier = init(value, options)
     try lambda(handle(carrier)) finally close(carrier)
 

--- a/lib/galilei/src/core/galilei.Volume.scala
+++ b/lib/galilei/src/core/galilei.Volume.scala
@@ -39,6 +39,7 @@ import gossamer.*
 import spectacular.*
 
 object Volume:
-  given inspectable: Volume is Inspectable = volume => t"volume[${volume.name}:${volume.volumeType}]"
+  given inspectable: Volume is Inspectable =
+    volume => t"volume[${volume.name}:${volume.volumeType}]"
 
 case class Volume(name: Text, volumeType: Text)

--- a/lib/geodesy/src/core/geodesy.Geodesy.scala
+++ b/lib/geodesy/src/core/geodesy.Geodesy.scala
@@ -108,13 +108,7 @@ object Geodesy:
         val long0 = left&0xffffffffL
         if long0 < 0 then (long0 + Int.MaxValue).toInt else (long0 - Int.MaxValue).toInt
 
-      def recur
-         (value:   Long,
-          latMin:  Long,
-          latMax:  Long,
-          longMin: Long,
-          longMax: Long,
-          count: Int)
+      def recur(value: Long, latMin: Long, latMax: Long, longMin: Long, longMax: Long, count: Int)
       :     Long =
 
         if count >= bits then value else (count%2).absolve match

--- a/lib/gossamer/src/core/gossamer-core.scala
+++ b/lib/gossamer/src/core/gossamer-core.scala
@@ -203,8 +203,7 @@ extension [textual: Textual](text: textual)
   def search(regex: Regex, overlap: Boolean = false): Stream[textual] =
     regex.search(textual.text(text), overlap = overlap).map(text.segment(_))
 
-  def extract[value](start: Ordinal)(lambda: Scanner ?=> textual ~> value)
-  :     Stream[value] =
+  def extract[value](start: Ordinal)(lambda: Scanner ?=> textual ~> value): Stream[value] =
 
     val input = textual.text(text)
     if start.n0 < input.s.length then

--- a/lib/gossamer/src/core/gossamer.Cuttable.scala
+++ b/lib/gossamer/src/core/gossamer.Cuttable.scala
@@ -82,7 +82,8 @@ object Cuttable:
   given textRegex: Text is Cuttable by Regex = (text, regex, limit) =>
     text.s.split(regex.pattern.s, limit).nn.map(_.nn.tt).to(List)
 
-  given textualText: [textual] => (cuttable: textual is Cuttable by Text) => textual is Cuttable by Char =
+  given textualText: [textual] => (cuttable: textual is Cuttable by Text)
+        => textual is Cuttable by Char =
     (text, delimiter, limit) =>
       cuttable.cut(text, delimiter.toString.tt, limit)
 

--- a/lib/gossamer/src/core/gossamer.Gossamer.scala
+++ b/lib/gossamer/src/core/gossamer.Gossamer.scala
@@ -97,8 +97,7 @@ object Gossamer:
 
       '{Ascii(Bytes(${Varargs(bytes)}*))}
 
-    def recur(first: List[Expr[Ascii]], second: List[Expr[Ascii]], expr: Expr[Ascii])
-    :     Expr[Ascii] =
+    def recur(first: List[Expr[Ascii]], second: List[Expr[Ascii]], expr: Expr[Ascii]): Expr[Ascii] =
       first match
         case head :: tail => recur(second, tail, '{$expr+$head})
         case Nil          => expr

--- a/lib/guillotine/src/core/guillotine.Executable.scala
+++ b/lib/guillotine/src/core/guillotine.Executable.scala
@@ -55,8 +55,7 @@ sealed trait Executable:
   def fork[result]()(using working: WorkingDirectory)
   :     Process[Exec, result] logs ExecEvent raises ExecError
 
-  def exec[result: Computable]()
-     (using working: WorkingDirectory)
+  def exec[result: Computable]()(using working: WorkingDirectory)
   :     result logs ExecEvent raises ExecError =
 
     fork[result]().await()

--- a/lib/guillotine/src/core/guillotine.Process.scala
+++ b/lib/guillotine/src/core/guillotine.Process.scala
@@ -69,8 +69,7 @@ class Process[+exec <: Label, result](process: java.lang.Process) extends Proces
   def stderr(): Stream[Bytes] raises StreamError =
     Readable.inputStream.stream(process.getErrorStream.nn)
 
-  def stdin[chunk](stream: Stream[chunk])
-     (using writable: ji.OutputStream is Writable by chunk)
+  def stdin[chunk](stream: Stream[chunk])(using writable: ji.OutputStream is Writable by chunk)
   :     Unit =
 
     writable.write(process.getOutputStream.nn, stream)

--- a/lib/hallucination/src/core/hallucination.ImageCodec.scala
+++ b/lib/hallucination/src/core/hallucination.ImageCodec.scala
@@ -48,8 +48,7 @@ abstract class ImageCodec[format <: ImageFormat](name: Text):
   protected lazy val reader: ji.ImageReader = ji.ImageIO.getImageReaders(name.s).nn.next().nn
   protected lazy val writer: ji.ImageWriter = ji.ImageIO.getImageWriter(reader).nn
 
-  given response
-  :     (Image in format) is Abstractable across HttpStreams into HttpStreams.Content =
+  given response: (Image in format) is Abstractable across HttpStreams into HttpStreams.Content =
     new Abstractable:
       type Self = Image in format
       type Domain = HttpStreams

--- a/lib/honeycomb/src/core/honeycomb.Element.scala
+++ b/lib/honeycomb/src/core/honeycomb.Element.scala
@@ -49,8 +49,7 @@ object Element:
 
     new Element(labelString, attributes, flatten(children))
 
-  private def flatten[child <: Label]
-     (nodes: Seq[Optional[Html[child]] | Seq[Html[child]]])
+  private def flatten[child <: Label](nodes: Seq[Optional[Html[child]] | Seq[Html[child]]])
   :     Seq[Html[child]] =
 
     nodes.flatMap:

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -53,9 +53,7 @@ object Honeycomb:
 
     import quotes.reflect.*
 
-    def recur(exprs: Seq[Expr[(Label, Any)]])
-    :     List[Expr[Optional[(String, Optional[Text])]]] =
-
+    def recur(exprs: Seq[Expr[(Label, Any)]]): List[Expr[Optional[(String, Optional[Text])]]] =
       exprs match
         case '{("", $value: valueType)} +: tail =>
           val expr: Expr[HtmlAttribute[valueType]] =

--- a/lib/honeycomb/src/core/honeycomb.HtmlDoc.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlDoc.scala
@@ -53,8 +53,7 @@ object HtmlDoc:
       def genericize(doc: HtmlDoc): HttpStreams.Content =
         (t"text/html; charset=${encoder.encoding.name}", Stream(HtmlDoc.serialize(doc).bytes))
 
-  def serialize[output](doc: HtmlDoc, maxWidth: Int = -1)
-     (using serializer: HtmlSerializer[output])
+  def serialize[output](doc: HtmlDoc, maxWidth: Int = -1)(using serializer: HtmlSerializer[output])
   :     output =
     serializer.serialize(doc, maxWidth)
 

--- a/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
@@ -182,8 +182,7 @@ object Regex:
       case other =>
         abort(RegexError(index, UnexpectedChar))
 
-    def group
-       (start: Int, children: List[Group], top: Boolean, escape: Boolean, charClass: Boolean)
+    def group(start: Int, children: List[Group], top: Boolean, escape: Boolean, charClass: Boolean)
     :     Group =
 
       current() match

--- a/lib/legerdemain/src/core/legerdemain-core.scala
+++ b/lib/legerdemain/src/core/legerdemain-core.scala
@@ -48,11 +48,12 @@ def elicit[value: Formulable]
    (query: Optional[Query] = Unset, errors: Errors, submit: Optional[Text])
    (using formulation: Formulation)
 :     Html[Flow] =
-  formulation.form(value.fields(t"", t"", query.or(Query.empty), errors), submit)
+  formulation.form(value.fields(t"", t"", query.or(Query.empty), errors, formulation), submit)
 
 extension [formulable: {Formulable, Encodable in Query}](value: formulable)
   def edit(errors: Errors, submit: Optional[Text])(using formulation: Formulation): Html[Flow] =
-    formulation.form(formulable.fields(t"", t"", formulable.encoded(value), errors), submit)
+    formulation.form
+     (formulable.fields(t"", t"", formulable.encoded(value), errors, formulation), submit)
 
 package formulations:
   given default: Formulation:

--- a/lib/legerdemain/src/core/legerdemain.Query.scala
+++ b/lib/legerdemain/src/core/legerdemain.Query.scala
@@ -88,13 +88,13 @@ object Query extends Dynamic:
   given booleanDecodable: Boolean is Decodable in Query = _().present
 
   inline given encodable: [value] => value is Encodable in Query = summonFrom:
-    case given (`value` is Encodable in Text) =>
-      value => Query.of(value.encode)
+    case given (`value` is Encodable in Text) => value => Query.of(value.encode)
 
     case given ProductReflection[`value` & Product] =>
       EncodableDerivation.join[value & Product].asInstanceOf[value is Encodable in Query]
 
-  given showable: Query is Showable = _.values.map { case (key, value) => t"$key = \"${value}\"" }.join(t", ")
+  given showable: Query is Showable =
+    _.values.map { case (key, value) => t"$key = \"${value}\"" }.join(t", ")
 
   inline given decodable: [value] => value is Decodable in Query =
     summonFrom:

--- a/lib/mercator/src/core/mercator-core.scala
+++ b/lib/mercator/src/core/mercator-core.scala
@@ -77,8 +77,7 @@ extension [collection[element] <: Iterable[element], element]
             buildFrom: BuildFrom[List[element2], element2, collection[element2]])
   :     monad[collection[element2]] =
 
-    def recur(todo: Iterable[element], accumulator: monad[List[element2]])
-    :     monad[List[element2]] =
+    def recur(todo: Iterable[element], accumulator: monad[List[element2]]): monad[List[element2]] =
       if todo.isEmpty then accumulator
       else recur(todo.tail, accumulator.flatMap { xs => lambda(todo.head).map(_ :: xs) })
 

--- a/lib/mercator/src/core/mercator.Functor.scala
+++ b/lib/mercator/src/core/mercator.Functor.scala
@@ -42,5 +42,4 @@ trait Functor[functor[_]]:
     def map[value2](lambda: value => value2): functor[value2] =
       apply(value)(lambda)
 
-  def apply[value, value2](value: functor[value])(lambda: value => value2)
-  :     functor[value2]
+  def apply[value, value2](value: functor[value])(lambda: value => value2): functor[value2]

--- a/lib/mercator/src/core/mercator.Mercator.scala
+++ b/lib/mercator/src/core/mercator.Mercator.scala
@@ -92,9 +92,7 @@ object Mercator:
       new Functor[functor]:
         def point[value](value: value): functor[value] = ${pointExpr}.point(value)
 
-        def apply[value, value2](value: functor[value])
-           (lambda: value => value2)
-        :     functor[value2] =
+        def apply[value, value2](value: functor[value])(lambda: value => value2): functor[value2] =
           ${'value.asTerm.select(mapMethods(0)).appliedToType(TypeRepr.of[value2])
             . appliedTo('lambda.asTerm).asExprOf[functor[value2]]}
     }
@@ -124,9 +122,7 @@ object Mercator:
            (value: monad[value])(lambda: value => value2): monad[value2] =
           ${functorExpr}.map(value)(lambda)
 
-        def bind
-           [value, value2]
-           (value: monad[value])(lambda: value => monad[value2])
+        def bind[value, value2](value: monad[value])(lambda: value => monad[value2])
         :     monad[value2] =
           ${'value.asTerm
             . select(flatMapMethods(0))

--- a/lib/mercator/src/core/mercator.Monad.scala
+++ b/lib/mercator/src/core/mercator.Monad.scala
@@ -36,11 +36,7 @@ object Monad:
   inline given monad: [monad[_]] => Monad[monad] = ${Mercator.monad[monad]}
 
 trait Monad[monad[_]] extends Functor[monad]:
-  def bind[value, value2](value: monad[value])
-     (lambda: value => monad[value2])
-  :     monad[value2]
+  def bind[value, value2](value: monad[value])(lambda: value => monad[value2]): monad[value2]
 
   extension [value](value: monad[value])
-    def flatMap[value2](lambda: value => monad[value2])
-    :     monad[value2] =
-      bind(value)(lambda)
+    def flatMap[value2](lambda: value => monad[value2]): monad[value2] = bind(value)(lambda)

--- a/lib/monotonous/src/core/monotonous-core.scala
+++ b/lib/monotonous/src/core/monotonous-core.scala
@@ -146,8 +146,7 @@ package alphabets:
       Alphabet(Text(IArray.tabulate(256) { byte => (byte + '\u2800').toChar }), false)
 
 extension (value: Text)
-  def deserialize[scheme <: Serialization](using deserializable: Deserializable in scheme)
-  :     Bytes =
+  def deserialize[scheme <: Serialization](using deserializable: Deserializable in scheme): Bytes =
     deserializable.deserialize(value)
 
 extension (stream: Stream[Text])

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -71,8 +71,7 @@ class Matrix[element, rows <: Int, columns <: Int]
     new Matrix(rows, columns, elements2)
 
   @targetName("scalarDiv")
-  def / [right](right: right)(using div: element is Divisible by right)
-     (using ClassTag[div.Result])
+  def / [right](right: right)(using div: element is Divisible by right)(using ClassTag[div.Result])
   :     Matrix[div.Result, rows, columns] =
 
     val elements2 = IArray.create[div.Result](elements.length): array =>

--- a/lib/mosquito/src/core/mosquito.Mosquito.scala
+++ b/lib/mosquito/src/core/mosquito.Mosquito.scala
@@ -47,8 +47,7 @@ object Mosquito:
   object Vector:
     def apply(elems: Tuple): Vector[Tuple.Union[elems.type], Tuple.Size[elems.type]] = elems
 
-    def take[element](list: List[element], size: Int)
-    :     Optional[Vector[element, size.type]] =
+    def take[element](list: List[element], size: Int): Optional[Vector[element, size.type]] =
       if size == 0 then Zero else list match
         case Nil          => Unset
         case head :: tail => take(tail, size - 1).let(head *: _)
@@ -123,8 +122,7 @@ object Mosquito:
       recur(left)
 
     @targetName("add")
-    def + [right](right: Vector[right, size])
-       (using addition: left is Addable by right)
+    def + [right](right: Vector[right, size])(using addition: left is Addable by right)
     :     Vector[addition.Result, size] =
 
       def recur(left: Tuple, right: Tuple): Tuple = left match
@@ -142,8 +140,7 @@ object Mosquito:
       recur(left, right)
 
     @targetName("sub")
-    def - [right](right: Vector[right, size])
-       (using sub: left is Subtractable by right)
+    def - [right](right: Vector[right, size])(using sub: left is Subtractable by right)
     :     Vector[sub.Result, size] =
 
       def recur(left: Tuple, right: Tuple): Tuple = left match
@@ -160,15 +157,13 @@ object Mosquito:
       recur(left, right)
 
     @targetName("scalarMul")
-    def * [right](right: right)
-       (using multiplication: left is Multiplicable by right)
+    def * [right](right: right)(using multiplication: left is Multiplicable by right)
     :     Vector[multiplication.Result, size] =
 
       map(_*right)
 
     @targetName("scalarDiv")
-    def / [right](right: right)(using div: left is Divisible by right)
-    :     Vector[div.Result, size] =
+    def / [right](right: right)(using div: left is Divisible by right): Vector[div.Result, size] =
 
       map(_/right)
 

--- a/lib/nettlesome/src/core/nettlesome-core.scala
+++ b/lib/nettlesome/src/core/nettlesome-core.scala
@@ -54,8 +54,7 @@ extension [remote: Connectable](value: remote)
     Endpoint(remote.remote(value), port)
 
 extension [port](port: port)
-  def serve[protocol: Protocolic over port]
-     (handler: protocol.Request ?=> protocol.Response)
+  def serve[protocol: Protocolic over port](handler: protocol.Request ?=> protocol.Response)
   :     protocol.Server =
     protocol.server(port)(handler)
 

--- a/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
+++ b/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
@@ -54,7 +54,9 @@ import EmailAddressError.Reason.*
 object EmailAddress:
   given realm: Realm = realm"nettlesome"
 
-  given decodable: Tactic[EmailAddressError] => EmailAddress is Decodable in Text = EmailAddress.parse(_)
+  given decodable: Tactic[EmailAddressError] => EmailAddress is Decodable in Text =
+    EmailAddress.parse(_)
+
   given encodable: EmailAddress is Encodable in Text = _.text
 
   def expand(context: Expr[StringContext])(using Quotes): Expr[EmailAddress] = abortive:

--- a/lib/nettlesome/src/url/nettlesome.Url.scala
+++ b/lib/nettlesome/src/url/nettlesome.Url.scala
@@ -114,8 +114,7 @@ object Url:
   given communicable: [scheme <: Label] => Url[scheme] is Communicable =
     url => Message(url.show)
 
-  def parse[scheme <: Label](value: Text)
-  :     Url[scheme] raises UrlError =
+  def parse[scheme <: Label](value: Text): Url[scheme] raises UrlError =
     import UrlError.Expectation.*
 
     safely(value.where(_ == ':')).asMatchable match

--- a/lib/nettlesome/src/url/nettlesome.UrlInterpolator.scala
+++ b/lib/nettlesome/src/url/nettlesome.UrlInterpolator.scala
@@ -46,8 +46,7 @@ import errorDiagnostics.empty
 
 object UrlInterpolator extends contextual.Interpolator[UrlFragment, Text, Url[Label]]:
 
-  def refined(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes)
-  :     Expr[Url[Label]] =
+  def refined(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes): Expr[Url[Label]] =
     import quotes.reflect.*
 
     val constant = context.value.get.parts.head.split(":").nn.head.nn

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -74,8 +74,7 @@ object Nomenclature2:
       case _ =>
         panic(m"StringContext did not contains Strings")
 
-  def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])
-     (using Quotes)
+  def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])(using Quotes)
   :     Expr[Boolean] =
     parse[platform, name]
     '{${Expr(constant[name])}.tt == $scrutinee.text}
@@ -85,8 +84,7 @@ object Nomenclature2:
     TypeRepr.of[text].asMatchable.absolve match
       case ConstantType(StringConstant(value)) => value.tt.asInstanceOf[text]
 
-  def companion[companion: Typeable](using Quotes)(symbol: quotes.reflect.Symbol)
-  :     companion =
+  def companion[companion: Typeable](using Quotes)(symbol: quotes.reflect.Symbol): companion =
     Class.forName(s"${symbol.companionModule.fullName}$$").nn.getField("MODULE$").nn.get(null) match
       case module: `companion` => module
       case _                   => halt(m"The companion object did not have the expected type.")

--- a/lib/octogenarian/src/core/octogenarian.GitRepo.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRepo.scala
@@ -152,17 +152,15 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
   def branch()(using GitCommand, WorkingDirectory, Tactic[ExecError]): GitBranch logs GitEvent =
     GitBranch.unsafe(sh"$git $repoOptions branch --show-current".exec[String]().tt)
 
-  def makeBranch(branch: GitBranch)
-     (using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
-  :     Unit logs GitEvent =
+  def makeBranch(branch: GitBranch)(using GitCommand, WorkingDirectory)
+  :     Unit logs GitEvent raises ExecError raises GitError =
 
     sh"$git $repoOptions checkout -b $branch".exec[Exit]() match
       case Exit.Ok => ()
       case failure       => abort(GitError(BranchFailed))
 
-  def add[path: Abstractable across Paths into Text](path: path)
-     (using GitCommand, WorkingDirectory, Tactic[ExecError], Tactic[GitError])
-  :     Unit logs GitEvent raises PathError raises NameError =
+  def add[path: Abstractable across Paths into Text](path: path)(using GitCommand, WorkingDirectory)
+  :     Unit logs GitEvent raises PathError raises NameError raises ExecError raises GitError =
 
     val relativePath: Relative =
       workTree.let: workTree =>

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -51,9 +51,7 @@ object Panopticon:
     def make[from, path <: Tuple, to](): Lens[from, path, to] = 0
 
   extension [from](initLens: InitLens[from])
-    def apply[path <: Tuple, to]
-       (lambda: Aim[from, Zero] => Aim[to, path])
-    :     Lens[from, path, to] =
+    def apply[path <: Tuple, to](lambda: Aim[from, Zero] => Aim[to, path]): Lens[from, path, to] =
       0
 
   extension [from, path <: Tuple, to](lens: Lens[from, path, to])
@@ -68,8 +66,7 @@ object Panopticon:
     inline def update(aim: from, newValue: to): from =
       ${Panopticon.set[from, path, to]('aim, 'newValue)}
 
-  private def getPath[tuple <: Tuple: Type](path: List[String] = Nil)(using Quotes)
-  :     List[String] =
+  private def getPath[tuple <: Tuple: Type](path: List[String] = Nil)(using Quotes): List[String] =
     import quotes.reflect.*
 
     Type.of[tuple] match
@@ -91,9 +88,7 @@ object Panopticon:
       case _ =>
         halt(m"unexpectedly did not match")
 
-  def get[from: Type, path <: Tuple: Type, to: Type](value: Expr[from])
-     (using Quotes)
-  :     Expr[to] =
+  def get[from: Type, path <: Tuple: Type, to: Type](value: Expr[from])(using Quotes): Expr[to] =
 
     import quotes.reflect.*
 
@@ -115,8 +110,7 @@ object Panopticon:
 
     select[from](getPath[path](), value).asExprOf[to]
 
-  def set[from: Type, path <: Tuple: Type, to: Type]
-     (value: Expr[from], newValue: Expr[to])
+  def set[from: Type, path <: Tuple: Type, to: Type](value: Expr[from], newValue: Expr[to])
      (using Quotes)
   :     Expr[from] =
 
@@ -146,8 +140,7 @@ object Panopticon:
 
     rewrite(getPath[path](), value.asTerm).asExprOf[from]
 
-  def dereference[aim: Type, tuple <: Tuple: Type](member: Expr[String])(using Quotes)
-  :     Expr[Any] =
+  def dereference[aim: Type, tuple <: Tuple: Type](member: Expr[String])(using Quotes): Expr[Any] =
     import quotes.reflect.*
 
     val fieldName = member.valueOrAbort

--- a/lib/parasite/src/core/parasite.Promise.scala
+++ b/lib/parasite/src/core/parasite.Promise.scala
@@ -73,8 +73,7 @@ final case class Promise[value]():
     case Complete(_) => true
     case _           => false
 
-  private def completeIncomplete(supplied: value)(current: State[value] | Null)
-  :     State[value] =
+  private def completeIncomplete(supplied: value)(current: State[value] | Null): State[value] =
     current.nn match
       case Incomplete(waiting) => Complete(supplied.nn).also(waiting.each(jucl.LockSupport.unpark))
       case current             => current
@@ -113,8 +112,7 @@ final case class Promise[value]():
     case Incomplete(waiting) => waiting.each(jucl.LockSupport.unpark)
     case _                   => ()
 
-  def await[generic: GenericDuration](duration: generic)
-  :     value raises AsyncError =
+  def await[generic: GenericDuration](duration: generic): value raises AsyncError =
     val deadline = System.nanoTime() + generic.milliseconds(duration)*1000000L
 
     @tailrec

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -42,8 +42,7 @@ import mercator.*
 import vacuous.*
 
 object Task:
-  def apply[result]
-     (evaluate: Worker => result, daemon: Boolean, name: Optional[Text])
+  def apply[result](evaluate: Worker => result, daemon: Boolean, name: Optional[Text])
      (using monitor: Monitor, codepoint: Codepoint, codicil: Codicil)
   :     Task[result] =
     inline def evaluate0: Worker => result = evaluate
@@ -56,14 +55,12 @@ object Task:
       def evaluate(worker: Worker): Result = evaluate0(worker)
 
   given monad: (Monitor, Codicil, Tactic[AsyncError]) => Monad[Task]:
-    def bind[value, value2](value: Task[value])(lambda: value => Task[value2])
-    :     Task[value2] =
+    def bind[value, value2](value: Task[value])(lambda: value => Task[value2]): Task[value2] =
       value.bind(lambda)
 
     def point[value](value: value): Task[value] = async(value)
 
-    def apply[value, value2](value: Task[value])(lambda: value -> value2)
-    :     Task[value2] =
+    def apply[value, value2](value: Task[value])(lambda: value -> value2): Task[value2] =
       value.map(lambda)
 
 trait Task[+result]:

--- a/lib/plutocrat/src/core/plutocrat.Plutocrat.scala
+++ b/lib/plutocrat/src/core/plutocrat.Plutocrat.scala
@@ -46,9 +46,7 @@ object Plutocrat:
   opaque type Money[+currency <: Currency & Singleton] = Long
 
   object Money:
-    erased given underlying[currency <: Currency & Singleton]
-    :     Underlying[Money[currency], Int] =
-      !!
+    erased given underlying[currency <: Currency & Singleton]: Underlying[Money[currency], Int] = !!
 
     def apply(currency: Currency & Singleton)(wholePart: Long, subunit: Int): Money[currency.type] =
       wholePart*currency.modulus + subunit

--- a/lib/probably/src/core/probably.Probably.scala
+++ b/lib/probably/src/core/probably.Probably.scala
@@ -172,8 +172,7 @@ object Probably:
       inc.include(runner.report, test.id, verdict)
       result(run)
 
-  def debug[test: Type](expr: Expr[test], test: Expr[Harness])(using Quotes)
-  :     Expr[test] =
+  def debug[test: Type](expr: Expr[test], test: Expr[Harness])(using Quotes): Expr[test] =
     import quotes.reflect.*
 
     val exprName: Text = expr.asTerm.pos match

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -212,8 +212,7 @@ object Markdown:
     node.getChildren.nn.iterator.nn.asScala.to(List).collect:
       case node: (cvfa.BulletListItem | cvfa.OrderedListItem) => ListItem(flowChildren(root, node)*)
 
-  def phrasing
-     (root: cvfua.Document, node: PhrasingInput)
+  def phrasing(root: cvfua.Document, node: PhrasingInput)
   :     Markdown.Ast.Inline raises MarkdownError = node match
     case node: cvfa.Emphasis       => Emphasis(phraseChildren(root, node)*)
     case node: cvfa.SoftLineBreak  => Prose(t"\n")

--- a/lib/punctuation/src/html/punctuation.OutlineConverter.scala
+++ b/lib/punctuation/src/html/punctuation.OutlineConverter.scala
@@ -50,8 +50,7 @@ object OutlineConverter extends HtmlConverter():
     List(Ul(recur(structure(Unset, nodes.to(List), Nil))*))
 
   @tailrec
-  def structure
-     (minimum: Optional[Int], nodes: List[Markdown.Ast.Node], stack: List[List[Entry]])
+  def structure(minimum: Optional[Int], nodes: List[Markdown.Ast.Node], stack: List[List[Entry]])
   :     List[Entry] =
     nodes match
       case Nil => stack match

--- a/lib/quantitative/src/core/quantitative-core.scala
+++ b/lib/quantitative/src/core/quantitative-core.scala
@@ -56,9 +56,7 @@ extension [units <: Measure](quantity: into Quantity[units])
   transparent inline def invert: Any = Quantity[Measure](1.0)/quantity
 
   @targetName("times2")
-  transparent inline infix def * [units2 <: Measure](inline quantity2: Quantity[units2])
-  :     Any =
-
+  transparent inline infix def * [units2 <: Measure](inline quantity2: Quantity[units2]): Any =
     ${Quantitative.multiply[units, units2]('quantity, 'quantity2, false)}
 
   @targetName("times3")
@@ -66,8 +64,7 @@ extension [units <: Measure](quantity: into Quantity[units])
     quantity*Quantity(double)
 
   @targetName("divide2")
-  transparent inline infix def / [units2 <: Measure](inline quantity2: Quantity[units2])
-  :     Any =
+  transparent inline infix def / [units2 <: Measure](inline quantity2: Quantity[units2]): Any =
 
     ${Quantitative.multiply[units, units2]('quantity, 'quantity2, true)}
 

--- a/lib/quantitative/src/core/quantitative.Quantitative.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative.scala
@@ -144,7 +144,7 @@ object Quantitative extends Quantitative2:
 
       inline def compare
          (inline left:        Quantity[units],
-          inline right:       Quantity[units2],
+inline right:       Quantity[units2],
           inline strict:      Boolean,
           inline greaterThan: Boolean)
       :     Boolean =

--- a/lib/quantitative/src/core/quantitative.Quantitative2.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative2.scala
@@ -369,9 +369,7 @@ trait Quantitative2:
        '{ Divisible[Quantity[left], Quantity[right], Double]: (left, right) =>
             ${Quantitative.multiply('left, 'right, true).asExprOf[Double]} }
 
-  def sqrtTypeclass[value <: Measure: Type](using Quotes)
-  :     Expr[Quantity[value] is Rootable[2]] =
-
+  def sqrtTypeclass[value <: Measure: Type](using Quotes): Expr[Quantity[value] is Rootable[2]] =
     val units = UnitsMap[value]
 
     if !units.map.values.all(_.power%2 == 0)
@@ -390,8 +388,7 @@ trait Quantitative2:
 
           '{Rootable[2, Quantity[value], Quantity[result]]($cast(_))}
 
-  def cbrtTypeclass[value <: Measure: Type](using Quotes)
-  :     Expr[Quantity[value] is Rootable[3]] =
+  def cbrtTypeclass[value <: Measure: Type](using Quotes): Expr[Quantity[value] is Rootable[3]] =
 
     val units = UnitsMap[value]
 

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -88,10 +88,7 @@ object Path:
 
       recur(left.textDescent, right.ascent)
 
-  def apply
-     [root <: Root on platform,
-      element,
-      platform: {Navigable by element, Radical from root}]
+  def apply[root <: Root on platform, element, platform: {Navigable by element, Radical from root}]
      (root0: root, elements: List[element])
   :     Path on platform =
     if elements.isEmpty then root0 else
@@ -197,8 +194,7 @@ extends Pathlike:
     val left0 = textDescent.drop(difference)
     val right0 = right.textDescent.drop(-difference)
 
-    def recur(left: List[Text], right: List[Text], size: Int, count: Int)
-    :     Path on Platform =
+    def recur(left: List[Text], right: List[Text], size: Int, count: Int): Path on Platform =
       if left.isEmpty
       then Path.from(textRoot, left0.drop(size - count), separator, caseSensitivity)
       else if left.head == right.head then recur(left.tail, right.tail, size + 1, count + 1)

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -62,8 +62,7 @@ object Relative:
         => (Relative by element) is Decodable in Text =
     parse(_)
 
-  def parse[element](using navigable: Navigable by element)(text: Text)
-  :     Relative by element =
+  def parse[element](using navigable: Navigable by element)(text: Text): Relative by element =
     def recur(start: Int, ascent: Int, elements: List[element]): Relative by element =
       if start >= text.length then Relative(ascent, elements)
       else
@@ -78,8 +77,7 @@ object Relative:
 
     if text == navigable.selfText then Relative(0, Nil) else recur(0, 0, Nil)
 
-  def apply[element](using navigable: Navigable by element)
-     (ascent0: Int, descent0: List[element])
+  def apply[element](using navigable: Navigable by element)(ascent0: Int, descent0: List[element])
   :     Relative by element =
     Relative.from[element](ascent0, descent0.map(navigable.makeElement(_)), navigable.separator)
 

--- a/lib/symbolism/src/core/symbolism.Divisible.scala
+++ b/lib/symbolism/src/core/symbolism.Divisible.scala
@@ -37,8 +37,7 @@ import prepositional.*
 import scala.annotation.targetName
 
 object Divisible:
-  def apply[dividend, divisor, result]
-     (lambda: (dividend, divisor) => result)
+  def apply[dividend, divisor, result](lambda: (dividend, divisor) => result)
   :     dividend is Divisible by divisor into result = new Divisible:
     type Self = dividend
     type Result = result

--- a/lib/symbolism/src/core/symbolism.Multiplicable.scala
+++ b/lib/symbolism/src/core/symbolism.Multiplicable.scala
@@ -37,8 +37,7 @@ import prepositional.*
 import scala.annotation.targetName
 
 object Multiplicable:
-  def apply[multiplicand, multiplier, result]
-     (lambda: (multiplicand, multiplier) => result)
+  def apply[multiplicand, multiplier, result](lambda: (multiplicand, multiplier) => result)
   :     multiplicand is Multiplicable by multiplier into result = new Multiplicable:
     type Self = multiplicand
     type Result = result

--- a/lib/symbolism/src/core/symbolism.Subtractable.scala
+++ b/lib/symbolism/src/core/symbolism.Subtractable.scala
@@ -37,8 +37,7 @@ import prepositional.*
 import scala.annotation.targetName
 
 object Subtractable:
-  def apply[minuend, subtrahend, result]
-     (lambda: (minuend, subtrahend) => result)
+  def apply[minuend, subtrahend, result](lambda: (minuend, subtrahend) => result)
   :     minuend is Subtractable by subtrahend into result = new Subtractable:
     type Self = minuend
     type Result = result

--- a/lib/tarantula/src/core/tarantula.WebDriver.scala
+++ b/lib/tarantula/src/core/tarantula.WebDriver.scala
@@ -133,8 +133,7 @@ case class WebDriver(server: Browser#Server):
       url(get(t"url").url.as[Text])
 
     @targetName("at")
-    infix def / [element: Focusable](value: element)
-    :     List[Element] logs HttpEvent =
+    infix def / [element: Focusable](value: element): List[Element] logs HttpEvent =
 
       case class Data(`using`: Text, value: Text)
 
@@ -144,8 +143,7 @@ case class WebDriver(server: Browser#Server):
       . map(_(Wei).as[Text])
       . map(Element(_))
 
-    def element[element: Focusable](value: element)
-    :     Element logs HttpEvent =
+    def element[element: Focusable](value: element): Element logs HttpEvent =
 
       case class Data(`using`: Text, value: Text)
       val e = post(t"element", Data(element.strategy, element.focus(value)).json)

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -52,8 +52,7 @@ import vacuous.*
 import alphabets.base256.alphanumericOrBraille
 
 object Postable:
-  def apply[response](medium0: Medium, stream0: response => Stream[Bytes])
-  :     response is Postable =
+  def apply[response](medium0: Medium, stream0: response => Stream[Bytes]): response is Postable =
     new Postable:
       type Self = response
       def medium(response: response): Medium = medium0

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -42,8 +42,7 @@ import spectacular.*
 import turbulence.*
 
 object Servable:
-  def apply[response](medium: response => Medium)
-     (lambda: response => Stream[Bytes])
+  def apply[response](medium: response => Medium)(lambda: response => Stream[Bytes])
   :     response is Servable = response =>
 
     val headers = List(Http.Header(t"content-type", medium(response).show))

--- a/lib/telekinesis/src/core/telekinesis.Submission.scala
+++ b/lib/telekinesis/src/core/telekinesis.Submission.scala
@@ -32,10 +32,27 @@
                                                                                                   */
 package telekinesis
 
+import anticipation.*
+import contingency.*
+import distillate.*
+import fulminate.*
 import honeycomb.*
 import legerdemain.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
 
-enum Submission[value]:
-  case Complete(value: value)
-  case Invalid(query: Query)
-  case Incomplete(form: Html[Flow])
+case class Submission[value](query: Optional[Query]):
+  def fresh: Boolean = query.absent
+  def value(using value is Decodable in Query): Optional[value] = query.let(_.decode[value])
+
+  def form
+     (submit: Optional[Text]   = Unset,
+      value:  Optional[value]  = Unset,
+      errors: Optional[Errors] = Unset)
+     (using value is Formulable, value is Encodable in Query, Formulation)
+  :     Html[Flow] =
+
+    val data: Optional[Query] = query.or(value.let(_.encode))
+    import errorDiagnostics.stackTraces
+    elicit[value](query, errors.or(Errors()), submit)

--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -48,8 +48,7 @@ import rudiments.*
 import vacuous.*
 
 extension [value](value: value)
-  def stream[element](using readable: value is Readable by element)
-  :     Stream[element] =
+  def stream[element](using readable: value is Readable by element): Stream[element] =
     readable.stream(value)
 
   inline def read[result]: result =
@@ -163,9 +162,7 @@ extension [element](stream: Stream[element])
 
     val Limit = maxSize.or(Int.MaxValue)
 
-    def recur(stream: Stream[element], list: List[element], count: Int)
-    :     Stream[List[element]] =
-
+    def recur(stream: Stream[element], list: List[element], count: Int): Stream[List[element]] =
       count match
         case 0 => safely(async(stream.isEmpty).await()) match
           case Unset => recur(stream, Nil, 0)
@@ -182,8 +179,7 @@ extension [element](stream: Stream[element])
 
     Stream.defer(recur(stream, Nil, 0))
 
-  def parallelMap[element2](lambda: element => element2)(using Monitor)
-  :     Stream[element2] =
+  def parallelMap[element2](lambda: element => element2)(using Monitor): Stream[element2] =
 
     val out: Spool[element2] = Spool()
 
@@ -211,13 +207,11 @@ package lineSeparation:
     case _: String => adaptiveLinefeed
 
 extension (obj: Stream.type)
-  def multiplex[element](streams: Stream[element]*)(using Monitor)
-  :     Stream[element] =
+  def multiplex[element](streams: Stream[element]*)(using Monitor): Stream[element] =
 
     multiplexer(streams*).stream
 
-  def multiplexer[element](streams: Stream[element]*)(using Monitor)
-  :     Multiplexer[Any, element] =
+  def multiplexer[element](streams: Stream[element]*)(using Monitor): Multiplexer[Any, element] =
 
     val multiplexer = Multiplexer[Any, element]()
     streams.zipWithIndex.map(_.swap).each(multiplexer.add)

--- a/lib/turbulence/src/core/turbulence.Err.scala
+++ b/lib/turbulence/src/core/turbulence.Err.scala
@@ -38,8 +38,7 @@ import rudiments.*
 object Err:
   def write(bytes: Bytes)(using stdio: Stdio): Unit = stdio.writeErr(bytes)
 
-  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio)
-  :     Unit =
+  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio): Unit =
     stdio.printErr(printable.print(text(using stdio.termcap), stdio.termcap))
 
   def println[textual: Printable](lines: Termcap ?=> textual*)(using stdio: Stdio): Unit =

--- a/lib/turbulence/src/core/turbulence.Out.scala
+++ b/lib/turbulence/src/core/turbulence.Out.scala
@@ -38,8 +38,7 @@ import rudiments.*
 object Out:
   def write(bytes: Bytes)(using stdio: Stdio): Unit = stdio.write(bytes)
 
-  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio)
-  :     Unit =
+  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio): Unit =
     stdio.print(printable.print(text(using stdio.termcap), stdio.termcap))
 
   def println()(using Stdio): Unit = print("\n".tt)

--- a/lib/vacuous/src/core/vacuous.Optional.scala
+++ b/lib/vacuous/src/core/vacuous.Optional.scala
@@ -67,15 +67,12 @@ extension [value](optional: Optional[value])(using Optionality[optional.type])
   def option: Option[value] = if absent then None else Some(vouch)
   def assume(using absentValue: CanThrow[UnsetError]): value = optional.or(throw UnsetError())
 
-  inline def lay[value2](inline alternative: => value2)
-     (inline lambda: value => value2)
-  :     value2 =
+  inline def lay[value2](inline alternative: => value2)(inline lambda: value => value2): value2 =
 
     if absent then alternative else lambda(vouch)
 
 
-  inline def layGiven[value2](inline alternative: => value2)
-     (inline block: value ?=> value2)
+  inline def layGiven[value2](inline alternative: => value2)(inline block: value ?=> value2)
   :     value2 =
 
     if absent then alternative else block(using vouch)

--- a/lib/vacuous/src/core/vacuous.Vacuous.scala
+++ b/lib/vacuous/src/core/vacuous.Vacuous.scala
@@ -43,8 +43,7 @@ object Vacuous:
     then '{null.asInstanceOf[Optionality[value]]}
     else halt(m"the type ${TypeRepr.of[value].widen.show} is not an `Optional`")
 
-  def optimizeOr[value: Type]
-     (optional: Expr[Optional[value]], default: Expr[value])(using Quotes)
+  def optimizeOr[value: Type](optional: Expr[Optional[value]], default: Expr[value])(using Quotes)
   :     Expr[value] =
 
     import quotes.reflect.*

--- a/lib/vicarious/src/core/vicarious.Catalog.scala
+++ b/lib/vicarious/src/core/vicarious.Catalog.scala
@@ -41,8 +41,7 @@ import language.dynamics
 case class Catalog[key, value: ClassTag](values: IArray[value]):
   def size: Int = values.length
 
-  inline def apply(accessor: (`*`: Proxy[key, value, 0]) ?=> Proxy[key, value, ?])
-  :     value =
+  inline def apply(accessor: (`*`: Proxy[key, value, 0]) ?=> Proxy[key, value, ?]): value =
     values(accessor(using Proxy()).id.vouch)
 
   def map[value2: ClassTag](lambda: value => value2): Catalog[key, value2] =

--- a/lib/vicarious/src/core/vicarious.Vicarious.scala
+++ b/lib/vicarious/src/core/vicarious.Vicarious.scala
@@ -63,8 +63,7 @@ object Vicarious:
       field.info.asType.absolve match
         case '[fieldType] => label :: fieldNames[fieldType](label)
 
-  def dereference[key: Type, value: Type, id <: Nat: Type]
-     (key: Expr[String])(using Quotes)
+  def dereference[key: Type, value: Type, id <: Nat: Type](key: Expr[String])(using Quotes)
   :     Expr[value | Proxy[key, value, Nat]] =
 
     import quotes.reflect.*

--- a/lib/wisteria/src/core/wisteria.SumDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivation.scala
@@ -36,9 +36,7 @@ import scala.deriving.*
 import scala.compiletime.*
 
 trait SumDerivation[typeclass[_]] extends SumDerivationMethods[typeclass]:
-  inline given derived[derivation](using Reflection[derivation])
-  :     typeclass[derivation] =
-
+  inline given derived[derivation](using Reflection[derivation]): typeclass[derivation] =
     inline summon[Reflection[derivation]] match
       case reflection: SumReflection[derivationType] =>
         split[derivationType](using reflection).asMatchable match

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -59,10 +59,8 @@ trait SumDerivationMethods[typeclass[_]]:
     case _                                 => false
 
   protected transparent inline def complement[derivation, variant](sum: derivation)
-     (using variantIndex: Int & VariantIndex[variant],
-            reflection:   SumReflection[derivation])
+     (using variantIndex: Int & VariantIndex[variant], reflection:   SumReflection[derivation])
   :     Optional[variant] =
-
     type Labels = reflection.MirroredElemLabels
     type Variants = reflection.MirroredElemTypes
     val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
@@ -71,8 +69,7 @@ trait SumDerivationMethods[typeclass[_]]:
       [variant2 <: derivation] => field =>
         if index == variantIndex then field.asInstanceOf[variant] else Unset
 
-  protected inline def variantLabels[derivation]
-     (using reflection: SumReflection[derivation])
+  protected inline def variantLabels[derivation](using reflection: SumReflection[derivation])
   :     List[Text] =
 
     constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
@@ -88,8 +85,7 @@ trait SumDerivationMethods[typeclass[_]]:
       summonInline[Tactic[VariantError]].give:
         abort(VariantError[derivation](input))
 
-  private transparent inline def singletonFold
-     [derivation, variants <: Tuple, labels <: Tuple]
+  private transparent inline def singletonFold[derivation, variants <: Tuple, labels <: Tuple]
      (using reflection: SumReflection[derivation])
      (predicate: Text => Boolean)
   :     Optional[derivation] =

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -182,10 +182,7 @@ extends Xml, Dynamic:
   infix def + (other: Xml): XmlDoc raises XmlAccessError =
     XmlDoc(XmlAst.Root(Xml.normalize(this) ++ Xml.normalize(other)*))
 
-  def as
-     [value]
-     (using decoder: XmlDecoder[value])
-  :     value raises XmlAccessError raises XmlReadError =
+  def as[value](using decoder: XmlDecoder[value]): value raises XmlAccessError raises XmlReadError =
     apply().as[value]
 
 case class XmlNode(head: Int, path: XmlPath, root: XmlAst.Root) extends Xml, Dynamic:

--- a/lib/xylophone/src/core/xylophone.XmlEncoder.scala
+++ b/lib/xylophone/src/core/xylophone.XmlEncoder.scala
@@ -38,7 +38,8 @@ import spectacular.*
 import wisteria.*
 
 object XmlEncoder extends Derivation[XmlEncoder]:
-  given text: XmlEncoder[Text] = text => XmlAst.Element(XmlName(t"Text"), List(XmlAst.Textual(text)))
+  given text: XmlEncoder[Text] =
+    text => XmlAst.Element(XmlName(t"Text"), List(XmlAst.Textual(text)))
 
   given string: XmlEncoder[String] =
     string => XmlAst.Element(XmlName(t"String"), List(XmlAst.Textual(string.tt)))

--- a/lib/zeppelin/src/core/zeppelin.ZipFile.scala
+++ b/lib/zeppelin/src/core/zeppelin.ZipFile.scala
@@ -103,9 +103,7 @@ object Zipfile:
 
   private val cache: scc.TrieMap[Text, Semaphore] = scc.TrieMap()
 
-  def write[path: Abstractable across Paths into Text](path: path)(stream: Stream[ZipEntry])
-  :     Unit =
-
+  def write[path: Abstractable across Paths into Text](path: path)(stream: Stream[ZipEntry]): Unit =
     val filename = path.generic
     val out: juz.ZipOutputStream = juz.ZipOutputStream(ji.FileOutputStream(ji.File(filename.s)))
     val directories: scm.HashSet[Path on Zip] = scm.HashSet()


### PR DESCRIPTION
One positive effect of #247 was that every mention of a type parameter in a method signature reduced the line length by four characters as `Type` was deleted. This means that several lines that had to previously be split over multiple lines now fit on a single line.