### PR TITLE
Better error messages for nonempty `Name`s

### DIFF
--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -164,7 +164,7 @@ object Bootstrapper:
           manifest2 - MainClass + require + burdockMain + verbosity
           + MainClass(fqcn"burdock.Bootstrap")
 
-        val tmpFile = jarfile.parent.vouch / Name(jarfile.name.vouch.text+t".tmp")
+        val tmpFile = jarfile.parent.vouch / Name(jarfile.name.vouch+t".tmp")
 
         Zipfile.write(tmpFile):
           ZipEntry(Path.parse[Zip](t"META-INF/MANIFEST.MF"), manifest3.serialize) #::

--- a/lib/fulminate/src/core/fulminate.Communicable.scala
+++ b/lib/fulminate/src/core/fulminate.Communicable.scala
@@ -39,7 +39,7 @@ import scala.quoted.*
 import anticipation.*
 
 object Communicable:
-  given text: Text is Communicable = Message(_)
+  given text: Text is Communicable = text => Message(if text == "".tt then "“”".tt else text)
   given string: String is Communicable = string => Message(string.tt)
   given char: Char is Communicable = char => Message(char.toString.tt)
   given int: Int is Communicable = int => Message(int.toString.tt)

--- a/lib/galilei/src/core/galilei.Dos.scala
+++ b/lib/galilei/src/core/galilei.Dos.scala
@@ -76,5 +76,5 @@ object Dos:
       val selfText: Text = t"."
 
       def element(element: Text): Name[Dos] = Name(element)
-      def elementText(element: Name[Dos]): Text = element.text
+      def elementText(element: Name[Dos]): Text = element
       def caseSensitivity: Case = Case.Upper

--- a/lib/galilei/src/core/galilei.Linux.scala
+++ b/lib/galilei/src/core/galilei.Linux.scala
@@ -74,7 +74,7 @@ object Linux:
       val parentElement: Text = t".."
       val selfText: Text = t"."
       def element(element: Text): Name[Linux] = Name(element)
-      def elementText(element: Name[Linux]): Text = element.text
+      def elementText(element: Name[Linux]): Text = element
       def caseSensitivity: Case = Case.Sensitive
 
 erased trait Linux extends Posix

--- a/lib/galilei/src/core/galilei.MacOs.scala
+++ b/lib/galilei/src/core/galilei.MacOs.scala
@@ -73,7 +73,7 @@ object MacOs:
       val selfText: Text = t"."
 
       def element(element: Text): Name[MacOs] = Name(element)
-      def elementText(element: Name[MacOs]): Text = element.text
+      def elementText(element: Name[MacOs]): Text = element
       def caseSensitivity: Case = Case.Preserving
 
 erased trait MacOs extends Posix

--- a/lib/galilei/src/core/galilei.Posix.scala
+++ b/lib/galilei/src/core/galilei.Posix.scala
@@ -72,7 +72,7 @@ object Posix:
       val selfText: Text = t"."
 
       def element(element: Text): Name[Posix] = Name(element)
-      def elementText(element: Name[Posix]): Text = element.text
+      def elementText(element: Name[Posix]): Text = element
       def caseSensitivity: Case = Case.Sensitive
 
 erased trait Posix extends Filesystem

--- a/lib/galilei/src/core/galilei.Windows.scala
+++ b/lib/galilei/src/core/galilei.Windows.scala
@@ -66,7 +66,7 @@ object Windows:
       val parentElement: Text = t".."
       val selfText: Text = t"."
       def element(element: Text): Name[Windows] = Name(element)
-      def elementText(element: Name[Windows]): Text = element.text
+      def elementText(element: Name[Windows]): Text = element
       def caseSensitivity: Case = Case.Preserving
 
   given radical: Tactic[PathError] => Windows is Radical from WindowsDrive = new Radical:

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -85,7 +85,7 @@ object Classpath:
       val parentElement: Text = t".."
       val selfText: Text = t".."
 
-      def elementText(element: Name[Classpath]): Text = element.text
+      def elementText(element: Name[Classpath]): Text = element
       def element(text: Text): Name[Classpath] = Name(text)
       def caseSensitivity: Case = Case.Sensitive
 

