### PR TITLE
Introduce `certify` method for checking untainted `Tactic`s

### DIFF
--- a/lib/contingency/src/core/contingency-core.scala
+++ b/lib/contingency/src/core/contingency-core.scala
@@ -59,14 +59,18 @@ package strategies:
     given diagnostics: Diagnostics = errorDiagnostics.stackTraces
     def record(error: Diagnostics ?=> exception): Unit = exception.status(error).terminate()
     def abort(error: Diagnostics ?=> exception): Nothing = exception.status(error).terminate()
+    def certify(): Unit = ()
 
   given uncheckedErrors: [error <: Exception] => (erased error is Unchecked) => Tactic[error]:
     given diagnostics: Diagnostics = errorDiagnostics.stackTraces
     given canThrow: CanThrow[Exception] = unsafeExceptions.canThrowAny
     def record(error: Diagnostics ?=> error): Unit = throw error
     def abort(error: Diagnostics ?=> error): Nothing = throw error
+    def certify(): Unit = ()
 
 given realm: Realm = realm"contingency"
+
+def certify[error <: Exception: Tactic](): Unit = error.certify()
 
 def raise[success, exception <: Exception: Recoverable into success]
    (error: Diagnostics ?=> exception)

--- a/lib/contingency/src/core/contingency.AccrueTactic.scala
+++ b/lib/contingency/src/core/contingency.AccrueTactic.scala
@@ -56,3 +56,5 @@ extends Tactic[error]:
     boundary.break(None)(using label)
 
   def finish(): Unit = ()
+
+  def certify(): Unit = if initial != ref.get() then boundary.break(None)(using label)

--- a/lib/contingency/src/core/contingency.AmalgamateTactic.scala
+++ b/lib/contingency/src/core/contingency.AmalgamateTactic.scala
@@ -46,3 +46,4 @@ extends Tactic[error]:
   def diagnostics: Diagnostics = summon[Diagnostics]
   def record(error: Diagnostics ?=> error): Unit = boundary.break(error)(using label)
   def abort(error: Diagnostics ?=> error): Nothing = boundary.break(error)(using label)
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.AttemptTactic.scala
+++ b/lib/contingency/src/core/contingency.AttemptTactic.scala
@@ -37,17 +37,15 @@ import language.experimental.pureFunctions
 import fulminate.*
 import proscenium.*
 
-class AttemptTactic[error <: Exception, success]
-   (label: boundary.Label[Attempt[success, error]])
-   (using Diagnostics)
+class AttemptTactic[error <: Exception, success](label: boundary.Label[Attempt[success, error]])
+       (using Diagnostics)
 extends Tactic[error]:
+  private given boundary.Label[Attempt[success, error]] = label
+
   type Result = Attempt[success, error]
   type Return = Attempt[success, error]
 
   def diagnostics: Diagnostics = summon[Diagnostics]
-
-  def record(error: Diagnostics ?=> error): Unit =
-    boundary.break(Attempt.Failure(error))(using label)
-
-  def abort(error: Diagnostics ?=> error): Nothing =
-    boundary.break(Attempt.Failure(error))(using label)
+  def record(error: Diagnostics ?=> error): Unit = boundary.break(Attempt.Failure(error))
+  def abort(error: Diagnostics ?=> error): Nothing = boundary.break(Attempt.Failure(error))
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.EitherTactic.scala
+++ b/lib/contingency/src/core/contingency.EitherTactic.scala
@@ -37,10 +37,10 @@ import language.experimental.pureFunctions
 import fulminate.*
 import proscenium.*
 
-class EitherTactic[error <: Exception, success]
-   (label: boundary.Label[Either[error, success]])
+class EitherTactic[error <: Exception, success](label: boundary.Label[Either[error, success]])
    (using Diagnostics)
 extends Tactic[error]:
   def diagnostics: Diagnostics = summon[Diagnostics]
   def record(error: Diagnostics ?=> error): Unit = boundary.break(Left(error))(using label)
   def abort(error: Diagnostics ?=> error): Nothing = boundary.break(Left(error))(using label)
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.EscapeTactic.scala
+++ b/lib/contingency/src/core/contingency.EscapeTactic.scala
@@ -39,8 +39,8 @@ class EscapeTactic[result](label: boundary.Label[result])
 extends Tactic[Break[result]]:
 
   given diagnostics: Diagnostics = Diagnostics.omit
+  private given boundary.Label[result] = label
 
-  def abort(escape: Diagnostics ?=> Break[result]): Nothing =
-    boundary.break(escape.value)(using label)
-
+  def abort(escape: Diagnostics ?=> Break[result]): Nothing = boundary.break(escape.value)
   def record(escape: Diagnostics ?=> Break[result]): Unit = abort(escape)
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.Foci.scala
+++ b/lib/contingency/src/core/contingency.Foci.scala
@@ -59,6 +59,7 @@ trait Foci[focus]:
   :     accrual
 
   def supplement(count: Int, transform: Optional[focus] => focus): Unit
