### PR TITLE
Rename `Medium` to `MediaType`

### DIFF
--- a/lib/gesticulate/src/core/gesticulate-core.scala
+++ b/lib/gesticulate/src/core/gesticulate-core.scala
@@ -35,5 +35,5 @@ package gesticulate
 import language.experimental.captureChecking
 
 extension (inline ctx: StringContext)
-  transparent inline def media(inline parts: String*): Medium =
+  transparent inline def media(inline parts: String*): MediaType =
     ${Media.Prefix.expand('ctx, 'parts)}

--- a/lib/gesticulate/src/core/gesticulate.Content.scala
+++ b/lib/gesticulate/src/core/gesticulate.Content.scala
@@ -35,4 +35,4 @@ package gesticulate
 import anticipation.*
 import proscenium.*
 
-case class Content(media: Medium, stream: Stream[Bytes])
+case class Content(media: MediaType, stream: Stream[Bytes])

--- a/lib/gesticulate/src/core/gesticulate.Extensions.scala
+++ b/lib/gesticulate/src/core/gesticulate.Extensions.scala
@@ -38,9 +38,9 @@ import gossamer.*
 import language.experimental.captureChecking
 
 object Extensions:
-  def guess(ext: Text): Medium = mediums.getOrElse(ext, media"application/octet-stream")
+  def guess(ext: Text): MediaType = mediaTypes.getOrElse(ext, media"application/octet-stream")
 