--- a/lib/nettlesome/src/url/nettlesome.Url.scala
+++ b/lib/nettlesome/src/url/nettlesome.Url.scala
@@ -89,7 +89,7 @@ object Url:
     val selfText: Text = t"."
 
     def element(element: Text): Name[HttpUrl] = Name(element)
-    def elementText(element: Name[HttpUrl]): Text = element.text
+    def elementText(element: Name[HttpUrl]): Text = element
     def caseSensitivity: Case = Case.Sensitive
 
   given abstractable: HttpUrl is Abstractable across Urls into Text = _.show

--- a/lib/nomenclature/src/core/nomenclature.MustNotEqual.scala
+++ b/lib/nomenclature/src/core/nomenclature.MustNotEqual.scala
@@ -36,6 +36,6 @@ import anticipation.*
 import fulminate.*
 import proscenium.*
 
-object MustNotEqual extends Rule({ text => m"must not equal $text"}, _ != _)
+object MustNotEqual extends Rule({ text => if text == "".tt then m"must not be empty" else m"must not equal $text" }, _ != _)
 
 erased trait MustNotEqual[text <: Label] extends Check[text]

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
@@ -43,12 +43,9 @@ import spectacular.*
 import scala.compiletime.*
 
 object Nomenclature:
-  opaque type Name[-platform] = anticipation.Text
+  opaque type Name[-platform] <: anticipation.Text = anticipation.Text
 
   object Name:
-    given communicable: [platform] => Name[platform] is Communicable = name => Message(name.text)
-    given encodable: [platform] => Name[platform] is Encodable in Text = _.text
-
     inline given decodable: [platform] => (platform is Nominative, Tactic[NameError])
                  =>  Name[platform] is Decodable in Text =
 
@@ -80,5 +77,3 @@ object Nomenclature:
       name.asInstanceOf[Name[platform]]
 
     given showable: [platform] => Name[platform] is Showable = identity(_)
-
-  extension [rules](name: Name[rules]) def text: Text = name

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -77,7 +77,7 @@ object Nomenclature2:
   def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])(using Quotes)
   :     Expr[Boolean] =
     parse[platform, name]
-    '{${Expr(constant[name])}.tt == $scrutinee.text}
+    '{${Expr(constant[name])}.tt == $scrutinee}
 
   def constant[text <: String: Type](using Quotes): text =
     import quotes.reflect.*

--- a/lib/nomenclature/src/test/nomenclature.Tests.scala
+++ b/lib/nomenclature/src/test/nomenclature.Tests.scala
@@ -50,12 +50,12 @@ object Tests extends Suite(m"Nomenclature tests"):
 
     test(m"Create a successful new name"):
       Name[Id](t"hello!")
-    .assert(_.text == t"hello!")
+    .assert(_ == t"hello!")
 
     test(m"Create a successful new name with inference"):
       val name: Name[Id] = Name(t"hello!")
       name
-    .assert(_.text == t"hello!")
+    .assert(_ == t"hello!")
 
     test(m"Name must not start with 0"):
       capture[NameError](Name[Id](t"0hello!")).message.show
@@ -79,4 +79,8 @@ object Tests extends Suite(m"Nomenclature tests"):
 
     test(m"Construct a new name at compiletime"):
       n"hello": Name[Id2]
-    .assert(_.text == t"hello")
+    .assert(_ == t"hello")
+
+    test(m"Name is required"):
+      capture[NameError](Name[Required](t"")).message.show
+    .assert(_ == t"""the name “” is not valid because it must not be empty""")

--- a/lib/zeppelin/src/core/zeppelin.ZipFile.scala
+++ b/lib/zeppelin/src/core/zeppelin.ZipFile.scala
@@ -81,7 +81,7 @@ object Zip:
     val selfText: Text = t"."
 
     def element(element: Text): Name[Zip] = Name(element)
-    def elementText(element: Name[Zip]): Text = element.text
+    def elementText(element: Name[Zip]): Text = element
     def caseSensitivity: Case = Case.Sensitive
 
 erased trait Zip


### PR DESCRIPTION
Customize the error message when attempting to create a `Name[Required]` from an empty string. This also improves the rendering of empty strings in `Message`s.