### PR TITLE
Make `Bytecode` `Printable`

### DIFF
--- a/etc/publish
+++ b/etc/publish
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-echo Username is $MILL_SONATYPE_USERNAME
-echo mill -i mill.contrib.sonatypecentral.SonatypeCentralPublishModule/publishAll \
+mill -i mill.contrib.sonatypecentral.SonatypeCentralPublishModule/publishAll \
   --publishArtifacts __.publishArtifacts \
   --shouldRelease true

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -62,7 +62,6 @@ object Austronesian2:
 
   object DecodableDerivation extends Derivable[Decodable in Stdlib]:
     inline def join[derivation <: Product: ProductReflection]: derivation is Decodable in Stdlib =
-
       case array: Array[Stdlib] =>
         construct: [field] =>
           _.decoded(array(index))

--- a/lib/dissonance/src/core/dissonance.Evolution.scala
+++ b/lib/dissonance/src/core/dissonance.Evolution.scala
@@ -51,7 +51,7 @@ object Evolution:
     def add(n: Ordinal): Atom[element] = copy(presence = presence + n)
     def has(n: Ordinal): Boolean = presence.contains(n)
 
-def evolve[element](versions: List[List[element]]): Evolution[element] =
+def evolve[element: ClassTag](versions: List[List[element]]): Evolution[element] =
   import Evolution.Atom
 
   def recur(iteration: Ordinal, todo: List[Seq[element]], evolution: Evolution[element])
@@ -60,7 +60,8 @@ def evolve[element](versions: List[List[element]]): Evolution[element] =
       case Nil | _ :: Nil => evolution
 
       case left :: right :: more =>
-        val changes: List[Edit[element]] = diff(left.to(Vector), right.to(Vector)).edits.to(List)
+        val changes: List[Edit[element]] =
+          diff(IArray.from(left), IArray.from(right)).edits.to(List)
 
         def merge
              (atoms:   List[Atom[element]],

--- a/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
+++ b/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
@@ -70,7 +70,6 @@ object Hyperbole:
     import quotes.reflect.*
 
     val inlining = inlining0.valueOrAbort
-
     val sources: scm.HashMap[Text, SourceCode] = scm.HashMap()
 
     def source(tree: Tree): Teletype = tree.pos match

--- a/lib/mandible/src/core/mandible.Bytecode.scala
+++ b/lib/mandible/src/core/mandible.Bytecode.scala
@@ -61,7 +61,7 @@ import textMetrics.uniform
 import columnAttenuation.ignore
 
 object Bytecode:
-  given Bytecode is Teletypeable = bytecode =>
+  given teletypeable: Bytecode is Teletypeable = bytecode =>
     val table = Table[Instruction]
                  (Column(e"$Bold(Source)", textAlign = TextAlignment.Right): line =>
                     line.line.let: line =>
@@ -74,6 +74,7 @@ object Bytecode:
 
     table.tabulate(bytecode.instructions).grid(160).render.join(e"\n")
 
+  given printable: Bytecode is Printable = _.teletype.render(_)
 
   given stack: List[Frame] is Teletypeable = stack =>
     e"${rgb"#aaaaaa"}(${stack.reverse.map(_.teletype).join(e"┃ ", e" ┊ ", e"")})"


### PR DESCRIPTION
Provides a `Printable` instance for `Bytecode`. This should make it more convenient to print output from disassembly in tests.