### PR TITLE
Include more currency definitions

### DIFF
--- a/lib/plutocrat/src/core/plutocrat-core.scala
+++ b/lib/plutocrat/src/core/plutocrat-core.scala
@@ -40,11 +40,14 @@ package currencyStyles:
   given generic: CurrencyStyle = (currency, unit, subunit) => t"$unit.$subunit ${currency.isoCode}"
 
 package currencies:
-  type Eur = Eur.type
-  object Eur extends Currency(t"EUR", t"€",    t"Euro",               100)
+  // These are listed as the "most traded currencies" on Wikipedia
+  // Source: https://en.wikipedia.org/wiki/Template:Most_traded_currencies
 
   type Usd = Usd.type
   object Usd extends Currency(t"USD", t"$$",   t"US Dollar",          100)
+
+  type Eur = Eur.type
+  object Eur extends Currency(t"EUR", t"€",    t"Euro",               100)
 
   type Jpy = Jpy.type
   object Jpy extends Currency(t"JPY", t"¥",    t"Japanese Yen",       100)
@@ -87,6 +90,66 @@ package currencies:
 
   type Mxn = Mxn.type
   object Mxn extends Currency(t"MXN", t"$$",   t"Mexican Peso",       100)
+
+  type Twd = Twd.type
+  object Twd extends Currency(t"TWD", t"NT$$", t"New Taiwan Dollar",  100)
+
+  type Zar = Zar.type
+  object Zar extends Currency(t"ZAR", t"R",    t"South African Rand", 100)
+
+  type Brl = Brl.type
+  object Brl extends Currency(t"BRL", t"R$$",  t"Brazilian Real",     100)
+
+  type Dkk = Dkk.type
+  object Dkk extends Currency(t"DKK", t"kr",   t"Danish Krone",       100)
+
+  type Pln = Pln.type
+  object Pln extends Currency(t"PLN", t"zł",   t"Polish Złoty",       100)
+
+  type Thb = Thb.type
+  object Thb extends Currency(t"THB", t"฿",    t"Thai Baht",          100)
+
+  type Ils = Ils.type
+  object Ils extends Currency(t"ILS", t"₪",    t"Israeli New Shekel", 100)
+
+  type Idr = Idr.type
+  object Idr extends Currency(t"IDR", t"Rp",   t"Indonesian Rupiah",  100)
+
+  type Czk = Czk.type
+  object Czk extends Currency(t"CZK", t"Kč",   t"Czech Koruna",       100)
+
+  type Aed = Aed.type
+  object Aed extends Currency(t"AED", t"Dh",   t"UAE Dirham",         100)
+
+  type Try = Try.type
+  object Try extends Currency(t"TRY", t"₺",    t"Turkish Lira",       100)
+
+  type Huf = Huf.type
+  object Huf extends Currency(t"HUF", t"Ft",   t"Hungarian Forint",   100)
+
+  type Clp = Clp.type
+  object Clp extends Currency(t"CLP", t"$$",   t"Chilean Peso",       100)
+
+  type Sar = Sar.type
+  object Sar extends Currency(t"SAR", t"SAR",  t"Saudi Ryial",        100)
+
+  type Php = Php.type
+  object Php extends Currency(t"PHP", t"₱",    t"Philippine Peso",    100)
+
+  type Myr = Myr.type
+  object Myr extends Currency(t"MYR", t"RM",   t"Malaysian Ringgit",  100)
+
+  type Cop = Cop.type
+  object Cop extends Currency(t"COP", t"$$",   t"Colombian Peso",     100)
+
+  type Rub = Rub.type
+  object Rub extends Currency(t"RUB", t"₽",    t"Russian Ruble",      100)
+
+  type Ron = Ron.type
+  object Ron extends Currency(t"RON", t"lei",  t"Romanian Leu",       100)
+
+  type Pen = Pen.type
+  object Pen extends Currency(t"PEN", t"S/",   t"Peruvian Sol",       100)
 
 export Plutocrat.Money
 

--- a/lib/plutocrat/src/core/soundness+plutocrat-core.scala
+++ b/lib/plutocrat/src/core/soundness+plutocrat-core.scala
@@ -39,4 +39,5 @@ package currencyStyles:
 
 package currencies:
   export plutocrat.currencies
-  . { Eur, Usd, Jpy, Gbp, Cny, Aud, Cad, Chf, Hkd, Sgd, Sek, Krw, Nok, Nzd, Inr, Mxn }
+  . { Eur, Usd, Jpy, Gbp, Cny, Aud, Cad, Chf, Hkd, Sgd, Sek, Krw, Nok, Nzd, Inr, Mxn, Twd, Zar, Brl,
+      Dkk, Pln, Thb, Ils, Idr, Czk, Aed, Try, Huf, Clp, Sar, Php, Myr, Cop, Rub, Ron, Pen }

--- a/lib/spectacular/src/core/spectacular.Showable.scala
+++ b/lib/spectacular/src/core/spectacular.Showable.scala
@@ -62,7 +62,7 @@ object Showable:
   given double: (decimalizer: DecimalConverter) => Double is Showable = decimalizer.decimalize(_)
   given boolean: (booleanStyle: BooleanStyle) => Boolean is Showable = booleanStyle(_)
   given option: [value: Showable] => Option[value] is Showable = _.fold("none".tt)(value.text(_))
-  given uid: Uuid is Showable = _.text
+  given uuid: Uuid is Showable = _.text
   given memory: Memory is Showable = _.text
   given enumeration: [enumeration <: reflect.Enum] => enumeration is Showable = _.toString.tt
 


### PR DESCRIPTION
This includes the 36 most traded currencies, [according to Wikipedia](https://en.wikipedia.org/wiki/Template:Most_traded_currencies).