### PR TITLE
Month and Year improvements

### DIFF
--- a/lib/aviation/src/core/aviation-core.scala
+++ b/lib/aviation/src/core/aviation-core.scala
@@ -41,7 +41,7 @@ import spectacular.*
 import vacuous.*
 
 export Aviation2.{Instant, Duration}
-export Aviation.Date
+export Aviation.{Date, Year}
 export Month.{Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec}
 
 given realm: Realm = realm"aviation"
@@ -175,12 +175,14 @@ package timeFormats:
 
 package calendars:
   given julian: RomanCalendar:
-    def leapYear(year: YearUnit): Boolean = year%4 == 0
-    def leapYearsSinceEpoch(year: Int): Int = year/4
+    def leapYear(year: YearUnit): Boolean = year.int%4 == 0
+    def leapYearsSinceEpoch(year: Year): Int = year.int/4
 
   given gregorian: RomanCalendar:
-    def leapYear(year: YearUnit): Boolean = year%4 == 0 && year%100 != 0 || year%400 == 0
-    def leapYearsSinceEpoch(year: Int): Int = year/4 - year/100 + year/400 + 1
+    def leapYear(year: YearUnit): Boolean =
+      year.int%4 == 0 && year.int%100 != 0 || year.int%400 == 0
+
+    def leapYearsSinceEpoch(year: Year): Int = year.int/4 - year.int/100 + year.int/400 + 1
 
 def now()(using clock: Clock): Instant = clock()
 

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -80,6 +80,7 @@ object Aviation:
 
   object Date:
     erased given underlying: Underlying[Date, Int] = !!
+
     def of(day: Int): Date = day
 
     def apply(using cal: Calendar)(year: cal.YearUnit, month: cal.MonthUnit, day: cal.DayUnit)
@@ -160,6 +161,10 @@ object Aviation:
   extension (date: Date)
     def day(using calendar: Calendar): calendar.DayUnit = calendar.getDay(date)
     def month(using calendar: Calendar): calendar.MonthUnit = calendar.getMonth(date)
+
+    def monthstamp(using calendar: RomanCalendar): Monthstamp =
+      Monthstamp(calendar.getYear(date), calendar.getMonth(date))
+
     def year(using calendar: Calendar): calendar.YearUnit = calendar.getYear(date)
 
     def yearDay(using calendar: Calendar): Int =

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -53,7 +53,7 @@ object Aviation:
   opaque type Date = Int
   opaque type Year = Int
 
-  extension (year: Year) def int: Int = year
+  extension (year: Year) inline def int: Int = year
 
   object Year:
     inline def apply(year: Int): Year = year
@@ -61,6 +61,15 @@ object Aviation:
     given addable: Year is Addable by Int into Year = _ + _
     given subtractable: Year is Subtractable by Int into Year = _ - _
     given decodable: (int: Int is Decodable in Text) => Year is Decodable in Text = int.map(Year(_))
+
+    given orderable: Year is Orderable:
+      inline def compare
+                  (inline left:        Year,
+                   inline right:       Year,
+                   inline strict:      Boolean,
+                   inline greaterThan: Boolean)
+      :     Boolean =
+        if left.int == right.int then !strict else (left.int < right.int)^greaterThan
 
   def validTime(time: Expr[Double], pm: Boolean)(using Quotes): Expr[Clockface] =
     import quotes.reflect.*

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -51,6 +51,16 @@ import java.util as ju
 
 object Aviation:
   opaque type Date = Int
+  opaque type Year = Int
+
+  extension (year: Year) def int: Int = year
+
+  object Year:
+    inline def apply(year: Int): Year = year
+    given showable: Year is Showable = _.toString.tt
+    given addable: Year is Addable by Int into Year = _ + _
+    given subtractable: Year is Subtractable by Int into Year = _ - _
+    given decodable: (int: Int is Decodable in Text) => Year is Decodable in Text = int.map(Year(_))
 
   def validTime(time: Expr[Double], pm: Boolean)(using Quotes): Expr[Clockface] =
     import quotes.reflect.*

--- a/lib/aviation/src/core/aviation.Aviation2.scala
+++ b/lib/aviation/src/core/aviation.Aviation2.scala
@@ -148,7 +148,7 @@ object Aviation2:
       val zonedTime = jt.Instant.ofEpochMilli(instant).nn.atZone(jt.ZoneId.of(timezone.name.s)).nn
 
       val date = zonedTime.getMonthValue.absolve match
