### PR TITLE
Rename `Count` to `Quanta` and related changes

### DIFF
--- a/lib/abacist/src/core/abacist-core.scala
+++ b/lib/abacist/src/core/abacist-core.scala
@@ -36,11 +36,11 @@ import quantitative.*
 
 import scala.quoted.*
 
-export Abacist2.Count
+export Abacist2.Quanta
 
 type TimeMinutes = (Hours[1], Minutes[1])
 type TimeSeconds = (Hours[1], Minutes[1], Seconds[1])
 
 extension [units <: Measure](inline quantity: Quantity[units])
-  inline def count[count <: Tuple]: Count[count] =
+  inline def quanta[count <: Tuple]: Quanta[count] =
     ${Abacist.fromQuantity[units, count]('quantity)}

--- a/lib/abacist/src/core/abacist.Abacist2.scala
+++ b/lib/abacist/src/core/abacist.Abacist2.scala
@@ -42,50 +42,50 @@ import symbolism.*
 import scala.compiletime.*, ops.int.*
 
 object Abacist2:
-  opaque type Count[units <: Tuple] = Long
+  opaque type Quanta[units <: Tuple] = Long
 
-  object Count:
-    erased given underlying: [units <: Tuple] => Underlying[Count[units], Long] = !!
-    given zeroic: [units <: Tuple] => Count[units] is Zeroic:
-      inline def zero: Count[units] = 0L
+  object Quanta:
+    erased given underlying: [units <: Tuple] => Underlying[Quanta[units], Long] = !!
+    given zeroic: [units <: Tuple] => Quanta[units] is Zeroic:
+      inline def zero: Quanta[units] = 0L
 
-    given typeable: [units <: Tuple] => Typeable[Count[units]]:
-      def unapply(count: Any): Option[count.type & Count[units]] = count.asMatchable match
+    given typeable: [units <: Tuple] => Typeable[Quanta[units]]:
+      def unapply(count: Any): Option[count.type & Quanta[units]] = count.asMatchable match
         case count: Long => Some(count)
         case _           => None
 
 
-    def fromLong[units <: Tuple](long: Long): Count[units] = long
-    given integral: [units <: Tuple] => Integral[Count[units]] = summon[Integral[Long]]
+    def fromLong[units <: Tuple](long: Long): Quanta[units] = long
+    given integral: [units <: Tuple] => Integral[Quanta[units]] = summon[Integral[Long]]
 
-    inline def apply[units <: Tuple](inline values: Int*): Count[units] =
+    inline def apply[units <: Tuple](inline values: Int*): Quanta[units] =
       ${Abacist.make[units]('values)}
 
-    given addable: [units <: Tuple] => Count[units] is Addable:
-      type Operand = Count[units]
-      type Result = Count[units]
+    given addable: [units <: Tuple] => Quanta[units] is Addable:
+      type Operand = Quanta[units]
+      type Result = Quanta[units]
 
-      def add(left: Count[units], right: Count[units]): Count[units] = left + right
+      def add(left: Quanta[units], right: Quanta[units]): Quanta[units] = left + right
 
-    given subtractable: [units <: Tuple] => Count[units] is Subtractable:
-      type Operand = Count[units]
-      type Result = Count[units]
+    given subtractable: [units <: Tuple] => Quanta[units] is Subtractable:
+      type Operand = Quanta[units]
+      type Result = Quanta[units]
 
-      def subtract(left: Count[units], right: Count[units]): Count[units] = left - right
+      def subtract(left: Quanta[units], right: Quanta[units]): Quanta[units] = left - right
 
-    given multiplicable: [units <: Tuple] => Count[units] is Multiplicable:
+    given multiplicable: [units <: Tuple] => Quanta[units] is Multiplicable:
       type Operand = Double
-      type Result = Count[units]
+      type Result = Quanta[units]
 
-      def multiply(left: Count[units], right: Double): Count[units] = left.multiply(right)
+      def multiply(left: Quanta[units], right: Double): Quanta[units] = left.multiply(right)
 
-    given divisible: [units <: Tuple] => Count[units] is Divisible:
+    given divisible: [units <: Tuple] => Quanta[units] is Divisible:
       type Operand = Double
-      type Result = Count[units]
+      type Result = Quanta[units]
 
-      def divide(left: Count[units], right: Double): Count[units] = left.divide(right)
+      def divide(left: Quanta[units], right: Double): Quanta[units] = left.divide(right)
 
-    inline given showable: [units <: Tuple] => Count[units] is Showable = summonFrom:
+    inline given showable: [units <: Tuple] => Quanta[units] is Showable = summonFrom:
       case names: UnitsNames[units] => count =>
         val nonzeroComponents = count.components.filter(_(1) != 0)
         val nonzeroUnits = nonzeroComponents.map(_(1).toString.tt).to(List)
@@ -96,26 +96,26 @@ object Abacist2:
         val nonzeroComponents = count.components.filter(_(1) != 0)
         nonzeroComponents.map { (unit, count) => count.toString+unit }.mkString(" ").tt
 
-  extension [units <: Tuple](count: Count[units])
+  extension [units <: Tuple](count: Quanta[units])
     def longValue: Long = count
 
-  extension [units <: Tuple](inline count: Count[units])
+  extension [units <: Tuple](inline count: Quanta[units])
     @targetName("negate")
-    inline def `unary_-`: Count[units] = -count
+    inline def `unary_-`: Quanta[units] = -count
 
     inline def apply[unit[power <: Nat] <: Units[power, ? <: Dimension]]: Int =
       ${Abacist.get[units, unit[1]]('count)}
 
     transparent inline def quantity: Any = ${Abacist.toQuantity[units]('count)}
-    inline def components: ListMap[Text, Long] = ${Abacist.describeCount[units]('count)}
+    inline def components: ListMap[Text, Long] = ${Abacist.describeQuanta[units]('count)}
 
     transparent inline def multiply(inline multiplier: Double): Any =
-      ${Abacist.multiplyCount('count, 'multiplier, false)}
+      ${Abacist.multiplyQuanta('count, 'multiplier, false)}
 
     transparent inline def divide(inline multiplier: Double): Any =
-      ${Abacist.multiplyCount('count, 'multiplier, true)}
+      ${Abacist.multiplyQuanta('count, 'multiplier, true)}
 
     transparent inline def collapse(length: Int)(using length.type < Tuple.Size[units] =:= true)
-    :     Count[Tuple.Drop[units, length.type]] =
+    :     Quanta[Tuple.Drop[units, length.type]] =
 
       count

--- a/lib/abacist/src/core/soundness+abacist-core.scala
+++ b/lib/abacist/src/core/soundness+abacist-core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export abacist.{Count, UnitsNames}
+export abacist.{Quanta, UnitsNames, quanta}

--- a/lib/abacist/src/test/abacist.Tests.scala
+++ b/lib/abacist/src/test/abacist.Tests.scala
@@ -47,160 +47,160 @@ given decimalizer: Decimalizer = Decimalizer(3)
 
 object Tests extends Suite(m"Abacist Tests"):
   def run(): Unit =
-    suite(m"Count tests"):
+    suite(m"Quanta tests"):
       type Height = (Feet[1], Inches[1])
 
       test(m"Access seconds in an HMS time"):
-        val hmsTime = Count[TimeSeconds](27, 18, 9)
+        val hmsTime = Quanta[TimeSeconds](27, 18, 9)
         hmsTime[Seconds]
       .assert(_ == 9)
 
       test(m"Access minutes in an HMS time"):
-        val hmsTime = Count[TimeSeconds](27, 18, 9)
+        val hmsTime = Quanta[TimeSeconds](27, 18, 9)
         hmsTime[Minutes]
       .assert(_ == 18)
 
       test(m"Access hours in an HMS time"):
-        val hmsTime = Count[TimeSeconds](27, 18, 9)
+        val hmsTime = Quanta[TimeSeconds](27, 18, 9)
         hmsTime[Hours]
       .assert(_ == 27)
 
       test(m"Access inches in an imperial distance"):
-        val imperialDistance = Count[(Miles[1], Yards[1], Feet[1], Inches[1])](1800, 4, 2, 11)
+        val imperialDistance = Quanta[(Miles[1], Yards[1], Feet[1], Inches[1])](1800, 4, 2, 11)
         imperialDistance[Feet]
       .assert(_ == 2)
 
       test(m"Units of different dimensions cannot be mixed"):
         demilitarize:
-          Count[(Miles[1], Yards[1], Seconds[1], Inches[1])](1, 2, 3)
+          Quanta[(Miles[1], Yards[1], Seconds[1], Inches[1])](1, 2, 3)
       .assert(_.nonEmpty)
 
-      test(m"Convert a length to a Count"):
+      test(m"Convert a length to a Quanta"):
         val length: Quantity[Metres[1]] = (5.9*Foot + 10.0*Inch)
-        val count = length.count[Height]
+        val count = length.quanta[Height]
         (count[Feet], count[Inches])
       .assert(_ == (6, 9))
 
       type Weight = (Stones[1], Pounds[1], Ounces[1])
 
-      test(m"Convert a mass Quantity to a Count"):
+      test(m"Convert a mass Quantity to a Quanta"):
         val weight: Quantity[Kilograms[1]] = 20.0*Kilo(Gram)
-        val count = weight.count[Weight]
+        val count = weight.quanta[Weight]
         (count[Stones], count[Pounds], count[Ounces])
       .assert(_ == (3, 2, 1))
 
-      test(m"Convert a Count to a Quantity"):
-        val weight: Count[Weight] = Count(5, 6)
+      test(m"Convert a Quanta to a Quantity"):
+        val weight: Quanta[Weight] = Quanta(5, 6)
         weight.quantity
       .assert(_ == 2.438057*Kilo(Gram))
 
-      test(m"Convert a Count to a Quantity in pounds"):
-        val weight: Count[Weight] = Count(5, 6)
+      test(m"Convert a Quanta to a Quantity in pounds"):
+        val weight: Quanta[Weight] = Quanta(5, 6)
         weight.quantity.in[Pounds]
       .assert(_ == 5.375*Pound)
 
-      test(m"Add two Counts"):
-        val weight: Count[Weight] = Count(12, 9)
-        val sum: Count[Weight] = weight + Count[Weight](1)
+      test(m"Add two Quantas"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val sum: Quanta[Weight] = weight + Quanta[Weight](1)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 12, 10))
 
-      test(m"Add two Counts 2"):
-        val weight: Count[Weight] = Count(12, 9)
-        val sum: Count[Weight] = weight + Count[Weight](2)
+      test(m"Add two Quantas 2"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val sum: Quanta[Weight] = weight + Quanta[Weight](2)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 12, 11))
 
-      test(m"Add two Counts 3"):
-        val weight: Count[Weight] = Count(12, 9)
-        val sum: Count[Weight] = weight + Count[Weight](5)
+      test(m"Add two Quantas 3"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val sum: Quanta[Weight] = weight + Quanta[Weight](5)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 12, 14))
 
-      test(m"Add two Counts 4"):
-        val weight: Count[Weight] = Count(12, 9)
-        val sum: Count[Weight] = weight + Count[Weight](7)
+      test(m"Add two Quantas 4"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val sum: Quanta[Weight] = weight + Quanta[Weight](7)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 13, 0))
 
-      test(m"Add two Counts 5"):
-        val weight: Count[Weight] = Count(12, 9)
-        val sum: Count[Weight] = weight + Count[Weight](8)
+      test(m"Add two Quantas 5"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val sum: Quanta[Weight] = weight + Quanta[Weight](8)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (0, 13, 1))
 
-      test(m"Subtract two Counts 1"):
-        val weight: Count[Weight] = Count(12, 9)
-        val weight2: Count[Weight] = Count(0, 2)
+      test(m"Subtract two Quantas 1"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val weight2: Quanta[Weight] = Quanta(0, 2)
         val result = weight - weight2
         (result[Stones], result[Pounds], result[Ounces])
       .assert(_ == (0, 12, 7))
 
-      test(m"Subtract two Counts 2"):
-        val weight: Count[Weight] = Count(12, 9)
-        val weight2: Count[Weight] = Count(0, 2)
+      test(m"Subtract two Quantas 2"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
+        val weight2: Quanta[Weight] = Quanta(0, 2)
         val result = weight2 - weight
         (result[Stones], result[Pounds], result[Ounces])
       .assert(_ == (0, -12, -7))
 
-      test(m"Multiply a count by a double"):
-        val weight: Count[Weight] = Count(12, 9)
+      test(m"Multiply a Quanta by a double"):
+        val weight: Quanta[Weight] = Quanta(12, 9)
         val result = weight*2.5
         (result[Stones], result[Pounds], result[Ounces])
       .assert(_ == (2, 3, 7))
 
       test(m"Adding with double carry"):
-        val weight: Count[Weight] = Count(100, 13, 15)
-        val sum: Count[Weight] = weight + Count[Weight](1)
+        val weight: Quanta[Weight] = Quanta(100, 13, 15)
+        val sum: Quanta[Weight] = weight + Quanta[Weight](1)
         (sum[Stones], sum[Pounds], sum[Ounces])
       .assert(_ == (101, 0, 0))
 
       test(m"Collapse a weight value"):
-        val weight: Count[Weight] = Count(2, 3, 4)
+        val weight: Quanta[Weight] = Quanta(2, 3, 4)
         val weight2 = weight.collapse(1)
         (weight2[Pounds], weight2[Ounces])
       .assert(_ == (31, 4))
 
       test(m"Collapse a weight value 2"):
-        val weight: Count[Weight] = Count(2, 3, 4)
+        val weight: Quanta[Weight] = Quanta(2, 3, 4)
         val weight2 = weight.collapse(2)
         weight2[Ounces]
       .assert(_ == 500)
 
       test(m"Cannot collapse beyond last unit"):
         demilitarize:
-          val weight: Count[Weight] = Count(2, 3, 4)
+          val weight: Quanta[Weight] = Quanta(2, 3, 4)
           weight.collapse(3)
       .assert(_.length == 1)
 
-      suite(m"Showing Count values"):
+      suite(m"Showing Quanta values"):
         test(m"Show a single-unit weight"):
-          Count[Weight](2).show
+          Quanta[Weight](2).show
         .assert(_ == t"2oz")
 
         test(m"Show a more complex weight"):
-          Count[Weight](3, 2).show
+          Quanta[Weight](3, 2).show
         .assert(_ == t"3lb 2oz")
 
         test(m"Show a weight of three parts"):
-          Count[Weight](1, 3, 2).show
+          Quanta[Weight](1, 3, 2).show
         .assert(_ == t"1st 3lb 2oz")
 
         test(m"Show a weight of three parts"):
-          Count[Weight](1, 3, 2).show
+          Quanta[Weight](1, 3, 2).show
         .assert(_ == t"1st 3lb 2oz")
 
 
         test(m"Show with custom unit rendering"):
           given UnitsNames[Height] = () => List(t"'", t"\"")
-          Count[Height](5, 9).show
+          Quanta[Height](5, 9).show
         .assert(_ == t"5' 9\"")
 
       suite(m"Aggregate tests"):
         test(m"Total of several values"):
-          List[Count[Weight]](Count(10), Count(1, 6), Count(2, 4, 1)).total
-        . assert(_ == Count(2, 6, 1))
+          List[Quanta[Weight]](Quanta(10), Quanta(1, 6), Quanta(2, 4, 1)).total
+        . assert(_ == Quanta(2, 6, 1))
 
         test(m"Mean of several values"):
-          List[Count[Weight]](Count(10), Count(1, 6), Count(2, 4, 1)).mean
-        . assert(_ == Count(11, 6))
+          List[Quanta[Weight]](Quanta(10), Quanta(1, 6), Quanta(2, 4, 1)).mean
+        . assert(_ == Quanta(11, 6))

--- a/lib/phoenicia/src/core/phoenicia.FontSize.scala
+++ b/lib/phoenicia/src/core/phoenicia.FontSize.scala
@@ -36,6 +36,6 @@ import quantitative.*
 import rudiments.*
 
 object FontSize:
-  erased given quantity: Measurement[Units[1, FontSize], "font size"] = !!
+  erased given quantity: Amount[Units[1, FontSize], "font size"] = !!
 
 erased trait FontSize extends Dimension

--- a/lib/quantitative/src/core/quantitative.Amount.scala
+++ b/lib/quantitative/src/core/quantitative.Amount.scala
@@ -37,16 +37,16 @@ import language.implicitConversions
 import proscenium.*
 import rudiments.*
 
-erased trait Measurement[dimension <: Units[?, ?], label <: Label]()
+erased trait Amount[dimension <: Units[?, ?], label <: Label]()
 
-object Measurement:
+object Amount:
   // base units
-  erased given distance: Measurement[Units[1, Distance], "distance"] = !!
-  erased given mass: Measurement[Units[1, Mass], "mass"] = !!
-  erased given time: Measurement[Units[1, Time], "time"] = !!
-  erased given current: Measurement[Units[1, Current], "current"] = !!
-  erased given temperature: Measurement[Units[1, Temperature], "temperature"] = !!
-  erased given luminosity: Measurement[Units[1, Luminosity], "luminosity"] = !!
+  erased given distance: Amount[Units[1, Distance], "distance"] = !!
+  erased given mass: Amount[Units[1, Mass], "mass"] = !!
+  erased given time: Amount[Units[1, Time], "time"] = !!
+  erased given current: Amount[Units[1, Current], "current"] = !!
+  erased given temperature: Amount[Units[1, Temperature], "temperature"] = !!
+  erased given luminosity: Amount[Units[1, Luminosity], "luminosity"] = !!
 
   // derived units from https://en.wikipedia.org/wiki/List_of_physical_quantities
 
@@ -139,87 +139,87 @@ object Measurement:
   type ElectricalResistivity =
     Units[3, Distance] & Units[1, Mass] & Units[-3, Time] & Units[-2, Current]
 
-  erased given absement: Measurement[Absement, "absement"] = !!
-  erased given absorbedDoseRate: Measurement[AbsorbedDoseRate, "absorbed dose rate"] = !!
-  erased given acceleration: Measurement[Acceleration, "acceleration"] = !!
-  erased given area: Measurement[Area, "area"] = !!
-  erased given areaDensity: Measurement[AreaDensity, "area density"] = !!
-  erased given capacitance: Measurement[Capacitance, "capacitance"] = !!
-  erased given crackle: Measurement[Crackle, "crackle"] = !!
-  erased given currentDensity: Measurement[CurrentDensity, "current density"] = !!
-  erased given dynamicViscosity: Measurement[DynamicViscosity, "dynamic viscosity"] = !!
-  erased given electricCharge: Measurement[ElectricCharge, "electric charge"] = !!
-  erased given energy: Measurement[Energy, "energy"] = !!
-  erased given entropy: Measurement[Entropy, "entropy"] = !!
-  erased given force: Measurement[Force, "force"] = !!
-  erased given frequency: Measurement[Frequency, "frequency"] = !!
-  erased given substance: Measurement[Units[1, AmountOfSubstance], "amount of substance"] = !!
-  erased given illuminance: Measurement[Illuminance, "illuminance"] = !!
-  erased given impedance: Measurement[Impedance, "impedance"] = !!
-  erased given inductance: Measurement[Inductance, "inductance"] = !!
-  erased given jerk: Measurement[Jerk, "jerk"] = !!
-  erased given jounce: Measurement[Jounce, "jounce"] = !!
-  erased given linearDensity: Measurement[LinearDensity, "linear density"] = !!
-  erased given magneticFlux: Measurement[MagneticFlux, "magnetic flux"] = !!
-  erased given magneticMoment: Measurement[MagneticMoment, "magnetic moment"] = !!
-  erased given magnetization: Measurement[Magnetization, "magnetization"] = !!
-  erased given massDensity: Measurement[MassDensity, "mass density"] = !!
-  erased given molarConcentration: Measurement[MolarConcentration, "molar concentration"] = !!
-  erased given chemicalPotential: Measurement[ChemicalPotential, "chemical potential"] = !!
-  erased given molarEntropy: Measurement[MolarEntropy, "molar entropy"] = !!
-  erased given momentOfInertia: Measurement[MomentOfInertia, "moment of inertia"] = !!
-  erased given momentum: Measurement[Momentum, "momentum"] = !!
-  erased given opticalPower: Measurement[OpticalPower, "optical power"] = !!
-  erased given permeability: Measurement[Permeability, "permeability"] = !!
-  erased given permittivity: Measurement[Permittivity, "permittivity"] = !!
-  erased given power: Measurement[Power, "power"] = !!
-  erased given pressure: Measurement[Pressure, "pressure"] = !!
-  erased given pop: Measurement[Pop, "pop"] = !!
-  erased given radiance: Measurement[Radiance, "radiance"] = !!
-  erased given reactionRate: Measurement[ReactionRate, "reaction rate"] = !!
-  erased given reluctance: Measurement[Reluctance, "reluctance"] = !!
-  erased given specificEnergy: Measurement[SpecificEnergy, "specific energy"] = !!
-  erased given specificVolume: Measurement[SpecificVolume, "specific volume"] = !!
-  erased given spin: Measurement[Spin, "spin"] = !!
-  erased given surfaceTension: Measurement[SurfaceTension, "surface tension"] = !!
-  erased given thermalConductance: Measurement[ThermalConductance, "thermal conductance"] = !!
-  erased given thermalResistance: Measurement[ThermalResistance, "thermal resistance"] = !!
-  erased given thermalResistivity: Measurement[ThermalResistivity, "thermal resistivity"] = !!
-  erased given velocity: Measurement[Velocity, "velocity"] = !!
-  erased given volume: Measurement[Volume, "volume"] = !!
+  erased given absement: Amount[Absement, "absement"] = !!
+  erased given absorbedDoseRate: Amount[AbsorbedDoseRate, "absorbed dose rate"] = !!
+  erased given acceleration: Amount[Acceleration, "acceleration"] = !!
+  erased given area: Amount[Area, "area"] = !!
+  erased given areaDensity: Amount[AreaDensity, "area density"] = !!
+  erased given capacitance: Amount[Capacitance, "capacitance"] = !!
+  erased given crackle: Amount[Crackle, "crackle"] = !!
+  erased given currentDensity: Amount[CurrentDensity, "current density"] = !!
+  erased given dynamicViscosity: Amount[DynamicViscosity, "dynamic viscosity"] = !!
+  erased given electricCharge: Amount[ElectricCharge, "electric charge"] = !!
+  erased given energy: Amount[Energy, "energy"] = !!
+  erased given entropy: Amount[Entropy, "entropy"] = !!
+  erased given force: Amount[Force, "force"] = !!
+  erased given frequency: Amount[Frequency, "frequency"] = !!
+  erased given substance: Amount[Units[1, AmountOfSubstance], "amount of substance"] = !!
+  erased given illuminance: Amount[Illuminance, "illuminance"] = !!
+  erased given impedance: Amount[Impedance, "impedance"] = !!
+  erased given inductance: Amount[Inductance, "inductance"] = !!
+  erased given jerk: Amount[Jerk, "jerk"] = !!
+  erased given jounce: Amount[Jounce, "jounce"] = !!
+  erased given linearDensity: Amount[LinearDensity, "linear density"] = !!
+  erased given magneticFlux: Amount[MagneticFlux, "magnetic flux"] = !!
+  erased given magneticMoment: Amount[MagneticMoment, "magnetic moment"] = !!
+  erased given magnetization: Amount[Magnetization, "magnetization"] = !!
+  erased given massDensity: Amount[MassDensity, "mass density"] = !!
+  erased given molarConcentration: Amount[MolarConcentration, "molar concentration"] = !!
+  erased given chemicalPotential: Amount[ChemicalPotential, "chemical potential"] = !!
+  erased given molarEntropy: Amount[MolarEntropy, "molar entropy"] = !!
+  erased given momentOfInertia: Amount[MomentOfInertia, "moment of inertia"] = !!
+  erased given momentum: Amount[Momentum, "momentum"] = !!
+  erased given opticalPower: Amount[OpticalPower, "optical power"] = !!
+  erased given permeability: Amount[Permeability, "permeability"] = !!
+  erased given permittivity: Amount[Permittivity, "permittivity"] = !!
+  erased given power: Amount[Power, "power"] = !!
+  erased given pressure: Amount[Pressure, "pressure"] = !!
+  erased given pop: Amount[Pop, "pop"] = !!
+  erased given radiance: Amount[Radiance, "radiance"] = !!
+  erased given reactionRate: Amount[ReactionRate, "reaction rate"] = !!
+  erased given reluctance: Amount[Reluctance, "reluctance"] = !!
+  erased given specificEnergy: Amount[SpecificEnergy, "specific energy"] = !!
+  erased given specificVolume: Amount[SpecificVolume, "specific volume"] = !!
+  erased given spin: Amount[Spin, "spin"] = !!
+  erased given surfaceTension: Amount[SurfaceTension, "surface tension"] = !!
+  erased given thermalConductance: Amount[ThermalConductance, "thermal conductance"] = !!
+  erased given thermalResistance: Amount[ThermalResistance, "thermal resistance"] = !!
+  erased given thermalResistivity: Amount[ThermalResistivity, "thermal resistivity"] = !!
+  erased given velocity: Amount[Velocity, "velocity"] = !!
+  erased given volume: Amount[Volume, "volume"] = !!
 
-  erased given electricChargeDensity: Measurement[ElectricChargeDensity,
+  erased given electricChargeDensity: Amount[ElectricChargeDensity,
       "electric charge density"] = !!
 
-  erased given electricDipoleMoment: Measurement[ElectricDipoleMoment,
+  erased given electricDipoleMoment: Amount[ElectricDipoleMoment,
       "electric dipole moment"] = !!
 
-  erased given electricFieldStrength: Measurement[ElectricFieldStrength,
+  erased given electricFieldStrength: Amount[ElectricFieldStrength,
       "electric field strength"] = !!
 
-  erased given electricalConductance: Measurement[ElectricalConductance,
+  erased given electricalConductance: Amount[ElectricalConductance,
       "electric conductance"] = !!
 
-  erased given electricalConductivity: Measurement[ElectricalConductivity,
+  erased given electricalConductivity: Amount[ElectricalConductivity,
       "electric conductivity"] = !!
 
-  erased given electricalPotential: Measurement[ElectricalPotential, "electric potential"] =
+  erased given electricalPotential: Amount[ElectricalPotential, "electric potential"] =
     !!
 
-  erased given electricalResistivity: Measurement[ElectricalResistivity,
+  erased given electricalResistivity: Amount[ElectricalResistivity,
       "electric resistivity"] = !!
 
-  erased given magneticFluxDensity: Measurement[MagneticFluxDensity, "magnetic flux density"] =
+  erased given magneticFluxDensity: Amount[MagneticFluxDensity, "magnetic flux density"] =
     !!
 
-  erased given specificHeatCapacity: Measurement[SpecificHeatCapacity,
+  erased given specificHeatCapacity: Amount[SpecificHeatCapacity,
       "specific heat capacity"] = !!
 
-  erased given thermalConductivity: Measurement[ThermalConductivity, "thermal conductivity"] =
+  erased given thermalConductivity: Amount[ThermalConductivity, "thermal conductivity"] =
     !!
 
-  erased given volumetricFlowRate: Measurement[VolumetricFlowRate, "volumetric flow rate"] =
+  erased given volumetricFlowRate: Amount[VolumetricFlowRate, "volumetric flow rate"] =
     !!
 
-  erased given electricDisplacementField: Measurement[ElectricDisplacementField,
+  erased given electricDisplacementField: Amount[ElectricDisplacementField,
       "electric displacement field"] = !!

--- a/lib/quantitative/src/core/quantitative.Quantitative2.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative2.scala
@@ -79,10 +79,10 @@ trait Quantitative2:
 
       recur(map.to(List), TypeRepr.of[Units[?, ?]]).asType.absolve match
         case '[type units <: Units[?, ?]; units] =>
-          Expr.summon[Measurement[units, ?]].map: value =>
+          Expr.summon[Amount[units, ?]].map: value =>
             value.absolve match
               case '{$name: dimension} => Type.of[dimension].absolve match
-                case '[Measurement[?, name]] =>
+                case '[Amount[?, name]] =>
                   TypeRepr.of[name].asMatchable.absolve match
                     case ConstantType(StringConstant(name)) => name
 

--- a/lib/quantitative/src/core/soundness+quantitative-core.scala
+++ b/lib/quantitative/src/core/soundness+quantitative-core.scala
@@ -33,7 +33,7 @@
 package soundness
 
 export quantitative
-. { Distance, Mass, Time, Current, Luminosity, Temperature, AmountOfSubstance, Measurement,
+. { Distance, Mass, Time, Current, Luminosity, Temperature, AmountOfSubstance, Amount,
     Measure, Units, Metres, Kilograms, Candelas, Moles, Amperes, Kelvins, Seconds, Designation,
     Principal, Redesignation, Offset, Quantity, MetricUnit, Quantifiable, invert, in, sqrt, cbrt,
     units, express, dimension, Metric, NoPrefix, Deka, Hecto, Kilo, Mega, Giga, Tera, Peta,


### PR DESCRIPTION
This also renames `Measurement` to `Amount`. But more importantly, the method previously called `count` is now called `quanta` which means it no longer conflicts with the _other_ `count` method defined in Gossamer.