### PR TITLE
Fix off-by-one error in numerical month rendering

### DIFF
--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -99,8 +99,8 @@ object Aviation:
           case FullYear     => date.year.show
 
         val month: Text = summon[DateNumerics] match
-          case FixedWidth    => pad(date.month.ordinal)
-          case VariableWidth => date.month.ordinal.show
+          case FixedWidth    => pad(date.month.numerical)
+          case VariableWidth => date.month.numerical.show
 
         val day: Text = summon[DateNumerics] match
           case FixedWidth    => pad(date.day)


### PR DESCRIPTION
Fixes the issue where we were using `ordinal` instead of `numerical` when showing months, so January was "0" rather than "1".