### PR TITLE
Reinstate checking of time literals

### DIFF
--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -39,6 +39,7 @@ import fulminate.*
 import gossamer.*
 import hieroglyph.*
 import hypotenuse.*
+import kaleidoscope.*
 import prepositional.*
 import proscenium.*
 import rudiments.*
@@ -129,10 +130,10 @@ object Aviation:
         val h: Base24 = (hour + (if pm then 12 else 0)).asInstanceOf[Base24]
         val length = lit.pos.endColumn - lit.pos.startColumn
 
-        if (hour < 10 && length != 4) || (hour >= 10 && length != 5) then
-          if length == 0
-          then warn(m"time is unchecked because range positions are not available")
-          else halt(m"the time should have exactly two minutes digits", lit.pos)
+        Position.ofMacroExpansion.sourceCode.get.tt match
+          case r"[0-9][0-9]?\.[0-9][0-9][^0-9]*" =>
+          case other =>
+            halt(m"the time should have exactly two minutes digits", lit.pos)
 
         val m: Base60 = minutes.asInstanceOf[Base60]
         '{Clockface(${Expr[Base24](h)}, ${Expr[Base60](m)}, 0)}

--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -258,7 +258,20 @@ object Tests extends Suite(m"Aviation Tests"):
         7.25.pm
       .assert(_ == Clockface(19, 25, 0))
 
+      test(m"Time with too many minutes is invalid"):
+        demilitarize(7.88.am)
+      .assert(_.nonEmpty)
+
+      test(m"Time with too few minute digits is invalid"):
+        demilitarize(7.8.am)
+      .assert(_.nonEmpty)
+
+      test(m"Time with too many minute digits is invalid"):
+        demilitarize(7.585.am)
+      .assert(_.nonEmpty)
+
       import calendars.gregorian
+
       test(m"Specify datetime"):
         2018-Aug-11 at 5.25.pm
       .assert(_ == Timestamp(Date(Year(2018), Aug, Day(11)), Clockface(17, 25, 0)))


### PR DESCRIPTION
Time literals of the form `7.00.pm` or `11.48.am` will now be checked by a macro to ensure that there are exactly two minute digits. This was checked in a previous version, but started failing when some compiler detail around range positions changed.