### PR TITLE
Tidy up multiline `extension` methods

### DIFF
--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -182,8 +182,7 @@ extension [accrual <: Exception,  lambda[_]](inline accrue: Accrue[accrual, lamb
   :     result =
     ${Contingency.accrueWithin[accrual, lambda, result]('accrue, 'lambda, 'tactic, 'diagnostics)}
 
-extension [accrual <: Exception,  lambda[_], focus]
-   (inline track: Tracking[accrual, lambda, focus])
+extension [accrual <: Exception,  lambda[_], focus](inline track: Tracking[accrual, lambda, focus])
   inline def within[result](inline lambda: Foci[focus] ?=> lambda[result])
      (using tactic: Tactic[accrual], diagnostics: Diagnostics)
   :     result =
@@ -191,7 +190,7 @@ extension [accrual <: Exception,  lambda[_], focus]
           'diagnostics)}
 
 extension [accrual <: Exception,  lambda[_], focus]
-    (inline validate: Validate[accrual, lambda, focus])
+          (inline validate: Validate[accrual, lambda, focus])
   inline def within(inline lambda: Foci[focus] ?=> lambda[Any])(using diagnostics: Diagnostics)
   :     accrual =
     ${Contingency.validateWithin[accrual, lambda, focus]('validate, 'lambda, 'diagnostics)}

--- a/lib/eucalyptus/src/core/eucalyptus-core.scala
+++ b/lib/eucalyptus/src/core/eucalyptus-core.scala
@@ -74,7 +74,7 @@ def mute[format](using erased Void)[result](lambda: (format is Loggable) ?=> res
 
 extension (logObject: Log.type)
   def envelop[tag, event: {Taggable by tag, Loggable as loggable}](value: tag)[result]
-     (lambda: (event is Loggable) ?=> result)
+       (lambda: (event is Loggable) ?=> result)
   :     result =
     lambda(using loggable.contramap(_.tag(value)))
 

--- a/lib/hieroglyph/src/core/hieroglyph-core.scala
+++ b/lib/hieroglyph/src/core/hieroglyph-core.scala
@@ -40,8 +40,8 @@ import vacuous.*
 
 import language.experimental.pureFunctions
 
-extension (encoding: Encoding { type CanEncode = true }) def encoder: CharEncoder =
-  CharEncoder(encoding)
+extension (encoding: Encoding { type CanEncode = true })
+  def encoder: CharEncoder = CharEncoder(encoding)
 
 extension (char: Char)
   def whitespace: Boolean = Character.isWhitespace(char)

--- a/lib/mercator/src/core/mercator-core.scala
+++ b/lib/mercator/src/core/mercator-core.scala
@@ -39,8 +39,7 @@ import scala.collection.BuildFrom
 
 given realm: Realm = realm"mercator"
 
-extension [value, functor[_]](using functor: Functor[functor])
-   (value: functor[value])
+extension [value, functor[_]](using functor: Functor[functor])(value: functor[value])
   def map[value2](lambda: value => value2): functor[value2] =
     functor.map(value)(lambda)
 
@@ -56,8 +55,8 @@ extension (text: into Text)
     builder.toString.tt
 
 extension [monad[_], collection[element] <: Iterable[element], element]
-   (elems: collection[monad[element]])
-   (using monad: Monad[monad])
+          (elems: collection[monad[element]])
+          (using monad: Monad[monad])
 
   def sequence(using buildFrom: BuildFrom[List[element], element, collection[element]])
   :     monad[collection[element]] =
@@ -69,8 +68,7 @@ extension [monad[_], collection[element] <: Iterable[element], element]
 
     recur(elems, monad.point(List())).map(_.reverse.to(buildFrom.toFactory(Nil)))
 
-extension [collection[element] <: Iterable[element], element]
-   (elems: collection[element])
+extension [collection[element] <: Iterable[element], element](elems: collection[element])
 
   def traverse[element2, monad[_]](lambda: element => monad[element2])
      (using monad:     Monad[monad],


### PR DESCRIPTION
Added some indentation to follow-on lines of `extension` signatures.