### PR TITLE
Implement the `survive` method

### DIFF
--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -195,6 +195,13 @@ extension [accrual <: Exception,  lambda[_], focus]
   :     accrual =
     ${Contingency.validateWithin[accrual, lambda, focus]('validate, 'lambda, 'diagnostics)}
 
+extension [element](sequence: Iterable[element])
+  transparent inline def survive[result](using Void)[error <: Exception]
+                          (lambda: (OptionalTactic[error, result], Diagnostics, CanThrow[Exception])
+                                    ?=> element => result)
+  :     Iterable[result] =
+    sequence.map { element => safely(lambda(element)) }.compact
+
 extension [value](optional: Optional[value])
   def lest[success, error <: Exception: Tactic](error: Diagnostics ?=> error): value =
     optional.or(abort(error))

--- a/lib/contingency/src/core/soundness+contingency-core.scala
+++ b/lib/contingency/src/core/soundness+contingency-core.scala
@@ -35,7 +35,7 @@ package soundness
 export contingency
 . { Tactic, Fatal, Recoverable, raise, abort, safely, unsafely, throwErrors, capture, attempt,
     abortive, ExpectationError, raises, Attempt, tend, mend, Unchecked, accrue, within, Foci, track,
-    focus, lest, dare, Errors, validate, Validation, Pointer }
+    focus, lest, dare, Errors, validate, Validation, Pointer, survive }
 
 package strategies:
   export contingency.strategies


### PR DESCRIPTION
The `survive` method is like a `map`, but performs the operation _safely_, and automatically compacts the results.

It's more or less equivalent to,
```scala
extension [element](list: List[element])
  def survive[result](action: element => result): List[result] =
    list.flatMap: element =>
      try Some(action(element)) catch case _ => None
```