### PR TITLE
Make any value with a `Textualizer` also `Communicable`

### DIFF
--- a/lib/adversaria/src/core/adversaria.Adversaria.scala
+++ b/lib/adversaria/src/core/adversaria.Adversaria.scala
@@ -112,5 +112,5 @@ object Adversaria:
     if annotations.isEmpty
     then
       val typeName = TypeRepr.of[annotation].show
-      panic(m"the type ${targetType.show} did not have the annotation $typeName")
+      panic(m"the type $targetType did not have the annotation $typeName")
     else '{Annotations[annotation, target](${Expr.ofList(annotations)}*)}

--- a/lib/contingency/src/core/contingency.Contingency.scala
+++ b/lib/contingency/src/core/contingency.Contingency.scala
@@ -262,7 +262,7 @@ object Contingency:
                     '{$errorTactic.contramap($partialFunction(_).asInstanceOf[errorType])}.asTerm
 
                   case None =>
-                    halt(m"There is no available handler for ${TypeRepr.of[errorType].show}")
+                    halt(m"There is no available handler for ${TypeRepr.of[errorType]}")
         case _ =>
           halt(m"argument to `tend` should be a partial function implemented as match cases")
 

--- a/lib/fulminate/src/core/fulminate.Communicable.scala
+++ b/lib/fulminate/src/core/fulminate.Communicable.scala
@@ -49,6 +49,8 @@ object Communicable:
   given meta: [meta] => Quotes => Type[meta] is Communicable =
     tpe => Message(quotes.reflect.TypeRepr.of(using tpe).show.tt)
 
+  given [text: Textualizer] => text is Communicable = value => Message(value.textual)
+
   given typeRepr: (quotes: Quotes) => quotes.reflect.TypeRepr is Communicable =
     tpe => Message(tpe.show)
 

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -136,7 +136,7 @@ object Panopticon:
                 newParams)
 
             case None =>
-              halt(m"the type ${fromTypeRepr.show} does not have a primary constructor")
+              halt(m"the type $fromTypeRepr does not have a primary constructor")
 
     rewrite(getPath[path](), value.asTerm).asExprOf[from]
 
@@ -157,7 +157,7 @@ object Panopticon:
           case _ =>
             aimType.typeSymbol.caseFields.find(_.name == fieldName) match
               case None =>
-                halt(m"the field $fieldName is not a member of ${aimType.show}")
+                halt(m"the field $fieldName is not a member of $aimType")
 
               case Some(symbol) => symbol.info.asType.absolve match
                 case '[result] => '{Aim[result, fieldName *: tuple]()}

--- a/lib/vacuous/src/core/vacuous.Vacuous.scala
+++ b/lib/vacuous/src/core/vacuous.Vacuous.scala
@@ -41,7 +41,7 @@ object Vacuous:
     import quotes.reflect.*
     if TypeRepr.of[Unset.type] <:< TypeRepr.of[value].widen
     then '{null.asInstanceOf[Optionality[value]]}
-    else halt(m"the type ${TypeRepr.of[value].widen.show} is not an `Optional`")
+    else halt(m"the type ${TypeRepr.of[value].widen} is not an `Optional`")
 
   def optimizeOr[value: Type](optional: Expr[Optional[value]], default: Expr[value])(using Quotes)
   :     Expr[value] =


### PR DESCRIPTION
We couldn't embed non-`Communicable` things inside `m""` messages, even when a `Showable` exists. Now we can.