### PR TITLE
Upgrade to Scala 3.7

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -9,8 +9,8 @@ import publish._
 import os.Path
 
 object settings {
-  val scalaVersion = "3.6.2"
-  //val scalaVersion = "3.7.0-RC2"
+  //val scalaVersion = "3.6.2"
+  val scalaVersion = "3.7.0"
   val scalaOptions = Seq(
     "-experimental",
     "-new-syntax",

--- a/build.mill
+++ b/build.mill
@@ -48,6 +48,13 @@ trait BaseScalaModule extends ScalaModule {
     } catch { case error: Exception => "unknown" }
   }
 
+  override def docJar = T {
+    val jar = T.dest / "empty.jar"
+    val zos = new java.util.zip.ZipOutputStream(new java.io.FileOutputStream(jar.toIO))
+    zos.close()
+    PathRef(jar)
+  }
+
   def artifactSuffix = T("")
   def pomSettings = T(PomSettings(
     description = "soundness-all",


### PR DESCRIPTION
This makes the necessary changes to get Soundness working on Scala 3.7.

This included:
- tweaking the `CodlEncoder` given priority for the generic case
- avoiding running Scaladoc when publishing