### PR TITLE
Implement all TASTy extractors

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -911,12 +911,12 @@ object hieroglyph extends SoundnessModule {
 
 object hyperbole extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq(harlequin.core, escapade.core, escritoire.core, dendrology.tree, hieroglyph.core)
-    def compileIvyDeps = Agg(ivy"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
+    def moduleDeps = Seq(harlequin.ansi, escapade.core, escritoire.core, dendrology.tree, hieroglyph.core)
+    def ivyDeps = Agg(ivy"org.scala-lang:scala3-staging_3:${scalaVersion()}")
   }
 
   object test extends ProbablyTestModule {
-    def moduleDeps = Seq(probably.cli, core)
+    def moduleDeps = Seq(probably.cli, core, quantitative.units, mandible.core)
   }
 }
 
@@ -1004,10 +1004,7 @@ object legerdemain extends SoundnessModule {
 object mandible extends SoundnessModule {
   object core extends SoundnessSubModule {
     def moduleDeps = Seq(hellenism.core, hyperbole.core, escritoire.core)
-    def ivyDeps = Agg(
-      ivy"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
-      ivy"org.scala-lang:scala3-staging_3:${scalaVersion()}"
-    )
+    def ivyDeps = Agg(ivy"org.scala-lang:scala3-staging_3:${scalaVersion()}")
   }
 
   object test extends ProbablyTestModule {

--- a/lib/hyperbole/src/core/hyperbole-core.scala
+++ b/lib/hyperbole/src/core/hyperbole-core.scala
@@ -37,8 +37,9 @@ import escapade.*
 
 import scala.quoted.*
 
-transparent inline def introspect[value](inline value: value): Text =
-  ${Hyperbole.introspection[value]('value)}
+transparent inline def introspect[value](inline inlining: Boolean = false)(inline value: value)
+:     Text =
+  ${Hyperbole.introspection[value]('value, 'inlining)}
 
 extension [value](expr: Expr[value])(using Quotes)
-  def introspect: Teletype = Hyperbole.introspect[value](expr)
+  def introspect: Teletype = Hyperbole.introspect[value](expr, '{false})

--- a/lib/hyperbole/src/core/hyperbole.Expansion.scala
+++ b/lib/hyperbole/src/core/hyperbole.Expansion.scala
@@ -36,4 +36,5 @@ import anticipation.*
 import escapade.*
 import vacuous.*
 
-case class Expansion(text: Teletype, param: Optional[Text], expr: Text, source: Teletype)
+case class Expansion
+            (text: Teletype, typeName: Text, param: Optional[Text], expr: Text, source: Teletype)

--- a/lib/hyperbole/src/core/hyperbole.Expansion.scala
+++ b/lib/hyperbole/src/core/hyperbole.Expansion.scala
@@ -33,6 +33,7 @@
 package hyperbole
 
 import anticipation.*
+import escapade.*
 import vacuous.*
 
-case class Expansion(text: Text, param: Optional[Text], expr: Text, source: Text)
+case class Expansion(text: Teletype, param: Optional[Text], expr: Text, source: Teletype)

--- a/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
+++ b/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
@@ -68,33 +68,59 @@ object Hyperbole:
         e""
 
     case class TastyTree
-                (name:     Text,
-                 expr:     Text,
-                 source:   Text,
-                 children: List[TastyTree],
-                 param:    Optional[Text]):
+                (name:   Text,
+                 expr:   Text,
+                 source: Text,
+                 nodes:  List[TastyTree],
+                 param:  Optional[Text]):
 
       def shortCode: Text =
         val c = expr.upto(_ != '\n')
-        //if c.length != expr.length then t"$c..." else expr
-        expr
+        if c.length != expr.length then t"$c..." else expr
+
+      def apply(children: List[Tree]): TastyTree = copy(nodes = children.map(TastyTree.expand))
+
 
     object TastyTree:
       def apply
-           (name: Text, tree: Tree, children: List[TastyTree], parameter: Optional[Text] = Unset)
+           (name: Text, tree: Tree, children: List[TastyTree] = Nil, parameter: Optional[Text] = Unset)
       :     TastyTree =
 
-        TastyTree(name, tree.show.show, source(tree).plain, children, parameter)
+        TastyTree(name, tree.show.tt, source(tree).plain, children, parameter)
 
       def expand(tree: Tree): TastyTree = tree match
         case PackageClause(ref, chs) =>
-          TastyTree(t"PackageClause", tree, expand(ref) :: chs.map(expand))
+          TastyTree(t"PackageClause", tree, expand(ref) :: chs.map(expand))(chs)
+
+        case Import(expr, selectors) =>
+          TastyTree(t"Import", tree, Nil)
+
+        case Export(tree, selectors) =>
+          TastyTree(t"Export", tree, Nil)
+
+        case ClassDef(name, constructor, parents, selfOpt, body) =>
+          TastyTree(t"ClassDef", tree, body.map(expand), name.tt)
+
+        case TypeDef(name, rhs) =>
+          TastyTree(t"TypeDef", tree, List(expand(rhs)), name.tt)
+
+        case Wildcard() =>
+          TastyTree(t"Wildcard", tree, Nil)
+
+        case This(qual) =>
+          TastyTree(t"This", tree, Nil, qual.map(_.tt).getOrElse(t""))
+
+        case New(tpt) =>
+          TastyTree(t"New", tree, List(expand(tpt)))
+
+        case NamedArg(name, arg) =>
+          TastyTree(t"NamedArg", tree, List(expand(arg)), name.tt)
 
         case Bind(name, term) =>
-          TastyTree(t"Bind", tree, List(expand(term)), name.show)
+          TastyTree(t"Bind", tree, List(expand(term)), name.tt)
 
-        case Typed(focus, tt) =>
-          TastyTree(t"Typed", tree, List(expand(focus), expand(tt)))
+        case Typed(expr, tpt) =>
+          TastyTree(t"Typed", tree, List(expand(expr), expand(tpt)))
 
         case TypedOrTest(focus, tt) =>
           TastyTree(t"TypedOrTest", tree, List(expand(focus), expand(tt)))
@@ -102,66 +128,147 @@ object Hyperbole:
         case Inlined(Some(tree), _, child) =>
           TastyTree(t"Inlined", tree, List(expand(tree), expand(child)))
 
-        case Inlined(None, _, child) =>
-          TastyTree(t"Inlined", tree, List(expand(child)))
+        case Inlined(call, bindings, child) =>
+          TastyTree
+           (t"Inlined",
+            tree,
+            call.map(expand).to(List) ::: bindings.map(expand) ::: List(expand(child)))
 
-        case Apply(focus, children) =>
-          TastyTree(t"Apply", tree, expand(focus) :: children.map(expand))
+        case Apply(fun, args) =>
+          TastyTree(t"Apply", tree, expand(fun) :: args.map(expand))
 
-        case TypeApply(focus, children) =>
-          TastyTree(t"TypeApply", tree, expand(focus) :: children.map(expand))
+        case Assign(lhs, rhs) =>
+          TastyTree(t"Assign", tree, List(expand(lhs), expand(rhs)))
 
-        case Select(focus, name) =>
-          TastyTree(t"Select", tree, List(expand(focus)), name.show)
+        case TypeApply(fun, args) =>
+          TastyTree(t"TypeApply", tree, expand(fun) :: args.map(expand))
+
+        case Select(qualifier, name) =>
+          TastyTree(t"Select", tree, List(expand(qualifier)), name.tt)
+
+        case SelectOuter(qualifier, name, levels) =>
+          TastyTree(t"SelectOuter", tree, List(expand(qualifier)), t"$name^$levels")
+
+        case Singleton(ref) =>
+          TastyTree(t"Singleton", tree, List(expand(ref)))
+
+        case Super(qual, mix) =>
+          TastyTree(t"Super", tree, List(expand(qual)), mix.map(_.tt).getOrElse(t""))
 
         case Ident(name) =>
-          TastyTree(t"Ident", tree, Nil, name.show)
+          TastyTree(t"Ident", tree, Nil, name.tt)
+
+        case If(cond, thenp, elsep) =>
+          TastyTree(t"If", tree, List(cond, thenp, elsep).map(expand))
+
+        case While(cond, body) =>
+          TastyTree(t"While", tree, List(cond, body).map(expand))
 
         case TypeIdent(name) =>
-          TastyTree(t"TypeIdent", tree, Nil, name.show)
+          TastyTree(t"TypeIdent", tree, Nil, name.tt)
+
+        case TypeProjection(qualifier, name) =>
+          TastyTree(t"TypeProjection", tree, List(expand(qualifier)), name.tt)
+
+        case Inferred() =>
+          TastyTree(t"Inferred", tree, Nil)
 
         case TypeSelect(term, name) =>
-          TastyTree(t"TypeIdent", tree, List(expand(term)), name.show)
+          TastyTree(t"TypeIdent", tree, List(expand(term)), name.tt)
+
+        case Try(expr, cases, finalizer) =>
+          TastyTree
+           (t"Try",
+            tree,
+            expand(expr) :: cases.map(expand) ::: finalizer.map(expand).to(List))
 
         case Block(statements, last) =>
           TastyTree(t"Block", tree, statements.map(expand) :+ expand(last))
 
-        case Closure(focus, _) =>
+        case ByName(result) =>
+          TastyTree(t"ByName", tree, List(expand(result)))
+
+        case Closure(focus, tpe) =>
           TastyTree(t"Closure", tree, List(expand(focus)))
 
         case Literal(value) =>
-          TastyTree(t"Literal", tree, Nil, value.show.show)
+          TastyTree(t"Literal", tree, Nil, value.show.tt)
 
-        case Match(focus, cases) =>
-          TastyTree(t"Match", tree, expand(focus) :: cases.map(expand))
+        case Lambda(defs, term) =>
+          TastyTree(t"Lambda", tree, defs.map(expand) ::: List(expand(term)))
 
-        case Applied(name, tts) =>
-          TastyTree(t"Applied", tree, expand(name) :: tts.map(expand))
+        case LambdaTypeTree(tparams, body) =>
+          TastyTree(t"LambdaTypeTree", tree, tparams.map(expand) ::: List(expand(body)))
 
-        case Repeated(xs, _) =>
-          TastyTree(t"Repeated", tree, Nil)
+        case TypeBoundsTree(low, high) =>
+          TastyTree(t"TypeBoundsTree", tree, List(low, high).map(expand))
 
-        case Unapply(fn, _, tts) =>
-          TastyTree(t"UnApply", tree, expand(fn) :: tts.map(expand))
+        case WildcardTypeTree() =>
+          TastyTree(t"WildcardTypeTree", tree, Nil)
 
-        case tree: TypeTree =>
-          TastyTree(t"TypeTree", tree, Nil)
+        case TypeBind(name, tpt) =>
+          TastyTree(t"TypeBind", tree, List(expand(tpt)), name.tt)
 
-        case DefDef(name, ps, typs, ch) =>
-          TastyTree(t"DefDef", tree, ch.to(List).map(expand))
+        case TypeBlock(aliases, tpt) =>
+          TastyTree(t"TypeBlock", tree, aliases.map(expand) ::: List(expand(tpt)))
+
+        case Match(selector, cases) =>
+          TastyTree(t"Match", tree, expand(selector) :: cases.map(expand))
+
+        case MatchTypeTree(bound, selector, cases) =>
+          TastyTree
+           (t"MatchTypeTree",
+            tree,
+            bound.map(expand).to(List) ++ List(expand(selector)) ++ cases.map(expand))
+
+        case Applied(tpt, args) =>
+          TastyTree(t"Applied", tree, expand(tpt) :: args.map(expand))
+
+        case Annotated(arg, annotation) =>
+          TastyTree(t"Annotated", tree, List(expand(arg), expand(annotation)))
+
+        case Repeated(elems, tpt) =>
+          TastyTree(t"Repeated", tree, elems.map(expand) ::: List(expand(tpt)))
+
+        case Refined(tpt, refinements) =>
+          TastyTree(t"Refined", tree, expand(tpt) :: refinements.map(expand))
+
+        case Return(expr, from) =>
+          TastyTree(t"Return", tree, List(expand(expr)))
+
+        case Unapply(fun, implicits, patterns) =>
+          TastyTree(t"Unapply", tree, expand(fun) :: implicits.map(expand) ::: patterns.map(expand))
+
+        case Alternatives(patterns) =>
+          TastyTree(t"Alternatives", tree, patterns.map(expand))
+
+        case TypeCaseDef(pattern, rhs) =>
+          TastyTree(t"TypeCaseDef", tree, List(expand(pattern), expand(rhs)))
+
+        case DefDef(name, paramss, tpt, rhs) =>
+          TastyTree(t"DefDef", tree, rhs.to(List).map(expand))
+
+        case SummonFrom(cases) =>
+          TastyTree(t"SummonFrom", tree, cases.map(expand))
 
         case ValDef(name, tpe, rhs) =>
           TastyTree(t"ValDef", tree, rhs.to(List).map(expand))
 
-        case CaseDef(focus, t1, t2) =>
-          TastyTree(t"CaseDef", tree, expand(focus) +: t1.to(List).map(expand) :+ expand(t2))
+        case CaseDef(pattern, guard, rhs) =>
+          TastyTree(t"CaseDef", tree, expand(pattern) +: guard.to(List).map(expand) :+ expand(rhs))
+
+        // case TermParamClause(params) =>
+        //   TastyTree(t"TermParamClause", tree, params.map(expand))
+
+        // case TypeParamClause(params) =>
+        //   TastyTree(t"TypeParamClause", tree, params.map(expand))
 
         case _ =>
           TastyTree(t"?${tree.toString}: ${tree.getClass.toString}", tree, Nil)
 
     val tree: TastyTree = TastyTree.expand(expr.asTerm)
 
-    val seq: Seq[Expansion] = TreeDiagram.by[TastyTree](_.children)(tree).map: node =>
+    val seq: Seq[Expansion] = TreeDiagram.by[TastyTree](_.nodes)(tree).map: node =>
       Expansion
        (tiles.drop(1).map(treeStyles.default.text(_)).join+t"▪ "+node.name,
         node.param,

--- a/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
+++ b/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
@@ -200,8 +200,22 @@ object Hyperbole:
           case FlexibleType(tpe) =>
             TastyTree.repr("FlexibleType", repr).typeChildren(tpe)
 
-          case constant: Constant =>
-            TastyTree.repr(t"Constant", repr)
+          case constant: ConstantType =>
+            def value = constant.constant.value.toString.tt
+
+            constant.constant match
+              case BooleanConstant(_) => TastyTree.repr(t"BooleanConstant", repr, value)
+              case ByteConstant(_)    => TastyTree.repr(t"ByteConstant", repr, value)
+              case ShortConstant(_)   => TastyTree.repr(t"ShortConstant", repr, value)
+              case IntConstant(_)     => TastyTree.repr(t"IntConstant", repr, value)
+              case LongConstant(_)    => TastyTree.repr(t"LongConstant", repr, value)
+              case FloatConstant(_)   => TastyTree.repr(t"FloatConstant", repr, value)
+              case DoubleConstant(_)  => TastyTree.repr(t"DoubleConstant", repr, value)
+              case CharConstant(_)    => TastyTree.repr(t"CharConstant", repr, value)
+              case StringConstant(_)  => TastyTree.repr(t"StringConstant", repr, value)
+              case UnitConstant()     => TastyTree.repr(t"UnitConstant", repr, t"()")
+              case NullConstant()     => TastyTree.repr(t"NullConstant", repr, t"null")
+              case ClassOfConstant(_) => TastyTree.repr(t"ClassOfConstant", repr, value)
 
           case TermRef(qual, name) =>
             TastyTree.repr("TermRef", repr, name.tt).typeChildren(qual)

--- a/lib/hyperbole/src/core/soundness+hyperbole-core.scala
+++ b/lib/hyperbole/src/core/soundness+hyperbole-core.scala
@@ -30,22 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package hyperbole
+package soundness
 
-import soundness.*
-
-import temporaryDirectories.environment
-import classloaders.threadContext
-import stdioSources.virtualMachine.ansi
-
-object Tests extends Suite(m"Hyperbole Tests"):
-  def run(): Unit =
-    Out.println:
-      introspect:
-        val x = 1*Second + 32*Minute
-        type Example = x.type
-        1.0.asInstanceOf[Example]
-        println("hello world")
-
-    Out.println:
-      disassemble('{ 1*Second + 32*Minute }).teletype
+export hyperbole.introspect

--- a/lib/hyperbole/src/test/hyperbole.Tests.scala
+++ b/lib/hyperbole/src/test/hyperbole.Tests.scala
@@ -42,10 +42,5 @@ object Tests extends Suite(m"Hyperbole Tests"):
   def run(): Unit =
     Out.println:
       introspect:
-        val x = 1*Second + 32*Minute
-        type Example = x.type
-        1.0.asInstanceOf[Example]
+        def fn[T <: String: Showable](name: T) = name.show
         println("hello world")
-
-    Out.println:
-      disassemble('{ 1*Second + 32*Minute }).teletype

--- a/lib/hyperbole/src/test/hyperbole.Tests.scala
+++ b/lib/hyperbole/src/test/hyperbole.Tests.scala
@@ -41,6 +41,9 @@ import stdioSources.virtualMachine.ansi
 object Tests extends Suite(m"Hyperbole Tests"):
   def run(): Unit =
     Out.println:
-      introspect:
-        def fn[T <: String: Showable](name: T) = name.show
-        println("hello world")
+      introspect(false):
+        class Hello[Param <: String & Double: Showable]
+               (string: Text)(value: Int):
+          def apply(): true =
+            println(string)
+            true

--- a/lib/hyperbole/src/test/hyperbole.Tests.scala
+++ b/lib/hyperbole/src/test/hyperbole.Tests.scala
@@ -42,8 +42,4 @@ object Tests extends Suite(m"Hyperbole Tests"):
   def run(): Unit =
     Out.println:
       introspect(false):
-        class Hello[Param <: String & Double: Showable]
-               (string: Text)(value: Int):
-          def apply(): true =
-            println(string)
-            true
+        1 + 1

--- a/lib/mandible/src/core/soundness+mandible-core.scala
+++ b/lib/mandible/src/core/soundness+mandible-core.scala
@@ -30,22 +30,6 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package hyperbole
+package soundness
 
-import soundness.*
-
-import temporaryDirectories.environment
-import classloaders.threadContext
-import stdioSources.virtualMachine.ansi
-
-object Tests extends Suite(m"Hyperbole Tests"):
-  def run(): Unit =
-    Out.println:
-      introspect:
-        val x = 1*Second + 32*Minute
-        type Example = x.type
-        1.0.asInstanceOf[Example]
-        println("hello world")
-
-    Out.println:
-      disassemble('{ 1*Second + 32*Minute }).teletype
+export mandible.{disassemble, Bytecode, Classfile}

--- a/lib/mandible/src/test/mandible.Tests.scala
+++ b/lib/mandible/src/test/mandible.Tests.scala
@@ -38,6 +38,7 @@ import classloaders.threadContext
 import stdioSources.virtualMachine.ansi
 import temporaryDirectories.environment
 
+
 object Tests extends Suite(m"Mandible tests"):
   def run(): Unit =
     test(m"Compile something"):


### PR DESCRIPTION
All the extractors defined in `QuotesImpl.scala` are now implemented as `case`s in Hyperbole, and should expand.