### PR TITLE
More soft modifiers

### DIFF
--- a/lib/dissonance/src/core/dissonance.Evolution.scala
+++ b/lib/dissonance/src/core/dissonance.Evolution.scala
@@ -83,7 +83,9 @@ def evolve[element](versions: List[List[element]]): Evolution[element] =
             updates ::: done
 
           edits match
-            case Nil => finish().reverse
+            case Nil => atoms match
+             case Nil           => finish().reverse
+             case atom :: atoms => merge(atoms, Nil, done, atom :: skips, inserts)
 
             case edit :: edits => atoms match
               case Nil => edit match

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -75,23 +75,14 @@ object SourceCode:
     else if token >= 63 && token <= 84 then Accent.Symbol
     else Accent.Parens
 
-  private val soft: Set[Text] = Set(t"inline", t"opaque", t"open", t"transparent", t"infix")
+  // This list was found in scala/scala3:compiler/src/dotty/tools/dotc/core/parsing/Parserse.scala
+  private val soft: Set[Text] =
+    Set(t"inline", t"opaque", t"open", t"transparent", t"infix", t"mut", t"erased", t"tracked")
 
   def apply(language: ProgrammingLanguage, text: Text): SourceCode =
     val source: SourceFile = SourceFile.virtual("<highlighting>", text.s)
     val ctx0 = Contexts.ContextBase().initialCtx.fresh.setReporter(Reporter.NoReporter)
 
-    /*val languageSettings =
-      List
-       ("experimental.clauseInterleaving",
-        "experimental.genericNumberLiterals",
-        "experimental.fewerBraces",
-        "experimental.modularity",
-        "experimental.erasedDefinitions",
-        "experimental.saferExceptions",
-        "experimental.namedTypeArguments")*/
-
-    //ctx0.setSetting(ctx0.settings.language, languageSettings)
     ctx0.setSetting(ctx0.settings.source, "future")
 
     given ctx: Contexts.Context =

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -112,7 +112,7 @@ object SourceCode:
       case SourceToken(_, Accent.Unparsed) #:: more                   => hard(more)
       case SourceToken(text, Accent.Ident) #:: more if soft.has(text) => hard(more)
       case SourceToken(text, Accent.Keyword | Accent.Modifier) #:: _  => true
-      case other #:: _                                                => false
+      case other                                                      => false
 
     def soften(stream: Stream[SourceToken]): Stream[SourceToken] = stream match
       case (token@SourceToken(text, Accent.Ident)) #:: more if soft.has(text) =>
@@ -122,7 +122,7 @@ object SourceCode:
       case token #:: more =>
         token #:: soften(more)
 
-      case _ =>
+      case Stream() =>
         Stream()
 
     def stream(lastEnd: Int = 0): Stream[SourceToken] = scanner.token match
@@ -153,7 +153,7 @@ object SourceCode:
                (SourceToken(line, trees(start, end).getOrElse(accent(token))), SourceToken.Newline)
             . init
 
-        soften(unparsed #::: content #::: stream(end))
+        unparsed #::: soften(content) #::: stream(end)
 
     def lines(seq: List[SourceToken], acc: List[List[SourceToken]] = Nil): List[List[SourceToken]] =
       seq match


### PR DESCRIPTION
A few more soft modifiers were missing from the recent change to start highlighting them: `tracked`, `mut` and `erased`.