### PR TITLE
Unify the `html` extension method to use `Renderable`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1215,7 +1215,7 @@ object profanity extends SoundnessModule {
 
 object punctuation extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq(gossamer.core, turbulence.core)
+    def moduleDeps = Seq(gossamer.core, turbulence.core, honeycomb.core)
     def ivyDeps = Agg(
       ivy"com.vladsch.flexmark:flexmark:0.42.12",
       ivy"com.vladsch.flexmark:flexmark-ext-tables:0.42.12",
@@ -1229,7 +1229,7 @@ object punctuation extends SoundnessModule {
   }
 
   object ansi extends SoundnessSubModule {
-    def moduleDeps = Seq(core, honeycomb.core, escapade.core, harlequin.core)
+    def moduleDeps = Seq(core, escapade.core, harlequin.core)
   }
 
   object test extends ProbablyTestModule {

--- a/lib/cellulose/src/core/cellulose.Codl.scala
+++ b/lib/cellulose/src/core/cellulose.Codl.scala
@@ -266,7 +266,7 @@ object Codl:
     then CodlDoc() else recur(stream, Proto(), Nil, Map(), Nil, 0, subs.reverse, Stream(), Nil)
 
   def tokenize(in: Stream[Text], fromStart: Boolean = false)(using Diagnostics)
-  :     (Int, Stream[CodlToken]) =
+  :     (Int, Stream[CodlToken]) raises CodlError =
 
     val reader: PositionReader = new PositionReader(in.map(identity))
 
@@ -281,7 +281,7 @@ object Codl:
       val ch = reader.next()
       if ch.char == '\n' || ch.char == ' ' then cue(count + 1) else (ch, count)
 
-    val (first: Character, start: Int) = try throwErrors(cue(0)) catch case err: CodlError => ???
+    val (first: Character, start: Int) = cue(0)
     val margin: Int = first.column
 
     def istream
@@ -303,7 +303,7 @@ object Codl:
     :     Stream[CodlToken] =
 
       inline def next(): Character =
-        try throwErrors(reader.next())
+        try reader.next()
         catch case err: CodlError => Character('\n', err.line, err.col)
 
       inline def recur

--- a/lib/harlequin/src/md/harlequin.CommonEmbedding.scala
+++ b/lib/harlequin/src/md/harlequin.CommonEmbedding.scala
@@ -34,10 +34,20 @@ package harlequin
 
 import anticipation.*
 import gossamer.*
-import honeycomb.*
-import punctuation.*
+import harlequin.*
+import honeycomb.*, html5.*
+import spectacular.*
 import vacuous.*
 
-object ScalaRenderer extends Renderer(t"scala"), CommonRenderer:
-  def render(meta: Optional[Text], content: Text): Seq[Html[Flow]] =
-    postprocess(Scala.highlight(content))
+trait CommonEmbedding:
+  def className(accent: Accent): List[CssClass] = List(CssClass(accent.show.lower))
+
+  def element(accent: Accent, text: Text): Element["code"] =
+    html5.Code(`class` = className(accent))(text)
+
+  protected def postprocess(source: SourceCode): Seq[Html[Flow]] =
+    val code = source.lines.map: line =>
+      Span.line:
+        line.map { case SourceToken(text, accent) => element(accent, text) }
+
+    List(Div.amok(Pre(code)))

--- a/lib/harlequin/src/md/harlequin.JavaEmbedding.scala
+++ b/lib/harlequin/src/md/harlequin.JavaEmbedding.scala
@@ -34,20 +34,10 @@ package harlequin
 
 import anticipation.*
 import gossamer.*
-import harlequin.*
-import honeycomb.*, html5.*
-import spectacular.*
+import honeycomb.*
+import punctuation.*
 import vacuous.*
 
-trait CommonRenderer:
-  def className(accent: Accent): List[CssClass] = List(CssClass(accent.show.lower))
-
-  def element(accent: Accent, text: Text): Element["code"] =
-    html5.Code(`class` = className(accent))(text)
-
-  protected def postprocess(source: SourceCode): Seq[Html[Flow]] =
-    val code = source.lines.map: line =>
-      Span.line:
-        line.map { case SourceToken(text, accent) => element(accent, text) }
-
-    List(Div.amok(Pre(code)))
+object JavaEmbedding extends Embedding(t"java"), CommonEmbedding:
+  def render(meta: Optional[Text], content: Text): Seq[Html[Flow]] =
+    postprocess(Java.highlight(content))

--- a/lib/harlequin/src/md/harlequin.ScalaEmbedding.scala
+++ b/lib/harlequin/src/md/harlequin.ScalaEmbedding.scala
@@ -30,11 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package punctuation
+package harlequin
 
 import anticipation.*
+import gossamer.*
 import honeycomb.*
+import punctuation.*
 import vacuous.*
 
-abstract class Renderer(val language: Optional[Text]):
-  def render(meta: Optional[Text], content: Text): Seq[Html[Flow]]
+object ScalaEmbedding extends Embedding(t"scala"), CommonEmbedding:
+  def render(meta: Optional[Text], content: Text): Seq[Html[Flow]] =
+    postprocess(Scala.highlight(content))

--- a/lib/harlequin/src/md/punctuation+harlequin-md.scala
+++ b/lib/harlequin/src/md/punctuation+harlequin-md.scala
@@ -34,5 +34,5 @@ package punctuation
 
 import harlequin.*
 
-package htmlRenderers:
-  given scalaSyntax: HtmlConverter = HtmlConverter(ScalaRenderer, JavaRenderer)
+package htmlEmbeddings:
+  given scalaSyntax: HtmlTranslator = HtmlTranslator(ScalaEmbedding, JavaEmbedding)

--- a/lib/harlequin/src/md/soundness+harlequin-md.scala
+++ b/lib/harlequin/src/md/soundness+harlequin-md.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export harlequin.{CommonRenderer, JavaRenderer, ScalaRenderer}
+export harlequin.{CommonEmbedding, JavaEmbedding, ScalaEmbedding}
 
-package htmlRenderers:
-  export punctuation.htmlRenderers.scalaSyntax
+package htmlEmbeddings:
+  export punctuation.htmlEmbeddings.scalaSyntax

--- a/lib/honeycomb/src/core/honeycomb-core.scala
+++ b/lib/honeycomb/src/core/honeycomb-core.scala
@@ -39,7 +39,7 @@ import vacuous.*
 import language.dynamics
 
 extension [renderable: Renderable](value: renderable)
-  def html: List[Html[renderable.Result]] = renderable.html(value)
+  def html: Seq[Html[renderable.Result]] = renderable.html(value)
 
 extension (context: StringContext)
   def cls(): CssClass = CssClass(context.parts.head.tt)

--- a/lib/honeycomb/src/core/honeycomb.Renderable.scala
+++ b/lib/honeycomb/src/core/honeycomb.Renderable.scala
@@ -43,8 +43,9 @@ object Renderable:
 
   given message: Message is Renderable into Phrasing = message =>
     message.segments.flatMap:
-      case text: Text       => List(text)
       case message: Message => message.html
+      case text: Text       => List(text)
+      case _                => Nil
 
 
   given abstractable: [value: Abstractable across HtmlContent into List[Sgml]]
@@ -52,7 +53,7 @@ object Renderable:
     type Self = value
     type Result = Label
 
-    def html(value: value): List[Html[Result]] = value.generic.map(convert)
+    def html(value: value): Seq[Html[Result]] = value.generic.map(convert)
 
     private def convert(html: Sgml): Html[?] = html match
       case Sgml.Textual(text)               => text
@@ -65,4 +66,4 @@ object Renderable:
 trait Renderable:
   type Self
   type Result <: Label
-  def html(value: Self): List[Html[Result]]
+  def html(value: Self): Seq[Html[Result]]

--- a/lib/legerdemain/src/core/legerdemain-core.scala
+++ b/lib/legerdemain/src/core/legerdemain-core.scala
@@ -60,11 +60,11 @@ extension [formulaic: {Formulaic, Encodable in Query}](value: formulaic)
 
 package formulations:
   given default: Formulation:
-    def form(content: List[Html[Flow]], submit: Optional[Text]): Html[Flow] =
+    def form(content: Seq[Html[Flow]], submit: Optional[Text]): Html[Flow] =
       Form(action = t".", method = Method.Post)(content, Input.Submit(value = submit.or(t"Submit")))
 
     def element
-         (widget:     List[Html[Phrasing]],
+         (widget:     Seq[Html[Phrasing]],
           legend:     Text,
           validation: Optional[Message],
           required:   Boolean)

--- a/lib/legerdemain/src/core/legerdemain.Combobox.scala
+++ b/lib/legerdemain/src/core/legerdemain.Combobox.scala
@@ -41,7 +41,7 @@ import vacuous.*
 import html5.*
 
 object Combobox:
-  given renderable: Combobox is Renderable into Phrasing = combobox => List[Html[Phrasing]]
+  given renderable: Combobox is Renderable into Phrasing = combobox => Seq[Html[Phrasing]]
    (Input(name = combobox.name, list = DomId(combobox.name), value = combobox.value),
     Datalist(id = DomId(combobox.name)):
       combobox.options.map: option =>

--- a/lib/legerdemain/src/core/legerdemain.Formulation.scala
+++ b/lib/legerdemain/src/core/legerdemain.Formulation.scala
@@ -38,10 +38,10 @@ import honeycomb.*
 import vacuous.*
 
 trait Formulation:
-  def form(content: List[Html[Flow]], submit: Optional[Text]): Html[Flow]
+  def form(content: Seq[Html[Flow]], submit: Optional[Text]): Html[Flow]
 
   def element
-       (widget:     List[Html[Phrasing]],
+       (widget:     Seq[Html[Phrasing]],
         legend:     Text,
         validation: Optional[Message],
         required:   Boolean)

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import contingency.*
 import distillate.*
 import gossamer.*
+import honeycomb.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
@@ -68,6 +69,14 @@ object Markdown:
   given decoder: Tactic[MarkdownError] => InlineMd is Decodable in Text = parseInline(_)
   given encodable: InlineMd is Encodable in Text = _.serialize
   given showable: InlineMd is Showable = _.serialize
+
+  given renderable: [markdown <: Markdown[Markdown.Ast.Node]] => (translator: Translator)
+        => markdown is Renderable into Flow =
+    content => translator.translate(content.nodes)
+
+  given renderable2: [markdown <: Markdown.Ast.Inline] => (translator: Translator)
+        => markdown is Renderable into Phrasing =
+    translator.phrasing(_)
 
   object Ast:
     type Node = Block | Inline

--- a/lib/punctuation/src/core/punctuation.Translator.scala
+++ b/lib/punctuation/src/core/punctuation.Translator.scala
@@ -30,14 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package harlequin
+package punctuation
 
-import anticipation.*
-import gossamer.*
 import honeycomb.*
-import punctuation.*
-import vacuous.*
 
-object JavaRenderer extends Renderer(t"java"), CommonRenderer:
-  def render(meta: Optional[Text], content: Text): Seq[Html[Flow]] =
-    postprocess(Java.highlight(content))
+trait Translator:
+  def translate(nodes: Seq[Markdown.Ast.Node]): Seq[Html[Flow]]
+  def phrasing(node: Markdown.Ast.Inline): Seq[Html[Phrasing]]

--- a/lib/punctuation/src/core/soundness+punctuation-core.scala
+++ b/lib/punctuation/src/core/soundness+punctuation-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export punctuation.{Markdown, MarkdownError, Md, md, InlineMd}
+export punctuation.{Markdown, MarkdownError, Md, md, InlineMd, Translator}

--- a/lib/punctuation/src/html/punctuation-html.scala
+++ b/lib/punctuation/src/html/punctuation-html.scala
@@ -35,13 +35,6 @@ package punctuation
 import honeycomb.*
 import proscenium.*
 
-extension (value: Markdown[Markdown.Ast.Node])(using conv: HtmlConverter)
-  def html: Seq[Html[Flow]] = conv.convert(value.nodes)
-
-extension (value: Markdown.Ast.Inline)(using conv: HtmlConverter)
-  @targetName("html2")
-  def html: Seq[Html[Phrasing]] = conv.phrasing(value)
-
-package htmlRenderers:
-  given standard: HtmlConverter = HtmlConverter()
-  given outline: HtmlConverter = OutlineConverter
+package htmlEmbeddings:
+  given standard: HtmlTranslator = HtmlTranslator()
+  given outline: Outliner.type = Outliner

--- a/lib/punctuation/src/html/punctuation.Embedding.scala
+++ b/lib/punctuation/src/html/punctuation.Embedding.scala
@@ -30,59 +30,11 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package legerdemain
+package punctuation
 
 import anticipation.*
-import contingency.*
-import distillate.*
-import fulminate.*
-import gossamer.*
 import honeycomb.*
-import prepositional.*
 import vacuous.*
-import wisteria.*
 
-import html5.*
-
-object Formulaic extends ProductDerivable[Formulaic]:
-  given elicitable: [value]
-        => (elicitable: value is Elicitable)
-        => (renderable: elicitable.Operand is Renderable into Phrasing)
-        =>  value is Formulaic:
-
-    def fields
-         (pointer:     Pointer,
-          legend:      Text,
-          query:       Query,
-          validation:  Validation,
-          formulation: Formulation)
-    :     Seq[Html[Flow]] =
-
-      val message: Optional[Message] = validation(pointer)
-      val widget = renderable.html(elicitable.widget(pointer.text, legend, query().or(t"")))
-      val required = false//safely(decodable.decoded(t"")).absent
-      List(formulation.element(widget, legend, message, required))
-
-  inline def join[derivation <: Product: ProductReflection]: derivation is Formulaic =
-    (pointer, legend, query, errors, formulation) =>
-      val content: IArray[Html[Flow]] =
-        contexts:
-          [field] => context =>
-            val label2 = if pointer == Pointer.Self then Pointer(label) else pointer(label)
-            val legend = label.uncamel.map(_.lower.capitalize).spaced
-            context.fields(label2, legend, query(label), errors, formulation)
-
-        . flatten
-
-      List(Fieldset(Legend(legend), content))
-
-trait Formulaic:
-  type Self
-
-  def fields
-       (pointer:     Pointer,
-        legend:      Text,
-        query:       Query,
-        validation:  Validation,
-        formulation: Formulation)
-  : Seq[Html[Flow]]
+abstract class Embedding(val language: Optional[Text]):
+  def render(meta: Optional[Text], content: Text): Seq[Html[Flow]]

--- a/lib/punctuation/src/html/punctuation.Outliner.scala
+++ b/lib/punctuation/src/html/punctuation.Outliner.scala
@@ -39,11 +39,11 @@ import honeycomb.*, html5.*
 import proscenium.*
 import vacuous.*
 
-object OutlineConverter extends HtmlConverter():
+object Outliner extends HtmlTranslator():
   case class Entry(label: Text, children: List[Entry])
 
-  override def convert(nodes: Seq[Markdown.Ast.Node]): Seq[Html[Flow]] =
-    def recur(entries: List[Entry]): List[Html[Ul.Content]] = entries.map: entry =>
+  override def translate(nodes: Seq[Markdown.Ast.Node]): Seq[Html[Flow]] =
+    def recur(entries: List[Entry]): Seq[Html[Ul.Content]] = entries.map: entry =>
       val link = A(href = t"#${slug(entry.label)}")(entry.label)
       if entry.children.isEmpty then Li(link) else Li(link, Ul(recur(entry.children)))
 

--- a/lib/punctuation/src/html/soundness+punctuation-html.scala
+++ b/lib/punctuation/src/html/soundness+punctuation-html.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export punctuation.{HtmlConverter, OutlineConverter, Renderer}
+export punctuation.{HtmlTranslator, Outliner, Embedding}
 
-package htmlRenderers:
-  export punctuation.htmlRenderers.{standard, outline}
+package htmlEmbeddings:
+  export punctuation.htmlEmbeddings.{standard, outline}

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -49,6 +49,7 @@ object Tests extends Suite(m"Soundness tests"):
     capricious.Tests()
     cardinality.Tests()
     cataclysm.Tests()
+    cellulose.Tests()
     charisma.Tests()
     contextual.Tests()
     contingency.Tests()
@@ -115,7 +116,6 @@ object Tests extends Suite(m"Soundness tests"):
 object FailingTests extends Suite(m"Failing tests"):
   def run(): Unit =
     baroque.Tests()
-    cellulose.Tests()
     chiaroscuro.Tests()
     enigmatic.Tests()
     mandible.Tests()


### PR DESCRIPTION
We had three definitions of `html`—one for general `Renderable`s, and two for `Markdown`. These have been unified.