+  def tainted: Boolean = length > 0
 
 class TrackFoci[focus]() extends Foci[focus]:
   private val errors: scm.ArrayBuffer[Exception] = scm.ArrayBuffer()

--- a/lib/contingency/src/core/contingency.HaltTactic.scala
+++ b/lib/contingency/src/core/contingency.HaltTactic.scala
@@ -44,3 +44,4 @@ extends Tactic[error]:
   given diagnostics: Diagnostics = Diagnostics.omit
   def record(error: Diagnostics ?=> error): Unit = halt(error.message)
   def abort(error: Diagnostics ?=> error): Nothing = halt(error.message)
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.OptionalTactic.scala
+++ b/lib/contingency/src/core/contingency.OptionalTactic.scala
@@ -38,12 +38,14 @@ import fulminate.*
 import proscenium.*
 import vacuous.*
 
-class OptionalTactic[error <: Exception, success]
-   (label: boundary.Label[Optional[success]])
+class OptionalTactic[error <: Exception, success](label: boundary.Label[Optional[success]])
 extends Tactic[error]:
+  private given boundary.Label[Optional[success]] = label
+
   type Result = Optional[success]
   type Return = Optional[success]
 
   def diagnostics: Diagnostics = Diagnostics.omit
   def record(error: Diagnostics ?=> error): Unit = boundary.break(Unset)(using label)
   def abort(error: Diagnostics ?=> error): Nothing = boundary.break(Unset)(using label)
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.Tactic.scala
+++ b/lib/contingency/src/core/contingency.Tactic.scala
@@ -42,9 +42,11 @@ trait Tactic[-error <: Exception]:
   def diagnostics: Diagnostics
   def record(error: Diagnostics ?=> error): Unit
   def abort(error: Diagnostics ?=> error): Nothing
+  def certify(): Unit
 
   def contramap[error2 <: Exception](lambda: error2 => error): Tactic[error2] =
     new Tactic[error2]:
       def diagnostics: Diagnostics = tactic.diagnostics
       def record(error: Diagnostics ?=> error2): Unit = tactic.record(lambda(error))
       def abort(error: Diagnostics ?=> error2): Nothing = tactic.abort(lambda(error))
+      def certify(): Unit = tactic.certify()

--- a/lib/contingency/src/core/contingency.ThrowTactic.scala
+++ b/lib/contingency/src/core/contingency.ThrowTactic.scala
@@ -36,10 +36,9 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-class ThrowTactic[error <: Exception, success]()
-   (using @annotation.constructorOnly error: CanThrow[error])
+class ThrowTactic[error <: Exception, success]()(using error: CanThrow[error])
 extends Tactic[error]:
-
   def diagnostics: Diagnostics = Diagnostics.capture
   def record(error: Diagnostics ?=> error): Unit = throw error(using diagnostics)
   def abort(error: Diagnostics ?=> error): Nothing = throw error(using diagnostics)
+  def certify(): Unit = ()

--- a/lib/contingency/src/core/contingency.TrackTactic.scala
+++ b/lib/contingency/src/core/contingency.TrackTactic.scala
@@ -41,10 +41,14 @@ class TrackTactic[error <: Exception, accrual, result, supplement]
    (label: boundary.Label[Option[result]], initial: accrual, foci: Foci[supplement])
    (using Diagnostics)
 extends Tactic[error]:
+
+  private given boundary.Label[Option[result]] = label
+
   def diagnostics: Diagnostics = summon[Diagnostics]
   def record(error: Diagnostics ?=> error): Unit = foci.register(error)
   def finish(): Unit = ()
+  def certify(): Unit = if foci.tainted then boundary.break(None)
 
   def abort(error: Diagnostics ?=> error): Nothing =
     foci.register(error)
-    boundary.break(None)(using label)
+    boundary.break(None)

--- a/lib/contingency/src/core/soundness+contingency-core.scala
+++ b/lib/contingency/src/core/soundness+contingency-core.scala
@@ -35,7 +35,7 @@ package soundness
 export contingency
 . { Tactic, Fatal, Recoverable, raise, abort, safely, unsafely, throwErrors, capture, attempt,
     abortive, ExpectationError, raises, Attempt, mitigate, recover, Unchecked, accrue, within, Foci,
-    track, focus, lest, dare, Errors, validate, Validation, Pointer, survive }
+    track, focus, lest, dare, Errors, validate, Validation, Pointer, survive, certify }
 
 package strategies:
   export contingency.strategies


### PR DESCRIPTION
If we're working in an error context, and we want to assert that there have been no `XyzError`s raised (but not aborted) in a prior step, we can invoke `certify[XyzError]()`. This will abort immediately if there have been.