-  val mediums: Map[Text, Medium] = Map
+  val mediaTypes: Map[Text, MediaType] = Map
    (t"aac"    -> media"audio/aac",
     t"abw"    -> media"application/x-abiword",
     t"arc"    -> media"application/x-freearc",

--- a/lib/gesticulate/src/core/gesticulate.MediaType.scala
+++ b/lib/gesticulate/src/core/gesticulate.MediaType.scala
@@ -45,7 +45,7 @@ import vacuous.*
 import language.dynamics
 //import language.experimental.captureChecking
 
-case class Medium
+case class MediaType
    (group:     Media.Group,
     subtype:    Media.Subtype,
     suffixes:   List[Media.Suffix] = Nil,
@@ -54,36 +54,36 @@ extends Dynamic:
 
   private def suffixString: Text = suffixes.map { s => t"+${s.name}" }.join
   def basic: Text = t"${group.name}/${subtype.name}$suffixString"
-  def base: Medium = Medium(group, subtype, suffixes)
+  def base: MediaType = MediaType(group, subtype, suffixes)
 
   def at(name: Text): Optional[Text] = parameters.where(_(0) == name).let(_(1))
 
-  def applyDynamicNamed(apply: "apply")(kvs: (String, Text)*): Medium =
+  def applyDynamicNamed(apply: "apply")(kvs: (String, Text)*): MediaType =
     copy(parameters = parameters ::: kvs.map(_.show -> _).to(List))
 
-object Medium:
-  given inspectable: Medium is Inspectable = mt => t"""media"${mt}""""
+object MediaType:
+  given inspectable: MediaType is Inspectable = mt => t"""media"${mt}""""
 
-  given showable: Medium is Showable =
+  given showable: MediaType is Showable =
     mt => t"${mt.basic}${mt.parameters.map { p => t"; ${p(0)}=${p(1)}" }.join}"
 
-  given encodable: Medium is Encodable in Text = _.show
-  given decodable: Tactic[MediumError] => Medium is Decodable in Text = Media.parse(_)
+  given encodable: MediaType is Encodable in Text = _.show
+  given decodable: Tactic[MediaTypeError] => MediaType is Decodable in Text = Media.parse(_)
 
-  given formenctype: ("formenctype" is GenericHtmlAttribute[Medium]):
+  given formenctype: ("formenctype" is GenericHtmlAttribute[MediaType]):
     def name: Text = t"formenctype"
-    def serialize(medium: Medium): Text = medium.show
+    def serialize(mediaType: MediaType): Text = mediaType.show
 
-  given media: ("media" is GenericHtmlAttribute[Medium]):
+  given media: ("media" is GenericHtmlAttribute[MediaType]):
     def name: Text = t"media"
-    def serialize(medium: Medium): Text = medium.show
+    def serialize(mediaType: MediaType): Text = mediaType.show
 
-  given enctype: ("enctype" is GenericHtmlAttribute[Medium]):
+  given enctype: ("enctype" is GenericHtmlAttribute[MediaType]):
     def name: Text = t"enctype"
-    def serialize(medium: Medium): Text = medium.show
+    def serialize(mediaType: MediaType): Text = mediaType.show
 
-  given htype: ("htype" is GenericHtmlAttribute[Medium]):
+  given htype: ("htype" is GenericHtmlAttribute[MediaType]):
     def name: Text = t"type"
-    def serialize(medium: Medium): Text = medium.show
+    def serialize(mediaType: MediaType): Text = mediaType.show
 
-  def unapply(value: Text): Option[Medium] = safely(Some(Media.parse(value))).or(None)
+  def unapply(value: Text): Option[MediaType] = safely(Some(Media.parse(value))).or(None)

--- a/lib/gesticulate/src/core/gesticulate.MediaTypeError.scala
+++ b/lib/gesticulate/src/core/gesticulate.MediaTypeError.scala
@@ -43,7 +43,7 @@ import vacuous.*
 import language.dynamics
 //import language.experimental.captureChecking
 
-object MediumError:
+object MediaTypeError:
   enum Reason:
     case NotOneSlash, MissingParam, InvalidGroup
     case InvalidChar(char: Char)
@@ -57,5 +57,5 @@ object MediumError:
       case InvalidChar(c)   => txt"the character '$c' is not allowed"
       case InvalidSuffix(s) => txt"the suffix '$s' is not recognized"
 
-case class MediumError(value: Text, reason: MediumError.Reason)(using Diagnostics)
+case class MediaTypeError(value: Text, reason: MediaTypeError.Reason)(using Diagnostics)
 extends Error(m"the value $value is not a valid media type; ${reason.message}")

--- a/lib/gesticulate/src/core/gesticulate.MultipartError.scala
+++ b/lib/gesticulate/src/core/gesticulate.MultipartError.scala
@@ -40,13 +40,13 @@ import scala.reflect.*
 object MultipartError:
   enum Reason:
     case Expected(char: Char)
-    case StreamContinues, BadBoundaryEnding, Medium, BadDisposition
+    case StreamContinues, BadBoundaryEnding, MediaType, BadDisposition
 
   given communicable: Reason is Communicable =
     case Reason.Expected(char)    => m"the character '$char' was expected"
     case Reason.StreamContinues   => m"the stream continues beyond the last part"
     case Reason.BadBoundaryEnding => m"unexpected content followed the boundary"
-    case Reason.Medium            => m"the media type is invalid"
+    case Reason.MediaType         => m"the media type is invalid"
     case Reason.BadDisposition    => m"the `Content-Disposition` header has the wrong format"
 
 import MultipartError.Reason

--- a/lib/gesticulate/src/core/soundness+gesticulate-core.scala
+++ b/lib/gesticulate/src/core/soundness+gesticulate-core.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export gesticulate
-. { Extensions, Media, Medium, MediumError, media, Multipart, MultipartError, Part, Content }
+. { Extensions, Media, MediaType, MediaTypeError, media, Multipart, MultipartError, Part, Content }

--- a/lib/gesticulate/src/test/gesticulate.Tests.scala
+++ b/lib/gesticulate/src/test/gesticulate.Tests.scala
@@ -57,14 +57,14 @@ object Tests extends Suite(m"Gesticulate tests"):
 
     test(m"parse full media type"):
       Media.parse(t"application/json")
-    .assert(_ == Medium(Media.Group.Application, Media.Subtype.Standard(t"json")))
+    .assert(_ == MediaType(Media.Group.Application, Media.Subtype.Standard(t"json")))
 
     test(m"parse full media type with parameter"):
       Media.parse(t"application/json; charset=UTF-8")
-    .assert(_ == Medium(Media.Group.Application, Media.Subtype.Standard(t"json"),
+    .assert(_ == MediaType(Media.Group.Application, Media.Subtype.Standard(t"json"),
         parameters = List((t"charset", t"UTF-8"))))
 
     test(m"invalid media type"):
       capture(Media.parse(t"applicationjson"))
-    .assert(_ == MediumError(t"applicationjson",
-        MediumError.Reason.NotOneSlash))
+    .assert(_ == MediaTypeError(t"applicationjson",
+        MediaTypeError.Reason.NotOneSlash))

--- a/lib/hallucination/src/core/hallucination.Bmp.scala
+++ b/lib/hallucination/src/core/hallucination.Bmp.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Bmp extends ImageFormat
 
 object Bmp extends ImageCodec[Bmp]("BMP".tt):
-  def medium = media"image/bmp"
+  def mediaType = media"image/bmp"

--- a/lib/hallucination/src/core/hallucination.Gif.scala
+++ b/lib/hallucination/src/core/hallucination.Gif.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Gif extends ImageFormat
 
 object Gif extends ImageCodec[Gif]("GIF".tt):
-  def medium = media"image/gif"
+  def mediaType = media"image/gif"

--- a/lib/hallucination/src/core/hallucination.ImageCodec.scala
+++ b/lib/hallucination/src/core/hallucination.ImageCodec.scala
@@ -44,7 +44,7 @@ import javax.imageio as ji
 
 abstract class ImageCodec[format <: ImageFormat](name: Text):
   inline def codec: ImageCodec[format] = this
-  protected def medium: Medium
+  protected def mediaType: MediaType
   protected lazy val reader: ji.ImageReader = ji.ImageIO.getImageReaders(name.s).nn.next().nn
   protected lazy val writer: ji.ImageWriter = ji.ImageIO.getImageWriter(reader).nn
 
@@ -55,7 +55,7 @@ abstract class ImageCodec[format <: ImageFormat](name: Text):
       type Result = HttpStreams.Content
 
       def genericize(image: Image in format): HttpStreams.Content =
-        (medium.show, image.serialize(using codec))
+        (mediaType.show, image.serialize(using codec))
 
   def read[input: Readable by Bytes](inputType: input): Image in format =
     reader.synchronized:

--- a/lib/hallucination/src/core/hallucination.Jpeg.scala
+++ b/lib/hallucination/src/core/hallucination.Jpeg.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Jpeg extends ImageFormat
 
 object Jpeg extends ImageCodec[Jpeg]("JPEG".tt):
-  def medium = media"image/jpeg"
+  def mediaType = media"image/jpeg"

--- a/lib/hallucination/src/core/hallucination.Png.scala
+++ b/lib/hallucination/src/core/hallucination.Png.scala
@@ -38,4 +38,4 @@ import gesticulate.*
 erased trait Png extends ImageFormat
 
 object Png extends ImageCodec[Png]("PNG".tt):
-  def medium = media"image/png"
+  def mediaType = media"image/png"

--- a/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
@@ -128,7 +128,7 @@ object HtmlAttribute:
   given download: ("download" is HtmlAttribute[Text]) = identity(_)
 
   given draggable: ("draggable" is HtmlAttribute[Boolean]) = if _ then Unset else NotShown
-  given enctype: ("enctype" is HtmlAttribute[Medium]) = _.show
+  given enctype: ("enctype" is HtmlAttribute[MediaType]) = _.show
 
   given hfor: ("hfor" is HtmlAttribute[DomId]):
     override def rename: Optional[Text] = t"for"
@@ -251,7 +251,7 @@ object HtmlAttribute:
   given target2: ("target" is HtmlAttribute[DomId]) = _.name
   given title: ("title" is HtmlAttribute[Text]) = identity(_)
   given translate: ("translate" is HtmlAttribute[Boolean]) = if _ then Unset else NotShown
-  given linkType: ("type" is HtmlAttribute[Medium] onto "link") = _.show
+  given linkType: ("type" is HtmlAttribute[MediaType] onto "link") = _.show
   given buttonType: ("type" is HtmlAttribute[Text] onto "button") = _.show
   given capture: ("capture" is HtmlAttribute[Capture]) = _.show
 

--- a/lib/scintillate/src/server/scintillate.Acceptable.scala
+++ b/lib/scintillate/src/server/scintillate.Acceptable.scala
@@ -48,18 +48,18 @@ import errorDiagnostics.stackTraces
 object Acceptable:
   given multipart: Tactic[MultipartError] => Multipart is Acceptable = request =>
     tend:
-      case _: MediumError => MultipartError(MultipartError.Reason.Medium)
+      case _: MediaTypeError => MultipartError(MultipartError.Reason.MediaType)
 
     . within:
         val contentType = request.headers.contentType.prim.or:
-          abort(MultipartError(MultipartError.Reason.Medium))
+          abort(MultipartError(MultipartError.Reason.MediaType))
 
         if contentType.base == media"multipart/form-data" then
           val boundary = contentType.at(t"boundary").or:
-            abort(MultipartError(MultipartError.Reason.Medium))
+            abort(MultipartError(MultipartError.Reason.MediaType))
 
           Multipart.parse(request.body(), boundary)
-        else abort(MultipartError(MultipartError.Reason.Medium))
+        else abort(MultipartError(MultipartError.Reason.MediaType))
 
 trait Acceptable:
   type Self

--- a/lib/scintillate/src/server/scintillate.Retrievable.scala
+++ b/lib/scintillate/src/server/scintillate.Retrievable.scala
@@ -40,7 +40,7 @@ import rudiments.*
 import spectacular.*
 import telekinesis.*
 
-trait Retrievable(val medium: Medium) extends Servable:
+trait Retrievable(val mediaType: MediaType) extends Servable:
   type Self
 
   def stream(response: Self): Stream[Bytes]
@@ -48,6 +48,6 @@ trait Retrievable(val medium: Medium) extends Servable:
   final def process(content: Self, status: Int, headers: Map[Text, Text], responder: Responder)
   :     Unit =
 
-    responder.addHeader(t"content-type", medium.show)
+    responder.addHeader(t"content-type", mediaType.show)
     headers.each(responder.addHeader)
     responder.sendBody(status, stream(content))

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -157,7 +157,7 @@ object Http:
     case PreconditionFailed            extends Status(412, t"Precondition Failed")
     case PayloadTooLarge               extends Status(413, t"Payload Too Large")
     case UriTooLong                    extends Status(414, t"URI Too Long")
-    case UnsupportedMedium             extends Status(415, t"Unsupported Media Type")
+    case UnsupportedMediaType          extends Status(415, t"Unsupported Media Type")
     case RangeNotSatisfiable           extends Status(416, t"Range Not Satisfiable")
     case ExpectationFailed             extends Status(417, t"Expectation Failed")
     case UnprocessableEntity           extends Status(422, t"Unprocessable Entity")
@@ -287,7 +287,7 @@ object Http:
         val name2 = name.tt.uncamel.kebab.lower
         textHeaders.filter(_.key.lower == name2).map(_.value.decode)
 
-    lazy val contentType: Optional[Medium] = safely(headers.contentType.prim)
+    lazy val contentType: Optional[MediaType] = safely(headers.contentType.prim)
 
     lazy val textCookies: Map[Text, Text] =
       headers.cookie.flatMap: cookie =>

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -52,10 +52,11 @@ import vacuous.*
 import alphabets.base256.alphanumericOrBraille
 
 object Postable:
-  def apply[response](medium0: Medium, stream0: response => Stream[Bytes]): response is Postable =
+  def apply[response](mediaType0: MediaType, stream0: response => Stream[Bytes])
+  :     response is Postable =
     new Postable:
       type Self = response
-      def medium(response: response): Medium = medium0
+      def mediaType(response: response): MediaType = mediaType0
       def stream(response: response): Stream[Bytes] = stream0(response)
 
   given text: (encoder: CharEncoder) => Text is Postable =
@@ -74,18 +75,18 @@ object Postable:
     Postable(media"application/x-www-form-urlencoded", query => Stream(query.queryString.bytes))
 
   given dataStream: [response: Abstractable across HttpStreams into HttpStreams.Content]
-        =>  Tactic[MediumError]
+        =>  Tactic[MediaTypeError]
         =>  response is Postable =
 
     new Postable:
       type Self = response
 
-      def medium(content: response): Medium = content.generic(0).decode[Medium]
+      def mediaType(content: response): MediaType = content.generic(0).decode[MediaType]
       def stream(content: response): Stream[Bytes] = content.generic(1)
 
 trait Postable:
   type Self
-  def medium(content: Self): Medium
+  def mediaType(content: Self): MediaType
   def stream(content: Self): Stream[Bytes]
 
   def preview(value: Self): Text = stream(value).prim.lay(t""): bytes =>

--- a/lib/telekinesis/src/core/telekinesis.Prefixable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Prefixable.scala
@@ -48,14 +48,14 @@ object Prefixable:
   given contentEncoding: [encoding <: Encoding]
         => ("contentEncoding" is Prefixable of encoding) = _.name
 
-  given accept: ("accept" is Prefixable of Medium) = _.show
-  given accept2: ("accept" is Prefixable of List[Medium]) = _.map(_.show).join(t",")
+  given accept: ("accept" is Prefixable of MediaType) = _.show
+  given accept2: ("accept" is Prefixable of List[MediaType]) = _.map(_.show).join(t",")
 
   given authorization: ("authorization" is Prefixable of Auth) = _.show
   given cacheControl: ("cacheControl" is Prefixable of Text) = identity(_)
   given connection: ("connection" is Prefixable of Text) = identity(_)
   given contentMd5: ("contentMd5" is Prefixable of Text) = identity(_)
-  given contentType: ("contentType" is Prefixable of Medium) = _.basic
+  given contentType: ("contentType" is Prefixable of MediaType) = _.basic
   given contentLength: ("contentLength" is Prefixable of Memory) = _.long.toString.tt
   given cookie: ("cookie" is Prefixable of List[Cookie.Value]) = _.map(_.show).join(t"; ")
   given date: ("date" is Prefixable of Text) = identity(_)

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -42,10 +42,10 @@ import spectacular.*
 import turbulence.*
 
 object Servable:
-  def apply[response](medium: response => Medium)(lambda: response => Stream[Bytes])
+  def apply[response](mediaType: response => MediaType)(lambda: response => Stream[Bytes])
   :     response is Servable = response =>
 
-    val headers = List(Http.Header(t"content-type", medium(response).show))
+    val headers = List(Http.Header(t"content-type", mediaType(response).show))
     Http.Response.make(Http.Ok, headers, lambda(response))
 
   given content: Content is Servable:
@@ -65,11 +65,11 @@ object Servable:
   inline given media: [media: Media] => media is Servable =
     compiletime.summonFrom:
       case encodable: (`media` is Encodable in Bytes) => value =>
-        val headers = List(Http.Header(t"content-type", media.medium(value).show))
+        val headers = List(Http.Header(t"content-type", media.mediaType(value).show))
         Http.Response.make(Http.Ok, headers, Stream(encodable.encode(value)))
 
       case given (`media` is Readable by Bytes)       => value =>
-        val headers = List(Http.Header(t"content-type", media.medium(value).show))
+        val headers = List(Http.Header(t"content-type", media.mediaType(value).show))
         Http.Response.make(Http.Ok, headers, value.stream[Bytes])
 
 trait Servable:

--- a/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
+++ b/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
@@ -129,7 +129,7 @@ object Telekinesis:
             val host: Hostname = $submit.host
             val body = $postable.stream($payload)
             val path = $submit.originForm
-            val contentType = Http.Header("content-type".tt, $postable.medium($payload).show)
+            val contentType = Http.Header("content-type".tt, $postable.mediaType($payload).show)
 
             val request =
               Http.Request($method, 1.1, host, path, contentType :: $headers.to(List), () => body)


### PR DESCRIPTION
In a struggle to avoid introducing a name which conflicted with the naming scheme for type parameters, media types were called `Medium`s. But since the naming scheme for type parameters has now changed, we can rename them to `MediaType` without the risk that `MediaType` would be misinterpreted as a type parameter.