### PR TITLE
Define `intercalate`

### DIFF
--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -123,6 +123,10 @@ extension [value](iterator: Iterator[value])
 
   inline def all(predicate: value => Boolean): Boolean = iterator.forall(predicate)
 
+extension [value](iterables: Iterable[Iterable[value]])
+  def intercalate(between: Iterable[value] = Iterable()): Iterable[value] =
+    if iterables.isEmpty then Iterable() else iterables.reduceLeft(_ ++ between ++ _)
+
 extension [value](iterable: Iterable[value])
   transparent inline def total
                           (using addable:  value is Addable by value,

--- a/lib/rudiments/src/core/soundness+rudiments-core.scala
+++ b/lib/rudiments/src/core/soundness+rudiments-core.scala
@@ -40,7 +40,7 @@ export rudiments
     WorkingDirectoryError, HomeDirectoryError, WorkingDirectory, HomeDirectory, workingDirectory,
     homeDirectory, prim, sec, ter, unwind, at, Indexable, yet, Bijection, bijection, segment,
     Segmentable, Digit, temporaryDirectory, total, product, mean, variance, standardDeviation,
-    annex }
+    annex, intercalate }
 
 package workingDirectories:
   export rudiments.workingDirectories.{systemProperty, default}


### PR DESCRIPTION
Define an `intercalate` method on `Iterable`s, like a `mkString` for non-String sequences. Unfortunately, this doesn't currently return a more precise collection type than `Iterable`.