### PR TITLE
Compile `ansi` and `md` modules of Harlequin

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -139,7 +139,8 @@ object soundness extends ScalaModule {
 
   object tool extends SoundnessGroupModule {
     def moduleDeps = Seq(anthology.core, harlequin.core, hellenism.core, hyperbole.core,
-        octogenarian.core, revolution.core, umbrageous.plugin, anthology.java)
+        octogenarian.core, revolution.core, umbrageous.plugin, anthology.java, harlequin.md,
+        harlequin.ansi)
   }
 
   object web extends SoundnessGroupModule {
@@ -862,11 +863,19 @@ object hallucination extends SoundnessModule {
 object harlequin extends SoundnessModule {
   object core extends SoundnessSubModule {
     def moduleDeps = Seq(anthology.scala, gossamer.core)
-    def compileIvyDeps = Agg(ivy"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+    def ivyDeps = Agg(ivy"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+  }
+
+  object ansi extends SoundnessSubModule {
+    def moduleDeps = Seq(core, escapade.core)
+  }
+
+  object md extends SoundnessSubModule {
+    def moduleDeps = Seq(core, punctuation.html, honeycomb.core)
   }
 
   object test extends ProbablyTestModule {
-    def moduleDeps = Seq(probably.cli, core)
+    def moduleDeps = Seq(probably.cli, ansi, md)
   }
 }
 
@@ -1584,7 +1593,9 @@ object publishing extends Module {
     gossamer.core.publishLocal().t()
     guillotine.core.publishLocal().t()
     hallucination.core.publishLocal().t()
+    harlequin.ansi.publishLocal().t()
     harlequin.core.publishLocal().t()
+    harlequin.md.publishLocal().t()
     hellenism.core.publishLocal().t()
     hieroglyph.core.publishLocal().t()
     honeycomb.core.publishLocal().t()

--- a/lib/harlequin/src/ansi/harlequin-ansi.scala
+++ b/lib/harlequin/src/ansi/harlequin-ansi.scala
@@ -37,6 +37,7 @@ import gossamer.*
 import hieroglyph.*, textMetrics.uniform
 import iridescence.*
 import spectacular.*
+import symbolism.*
 import vacuous.*
 
 package syntaxHighlighting:

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -147,7 +147,6 @@ object SourceCode:
 
     SourceCode(language, 1, IArray(lines(stream().to(List)).reverse*))
 
-
   private class Trees() extends ast.untpd.UntypedTreeTraverser:
     import ast.*, untpd.*
 

--- a/lib/harlequin/src/core/soundness+harlequin-core.scala
+++ b/lib/harlequin/src/core/soundness+harlequin-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export harlequin.{Accent, ProgrammingLanguage, SourceCode, SourceToken}
+export harlequin.{Accent, ProgrammingLanguage, SourceCode, SourceToken, Scala, Java}


### PR DESCRIPTION
These two modules had been forgotten. It was possible to make them both compile with minimal changes.