### PR TITLE
Provide a simple way of specifying non-empty `Text` values

### DIFF
--- a/lib/nomenclature/src/core/nomenclature.Required.scala
+++ b/lib/nomenclature/src/core/nomenclature.Required.scala
@@ -30,9 +30,12 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package nomenclature
 
-export nomenclature
-. { n, Check, MustContain, MustEnd, MustMatch, MustNotContain, MustNotEnd, MustNotEqual,
-    MustNotMatch, MustNotStart, MustStart, NameError, NameExtractor, Nominative, Rule, Name,
-    Required }
+import prepositional.*
+import rudiments.*
+
+object Required:
+  erased given Required is Nominative under MustNotEqual[""] = !!
+
+erased trait Required


### PR DESCRIPTION
Better support for non-empty text values using `Name[Required]`.