-        case Month(month) => unsafely(Date(zonedTime.getYear, month, zonedTime.getDayOfMonth))
+        case Month(month) => unsafely(Date(Year(zonedTime.getYear), month, zonedTime.getDayOfMonth))
 
       val time = (zonedTime.getHour, zonedTime.getMinute, zonedTime.getSecond).absolve match
         case (Base24(hour), Base60(minute), Base60(second)) => Clockface(hour, minute, second)

--- a/lib/aviation/src/core/aviation.LeapSeconds.scala
+++ b/lib/aviation/src/core/aviation.LeapSeconds.scala
@@ -43,12 +43,12 @@ object LeapSeconds:
   private var june:     Long = bin"1000000001110100000011100100000000000000100100000000000000000000"
   private var december: Long = bin"1111111100000001011000010010000001001000000010000000000000000000"
 
-  def addLeapSecond(year: Int, midYear: Boolean): Unit =
-    if midYear then june |= (Long.MinValue >> (year - 1972))
-    else december |= (Long.MinValue >> (year - 1972))
+  def addLeapSecond(year: Year, midYear: Boolean): Unit =
+    if midYear then june |= (Long.MinValue >> (year.int - 1972))
+    else december |= (Long.MinValue >> (year.int - 1972))
 
-  def during(year: Int, plusSixMonths: Boolean): Int =
-    before((year - 1972)*2 + (if plusSixMonths then 1 else 0))
+  def during(year: Year, plusSixMonths: Boolean): Int =
+    before((year.int - 1972)*2 + (if plusSixMonths then 1 else 0))
 
   private def before(n: Int): Int =
     inline def ones(long: Long): Int = long.bits.ones.int

--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -44,7 +44,7 @@ object Moment:
 case class Moment(date: Date, time: Clockface, timezone: Timezone):
   def instant(using RomanCalendar): Instant =
     val ldt = jt.LocalDateTime.of
-               (date.year, date.month.numerical, date.day, time.hour, time.minute, time.second)
+               (date.year.int, date.month.numerical, date.day, time.hour, time.minute, time.second)
 
     Instant.of(ldt.nn.atZone(jt.ZoneId.of(timezone.name.s)).nn.toInstant.nn.toEpochMilli)
 

--- a/lib/aviation/src/core/aviation.Month.scala
+++ b/lib/aviation/src/core/aviation.Month.scala
@@ -52,7 +52,7 @@ object Month:
     type Result = Monthstamp
     type Operand = Month
 
-    def subtract(year: Int, month: Month) = new Monthstamp(year, month)
+    def subtract(year: Int, month: Month) = new Monthstamp(Year(year), month)
 
 enum Month:
   case Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec

--- a/lib/aviation/src/core/aviation.Month.scala
+++ b/lib/aviation/src/core/aviation.Month.scala
@@ -47,12 +47,12 @@ object Month:
   def unapply(value: Int): Option[Month] =
     if value < 1 || value > 12 then None else Some(fromOrdinal(value - 1))
 
-  given monthOfYear: Int is Subtractable by Month into YearMonth = new Subtractable:
+  given monthOfYear: Int is Subtractable by Month into Monthstamp = new Subtractable:
     type Self = Int
-    type Result = YearMonth
+    type Result = Monthstamp
     type Operand = Month
 
-    def subtract(year: Int, month: Month) = new YearMonth(year, month)
+    def subtract(year: Int, month: Month) = new Monthstamp(year, month)
 
 enum Month:
   case Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec

--- a/lib/aviation/src/core/aviation.Monthstamp.scala
+++ b/lib/aviation/src/core/aviation.Monthstamp.scala
@@ -35,7 +35,7 @@ package aviation
 import contingency.*
 import symbolism.*
 
-case class Monthstamp(year: Int, month: Month):
+case class Monthstamp(year: Year, month: Month):
   import scala.compiletime.ops.int.*
 
 object Monthstamp:

--- a/lib/aviation/src/core/aviation.Monthstamp.scala
+++ b/lib/aviation/src/core/aviation.Monthstamp.scala
@@ -35,13 +35,13 @@ package aviation
 import contingency.*
 import symbolism.*
 
-case class YearMonth(year: Int, month: Month):
+case class Monthstamp(year: Int, month: Month):
   import scala.compiletime.ops.int.*
 
-object YearMonth:
-  given dayOfMonth: YearMonth is Subtractable:
+object Monthstamp:
+  given dayOfMonth: Monthstamp is Subtractable:
     type Result = Date
     type Operand = Int
 
