### PR TITLE
Improve highlighting

### DIFF
--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -79,7 +79,8 @@ object SourceCode:
   private val soft: Set[Text] =
     Set(t"inline", t"opaque", t"open", t"transparent", t"infix", t"mut", t"erased", t"tracked")
 
-  def apply(language: ProgrammingLanguage, text: Text): SourceCode =
+  def apply(language: ProgrammingLanguage, text0: Text): SourceCode =
+    val text = ("val x = {\n"+text0+"\n}").tt
     val source: SourceFile = SourceFile.virtual("<highlighting>", text.s)
     val ctx0 = Contexts.ContextBase().initialCtx.fresh.setReporter(Reporter.NoReporter)
 
@@ -153,7 +154,7 @@ object SourceCode:
           case -1  => xs :: acc
           case idx => lines(xs.drop(idx + 1), xs.take(idx) :: acc)
 
-    SourceCode(language, 1, IArray(lines(soften(stream()).to(List)).reverse*))
+    SourceCode(language, 1, IArray(lines(soften(stream()).to(List)).tail.reverse.tail*))
 
   private class Trees() extends ast.untpd.UntypedTreeTraverser:
     import ast.*, untpd.*

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -106,6 +106,8 @@ object SourceCode:
       case other                                                      => false
 
     def soften(stream: Stream[SourceToken]): Stream[SourceToken] = stream match
+      case (SourceToken(text@(t"using" | t"erased"), Accent.Ident)) #:: more =>
+        SourceToken(text, Accent.Modifier) #:: soften(more)
       case (token@SourceToken(text, Accent.Ident)) #:: more if soft.has(text) =>
         if hard(more) then SourceToken(text, Accent.Modifier) #:: soften(more)
         else token #:: soften(more)
@@ -181,7 +183,7 @@ object SourceCode:
         case tree: Ident if tree.isType =>
           if tree.span.exists then trees += (tree.span.start, tree.span.end) -> Accent.Typed
 
-        case _: TypTree =>
+        case tree: TypTree =>
           if tree.span.exists then trees += (tree.span.start, tree.span.end) -> Accent.Typed
 
         case other =>

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -79,8 +79,7 @@ object SourceCode:
   private val soft: Set[Text] =
     Set(t"inline", t"opaque", t"open", t"transparent", t"infix", t"mut", t"erased", t"tracked")
 
-  def apply(language: ProgrammingLanguage, text0: Text): SourceCode =
-    val text = ("val x = {\n"+text0+"\n}").tt
+  def apply(language: ProgrammingLanguage, text: Text): SourceCode =
     val source: SourceFile = SourceFile.virtual("<highlighting>", text.s)
     val ctx0 = Contexts.ContextBase().initialCtx.fresh.setReporter(Reporter.NoReporter)
 
@@ -154,7 +153,7 @@ object SourceCode:
           case -1  => xs :: acc
           case idx => lines(xs.drop(idx + 1), xs.take(idx) :: acc)
 
-    SourceCode(language, 1, IArray(lines(soften(stream()).to(List)).tail.reverse.tail*))
+    SourceCode(language, 1, IArray(lines(soften(stream()).to(List)).reverse*))
 
   private class Trees() extends ast.untpd.UntypedTreeTraverser:
     import ast.*, untpd.*


### PR DESCRIPTION
The tokenizer doesn't seem to disambiguate between `using` or `erased` and identifiers. This rewrites identifiers that are `using` or `erased` as modifiers.