### PR TITLE
Do not execute code when it's disassembled

### DIFF
--- a/etc/header.txt
+++ b/etc/header.txt
@@ -11,7 +11,7 @@
 ┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
 ┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
 ┃                                                                                                  ┃
-┃    Soundness, version 0.27.0.                                                                    ┃
+┃    Soundness, version 0.30.0.                                                                    ┃
 ┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
 ┃                                                                                                  ┃
 ┃    The primary distribution site is:                                                             ┃

--- a/lib/mandible/src/core/mandible-core.scala
+++ b/lib/mandible/src/core/mandible-core.scala
@@ -69,7 +69,7 @@ import filesystemOptions.createNonexistent.disabled
 import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.disabled
 
-def disassemble(using codepoint: Codepoint)(code: Quotes ?=> Expr[Any])(using TemporaryDirectory)
+def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using TemporaryDirectory)
      (using classloader: Classloader)
 :     Bytecode =
   val uuid = Uuid()
@@ -83,9 +83,10 @@ def disassemble(using codepoint: Codepoint)(code: Quotes ?=> Expr[Any])(using Te
 
   unsafely:
     val file: Path on Linux = out / Name[Linux](t"Generated$$Code$$From$$Quoted.class")
+    val code: Quotes ?=> Expr[Unit] = '{ def _code(): Unit = $code0 }
     staging.run(code)
     val classfile: Classfile = new Classfile(file.open(_.read[Bytes]))
-    classfile.methods.find(_.name == t"apply").map(_.bytecode).get.vouch.embed(codepoint)
+    classfile.methods.find(_.name == t"_code$$1").map(_.bytecode).get.vouch.embed(codepoint)
 
 
 case class ClassfileError()(using Diagnostics)


### PR DESCRIPTION
When `disassemble`ing code, the staging compiler didn't provide a way to compile the code without executing it, so we were executing it. This was usually innocuous, but it was annoying, and at worst, dangerous. Now, we compile it inside a method, `_code`, instead of in the main quoted code, so all we actually run is a method definition, while it still gets compiled to a classfile.