-    def subtract(yearMonth: YearMonth, day: Int): Date =
-      unsafely(calendars.gregorian.julianDay(yearMonth.year, yearMonth.month, day))
+    def subtract(monthstamp: Monthstamp, day: Int): Date =
+      unsafely(calendars.gregorian.julianDay(monthstamp.year, monthstamp.month, day))

--- a/lib/aviation/src/core/aviation.RomanCalendar.scala
+++ b/lib/aviation/src/core/aviation.RomanCalendar.scala
@@ -38,10 +38,11 @@ import contingency.*
 import fulminate.*
 import gossamer.*
 import spectacular.*
+import symbolism.*
 import vacuous.*
 
 abstract class RomanCalendar() extends Calendar:
-  type YearUnit = Int
+  type YearUnit = Year
   type MonthUnit = Month
   type DayUnit = Int
 
@@ -55,22 +56,24 @@ abstract class RomanCalendar() extends Calendar:
   def add(date: Date, period: Timespan): Date =
     val monthTotal = getMonth(date).ordinal + period.months
     val month2 = Month.fromOrdinal(monthTotal%12)
-    val year2 = getYear(date) + period.years + monthTotal/12
+    val year2: Year = Year(getYear(date).int + period.years + monthTotal/12)
 
     safely(julianDay(year2, month2, getDay(date)).addDays(period.days)).vouch
 
-  def leapYearsSinceEpoch(year: Int): Int
+  def leapYearsSinceEpoch(year: Year): Int
   def daysInYear(year: YearUnit): Int = if leapYear(year) then 366 else 365
 
   def zerothDayOfYear(year: YearUnit): Date =
-    Date.of(year*365 + leapYearsSinceEpoch(year) + 1721059)
+    Date.of(year.int*365 + leapYearsSinceEpoch(year) + 1721059)
 
-  def getYear(date: Date): Int =
-    def recur(year: Int): Int =
+  def getYear(date: Date): Year =
+    def recur(year: Year): Year =
       val z = zerothDayOfYear(year).julianDay
-      if z < date.julianDay && z + daysInYear(year) > date.julianDay then year else recur(year + 1)
 
-    recur(((date.julianDay - 1721059)/366).toInt)
+      if z < date.julianDay && z + daysInYear(year) > date.julianDay then year
+      else recur(year + 1)
+
+    recur(Year(((date.julianDay - 1721059)/366).toInt))
 
   def getMonth(date: Date): Month =
     val year = getYear(date)
@@ -82,9 +85,9 @@ abstract class RomanCalendar() extends Calendar:
     val month = getMonth(date)
     date.julianDay - zerothDayOfYear(year).julianDay - month.offset(leapYear(year))
 
-  def julianDay(year: Int, month: Month, day: Int): Date raises DateError =
+  def julianDay(year: Year, month: Month, day: Int): Date raises DateError =
     if day < 1 || day > daysInMonth(month, year) then
       raise(DateError(t"$year-${month.numerical}-$day"))
-      Date(using calendars.julian)(2000, Month(1), 1)
+      Date(using calendars.julian)(Year(2000), Month(1), 1)
 
     zerothDayOfYear(year).addDays(month.offset(leapYear(year)) + day)

--- a/lib/aviation/src/core/aviation.Timestamp.scala
+++ b/lib/aviation/src/core/aviation.Timestamp.scala
@@ -61,7 +61,7 @@ object Timestamp:
 
         . within:
             Timestamp
