### PR TITLE
Mandible improvements

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -881,7 +881,7 @@ object mandible extends SoundnessModule {
   }
 
   object test extends ProbablyTestModule {
-    def moduleDeps = Seq(probably.cli, core, revolution.core)
+    def moduleDeps = Seq(probably.cli, core, revolution.core, quantitative.units)
   }
 }
 

--- a/build.mill
+++ b/build.mill
@@ -874,7 +874,10 @@ object legerdemain extends SoundnessModule {
 object mandible extends SoundnessModule {
   object core extends SoundnessSubModule {
     def moduleDeps = Seq(hellenism.core, hyperbole.core, escritoire.core)
-    def compileIvyDeps = Agg(ivy"org.scala-lang:scala3-staging_3:${scalaVersion()}")
+    def ivyDeps = Agg(
+      ivy"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      ivy"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
   }
 
   object test extends ProbablyTestModule {

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -187,7 +187,7 @@ object StackTrace:
             case 'i' => token(idx,         "$minus",               "-")
             case _   => skip()
           case 'p' => char(idx + 2) match
-            case 'a' => token(idx,         "$package",             "⋮π")
+            case 'a' => token(idx,         "$package",             "⋮")
             case 'e' => token(idx,         "$percent",             "%")
             case 'l' => token(idx,         "$plus",                "+")
             case _   => skip()
@@ -228,7 +228,10 @@ object StackTrace:
 
     else if rewritten.s.endsWith("#") then
       val pivot = rewritten.s.lastIndexOf(".")
-      (rewritten.s.substring(0, pivot).nn+".Ξ"+rewritten.s.substring(pivot + 1).nn.dropRight(1)).tt
+      val sub = if rewritten.s.endsWith("⋮#") then "⋮" else "Ξ"
+
+      (rewritten.s.substring(0, pivot).nn+"."+sub+rewritten.s.substring(pivot + 1).nn.dropRight(1))
+      . tt
     else rewritten
 
   def apply(exception: Throwable): StackTrace =

--- a/lib/digression/src/core/digression.StackTrace.scala
+++ b/lib/digression/src/core/digression.StackTrace.scala
@@ -53,10 +53,11 @@ object StackTrace:
      ("λₙ".tt -> "anonymous function".tt,
       "αₙ".tt -> "anonymous class".tt,
       "ι".tt  -> "initialization".tt,
-      "ς".tt  -> "super reference".tt,
-      "⋮ε".tt -> "extension method".tt,
-      "ϕ".tt  -> "direct".tt,
-      "⋮π".tt -> "package file".tt,
+      "↑".tt  -> "super reference".tt,
+      "⊢".tt  -> "extension method".tt,
+      "∂".tt  -> "direct".tt,
+      "δ".tt  -> "default".tt,
+      "⋮⋮".tt -> "package file".tt,
       "ⲛ".tt  -> "class initializer".tt,
       "ℓ".tt  -> "lazy initializer".tt,
       "Σ".tt  -> "specialized method".tt,
@@ -130,7 +131,7 @@ object StackTrace:
         case 's' =>
           if (0 until 6).all { i => char(idx + i) == "super$"(i) }
           then
-            buffer.append("ς")
+            buffer.append("↑")
             recur(idx + 6)
           else
             buffer.append("s")
@@ -155,13 +156,13 @@ object StackTrace:
           case 'd' => char(idx + 2) match
             case 'e' => token(idx,         "$default",             "δ")
             case 'i' => char(idx + 3) match
-              case 'r' => token(idx,       "$direct",              "⋮ϕ")
+              case 'r' => token(idx,       "$direct",              "∂")
               case 'v' => token(idx,       "$div",                 "/")
               case _   => skip()
             case _   => skip()
           case 'e' => char(idx + 2) match
             case 'q' => token(idx,         "$eq",                  "=")
-            case 'x' => token(idx,         "$extension",           "⋮ε")
+            case 'x' => token(idx,         "$extension",           "⊢")
             case _   => skip()
           case 'g' => token(idx,           "$greater",             ">")
           case 'h' => token(idx,           "$hash",                "#")

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -39,6 +39,7 @@ import gossamer.*
 import hieroglyph.*
 import iridescence.*
 import spectacular.*
+import symbolism.*
 import vacuous.*
 
 object Teletypeable:

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -37,6 +37,7 @@ import digression.*
 import fulminate.*
 import gossamer.*
 import hieroglyph.*
+import iridescence.*
 import spectacular.*
 import vacuous.*
 
@@ -65,7 +66,34 @@ object Teletypeable:
 
   given error: Error is Teletypeable = _.message.teletype
 
+  private val pkgColor = Fg(0xffff00)
+  private val clsColor = Fg(0xff0000)
+  private val methColor = Fg(0x00ffff)
+
   given stackTrace: (Text is Measurable) => StackTrace is Teletypeable = stack =>
+    def heat(level: Int): Int = level match
+      case 0 => 0xd84020
+      case 1 => 0xd88600
+      case 2 => 0xdede00
+      case 3 => 0xfefe00
+      case _ => 0xaefe00
+
+    def dedup[element]
+         (todo: List[element], seen: Set[element] = Set(), done: List[element] = Nil)
+    :     List[element] =
+      todo match
+        case Nil => done
+
+        case head :: tail =>
+          if seen.contains(head) then dedup(tail, seen, done)
+          else dedup(tail, seen + head, head :: done)
+
+    val packages: Map[Text, Int] =
+      dedup[Text](stack.frames.map(_.method.prefix), Set(), Nil)
+      . zipWithIndex.map: (prefix, idx) =>
+          prefix -> heat(idx)
+      . to(Map)
+
     val methodWidth = stack.frames.map(_.method.method.length).maxOption.getOrElse(0)
     val classWidth = stack.frames.map(_.method.className.length).maxOption.getOrElse(0)
     val fileWidth = stack.frames.map(_.file.length).maxOption.getOrElse(0)
@@ -73,18 +101,30 @@ object Teletypeable:
     val fullClass = e"$Italic(${stack.component}.$Bold(${stack.className}))"
     val init = e"${Fg(0xffffff)}($fullClass): ${stack.message}"
 
+    var lastClass: Text = t""
+
     val root = stack.frames.foldLeft(init):
       case (msg, frame) =>
-        val obj = frame.method.className.ends(t"#")
-        val drop = if obj then 1 else 0
+        val obj = frame.method.cls.starts(t"Ξ")
         val file = e"${Fg(0x5f9e9f)}(${frame.file.fit(fileWidth, Rtl)})"
-        val dot = if obj then t"." else t"#"
+        val dot = if obj then t"." else t"⌗"
+
+        val sameClass = frame.method.className == lastClass
+        lastClass = frame.method.className
 
         val className =
-          e"${Fg(0xc61485)}(${frame.method.className.skip(drop, Rtl).fit(classWidth, Rtl)})"
+          val color = packages(frame.method.prefix)
+          if sameClass
+          then
+            e"${Fg(color)}(${t"|  |  |  |  |  |  | ".fit(frame.method.className.length, Rtl)})"
+            . fit(classWidth, Rtl)
+          else
 
-        val method = e"${Fg(0xdb6f92)}(${frame.method.method.fit(methodWidth)})"
-        val line = e"${Fg(0x47d1cc)}(${frame.line.let(_.show).or(t"?")})"
+            e"${Fg(color/2)}(${frame.method.prefix}.$Bold(${Fg(color)}(${frame.method.cls})))"
+            . fit(classWidth, Rtl)
+
+        val method = e"${Fg(0xdbdf92)}(${frame.method.method.fit(methodWidth)})"
+        val line = e"${Fg(0x47d1cc)}(${frame.line.let(_.show).or(t"")})"
         val gray = Fg(0x808080)
         e"$msg\n  $gray(at) $className$gray($dot)$method $file$gray(:)$line"
 
@@ -96,12 +136,12 @@ object Teletypeable:
     val method = e"${Fg(0xdb6f92)}(${frame.method.method.fit(40)})"
     val file = e"${Fg(0x5f9e9f)}(${frame.file.fit(18, Rtl)})"
     val line = e"${Fg(0x47d1cc)}(${frame.line.let(_.show).or(t"?")})"
-    e"$className${Fg(0x808080)}(#)$method $file${Fg(0x808080)}(:)$line"
+    e"$className${Fg(0x808080)}( # )$method $file${Fg(0x808080)}(:)$line"
 
   given method: StackTrace.Method is Teletypeable = method =>
     val className = e"${Fg(0xc61485)}(${method.className})"
     val methodName = e"${Fg(0xdb6f92)}(${method.method})"
-    e"$className${Fg(0x808080)}(#)$methodName"
+    e"$className${Fg(0x808080)}( # )$methodName"
 
   given double: (decimalizer: Decimalizer) => Double is Teletypeable = double =>
     Teletype.make(decimalizer.decimalize(double), _.copy(fg = 0xffd600))

--- a/lib/gossamer/src/core/gossamer.Textual.scala
+++ b/lib/gossamer/src/core/gossamer.Textual.scala
@@ -58,7 +58,7 @@ trait Textual extends Concatenable, Countable, Segmentable, Zeroic:
   def indexOf(text: Self, sub: Text, start: Ordinal = Prim): Optional[Ordinal]
   def builder(size: Optional[Int] = Unset): Builder[Self]
   def segment(text: Self, interval: Interval): Self
-  protected def makeZero(): Self = empty
+  inline def zero(): Self = empty
 
 object Textual:
   def apply[textual: Textual](text: Text): textual = textual(text)

--- a/lib/mandible/src/core/mandible-core.scala
+++ b/lib/mandible/src/core/mandible-core.scala
@@ -41,6 +41,7 @@ import scala.quoted.*
 import anthology.*
 import anticipation.*
 import contingency.*
+import digression.*
 import escritoire.*
 import escapade.*
 import fulminate.*
@@ -67,7 +68,7 @@ import filesystemOptions.createNonexistent.disabled
 import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.disabled
 
-def disassemble(code: Quotes ?=> Expr[Any])(using TemporaryDirectory)
+def disassemble(using codepoint: Codepoint)(code: Quotes ?=> Expr[Any])(using TemporaryDirectory)
      (using classloader: Classloader)
 :     Bytecode =
   val uuid = Uuid()
@@ -83,7 +84,7 @@ def disassemble(code: Quotes ?=> Expr[Any])(using TemporaryDirectory)
     val file: Path on Linux = out / Name(t"Generated$$Code$$From$$Quoted.class")
     staging.run(code)
     val classfile: Classfile = new Classfile(file.open(_.read[Bytes]))
-    classfile.methods.find(_.name == t"apply").map(_.bytecode).get.vouch.copy(sourceFile = Unset)
+    classfile.methods.find(_.name == t"apply").map(_.bytecode).get.vouch.embed(codepoint)
 
 
 case class ClassfileError()(using Diagnostics)

--- a/lib/mandible/src/core/mandible-core.scala
+++ b/lib/mandible/src/core/mandible-core.scala
@@ -82,7 +82,7 @@ def disassemble(using codepoint: Codepoint)(code: Quotes ?=> Expr[Any])(using Te
 
   unsafely:
     val file: Path on Linux = out / Name(t"Generated$$Code$$From$$Quoted.class")
-    staging.run(code)
+    staging.withQuotes(code)
     val classfile: Classfile = new Classfile(file.open(_.read[Bytes]))
     classfile.methods.find(_.name == t"apply").map(_.bytecode).get.vouch.embed(codepoint)
 

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -52,6 +52,7 @@ import prepositional.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 import turbulence.*
 import vacuous.*
 
@@ -63,7 +64,10 @@ object Bytecode:
   given Bytecode is Teletypeable = bytecode =>
     val table = Table[Instruction]
                  (Column(e"$Bold(Source)", textAlign = TextAlignment.Right): line =>
-                    e"${rgb"#ddddbb"}(${line.line.let(_.show+t":").or(t"")})",
+                    line.line.let: line =>
+                      val source = e"${rgb"#88aabb"}(${bytecode.sourceFile.or(t"")})"
+                      e"$source:${rgb"#ddddbb"}(${line.show})"
+                    . or(e""),
                   Column(e"")(_.offset.show.subscripts),
                   Column(e"$Bold(Opcode)")(_.opcode.teletype),
                   Column(e"$Bold(Stack)")(_.stack.let(_.teletype).or(e"")))
@@ -366,12 +370,15 @@ object Bytecode:
         case 170 | 171 | 187 | 188 | 189 | 197| 194 | 195 | 191 | 185 | 186 =>
           3
 
+        case opcode =>
+          panic(m"unrecognized opcode $opcode")
+
     def highlight: Rgb24 = cost match
       case 0 => rgb"#1a6a6c"
       case 1 => rgb"#659e24"
       case 2 => rgb"#e3a232"
       case 3 => rgb"#b31250"
-      case 5 => rgb"#777777"
+      case _ => rgb"#777777"
 
 
     def transform(stack: List[Frame]): List[Frame] =
@@ -618,6 +625,9 @@ object Bytecode:
         case 199 => Ifnonnull(0)
         case 200 => GotoW(0)
         case 201 => JsrW(0)
+
+        case opcode =>
+          panic(m"unrecognized opcode $opcode")
 
     given Opcode is Teletypeable = opcode =>
       opcode.show.cut(t" ") match
@@ -883,4 +893,4 @@ object Bytecode:
       case Impdep1                  => t"imp·dep₁"
       case Impdep2                  => t"imp·dep₂"
 
-case class Bytecode(instructions: Bytecode.Instruction*)
+case class Bytecode(sourceFile: Optional[Text], instructions: Bytecode.Instruction*)

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -79,10 +79,15 @@ object Bytecode:
     e"${rgb"#aaaaaa"}(${stack.reverse.map(_.teletype).join(e"┃ ", e" ┊ ", e"")})"
 
   object Frame:
-    given showable: Frame is Showable = _.toString.tt.lower
+    given showable: Frame is Showable =
+      case Array(frame) => t"[$frame]"
+      case L(name)      => t"*$name"
+      case other        => other.toString.tt
 
   enum Frame:
-    case Obj, Val, Nul, Idx, Arr, Res, Adr, Key, Arg
+    case Z, B, C, S, I, J, F, D
+    case L(name: Text)
+    case Array(frame: Frame)
 
   case class Instruction
               (opcode: Opcode, line: Optional[Int], stack: Optional[List[Frame]], offset: Int)
@@ -384,31 +389,32 @@ object Bytecode:
     def transform(stack: List[Frame]): List[Frame] =
       import Frame.*
       this match
+        case anyithng => stack
         case Nop                      => stack
-        case New(_)                   => Obj :: stack
-        case Dup                      => Val :: Val :: stack.tail
-        case Invokespecial(_, _)      => Res :: stack.tail // FIXME
+        case New(_)                   => L(t"class") :: stack
+        case Dup                      => stack.head :: stack.head :: stack.tail
+        case Invokespecial(_, _)      => L(t"unknown") :: stack.tail // FIXME
         case Astore(_)                => stack.tail
         case Astore1                  => stack.tail
         case Astore2                  => stack.tail
         case Astore3                  => stack.tail
-        case Aload(_)                 => Obj :: stack
-        case Aload0                   => Obj :: stack
-        case Aload1                   => Obj :: stack
-        case Aload2                   => Obj :: stack
-        case Aload3                   => Obj :: stack
-        case Athrow                   => Obj :: Nil
-        case Areturn                  => Obj :: Nil
-        case Iload1                   => Val :: stack
-        case Checkcast(_)             => Obj :: stack.tail
-        case Invokedynamic(_)         => Res :: stack.tail // FIXME
-        case Getstatic(_)             => Val :: stack
-        case Invokevirtual(_, _)      => Res :: stack.tail
-        case Invokestatic(_, _)       => Res :: stack.tail
-        case Invokeinterface(_, _, _) => Res :: stack.tail
+        case Aload(_)                 => L(t"?") :: stack
+        case Aload0                   => L(t"?") :: stack
+        case Aload1                   => L(t"?") :: stack
+        case Aload2                   => L(t"?") :: stack
+        case Aload3                   => L(t"?") :: stack
+        case Athrow                   => L(t"?") :: Nil
+        case Areturn                  => L(t"?") :: Nil
+        case Iload1                   => I :: stack
+        case Checkcast(_)             => L(t"?") :: stack.tail
+        case Invokedynamic(_)         => L(t"?") :: stack.tail // FIXME
+        case Getstatic(_)             => L(t"?") :: stack
+        case Invokevirtual(_, _)      => L(t"?") :: stack.tail
+        case Invokestatic(_, _)       => L(t"?") :: stack.tail
+        case Invokeinterface(_, _, _) => L(t"?") :: stack.tail
         case Ifnonnull(_)             => stack.tail
         case Ifeq(_)                  => stack.tail
-        case Instanceof(_)            => Res :: stack.tail
+        case Instanceof(_)            => L(t"?") :: stack.tail
         case opcode                   => unsafely(throw Exception("Unhandled "+opcode))
 
   object Opcode:
@@ -425,7 +431,8 @@ object Bytecode:
           case 185 => Invokeinterface(classname, method, 0)
 
       case invocation: jlci.InvokeDynamicInstruction =>
-        Invokedynamic(invocation.name.nn.stringValue.nn.tt)
+        val method = StackTrace.rewrite(invocation.name.nn.stringValue.nn, true)
+        Invokedynamic(method)
 
       case other => source.opcode.nn.bytecode match
         case 0   => Nop
@@ -893,4 +900,4 @@ object Bytecode:
       case Impdep1                  => t"imp·dep₁"
       case Impdep2                  => t"imp·dep₂"
 
-case class Bytecode(sourceFile: Optional[Text], instructions: Bytecode.Instruction*)
+case class Bytecode(sourceFile: Optional[Text], instructions: List[Bytecode.Instruction])

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -825,10 +825,10 @@ object Bytecode:
       case Putstatic(_)             => t"put·static"
       case Getfield(_)              => t"get·field"
       case Putfield(_)              => t"put·field"
-      case Invokevirtual(cls, name) => t"invoke·virtual $cls#$name"
-      case Invokespecial(cls, name) => t"invoke·special $cls.$name"
-      case Invokestatic(cls, name)  => t"invoke·static $cls.$name"
-      case Invokeinterface(cls, name, _) => t"invoke·interface $cls#$name"
+      case Invokevirtual(cls, name) => t"invoke·virtual $cls # $name"
+      case Invokespecial(cls, name) => t"invoke·special $cls . $name"
+      case Invokestatic(cls, name)  => t"invoke·static $cls . $name"
+      case Invokeinterface(cls, name, _) => t"invoke·interface $cls # $name"
       case Invokedynamic(name)      => t"invoke·dynamic $name"
       case New(_)                   => t"new"
       case Newarray(_)              => t"new·array"
@@ -900,4 +900,9 @@ object Bytecode:
       case Impdep1                  => t"imp·dep₁"
       case Impdep2                  => t"imp·dep₂"
 
-case class Bytecode(sourceFile: Optional[Text], instructions: List[Bytecode.Instruction])
+case class Bytecode(sourceFile: Optional[Text], instructions: List[Bytecode.Instruction]):
+  def embed(codepoint: Codepoint): Bytecode =
+    val instructions2 = instructions.map: instruction =>
+      instruction.copy(line = instruction.line.let(_ + codepoint.line - 1))
+
+    Bytecode(codepoint.source.cut(t"/").last, instructions2)

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -61,7 +61,7 @@ import columnAttenuation.ignore
 import jlc.attribute.UnknownAttribute
 
 object Classfile:
-  given Classfile is Aggregable by Bytes = stream => new Classfile(stream.read[Bytes])
+  given aggregable: Classfile is Aggregable by Bytes = stream => new Classfile(stream.read[Bytes])
 
   def apply(name: Text)(using classloader: Classloader): Optional[Classfile] =
     classloader(name).let(new Classfile(_))
@@ -118,7 +118,7 @@ class Classfile(data: Bytes):
 
       val instructions = recur(code.elementList.nn.asScala.to(List), Unset, Nil, Nil, 0)
 
-      Bytecode(sourceFile, instructions*)
+      Bytecode(sourceFile, instructions)
 
 
   private lazy val model: jlc.ClassModel = jlc.ClassFile.of().nn.parse(unsafely(data.mutable)).nn

--- a/lib/mandible/src/core/mandible.Mandible.scala
+++ b/lib/mandible/src/core/mandible.Mandible.scala
@@ -47,6 +47,7 @@ import prepositional.*
 import proscenium.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 import turbulence.*
 import vacuous.*
 

--- a/lib/mandible/src/test/mandible.Tests.scala
+++ b/lib/mandible/src/test/mandible.Tests.scala
@@ -36,14 +36,20 @@ import soundness.*
 
 import classloaders.threadContext
 import stdioSources.virtualMachine.ansi
+import temporaryDirectories.environment
 
 object Tests extends Suite(m"Mandible tests"):
   def run(): Unit =
-    test(m"One plus one"):
+    // test(m"One plus one"):
 
-      disassemble[Manifest](_.serialize).let: bytecode =>
-        Out.println(bytecode.teletype)
+    //   disassemble[Manifest](_.serialize).let: bytecode =>
+    //     Out.println(bytecode.teletype)
 
-      val rewrite =
-        Classfile[StackTrace].let(_.methods.find(_.name == t"rewrite").getOrElse(Unset)).vouch
-    . assert()
+    //   val rewrite =
+    //     Classfile[StackTrace].let(_.methods.find(_.name == t"rewrite").getOrElse(Unset)).vouch
+    // . assert()
+    //
+    test(m"Compile something"):
+      Out.println(disassemble('{ List(1, 2, 3).total }).teletype)
+      1
+    .assert(_ == 1)

--- a/lib/mandible/src/test/mandible.Tests.scala
+++ b/lib/mandible/src/test/mandible.Tests.scala
@@ -51,8 +51,7 @@ object Tests extends Suite(m"Mandible tests"):
     //
     test(m"Compile something"):
       Out.println(disassemble('{
-       val x = 3.6*Metre
-       println(x)
+       println("Hello world")
       }).teletype)
 
       1

--- a/lib/mandible/src/test/mandible.Tests.scala
+++ b/lib/mandible/src/test/mandible.Tests.scala
@@ -50,6 +50,10 @@ object Tests extends Suite(m"Mandible tests"):
     // . assert()
     //
     test(m"Compile something"):
-      Out.println(disassemble('{ List(1, 2, 3).total }).teletype)
+      Out.println(disassemble('{
+       val x = 3.6*Metre
+       println(x)
+      }).teletype)
+
       1
     .assert(_ == 1)

--- a/lib/mandible/src/test/mandible.Tests.scala
+++ b/lib/mandible/src/test/mandible.Tests.scala
@@ -46,6 +46,4 @@ object Tests extends Suite(m"Mandible tests"):
 
       val rewrite =
         Classfile[StackTrace].let(_.methods.find(_.name == t"rewrite").getOrElse(Unset)).vouch
-
-      println(rewrite.bytecode)
     . assert()

--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -130,7 +130,7 @@ extension [value](iterable: Iterable[value])
   :     Optional[value] =
     compiletime.summonFrom:
       case zeroic: ((? <: value) is Zeroic) =>
-        iterable.foldLeft(zeroic.zero)(addable.add)
+        iterable.foldLeft(zeroic.zero())(addable.add)
 
       case _ =>
         if iterable.isEmpty then Unset else iterable.tail.foldLeft(iterable.head)(addable.add)

--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -142,7 +142,7 @@ extension [value](iterable: Iterable[value])
   :     Optional[divisible.Result] =
    compiletime.summonFrom:
      case zeroic: ((? <: value) is Zeroic) =>
-       iterable.foldLeft[value](zeroic.zero)(addable.add)/iterable.size.toDouble
+       iterable.foldLeft[value](zeroic.zero())(addable.add)/iterable.size.toDouble
 
      case _ =>
        iterable.total.let(_/iterable.size.toDouble)

--- a/lib/symbolism/src/core/symbolism.Multiplicable.scala
+++ b/lib/symbolism/src/core/symbolism.Multiplicable.scala
@@ -70,7 +70,7 @@ object Multiplicable:
     type Result = textual
 
     def multiply(text: textual, count: Int): textual =
-      var result: textual = textual.zero
+      var result: textual = textual.zero()
       for i <- 0 until count do result = result+text
       result
 

--- a/lib/symbolism/src/core/symbolism.Zeroic.scala
+++ b/lib/symbolism/src/core/symbolism.Zeroic.scala
@@ -33,15 +33,27 @@
 package symbolism
 
 object Zeroic:
-  given long: Long is Zeroic = () => 0L
-  given int: Int is Zeroic = () => 0
-  given short: Short is Zeroic = () => 0.toShort
-  given byte: Byte is Zeroic = () => 0.toByte
-  given double: Double is Zeroic = () => 0.0
-  given float: Float is Zeroic = () => 0.0f
-  given string: String is Zeroic = () => ""
+  given long: Long is Zeroic:
+    inline def zero(): Long = 0L
+
+  given int: Int is Zeroic:
+    inline def zero(): Int = 0
+
+  given short: Short is Zeroic:
+    inline def zero(): Short = 0.toShort
+
+  given byte: Byte is Zeroic:
+    inline def zero(): Byte = 0.toByte
+
+  given double: Double is Zeroic:
+    inline def zero(): Double = 0.0
+
+  given float: Float is Zeroic:
+    inline def zero(): Float = 0.0f
+
+  given string: String is Zeroic:
+    inline def zero(): String = ""
 
 trait Zeroic:
   type Self
-  protected def makeZero(): Self
-  def zero: Self = makeZero()
+  def zero(): Self


### PR DESCRIPTION
It's now possible to get the bytecode for arbitrary code. You need to write the code in quotes and pass it as a parameter to the `disassemble` method. Like this:
```scala
val bytecode: Bytecode = disassemble('{ println("Hello world") })
```

This will currently produce output that looks like this:
```
                   Source        Opcode                                     Stack
╶─────────────────────────────────────────────────────────────────────────────────╴
  mandible.Tests.scala:53   ₀    get·static                                 ┃
                            ₃    ldc                                        ┃
                            ₅    invoke·virtual scala.ΞPredef # println()   ┃
                            ₈    get·static                                 ┃
                            ₁₁   a·return                                   ┃
```
