### PR TITLE
Fix several errors with the `metronome` implementation

### DIFF
--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -225,9 +225,9 @@ extension (obj: Stream.type)
 
     def recur(iteration: Int): Stream[Unit] =
       try
-        snooze(startTime + generic.milliseconds(duration)*iteration)
-        () #:: metronome(duration)
-      catch case err: AsyncError => Stream()
+        sleep(startTime + generic.milliseconds(duration)*iteration)
+        () #:: recur(iteration + 1)
+      catch case error: AsyncError => Stream()
 
     recur(0)
 


### PR DESCRIPTION
There was a very high density of errors in just a few lines of the `metronome` implementation, which meant that it had no chance of working. It does now.