-             (Date(year.decode[Int],
+             (Date(year.decode[Year],
               Month(month.decode[Int]),
               day.decode[Int]),
               Clockface(Base24(hour.decode[Int]),
@@ -84,7 +84,7 @@ case class Timestamp(date: Date, time: Clockface):
 
   def stdlib(using RomanCalendar): jt.LocalDateTime =
     jt.LocalDateTime.of
-     (date.year, date.month.ordinal, date.day, time.hour, time.minute, time.second)
+     (date.year.int, date.month.ordinal, date.day, time.hour, time.minute, time.second)
     . nn
 
   def instant(using timezone: Timezone, calendar: RomanCalendar): Instant =

--- a/lib/aviation/src/core/aviation.Timestamp.scala
+++ b/lib/aviation/src/core/aviation.Timestamp.scala
@@ -72,6 +72,14 @@ object Timestamp:
         raise(TimestampError(value)) yet Timestamp(2000-Jan-1, Clockface(0, 0, 0))
 
 case class Timestamp(date: Date, time: Clockface):
+  def year(using calendar: Calendar): calendar.YearUnit = date.year
+  def month(using calendar: Calendar): calendar.MonthUnit = date.month
+  def monthstamp(using RomanCalendar): Monthstamp = date.monthstamp
+  def day(using calendar: Calendar): calendar.DayUnit = date.day
+  def hour: Int = time.hour
+  def minute: Int = time.minute
+  def second: Int = time.second
+
   def in(timezone: Timezone): Moment = Moment(date, time, timezone)
 
   def stdlib(using RomanCalendar): jt.LocalDateTime =

--- a/lib/aviation/src/core/soundness+aviation-core.scala
+++ b/lib/aviation/src/core/soundness+aviation-core.scala
@@ -35,7 +35,7 @@ package soundness
 export aviation
 . { Base24, Base60, Calendar, Clock, Clockface, DateError, Horology, Period, LeapSeconds, Moment,
     Month, RomanCalendar, StandardTime, Timespan, Timestamp, Chronology, Timezone, TimezoneError,
-    Tzdb, TzdbError, Weekday, YearMonth, now, today, TimeEvent, am, pm, year, month, week, day,
+    Tzdb, TzdbError, Weekday, Monthstamp, now, today, TimeEvent, am, pm, year, month, week, day,
     hour, minute, second, years, months, weeks, days, hours, minutes, seconds, tz, TimestampError,
     Instant, Duration, Date, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec,
     DateNumerics, DateSeparation, Endianness, YearFormat, Meridiem, TimeFormat, TimeSeparation,

--- a/lib/aviation/src/core/soundness+aviation-core.scala
+++ b/lib/aviation/src/core/soundness+aviation-core.scala
@@ -39,7 +39,7 @@ export aviation
     hour, minute, second, years, months, weeks, days, hours, minutes, seconds, tz, TimestampError,
     Instant, Duration, Date, Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec,
     DateNumerics, DateSeparation, Endianness, YearFormat, Meridiem, TimeFormat, TimeSeparation,
-    TimeNumerics, TimeSpecificity }
+    TimeNumerics, TimeSpecificity, Year }
 
 package calendars:
   export aviation.calendars.{gregorian, julian}

--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -71,88 +71,88 @@ object Tests extends Suite(m"Aviation Tests"):
 
     suite(m"Leap Seconds tests"):
       test(m"There are 10 leap seconds for any year before 1972"):
-        LeapSeconds.during(1900, false)
+        LeapSeconds.during(Year(1900), false)
       .assert(_ == 10)
 
       test(m"There are 10 leap seconds in the first half of 1972"):
-        LeapSeconds.during(1972, false)
+        LeapSeconds.during(Year(1972), false)
       .assert(_ == 10)
 
       test(m"There are 11 leap seconds in the second half of 1972"):
-        LeapSeconds.during(1972, true)
+        LeapSeconds.during(Year(1972), true)
       .assert(_ == 11)
 
       test(m"There are 12 leap seconds in the first half of 1973"):
-        LeapSeconds.during(1973, false)
+        LeapSeconds.during(Year(1973), false)
       .assert(_ == 12)
 
       test(m"There are 12 leap seconds in the second half of 1973"):
-        LeapSeconds.during(1973, true)
+        LeapSeconds.during(Year(1973), true)
       .assert(_ == 12)
 
       test(m"There are 13 leap seconds in the first half of 1974"):
-        LeapSeconds.during(1974, false)
+        LeapSeconds.during(Year(1974), false)
       .assert(_ == 13)
 
       test(m"There are 13 leap seconds in the second half of 1974"):
-        LeapSeconds.during(1974, true)
+        LeapSeconds.during(Year(1974), true)
       .assert(_ == 13)
 
       test(m"There are 19 leap seconds in the first half of 1980"):
-        LeapSeconds.during(1980, false).tap(println)
+        LeapSeconds.during(Year(1980), false).tap(println)
       .assert(_ == 19)
 
       test(m"There are 19 leap seconds in the first half of 1981"):
-        LeapSeconds.during(1981, false)
+        LeapSeconds.during(Year(1981), false)
       .assert(_ == 19)
 
       test(m"There are 20 leap seconds in the second half of 1981"):
-        LeapSeconds.during(1981, true)
+        LeapSeconds.during(Year(1981), true)
       .assert(_ == 20)
 
       test(m"There are 19 leap seconds in the first half of 1981"):
-        LeapSeconds.during(1981, false)
+        LeapSeconds.during(Year(1981), false)
       .assert(_ == 19)
 
       test(m"There are 20 leap seconds in the second half of 1981"):
-        LeapSeconds.during(1981, true)
+        LeapSeconds.during(Year(1981), true)
       .assert(_ == 20)
 
       test(m"There are 20 leap seconds in the first half of 1982"):
-        LeapSeconds.during(1982, false)
+        LeapSeconds.during(Year(1982), false)
       .assert(_ == 20)
 
       test(m"There are 21 leap seconds in the second half of 1982"):
-        LeapSeconds.during(1982, true)
+        LeapSeconds.during(Year(1982), true)
       .assert(_ == 21)
 
       test(m"There are 24 leap seconds in the second half of 1988"):
-        LeapSeconds.during(1988, true)
+        LeapSeconds.during(Year(1988), true)
       .assert(_ == 24)
 
       test(m"There are 32 leap seconds in the first half of 2000"):
-        LeapSeconds.during(2000, false)
+        LeapSeconds.during(Year(2000), false)
       .assert(_ == 32)
 
       test(m"There are 37 leap seconds in the first half of 2017"):
-        LeapSeconds.during(2017, false)
+        LeapSeconds.during(Year(2017), false)
       .assert(_ == 37)
 
       test(m"There are 37 leap seconds in the first half of 2100"):
-        LeapSeconds.during(2100, false)
+        LeapSeconds.during(Year(2100), false)
       .assert(_ == 37)
 
     suite(m"Gregorian Calendar Tests"):
       test(m"2000 is a leap year"):
-        calendars.gregorian.leapYear(2000)
+        calendars.gregorian.leapYear(Year(2000))
       .assert(_ == true)
 
       test(m"1800, 1900, 2100, 2200 are not leap years"):
-        List(1800, 1900, 2100, 2200).map(calendars.gregorian.leapYear)
+        List(Year(1800), Year(1900), Year(2100), Year(2200)).map(calendars.gregorian.leapYear)
       .assert(_.all(!_))
 
       test(m"Years not divisble by 4 are never leap years"):
-        List(1985, 2001, 2023, 1843).map(calendars.gregorian.leapYear)
+        List(Year(1985), Year(200), Year(202), Year(1843)).map(calendars.gregorian.leapYear)
       .assert(_.all(!_))
 
       test(m"Check recent Julian Day"):
@@ -176,15 +176,15 @@ object Tests extends Suite(m"Aviation Tests"):
       .assert(_ == 1721426)
 
       test(m"Get zeroth day of year"):
-        (2010-Jan-1).julianDay -> (calendars.gregorian.zerothDayOfYear(2010).julianDay + 1)
+        (2010-Jan-1).julianDay -> (calendars.gregorian.zerothDayOfYear(Year(2010)).julianDay + 1)
       .assert(_ == _)
 
       test(m"Get days in non-leap-year"):
-        calendars.gregorian.daysInYear(1995)
+        calendars.gregorian.daysInYear(Year(1995))
       .assert(_ == 365)
 
       test(m"Get days in leap-year"):
-        calendars.gregorian.daysInYear(1996)
+        calendars.gregorian.daysInYear(Year(1996))
       .assert(_ == 366)
 
       test(m"Get Year from Date"):
@@ -257,7 +257,7 @@ object Tests extends Suite(m"Aviation Tests"):
       import calendars.gregorian
       test(m"Specify datetime"):
         2018-Aug-11 at 5.25.pm
-      .assert(_ == Timestamp(Date(2018, Aug, 11), Clockface(17, 25, 0)))
+      .assert(_ == Timestamp(Date(Year(2018), Aug, 11), Clockface(17, 25, 0)))
 
       test(m"Add two months to a date"):
         2014-Nov-20 + 2.months

--- a/lib/plutocrat/src/core/plutocrat.Currency.scala
+++ b/lib/plutocrat/src/core/plutocrat.Currency.scala
@@ -40,4 +40,9 @@ open case class Currency(isoCode: Text, symbol: Text, name: Text, modulus: Int):
     val tweak = (if integral < 0 then -0.5 else 0.5)/modulus
     Money(this)(integral, ((value - integral + tweak)*modulus).toInt)
 
+  def minor(long: Long): Money[this.type] =
+    val major = long/modulus
+    val minor = long%modulus
+    Money(this)(major, minor.toInt)
+
   def zero: Money[this.type] = apply(0.00)


### PR DESCRIPTION
Improve the typesafety around years by giving them their own opaque type, `Year`. So methods involving years should now use `Year` instead of `Int`. A `Year` can be converted to an `Int` with its `int` method.

This also develops the concept of a `Monthstamp`, which is the combination of a `Year` and `Month`, while a `Month` remains a named month, in no particular year.