### PR TITLE
Generalized interception of events

### DIFF
--- a/lib/anamnesis/src/core/anamnesis.DataError.scala
+++ b/lib/anamnesis/src/core/anamnesis.DataError.scala
@@ -34,4 +34,4 @@ package anamnesis
 
 import fulminate.*
 
-case class DataError()(using Diagnostics) extends Error(m"Database error")
+case class DataError()(using Diagnostics) extends Error(m"there was a database error")

--- a/lib/austronesian/src/core/austronesian.StdlibError.scala
+++ b/lib/austronesian/src/core/austronesian.StdlibError.scala
@@ -35,4 +35,5 @@ package austronesian
 import anticipation.*
 import fulminate.*
 
-case class StdlibError()(using Diagnostics) extends Error(m"JavaError")
+case class StdlibError()(using Diagnostics)
+extends Error(m"could not deserialize from Java stdlib types")

--- a/lib/aviation/src/core/aviation.TimestampError.scala
+++ b/lib/aviation/src/core/aviation.TimestampError.scala
@@ -36,4 +36,4 @@ import anticipation.*
 import fulminate.*
 
 case class TimestampError(value: Text)(using Diagnostics)
-extends Error(m"The time $value could not be parsed")
+extends Error(m"the time $value could not be parsed")

--- a/lib/caesura/src/core/caesura.DsvError.scala
+++ b/lib/caesura/src/core/caesura.DsvError.scala
@@ -42,4 +42,4 @@ object DsvError:
     case MisplacedQuote
 
 case class DsvError(format: DsvFormat, reason: DsvError.Reason)(using Diagnostics)
-extends Error(m"Could not parse row data because $reason")
+extends Error(m"could not parse row data because $reason")

--- a/lib/camouflage/src/core/camouflage.Cache.scala
+++ b/lib/camouflage/src/core/camouflage.Cache.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package camouflage
 
+import java.lang as jl
+
 import anticipation.*
 import parasite.*
 import rudiments.*
@@ -48,8 +50,8 @@ class Cache[value](lifetime: Optional[Long]):
   private var value: Promise[value] = Promise()
 
   def establish(block: => value): value = value.synchronized:
-    if expiry < System.currentTimeMillis then value = Promise()
+    if expiry < jl.System.currentTimeMillis then value = Promise()
 
     if value.ready then value().vouch else block.tap: result =>
       value.offer(result)
-      expiry = lifetime.lay(Long.MaxValue)(_ + System.currentTimeMillis)
+      expiry = lifetime.lay(Long.MaxValue)(_ + jl.System.currentTimeMillis)

--- a/lib/contingency/src/core/contingency.Break.scala
+++ b/lib/contingency/src/core/contingency.Break.scala
@@ -35,4 +35,4 @@ package contingency
 import anticipation.*
 import fulminate.*
 
-case class Break[result](value: result) extends Error(m"Escaping")(using Diagnostics.omit)
+case class Break[result](value: result) extends Error(m"escaping")(using Diagnostics.omit)

--- a/lib/contingency/src/test/contingency.Tests.scala
+++ b/lib/contingency/src/test/contingency.Tests.scala
@@ -34,8 +34,8 @@ package contingency
 
 import soundness.*
 
-case class VarargsError(args: Text*)(using Diagnostics) extends Error(m"Varargs error")
-case class VarargsError2(arg: Text, args: Text*)(using Diagnostics) extends Error(m"Varargs error 2")
+case class VarargsError(args: Text*)(using Diagnostics) extends Error(m"varargs error")
+case class VarargsError2(arg: Text, args: Text*)(using Diagnostics) extends Error(m"varargs error 2")
 
 object Tests extends Suite(m"Contingency tests"):
 

--- a/lib/escritoire/src/core/escritoire.TableError.scala
+++ b/lib/escritoire/src/core/escritoire.TableError.scala
@@ -35,5 +35,5 @@ package escritoire
 import fulminate.*
 
 case class TableError(minimumWidth: Int, availableWidth: Int)(using Diagnostics)
