### PR TITLE
Add `Concrete` type constraint

### DIFF
--- a/lib/rudiments/src/core/rudiments.Concrete.scala
+++ b/lib/rudiments/src/core/rudiments.Concrete.scala
@@ -30,23 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package rudiments
 
-export rudiments
-. { Memory, b, kib, mib, gib, tib, memory, sift, has, weave, each, all, sumBy, bi, tri, indexBy,
-    longestTrain, mutable, immutable, snapshot, place, upsert, collate, establish, plus, runs,
-    runsBy, create, javaInputStream, DecimalConverter, !!, Exit, unit, waive, twin, triple, is,
-    matchable, give, pipe, fuse, tap, also, Counter, loop, Loop, &, tuple, to,
-    WorkingDirectoryError, HomeDirectoryError, WorkingDirectory, HomeDirectory, workingDirectory,
-    homeDirectory, prim, sec, ter, unwind, at, Indexable, yet, Bijection, bijection, segment,
-    Segmentable, Digit, temporaryDirectory, total, product, mean, variance, standardDeviation,
-    annex, intercalate, Concrete }
+object Concrete:
+ inline given concrete: [typeRef] => typeRef is Concrete = ${Rudiments.concrete[typeRef]}
 
-package workingDirectories:
-  export rudiments.workingDirectories.{systemProperty, default}
-
-package homeDirectories:
-  export rudiments.homeDirectories.{systemProperty, environment}
-
-package temporaryDirectories:
-  export rudiments.temporaryDirectories.{systemProperty, environment}
+erased trait Concrete:
+  type Self

--- a/lib/rudiments/src/core/rudiments.Rudiments.scala
+++ b/lib/rudiments/src/core/rudiments.Rudiments.scala
@@ -34,6 +34,8 @@ package rudiments
 
 import language.experimental.captureChecking
 
+import scala.quoted.*
+
 import anticipation.*
 import fulminate.*
 import prepositional.*
@@ -59,6 +61,13 @@ object Rudiments:
   extension (digit: Digit)
     def int: Int = digit
     def char: Char = ('0' + int).toChar
+
+  def concrete[typeRef: Type](using Quotes): Expr[typeRef is Concrete] =
+    import quotes.reflect.*
+
+    if TypeRepr.of[typeRef].typeSymbol.isAbstractType
+    then halt(m"type ${Type.of[typeRef]} is abstract")
+    else '{!![typeRef is Concrete]}
 
   object Memory:
     def apply(long: Long): Memory = long


### PR DESCRIPTION
Sometimes we want to check that a type is concrete (i.e. not abstract) because we want to use it in a union with another concrete type, but want to make sure they're distinguishable.

The `: Concrete` type bound will now do this. In combination with `NotGiven[T <:< S]`, where `S` is concrete, we can be sure that T is not a subtype of S, whereas the abstractness of `T` could be used as a loophole.

Todo: write a `Distinct` typeclass so we can say,
```
inline def foo[T: Distinct from Int]
```
for example.

Note that inlining is necessary for this to be useful.