### PR TITLE
Remove unnecessary `Showable`

### DIFF
--- a/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
@@ -76,5 +76,3 @@ object Nomenclature:
         case v => check[v.type](name)
 
       name.asInstanceOf[Name[platform]]
-
-    given showable: [platform] => Name[platform] is Showable = identity(_)


### PR DESCRIPTION
We don't need a `Showable` instance for `Name`s because they're subtypes of `Text`.