-extends Error(m"""The table required a minimum width of $minimumWidth, but only $availableWidth was
+extends Error(m"""the table required a minimum width of $minimumWidth, but only $availableWidth was
                   available""")

--- a/lib/ethereal/src/core/ethereal-core.scala
+++ b/lib/ethereal/src/core/ethereal-core.scala
@@ -151,7 +151,7 @@ def cli[bus <: Matchable](using executive: Executive)
   lazy val termination: Unit =
     portFile.wipe()
     pidFile.wipe()
-    System.exit(0)
+    java.lang.System.exit(0)
 
   def shutdown(pid: Optional[Pid])(using Stdio): Unit logs DaemonLogEvent =
     Log.warn(DaemonLogEvent.Shutdown)
@@ -297,7 +297,7 @@ def cli[bus <: Matchable](using executive: Executive)
     import stdioSources.virtualMachine.ansi
     import asyncTermination.await
 
-    Hook.onShutdown:
+    System.intercept[Shutdown]:
       portFile.wipe()
       pidFile.wipe()
 

--- a/lib/eucalyptus/src/core/eucalyptus-core.scala
+++ b/lib/eucalyptus/src/core/eucalyptus-core.scala
@@ -99,9 +99,9 @@ extension (logObject: Log.type)
       private lazy val spool: Spool[writable.Operand] = Spool().tap: spool =>
         val task = async(spool.stream.writeTo(target))
 
-        Hook.onShutdown:
+        System.intercept[Shutdown]:
           spool.stop()
-          unsafely(task.await())
+          safely(task.await())
 
       def log(level: Level, realm: Realm, timestamp: Long, event: entry): Unit =
         spool.put(event.format(level, realm, timestamp))

--- a/lib/geodesy/src/core/geodesy.GeolocationError.scala
+++ b/lib/geodesy/src/core/geodesy.GeolocationError.scala
@@ -49,4 +49,4 @@ object GeolocationError:
     case Reason.BadUncertainty      => m"the `uncertainty` parameter vas not a valid number"
 
 case class GeolocationError(reason: GeolocationError.Reason)(using Diagnostics)
-extends Error(m"The geo URI is not in the correct format because $reason")
+extends Error(m"the geo URI is not in the correct format because $reason")

--- a/lib/gesticulate/src/core/gesticulate.MultipartError.scala
+++ b/lib/gesticulate/src/core/gesticulate.MultipartError.scala
@@ -52,4 +52,4 @@ object MultipartError:
 import MultipartError.Reason
 
 case class MultipartError(reason: MultipartError.Reason)(using Diagnostics)
-extends Error(m"The multipart data could not be read because $reason")
+extends Error(m"multipart data could not be read because $reason")

--- a/lib/hieroglyph/src/core/hieroglyph.CharEncodeError.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharEncodeError.scala
@@ -37,4 +37,4 @@ import language.experimental.captureChecking
 import fulminate.*
 
 case class CharEncodeError(char: Char, encoding: Encoding)(using Diagnostics)
-extends Error(m"The character $char cannot be encoded with the encoding $encoding")
+extends Error(m"character $char cannot be encoded with the encoding $encoding")

--- a/lib/merino/src/core/merino.JsonParseError.scala
+++ b/lib/merino/src/core/merino.JsonParseError.scala
@@ -117,4 +117,4 @@ object JsonParseError:
 import JsonParseError.Reason
 
 case class JsonParseError(line: Int, col: Int, reason: Reason)(using Diagnostics)
-extends Error(m"Could not parse JSON because $reason at ${line + 1}:${col + 1}")
+extends Error(m"could not parse JSON because $reason at ${line + 1}:${col + 1}")

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
@@ -76,3 +76,5 @@ object Nomenclature:
         case v => check[v.type](name)
 
       name.asInstanceOf[Name[platform]]
+
+    given showable: [platform] => Name[platform] is Showable = identity(_)

--- a/lib/parasite/src/core/parasite-core.scala
+++ b/lib/parasite/src/core/parasite-core.scala
@@ -35,6 +35,8 @@ package parasite
 import language.experimental.into
 import language.experimental.pureFunctions
 
+import java.lang as jl
+
 import scala.compiletime.*
 
 import anticipation.*
@@ -83,7 +85,7 @@ def async[result](using Codepoint)(evaluate: Worker ?=> result)(using Monitor, C
   Task(evaluate(using _), daemon = false, name = Unset)
 
 def task[result](using Codepoint)(name: into Text)(evaluate: Worker ?=> result)
-   (using Monitor, Codicil)
+     (using Monitor, Codicil)
 :     Task[result] =
 
   Task(evaluate(using _), daemon = false, name = name)
@@ -96,17 +98,16 @@ def snooze[duration: GenericDuration](duration: duration)(using Monitor): Unit =
   monitor.snooze(duration)
 
 def delay[generic: GenericDuration](duration: generic)(using Monitor): Unit =
-  hibernate(System.currentTimeMillis + generic.milliseconds(duration))
+  hibernate(jl.System.currentTimeMillis + generic.milliseconds(duration))
 
 def sleep[instant: Abstractable across Instants into Long](instant: instant)(using Monitor)
 :     Unit =
-  monitor.snooze(instant.generic - System.currentTimeMillis)
+  monitor.snooze(instant.generic - jl.System.currentTimeMillis)
 
 def hibernate[instant: Abstractable across Instants into Long](instant: instant)
    (using Monitor)
 :     Unit =
-  while instant.generic > System.currentTimeMillis
-  do sleep(instant.generic)
+  while instant.generic > jl.System.currentTimeMillis do sleep(instant.generic)
 
 extension [result](tasks: Seq[Task[result]])
   def sequence(using Monitor, Codicil): Task[Seq[result]] raises AsyncError =
@@ -123,8 +124,7 @@ extension [result](stream: Stream[result])
   def concurrent(using Monitor, Codicil): Stream[result] raises AsyncError =
     if async(stream.isEmpty).await() then Stream() else stream.head #:: stream.tail.concurrent
 
-def supervise[result](block: Monitor ?=> result)
-   (using model: ThreadModel, codepoint: Codepoint)
+def supervise[result](block: Monitor ?=> result)(using model: ThreadModel, codepoint: Codepoint)
 :     result raises AsyncError =
   block(using model.supervisor())
 
@@ -138,6 +138,7 @@ def retry[value](evaluate: (surrender: () => Nothing, persevere: () => Nothing) 
       sleep(summon[Tenacity].delay(attempt).or(abort(RetryError(attempt.n1))))
       def surrender = boundary.break(Perseverance.Surrender)
       def persevere = boundary.break(Perseverance.Persevere)
+
       Perseverance.Prevail(evaluate(using () => surrender, () => persevere))
 
     . match
@@ -147,4 +148,7 @@ def retry[value](evaluate: (surrender: () => Nothing, persevere: () => Nothing) 
 
   recur(Prim)
 
-export Parasite.Stale
+extension [target](value: target)
+  def intercept[event](using interceptable: event is Interceptable onto target)(action: => Unit)
+  :     Hook =
+    Hook(interceptable.register(value, action))

--- a/lib/parasite/src/core/parasite.Destruction.scala
+++ b/lib/parasite/src/core/parasite.Destruction.scala
@@ -32,7 +32,23 @@
                                                                                                   */
 package parasite
 
+import language.experimental.into
 import language.experimental.pureFunctions
 
-enum Transgression:
-  case Dispose, Escalate, Cancel
+import java.lang.ref as jlr
+
+import prepositional.*
+
+object Destruction:
+  given [value] => Destruction is Interceptable:
+    type Target = value
+
+    def register(value: value, action: => Unit): () => Unit =
+      var cancelled = false
+      val cleanable = System.cleaner.register(value, () => if !cancelled then action).nn
+
+      () =>
+        cancelled = true
+        cleanable.clean()
+
+erased trait Destruction

--- a/lib/parasite/src/core/parasite.Hook.scala
+++ b/lib/parasite/src/core/parasite.Hook.scala
@@ -35,13 +35,7 @@ package parasite
 import language.experimental.into
 import language.experimental.pureFunctions
 
+import prepositional.*
 
-class Hook(private val thread: Thread):
-  def cancel(): Unit = Runtime.getRuntime.nn.removeShutdownHook(thread)
-
-object Hook:
-  def onShutdown(block: => Unit): Hook =
-    val runnable: Runnable = () => block
-    val thread: Thread = Thread(runnable)
-    Runtime.getRuntime.nn.addShutdownHook(thread)
-    Hook(thread)
+class Hook(unregister: () => Unit):
+  def cancel(): Unit = unregister()

--- a/lib/parasite/src/core/parasite.Interceptable.scala
+++ b/lib/parasite/src/core/parasite.Interceptable.scala
@@ -32,7 +32,14 @@
                                                                                                   */
 package parasite
 
+import language.experimental.into
 import language.experimental.pureFunctions
 
-enum Transgression:
-  case Dispose, Escalate, Cancel
+import java.lang.ref as jlr
+
+import prepositional.*
+
+trait Interceptable:
+  type Self
+  type Target
+  def register(target: Target, action: => Unit): () => Unit

--- a/lib/parasite/src/core/parasite.Observation.scala
+++ b/lib/parasite/src/core/parasite.Observation.scala
@@ -32,10 +32,6 @@
                                                                                                   */
 package parasite
 
-object Parasite:
-  opaque type Stale[value] = value
-
-  extension [value](stale: Stale[value]) def apply(): value = stale
-
-  object Stale:
-    def apply[value](value: value): Stale[value] = value
+enum Observation[value]:
+  case Fresh(observation: value)
+  case Stale(observation: value)

--- a/lib/parasite/src/core/parasite.RetryError.scala
+++ b/lib/parasite/src/core/parasite.RetryError.scala
@@ -37,4 +37,4 @@ import language.experimental.captureChecking
 import fulminate.*
 
 case class RetryError(count: Int)(using Diagnostics)
-extends Error(m"Aborted repeated evaluation after $count attempts")
+extends Error(m"aborted repeated evaluation after $count attempts")

--- a/lib/parasite/src/core/parasite.Shutdown.scala
+++ b/lib/parasite/src/core/parasite.Shutdown.scala
@@ -30,3 +30,24 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
+package parasite
+
+import language.experimental.into
+import language.experimental.pureFunctions
+
+import java.lang.ref as jlr
+
+import prepositional.*
+
+object Shutdown:
+  given Shutdown is Interceptable:
+    type Target = System.type
+
+    def register(value: System.type, action: => Unit): () => Unit =
+      val runnable: Runnable = () => action
+      val thread: Thread = Thread(runnable)
+      Runtime.getRuntime.nn.addShutdownHook(thread)
+
+      () => Runtime.getRuntime.nn.removeShutdownHook(thread)
+
+erased trait Shutdown

--- a/lib/parasite/src/core/parasite.System.scala
+++ b/lib/parasite/src/core/parasite.System.scala
@@ -32,7 +32,12 @@
                                                                                                   */
 package parasite
 
+import language.experimental.into
 import language.experimental.pureFunctions
 
-enum Transgression:
-  case Dispose, Escalate, Cancel
+import java.lang.ref as jlr
+
+import prepositional.*
+
+object System:
+  private[parasite] val cleaner: jlr.Cleaner = jlr.Cleaner.create().nn

--- a/lib/parasite/src/core/parasite.Tenacity.scala
+++ b/lib/parasite/src/core/parasite.Tenacity.scala
@@ -46,11 +46,10 @@ trait Tenacity:
       if attempt.n1 > n then abort(RetryError(attempt.n1 - 1)) else tenacity.delay(attempt)
 
 object Tenacity:
-  def exponential[duration: GenericDuration](initial: duration, base: Double): Tenacity =
-    new:
-      def delay(attempt: Ordinal): Optional[Long] raises RetryError =
-        if attempt == Prim then 0L
-        else (duration.milliseconds(initial)*math.pow(base, attempt.n1)).toLong
+  def exponential[duration: GenericDuration](initial: duration, base: Double): Tenacity = new:
+    def delay(attempt: Ordinal): Optional[Long] raises RetryError =
+      if attempt == Prim then 0L
+      else (duration.milliseconds(initial)*math.pow(base, attempt.n1)).toLong
 
   def fixed[generic: GenericDuration](duration: generic): Tenacity = new:
     def delay(attempt: Ordinal): Optional[Long] raises RetryError =

--- a/lib/parasite/src/core/soundness+parasite-core.scala
+++ b/lib/parasite/src/core/soundness+parasite-core.scala
@@ -35,7 +35,8 @@ package soundness
 export parasite
 . { Codicil, Completion, AsyncError, Daemon, Hook, Monitor, Promise, Task, ThreadModel, Chain,
     Transgression, monitor, daemon, async, task, relent, cancel, sleep, snooze, hibernate, delay,
-    race, supervise, Tenacity, retry, Stale, trap }
+    race, supervise, Tenacity, retry, Observation, trap, System, Destruction, Shutdown, intercept,
+    Interceptable }
 
 package threadModels:
   export parasite.threadModels.{platform, virtual, adaptive}

--- a/lib/scintillate/src/server/scintillate.ServerError.scala
+++ b/lib/scintillate/src/server/scintillate.ServerError.scala
@@ -35,4 +35,4 @@ package scintillate
 import fulminate.*
 
 case class ServerError(port: Int)(using Diagnostics)
-extends Error(m"Could not start an HTTP server on port $port")
+extends Error(m"could not start an HTTP server on port $port")

--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -35,6 +35,7 @@ package turbulence
 import language.adhocExtensions
 
 import java.io as ji
+import java.lang as jl
 import java.util.zip as juz
 
 import anticipation.*
@@ -72,10 +73,10 @@ package stdioSources:
 
   package system:
     given textOnly: Stdio =
-      Stdio(System.out.nn, System.err.nn, System.in.nn, termcapDefinitions.basic)
+      Stdio(jl.System.out.nn, jl.System.err.nn, jl.System.in.nn, termcapDefinitions.basic)
 
     given ansi: Stdio =
-      Stdio(System.out.nn, System.err.nn, System.in.nn, termcapDefinitions.xterm256)
+      Stdio(jl.System.out.nn, jl.System.err.nn, jl.System.in.nn, termcapDefinitions.xterm256)
 
   package virtualMachine:
     given textOnly: Stdio =
@@ -115,12 +116,12 @@ extension [element](stream: Stream[element])
     def recur(stream: Stream[element], last: Long): Stream[element] =
       stream.flow(Stream()):
         val duration2 =
-          SpecificDuration(generic.milliseconds(duration) - (System.currentTimeMillis - last))
+          SpecificDuration(generic.milliseconds(duration) - (jl.System.currentTimeMillis - last))
 
         if generic.milliseconds(duration2) > 0 then snooze(duration2)
         stream
 
-    async(recur(stream, System.currentTimeMillis)).await()
+    async(recur(stream, jl.System.currentTimeMillis)).await()
 
   def multiplexWith(that: Stream[element])(using Monitor): Stream[element] =
     unsafely(Stream.multiplex(stream, that))
@@ -200,7 +201,7 @@ package lineSeparation:
   given carriageReturnLinefeed: LineSeparation(NewlineSeq.CrLf, Skip, Lf, Nl, LfNl)
   given adaptiveLinefeed: LineSeparation(NewlineSeq.Lf, Nl, Nl, Nl, Nl)
 
-  given virtualMachine: LineSeparation = System.lineSeparator.nn match
+  given virtualMachine: LineSeparation = jl.System.lineSeparator.nn match
     case "\r\n"    => carriageReturnLinefeed
     case "\r"      => carriageReturn
     case "\n"      => linefeed
@@ -221,7 +222,7 @@ extension (obj: Stream.type)
     (null.asInstanceOf[element] #:: stream).tail
 
   def pulsar[generic: GenericDuration](duration: generic)(using Monitor): Stream[Unit] =
-    val startTime: Long = System.currentTimeMillis
+    val startTime: Long = jl.System.currentTimeMillis
 
     def recur(iteration: Int): Stream[Unit] =
       try
@@ -283,13 +284,13 @@ extension (stream: Stream[Bytes])
           val free = dest.length - destPos
 
           if ready < free then
-            System.arraycopy(source, sourcePos, dest, destPos, ready)
+            jl.System.arraycopy(source, sourcePos, dest, destPos, ready)
             recur(more, 0, dest, destPos + ready)
           else if free < ready then
-            System.arraycopy(source, sourcePos, dest, destPos, free)
+            jl.System.arraycopy(source, sourcePos, dest, destPos, free)
             dest.immutable(using Unsafe) #:: recur(stream, sourcePos + free, newArray(), 0)
           else // free == ready
-            System.arraycopy(source, sourcePos, dest, destPos, free)
+            jl.System.arraycopy(source, sourcePos, dest, destPos, free)
             dest.immutable(using Unsafe) #:: recur(more, 0, newArray(), 0)
 
         case _ =>
@@ -310,13 +311,13 @@ extension (stream: Stream[Bytes])
           val free = dest.length - destPos
 
           if ready < free then
-            System.arraycopy(source, sourcePos, dest, destPos, ready)
+            jl.System.arraycopy(source, sourcePos, dest, destPos, ready)
             recur(more, 0, dest, destPos + ready)
           else if free < ready then
-            System.arraycopy(source, sourcePos, dest, destPos, free)
+            jl.System.arraycopy(source, sourcePos, dest, destPos, free)
             dest.immutable(using Unsafe) #:: recur(stream, sourcePos + free, newArray(), 0)
           else // free == ready
-            System.arraycopy(source, sourcePos, dest, destPos, free)
+            jl.System.arraycopy(source, sourcePos, dest, destPos, free)
             dest.immutable(using Unsafe) #:: recur(more, 0, newArray(), 0)
 
         case _ =>
@@ -358,7 +359,7 @@ extension (stream: Stream[Bytes])
         val count = length.min(available())
 
         if count == 0 then -1 else
-          if count > 0 then System.arraycopy(focus, offset, array, arrayOffset, count)
+          if count > 0 then jl.System.arraycopy(focus, offset, array, arrayOffset, count)
           offset += count
           count
 


### PR DESCRIPTION
Supports the generalized interception of lifecycle events on the JVM. For now this includes the destruction (GC) of an object and shutdown of the JVM, but it should be flexible enough to support other events too.