### PR TITLE
Make it possible to test type distinctness

### DIFF
--- a/lib/rudiments/src/core/rudiments.Concrete.scala
+++ b/lib/rudiments/src/core/rudiments.Concrete.scala
@@ -30,23 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package rudiments
 
-export rudiments
-. { Memory, b, kib, mib, gib, tib, memory, sift, has, weave, each, all, sumBy, bi, tri, indexBy,
-    longestTrain, mutable, immutable, snapshot, place, upsert, collate, establish, plus, runs,
-    runsBy, create, javaInputStream, DecimalConverter, !!, Exit, unit, waive, twin, triple, is,
-    matchable, give, pipe, fuse, tap, also, Counter, loop, Loop, &, tuple, to,
-    WorkingDirectoryError, HomeDirectoryError, WorkingDirectory, HomeDirectory, workingDirectory,
-    homeDirectory, prim, sec, ter, unwind, at, Indexable, yet, Bijection, bijection, segment,
-    Segmentable, Digit, temporaryDirectory, total, product, mean, variance, standardDeviation,
-    annex, intercalate, Concrete }
+object Concrete:
+ inline given concrete: [typeRef] => typeRef is Concrete = ${Rudiments.concrete[typeRef]}
 
-package workingDirectories:
-  export rudiments.workingDirectories.{systemProperty, default}
-
-package homeDirectories:
-  export rudiments.homeDirectories.{systemProperty, environment}
-
-package temporaryDirectories:
-  export rudiments.temporaryDirectories.{systemProperty, environment}
+erased trait Concrete:
+  type Self

--- a/lib/rudiments/src/core/rudiments.Rudiments.scala
+++ b/lib/rudiments/src/core/rudiments.Rudiments.scala
@@ -34,6 +34,8 @@ package rudiments
 
 import language.experimental.captureChecking
 
+import scala.quoted.*
+
 import anticipation.*
 import fulminate.*
 import prepositional.*
@@ -59,6 +61,13 @@ object Rudiments:
   extension (digit: Digit)
     def int: Int = digit
     def char: Char = ('0' + int).toChar
+
+  def concrete[typeRef: Type](using Quotes): Expr[typeRef is Concrete] =
+    import quotes.reflect.*
+
+    if TypeRepr.of[typeRef].typeSymbol.isAbstractType
+    then halt(m"type ${Type.of[typeRef]} is abstract")
+    else '{!![typeRef is Concrete]}
 
   object Memory:
     def apply(long: Long): Memory = long

--- a/lib/rudiments/src/core/rudiments.Rudiments.scala
+++ b/lib/rudiments/src/core/rudiments.Rudiments.scala
@@ -62,13 +62,6 @@ object Rudiments:
     def int: Int = digit
     def char: Char = ('0' + int).toChar
 
-  def concrete[typeRef: Type](using Quotes): Expr[typeRef is Concrete] =
-    import quotes.reflect.*
-
-    if TypeRepr.of[typeRef].typeSymbol.isAbstractType
-    then halt(m"type ${Type.of[typeRef]} is abstract")
-    else '{!![typeRef is Concrete]}
-
   object Memory:
     def apply(long: Long): Memory = long
     given ordering: Ordering[Memory] = Ordering.Long.on(_.long)

--- a/lib/vacuous/src/core/soundness+vacuous-core.scala
+++ b/lib/vacuous/src/core/soundness+vacuous-core.scala
@@ -35,4 +35,4 @@ package soundness
 export vacuous
 . { Default, default, Unset, Optional, UnsetError, or, absent, present, vouch, mask, javaOptional,
     presume, option, assume, lay, layGiven, let, letGiven, compact, optional, puncture, only,
-    unless, Unsafe, Extractor }
+    unless, Unsafe, Extractor, Concrete, Distinct }

--- a/lib/vacuous/src/core/vacuous.Concrete.scala
+++ b/lib/vacuous/src/core/vacuous.Concrete.scala
@@ -30,23 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package vacuous
 
-export rudiments
-. { Memory, b, kib, mib, gib, tib, memory, sift, has, weave, each, all, sumBy, bi, tri, indexBy,
-    longestTrain, mutable, immutable, snapshot, place, upsert, collate, establish, plus, runs,
-    runsBy, create, javaInputStream, DecimalConverter, !!, Exit, unit, waive, twin, triple, is,
-    matchable, give, pipe, fuse, tap, also, Counter, loop, Loop, &, tuple, to,
-    WorkingDirectoryError, HomeDirectoryError, WorkingDirectory, HomeDirectory, workingDirectory,
-    homeDirectory, prim, sec, ter, unwind, at, Indexable, yet, Bijection, bijection, segment,
-    Segmentable, Digit, temporaryDirectory, total, product, mean, variance, standardDeviation,
-    annex, intercalate }
+object Concrete:
+ inline given concrete: [typeRef] => typeRef is Concrete = ${Vacuous.concrete[typeRef]}
 
