### PR TITLE
Sufficient changes for Cellulose tests to compile again

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -198,6 +198,7 @@ object test extends ScalaModule {
     baroque.test,
     burdock.test,
     cataclysm.test,
+    cellulose.test,
     charisma.test,
     chiaroscuro.test,
     contextual.test,
@@ -228,7 +229,6 @@ object test extends ScalaModule {
 
     // Not compiling
     // bitumen
-    // cellulose
     // coaxial
     // cosmopolite
     // dendrology

--- a/lib/escapade/src/test/escapade.Tests.scala
+++ b/lib/escapade/src/test/escapade.Tests.scala
@@ -32,16 +32,9 @@
                                                                                                   */
 package escapade
 
-import contingency.*
-import gossamer.*
-import iridescence.*, colors.{Red, Yellow}
-import probably.*
-import rudiments.*
-import spectacular.*
-import vacuous.*
-import yossarian.*
+import soundness.*
 
-import escapes.*
+import webColors.{Red, Yellow}
 
 object Tests extends Suite(m"Escapade tests"):
   def run(): Unit =

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -92,6 +92,7 @@ object Tests extends Suite(m"Soundness tests"):
 object FailingTests extends Suite(m"Failing tests"):
   def run(): Unit =
     baroque.Tests()
+    cellulose.Tests()
     chiaroscuro.Tests()
     mandible.Tests()
     monotonous.Tests()


### PR DESCRIPTION
Various changes had been made to Contingency, and not reflected in the Cellulose tests, that made these changes necessary. Many tests still don't pass, but this is a step in the right direction.