### PR TITLE
Do not export `classOf` because the exported version doesn't work

### DIFF
--- a/lib/proscenium/src/core/proscenium-core.scala
+++ b/lib/proscenium/src/core/proscenium-core.scala
@@ -40,7 +40,7 @@ export scala.collection.concurrent.TrieMap
 
 export Predef
 . { nn, identity, summon, charWrapper, $conforms, ArrowAssoc, intWrapper, longWrapper,
-    shortWrapper, byteWrapper, valueOf, doubleWrapper, floatWrapper, classOf, locally }
+    shortWrapper, byteWrapper, valueOf, doubleWrapper, floatWrapper, locally }
 
 export scala.util.control.NonFatal
 

--- a/lib/proscenium/src/core/soundness+proscenium-core.scala
+++ b/lib/proscenium/src/core/soundness+proscenium-core.scala
@@ -40,7 +40,7 @@ export scala.collection.concurrent.TrieMap
 
 export Predef
 . { nn, identity, summon, charWrapper, $conforms, ArrowAssoc, intWrapper, longWrapper, shortWrapper,
-    byteWrapper, valueOf, doubleWrapper, floatWrapper, classOf, locally }
+    byteWrapper, valueOf, doubleWrapper, floatWrapper, locally }
 
 export scala.util.control.NonFatal
 


### PR DESCRIPTION
We were exporting `classOf` from `Predef` in Proscenium. @jackgene discovered, indirectly, that this wasn't working and `java.lang.Object` was always being resolved, rather than the specified type.

It appears that the export is effectively "un-inlined", which means that the type parameter arrives as an abstract type variable, rather than the concrete type it requires. Subsequently, this type variable always erases to `java.lang.Object`, which explains the observed behavior.