-package workingDirectories:
-  export rudiments.workingDirectories.{systemProperty, default}
-
-package homeDirectories:
-  export rudiments.homeDirectories.{systemProperty, environment}
-
-package temporaryDirectories:
-  export rudiments.temporaryDirectories.{systemProperty, environment}
+erased trait Concrete:
+  type Self

--- a/lib/vacuous/src/core/vacuous.Distinct.scala
+++ b/lib/vacuous/src/core/vacuous.Distinct.scala
@@ -30,10 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package rudiments
+package vacuous
 
-object Concrete:
- inline given concrete: [typeRef] => typeRef is Concrete = ${Rudiments.concrete[typeRef]}
+import prepositional.*
 
-erased trait Concrete:
+object Distinct:
+  inline given distinct: [typeRef, otherType] => typeRef is Distinct from otherType =
+    ${Vacuous.distinct[typeRef, otherType]}
+
+erased trait Distinct:
   type Self
+  type Source

--- a/lib/vacuous/src/test/vacuous.Tests.scala
+++ b/lib/vacuous/src/test/vacuous.Tests.scala
@@ -32,7 +32,124 @@
                                                                                                   */
 package vacuous
 
+import scala.compiletime.*
+
 import soundness.*
 
 object Tests extends Suite(m"Vacuous Tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+   suite(m"Vacuous tests"):
+     test(m"String is concrete"):
+       erased val x = summon[String is Concrete]
+     . assert()
+
+     test(m"Abstract method type is not concrete"):
+       demilitarize:
+         def abstractType[notConcrete]: Unit =
+           summon[notConcrete is Concrete]
+       . map(_.message)
+     . assert(_ == List(t"vacuous: type notConcrete is abstract"))
+
+     test(m"Unexpanded inlined abstract method type is not concrete"):
+       demilitarize:
+         inline def abstractType[notConcrete]: Unit =
+           summon[notConcrete is Concrete]
+       . map(_.message)
+     . assert(_ == Nil)
+
+     test(m"Expanded inlined abstract method type is not concrete"):
+       demilitarize:
+         inline def abstractType[notConcrete]: Unit =
+           summon[notConcrete is Concrete]
+
+         erased val x = abstractType[Int]
+
+       . map(_.message)
+     . assert(_ == Nil)
+
+     test(m"Int and String are distinct types"):
+       demilitarize:
+         erased val x = summonInline[Int is Distinct from String]
+
+       . map(_.message)
+     . assert(_ == Nil)
+
+     test(m"Int and (Int | String) are not distinct types"):
+       demilitarize:
+         erased val x = summonInline[Int is Distinct from (Int | String)]
+
+       . map(_.message)
+     . assert(_.nonEmpty)
+
+     test(m"String is not distinct from itself"):
+       demilitarize:
+         erased val x = summonInline[String is Distinct from String]
+
+       . map(_.message)
+     . assert(_.nonEmpty)
+
+     test(m"Abstract type is not proven distinct from anything, e.g. String"):
+       demilitarize:
+         def foo[T]: Unit = summonInline[T is Distinct from String].unit
+         foo[String]
+
+       . map(_.message)
+     . assert(_.contains(t"vacuous: type T is abstract"))
+
+     test(m"Abstract type is not proven distinct from anything, e.g. Int"):
+       demilitarize:
+         def foo[T]: Unit = summonInline[T is Distinct from String].unit
+         foo[Int]
+
+       . map(_.message)
+     . assert(_.contains(t"vacuous: type T is abstract"))
+
+     test(m"Inline abstract type is not proven distinct from anything, e.g. Int"):
+       demilitarize:
+         inline def foo[T]: Unit =
+           erased val x = summonInline[T is Distinct from String]
+
+         foo[Int]
+
+       . map(_.message)
+     . assert(_ == Nil)
+
+     test(m"Inline abstract type is not proven distinct from anything, e.g. String"):
+       demilitarize:
+         inline def foo[T]: Unit =
+           erased val x = summonInline[T is Distinct from String]
+
+         foo[String]
+
+       . map(_.message)
+     . assert(_.nonEmpty)
+
+     test(m"String is not distinct from String | Int"):
+       demilitarize:
+         inline def foo[T]: Unit =
+           erased val x = summonInline[T is Distinct from (String | Int)]
+
+         foo[String]
+
+       . map(_.message)
+     . assert(_.nonEmpty)
+
+     test(m"String singleton is not distinct from String"):
+       demilitarize:
+         inline def foo[T]: Unit =
+           erased val x = summonInline[T is Distinct from (String | Int)]
+
+         foo[""]
+
+       . map(_.message)
+     . assert(_.nonEmpty)
+
+     test(m"String singleton is not distinct from different String singleton"):
+       demilitarize:
+         inline def foo[T]: Unit =
+           erased val x = summonInline[T is Distinct from "foo"]
+
+         foo[""]
+
+       . map(_.message)
+     . assert(_ == Nil)


### PR DESCRIPTION
We can now add a constraint to ensure that a type is distinct from another. For example:
```scala
def merge[T: Distinct from String](value: T): String | T =
  if math.random < 0.5 then value else "other"
```

We can call `merge(42)`, but we cannot call `merge("string")`.