### PR TITLE
Cleanup whitespace

### DIFF
--- a/lib/abacist/src/core/abacist.Abacist2.scala
+++ b/lib/abacist/src/core/abacist.Abacist2.scala
@@ -115,7 +115,8 @@ object Abacist2:
     transparent inline def divide(inline multiplier: Double): Any =
       ${Abacist.multiplyQuanta('count, 'multiplier, true)}
 
-    transparent inline def collapse(length: Int)(using length.type < Tuple.Size[units] =:= true)
-    :     Quanta[Tuple.Drop[units, length.type]] =
 
-      count
+    transparent inline def collapse(length: Int)(using length.type < Tuple.Size[units] =:= true)
+    : Quanta[Tuple.Drop[units, length.type]] =
+
+        count

--- a/lib/adversaria/src/core/adversaria.Annotations.scala
+++ b/lib/adversaria/src/core/adversaria.Annotations.scala
@@ -46,12 +46,14 @@ object Annotations:
   transparent inline def field[target](inline lambda: target => Any): List[StaticAnnotation] =
     ${Adversaria.fieldAnnotations[target]('lambda)}
 
-  transparent inline def fields[target <: Product, annotation <: StaticAnnotation]
-  :     List[CaseField[target, annotation]] =
 
-    ${Adversaria.fields[target, annotation]}
+  transparent inline def fields[target <: Product, annotation <: StaticAnnotation]
+  : List[CaseField[target, annotation]] =
+
+      ${Adversaria.fields[target, annotation]}
+
 
   transparent inline def firstField[target <: Product, annotation <: StaticAnnotation]
-  :     CaseField[target, annotation] =
+  : CaseField[target, annotation] =
 
-    ${Adversaria.firstField[target, annotation]}
+      ${Adversaria.firstField[target, annotation]}

--- a/lib/adversaria/src/core/adversaria.CaseField.scala
+++ b/lib/adversaria/src/core/adversaria.CaseField.scala
@@ -39,17 +39,19 @@ import proscenium.*
 object CaseField:
   def apply[target <: Product, annotation <: StaticAnnotation, field]
        (name: Text, access: target => field, annotation0: annotation)
-  :     CaseField[target, annotation] of field =
+  : CaseField[target, annotation] of field =
 
-    new CaseField[target, annotation](name):
-      type Subject = field
-      def apply(value: target) = access(value)
-      def annotation: annotation = annotation0
+      new CaseField[target, annotation](name):
+        type Subject = field
+        def apply(value: target) = access(value)
+        def annotation: annotation = annotation0
+
 
   transparent inline given[target <: Product, annotation <: StaticAnnotation]
-  :     CaseField[target, annotation] =
+  : CaseField[target, annotation] =
 
-    Annotations.firstField[target, annotation]
+      Annotations.firstField[target, annotation]
+
 
 trait CaseField[target <: Product, annotation <: StaticAnnotation](val name: Text):
   type Subject

--- a/lib/ambience/src/core/ambience.Environment.scala
+++ b/lib/ambience/src/core/ambience.Environment.scala
@@ -47,16 +47,17 @@ trait Environment:
 object Environment extends Dynamic:
   def apply[variable](variable: Text)
        (using environment: Environment, reader: EnvironmentVariable[Label, variable])
-  :     variable raises EnvironmentError =
+  : variable raises EnvironmentError =
 
-    environment.variable(variable).let(reader.read).or(raise(EnvironmentError(variable)))
-    . yet(reader.read("".tt))
+      environment.variable(variable).let(reader.read).or(raise(EnvironmentError(variable)))
+      . yet(reader.read("".tt))
+
 
   inline def selectDynamic[variable](key: String)
               (using environment:      Environment,
                      reader:           EnvironmentVariable[key.type, variable],
                      environmentError: Tactic[EnvironmentError])
-  :     variable =
+  : variable =
 
-    environment.variable(reader.defaultName).let(reader.read(_)).or:
-      raise(EnvironmentError(reader.defaultName)) yet reader.read(Text(""))
+      environment.variable(reader.defaultName).let(reader.read(_)).or:
+        raise(EnvironmentError(reader.defaultName)) yet reader.read(Text(""))

--- a/lib/ambience/src/core/ambience.EnvironmentVariable2.scala
+++ b/lib/ambience/src/core/ambience.EnvironmentVariable2.scala
@@ -40,10 +40,10 @@ import prepositional.*
 import proscenium.*
 
 trait EnvironmentVariable2:
-  given generic[unknown <: Label]: EnvironmentVariable[unknown, Text] =
-    identity(_)
+  given generic[unknown <: Label]: EnvironmentVariable[unknown, Text] = identity(_)
+
 
   given decoder[unknown <: Label, variable: Decodable in Text]
-  :     EnvironmentVariable[unknown, variable] =
+  : EnvironmentVariable[unknown, variable] =
 
-    variable.decoded(_)
+      variable.decoded(_)

--- a/lib/ambience/src/core/ambience.Properties.scala
+++ b/lib/ambience/src/core/ambience.Properties.scala
@@ -43,8 +43,9 @@ object Properties extends Dynamic:
        (using properties:     SystemProperties,
               reader:         SystemProperty[String, property],
               systemProperty: Tactic[SystemPropertyError])
-  :     property =
+  : property =
 
-    properties(property).let(reader.read).lest(SystemPropertyError(property))
+      properties(property).let(reader.read).lest(SystemPropertyError(property))
+
 
   def selectDynamic(key: String): PropertyAccess[key.type] = PropertyAccess[key.type](key)

--- a/lib/ambience/src/core/ambience.PropertyAccess.scala
+++ b/lib/ambience/src/core/ambience.PropertyAccess.scala
@@ -45,20 +45,21 @@ case class PropertyAccess[name <: String](property: String) extends Dynamic:
   def selectDynamic(key: String): PropertyAccess[name+"."+key.type] =
     PropertyAccess[name+"."+key.type](property+"."+key)
 
+
   def applyDynamic[property](key: String)()
        (using properties:     SystemProperties,
               reader:         SystemProperty[name+"."+key.type, property],
               systemProperty: Tactic[SystemPropertyError])
-  :     property =
+  : property =
 
-    properties((property+"."+key).tt).let(reader.read(_)).or:
-      abort(SystemPropertyError((property+"."+key).tt))
+      properties((property+"."+key).tt).let(reader.read(_)).or:
+        abort(SystemPropertyError((property+"."+key).tt))
+
 
   inline def apply[property]()
               (using properties:     SystemProperties,
                      reader:         SystemProperty[name, property],
                      systemProperty: Tactic[SystemPropertyError])
-  :     property =
+  : property =
 
-    properties(valueOf[name].tt).let(reader.read(_)).or:
-      abort(SystemPropertyError(valueOf[name].tt))
+      properties(valueOf[name].tt).let(reader.read(_)).lest(SystemPropertyError(valueOf[name].tt))

--- a/lib/ambience/src/core/ambience.Xdg.scala
+++ b/lib/ambience/src/core/ambience.Xdg.scala
@@ -44,41 +44,54 @@ import vacuous.*
 object Xdg:
   def dataHome[path: Instantiable across Paths from Text]
        (using environment: Environment, home: HomeDirectory)
-  :     path =
-    safely(Environment.xdgDataHome[path]).or(path(t"${home.directory()}/.local/share"))
+  : path =
+
+      safely(Environment.xdgDataHome[path]).or(path(t"${home.directory()}/.local/share"))
+
 
   def configHome[path: Instantiable across Paths from Text]
        (using environment: Environment, home: HomeDirectory)
-  :     path =
-    safely(Environment.xdgConfigHome[path]).or(path(t"${home.directory()}/.config"))
+  : path =
+
+      safely(Environment.xdgConfigHome[path]).or(path(t"${home.directory()}/.config"))
+
 
   def cacheHome[path: Instantiable across Paths from Text]
        (using environment: Environment, home: HomeDirectory)
-  :     path =
+  : path =
 
-    safely(Environment.xdgCacheHome[path]).or(path(t"${home.directory()}/.cache"))
+      safely(Environment.xdgCacheHome[path]).or(path(t"${home.directory()}/.cache"))
+
 
   def stateHome[path: Instantiable across Paths from Text]
        (using environment: Environment, home: HomeDirectory)
-  :     path =
+  : path =
 
-    safely(Environment.xdgStateHome[path]).or(path(t"${home.directory()}/.local/state"))
+      safely(Environment.xdgStateHome[path]).or(path(t"${home.directory()}/.local/state"))
 
-  def runtimeDir[path: Instantiable across Paths from Text]
-       (using environment: Environment): Optional[path] =
-    safely(Environment.xdgRuntimeDir[path])
+
+  def runtimeDir[path: Instantiable across Paths from Text](using environment: Environment)
+  : Optional[path] =
+
+      safely(Environment.xdgRuntimeDir[path])
+
 
   def bin[path: Instantiable across Paths from Text]
        (using environment: Environment, home: HomeDirectory)
-  :     path =
-    safely(Environment.xdgConfigHome[path]).or(path(t"${home.directory()}/.local/bin"))
+  : path =
+
+      safely(Environment.xdgConfigHome[path]).or(path(t"${home.directory()}/.local/bin"))
+
 
   def dataDirs[path: Instantiable across Paths from Text]
        (using environment: Environment, systemProperties: SystemProperties)
-  :     List[path] =
-    safely(Environment.xdgDataDirs[List[path]]).or:
-      List(t"/usr/local/share", t"/usr/share").map(path(_))
+  : List[path] =
+
+      safely(Environment.xdgDataDirs[List[path]]).or:
+        List(t"/usr/local/share", t"/usr/share").map(path(_))
+
 
   def configDirs[path: Instantiable across Paths from Text](using Environment, SystemProperties)
-  :     List[path] =
-    safely(Environment.xdgConfigDirs[List[path]]).or(List(t"/etc/xdg").map(path(_)))
+  : List[path] =
+
+      safely(Environment.xdgConfigDirs[List[path]]).or(List(t"/etc/xdg").map(path(_)))

--- a/lib/anamnesis/src/core/anamnesis-core.scala
+++ b/lib/anamnesis/src/core/anamnesis-core.scala
@@ -42,16 +42,22 @@ def every[entity <: Entity: Listable]: Iterable[Reference[entity]] = entity.list
 
 extension [left](using db: Database)(left: Ref of left in db.type)
   inline def unassign[right](right: Ref of right in db.type)(using db.Has[left -< right])
-  :     Unit raises DataError =
-    db.unassign(left, right)
+  : Unit raises DataError =
+
+      db.unassign(left, right)
+
 
   inline def lookup[right](using db.Has[left -< right])
-  :     Set[Ref of right in db.type] raises DataError =
-    db.lookup[left, right](left)
+  : Set[Ref of right in db.type] raises DataError =
+
+      db.lookup[left, right](left)
+
 
   inline def assign[right](right: Ref of right in db.type)(using db.Has[left -< right])
-  :     Unit raises DataError =
+  : Unit raises DataError =
+
       db.assign(left, right)
+
 
 extension [left](using db: Database)(left: left)
   inline def store(): Ref of left in db.type = db.store(left)

--- a/lib/anamnesis/src/core/anamnesis.Database.scala
+++ b/lib/anamnesis/src/core/anamnesis.Database.scala
@@ -84,36 +84,40 @@ class Database(size: Int):
   inline def ref[left](left: left): Ref of left in this.type raises DataError =
     references.at(left).or(abort(DataError())).asInstanceOf[Ref of left in this.type]
 
+
   inline def assign[left, right]
               (left: Ref of left in this.type, right: Ref of right in this.type)
               (using (left -< right) <:< Tuple.Union[Subject])
-  :     Unit raises DataError =
+  : Unit raises DataError =
 
-    val relationIndex = !![Subject].indexOf[left -< right]
-    val relation = relate[left, right]
-    val corelation = corelate[left, right]
+      val relationIndex = !![Subject].indexOf[left -< right]
+      val relation = relate[left, right]
+      val corelation = corelate[left, right]
 
-    val relation2 = relation.updated(left, relation.at(left).or(Set()) + right)
-    val corelation2 = corelation.updated(right, left)
-    relations(relationIndex) = relation2
-    corelations(relationIndex) = corelation2
+      val relation2 = relation.updated(left, relation.at(left).or(Set()) + right)
+      val corelation2 = corelation.updated(right, left)
+      relations(relationIndex) = relation2
+      corelations(relationIndex) = corelation2
+
 
   inline def lookup[left, right](left: Ref of left in this.type)
-  :     Set[Ref of right in this.type] raises DataError =
-    relate[left, right].at(left).or(Set()).asInstanceOf[Set[Ref of right in this.type]]
+  : Set[Ref of right in this.type] raises DataError =
+
+      relate[left, right].at(left).or(Set()).asInstanceOf[Set[Ref of right in this.type]]
+
 
   inline def unassign[left, right]
               (left: Ref of left in this.type, right: Ref of right in this.type)
               (using (left -< right) <:< Tuple.Union[Subject])
-  :     Unit raises DataError =
+  : Unit raises DataError =
 
-    val relationIndex = !![Subject].indexOf[left -< right]
-    val relation = relate[left, right]
-    val corelation = corelate[left, right]
+      val relationIndex = !![Subject].indexOf[left -< right]
+      val relation = relate[left, right]
+      val corelation = corelate[left, right]
 
-    val relation2: Map[Ref, Set[Ref]] =
-      relation.updated(left, relation.at(left).let(_ - right).or(Set()))
+      val relation2: Map[Ref, Set[Ref]] =
+        relation.updated(left, relation.at(left).let(_ - right).or(Set()))
 
-    val corelation2 = corelation - right
-    relations(relationIndex) = relation2
-    corelations(relationIndex) = corelation2
+      val corelation2 = corelation - right
+      relations(relationIndex) = relation2
+      corelations(relationIndex) = corelation2

--- a/lib/anthology/src/core/anthology.Compiler.scala
+++ b/lib/anthology/src/core/anthology.Compiler.scala
@@ -43,4 +43,4 @@ trait Compiler:
   def apply(classpath: LocalClasspath)[path: Abstractable across Paths into Text]
        (sources: Map[Text, Text], out: path)
        (using SystemProperties, Monitor)
-  :     CompileProcess logs CompileEvent raises CompilerError
+  : CompileProcess logs CompileEvent raises CompilerError

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -45,11 +45,12 @@ object Austronesian2:
   object EncodableDerivation extends Derivation[[Type] =>> Type is Encodable in Stdlib]:
 
     inline def join[derivation <: Product: ProductReflection]
-    :     derivation is Encodable in _root_.austronesian.Austronesian.Stdlib =
+    : derivation is Encodable in _root_.austronesian.Austronesian.Stdlib =
 
-      fields(_):
-        [field] => _.encode
-      .asInstanceOf[Stdlib]
+        fields(_):
+          [field] => _.encode
+        .asInstanceOf[Stdlib]
+
 
     inline def split[derivation: SumReflection]: derivation is Encodable in Stdlib =
       variant(_):

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -104,6 +104,7 @@ object Aviation:
     given decodable: (Int is Decodable in Text) => Year is Decodable in Text = year =>
       Year(year.decode[Int])
 
+
     given orderable: Year is Orderable:
       inline def compare
                   (inline left:        Year,

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -110,8 +110,10 @@ object Aviation:
                    inline right:       Year,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
-        if left == right then !strict else (left < right)^greaterThan
+      : Boolean =
+
+          if left == right then !strict else (left < right)^greaterThan
+
 
   object Day:
     inline def apply(day: Int): Day = day
@@ -154,8 +156,9 @@ object Aviation:
 
     def apply(using calendar: Calendar)
          (year: calendar.Annual, month: calendar.Mensual, day: calendar.Diurnal)
-    :     Date raises TimeError =
-      calendar.jdn(year, month, day)
+    : Date raises TimeError =
+
+        calendar.jdn(year, month, day)
 
     trait Format(val name: Text):
       type Issue: Communicable
@@ -203,8 +206,10 @@ object Aviation:
                    inline right:       Date,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
-        if left == right then !strict else (left < right)^greaterThan
+      : Boolean =
+
+          if left == right then !strict else (left < right)^greaterThan
+
 
     given ordering: Ordering[Date] = Ordering.Int
 

--- a/lib/aviation/src/core/aviation.Aviation2.scala
+++ b/lib/aviation/src/core/aviation.Aviation2.scala
@@ -121,7 +121,7 @@ object Aviation2:
       type Result = Instant
 
       def add(instant: Instant, duration: Quantity[units]): Instant =
-        instant + (duration.normalize.value/1000.0).toLong
+        instant + (duration.normalize.value*1000.0).toLong
 
     given minus: [operand: InstantSubtractable]
           =>  Instant is Subtractable by operand into operand.Result =

--- a/lib/aviation/src/core/aviation.Aviation2.scala
+++ b/lib/aviation/src/core/aviation.Aviation2.scala
@@ -109,8 +109,9 @@ object Aviation2:
                    inline right:       Instant,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
-        if left.long == right.long then !strict else (left.long < right.long)^greaterThan
+      : Boolean =
+
+          if left.long == right.long then !strict else (left.long < right.long)^greaterThan
 
     given ordering: Ordering[Instant] = Ordering.Long
 

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -61,11 +61,13 @@ object Timespan:
   def fixed
        (denomination: StandardTime.Second.type | StandardTime.Minute.type | StandardTime.Hour.type,
         n: Int)
-  :     Timespan =
-    denomination match
-      case StandardTime.Hour   => new Timespan(0, 0, 0, n, 0, 0)
-      case StandardTime.Minute => new Timespan(0, 0, 0, 0, n, 0)
-      case StandardTime.Second => new Timespan(0, 0, 0, 0, 0, n)
+  : Timespan =
+
+      denomination match
+        case StandardTime.Hour   => new Timespan(0, 0, 0, n, 0, 0)
+        case StandardTime.Minute => new Timespan(0, 0, 0, 0, n, 0)
+        case StandardTime.Second => new Timespan(0, 0, 0, 0, 0, n)
+
 
   given addable: Chronology[StandardTime] => Timespan is Addable:
     type Result = Timespan

--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -318,9 +318,57 @@ object Tests extends Suite(m"Aviation Tests"):
         //   t"2016-12-31T23:59:60Z".decode[Instant]
         // . assert(_ == Instant(1483228800000L))
 
+        test(m"Month-only format"):
+          t"2012-11".decode[Instant]
+        . assert(_ == Instant(1351728000000L))
+
         test(m"ISO 8601 with timezone offset and fractional seconds"):
           t"2023-03-25T10:15:30.456+02:00".decode[Instant]
         . assert(_ == Instant(1679732130456L))
+
+        test(m"Calendar date, full time, Z"):
+          t"2023-05-28T14:30:59Z".decode[Instant]
+        . assert(_ == Instant(1685284259000L))
+
+        test(m"Calendar date, basic format, full time, Z"):
+          t"20230528T143059Z".decode[Instant]
+        . assert(_ == Instant(1685284259000L))
+
+        test(m"Calendar date, full time, offset +00:00"):
+          t"2023-05-28T14:30:59+00:00".decode[Instant]
+        . assert(_ == Instant(1685284259000L))
+
+        test(m"Calendar date, full time, offset +02:00"):
+          t"2023-05-28T14:30:59+02:00".decode[Instant]
+        . assert(_ == Instant(1685277059000L))
+
+        test(m"Calendar date, full time, offset -05:00"):
+          t"2023-05-28T14:30:59-05:00".decode[Instant]
+        . assert(_ == Instant(1685302259000L))
+
+        test(m"Calendar date, fractional seconds, Z"):
+          t"2023-05-28T14:30:59.123Z".decode[Instant]
+        . assert(_ == Instant(1685284259123L))
+
+        test(m"Calendar date, comma as decimal separator, Z"):
+          t"2023-05-28T14:30:59,123Z".decode[Instant]
+        . assert(_ == Instant(1685284259123L))
+
+        test(m"Calendar date, hours and minutes, Z"):
+          t"2023-05-28T14:30Z".decode[Instant]
+        . assert(_ == Instant(1685284200000L))
+
+        test(m"Calendar date, hour only, Z"):
+          t"2023-05-28T14Z".decode[Instant]
+        . assert(_ == Instant(1685282400000L))
+
+        // test(m"Week date, Sunday of week 21, full time, Z"):
+        //   t"2023-W21-7T14:30:59Z".decode[Instant]
+        // . assert(_ == Instant(1685284259000L))
+
+        // test(m"Week date, basic format, Sunday of week 21, full time, Z"):
+        //   t"2023W217T143059Z".decode[Instant]
+        // . assert(_ == Instant(1685284259000L))
 
       suite(m"RFC 1123"):
         import timestampDecoders.rfc1123

--- a/lib/baroque/src/core/baroque.Complex.scala
+++ b/lib/baroque/src/core/baroque.Complex.scala
@@ -104,21 +104,27 @@ object Complex:
 
   def polar[component: Multiplicable by Double as multiplication]
        (modulus: component, argument: Double)
-  :     Complex[multiplication.Result] =
-    Complex(modulus*math.cos(argument), modulus*math.sin(argument))
+  : Complex[multiplication.Result] =
+
+      Complex(modulus*math.cos(argument), modulus*math.sin(argument))
+
 
 case class Complex[component](real: component, imaginary: component):
   @targetName("add")
   inline infix def + [component2](right: Complex[component2])
                      (using addition: component is Addable by component2)
-  :     Complex[addition.Result] =
-    Complex(this.real + right.real, this.imaginary + right.imaginary)
+  : Complex[addition.Result] =
+
+      Complex(this.real + right.real, this.imaginary + right.imaginary)
+
 
   @targetName("sub")
   inline infix def - [component2](right: Complex[component2])
                      (using subtraction: component is Subtractable by component2)
-  :     Complex[subtraction.Result] =
-    Complex(this.real - right.real, this.imaginary - right.imaginary)
+  : Complex[subtraction.Result] =
+
+      Complex(this.real - right.real, this.imaginary - right.imaginary)
+
 
   @targetName("mul")
   inline infix def * [component2](right: Complex[component2])
@@ -127,10 +133,11 @@ case class Complex[component](real: component, imaginary: component):
                                              multiplication.Result,
                             subtraction:    multiplication.Result is Subtractable by
                                              multiplication.Result)
-  :     Complex[subtraction.Result | addition.Result] =
+  : Complex[subtraction.Result | addition.Result] =
 
-    Complex
-     (real*right.real - imaginary*right.imaginary, real*right.imaginary + imaginary*right.real)
+      Complex
+       (real*right.real - imaginary*right.imaginary, real*right.imaginary + imaginary*right.real)
+
 
   inline def argument
               (using multiplication: component is Multiplicable by component,
@@ -138,16 +145,19 @@ case class Complex[component](real: component, imaginary: component):
                      sqrt:           addition.Result is Rootable[2],
                      division:       component is Divisible by sqrt.Result,
                      equality:       division.Result =:= Double)
-  :     Double =
+  : Double =
 
-    scala.math.atan2(imaginary/modulus, real/modulus)
+      scala.math.atan2(imaginary/modulus, real/modulus)
+
 
   inline def modulus
               (using multiplication: component is Multiplicable by component,
                      addition:       multiplication.Result is Addable by multiplication.Result,
                      squareRoot:     addition.Result is Rootable[2])
-  :     squareRoot.Result =
-    squareRoot.root(real*real + imaginary*imaginary)
+  : squareRoot.Result =
+
+      squareRoot.root(real*real + imaginary*imaginary)
+
 
   inline def sqrt
               (using multiplication:  component is Multiplicable by component,
@@ -157,8 +167,10 @@ case class Complex[component](real: component, imaginary: component):
                      equality:        division.Result =:= Double,
                      sqrt2:           sqrt.Result is Rootable[2],
                      multiplication2: sqrt2.Result is Multiplicable by Double)
-  :     Complex[multiplication2.Result] =
-    Complex.polar(modulus.sqrt, argument/2.0)
+  : Complex[multiplication2.Result] =
+
+      Complex.polar(modulus.sqrt, argument/2.0)
+
 
   @targetName("conjugate")
   inline def unary_~(using neg: component is Negatable): Complex[component | neg.Result] =

--- a/lib/caduceus/src/core/caduceus-core.scala
+++ b/lib/caduceus/src/core/caduceus-core.scala
@@ -53,6 +53,6 @@ extension [sendable: Sendable](email: sendable)
         bcc:     EmailAddress | List[EmailAddress] = Nil,
         replyTo: EmailAddress | List[EmailAddress] = Nil)
        (using courier: Courier, sender: Sender)
-  :     courier.Result =
+  : courier.Result =
 
-   courier.send(Envelope(email, to, cc, bcc, replyTo, subject))
+     courier.send(Envelope(email, to, cc, bcc, replyTo, subject))

--- a/lib/caduceus/src/core/caduceus.Envelope.scala
+++ b/lib/caduceus/src/core/caduceus.Envelope.scala
@@ -57,15 +57,18 @@ object Envelope:
         bcc:     EmailAddress | List[EmailAddress],
         replyTo: EmailAddress | List[EmailAddress],
         subject: Text)
-       (using courier: Courier, sender: Sender): Envelope =
-    Envelope
-     (sender.email,
-      many(to),
-      many(cc),
-      many(bcc),
-      many(replyTo),
-      subject,
-      sendable.email(email))
+       (using courier: Courier, sender: Sender)
+  : Envelope =
+
+      Envelope
+       (sender.email,
+        many(to),
+        many(cc),
+        many(bcc),
+        many(replyTo),
+        subject,
+        sendable.email(email))
+
 
 case class Envelope
             (from:        EmailAddress,

--- a/lib/caesura/src/core/caesura.Row.scala
+++ b/lib/caesura/src/core/caesura.Row.scala
@@ -54,8 +54,10 @@ case class Row(data: IArray[Text], columns: Optional[Map[Text, Int]] = Unset) ex
 
   def selectDynamic[value: Decodable in Text](field: String)
        (using DynamicDsvEnabler, DsvRedesignation)
-  :     Optional[value] =
-    apply(summon[DsvRedesignation].transform(field.tt))
+  : Optional[value] =
+
+      apply(summon[DsvRedesignation].transform(field.tt))
+
 
   def apply[value: Decodable in Text](field: Text): Optional[value] =
     columns.let(_.at(field)).let { index => data.at(index.z) }.let(value.decoded(_))

--- a/lib/capricious/src/core/capricious-core.scala
+++ b/lib/capricious/src/core/capricious-core.scala
@@ -69,9 +69,10 @@ package randomization:
   given secureSeeded: (seed: Seed) => Randomization = () =>
     su.Random(js.SecureRandom(seed.value.to(Array)))
 
-def stochastic[result](using randomization: Randomization)(block: Random ?=> result)
-:     result =
+
+def stochastic[result](using randomization: Randomization)(block: Random ?=> result): result =
   block(using new Random(randomization.make()))
+
 
 def arbitrary[value: Randomizable]()(using Random): value = value()
 

--- a/lib/cardinality/src/core/cardinality.Cardinality.scala
+++ b/lib/cardinality/src/core/cardinality.Cardinality.scala
@@ -55,32 +55,33 @@ object Cardinality:
 
   given realm: Realm = realm"cardinality"
 
+
   def apply[left <: Double: Type, right <: Double: Type](digits: Expr[String])(using Quotes)
-  :     Expr[left ~ right] =
+  : Expr[left ~ right] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    digits.value match
-      case Some(string) =>
-        TypeRepr.of[left].asMatchable match
-          case ConstantType(DoubleConstant(lowerBound)) =>
-            TypeRepr.of[right].asMatchable match
-              case ConstantType(DoubleConstant(upperBound)) =>
-                val value = string.toDouble
+      digits.value match
+        case Some(string) =>
+          TypeRepr.of[left].asMatchable match
+            case ConstantType(DoubleConstant(lowerBound)) =>
+              TypeRepr.of[right].asMatchable match
+                case ConstantType(DoubleConstant(upperBound)) =>
+                  val value = string.toDouble
 
-                if value < lowerBound
-                then halt(m"""the value $string is less than the lower bound for this value,
-                    ${lowerBound.toString}""")
+                  if value < lowerBound
+                  then halt(m"""the value $string is less than the lower bound for this value,
+                      ${lowerBound.toString}""")
 
-                if value > upperBound
-                then halt(m"""the value $string is greater than the upper bound for this value,
-                    ${upperBound.toString}""")
+                  if value > upperBound
+                  then halt(m"""the value $string is greater than the upper bound for this value,
+                      ${upperBound.toString}""")
 
-                '{${Expr(value)}.asInstanceOf[left ~ right]}
+                  '{${Expr(value)}.asInstanceOf[left ~ right]}
 
-              case _ =>
-                halt(m"the upper bound must be a Double singleton literal types")
-          case _ =>
-            halt(m"the lower bound must be a Double singleton literal types")
-      case None =>
-        '{NumericRange($digits.toDouble)}
+                case _ =>
+                  halt(m"the upper bound must be a Double singleton literal types")
+            case _ =>
+              halt(m"the lower bound must be a Double singleton literal types")
+        case None =>
+          '{NumericRange($digits.toDouble)}

--- a/lib/cardinality/src/core/cardinality.NumericRange.scala
+++ b/lib/cardinality/src/core/cardinality.NumericRange.scala
@@ -69,79 +69,82 @@ object NumericRange:
     extension [leftMin <: Double, leftMax <: Double](left: leftMin ~ leftMax)
       def double: Double = left
 
+
       @annotation.targetName("add")
       infix def + [rightMin <: Double, rightMax <: Double](right: rightMin ~ rightMax)
-      :     (leftMin + rightMin) ~ (leftMax + rightMax) =
-        left + right
+      : (leftMin + rightMin) ~ (leftMax + rightMax) =
+
+          left + right
+
 
       @annotation.targetName("add2")
       infix def + [E <: Double & Singleton](right: E)
-      :     (leftMin + right.type) ~ (leftMax + right.type) =
-        left + right
+      : (leftMin + right.type) ~ (leftMax + right.type) =
+
+          left + right
+
 
       @annotation.targetName("add3")
       infix def + (right: Double): Double = left + right
 
       @annotation.targetName("times")
       infix def * [rightMin <: Double, rightMax <: Double](right: rightMin ~ rightMax)
-      :     (Min4
-              [leftMin*rightMin,
-               leftMin*rightMax,
-               leftMax*rightMax,
-               leftMax*rightMin]) ~ (Max4
-                                              [leftMin*rightMin,
-                                               leftMin*rightMax,
-                                               leftMax*rightMax,
-                                               leftMax*rightMin]) =
+      : (Min4[leftMin*rightMin, leftMin*rightMax, leftMax*rightMax, leftMax*rightMin])
+        ~ (Max4[leftMin*rightMin, leftMin*rightMax, leftMax*rightMax, leftMax*rightMin]) =
 
         left*right
+
 
       @annotation.targetName("times2")
       infix def * [right <: Double & Singleton](right: right)
-      :     Min[leftMin*right, leftMax*right] ~ Max[leftMin*right, leftMax*right] =
+      : Min[leftMin*right, leftMax*right] ~ Max[leftMin*right, leftMax*right] =
 
-        left*right
+          left*right
+
 
       @annotation.targetName("times3")
       infix def * (right: Double): Double = left*right
 
+
       @annotation.targetName("minus")
       infix def - [rightMin <: Double, rightMax <: Double](right: rightMin ~ rightMax)
-      :     Min[leftMin - rightMin, leftMin - rightMax] ~ Max[leftMax - rightMin, leftMax -
-             rightMax] =
-        left - right
+      : Min[leftMin - rightMin, leftMin - rightMax] ~ Max[leftMax - rightMin, leftMax - rightMax] =
+
+          left - right
+
 
       @annotation.targetName("minus2")
       infix def - [right <: Double & Singleton](right: right)
-      :     Min[leftMin - right, leftMax - right] ~ Max[leftMin - right, leftMax - right] =
+      : Min[leftMin - right, leftMax - right] ~ Max[leftMin - right, leftMax - right] =
 
-        left - right
+          left - right
+
 
       @annotation.targetName("minus3")
       infix def - (right: Double): Double = left - right
 
+
       @annotation.targetName("divide")
       infix def / [right <: Double & Singleton](right: right)
-      :     Min[leftMin/right, leftMax/right] ~ Max[leftMin/right, leftMax/right] =
+      : Min[leftMin/right, leftMax/right] ~ Max[leftMin/right, leftMax/right] =
 
-        left/right
+          left/right
+
 
       @annotation.targetName("divide2")
       infix def / [rightMin <: Double, rightMax <: Double]
          (right: rightMin ~ rightMax)
-      :     Asym
-             [rightMin*rightMax,
-              Min4[leftMin/rightMin, leftMax/rightMin, leftMin/rightMax, leftMax/rightMax],
-              -1.0/0.0]
-            ~ Asym
-                           [rightMin*rightMax,
-                            Max4
-                             [leftMin/rightMin,
-                              leftMax/rightMin,
-                              leftMin/rightMax,
-                              leftMax/rightMax],
-                            1.0/0.0] =
-        left/right
+      : Asym
+         [rightMin*rightMax,
+          Min4[leftMin/rightMin, leftMax/rightMin, leftMin/rightMax, leftMax/rightMax],
+          -1.0/0.0]
+        ~ Asym
+           [rightMin*rightMax,
+            Max4[leftMin/rightMin, leftMax/rightMin, leftMin/rightMax, leftMax/rightMax],
+            1.0/0.0] =
+
+          left/right
+
 
       @annotation.targetName("divide3")
       infix def / (right: Double): Double = left/right

--- a/lib/cataclysm/src/core/cataclysm.FontFace.scala
+++ b/lib/cataclysm/src/core/cataclysm.FontFace.scala
@@ -38,18 +38,18 @@ import proscenium.*
 import vacuous.*
 
 case class FontFace
-   (ascentOverride:     Optional[Text] = Unset,
-    descentOverride:      Optional[Text] = Unset,
-    fontDisplay:        Optional[Text] = Unset,
-    fontFamily:         Optional[Text] = Unset,
-    fontStretch:        Optional[Text] = Unset,
-    fontStyle:          Optional[Text] = Unset,
-    fontWeight:         Optional[Text] = Unset,
+   (ascentOverride:        Optional[Text] = Unset,
+    descentOverride:       Optional[Text] = Unset,
+    fontDisplay:           Optional[Text] = Unset,
+    fontFamily:            Optional[Text] = Unset,
+    fontStretch:           Optional[Text] = Unset,
+    fontStyle:             Optional[Text] = Unset,
+    fontWeight:            Optional[Text] = Unset,
     fontVariationSettings: Optional[Text] = Unset,
-    lineGapOverride:      Optional[Text] = Unset,
-    sizeAdjust:         Optional[Text] = Unset,
-    src:                Optional[Text] = Unset,
-    unicodeRange:       Optional[Text] = Unset)
+    lineGapOverride:       Optional[Text] = Unset,
+    sizeAdjust:            Optional[Text] = Unset,
+    src:                   Optional[Text] = Unset,
+    unicodeRange:          Optional[Text] = Unset)
 extends CssStylesheet.Item:
 
   def text: Text =

--- a/lib/cellulose/src/core/cellulose.Codl.scala
+++ b/lib/cellulose/src/core/cellulose.Codl.scala
@@ -47,9 +47,10 @@ erased trait Codl
 
 object Codl:
   def read[value: CodlDecoder](source: Any)(using readable: source.type is Readable by Text)
-  :     value raises CodlError raises CodlReadError =
+  : value raises CodlError raises CodlReadError =
 
-    summon[CodlDecoder[value]].schema.parse(readable.stream(source)).as[value]
+      summon[CodlDecoder[value]].schema.parse(readable.stream(source)).as[value]
+
 
   def parse[source]
        (source:    source,
@@ -57,368 +58,380 @@ object Codl:
         subs:      List[Data] = Nil,
         fromStart: Boolean    = false)
        (using readable: source is Readable by Text, aggregate: Tactic[CodlError])
-  :     CodlDoc =
+  : CodlDoc =
 
-    val (margin, stream) = tokenize(readable.stream(source), fromStart)(using aggregate.diagnostics)
-    val baseSchema: CodlSchema = schema
+      val (margin, stream) = tokenize(readable.stream(source), fromStart)(using aggregate.diagnostics)
+      val baseSchema: CodlSchema = schema
 
-    case class Proto
-                (key:      Optional[Text]   = Unset,
-                 line:     Int              = 0,
-                 col:      Int              = 0,
-                 children:  List[CodlNode]  = Nil,
-                 extra:     Optional[Extra] = Unset,
-                 schema:    CodlSchema      = CodlSchema.Free,
-                 params:    Int             = 0,
-                 multiline: Boolean         = false):
+      case class Proto
+                  (key:      Optional[Text]   = Unset,
+                  line:     Int              = 0,
+                  col:      Int              = 0,
+                  children:  List[CodlNode]  = Nil,
+                  extra:     Optional[Extra] = Unset,
+                  schema:    CodlSchema      = CodlSchema.Free,
+                  params:    Int             = 0,
+                  multiline: Boolean         = false):
 
-      def commit(child: Proto): (Optional[(Text, (Int, Int))], Proto) =
-        val closed = child.close
+        def commit(child: Proto): (Optional[(Text, (Int, Int))], Proto) =
+          val closed = child.close
 
-        val uniqueId2 =
-          if child.schema.arity == Arity.Unique
-          then (child.key.vouch, (child.line, child.col)) else Unset
+          val uniqueId2 =
+            if child.schema.arity == Arity.Unique
+            then (child.key.vouch, (child.line, child.col)) else Unset
 
-        (uniqueId2, copy(children = closed :: children, params = params + 1))
+          (uniqueId2, copy(children = closed :: children, params = params + 1))
 
-      def substitute(data: Data): Proto =
-        copy(children = CodlNode(data) :: children, params = params + 1)
+        def substitute(data: Data): Proto =
+          copy(children = CodlNode(data) :: children, params = params + 1)
 
-      def setExtra(extra: Optional[Extra]): Proto = copy(extra = extra)
+        def setExtra(extra: Optional[Extra]): Proto = copy(extra = extra)
 
-      def close: CodlNode =
-        key.lay(CodlNode(Unset, extra)):
-          case key: Text =>
-            val extra2 = extra.let { m => m.copy(comments = m.comments.reverse) }
-
-            val data = Data
-                        (key,
-                         IArray.from(children.reverse),
-                         Layout(params, multiline, col - margin),
-                         schema)
-
-            val node = CodlNode(data, extra2)
-
-            schema.requiredKeys.each: key =>
-              if !node.data.let(_.has(key)).or(false) then raise:
-                CodlError(line, col, node.key.or(t"?").length, MissingKey(node.key.or(t"?"), key))
-
-            node
-
-    @tailrec
-    def recur
-         (tokens:  Stream[CodlToken],
-          focus:   Proto,
-          peers:   List[CodlNode],
-          peerIds: Map[Text, (Int, Int)],
-          stack:   List[(Proto, List[CodlNode])],
-          lines:   Int,
-          subs:    List[Data],
-          body:    Stream[Char],
-          tabs:    List[Int])
-    :     CodlDoc =
-
-      def schema: CodlSchema = stack.prim.lay(baseSchema)(_.head.schema)
-
-      inline def go
-                  (tokens:  Stream[CodlToken]           = tokens.tail,
-                   focus:   Proto                         = focus,
-                   peers:   List[CodlNode]                = peers,
-                   peerIds: Map[Text, (Int, Int)]         = peerIds,
-                   stack:   List[(Proto, List[CodlNode])] = stack,
-                   lines:   Int                           = lines,
-                   subs:    List[Data]                    = subs,
-                   body:    Stream[Char]                  = Stream(),
-                   tabs:    List[Int]                     = Nil)
-      :     CodlDoc =
-        recur(tokens, focus, peers, peerIds, stack, lines, subs, body, tabs)
-
-      tokens match
-        case token #:: tail => token match
-          case CodlToken.Body(stream) =>
-            go(tokens = Stream(), body = stream)
-
-          case CodlToken.Error(error) =>
-            raise(error)
-            go()
-
-          case CodlToken.Peer => focus.key match
+        def close: CodlNode =
+          key.lay(CodlNode(Unset, extra)):
             case key: Text =>
-              val closed = focus.close
-              go(focus = Proto(), peers = closed :: peers)
+              val extra2 = extra.let { m => m.copy(comments = m.comments.reverse) }
 
-            case _ =>
-              val proto =
-                Proto(Unset, extra = focus.extra.or(if lines == 0 then Unset else Extra(lines)))
+              val data = Data
+                          (key,
+                          IArray.from(children.reverse),
+                          Layout(params, multiline, col - margin),
+                          schema)
 
-              go(focus = proto)
+              val node = CodlNode(data, extra2)
 
-          case CodlToken.Indent =>
-            if focus.key.absent then raise(CodlError(focus.line, focus.col, 1, IndentAfterComment))
+              schema.requiredKeys.each: key =>
+                if !node.data.let(_.has(key)).or(false) then raise:
+                  CodlError(line, col, node.key.or(t"?").length, MissingKey(node.key.or(t"?"), key))
 
-            go(focus = Proto(), peers = Nil, stack = (focus -> peers) :: stack)
+              node
 
-          case CodlToken.Outdent(n) => stack match
-            case Nil =>
-              go(Stream())
 
-            case (proto, rest) :: stack2 =>
-              val next = if n == 1 then CodlToken.Peer else CodlToken.Outdent(n - 1)
-              val closed = focus.close
+      @tailrec
+      def recur
+          (tokens:  Stream[CodlToken],
+            focus:   Proto,
+            peers:   List[CodlNode],
+            peerIds: Map[Text, (Int, Int)],
+            stack:   List[(Proto, List[CodlNode])],
+            lines:   Int,
+            subs:    List[Data],
+            body:    Stream[Char],
+            tabs:    List[Int])
+      : CodlDoc =
 
-              val focus2 = proto.copy(children = closed :: peers ::: proto.children)
+          def schema: CodlSchema = stack.prim.lay(baseSchema)(_.head.schema)
 
-              go(next #:: tail, focus = focus2, peers = rest, stack = stack2)
+          inline def go
+                      (tokens:  Stream[CodlToken]             = tokens.tail,
+                       focus:   Proto                         = focus,
+                       peers:   List[CodlNode]                = peers,
+                       peerIds: Map[Text, (Int, Int)]         = peerIds,
+                       stack:   List[(Proto, List[CodlNode])] = stack,
+                       lines:   Int                           = lines,
+                       subs:    List[Data]                    = subs,
+                       body:    Stream[Char]                  = Stream(),
+                       tabs:    List[Int]                     = Nil)
+          : CodlDoc =
 
-          case CodlToken.Blank => focus.extra match
-            case Unset            =>
-              go(lines = lines + 1)
-            case Extra(l, _, _) =>
-              val closed = focus.close
+              recur(tokens, focus, peers, peerIds, stack, lines, subs, body, tabs)
 
-              go(focus = Proto(), peers = closed :: peers, lines = lines + 1)
 
-          case CodlToken.Argument =>
-            go(focus = focus.substitute(subs.head), subs = subs.tail)
+          tokens match
+            case token #:: tail => token match
+              case CodlToken.Body(stream) =>
+                go(tokens = Stream(), body = stream)
 
-          case CodlToken.Item(word, line, col, block) =>
-            val extra2: Optional[Extra] =
-              focus.extra.or(if lines == 0 then Unset else Extra(blank = lines))
+              case CodlToken.Error(error) =>
+                raise(error)
+                go()
 
-            focus.key match
-              case key: Text => focus.schema match
-                case field@Field(_, _) =>
-                  val (uniqueId, focus2) = focus.commit(Proto(word, line, col, multiline = block))
+              case CodlToken.Peer => focus.key match
+                case key: Text =>
+                  val closed = focus.close
+                  go(focus = Proto(), peers = closed :: peers)
 
-                  uniqueId.let: uniqueId =>
-                    if peerIds.contains(uniqueId(0)) then
-                      val first = peerIds(uniqueId(0))
-                      val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
-                      raise(CodlError(line, col, uniqueId(0).length, duplicate))
+                case _ =>
+                  val proto =
+                    Proto(Unset, extra = focus.extra.or(if lines == 0 then Unset else Extra(lines)))
 
-                  val peerIds2 = uniqueId.let(peerIds.updated(_, _)).or(peerIds)
-                  go(focus = focus2, peerIds = peerIds2, lines = 0)
+                  go(focus = proto)
 
-                case CodlSchema.Free =>
-                  val (uniqueId, focus2) = focus.commit(Proto(word, line, col, multiline = block))
+              case CodlToken.Indent =>
+                if focus.key.absent then raise(CodlError(focus.line, focus.col, 1, IndentAfterComment))
 
-                  uniqueId.let: uniqueId =>
-                    if peerIds.contains(uniqueId(0)) then
-                      val first = peerIds(uniqueId(0))
-                      val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
-                      raise(CodlError(line, col, uniqueId(0).length, duplicate))
+                go(focus = Proto(), peers = Nil, stack = (focus -> peers) :: stack)
 
-                  val peerIds2 = uniqueId.let(peerIds.updated(_, _)).or(peerIds)
-                  go(focus = focus2, peerIds = peerIds2, lines = 0)
+              case CodlToken.Outdent(n) => stack match
+                case Nil =>
+                  go(Stream())
 
-                case struct@Struct(_, _) => struct.param(focus.children.length) match
-                  case Unset =>
-                    raise(CodlError(line, col, word.length, SurplusParams(word, key)))
-                    go()
+                case (proto, rest) :: stack2 =>
+                  val next = if n == 1 then CodlToken.Peer else CodlToken.Outdent(n - 1)
+                  val closed = focus.close
 
-                  case entry: CodlSchema.Entry =>
-                    val peer = Proto(word, line, col, schema = entry.schema, multiline = block)
-                    val (uniqueId, focus2) = focus.commit(peer)
+                  val focus2 = proto.copy(children = closed :: peers ::: proto.children)
 
-                    uniqueId.let: uniqueId =>
-                      if peerIds.contains(uniqueId(0)) then
-                        val first = peerIds(uniqueId(0))
-                        val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
-                        raise(CodlError(line, col, uniqueId(0).length, duplicate))
+                  go(next #:: tail, focus = focus2, peers = rest, stack = stack2)
 
-                    val peerIds2 = uniqueId.let(peerIds.updated(_, _)).or(peerIds)
-                    go(focus = focus2, peerIds = peerIds2, lines = 0)
+              case CodlToken.Blank => focus.extra match
+                case Unset            =>
+                  go(lines = lines + 1)
+                case Extra(l, _, _) =>
+                  val closed = focus.close
+
+                  go(focus = Proto(), peers = closed :: peers, lines = lines + 1)
+
+              case CodlToken.Argument =>
+                go(focus = focus.substitute(subs.head), subs = subs.tail)
+
+              case CodlToken.Item(word, line, col, block) =>
+                val extra2: Optional[Extra] =
+                  focus.extra.or(if lines == 0 then Unset else Extra(blank = lines))
+
+                focus.key match
+                  case key: Text => focus.schema match
+                    case field@Field(_, _) =>
+                      val (uniqueId, focus2) = focus.commit(Proto(word, line, col, multiline = block))
+
+                      uniqueId.let: uniqueId =>
+                        if peerIds.contains(uniqueId(0)) then
+                          val first = peerIds(uniqueId(0))
+                          val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
+                          raise(CodlError(line, col, uniqueId(0).length, duplicate))
+
+                      val peerIds2 = uniqueId.let(peerIds.updated(_, _)).or(peerIds)
+                      go(focus = focus2, peerIds = peerIds2, lines = 0)
+
+                    case CodlSchema.Free =>
+                      val (uniqueId, focus2) = focus.commit(Proto(word, line, col, multiline = block))
+
+                      uniqueId.let: uniqueId =>
+                        if peerIds.contains(uniqueId(0)) then
+                          val first = peerIds(uniqueId(0))
+                          val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
+                          raise(CodlError(line, col, uniqueId(0).length, duplicate))
+
+                      val peerIds2 = uniqueId.let(peerIds.updated(_, _)).or(peerIds)
+                      go(focus = focus2, peerIds = peerIds2, lines = 0)
+
+                    case struct@Struct(_, _) => struct.param(focus.children.length) match
+                      case Unset =>
+                        raise(CodlError(line, col, word.length, SurplusParams(word, key)))
+                        go()
+
+                      case entry: CodlSchema.Entry =>
+                        val peer = Proto(word, line, col, schema = entry.schema, multiline = block)
+                        val (uniqueId, focus2) = focus.commit(peer)
+
+                        uniqueId.let: uniqueId =>
+                          if peerIds.contains(uniqueId(0)) then
+                            val first = peerIds(uniqueId(0))
+                            val duplicate = DuplicateId(uniqueId(0), first(0), first(1))
+                            raise(CodlError(line, col, uniqueId(0).length, duplicate))
+
+                        val peerIds2 = uniqueId.let(peerIds.updated(_, _)).or(peerIds)
+                        go(focus = focus2, peerIds = peerIds2, lines = 0)
+
+                  case _ =>
+                    val fschema: CodlSchema =
+                      if schema == CodlSchema.Free then schema
+                      else schema(word).or:
+                        raise(CodlError(line, col, word.length, InvalidKey(word, word)))
+                        CodlSchema.Free
+
+                    if fschema.unique && peers.exists(_.data.let(_.key) == word)
+                    then raise(CodlError(line, col, word.length, DuplicateKey(word, word)))
+
+                    go(focus = Proto(word, line, col, extra = extra2, schema = fschema,
+                        multiline = block), lines = 0)
+
+              case CodlToken.Comment(txt, line, col) => focus.key match
+                case key: Text =>
+                  go(focus = focus.setExtra(focus.extra.or(Extra()).copy(remark = txt, blank = lines)))
+
+                case _ =>
+                  val extra = focus.extra.or(Extra())
+
+                  go(focus = Proto(line = line, col = col, extra = extra.copy(blank = lines, comments =
+                      txt :: extra.comments)))
+
+            case _ => stack match
+              case Nil =>
+                val closed = focus.close
+                val children = if closed.blank then peers.reverse else (closed :: peers).reverse
+
+                CodlDoc(IArray.from(children), baseSchema, margin, body)
 
               case _ =>
-                val fschema: CodlSchema =
-                  if schema == CodlSchema.Free then schema
-                  else schema(word).or:
-                    raise(CodlError(line, col, word.length, InvalidKey(word, word)))
-                    CodlSchema.Free
+                go(Stream(CodlToken.Outdent(stack.length + 1)))
 
-                if fschema.unique && peers.exists(_.data.let(_.key) == word)
-                then raise(CodlError(line, col, word.length, DuplicateKey(word, word)))
+      if stream.isEmpty
+      then CodlDoc() else recur(stream, Proto(), Nil, Map(), Nil, 0, subs.reverse, Stream(), Nil)
 
-                go(focus = Proto(word, line, col, extra = extra2, schema = fschema,
-                    multiline = block), lines = 0)
-
-          case CodlToken.Comment(txt, line, col) => focus.key match
-            case key: Text =>
-              go(focus = focus.setExtra(focus.extra.or(Extra()).copy(remark = txt, blank = lines)))
-
-            case _ =>
-              val extra = focus.extra.or(Extra())
-
-              go(focus = Proto(line = line, col = col, extra = extra.copy(blank = lines, comments =
-                  txt :: extra.comments)))
-
-        case _ => stack match
-          case Nil =>
-            val closed = focus.close
-            val children = if closed.blank then peers.reverse else (closed :: peers).reverse
-
-            CodlDoc(IArray.from(children), baseSchema, margin, body)
-
-          case _ =>
-            go(Stream(CodlToken.Outdent(stack.length + 1)))
-
-    if stream.isEmpty
-    then CodlDoc() else recur(stream, Proto(), Nil, Map(), Nil, 0, subs.reverse, Stream(), Nil)
 
   def tokenize(in: Stream[Text], fromStart: Boolean = false)(using Diagnostics)
-  :     (Int, Stream[CodlToken]) raises CodlError =
+  : (Int, Stream[CodlToken]) raises CodlError =
 
-    val reader: PositionReader = new PositionReader(in.map(identity))
+      val reader: PositionReader = new PositionReader(in.map(identity))
 
-    enum State:
-      case Word, Hash, Comment, Indent, Space, Margin
-      case Pending(ch: Character)
+      enum State:
+        case Word, Hash, Comment, Indent, Space, Margin
+        case Pending(ch: Character)
 
-    import State.*
+      import State.*
 
-    @tailrec
-    def cue(count: Int = 0)(using Tactic[CodlError]): (Character, Int) =
-      val ch = reader.next()
-      if ch.char == '\n' || ch.char == ' ' then cue(count + 1) else (ch, count)
+      @tailrec
+      def cue(count: Int = 0)(using Tactic[CodlError]): (Character, Int) =
+        val ch = reader.next()
+        if ch.char == '\n' || ch.char == ' ' then cue(count + 1) else (ch, count)
 
-    val (first: Character, start: Int) = cue(0)
-    val margin: Int = first.column
+      val (first: Character, start: Int) = cue(0)
+      val margin: Int = first.column
 
-    def istream
-         (char:    Character,
-          state:   State     = Indent,
-          indent:  Int       = margin,
-          count:   Int,
-          padding: Boolean)
-    :     Stream[CodlToken] =
-      stream(char, state, indent, count, padding)
 
-    @tailrec
-    def stream
-         (char:    Character,
-          state:   State     = Indent,
-          indent:  Int       = margin,
-          count:   Int       = start,
-          padding: Boolean)
-    :     Stream[CodlToken] =
+      def istream
+          (char:    Character,
+            state:   State     = Indent,
+            indent:  Int       = margin,
+            count:   Int,
+            padding: Boolean)
+      : Stream[CodlToken] =
 
-      inline def next(): Character =
-        try reader.next()
-        catch case err: CodlError => Character('\n', err.line, err.col)
+          stream(char, state, indent, count, padding)
 
-      inline def recur
-                  (state:   State,
-                   indent:  Int     = indent,
-                   count:   Int     = count + 1,
-                   padding: Boolean = padding)
-      :     Stream[CodlToken] =
 
-        stream(next(), state, indent, count, padding)
+      @tailrec
+      def stream
+          (char:    Character,
+            state:   State     = Indent,
+            indent:  Int       = margin,
+            count:   Int       = start,
+            padding: Boolean)
+      : Stream[CodlToken] =
 
-      inline def body(): Stream[CodlToken] =
-        reader.get()
-        val char = next()
+          inline def next(): Character =
+            try reader.next()
+            catch case err: CodlError => Character('\n', err.line, err.col)
 
-        if char.char != '\n' && char != Character.End
-        then fail(Comment, CodlError(char.line, col(char), 1, BadTermination))
-        else if char == Character.End then Stream() else Stream(CodlToken.Body(reader.charStream()))
 
-      inline def irecur
-                  (state: State,
-                   indent: Int      = indent,
-                   count: Int       = count + 1,
-                   padding: Boolean = padding)
-      :     Stream[CodlToken] =
+          inline def recur
+                      (state:   State,
+                      indent:  Int     = indent,
+                      count:   Int     = count + 1,
+                      padding: Boolean = padding)
+          : Stream[CodlToken] =
 
-        istream(next(), state, indent, count, padding)
+              stream(next(), state, indent, count, padding)
 
-      inline def diff: Int = char.column - indent
-      inline def col(char: Character): Int = if fromStart then count else char.column
 
-      def put(next: State, stop: Boolean = false, padding: Boolean = padding): Stream[CodlToken] =
-        token() #:: irecur(next, padding = padding)
+          inline def body(): Stream[CodlToken] =
+            reader.get()
+            val char = next()
 
-      def token(): CodlToken = state.absolve match
-        case Comment =>
-          CodlToken.Comment(reader.get(), reader.start()(0), reader.start()(1) - 1)
+            if char.char != '\n' && char != Character.End
+            then fail(Comment, CodlError(char.line, col(char), 1, BadTermination))
+            else if char == Character.End then Stream() else Stream(CodlToken.Body(reader.charStream()))
 
-        case Margin =>
-          val text: Text = reader.get()
-          val trimmed = if text.s.last == '\n' then text.skip(1, Rtl) else text
-          CodlToken.Item(trimmed, reader.start()(0), reader.start()(1), true)
 
-        case Word | Pending(_) =>
-          val word = reader.get()
-          if word == t"\u0000" then CodlToken.Argument
-          else CodlToken.Item(word, reader.start()(0), reader.start()(1), false)
+          inline def irecur
+                      (state: State,
+                      indent: Int      = indent,
+                      count: Int       = count + 1,
+                      padding: Boolean = padding)
+          : Stream[CodlToken] =
 
-      inline def consume(next: State, padding: Boolean = padding): Stream[CodlToken] =
-        reader.put(char)
-        recur(next, padding = padding)
+              istream(next(), state, indent, count, padding)
 
-      inline def block(): Stream[CodlToken] =
-        if diff >= 4 || char.char == '\n' then consume(Margin, padding = false)
-        else if char.char == ' ' then recur(Margin, padding = false)
-        else token() #:: istream(char, count = count + 1, indent = indent, padding = false)
 
-      def fail(next: State, error: CodlError, adjust: Optional[Int] = Unset): Stream[CodlToken] =
-        CodlToken.Error(error) #:: irecur(next, indent = adjust.or(char.column))
+          inline def diff: Int = char.column - indent
+          inline def col(char: Character): Int = if fromStart then count else char.column
 
-      def newline(next: State): Stream[CodlToken] =
-        if diff > 4 then fail(Margin, CodlError(char.line, col(char), 1, SurplusIndent), indent)
-        else if char.column < margin
-        then fail(Indent, CodlError(char.line, col(char), 1, InsufficientIndent), margin)
-        else if diff%2 != 0 then
-          fail
-           (Indent,
-            CodlError(char.line, col(char), 1, UnevenIndent(margin, char.column)),
-            char.column + 1)
-        else diff match
-          case 2 => CodlToken.Indent #:: irecur(next, indent = char.column)
-          case 0 => CodlToken.Peer #:: irecur(next, indent = char.column)
-          case n => CodlToken.Outdent(-diff/2) #:: irecur(next, indent = char.column)
+          def put(next: State, stop: Boolean = false, padding: Boolean = padding): Stream[CodlToken] =
+            token() #:: irecur(next, padding = padding)
 
-      char.char match
-        case _ if char == Character.End => state match
-          case Indent | Space | Hash | Pending(_) => Stream()
-          case Comment | Word | Margin            => Stream(token())
+          def token(): CodlToken = state.absolve match
+            case Comment =>
+              CodlToken.Comment(reader.get(), reader.start()(0), reader.start()(1) - 1)
 
-        case '\n' => state match
-          case Word | Comment | Pending(_) => put(Indent, padding = false)
-          case Margin                      => block()
-          case Indent | Space              => CodlToken.Blank #:: irecur(Indent, padding = false)
-          case _                           => recur(Indent, padding = false)
+            case Margin =>
+              val text: Text = reader.get()
+              val trimmed = if text.s.last == '\n' then text.skip(1, Rtl) else text
+              CodlToken.Item(trimmed, reader.start()(0), reader.start()(1), true)
 
-        case ' ' => state match
-          case Space              => recur(Space, padding = true)
-          case Pending(_)         => put(Space)
-          case Indent             => recur(Indent)
-          case Word               => if padding then recur(Pending(char)) else put(Space)
-          case Comment            => consume(state)
-          case Margin             => block()
-          case Hash               => reader.get(); recur(Comment)
+            case Word | Pending(_) =>
+              val word = reader.get()
+              if word == t"\u0000" then CodlToken.Argument
+              else CodlToken.Item(word, reader.start()(0), reader.start()(1), false)
 
-        case '#' => state match
-          case Pending(_) | Space => consume(Hash)
-          case Comment            => body()
-          case Word               => consume(Word)
-          case Indent             => if diff == 4 then recur(Margin) else newline(Comment)
-          case Margin             => block()
-          case Hash               => consume(Word)
+          inline def consume(next: State, padding: Boolean = padding): Stream[CodlToken] =
+            reader.put(char)
+            recur(next, padding = padding)
 
-        case ch => state match
-          case Pending(ch)    => reader.put(ch); consume(Word)
-          case Space | Word   => consume(Word)
-          case Comment        => consume(state)
-          case Indent         => reader.put(char)
-                                 if diff == 4 then recur(Margin) else newline(Word)
-          case Margin         => block()
+          inline def block(): Stream[CodlToken] =
+            if diff >= 4 || char.char == '\n' then consume(Margin, padding = false)
+            else if char.char == ' ' then recur(Margin, padding = false)
+            else token() #:: istream(char, count = count + 1, indent = indent, padding = false)
 
-          case Hash => char.char match
-            case '!' if first.line == 0 && first.column == 1 => consume(Comment)
-            case ch                                          => consume(Word)
+          def fail(next: State, error: CodlError, adjust: Optional[Int] = Unset): Stream[CodlToken] =
+            CodlToken.Error(error) #:: irecur(next, indent = adjust.or(char.column))
 
-    (first.column, stream(first, padding = false).drop(1))
+          def newline(next: State): Stream[CodlToken] =
+            if diff > 4 then fail(Margin, CodlError(char.line, col(char), 1, SurplusIndent), indent)
+            else if char.column < margin
+            then fail(Indent, CodlError(char.line, col(char), 1, InsufficientIndent), margin)
+            else if diff%2 != 0 then
+              fail
+               (Indent,
+                CodlError(char.line, col(char), 1, UnevenIndent(margin, char.column)),
+                char.column + 1)
+            else diff match
+              case 2 => CodlToken.Indent #:: irecur(next, indent = char.column)
+              case 0 => CodlToken.Peer #:: irecur(next, indent = char.column)
+              case n => CodlToken.Outdent(-diff/2) #:: irecur(next, indent = char.column)
+
+          char.char match
+            case _ if char == Character.End => state match
+              case Indent | Space | Hash | Pending(_) => Stream()
+              case Comment | Word | Margin            => Stream(token())
+
+            case '\n' => state match
+              case Word | Comment | Pending(_) => put(Indent, padding = false)
+              case Margin                      => block()
+              case Indent | Space              => CodlToken.Blank #:: irecur(Indent, padding = false)
+              case _                           => recur(Indent, padding = false)
+
+            case ' ' => state match
+              case Space              => recur(Space, padding = true)
+              case Pending(_)         => put(Space)
+              case Indent             => recur(Indent)
+              case Word               => if padding then recur(Pending(char)) else put(Space)
+              case Comment            => consume(state)
+              case Margin             => block()
+              case Hash               => reader.get(); recur(Comment)
+
+            case '#' => state match
+              case Pending(_) | Space => consume(Hash)
+              case Comment            => body()
+              case Word               => consume(Word)
+              case Indent             => if diff == 4 then recur(Margin) else newline(Comment)
+              case Margin             => block()
+              case Hash               => consume(Word)
+
+            case ch => state match
+              case Pending(ch)    => reader.put(ch); consume(Word)
+              case Space | Word   => consume(Word)
+              case Comment        => consume(state)
+              case Indent         => reader.put(char)
+                                    if diff == 4 then recur(Margin) else newline(Word)
+              case Margin         => block()
+
+              case Hash => char.char match
+                case '!' if first.line == 0 && first.column == 1 => consume(Comment)
+                case ch                                          => consume(Word)
+
+      (first.column, stream(first, padding = false).drop(1))
+
 
   case class State(parts: List[Text], subs: List[Data]):
     def content: Text = parts.reverse.join(t"\u0000")

--- a/lib/cellulose/src/core/cellulose.CodlDecoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlDecoder.scala
@@ -47,12 +47,14 @@ trait CodlDecoder[value]:
   def schema: CodlSchema
 
 object CodlDecoder:
-
   def apply[value]
        (schema0: => CodlSchema, decode0: Tactic[CodlReadError] ?=> List[Indexed] => value)
-  :     CodlDecoder[value] = new:
-    def decoded(value: List[Indexed]): value raises CodlReadError = decode0(value)
-    def schema: CodlSchema  = schema0
+  : CodlDecoder[value] =
+
+      new:
+        def decoded(value: List[Indexed]): value raises CodlReadError = decode0(value)
+        def schema: CodlSchema  = schema0
+
 
   inline given derived[value]: CodlDecoder[value] = compiletime.summonFrom:
     case given (`value` is Decodable in Text) => field[`value`]

--- a/lib/cellulose/src/core/cellulose.CodlEncoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoder.scala
@@ -56,10 +56,12 @@ trait CodlEncoder2:
 
 object CodlEncoder extends CodlEncoder2:
   def apply[value](schema0: CodlSchema, encode0: value => List[IArray[CodlNode]])
-  :     CodlEncoder[value] =
-    new:
-      def schema: CodlSchema = schema0
-      def encode(value: value): List[IArray[CodlNode]] = encode0(value)
+  : CodlEncoder[value] =
+
+      new:
+        def schema: CodlSchema = schema0
+        def encode(value: value): List[IArray[CodlNode]] = encode0(value)
+
 
   given boolean: CodlFieldWriter[Boolean] = if _ then t"yes" else t"no"
   given text: CodlFieldWriter[Text] = _.show

--- a/lib/cellulose/src/core/cellulose.CodlNode.scala
+++ b/lib/cellulose/src/core/cellulose.CodlNode.scala
@@ -87,12 +87,16 @@ case class CodlNode(data: Optional[Data] = Unset, extra: Optional[Extra] = Unset
     case data: Data => data
 
   def selectDynamic(key: String)(using erased DynamicCodlEnabler)
-  :     List[Data] raises MissingValueError =
-    data.lest(MissingValueError(key.show)).selectDynamic(key)
+  : List[Data] raises MissingValueError =
+
+      data.lest(MissingValueError(key.show)).selectDynamic(key)
+
 
   def applyDynamic(key: String)(idx: Int = 0)(using erased DynamicCodlEnabler)
-  :     Data raises MissingValueError =
-    selectDynamic(key)(idx)
+  : Data raises MissingValueError =
+
+      selectDynamic(key)(idx)
+
 
   def untyped: CodlNode =
     val data2 = data.let { data => Data(data.key, children = data.children.map(_.untyped)) }

--- a/lib/cellulose/src/core/cellulose.CodlSchema.scala
+++ b/lib/cellulose/src/core/cellulose.CodlSchema.scala
@@ -76,9 +76,12 @@ extends Dynamic:
   def optional: CodlSchema
   def entry(n: Int): Entry = subschemas(n)
 
+
   def parse[source](source: source)(using readable: source is Readable by Text)
-  :     CodlDoc raises CodlError =
-    Codl.parse(source, this)
+  : CodlDoc raises CodlError =
+
+      Codl.parse(source, this)
+
 
   def apply(key: Text): Optional[CodlSchema] = dictionary.at(key).or(dictionary.at(Unset)).or(Unset)
   def apply(idx: Int): Entry = subschemas(idx)

--- a/lib/cellulose/src/core/cellulose.Indexed.scala
+++ b/lib/cellulose/src/core/cellulose.Indexed.scala
@@ -81,11 +81,13 @@ trait Indexed extends Dynamic:
           Data(key, IArray(unsafely(children(idx))), Layout.empty, CodlSchema.Free)
 
   def selectDynamic(key: String)(using erased DynamicCodlEnabler)
-  :     List[Data] raises MissingValueError =
-    index(key.show).map(children(_).data).collect:
-      case data: Data => data
+  : List[Data] raises MissingValueError =
+
+      index(key.show).map(children(_).data).collect:
+        case data: Data => data
+
 
   def applyDynamic(key: String)(idx: Int = 0)(using erased DynamicCodlEnabler)
-  :     Data raises MissingValueError =
+  : Data raises MissingValueError =
 
-    selectDynamic(key)(idx)
+      selectDynamic(key)(idx)

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -125,28 +125,29 @@ object Contrastable extends Contrastable2:
         right:      IArray[Decomposition],
         leftDebug:  Text,
         rightDebug: Text)
-  :     Juxtaposition =
-    if left == right then Juxtaposition.Same(leftDebug) else
-      val comparison = IArray.from:
-        diff(left, right).rdiff(_ == _, 10).changes.map:
-          case Par(leftIndex, rightIndex, value) =>
-            val label =
-              if leftIndex == rightIndex then leftIndex.show
-              else t"${leftIndex.show.superscripts}╱${rightIndex.show.subscripts}"
+  : Juxtaposition =
 
-            label -> Juxtaposition.Same(value.let(_.short).or(t"?"))
+      if left == right then Juxtaposition.Same(leftDebug) else
+        val comparison = IArray.from:
+          diff(left, right).rdiff(_ == _, 10).changes.map:
+            case Par(leftIndex, rightIndex, value) =>
+              val label =
+                if leftIndex == rightIndex then leftIndex.show
+                else t"${leftIndex.show.superscripts}╱${rightIndex.show.subscripts}"
 
-          case Ins(rightIndex, value) =>
-            t" ⧸${rightIndex.show.subscripts}"
-            -> Juxtaposition.Different(t"", value.short)
+              label -> Juxtaposition.Same(value.let(_.short).or(t"?"))
 
-          case Del(leftIndex, value) =>
-            t"${leftIndex.show.superscripts}╱ "
-            -> Juxtaposition.Different(value.let(_.short).or(t"?"), t"")
+            case Ins(rightIndex, value) =>
+              t" ⧸${rightIndex.show.subscripts}"
+              -> Juxtaposition.Different(t"", value.short)
 
-          case Sub(leftIndex, rightIndex, leftValue, rightValue) =>
-            val label = t"${leftIndex.show.superscripts}╱${rightIndex.show.subscripts}"
+            case Del(leftIndex, value) =>
+              t"${leftIndex.show.superscripts}╱ "
+              -> Juxtaposition.Different(value.let(_.short).or(t"?"), t"")
 
-            label -> juxtaposition(Decomposition(leftValue), Decomposition(rightValue))
+            case Sub(leftIndex, rightIndex, leftValue, rightValue) =>
+              val label = t"${leftIndex.show.superscripts}╱${rightIndex.show.subscripts}"
 
-      Juxtaposition.Collation(comparison, leftDebug, rightDebug)
+              label -> juxtaposition(Decomposition(leftValue), Decomposition(rightValue))
+
+        Juxtaposition.Collation(comparison, leftDebug, rightDebug)

--- a/lib/coaxial/src/core/coaxial.Control.scala
+++ b/lib/coaxial/src/core/coaxial.Control.scala
@@ -55,13 +55,14 @@ object Control:
   object Conclude:
     def apply[transmissible: Transmissible, state]
          (message: transmissible, state: Optional[state] = Unset)
-    :     Conclude[state] =
+    : Conclude[state] =
 
-      Conclude(transmissible.serialize(message), state)
+        Conclude(transmissible.serialize(message), state)
+
 
   object Reply:
     def apply[transmissible: Transmissible, state]
          (message: transmissible, state: Optional[state] = Unset)
-    :     Reply[state] =
+    : Reply[state] =
 
-      Reply(transmissible.serialize(message), state)
+        Reply(transmissible.serialize(message), state)

--- a/lib/contextual/src/core/contextual.Verifier.scala
+++ b/lib/contextual/src/core/contextual.Verifier.scala
@@ -46,6 +46,9 @@ extends Interpolator[Nothing, Optional[result], result]:
   protected def insert(state: Optional[result], value: Nothing): Optional[result] = state
   protected def complete(value: Optional[result]): result = value.option.get
 
+
   def expand(context: Expr[StringContext])(using Quotes, Type[result])
        (using thisType: Type[this.type])
-  :     Expr[result] = expand(context, '{Nil})(using thisType)
+  : Expr[result] =
+
+      expand(context, '{Nil})(using thisType)

--- a/lib/contingency/src/core/contingency.Contingency.scala
+++ b/lib/contingency/src/core/contingency.Contingency.scala
@@ -51,94 +51,98 @@ object Contingency:
       case Block(List(DefDef(_, _, _, Some(Inlined(_, _, block)))), _) => unwrap(block)
       case ast                                                         => ast
 
+
   private def caseDefs[error <: Exception: Type](using Quotes)(handler: quotes.reflect.Term)
-  :     List[quotes.reflect.CaseDef] =
-    import quotes.reflect.*
+  : List[quotes.reflect.CaseDef] =
 
-    unwrap(handler) match
-      case Block(List(DefDef(_, _, _, Some(Match(_, cases)))), _) =>
-        cases.flatMap:
-          case caseDef@CaseDef(pattern, None, rhs) => List(caseDef)
-          case _                                   => Nil
+      import quotes.reflect.*
 
-      case other =>
-        halt(m"unexpected AST: ${other.toString}")
+      unwrap(handler) match
+        case Block(List(DefDef(_, _, _, Some(Match(_, cases)))), _) =>
+          cases.flatMap:
+            case caseDef@CaseDef(pattern, None, rhs) => List(caseDef)
+            case _                                   => Nil
+
+        case other =>
+          halt(m"unexpected AST: ${other.toString}")
+
 
   private def mapping[error <: Exception: Type](using Quotes)(handler: quotes.reflect.Term)
-  :     Map[quotes.reflect.Symbol, quotes.reflect.Symbol] =
+  : Map[quotes.reflect.Symbol, quotes.reflect.Symbol] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    object RepeatedParam:
-      def unapply(using quotes: Quotes)(param: quotes.reflect.Symbol)
-      :     Option[quotes.reflect.TypeRepr] =
-        import quotes.reflect.*
-        param.info match
-          case AnnotatedType(repr, Apply(Select(New(annotation), _), _))
-          if annotation.symbol == defn.RepeatedAnnot                  => Some(repr)
-          case _                                                      => None
+      object RepeatedParam:
+        def unapply(using quotes: Quotes)(param: quotes.reflect.Symbol)
+        : Option[quotes.reflect.TypeRepr] =
+          import quotes.reflect.*
+          param.info match
+            case AnnotatedType(repr, Apply(Select(New(annotation), _), _))
+            if annotation.symbol == defn.RepeatedAnnot                  => Some(repr)
+            case _                                                      => None
 
-    def exhaustive(pattern: Tree, patternType: TypeRepr): Boolean = pattern match
-      case Wildcard()          => true
-      case Typed(_, matchType) => patternType <:< matchType.tpe
-      case Bind(_, pattern)    => exhaustive(pattern, patternType)
+      def exhaustive(pattern: Tree, patternType: TypeRepr): Boolean = pattern match
+        case Wildcard()          => true
+        case Typed(_, matchType) => patternType <:< matchType.tpe
+        case Bind(_, pattern)    => exhaustive(pattern, patternType)
 
-      case TypedOrTest(Unapply(Select(target, method), _, params), _) =>
-        val types = patternType.typeSymbol.caseFields
+        case TypedOrTest(Unapply(Select(target, method), _, params), _) =>
+          val types = patternType.typeSymbol.caseFields
 
-        val repetition = types.exists:
-          case RepeatedParam(_) => true
-          case _                => false
+          val repetition = types.exists:
+            case RepeatedParam(_) => true
+            case _                => false
 
-        val isExhaustive = params.zip(types).all:
-          case (param, pattern@RepeatedParam(patternType)) => param match
-            case Bind(_, Typed(Ident("_*"), bound)) => true
-            case other                              => false
+          val isExhaustive = params.zip(types).all:
+            case (param, pattern@RepeatedParam(patternType)) => param match
+              case Bind(_, Typed(Ident("_*"), bound)) => true
+              case other                              => false
 
-          case (param, pattern) =>
-            exhaustive(param, pattern.info.typeSymbol.typeRef)
+            case (param, pattern) =>
+              exhaustive(param, pattern.info.typeSymbol.typeRef)
 
-        if isExhaustive then true else
-          if repetition
-          then halt(m"the pattern (which involves repeated parameters) is not exhaustive")
-          else halt(m"the pattern is not exhaustive")
+          if isExhaustive then true else
+            if repetition
+            then halt(m"the pattern (which involves repeated parameters) is not exhaustive")
+            else halt(m"the pattern is not exhaustive")
 
-      case Unapply(Select(target, method), _, params) =>
-        // TODO: Check that extractor is exhaustive
-        val types = patternType.typeSymbol.caseFields.map(_.info.typeSymbol.typeRef)
-        params.zip(types).all(exhaustive) || halt(m"this type of pattern is not recognized")
+        case Unapply(Select(target, method), _, params) =>
+          // TODO: Check that extractor is exhaustive
+          val types = patternType.typeSymbol.caseFields.map(_.info.typeSymbol.typeRef)
+          params.zip(types).all(exhaustive) || halt(m"this type of pattern is not recognized")
 
-      case other =>
-        halt(m"bad pattern")
+        case other =>
+          halt(m"bad pattern")
 
-    def unpack(repr: TypeRepr): Set[TypeRepr] = repr.asMatchable match
-      case OrType(left, right) => unpack(left) ++ unpack(right)
-      case other               => Set(other)
+      def unpack(repr: TypeRepr): Set[TypeRepr] = repr.asMatchable match
+        case OrType(left, right) => unpack(left) ++ unpack(right)
+        case other               => Set(other)
 
-    val requiredHandlers = unpack(TypeRepr.of[error]).map(_.typeSymbol)
+      val requiredHandlers = unpack(TypeRepr.of[error]).map(_.typeSymbol)
 
-    def patternType(pattern: Tree): List[TypeRepr] = pattern match
-      case Typed(_, matchType)   => List(matchType.tpe)
-      case Bind(_, pattern)      => patternType(pattern)
-      case Alternatives(patters) => patters.flatMap(patternType)
-      case Wildcard()            => halt(m"wildcard")
+      def patternType(pattern: Tree): List[TypeRepr] = pattern match
+        case Typed(_, matchType)   => List(matchType.tpe)
+        case Bind(_, pattern)      => patternType(pattern)
+        case Alternatives(patters) => patters.flatMap(patternType)
+        case Wildcard()            => halt(m"wildcard")
 
-      case Unapply(select, _, _) =>
-        if exhaustive(pattern, TypeRepr.of[error]) then List(TypeRepr.of[error])
-        else halt(m"Unapply ${select.symbol.declaredType.toString}")
+        case Unapply(select, _, _) =>
+          if exhaustive(pattern, TypeRepr.of[error]) then List(TypeRepr.of[error])
+          else halt(m"Unapply ${select.symbol.declaredType.toString}")
 
-      case TypedOrTest(Unapply(Select(target, method), _, _), typeTree) =>
-        if exhaustive(pattern, typeTree.tpe) then List(typeTree.tpe) else Nil
+        case TypedOrTest(Unapply(Select(target, method), _, _), typeTree) =>
+          if exhaustive(pattern, typeTree.tpe) then List(typeTree.tpe) else Nil
 
-      case other =>
-        halt(m"this pattern could not be recognized as a distinct `Error` type")
+        case other =>
+          halt(m"this pattern could not be recognized as a distinct `Error` type")
 
-    caseDefs(handler).flatMap:
-      case CaseDef(pattern, _, rhs) => rhs.asExpr.absolve match
-        case '{$rhs: rhsType} =>
-          patternType(pattern).map(_.typeSymbol -> TypeRepr.of[rhsType].typeSymbol)
+      caseDefs(handler).flatMap:
+        case CaseDef(pattern, _, rhs) => rhs.asExpr.absolve match
+          case '{$rhs: rhsType} =>
+            patternType(pattern).map(_.typeSymbol -> TypeRepr.of[rhsType].typeSymbol)
 
-    . to(Map)
+      . to(Map)
+
 
   def unpack(using Quotes)(repr: quotes.reflect.TypeRepr): List[quotes.reflect.TypeRepr] =
     repr.asMatchable match
@@ -147,87 +151,91 @@ object Contingency:
 
 
   def mitigate[errors <: Exception: Type](handler: Expr[Exception ~> errors])(using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    val errors = mapping(handler.asTerm)
-    val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
-    val functionType = defn.FunctionClass(errors.size, true).typeRef
+      val errors = mapping(handler.asTerm)
+      val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
+      val functionType = defn.FunctionClass(errors.size, true).typeRef
 
-    val typeLambda =
-      TypeLambda
-       (List("result"),
-        _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
-        typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
+      val typeLambda =
+        TypeLambda
+         (List("result"),
+          _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
+          typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
 
-    typeLambda.asType.absolve match
-      case '[type typeLambda[_]; typeLambda] => '{Mitigation[typeLambda]($handler)}
+      typeLambda.asType.absolve match
+        case '[type typeLambda[_]; typeLambda] => '{Mitigation[typeLambda]($handler)}
+
 
   def track[accrual <: Exception: Type, focus: Type]
        (accrual: Expr[accrual], handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
        (using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    val errors = mapping(handler.asTerm)
-    val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
-    val functionType = defn.FunctionClass(errors.size, true).typeRef
+      val errors = mapping(handler.asTerm)
+      val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
+      val functionType = defn.FunctionClass(errors.size, true).typeRef
 
-    val typeLambda =
-      TypeLambda
-       (List("result"),
-        _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
-        typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
+      val typeLambda =
+        TypeLambda
+         (List("result"),
+          _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
+          typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
 
-    typeLambda.asType.absolve match
-      case '[type typeLambda[_]; typeLambda] =>
-        '{Tracking[accrual, typeLambda, focus]($accrual, (focus, accrual) ?=> $handler(using
-            focus, accrual))}
+      typeLambda.asType.absolve match
+        case '[type typeLambda[_]; typeLambda] =>
+          '{Tracking[accrual, typeLambda, focus]($accrual, (focus, accrual) ?=> $handler(using
+              focus, accrual))}
+
 
   def validate[accrual: Type, focus: Type]
        (accrual: Expr[accrual], handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
        (using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    val errors = mapping(handler.asTerm)
-    val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
-    val functionType = defn.FunctionClass(errors.size, true).typeRef
+      val errors = mapping(handler.asTerm)
+      val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
+      val functionType = defn.FunctionClass(errors.size, true).typeRef
 
-    val typeLambda =
-      TypeLambda
-       (List("result"),
-        _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
-        typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
+      val typeLambda =
+        TypeLambda
+         (List("result"),
+          _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
+          typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
 
-    typeLambda.asType.absolve match
-      case '[type typeLambda[_]; typeLambda] =>
-        '{Validate[accrual, typeLambda, focus]($accrual, (focus, accrual) ?=> $handler(using
-            focus, accrual))}
+      typeLambda.asType.absolve match
+        case '[type typeLambda[_]; typeLambda] =>
+          '{Validate[accrual, typeLambda, focus]($accrual, (focus, accrual) ?=> $handler(using
+              focus, accrual))}
+
 
   def accrue[accrual <: Exception: Type]
        (accrual: Expr[accrual], handler: Expr[accrual ?=> Exception ~> accrual])
        (using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    val errors = mapping(handler.asTerm)
-    val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
-    val functionType = defn.FunctionClass(errors.size, true).typeRef
+      val errors = mapping(handler.asTerm)
+      val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
+      val functionType = defn.FunctionClass(errors.size, true).typeRef
 
-    val typeLambda =
-      TypeLambda
-       (List("result"),
-        _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
-        typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
+      val typeLambda =
+        TypeLambda
+         (List("result"),
+          _ => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
+          typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)))
 
-    typeLambda.asType.absolve match
-      case '[type typeLambda[_]; typeLambda] =>
-        '{Accrue[accrual, typeLambda]($accrual, accrual ?=> $handler(using accrual))}
+      typeLambda.asType.absolve match
+        case '[type typeLambda[_]; typeLambda] =>
+          '{Accrue[accrual, typeLambda]($accrual, accrual ?=> $handler(using accrual))}
+
 
   def recover[result: Type](handler: Expr[Exception ~> result])(using Quotes): Expr[Any] =
     import quotes.reflect.*
@@ -245,61 +253,65 @@ object Contingency:
     typeLambda.asType.absolve match
       case '[type typeLambda[_]; typeLambda] => '{Recovery[result, typeLambda]($handler)}
 
+
   def mitigateWithin[context[_]: Type, result: Type]
        (mitigate: Expr[Mitigation[context]], lambda: Expr[context[result]])
        (using Quotes)
-    :     Expr[result] =
-      import quotes.reflect.*
+    : Expr[result] =
 
-      val tactics = unwrap(mitigate.asTerm) match
-        case Apply(_, List(Inlined(_, _, matches))) =>
-          val partialFunction = matches.asExprOf[Exception ~> Exception]
+        import quotes.reflect.*
 
-          mapping(partialFunction.asTerm).values.map: errorType =>
-            errorType.typeRef.asType.absolve match
-              case '[type errorType <: Exception; errorType] =>
-                Expr.summon[Tactic[errorType]] match
-                  case Some(errorTactic) =>
-                    '{$errorTactic.contramap($partialFunction(_).asInstanceOf[errorType])}.asTerm
+        val tactics = unwrap(mitigate.asTerm) match
+          case Apply(_, List(Inlined(_, _, matches))) =>
+            val partialFunction = matches.asExprOf[Exception ~> Exception]
 
-                  case None =>
-                    halt(m"There is no available handler for ${TypeRepr.of[errorType]}")
-        case _ =>
-          halt(m"argument to `mitigate` should be a partial function implemented as match cases")
+            mapping(partialFunction.asTerm).values.map: errorType =>
+              errorType.typeRef.asType.absolve match
+                case '[type errorType <: Exception; errorType] =>
+                  Expr.summon[Tactic[errorType]] match
+                    case Some(errorTactic) =>
+                      '{$errorTactic.contramap($partialFunction(_).asInstanceOf[errorType])}.asTerm
 
-      val method = TypeRepr.of[context[result]].typeSymbol.declaredMethod("apply").head
-      lambda.asTerm.select(method).appliedToArgs(tactics.to(List)).asExprOf[result]
+                    case None =>
+                      halt(m"There is no available handler for ${TypeRepr.of[errorType]}")
+          case _ =>
+            halt(m"argument to `mitigate` should be a partial function implemented as match cases")
+
+        val method = TypeRepr.of[context[result]].typeSymbol.declaredMethod("apply").head
+        lambda.asTerm.select(method).appliedToArgs(tactics.to(List)).asExprOf[result]
+
 
   def recoverWithin[context[_]: Type, result: Type]
        (recovery: Expr[Recovery[?, context]], lambda: Expr[context[result]])
        (using Quotes)
-  :     Expr[result] =
+  : Expr[result] =
 
-    type ContextResult = context[result]
+      type ContextResult = context[result]
 
-    '{
-        boundary[result]: label ?=>
-          val tactic: Tactic[Break[result]] = EscapeTactic(label)
-          ${
-              import quotes.reflect.*
-              val partialFunction = unwrap(recovery.asTerm) match
-                case Apply(_, List(Inlined(_, _, matches))) => matches
+      '{
+          boundary[result]: label ?=>
+            val tactic: Tactic[Break[result]] = EscapeTactic(label)
+            ${
+                import quotes.reflect.*
+                val partialFunction = unwrap(recovery.asTerm) match
+                  case Apply(_, List(Inlined(_, _, matches))) => matches
 
-                case _ =>
-                  halt:
-                    m"argument to `recover` should be a partial function implemented as match cases"
+                  case _ =>
+                    halt:
+                      m"argument to `recover` should be a partial function implemented as match cases"
 
-              val pfExpr = partialFunction.asExprOf[Exception ~> result]
+                val pfExpr = partialFunction.asExprOf[Exception ~> result]
 
-              val tactics = mapping(partialFunction).map: (_, _) =>
-                '{
-                    tactic.contramap: error =>
-                      Break[result]($pfExpr(error))
-                }.asTerm
+                val tactics = mapping(partialFunction).map: (_, _) =>
+                  '{
+                      tactic.contramap: error =>
+                        Break[result]($pfExpr(error))
+                  }.asTerm
 
-              val method = TypeRepr.of[ContextResult].typeSymbol.declaredMethod("apply").head
-              lambda.asTerm.select(method).appliedToArgs(tactics.to(List)).asExprOf[result]  }
-    }
+                val method = TypeRepr.of[ContextResult].typeSymbol.declaredMethod("apply").head
+                lambda.asTerm.select(method).appliedToArgs(tactics.to(List)).asExprOf[result]  }
+      }
+
 
   def accrueWithin[accrual <: Exception: Type, context[_]: Type, result: Type]
        (accrue:      Expr[Accrue[accrual, context]],
@@ -307,39 +319,40 @@ object Contingency:
         tactic:      Expr[Tactic[accrual]],
         diagnostics: Expr[Diagnostics])
      (using Quotes)
-  :     Expr[result] =
+  : Expr[result] =
 
-    '{  val ref: juca.AtomicReference[accrual] = juca.AtomicReference(null)
-        val result = boundary[Option[result]]: label ?=>
-          ${  import quotes.reflect.*
+      '{  val ref: juca.AtomicReference[accrual] = juca.AtomicReference(null)
+          val result = boundary[Option[result]]: label ?=>
+            ${  import quotes.reflect.*
 
-              val cases = unwrap(accrue.asTerm) match
-                case Apply(_, List(_, Block(List(DefDef(_, _, _, Some(block))), _))) =>
-                  mapping(unwrap(block))
+                val cases = unwrap(accrue.asTerm) match
+                  case Apply(_, List(_, Block(List(DefDef(_, _, _, Some(block))), _))) =>
+                    mapping(unwrap(block))
 
-                case other => halt:
-                  m"argument to `accrue` should be a partial function implemented as match cases"
+                  case other => halt:
+                    m"argument to `accrue` should be a partial function implemented as match cases"
 
-              val tactics = cases.map: (_, _) =>
-                '{AccrueTactic(label, ref, $accrue.initial)($accrue.lambda)(using $diagnostics)}
-                . asTerm
+                val tactics = cases.map: (_, _) =>
+                  '{AccrueTactic(label, ref, $accrue.initial)($accrue.lambda)(using $diagnostics)}
+                  . asTerm
 
-              val contextTypeRepr = TypeRepr.of[context[result]]
-              val method = contextTypeRepr.typeSymbol.declaredMethod("apply").head
-              val term = lambda.asTerm.select(method).appliedToArgs(tactics.to(List))
-              val expr = term.asExprOf[result]
+                val contextTypeRepr = TypeRepr.of[context[result]]
+                val method = contextTypeRepr.typeSymbol.declaredMethod("apply").head
+                val term = lambda.asTerm.select(method).appliedToArgs(tactics.to(List))
+                val expr = term.asExprOf[result]
 
-              '{Some($expr)}  }
+                '{Some($expr)}  }
 
-        result match
-          case None        => $tactic.abort:
-            ref.get() match
-              case null  => $accrue.initial
-              case error => error
-          case Some(value) => ref.get() match
-            case null        => value
-            case error       => $tactic.abort(error)
-    }
+          result match
+            case None        => $tactic.abort:
+              ref.get() match
+                case null  => $accrue.initial
+                case error => error
+            case Some(value) => ref.get() match
+              case null        => value
+              case error       => $tactic.abort(error)
+      }
+
 
   def trackWithin[accrual <: Exception: Type, context[_]: Type, result: Type, focus: Type]
        (track:       Expr[Tracking[accrual, context, focus]],
@@ -347,73 +360,74 @@ object Contingency:
         tactic:      Expr[Tactic[accrual]],
         diagnostics: Expr[Diagnostics])
        (using Quotes)
-  :     Expr[result] =
+  : Expr[result] =
 
-    '{  val foci: Foci[focus] = TrackFoci()
+      '{  val foci: Foci[focus] = TrackFoci()
 
-        val result: Option[result] = boundary[Option[result]]: label ?=>
-          ${  import quotes.reflect.*
+          val result: Option[result] = boundary[Option[result]]: label ?=>
+            ${  import quotes.reflect.*
 
-              val cases = unwrap(track.asTerm) match
-                case Apply(_, List(_, Block(List(DefDef(_, _, _, Some(block))), _))) =>
-                  mapping(unwrap(block))
+                val cases = unwrap(track.asTerm) match
+                  case Apply(_, List(_, Block(List(DefDef(_, _, _, Some(block))), _))) =>
+                    mapping(unwrap(block))
 
-                case other => halt:
-                  m"argument to `track` should be a partial function implemented as match cases"
+                  case other => halt:
+                    m"argument to `track` should be a partial function implemented as match cases"
 
-              val tactics = cases.map: (_, _) =>
-                '{TrackTactic(label, $track.initial, foci)(using $diagnostics)}.asTerm
+                val tactics = cases.map: (_, _) =>
+                  '{TrackTactic(label, $track.initial, foci)(using $diagnostics)}.asTerm
 
-              val contextTypeRepr = TypeRepr.of[context[result]]
-              val method = contextTypeRepr.typeSymbol.declaredMethod("apply").head
+                val contextTypeRepr = TypeRepr.of[context[result]]
+                val method = contextTypeRepr.typeSymbol.declaredMethod("apply").head
 
-              val term =
-                '{$lambda(using foci)}.asTerm.select(method).appliedToArgs(tactics.to(List))
+                val term =
+                  '{$lambda(using foci)}.asTerm.select(method).appliedToArgs(tactics.to(List))
 
-              val expr = term.asExprOf[result]
+                val expr = term.asExprOf[result]
 
-              '{Some($expr)}  }
+                '{Some($expr)}  }
 
-        result match
-          case None =>
-            $tactic.abort(foci.fold[accrual]($track.initial)($track.lambda(using _, _)))
+          result match
+            case None =>
+              $tactic.abort(foci.fold[accrual]($track.initial)($track.lambda(using _, _)))
 
-          case Some(value) =>
-            if foci.success then value
-            else $tactic.abort(foci.fold[accrual]($track.initial)($track.lambda(using _, _)))
+            case Some(value) =>
+              if foci.success then value
+              else $tactic.abort(foci.fold[accrual]($track.initial)($track.lambda(using _, _)))
 
-    }
+      }
+
 
   def validateWithin[accrual <: Exception: Type, context[_]: Type, focus: Type]
        (validate:    Expr[Validate[accrual, context, focus]],
         lambda:      Expr[Foci[focus] ?=> context[Any]],
         diagnostics: Expr[Diagnostics])
        (using Quotes)
-  :     Expr[accrual] =
+  : Expr[accrual] =
 
-    '{  val foci: Foci[focus] = TrackFoci()
+      '{  val foci: Foci[focus] = TrackFoci()
 
-        boundary[Any]: label ?=>
-          ${  import quotes.reflect.*
+          boundary[Any]: label ?=>
+            ${  import quotes.reflect.*
 
-              val cases = unwrap(validate.asTerm) match
-                case Apply(_, List(_, Block(List(DefDef(_, _, _, Some(block))), _))) =>
-                  mapping(unwrap(block))
+                val cases = unwrap(validate.asTerm) match
+                  case Apply(_, List(_, Block(List(DefDef(_, _, _, Some(block))), _))) =>
+                    mapping(unwrap(block))
 
-                case other => halt:
-                  m"argument to `validate` should be a partial function implemented as match cases"
+                  case other => halt:
+                    m"argument to `validate` should be a partial function implemented as match cases"
 
-              val tactics = cases.map: (_, _) =>
-                '{TrackTactic(label, $validate.initial, foci)(using $diagnostics)}.asTerm
+                val tactics = cases.map: (_, _) =>
+                  '{TrackTactic(label, $validate.initial, foci)(using $diagnostics)}.asTerm
 
-              val contextTypeRepr = TypeRepr.of[context[Any]]
-              val method = contextTypeRepr.typeSymbol.declaredMethod("apply").head
+                val contextTypeRepr = TypeRepr.of[context[Any]]
+                val method = contextTypeRepr.typeSymbol.declaredMethod("apply").head
 
-              val term =
-                '{$lambda(using foci)}.asTerm.select(method).appliedToArgs(tactics.to(List))
+                val term =
+                  '{$lambda(using foci)}.asTerm.select(method).appliedToArgs(tactics.to(List))
 
-              term.asExpr  }
+                term.asExpr  }
 
-        foci.fold[accrual]($validate.initial)($validate.lambda(using _, _))
+          foci.fold[accrual]($validate.initial)($validate.lambda(using _, _))
 
-    }
+      }

--- a/lib/contingency/src/core/contingency.Foci.scala
+++ b/lib/contingency/src/core/contingency.Foci.scala
@@ -44,9 +44,11 @@ object Foci:
     def success: Boolean = false
     def register(error: Exception): Unit = ()
 
+
     def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
-    :     accrual =
-      initial
+    : accrual =
+
+        initial
 
     def supplement(count: Int, transform: Optional[focus] => focus): Unit = ()
 
@@ -56,7 +58,7 @@ trait Foci[focus]:
   def register(error: Exception): Unit
 
   def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
-  :     accrual
+  : accrual
 
   def supplement(count: Int, transform: Optional[focus] => focus): Unit
   def tainted: Boolean = length > 0
@@ -72,9 +74,12 @@ class TrackFoci[focus]() extends Foci[focus]:
     errors.append(error)
     focuses.append(Unset)
 
+
   def fold[accrual](initial: accrual)(lambda: (Optional[focus], accrual) => Exception ~> accrual)
-  :     accrual =
-    (0 until errors.length).fuse(initial)(lambda(focuses(next), state)(errors(next)))
+  : accrual =
+
+      (0 until errors.length).fuse(initial)(lambda(focuses(next), state)(errors(next)))
+
 
   def supplement(count: Int, transform: Optional[focus] => focus): Unit =
     for i <- (errors.length - count) until errors.length

--- a/lib/cosmopolite/src/core/cosmopolite.Polyglot.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.Polyglot.scala
@@ -37,12 +37,14 @@ import proscenium.*
 case class Polyglot[+value, language](values: Map[Language, value]):
   @targetName("or")
   transparent inline infix def | [value2 >: value, language2](polyglot: Polyglot[value2, language2])
-  :     Polyglot[value2, language & language2] | value2 =
-    compiletime.summonFrom:
-      case locale: Locale[language & language2] =>
-        (values ++ polyglot.values)(locale.language)
+  : Polyglot[value2, language & language2] | value2 =
 
-      case _ =>
-        Polyglot[value2, language & language2](values ++ polyglot.values)
+      compiletime.summonFrom:
+        case locale: Locale[language & language2] =>
+          (values ++ polyglot.values)(locale.language)
+
+        case _ =>
+          Polyglot[value2, language & language2](values ++ polyglot.values)
+
 
   def apply()(using locale: Locale[language]): value = values(locale.language)

--- a/lib/cosmopolite/src/core/cosmopolite.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.scala
@@ -50,12 +50,12 @@ case class Polyglot[+value, +localization <: Localization](value: Map[String, va
   def ap(polyglotFn: Polyglot[value => value2, localization])
 
   infix def & [value2 >: value, localization2](other: Polyglot[value2, localization2])
-  :     Polyglot[value2, localization2]
+  : Polyglot[value2, localization2]
 
 object Cosmopolite:
   def access[value: Type, localization <: Localization: Type](value: Expr[Map[String, value]])
      (using Quotes)
-  :     Expr[value] =
+  : Expr[value] =
 
     import quotes.reflect.*
 

--- a/lib/dendrology/src/dag/dendrology.TextualDagStyle.scala
+++ b/lib/dendrology/src/dag/dendrology.TextualDagStyle.scala
@@ -39,15 +39,16 @@ import symbolism.*
 import DagTile.*
 
 case class TextualDagStyle[line: Textual]
-   (space:      Text,
-    corner:     Text,
-    vertical:   Text,
-    firstMid:   Text,
-    horizontal: Text,
-    midLast:    Text,
-    cross:      Text,
-    overlap:    Text)
+            (space:      Text,
+             corner:     Text,
+             vertical:   Text,
+             firstMid:   Text,
+             horizontal: Text,
+             midLast:    Text,
+             cross:      Text,
+             overlap:    Text)
 extends DagStyle[line]:
+
   def serialize(tiles: List[DagTile], node: line): line =
     line(tiles.map(text(_)).join)+node
 

--- a/lib/denominative/src/core/denominative.Denominative.scala
+++ b/lib/denominative/src/core/denominative.Denominative.scala
@@ -103,17 +103,19 @@ object Denominative:
         lambda(i)
         i = i.next
 
+
     inline def fuse[value](inline initial: value)
                 (inline lambda: (state: value, next: Ordinal) ?=> value)
-    :     value =
+    : value =
 
-      var i: Ordinal = start
-      var acc: value = initial
+        var i: Ordinal = start
+        var acc: value = initial
 
-      while i <= end do
-        acc = lambda(using acc, i)
-        i = i.next
-      acc
+        while i <= end do
+          acc = lambda(using acc, i)
+          i = i.next
+        acc
+
 
     inline def empty: Boolean = end < start
 

--- a/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
@@ -53,14 +53,17 @@ class PrivateKey[cipher <: Cipher](private[enigmatic] val privateBytes: Bytes):
   def public(using cipher: cipher): PublicKey[cipher] =
     PublicKey(cipher.privateToPublic(privateBytes))
 
+
   def decrypt[decodable: Decodable in Bytes](bytes: Bytes)(using cipher: cipher & Encryption)
   : decodable raises CryptoError =
 
-    decodable.decoded(cipher.decrypt(bytes, privateBytes))
+      decodable.decoded(cipher.decrypt(bytes, privateBytes))
+
 
   def sign[encodable: Encodable in Bytes](value: encodable)(using cipher: cipher & Signing)
   : Signature[cipher] =
 
-    Signature(cipher.sign(encodable.encode(value), privateBytes))
+      Signature(cipher.sign(encodable.encode(value), privateBytes))
+
 
   def pem(reveal: ExposeSecretKey.type): Pem = Pem(PemLabel.PrivateKey, privateBytes)

--- a/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
@@ -54,12 +54,12 @@ class PrivateKey[cipher <: Cipher](private[enigmatic] val privateBytes: Bytes):
     PublicKey(cipher.privateToPublic(privateBytes))
 
   def decrypt[decodable: Decodable in Bytes](bytes: Bytes)(using cipher: cipher & Encryption)
-  :     decodable raises CryptoError =
+  : decodable raises CryptoError =
 
     decodable.decoded(cipher.decrypt(bytes, privateBytes))
 
   def sign[encodable: Encodable in Bytes](value: encodable)(using cipher: cipher & Signing)
-  :     Signature[cipher] =
+  : Signature[cipher] =
 
     Signature(cipher.sign(encodable.encode(value), privateBytes))
 

--- a/lib/enigmatic/src/core/enigmatic.PublicKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PublicKey.scala
@@ -47,13 +47,13 @@ object PublicKey:
 
 case class PublicKey[cipher <: Cipher](bytes: Bytes):
   def encrypt[value: Encodable in Bytes](value: value)(using algorithm: cipher & Encryption)
-  :     Bytes =
+  : Bytes =
 
     algorithm.encrypt(value.bytestream, bytes)
 
   def verify[encodable: Encodable in Bytes](value: encodable, signature: Signature[cipher])
        (using algorithm: cipher & Signing)
-  :     Boolean =
+  : Boolean =
 
     algorithm.verify(encodable.encode(value), signature.bytes, bytes)
 

--- a/lib/enigmatic/src/core/enigmatic.PublicKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PublicKey.scala
@@ -45,16 +45,19 @@ object PublicKey:
 
   given encodable: [cipher <: Cipher] => PublicKey[cipher] is Encodable in Bytes = _.bytes
 
+
 case class PublicKey[cipher <: Cipher](bytes: Bytes):
   def encrypt[value: Encodable in Bytes](value: value)(using algorithm: cipher & Encryption)
   : Bytes =
 
-    algorithm.encrypt(value.bytestream, bytes)
+      algorithm.encrypt(value.bytestream, bytes)
+
 
   def verify[encodable: Encodable in Bytes](value: encodable, signature: Signature[cipher])
        (using algorithm: cipher & Signing)
   : Boolean =
 
-    algorithm.verify(encodable.encode(value), signature.bytes, bytes)
+      algorithm.verify(encodable.encode(value), signature.bytes, bytes)
+
 
   def pem: Pem = Pem(PemLabel.PublicKey, bytes)

--- a/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
@@ -46,8 +46,9 @@ extends PrivateKey[cipher](bytes):
   def encrypt[value: Encodable in Bytes](value: value)(using cipher & Encryption): Bytes =
     public.encrypt(value)
 
+
   def verify[value: Encodable in Bytes](value: value, signature: Signature[cipher])
        (using cipher & Signing)
   : Boolean =
 
-    public.verify(value, signature)
+      public.verify(value, signature)

--- a/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
@@ -48,6 +48,6 @@ extends PrivateKey[cipher](bytes):
 
   def verify[value: Encodable in Bytes](value: value, signature: Signature[cipher])
        (using cipher & Signing)
-  :     Boolean =
+  : Boolean =
 
     public.verify(value, signature)

--- a/lib/escapade/src/core/escapade.Colorable.scala
+++ b/lib/escapade/src/core/escapade.Colorable.scala
@@ -42,11 +42,14 @@ object Colorable:
       type Self = value
       extension (value: value) def color: Fg = Fg(color0.asRgb24Int)
 
+
   def apply[value](using erased Void)[color: Chromatic](chooseColor: value -> color)
   : value is Colorable =
-    new Colorable:
-      type Self = value
-      extension (value: value) def color: Fg = Fg(chooseColor(value).asRgb24Int)
+
+      new Colorable:
+        type Self = value
+        extension (value: value) def color: Fg = Fg(chooseColor(value).asRgb24Int)
+
 
 trait Colorable:
   type Self

--- a/lib/escapade/src/core/escapade.Colorable.scala
+++ b/lib/escapade/src/core/escapade.Colorable.scala
@@ -43,7 +43,7 @@ object Colorable:
       extension (value: value) def color: Fg = Fg(color0.asRgb24Int)
 
   def apply[value](using erased Void)[color: Chromatic](chooseColor: value -> color)
-  :     value is Colorable =
+  : value is Colorable =
     new Colorable:
       type Self = value
       extension (value: value) def color: Fg = Fg(chooseColor(value).asRgb24Int)

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -182,7 +182,7 @@ case class Teletype
           style:      TextStyle                         = TextStyle(),
           stack:      List[(CharSpan, TextStyle)]       = Nil,
           insertions: TreeMap[Int, Text]                = TreeMap())
-    :     Text =
+    : Text =
 
       inline def addSpan(): Text =
         val newInsertions = addText(pos, spans.head(0).start, insertions)

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -91,14 +91,17 @@ object Teletypeable:
       case 3 => 0xfeae00
       case _ => 0xaefe00
 
+
     def dedup[element](todo: List[element], seen: Set[element] = Set(), done: List[element] = Nil)
     : List[element] =
-      todo match
-        case Nil => done
 
-        case head :: tail =>
-          if seen.contains(head) then dedup(tail, seen, done)
-          else dedup(tail, seen + head, head :: done)
+        todo match
+          case Nil => done
+
+          case head :: tail =>
+            if seen.contains(head) then dedup(tail, seen, done)
+            else dedup(tail, seen + head, head :: done)
+
 
     val packages: Map[Text, Int] =
       dedup[Text](stack.frames.map(_.method.prefix), Set(), Nil)

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -92,7 +92,7 @@ object Teletypeable:
       case _ => 0xaefe00
 
     def dedup[element](todo: List[element], seen: Set[element] = Set(), done: List[element] = Nil)
-    :     List[element] =
+    : List[element] =
       todo match
         case Nil => done
 

--- a/lib/escritoire/src/core/escritoire-core.scala
+++ b/lib/escritoire/src/core/escritoire-core.scala
@@ -67,7 +67,7 @@ package tableStyles:
 package columnar:
   object Prose extends Columnar:
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
-    :     Optional[Int] =
+    : Optional[Int] =
 
       def longestWord(text: textual, position: Int, lastStart: Int, max: Int): Int =
         if position < text.length then
@@ -80,10 +80,10 @@ package columnar:
       lines.map(longestWord(_, 0, 0, 0)).max.max((slack*maxWidth).toInt).min(longestLine)
 
     def fit[textual: Textual](lines: IArray[textual], width: Int, textAlign: TextAlignment)
-    :     IndexedSeq[textual] =
+    : IndexedSeq[textual] =
 
       def format(text: textual, position: Int, lineStart: Int, lastSpace: Int, lines: List[textual])
-      :     List[textual] =
+      : List[textual] =
 
         if position < text.length then
           if textual.unsafeChar(text, position.z) == ' '
@@ -108,7 +108,7 @@ package columnar:
       fixedWidth
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
-    :     IndexedSeq[text] =
+    : IndexedSeq[text] =
 
       lines.to(IndexedSeq).map: line =>
         if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
@@ -119,7 +119,7 @@ package columnar:
       (maxWidth*slack).toInt.min(naturalWidth)
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
-    :     IndexedSeq[text] =
+    : IndexedSeq[text] =
 
       lines.to(IndexedSeq).map: line =>
         if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
@@ -129,6 +129,6 @@ package columnar:
       if slack > threshold then lines.map(_.length).max else Unset
 
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
-    :     IndexedSeq[text] =
+    : IndexedSeq[text] =
 
       lines.to(IndexedSeq)

--- a/lib/escritoire/src/core/escritoire-core.scala
+++ b/lib/escritoire/src/core/escritoire-core.scala
@@ -66,69 +66,79 @@ package tableStyles:
 
 package columnar:
   object Prose extends Columnar:
+
     def width[textual: Textual](lines: IArray[textual], maxWidth: Int, slack: Double)
     : Optional[Int] =
 
-      def longestWord(text: textual, position: Int, lastStart: Int, max: Int): Int =
-        if position < text.length then
-          if textual.unsafeChar(text, position.z) == ' '
-          then longestWord(text, position + 1, position + 1, max.max(position - lastStart))
-          else longestWord(text, position + 1, lastStart, max)
-        else max.max(position - lastStart)
+        def longestWord(text: textual, position: Int, lastStart: Int, max: Int): Int =
+          if position < text.length then
+            if textual.unsafeChar(text, position.z) == ' '
+            then longestWord(text, position + 1, position + 1, max.max(position - lastStart))
+            else longestWord(text, position + 1, lastStart, max)
+          else max.max(position - lastStart)
 
-      val longestLine = lines.map(_.length).max
-      lines.map(longestWord(_, 0, 0, 0)).max.max((slack*maxWidth).toInt).min(longestLine)
+        val longestLine = lines.map(_.length).max
+        lines.map(longestWord(_, 0, 0, 0)).max.max((slack*maxWidth).toInt).min(longestLine)
+
 
     def fit[textual: Textual](lines: IArray[textual], width: Int, textAlign: TextAlignment)
     : IndexedSeq[textual] =
 
-      def format(text: textual, position: Int, lineStart: Int, lastSpace: Int, lines: List[textual])
-      : List[textual] =
 
-        if position < text.length then
-          if textual.unsafeChar(text, position.z) == ' '
-          then format(text, position + 1, lineStart, position, lines)
-          else
-            if position - lineStart >= width
-            then format
-                  (text,
-                   position + 1,
-                   lastSpace + 1,
-                   lastSpace,
-                   text.segment(lineStart.z ~ Ordinal.natural(lastSpace)) :: lines)
+        def format(text: textual, position: Int, lineStart: Int, lastSpace: Int, lines: List[textual])
+        : List[textual] =
 
-            else format(text, position + 1, lineStart, lastSpace, lines)
-        else if lineStart == position then lines
-        else text.segment(lineStart.z ~ Ordinal.natural(position)) :: lines
+            if position < text.length then
+              if textual.unsafeChar(text, position.z) == ' '
+              then format(text, position + 1, lineStart, position, lines)
+              else
+                if position - lineStart >= width
+                then format
+                      (text,
+                      position + 1,
+                      lastSpace + 1,
+                      lastSpace,
+                      text.segment(lineStart.z ~ Ordinal.natural(lastSpace)) :: lines)
 
-      lines.to(IndexedSeq).flatMap(format(_, 0, 0, 0, Nil).reverse)
+                else format(text, position + 1, lineStart, lastSpace, lines)
+            else if lineStart == position then lines
+            else text.segment(lineStart.z ~ Ordinal.natural(position)) :: lines
+
+
+        lines.to(IndexedSeq).flatMap(format(_, 0, 0, 0, Nil).reverse)
+
 
   case class Fixed(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
     def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
       fixedWidth
 
+
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
     : IndexedSeq[text] =
 
-      lines.to(IndexedSeq).map: line =>
-        if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+        lines.to(IndexedSeq).map: line =>
+          if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+
 
   case class Shortened(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
     def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
       val naturalWidth = lines.map(_.length).max
       (maxWidth*slack).toInt.min(naturalWidth)
 
+
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
     : IndexedSeq[text] =
 
-      lines.to(IndexedSeq).map: line =>
-        if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+        lines.to(IndexedSeq).map: line =>
+          if line.length > width then line.keep(width - ellipsis.length)+text(ellipsis) else line
+
 
   case class Collapsible(threshold: Double) extends Columnar:
     def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int] =
       if slack > threshold then lines.map(_.length).max else Unset
 
+
     def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
     : IndexedSeq[text] =
 
-      lines.to(IndexedSeq)
+        lines.to(IndexedSeq)

--- a/lib/escritoire/src/core/escritoire.Column.scala
+++ b/lib/escritoire/src/core/escritoire.Column.scala
@@ -44,7 +44,7 @@ object Column:
        (get: row => cell)
        (using columnAlignment: ColumnAlignment[cell] = ColumnAlignment.topLeft)
        (using text.Show[cell])
-  :     Column[row, text] =
+  : Column[row, text] =
 
     def contents(row: row): text = text.show(get(row))
 

--- a/lib/escritoire/src/core/escritoire.Column.scala
+++ b/lib/escritoire/src/core/escritoire.Column.scala
@@ -46,14 +46,15 @@ object Column:
        (using text.Show[cell])
   : Column[row, text] =
 
-    def contents(row: row): text = text.show(get(row))
+      def contents(row: row): text = text.show(get(row))
 
-    Column
-     (title,
-      contents,
-      textAlign.or(columnAlignment.text),
-      verticalAlign.or(columnAlignment.vertical),
-      sizing)
+      Column
+       (title,
+        contents,
+        textAlign.or(columnAlignment.text),
+        verticalAlign.or(columnAlignment.vertical),
+        sizing)
+
 
 case class Column[row, text: Textual]
    (title:         text,

--- a/lib/escritoire/src/core/escritoire.Columnar.scala
+++ b/lib/escritoire/src/core/escritoire.Columnar.scala
@@ -39,4 +39,4 @@ trait Columnar:
   def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double): Optional[Int]
 
   def fit[text: Textual](lines: IArray[text], width: Int, textAlign: TextAlignment)
-  :     IndexedSeq[text]
+  : IndexedSeq[text]

--- a/lib/escritoire/src/core/escritoire.LineCharset.scala
+++ b/lib/escritoire/src/core/escritoire.LineCharset.scala
@@ -46,4 +46,5 @@ enum LineCharset:
         bottom: BoxLine = BoxLine.Blank,
         left: BoxLine = BoxLine.Blank)
   : Char =
-    this()(left.ordinal + bottom.ordinal*4 + right.ordinal*16 + top.ordinal*64)
+
+      this()(left.ordinal + bottom.ordinal*4 + right.ordinal*16 + top.ordinal*64)

--- a/lib/escritoire/src/core/escritoire.LineCharset.scala
+++ b/lib/escritoire/src/core/escritoire.LineCharset.scala
@@ -45,5 +45,5 @@ enum LineCharset:
         right: BoxLine = BoxLine.Blank,
         bottom: BoxLine = BoxLine.Blank,
         left: BoxLine = BoxLine.Blank)
-  :     Char =
+  : Char =
     this()(left.ordinal + bottom.ordinal*4 + right.ordinal*16 + top.ordinal*64)

--- a/lib/escritoire/src/core/escritoire.Table.scala
+++ b/lib/escritoire/src/core/escritoire.Table.scala
@@ -43,23 +43,23 @@ object Table:
   def apply[row](using erased Void)[text: ClassTag: Textual](columns0: Column[row, text]*)
   : Table[row, text] =
 
-    new Table(columns0*)
+      new Table(columns0*)
 
-case class Table[row, text: {ClassTag, Textual as textual}]
-   (columns0: Column[row, text]*):
+
+case class Table[row, text: {ClassTag, Textual as textual}](columns0: Column[row, text]*):
   table =>
 
-  val columns: IArray[Column[row, text]] = IArray.from(columns0)
-  val titles: Seq[IArray[IArray[text]]] =
-    Seq(IArray.from(columns.map { column => IArray.from(column.title.cut(t"\n")) }))
+    val columns: IArray[Column[row, text]] = IArray.from(columns0)
+    val titles: Seq[IArray[IArray[text]]] =
+      Seq(IArray.from(columns.map { column => IArray.from(column.title.cut(t"\n")) }))
 
-  def tabulate(data: Seq[row]): Tabulation[text] { type Row = row } =
-    new Tabulation[text]:
-      type Row = row
+    def tabulate(data: Seq[row]): Tabulation[text] { type Row = row } =
+      new Tabulation[text]:
+        type Row = row
 
-      val columns: IArray[Column[Row, text]] = table.columns
-      val titles: Seq[IArray[IArray[text]]] = table.titles
-      val dataLength: Int = data.length
+        val columns: IArray[Column[Row, text]] = table.columns
+        val titles: Seq[IArray[IArray[text]]] = table.titles
+        val dataLength: Int = data.length
 
-      val rows: Seq[IArray[IArray[text]]] =
-        data.map { row => columns.map { column => IArray.from(column.get(row).lines) } }
+        val rows: Seq[IArray[IArray[text]]] =
+          data.map { row => columns.map { column => IArray.from(column.get(row).lines) } }

--- a/lib/escritoire/src/core/escritoire.Table.scala
+++ b/lib/escritoire/src/core/escritoire.Table.scala
@@ -41,7 +41,7 @@ import scala.collection.immutable as sci
 object Table:
   @targetName("make")
   def apply[row](using erased Void)[text: ClassTag: Textual](columns0: Column[row, text]*)
-  :     Table[row, text] =
+  : Table[row, text] =
 
     new Table(columns0*)
 

--- a/lib/escritoire/src/core/escritoire.Tabulation.scala
+++ b/lib/escritoire/src/core/escritoire.Tabulation.scala
@@ -62,7 +62,7 @@ abstract class Tabulation[text: ClassTag]():
   def grid(width: Int)
        (using style: TableStyle, metrics: Text is Measurable, textual: text is Textual)
        (using attenuation: Attenuation)
-  :     Grid[text] =
+  : Grid[text] =
 
     case class Layout(slack: Double, indices: IArray[Int], widths: IArray[Int], totalWidth: Int):
       lazy val include: sci.BitSet = indices.to(sci.BitSet)

--- a/lib/escritoire/src/core/escritoire.Tabulation.scala
+++ b/lib/escritoire/src/core/escritoire.Tabulation.scala
@@ -59,71 +59,72 @@ abstract class Tabulation[text: ClassTag]():
   def rows: Seq[IArray[IArray[text]]]
   def dataLength: Int
 
+
   def grid(width: Int)
        (using style: TableStyle, metrics: Text is Measurable, textual: text is Textual)
        (using attenuation: Attenuation)
   : Grid[text] =
 
-    case class Layout(slack: Double, indices: IArray[Int], widths: IArray[Int], totalWidth: Int):
-      lazy val include: sci.BitSet = indices.to(sci.BitSet)
+      case class Layout(slack: Double, indices: IArray[Int], widths: IArray[Int], totalWidth: Int):
+        lazy val include: sci.BitSet = indices.to(sci.BitSet)
 
-      lazy val columnWidths: IArray[(Int, Column[Row, text], Int)] = IArray.from:
-        indices.indices.map: index =>
-          val columnIndex = indices(index)
-          (columnIndex, columns(columnIndex), widths(index))
+        lazy val columnWidths: IArray[(Int, Column[Row, text], Int)] = IArray.from:
+          indices.indices.map: index =>
+            val columnIndex = indices(index)
+            (columnIndex, columns(columnIndex), widths(index))
 
-    def bisect(include: Int => Boolean): (Layout, Layout) =
-      def shrink(slack: Double): Layout =
-        val widths: IndexedSeq[Optional[Int]] =
-          columns.indices.map: index =>
-            val dataMax =
-              if !include(index) then 0 else rows.map: cells =>
-                columns(index).sizing.width[text](cells(index), width, slack).or(0)
+      def bisect(include: Int => Boolean): (Layout, Layout) =
+        def shrink(slack: Double): Layout =
+          val widths: IndexedSeq[Optional[Int]] =
+            columns.indices.map: index =>
+              val dataMax =
+                if !include(index) then 0 else rows.map: cells =>
+                  columns(index).sizing.width[text](cells(index), width, slack).or(0)
 
-              . maxOption.getOrElse(0)
+                . maxOption.getOrElse(0)
 
-            val titleMax =
-              if !include(index) then 0 else titles.map: cells =>
-                columns(index).sizing.width[text](cells(index), width, slack).or(0)
+              val titleMax =
+                if !include(index) then 0 else titles.map: cells =>
+                  columns(index).sizing.width[text](cells(index), width, slack).or(0)
 
-              . maxOption.getOrElse(0)
+                . maxOption.getOrElse(0)
 
-            dataMax.max(titleMax).puncture(0)
+              dataMax.max(titleMax).puncture(0)
 
-        val indices: IndexedSeq[Int] =
-          widths.indices.map { index => widths(index).let(index.waive) }.compact
+          val indices: IndexedSeq[Int] =
+            widths.indices.map { index => widths(index).let(index.waive) }.compact
 
-        val totalWidth = widths.sumBy(_.or(0)) + style.cost(indices.size)
+          val totalWidth = widths.sumBy(_.or(0)) + style.cost(indices.size)
 
-        Layout(slack, IArray.from(indices), IArray.from(widths.compact), totalWidth)
+          Layout(slack, IArray.from(indices), IArray.from(widths.compact), totalWidth)
 
-      def recur(min: Layout, max: Layout, gas: Int = 8): (Layout, Layout) =
-        if gas == 0 || max.totalWidth - min.totalWidth <= 1 then (min, max)
-        else
-          val point = shrink((min.slack + max.slack)/2)
+        def recur(min: Layout, max: Layout, gas: Int = 8): (Layout, Layout) =
+          if gas == 0 || max.totalWidth - min.totalWidth <= 1 then (min, max)
+          else
+            val point = shrink((min.slack + max.slack)/2)
 
-          if point.totalWidth == width then (point, point)
-          else if point.totalWidth > width then recur(min, point, gas - 1)
-          else recur(point, max, gas - 1)
+            if point.totalWidth == width then (point, point)
+            else if point.totalWidth > width then recur(min, point, gas - 1)
+            else recur(point, max, gas - 1)
 
-      recur(shrink(0), shrink(1), 8)
+        recur(shrink(0), shrink(1), 8)
 
-    val rowLayout = bisect(_ => true)(0)
-    val rowLayout2 = bisect(rowLayout.include(_))(0)
+      val rowLayout = bisect(_ => true)(0)
+      val rowLayout2 = bisect(rowLayout.include(_))(0)
 
-    // We may be able to increase the slack in some of the remaining columns
-    if rowLayout2.totalWidth > width then attenuation(rowLayout2.totalWidth, width)
+      // We may be able to increase the slack in some of the remaining columns
+      if rowLayout2.totalWidth > width then attenuation(rowLayout2.totalWidth, width)
 
-    def lines(data: Seq[IArray[IArray[text]]]): Stream[TableRow[text]] =
-      data.to(Stream).map: cells =>
-        val tableCells = rowLayout2.columnWidths.map: (index, column, width) =>
-          val lines = column.sizing.fit(cells(index), width, column.textAlign)
-          TableCell(width, 1, lines, lines.length, column.textAlign)
+      def lines(data: Seq[IArray[IArray[text]]]): Stream[TableRow[text]] =
+        data.to(Stream).map: cells =>
+          val tableCells = rowLayout2.columnWidths.map: (index, column, width) =>
+            val lines = column.sizing.fit(cells(index), width, column.textAlign)
+            TableCell(width, 1, lines, lines.length, column.textAlign)
 
-        val height = tableCells.maxBy(_.minHeight).minHeight
+          val height = tableCells.maxBy(_.minHeight).minHeight
 
-        TableRow(tableCells, false, height)
+          TableRow(tableCells, false, height)
 
-    val widths = rowLayout2.columnWidths.map(_(2))
+      val widths = rowLayout2.columnWidths.map(_(2))
 
-    Grid(List(TableSection(widths, lines(titles)), TableSection(widths, lines(rows))), style)
+      Grid(List(TableSection(widths, lines(titles)), TableSection(widths, lines(rows))), style)

--- a/lib/ethereal/src/core/ethereal-core.scala
+++ b/lib/ethereal/src/core/ethereal-core.scala
@@ -157,141 +157,142 @@ def cli[bus <: Matchable](using executive: Executive)
     Log.warn(DaemonLogEvent.Shutdown)
     pid.let(terminatePid.fulfill(_)).or(termination)
 
+
   def makeClient(socket: jn.Socket)(using Monitor, Stdio, Codicil)
   : Unit logs DaemonLogEvent raises StreamError raises CharDecodeError raises NumberError =
 
-    async:
-      val in = socket.getInputStream.nn
-      val reader = ji.BufferedReader(ji.InputStreamReader(in, "UTF-8"))
+      async:
+        val in = socket.getInputStream.nn
+        val reader = ji.BufferedReader(ji.InputStreamReader(in, "UTF-8"))
 
-      def line(): Text = reader.readLine().nn.tt
+        def line(): Text = reader.readLine().nn.tt
 
-      def chunk(): Text =
-        var buffer: Text = line()
-        var current: Text = t""
+        def chunk(): Text =
+          var buffer: Text = line()
+          var current: Text = t""
 
-        while
-          current = line()
-          current != t"##"
-        do buffer += t"\n$current"
+          while
+            current = line()
+            current != t"##"
+          do buffer += t"\n$current"
 
-        buffer
+          buffer
 
-      val message: Optional[DaemonEvent] = line() match
-        case t"e" =>
-          val pid: Pid = line().decode[Pid]
-          DaemonEvent.Stderr(pid)
+        val message: Optional[DaemonEvent] = line() match
+          case t"e" =>
+            val pid: Pid = line().decode[Pid]
+            DaemonEvent.Stderr(pid)
 
-        case t"s" =>
-          val pid: Pid = line().decode[Pid]
-          val signal: Signal = line().decode[Signal]
-          DaemonEvent.Trap(pid, signal)
+          case t"s" =>
+            val pid: Pid = line().decode[Pid]
+            val signal: Signal = line().decode[Signal]
+            DaemonEvent.Trap(pid, signal)
 
-        case t"x" =>
-          DaemonEvent.Exit(line().decode[Pid])
+          case t"x" =>
+            DaemonEvent.Exit(line().decode[Pid])
 
-        case t"i" =>
-          val cliInput: CliInput = if line() == t"p" then CliInput.Pipe else CliInput.Terminal
-          val pid: Pid = Pid(line().decode[Int])
-          val script: Text = line()
-          val pwd: Text = line()
-          val argCount: Int = line().decode[Int]
-          val textArguments: List[Text] = chunk().cut(t"\u0000").take(argCount).to(List)
-          val environment: List[Text] = chunk().cut(t"\u0000").init.to(List)
+          case t"i" =>
+            val cliInput: CliInput = if line() == t"p" then CliInput.Pipe else CliInput.Terminal
+            val pid: Pid = Pid(line().decode[Int])
+            val script: Text = line()
+            val pwd: Text = line()
+            val argCount: Int = line().decode[Int]
+            val textArguments: List[Text] = chunk().cut(t"\u0000").take(argCount).to(List)
+            val environment: List[Text] = chunk().cut(t"\u0000").init.to(List)
 
-          DaemonEvent.Init(pid, pwd, script, cliInput, textArguments, environment)
+            DaemonEvent.Init(pid, pwd, script, cliInput, textArguments, environment)
 
-        case _ =>
-          Unset
+          case _ =>
+            Unset
 
-      message match
-        case Unset =>
-          Log.warn(DaemonLogEvent.UnrecognizedMessage)
-          socket.close()
-
-        case DaemonEvent.Trap(pid, signal) =>
-          Log.info(DaemonLogEvent.ReceivedSignal(signal))
-          client(pid).signals.put(signal)
-          socket.close()
-
-        case DaemonEvent.Exit(pid) =>
-          Log.fine(DaemonLogEvent.ExitStatusRequest(pid))
-          val exitStatus: Exit = client(pid).exitPromise.await()
-
-          socket.getOutputStream.nn.write(exitStatus().show.bytes.mutable(using Unsafe))
-          socket.close()
-          clients.remove(pid)
-          if terminatePid() == pid then termination
-
-        case DaemonEvent.Stderr(pid) =>
-          Log.fine(DaemonLogEvent.StderrRequest(pid))
-          client(pid).stderr.offer(socket.getOutputStream.nn)
-
-        case DaemonEvent.Init(pid, directory, scriptName, shellInput, textArguments, env) =>
-          Log.fine(DaemonLogEvent.Init(pid))
-          val connection = client(pid)
-          connection.socket.fulfill(socket)
-
-          val lazyStderr: ji.OutputStream =
-            if !stderrSupport() then socket.getOutputStream.nn
-            else new ji.OutputStream():
-              private lazy val wrapped = connection.stderr.await()
-              def write(i: Int): Unit = wrapped.write(i)
-              override def write(bytes: Array[Byte] | Null): Unit = wrapped.write(bytes)
-
-              override def write(bytes: Array[Byte] | Null, offset: Int, length: Int): Unit =
-                wrapped.write(bytes, offset, length)
-
-          given environment: Environment = LazyEnvironment(env)
-
-          val termcap: Termcap = new Termcap:
-            def ansi: Boolean = true
-
-            lazy val color: ColorDepth =
-              import workingDirectories.systemProperty
-
-              if safely(Environment.colorterm[Text]) == t"truecolor" then ColorDepth.TrueColor
-              else ColorDepth
-                    (safely(mute[ExecEvent](sh"tput colors".exec[Text]().decode[Int])).or(-1))
-
-          val stdio: Stdio =
-            Stdio
-             (ji.PrintStream(socket.getOutputStream.nn), ji.PrintStream(lazyStderr), in, termcap)
-
-          def deliver(sourcePid: Pid, message: bus): Unit =
-            clients.each: (pid, client) =>
-              if sourcePid != pid then client.receive(message)
-
-          val service: DaemonService[bus] =
-            DaemonService[bus]
-             (pid,
-              () => shutdown(pid),
-              shellInput,
-              scriptName.decode[Path on Linux],
-              deliver(pid, _),
-              connection.bus.stream,
-              name)
-
-          Log.fine(DaemonLogEvent.NewCli)
-
-          try
-            val cli: executive.Interface =
-              executive.invocation
-               (textArguments, environment, () => directory, stdio, connection.signals)
-
-            val result = block(using service)(using cli)
-            val exitStatus: Exit = executive.process(cli)(result)
-
-            connection.exitPromise.fulfill(exitStatus)
-
-          catch
-            case exception: Exception =>
-              Log.warn(DaemonLogEvent.Failure)
-              connection.exitPromise.fulfill(handler.handle(exception)(using stdio))
-
-          finally
+        message match
+          case Unset =>
+            Log.warn(DaemonLogEvent.UnrecognizedMessage)
             socket.close()
-            Log.info(DaemonLogEvent.CloseConnection(pid))
+
+          case DaemonEvent.Trap(pid, signal) =>
+            Log.info(DaemonLogEvent.ReceivedSignal(signal))
+            client(pid).signals.put(signal)
+            socket.close()
+
+          case DaemonEvent.Exit(pid) =>
+            Log.fine(DaemonLogEvent.ExitStatusRequest(pid))
+            val exitStatus: Exit = client(pid).exitPromise.await()
+
+            socket.getOutputStream.nn.write(exitStatus().show.bytes.mutable(using Unsafe))
+            socket.close()
+            clients.remove(pid)
+            if terminatePid() == pid then termination
+
+          case DaemonEvent.Stderr(pid) =>
+            Log.fine(DaemonLogEvent.StderrRequest(pid))
+            client(pid).stderr.offer(socket.getOutputStream.nn)
+
+          case DaemonEvent.Init(pid, directory, scriptName, shellInput, textArguments, env) =>
+            Log.fine(DaemonLogEvent.Init(pid))
+            val connection = client(pid)
+            connection.socket.fulfill(socket)
+
+            val lazyStderr: ji.OutputStream =
+              if !stderrSupport() then socket.getOutputStream.nn
+              else new ji.OutputStream():
+                private lazy val wrapped = connection.stderr.await()
+                def write(i: Int): Unit = wrapped.write(i)
+                override def write(bytes: Array[Byte] | Null): Unit = wrapped.write(bytes)
+
+                override def write(bytes: Array[Byte] | Null, offset: Int, length: Int): Unit =
+                  wrapped.write(bytes, offset, length)
+
+            given environment: Environment = LazyEnvironment(env)
+
+            val termcap: Termcap = new Termcap:
+              def ansi: Boolean = true
+
+              lazy val color: ColorDepth =
+                import workingDirectories.systemProperty
+
+                if safely(Environment.colorterm[Text]) == t"truecolor" then ColorDepth.TrueColor
+                else ColorDepth
+                      (safely(mute[ExecEvent](sh"tput colors".exec[Text]().decode[Int])).or(-1))
+
+            val stdio: Stdio =
+              Stdio
+               (ji.PrintStream(socket.getOutputStream.nn), ji.PrintStream(lazyStderr), in, termcap)
+
+            def deliver(sourcePid: Pid, message: bus): Unit =
+              clients.each: (pid, client) =>
+                if sourcePid != pid then client.receive(message)
+
+            val service: DaemonService[bus] =
+              DaemonService[bus]
+               (pid,
+                () => shutdown(pid),
+                shellInput,
+                scriptName.decode[Path on Linux],
+                deliver(pid, _),
+                connection.bus.stream,
+                name)
+
+            Log.fine(DaemonLogEvent.NewCli)
+
+            try
+              val cli: executive.Interface =
+                executive.invocation
+                 (textArguments, environment, () => directory, stdio, connection.signals)
+
+              val result = block(using service)(using cli)
+              val exitStatus: Exit = executive.process(cli)(result)
+
+              connection.exitPromise.fulfill(exitStatus)
+
+            catch
+              case exception: Exception =>
+                Log.warn(DaemonLogEvent.Failure)
+                connection.exitPromise.fulfill(handler.handle(exception)(using stdio))
+
+            finally
+              socket.close()
+              Log.info(DaemonLogEvent.CloseConnection(pid))
 
   application(using executives.direct(using unhandledErrors.silent))(Nil):
     import stdioSources.virtualMachine.ansi

--- a/lib/ethereal/src/core/ethereal-core.scala
+++ b/lib/ethereal/src/core/ethereal-core.scala
@@ -158,7 +158,7 @@ def cli[bus <: Matchable](using executive: Executive)
     pid.let(terminatePid.fulfill(_)).or(termination)
 
   def makeClient(socket: jn.Socket)(using Monitor, Stdio, Codicil)
-  :     Unit logs DaemonLogEvent raises StreamError raises CharDecodeError raises NumberError =
+  : Unit logs DaemonLogEvent raises StreamError raises CharDecodeError raises NumberError =
 
     async:
       val in = socket.getInputStream.nn

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -78,81 +78,85 @@ object Installer:
     case Installed(script: Text, path: Text)
     case PathNotWritable
 
+
   def candidateTargets()(using service: DaemonService[?], diagnostics: Diagnostics)
        (using Environment, HomeDirectory, SystemProperties)
   : List[Path on Linux] logs DaemonLogEvent raises InstallError =
-    mitigate:
-      case PathError(_, _)     => InstallError(InstallError.Reason.Environment)
-      case EnvironmentError(_) => InstallError(InstallError.Reason.Environment)
-      case IoError(_, _, _)    => InstallError(InstallError.Reason.Io)
-      case NameError(_, _, _)  => InstallError(InstallError.Reason.Io)
 
-    . within:
-        val paths: List[Path on Linux] = Environment.path
+      mitigate:
+        case PathError(_, _)     => InstallError(InstallError.Reason.Environment)
+        case EnvironmentError(_) => InstallError(InstallError.Reason.Environment)
+        case IoError(_, _, _)    => InstallError(InstallError.Reason.Io)
+        case NameError(_, _, _)  => InstallError(InstallError.Reason.Io)
 
-        summon[Linux is Navigable]
+      . within:
+          val paths: List[Path on Linux] = Environment.path
 
-        val preferences: List[Path on Linux] = List
-         (Xdg.bin[Path on Linux],
-          % / n"usr" / n"local" / n"bin",
-          % / n"usr" / n"bin",
-          % / n"usr" / n"local" / n"sbin",
-          % / n"opt" / n"bin",
-          % / n"bin",
-          % / n"bin")
+          summon[Linux is Navigable]
 
-        paths.filter(_.exists()).filter(_.writable()).sortBy: directory =>
-          preferences.indexOf(directory) match
-            case -1    => Int.MaxValue
-            case index => index
+          val preferences: List[Path on Linux] =
+            List
+             (Xdg.bin[Path on Linux],
+              % / n"usr" / n"local" / n"bin",
+              % / n"usr" / n"bin",
+              % / n"usr" / n"local" / n"sbin",
+              % / n"opt" / n"bin",
+              % / n"bin",
+              % / n"bin")
+
+          paths.filter(_.exists()).filter(_.writable()).sortBy: directory =>
+            preferences.indexOf(directory) match
+              case -1    => Int.MaxValue
+              case index => index
+
 
   def install(force: Boolean = false, target: Optional[Path on Linux] = Unset)
        (using service: DaemonService[?], environment: Environment, home: HomeDirectory)
        (using Effectful, Diagnostics)
   : Result logs DaemonLogEvent raises InstallError =
-    import workingDirectories.systemProperty
-    import systemProperties.virtualMachine
 
-    mitigate:
-      case PathError(_, _)        => InstallError(InstallError.Reason.Environment)
-      case SystemPropertyError(_) => InstallError(InstallError.Reason.Environment)
-      case NumberError(_, _)      => InstallError(InstallError.Reason.Environment)
-      case IoError(_, _, _)       => InstallError(InstallError.Reason.Io)
-      case NameError(_, _, _)     => InstallError(InstallError.Reason.Io)
-      case ExecError(_, _, _)     => InstallError(InstallError.Reason.Io)
-      case StreamError(_)         => InstallError(InstallError.Reason.Io)
+      import workingDirectories.systemProperty
+      import systemProperties.virtualMachine
 
-    . within:
-        val command: Text = service.scriptName
-        val scriptPath = mute[ExecEvent](sh"sh -c 'command -v $command'".exec[Text]())
+      mitigate:
+        case PathError(_, _)        => InstallError(InstallError.Reason.Environment)
+        case SystemPropertyError(_) => InstallError(InstallError.Reason.Environment)
+        case NumberError(_, _)      => InstallError(InstallError.Reason.Environment)
+        case IoError(_, _, _)       => InstallError(InstallError.Reason.Io)
+        case NameError(_, _, _)     => InstallError(InstallError.Reason.Io)
+        case ExecError(_, _, _)     => InstallError(InstallError.Reason.Io)
+        case StreamError(_)         => InstallError(InstallError.Reason.Io)
 
-        if safely(scriptPath.decode[Path on Linux]) == service.script && !force
-        then Result.AlreadyOnPath(command, service.script.text)
-        else
-          val payloadSize: Memory = Memory(Properties.ethereal.payloadSize[Int]())
-          val jarSize: Memory = Memory(Properties.ethereal.jarSize[Int]())
-          val scriptFile: Path on Linux = service.script
-          val fileSize = scriptFile.size()
-          val prefixSize = fileSize - payloadSize - jarSize
-          val installDirectory: Path on Linux = target.or(candidateTargets().prim).or:
-            abort(InstallError(InstallError.Reason.Environment))
+      . within:
+          val command: Text = service.scriptName
+          val scriptPath = mute[ExecEvent](sh"sh -c 'command -v $command'".exec[Text]())
 
-          val installFile: Optional[Path on Linux] =
-            (installDirectory / Name(command)).make[File]().on[Linux]
+          if safely(scriptPath.decode[Path on Linux]) == service.script && !force
+          then Result.AlreadyOnPath(command, service.script.text)
+          else
+            val payloadSize: Memory = Memory(Properties.ethereal.payloadSize[Int]())
+            val jarSize: Memory = Memory(Properties.ethereal.jarSize[Int]())
+            val scriptFile: Path on Linux = service.script
+            val fileSize = scriptFile.size()
+            val prefixSize = fileSize - payloadSize - jarSize
+            val installDirectory: Path on Linux = target.or(candidateTargets().prim).or:
+              abort(InstallError(InstallError.Reason.Environment))
 
-          installFile.let: file =>
-            val filename: Text = file.inspect
-            Log.info(DaemonLogEvent.WriteExecutable(filename))
+            val installFile: Optional[Path on Linux] =
+              (installDirectory / Name(command)).make[File]().on[Linux]
 
-            scriptFile.open: file =>
-              val stream = file.stream[Bytes]
+            installFile.let: file =>
+              val filename: Text = file.inspect
+              Log.info(DaemonLogEvent.WriteExecutable(filename))
 
-              if prefixSize > 0.b
-              then (stream.take(prefixSize) ++ stream.discard(fileSize - jarSize)).writeTo(file)
-              else stream.writeTo(file)
+              scriptFile.open: file =>
+                val stream = file.stream[Bytes]
 
-            file.executable() = true
-            Result.Installed(command, file.text)
+                if prefixSize > 0.b
+                then (stream.take(prefixSize) ++ stream.discard(fileSize - jarSize)).writeTo(file)
+                else stream.writeTo(file)
 
-          . or:
-              Result.PathNotWritable
+              file.executable() = true
+              Result.Installed(command, file.text)
+
+            . or(Result.PathNotWritable)

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -80,7 +80,7 @@ object Installer:
 
   def candidateTargets()(using service: DaemonService[?], diagnostics: Diagnostics)
        (using Environment, HomeDirectory, SystemProperties)
-  :     List[Path on Linux] logs DaemonLogEvent raises InstallError =
+  : List[Path on Linux] logs DaemonLogEvent raises InstallError =
     mitigate:
       case PathError(_, _)     => InstallError(InstallError.Reason.Environment)
       case EnvironmentError(_) => InstallError(InstallError.Reason.Environment)
@@ -109,7 +109,7 @@ object Installer:
   def install(force: Boolean = false, target: Optional[Path on Linux] = Unset)
        (using service: DaemonService[?], environment: Environment, home: HomeDirectory)
        (using Effectful, Diagnostics)
-  :     Result logs DaemonLogEvent raises InstallError =
+  : Result logs DaemonLogEvent raises InstallError =
     import workingDirectories.systemProperty
     import systemProperties.virtualMachine
 

--- a/lib/eucalyptus/src/core/eucalyptus-core.scala
+++ b/lib/eucalyptus/src/core/eucalyptus-core.scala
@@ -75,7 +75,7 @@ def mute[format](using erased Void)[result](lambda: (format is Loggable) ?=> res
 extension (logObject: Log.type)
   def envelop[tag, event: {Taggable by tag, Loggable as loggable}](value: tag)[result]
        (lambda: (event is Loggable) ?=> result)
-  :     result =
+  : result =
     lambda(using loggable.contramap(_.tag(value)))
 
   def ignore[event, message]: message transcribes event = new Transcribable:
@@ -91,7 +91,7 @@ extension (logObject: Log.type)
   def route[format](using erased Void)[entry: Inscribable in format, writable: Writable by format]
        (target: writable)
        (using Monitor)
-  :     entry is Loggable =
+  : entry is Loggable =
 
     new:
       type Self = entry

--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -45,12 +45,13 @@ case class Argument(position: Int, value: Text, cursor: Optional[Int]):
   def suggest(using cli: Cli)(update: (prior: List[Suggestion]) ?=> List[Suggestion]) =
     cli.suggest(this, update)
 
+
   def select[operand](options: Seq[operand])
        (using cli: Cli, interpreter: CliInterpreter, suggestible: operand is Suggestible)
   : Optional[operand] =
 
-    val mapping: Map[Text, operand] =
-      options.map { option => (suggestible.suggest(option).text, option) }.to(Map)
+      val mapping: Map[Text, operand] =
+        options.map { option => (suggestible.suggest(option).text, option) }.to(Map)
 
-    suggest(options.to(List).map(suggestible.suggest(_)))
-    mapping.at(this())
+      suggest(options.to(List).map(suggestible.suggest(_)))
+      mapping.at(this())

--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -47,7 +47,7 @@ case class Argument(position: Int, value: Text, cursor: Optional[Int]):
 
   def select[operand](options: Seq[operand])
        (using cli: Cli, interpreter: CliInterpreter, suggestible: operand is Suggestible)
-  :     Optional[operand] =
+  : Optional[operand] =
 
     val mapping: Map[Text, operand] =
       options.map { option => (suggestible.suggest(option).text, option) }.to(Map)

--- a/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
@@ -37,6 +37,8 @@ import vacuous.*
 case class Arguments(sequence: Argument*) extends FlagParameters:
   def read[operand](flag: Flag)(using Cli, FlagInterpreter[operand], Suggestions[operand])
   : Optional[operand] =
-    Unset // FIXME
+
+      Unset // FIXME
+
 
   def focusFlag: Optional[Argument] = Unset

--- a/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
@@ -36,7 +36,7 @@ import vacuous.*
 
 case class Arguments(sequence: Argument*) extends FlagParameters:
   def read[operand](flag: Flag)(using Cli, FlagInterpreter[operand], Suggestions[operand])
-  :     Optional[operand] =
+  : Optional[operand] =
     Unset // FIXME
 
   def focusFlag: Optional[Argument] = Unset

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -46,8 +46,9 @@ object Cli:
         position:      Optional[Int] = Unset)
   : List[Argument] =
 
-    textArguments.to(List).padTo(focus.or(0) + 1, t"").zipWithIndex.map: (text, index) =>
-      Argument(index, text, if focus == index then position else Unset)
+      textArguments.to(List).padTo(focus.or(0) + 1, t"").zipWithIndex.map: (text, index) =>
+        Argument(index, text, if focus == index then position else Unset)
+
 
 trait Cli extends ProcessContext:
   def arguments: List[Argument]

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -44,7 +44,7 @@ object Cli:
        (textArguments: Iterable[Text],
         focus:         Optional[Int] = Unset,
         position:      Optional[Int] = Unset)
-  :     List[Argument] =
+  : List[Argument] =
 
     textArguments.to(List).padTo(focus.or(0) + 1, t"").zipWithIndex.map: (text, index) =>
       Argument(index, text, if focus == index then position else Unset)
@@ -55,7 +55,7 @@ trait Cli extends ProcessContext:
   def workingDirectory: WorkingDirectory
 
   def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
-  :     Optional[operand]
+  : Optional[operand]
 
   def register(flag: Flag, suggestions: Suggestions[?]): Unit = ()
   def present(flag: Flag): Unit = ()

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -74,14 +74,14 @@ case class Flag
               interpreter:     CliInterpreter,
               flagInterpreter: FlagInterpreter[operand],
               suggestions:     Suggestions[operand] = Suggestions.noSuggestions)
-  :     Optional[operand] =
+  : Optional[operand] =
 
     cli.register(this, suggestions)
     cli.readParameter(this)
 
   def select[operand](options: Iterable[operand])
        (using cli: Cli, interpreter: CliInterpreter, suggestible: operand is Suggestible)
-  :     Optional[operand] =
+  : Optional[operand] =
 
     val mapping: Map[Text, operand] =
       options.map { option => (suggestible.suggest(option).text, option) }.to(Map)

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -76,20 +76,21 @@ case class Flag
               suggestions:     Suggestions[operand] = Suggestions.noSuggestions)
   : Optional[operand] =
 
-    cli.register(this, suggestions)
-    cli.readParameter(this)
+      cli.register(this, suggestions)
+      cli.readParameter(this)
+
 
   def select[operand](options: Iterable[operand])
        (using cli: Cli, interpreter: CliInterpreter, suggestible: operand is Suggestible)
   : Optional[operand] =
 
-    val mapping: Map[Text, operand] =
-      options.map { option => (suggestible.suggest(option).text, option) }.to(Map)
+      val mapping: Map[Text, operand] =
+        options.map { option => (suggestible.suggest(option).text, option) }.to(Map)
 
-    given flagInterpreter: FlagInterpreter[operand] =
-      case List(value) => mapping.at(value())
-      case _           => Unset
+      given flagInterpreter: FlagInterpreter[operand] =
+        case List(value) => mapping.at(value())
+        case _           => Unset
 
-    given suggestions: Suggestions[operand] = () => options.map(suggestible.suggest(_))
+      given suggestions: Suggestions[operand] = () => options.map(suggestible.suggest(_))
 
-    this()
+      this()

--- a/lib/exoskeleton/src/args/exoskeleton.FlagParameters.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.FlagParameters.scala
@@ -36,6 +36,6 @@ import vacuous.*
 
 trait FlagParameters:
   def read[operand](flag: Flag)(using Cli, FlagInterpreter[operand], Suggestions[operand])
-  :     Optional[operand]
+  : Optional[operand]
 
   def focusFlag: Optional[Argument]

--- a/lib/exoskeleton/src/args/exoskeleton.PosixCliInterpreter.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.PosixCliInterpreter.scala
@@ -48,23 +48,24 @@ object PosixCliInterpreter extends CliInterpreter:
           parameters: PosixParameters)
     : PosixParameters =
 
-      def push(): PosixParameters = current match
-        case Unset =>
-          PosixParameters(arguments.reverse)
+        def push(): PosixParameters = current match
+          case Unset =>
+            PosixParameters(arguments.reverse)
 
-        case current: Argument =>
-          parameters.copy(parameters = parameters.parameters.updated(current, arguments.reverse))
+          case current: Argument =>
+            parameters.copy(parameters = parameters.parameters.updated(current, arguments.reverse))
 
-      todo match
-        case head :: tail =>
-          if head() == t"--" then push().copy(postpositional = tail)
-          else if head().starts(t"-") then recur(tail, Nil, head, push())
-          else
-            val parameters2 =
-              if head.cursor.present then parameters.copy(focusFlag = current) else parameters
-            recur(tail, head :: arguments, current, parameters2)
+        todo match
+          case head :: tail =>
+            if head() == t"--" then push().copy(postpositional = tail)
+            else if head().starts(t"-") then recur(tail, Nil, head, push())
+            else
+              val parameters2 =
+                if head.cursor.present then parameters.copy(focusFlag = current) else parameters
+              recur(tail, head :: arguments, current, parameters2)
 
-        case Nil =>
-          push()
+          case Nil =>
+            push()
+
 
     recur(arguments, Nil, Unset, PosixParameters())

--- a/lib/exoskeleton/src/args/exoskeleton.PosixCliInterpreter.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.PosixCliInterpreter.scala
@@ -46,7 +46,7 @@ object PosixCliInterpreter extends CliInterpreter:
           arguments:  List[Argument],
           current:    Optional[Argument],
           parameters: PosixParameters)
-    :     PosixParameters =
+    : PosixParameters =
 
       def push(): PosixParameters = current match
         case Unset =>

--- a/lib/exoskeleton/src/args/exoskeleton.PosixParameters.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.PosixParameters.scala
@@ -39,10 +39,10 @@ import vacuous.*
 import language.experimental.pureFunctions
 
 case class PosixParameters
-   (positional:    List[Argument]                = Nil,
-    parameters:    Map[Argument, List[Argument]] = Map(),
+   (positional:     List[Argument]                = Nil,
+    parameters:     Map[Argument, List[Argument]] = Map(),
     postpositional: List[Argument]                = Nil,
-    focusFlag:     Optional[Argument]            = Unset)
+    focusFlag:      Optional[Argument]            = Unset)
 extends FlagParameters:
 
   def read[operand](flag: Flag)
@@ -51,8 +51,8 @@ extends FlagParameters:
               suggestions: Suggestions[operand])
   : Optional[operand] =
 
-    cli.register(flag, suggestions)
+      cli.register(flag, suggestions)
 
-    parameters.where { (key, _) => flag.matches(key) }.let: (_, operands) =>
-      cli.present(flag)
-      safely(interpreter.interpret(operands))
+      parameters.where { (key, _) => flag.matches(key) }.let: (_, operands) =>
+        cli.present(flag)
+        safely(interpreter.interpret(operands))

--- a/lib/exoskeleton/src/args/exoskeleton.PosixParameters.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.PosixParameters.scala
@@ -49,7 +49,7 @@ extends FlagParameters:
        (using cli:         Cli,
               interpreter: FlagInterpreter[operand],
               suggestions: Suggestions[operand])
-  :     Optional[operand] =
+  : Optional[operand] =
 
     cli.register(flag, suggestions)
 

--- a/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
@@ -45,7 +45,7 @@ object Suggestion:
         hidden:     Boolean                   = false,
         incomplete:  Boolean                   = false,
         aliases:    List[Text]                = Nil)
-  :     Suggestion =
+  : Suggestion =
 
     new Suggestion(text, description, hidden, incomplete, aliases)
 

--- a/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
@@ -42,12 +42,13 @@ object Suggestion:
   def apply
        (text: Text,
         description: Optional[Text | Teletype],
-        hidden:     Boolean                   = false,
+        hidden:      Boolean                   = false,
         incomplete:  Boolean                   = false,
-        aliases:    List[Text]                = Nil)
+        aliases:     List[Text]                = Nil)
   : Suggestion =
 
-    new Suggestion(text, description, hidden, incomplete, aliases)
+      new Suggestion(text, description, hidden, incomplete, aliases)
+
 
 case class Suggestion
    (text:        Text,

--- a/lib/exoskeleton/src/args/exoskeleton.Switch.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Switch.scala
@@ -46,4 +46,4 @@ object Switch:
         secret: Boolean             = false)
   : Flag =
 
-    Flag(name, repeatable, aliases, description, secret)
+      Flag(name, repeatable, aliases, description, secret)

--- a/lib/exoskeleton/src/args/exoskeleton.Switch.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Switch.scala
@@ -44,6 +44,6 @@ object Switch:
         aliases: List[Text | Char]  = Nil,
         description: Optional[Text] = Unset,
         secret: Boolean             = false)
-  :     Flag =
+  : Flag =
 
     Flag(name, repeatable, aliases, description, secret)

--- a/lib/exoskeleton/src/completions/exoskeleton-completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton-completions.scala
@@ -62,7 +62,7 @@ package executives:
           stdio:            Stdio,
           signals:          Spool[Signal])
          (using interpreter: CliInterpreter)
-    :     Cli =
+    : Cli =
       arguments match
         case t"{completions}" :: shellName :: As[Int](focus) :: As[Int](position) :: t"--"
              :: command

--- a/lib/exoskeleton/src/completions/exoskeleton-completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton-completions.scala
@@ -55,6 +55,7 @@ package executives:
     type Interface = Cli
     type Return = Execution
 
+
     def invocation
          (arguments:        Iterable[Text],
           environment:      Environment,
@@ -63,29 +64,31 @@ package executives:
           signals:          Spool[Signal])
          (using interpreter: CliInterpreter)
     : Cli =
-      arguments match
-        case t"{completions}" :: shellName :: As[Int](focus) :: As[Int](position) :: t"--"
-             :: command
-             :: rest =>
 
-          val shell = shellName match
-            case t"zsh"  => Shell.Zsh
-            case t"fish" => Shell.Fish
-            case _       => Shell.Bash
+        arguments match
+          case t"{completions}" :: shellName :: As[Int](focus) :: As[Int](position) :: t"--"
+              :: command
+              :: rest =>
 
-          CliCompletion
-           (Cli.arguments(arguments, focus - 1, position),
-            Cli.arguments(rest, focus - 1, position),
-            environment,
-            workingDirectory,
-            shell,
-            focus - 1,
-            position,
-            stdio,
-            signals)
+            val shell = shellName match
+              case t"zsh"  => Shell.Zsh
+              case t"fish" => Shell.Fish
+              case _       => Shell.Bash
 
-        case other =>
-          CliInvocation(Cli.arguments(arguments), environment, workingDirectory, stdio, signals)
+            CliCompletion
+             (Cli.arguments(arguments, focus - 1, position),
+              Cli.arguments(rest, focus - 1, position),
+              environment,
+              workingDirectory,
+              shell,
+              focus - 1,
+              position,
+              stdio,
+              signals)
+
+          case other =>
+            CliInvocation(Cli.arguments(arguments), environment, workingDirectory, stdio, signals)
+
 
     def process(cli: Cli)(execution: Cli ?=> Execution): Exit = cli.absolve match
       case completion: CliCompletion =>

--- a/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
@@ -66,11 +66,13 @@ extends Cli:
   var explanation: Optional[Text] = Unset
   var cursorSuggestions: List[Suggestion] = Nil
 
+
   def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
   : Optional[operand] =
 
-    given cli: Cli = this
-    parameters.read(flag)
+      given cli: Cli = this
+      parameters.read(flag)
+
 
   def focus: Argument = arguments(currentArgument)
 

--- a/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
@@ -67,7 +67,7 @@ extends Cli:
   var cursorSuggestions: List[Suggestion] = Nil
 
   def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
-  :     Optional[operand] =
+  : Optional[operand] =
 
     given cli: Cli = this
     parameters.read(flag)

--- a/lib/exoskeleton/src/completions/exoskeleton.TabCompletions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.TabCompletions.scala
@@ -59,7 +59,7 @@ import pathNavigation.posix
 object TabCompletions:
   def install(force: Boolean = false)(using service: ShellContext)
        (using WorkingDirectory, Effectful, Diagnostics)
-  :     TabCompletionsInstallation raises InstallError logs CliEvent =
+  : TabCompletionsInstallation raises InstallError logs CliEvent =
     mitigate:
       case PathError(_, _)    => InstallError(InstallError.Reason.Environment)
       case NameError(_, _, _) => InstallError(InstallError.Reason.Environment)
@@ -111,7 +111,7 @@ object TabCompletions:
 
   def install(shell: Shell, command: Text, scriptName: Name[Posix], dirs: List[Path on Posix])
        (using Effectful, Diagnostics)
-  :     TabCompletionsInstallation.InstallResult raises InstallError logs CliEvent =
+  : TabCompletionsInstallation.InstallResult raises InstallError logs CliEvent =
 
     mitigate:
       case IoError(_, _, _)   => InstallError(InstallError.Reason.Io)

--- a/lib/exoskeleton/src/core/exoskeleton-core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton-core.scala
@@ -92,7 +92,7 @@ package executives:
           stdio:            Stdio,
           signals:          Spool[Signal])
          (using interpreter: CliInterpreter)
-    :     CliInvocation =
+    : CliInvocation =
 
       CliInvocation
        (Cli.arguments(arguments),
@@ -109,7 +109,7 @@ package executives:
 def application(using executive: Executive, interpreter: CliInterpreter)
    (arguments: Iterable[Text], signals: List[Signal] = Nil)
    (block: Cli ?=> executive.Return)
-:     Unit =
+: Unit =
 
   val spool: Spool[Signal] = Spool()
   signals.each: signal =>

--- a/lib/exoskeleton/src/core/exoskeleton-core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton-core.scala
@@ -85,6 +85,7 @@ package executives:
     type Return = Exit
     type Interface = CliInvocation
 
+
     def invocation
          (arguments:        Iterable[Text],
           environment:      Environment,
@@ -94,12 +95,13 @@ package executives:
          (using interpreter: CliInterpreter)
     : CliInvocation =
 
-      CliInvocation
-       (Cli.arguments(arguments),
-        environments.virtualMachine,
-        workingDirectories.systemProperty,
-        stdio,
-        signals)
+        CliInvocation
+         (Cli.arguments(arguments),
+          environments.virtualMachine,
+          workingDirectories.systemProperty,
+          stdio,
+          signals)
+
 
     def process(cli: CliInvocation)(exitStatus: Interface ?=> Exit): Exit =
       try exitStatus(using cli)

--- a/lib/exoskeleton/src/core/exoskeleton.CliInvocation.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.CliInvocation.scala
@@ -52,7 +52,9 @@ extends Cli, Stdio:
 
   private lazy val parameters: interpreter.Parameters = interpreter.interpret(arguments)
 
+
   def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
   : Optional[operand] =
-    given cli: Cli = this
-    parameters.read(flag)
+
+      given cli: Cli = this
+      parameters.read(flag)

--- a/lib/exoskeleton/src/core/exoskeleton.CliInvocation.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.CliInvocation.scala
@@ -53,6 +53,6 @@ extends Cli, Stdio:
   private lazy val parameters: interpreter.Parameters = interpreter.interpret(arguments)
 
   def readParameter[operand](flag: Flag)(using FlagInterpreter[operand], Suggestions[operand])
-  :     Optional[operand] =
+  : Optional[operand] =
     given cli: Cli = this
     parameters.read(flag)

--- a/lib/exoskeleton/src/core/exoskeleton.Executive.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Executive.scala
@@ -49,6 +49,6 @@ trait Executive:
         stdio:            Stdio,
         signals:          Spool[Signal])
        (using interpreter: CliInterpreter)
-  :     Interface
+  : Interface
 
   def process(cli: Interface)(result: Interface ?=> Return): Exit

--- a/lib/fulminate/src/core/fulminate-core.scala
+++ b/lib/fulminate/src/core/fulminate-core.scala
@@ -48,44 +48,48 @@ def panic(message: Message): Nothing = throw Panic(message)
 
 def halt(using Quotes)(message: Message, pos: quotes.reflect.Position | Null = null)(using Realm)
 : Nothing =
-  import quotes.reflect.*
-  import dotty.tools.dotc.config.Settings.Setting.value
 
-  val useColor: Boolean = quotes match
-    case quotes: runtime.impl.QuotesImpl =>
-      value(quotes.ctx.settings.color)(using quotes.ctx) != "never"
+    import quotes.reflect.*
+    import dotty.tools.dotc.config.Settings.Setting.value
 
-    case _ =>
-      false
+    val useColor: Boolean = quotes match
+      case quotes: runtime.impl.QuotesImpl =>
+        value(quotes.ctx.settings.color)(using quotes.ctx) != "never"
 
-  val esc = 27.toChar
+      case _ =>
+        false
 
-  val text =
-    if useColor then s"$esc[38;2;0;190;255m$esc[1m${summon[Realm].name}$esc[0m ${message.colorText}"
-    else s"${summon[Realm].name}: ${message.text}"
+    val esc = 27.toChar
 
-  if pos == null then report.errorAndAbort(text) else report.errorAndAbort(text, pos)
+    val text =
+      if useColor then s"$esc[38;2;0;190;255m$esc[1m${summon[Realm].name}$esc[0m ${message.colorText}"
+      else s"${summon[Realm].name}: ${message.text}"
+
+    if pos == null then report.errorAndAbort(text) else report.errorAndAbort(text, pos)
+
 
 def warn(using Quotes)(message: Message, pos: quotes.reflect.Position | Null = null)(using Realm)
 : Unit =
-  import quotes.reflect.*
-  import dotty.tools.dotc.config.Settings.Setting.value
 
-  val esc = 27.toChar
+    import quotes.reflect.*
+    import dotty.tools.dotc.config.Settings.Setting.value
 
-  val useColor: Boolean = quotes match
-    case quotes: runtime.impl.QuotesImpl =>
-      value(quotes.ctx.settings.color)(using quotes.ctx) != "never"
+    val esc = 27.toChar
 
-    case _ =>
-      false
+    val useColor: Boolean = quotes match
+      case quotes: runtime.impl.QuotesImpl =>
+        value(quotes.ctx.settings.color)(using quotes.ctx) != "never"
 
-  val text =
-    if useColor
-    then s"$esc[38;2;0;190;255m$esc[1m${summon[Realm].name}$esc[0m ${message.colorText}"
-    else s"${summon[Realm].name}: ${message.text}"
+      case _ =>
+        false
 
-  if pos == null then report.warning(text) else report.warning(text, pos)
+    val text =
+      if useColor
+      then s"$esc[38;2;0;190;255m$esc[1m${summon[Realm].name}$esc[0m ${message.colorText}"
+      else s"${summon[Realm].name}: ${message.text}"
+
+    if pos == null then report.warning(text) else report.warning(text, pos)
+
 
 extension (inline context: StringContext)
   transparent inline def m[param](inline subs: param = Zero): Message =

--- a/lib/fulminate/src/core/fulminate-core.scala
+++ b/lib/fulminate/src/core/fulminate-core.scala
@@ -47,7 +47,7 @@ package errorDiagnostics:
 def panic(message: Message): Nothing = throw Panic(message)
 
 def halt(using Quotes)(message: Message, pos: quotes.reflect.Position | Null = null)(using Realm)
-:     Nothing =
+: Nothing =
   import quotes.reflect.*
   import dotty.tools.dotc.config.Settings.Setting.value
 
@@ -67,7 +67,7 @@ def halt(using Quotes)(message: Message, pos: quotes.reflect.Position | Null = n
   if pos == null then report.errorAndAbort(text) else report.errorAndAbort(text, pos)
 
 def warn(using Quotes)(message: Message, pos: quotes.reflect.Position | Null = null)(using Realm)
-:     Unit =
+: Unit =
   import quotes.reflect.*
   import dotty.tools.dotc.config.Settings.Setting.value
 

--- a/lib/fulminate/src/core/fulminate.Message.scala
+++ b/lib/fulminate/src/core/fulminate.Message.scala
@@ -46,7 +46,7 @@ object Message:
   given communicable: [event: Communicable] => Message transcribes event = _.communicate
 
   transparent inline def make[tuple <: Tuple](inline messages: tuple, done: List[Message])
-  :     List[Message] =
+  : List[Message] =
     inline erasedValue[tuple] match
       case _: (message *: tail) => messages.absolve match
         case message *: tail =>

--- a/lib/fulminate/src/core/fulminate.Message.scala
+++ b/lib/fulminate/src/core/fulminate.Message.scala
@@ -45,17 +45,20 @@ object Message:
   given printable: Message is Printable = (message, termcap) => message.text
   given communicable: [event: Communicable] => Message transcribes event = _.communicate
 
+
   transparent inline def make[tuple <: Tuple](inline messages: tuple, done: List[Message])
   : List[Message] =
-    inline erasedValue[tuple] match
-      case _: (message *: tail) => messages.absolve match
-        case message *: tail =>
-          val message2 = message.asInstanceOf[message]
-          val communicable = summonInline[(? >: message) is Communicable]
-          make[tail](tail.asInstanceOf[tail], communicable.message(message2) :: done)
 
-      case _ =>
-        done.reverse
+      inline erasedValue[tuple] match
+        case _: (message *: tail) => messages.absolve match
+          case message *: tail =>
+            val message2 = message.asInstanceOf[message]
+            val communicable = summonInline[(? >: message) is Communicable]
+            make[tail](tail.asInstanceOf[tail], communicable.message(message2) :: done)
+
+        case _ =>
+          done.reverse
+
 
 case class Message(texts: List[Text], messages: List[Message] = Nil):
   @targetName("append")

--- a/lib/fulminate/src/core/fulminate.TextEscapes.scala
+++ b/lib/fulminate/src/core/fulminate.TextEscapes.scala
@@ -40,28 +40,32 @@ import anticipation.*
 
 object TextEscapes:
   import errorDiagnostics.stackTraces
+
+
   def standardEscape(text: into Text, cur: Int, esc: Boolean)
   : (Int, Int, Boolean) throws EscapeError =
-    text.s.charAt(cur) match
-      case '\\' if !esc => (-1, cur + 1, true)
-      case '\\'         => ('\\', cur + 1, false)
-      case 'n' if esc   => ('\n', cur + 1, false)
-      case 'r' if esc   => ('\r', cur + 1, false)
-      case 'f' if esc   => ('\f', cur + 1, false)
-      case 'b' if esc   => ('\b', cur + 1, false)
-      case 't' if esc   => ('\t', cur + 1, false)
-      case 'u' if esc   => (parseUnicode(text.s.slice(cur + 1, cur + 5)), cur + 5, false)
-      case 'e' if esc   => ('\u001b', cur + 1, false)
-      case '"' if esc   => ('"', cur + 1, false)
-      case '\'' if esc  => ('\'', cur + 1, false)
-      case ch if esc    =>
-        throw EscapeError
-               (Message
-                 (List("the character ".tt, " should not be escaped".tt),
-                  List(Message(ch.toString.tt))))
 
-      case ch =>
-        (ch, cur + 1, false)
+      text.s.charAt(cur) match
+        case '\\' if !esc => (-1, cur + 1, true)
+        case '\\'         => ('\\', cur + 1, false)
+        case 'n' if esc   => ('\n', cur + 1, false)
+        case 'r' if esc   => ('\r', cur + 1, false)
+        case 'f' if esc   => ('\f', cur + 1, false)
+        case 'b' if esc   => ('\b', cur + 1, false)
+        case 't' if esc   => ('\t', cur + 1, false)
+        case 'u' if esc   => (parseUnicode(text.s.slice(cur + 1, cur + 5)), cur + 5, false)
+        case 'e' if esc   => ('\u001b', cur + 1, false)
+        case '"' if esc   => ('"', cur + 1, false)
+        case '\'' if esc  => ('\'', cur + 1, false)
+        case ch if esc    =>
+          throw EscapeError
+                (Message
+                  (List("the character ".tt, " should not be escaped".tt),
+                    List(Message(ch.toString.tt))))
+
+        case ch =>
+          (ch, cur + 1, false)
+
 
   private def parseUnicode(chars: String): Char throws EscapeError =
     if chars.length < 4

--- a/lib/fulminate/src/core/fulminate.TextEscapes.scala
+++ b/lib/fulminate/src/core/fulminate.TextEscapes.scala
@@ -41,7 +41,7 @@ import anticipation.*
 object TextEscapes:
   import errorDiagnostics.stackTraces
   def standardEscape(text: into Text, cur: Int, esc: Boolean)
-  :     (Int, Int, Boolean) throws EscapeError =
+  : (Int, Int, Boolean) throws EscapeError =
     text.s.charAt(cur) match
       case '\\' if !esc => (-1, cur + 1, true)
       case '\\'         => ('\\', cur + 1, false)

--- a/lib/galilei/src/core/galilei-core.scala
+++ b/lib/galilei/src/core/galilei-core.scala
@@ -69,12 +69,12 @@ final val `$`: MacOs.Root = MacOs.RootSingleton
 
 extension [openable: Openable](value: openable)
   def open[result](lambda: openable.Result => result, options: List[openable.Operand] = Nil)
-  :     result =
+  : result =
     openable.open(value, lambda, options)
 
 extension [platform <: Filesystem](path: Path on platform)
   private[galilei] def protect[result](operation: Operation)(block: => result)
-  :     result raises IoError =
+  : result raises IoError =
     import Reason.*
     try block catch
       case break: boundary.Break[?]          => throw break
@@ -109,14 +109,14 @@ extension [platform <: Filesystem](path: Path on platform)
     descendants.fuse(jnf.Files.size(path.javaPath).b)(state + next.size())
 
   def delete()(using deleteRecursively: DeleteRecursively on platform)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
     protect(Operation.Delete):
       deleteRecursively.conditionally(path)(jnf.Files.delete(path.javaPath))
 
     path
 
   def wipe()(using deleteRecursively: DeleteRecursively on platform)(using io: Tactic[IoError])
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
     deleteRecursively.conditionally(path)(jnf.Files.deleteIfExists(javaPath))
     path
 
@@ -127,7 +127,7 @@ extension [platform <: Filesystem](path: Path on platform)
   def hardLinkTo(destination: Path on platform)
        (using overwritePreexisting: OverwritePreexisting on platform,
               createNonexistentParents: CreateNonexistentParents on platform)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     createNonexistentParents(destination):
       overwritePreexisting(destination):
@@ -153,7 +153,7 @@ extension [platform <: Filesystem](path: Path on platform)
        (using overwritePreexisting:     OverwritePreexisting on platform,
               dereferenceSymlinks:      DereferenceSymlinks,
               createNonexistentParents: CreateNonexistentParents on platform)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     createNonexistentParents(destination):
       overwritePreexisting(destination):
@@ -166,7 +166,7 @@ extension [platform <: Filesystem](path: Path on platform)
        (using overwritePreexisting: OverwritePreexisting on platform,
               dereferenceSymlinks:  DereferenceSymlinks,
               substantiable:        (Path on platform) is Substantiable)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     given createNonexistentParents: CreateNonexistentParents on platform =
       filesystemOptions.createNonexistentParents.enabled[platform]
@@ -180,7 +180,7 @@ extension [platform <: Filesystem](path: Path on platform)
               dereferenceSymlinks:      DereferenceSymlinks,
               createNonexistentParents: CreateNonexistentParents on platform)
        (name: (prior: navigable.Operand) ?=> navigable.Operand)
-  :     Path on platform raises IoError raises PathError =
+  : Path on platform raises IoError raises PathError =
     val name0 = path.name.or:
       abort(IoError(path, IoError.Operation.Metadata, Reason.Unsupported))
 
@@ -191,7 +191,7 @@ extension [platform <: Filesystem](path: Path on platform)
               moveAtomically:           MoveAtomically,
               dereferenceSymlinks:      DereferenceSymlinks,
               createNonexistentParents: CreateNonexistentParents on platform)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     val options: Seq[jnf.CopyOption] = dereferenceSymlinks.options() ++ moveAtomically.options()
 
@@ -207,7 +207,7 @@ extension [platform <: Filesystem](path: Path on platform)
               moveAtomically:       MoveAtomically,
               substantiable:        (Path on platform) is Substantiable,
               dereferenceSymlinks:  DereferenceSymlinks)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     import filesystemOptions.createNonexistentParents.enabled
     moveTo(unsafely(destination.child(path.textDescent.head)))
@@ -215,7 +215,7 @@ extension [platform <: Filesystem](path: Path on platform)
   def symlinkTo(destination: Path on platform)
        (using overwritePreexisting:     OverwritePreexisting on platform,
               createNonexistentParents: CreateNonexistentParents on platform)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     createNonexistentParents(destination):
       overwritePreexisting(destination):
@@ -229,7 +229,7 @@ extension [platform <: Filesystem](path: Path on platform)
               moveAtomically:       MoveAtomically,
               substantiable:        (Path on platform) is Substantiable,
               dereferenceSymlinks:  DereferenceSymlinks)
-  :     Path on platform raises IoError =
+  : Path on platform raises IoError =
 
     import filesystemOptions.createNonexistentParents.enabled
     symlinkTo(unsafely(destination.child(path.textDescent.head)))

--- a/lib/galilei/src/core/galilei-core.scala
+++ b/lib/galilei/src/core/galilei-core.scala
@@ -67,10 +67,13 @@ final val `%`: Linux.Root = Linux.RootSingleton
 @targetName("MacOsRoot")
 final val `$`: MacOs.Root = MacOs.RootSingleton
 
+
 extension [openable: Openable](value: openable)
   def open[result](lambda: openable.Result => result, options: List[openable.Operand] = Nil)
   : result =
-    openable.open(value, lambda, options)
+
+      openable.open(value, lambda, options)
+
 
 extension [platform <: Filesystem](path: Path on platform)
   private[galilei] def protect[result](operation: Operation)(block: => result)
@@ -96,44 +99,54 @@ extension [platform <: Filesystem](path: Path on platform)
     list.map: child =>
       unsafely(path.child(child.getFileName.nn.toString.nn.tt))
 
+
   def descendants(using DereferenceSymlinks, TraversalOrder)
-      : Stream[Path on platform] raises IoError =
-    children.flatMap: child =>
-      summon[TraversalOrder] match
-        case TraversalOrder.PreOrder  => child #:: child.descendants
-        case TraversalOrder.PostOrder => child.descendants #::: Stream(child)
+  : Stream[Path on platform] raises IoError =
+
+      children.flatMap: child =>
+        summon[TraversalOrder] match
+          case TraversalOrder.PreOrder  => child #:: child.descendants
+          case TraversalOrder.PostOrder => child.descendants #::: Stream(child)
+
 
   def size(): Memory raises IoError =
     import filesystemOptions.dereferenceSymlinks.disabled
     given traversalOrder: TraversalOrder = TraversalOrder.PreOrder
     descendants.fuse(jnf.Files.size(path.javaPath).b)(state + next.size())
 
+
   def delete()(using deleteRecursively: DeleteRecursively on platform)
   : Path on platform raises IoError =
-    protect(Operation.Delete):
-      deleteRecursively.conditionally(path)(jnf.Files.delete(path.javaPath))
 
-    path
+      protect(Operation.Delete):
+        deleteRecursively.conditionally(path)(jnf.Files.delete(path.javaPath))
+
+      path
+
 
   def wipe()(using deleteRecursively: DeleteRecursively on platform)(using io: Tactic[IoError])
   : Path on platform raises IoError =
-    deleteRecursively.conditionally(path)(jnf.Files.deleteIfExists(javaPath))
-    path
+
+      deleteRecursively.conditionally(path)(jnf.Files.deleteIfExists(javaPath))
+      path
+
 
   def volume(): Volume =
     val fileStore = jnf.Files.getFileStore(path.javaPath).nn
     Volume(fileStore.name.nn.tt, fileStore.`type`.nn.tt)
+
 
   def hardLinkTo(destination: Path on platform)
        (using overwritePreexisting: OverwritePreexisting on platform,
               createNonexistentParents: CreateNonexistentParents on platform)
   : Path on platform raises IoError =
 
-    createNonexistentParents(destination):
-      overwritePreexisting(destination):
-        jnf.Files.createLink(destination.javaPath, path.javaPath)
+      createNonexistentParents(destination):
+        overwritePreexisting(destination):
+          jnf.Files.createLink(destination.javaPath, path.javaPath)
 
-    destination
+      destination
+
 
   def entry()(using symlinks: DereferenceSymlinks): Entry =
     if !symlinks.dereference && jnf.Files.isSymbolicLink(javaPath) then Symlink
@@ -149,17 +162,19 @@ extension [platform <: Filesystem](path: Path on platform)
           case 49152 => Socket
           case _     => panic(m"an unexpected POSIX mode value was returned")
 
+
   def copyTo(destination: Path on platform)
        (using overwritePreexisting:     OverwritePreexisting on platform,
               dereferenceSymlinks:      DereferenceSymlinks,
               createNonexistentParents: CreateNonexistentParents on platform)
   : Path on platform raises IoError =
 
-    createNonexistentParents(destination):
-      overwritePreexisting(destination):
-        jnf.Files.copy(path.javaPath, destination.javaPath, dereferenceSymlinks.options()*)
+      createNonexistentParents(destination):
+        overwritePreexisting(destination):
+          jnf.Files.copy(path.javaPath, destination.javaPath, dereferenceSymlinks.options()*)
 
-    destination
+      destination
+
 
   def copyInto
        (destination: Path on platform)
@@ -168,10 +183,11 @@ extension [platform <: Filesystem](path: Path on platform)
               substantiable:        (Path on platform) is Substantiable)
   : Path on platform raises IoError =
 
-    given createNonexistentParents: CreateNonexistentParents on platform =
-      filesystemOptions.createNonexistentParents.enabled[platform]
+      given createNonexistentParents: CreateNonexistentParents on platform =
+        filesystemOptions.createNonexistentParents.enabled[platform]
 
-    copyTo(unsafely(destination.child(path.textDescent.head)))
+      copyTo(unsafely(destination.child(path.textDescent.head)))
+
 
   def renameTo
        (using navigable: platform is Navigable,
@@ -181,10 +197,12 @@ extension [platform <: Filesystem](path: Path on platform)
               createNonexistentParents: CreateNonexistentParents on platform)
        (name: (prior: navigable.Operand) ?=> navigable.Operand)
   : Path on platform raises IoError raises PathError =
-    val name0 = path.name.or:
-      abort(IoError(path, IoError.Operation.Metadata, Reason.Unsupported))
 
-    path.moveTo(path.peer(name(using name0)))
+      val name0 = path.name.or:
+        abort(IoError(path, IoError.Operation.Metadata, Reason.Unsupported))
+
+      path.moveTo(path.peer(name(using name0)))
+
 
   def moveTo(destination: Path on platform)
        (using overwritePreexisting:     OverwritePreexisting on platform,
@@ -193,13 +211,14 @@ extension [platform <: Filesystem](path: Path on platform)
               createNonexistentParents: CreateNonexistentParents on platform)
   : Path on platform raises IoError =
 
-    val options: Seq[jnf.CopyOption] = dereferenceSymlinks.options() ++ moveAtomically.options()
+      val options: Seq[jnf.CopyOption] = dereferenceSymlinks.options() ++ moveAtomically.options()
 
-    createNonexistentParents(destination):
-      overwritePreexisting(destination):
-        jnf.Files.move(path.javaPath, destination.javaPath, options*)
+      createNonexistentParents(destination):
+        overwritePreexisting(destination):
+          jnf.Files.move(path.javaPath, destination.javaPath, options*)
 
-    destination
+      destination
+
 
   def moveInto
        (destination: Path on platform)
@@ -209,19 +228,21 @@ extension [platform <: Filesystem](path: Path on platform)
               dereferenceSymlinks:  DereferenceSymlinks)
   : Path on platform raises IoError =
 
-    import filesystemOptions.createNonexistentParents.enabled
-    moveTo(unsafely(destination.child(path.textDescent.head)))
+      import filesystemOptions.createNonexistentParents.enabled
+      moveTo(unsafely(destination.child(path.textDescent.head)))
+
 
   def symlinkTo(destination: Path on platform)
        (using overwritePreexisting:     OverwritePreexisting on platform,
               createNonexistentParents: CreateNonexistentParents on platform)
   : Path on platform raises IoError =
 
-    createNonexistentParents(destination):
-      overwritePreexisting(destination):
-        jnf.Files.createSymbolicLink(destination.javaPath, path.javaPath)
+      createNonexistentParents(destination):
+        overwritePreexisting(destination):
+          jnf.Files.createSymbolicLink(destination.javaPath, path.javaPath)
 
-    destination
+      destination
+
 
   def symlinkInto
        (destination: Path on platform)
@@ -231,8 +252,9 @@ extension [platform <: Filesystem](path: Path on platform)
               dereferenceSymlinks:  DereferenceSymlinks)
   : Path on platform raises IoError =
 
-    import filesystemOptions.createNonexistentParents.enabled
-    symlinkTo(unsafely(destination.child(path.textDescent.head)))
+      import filesystemOptions.createNonexistentParents.enabled
+      symlinkTo(unsafely(destination.child(path.textDescent.head)))
+
 
   def modified[instant: Instantiable across Instants from Long](): instant =
     instant(jnf.Files.getLastModifiedTime(path.javaPath).nn.toInstant.nn.toEpochMilli)

--- a/lib/galilei/src/core/galilei.Makable.scala
+++ b/lib/galilei/src/core/galilei.Makable.scala
@@ -104,8 +104,8 @@ object Makable:
         => (createNonexistentParents: CreateNonexistentParents on platform,
             overwritePreexisting:     OverwritePreexisting on platform,
             working:                  WorkingDirectory,
-        tactic:                   Tactic[IoError],
-        loggable:                 ExecEvent is Loggable)
+            tactic:                   Tactic[IoError],
+            loggable:                 ExecEvent is Loggable)
         =>  Fifo is Makable into (Path on platform) =
     new Makable:
       type Self = Fifo

--- a/lib/geodesy/src/core/geodesy.Geodesy.scala
+++ b/lib/geodesy/src/core/geodesy.Geodesy.scala
@@ -107,7 +107,7 @@ object Geodesy:
         if long0 < 0 then (long0 + Int.MaxValue).toInt else (long0 - Int.MaxValue).toInt
 
       def recur(value: Long, latMin: Long, latMax: Long, longMin: Long, longMax: Long, count: Int)
-      :     Long =
+      : Long =
 
         if count >= bits then value else (count%2).absolve match
           case 0 =>

--- a/lib/geodesy/src/core/geodesy.Geodesy.scala
+++ b/lib/geodesy/src/core/geodesy.Geodesy.scala
@@ -106,21 +106,23 @@ object Geodesy:
         val long0 = left&0xffffffffL
         if long0 < 0 then (long0 + Int.MaxValue).toInt else (long0 - Int.MaxValue).toInt
 
+
       def recur(value: Long, latMin: Long, latMax: Long, longMin: Long, longMax: Long, count: Int)
       : Long =
 
-        if count >= bits then value else (count%2).absolve match
-          case 0 =>
-            val midpoint = (longMin + longMax)/2
-            if long < midpoint
-            then recur(value << 1, latMin, latMax, longMin, midpoint, count + 1)
-            else recur((value << 1) | 1L, latMin, latMax, midpoint, longMax, count + 1)
+          if count >= bits then value else (count%2).absolve match
+            case 0 =>
+              val midpoint = (longMin + longMax)/2
+              if long < midpoint
+              then recur(value << 1, latMin, latMax, longMin, midpoint, count + 1)
+              else recur((value << 1) | 1L, latMin, latMax, midpoint, longMax, count + 1)
 
-          case 1 =>
-            val midpoint = (latMin + latMax)/2
-            if lat < midpoint
-            then recur(value << 1, latMin, midpoint, longMin, longMax, count + 1)
-            else recur((value << 1) | 1L, midpoint, latMax, longMin, longMax, count + 1)
+            case 1 =>
+              val midpoint = (latMin + latMax)/2
+              if lat < midpoint
+              then recur(value << 1, latMin, midpoint, longMin, longMax, count + 1)
+              else recur((value << 1) | 1L, midpoint, latMax, longMin, longMax, count + 1)
+
 
       val binary = recur(0L, Int.MinValue + 1, Int.MaxValue, Int.MinValue + 1, Int.MaxValue, 0)
 

--- a/lib/gesticulate/src/core/gesticulate.Multipart.scala
+++ b/lib/gesticulate/src/core/gesticulate.Multipart.scala
@@ -52,7 +52,7 @@ object Multipart:
     case Inline, Attachment, FormData
 
   def parse[input: Readable by Bytes](input: input, boundary0: Optional[Text] = Unset)
-  :     Multipart raises MultipartError =
+  : Multipart raises MultipartError =
 
     val conduit = Conduit(input.stream)
     conduit.mark()

--- a/lib/gesticulate/src/core/gesticulate.Multipart.scala
+++ b/lib/gesticulate/src/core/gesticulate.Multipart.scala
@@ -54,117 +54,118 @@ object Multipart:
   def parse[input: Readable by Bytes](input: input, boundary0: Optional[Text] = Unset)
   : Multipart raises MultipartError =
 
-    val conduit = Conduit(input.stream)
-    conduit.mark()
-    conduit.next()
-    if conduit.datum != '-' then raise(MultipartError(Reason.Expected('-')))
-    conduit.next()
-    if conduit.datum != '-' then raise(MultipartError(Reason.Expected('-')))
-    conduit.seek('\r')
-    val boundary = conduit.save()
-    conduit.next()
-    if conduit.datum != '\n' then raise(MultipartError(Reason.Expected('\n')))
-    conduit.next()
+      val conduit = Conduit(input.stream)
+      conduit.mark()
+      conduit.next()
+      if conduit.datum != '-' then raise(MultipartError(Reason.Expected('-')))
+      conduit.next()
+      if conduit.datum != '-' then raise(MultipartError(Reason.Expected('-')))
+      conduit.seek('\r')
+      val boundary = conduit.save()
+      conduit.next()
+      if conduit.datum != '\n' then raise(MultipartError(Reason.Expected('\n')))
+      conduit.next()
 
-    def headers(list: List[(Text, Text)]): Map[Text, Text] =
-      conduit.datum match
-        case '\r' =>
-          conduit.next()
-          if conduit.datum != '\n' then raise(MultipartError(Reason.Expected('\n')))
-          conduit.break()
+      def headers(list: List[(Text, Text)]): Map[Text, Text] =
+        conduit.datum match
+          case '\r' =>
+            conduit.next()
+            if conduit.datum != '\n' then raise(MultipartError(Reason.Expected('\n')))
+            conduit.break()
+            conduit.cue()
+            list.to(Map)
+
+          case other =>
+            conduit.mark()
+            conduit.seek(':')
+            val key = Text.ascii(conduit.save())
+            conduit.next()
+            if conduit.datum != ' ' then raise(MultipartError(Reason.Expected(' ')))
+            conduit.next()
+            conduit.mark()
+            conduit.seek('\r')
+            val value = Text.ascii(conduit.save())
+            conduit.next()
+            if conduit.datum != '\n' then raise(MultipartError(Reason.Expected('\n')))
+            conduit.next()
+            headers((key, value) :: list)
+
+      def body(): Stream[Bytes] = conduit.step() match
+        case Conduit.State.Clutch =>
+          val block = conduit.block
           conduit.cue()
-          list.to(Map)
-
-        case other =>
-          conduit.mark()
-          conduit.seek(':')
-          val key = Text.ascii(conduit.save())
-          conduit.next()
-          if conduit.datum != ' ' then raise(MultipartError(Reason.Expected(' ')))
-          conduit.next()
-          conduit.mark()
-          conduit.seek('\r')
-          val value = Text.ascii(conduit.save())
-          conduit.next()
-          if conduit.datum != '\n' then raise(MultipartError(Reason.Expected('\n')))
-          conduit.next()
-          headers((key, value) :: list)
-
-    def body(): Stream[Bytes] = conduit.step() match
-      case Conduit.State.Clutch =>
-        val block = conduit.block
-        conduit.cue()
-        block #:: body()
-      case Conduit.State.End =>
-        Stream()
-      case Conduit.State.Data   => conduit.datum match
-        case '\r' =>
-          if conduit.lookahead:
-            conduit.next() && conduit.datum == '\n' && boundary.forall: char =>
-              conduit.next() && conduit.datum == char
-          then
-            conduit.truncate()
-            Stream(conduit.block).also:
-              conduit.skip(boundary.length + 3)
-          else body()
-        case other =>
-          body()
-
-    def parsePart(headers: Map[Text, Text], stream: Stream[Bytes]): Part =
-      headers.at(t"Content-Disposition").let: disposition =>
-        val parts = disposition.cut(t";").map(_.trim)
-
-        val params: Map[Text, Text] =
-          parts.drop(1).map: param =>
-            param.cut(t"=", 2) match
-              case List(key, value) => if value.starts(t"\"") && value.ends(t"\"")
-                                       then key -> value.segment(Sec ~ Pen.of(value))
-                                       else key -> value
-              case _                => raise(MultipartError(Reason.BadDisposition)) yet (t"", t"")
-
-          . to(Map)
-
-        val dispositionValue = parts.prim match
-          case t"inline"     => Multipart.Disposition.Inline
-          case t"form-data"  => Multipart.Disposition.FormData
-          case t"attachment" => Multipart.Disposition.Attachment
-          case _ =>
-            raise(MultipartError(Reason.BadDisposition)) yet Multipart.Disposition.FormData
-
-        val filename = params.at(t"filename")
-        val name = params.at(t"name")
-
-        Part(dispositionValue, headers, name, filename, stream)
-
-      . or(Part(Multipart.Disposition.FormData, Map(), Unset, Unset, stream))
-
-    def parts(): Stream[Part] =
-      val part = parsePart(headers(Nil), body())
-
-      conduit.datum match
-        case '\r' =>
-          if !conduit.next() || conduit.datum != '\n'
-          then raise(MultipartError(Reason.Expected('\n')))
-
-          part #:: { part.body.strict; conduit.next(); parts() }
-
-        case '-' =>
-          if !conduit.next() || conduit.datum != '-'
-          then raise(MultipartError(Reason.Expected('-')))
-
-          if !conduit.next() || conduit.datum != '\r'
-          then raise(MultipartError(Reason.Expected('\r')))
-
-          if !conduit.next() || conduit.datum != '\n'
-          then raise(MultipartError(Reason.Expected('\n')))
-          //if conduit.next() then raise(MultipartError(Reason.StreamContinues))
-          Stream(part)
-
-        case other =>
-          raise(MultipartError(Reason.Expected('-')))
+          block #:: body()
+        case Conduit.State.End =>
           Stream()
+        case Conduit.State.Data   => conduit.datum match
+          case '\r' =>
+            if conduit.lookahead:
+              conduit.next() && conduit.datum == '\n' && boundary.forall: char =>
+                conduit.next() && conduit.datum == char
+            then
+              conduit.truncate()
+              Stream(conduit.block).also:
+                conduit.skip(boundary.length + 3)
+            else body()
+          case other =>
+            body()
 
-    Multipart(parts())
+      def parsePart(headers: Map[Text, Text], stream: Stream[Bytes]): Part =
+        headers.at(t"Content-Disposition").let: disposition =>
+          val parts = disposition.cut(t";").map(_.trim)
+
+          val params: Map[Text, Text] =
+            parts.drop(1).map: param =>
+              param.cut(t"=", 2) match
+                case List(key, value) => if value.starts(t"\"") && value.ends(t"\"")
+                                        then key -> value.segment(Sec ~ Pen.of(value))
+                                        else key -> value
+                case _                => raise(MultipartError(Reason.BadDisposition)) yet (t"", t"")
+
+            . to(Map)
+
+          val dispositionValue = parts.prim match
+            case t"inline"     => Multipart.Disposition.Inline
+            case t"form-data"  => Multipart.Disposition.FormData
+            case t"attachment" => Multipart.Disposition.Attachment
+            case _ =>
+              raise(MultipartError(Reason.BadDisposition)) yet Multipart.Disposition.FormData
+
+          val filename = params.at(t"filename")
+          val name = params.at(t"name")
+
+          Part(dispositionValue, headers, name, filename, stream)
+
+        . or(Part(Multipart.Disposition.FormData, Map(), Unset, Unset, stream))
+
+      def parts(): Stream[Part] =
+        val part = parsePart(headers(Nil), body())
+
+        conduit.datum match
+          case '\r' =>
+            if !conduit.next() || conduit.datum != '\n'
+            then raise(MultipartError(Reason.Expected('\n')))
+
+            part #:: { part.body.strict; conduit.next(); parts() }
+
+          case '-' =>
+            if !conduit.next() || conduit.datum != '-'
+            then raise(MultipartError(Reason.Expected('-')))
+
+            if !conduit.next() || conduit.datum != '\r'
+            then raise(MultipartError(Reason.Expected('\r')))
+
+            if !conduit.next() || conduit.datum != '\n'
+            then raise(MultipartError(Reason.Expected('\n')))
+            //if conduit.next() then raise(MultipartError(Reason.StreamContinues))
+            Stream(part)
+
+          case other =>
+            raise(MultipartError(Reason.Expected('-')))
+            Stream()
+
+      Multipart(parts())
+
 
 case class Multipart(parts: Stream[Part]):
   def at(name: Text): Optional[Part] = parts.find(_.name == name).getOrElse(Unset)

--- a/lib/gossamer/src/core/gossamer-core.scala
+++ b/lib/gossamer/src/core/gossamer-core.scala
@@ -60,13 +60,17 @@ export Gossamer.opaques.Ascii
 def append[textual: Textual, value](using builder: Builder[textual])(value: value)
    (using textual.Show[value])
 : Unit =
-  builder.append(textual.show(value))
+
+    builder.append(textual.show(value))
+
 
 def appendln[textual: Textual, value](using builder: Builder[textual])(value: value)
    (using textual.Show[value])
 : Unit =
-  builder.append(textual.show(value))
-  builder.append(textual("\n".tt))
+
+    builder.append(textual.show(value))
+    builder.append(textual("\n".tt))
+
 
 extension (textObject: Text.type)
   def construct(block: (builder: TextBuilder) ?=> Unit): Text =

--- a/lib/gossamer/src/core/gossamer-core.scala
+++ b/lib/gossamer/src/core/gossamer-core.scala
@@ -59,12 +59,12 @@ export Gossamer.opaques.Ascii
 
 def append[textual: Textual, value](using builder: Builder[textual])(value: value)
    (using textual.Show[value])
-:     Unit =
+: Unit =
   builder.append(textual.show(value))
 
 def appendln[textual: Textual, value](using builder: Builder[textual])(value: value)
    (using textual.Show[value])
-:     Unit =
+: Unit =
   builder.append(textual.show(value))
   builder.append(textual("\n".tt))
 
@@ -107,7 +107,7 @@ extension (bytes: Bytes)
 extension [textual](text: textual)
   def cut[delimiter](delimiter: delimiter, limit: Int = Int.MaxValue)
        (using cuttable: textual is Cuttable by delimiter)
-  :     List[textual] =
+  : List[textual] =
 
     cuttable.cut(text, delimiter, limit)
 
@@ -222,7 +222,7 @@ extension [textual: Textual](text: textual)
     text.segment(start ~ end)
 
   def where(pred: Char => Boolean, start: Optional[Ordinal] = Unset, bidi: Bidi = Ltr)
-  :     Optional[Ordinal] =
+  : Optional[Ordinal] =
     val step: Int = bidi match
       case Ltr => 1
       case Rtl => -1

--- a/lib/guillotine/src/core/guillotine.Executable.scala
+++ b/lib/guillotine/src/core/guillotine.Executable.scala
@@ -55,10 +55,12 @@ sealed trait Executable:
   def fork[result]()(using working: WorkingDirectory)
   : Process[Exec, result] logs ExecEvent raises ExecError
 
+
   def exec[result: Computable]()(using working: WorkingDirectory)
   : result logs ExecEvent raises ExecError =
 
-    fork[result]().await()
+      fork[result]().await()
+
 
   def apply()
        (using erased intelligible: Exec is Intelligible,
@@ -66,7 +68,8 @@ sealed trait Executable:
                      computable:   intelligible.Result is Computable)
   : intelligible.Result logs ExecEvent raises ExecError =
 
-    fork[intelligible.Result]().await()
+      fork[intelligible.Result]().await()
+
 
   def apply(command: Executable): Pipeline = command match
     case Pipeline(commands*) => this match

--- a/lib/guillotine/src/core/guillotine.Executable.scala
+++ b/lib/guillotine/src/core/guillotine.Executable.scala
@@ -53,10 +53,10 @@ sealed trait Executable:
   type Exec <: Label
 
   def fork[result]()(using working: WorkingDirectory)
-  :     Process[Exec, result] logs ExecEvent raises ExecError
+  : Process[Exec, result] logs ExecEvent raises ExecError
 
   def exec[result: Computable]()(using working: WorkingDirectory)
-  :     result logs ExecEvent raises ExecError =
+  : result logs ExecEvent raises ExecError =
 
     fork[result]().await()
 
@@ -64,7 +64,7 @@ sealed trait Executable:
        (using erased intelligible: Exec is Intelligible,
                      working:      WorkingDirectory,
                      computable:   intelligible.Result is Computable)
-  :     intelligible.Result logs ExecEvent raises ExecError =
+  : intelligible.Result logs ExecEvent raises ExecError =
 
     fork[intelligible.Result]().await()
 

--- a/lib/guillotine/src/core/guillotine.Process.scala
+++ b/lib/guillotine/src/core/guillotine.Process.scala
@@ -70,7 +70,7 @@ class Process[+exec <: Label, result](process: java.lang.Process) extends Proces
     Readable.inputStream.stream(process.getErrorStream.nn)
 
   def stdin[chunk](stream: Stream[chunk])(using writable: ji.OutputStream is Writable by chunk)
-  :     Unit =
+  : Unit =
 
     writable.write(process.getOutputStream.nn, stream)
 

--- a/lib/guillotine/src/core/guillotine.Process.scala
+++ b/lib/guillotine/src/core/guillotine.Process.scala
@@ -69,10 +69,12 @@ class Process[+exec <: Label, result](process: java.lang.Process) extends Proces
   def stderr(): Stream[Bytes] raises StreamError =
     Readable.inputStream.stream(process.getErrorStream.nn)
 
+
   def stdin[chunk](stream: Stream[chunk])(using writable: ji.OutputStream is Writable by chunk)
   : Unit =
 
-    writable.write(process.getOutputStream.nn, stream)
+      writable.write(process.getOutputStream.nn, stream)
+
 
   def await()(using computable: result is Computable): result = computable.compute(process)
 

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -60,7 +60,7 @@ case class SourceCode
     else fragment(range.startLine, (range.endLine + 1).min(lastLine), focus)
 
   def fragment(startLine: Int, endLine: Int, focus: Optional[((Int, Int), (Int, Int))] = Unset)
-  :     SourceCode =
+  : SourceCode =
     SourceCode(language, startLine, lines.slice(startLine - offset, endLine - offset + 1), focus)
 
 object SourceCode:

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -59,9 +59,12 @@ case class SourceCode
     then fragment(range.startLine, (range.endLine + 2).min(lastLine), focus)
     else fragment(range.startLine, (range.endLine + 1).min(lastLine), focus)
 
+
   def fragment(startLine: Int, endLine: Int, focus: Optional[((Int, Int), (Int, Int))] = Unset)
   : SourceCode =
-    SourceCode(language, startLine, lines.slice(startLine - offset, endLine - offset + 1), focus)
+
+      SourceCode(language, startLine, lines.slice(startLine - offset, endLine - offset + 1), focus)
+
 
 object SourceCode:
   private def accent(token: Int): Accent =

--- a/lib/hellenism/src/core/hellenism.Classloader.scala
+++ b/lib/hellenism/src/core/hellenism.Classloader.scala
@@ -60,6 +60,8 @@ class Classloader(val java: ClassLoader) extends Root("/".tt, "/".tt, Case.Sensi
   def apply(path: Text): Optional[Bytes] =
     Optional(java.getResourceAsStream(path.s)).let(_.readAllBytes().nn.immutable(using Unsafe))
 
+
   private[hellenism] def inputStream(path: Text)(using notFound: Tactic[ClasspathError])
   : ji.InputStream =
-    Optional(java.getResourceAsStream(path.s)).or(abort(ClasspathError(path)))
+
+      Optional(java.getResourceAsStream(path.s)).or(abort(ClasspathError(path)))

--- a/lib/hellenism/src/core/hellenism.Classloader.scala
+++ b/lib/hellenism/src/core/hellenism.Classloader.scala
@@ -61,5 +61,5 @@ class Classloader(val java: ClassLoader) extends Root("/".tt, "/".tt, Case.Sensi
     Optional(java.getResourceAsStream(path.s)).let(_.readAllBytes().nn.immutable(using Unsafe))
 
   private[hellenism] def inputStream(path: Text)(using notFound: Tactic[ClasspathError])
-  :     ji.InputStream =
+  : ji.InputStream =
     Optional(java.getResourceAsStream(path.s)).or(abort(ClasspathError(path)))

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -51,10 +51,13 @@ object Classpath:
   given substantiable: (classloader: Classloader) => (Path on Classpath) is Substantiable =
     path => classloader.java.getResourceAsStream(path.text.s) != null
 
+
   @targetName("child")
   infix def / (child: Text)(using classloader: Classloader)
   : Path on Classpath raises NameError =
-    Path(classloader, List(child))
+
+      Path(classloader, List(child))
+
 
   def apply(classloader: jn.URLClassLoader): Classpath =
     val entries = classloader.getURLs.nn.to(List).map(_.nn).flatMap(ClasspathEntry(_).option)

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -53,7 +53,7 @@ object Classpath:
 
   @targetName("child")
   infix def / (child: Text)(using classloader: Classloader)
-  :     Path on Classpath raises NameError =
+  : Path on Classpath raises NameError =
     Path(classloader, List(child))
 
   def apply(classloader: jn.URLClassLoader): Classpath =

--- a/lib/hellenism/src/core/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/core/hellenism.LocalClasspath.scala
@@ -62,7 +62,7 @@ object LocalClasspath:
   def apply
        (entries: List[ClasspathEntry.Directory | ClasspathEntry.Jar |
                   ClasspathEntry.JavaRuntime.type])
-  :     LocalClasspath =
+  : LocalClasspath =
     new LocalClasspath(entries, entries.to(Set))
 
   given paths: [path: Abstractable across Paths into Text]

--- a/lib/hellenism/src/core/hellenism.LocalClasspath.scala
+++ b/lib/hellenism/src/core/hellenism.LocalClasspath.scala
@@ -59,11 +59,16 @@ object LocalClasspath:
 
       new LocalClasspath(entries, entries.to(Set))
 
+
   def apply
-       (entries: List[ClasspathEntry.Directory | ClasspathEntry.Jar |
-                  ClasspathEntry.JavaRuntime.type])
+       (entries: List
+                  [ClasspathEntry.Directory
+                   | ClasspathEntry.Jar
+                   | ClasspathEntry.JavaRuntime.type])
   : LocalClasspath =
-    new LocalClasspath(entries, entries.to(Set))
+
+      new LocalClasspath(entries, entries.to(Set))
+
 
   given paths: [path: Abstractable across Paths into Text]
         => (Tactic[PathError], Tactic[IoError], Tactic[NameError], Navigable, DereferenceSymlinks)

--- a/lib/honeycomb/src/core/honeycomb.ClearTag.scala
+++ b/lib/honeycomb/src/core/honeycomb.ClearTag.scala
@@ -51,13 +51,15 @@ extends Node[name], Dynamic:
   def children: Seq[Node[?] | Text | Int | HtmlXml] = Nil
   def label: Text = labelString.tt
 
+
   inline def applyDynamicNamed(method: String)(inline attributes: (attribute, Any)*)
   : StartTag[name, child] =
 
-    ${  Honeycomb.read[name, child, child]('this, 'method, 'labelString, 'attributes)  }
+      ${  Honeycomb.read[name, child, child]('this, 'method, 'labelString, 'attributes)  }
+
 
   def applyDynamic[Return <: Label](method: "apply")
        (children: (Optional[Html[Return]] | Seq[Html[Return]])*)
   : Element[Return] =
 
-    Element(labelString, Map(), children)
+      Element(labelString, Map(), children)

--- a/lib/honeycomb/src/core/honeycomb.ClearTag.scala
+++ b/lib/honeycomb/src/core/honeycomb.ClearTag.scala
@@ -52,12 +52,12 @@ extends Node[name], Dynamic:
   def label: Text = labelString.tt
 
   inline def applyDynamicNamed(method: String)(inline attributes: (attribute, Any)*)
-  :     StartTag[name, child] =
+  : StartTag[name, child] =
 
     ${  Honeycomb.read[name, child, child]('this, 'method, 'labelString, 'attributes)  }
 
   def applyDynamic[Return <: Label](method: "apply")
        (children: (Optional[Html[Return]] | Seq[Html[Return]])*)
-  :     Element[Return] =
+  : Element[Return] =
 
     Element(labelString, Map(), children)

--- a/lib/honeycomb/src/core/honeycomb.Element.scala
+++ b/lib/honeycomb/src/core/honeycomb.Element.scala
@@ -45,12 +45,12 @@ object Element:
        (labelString: String,
         attributes:  Attributes,
         children:    Seq[Optional[Html[child]] | Seq[Html[child]]] = Nil)
-  :     Element[node] =
+  : Element[node] =
 
     new Element(labelString, attributes, flatten(children))
 
   private def flatten[child <: Label](nodes: Seq[Optional[Html[child]] | Seq[Html[child]]])
-  :     Seq[Html[child]] =
+  : Seq[Html[child]] =
 
     nodes.flatMap:
       case Unset                              => Seq()

--- a/lib/honeycomb/src/core/honeycomb.Element.scala
+++ b/lib/honeycomb/src/core/honeycomb.Element.scala
@@ -47,15 +47,17 @@ object Element:
         children:    Seq[Optional[Html[child]] | Seq[Html[child]]] = Nil)
   : Element[node] =
 
-    new Element(labelString, attributes, flatten(children))
+      new Element(labelString, attributes, flatten(children))
+
 
   private def flatten[child <: Label](nodes: Seq[Optional[Html[child]] | Seq[Html[child]]])
   : Seq[Html[child]] =
 
-    nodes.flatMap:
-      case Unset                              => Seq()
-      case seq: Seq[Html[`child`] @unchecked] => seq
-      case node: Html[`child`] @unchecked     => Seq(node)
+      nodes.flatMap:
+        case Unset                              => Seq()
+        case seq: Seq[Html[`child`] @unchecked] => seq
+        case node: Html[`child`] @unchecked     => Seq(node)
+
 
 case class Element[+name <: Label]
    (labelString: String, attributes: Map[String, Optional[Text]], children: Seq[Html[?]])

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -49,7 +49,7 @@ object Honeycomb:
         name:       Expr[name],
         attributes: Expr[Seq[(Label, Any)]])
        (using Quotes)
-  :     Expr[StartTag[name, result]] =
+  : Expr[StartTag[name, result]] =
 
     import quotes.reflect.*
 

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -43,6 +43,7 @@ import scala.quoted.*
 object Honeycomb:
   given realm: Realm = realm"honeycomb"
 
+
   def read[name <: Label: Type, child <: Label: Type, result <: Label: Type]
        (node:       Expr[Node[name]],
         className:  Expr[String],
@@ -51,55 +52,55 @@ object Honeycomb:
        (using Quotes)
   : Expr[StartTag[name, result]] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    def recur(exprs: Seq[Expr[(Label, Any)]]): List[Expr[Optional[(String, Optional[Text])]]] =
-      exprs match
-        case '{("", $value: valueType)} +: tail =>
-          val expr: Expr[HtmlAttribute[valueType]] =
-            Expr.summon[HtmlAttribute[valueType] onto name]
-            . orElse(Expr.summon[HtmlAttribute[valueType]])
-            . getOrElse:
-                val typeName = TypeRepr.of[valueType]
-                halt(m"the attribute name cannot be uniquely determined from its type, $typeName")
+      def recur(exprs: Seq[Expr[(Label, Any)]]): List[Expr[Optional[(String, Optional[Text])]]] =
+        exprs match
+          case '{("", $value: valueType)} +: tail =>
+            val expr: Expr[HtmlAttribute[valueType]] =
+              Expr.summon[HtmlAttribute[valueType] onto name]
+              . orElse(Expr.summon[HtmlAttribute[valueType]])
+              . getOrElse:
+                  val typeName = TypeRepr.of[valueType]
+                  halt(m"the attribute name cannot be uniquely determined from its type, $typeName")
 
-          val key: Text = expr.absolve match
-            case '{ type keyType <: Label
-                    $attribute: (HtmlAttribute[valueType] { type Self = keyType}) } =>
-              TypeRepr.of[keyType].absolve match
-                case ConstantType(StringConstant(key)) => key.tt
+            val key: Text = expr.absolve match
+              case '{ type keyType <: Label
+                      $attribute: (HtmlAttribute[valueType] { type Self = keyType}) } =>
+                TypeRepr.of[keyType].absolve match
+                  case ConstantType(StringConstant(key)) => key.tt
 
 
-          '{  $expr.convert($value) match
-                case HtmlAttribute.NotShown => Unset
-                case Unset                  => ($expr.rename.or(${Expr(key)}).s, Unset)
-                case attribute: Text        => ($expr.rename.or(${Expr(key)}).s, attribute)
-           } :: recur(tail)
+            '{  $expr.convert($value) match
+                  case HtmlAttribute.NotShown => Unset
+                  case Unset                  => ($expr.rename.or(${Expr(key)}).s, Unset)
+                  case attribute: Text        => ($expr.rename.or(${Expr(key)}).s, attribute)
+            } :: recur(tail)
 
-        case '{type keyType <: Label; ($key: keyType, $value: valueType)} +: tail =>
-          val attribute: String = key.value.get
+          case '{type keyType <: Label; ($key: keyType, $value: valueType)} +: tail =>
+            val attribute: String = key.value.get
 
-          val expr: Expr[keyType is HtmlAttribute[valueType]] =
-            Expr.summon[keyType is HtmlAttribute[valueType] onto name]
-            . orElse(Expr.summon[keyType is HtmlAttribute[valueType]])
-            . getOrElse:
-                val typeName = TypeRepr.of[valueType]
-                halt(m"the attribute $attribute cannot take a value of type $typeName")
+            val expr: Expr[keyType is HtmlAttribute[valueType]] =
+              Expr.summon[keyType is HtmlAttribute[valueType] onto name]
+              . orElse(Expr.summon[keyType is HtmlAttribute[valueType]])
+              . getOrElse:
+                  val typeName = TypeRepr.of[valueType]
+                  halt(m"the attribute $attribute cannot take a value of type $typeName")
 
-          '{  $expr.convert($value) match
-                case HtmlAttribute.NotShown => Unset
-                case Unset                  => ($expr.rename.or($key.tt).s, Unset)
-                case attribute: Text        => ($expr.rename.or($key.tt).s, attribute)
-           } :: recur(tail)
+            '{  $expr.convert($value) match
+                  case HtmlAttribute.NotShown => Unset
+                  case Unset                  => ($expr.rename.or($key.tt).s, Unset)
+                  case attribute: Text        => ($expr.rename.or($key.tt).s, attribute)
+            } :: recur(tail)
 
-        case _ =>
-          if className.value == Some("apply") then Nil else List('{("class", $className.tt)})
+          case _ =>
+            if className.value == Some("apply") then Nil else List('{("class", $className.tt)})
 
-    attributes.absolve match
-      case Varargs(exprs) =>
-        '{
-            StartTag
-             ($name,
-              $node.attributes ++ ${Expr.ofSeq(recur(exprs))}.compact.collect:
-                case (key, value: Text) => (key, value)
-                case (key, Unset)       => (key, Unset))  }
+      attributes.absolve match
+        case Varargs(exprs) =>
+          '{
+              StartTag
+               ($name,
+                $node.attributes ++ ${Expr.ofSeq(recur(exprs))}.compact.collect:
+                  case (key, value: Text) => (key, value)
+                  case (key, Unset)       => (key, Unset))  }

--- a/lib/honeycomb/src/core/honeycomb.HtmlDoc.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlDoc.scala
@@ -57,13 +57,14 @@ object HtmlDoc:
   def serialize[output: HtmlSerializer](doc: HtmlDoc, maxWidth: Optional[Int] = Unset): output =
     output.serialize(doc, maxWidth)
 
+
   def simple[Stylesheet](title: Text, stylesheet: Stylesheet = false)
        (content: (Optional[Html[html5.Flow]] | Seq[Html[html5.Flow]])*)
        (using att: "href" is HtmlAttribute[Stylesheet])
   : HtmlDoc =
 
-    val link = att.convert(stylesheet).absolve match
-      case Unset      => Nil
-      case text: Text => Seq(html5.Link.Stylesheet(href = text))
+      val link = att.convert(stylesheet).absolve match
+        case Unset      => Nil
+        case text: Text => Seq(html5.Link.Stylesheet(href = text))
 
-    HtmlDoc(Html(html5.Head(html5.Title(title), link), html5.Body(content*)))
+      HtmlDoc(Html(html5.Head(html5.Title(title), link), html5.Body(content*)))

--- a/lib/honeycomb/src/core/honeycomb.HtmlDoc.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlDoc.scala
@@ -60,7 +60,7 @@ object HtmlDoc:
   def simple[Stylesheet](title: Text, stylesheet: Stylesheet = false)
        (content: (Optional[Html[html5.Flow]] | Seq[Html[html5.Flow]])*)
        (using att: "href" is HtmlAttribute[Stylesheet])
-  :     HtmlDoc =
+  : HtmlDoc =
 
     val link = att.convert(stylesheet).absolve match
       case Unset      => Nil

--- a/lib/honeycomb/src/core/honeycomb.Node.scala
+++ b/lib/honeycomb/src/core/honeycomb.Node.scala
@@ -60,7 +60,7 @@ object Node:
     else t"<${item.label}$filling>${item.children.map(_.show).join}</${item.label}>"
 
   def apply(label0: Text, attributes0: Attributes, children0: Seq[Node[?] | Text | Int | HtmlXml])
-  :     Html[?] = new Node:
+  : Html[?] = new Node:
     def label = label0
     def attributes = attributes0
     def children: Seq[Node[?] | Text | Int | HtmlXml] = children0

--- a/lib/honeycomb/src/core/honeycomb.Node.scala
+++ b/lib/honeycomb/src/core/honeycomb.Node.scala
@@ -59,11 +59,15 @@ object Node:
     then t"<${item.label}$filling${if item.unclosed then t"" else t"/"}>"
     else t"<${item.label}$filling>${item.children.map(_.show).join}</${item.label}>"
 
+
   def apply(label0: Text, attributes0: Attributes, children0: Seq[Node[?] | Text | Int | HtmlXml])
-  : Html[?] = new Node:
-    def label = label0
-    def attributes = attributes0
-    def children: Seq[Node[?] | Text | Int | HtmlXml] = children0
+  : Html[?] =
+
+      new Node:
+        def label = label0
+        def attributes = attributes0
+        def children: Seq[Node[?] | Text | Int | HtmlXml] = children0
+
 
 trait Node[+name <: Label]:
   def label: Text

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -58,12 +58,12 @@ extends Node[name], Dynamic:
   type Content = child
 
   inline def applyDynamicNamed(method: String)(inline attributes: ("" | attribute, Any)*)
-  :     StartTag[name, child] =
+  : StartTag[name, child] =
 
     ${  Honeycomb.read[name, child, child]('this, 'method, 'labelString, 'attributes)  }
 
   def applyDynamic(method: String)(children: (Optional[Html[child]] | Seq[Html[child]])*)
-  :     Element[name] =
+  : Element[name] =
     method match
       case "apply"   => Element(labelString, attributes, children)
       case className => Element(labelString, attributes.updated("class", className.tt), children)

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -57,13 +57,16 @@ extends Node[name], Dynamic:
 
   type Content = child
 
+
   inline def applyDynamicNamed(method: String)(inline attributes: ("" | attribute, Any)*)
   : StartTag[name, child] =
 
-    ${  Honeycomb.read[name, child, child]('this, 'method, 'labelString, 'attributes)  }
+      ${  Honeycomb.read[name, child, child]('this, 'method, 'labelString, 'attributes)  }
+
 
   def applyDynamic(method: String)(children: (Optional[Html[child]] | Seq[Html[child]])*)
   : Element[name] =
-    method match
-      case "apply"   => Element(labelString, attributes, children)
-      case className => Element(labelString, attributes.updated("class", className.tt), children)
+
+      method match
+        case "apply"   => Element(labelString, attributes, children)
+        case className => Element(labelString, attributes.updated("class", className.tt), children)

--- a/lib/hyperbole/src/core/hyperbole-core.scala
+++ b/lib/hyperbole/src/core/hyperbole-core.scala
@@ -37,9 +37,12 @@ import escapade.*
 
 import scala.quoted.*
 
+
 transparent inline def introspect[value](inline inlining: Boolean = false)(inline value: value)
 : Text =
-  ${Hyperbole.introspection[value]('value, 'inlining)}
+
+    ${Hyperbole.introspection[value]('value, 'inlining)}
+
 
 extension [value](expr: Expr[value])(using Quotes)
   def introspect: Teletype = Hyperbole.introspect[value](expr, '{false})

--- a/lib/hyperbole/src/core/hyperbole-core.scala
+++ b/lib/hyperbole/src/core/hyperbole-core.scala
@@ -38,7 +38,7 @@ import escapade.*
 import scala.quoted.*
 
 transparent inline def introspect[value](inline inlining: Boolean = false)(inline value: value)
-:     Text =
+: Text =
   ${Hyperbole.introspection[value]('value, 'inlining)}
 
 extension [value](expr: Expr[value])(using Quotes)

--- a/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
+++ b/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
@@ -129,7 +129,7 @@ object Hyperbole:
             tree:      Optional[Tree],
             repr:      Optional[TypeRepr] = Unset,
             parameter: Optional[Text]     = Unset)
-      :     TastyTree =
+      : TastyTree =
         val shown = tree.let(_.show.tt).or(repr.let(_.show.tt)).or(t"")
         val code = tree.let(source(_)).or(e"")
 

--- a/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
+++ b/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
@@ -130,10 +130,12 @@ object Hyperbole:
             repr:      Optional[TypeRepr] = Unset,
             parameter: Optional[Text]     = Unset)
       : TastyTree =
-        val shown = tree.let(_.show.tt).or(repr.let(_.show.tt)).or(t"")
-        val code = tree.let(source(_)).or(e"")
 
-        TastyTree(tag, typeName, name, shown, code, Nil, parameter, true, false)
+          val shown = tree.let(_.show.tt).or(repr.let(_.show.tt)).or(t"")
+          val code = tree.let(source(_)).or(e"")
+
+          TastyTree(tag, typeName, name, shown, code, Nil, parameter, true, false)
+
 
       def repr(name: Text, repr: Optional[TypeRepr], parameter: Optional[Text] = Unset): TastyTree =
         apply(' ', t"", name, Unset, repr, parameter).typeNode

--- a/lib/hypotenuse/src/core/hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse-core.scala
@@ -410,28 +410,28 @@ extension [left](inline left: left)
   @targetName("lt")
   inline infix def < [right](inline right: right)
                      (using inline commensurable: left is Commensurable by right)
-  :     Boolean =
+  : Boolean =
 
     commensurable.compare(left, right, true, false)
 
   @targetName("lte")
   inline infix def <= [right](inline right: right)
                       (using inline commensurable: left is Commensurable by right)
-  :     Boolean =
+  : Boolean =
 
     commensurable.compare(left, right, false, false)
 
   @targetName("gt")
   inline infix def > [right](inline right: right)
                      (using inline commensurable: left is Commensurable by right)
-  :     Boolean =
+  : Boolean =
 
     commensurable.compare(left, right, true, true)
 
   @targetName("gte")
   inline infix def >= [right](inline right: right)
     (using inline commensurable: left is Commensurable by right)
-  :     Boolean =
+  : Boolean =
 
     commensurable.compare(left, right, false, true)
 

--- a/lib/hypotenuse/src/core/hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse-core.scala
@@ -412,28 +412,32 @@ extension [left](inline left: left)
                      (using inline commensurable: left is Commensurable by right)
   : Boolean =
 
-    commensurable.compare(left, right, true, false)
+      commensurable.compare(left, right, true, false)
+
 
   @targetName("lte")
   inline infix def <= [right](inline right: right)
                       (using inline commensurable: left is Commensurable by right)
   : Boolean =
 
-    commensurable.compare(left, right, false, false)
+      commensurable.compare(left, right, false, false)
+
 
   @targetName("gt")
   inline infix def > [right](inline right: right)
                      (using inline commensurable: left is Commensurable by right)
   : Boolean =
 
-    commensurable.compare(left, right, true, true)
+      commensurable.compare(left, right, true, true)
+
 
   @targetName("gte")
   inline infix def >= [right](inline right: right)
     (using inline commensurable: left is Commensurable by right)
   : Boolean =
 
-    commensurable.compare(left, right, false, true)
+      commensurable.compare(left, right, false, true)
+
 
   inline infix def min (inline right: left)(using left is Orderable): left =
     if left < right then left else right

--- a/lib/hypotenuse/src/core/hypotenuse.Commensurable.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Commensurable.scala
@@ -47,7 +47,7 @@ object Commensurable:
                  inline right: operand,
                  inline strict: Boolean,
                  inline greaterThan: Boolean)
-    :     Boolean =
+    : Boolean =
 
       ${Hypotenuse2.commensurable('left, 'right, 'strict, 'greaterThan)}
 
@@ -57,7 +57,7 @@ object Commensurable:
                  inline right:   Memory,
                  inline strict:  Boolean,
                  inline greater: Boolean)
-    :     Boolean =
+    : Boolean =
 
       !strict && left.long == right.long || (left.long < right.long) ^ greater
 
@@ -67,7 +67,7 @@ object Commensurable:
                  inline right:   Countback,
                  inline strict:  Boolean,
                  inline greater: Boolean)
-    :     Boolean =
+    : Boolean =
 
       inline if greater then inline if strict then left.gt(right) else left.ge(right)
       else inline if strict then left.lt(right) else left.le(right)
@@ -78,7 +78,7 @@ object Commensurable:
                  inline right:   Ordinal,
                  inline strict:  Boolean,
                  inline greater: Boolean)
-    :     Boolean =
+    : Boolean =
 
       inline if greater then inline if strict then left.gt(right) else left.ge(right)
       else inline if strict then left.lt(right) else left.le(right)
@@ -92,4 +92,4 @@ trait Commensurable:
                inline right:       Operand,
                inline strict:      Boolean,
                inline greaterThan: Boolean)
-  :     Boolean
+  : Boolean

--- a/lib/hypotenuse/src/core/hypotenuse.Commensurable.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Commensurable.scala
@@ -42,6 +42,7 @@ object Commensurable:
         =>  Boolean is Commensurable:
     type Operand = operand
 
+
     inline def compare
                 (inline left: Boolean,
                  inline right: operand,
@@ -49,7 +50,8 @@ object Commensurable:
                  inline greaterThan: Boolean)
     : Boolean =
 
-      ${Hypotenuse2.commensurable('left, 'right, 'strict, 'greaterThan)}
+        ${Hypotenuse2.commensurable('left, 'right, 'strict, 'greaterThan)}
+
 
   given orderable: Memory is Orderable:
     inline def compare
@@ -59,7 +61,8 @@ object Commensurable:
                  inline greater: Boolean)
     : Boolean =
 
-      !strict && left.long == right.long || (left.long < right.long) ^ greater
+        !strict && left.long == right.long || (left.long < right.long) ^ greater
+
 
   inline given countback: Countback is Orderable:
     inline def compare
@@ -69,8 +72,9 @@ object Commensurable:
                  inline greater: Boolean)
     : Boolean =
 
-      inline if greater then inline if strict then left.gt(right) else left.ge(right)
-      else inline if strict then left.lt(right) else left.le(right)
+        inline if greater then inline if strict then left.gt(right) else left.ge(right)
+        else inline if strict then left.lt(right) else left.le(right)
+
 
   inline given ordinal: Ordinal is Orderable:
     inline def compare
@@ -80,8 +84,9 @@ object Commensurable:
                  inline greater: Boolean)
     : Boolean =
 
-      inline if greater then inline if strict then left.gt(right) else left.ge(right)
-      else inline if strict then left.lt(right) else left.le(right)
+        inline if greater then inline if strict then left.gt(right) else left.ge(right)
+        else inline if strict then left.lt(right) else left.le(right)
+
 
 trait Commensurable:
   type Self

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -91,7 +91,6 @@ object Hypotenuse:
     inline def apply(inline double: Double): F64 = double
 
     inline given orderable: F64 is Orderable:
-
       inline def compare
                   (inline left:    F64,
                    inline right:   F64,
@@ -99,13 +98,14 @@ object Hypotenuse:
                    inline greater: Boolean)
       : Boolean =
 
-        inline if greater
-        then
-          inline if strict then (left: Double) > (right: Double)
-          else (left: Double) >= (right: Double)
-        else
-          inline if strict then (left: Double) < (right: Double)
-          else (left: Double) <= (right: Double)
+          inline if greater
+          then
+            inline if strict then (left: Double) > (right: Double)
+            else (left: Double) >= (right: Double)
+          else
+            inline if strict then (left: Double) < (right: Double)
+            else (left: Double) <= (right: Double)
+
 
     inline given commensurableInt: F64 is Commensurable:
       type Operand = Int
@@ -117,9 +117,10 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then inline if strict then left > right else left >= right
-        else inline if strict then left < right else left <= right
+          inline if greaterThan
+          then inline if strict then left > right else left >= right
+          else inline if strict then left < right else left <= right
+
 
     given divisible: F64 is Divisible:
       type Self = F64
@@ -136,6 +137,7 @@ object Hypotenuse:
     inline given commensurable: F64 is Commensurable:
       type Operand = Double
 
+
       inline def compare
                   (inline left:        F64,
                    inline right:       Double,
@@ -143,9 +145,10 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then inline if strict then left > right else left >= right
-        else inline if strict then left < right else left <= right
+          inline if greaterThan
+          then inline if strict then left > right else left >= right
+          else inline if strict then left < right else left <= right
+
 
     inline given doubleConversion: Conversion[Double, F64]:
       inline def apply(value: Double): F64 = value
@@ -190,7 +193,6 @@ object Hypotenuse:
       erasedValue
 
     inline given orderable: F32 is Orderable:
-
       inline def compare
                   (inline left:        F32,
                    inline right:       F32,
@@ -198,11 +200,14 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then
-          inline if strict then (left: Float) > (right: Float) else (left: Float) >= (right: Float)
-        else
-          inline if strict then (left: Float) < (right: Float) else (left: Float) <= (right: Float)
+          inline if greaterThan
+          then
+            inline if strict then (left: Float) > (right: Float)
+            else (left: Float) >= (right: Float)
+          else
+            inline if strict then (left: Float) < (right: Float)
+            else (left: Float) <= (right: Float)
+
 
     inline def apply(inline sign: Boolean, inline exponent: B16, inline mantissa: B32): F32 =
       val signBit = if sign then 0 else 1 << 31
@@ -245,7 +250,6 @@ object Hypotenuse:
     inline def apply(inline bits: B64): U64 = bits
 
     inline given orderable: U64 is Orderable:
-
       inline def compare
                   (inline left:        U64,
                    inline right:       U64,
@@ -253,12 +257,13 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan then
-          inline if strict then JLong.compareUnsigned(left, right) == 1
-          else JLong.compareUnsigned(left, right) != -1
-        else
-          inline if strict then JLong.compareUnsigned(left, right) == -1
-          else JLong.compareUnsigned(left, right) != 1
+          inline if greaterThan then
+            inline if strict then JLong.compareUnsigned(left, right) == 1
+            else JLong.compareUnsigned(left, right) != -1
+          else
+            inline if strict then JLong.compareUnsigned(left, right) == -1
+            else JLong.compareUnsigned(left, right) != 1
+
 
   object S64:
     final val Min: U64 = Long.MinValue
@@ -284,9 +289,9 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then inline if strict then (left: Long) > (right: Long) else (left: Long) >= (right: Long)
-        else inline if strict then (left: Long) < (right: Long) else (left: Long) <= (right: Long)
+          inline if greaterThan
+          then inline if strict then (left: Long) > (right: Long) else (left: Long) >= (right: Long)
+          else inline if strict then (left: Long) < (right: Long) else (left: Long) <= (right: Long)
 
 
   object U32:
@@ -301,6 +306,7 @@ object Hypotenuse:
     given textualizer: U32 is Textualizer = JInt.toUnsignedString(_).nn.tt
     inline def apply(inline bits: B32): U32 = bits
 
+
     inline given orderable: U32 is Orderable:
       inline def compare
                   (inline left:        U32,
@@ -309,12 +315,13 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan then
-          inline if strict then JLong.compareUnsigned(left, right) == 1
-          else JInt.compareUnsigned(left, right) != -1
-        else
-          inline if strict then JLong.compareUnsigned(left, right) == -1
-          else JInt.compareUnsigned(left, right) != 1
+          inline if greaterThan then
+            inline if strict then JLong.compareUnsigned(left, right) == 1
+            else JInt.compareUnsigned(left, right) != -1
+          else
+            inline if strict then JLong.compareUnsigned(left, right) == -1
+            else JInt.compareUnsigned(left, right) != 1
+
 
   object S32:
     final val Min: S32 = Int.MinValue
@@ -332,7 +339,6 @@ object Hypotenuse:
     inline def apply(inline bits: B32): S32 = bits
 
     inline given orderable: S32 is Orderable:
-
       inline def compare
                   (inline left:        S32,
                    inline right:       S32,
@@ -340,9 +346,10 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then inline if strict then (left: Int) > (right: Int) else (left: Int) >= (right: Int)
-        else inline if strict then (left: Int) < (right: Int) else (left: Int) <= (right: Int)
+          inline if greaterThan
+          then inline if strict then (left: Int) > (right: Int) else (left: Int) >= (right: Int)
+          else inline if strict then (left: Int) < (right: Int) else (left: Int) <= (right: Int)
+
 
   object U16:
     final val Min: S16 = 0
@@ -356,8 +363,8 @@ object Hypotenuse:
     given textualizer: U16 is Textualizer = u16 => JShort.toUnsignedInt(u16).toString.nn.tt
     inline def apply(inline bits: B16): U16 = bits
 
-    inline given orderable: U16 is Orderable:
 
+    inline given orderable: U16 is Orderable:
       inline def compare
                   (inline left:        U16,
                    inline right:       U16,
@@ -365,20 +372,22 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        val left2 = JShort.toUnsignedInt(left)
-        val right2 = JShort.toUnsignedInt(right)
+          val left2 = JShort.toUnsignedInt(left)
+          val right2 = JShort.toUnsignedInt(right)
 
-        inline if greaterThan
-        then inline if strict then left2 > right2 else left.toInt >= right2
-        else inline if strict then left2 < right2 else left.toInt <= right2
+          inline if greaterThan
+          then inline if strict then left2 > right2 else left.toInt >= right2
+          else inline if strict then left2 < right2 else left.toInt <= right2
+
 
   object S16:
     final val Min: S16 = Short.MinValue
     final val Max: S16 = Short.MaxValue
     erased given underlying: Underlying[S16, Short] = erasedValue
 
-    inline given canEqual: CanEqual[S16, F64 | F32 | S64 | S32 | S16 | S8 | Float | Double | Long
-                                    | Int | Short | Byte] =
+    inline given canEqual: CanEqual[S16,
+                                    F64 | F32 | S64 | S32 | S16 | S8 | Float | Double | Long | Int
+                                    | Short | Byte] =
       erasedValue
 
     given fromDigits: FromDigits[S16]:
@@ -388,7 +397,6 @@ object Hypotenuse:
     inline def apply(inline bits: B16): S16 = bits
 
     inline given orderable: S16 is Orderable:
-
       inline def compare
                   (inline left:        S16,
                    inline right:       S16,
@@ -396,11 +404,14 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then
-          inline if strict then (left: Short) > (right: Short) else (left: Short) >= (right: Short)
-        else
-          inline if strict then (left: Short) < (right: Short) else (left: Short) <= (right: Short)
+          inline if greaterThan
+          then
+            inline if strict then (left: Short) > (right: Short)
+            else (left: Short) >= (right: Short)
+          else
+            inline if strict then (left: Short) < (right: Short)
+            else (left: Short) <= (right: Short)
+
 
   object U8:
     final val Min: U8 = 0
@@ -415,7 +426,6 @@ object Hypotenuse:
     inline def apply(inline bits: B8): U8 = bits
 
     inline given orderable: U8 is Orderable:
-
       inline def compare
                   (inline left:        U8,
                    inline right:       U8,
@@ -423,12 +433,13 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        val left2 = JByte.toUnsignedInt(left)
-        val right2 = JByte.toUnsignedInt(right)
+          val left2 = JByte.toUnsignedInt(left)
+          val right2 = JByte.toUnsignedInt(right)
 
-        inline if greaterThan
-        then inline if strict then left2 > right2 else left2 >= right2
-        else inline if strict then left2 < right2 else left2 <= right2
+          inline if greaterThan
+          then inline if strict then left2 > right2 else left2 >= right2
+          else inline if strict then left2 < right2 else left2 <= right2
+
 
   object S8:
     final val Min: S8 = Byte.MinValue
@@ -446,7 +457,6 @@ object Hypotenuse:
     inline def apply(inline bits: B8): S8 = bits
 
     inline given inquality: S8 is Orderable:
-
       inline def compare
                   (inline left:        S8,
                    inline right:       S8,
@@ -454,9 +464,10 @@ object Hypotenuse:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        inline if greaterThan
-        then inline if strict then (left: Byte) > (right: Byte) else (left: Byte) >= (right: Byte)
-        else inline if strict then (left: Byte) < (right: Byte) else (left: Byte) <= (right: Byte)
+          inline if greaterThan
+          then inline if strict then (left: Byte) > (right: Byte) else (left: Byte) >= (right: Byte)
+          else inline if strict then (left: Byte) < (right: Byte) else (left: Byte) <= (right: Byte)
+
 
   object B64:
     erased given underlying: Underlying[B64, Long] = erasedValue

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -97,7 +97,7 @@ object Hypotenuse:
                    inline right:   F64,
                    inline strict:  Boolean,
                    inline greater: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greater
         then
@@ -115,7 +115,7 @@ object Hypotenuse:
                    inline right:       Int,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then inline if strict then left > right else left >= right
@@ -141,7 +141,7 @@ object Hypotenuse:
                    inline right:       Double,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then inline if strict then left > right else left >= right
@@ -196,7 +196,7 @@ object Hypotenuse:
                    inline right:       F32,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then
@@ -251,7 +251,7 @@ object Hypotenuse:
                    inline right:       U64,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan then
           inline if strict then JLong.compareUnsigned(left, right) == 1
@@ -282,7 +282,7 @@ object Hypotenuse:
                    inline right:       S64,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then inline if strict then (left: Long) > (right: Long) else (left: Long) >= (right: Long)
@@ -307,7 +307,7 @@ object Hypotenuse:
                    inline right:       U32,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan then
           inline if strict then JLong.compareUnsigned(left, right) == 1
@@ -338,7 +338,7 @@ object Hypotenuse:
                    inline right:       S32,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then inline if strict then (left: Int) > (right: Int) else (left: Int) >= (right: Int)
@@ -363,7 +363,7 @@ object Hypotenuse:
                    inline right:       U16,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         val left2 = JShort.toUnsignedInt(left)
         val right2 = JShort.toUnsignedInt(right)
@@ -394,7 +394,7 @@ object Hypotenuse:
                    inline right:       S16,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then
@@ -421,7 +421,7 @@ object Hypotenuse:
                    inline right:       U8,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         val left2 = JByte.toUnsignedInt(left)
         val right2 = JByte.toUnsignedInt(right)
@@ -452,7 +452,7 @@ object Hypotenuse:
                    inline right:       S8,
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         inline if greaterThan
         then inline if strict then (left: Byte) > (right: Byte) else (left: Byte) >= (right: Byte)

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
@@ -150,6 +150,7 @@ object Hypotenuse2:
 
       Expr(int.toByte)
 
+
   def commensurable
        (expr: Expr[Boolean],
         bound: Expr[Int | Double | Char | Byte | Short | Long | Float],
@@ -158,52 +159,52 @@ object Hypotenuse2:
        (using Quotes)
   : Expr[Boolean] =
 
-    val errorMessage = m"this cannot be written as a range expression"
+      val errorMessage = m"this cannot be written as a range expression"
 
-    val value =
-      if greaterThan.valueOrAbort then expr match
-        case '{($bound: Int) > ($value: Int)}        => value
-        case '{($bound: Int) >= ($value: Int)}       => value
-        case '{($bound: Double) > ($value: Double)}  => value
-        case '{($bound: Double) >= ($value: Double)} => value
-        case '{($bound: Char) > ($value: Char)}      => value
-        case '{($bound: Char) >= ($value: Char)}     => value
-        case '{($bound: Byte) > ($value: Byte)}      => value
-        case '{($bound: Byte) >= ($value: Byte)}     => value
-        case '{($bound: Short) > ($value: Short)}    => value
-        case '{($bound: Short) >= ($value: Short)}   => value
-        case '{($bound: Long) > ($value: Long)}      => value
-        case '{($bound: Long) >= ($value: Long)}     => value
-        case '{($bound: Float) > ($value: Float)}    => value
-        case '{($bound: Float) >= ($value: Float)}   => value
-        case _                                       => halt(errorMessage)
+      val value =
+        if greaterThan.valueOrAbort then expr match
+          case '{($bound: Int) > ($value: Int)}        => value
+          case '{($bound: Int) >= ($value: Int)}       => value
+          case '{($bound: Double) > ($value: Double)}  => value
+          case '{($bound: Double) >= ($value: Double)} => value
+          case '{($bound: Char) > ($value: Char)}      => value
+          case '{($bound: Char) >= ($value: Char)}     => value
+          case '{($bound: Byte) > ($value: Byte)}      => value
+          case '{($bound: Byte) >= ($value: Byte)}     => value
+          case '{($bound: Short) > ($value: Short)}    => value
+          case '{($bound: Short) >= ($value: Short)}   => value
+          case '{($bound: Long) > ($value: Long)}      => value
+          case '{($bound: Long) >= ($value: Long)}     => value
+          case '{($bound: Float) > ($value: Float)}    => value
+          case '{($bound: Float) >= ($value: Float)}   => value
+          case _                                       => halt(errorMessage)
 
-      else expr match
-        case '{($bound: Int) < ($value: Int)}        => value
-        case '{($bound: Int) <= ($value: Int)}       => value
-        case '{($bound: Double) < ($value: Double)}  => value
-        case '{($bound: Double) <= ($value: Double)} => value
-        case '{($bound: Char) < ($value: Char)}      => value
-        case '{($bound: Char) <= ($value: Char)}     => value
-        case '{($bound: Byte) < ($value: Byte)}      => value
-        case '{($bound: Byte) <= ($value: Byte)}     => value
-        case '{($bound: Short) < ($value: Short)}    => value
-        case '{($bound: Short) <= ($value: Short)}   => value
-        case '{($bound: Long) < ($value: Long)}      => value
-        case '{($bound: Long) <= ($value: Long)}     => value
-        case '{($bound: Float) < ($value: Float)}    => value
-        case '{($bound: Float) <= ($value: Float)}   => value
-        case _                                       => halt(errorMessage)
+        else expr match
+          case '{($bound: Int) < ($value: Int)}        => value
+          case '{($bound: Int) <= ($value: Int)}       => value
+          case '{($bound: Double) < ($value: Double)}  => value
+          case '{($bound: Double) <= ($value: Double)} => value
+          case '{($bound: Char) < ($value: Char)}      => value
+          case '{($bound: Char) <= ($value: Char)}     => value
+          case '{($bound: Byte) < ($value: Byte)}      => value
+          case '{($bound: Byte) <= ($value: Byte)}     => value
+          case '{($bound: Short) < ($value: Short)}    => value
+          case '{($bound: Short) <= ($value: Short)}   => value
+          case '{($bound: Long) < ($value: Long)}      => value
+          case '{($bound: Long) <= ($value: Long)}     => value
+          case '{($bound: Float) < ($value: Float)}    => value
+          case '{($bound: Float) <= ($value: Float)}   => value
+          case _                                       => halt(errorMessage)
 
-    val (lessStrict, less) =
-      (if greaterThan.valueOrAbort then (bound, value) else (value, bound)) match
-        case ('{$left: Int}, '{$right: Int})       => ('{$left < $right}, '{$left <= $right})
-        case ('{$left: Float}, '{$right: Float})   => ('{$left < $right}, '{$left <= $right})
-        case ('{$left: Double}, '{$right: Double}) => ('{$left < $right}, '{$left <= $right})
-        case ('{$left: Long}, '{$right: Long})     => ('{$left < $right}, '{$left <= $right})
-        case ('{$left: Char}, '{$right: Char})     => ('{$left < $right}, '{$left <= $right})
-        case ('{$left: Byte}, '{$right: Byte})     => ('{$left < $right}, '{$left <= $right})
-        case ('{$left: Short}, '{$right: Short})   => ('{$left < $right}, '{$left <= $right})
-        case _                                      => halt(errorMessage)
+      val (lessStrict, less) =
+        (if greaterThan.valueOrAbort then (bound, value) else (value, bound)) match
+          case ('{$left: Int}, '{$right: Int})       => ('{$left < $right}, '{$left <= $right})
+          case ('{$left: Float}, '{$right: Float})   => ('{$left < $right}, '{$left <= $right})
+          case ('{$left: Double}, '{$right: Double}) => ('{$left < $right}, '{$left <= $right})
+          case ('{$left: Long}, '{$right: Long})     => ('{$left < $right}, '{$left <= $right})
+          case ('{$left: Char}, '{$right: Char})     => ('{$left < $right}, '{$left <= $right})
+          case ('{$left: Byte}, '{$right: Byte})     => ('{$left < $right}, '{$left <= $right})
+          case ('{$left: Short}, '{$right: Short})   => ('{$left < $right}, '{$left <= $right})
+          case _                                      => halt(errorMessage)
 
-    '{$expr && ${if strict.valueOrAbort then lessStrict else less}}
+      '{$expr && ${if strict.valueOrAbort then lessStrict else less}}

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
@@ -156,7 +156,7 @@ object Hypotenuse2:
         strict: Expr[Boolean],
         greaterThan: Expr[Boolean])
        (using Quotes)
-  :     Expr[Boolean] =
+  : Expr[Boolean] =
 
     val errorMessage = m"this cannot be written as a range expression"
 

--- a/lib/hypotenuse/src/core/hypotenuse.Orderable.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Orderable.scala
@@ -42,10 +42,11 @@ object Orderable:
                  inline strict:  Boolean,
                  inline greater: Boolean)
     : Boolean =
-      val n = value.compare(left, right)
-      inline if greater
-      then inline if strict then n > 0 else n >= 0
-      else inline if strict then n < 0 else n <= 0
+
+        val n = value.compare(left, right)
+        inline if greater
+        then inline if strict then n > 0 else n >= 0
+        else inline if strict then n < 0 else n <= 0
 
 
 trait Orderable extends Commensurable:
@@ -56,10 +57,12 @@ trait Orderable extends Commensurable:
   def contramap[self](lambda: self => Self): self is Orderable = new Orderable:
     type Self = self
 
+
     inline def compare
                 (inline left:    self,
                  inline right:   self,
                  inline strict:  Boolean,
                  inline greater: Boolean)
     : Boolean =
-      orderable.compare(lambda(left), lambda(right), strict, greater)
+
+        orderable.compare(lambda(left), lambda(right), strict, greater)

--- a/lib/hypotenuse/src/core/hypotenuse.Orderable.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Orderable.scala
@@ -41,7 +41,7 @@ object Orderable:
                  inline right:   value,
                  inline strict:  Boolean,
                  inline greater: Boolean)
-    :     Boolean =
+    : Boolean =
       val n = value.compare(left, right)
       inline if greater
       then inline if strict then n > 0 else n >= 0
@@ -61,5 +61,5 @@ trait Orderable extends Commensurable:
                  inline right:   self,
                  inline strict:  Boolean,
                  inline greater: Boolean)
-    :     Boolean =
+    : Boolean =
       orderable.compare(lambda(left), lambda(right), strict, greater)

--- a/lib/imperial/src/core/imperial.Base.scala
+++ b/lib/imperial/src/core/imperial.Base.scala
@@ -43,7 +43,7 @@ import vacuous.*
 object Base extends BaseLayout(Unset)(using BaseLayout.Dir(false, Nil)):
   override def apply[path: Instantiable across Paths from Text]()
                 (using SystemProperties, Environment)
-  :     path raises SystemPropertyError raises EnvironmentError =
+  : path raises SystemPropertyError raises EnvironmentError =
 
     path(t"/")
 

--- a/lib/imperial/src/core/imperial.Base.scala
+++ b/lib/imperial/src/core/imperial.Base.scala
@@ -45,7 +45,8 @@ object Base extends BaseLayout(Unset)(using BaseLayout.Dir(false, Nil)):
                 (using SystemProperties, Environment)
   : path raises SystemPropertyError raises EnvironmentError =
 
-    path(t"/")
+      path(t"/")
+
 
   object Boot extends BaseLayout(t"boot", readOnly = true)
   object Efi extends BaseLayout(t"efi", readOnly = true)

--- a/lib/imperial/src/core/imperial.BaseLayout.scala
+++ b/lib/imperial/src/core/imperial.BaseLayout.scala
@@ -53,7 +53,7 @@ case class BaseLayout(private val part: Optional[Text], readOnly: Boolean = fals
    (using baseDir: BaseLayout.Dir):
 
   def absolutePath(using Environment, SystemProperties)
-  :     Text raises EnvironmentError raises SystemPropertyError =
+  : Text raises EnvironmentError raises SystemPropertyError =
 
     val home: Text = Environment.home[Text]
     val home2: Text = if home.ends(t"/") then home.skip(1, Rtl) else home
@@ -64,7 +64,7 @@ case class BaseLayout(private val part: Optional[Text], readOnly: Boolean = fals
 
   def apply[instantiable: Instantiable across Paths from Text]()
        (using SystemProperties, Environment)
-  :     instantiable raises SystemPropertyError raises EnvironmentError =
+  : instantiable raises SystemPropertyError raises EnvironmentError =
 
     val path: Text = absolutePath
     instantiable(path)

--- a/lib/imperial/src/core/imperial.BaseLayout.scala
+++ b/lib/imperial/src/core/imperial.BaseLayout.scala
@@ -52,19 +52,22 @@ object BaseLayout:
 case class BaseLayout(private val part: Optional[Text], readOnly: Boolean = false)
    (using baseDir: BaseLayout.Dir):
 
+
   def absolutePath(using Environment, SystemProperties)
   : Text raises EnvironmentError raises SystemPropertyError =
 
-    val home: Text = Environment.home[Text]
-    val home2: Text = if home.ends(t"/") then home.skip(1, Rtl) else home
-    part.let(baseDir / _).or(baseDir).render(home2)
+      val home: Text = Environment.home[Text]
+      val home2: Text = if home.ends(t"/") then home.skip(1, Rtl) else home
+      part.let(baseDir / _).or(baseDir).render(home2)
+
 
   given dir: BaseLayout.Dir =
     BaseLayout.Dir(baseDir.home, part.let(_ :: baseDir.path).or(baseDir.path))
+
 
   def apply[instantiable: Instantiable across Paths from Text]()
        (using SystemProperties, Environment)
   : instantiable raises SystemPropertyError raises EnvironmentError =
 
-    val path: Text = absolutePath
-    instantiable(path)
+      val path: Text = absolutePath
+      instantiable(path)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -84,7 +84,7 @@ trait Json2:
 
   object DecodableDerivation extends Derivable[Decodable in Json]:
     inline def join[derivation <: Product: ProductReflection]
-    :     derivation is Decodable in Json =
+    : derivation is Decodable in Json =
       json =>
         summonInline[Foci[JsonPointer]].give:
           summonInline[Tactic[JsonError]].give:
@@ -263,7 +263,7 @@ class Json(rootValue: Any) extends Dynamic derives CanEqual:
     apply(field.tt)
 
   def applyDynamic(field: String)(index: Int)(using erased DynamicJsonEnabler)
-  :     Json raises JsonError =
+  : Json raises JsonError =
     apply(field.tt)(index)
 
   def apply(field: Text): Json raises JsonError =

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -83,8 +83,7 @@ trait Json2:
     case given Reflection[`value`]            => EncodableDerivation.derived
 
   object DecodableDerivation extends Derivable[Decodable in Json]:
-    inline def join[derivation <: Product: ProductReflection]
-    : derivation is Decodable in Json =
+    inline def join[derivation <: Product: ProductReflection]: derivation is Decodable in Json =
       json =>
         summonInline[Foci[JsonPointer]].give:
           summonInline[Tactic[JsonError]].give:
@@ -140,10 +139,6 @@ trait Json2:
                 case labels: IArray[String] => values.asMatchable.absolve match
                   case values: IArray[JsonAst] =>
                     JsonAst((("_type" +: labels), (label.asInstanceOf[JsonAst] +: values)))
-
-  // given integral: [integral: Numeric](using Tactic[JsonError])
-  //       =>  integral is Decodable in Json =
-  //   (value, omit) => integral.fromInt(value.root.long.toInt)
 
 object Json extends Json2, Dynamic:
   def ast(value: JsonAst): Json = new Json(value)
@@ -262,9 +257,12 @@ class Json(rootValue: Any) extends Dynamic derives CanEqual:
   def selectDynamic(field: String)(using erased DynamicJsonEnabler): Json raises JsonError =
     apply(field.tt)
 
+
   def applyDynamic(field: String)(index: Int)(using erased DynamicJsonEnabler)
   : Json raises JsonError =
-    apply(field.tt)(index)
+
+      apply(field.tt)(index)
+
 
   def apply(field: Text): Json raises JsonError =
     root.obj(0).indexWhere(_ == field.s) match

--- a/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
@@ -183,7 +183,7 @@ object Regex:
         abort(RegexError(index, UnexpectedChar))
 
     def group(start: Int, children: List[Group], top: Boolean, escape: Boolean, charClass: Boolean)
-    :     Group =
+    : Group =
 
       current() match
         case '\u0000' =>
@@ -255,7 +255,7 @@ object Regex:
     Regex(text, mainGroup.groups)
 
   def makePattern(pattern: Text, todo: List[Group], last: Int, text: Text, end: Int, index: Int)
-  :     (Int, Text) =
+  : (Int, Text) =
 
     todo match
       case Nil =>
@@ -300,7 +300,7 @@ case class Regex(pattern: Text, groups: List[Regex.Group]):
   def matches(text: Text)(using Scanner): Boolean = !matchGroups(text).isEmpty
 
   def matchGroups(text: Text)(using scanner: Scanner)
-  :     Option[IArray[List[Text | Char] | Optional[Text | Char]]] =
+  : Option[IArray[List[Text | Char] | Optional[Text | Char]]] =
 
     val matcher: jur.Matcher = javaPattern.matcher(text.s).nn
 
@@ -308,7 +308,7 @@ case class Regex(pattern: Text, groups: List[Regex.Group]):
          (todo:    List[Regex.Group],
           matches: List[Optional[Text | Char] | List[Text | Char]],
           index:   Int)
-    :     List[Optional[Text | Char] | List[Text | Char]] =
+    : List[Optional[Text | Char] | List[Text | Char]] =
 
       todo match
         case Nil =>

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -59,7 +59,7 @@ object Subcompiler:
 
   def compile
     (language: List[Settings.Setting.ChoiceWithHelp[String]], classpath: String, source: String)
-  :     List[CompileError] =
+  : List[CompileError] =
     compile(language, classpath, source, Set((0, source.length)))
 
   def compile
@@ -67,7 +67,7 @@ object Subcompiler:
         classpath: String,
         source:    String,
       regions:   Set[(Int, Int)])
-  :     List[CompileError] =
+  : List[CompileError] =
 
     object driver extends Driver:
       val currentCtx: Context =
@@ -76,7 +76,7 @@ object Subcompiler:
         setup(Array[String](""), ctx2).map(_(1)).get
 
       def run(source: String, regions: Set[(Int, Int)], errors: List[CompileError])
-      :     List[CompileError] =
+      : List[CompileError] =
 
         if regions.isEmpty then errors else
           val reporter: CustomReporter = CustomReporter()
@@ -98,7 +98,7 @@ object Subcompiler:
           val newErrors = reporter.errors.to(List)
 
           def recompile(todo: List[CompileError], done: Set[(Int, Int)], source: String)
-          :     List[CompileError] =
+          : List[CompileError] =
 
             todo match
               case Nil =>

--- a/lib/legerdemain/src/core/legerdemain-core.scala
+++ b/lib/legerdemain/src/core/legerdemain-core.scala
@@ -44,24 +44,30 @@ import html5.*
 
 given realm: Realm = realm"legerdemain"
 
+
 def elicit[value: Formulaic]
    (query: Optional[Query] = Unset, validation: Validation, submit: Optional[Text])
    (using formulation: Formulation)
 : Html[Flow] =
-  formulation.form
-   (value.fields(Pointer.Self, t"", query.or(Query.empty), validation, formulation), submit)
+
+    formulation.form
+     (value.fields(Pointer.Self, t"", query.or(Query.empty), validation, formulation), submit)
+
 
 extension [formulaic: {Formulaic, Encodable in Query}](value: formulaic)
   def edit(validation: Validation, submit: Optional[Text])(using formulation: Formulation)
   : Html[Flow] =
-    formulation.form
-     (formulaic.fields(Pointer.Self, t"", formulaic.encoded(value), validation, formulation),
-      submit)
+
+      formulation.form
+       (formulaic.fields(Pointer.Self, t"", formulaic.encoded(value), validation, formulation),
+        submit)
+
 
 package formulations:
   given default: Formulation:
     def form(content: Seq[Html[Flow]], submit: Optional[Text]): Html[Flow] =
       Form(action = t".", method = Method.Post)(content, Input.Submit(value = submit.or(t"Submit")))
+
 
     def element
          (widget:     Seq[Html[Phrasing]],
@@ -69,5 +75,6 @@ package formulations:
           validation: Optional[Message],
           required:   Boolean)
     : Html[Flow] =
-      val validation2 = validation.let(_.html)
-      Div(validation2.let(P.alert(_)), Label(legend, widget), Span.required(t"*").unless(!required))
+
+        val validation2 = validation.let(_.html)
+        Div(validation2.let(P.alert(_)), Label(legend, widget), Span.required(t"*").unless(!required))

--- a/lib/legerdemain/src/core/legerdemain-core.scala
+++ b/lib/legerdemain/src/core/legerdemain-core.scala
@@ -47,13 +47,13 @@ given realm: Realm = realm"legerdemain"
 def elicit[value: Formulaic]
    (query: Optional[Query] = Unset, validation: Validation, submit: Optional[Text])
    (using formulation: Formulation)
-:     Html[Flow] =
+: Html[Flow] =
   formulation.form
    (value.fields(Pointer.Self, t"", query.or(Query.empty), validation, formulation), submit)
 
 extension [formulaic: {Formulaic, Encodable in Query}](value: formulaic)
   def edit(validation: Validation, submit: Optional[Text])(using formulation: Formulation)
-  :     Html[Flow] =
+  : Html[Flow] =
     formulation.form
      (formulaic.fields(Pointer.Self, t"", formulaic.encoded(value), validation, formulation),
       submit)
@@ -68,6 +68,6 @@ package formulations:
           legend:     Text,
           validation: Optional[Message],
           required:   Boolean)
-    :     Html[Flow] =
+    : Html[Flow] =
       val validation2 = validation.let(_.html)
       Div(validation2.let(P.alert(_)), Label(legend, widget), Span.required(t"*").unless(!required))

--- a/lib/legerdemain/src/core/legerdemain.Formulaic.scala
+++ b/lib/legerdemain/src/core/legerdemain.Formulaic.scala
@@ -50,6 +50,7 @@ object Formulaic extends ProductDerivable[Formulaic]:
         => (renderable: elicitable.Operand is Renderable into Phrasing)
         =>  value is Formulaic:
 
+
     def fields
          (pointer:     Pointer,
           legend:      Text,
@@ -58,10 +59,12 @@ object Formulaic extends ProductDerivable[Formulaic]:
           formulation: Formulation)
     : Seq[Html[Flow]] =
 
-      val message: Optional[Message] = validation(pointer)
-      val widget = renderable.html(elicitable.widget(pointer.text, legend, query().or(t"")))
-      val required = false//safely(decodable.decoded(t"")).absent
-      List(formulation.element(widget, legend, message, required))
+        val message: Optional[Message] = validation(pointer)
+        val widget = renderable.html(elicitable.widget(pointer.text, legend, query().or(t"")))
+        val required = false//safely(decodable.decoded(t"")).absent
+
+        List(formulation.element(widget, legend, message, required))
+
 
   inline def join[derivation <: Product: ProductReflection]: derivation is Formulaic =
     (pointer, legend, query, errors, formulation) =>
@@ -75,6 +78,7 @@ object Formulaic extends ProductDerivable[Formulaic]:
         . flatten
 
       List(Fieldset(Legend(legend), content))
+
 
 trait Formulaic:
   type Self

--- a/lib/legerdemain/src/core/legerdemain.Formulaic.scala
+++ b/lib/legerdemain/src/core/legerdemain.Formulaic.scala
@@ -56,7 +56,7 @@ object Formulaic extends ProductDerivable[Formulaic]:
           query:       Query,
           validation:  Validation,
           formulation: Formulation)
-    :     Seq[Html[Flow]] =
+    : Seq[Html[Flow]] =
 
       val message: Optional[Message] = validation(pointer)
       val widget = renderable.html(elicitable.widget(pointer.text, legend, query().or(t"")))

--- a/lib/legerdemain/src/core/legerdemain.Formulation.scala
+++ b/lib/legerdemain/src/core/legerdemain.Formulation.scala
@@ -45,4 +45,4 @@ trait Formulation:
         legend:     Text,
         validation: Optional[Message],
         required:   Boolean)
-  :     Html[html5.Flow]
+  : Html[html5.Flow]

--- a/lib/legerdemain/src/core/legerdemain.Legerdemain.scala
+++ b/lib/legerdemain/src/core/legerdemain.Legerdemain.scala
@@ -43,7 +43,7 @@ object Legerdemain:
   def query(values: Expr[Seq[(Label, Any)]])(using Quotes): Expr[Query] =
 
     def recur(exprs: List[Expr[(Label, Any)]], done: List[Expr[List[(Text, Text)]]] = Nil)
-    :     Expr[Query] =
+    : Expr[Query] =
 
       exprs match
         case '{ type keyType <: Label

--- a/lib/legerdemain/src/core/legerdemain.Query.scala
+++ b/lib/legerdemain/src/core/legerdemain.Query.scala
@@ -64,7 +64,7 @@ object Query extends Dynamic:
 
   object EncodableDerivation extends ProductDerivation[[Type] =>> Type is Encodable in Query]:
     inline def join[derivation <: Product: ProductReflection]
-    :     derivation is Encodable in Query =
+    : derivation is Encodable in Query =
 
       value =>
         Query.of:
@@ -74,7 +74,7 @@ object Query extends Dynamic:
 
   object DecodableDerivation extends ProductDerivation[[Type] =>> Type is Decodable in Query]:
     inline def join[derivation <: Product: ProductReflection]
-    :     derivation is Decodable in Query =
+    : derivation is Decodable in Query =
 
       summonInline[Foci[Pointer]].give:
         value =>
@@ -127,7 +127,7 @@ case class Query private (values: List[(Text, Text)]) extends Dynamic:
 
   def selectDynamic[result](label: String)(using erased (label.type is Parametric into result))
        (using decodable: result is Decodable in Query)
-  :     result =
+  : result =
     decodable.decoded(apply(label.tt))
 
   def at[value: Decodable in Text](name: Text): Optional[Text] = apply(name)().let(_.decode)

--- a/lib/legerdemain/src/core/legerdemain.Query.scala
+++ b/lib/legerdemain/src/core/legerdemain.Query.scala
@@ -66,22 +66,24 @@ object Query extends Dynamic:
     inline def join[derivation <: Product: ProductReflection]
     : derivation is Encodable in Query =
 
-      value =>
-        Query.of:
-          fields(value) { [field] => field => context.encoded(field).prefix(label) }
-          . to(List)
-          . flatMap(_.values)
+        value =>
+          Query.of:
+            fields(value) { [field] => field => context.encoded(field).prefix(label) }
+            . to(List)
+            . flatMap(_.values)
+
 
   object DecodableDerivation extends ProductDerivation[[Type] =>> Type is Decodable in Query]:
     inline def join[derivation <: Product: ProductReflection]
     : derivation is Decodable in Query =
 
-      summonInline[Foci[Pointer]].give:
-        value =>
-          construct:
-            [field] => context =>
-              focus(prior.lay(Pointer(label))(_(label))):
-                context.decoded(value(label))
+        summonInline[Foci[Pointer]].give:
+          value =>
+            construct:
+              [field] => context =>
+                focus(prior.lay(Pointer(label))(_(label))):
+                  context.decoded(value(label))
+
 
   given booleanEncodable: Boolean is Encodable in Query =
     boolean => if boolean then Query.of(t"on") else Query.empty
@@ -125,10 +127,13 @@ case class Query private (values: List[(Text, Text)]) extends Dynamic:
   @targetName("appendAll")
   infix def ++ (query: Query) = Query(values ++ query.values)
 
+
   def selectDynamic[result](label: String)(using erased (label.type is Parametric into result))
        (using decodable: result is Decodable in Query)
   : result =
-    decodable.decoded(apply(label.tt))
+
+      decodable.decoded(apply(label.tt))
+
 
   def at[value: Decodable in Text](name: Text): Optional[Text] = apply(name)().let(_.decode)
   def as[value: Decodable in Query]: value tracks Pointer = value.decoded(this)

--- a/lib/mandible/src/core/mandible-core.scala
+++ b/lib/mandible/src/core/mandible-core.scala
@@ -69,24 +69,26 @@ import filesystemOptions.createNonexistent.disabled
 import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.disabled
 
+
 def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using TemporaryDirectory)
      (using classloader: Classloader)
 : Bytecode =
-  val uuid = Uuid()
-  val out: Path on Linux = unsafely(temporaryDirectory[Path on Linux] / Name[Linux](uuid.show))
-  val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))
 
-  val settings: staging.Compiler.Settings =
-    staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))
+    val uuid = Uuid()
+    val out: Path on Linux = unsafely(temporaryDirectory[Path on Linux] / Name[Linux](uuid.show))
+    val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))
 
-  given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
+    val settings: staging.Compiler.Settings =
+      staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))
 
-  unsafely:
-    val file: Path on Linux = out / Name[Linux](t"Generated$$Code$$From$$Quoted.class")
-    val code: Quotes ?=> Expr[Unit] = '{ def _code(): Unit = $code0 }
-    staging.run(code)
-    val classfile: Classfile = new Classfile(file.open(_.read[Bytes]))
-    classfile.methods.find(_.name == t"_code$$1").map(_.bytecode).get.vouch.embed(codepoint)
+    given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
+
+    unsafely:
+      val file: Path on Linux = out / Name[Linux](t"Generated$$Code$$From$$Quoted.class")
+      val code: Quotes ?=> Expr[Unit] = '{ def _code(): Unit = $code0 }
+      staging.run(code)
+      val classfile: Classfile = new Classfile(file.open(_.read[Bytes]))
+      classfile.methods.find(_.name == t"_code$$1").map(_.bytecode).get.vouch.embed(codepoint)
 
 
 case class ClassfileError()(using Diagnostics)

--- a/lib/mandible/src/core/mandible-core.scala
+++ b/lib/mandible/src/core/mandible-core.scala
@@ -71,7 +71,7 @@ import filesystemOptions.writeAccess.disabled
 
 def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using TemporaryDirectory)
      (using classloader: Classloader)
-:     Bytecode =
+: Bytecode =
   val uuid = Uuid()
   val out: Path on Linux = unsafely(temporaryDirectory[Path on Linux] / Name[Linux](uuid.show))
   val scalac: Scalac[3.6] = Scalac[3.6](List(scalacOptions.experimental))

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -89,32 +89,33 @@ class Classfile(data: Bytes):
             stack: Optional[List[Bytecode.Frame]],
             count: Int)
       : List[Bytecode.Instruction] =
-        todo match
-          case Nil => done.reverse
 
-          case next :: todo => next match
-            case instruction: jlc.Instruction =>
-              val opcode = Bytecode.Opcode(instruction)
-              val stack2 = stack.let(opcode.transform(_))
+          todo match
+            case Nil => done.reverse
 
-              recur
-               (todo,
-                Unset,
-                Bytecode.Instruction(opcode, line, stack2, count) :: done,
-                stack2,
-                count + instruction.sizeInBytes)
+            case next :: todo => next match
+              case instruction: jlc.Instruction =>
+                val opcode = Bytecode.Opcode(instruction)
+                val stack2 = stack.let(opcode.transform(_))
 
-            case lineNo: jlci.LineNumber =>
-              recur(todo, lineNo.line, done, stack, count)
+                recur
+                 (todo,
+                  Unset,
+                  Bytecode.Instruction(opcode, line, stack2, count) :: done,
+                  stack2,
+                  count + instruction.sizeInBytes)
 
-            case other: jlci.LocalVariable =>
-              recur(todo, line, done, stack, count)
+              case lineNo: jlci.LineNumber =>
+                recur(todo, lineNo.line, done, stack, count)
 
-            case other: jlci.LabelTarget =>
-              recur(todo, line, done, stack, count)
+              case other: jlci.LocalVariable =>
+                recur(todo, line, done, stack, count)
 
-            case other =>
-              panic(m"did not handle ${other.toString.tt}")
+              case other: jlci.LabelTarget =>
+                recur(todo, line, done, stack, count)
+
+              case other =>
+                panic(m"did not handle ${other.toString.tt}")
 
       val instructions = recur(code.elementList.nn.asScala.to(List), Unset, Nil, Nil, 0)
 

--- a/lib/mandible/src/core/mandible.Classfile.scala
+++ b/lib/mandible/src/core/mandible.Classfile.scala
@@ -88,7 +88,7 @@ class Classfile(data: Bytes):
             done:  List[Bytecode.Instruction],
             stack: Optional[List[Bytecode.Frame]],
             count: Int)
-      :     List[Bytecode.Instruction] =
+      : List[Bytecode.Instruction] =
         todo match
           case Nil => done.reverse
 

--- a/lib/mandible/src/core/mandible.Mandible.scala
+++ b/lib/mandible/src/core/mandible.Mandible.scala
@@ -54,7 +54,7 @@ import vacuous.*
 object Mandible:
   def disassemble[target: Type](block: Expr[target => Any], classloader: Expr[Classloader])
        (using Quotes)
-  :     Expr[Optional[Bytecode]] =
+  : Expr[Optional[Bytecode]] =
     import quotes.reflect.*
     given Realm = realm"mandible"
 

--- a/lib/mandible/src/core/mandible.Mandible.scala
+++ b/lib/mandible/src/core/mandible.Mandible.scala
@@ -55,18 +55,19 @@ object Mandible:
   def disassemble[target: Type](block: Expr[target => Any], classloader: Expr[Classloader])
        (using Quotes)
   : Expr[Optional[Bytecode]] =
-    import quotes.reflect.*
-    given Realm = realm"mandible"
 
-    val name = block.asTerm match
-      case Inlined(_, _, Block(List(DefDef(_, _, _, Some(Select(_, name)))), _)) => name
+      import quotes.reflect.*
+      given Realm = realm"mandible"
 
-      case _ =>
-        halt(m"this type of lambda is not supported")
+      val name = block.asTerm match
+        case Inlined(_, _, Block(List(DefDef(_, _, _, Some(Select(_, name)))), _)) => name
 
-    val classname: Text =
-      TypeRepr.of[target].classSymbol.get.fullName.sub(t".", t"/").nn+t".class"
+        case _ =>
+          halt(m"this type of lambda is not supported")
 
-    '{  val classfile = Classfile(${Expr(classname)})(using $classloader)
-        classfile.let(_.methods.find(_.name == ${Expr(name.tt)}).getOrElse(Unset))
-        . let(_.bytecode)  }
+      val classname: Text =
+        TypeRepr.of[target].classSymbol.get.fullName.sub(t".", t"/").nn+t".class"
+
+      '{  val classfile = Classfile(${Expr(classname)})(using $classloader)
+          classfile.let(_.methods.find(_.name == ${Expr(name.tt)}).getOrElse(Unset))
+          . let(_.bytecode)  }

--- a/lib/mercator/src/core/mercator-core.scala
+++ b/lib/mercator/src/core/mercator-core.scala
@@ -61,22 +61,25 @@ extension [monad[_], collection[element] <: Iterable[element], element]
   def sequence(using buildFrom: BuildFrom[List[element], element, collection[element]])
   : monad[collection[element]] =
 
-    def recur(todo: Iterable[monad[element]], accumulator: monad[List[element]])
-    : monad[List[element]] =
-      if todo.isEmpty then accumulator
-      else recur(todo.tail, accumulator.flatMap { xs => todo.head.map(_ :: xs) })
 
-    recur(elems, monad.point(List())).map(_.reverse.to(buildFrom.toFactory(Nil)))
+      def recur(todo: Iterable[monad[element]], accumulator: monad[List[element]])
+      : monad[List[element]] =
+
+          if todo.isEmpty then accumulator
+          else recur(todo.tail, accumulator.flatMap { xs => todo.head.map(_ :: xs) })
+
+
+      recur(elems, monad.point(List())).map(_.reverse.to(buildFrom.toFactory(Nil)))
+
 
 extension [collection[element] <: Iterable[element], element](elems: collection[element])
-
   def traverse[element2, monad[_]](lambda: element => monad[element2])
        (using monad:     Monad[monad],
               buildFrom: BuildFrom[List[element2], element2, collection[element2]])
   : monad[collection[element2]] =
 
-    def recur(todo: Iterable[element], accumulator: monad[List[element2]]): monad[List[element2]] =
-      if todo.isEmpty then accumulator
-      else recur(todo.tail, accumulator.flatMap { xs => lambda(todo.head).map(_ :: xs) })
+      def recur(todo: Iterable[element], accumulator: monad[List[element2]]): monad[List[element2]] =
+        if todo.isEmpty then accumulator
+        else recur(todo.tail, accumulator.flatMap { xs => lambda(todo.head).map(_ :: xs) })
 
-    recur(elems, monad.point(List())).map(_.reverse.to(buildFrom.toFactory(Nil)))
+      recur(elems, monad.point(List())).map(_.reverse.to(buildFrom.toFactory(Nil)))

--- a/lib/mercator/src/core/mercator-core.scala
+++ b/lib/mercator/src/core/mercator-core.scala
@@ -59,10 +59,10 @@ extension [monad[_], collection[element] <: Iterable[element], element]
           (using monad: Monad[monad])
 
   def sequence(using buildFrom: BuildFrom[List[element], element, collection[element]])
-  :     monad[collection[element]] =
+  : monad[collection[element]] =
 
     def recur(todo: Iterable[monad[element]], accumulator: monad[List[element]])
-    :     monad[List[element]] =
+    : monad[List[element]] =
       if todo.isEmpty then accumulator
       else recur(todo.tail, accumulator.flatMap { xs => todo.head.map(_ :: xs) })
 
@@ -73,7 +73,7 @@ extension [collection[element] <: Iterable[element], element](elems: collection[
   def traverse[element2, monad[_]](lambda: element => monad[element2])
        (using monad:     Monad[monad],
               buildFrom: BuildFrom[List[element2], element2, collection[element2]])
-  :     monad[collection[element2]] =
+  : monad[collection[element2]] =
 
     def recur(todo: Iterable[element], accumulator: monad[List[element2]]): monad[List[element2]] =
       if todo.isEmpty then accumulator

--- a/lib/mercator/src/core/mercator.Mercator.scala
+++ b/lib/mercator/src/core/mercator.Mercator.scala
@@ -123,7 +123,7 @@ object Mercator:
           ${functorExpr}.map(value)(lambda)
 
         def bind[value, value2](value: monad[value])(lambda: value => monad[value2])
-        :     monad[value2] =
+        : monad[value2] =
           ${'value.asTerm
             . select(flatMapMethods(0))
             . appliedToType(TypeRepr.of[value2])

--- a/lib/mercator/src/core/mercator.Mercator.scala
+++ b/lib/mercator/src/core/mercator.Mercator.scala
@@ -122,13 +122,16 @@ object Mercator:
              (value: monad[value])(lambda: value => value2): monad[value2] =
           ${functorExpr}.map(value)(lambda)
 
+
         def bind[value, value2](value: monad[value])(lambda: value => monad[value2])
         : monad[value2] =
-          ${'value.asTerm
-            . select(flatMapMethods(0))
-            . appliedToType(TypeRepr.of[value2])
-            . appliedTo('lambda.asTerm)
-            . asExprOf[monad[value2]]}
+
+            ${'value.asTerm
+              . select(flatMapMethods(0))
+              . appliedToType(TypeRepr.of[value2])
+              . appliedTo('lambda.asTerm)
+              . asExprOf[monad[value2]]}
+
     }
 
     if flatMapMethods.length == 1 then makeMonad

--- a/lib/merino/src/core/merino.JsonAst.scala
+++ b/lib/merino/src/core/merino.JsonAst.scala
@@ -101,7 +101,7 @@ object JsonAst:
   def apply
        (value: Long | Double | BigDecimal | String | (IArray[String], IArray[Any]) | IArray[Any]
                | Boolean | Null | Unset.type)
-  :     JsonAst =
+  : JsonAst =
 
     value
 

--- a/lib/merino/src/core/merino.JsonAst.scala
+++ b/lib/merino/src/core/merino.JsonAst.scala
@@ -103,7 +103,8 @@ object JsonAst:
                | Boolean | Null | Unset.type)
   : JsonAst =
 
-    value
+      value
+
 
   def parse[readable: Readable by Bytes](source: readable): JsonAst raises JsonParseError =
 

--- a/lib/metamorphose/src/core/metamorphose.Permutation.scala
+++ b/lib/metamorphose/src/core/metamorphose.Permutation.scala
@@ -83,7 +83,7 @@ case class Permutation(factoradic: Factoradic):
           list:    List[element],
           current: Int,
           result:  List[element])
-    :     List[element] =
+    : List[element] =
 
       lehmer match
         case head :: tail =>

--- a/lib/metamorphose/src/core/metamorphose.Permutation.scala
+++ b/lib/metamorphose/src/core/metamorphose.Permutation.scala
@@ -77,6 +77,7 @@ case class Permutation(factoradic: Factoradic):
     if sequence.length < lehmer.length then
       raise(PermutationError(PermutationError.Reason.TooShort(sequence.length, lehmer.length)))
 
+
     def recur
          (lehmer:  List[Int],
           prefix:  List[element],
@@ -85,17 +86,18 @@ case class Permutation(factoradic: Factoradic):
           result:  List[element])
     : List[element] =
 
-      lehmer match
-        case head :: tail =>
-          if current == head
-          then recur(tail, prefix, list.tail, current, list.head :: result)
-          else
-            if current < head
-            then recur(lehmer, list.head :: prefix, list.tail, current + 1, result)
-            else recur(lehmer, prefix.tail, prefix.head :: list, current - 1, result)
+        lehmer match
+          case head :: tail =>
+            if current == head
+            then recur(tail, prefix, list.tail, current, list.head :: result)
+            else
+              if current < head
+              then recur(lehmer, list.head :: prefix, list.tail, current + 1, result)
+              else recur(lehmer, prefix.tail, prefix.head :: list, current - 1, result)
 
-        case Nil =>
-          result.reverse
+          case Nil =>
+            result.reverse
+
 
     val prefix = sequence.length - lehmer.length
     sequence.take(prefix) ::: recur(lehmer, Nil, sequence.drop(prefix), 0, Nil)

--- a/lib/monotonous/src/core/monotonous-core.scala
+++ b/lib/monotonous/src/core/monotonous-core.scala
@@ -149,10 +149,13 @@ extension (value: Text)
   def deserialize[scheme <: Serialization](using deserializable: Deserializable in scheme): Bytes =
     deserializable.deserialize(value)
 
+
 extension (stream: Stream[Text])
   def deserialize[scheme <: Serialization](using deserializable: Deserializable in scheme)
   : Stream[Bytes] =
-    deserializable.deserialize(stream)
+
+      deserializable.deserialize(stream)
+
 
 extension [value: Encodable in Bytes](value: value)
   def serialize[scheme <: Serialization](using encodable: Serializable in scheme): Text =

--- a/lib/monotonous/src/core/monotonous-core.scala
+++ b/lib/monotonous/src/core/monotonous-core.scala
@@ -151,7 +151,7 @@ extension (value: Text)
 
 extension (stream: Stream[Text])
   def deserialize[scheme <: Serialization](using deserializable: Deserializable in scheme)
-  :     Stream[Bytes] =
+  : Stream[Bytes] =
     deserializable.deserialize(stream)
 
 extension [value: Encodable in Bytes](value: value)

--- a/lib/monotonous/src/core/monotonous.Deserializable.scala
+++ b/lib/monotonous/src/core/monotonous.Deserializable.scala
@@ -64,7 +64,7 @@ trait Deserializable:
 
 object Deserializable:
   def base[base <: Serialization](base: Int)(using alphabet: Alphabet[base])
-  :     Deserializable in base raises SerializationError =
+  : Deserializable in base raises SerializationError =
     new:
       override protected val atomicity = 8.lcm(base)/base
 

--- a/lib/monotonous/src/core/monotonous.Deserializable.scala
+++ b/lib/monotonous/src/core/monotonous.Deserializable.scala
@@ -65,36 +65,38 @@ trait Deserializable:
 object Deserializable:
   def base[base <: Serialization](base: Int)(using alphabet: Alphabet[base])
   : Deserializable in base raises SerializationError =
-    new:
-      override protected val atomicity = 8.lcm(base)/base
 
-      def deserialize(previous: Text, text: Text, index0: Int, last: Boolean): Bytes =
-        val padding: Char = if alphabet.padding then alphabet(1 << base) else '\u0000'
+      new:
+        override protected val atomicity = 8.lcm(base)/base
 
-        val length =
-          if last then text.where(_ != padding, bidi = Rtl).let(_.n0 + 1).or(text.length)*base/8
-          else ((text.length - index0)/atomicity)*atomicity*base/8
+        def deserialize(previous: Text, text: Text, index0: Int, last: Boolean): Bytes =
+          val padding: Char = if alphabet.padding then alphabet(1 << base) else '\u0000'
 
-        IArray.create[Byte](length): array =>
-          var source = if index0 < 0 then previous else text
+          val length =
+            if last then text.where(_ != padding, bidi = Rtl).let(_.n0 + 1).or(text.length)*base/8
+            else ((text.length - index0)/atomicity)*atomicity*base/8
 
-          def recur(buffer: Int = 0, bits: Int = 0, count: Int = 0, index0: Int = 0): Unit =
-            val index = if index0 >= 0 then index0 else index0 + source.length
-            if index == 0 then source = text
+          IArray.create[Byte](length): array =>
+            var source = if index0 < 0 then previous else text
 
-            if count < length then
-              val value: Int = alphabet.invert(index, source.s.charAt(index))
-              val next: Int = (buffer << base) | value
+            def recur(buffer: Int = 0, bits: Int = 0, count: Int = 0, index0: Int = 0): Unit =
+              val index = if index0 >= 0 then index0 else index0 + source.length
+              if index == 0 then source = text
 
-              if bits + base >= 8 then
-                array(count) = ((next >>> (bits + base - 8)) & 0xff).toByte
-                recur(next, bits + base - 8, count + 1, index0 + 1)
-              else recur(next, bits + base, count, index0 + 1)
+              if count < length then
+                val value: Int = alphabet.invert(index, source.s.charAt(index))
+                val next: Int = (buffer << base) | value
 
-          recur(index0 = index0)
+                if bits + base >= 8 then
+                  array(count) = ((next >>> (bits + base - 8)) & 0xff).toByte
+                  recur(next, bits + base - 8, count + 1, index0 + 1)
+                else recur(next, bits + base, count, index0 + 1)
 
-  given base256: (Alphabet[Base256], Tactic[SerializationError])
-        => Deserializable in Base256 = base(8)
+            recur(index0 = index0)
+
+
+  given base256: (Alphabet[Base256], Tactic[SerializationError]) => Deserializable in Base256 =
+    base(8)
 
   given base64: (Alphabet[Base64], Tactic[SerializationError]) => Deserializable in Base64 = base(6)
   given base32: (Alphabet[Base32], Tactic[SerializationError]) => Deserializable in Base32 = base(5)

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -58,27 +58,31 @@ class Matrix[element, rows <: Int, columns <: Int]
 
   override def toString(): String = t"[${elements.inspect}]".s
 
+
   @targetName("scalarMul")
   def * [right](right: right)
         (using multiplication: element is Multiplicable by right)
         (using ClassTag[multiplication.Result])
   : Matrix[multiplication.Result, rows, columns] =
 
-    val elements2 = IArray.create[multiplication.Result](elements.length): array =>
-      elements.indices.foreach: index =>
-        array(index) = elements(index)*right
 
-    new Matrix(rows, columns, elements2)
+      val elements2 = IArray.create[multiplication.Result](elements.length): array =>
+        elements.indices.foreach: index =>
+          array(index) = elements(index)*right
+
+      new Matrix(rows, columns, elements2)
+
 
   @targetName("scalarDiv")
   def / [right](right: right)(using div: element is Divisible by right)(using ClassTag[div.Result])
   : Matrix[div.Result, rows, columns] =
 
-    val elements2 = IArray.create[div.Result](elements.length): array =>
-      elements.indices.foreach: index =>
-        array(index) = elements(index)/right
+      val elements2 = IArray.create[div.Result](elements.length): array =>
+        elements.indices.foreach: index =>
+          array(index) = elements(index)/right
 
-    new Matrix(rows, columns, elements2)
+      new Matrix(rows, columns, elements2)
+
 
   @targetName("mul")
   def * [right, rightColumns <: Int: ValueOf]
@@ -91,15 +95,16 @@ class Matrix[element, rows <: Int, columns <: Int]
                classTag:       ClassTag[multiplication.Result])
   : Matrix[multiplication.Result, rows, rightColumns] =
 
-    val columns2 = valueOf[rightColumns]
-    val inner = valueOf[columns]
+      val columns2 = valueOf[rightColumns]
+      val inner = valueOf[columns]
 
-    val elements = IArray.create[multiplication.Result](rows*columns2): array =>
-      for row <- 0 until rows; column <- 0 until columns2
-      do array(columns2*column + row) =
-        (0 until inner).map { index => apply(row, index)*right(index, column) }.reduce(_ + _)
+      val elements = IArray.create[multiplication.Result](rows*columns2): array =>
+        for row <- 0 until rows; column <- 0 until columns2
+        do array(columns2*column + row) =
+          (0 until inner).map { index => apply(row, index)*right(index, column) }.reduce(_ + _)
 
-    new Matrix(rows, columns2, elements)
+      new Matrix(rows, columns2, elements)
+
 
 object Matrix:
   given showable: [element: Showable] => Text is Measurable => Matrix[element, ?, ?] is Showable =
@@ -132,23 +137,23 @@ object Matrix:
     Tuple.Union[Tuple.Map[rows, [tuple] =>> Tuple.Size[tuple & Tuple]]]
 
   transparent inline def apply[Rows <: Int: ValueOf, Columns <: Int: ValueOf](using erased Void)
-                          [element]
-                          (rows: Tuple)
-                          (using Constraint[rows.type, element],
+                           [element]
+                           (rows: Tuple)
+                           (using Constraint[rows.type, element],
                                  Columns =:= ColumnConstraint[rows.type],
                                  Rows =:= Tuple.Size[rows.type],
                                  ClassTag[element])
-      : Any =
+  : Any =
 
-    val rowCount: Int = valueOf[Rows]
-    val columnCount = valueOf[Columns]
+      val rowCount: Int = valueOf[Rows]
+      val columnCount = valueOf[Columns]
 
-    new Matrix[element, Rows, Columns]
-         (rowCount,
-          columnCount,
-          IArray.create[element](columnCount*rowCount): array =>
-            for row <- 0 until rowCount; column <- 0 until columnCount
-            do rows.productElement(row).asMatchable.absolve match
-              case tuple: Tuple =>
-                array(columnCount*row + column) =
-                  tuple.productElement(column).asInstanceOf[element])
+      new Matrix[element, Rows, Columns]
+           (rowCount,
+            columnCount,
+            IArray.create[element](columnCount*rowCount): array =>
+              for row <- 0 until rowCount; column <- 0 until columnCount
+              do rows.productElement(row).asMatchable.absolve match
+                case tuple: Tuple =>
+                  array(columnCount*row + column) =
+                    tuple.productElement(column).asInstanceOf[element])

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -62,7 +62,7 @@ class Matrix[element, rows <: Int, columns <: Int]
   def * [right](right: right)
         (using multiplication: element is Multiplicable by right)
         (using ClassTag[multiplication.Result])
-  :     Matrix[multiplication.Result, rows, columns] =
+  : Matrix[multiplication.Result, rows, columns] =
 
     val elements2 = IArray.create[multiplication.Result](elements.length): array =>
       elements.indices.foreach: index =>
@@ -72,7 +72,7 @@ class Matrix[element, rows <: Int, columns <: Int]
 
   @targetName("scalarDiv")
   def / [right](right: right)(using div: element is Divisible by right)(using ClassTag[div.Result])
-  :     Matrix[div.Result, rows, columns] =
+  : Matrix[div.Result, rows, columns] =
 
     val elements2 = IArray.create[div.Result](elements.length): array =>
       elements.indices.foreach: index =>
@@ -89,7 +89,7 @@ class Matrix[element, rows <: Int, columns <: Int]
                rowValue:       ValueOf[rows],
                columnValue:    ValueOf[columns],
                classTag:       ClassTag[multiplication.Result])
-  :     Matrix[multiplication.Result, rows, rightColumns] =
+  : Matrix[multiplication.Result, rows, rightColumns] =
 
     val columns2 = valueOf[rightColumns]
     val inner = valueOf[columns]

--- a/lib/mosquito/src/core/mosquito.Mosquito.scala
+++ b/lib/mosquito/src/core/mosquito.Mosquito.scala
@@ -129,11 +129,12 @@ object Mosquito:
                 subtraction:    multiplication.Result is Subtractable by multiplication.Result)
     : Vector[addition.Result, 3] =
 
-      val first = left.element(1)*right.element(2) - left.element(2)*right.element(1)
-      val second = left.element(2)*right.element(0) - left.element(0)*right.element(2)
-      val third = left.element(0)*right.element(1) - left.element(1)*right.element(0)
+        val first = left.element(1)*right.element(2) - left.element(2)*right.element(1)
+        val second = left.element(2)*right.element(0) - left.element(0)*right.element(2)
+        val third = left.element(0)*right.element(1) - left.element(1)*right.element(0)
 
-      first *: second *: third *: Zero
+        first *: second *: third *: Zero
+
 
   extension [size <: Int, left](left: Vector[left, size])
     def element(index: Int): left = left.toArray(index).asInstanceOf[left]
@@ -142,19 +143,21 @@ object Mosquito:
     def iarray: IArray[left] = left.toIArray.asInstanceOf[IArray[left]]
     def size(using ValueOf[size]): Int = valueOf[size]
 
+
     def norm
          (using multiplicable: left is Multiplicable by left,
-                addable:       multiplicable.Result is Addable by multiplicable.Result into
-                                multiplicable.Result,
+                addable:       multiplicable.Result is Addable by multiplicable.Result
+                                into multiplicable.Result,
                 rootable:      multiplicable.Result is Rootable[2] into left)
     : left =
 
-      def recur(sum: multiplicable.Result, i: Int): left =
-        if i == 0 then sum.sqrt else
-          val x2: multiplicable.Result = left.element(i)*left.element(i)
-          recur(addable.add(sum, x2), i - 1)
+        def recur(sum: multiplicable.Result, i: Int): left =
+          if i == 0 then sum.sqrt else
+            val x2: multiplicable.Result = left.element(i)*left.element(i)
+            recur(addable.add(sum, x2), i - 1)
 
-      recur(left.element(0)*left.element(0), size - 1)
+        recur(left.element(0)*left.element(0), size - 1)
+
 
     def map[left2](fn: left => left2): Vector[left2, size] =
       def recur(tuple: Tuple): Tuple = tuple match
@@ -163,6 +166,7 @@ object Mosquito:
 
       recur(left)
 
+
     def unitary[square]
          (using multiplicable: left is Multiplicable by left into square,
                 addable:       square is Addable by square into square,
@@ -170,13 +174,14 @@ object Mosquito:
                 divisible:     left is Divisible by left into Double)
     : Vector[Double, size] =
 
-      val magnitude: left = left.norm
+        val magnitude: left = left.norm
 
-      def recur(tuple: Tuple): Tuple = tuple match
-        case head *: tail => (head.asInstanceOf[left]/magnitude) *: recur(tail)
-        case _            => Zero
+        def recur(tuple: Tuple): Tuple = tuple match
+          case head *: tail => (head.asInstanceOf[left]/magnitude) *: recur(tail)
+          case _            => Zero
 
-      recur(left)
+        recur(left)
+
 
     def dot[right](right: Vector[right, size])
          (using multiply: left is Multiplicable by right,
@@ -185,12 +190,13 @@ object Mosquito:
                 equality: addable.Result =:= multiply.Result)
     : multiply.Result =
 
-      def recur(index: Int, sum: multiply.Result): multiply.Result =
-        if index < 0 then sum
-        else recur(index - 1, addable.add(sum, left.element(index)*right.element(index)))
+        def recur(index: Int, sum: multiply.Result): multiply.Result =
+          if index < 0 then sum
+          else recur(index - 1, addable.add(sum, left.element(index)*right.element(index)))
 
-      val start = size.value - 1
-      recur(start - 1, left.element(start)*right.element(start))
+        val start = size.value - 1
+        recur(start - 1, left.element(start)*right.element(start))
+
 
 extension [element](list: List[element])
   def slide(size: Int): Stream[Vector[element, size.type]] = list match

--- a/lib/mosquito/src/core/mosquito.Mosquito.scala
+++ b/lib/mosquito/src/core/mosquito.Mosquito.scala
@@ -127,7 +127,7 @@ object Mosquito:
          (using multiplication: left is Multiplicable by right,
                 addition:       multiplication.Result is Addable by multiplication.Result,
                 subtraction:    multiplication.Result is Subtractable by multiplication.Result)
-    :     Vector[addition.Result, 3] =
+    : Vector[addition.Result, 3] =
 
       val first = left.element(1)*right.element(2) - left.element(2)*right.element(1)
       val second = left.element(2)*right.element(0) - left.element(0)*right.element(2)
@@ -147,7 +147,7 @@ object Mosquito:
                 addable:       multiplicable.Result is Addable by multiplicable.Result into
                                 multiplicable.Result,
                 rootable:      multiplicable.Result is Rootable[2] into left)
-    :     left =
+    : left =
 
       def recur(sum: multiplicable.Result, i: Int): left =
         if i == 0 then sum.sqrt else
@@ -168,7 +168,7 @@ object Mosquito:
                 addable:       square is Addable by square into square,
                 rootable:      square is Rootable[2] into left,
                 divisible:     left is Divisible by left into Double)
-    :     Vector[Double, size] =
+    : Vector[Double, size] =
 
       val magnitude: left = left.norm
 
@@ -183,7 +183,7 @@ object Mosquito:
                 size:     ValueOf[size],
                 addable:  multiply.Result is Addable by multiply.Result,
                 equality: addable.Result =:= multiply.Result)
-    :     multiply.Result =
+    : multiply.Result =
 
       def recur(index: Int, sum: multiply.Result): multiply.Result =
         if index < 0 then sum

--- a/lib/nettlesome/src/core/nettlesome-core.scala
+++ b/lib/nettlesome/src/core/nettlesome-core.scala
@@ -53,10 +53,13 @@ extension [remote: Connectable](value: remote)
   infix def via [port](port: port): Endpoint[port] =
     Endpoint(remote.remote(value), port)
 
+
 extension [port](port: port)
   def serve[protocol: Protocolic over port](handler: protocol.Request ?=> protocol.Response)
   : protocol.Server =
-    protocol.server(port)(handler)
+
+      protocol.server(port)(handler)
+
 
 def internet[result](online: Boolean)(block: Internet ?=> result): result =
   block(using Internet(online))

--- a/lib/nettlesome/src/core/nettlesome-core.scala
+++ b/lib/nettlesome/src/core/nettlesome-core.scala
@@ -55,7 +55,7 @@ extension [remote: Connectable](value: remote)
 
 extension [port](port: port)
   def serve[protocol: Protocolic over port](handler: protocol.Request ?=> protocol.Response)
-  :     protocol.Server =
+  : protocol.Server =
     protocol.server(port)(handler)
 
 def internet[result](online: Boolean)(block: Internet ?=> result): result =

--- a/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
+++ b/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
@@ -162,7 +162,7 @@ object Nettlesome:
         recur(groups)
 
       def apply(byte0: Byte, byte1: Byte, byte2: Byte, byte3: Byte, byte4: Byte, byte5: Byte)
-      :     MacAddress =
+      : MacAddress =
 
         def recur(todo: List[Byte], done: Long): Long = todo match
           case head :: tail => recur(tail, (done << 8) + head)
@@ -233,7 +233,7 @@ object Nettlesome:
   case class Ipv6(highBits: Long, lowBits: Long)
 
   def portService(context: Expr[StringContext], tcp: Boolean)(using Quotes)
-  :     Expr[TcpPort | UdpPort] =
+  : Expr[TcpPort | UdpPort] =
     import quotes.reflect.*
 
     val id = context.valueOrAbort.parts.head.tt

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
@@ -72,7 +72,7 @@ object Nomenclature:
     inline def apply[platform](name: Text)(using nominative: platform is Nominative)
     : Name[platform] raises NameError =
 
-      inline disintersect[nominative.Constraint] match
-        case v => check[v.type](name)
+        inline disintersect[nominative.Constraint] match
+          case v => check[v.type](name)
 
-      name.asInstanceOf[Name[platform]]
+        name.asInstanceOf[Name[platform]]

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature.scala
@@ -70,7 +70,7 @@ object Nomenclature:
             check[tail](name)
 
     inline def apply[platform](name: Text)(using nominative: platform is Nominative)
-    :     Name[platform] raises NameError =
+    : Name[platform] raises NameError =
 
       inline disintersect[nominative.Constraint] match
         case v => check[v.type](name)

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -74,10 +74,13 @@ object Nomenclature2:
       case _ =>
         panic(m"StringContext did not contains Strings")
 
+
   def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])(using Quotes)
   : Expr[Boolean] =
-    parse[platform, name]
-    '{${Expr(constant[name])}.tt == $scrutinee}
+
+      parse[platform, name]
+      '{${Expr(constant[name])}.tt == $scrutinee}
+
 
   def constant[text <: String: Type](using Quotes): text =
     import quotes.reflect.*

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -75,7 +75,7 @@ object Nomenclature2:
         panic(m"StringContext did not contains Strings")
 
   def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])(using Quotes)
-  :     Expr[Boolean] =
+  : Expr[Boolean] =
     parse[platform, name]
     '{${Expr(constant[name])}.tt == $scrutinee}
 

--- a/lib/octogenarian/src/core/octogenarian.Git.scala
+++ b/lib/octogenarian/src/core/octogenarian.Git.scala
@@ -82,7 +82,7 @@ object Git:
               (Path on Posix) is Decodable in Text,
               Tactic[ExecError])
        (using command: GitCommand)
-  :     GitRepo logs GitEvent raises NameError =
+  : GitRepo logs GitEvent raises NameError =
     try
       throwErrors[PathError | IoError]:
         val bareOpt = if bare then sh"--bare" else sh""
@@ -103,7 +103,7 @@ object Git:
                      Tactic[GitError],
                      Tactic[ExecError],
                      WorkingDirectory)
-  :     GitProcess[GitRepo] logs GitEvent raises NameError =
+  : GitProcess[GitRepo] logs GitEvent raises NameError =
 
     val sourceText = inline source match
       case source: SshUrl => source.text
@@ -125,7 +125,7 @@ object Git:
                      Tactic[ExecError],
                      GitCommand)
      (using gitError: Tactic[GitError])
-  :     GitProcess[GitRepo] logs GitEvent raises PathError raises NameError =
+  : GitProcess[GitRepo] logs GitEvent raises PathError raises NameError =
 
     val sourceText = inline source match
       case source: SshUrl => source.text
@@ -141,7 +141,7 @@ object Git:
                (using gitError:         Tactic[GitError],
                       exec:             Tactic[ExecError],
                       workingDirectory: WorkingDirectory)
-  :     GitProcess[GitRepo] logs GitEvent raises NameError =
+  : GitProcess[GitRepo] logs GitEvent raises NameError =
 
     val gitRepo = init(targetPath)
     val fetch = gitRepo.fetch(1, source, commit)
@@ -163,7 +163,7 @@ object Git:
                  Tactic[ExecError],
                  GitCommand)
                 (using gitError: Tactic[GitError])
-  :     GitProcess[GitRepo] logs GitEvent raises PathError raises NameError =
+  : GitProcess[GitRepo] logs GitEvent raises PathError raises NameError =
 
     val target: Path on Posix =
       try targetPath.generic.decode[Path on Posix]

--- a/lib/octogenarian/src/core/octogenarian.GitRepo.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRepo.scala
@@ -61,7 +61,7 @@ import GitError.Reason.*
 object GitRepo:
   def apply[path: Abstractable across Paths into Text](path: path)
        (using gitError: Tactic[GitError], io: Tactic[IoError])
-  :     GitRepo raises PathError raises NameError =
+  : GitRepo raises PathError raises NameError =
 
     unsafely(path.generic.decode[Path on Posix]).pipe: path =>
       if !path.exists() then abort(GitError(RepoDoesNotExist))
@@ -77,32 +77,32 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
 
   @targetName("checkoutTag")
   def checkout(tag: GitTag)(using GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
     sh"$git $repoOptions checkout $tag".exec[Exit]()
 
   @targetName("checkoutBranch")
   def checkout(branch: GitBranch)(using GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
     sh"$git $repoOptions checkout $branch".exec[Exit]()
 
   @targetName("checkoutGitHash")
   def checkout(commit: GitHash)(using GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
     sh"$git $repoOptions checkout $commit".exec[Exit]()
 
   def pushTags()(using Internet, Tactic[GitError], GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
 
     sh"$git $repoOptions push --tags".exec[Exit]()
 
   def push()(using Internet, Tactic[GitError], GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
 
     sh"$git $repoOptions push".exec[Exit]()
 
   def switch(branch: GitBranch)
        (using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
 
     sh"$git $repoOptions switch $branch".exec[Exit]() match
       case Exit.Ok => ()
@@ -110,7 +110,7 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
 
   def pull()(using GitCommand, Internet, WorkingDirectory)
        (using gitError: Tactic[GitError], exec: Tactic[ExecError])
-  :     GitProcess[Unit] logs GitEvent =
+  : GitProcess[Unit] logs GitEvent =
 
     val process = sh"$git $repoOptions pull --progress".fork[Exit]()
 
@@ -122,7 +122,7 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
   def fetch(depth: Optional[Int] = Unset, repo: Text, refspec: Refspec)
        (using GitCommand, Internet, WorkingDirectory)
        (using gitError: Tactic[GitError], exec: Tactic[ExecError])
-  :     GitProcess[Unit] logs GitEvent /*^{gitError, exec}*/ =
+  : GitProcess[Unit] logs GitEvent /*^{gitError, exec}*/ =
 
     val depthOption = depth.lay(sh"") { depth => sh"--depth=$depth" }
     val command = sh"$git $repoOptions fetch $depthOption --progress $repo $refspec"
@@ -134,14 +134,14 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
         case failure       => abort(GitError(PullFailed))
 
   def commit(message: Text)(using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
-  :     Unit logs GitEvent =
+  : Unit logs GitEvent =
 
     sh"$git $repoOptions commit -m $message".exec[Exit]() match
       case Exit.Ok => ()
       case failure       => abort(GitError(CommitFailed))
 
   def branches()(using GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     List[GitBranch] logs GitEvent =
+  : List[GitBranch] logs GitEvent =
     sh"$git $repoOptions branch"
     . exec[Stream[Text]]()
     . map(_.skip(2))
@@ -154,14 +154,14 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
     GitBranch.unsafe(sh"$git $repoOptions branch --show-current".exec[String]().tt)
 
   def makeBranch(branch: GitBranch)(using GitCommand, WorkingDirectory)
-  :     Unit logs GitEvent raises ExecError raises GitError =
+  : Unit logs GitEvent raises ExecError raises GitError =
 
     sh"$git $repoOptions checkout -b $branch".exec[Exit]() match
       case Exit.Ok => ()
       case failure       => abort(GitError(BranchFailed))
 
   def add[path: Abstractable across Paths into Text](path: path)(using GitCommand, WorkingDirectory)
-  :     Unit logs GitEvent raises PathError raises NameError raises ExecError raises GitError =
+  : Unit logs GitEvent raises PathError raises NameError raises ExecError raises GitError =
 
     val relativePath: Relative =
       workTree.let: workTree =>
@@ -182,14 +182,14 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
   object config:
     def get[value: Decodable in Text](variable: Text)
          (using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
-    :     value logs GitEvent =
+    : value logs GitEvent =
       sh"$git $repoOptions config --get $variable".exec[Text]().decode[value]
 
   def tags()(using GitCommand, WorkingDirectory, Tactic[ExecError]): List[GitTag] logs GitEvent =
     sh"$git $repoOptions tag".exec[Stream[Text]]().to(List).map(GitTag.unsafe(_))
 
   def tag(name: GitTag)(using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
-  :     GitTag logs GitEvent =
+  : GitTag logs GitEvent =
     sh"$git $repoOptions tag $name".exec[Exit]() match
       case Exit.Ok => name
       case failure       => abort(GitError(TagFailed))
@@ -206,7 +206,7 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
           committer: Optional[Text]    = Unset,
           signature: List[Text]        = Nil,
           lines:     List[Text]        = Nil)
-    :     Stream[Commit] =
+    : Stream[Commit] =
 
       def commit(): Stream[Commit] =
         if hash.absent || tree.absent || author.absent || committer.absent then Stream()
@@ -268,11 +268,11 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
   def reflog(): Unit = ()
 
   def revParse(refspec: Refspec)(using GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     GitHash logs GitEvent =
+  : GitHash logs GitEvent =
     GitHash.unsafe(sh"$git $repoOptions rev-parse $refspec".exec[Text]())
 
   def status(ignored: Boolean = false)(using GitCommand, WorkingDirectory, Tactic[ExecError])
-  :     List[GitPathStatus] logs GitEvent =
+  : List[GitPathStatus] logs GitEvent =
     val ignoredParam = if ignored then sh"--ignored" else sh""
 
     def unescape(text: Text): Text = if text.at(Prim) != '"' then text else Text.construct:

--- a/lib/octogenarian/src/core/octogenarian.GitRepo.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRepo.scala
@@ -63,11 +63,12 @@ object GitRepo:
        (using gitError: Tactic[GitError], io: Tactic[IoError])
   : GitRepo raises PathError raises NameError =
 
-    unsafely(path.generic.decode[Path on Posix]).pipe: path =>
-      if !path.exists() then abort(GitError(RepoDoesNotExist))
+      unsafely(path.generic.decode[Path on Posix]).pipe: path =>
+        if !path.exists() then abort(GitError(RepoDoesNotExist))
 
-      if (path / n".git").exists() then GitRepo((path / n".git"), path)
-      else new GitRepo(path)
+        if (path / n".git").exists() then GitRepo((path / n".git"), path)
+        else new GitRepo(path)
+
 
 case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Unset):
 
@@ -75,106 +76,123 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
     case Unset          => sh"--git-dir=$gitDir"
     case workTree: Path => sh"--git-dir=$gitDir --work-tree=$workTree"
 
+
   @targetName("checkoutTag")
   def checkout(tag: GitTag)(using GitCommand, WorkingDirectory, Tactic[ExecError])
   : Unit logs GitEvent =
-    sh"$git $repoOptions checkout $tag".exec[Exit]()
+
+      sh"$git $repoOptions checkout $tag".exec[Exit]()
+
 
   @targetName("checkoutBranch")
   def checkout(branch: GitBranch)(using GitCommand, WorkingDirectory, Tactic[ExecError])
   : Unit logs GitEvent =
-    sh"$git $repoOptions checkout $branch".exec[Exit]()
+
+      sh"$git $repoOptions checkout $branch".exec[Exit]()
+
 
   @targetName("checkoutGitHash")
   def checkout(commit: GitHash)(using GitCommand, WorkingDirectory, Tactic[ExecError])
   : Unit logs GitEvent =
-    sh"$git $repoOptions checkout $commit".exec[Exit]()
+
+      sh"$git $repoOptions checkout $commit".exec[Exit]()
+
 
   def pushTags()(using Internet, Tactic[GitError], GitCommand, WorkingDirectory, Tactic[ExecError])
   : Unit logs GitEvent =
 
-    sh"$git $repoOptions push --tags".exec[Exit]()
+      sh"$git $repoOptions push --tags".exec[Exit]()
+
 
   def push()(using Internet, Tactic[GitError], GitCommand, WorkingDirectory, Tactic[ExecError])
   : Unit logs GitEvent =
 
-    sh"$git $repoOptions push".exec[Exit]()
+      sh"$git $repoOptions push".exec[Exit]()
+
 
   def switch(branch: GitBranch)
        (using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
   : Unit logs GitEvent =
 
-    sh"$git $repoOptions switch $branch".exec[Exit]() match
-      case Exit.Ok => ()
-      case failure       => abort(GitError(CannotSwitchBranch))
+      sh"$git $repoOptions switch $branch".exec[Exit]() match
+        case Exit.Ok => ()
+        case failure       => abort(GitError(CannotSwitchBranch))
+
 
   def pull()(using GitCommand, Internet, WorkingDirectory)
        (using gitError: Tactic[GitError], exec: Tactic[ExecError])
   : GitProcess[Unit] logs GitEvent =
 
-    val process = sh"$git $repoOptions pull --progress".fork[Exit]()
+      val process = sh"$git $repoOptions pull --progress".fork[Exit]()
 
-    GitProcess[Unit](Git.progress(process)):
-      process.await() match
-        case Exit.Ok => ()
-        case failure       => abort(GitError(PullFailed))
+      GitProcess[Unit](Git.progress(process)):
+        process.await() match
+          case Exit.Ok => ()
+          case failure       => abort(GitError(PullFailed))
+
 
   def fetch(depth: Optional[Int] = Unset, repo: Text, refspec: Refspec)
        (using GitCommand, Internet, WorkingDirectory)
        (using gitError: Tactic[GitError], exec: Tactic[ExecError])
   : GitProcess[Unit] logs GitEvent /*^{gitError, exec}*/ =
 
-    val depthOption = depth.lay(sh"") { depth => sh"--depth=$depth" }
-    val command = sh"$git $repoOptions fetch $depthOption --progress $repo $refspec"
-    val process = command.fork[Exit]()
+      val depthOption = depth.lay(sh"") { depth => sh"--depth=$depth" }
+      val command = sh"$git $repoOptions fetch $depthOption --progress $repo $refspec"
+      val process = command.fork[Exit]()
 
-    GitProcess[Unit](Git.progress(process)):
-      process.await() match
-        case Exit.Ok => ()
-        case failure       => abort(GitError(PullFailed))
+      GitProcess[Unit](Git.progress(process)):
+        process.await() match
+          case Exit.Ok => ()
+          case failure       => abort(GitError(PullFailed))
+
 
   def commit(message: Text)(using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
   : Unit logs GitEvent =
 
-    sh"$git $repoOptions commit -m $message".exec[Exit]() match
-      case Exit.Ok => ()
-      case failure       => abort(GitError(CommitFailed))
+      sh"$git $repoOptions commit -m $message".exec[Exit]() match
+        case Exit.Ok => ()
+        case failure       => abort(GitError(CommitFailed))
+
 
   def branches()(using GitCommand, WorkingDirectory, Tactic[ExecError])
   : List[GitBranch] logs GitEvent =
-    sh"$git $repoOptions branch"
-    . exec[Stream[Text]]()
-    . map(_.skip(2))
-    . to(List)
-    . map(GitBranch.unsafe(_))
+
+      sh"$git $repoOptions branch"
+      . exec[Stream[Text]]()
+      . map(_.skip(2))
+      . to(List)
+      . map(GitBranch.unsafe(_))
 
   // FIXME: this uses an `Executor[String]` instead of an `Executor[Text]` because, for some
   // reason, the latter captures the `WorkingDirectory` parameter
   def branch()(using GitCommand, WorkingDirectory, Tactic[ExecError]): GitBranch logs GitEvent =
     GitBranch.unsafe(sh"$git $repoOptions branch --show-current".exec[String]().tt)
 
+
   def makeBranch(branch: GitBranch)(using GitCommand, WorkingDirectory)
   : Unit logs GitEvent raises ExecError raises GitError =
 
-    sh"$git $repoOptions checkout -b $branch".exec[Exit]() match
-      case Exit.Ok => ()
-      case failure       => abort(GitError(BranchFailed))
+      sh"$git $repoOptions checkout -b $branch".exec[Exit]() match
+        case Exit.Ok => ()
+        case failure       => abort(GitError(BranchFailed))
+
 
   def add[path: Abstractable across Paths into Text](path: path)(using GitCommand, WorkingDirectory)
   : Unit logs GitEvent raises PathError raises NameError raises ExecError raises GitError =
 
-    val relativePath: Relative =
-      workTree.let: workTree =>
-        safely(path.generic.decode[Path on Posix].relativeTo(workTree)).or:
-          abort(GitError(AddFailed))
+      val relativePath: Relative =
+        workTree.let: workTree =>
+          safely(path.generic.decode[Path on Posix].relativeTo(workTree)).or:
+            abort(GitError(AddFailed))
 
-      . or(abort(GitError(NoWorkTree)))
+        . or(abort(GitError(NoWorkTree)))
 
-    val command = sh"$git $repoOptions add $relativePath"
+      val command = sh"$git $repoOptions add $relativePath"
 
-    command.exec[Exit]() match
-      case Exit.Ok => ()
-      case failure       => abort(GitError(AddFailed))
+      command.exec[Exit]() match
+        case Exit.Ok => ()
+        case failure       => abort(GitError(AddFailed))
+
 
   def reset(): Unit = ()
   def mv(): Unit = ()
@@ -183,16 +201,21 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
     def get[value: Decodable in Text](variable: Text)
          (using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
     : value logs GitEvent =
-      sh"$git $repoOptions config --get $variable".exec[Text]().decode[value]
+
+        sh"$git $repoOptions config --get $variable".exec[Text]().decode[value]
+
 
   def tags()(using GitCommand, WorkingDirectory, Tactic[ExecError]): List[GitTag] logs GitEvent =
     sh"$git $repoOptions tag".exec[Stream[Text]]().to(List).map(GitTag.unsafe(_))
 
+
   def tag(name: GitTag)(using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError])
   : GitTag logs GitEvent =
-    sh"$git $repoOptions tag $name".exec[Exit]() match
-      case Exit.Ok => name
-      case failure       => abort(GitError(TagFailed))
+
+      sh"$git $repoOptions tag $name".exec[Exit]() match
+        case Exit.Ok => name
+        case failure       => abort(GitError(TagFailed))
+
 
   private def parsePem(text: Text): Optional[Pem] = safely(Pem.parse(text))
 
@@ -208,110 +231,116 @@ case class GitRepo(gitDir: Path on Posix, workTree: Optional[Path on Posix] = Un
           lines:     List[Text]        = Nil)
     : Stream[Commit] =
 
-      def commit(): Stream[Commit] =
-        if hash.absent || tree.absent || author.absent || committer.absent then Stream()
-        else
-          given unsafe: Unsafe = Unsafe
-          val pem = parsePem(signature.join(t"\n"))
+        def commit(): Stream[Commit] =
+          if hash.absent || tree.absent || author.absent || committer.absent then Stream()
+          else
+            given unsafe: Unsafe = Unsafe
+            val pem = parsePem(signature.join(t"\n"))
 
-          Stream:
-            Commit
-             (hash.vouch,
-              tree.vouch,
-              parents.reverse,
-              author.vouch,
-              committer.vouch,
-              pem,
-              lines.reverse)
+            Stream:
+              Commit
+               (hash.vouch,
+                tree.vouch,
+                parents.reverse,
+                author.vouch,
+                committer.vouch,
+                pem,
+                lines.reverse)
 
-      def read(stream: Stream[Text], lines: List[Text]): (List[Text], Stream[Text]) =
+        def read(stream: Stream[Text], lines: List[Text]): (List[Text], Stream[Text]) =
+          stream match
+            case r" $line(.*)" #:: tail => read(tail, line :: lines)
+            case _                      => (lines.reverse, stream)
+
         stream match
-          case r" $line(.*)" #:: tail => read(tail, line :: lines)
-          case _                      => (lines.reverse, stream)
+          case head #:: tail => head match
+            case t"" =>
+              recur(tail, hash, tree, parents, author, committer, signature, lines)
 
-      stream match
-        case head #:: tail => head match
-          case t"" =>
-            recur(tail, hash, tree, parents, author, committer, signature, lines)
+            case r"commit $hash(.{40})" =>
+              commit() #::: recur(tail, GitHash.unsafe(hash), Unset, Nil, Unset, Unset, Nil, Nil)
 
-          case r"commit $hash(.{40})" =>
-            commit() #::: recur(tail, GitHash.unsafe(hash), Unset, Nil, Unset, Unset, Nil, Nil)
+            case r"tree $tree(.{40})" =>
+              recur(tail, hash, GitHash.unsafe(tree), parents, author, committer, signature, lines)
 
-          case r"tree $tree(.{40})" =>
-            recur(tail, hash, GitHash.unsafe(tree), parents, author, committer, signature, lines)
+            case r"parent $parent(.{40})" =>
+              val parents2 = GitHash.unsafe(parent) :: parents
+              recur(tail, hash, tree, parents2, author, committer, signature, lines)
 
-          case r"parent $parent(.{40})" =>
-            val parents2 = GitHash.unsafe(parent) :: parents
-            recur(tail, hash, tree, parents2, author, committer, signature, lines)
+            case r"author $author(.*) $timestamp([0-9]+) $time(.....)" =>
+              recur(tail, hash, tree, parents, author, committer, signature, lines)
 
-          case r"author $author(.*) $timestamp([0-9]+) $time(.....)" =>
-            recur(tail, hash, tree, parents, author, committer, signature, lines)
+            case r"committer $committer(.*) $timestamp([0-9]+) $time(.....)" =>
+              recur(tail, hash, tree, parents, author, committer, signature, lines)
 
-          case r"committer $committer(.*) $timestamp([0-9]+) $time(.....)" =>
-            recur(tail, hash, tree, parents, author, committer, signature, lines)
+            case r"gpgsig $start(.*)" =>
+              val (signature, rest) = read(tail, Nil)
+              recur(rest, hash, tree, parents, author, committer, start :: signature, lines)
 
-          case r"gpgsig $start(.*)" =>
-            val (signature, rest) = read(tail, Nil)
-            recur(rest, hash, tree, parents, author, committer, start :: signature, lines)
+            case r"    $line(.*)" =>
+              recur(tail, hash, tree, parents, author, committer, signature, line :: lines)
 
-          case r"    $line(.*)" =>
-            recur(tail, hash, tree, parents, author, committer, signature, line :: lines)
+            case other =>
+              recur(tail, hash, tree, parents, author, committer, signature, lines)
 
-          case other =>
-            recur(tail, hash, tree, parents, author, committer, signature, lines)
-
-        case _ =>
-          commit()
+          case _ =>
+            commit()
 
     recur(sh"$git $repoOptions log --format=raw --color=never".exec[Stream[Text]]())
 
+
   def reflog(): Unit = ()
+
 
   def revParse(refspec: Refspec)(using GitCommand, WorkingDirectory, Tactic[ExecError])
   : GitHash logs GitEvent =
-    GitHash.unsafe(sh"$git $repoOptions rev-parse $refspec".exec[Text]())
+
+      GitHash.unsafe(sh"$git $repoOptions rev-parse $refspec".exec[Text]())
+
 
   def status(ignored: Boolean = false)(using GitCommand, WorkingDirectory, Tactic[ExecError])
   : List[GitPathStatus] logs GitEvent =
-    val ignoredParam = if ignored then sh"--ignored" else sh""
 
-    def unescape(text: Text): Text = if text.at(Prim) != '"' then text else Text.construct:
-      def recur(index: Int, escape: Boolean): Unit =
-        if index < text.length then
-          text.s.charAt(index) match
-            case '\\' =>
-              if escape then append('\\')
-              recur(index + 1, !escape)
+      val ignoredParam = if ignored then sh"--ignored" else sh""
 
-            case '"' =>
-              if escape then
-                append('"')
+      def unescape(text: Text): Text = if text.at(Prim) != '"' then text else Text.construct:
+        def recur(index: Int, escape: Boolean): Unit =
+          if index < text.length then
+            text.s.charAt(index) match
+              case '\\' =>
+                if escape then append('\\')
+                recur(index + 1, !escape)
+
+              case '"' =>
+                if escape then
+                  append('"')
+                  recur(index + 1, false)
+
+              case char =>
+                append(char)
                 recur(index + 1, false)
 
-            case char =>
-              append(char)
-              recur(index + 1, false)
+        recur(1, false)
 
-      recur(1, false)
+      def key(character: Text): Optional[GitStatus] = character match
+        case t" " => Unset
+        case t"M" => GitStatus.Updated
+        case t"A" => GitStatus.Added
+        case t"D" => GitStatus.Deleted
+        case t"R" => GitStatus.Renamed
+        case t"C" => GitStatus.Copied
+        case t"U" => GitStatus.Unmerged
+        case t"?" => GitStatus.Untracked
+        case t"!" => GitStatus.Ignored
+        case _    => Unset
 
-    def key(character: Text): Optional[GitStatus] = character match
-      case t" " => Unset
-      case t"M" => GitStatus.Updated
-      case t"A" => GitStatus.Added
-      case t"D" => GitStatus.Deleted
-      case t"R" => GitStatus.Renamed
-      case t"C" => GitStatus.Copied
-      case t"U" => GitStatus.Unmerged
-      case t"?" => GitStatus.Untracked
-      case t"!" => GitStatus.Ignored
-      case _    => Unset
+      sh"$git $repoOptions status --porcelain $ignoredParam".exec[List[Text]]().flatMap:
+        case r"$key1([ ACDMRU?!])$key2([ ADMU?!]) $path(.*)$path2( -> (.*))?" =>
+          val optionalPath = path2.let(_.skip(4)).let(unescape)
+          List(GitPathStatus(key(key1), key(key2), unescape(path), optionalPath))
 
-    sh"$git $repoOptions status --porcelain $ignoredParam".exec[List[Text]]().flatMap:
-      case r"$key1([ ACDMRU?!])$key2([ ADMU?!]) $path(.*)$path2( -> (.*))?" =>
-        val optionalPath = path2.let(_.skip(4)).let(unescape)
-        List(GitPathStatus(key(key1), key(key2), unescape(path), optionalPath))
+        case _ =>
+          Nil
 
-      case _ =>
-        Nil
 
   def diff(): Unit = ()

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -57,7 +57,7 @@ object Panopticon:
   extension [from, path <: Tuple, to](lens: Lens[from, path, to])
     @targetName("append")
     infix def ++ [to2, path2 <: Tuple](right: Lens[to, path2, to2])
-    :     Lens[from, Tuple.Concat[path, path2], to2] =
+    : Lens[from, Tuple.Concat[path, path2], to2] =
 
       Lens.make()
 
@@ -78,7 +78,7 @@ object Panopticon:
         path
 
   def getPaths[tuple <: Tuple: Type](paths: List[List[String]] = Nil)(using Quotes)
-  :     List[List[String]] =
+  : List[List[String]] =
     Type.of[tuple] match
       case '[type tail <: Tuple; head *: tail] =>
         Type.of[head].absolve match
@@ -112,7 +112,7 @@ object Panopticon:
 
   def set[from: Type, path <: Tuple: Type, to: Type](value: Expr[from], newValue: Expr[to])
        (using Quotes)
-  :     Expr[from] =
+  : Expr[from] =
 
     import quotes.reflect.*
 

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -59,7 +59,8 @@ object Panopticon:
     infix def ++ [to2, path2 <: Tuple](right: Lens[to, path2, to2])
     : Lens[from, Tuple.Concat[path, path2], to2] =
 
-      Lens.make()
+        Lens.make()
+
 
     inline def apply(aim: from): to = ${Panopticon.get[from, path, to]('aim)}
 
@@ -77,16 +78,19 @@ object Panopticon:
       case _ =>
         path
 
+
   def getPaths[tuple <: Tuple: Type](paths: List[List[String]] = Nil)(using Quotes)
   : List[List[String]] =
-    Type.of[tuple] match
-      case '[type tail <: Tuple; head *: tail] =>
-        Type.of[head].absolve match
-          case '[type tupleType <: Tuple; tupleType] =>
-            getPath[tupleType]() :: getPaths[tail]()
 
-      case _ =>
-        halt(m"unexpectedly did not match")
+      Type.of[tuple] match
+        case '[type tail <: Tuple; head *: tail] =>
+          Type.of[head].absolve match
+            case '[type tupleType <: Tuple; tupleType] =>
+              getPath[tupleType]() :: getPaths[tail]()
+
+        case _ =>
+          halt(m"unexpectedly did not match")
+
 
   def get[from: Type, path <: Tuple: Type, to: Type](value: Expr[from])(using Quotes): Expr[to] =
 
@@ -110,35 +114,37 @@ object Panopticon:
 
     select[from](getPath[path](), value).asExprOf[to]
 
+
   def set[from: Type, path <: Tuple: Type, to: Type](value: Expr[from], newValue: Expr[to])
        (using Quotes)
   : Expr[from] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    val fromTypeRepr: TypeRepr = TypeRepr.of[from]
+      val fromTypeRepr: TypeRepr = TypeRepr.of[from]
 
-    def rewrite(path: List[String], term: Term): Term =
-      path match
-        case Nil =>
-          term
+      def rewrite(path: List[String], term: Term): Term =
+        path match
+          case Nil =>
+            term
 
-        case next :: tail =>
-          val newParams = term.tpe.typeSymbol.caseFields.map: field =>
-            if field.name == next then
-              if tail == Nil then newValue.asTerm else rewrite(tail, Select(term, field))
-            else Select(term, field)
+          case next :: tail =>
+            val newParams = term.tpe.typeSymbol.caseFields.map: field =>
+              if field.name == next then
+                if tail == Nil then newValue.asTerm else rewrite(tail, Select(term, field))
+              else Select(term, field)
 
-          term.tpe.classSymbol match
-            case Some(classSymbol) =>
-              Apply
-               (Select(New(TypeIdent(classSymbol)), term.tpe.typeSymbol.primaryConstructor),
-                newParams)
+            term.tpe.classSymbol match
+              case Some(classSymbol) =>
+                Apply
+                 (Select(New(TypeIdent(classSymbol)), term.tpe.typeSymbol.primaryConstructor),
+                  newParams)
 
-            case None =>
-              halt(m"the type $fromTypeRepr does not have a primary constructor")
+              case None =>
+                halt(m"the type $fromTypeRepr does not have a primary constructor")
 
-    rewrite(getPath[path](), value.asTerm).asExprOf[from]
+      rewrite(getPath[path](), value.asTerm).asExprOf[from]
+
 
   def dereference[aim: Type, tuple <: Tuple: Type](member: Expr[String])(using Quotes): Expr[Any] =
     import quotes.reflect.*

--- a/lib/parasite/src/core/parasite-core.scala
+++ b/lib/parasite/src/core/parasite-core.scala
@@ -83,13 +83,15 @@ def daemon(using Codepoint)(evaluate: Worker ?=> Unit)(using Monitor, Codicil): 
 def async[result](using Codepoint)(evaluate: Worker ?=> result)(using Monitor, Codicil)
 : Task[result] =
 
-  Task(evaluate(using _), daemon = false, name = Unset)
+    Task(evaluate(using _), daemon = false, name = Unset)
+
 
 def task[result](using Codepoint)(name: into Text)(evaluate: Worker ?=> result)
      (using Monitor, Codicil)
 : Task[result] =
 
-  Task(evaluate(using _), daemon = false, name = name)
+    Task(evaluate(using _), daemon = false, name = name)
+
 
 def relent[result]()(using Worker): Unit = monitor.relent()
 def cancel[result]()(using Monitor): Unit = monitor.cancel()
@@ -103,9 +105,12 @@ def delay[generic: GenericDuration](duration: generic)(using Monitor): Unit =
 def sleep[instant: Abstractable across Instants into Long](instant: instant)(using Monitor): Unit =
   monitor.snooze(instant.generic - jl.System.currentTimeMillis)
 
+
 def hibernate[instant: Abstractable across Instants into Long](instant: instant)(using Monitor)
 : Unit =
+
   while instant.generic > jl.System.currentTimeMillis do sleep(instant.generic)
+
 
 extension [result](tasks: Seq[Task[result]])
   def sequence(using Monitor, Codicil): Task[Seq[result]] raises AsyncError =
@@ -122,32 +127,37 @@ extension [result](stream: Stream[result])
   def concurrent(using Monitor, Codicil): Stream[result] raises AsyncError =
     if async(stream.isEmpty).await() then Stream() else stream.head #:: stream.tail.concurrent
 
+
 def supervise[result](block: Monitor ?=> result)(using model: ThreadModel, codepoint: Codepoint)
 : result raises AsyncError =
-  block(using model.supervisor())
+
+    block(using model.supervisor())
+
 
 def retry[value](evaluate: (surrender: () => Nothing, persevere: () => Nothing) ?=> value)
    (using Tenacity, Monitor)
 : value raises RetryError =
 
-  @tailrec
-  def recur(attempt: Ordinal): value =
-    boundary[Perseverance[value]]: label ?=>
-      sleep(summon[Tenacity].delay(attempt).or(abort(RetryError(attempt.n1))))
-      def surrender(): Nothing = boundary.break(Perseverance.Surrender)
-      def persevere(): Nothing = boundary.break(Perseverance.Persevere)
+    @tailrec
+    def recur(attempt: Ordinal): value =
+      boundary[Perseverance[value]]: label ?=>
+        sleep(summon[Tenacity].delay(attempt).or(abort(RetryError(attempt.n1))))
+        def surrender(): Nothing = boundary.break(Perseverance.Surrender)
+        def persevere(): Nothing = boundary.break(Perseverance.Persevere)
 
-      Perseverance.Prevail(evaluate(using surrender, persevere))
+        Perseverance.Prevail(evaluate(using surrender, persevere))
 
-    . match
-        case Perseverance.Surrender      => abort(RetryError(attempt.n1))
-        case Perseverance.Prevail(value) => value
-        case Perseverance.Persevere      => recur(attempt + 1)
+      . match
+          case Perseverance.Surrender      => abort(RetryError(attempt.n1))
+          case Perseverance.Prevail(value) => value
+          case Perseverance.Persevere      => recur(attempt + 1)
 
-  recur(Prim)
+    recur(Prim)
+
 
 extension [target](value: target)
   def intercept[event](using interceptable: event is Interceptable onto target)
        (action: (event: event) ?=> Unit)
   : Hook =
-    Hook(interceptable.register(value, action(using _)))
+
+      Hook(interceptable.register(value, action(using _)))

--- a/lib/parasite/src/core/parasite-core.scala
+++ b/lib/parasite/src/core/parasite-core.scala
@@ -81,13 +81,13 @@ def daemon(using Codepoint)(evaluate: Worker ?=> Unit)(using Monitor, Codicil): 
   Daemon(evaluate(using _))
 
 def async[result](using Codepoint)(evaluate: Worker ?=> result)(using Monitor, Codicil)
-:     Task[result] =
+: Task[result] =
 
   Task(evaluate(using _), daemon = false, name = Unset)
 
 def task[result](using Codepoint)(name: into Text)(evaluate: Worker ?=> result)
      (using Monitor, Codicil)
-:     Task[result] =
+: Task[result] =
 
   Task(evaluate(using _), daemon = false, name = name)
 
@@ -104,7 +104,7 @@ def sleep[instant: Abstractable across Instants into Long](instant: instant)(usi
   monitor.snooze(instant.generic - jl.System.currentTimeMillis)
 
 def hibernate[instant: Abstractable across Instants into Long](instant: instant)(using Monitor)
-:     Unit =
+: Unit =
   while instant.generic > jl.System.currentTimeMillis do sleep(instant.generic)
 
 extension [result](tasks: Seq[Task[result]])
@@ -123,12 +123,12 @@ extension [result](stream: Stream[result])
     if async(stream.isEmpty).await() then Stream() else stream.head #:: stream.tail.concurrent
 
 def supervise[result](block: Monitor ?=> result)(using model: ThreadModel, codepoint: Codepoint)
-:     result raises AsyncError =
+: result raises AsyncError =
   block(using model.supervisor())
 
 def retry[value](evaluate: (surrender: () => Nothing, persevere: () => Nothing) ?=> value)
    (using Tenacity, Monitor)
-:     value raises RetryError =
+: value raises RetryError =
 
   @tailrec
   def recur(attempt: Ordinal): value =
@@ -149,5 +149,5 @@ def retry[value](evaluate: (surrender: () => Nothing, persevere: () => Nothing) 
 extension [target](value: target)
   def intercept[event](using interceptable: event is Interceptable onto target)
        (action: (event: event) ?=> Unit)
-  :     Hook =
+  : Hook =
     Hook(interceptable.register(value, action(using _)))

--- a/lib/parasite/src/core/parasite.Daemon.scala
+++ b/lib/parasite/src/core/parasite.Daemon.scala
@@ -42,7 +42,7 @@ import vacuous.*
 object Daemon:
   def apply(evaluate: Worker => Unit)
        (using monitor: Monitor, codepoint: Codepoint, codicil: Codicil)
-  :     Daemon =
+  : Daemon =
     inline def evaluate0: Worker => Unit = evaluate
 
     new Worker(codepoint, monitor, codicil) with Daemon:

--- a/lib/parasite/src/core/parasite.Daemon.scala
+++ b/lib/parasite/src/core/parasite.Daemon.scala
@@ -43,13 +43,15 @@ object Daemon:
   def apply(evaluate: Worker => Unit)
        (using monitor: Monitor, codepoint: Codepoint, codicil: Codicil)
   : Daemon =
-    inline def evaluate0: Worker => Unit = evaluate
 
-    new Worker(codepoint, monitor, codicil) with Daemon:
-      type Result = Unit
-      def name: Optional[Text] = Unset
-      def daemon: Boolean = true
-      def evaluate(worker: Worker): Result = evaluate0(worker)
+      inline def evaluate0: Worker => Unit = evaluate
+
+      new Worker(codepoint, monitor, codicil) with Daemon:
+        type Result = Unit
+        def name: Optional[Text] = Unset
+        def daemon: Boolean = true
+        def evaluate(worker: Worker): Result = evaluate0(worker)
+
 
 trait Daemon:
   def attend(): Unit

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -142,15 +142,18 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
       case Failed(_)       => panic(m"should not be relenting after failure")
       case Cancelled       => panic(m"should not be relenting after cancellation")
 
+
   def map[result2](lambda: Result => result2)(using Monitor, Codicil)
   : Task[result2] raises AsyncError =
 
-    async(lambda(await()))
+      async(lambda(await()))
+
 
   def bind[result2](lambda: Result => Task[result2])(using Monitor, Codicil)
   : Task[result2] raises AsyncError =
 
-    async(lambda(await()).await())
+      async(lambda(await()).await())
+
 
   def cancel(): Unit =
     val state2 = state.updateAndGet:

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -143,12 +143,12 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
       case Cancelled       => panic(m"should not be relenting after cancellation")
 
   def map[result2](lambda: Result => result2)(using Monitor, Codicil)
-  :     Task[result2] raises AsyncError =
+  : Task[result2] raises AsyncError =
 
     async(lambda(await()))
 
   def bind[result2](lambda: Result => Task[result2])(using Monitor, Codicil)
-  :     Task[result2] raises AsyncError =
+  : Task[result2] raises AsyncError =
 
     async(lambda(await()).await())
 

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -44,7 +44,7 @@ import vacuous.*
 object Task:
   def apply[result](evaluate: Worker => result, daemon: Boolean, name: Optional[Text])
        (using monitor: Monitor, codepoint: Codepoint, codicil: Codicil)
-  :     Task[result] =
+  : Task[result] =
     inline def evaluate0: Worker => result = evaluate
     inline def name0: Optional[Text] = name
 
@@ -72,7 +72,7 @@ trait Task[+result]:
   def await[duration: GenericDuration](duration: duration): result raises AsyncError
 
   def bind[result2](lambda: result => Task[result2])(using Monitor, Codicil)
-  :     Task[result2] raises AsyncError
+  : Task[result2] raises AsyncError
 
   def map[result2](lambda: result => result2)(using Monitor, Codicil)
-  :     Task[result2] raises AsyncError
+  : Task[result2] raises AsyncError

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -45,14 +45,16 @@ object Task:
   def apply[result](evaluate: Worker => result, daemon: Boolean, name: Optional[Text])
        (using monitor: Monitor, codepoint: Codepoint, codicil: Codicil)
   : Task[result] =
-    inline def evaluate0: Worker => result = evaluate
-    inline def name0: Optional[Text] = name
 
-    new Worker(codepoint, monitor, codicil) with Task[result]:
-      type Result = result
-      def name: Optional[Text] = name0
-      def daemon: Boolean = false
-      def evaluate(worker: Worker): Result = evaluate0(worker)
+      inline def evaluate0: Worker => result = evaluate
+      inline def name0: Optional[Text] = name
+
+      new Worker(codepoint, monitor, codicil) with Task[result]:
+        type Result = result
+        def name: Optional[Text] = name0
+        def daemon: Boolean = false
+        def evaluate(worker: Worker): Result = evaluate0(worker)
+
 
   given monad: (Monitor, Codicil, Tactic[AsyncError]) => Monad[Task]:
     def bind[value, value2](value: Task[value])(lambda: value => Task[value2]): Task[value2] =

--- a/lib/parasite/src/core/parasite.Timeout.scala
+++ b/lib/parasite/src/core/parasite.Timeout.scala
@@ -45,15 +45,16 @@ object Timeout:
   def apply[duration: GenericDuration](timeout0: duration)(action: => Unit)(using Monitor, Codicil)
   : Timeout =
 
-    val timeout = duration.milliseconds(timeout0)
+      val timeout = duration.milliseconds(timeout0)
 
-    def process(expiry: juca.AtomicLong): Task[Unit] = task("timeout".tt):
-      while jl.System.currentTimeMillis < expiry.get()
-      do sleep(expiry.get() - jl.System.currentTimeMillis)
-      expiry.set(Long.MinValue)
-      action
+      def process(expiry: juca.AtomicLong): Task[Unit] = task("timeout".tt):
+        while jl.System.currentTimeMillis < expiry.get()
+        do sleep(expiry.get() - jl.System.currentTimeMillis)
+        expiry.set(Long.MinValue)
+        action
 
-    new Timeout(timeout, process)
+      new Timeout(timeout, process)
+
 
 class Timeout private(duration: Long, makeProcess: juca.AtomicLong => Task[Unit]):
   private val expiry: juca.AtomicLong = juca.AtomicLong(jl.System.currentTimeMillis + duration)

--- a/lib/parasite/src/core/parasite.Timeout.scala
+++ b/lib/parasite/src/core/parasite.Timeout.scala
@@ -43,7 +43,7 @@ import prepositional.*
 
 object Timeout:
   def apply[duration: GenericDuration](timeout0: duration)(action: => Unit)(using Monitor, Codicil)
-  :     Timeout =
+  : Timeout =
 
     val timeout = duration.milliseconds(timeout0)
 

--- a/lib/perihelion/src/core/perihelion-core.scala
+++ b/lib/perihelion/src/core/perihelion-core.scala
@@ -38,6 +38,6 @@ import telekinesis.*
 def websocket[ResultType](lambda: (frames: LazyList[Frame]) ?=> ResultType)
      (using request: Http.Request)
      (using Monitor, Codicil)
-:     Websocket[ResultType] =
+: Websocket[ResultType] =
   val websocket = Websocket(request, lambda(using _))
   websocket

--- a/lib/perihelion/src/core/perihelion-core.scala
+++ b/lib/perihelion/src/core/perihelion-core.scala
@@ -35,9 +35,10 @@ package perihelion
 import parasite.*
 import telekinesis.*
 
+
 def websocket[ResultType](lambda: (frames: LazyList[Frame]) ?=> ResultType)
      (using request: Http.Request)
      (using Monitor, Codicil)
 : Websocket[ResultType] =
-  val websocket = Websocket(request, lambda(using _))
-  websocket
+
+    Websocket(request, lambda(using _))

--- a/lib/plutocrat/src/core/plutocrat.Plutocrat.scala
+++ b/lib/plutocrat/src/core/plutocrat.Plutocrat.scala
@@ -105,7 +105,7 @@ object Plutocrat:
                    inline right:       Money[currency],
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
         if left.value == right.value then !strict else (left.value < right.value)^greaterThan
 
     given zeroic: [currency <: Currency & Singleton] => Money[currency] is Zeroic:

--- a/lib/plutocrat/src/core/plutocrat.Plutocrat.scala
+++ b/lib/plutocrat/src/core/plutocrat.Plutocrat.scala
@@ -99,6 +99,7 @@ object Plutocrat:
 
       def divide(left: left, right: right): Double = left.toDouble/right.toDouble
 
+
     inline given orderable: [currency <: Currency & Singleton] => Money[currency] is Orderable:
       inline def compare
                   (inline left:        Money[currency],
@@ -106,7 +107,9 @@ object Plutocrat:
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
       : Boolean =
-        if left.value == right.value then !strict else (left.value < right.value)^greaterThan
+
+          if left.value == right.value then !strict else (left.value < right.value)^greaterThan
+
 
     given zeroic: [currency <: Currency & Singleton] => Money[currency] is Zeroic:
       def zero: Money[currency] = 0L

--- a/lib/polyvinyl/src/core/polyvinyl.Schema.scala
+++ b/lib/polyvinyl/src/core/polyvinyl.Schema.scala
@@ -46,7 +46,7 @@ trait Schema[data, record <: Record in data]:
 
   def build(value: Expr[data])(using Quotes, Type[record], Type[data])
        (using thisType: Type[this.type])
-  :     Expr[record] =
+  : Expr[record] =
 
     import quotes.reflect.*
 
@@ -61,7 +61,7 @@ trait Schema[data, record <: Record in data]:
           fields:      List[(String, RecordField)],
           refinedType: TypeRepr,
           caseDefs:    List[CaseDef] = List(CaseDef(Wildcard(), None, '{???}.asTerm)))
-    :     (TypeRepr, List[CaseDef]) =
+    : (TypeRepr, List[CaseDef]) =
       fields match
         case Nil =>
           (refinedType, caseDefs)

--- a/lib/probably/src/core/probably-core.scala
+++ b/lib/probably/src/core/probably-core.scala
@@ -62,11 +62,13 @@ extension (value: Double)
 def test[report](name: Message)(using suite: Testable, codepoint: Codepoint): TestId =
   TestId(name, suite, codepoint)
 
+
 def suite[report](name: Message)(using suite: Testable, runner: Runner[report])
    (block: Testable ?=> Unit)
 : Unit =
 
-  runner.suite(Testable(name, suite), block)
+    runner.suite(Testable(name, suite), block)
+
 
 extension [test](test: Test[test])
   inline def aspire[report](inline predicate: test => Boolean)
@@ -74,7 +76,9 @@ extension [test](test: Test[test])
                      inc:    Inclusion[report, Verdict],
                      inc2:   Inclusion[report, Verdict.Detail])
   : Unit =
-    ${Probably.aspire[test, report]('test, 'runner, 'inc, 'inc2)}
+
+      ${Probably.aspire[test, report]('test, 'runner, 'inc, 'inc2)}
+
 
   inline def assert[report]
               (inline predicate: test => Boolean)
@@ -82,7 +86,9 @@ extension [test](test: Test[test])
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
   : Unit =
-    ${Probably.assert[test, report]('test, 'predicate, 'runner, 'inclusion, 'inclusion2)}
+
+      ${Probably.assert[test, report]('test, 'predicate, 'runner, 'inclusion, 'inclusion2)}
+
 
   inline def check[report]
               (inline predicate: test => Boolean)
@@ -90,16 +96,20 @@ extension [test](test: Test[test])
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
   : test =
-    ${Probably.check[test, report]('test, 'predicate, 'runner, 'inclusion, 'inclusion2)}
+
+      ${Probably.check[test, report]('test, 'predicate, 'runner, 'inclusion, 'inclusion2)}
+
 
   inline def assert[report]()
               (using runner:     Runner[report],
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
   : Unit =
-    ${
-        Probably.assert[test, report]
-         ('test, '{Probably.succeed}, 'runner, 'inclusion, 'inclusion2) }
+
+      ${
+          Probably.assert[test, report]
+           ('test, '{Probably.succeed}, 'runner, 'inclusion, 'inclusion2) }
+
 
   inline def check[report]()
               (using runner:     Runner[report],
@@ -107,9 +117,10 @@ extension [test](test: Test[test])
                      inclusion2: Inclusion[report, Verdict.Detail])
   : test =
 
-    ${
-        Probably.check[test, report]
-         ('test, '{Probably.succeed}, 'runner, 'inclusion, 'inclusion2) }
+      ${
+          Probably.check[test, report]
+           ('test, '{Probably.succeed}, 'runner, 'inclusion, 'inclusion2) }
+
 
   inline def matches[report](inline pf: test ~> Any)
               (using runner: Runner[report],
@@ -117,7 +128,8 @@ extension [test](test: Test[test])
                      inc2:   Inclusion[report, Verdict.Detail])
   : Unit =
 
-    assert[report](pf.isDefinedAt(_))
+      assert[report](pf.isDefinedAt(_))
+
 
 extension [value](inline value: value)(using inline test: Harness)
   inline def debug: value = ${Probably.debug('value, 'test)}

--- a/lib/probably/src/core/probably-core.scala
+++ b/lib/probably/src/core/probably-core.scala
@@ -64,7 +64,7 @@ def test[report](name: Message)(using suite: Testable, codepoint: Codepoint): Te
 
 def suite[report](name: Message)(using suite: Testable, runner: Runner[report])
    (block: Testable ?=> Unit)
-:     Unit =
+: Unit =
 
   runner.suite(Testable(name, suite), block)
 
@@ -73,7 +73,7 @@ extension [test](test: Test[test])
               (using runner: Runner[report],
                      inc:    Inclusion[report, Verdict],
                      inc2:   Inclusion[report, Verdict.Detail])
-  :     Unit =
+  : Unit =
     ${Probably.aspire[test, report]('test, 'runner, 'inc, 'inc2)}
 
   inline def assert[report]
@@ -81,7 +81,7 @@ extension [test](test: Test[test])
               (using runner:     Runner[report],
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
-  :     Unit =
+  : Unit =
     ${Probably.assert[test, report]('test, 'predicate, 'runner, 'inclusion, 'inclusion2)}
 
   inline def check[report]
@@ -89,14 +89,14 @@ extension [test](test: Test[test])
               (using runner:     Runner[report],
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
-  :     test =
+  : test =
     ${Probably.check[test, report]('test, 'predicate, 'runner, 'inclusion, 'inclusion2)}
 
   inline def assert[report]()
               (using runner:     Runner[report],
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
-  :     Unit =
+  : Unit =
     ${
         Probably.assert[test, report]
          ('test, '{Probably.succeed}, 'runner, 'inclusion, 'inclusion2) }
@@ -105,7 +105,7 @@ extension [test](test: Test[test])
               (using runner:     Runner[report],
                      inclusion:  Inclusion[report, Verdict],
                      inclusion2: Inclusion[report, Verdict.Detail])
-  :     test =
+  : test =
 
     ${
         Probably.check[test, report]
@@ -115,7 +115,7 @@ extension [test](test: Test[test])
               (using runner: Runner[report],
                      inc:    Inclusion[report, Verdict],
                      inc2:   Inclusion[report, Verdict.Detail])
-  :     Unit =
+  : Unit =
 
     assert[report](pf.isDefinedAt(_))
 

--- a/lib/probably/src/core/probably.Probably.scala
+++ b/lib/probably/src/core/probably.Probably.scala
@@ -52,7 +52,7 @@ object Probably:
                   inc2:      Expr[Inclusion[report, Verdict.Detail]],
                   action:    Expr[Trial[test] => result])
                  (using Quotes)
-  :     Expr[result] =
+  : Expr[result] =
 
     import quotes.reflect.*
 
@@ -103,7 +103,7 @@ object Probably:
         inc:       Expr[Inclusion[report, Verdict]],
         inc2:      Expr[Inclusion[report, Verdict.Detail]])
        (using Quotes)
-  :     Expr[test] =
+  : Expr[test] =
 
     general[test, report, test]
      (test, predicate, runner, inc, inc2, '{ (t: Trial[test]) => t.get })
@@ -115,7 +115,7 @@ object Probably:
         inc:       Expr[Inclusion[report, Verdict]],
         inc2:      Expr[Inclusion[report, Verdict.Detail]])
        (using Quotes)
-  :     Expr[Unit] =
+  : Expr[Unit] =
     general[test, report, Unit](test, predicate, runner, inc, inc2, '{ _ => () })
 
   def aspire[test: Type, report: Type]
@@ -124,7 +124,7 @@ object Probably:
         inc:    Expr[Inclusion[report, Verdict]],
         inc2:   Expr[Inclusion[report, Verdict.Detail]])
        (using Quotes)
-  :     Expr[Unit] =
+  : Expr[Unit] =
 
     general[test, report, Unit](test, '{ _ => true }, runner, inc, inc2, '{ _ => () })
 
@@ -140,7 +140,7 @@ object Probably:
         inc:          Inclusion[report, Verdict],
         inc2:         Inclusion[report, Verdict.Detail],
         decomposable: test is Decomposable)
-  :     result =
+  : result =
 
     runner.run(test).pipe: run =>
       val verdict = run match

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -350,11 +350,11 @@ class Report(using Environment):
         val text3 = if !pass then t"  ┗┛    ┗┛ ┗┛  ┗┛  ┗┻━━╸  " else t"┗┛     ┗┛ ┗┛  ╺━━┻┛  ╺━━┻┛"
 
         if !pass || !tabulation then
-          Out.println(e"$color(╭${t"─"*44}╮)")
-          Out.println(e"$color(│) $Bold(${Bg(color)}($Black(${t" "*8}$text1${t" "*8}))) $color(│)")
-          Out.println(e"$color(│) $Bold(${Bg(color)}($Black(${t" "*8}$text2${t" "*8}))) $color(│)")
-          Out.println(e"$color(│) $Bold(${Bg(color)}($Black(${t" "*8}$text3${t" "*8}))) $color(│)")
-          Out.println(e"$color(╰${t"─"*44}╯)")
+          Out.println(e"$color(╭${t"─"*36}╮)")
+          Out.println(e"$color(│) $Bold(${Bg(color)}($Black(    $text1    ))) $color(│)")
+          Out.println(e"$color(│) $Bold(${Bg(color)}($Black(    $text2    ))) $color(│)")
+          Out.println(e"$color(│) $Bold(${Bg(color)}($Black(    $text3    ))) $color(│)")
+          Out.println(e"$color(╰${t"─"*36}╯)")
 
           given decimalizer: Decimalizer = Decimalizer(decimalPlaces = 1)
           val passText = e"$Bold($White($passed)) passed (${100.0*passed/total}%)"

--- a/lib/probably/src/coverage/probably.Juncture.scala
+++ b/lib/probably/src/coverage/probably.Juncture.scala
@@ -62,7 +62,7 @@ case class Juncture
     val lines = code.flatMap(_.cut(t"\\n"))
     if lines.length > 1 then t"${lines.head}..." else lines.head
 
-  def method: StackTrace.Method = StackTrace.Method(
-    StackTrace.rewrite(className.s),
-    StackTrace.rewrite(methodName.s, method = true),
-  )
+  def method: StackTrace.Method =
+    StackTrace.Method
+     (StackTrace.rewrite(className.s),
+      StackTrace.rewrite(methodName.s, method = true))

--- a/lib/profanity/src/core/profanity-core.scala
+++ b/lib/profanity/src/core/profanity-core.scala
@@ -49,7 +49,7 @@ def terminal[result](block: (terminal: Terminal) ?=> result)
           BackgroundColorDetection,
           TerminalFocusDetection,
           TerminalSizeDetection)
-:     result raises TerminalError =
+: result raises TerminalError =
 
   given terminal: Terminal = Terminal(context.signals)
 

--- a/lib/profanity/src/core/profanity.Interaction.scala
+++ b/lib/profanity/src/core/profanity.Interaction.scala
@@ -47,27 +47,30 @@ trait Interaction[result, question]:
   def after(): Unit = ()
   def result(state: question): result
 
+
   @tailrec
   final def recur
              (stream: Stream[TerminalEvent], state: question, oldState: Optional[question])
              (key: (question, TerminalEvent) => question)
   : Optional[(result, Stream[TerminalEvent])] =
 
-    render(oldState, state)
+      render(oldState, state)
 
-    stream match
-      case Keypress.Enter #:: tail           => (result(state), tail)
-      case Keypress.Ctrl('C' | 'D') #:: tail => Unset
-      case Keypress.Escape #:: tail          => Unset
-      case other #:: tail                    => recur(tail, key(state, other), state)(key)
-      case _                                 => Unset
+      stream match
+        case Keypress.Enter #:: tail           => (result(state), tail)
+        case Keypress.Ctrl('C' | 'D') #:: tail => Unset
+        case Keypress.Escape #:: tail          => Unset
+        case other #:: tail                    => recur(tail, key(state, other), state)(key)
+        case _                                 => Unset
+
 
   def apply(stream: Stream[TerminalEvent], state: question)
        (key: (question, TerminalEvent) => question)
   : Optional[(result, Stream[TerminalEvent])] =
 
-    before()
-    recur(stream, state, Unset)(key).also(after())
+      before()
+      recur(stream, state, Unset)(key).also(after())
+
 
 object Interaction:
   given selectMenu: [item: Showable] => Stdio => Interaction[item, SelectMenu[item]]:

--- a/lib/profanity/src/core/profanity.Interaction.scala
+++ b/lib/profanity/src/core/profanity.Interaction.scala
@@ -51,7 +51,7 @@ trait Interaction[result, question]:
   final def recur
              (stream: Stream[TerminalEvent], state: question, oldState: Optional[question])
              (key: (question, TerminalEvent) => question)
-  :     Optional[(result, Stream[TerminalEvent])] =
+  : Optional[(result, Stream[TerminalEvent])] =
 
     render(oldState, state)
 
@@ -64,7 +64,7 @@ trait Interaction[result, question]:
 
   def apply(stream: Stream[TerminalEvent], state: question)
        (key: (question, TerminalEvent) => question)
-  :     Optional[(result, Stream[TerminalEvent])] =
+  : Optional[(result, Stream[TerminalEvent])] =
 
     before()
     recur(stream, state, Unset)(key).also(after())

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -42,7 +42,7 @@ object Keyboard:
   import Keypress.*
 
   def modified(code: Char, keypress: EditKey | FunctionKey)
-  :     EditKey | FunctionKey | Shift | Alt | Ctrl | Meta =
+  : EditKey | FunctionKey | Shift | Alt | Ctrl | Meta =
     val n = code - '1'
     val shift: EditKey | FunctionKey | Shift = if (n&1) == 1 then Shift(keypress) else keypress
     val alt: EditKey | FunctionKey | Shift | Alt = if (n&2) == 2 then Alt(shift) else shift

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -41,14 +41,16 @@ trait Keyboard:
 object Keyboard:
   import Keypress.*
 
+
   def modified(code: Char, keypress: EditKey | FunctionKey)
   : EditKey | FunctionKey | Shift | Alt | Ctrl | Meta =
-    val n = code - '1'
-    val shift: EditKey | FunctionKey | Shift = if (n&1) == 1 then Shift(keypress) else keypress
-    val alt: EditKey | FunctionKey | Shift | Alt = if (n&2) == 2 then Alt(shift) else shift
-    val ctrl: EditKey | FunctionKey | Shift | Alt | Ctrl = if (n&4) == 4 then Ctrl(alt) else alt
+      val n = code - '1'
+      val shift: EditKey | FunctionKey | Shift = if (n&1) == 1 then Shift(keypress) else keypress
+      val alt: EditKey | FunctionKey | Shift | Alt = if (n&2) == 2 then Alt(shift) else shift
+      val ctrl: EditKey | FunctionKey | Shift | Alt | Ctrl = if (n&4) == 4 then Ctrl(alt) else alt
 
-    if (n&8) == 8 then Meta(ctrl) else ctrl
+      if (n&8) == 8 then Meta(ctrl) else ctrl
+
 
   def navigation(code: Char): Keypress.EditKey = code match
     case 'A' => Keypress.Up

--- a/lib/profanity/src/core/profanity.LineEditor.scala
+++ b/lib/profanity/src/core/profanity.LineEditor.scala
@@ -77,6 +77,7 @@ case class LineEditor(value: Text = t"", position0: Optional[Int] = Unset) exten
 
   catch case e: RangeError => this
 
+
   def ask
        (using interactivity: Interactivity[TerminalEvent],
               interaction:   Interaction[Text, LineEditor])
@@ -84,5 +85,5 @@ case class LineEditor(value: Text = t"", position0: Optional[Int] = Unset) exten
        (lambda: Interactivity[TerminalEvent] ?=> Text => result)
   : result raises DismissError =
 
-    interaction(interactivity.eventStream(), this)(_(_)).lay(abort(DismissError())):
-      (result, stream) => lambda(using Interactivity(stream))(result)
+      interaction(interactivity.eventStream(), this)(_(_)).lay(abort(DismissError())):
+        (result, stream) => lambda(using Interactivity(stream))(result)

--- a/lib/profanity/src/core/profanity.LineEditor.scala
+++ b/lib/profanity/src/core/profanity.LineEditor.scala
@@ -82,7 +82,7 @@ case class LineEditor(value: Text = t"", position0: Optional[Int] = Unset) exten
               interaction:   Interaction[Text, LineEditor])
        [result]
        (lambda: Interactivity[TerminalEvent] ?=> Text => result)
-  :     result raises DismissError =
+  : result raises DismissError =
 
     interaction(interactivity.eventStream(), this)(_(_)).lay(abort(DismissError())):
       (result, stream) => lambda(using Interactivity(stream))(result)

--- a/lib/profanity/src/core/profanity.SelectMenu.scala
+++ b/lib/profanity/src/core/profanity.SelectMenu.scala
@@ -51,6 +51,7 @@ extends Question[item]:
 
   catch case e: RangeError => this
 
+
   def ask
        (using interactivity: Interactivity[TerminalEvent],
               interaction: Interaction[item, SelectMenu[item]])
@@ -58,5 +59,5 @@ extends Question[item]:
        (lambda: Interactivity[TerminalEvent] ?=> item => result)
   : result raises DismissError =
 
-    interaction(interactivity.eventStream(), this)(_(_)).lay(abort(DismissError())):
-      (result, stream) => lambda(using Interactivity(stream))(result)
+      interaction(interactivity.eventStream(), this)(_(_)).lay(abort(DismissError())):
+        (result, stream) => lambda(using Interactivity(stream))(result)

--- a/lib/profanity/src/core/profanity.SelectMenu.scala
+++ b/lib/profanity/src/core/profanity.SelectMenu.scala
@@ -56,7 +56,7 @@ extends Question[item]:
               interaction: Interaction[item, SelectMenu[item]])
        [result]
        (lambda: Interactivity[TerminalEvent] ?=> item => result)
-  :     result raises DismissError =
+  : result raises DismissError =
 
     interaction(interactivity.eventStream(), this)(_(_)).lay(abort(DismissError())):
       (result, stream) => lambda(using Interactivity(stream))(result)

--- a/lib/profanity/src/core/profanity.TerminalEvent.scala
+++ b/lib/profanity/src/core/profanity.TerminalEvent.scala
@@ -63,7 +63,7 @@ enum Signal extends TerminalEvent:
 
 object CtrlChar:
   def unapply(code: Char)
-  :     Option
+  : Option
              ['A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N'
               | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' | '[' | '\\'
               | ']' | '^' | '_' | '@'] =

--- a/lib/profanity/src/core/profanity.TerminalEvent.scala
+++ b/lib/profanity/src/core/profanity.TerminalEvent.scala
@@ -64,17 +64,19 @@ enum Signal extends TerminalEvent:
 object CtrlChar:
   def unapply(code: Char)
   : Option
-             ['A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N'
-              | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' | '[' | '\\'
-              | ']' | '^' | '_' | '@'] =
-    (code + 64).toChar match
-      case char: ('@' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M'
-                  | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'
-                  | '[' | '\\' | ']' | '^' | '_' | '@') =>
-        Some(char)
+     ['A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P'
+      | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z' | '[' | '\\' | ']' | '^' | '_'
+      | '@'] =
 
-      case _ =>
-        None
+      (code + 64).toChar match
+        case char: ('@' | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L'
+                    | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y'
+                    | 'Z' | '[' | '\\' | ']' | '^' | '_' | '@') =>
+          Some(char)
+
+        case _ =>
+          None
+
 
 object Keypress:
   type EditKey = Tab.type | Home.type | End.type | PageUp.type | PageDown.type | Insert.type |

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -157,13 +157,16 @@ object Markdown:
 
   private val parser = Parser.builder(options).nn.build().nn
 
+
   def parse[readable: Readable by Text](value: readable)(using Tactic[MarkdownError])
   : Markdown[Markdown.Ast.Block] =
-    val text = value.stream[Text].read[Text]
-    val root = parser.parse(text.s).nn
-    val nodes = root.getChildIterator.nn.asScala.to(List).map(convert(root, _))
 
-    Markdown(nodes.collect { case child: Markdown.Ast.Block => child }*)
+      val text = value.stream[Text].read[Text]
+      val root = parser.parse(text.s).nn
+      val nodes = root.getChildIterator.nn.asScala.to(List).map(convert(root, _))
+
+      Markdown(nodes.collect { case child: Markdown.Ast.Block => child }*)
+
 
   def parseInline(text: Text)(using Tactic[MarkdownError]): InlineMd = parse(text) match
     case Markdown(Paragraph(xs*)) =>
@@ -173,16 +176,17 @@ object Markdown:
       raise(MarkdownError(MarkdownError.Reason.BlockInsideInline))
       Markdown[Markdown.Ast.Inline]()
 
+
   @tailrec
   private def coalesce[markdown >: Prose <: Markdown.Ast.Inline]
                (elements: List[markdown], done: List[markdown] = Nil)
   : List[markdown] =
 
-    elements match
-      case Nil                               => done.reverse
-      case Prose(str) :: Prose(str2) :: tail => coalesce(Prose(t"$str$str2") :: tail, done)
-      case Prose(str) :: tail                => coalesce(tail, Prose(format(str)) :: done)
-      case head :: tail                      => coalesce(tail, head :: done)
+      elements match
+        case Nil                               => done.reverse
+        case Prose(str) :: Prose(str2) :: tail => coalesce(Prose(t"$str$str2") :: tail, done)
+        case Prose(str) :: tail                => coalesce(tail, Prose(format(str)) :: done)
+        case head :: tail                      => coalesce(tail, head :: done)
 
 
   def format(str: Text): Text =
@@ -194,54 +198,66 @@ object Markdown:
     . replaceAll("'", "’").nn
     . tt
 
+
   private def resolveReference(root: cvfua.Document, node: cvfa.ImageRef | cvfa.LinkRef)
   : Text raises MarkdownError =
 
-    Optional(node.getReferenceNode(root)).let(_.nn.getUrl.toString.show).or:
-      raise(MarkdownError(MarkdownError.Reason.BrokenImageRef)) yet t"https://example.com/"
+      Optional(node.getReferenceNode(root)).let(_.nn.getUrl.toString.show).or:
+        raise(MarkdownError(MarkdownError.Reason.BrokenImageRef)) yet t"https://example.com/"
+
 
   type PhrasingInput =
     cvfa.Emphasis | cvfa.StrongEmphasis | cvfa.Code | cvfa.HardLineBreak | cvfa.Image
     | cvfa.ImageRef | cvfa.Link | cvfa.LinkRef | cvfa.MailLink | cvfa.Text | cvfa.SoftLineBreak
 
+
   def phraseChildren(root: cvfua.Document, node: cvfua.Node)
   : Seq[Markdown.Ast.Inline] raises MarkdownError =
-    coalesce:
-      node.getChildren.nn.iterator.nn.asScala.to(List).collect:
-        case node: PhrasingInput => phrasing(root, node)
+
+      coalesce:
+        node.getChildren.nn.iterator.nn.asScala.to(List).collect:
+          case node: PhrasingInput => phrasing(root, node)
+
 
   def flowChildren(root: cvfua.Document, node: cvfua.Node)
   : Seq[Markdown.Ast.Block] raises MarkdownError =
-    node.getChildren.nn.iterator.nn.asScala.to(List).collect:
-      case node: FlowInput => flow(root, node)
+
+      node.getChildren.nn.iterator.nn.asScala.to(List).collect:
+        case node: FlowInput => flow(root, node)
+
 
   def listItems(root: cvfua.Document, node: cvfa.BulletList | cvfa.OrderedList)
   : Seq[ListItem] raises MarkdownError =
 
-    node.getChildren.nn.iterator.nn.asScala.to(List).collect:
-      case node: (cvfa.BulletListItem | cvfa.OrderedListItem) => ListItem(flowChildren(root, node)*)
+      node.getChildren.nn.iterator.nn.asScala.to(List).collect:
+        case node: (cvfa.BulletListItem | cvfa.OrderedListItem) => ListItem(flowChildren(root, node)*)
+
 
   def phrasing(root: cvfua.Document, node: PhrasingInput)
-  : Markdown.Ast.Inline raises MarkdownError = node match
-    case node: cvfa.Emphasis       => Emphasis(phraseChildren(root, node)*)
-    case node: cvfa.SoftLineBreak  => Prose(t"\n")
-    case node: cvfa.StrongEmphasis => Strong(phraseChildren(root, node)*)
-    case node: cvfa.Code           => SourceCode(node.getText.toString.show)
-    case node: cvfa.HardLineBreak  => LineBreak
-    case node: cvfa.Image          => Image(node.getText.toString.show, node.getUrl.toString.show)
-    case node: cvfa.ImageRef       => Image
-                                       (node.getText.toString.show, resolveReference(root, node))
-    case node: cvfa.Link           => Weblink
-                                       (node.getUrl.toString.show, phraseChildren(root, node)*)
-    case node: cvfa.LinkRef        => Weblink
-                                       (resolveReference(root, node), phraseChildren(root, node)*)
-    case node: cvfa.MailLink       => Weblink
-                                       (node.getText.toString.show,
-                                        Prose(s"mailto:${node.getText.nn}".tt))
-    case node: cvfa.Text           => Prose(format(node.getChars.toString.show))
+  : Markdown.Ast.Inline raises MarkdownError =
 
-  type FlowInput = cvfa.BlockQuote | cvfa.BulletList | cvfa.CodeBlock | cvfa.FencedCodeBlock |
-      cvfa.ThematicBreak | cvfa.Paragraph | cvfa.IndentedCodeBlock | cvfa.Heading | cvfa.OrderedList
+      node match
+        case node: cvfa.Emphasis       => Emphasis(phraseChildren(root, node)*)
+        case node: cvfa.SoftLineBreak  => Prose(t"\n")
+        case node: cvfa.StrongEmphasis => Strong(phraseChildren(root, node)*)
+        case node: cvfa.Code           => SourceCode(node.getText.toString.show)
+        case node: cvfa.HardLineBreak  => LineBreak
+        case node: cvfa.Image          => Image(node.getText.toString.show, node.getUrl.toString.show)
+        case node: cvfa.ImageRef       => Image
+                                          (node.getText.toString.show, resolveReference(root, node))
+        case node: cvfa.Link           => Weblink
+                                          (node.getUrl.toString.show, phraseChildren(root, node)*)
+        case node: cvfa.LinkRef        => Weblink
+                                          (resolveReference(root, node), phraseChildren(root, node)*)
+        case node: cvfa.MailLink       => Weblink
+                                          (node.getText.toString.show,
+                                            Prose(s"mailto:${node.getText.nn}".tt))
+        case node: cvfa.Text           => Prose(format(node.getChars.toString.show))
+
+
+  type FlowInput =
+    cvfa.BlockQuote | cvfa.BulletList | cvfa.CodeBlock | cvfa.FencedCodeBlock | cvfa.ThematicBreak
+    | cvfa.Paragraph | cvfa.IndentedCodeBlock | cvfa.Heading | cvfa.OrderedList
 
   def flow(root: cvfua.Document, node: FlowInput): Markdown.Ast.Block raises MarkdownError =
     node match
@@ -275,35 +291,38 @@ object Markdown:
 
   def convert(root: cvfua.Document, node: cvfua.Node, noFormat: Boolean = false)
   : Markdown.Ast.Node raises MarkdownError =
-    node match
-      case node: cvfa.HardLineBreak => LineBreak
-      case node: cvfa.SoftLineBreak => Prose(t"\n")
-      case node: cvfa.ThematicBreak => ThematicBreak()
-      case node: tables.TableBlock  => Table(table(root, node)*)
-      case node: FlowInput          => flow(root, node)
-      case node: PhrasingInput      => phrasing(root, node)
 
-      case node: cvfa.Reference =>
-        Reference(node.getReference.toString.show, node.getUrl.toString.show)
+      node match
+        case node: cvfa.HardLineBreak => LineBreak
+        case node: cvfa.SoftLineBreak => Prose(t"\n")
+        case node: cvfa.ThematicBreak => ThematicBreak()
+        case node: tables.TableBlock  => Table(table(root, node)*)
+        case node: FlowInput          => flow(root, node)
+        case node: PhrasingInput      => phrasing(root, node)
 
-      case node: cvfua.Node =>
-        raise(MarkdownError(MarkdownError.Reason.UnexpectedNode)) yet Prose(t"?")
+        case node: cvfa.Reference =>
+          Reference(node.getReference.toString.show, node.getUrl.toString.show)
+
+        case node: cvfua.Node =>
+          raise(MarkdownError(MarkdownError.Reason.UnexpectedNode)) yet Prose(t"?")
+
 
   def table(root: cvfua.Document, node: tables.TableBlock)
   : List[Markdown.Ast.TablePart] raises MarkdownError =
 
-    node.getChildren.nn.iterator.nn.asScala.to(List).collect:
-      case node: (tables.TableHead | tables.TableBody) =>
-        val rows: Seq[Row] = node.getChildren.nn.iterator.nn.asScala.to(List).collect:
-          case row: tables.TableRow =>
-            val cells = node.getChildren.nn.iterator.nn.asScala.to(List).collect:
-              case cell: tables.TableCell => tableCell(root, cell)
+      node.getChildren.nn.iterator.nn.asScala.to(List).collect:
+        case node: (tables.TableHead | tables.TableBody) =>
+          val rows: Seq[Row] = node.getChildren.nn.iterator.nn.asScala.to(List).collect:
+            case row: tables.TableRow =>
+              val cells = node.getChildren.nn.iterator.nn.asScala.to(List).collect:
+                case cell: tables.TableCell => tableCell(root, cell)
 
-            Row(cells*)
+              Row(cells*)
 
-        node match
-          case node: tables.TableHead => TablePart.Head(rows*)
-          case node: tables.TableBody => TablePart.Body(rows*)
+          node match
+            case node: tables.TableHead => TablePart.Head(rows*)
+            case node: tables.TableBody => TablePart.Body(rows*)
+
 
   def tableCell(root: cvfua.Document, node: tables.TableCell): Cell raises MarkdownError =
     Cell(phraseChildren(root, node)*)

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -158,7 +158,7 @@ object Markdown:
   private val parser = Parser.builder(options).nn.build().nn
 
   def parse[readable: Readable by Text](value: readable)(using Tactic[MarkdownError])
-  :     Markdown[Markdown.Ast.Block] =
+  : Markdown[Markdown.Ast.Block] =
     val text = value.stream[Text].read[Text]
     val root = parser.parse(text.s).nn
     val nodes = root.getChildIterator.nn.asScala.to(List).map(convert(root, _))
@@ -176,7 +176,7 @@ object Markdown:
   @tailrec
   private def coalesce[markdown >: Prose <: Markdown.Ast.Inline]
                (elements: List[markdown], done: List[markdown] = Nil)
-  :     List[markdown] =
+  : List[markdown] =
 
     elements match
       case Nil                               => done.reverse
@@ -195,7 +195,7 @@ object Markdown:
     . tt
 
   private def resolveReference(root: cvfua.Document, node: cvfa.ImageRef | cvfa.LinkRef)
-  :     Text raises MarkdownError =
+  : Text raises MarkdownError =
 
     Optional(node.getReferenceNode(root)).let(_.nn.getUrl.toString.show).or:
       raise(MarkdownError(MarkdownError.Reason.BrokenImageRef)) yet t"https://example.com/"
@@ -205,24 +205,24 @@ object Markdown:
     | cvfa.ImageRef | cvfa.Link | cvfa.LinkRef | cvfa.MailLink | cvfa.Text | cvfa.SoftLineBreak
 
   def phraseChildren(root: cvfua.Document, node: cvfua.Node)
-  :     Seq[Markdown.Ast.Inline] raises MarkdownError =
+  : Seq[Markdown.Ast.Inline] raises MarkdownError =
     coalesce:
       node.getChildren.nn.iterator.nn.asScala.to(List).collect:
         case node: PhrasingInput => phrasing(root, node)
 
   def flowChildren(root: cvfua.Document, node: cvfua.Node)
-  :     Seq[Markdown.Ast.Block] raises MarkdownError =
+  : Seq[Markdown.Ast.Block] raises MarkdownError =
     node.getChildren.nn.iterator.nn.asScala.to(List).collect:
       case node: FlowInput => flow(root, node)
 
   def listItems(root: cvfua.Document, node: cvfa.BulletList | cvfa.OrderedList)
-  :     Seq[ListItem] raises MarkdownError =
+  : Seq[ListItem] raises MarkdownError =
 
     node.getChildren.nn.iterator.nn.asScala.to(List).collect:
       case node: (cvfa.BulletListItem | cvfa.OrderedListItem) => ListItem(flowChildren(root, node)*)
 
   def phrasing(root: cvfua.Document, node: PhrasingInput)
-  :     Markdown.Ast.Inline raises MarkdownError = node match
+  : Markdown.Ast.Inline raises MarkdownError = node match
     case node: cvfa.Emphasis       => Emphasis(phraseChildren(root, node)*)
     case node: cvfa.SoftLineBreak  => Prose(t"\n")
     case node: cvfa.StrongEmphasis => Strong(phraseChildren(root, node)*)
@@ -274,7 +274,7 @@ object Markdown:
           Heading(6, phraseChildren(root, node)*)
 
   def convert(root: cvfua.Document, node: cvfua.Node, noFormat: Boolean = false)
-  :     Markdown.Ast.Node raises MarkdownError =
+  : Markdown.Ast.Node raises MarkdownError =
     node match
       case node: cvfa.HardLineBreak => LineBreak
       case node: cvfa.SoftLineBreak => Prose(t"\n")
@@ -290,7 +290,7 @@ object Markdown:
         raise(MarkdownError(MarkdownError.Reason.UnexpectedNode)) yet Prose(t"?")
 
   def table(root: cvfua.Document, node: tables.TableBlock)
-  :     List[Markdown.Ast.TablePart] raises MarkdownError =
+  : List[Markdown.Ast.TablePart] raises MarkdownError =
 
     node.getChildren.nn.iterator.nn.asScala.to(List).collect:
       case node: (tables.TableHead | tables.TableBody) =>

--- a/lib/punctuation/src/core/punctuation.Punctuation.scala
+++ b/lib/punctuation/src/core/punctuation.Punctuation.scala
@@ -38,7 +38,7 @@ import scala.quoted.*
 
 object Punctuation:
   def md(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes)
-  :     Expr[Markdown[Markdown.Ast.Node]] =
+  : Expr[Markdown[Markdown.Ast.Node]] =
     Md.Interpolator.expansion(context, parts) match
       case (Md.Input.Inline(_), result) => '{$result.asInstanceOf[InlineMd]}
       case (Md.Input.Block(_), result)  => '{$result.asInstanceOf[Markdown[Markdown.Ast.Block]]}

--- a/lib/punctuation/src/core/punctuation.Punctuation.scala
+++ b/lib/punctuation/src/core/punctuation.Punctuation.scala
@@ -39,6 +39,7 @@ import scala.quoted.*
 object Punctuation:
   def md(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes)
   : Expr[Markdown[Markdown.Ast.Node]] =
-    Md.Interpolator.expansion(context, parts) match
-      case (Md.Input.Inline(_), result) => '{$result.asInstanceOf[InlineMd]}
-      case (Md.Input.Block(_), result)  => '{$result.asInstanceOf[Markdown[Markdown.Ast.Block]]}
+
+      Md.Interpolator.expansion(context, parts) match
+        case (Md.Input.Inline(_), result) => '{$result.asInstanceOf[InlineMd]}
+        case (Md.Input.Block(_), result)  => '{$result.asInstanceOf[Markdown[Markdown.Ast.Block]]}

--- a/lib/punctuation/src/html/punctuation.Outliner.scala
+++ b/lib/punctuation/src/html/punctuation.Outliner.scala
@@ -51,7 +51,7 @@ object Outliner extends HtmlTranslator():
 
   @tailrec
   def structure(minimum: Optional[Int], nodes: List[Markdown.Ast.Node], stack: List[List[Entry]])
-  :     List[Entry] =
+  : List[Entry] =
     nodes match
       case Nil => stack match
         case Nil         => Nil

--- a/lib/punctuation/src/html/punctuation.Outliner.scala
+++ b/lib/punctuation/src/html/punctuation.Outliner.scala
@@ -49,41 +49,43 @@ object Outliner extends HtmlTranslator():
 
     List(Ul(recur(structure(Unset, nodes.to(List), Nil))*))
 
+
   @tailrec
   def structure(minimum: Optional[Int], nodes: List[Markdown.Ast.Node], stack: List[List[Entry]])
   : List[Entry] =
-    nodes match
-      case Nil => stack match
-        case Nil         => Nil
-        case last :: Nil => last.reverse
 
-        case head :: (Entry(label, something) :: tail) :: more =>
-          structure(minimum, Nil, (Entry(label, head.reverse) :: tail) :: more)
+      nodes match
+        case Nil => stack match
+          case Nil         => Nil
+          case last :: Nil => last.reverse
 
-        case head :: Nil :: tail =>
-          structure(minimum, Nil, List(Entry(t"", head.reverse)) :: tail)
+          case head :: (Entry(label, something) :: tail) :: more =>
+            structure(minimum, Nil, (Entry(label, head.reverse) :: tail) :: more)
 
-      case Markdown.Ast.Block.Heading(level, children*) :: more if minimum.lay(true)(level >= _) =>
-        val minimum2 = minimum.or(level)
-        val depth = stack.length + minimum2 - 1
+          case head :: Nil :: tail =>
+            structure(minimum, Nil, List(Entry(t"", head.reverse)) :: tail)
 
-        if level > depth then structure(minimum2, nodes, Nil :: stack) else stack match
-          case Nil =>
-            panic(m"Stack should always be non-empty")
+        case Markdown.Ast.Block.Heading(level, children*) :: more if minimum.lay(true)(level >= _) =>
+          val minimum2 = minimum.or(level)
+          val depth = stack.length + minimum2 - 1
 
-          case head :: next :: stack2 =>
-            if level < depth then next match
-              case Entry(label, Nil) :: tail =>
-                structure(minimum2, nodes, (Entry(label, head.reverse) :: tail) :: stack2)
+          if level > depth then structure(minimum2, nodes, Nil :: stack) else stack match
+            case Nil =>
+              panic(m"Stack should always be non-empty")
 
-              case _ =>
-                structure(minimum2, nodes, (Entry(t"", head.reverse) :: Nil) :: stack2)
+            case head :: next :: stack2 =>
+              if level < depth then next match
+                case Entry(label, Nil) :: tail =>
+                  structure(minimum2, nodes, (Entry(label, head.reverse) :: tail) :: stack2)
 
-            else
-              structure(minimum2, more, (Entry(text(children), Nil) :: head) :: stack.tail)
+                case _ =>
+                  structure(minimum2, nodes, (Entry(t"", head.reverse) :: Nil) :: stack2)
 
-          case other :: Nil =>
-            structure(minimum2, more, (Entry(text(children), Nil) :: other) :: Nil)
+              else
+                structure(minimum2, more, (Entry(text(children), Nil) :: head) :: stack.tail)
 
-      case _ :: more =>
-        structure(minimum, more, stack)
+            case other :: Nil =>
+              structure(minimum2, more, (Entry(text(children), Nil) :: other) :: Nil)
+
+        case _ :: more =>
+          structure(minimum, more, stack)

--- a/lib/quantitative/src/core/quantitative-core.scala
+++ b/lib/quantitative/src/core/quantitative-core.scala
@@ -47,7 +47,7 @@ extension [units <: Measure](quantity: Quantity[units])
   transparent inline def invert: Any = Quantity[Measure](1.0)/quantity
 
   inline def normalize[units2 <: Measure](using normalizable: units is Normalizable into units2)
-  :     Quantity[units2] =
+  : Quantity[units2] =
     normalizable.normalize(quantity)
 
   inline def sqrt(using root: Quantity[units] is Rootable[2]): root.Result =

--- a/lib/quantitative/src/core/quantitative-core.scala
+++ b/lib/quantitative/src/core/quantitative-core.scala
@@ -46,9 +46,12 @@ extension [units <: Measure](quantity: Quantity[units])
 
   transparent inline def invert: Any = Quantity[Measure](1.0)/quantity
 
+
   inline def normalize[units2 <: Measure](using normalizable: units is Normalizable into units2)
   : Quantity[units2] =
-    normalizable.normalize(quantity)
+
+      normalizable.normalize(quantity)
+
 
   inline def sqrt(using root: Quantity[units] is Rootable[2]): root.Result =
     root.root(quantity)

--- a/lib/quantitative/src/core/quantitative.Quantitative.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative.scala
@@ -184,7 +184,7 @@ object Quantitative extends Quantitative2:
                    inline right:       Quantity[units2],
                    inline strict:      Boolean,
                    inline greaterThan: Boolean)
-      :     Boolean =
+      : Boolean =
 
         ${Quantitative.greaterThan[units, units2]('left, 'right, 'strict, 'greaterThan)}
 

--- a/lib/quantitative/src/core/quantitative.Quantitative.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative.scala
@@ -179,6 +179,7 @@ object Quantitative extends Quantitative2:
     given commensurable: [units <: Measure, units2 <: Measure] => Quantity[units] is Commensurable:
       type Operand = Quantity[units2]
 
+
       inline def compare
                   (inline left:        Quantity[units],
                    inline right:       Quantity[units2],
@@ -186,7 +187,8 @@ object Quantitative extends Quantitative2:
                    inline greaterThan: Boolean)
       : Boolean =
 
-        ${Quantitative.greaterThan[units, units2]('left, 'right, 'strict, 'greaterThan)}
+          ${Quantitative.greaterThan[units, units2]('left, 'right, 'strict, 'greaterThan)}
+
 
     class ShowableQuantity[units <: Measure](fn: Quantity[units] => Text)(using Decimalizer)
     extends Showable:

--- a/lib/quantitative/src/core/quantitative.Quantitative2.scala
+++ b/lib/quantitative/src/core/quantitative.Quantitative2.scala
@@ -222,7 +222,7 @@ trait Quantitative2:
 
   def normalizable[source <: Measure: Type, result <: Measure: Type]
        (using Quotes)
-  :     Expr[source is Normalizable into result] =
+  : Expr[source is Normalizable into result] =
     import quotes.reflect.*
 
     val sourceUnits = UnitsMap[source]
@@ -238,7 +238,7 @@ trait Quantitative2:
 
   def ratio(using Quotes)
        (from: UnitRef, to: UnitRef, power: Int, retry: Boolean = true, viaPrincipal: Boolean = true)
-  :     Expr[Double] =
+  : Expr[Double] =
 
     import quotes.reflect.*
 
@@ -274,10 +274,10 @@ trait Quantitative2:
 
   private def normalize(using Quotes)
                (units: UnitsMap, other: UnitsMap, init: Expr[Double], force: Boolean = false)
-  :     (UnitsMap, Expr[Double]) =
+  : (UnitsMap, Expr[Double]) =
 
     def recur(dimensions: List[DimensionRef], target: UnitsMap, expr: Expr[Double])
-    :     (UnitsMap, Expr[Double]) =
+    : (UnitsMap, Expr[Double]) =
 
       dimensions match
         case Nil =>
@@ -321,7 +321,7 @@ trait Quantitative2:
   def multiply[left <: Measure: Type, right <: Measure: Type]
        (leftExpr: Expr[Quantity[left]], rightExpr: Expr[Quantity[right]], division: Boolean)
        (using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
     val left: UnitsMap = UnitsMap[left]
     val right: UnitsMap = UnitsMap[right]
@@ -352,7 +352,7 @@ trait Quantitative2:
         right        <: Measure:         Type,
         multiplier   <: Quantity[right]: Type
        ](using Quotes)
-  :     Expr[multiplicand is Multiplicable by multiplier] =
+  : Expr[multiplicand is Multiplicable by multiplier] =
 
     val left = UnitsMap[left]
     val right = UnitsMap[right]
@@ -377,7 +377,7 @@ trait Quantitative2:
         right    <: Measure:         Type,
         divisor  <: Quantity[right]: Type]
        (using Quotes)
-  :     Expr[dividend is Divisible by divisor] =
+  : Expr[dividend is Divisible by divisor] =
 
     val left = UnitsMap[left]
     val right = UnitsMap[right]
@@ -396,7 +396,7 @@ trait Quantitative2:
             ${Quantitative.multiply('left, 'right, true).asExprOf[Double]} }
 
   def divTypeclass2[right <: Measure: Type, divisor <: Quantity[right]: Type](using Quotes)
-  :     Expr[Double is Divisible by divisor] =
+  : Expr[Double is Divisible by divisor] =
 
     val left = UnitsMap(Map())
     val right = UnitsMap[right]
@@ -415,7 +415,7 @@ trait Quantitative2:
             ${Quantitative.multiply('{Quantity(left)}, 'right, true).asExprOf[Double]} }
 
   def divTypeclass3[right <: Measure: Type, divisor <: Quantity[right]: Type](using Quotes)
-  :     Expr[Int is Divisible by divisor] =
+  : Expr[Int is Divisible by divisor] =
 
     val left = UnitsMap(Map())
     val right = UnitsMap[right]
@@ -479,7 +479,7 @@ trait Quantitative2:
         strict:    Expr[Boolean],
         invert:    Expr[Boolean])
        (using Quotes)
-  :     Expr[Boolean] =
+  : Expr[Boolean] =
 
     val left: UnitsMap = UnitsMap[left]
     val right: UnitsMap = UnitsMap[right]
@@ -497,7 +497,7 @@ trait Quantitative2:
   def add[left <: Measure: Type, right <: Measure: Type]
        (leftExpr: Expr[Quantity[left]], rightExpr: Expr[Quantity[right]], sub: Expr[Boolean])
        (using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
     val left: UnitsMap = UnitsMap[left]
     val right: UnitsMap = UnitsMap[right]
@@ -516,7 +516,7 @@ trait Quantitative2:
       case _                                             => resultValue
 
   def subTypeclass[left <: Measure: Type, right <: Measure: Type](using Quotes)
-  :     Expr[Quantity[left] is Subtractable by Quantity[right]] =
+  : Expr[Quantity[left] is Subtractable by Quantity[right]] =
 
     val (units, _) = normalize(UnitsMap[left], UnitsMap[right], '{0.0})
 
@@ -532,7 +532,7 @@ trait Quantitative2:
         right     <: Measure:         Type,
         quantity2 <: Quantity[right]: Type]
        (using Quotes)
-  :     Expr[quantity is Addable by quantity2] =
+  : Expr[quantity is Addable by quantity2] =
 
     val (units, _) = normalize(UnitsMap[left], UnitsMap[right], '{0.0})
 
@@ -545,7 +545,7 @@ trait Quantitative2:
   def norm[units <: Measure: Type, norm[power <: Nat] <: Units[power, ?]: Type]
        (expr: Expr[Quantity[units]])
        (using Quotes)
-  :     Expr[Any] =
+  : Expr[Any] =
 
     val units: UnitsMap = UnitsMap[units]
     val norm: UnitsMap = UnitsMap[norm[1]]

--- a/lib/revolution/src/core/revolution.Manifest.scala
+++ b/lib/revolution/src/core/revolution.Manifest.scala
@@ -74,7 +74,8 @@ case class Manifest(entries: Map[Text, Text]):
   def apply[key <: Label: DecodableManifest](attribute: ManifestAttribute[key])
   : Optional[key.Subject] =
 
-    if entries.contains(attribute.key) then key.decoded(entries(attribute.key)) else Unset
+      if entries.contains(attribute.key) then key.decoded(entries(attribute.key)) else Unset
+
 
   def serialize: Bytes =
     val manifest = juj.Manifest()

--- a/lib/revolution/src/core/revolution.Manifest.scala
+++ b/lib/revolution/src/core/revolution.Manifest.scala
@@ -72,7 +72,7 @@ object Manifest:
 
 case class Manifest(entries: Map[Text, Text]):
   def apply[key <: Label: DecodableManifest](attribute: ManifestAttribute[key])
-  :     Optional[key.Subject] =
+  : Optional[key.Subject] =
 
     if entries.contains(attribute.key) then key.decoded(entries(attribute.key)) else Unset
 

--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -132,24 +132,28 @@ extension [value](iterable: Iterable[value])
                           (using addable:  value is Addable by value,
                                  equality: addable.Result =:= value)
   : Optional[value] =
-    compiletime.summonFrom:
-      case zeroic: ((? <: value) is Zeroic) =>
-        iterable.foldLeft(zeroic.zero)(addable.add)
 
-      case _ =>
-        if iterable.isEmpty then Unset else iterable.tail.foldLeft(iterable.head)(addable.add)
+      compiletime.summonFrom:
+        case zeroic: ((? <: value) is Zeroic) =>
+          iterable.foldLeft(zeroic.zero)(addable.add)
+
+        case _ =>
+          if iterable.isEmpty then Unset else iterable.tail.foldLeft(iterable.head)(addable.add)
+
 
   transparent inline def mean
                           (using addable:   value is Addable by value,
                                  equality:  addable.Result =:= value,
                                  divisible: value is Divisible by Double)
   : Optional[divisible.Result] =
-   compiletime.summonFrom:
-     case zeroic: ((? <: value) is Zeroic) =>
-       iterable.foldLeft[value](zeroic.zero)(addable.add)/iterable.size.toDouble
 
-     case _ =>
-       iterable.total.let(_/iterable.size.toDouble)
+    compiletime.summonFrom:
+      case zeroic: ((? <: value) is Zeroic) =>
+        iterable.foldLeft[value](zeroic.zero)(addable.add)/iterable.size.toDouble
+
+      case _ =>
+        iterable.total.let(_/iterable.size.toDouble)
+
 
   def variance
        (using zeroic:        value is Zeroic,
@@ -163,8 +167,10 @@ extension [value](iterable: Iterable[value])
               equality2:     addable2.Result =:= multiplicable.Result,
               divisible2:    multiplicable.Result is Divisible by Double)
   : divisible2.Result =
-    val mean: divisible.Result = iterable.mean
-    iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble
+
+      val mean: divisible.Result = iterable.mean
+      iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble
+
 
   def standardDeviation
        (using zeroic:        value is Zeroic,
@@ -179,15 +185,19 @@ extension [value](iterable: Iterable[value])
               divisible2:    multiplicable.Result is Divisible by Double,
               rootable:      divisible2.Result is Rootable[2])
   : rootable.Result =
-    val mean: divisible.Result = iterable.mean
-    (iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble).sqrt
+
+      val mean: divisible.Result = iterable.mean
+      (iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble).sqrt
+
 
   def product
        (using unital:        value is Unital,
               multiplicable: value is Multiplicable by value,
               equality:      multiplicable.Result =:= value)
   : value =
-    iterable.foldLeft(unital.one)(multiplicable.multiply)
+
+      iterable.foldLeft(unital.one)(multiplicable.multiply)
+
 
   transparent inline def each(lambda: (ordinal: Ordinal) ?=> value => Unit): Unit =
     var ordinal: Ordinal = Prim
@@ -334,21 +344,25 @@ extension (bs: Long)
 extension (bytes: Bytes)
   def memory: Memory = Memory(bytes.size)
 
+
 def workingDirectory[path: Instantiable across Paths from Text](using directory: WorkingDirectory)
 : path =
 
-  directory.path[path]
+    directory.path[path]
+
 
 def homeDirectory[path: Instantiable across Paths from Text](using directory: HomeDirectory)
 : path =
 
-  directory.path[path]
+    directory.path[path]
+
 
 def temporaryDirectory[path: Instantiable across Paths from Text]
    (using directory: TemporaryDirectory)
 : path =
 
-  directory.path[path]
+    directory.path[path]
+
 
 package workingDirectories:
   given systemProperty: WorkingDirectory = () =>

--- a/lib/rudiments/src/core/rudiments-core.scala
+++ b/lib/rudiments/src/core/rudiments-core.scala
@@ -131,7 +131,7 @@ extension [value](iterable: Iterable[value])
   transparent inline def total
                           (using addable:  value is Addable by value,
                                  equality: addable.Result =:= value)
-  :     Optional[value] =
+  : Optional[value] =
     compiletime.summonFrom:
       case zeroic: ((? <: value) is Zeroic) =>
         iterable.foldLeft(zeroic.zero)(addable.add)
@@ -143,7 +143,7 @@ extension [value](iterable: Iterable[value])
                           (using addable:   value is Addable by value,
                                  equality:  addable.Result =:= value,
                                  divisible: value is Divisible by Double)
-  :     Optional[divisible.Result] =
+  : Optional[divisible.Result] =
    compiletime.summonFrom:
      case zeroic: ((? <: value) is Zeroic) =>
        iterable.foldLeft[value](zeroic.zero)(addable.add)/iterable.size.toDouble
@@ -162,7 +162,7 @@ extension [value](iterable: Iterable[value])
               zeroic2:       multiplicable.Result is Zeroic,
               equality2:     addable2.Result =:= multiplicable.Result,
               divisible2:    multiplicable.Result is Divisible by Double)
-  :     divisible2.Result =
+  : divisible2.Result =
     val mean: divisible.Result = iterable.mean
     iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble
 
@@ -178,7 +178,7 @@ extension [value](iterable: Iterable[value])
               equality2:     addable2.Result =:= multiplicable.Result,
               divisible2:    multiplicable.Result is Divisible by Double,
               rootable:      divisible2.Result is Rootable[2])
-  :     rootable.Result =
+  : rootable.Result =
     val mean: divisible.Result = iterable.mean
     (iterable.map(_ - mean).map { value => value*value }.total/iterable.size.toDouble).sqrt
 
@@ -186,7 +186,7 @@ extension [value](iterable: Iterable[value])
        (using unital:        value is Unital,
               multiplicable: value is Multiplicable by value,
               equality:      multiplicable.Result =:= value)
-  :     value =
+  : value =
     iterable.foldLeft(unital.one)(multiplicable.multiply)
 
   transparent inline def each(lambda: (ordinal: Ordinal) ?=> value => Unit): Unit =
@@ -335,18 +335,18 @@ extension (bytes: Bytes)
   def memory: Memory = Memory(bytes.size)
 
 def workingDirectory[path: Instantiable across Paths from Text](using directory: WorkingDirectory)
-:     path =
+: path =
 
   directory.path[path]
 
 def homeDirectory[path: Instantiable across Paths from Text](using directory: HomeDirectory)
-:     path =
+: path =
 
   directory.path[path]
 
 def temporaryDirectory[path: Instantiable across Paths from Text]
    (using directory: TemporaryDirectory)
-:     path =
+: path =
 
   directory.path[path]
 

--- a/lib/satirical/src/core/satirical.Wit.scala
+++ b/lib/satirical/src/core/satirical.Wit.scala
@@ -174,7 +174,7 @@ object Wit:
     def witExport(): Export = Export(???)
 
     def topLevel(pkg: Optional[Package] = Unset, members: List[World | Interface] = Nil)
-    :     List[World | Interface] =
+    : List[World | Interface] =
       keyword() match
         case t"package"   => topLevel(packageDeclaration(), members)
         case t"world"     => topLevel(pkg, world() :: members)

--- a/lib/satirical/src/core/satirical.Wit.scala
+++ b/lib/satirical/src/core/satirical.Wit.scala
@@ -161,8 +161,6 @@ object Wit:
         case other => fail(m"expected ':'")
 
 
-
-
     def interfaceItems(members: List[Primitive | Func] = Nil): List[Primitive | Func] = Nil
 
     def worldItems(done: List[Import | Export] = Nil): List[Import | Export] = keyword() match
@@ -173,13 +171,16 @@ object Wit:
     def witImport(): Import = Import(???)
     def witExport(): Export = Export(???)
 
+
     def topLevel(pkg: Optional[Package] = Unset, members: List[World | Interface] = Nil)
     : List[World | Interface] =
-      keyword() match
-        case t"package"   => topLevel(packageDeclaration(), members)
-        case t"world"     => topLevel(pkg, world() :: members)
-        case t"interface" => topLevel(pkg, interface() :: members)
-        case _            => members.reverse
+
+        keyword() match
+          case t"package"   => topLevel(packageDeclaration(), members)
+          case t"world"     => topLevel(pkg, world() :: members)
+          case t"interface" => topLevel(pkg, interface() :: members)
+          case _            => members.reverse
+
 
     whitespace()
     Wit(topLevel()*)

--- a/lib/savagery/src/core/savagery.Figure.scala
+++ b/lib/savagery/src/core/savagery.Figure.scala
@@ -51,9 +51,9 @@ case class Rectangle(position: Point, width: Float, height: Float) extends Figur
       t"""<rect x="${position.x} y="${position.y}" width="$width" height="$height"/>"""
 
 case class Outline
-   (ops:      List[Stroke]       = Nil,
-    style:    Optional[CssStyle] = Unset,
-    id:     Optional[SvgId]    = Unset,
+   (ops:       List[Stroke]       = Nil,
+    style:     Optional[CssStyle] = Unset,
+    id:        Optional[SvgId]    = Unset,
     transform: List[Transform]    = Nil)
 extends Figure:
   import Stroke.*

--- a/lib/scintillate/src/server/scintillate-core.scala
+++ b/lib/scintillate/src/server/scintillate-core.scala
@@ -78,7 +78,7 @@ def cookie(using request: Http.Request)(key: Text): Optional[Text] = request.tex
 
 def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.Response)
    (using connection: HttpConnection)
-:     Http.Response raises AuthError =
+: Http.Response raises AuthError =
   connection.headers.authorization match
     case List(Auth.Basic(username, password)) =>
       if validate(username, password) then response else Http.Response(Http.Forbidden)()
@@ -96,6 +96,6 @@ extension (request: Http.Request)
   def as[body: Acceptable]: body = body.accept(request)
 
   def path(using connection: HttpConnection)
-  :     HttpUrl raises PathError raises UrlError raises HostnameError =
+  : HttpUrl raises PathError raises UrlError raises HostnameError =
     val scheme = if connection.tls then t"https" else t"http"
     t"$scheme://${request.host}${request.pathText}".decode[HttpUrl]

--- a/lib/scintillate/src/server/scintillate-core.scala
+++ b/lib/scintillate/src/server/scintillate-core.scala
@@ -76,17 +76,20 @@ package httpServers:
 
 def cookie(using request: Http.Request)(key: Text): Optional[Text] = request.textCookies.at(key)
 
+
 def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.Response)
    (using connection: HttpConnection)
 : Http.Response raises AuthError =
-  connection.headers.authorization match
-    case List(Auth.Basic(username, password)) =>
-      if validate(username, password) then response else Http.Response(Http.Forbidden)()
 
-    case _ =>
-      val auth = t"""Basic realm="$realm", charset="UTF-8""""
+    connection.headers.authorization match
+      case List(Auth.Basic(username, password)) =>
+        if validate(username, password) then response else Http.Response(Http.Forbidden)()
 
-      Http.Response(Http.Unauthorized, wwwAuthenticate = auth)()
+      case _ =>
+        val auth = t"""Basic realm="$realm", charset="UTF-8""""
+
+        Http.Response(Http.Unauthorized, wwwAuthenticate = auth)()
+
 
 inline def request: Http.Request = compiletime.summonInline[Http.Request]
 
@@ -95,7 +98,9 @@ given realm: Realm = realm"scintillate"
 extension (request: Http.Request)
   def as[body: Acceptable]: body = body.accept(request)
 
+
   def path(using connection: HttpConnection)
   : HttpUrl raises PathError raises UrlError raises HostnameError =
-    val scheme = if connection.tls then t"https" else t"http"
-    t"$scheme://${request.host}${request.pathText}".decode[HttpUrl]
+
+      val scheme = if connection.tls then t"https" else t"http"
+      t"$scheme://${request.host}${request.pathText}".decode[HttpUrl]

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -50,7 +50,7 @@ import com.sun.net.httpserver as csnh
 
 case class HttpServer(port: Int, localhostOnly: Boolean = true) extends RequestServable:
   def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
-  :     Service logs HttpServerEvent raises ServerError =
+  : Service logs HttpServerEvent raises ServerError =
 
     def handle(exchange: csnh.HttpExchange | Null) =
       try

--- a/lib/scintillate/src/server/scintillate.Redirect.scala
+++ b/lib/scintillate/src/server/scintillate.Redirect.scala
@@ -40,7 +40,7 @@ import telekinesis.*
 
 object Redirect:
   def apply[link: Abstractable across Urls into Text](location: link, permanent: Boolean)
-  :     Redirect =
+  : Redirect =
     new Redirect(location.generic, permanent)
 
   given redirect: Redirect is Servable = redirect =>

--- a/lib/scintillate/src/server/scintillate.Redirect.scala
+++ b/lib/scintillate/src/server/scintillate.Redirect.scala
@@ -41,7 +41,9 @@ import telekinesis.*
 object Redirect:
   def apply[link: Abstractable across Urls into Text](location: link, permanent: Boolean)
   : Redirect =
-    new Redirect(location.generic, permanent)
+
+      new Redirect(location.generic, permanent)
+
 
   given redirect: Redirect is Servable = redirect =>
     val headers = List(Http.Header(t"location", redirect.location))

--- a/lib/scintillate/src/server/scintillate.RequestServable.scala
+++ b/lib/scintillate/src/server/scintillate.RequestServable.scala
@@ -40,4 +40,4 @@ import telekinesis.*
 
 trait RequestServable:
   def handle(handle: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
-  :     Service logs HttpServerEvent raises ServerError
+  : Service logs HttpServerEvent raises ServerError

--- a/lib/scintillate/src/server/scintillate.Retrievable.scala
+++ b/lib/scintillate/src/server/scintillate.Retrievable.scala
@@ -45,9 +45,10 @@ trait Retrievable(val mediaType: MediaType) extends Servable:
 
   def stream(response: Self): Stream[Bytes]
 
+
   final def process(content: Self, status: Int, headers: Map[Text, Text], responder: Responder)
   : Unit =
 
-    responder.addHeader(t"content-type", mediaType.show)
-    headers.each(responder.addHeader)
-    responder.sendBody(status, stream(content))
+      responder.addHeader(t"content-type", mediaType.show)
+      headers.each(responder.addHeader)
+      responder.sendBody(status, stream(content))

--- a/lib/scintillate/src/server/scintillate.Retrievable.scala
+++ b/lib/scintillate/src/server/scintillate.Retrievable.scala
@@ -46,7 +46,7 @@ trait Retrievable(val mediaType: MediaType) extends Servable:
   def stream(response: Self): Stream[Bytes]
 
   final def process(content: Self, status: Int, headers: Map[Text, Text], responder: Responder)
-  :     Unit =
+  : Unit =
 
     responder.addHeader(t"content-type", mediaType.show)
     headers.each(responder.addHeader)

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -53,7 +53,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
 
   protected def makeConnection
                  (request: jsh.HttpServletRequest, servletResponse: jsh.HttpServletResponse)
-  :     HttpConnection raises StreamError =
+  : HttpConnection raises StreamError =
     val uri = request.getRequestURI.nn.tt
     val query = Optional(request.getQueryString).let(_.tt)
     val target = uri+query.let(t"?"+_).or(t"")
@@ -101,7 +101,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
 
   override def service
                 (request: jsh.HttpServletRequest | Null, response: jsh.HttpServletResponse | Null)
-  :     Unit =
+  : Unit =
     if request != null && response != null then try handle(request, response) catch
       case error: Throwable =>
         error.printStackTrace(System.out)

--- a/lib/scintillate/src/servlet/scintillate.Scintillate.scala
+++ b/lib/scintillate/src/servlet/scintillate.Scintillate.scala
@@ -41,7 +41,7 @@ import telekinesis.*
 class servlet extends MacroAnnotation:
   override def transform(using Quotes)
                 (tree: quotes.reflect.Definition, companion: Option[quotes.reflect.Definition])
-  :     List[quotes.reflect.Definition] =
+  : List[quotes.reflect.Definition] =
     import quotes.reflect.*
 
     tree match

--- a/lib/scintillate/src/servlet/scintillate.Scintillate.scala
+++ b/lib/scintillate/src/servlet/scintillate.Scintillate.scala
@@ -44,23 +44,23 @@ class servlet extends MacroAnnotation:
   : List[quotes.reflect.Definition] =
     import quotes.reflect.*
 
-    tree match
-      case defDef@DefDef(name, params, returnType, Some(body)) =>
-        if !(returnType.tpe <:< TypeRepr.of[Http.Response])
-        then halt(m"the return type ${returnType.show} is not a subtype of HttpResponse[?]")
+      tree match
+        case defDef@DefDef(name, params, returnType, Some(body)) =>
+          if !(returnType.tpe <:< TypeRepr.of[Http.Response])
+          then halt(m"the return type ${returnType.show} is not a subtype of HttpResponse[?]")
 
-        val ref =
-          Ref(defDef.symbol).etaExpand(tree.symbol.owner).asExprOf[HttpConnection => Http.Response]
+          val ref =
+            Ref(defDef.symbol).etaExpand(tree.symbol.owner).asExprOf[HttpConnection => Http.Response]
 
-        val parents0 = List('{new JavaServletFn($ref)}.asTerm)
-        val parents = List(TypeTree.of[HttpConnection])
-        val newClassName = Symbol.freshName(name)
+          val parents0 = List('{new JavaServletFn($ref)}.asTerm)
+          val parents = List(TypeTree.of[HttpConnection])
+          val newClassName = Symbol.freshName(name)
 
-        val cls =
-          Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _ => Nil, selfType = None)
+          val cls =
+            Symbol.newClass(Symbol.spliceOwner, name, parents.map(_.tpe), _ => Nil, selfType = None)
 
-        val clsDef = ClassDef(cls, parents, body = Nil)
-        List(tree, clsDef)
+          val clsDef = ClassDef(cls, parents, body = Nil)
+          List(tree, clsDef)
 
-      case other =>
-        halt(m"the @servlet annotation must be applied to a method")
+        case other =>
+          halt(m"the @servlet annotation must be applied to a method")

--- a/lib/sedentary/src/core/sedentary-core.scala
+++ b/lib/sedentary/src/core/sedentary-core.scala
@@ -51,43 +51,43 @@ extension [test](test: Test[test])
                      genericDuration:  duration is GenericDuration  = durationApi.javaLong)
   : Unit =
 
-    val action = test.action
+      val action = test.action
 
-    var end =
-      System.currentTimeMillis + genericDuration.milliseconds(warmup.or(SpecificDuration(10000L)))
+      var end =
+        System.currentTimeMillis + genericDuration.milliseconds(warmup.or(SpecificDuration(10000L)))
 
-    val times: scm.ArrayBuffer[Long] = scm.ArrayBuffer()
-    times.sizeHint(4096)
-    val ctx = new Harness()
+      val times: scm.ArrayBuffer[Long] = scm.ArrayBuffer()
+      times.sizeHint(4096)
+      val ctx = new Harness()
 
-    while System.currentTimeMillis < end do
-      val t0 = System.nanoTime
-      val result = action(ctx)
-      val t1 = System.nanoTime - t0
-      times += t1
+      while System.currentTimeMillis < end do
+        val t0 = System.nanoTime
+        val result = action(ctx)
+        val t1 = System.nanoTime - t0
+        times += t1
 
-    times.clear()
+      times.clear()
 
-    end =
-      System.currentTimeMillis
-      + genericDuration.milliseconds(duration.or(SpecificDuration(10000L)))
+      end =
+        System.currentTimeMillis
+        + genericDuration.milliseconds(duration.or(SpecificDuration(10000L)))
 
-    while System.currentTimeMillis < end do
-      val t0 = System.nanoTime
-      val result = action(ctx)
-      val t1 = System.nanoTime - t0
-      times += t1
+      while System.currentTimeMillis < end do
+        val t0 = System.nanoTime
+        val result = action(ctx)
+        val t1 = System.nanoTime - t0
+        times += t1
 
-    val count = times.size
-    val total = times.sum
-    val min: Long = times.min
-    val mean: Double = total.toDouble/count
-    val max: Long = times.max
-    val variance: Double = (times.map { t => (mean - t)*(mean - t) }.sum)/count
-    val stdDev: Double = math.sqrt(variance)
+      val count = times.size
+      val total = times.sum
+      val min: Long = times.min
+      val mean: Double = total.toDouble/count
+      val max: Long = times.max
+      val variance: Double = (times.map { t => (mean - t)*(mean - t) }.sum)/count
+      val stdDev: Double = math.sqrt(variance)
 
-    val benchmark =
-      Benchmark
-       (total, times.size, min.toDouble, mean, max.toDouble, stdDev, confidence.or(95), baseline)
+      val benchmark =
+        Benchmark
+         (total, times.size, min.toDouble, mean, max.toDouble, stdDev, confidence.or(95), baseline)
 
-    inc.include(runner.report, test.id, benchmark)
+      inc.include(runner.report, test.id, benchmark)

--- a/lib/sedentary/src/core/sedentary-core.scala
+++ b/lib/sedentary/src/core/sedentary-core.scala
@@ -49,7 +49,7 @@ extension [test](test: Test[test])
                      inc:              Inclusion[report, Benchmark],
                      specificDuration: duration is SpecificDuration = durationApi.javaLong,
                      genericDuration:  duration is GenericDuration  = durationApi.javaLong)
-  :     Unit =
+  : Unit =
 
     val action = test.action
 

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -91,21 +91,26 @@ object Path:
 
       recur(left.textDescent, right.ascent)
 
+
   def apply[root <: Root on platform, element, platform: {Navigable by element, Radical from root}]
        (root0: root, elements: List[element])
   : Path on platform =
-    if elements.isEmpty then root0 else
-      Path.from[platform]
-       (platform.rootText(root0),
-        elements.map(platform.makeElement(_)),
-        platform.separator,
-        platform.caseSensitivity)
+
+      if elements.isEmpty then root0 else
+        Path.from[platform]
+         (platform.rootText(root0),
+          elements.map(platform.makeElement(_)),
+          platform.separator,
+          platform.caseSensitivity)
+
 
   private def from[platform]
                (root0: Text, elements: List[Text], separator: Text, caseSensitivity: Case)
   : Path on platform =
-    new Path(root0, elements, separator, caseSensitivity):
-      type Platform = platform
+
+      new Path(root0, elements, separator, caseSensitivity):
+        type Platform = platform
+
 
   def parse[platform: {Navigable, Radical}](path: Text): Path on platform =
     val root = platform.root(path)
@@ -212,17 +217,21 @@ extends Pathlike:
     Path.from
      (textRoot, textDescent.drop(depth - count), separator, caseSensitivity)
 
+
   def relativeTo(right: Path on Platform)(using navigable: Platform is Navigable)
   : Relative by navigable.Operand raises PathError =
-    if textRoot != right.textRoot then abort(PathError(PathError.Reason.DifferentRoots))
-    val common = conjunction(right).depth
-    Relative(right.depth - common, textDescent.dropRight(common).map(navigable.element(_)))
+
+      if textRoot != right.textRoot then abort(PathError(PathError.Reason.DifferentRoots))
+      val common = conjunction(right).depth
+      Relative(right.depth - common, textDescent.dropRight(common).map(navigable.element(_)))
+
 
   def resolve(text: Text)(using navigable: Platform is Navigable, radical: Platform is Radical)
   : Path on Platform raises PathError =
-    def relative: Relative by navigable.Operand = Relative.parse(text)
-    val path: Optional[Path on Platform] = safely(Path.parse[Platform](text))
-    val base: Path on Platform = this
 
-    path.or(safely(base + relative)).or:
-      abort(PathError(PathError.Reason.InvalidRoot))
+      def relative: Relative by navigable.Operand = Relative.parse(text)
+      val path: Optional[Path on Platform] = safely(Path.parse[Platform](text))
+      val base: Path on Platform = this
+
+      path.or(safely(base + relative)).or:
+        abort(PathError(PathError.Reason.InvalidRoot))

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -93,7 +93,7 @@ object Path:
 
   def apply[root <: Root on platform, element, platform: {Navigable by element, Radical from root}]
        (root0: root, elements: List[element])
-  :     Path on platform =
+  : Path on platform =
     if elements.isEmpty then root0 else
       Path.from[platform]
        (platform.rootText(root0),
@@ -103,7 +103,7 @@ object Path:
 
   private def from[platform]
                (root0: Text, elements: List[Text], separator: Text, caseSensitivity: Case)
-  :     Path on platform =
+  : Path on platform =
     new Path(root0, elements, separator, caseSensitivity):
       type Platform = platform
 
@@ -151,7 +151,7 @@ extends Pathlike:
     textDescent.prim.let(navigable.element(_))
 
   def peer(using navigable: Platform is Navigable)(name: navigable.Operand)
-  :     Path on Platform raises PathError =
+  : Path on Platform raises PathError =
     parent.let(_ / name).lest(PathError(PathError.Reason.RootParent))
 
   def descent(using navigable: Platform is Navigable): List[navigable.Operand] =
@@ -213,13 +213,13 @@ extends Pathlike:
      (textRoot, textDescent.drop(depth - count), separator, caseSensitivity)
 
   def relativeTo(right: Path on Platform)(using navigable: Platform is Navigable)
-  :     Relative by navigable.Operand raises PathError =
+  : Relative by navigable.Operand raises PathError =
     if textRoot != right.textRoot then abort(PathError(PathError.Reason.DifferentRoots))
     val common = conjunction(right).depth
     Relative(right.depth - common, textDescent.dropRight(common).map(navigable.element(_)))
 
   def resolve(text: Text)(using navigable: Platform is Navigable, radical: Platform is Radical)
-  :     Path on Platform raises PathError =
+  : Path on Platform raises PathError =
     def relative: Relative by navigable.Operand = Relative.parse(text)
     val path: Optional[Path on Platform] = safely(Path.parse[Platform](text))
     val base: Path on Platform = this

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -78,11 +78,11 @@ object Relative:
     if text == navigable.selfText then Relative(0, Nil) else recur(0, 0, Nil)
 
   def apply[element](using navigable: Navigable by element)(ascent0: Int, descent0: List[element])
-  :     Relative by element =
+  : Relative by element =
     Relative.from[element](ascent0, descent0.map(navigable.makeElement(_)), navigable.separator)
 
   private def from[element](ascent0: Int, descent0: List[Text], separator: Text)
-  :     Relative by element =
+  : Relative by element =
     new Relative(ascent0, descent0, separator):
       type Operand = element
 

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -77,17 +77,22 @@ object Relative:
 
     if text == navigable.selfText then Relative(0, Nil) else recur(0, 0, Nil)
 
+
   def apply[element](using navigable: Navigable by element)(ascent0: Int, descent0: List[element])
   : Relative by element =
-    Relative.from[element](ascent0, descent0.map(navigable.makeElement(_)), navigable.separator)
+
+      Relative.from[element](ascent0, descent0.map(navigable.makeElement(_)), navigable.separator)
+
 
   private def from[element](ascent0: Int, descent0: List[Text], separator: Text)
   : Relative by element =
-    new Relative(ascent0, descent0, separator):
-      type Operand = element
 
-  given addable: [element] => (Relative by element) is Addable by (Relative by element) into
-          (Relative by element) =
+      new Relative(ascent0, descent0, separator):
+        type Operand = element
+
+
+  given addable: [element]
+        => (Relative by element) is Addable by (Relative by element) into (Relative by element) =
     (left, right) =>
       def recur(ascent: Int, descent: List[Text], ascent2: Int): Relative by element =
         if ascent2 > 0 then

--- a/lib/serpentine/src/core/serpentine.Serpentine.scala
+++ b/lib/serpentine/src/core/serpentine.Serpentine.scala
@@ -48,7 +48,7 @@ object Serpentine:
   object `/`:
     def unapply[platform <: AnyRef & Matchable: {Navigable, Radical}, element]
        (path: Path on platform)
-    :     Option[(Path on platform, platform.Operand)] =
+    : Option[(Path on platform, platform.Operand)] =
       path.textDescent match
         case Nil          => None
         case head :: Nil  => Some((platform.root(path.textRoot), platform.element(head)))

--- a/lib/serpentine/src/core/serpentine.Serpentine.scala
+++ b/lib/serpentine/src/core/serpentine.Serpentine.scala
@@ -49,7 +49,8 @@ object Serpentine:
     def unapply[platform <: AnyRef & Matchable: {Navigable, Radical}, element]
        (path: Path on platform)
     : Option[(Path on platform, platform.Operand)] =
-      path.textDescent match
-        case Nil          => None
-        case head :: Nil  => Some((platform.root(path.textRoot), platform.element(head)))
-        case head :: tail => Some((unsafely(path.parent.vouch), platform.element(head)))
+
+        path.textDescent match
+          case Nil          => None
+          case head :: Nil  => Some((platform.root(path.textRoot), platform.element(head)))
+          case head :: tail => Some((unsafely(path.parent.vouch), platform.element(head)))

--- a/lib/superlunary/src/core/superlunary.Dispatcher.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatcher.scala
@@ -67,7 +67,7 @@ trait Dispatcher:
                      classloader: Classloader,
                      properties:  SystemProperties,
                      directory:   TemporaryDirectory)
-  :     Result[output] raises CompilerError =
+  : Result[output] raises CompilerError =
    try
     import strategies.throwUnsafely
     val uuid = Uuid()

--- a/lib/superlunary/src/core/superlunary.Dispatcher.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatcher.scala
@@ -60,6 +60,7 @@ trait Dispatcher:
   protected def scalac: Scalac[?]
   protected def invoke[output](dispatch: Dispatch[output]): Result[output]
 
+
   inline def dispatch[output: Decodable in Json]
               (body: References ?=> Quotes ?=> Expr[output])
               [version <: Scalac.All]
@@ -68,62 +69,63 @@ trait Dispatcher:
                      properties:  SystemProperties,
                      directory:   TemporaryDirectory)
   : Result[output] raises CompilerError =
-   try
-    import strategies.throwUnsafely
-    val uuid = Uuid()
 
-    val references = new References()
+      try
+        import strategies.throwUnsafely
+        val uuid = Uuid()
 
-    val (out, fn): (Path, Text => Text) =
-      if Dispatcher.cache.contains(codepoint) then
-        val settings: staging.Compiler.Settings =
-          staging.Compiler.Settings.make(None, scalac.commandLineArguments.map(_.s))
+        val references = new References()
 
-        given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
+        val (out, fn): (Path, Text => Text) =
+          if Dispatcher.cache.contains(codepoint) then
+            val settings: staging.Compiler.Settings =
+              staging.Compiler.Settings.make(None, scalac.commandLineArguments.map(_.s))
 
-        staging.withQuotes:
-          '{ (array: List[Json]) =>
-               ${  references.setRef('array)
-                   body(using references)  } }
+            given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
 
-        Dispatcher.cache(codepoint)
+            staging.withQuotes:
+              '{ (array: List[Json]) =>
+                  ${  references.setRef('array)
+                      body(using references)  } }
 
-      else
-        val out: Path on Linux = temporaryDirectory[Path on Linux] / Name[Linux](uuid.show)
-        val settings: staging.Compiler.Settings =
-          staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))
+            Dispatcher.cache(codepoint)
 
-        given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
+          else
+            val out: Path on Linux = temporaryDirectory[Path on Linux] / Name[Linux](uuid.show)
+            val settings: staging.Compiler.Settings =
+              staging.Compiler.Settings.make(Some(out.encode.s), scalac.commandLineArguments.map(_.s))
 
-        val fn: Text => Text = staging.run:
-          val fromList: Expr[List[Json] => Text] = '{ (array: List[Json]) =>
-            import Json.jsonEncodableInText
-            ${
-              references.setRef('array)
-              body(using references)
-            }.json.encode
-          }
+            given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
 
-          '{ text => $fromList(text.decode[Json].as[List[Json]]) }
+            val fn: Text => Text = staging.run:
+              val fromList: Expr[List[Json] => Text] = '{ (array: List[Json]) =>
+                import Json.jsonEncodableInText
+                ${
+                  references.setRef('array)
+                  body(using references)
+                }.json.encode
+              }
 
-        Dispatcher.cache = Dispatcher.cache.updated(codepoint, (out, fn))
-        (out, fn)
+              '{ text => $fromList(text.decode[Json].as[List[Json]]) }
 
-    val classpath = classloaders.threadContext.classpath match
-      case classpath: LocalClasspath =>
-        LocalClasspath(classpath.entries :+ ClasspathEntry.Directory(out.encode))
+            Dispatcher.cache = Dispatcher.cache.updated(codepoint, (out, fn))
+            (out, fn)
 
-      case _ =>
-        val systemClasspath = Properties.java.`class`.path()
-        LocalClasspath:
-          ClasspathEntry.Directory(out.encode) :: systemClasspath.decode[LocalClasspath].entries
+        val classpath = classloaders.threadContext.classpath match
+          case classpath: LocalClasspath =>
+            LocalClasspath(classpath.entries :+ ClasspathEntry.Directory(out.encode))
 
-    invoke[output]
-     (Dispatch
-       (out,
-        classpath, () => fn(references()).decode[Json].as[output],
-        (fn: Text => Text) => fn(references()).decode[Json].as[output]))
-   catch case throwable: Throwable =>
-     println("Failed, somehow")
-     println(throwable)
-     ???
+          case _ =>
+            val systemClasspath = Properties.java.`class`.path()
+            LocalClasspath:
+              ClasspathEntry.Directory(out.encode) :: systemClasspath.decode[LocalClasspath].entries
+
+        invoke[output]
+         (Dispatch
+           (out,
+            classpath, () => fn(references()).decode[Json].as[output],
+            (fn: Text => Text) => fn(references()).decode[Json].as[output]))
+      catch case throwable: Throwable =>
+        println("Failed, somehow")
+        println(throwable)
+        ???

--- a/lib/symbolism/src/core/symbolism-core.scala
+++ b/lib/symbolism/src/core/symbolism-core.scala
@@ -44,23 +44,23 @@ extension [value: Rootable[3] as rootable](value: value)
 
 extension [augend](left: augend)
   inline infix def + [addend](right: addend)(using addable: augend is Addable by addend)
-  :     addable.Result =
+  : addable.Result =
     addable.add(left, right)
 
 extension [minuend](left: minuend)
   inline infix def - [subtrahend](right: subtrahend)
                      (using subtractable: minuend is Subtractable by subtrahend)
-  :     subtractable.Result =
+  : subtractable.Result =
     subtractable.subtract(left, right)
 
 extension [dividend](left: dividend)
   inline infix def / [divisor](right: divisor)(using divisible: dividend is Divisible by divisor)
-  :     divisible.Result =
+  : divisible.Result =
     divisible.divide(left, right)
 
 extension [multiplicand](left: multiplicand)
   @targetName("multiply")
   inline infix def * [multiplier](right: multiplier)
                      (using multiplicable: multiplicand is Multiplicable by multiplier)
-  :     multiplicable.Result =
+  : multiplicable.Result =
     multiplicable.multiply(left, right)

--- a/lib/symbolism/src/core/symbolism-core.scala
+++ b/lib/symbolism/src/core/symbolism-core.scala
@@ -45,22 +45,29 @@ extension [value: Rootable[3] as rootable](value: value)
 extension [augend](left: augend)
   inline infix def + [addend](right: addend)(using addable: augend is Addable by addend)
   : addable.Result =
-    addable.add(left, right)
+
+      addable.add(left, right)
+
 
 extension [minuend](left: minuend)
   inline infix def - [subtrahend](right: subtrahend)
                      (using subtractable: minuend is Subtractable by subtrahend)
   : subtractable.Result =
-    subtractable.subtract(left, right)
+
+      subtractable.subtract(left, right)
+
 
 extension [dividend](left: dividend)
   inline infix def / [divisor](right: divisor)(using divisible: dividend is Divisible by divisor)
   : divisible.Result =
-    divisible.divide(left, right)
+
+      divisible.divide(left, right)
+
 
 extension [multiplicand](left: multiplicand)
   @targetName("multiply")
   inline infix def * [multiplier](right: multiplier)
                      (using multiplicable: multiplicand is Multiplicable by multiplier)
   : multiplicable.Result =
-    multiplicable.multiply(left, right)
+
+      multiplicable.multiply(left, right)

--- a/lib/symbolism/src/core/symbolism.Addable.scala
+++ b/lib/symbolism/src/core/symbolism.Addable.scala
@@ -38,7 +38,7 @@ import scala.annotation.targetName
 
 object Addable:
   def apply[augend, addend, result](lambda: (augend, addend) => result)
-  :     augend is Addable by addend into result = new Addable:
+  : augend is Addable by addend into result = new Addable:
     type Self = augend
     type Result = result
     type Operand = addend

--- a/lib/symbolism/src/core/symbolism.Addable.scala
+++ b/lib/symbolism/src/core/symbolism.Addable.scala
@@ -38,12 +38,16 @@ import scala.annotation.targetName
 
 object Addable:
   def apply[augend, addend, result](lambda: (augend, addend) => result)
-  : augend is Addable by addend into result = new Addable:
-    type Self = augend
-    type Result = result
-    type Operand = addend
+  : augend is Addable by addend into result =
 
-    def add(augend: augend, addend: addend): result = lambda(augend, addend)
+      new Addable:
+
+        type Self = augend
+        type Result = result
+        type Operand = addend
+
+        def add(augend: augend, addend: addend): result = lambda(augend, addend)
+
 
   given double: Double is Addable by Double into Double = Addable:
     (augend, addend) => augend + addend

--- a/lib/symbolism/src/core/symbolism.Divisible.scala
+++ b/lib/symbolism/src/core/symbolism.Divisible.scala
@@ -38,7 +38,7 @@ import scala.annotation.targetName
 
 object Divisible:
   def apply[dividend, divisor, result](lambda: (dividend, divisor) => result)
-  :     dividend is Divisible by divisor into result = new Divisible:
+  : dividend is Divisible by divisor into result = new Divisible:
     type Self = dividend
     type Result = result
     type Operand = divisor

--- a/lib/symbolism/src/core/symbolism.Divisible.scala
+++ b/lib/symbolism/src/core/symbolism.Divisible.scala
@@ -38,12 +38,15 @@ import scala.annotation.targetName
 
 object Divisible:
   def apply[dividend, divisor, result](lambda: (dividend, divisor) => result)
-  : dividend is Divisible by divisor into result = new Divisible:
-    type Self = dividend
-    type Result = result
-    type Operand = divisor
+  : dividend is Divisible by divisor into result =
 
-    def divide(dividend: dividend, divisor: divisor): result = lambda(dividend, divisor)
+      new Divisible:
+        type Self = dividend
+        type Result = result
+        type Operand = divisor
+
+        def divide(dividend: dividend, divisor: divisor): result = lambda(dividend, divisor)
+
 
   given double: Double is Divisible by Double into Double = Divisible:
     (dividend, divisor) => dividend/divisor

--- a/lib/symbolism/src/core/symbolism.Multiplicable.scala
+++ b/lib/symbolism/src/core/symbolism.Multiplicable.scala
@@ -38,7 +38,7 @@ import scala.annotation.targetName
 
 object Multiplicable:
   def apply[multiplicand, multiplier, result](lambda: (multiplicand, multiplier) => result)
-  :     multiplicand is Multiplicable by multiplier into result = new Multiplicable:
+  : multiplicand is Multiplicable by multiplier into result = new Multiplicable:
     type Self = multiplicand
     type Result = result
     type Operand = multiplier

--- a/lib/symbolism/src/core/symbolism.Multiplicable.scala
+++ b/lib/symbolism/src/core/symbolism.Multiplicable.scala
@@ -38,13 +38,16 @@ import scala.annotation.targetName
 
 object Multiplicable:
   def apply[multiplicand, multiplier, result](lambda: (multiplicand, multiplier) => result)
-  : multiplicand is Multiplicable by multiplier into result = new Multiplicable:
-    type Self = multiplicand
-    type Result = result
-    type Operand = multiplier
+  : multiplicand is Multiplicable by multiplier into result =
 
-    def multiply(multiplicand: multiplicand, multiplier: multiplier): result =
-      lambda(multiplicand, multiplier)
+      new Multiplicable:
+        type Self = multiplicand
+        type Result = result
+        type Operand = multiplier
+
+        def multiply(multiplicand: multiplicand, multiplier: multiplier): result =
+          lambda(multiplicand, multiplier)
+
 
   given double: Double is Multiplicable by Double into Double = Multiplicable:
     (multiplicand, multiplier) => multiplicand*multiplier

--- a/lib/symbolism/src/core/symbolism.Negatable.scala
+++ b/lib/symbolism/src/core/symbolism.Negatable.scala
@@ -38,7 +38,7 @@ import scala.annotation.targetName
 
 object Negatable:
   def apply[operand, result](lambda: operand => result)
-  :     operand is Negatable into result = new Negatable:
+  : operand is Negatable into result = new Negatable:
     type Self = operand
     type Result = result
 

--- a/lib/symbolism/src/core/symbolism.Negatable.scala
+++ b/lib/symbolism/src/core/symbolism.Negatable.scala
@@ -37,12 +37,13 @@ import prepositional.*
 import scala.annotation.targetName
 
 object Negatable:
-  def apply[operand, result](lambda: operand => result)
-  : operand is Negatable into result = new Negatable:
-    type Self = operand
-    type Result = result
+  def apply[operand, result](lambda: operand => result): operand is Negatable into result =
+    new Negatable:
+      type Self = operand
+      type Result = result
 
-    def negate(operand: Self): Result = lambda(operand)
+      def negate(operand: Self): Result = lambda(operand)
+
 
   given double: Double is Negatable into Double = Negatable(-_)
   given float: Float is Negatable into Float = Negatable(-_)

--- a/lib/symbolism/src/core/symbolism.Rootable.scala
+++ b/lib/symbolism/src/core/symbolism.Rootable.scala
@@ -36,7 +36,7 @@ import prepositional.*
 
 object Rootable:
   def apply[root <: Int & Singleton, operand, result](lambda: operand => result)
-  :     operand is Rootable[root] into result = new Rootable[root]:
+  : operand is Rootable[root] into result = new Rootable[root]:
     type Self = operand
     type Result = result
 

--- a/lib/symbolism/src/core/symbolism.Rootable.scala
+++ b/lib/symbolism/src/core/symbolism.Rootable.scala
@@ -36,11 +36,14 @@ import prepositional.*
 
 object Rootable:
   def apply[root <: Int & Singleton, operand, result](lambda: operand => result)
-  : operand is Rootable[root] into result = new Rootable[root]:
-    type Self = operand
-    type Result = result
+  : operand is Rootable[root] into result =
 
-    def root(operand: operand): result = lambda(operand)
+      new Rootable[root]:
+        type Self = operand
+        type Result = result
+
+        def root(operand: operand): result = lambda(operand)
+
 
   given sqrt: Double is Rootable[2] into Double = math.sqrt(_)
   given cbrt: Double is Rootable[3] into Double = math.cbrt(_)

--- a/lib/symbolism/src/core/symbolism.Subtractable.scala
+++ b/lib/symbolism/src/core/symbolism.Subtractable.scala
@@ -38,7 +38,7 @@ import scala.annotation.targetName
 
 object Subtractable:
   def apply[minuend, subtrahend, result](lambda: (minuend, subtrahend) => result)
-  :     minuend is Subtractable by subtrahend into result = new Subtractable:
+  : minuend is Subtractable by subtrahend into result = new Subtractable:
     type Self = minuend
     type Result = result
     type Operand = subtrahend

--- a/lib/symbolism/src/core/symbolism.Subtractable.scala
+++ b/lib/symbolism/src/core/symbolism.Subtractable.scala
@@ -38,13 +38,16 @@ import scala.annotation.targetName
 
 object Subtractable:
   def apply[minuend, subtrahend, result](lambda: (minuend, subtrahend) => result)
-  : minuend is Subtractable by subtrahend into result = new Subtractable:
-    type Self = minuend
-    type Result = result
-    type Operand = subtrahend
+  : minuend is Subtractable by subtrahend into result =
 
-    def subtract(minuend: minuend, subtrahend: subtrahend): result =
-      lambda(minuend, subtrahend)
+      new Subtractable:
+        type Self = minuend
+        type Result = result
+        type Operand = subtrahend
+
+        def subtract(minuend: minuend, subtrahend: subtrahend): result =
+          lambda(minuend, subtrahend)
+
 
   given double: Double is Subtractable by Double into Double = Subtractable(_ - _)
   given float: Float is Subtractable by Float into Float = Subtractable(_ - _)

--- a/lib/tarantula/src/core/tarantula.Browser.scala
+++ b/lib/tarantula/src/core/tarantula.Browser.scala
@@ -48,9 +48,10 @@ trait Browser(name: Text):
   def launch(port: Int)(using WorkingDirectory, Monitor): Server logs ExecEvent
   def stop(server: Server): Unit logs HttpEvent logs ExecEvent
 
+
   def session[result](port: Int = 4444)(block: (session: WebDriver#Session) ?=> result)
        (using WorkingDirectory, Monitor)
   : result logs HttpEvent logs ExecEvent =
 
-    val server = launch(port)
-    try block(using WebDriver(server).startSession()) finally server.stop()
+      val server = launch(port)
+      try block(using WebDriver(server).startSession()) finally server.stop()

--- a/lib/tarantula/src/core/tarantula.Browser.scala
+++ b/lib/tarantula/src/core/tarantula.Browser.scala
@@ -50,7 +50,7 @@ trait Browser(name: Text):
 
   def session[result](port: Int = 4444)(block: (session: WebDriver#Session) ?=> result)
        (using WorkingDirectory, Monitor)
-  :     result logs HttpEvent logs ExecEvent =
+  : result logs HttpEvent logs ExecEvent =
 
     val server = launch(port)
     try block(using WebDriver(server).startSession()) finally server.stop()

--- a/lib/telekinesis/src/core/telekinesis-core2.scala
+++ b/lib/telekinesis/src/core/telekinesis-core2.scala
@@ -63,5 +63,5 @@ class Orchestrate[value: Encodable in Query, result](initial: Optional[value] = 
 
 def orchestrate[value: Encodable in Query](initial: Optional[value] = Unset)[result]
      (render: (form: Text => Html[html5.Flow]) ?=> (value: Optional[value]) => result)
-:     Orchestrate[value, result] =
+: Orchestrate[value, result] =
   new Orchestrate[value, result](initial)(render(using _))

--- a/lib/telekinesis/src/core/telekinesis.Cookie.scala
+++ b/lib/telekinesis/src/core/telekinesis.Cookie.scala
@@ -58,10 +58,9 @@ object Cookie:
         expiry:   Optional[duration] = Unset,
         secure:   Boolean                = false,
         httpOnly: Boolean                = false,
-        path:    Optional[Text]         = Unset) =
+        path:     Optional[Text]         = Unset) =
 
-    new Cookie[value]
-         (name, domain, expiry.let(duration.milliseconds(_)), secure, httpOnly, path)
+    new Cookie[value](name, domain, expiry.let(duration.milliseconds(_)), secure, httpOnly, path)
 
   object Value:
     given showable: Value is Showable = cookie =>

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -284,8 +284,10 @@ object Http:
            (using prefixable: name.type is Prefixable,
                   decoder:    prefixable.Subject is Decodable in Text)
       : List[prefixable.Subject] =
-        val name2 = name.tt.uncamel.kebab.lower
-        textHeaders.filter(_.key.lower == name2).map(_.value.decode)
+
+          val name2 = name.tt.uncamel.kebab.lower
+          textHeaders.filter(_.key.lower == name2).map(_.value.decode)
+
 
     lazy val contentType: Optional[MediaType] = safely(headers.contentType.prim)
 
@@ -297,7 +299,9 @@ object Http:
   object Response extends Dynamic:
     transparent inline def applyDynamicNamed(id: "apply")(inline headers: (Label, Any)*)
     : Prototype | Response =
-      ${Telekinesis.response('headers)}
+
+        ${Telekinesis.response('headers)}
+
 
     transparent inline def applyDynamic(id: "apply")(inline headers: Any*): Prototype | Response =
       ${Telekinesis.response('headers)}
@@ -418,8 +422,10 @@ object Http:
            (using prefixable: name.type is Prefixable,
                   decoder:    prefixable.Subject is Decodable in Text)
       : List[prefixable.Subject] =
-        val name2 = name.tt.uncamel.kebab.lower
-        textHeaders.filter(_.key.lower == name2).map(_.value.decode)
+
+          val name2 = name.tt.uncamel.kebab.lower
+          textHeaders.filter(_.key.lower == name2).map(_.value.decode)
+
 
     @targetName("add")
     infix def + [value: Encodable in Http.Header](value: value): Response =
@@ -438,23 +444,24 @@ object Http:
                        client:   HttpClient onto target)
     : Http.Response =
 
-      ${
-          Telekinesis.submit[target, payload]
-           ('this, 'headers, 'online, 'loggable, 'payload, 'postable, 'client)  }
+        ${ ( Telekinesis.submit[target, payload]
+              ('this, 'headers, 'online, 'loggable, 'payload, 'postable, 'client) ) }
+
 
     inline def applyDynamic[payload: Postable as postable](id: "apply")(inline headers: Any*)
                 (payload: payload)
                 (using online:   Online,
-                  loggable: HttpEvent is Loggable,
-                  client:   HttpClient onto target)
+                       loggable: HttpEvent is Loggable,
+                       client:   HttpClient onto target)
     : Http.Response =
 
-      ${
-          Telekinesis.submit[target, payload]
-           ('this, 'headers, 'online, 'loggable, 'payload, 'postable, 'client)  }
+        ${ ( Telekinesis.submit[target, payload]
+              ('this, 'headers, 'online, 'loggable, 'payload, 'postable, 'client) ) }
+
 
   case class Fetch[target](originForm: Text, target: target, host: Hostname)
     extends Dynamic:
+
 
     inline def applyDynamicNamed(id: "apply")(inline headers: (Label, Any)*)
                 (using online:   Online,
@@ -463,7 +470,8 @@ object Http:
                        client:   HttpClient onto target)
     : Http.Response =
 
-      ${Telekinesis.fetch('this, 'headers, 'online, 'loggable, 'client)}
+        ${Telekinesis.fetch('this, 'headers, 'online, 'loggable, 'client)}
+
 
     inline def applyDynamic[payload](id: "apply")(inline headers: Any*)
                 (using online:   Online,
@@ -471,4 +479,4 @@ object Http:
                        client:   HttpClient onto target)
     : Http.Response =
 
-      ${Telekinesis.fetch('this, 'headers, 'online, 'loggable, 'client)}
+        ${Telekinesis.fetch('this, 'headers, 'online, 'loggable, 'client)}

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -283,7 +283,7 @@ object Http:
       def selectDynamic(name: Label)
            (using prefixable: name.type is Prefixable,
                   decoder:    prefixable.Subject is Decodable in Text)
-      :     List[prefixable.Subject] =
+      : List[prefixable.Subject] =
         val name2 = name.tt.uncamel.kebab.lower
         textHeaders.filter(_.key.lower == name2).map(_.value.decode)
 
@@ -296,7 +296,7 @@ object Http:
 
   object Response extends Dynamic:
     transparent inline def applyDynamicNamed(id: "apply")(inline headers: (Label, Any)*)
-    :     Prototype | Response =
+    : Prototype | Response =
       ${Telekinesis.response('headers)}
 
     transparent inline def applyDynamic(id: "apply")(inline headers: Any*): Prototype | Response =
@@ -417,7 +417,7 @@ object Http:
       def selectDynamic(name: Label)
            (using prefixable: name.type is Prefixable,
                   decoder:    prefixable.Subject is Decodable in Text)
-      :     List[prefixable.Subject] =
+      : List[prefixable.Subject] =
         val name2 = name.tt.uncamel.kebab.lower
         textHeaders.filter(_.key.lower == name2).map(_.value.decode)
 
@@ -436,7 +436,7 @@ object Http:
                        loggable: HttpEvent is Loggable,
                        postable: payload is Postable,
                        client:   HttpClient onto target)
-    :     Http.Response =
+    : Http.Response =
 
       ${
           Telekinesis.submit[target, payload]
@@ -447,7 +447,7 @@ object Http:
                 (using online:   Online,
                   loggable: HttpEvent is Loggable,
                   client:   HttpClient onto target)
-    :     Http.Response =
+    : Http.Response =
 
       ${
           Telekinesis.submit[target, payload]
@@ -461,7 +461,7 @@ object Http:
                        loggable: HttpEvent is Loggable,
                        postable: Unit is Postable,
                        client:   HttpClient onto target)
-    :     Http.Response =
+    : Http.Response =
 
       ${Telekinesis.fetch('this, 'headers, 'online, 'loggable, 'client)}
 
@@ -469,6 +469,6 @@ object Http:
                 (using online:   Online,
                        loggable: HttpEvent is Loggable,
                        client:   HttpClient onto target)
-    :     Http.Response =
+    : Http.Response =
 
       ${Telekinesis.fetch('this, 'headers, 'online, 'loggable, 'client)}

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -68,7 +68,7 @@ object HttpClient:
     type Target = Origin["http" | "https"]
 
     def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
-    :     Http.Response logs HttpEvent =
+    : Http.Response logs HttpEvent =
 
       val url = httpRequest.on(origin)
 

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -67,65 +67,66 @@ object HttpClient:
   given http: Tactic[ConnectError] => Online => HttpClient:
     type Target = Origin["http" | "https"]
 
+
     def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
     : Http.Response logs HttpEvent =
 
-      val url = httpRequest.on(origin)
+        val url = httpRequest.on(origin)
 
-      Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
+        Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-      val request: jnh.HttpRequest.Builder =
-        jnh.HttpRequest.newBuilder().nn.uri(jn.URI.create(url.show.s)).nn
+        val request: jnh.HttpRequest.Builder =
+          jnh.HttpRequest.newBuilder().nn.uri(jn.URI.create(url.show.s)).nn
 
-      lazy val body = httpRequest.body() match
-        case Stream()      =>
-          jnh.HttpRequest.BodyPublishers.noBody.nn
+        lazy val body = httpRequest.body() match
+          case Stream()      =>
+            jnh.HttpRequest.BodyPublishers.noBody.nn
 
-        case Stream(bytes) =>
-          jnh.HttpRequest.BodyPublishers.ofByteArray(bytes.mutable(using Unsafe))
+          case Stream(bytes) =>
+            jnh.HttpRequest.BodyPublishers.ofByteArray(bytes.mutable(using Unsafe))
 
-        case stream =>
-          jnh.HttpRequest.BodyPublishers.ofInputStream { () => stream.inputStream }
+          case stream =>
+            jnh.HttpRequest.BodyPublishers.ofInputStream { () => stream.inputStream }
 
-      httpRequest.method match
-        case Http.Delete  => request.DELETE().nn
-        case Http.Get     => request.GET().nn
-        case Http.Post    => request.POST(body).nn
-        case Http.Put     => request.PUT(body).nn
-        case Http.Connect => request.method("CONNECT", body).nn
-        case Http.Head    => request.method("HEAD", body).nn
-        case Http.Options => request.method("OPTIONS", body).nn
-        case Http.Patch   => request.method("PATCH", body).nn
-        case Http.Trace   => request.method("TRACE", body).nn
+        httpRequest.method match
+          case Http.Delete  => request.DELETE().nn
+          case Http.Get     => request.GET().nn
+          case Http.Post    => request.POST(body).nn
+          case Http.Put     => request.PUT(body).nn
+          case Http.Connect => request.method("CONNECT", body).nn
+          case Http.Head    => request.method("HEAD", body).nn
+          case Http.Options => request.method("OPTIONS", body).nn
+          case Http.Patch   => request.method("PATCH", body).nn
+          case Http.Trace   => request.method("TRACE", body).nn
 
-      request.header("User-Agent", "Telekinesis/1.0.0")
+        request.header("User-Agent", "Telekinesis/1.0.0")
 
-      httpRequest.textHeaders.each:
-        case Http.Header(key, value) => request.header(key.s, value.s)
+        httpRequest.textHeaders.each:
+          case Http.Header(key, value) => request.header(key.s, value.s)
 
-      val response: jnh.HttpResponse[ji.InputStream] =
-        import ConnectError.Reason.*, Ssl.Reason.*
+        val response: jnh.HttpResponse[ji.InputStream] =
+          import ConnectError.Reason.*, Ssl.Reason.*
 
-        val client = HttpClient.client
+          val client = HttpClient.client
 
-        try client.send(request.build(), jnh.HttpResponse.BodyHandlers.ofInputStream()).nn catch
-          case error: jns.SSLHandshakeException       => abort(ConnectError(Ssl(Handshake)))
-          case error: jns.SSLProtocolException        => abort(ConnectError(Ssl(Protocol)))
-          case error: jns.SSLPeerUnverifiedException  => abort(ConnectError(Ssl(Peer)))
-          case error: jns.SSLKeyException             => abort(ConnectError(Ssl(Key)))
-          case error: jn.UnknownHostException         => abort(ConnectError(Dns))
-          case error: jnh.HttpConnectTimeoutException => abort(ConnectError(Timeout))
-          case error: jn.ConnectException             => error.getMessage() match
-            case "Connection refused"                    => abort(ConnectError(Refused))
-            case "Connection timed out"                  => abort(ConnectError(Timeout))
-            case "HTTP connect timed out"                => abort(ConnectError(Timeout))
-            case error                                   => abort(ConnectError(Unknown))
-          case error: ji.IOException                  => abort(ConnectError(Unknown))
+          try client.send(request.build(), jnh.HttpResponse.BodyHandlers.ofInputStream()).nn catch
+            case error: jns.SSLHandshakeException       => abort(ConnectError(Ssl(Handshake)))
+            case error: jns.SSLProtocolException        => abort(ConnectError(Ssl(Protocol)))
+            case error: jns.SSLPeerUnverifiedException  => abort(ConnectError(Ssl(Peer)))
+            case error: jns.SSLKeyException             => abort(ConnectError(Ssl(Key)))
+            case error: jn.UnknownHostException         => abort(ConnectError(Dns))
+            case error: jnh.HttpConnectTimeoutException => abort(ConnectError(Timeout))
+            case error: jn.ConnectException             => error.getMessage() match
+              case "Connection refused"                    => abort(ConnectError(Refused))
+              case "Connection timed out"                  => abort(ConnectError(Timeout))
+              case "HTTP connect timed out"                => abort(ConnectError(Timeout))
+              case error                                   => abort(ConnectError(Unknown))
+            case error: ji.IOException                  => abort(ConnectError(Unknown))
 
-      val status2: Http.Status = Http.Status.unapply(response.statusCode()).getOrElse:
-        abort(ConnectError(ConnectError.Reason.Unknown))
+        val status2: Http.Status = Http.Status.unapply(response.statusCode()).getOrElse:
+          abort(ConnectError(ConnectError.Reason.Unknown))
 
-      val headers2: List[Http.Header] = response.headers.nn.map().nn.asScala.to(List).flatMap:
-        (key, values) => values.asScala.map { value => Http.Header(key.tt, value.tt) }
+        val headers2: List[Http.Header] = response.headers.nn.map().nn.asScala.to(List).flatMap:
+          (key, values) => values.asScala.map { value => Http.Header(key.tt, value.tt) }
 
-      Http.Response.make(status2, headers2, unsafely(response.body().nn.stream[Bytes]))
+        Http.Response.make(status2, headers2, unsafely(response.body().nn.stream[Bytes]))

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -53,7 +53,7 @@ import alphabets.base256.alphanumericOrBraille
 
 object Postable:
   def apply[response](mediaType0: MediaType, stream0: response => Stream[Bytes])
-  :     response is Postable =
+  : response is Postable =
     new Postable:
       type Self = response
       def mediaType(response: response): MediaType = mediaType0

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -54,10 +54,12 @@ import alphabets.base256.alphanumericOrBraille
 object Postable:
   def apply[response](mediaType0: MediaType, stream0: response => Stream[Bytes])
   : response is Postable =
-    new Postable:
-      type Self = response
-      def mediaType(response: response): MediaType = mediaType0
-      def stream(response: response): Stream[Bytes] = stream0(response)
+
+      new Postable:
+        type Self = response
+        def mediaType(response: response): MediaType = mediaType0
+        def stream(response: response): Stream[Bytes] = stream0(response)
+
 
   given text: (encoder: CharEncoder) => Text is Postable =
     Postable(media"text/plain", value => Stream(IArray.from(value.bytes)))

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -43,7 +43,7 @@ import turbulence.*
 
 object Servable:
   def apply[response](mediaType: response => MediaType)(lambda: response => Stream[Bytes])
-  :     response is Servable = response =>
+  : response is Servable = response =>
 
     val headers = List(Http.Header(t"content-type", mediaType(response).show))
     Http.Response.make(Http.Ok, headers, lambda(response))

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -45,8 +45,9 @@ object Servable:
   def apply[response](mediaType: response => MediaType)(lambda: response => Stream[Bytes])
   : response is Servable = response =>
 
-    val headers = List(Http.Header(t"content-type", mediaType(response).show))
-    Http.Response.make(Http.Ok, headers, lambda(response))
+      val headers = List(Http.Header(t"content-type", mediaType(response).show))
+      Http.Response.make(Http.Ok, headers, lambda(response))
+
 
   given content: Content is Servable:
     def serve(content: Content): Http.Response =

--- a/lib/telekinesis/src/core/telekinesis.Submission.scala
+++ b/lib/telekinesis/src/core/telekinesis.Submission.scala
@@ -58,7 +58,7 @@ case class Submission[value](query: Optional[Query]):
         value:      Optional[value]      = Unset,
         validation: Optional[Validation] = Unset)
        (using value is Formulaic, value is Encodable in Query, Formulation)
-  :     Html[html5.Flow] =
+  : Html[html5.Flow] =
 
     val data: Optional[Query] = query.or(value.let(_.encode))
     elicit[value](query, validation.or(Validation()), submit)

--- a/lib/telekinesis/src/core/telekinesis.Submission.scala
+++ b/lib/telekinesis/src/core/telekinesis.Submission.scala
@@ -60,5 +60,6 @@ case class Submission[value](query: Optional[Query]):
        (using value is Formulaic, value is Encodable in Query, Formulation)
   : Html[html5.Flow] =
 
-    val data: Optional[Query] = query.or(value.let(_.encode))
-    elicit[value](query, validation.or(Validation()), submit)
+      // FIXME: Check why `data` isn't used
+      val data: Optional[Query] = query.or(value.let(_.encode))
+      elicit[value](query, validation.or(Validation()), submit)

--- a/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
+++ b/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
@@ -51,58 +51,60 @@ object Telekinesis:
         done:    List[Expr[Http.Header]]      = Nil)
        (using Quotes)
   : (Optional[Expr[Http.Method]], Optional[Expr[Http.Status]], Expr[Seq[Http.Header]]) =
-    import quotes.reflect.*
 
-    def unnamed[value: Type](value: Expr[value], tail: Seq[Expr[Any]]) =
-      Expr.summon[Prefixable of ? >: value].getOrElse:
-        val typeName = TypeRepr.of[value].show
-        halt(m"the type $typeName does not uniquely identify a particular HTTP header")
+      import quotes.reflect.*
 
-      . absolve
-      . match
-          case '{ type keyType <: Label; $prefixable: (Prefixable { type Self = keyType }) } =>
-            TypeRepr.of[keyType].absolve match
-              case ConstantType(StringConstant(key)) =>
-                val header =
-                  '{Http.Header(${Expr(key)}.tt.uncamel.kebab, $prefixable.encode($value))}
+      def unnamed[value: Type](value: Expr[value], tail: Seq[Expr[Any]]) =
+        Expr.summon[Prefixable of ? >: value].getOrElse:
+          val typeName = TypeRepr.of[value].show
+          halt(m"the type $typeName does not uniquely identify a particular HTTP header")
 
-                expand(tail, method, status, header :: done)
+        . absolve
+        . match
+            case '{ type keyType <: Label; $prefixable: (Prefixable { type Self = keyType }) } =>
+              TypeRepr.of[keyType].absolve match
+                case ConstantType(StringConstant(key)) =>
+                  val header =
+                    '{Http.Header(${Expr(key)}.tt.uncamel.kebab, $prefixable.encode($value))}
 
-    todo.absolve match
-      case '{ $method2: Http.Method } +: tail =>
-        if method.present then halt(m"the request method can only be specified once")
-        expand(tail, method2, status, done)
+                  expand(tail, method, status, header :: done)
 
-      case '{ ("", $method2: Http.Method) } +: tail =>
-        if method.present then halt(m"the request method can only be specified once")
-        expand(tail, method2, status, done)
+      todo.absolve match
+        case '{ $method2: Http.Method } +: tail =>
+          if method.present then halt(m"the request method can only be specified once")
+          expand(tail, method2, status, done)
 
-      case '{ $status2: Http.Status } +: tail =>
-        if status.present then halt(m"the HTTP status can only be specified once")
-        expand(tail, method, status2, done)
+        case '{ ("", $method2: Http.Method) } +: tail =>
+          if method.present then halt(m"the request method can only be specified once")
+          expand(tail, method2, status, done)
 
-      case '{ ("", $status2: Http.Status) } +: tail =>
-        if status.present then halt(m"the HTTP status can only be specified once")
-        expand(tail, method, status2, done)
+        case '{ $status2: Http.Status } +: tail =>
+          if status.present then halt(m"the HTTP status can only be specified once")
+          expand(tail, method, status2, done)
 
-      case '{ ("", $value: valueType) } +: tail =>
-        unnamed[valueType](value, tail)
+        case '{ ("", $status2: Http.Status) } +: tail =>
+          if status.present then halt(m"the HTTP status can only be specified once")
+          expand(tail, method, status2, done)
 
-      case '{ type keyType <: Label; ($key: keyType, $value: valueType) } +: tail =>
-        val name: Text = key.value.get.tt.uncamel.map(_.capitalize).kebab
+        case '{ ("", $value: valueType) } +: tail =>
+          unnamed[valueType](value, tail)
 
-        val Prefixable = Expr.summon[keyType is Prefixable of valueType].getOrElse:
-          val typeName = TypeRepr.of[valueType].show
-          halt(m"the header $name cannot take a value of type $typeName")
+        case '{ type keyType <: Label; ($key: keyType, $value: valueType) } +: tail =>
+          val name: Text = key.value.get.tt.uncamel.map(_.capitalize).kebab
 
-        val header = '{Http.Header($key.tt.uncamel.kebab, $Prefixable.encode($value))}
-        expand(tail, method, status, header :: done)
+          val Prefixable = Expr.summon[keyType is Prefixable of valueType].getOrElse:
+            val typeName = TypeRepr.of[valueType].show
+            halt(m"the header $name cannot take a value of type $typeName")
 
-      case '{ $value: valueType } +: tail =>
-        unnamed[valueType](value, tail)
+          val header = '{Http.Header($key.tt.uncamel.kebab, $Prefixable.encode($value))}
+          expand(tail, method, status, header :: done)
 
-      case Seq() =>
-        (method, status, Expr.ofList(done.reverse))
+        case '{ $value: valueType } +: tail =>
+          unnamed[valueType](value, tail)
+
+        case Seq() =>
+          (method, status, Expr.ofList(done.reverse))
+
 
   def submit[target: Type, payload: Type]
        (submit:   Expr[Http.Submit[target]],
@@ -115,26 +117,27 @@ object Telekinesis:
        (using Quotes)
   : Expr[Http.Response] =
 
-    headers.absolve match
-      case Varargs(exprs) =>
-        val (method0, _, headers) = expand(exprs)
+      headers.absolve match
+        case Varargs(exprs) =>
+          val (method0, _, headers) = expand(exprs)
 
-        val method = method0 match
-          case Unset                     => '{Http.Post}
-          case method: Expr[Http.Method] => method
+          val method = method0 match
+            case Unset                     => '{Http.Post}
+            case method: Expr[Http.Method] => method
 
-        '{  given online0: Online = $online
-            given payload is Postable = $postable
-            given loggable0: HttpEvent is Loggable = $loggable
-            val host: Hostname = $submit.host
-            val body = $postable.stream($payload)
-            val path = $submit.originForm
-            val contentType = Http.Header("content-type".tt, $postable.mediaType($payload).show)
+          '{  given online0: Online = $online
+              given payload is Postable = $postable
+              given loggable0: HttpEvent is Loggable = $loggable
+              val host: Hostname = $submit.host
+              val body = $postable.stream($payload)
+              val path = $submit.originForm
+              val contentType = Http.Header("content-type".tt, $postable.mediaType($payload).show)
 
-            val request =
-              Http.Request($method, 1.1, host, path, contentType :: $headers.to(List), () => body)
+              val request =
+                Http.Request($method, 1.1, host, path, contentType :: $headers.to(List), () => body)
 
-            $client.request(request, $submit.target)  }
+              $client.request(request, $submit.target)  }
+
 
   def fetch[target: Type]
        (fetch:    Expr[Http.Fetch[target]],
@@ -145,40 +148,41 @@ object Telekinesis:
        (using Quotes)
   : Expr[Http.Response] =
 
-    headers.absolve match
-      case Varargs(exprs) =>
-        val (method0, _, headers) = expand(exprs)
+      headers.absolve match
+        case Varargs(exprs) =>
+          val (method0, _, headers) = expand(exprs)
 
-        val method = method0 match
-          case Unset                    => '{Http.Get}
-          case method: Expr[Http.Method] => method
+          val method = method0 match
+            case Unset                    => '{Http.Get}
+            case method: Expr[Http.Method] => method
 
-        '{  given online0: Online = $online
-            given loggable0: HttpEvent is Loggable = $loggable
+          '{  given online0: Online = $online
+              given loggable0: HttpEvent is Loggable = $loggable
 
-            val path = $fetch.originForm
+              val path = $fetch.originForm
 
-            val request =
-              Http.Request($method, 1.1, $fetch.host, path, $headers.to(List), () => Stream())
+              val request =
+                Http.Request($method, 1.1, $fetch.host, path, $headers.to(List), () => Stream())
 
-            $client.request(request, $fetch.target)  }
+              $client.request(request, $fetch.target)  }
+
 
   def response(headers: Expr[Seq[Any]])(using Quotes)
   : Expr[Http.Response.Prototype | Http.Response] =
 
-    headers.absolve.match
-      case Varargs(exprs) => exprs.to(List).only:
-        case '{ $value: valueType } :: Nil =>
-          Expr.summon[(? >: valueType) is Servable].map { servable => '{$servable.serve($value)} }
-          . optional
+      headers.absolve.match
+        case Varargs(exprs) => exprs.to(List).only:
+          case '{ $value: valueType } :: Nil =>
+            Expr.summon[(? >: valueType) is Servable].map { servable => '{$servable.serve($value)} }
+            . optional
 
-    . or:
-        headers.absolve match
-          case Varargs(exprs) =>
-            val (_, status, headers2) = expand(exprs.to(List))
+      . or:
+          headers.absolve match
+            case Varargs(exprs) =>
+              val (_, status, headers2) = expand(exprs.to(List))
 
-            val status2: Expr[Optional[Http.Status]] = status match
-              case Unset                   => '{Unset}
-              case expr: Expr[Http.Status] => expr
+              val status2: Expr[Optional[Http.Status]] = status match
+                case Unset                   => '{Unset}
+                case expr: Expr[Http.Status] => expr
 
-            '{Http.Response.Prototype($status2, $headers2)}
+              '{Http.Response.Prototype($status2, $headers2)}

--- a/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
+++ b/lib/telekinesis/src/core/telekinesis.Telekinesis.scala
@@ -50,7 +50,7 @@ object Telekinesis:
         status:  Optional[Expr[Http.Status]]  = Unset,
         done:    List[Expr[Http.Header]]      = Nil)
        (using Quotes)
-  :     (Optional[Expr[Http.Method]], Optional[Expr[Http.Status]], Expr[Seq[Http.Header]]) =
+  : (Optional[Expr[Http.Method]], Optional[Expr[Http.Status]], Expr[Seq[Http.Header]]) =
     import quotes.reflect.*
 
     def unnamed[value: Type](value: Expr[value], tail: Seq[Expr[Any]]) =
@@ -113,7 +113,7 @@ object Telekinesis:
         postable: Expr[payload is Postable],
         client:   Expr[HttpClient onto target])
        (using Quotes)
-  :     Expr[Http.Response] =
+  : Expr[Http.Response] =
 
     headers.absolve match
       case Varargs(exprs) =>
@@ -143,7 +143,7 @@ object Telekinesis:
         loggable: Expr[HttpEvent is Loggable],
         client:   Expr[HttpClient onto target])
        (using Quotes)
-  :     Expr[Http.Response] =
+  : Expr[Http.Response] =
 
     headers.absolve match
       case Varargs(exprs) =>
@@ -164,7 +164,7 @@ object Telekinesis:
             $client.request(request, $fetch.target)  }
 
   def response(headers: Expr[Seq[Any]])(using Quotes)
-  :     Expr[Http.Response.Prototype | Http.Response] =
+  : Expr[Http.Response.Prototype | Http.Response] =
 
     headers.absolve.match
       case Varargs(exprs) => exprs.to(List).only:

--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -65,7 +65,7 @@ extension [value](value: value)
 
   def writeTo[target](target: target)[element]
        (using readable: value is Readable by element, writable: target is Writable by element)
-  :     Unit =
+  : Unit =
 
     writable.write(target, readable.stream(value))
 
@@ -104,7 +104,7 @@ extension [element](stream: Stream[element])
 
   inline def flow[result](inline termination: => result)
               (inline proceed: (head: element, tail: Stream[element]) ?=> result)
-  :     result =
+  : result =
     stream match
       case head #:: tail => proceed(using head, tail)
       case _             => termination
@@ -112,7 +112,7 @@ extension [element](stream: Stream[element])
   def strict: Stream[element] = stream.length yet stream
 
   def rate[generic: {GenericDuration, SpecificDuration}](duration: generic)(using Monitor)
-  :     Stream[element] raises AsyncError =
+  : Stream[element] raises AsyncError =
 
     def recur(stream: Stream[element], last: Long): Stream[element] =
       stream.flow(Stream()):
@@ -132,7 +132,7 @@ extension [element](stream: Stream[element])
          (active: Boolean,
           stream: Stream[Some[element] | Tap.Regulation],
           buffer: List[element])
-    :     Stream[element] =
+    : Stream[element] =
 
       recur(active, stream, buffer)
 
@@ -141,7 +141,7 @@ extension [element](stream: Stream[element])
          (active: Boolean,
           stream: Stream[Some[element] | Tap.Regulation],
           buffer: List[element])
-    :     Stream[element] =
+    : Stream[element] =
 
       if active && buffer.nonEmpty then buffer.head #:: defer(true, stream, buffer.tail)
       else if stream.isEmpty then Stream()
@@ -160,7 +160,7 @@ extension [element](stream: Stream[element])
 
   def cluster[duration: GenericDuration](duration: duration, maxSize: Optional[Int] = Unset)
        (using Monitor)
-  :     Stream[List[element]] =
+  : Stream[List[element]] =
 
     val Limit = maxSize.or(Int.MaxValue)
 
@@ -274,7 +274,7 @@ extension (stream: Stream[Bytes])
     def newArray(): Array[Byte] = new Array[Byte](arbitrary[Double]().toInt.max(1))
 
     def recur(stream: Stream[Bytes], sourcePos: Int, dest: Array[Byte], destPos: Int)
-    :     Stream[Bytes] =
+    : Stream[Bytes] =
 
       stream match
         case source #:: more =>
@@ -301,7 +301,7 @@ extension (stream: Stream[Bytes])
     def newArray(): Array[Byte] = new Array[Byte](size)
 
     def recur(stream: Stream[Bytes], sourcePos: Int, dest: Array[Byte], destPos: Int)
-    :     Stream[Bytes] =
+    : Stream[Bytes] =
 
       stream match
         case source #:: more =>

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -41,7 +41,7 @@ object LineSeparation:
                inline mkNewline: => Unit,
                inline put: Byte  => Unit)
               (lineSeparators: LineSeparation)
-  :     Unit =
+  : Unit =
 
     val action: Action = read match
       case 10 =>

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -43,35 +43,35 @@ object LineSeparation:
               (lineSeparators: LineSeparation)
   : Unit =
 
-    val action: Action = read match
-      case 10 =>
-        next
+      val action: Action = read match
+        case 10 =>
+          next
 
-        read match
-          case 13 => next; lineSeparators.lfcr
-          case ch => lineSeparators.lf
+          read match
+            case 13 => next; lineSeparators.lfcr
+            case ch => lineSeparators.lf
 
-      case 13 =>
-        next
+        case 13 =>
+          next
 
-        read match
-          case 10 => next; lineSeparators.crlf
-          case ch => lineSeparators.cr
+          read match
+            case 10 => next; lineSeparators.crlf
+            case ch => lineSeparators.cr
 
-      case ch =>
-        put(ch)
-        Action.Skip
+        case ch =>
+          put(ch)
+          Action.Skip
 
-    action match
-      case Action.Nl   => mkNewline
-      case Action.NlCr => mkNewline; put(13)
-      case Action.NlLf => mkNewline; put(10)
-      case Action.CrNl => put(13); mkNewline
-      case Action.NlNl => mkNewline; mkNewline
-      case Action.Cr   => put(13)
-      case Action.Lf   => put(10)
-      case Action.LfNl => put(10); mkNewline
-      case Action.Skip => ()
+      action match
+        case Action.Nl   => mkNewline
+        case Action.NlCr => mkNewline; put(13)
+        case Action.NlLf => mkNewline; put(10)
+        case Action.CrNl => put(13); mkNewline
+        case Action.NlNl => mkNewline; mkNewline
+        case Action.Cr   => put(13)
+        case Action.Lf   => put(10)
+        case Action.LfNl => put(10); mkNewline
+        case Action.Skip => ()
 
   enum NewlineSeq:
     case Cr, Lf, CrLf, LfCr
@@ -87,8 +87,8 @@ object LineSeparation:
 
 case class LineSeparation
    (newline: LineSeparation.NewlineSeq,
-    cr:     LineSeparation.Action,
-    lf:     LineSeparation.Action,
+    cr:      LineSeparation.Action,
+    lf:      LineSeparation.Action,
     crlf:    LineSeparation.Action,
     lfcr:    LineSeparation.Action):
 

--- a/lib/turbulence/src/core/turbulence.Stdio.scala
+++ b/lib/turbulence/src/core/turbulence.Stdio.scala
@@ -40,22 +40,23 @@ import vacuous.*
 
 object Stdio:
   def apply
-       (out:    ji.PrintStream | Null,
-        err:    ji.PrintStream | Null,
-        in:     ji.InputStream | Null,
+       (out:     ji.PrintStream | Null,
+        err:     ji.PrintStream | Null,
+        in:      ji.InputStream | Null,
         termcap: Termcap)
   : Stdio =
 
-    val safeOut: ji.PrintStream = Optional(out).or(MutePrintStream)
-    val safeErr: ji.PrintStream = Optional(err).or(MutePrintStream)
-    val safeIn: ji.InputStream = Optional(in).or(MuteInputStream)
-    val termcap2: Termcap = termcap
+      val safeOut: ji.PrintStream = Optional(out).or(MutePrintStream)
+      val safeErr: ji.PrintStream = Optional(err).or(MutePrintStream)
+      val safeIn: ji.InputStream = Optional(in).or(MuteInputStream)
+      val termcap2: Termcap = termcap
 
-    new Stdio:
-      val termcap: Termcap = termcap2
-      val out: ji.PrintStream = safeOut
-      val err: ji.PrintStream = safeErr
-      val in: ji.InputStream = safeIn
+      new Stdio:
+        val termcap: Termcap = termcap2
+        val out: ji.PrintStream = safeOut
+        val err: ji.PrintStream = safeErr
+        val in: ji.InputStream = safeIn
+
 
   object MuteOutputStream extends ji.OutputStream:
     def write(byte: Int): Unit = ()

--- a/lib/turbulence/src/core/turbulence.Stdio.scala
+++ b/lib/turbulence/src/core/turbulence.Stdio.scala
@@ -44,7 +44,7 @@ object Stdio:
         err:    ji.PrintStream | Null,
         in:     ji.InputStream | Null,
         termcap: Termcap)
-  :     Stdio =
+  : Stdio =
 
     val safeOut: ji.PrintStream = Optional(out).or(MutePrintStream)
     val safeErr: ji.PrintStream = Optional(err).or(MutePrintStream)

--- a/lib/ulysses/src/core/ulysses.BloomFilter.scala
+++ b/lib/ulysses/src/core/ulysses.BloomFilter.scala
@@ -45,13 +45,14 @@ import scala.collection.mutable as scm
 
 object BloomFilter:
   def apply[element: Digestible](approximateSize: Int, targetErrorRate: 0.0 ~ 1.0)
-    [hash <: Algorithm]
-    (using HashFunction in hash)
+       [hash <: Algorithm]
+       (using HashFunction in hash)
   : BloomFilter[element, hash] =
 
-    val bitSize: Int = (-1.44*approximateSize*ln(targetErrorRate.double).double).toInt
-    val hashCount: Int = ((bitSize.toDouble/approximateSize.toDouble)*ln(2.0).double + 0.5).toInt
-    new BloomFilter(bitSize, hashCount, sci.BitSet())
+      val bitSize: Int = (-1.44*approximateSize*ln(targetErrorRate.double).double).toInt
+      val hashCount: Int = ((bitSize.toDouble/approximateSize.toDouble)*ln(2.0).double + 0.5).toInt
+      new BloomFilter(bitSize, hashCount, sci.BitSet())
+
 
 case class BloomFilter[element: Digestible, hash <: Algorithm]
    (bitSize: Int, hashCount: Int, bits: sci.BitSet)

--- a/lib/ulysses/src/core/ulysses.BloomFilter.scala
+++ b/lib/ulysses/src/core/ulysses.BloomFilter.scala
@@ -47,7 +47,7 @@ object BloomFilter:
   def apply[element: Digestible](approximateSize: Int, targetErrorRate: 0.0 ~ 1.0)
     [hash <: Algorithm]
     (using HashFunction in hash)
-  :     BloomFilter[element, hash] =
+  : BloomFilter[element, hash] =
 
     val bitSize: Int = (-1.44*approximateSize*ln(targetErrorRate.double).double).toInt
     val hashCount: Int = ((bitSize.toDouble/approximateSize.toDouble)*ln(2.0).double + 0.5).toInt

--- a/lib/umbrageous/src/plugin/umbrageous.Shader.scala
+++ b/lib/umbrageous/src/plugin/umbrageous.Shader.scala
@@ -54,7 +54,7 @@ class Shader(options: List[String]) extends PluginPhase:
     object transformer extends UntypedTreeMap:
       private def rewritePackage
                    (tree: Ident | Select, fqn: String, defs: List[Tree], select: Select => Select)
-      :     PackageDef =
+      : PackageDef =
         tree match
           case Ident(name) =>
             val pkg = name.decode.toString+"."+fqn

--- a/lib/umbrageous/src/plugin/umbrageous.Shader.scala
+++ b/lib/umbrageous/src/plugin/umbrageous.Shader.scala
@@ -55,29 +55,31 @@ class Shader(options: List[String]) extends PluginPhase:
       private def rewritePackage
                    (tree: Ident | Select, fqn: String, defs: List[Tree], select: Select => Select)
       : PackageDef =
-        tree match
-          case Ident(name) =>
-            val pkg = name.decode.toString+"."+fqn
-            val prefixes2 =
-              prefixes.filter { (k, v) => pkg == k || pkg.startsWith(k+".") }
-              . sortBy(_(0).length)
 
-            val ident = prefixes2.lastOption.fold(tree): (k, v) =>
-              select(Select(Ident(v.toTermName), name))
+          tree match
+            case Ident(name) =>
+              val pkg = name.decode.toString+"."+fqn
 
-            val imports =
-              prefixes2.lastOption.fold(prefixes) { (k, v) => prefixes.filter(_(0) != k) }
-              . map:
-                case (_, prefix) =>
-                  Import
-                   (Ident(prefix.toTermName), List(ImportSelector(Ident(StdNames.nme.WILDCARD))))
+              val prefixes2 =
+                prefixes.filter { (k, v) => pkg == k || pkg.startsWith(k+".") }
+                . sortBy(_(0).length)
 
-            PackageDef(ident, imports ::: defs)
+              val ident = prefixes2.lastOption.fold(tree): (k, v) =>
+                select(Select(Ident(v.toTermName), name))
 
-          case Select(pkg: (Ident | Select), name) =>
-            rewritePackage(pkg, s"${name.decode}.$fqn", defs, Select(_, name))
+              val imports =
+                prefixes2.lastOption.fold(prefixes) { (k, v) => prefixes.filter(_(0) != k) }.map:
+                  case (_, prefix) =>
+                    Import
+                     (Ident(prefix.toTermName), List(ImportSelector(Ident(StdNames.nme.WILDCARD))))
 
-          case _ => ???
+              PackageDef(ident, imports ::: defs)
+
+            case Select(pkg: (Ident | Select), name) =>
+              rewritePackage(pkg, s"${name.decode}.$fqn", defs, Select(_, name))
+
+            case _ => ???
+
 
       override def transform(tree: Tree)(using Context): Tree =
         tree match

--- a/lib/vacuous/src/core/vacuous-core.scala
+++ b/lib/vacuous/src/core/vacuous-core.scala
@@ -42,7 +42,7 @@ import fulminate.*
 inline def default[value]: value = summonInline[Default[value]]()
 
 inline def optimizable[value](lambda: Optional[value] => Optional[value])
-:     Optional[value] =
+: Optional[value] =
   lambda(Unset)
 
 extension [value](iterable: Iterable[Optional[value]])

--- a/lib/vacuous/src/core/vacuous-core.scala
+++ b/lib/vacuous/src/core/vacuous-core.scala
@@ -41,8 +41,7 @@ import fulminate.*
 
 inline def default[value]: value = summonInline[Default[value]]()
 
-inline def optimizable[value](lambda: Optional[value] => Optional[value])
-: Optional[value] =
+inline def optimizable[value](lambda: Optional[value] => Optional[value]): Optional[value] =
   lambda(Unset)
 
 extension [value](iterable: Iterable[Optional[value]])

--- a/lib/vacuous/src/core/vacuous.Optional.scala
+++ b/lib/vacuous/src/core/vacuous.Optional.scala
@@ -75,7 +75,8 @@ extension [value](optional: Optional[value])(using Optionality[optional.type])
   inline def layGiven[value2](inline alternative: => value2)(inline block: value ?=> value2)
   : value2 =
 
-    if absent then alternative else block(using vouch)
+      if absent then alternative else block(using vouch)
+
 
   def let[value2](lambda: value => value2): Optional[value2] =
     if absent then Unset else lambda(vouch)

--- a/lib/vacuous/src/core/vacuous.Optional.scala
+++ b/lib/vacuous/src/core/vacuous.Optional.scala
@@ -73,7 +73,7 @@ extension [value](optional: Optional[value])(using Optionality[optional.type])
 
 
   inline def layGiven[value2](inline alternative: => value2)(inline block: value ?=> value2)
-  :     value2 =
+  : value2 =
 
     if absent then alternative else block(using vouch)
 

--- a/lib/vacuous/src/core/vacuous.Vacuous.scala
+++ b/lib/vacuous/src/core/vacuous.Vacuous.scala
@@ -63,7 +63,7 @@ object Vacuous:
 
 
   def optimizeOr[value: Type](optional: Expr[Optional[value]], default: Expr[value])(using Quotes)
-  :     Expr[value] =
+  : Expr[value] =
 
     import quotes.reflect.*
 

--- a/lib/vacuous/src/core/vacuous.Vacuous.scala
+++ b/lib/vacuous/src/core/vacuous.Vacuous.scala
@@ -65,29 +65,29 @@ object Vacuous:
   def optimizeOr[value: Type](optional: Expr[Optional[value]], default: Expr[value])(using Quotes)
   : Expr[value] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    optional.runtimeChecked match
-      case '{ $optional: optionalType } => check[optionalType]
+      optional.runtimeChecked match
+        case '{ $optional: optionalType } => check[optionalType]
 
-    def optimize(term: Term): Term = term match
-      case inlined@Inlined
-            (call@Some(Apply(TypeApply(Ident("optimizable"), _), _)), bindings, term) =>
-        term match
-          case Typed(Apply(select, List(_)), typeTree) =>
-            Inlined(call, bindings, Typed(Apply(select, List(default.asTerm)), typeTree))
+      def optimize(term: Term): Term = term match
+        case inlined@Inlined
+              (call@Some(Apply(TypeApply(Ident("optimizable"), _), _)), bindings, term) =>
+          term match
+            case Typed(Apply(select, List(_)), typeTree) =>
+              Inlined(call, bindings, Typed(Apply(select, List(default.asTerm)), typeTree))
 
-          case term =>
-            ' { $optional match
-                  case Unset => $default
-                  case term  => term.asInstanceOf[value] } . asTerm
+            case term =>
+              ' { $optional match
+                    case Unset => $default
+                    case term  => term.asInstanceOf[value] } . asTerm
 
-      case Inlined(call, bindings, term) =>
-        Inlined(call, bindings, optimize(term))
+        case Inlined(call, bindings, term) =>
+          Inlined(call, bindings, optimize(term))
 
-      case term =>
-        ' { $optional match
-              case Unset => $default
-              case term  => term.asInstanceOf[value] } . asTerm
+        case term =>
+          ' { $optional match
+                case Unset => $default
+                case term  => term.asInstanceOf[value] } . asTerm
 
-    '{${optimize(optional.asTerm).asExpr}.asInstanceOf[value]}.asExprOf[value]
+      '{${optimize(optional.asTerm).asExpr}.asInstanceOf[value]}.asExprOf[value]

--- a/lib/vicarious/src/core/vicarious-core.scala
+++ b/lib/vicarious/src/core/vicarious-core.scala
@@ -41,5 +41,5 @@ given realm: Realm = realm"vicarious"
 inline def catalog[key](key: key)[value]
    (inline lambda: [field] => (field: field) => value)
    (using classTag: ClassTag[value])
-:     Catalog[key, value] =
+: Catalog[key, value] =
   ${Vicarious.catalog[key, value]('lambda, 'key, 'classTag)}

--- a/lib/vicarious/src/core/vicarious-core.scala
+++ b/lib/vicarious/src/core/vicarious-core.scala
@@ -38,8 +38,8 @@ import fulminate.*
 
 given realm: Realm = realm"vicarious"
 
-inline def catalog[key](key: key)[value]
-   (inline lambda: [field] => (field: field) => value)
+inline def catalog[key](key: key)[value](inline lambda: [field] => (field: field) => value)
    (using classTag: ClassTag[value])
 : Catalog[key, value] =
-  ${Vicarious.catalog[key, value]('lambda, 'key, 'classTag)}
+
+    ${Vicarious.catalog[key, value]('lambda, 'key, 'classTag)}

--- a/lib/vicarious/src/core/vicarious.Catalog.scala
+++ b/lib/vicarious/src/core/vicarious.Catalog.scala
@@ -50,20 +50,24 @@ case class Catalog[key, value: ClassTag](values: IArray[value]):
   def tie[result](using proxy: Proxy[key, value, 0])
        (lambda: (catalog: this.type, `*`: proxy.type) ?=> result)
   : result =
-    lambda(using this, proxy)
+
+      lambda(using this, proxy)
+
 
   def braid[value2: ClassTag](right: Catalog[key, value2])[result: ClassTag]
        (lambda: (value, value2) => result)
   : Catalog[key, result] =
-    Catalog(IArray.tabulate(values.length) { index => lambda(values(index), right.values(index)) })
+
+      Catalog(IArray.tabulate(values.length) { index => lambda(values(index), right.values(index)) })
+
 
 extension [key, value: ClassTag](catalog: Catalog[key, value])
   def brush(using proxy: Proxy[key, value, Nat])
        (lambda: (`*`: proxy.type) ?=> Proxy[key, value, Nat] ~> value)
   : Catalog[key, value] =
 
-    val partialFunction = lambda(using proxy)
+      val partialFunction = lambda(using proxy)
 
-    Catalog(IArray.tabulate(catalog.size): index =>
-      partialFunction.applyOrElse
-       (Proxy[key, value, index.type](), _ => catalog.values(index)))
+      Catalog(IArray.tabulate(catalog.size): index =>
+        partialFunction.applyOrElse
+         (Proxy[key, value, index.type](), _ => catalog.values(index)))

--- a/lib/vicarious/src/core/vicarious.Catalog.scala
+++ b/lib/vicarious/src/core/vicarious.Catalog.scala
@@ -49,18 +49,18 @@ case class Catalog[key, value: ClassTag](values: IArray[value]):
 
   def tie[result](using proxy: Proxy[key, value, 0])
        (lambda: (catalog: this.type, `*`: proxy.type) ?=> result)
-  :     result =
+  : result =
     lambda(using this, proxy)
 
   def braid[value2: ClassTag](right: Catalog[key, value2])[result: ClassTag]
        (lambda: (value, value2) => result)
-  :     Catalog[key, result] =
+  : Catalog[key, result] =
     Catalog(IArray.tabulate(values.length) { index => lambda(values(index), right.values(index)) })
 
 extension [key, value: ClassTag](catalog: Catalog[key, value])
   def brush(using proxy: Proxy[key, value, Nat])
        (lambda: (`*`: proxy.type) ?=> Proxy[key, value, Nat] ~> value)
-  :     Catalog[key, value] =
+  : Catalog[key, value] =
 
     val partialFunction = lambda(using proxy)
 

--- a/lib/vicarious/src/core/vicarious.Proxy.scala
+++ b/lib/vicarious/src/core/vicarious.Proxy.scala
@@ -41,7 +41,9 @@ object Proxy:
 class Proxy[key, value, +id <: Nat]() extends Selectable:
   transparent inline def selectDynamic(key: String)(using catalog: Catalog[key, value])
   : value | Proxy[key, value, Nat] =
-    ${Vicarious.dereference[key, value, id]('key)}
+
+      ${Vicarious.dereference[key, value, id]('key)}
+
 
   inline def id: Int = compiletime.summonInline[ValueOf[id]].value
   inline def apply()(using catalog: Catalog[key, value]): value = catalog.values(id)

--- a/lib/vicarious/src/core/vicarious.Proxy.scala
+++ b/lib/vicarious/src/core/vicarious.Proxy.scala
@@ -40,7 +40,7 @@ object Proxy:
 
 class Proxy[key, value, +id <: Nat]() extends Selectable:
   transparent inline def selectDynamic(key: String)(using catalog: Catalog[key, value])
-  :     value | Proxy[key, value, Nat] =
+  : value | Proxy[key, value, Nat] =
     ${Vicarious.dereference[key, value, id]('key)}
 
   inline def id: Int = compiletime.summonInline[ValueOf[id]].value

--- a/lib/vicarious/src/core/vicarious.Vicarious.scala
+++ b/lib/vicarious/src/core/vicarious.Vicarious.scala
@@ -44,7 +44,7 @@ object Vicarious:
         value: Expr[key],
         classTag: Expr[ClassTag[value]])
        (using Quotes)
-  :     Expr[Catalog[key, value]] =
+  : Expr[Catalog[key, value]] =
     import quotes.reflect.*
 
     def fields[product: Type](term: Term): List[Term] =
@@ -64,7 +64,7 @@ object Vicarious:
         case '[fieldType] => label :: fieldNames[fieldType](label)
 
   def dereference[key: Type, value: Type, id <: Nat: Type](key: Expr[String])(using Quotes)
-  :     Expr[value | Proxy[key, value, Nat]] =
+  : Expr[value | Proxy[key, value, Nat]] =
 
     import quotes.reflect.*
 

--- a/lib/wisteria/src/core/wisteria.ProductDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivation.scala
@@ -39,7 +39,7 @@ trait ProductDerivation[typeclass[_]] extends ProductDerivationMethods[typeclass
   inline given derived[derivation](using Reflection[derivation])
   : typeclass[derivation] =
 
-    inline summon[Reflection[derivation]] match
-      case reflection: ProductReflection[derivationType] =>
-        join[derivationType](using reflection).asMatchable match
-          case typeclass: typeclass[`derivation`] => typeclass
+      inline summon[Reflection[derivation]] match
+        case reflection: ProductReflection[derivationType] =>
+          join[derivationType](using reflection).asMatchable match
+            case typeclass: typeclass[`derivation`] => typeclass

--- a/lib/wisteria/src/core/wisteria.ProductDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivation.scala
@@ -37,7 +37,7 @@ import scala.compiletime.*
 
 trait ProductDerivation[typeclass[_]] extends ProductDerivationMethods[typeclass]:
   inline given derived[derivation](using Reflection[derivation])
-  :     typeclass[derivation] =
+  : typeclass[derivation] =
 
     inline summon[Reflection[derivation]] match
       case reflection: ProductReflection[derivationType] =>

--- a/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
@@ -52,7 +52,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                         label:     Text,
                                                         index:     Int & FieldIndex[field])
                                                     ?=> field)
-  :     derivation =
+  : derivation =
 
     type Fields = reflection.MirroredElemTypes
     type Labels = reflection.MirroredElemLabels
@@ -80,7 +80,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                               label:     Text,
                                               index:     Int & FieldIndex[field])
                                          ?=>  constructor[field])
-  :     constructor[derivation] =
+  : constructor[derivation] =
 
     type Fields = reflection.MirroredElemTypes
     type Labels = reflection.MirroredElemLabels
@@ -109,7 +109,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                         dereference: derivation => field,
                                                         index:       Int & FieldIndex[field])
                                                     ?=> result)
-  :     IArray[result] =
+  : IArray[result] =
 
     type Fields = reflection.MirroredElemTypes
     type Labels = reflection.MirroredElemLabels
@@ -137,7 +137,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                     (using fieldIndex:  Int & FieldIndex[field],
                                            reflection:  ProductReflection[derivation],
                                            requirement: ContextRequirement)
-  :     field =
+  : field =
 
     type Labels = reflection.MirroredElemLabels
     type Fields = reflection.MirroredElemTypes
@@ -161,7 +161,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                         label:   Text,
                                                         index:   Int & FieldIndex[field])
                                                     ?=> result)
-  :     IArray[result] =
+  : IArray[result] =
 
     summonInline[ClassTag[result]].give:
       type Labels = reflection.MirroredElemLabels
@@ -194,7 +194,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                       label:   Text,
                                                       index:   Int & FieldIndex[field])
                                                   ?=> result)
-  :     result =
+  : result =
 
     inline tuple match
       case Zero => accumulator
@@ -229,7 +229,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                       dereference: derivation => field,
                                                       index:       Int & FieldIndex[field])
                                                   ?=> result)
-  :     result =
+  : result =
 
     inline erasedValue[fields] match
       case _: Zero => accumulator

--- a/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
@@ -54,14 +54,15 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                     ?=> field)
   : derivation =
 
-    type Fields = reflection.MirroredElemTypes
-    type Labels = reflection.MirroredElemLabels
+      type Fields = reflection.MirroredElemTypes
+      type Labels = reflection.MirroredElemLabels
 
-    reflection.fromProduct:
-      fold[derivation, Fields, Labels, Tuple](Zero, 0): accumulator =>
-        [field] => context ?=> lambda[field](context) *: accumulator
+      reflection.fromProduct:
+        fold[derivation, Fields, Labels, Tuple](Zero, 0): accumulator =>
+          [field] => context ?=> lambda[field](context) *: accumulator
 
-      . reverse
+        . reverse
+
 
   protected transparent inline
   def constructWith[constructor[_]]
@@ -82,19 +83,20 @@ trait ProductDerivationMethods[typeclass[_]]:
                                          ?=>  constructor[field])
   : constructor[derivation] =
 
-    type Fields = reflection.MirroredElemTypes
-    type Labels = reflection.MirroredElemLabels
+      type Fields = reflection.MirroredElemTypes
+      type Labels = reflection.MirroredElemLabels
 
-    val tuple: constructor[Tuple] =
-      fold[derivation, Fields, Labels, constructor[Tuple]](pure(Zero), 0):
-        accumulator =>
-          [field] => context ?=>
-            bind(accumulator): accumulator2 =>
-              bind(lambda[field](context)): result =>
-                pure(result *: accumulator2)
+      val tuple: constructor[Tuple] =
+        fold[derivation, Fields, Labels, constructor[Tuple]](pure(Zero), 0):
+          accumulator =>
+            [field] => context ?=>
+              bind(accumulator): accumulator2 =>
+                bind(lambda[field](context)): result =>
+                  pure(result *: accumulator2)
 
-    bind(tuple): tuple =>
-      pure(reflection.fromProduct(tuple.reverse))
+      bind(tuple): tuple =>
+        pure(reflection.fromProduct(tuple.reverse))
+
 
   protected transparent inline def contexts[derivation <: Product]
                                     (using reflection:  ProductReflection[derivation],
@@ -111,13 +113,14 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                     ?=> result)
   : IArray[result] =
 
-    type Fields = reflection.MirroredElemTypes
-    type Labels = reflection.MirroredElemLabels
+      type Fields = reflection.MirroredElemTypes
+      type Labels = reflection.MirroredElemLabels
 
-    summonInline[ClassTag[result]].give:
-      IArray.create[result](valueOf[Tuple.Size[Fields]]): array =>
-        fold[derivation, Fields, Labels, Unit]((), 0): accumulator =>
-          [field] => context ?=> array(index) = lambda[field](context)
+      summonInline[ClassTag[result]].give:
+        IArray.create[result](valueOf[Tuple.Size[Fields]]): array =>
+          fold[derivation, Fields, Labels, Unit]((), 0): accumulator =>
+            [field] => context ?=> array(index) = lambda[field](context)
+
 
   inline def typeName[derivation](using reflection: Reflection[derivation]): Text =
     valueOf[reflection.MirroredLabel].tt
@@ -139,15 +142,16 @@ trait ProductDerivationMethods[typeclass[_]]:
                                            requirement: ContextRequirement)
   : field =
 
-    type Labels = reflection.MirroredElemLabels
-    type Fields = reflection.MirroredElemTypes
-    val tuple: Fields = Tuple.fromProductTyped(product)
+      type Labels = reflection.MirroredElemLabels
+      type Fields = reflection.MirroredElemTypes
+      val tuple: Fields = Tuple.fromProductTyped(product)
 
-    fold[derivation, Fields, Labels, Optional[field]](tuple, Unset, 0):
-      accumulator => [field2] => field =>
-        if index == fieldIndex then field.asInstanceOf[field] else accumulator
+      fold[derivation, Fields, Labels, Optional[field]](tuple, Unset, 0):
+        accumulator => [field2] => field =>
+          if index == fieldIndex then field.asInstanceOf[field] else accumulator
 
-    . vouch
+      . vouch
+
 
   protected transparent inline def fields[derivation <: Product](inline product: derivation)
                                     (using requirement: ContextRequirement)
@@ -163,20 +167,21 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                     ?=> result)
   : IArray[result] =
 
-    summonInline[ClassTag[result]].give:
-      type Labels = reflection.MirroredElemLabels
-      type Fields = reflection.MirroredElemTypes
-      val tuple: Fields = Tuple.fromProductTyped(product)
+      summonInline[ClassTag[result]].give:
+        type Labels = reflection.MirroredElemLabels
+        type Fields = reflection.MirroredElemTypes
+        val tuple: Fields = Tuple.fromProductTyped(product)
 
-      IArray.create[result](tuple.size):
-        array =>
-          fold[derivation, Fields, Labels, Unit](tuple, (), 0):
-            unit =>
-              [field] => field =>
-                given typeclass: requirement.Optionality[typeclass[field]] =
-                  requirement.wrap(context)
+        IArray.create[result](tuple.size):
+          array =>
+            fold[derivation, Fields, Labels, Unit](tuple, (), 0):
+              unit =>
+                [field] => field =>
+                  given typeclass: requirement.Optionality[typeclass[field]] =
+                    requirement.wrap(context)
 
-                array(index) = lambda[field](field)
+                  array(index) = lambda[field](field)
+
 
   // The two implementations of `fold` are very similar. We would prefer to have a single
   // implementation (closer to the non-erased `fold`), but it's difficult to abstract over the
@@ -196,26 +201,27 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                   ?=> result)
   : result =
 
-    inline tuple match
-      case Zero => accumulator
+      inline tuple match
+        case Zero => accumulator
 
-      case tuple: (fieldType *: moreFields) => tuple match
-        case field *: moreFields => inline erasedValue[labels] match
-          case _: (label *: moreLabels) => inline valueOf[label].asMatchable match
-            case label: String =>
-              val typeclass = requirement.summon[typeclass[fieldType]]
+        case tuple: (fieldType *: moreFields) => tuple match
+          case field *: moreFields => inline erasedValue[labels] match
+            case _: (label *: moreLabels) => inline valueOf[label].asMatchable match
+              case label: String =>
+                val typeclass = requirement.summon[typeclass[fieldType]]
 
-              val fieldIndex: Int & FieldIndex[fieldType] =
-                index.asInstanceOf[Int & FieldIndex[fieldType]]
+                val fieldIndex: Int & FieldIndex[fieldType] =
+                  index.asInstanceOf[Int & FieldIndex[fieldType]]
 
-              val default = Default(Wisteria.default[derivation, fieldType](index))
+                val default = Default(Wisteria.default[derivation, fieldType](index))
 
-              val accumulator2 =
-                lambda(accumulator)[fieldType](field)
-                 (using typeclass, default, label.tt, fieldIndex)
+                val accumulator2 =
+                  lambda(accumulator)[fieldType](field)
+                   (using typeclass, default, label.tt, fieldIndex)
 
-              fold[derivation, moreFields, moreLabels, result](moreFields, accumulator2, index + 1)
-                (lambda)
+                fold[derivation, moreFields, moreLabels, result](moreFields, accumulator2, index + 1)
+                  (lambda)
+
 
   private transparent inline def fold
                                   [derivation <: Product, fields <: Tuple, labels <: Tuple, result]
@@ -231,26 +237,27 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                   ?=> result)
   : result =
 
-    inline erasedValue[fields] match
-      case _: Zero => accumulator
+      inline erasedValue[fields] match
+        case _: Zero => accumulator
 
-      case _: (fieldType *: moreFields) => inline erasedValue[labels] match
-        case _: (label *: moreLabels) => inline valueOf[label].asMatchable match
-          case label: String =>
-            val typeclass = requirement.summon[typeclass[fieldType]]
+        case _: (fieldType *: moreFields) => inline erasedValue[labels] match
+          case _: (label *: moreLabels) => inline valueOf[label].asMatchable match
+            case label: String =>
+              val typeclass = requirement.summon[typeclass[fieldType]]
 
-            val fieldIndex: Int & FieldIndex[fieldType] =
-              index.asInstanceOf[Int & FieldIndex[fieldType]]
+              val fieldIndex: Int & FieldIndex[fieldType] =
+                index.asInstanceOf[Int & FieldIndex[fieldType]]
 
-            val default = Default(Wisteria.default[derivation, fieldType](index))
+              val default = Default(Wisteria.default[derivation, fieldType](index))
 
-            val dereference: derivation => fieldType =
-              _.productElement(fieldIndex).asInstanceOf[fieldType]
+              val dereference: derivation => fieldType =
+                _.productElement(fieldIndex).asInstanceOf[fieldType]
 
-            val accumulator2 =
-              lambda(accumulator)[fieldType](typeclass)
-               (using default, label.tt, dereference, fieldIndex)
+              val accumulator2 =
+                lambda(accumulator)[fieldType](typeclass)
+                 (using default, label.tt, dereference, fieldIndex)
 
-            fold[derivation, moreFields, moreLabels, result](accumulator2, index + 1)(lambda)
+              fold[derivation, moreFields, moreLabels, result](accumulator2, index + 1)(lambda)
+
 
   inline def join[derivation <: Product: ProductReflection]: typeclass[derivation]

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -58,50 +58,56 @@ trait SumDerivationMethods[typeclass[_]]:
       case _: (variant *: variants)  => all[variant, variants]
     case _                                 => false
 
+
   protected transparent inline def complement[derivation, variant](sum: derivation)
                                     (using variantIndex: Int & VariantIndex[variant],
                                            reflection:   SumReflection[derivation])
   : Optional[variant] =
-    type Labels = reflection.MirroredElemLabels
-    type Variants = reflection.MirroredElemTypes
-    val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
 
-    fold[derivation, Variants, Labels](sum, size, 0, false)(index == reflection.ordinal(sum)):
-      [variant2 <: derivation] => field =>
-        if index == variantIndex then field.asInstanceOf[variant] else Unset
+      type Labels = reflection.MirroredElemLabels
+      type Variants = reflection.MirroredElemTypes
+      val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
+
+      fold[derivation, Variants, Labels](sum, size, 0, false)(index == reflection.ordinal(sum)):
+        [variant2 <: derivation] => field =>
+          if index == variantIndex then field.asInstanceOf[variant] else Unset
+
 
   protected inline def variantLabels[derivation](using reflection: SumReflection[derivation])
   : List[Text] =
 
-    constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
+      constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
+
 
   protected transparent inline def singleton[derivation](input: Text)
                                     (using reflection: SumReflection[derivation])
   : derivation =
 
-    type Variants = reflection.MirroredElemTypes
-    type Labels = reflection.MirroredElemLabels
+      type Variants = reflection.MirroredElemTypes
+      type Labels = reflection.MirroredElemLabels
 
-    singletonFold[derivation, Variants, Labels](_ == input).or:
-      summonInline[Tactic[VariantError]].give:
-        abort(VariantError[derivation](input))
+      singletonFold[derivation, Variants, Labels](_ == input).or:
+        summonInline[Tactic[VariantError]].give:
+          abort(VariantError[derivation](input))
+
 
   private transparent inline def singletonFold[derivation, variants <: Tuple, labels <: Tuple]
                                   (using reflection: SumReflection[derivation])
                                   (predicate: Text => Boolean)
   : Optional[derivation] =
 
-    inline erasedValue[variants] match
-      case _: (variant *: variants) => inline erasedValue[labels] match
-        case _: (label *: labelsType) =>
-          type variant0 = variant & derivation
+      inline erasedValue[variants] match
+        case _: (variant *: variants) => inline erasedValue[labels] match
+          case _: (label *: labelsType) =>
+            type variant0 = variant & derivation
 
-          if predicate(valueOf[label & String].tt)
-          then summonInline[Mirror.ProductOf[variant0]].fromProduct(Zero)
-          else singletonFold[derivation, variants, labelsType](predicate)
+            if predicate(valueOf[label & String].tt)
+            then summonInline[Mirror.ProductOf[variant0]].fromProduct(Zero)
+            else singletonFold[derivation, variants, labelsType](predicate)
 
-      case _  =>
-        Unset
+        case _  =>
+          Unset
+
 
   protected transparent inline def delegate[derivation](label: Text)
                                     (using reflection:  SumReflection[derivation],
@@ -116,17 +122,18 @@ trait SumDerivationMethods[typeclass[_]]:
                                             ?=> result)
   : result =
 
-    type Labels = reflection.MirroredElemLabels
-    type Variants = reflection.MirroredElemTypes
+      type Labels = reflection.MirroredElemLabels
+      type Variants = reflection.MirroredElemTypes
 
-    val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
-    val variantLabel = label
+      val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
+      val variantLabel = label
 
-    // Here label comes from context of fold's predicate
-    fold[derivation, Variants, Labels](variantLabel, size, 0, true)(label == variantLabel):
-      [variant <: derivation] => context => lambda[variant](context)
+      // Here label comes from context of fold's predicate
+      fold[derivation, Variants, Labels](variantLabel, size, 0, true)(label == variantLabel):
+        [variant <: derivation] => context => lambda[variant](context)
 
-    . vouch
+      . vouch
+
 
   protected transparent inline def variant[derivation](sum: derivation)
                                     (using reflection:  SumReflection[derivation],
@@ -141,15 +148,16 @@ trait SumDerivationMethods[typeclass[_]]:
                                                     ?=> result)
   : result =
 
-    type Labels = reflection.MirroredElemLabels
-    type Variants = reflection.MirroredElemTypes
+      type Labels = reflection.MirroredElemLabels
+      type Variants = reflection.MirroredElemTypes
 
-    val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
+      val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
 
-    fold[derivation, Variants, Labels](sum, size, 0, false)(index == reflection.ordinal(sum)):
-      [variant <: derivation] => variant => lambda[variant](variant)
+      fold[derivation, Variants, Labels](sum, size, 0, false)(index == reflection.ordinal(sum)):
+        [variant <: derivation] => variant => lambda[variant](variant)
 
-    . vouch
+      . vouch
+
 
   private transparent inline def fold[derivation, variants <: Tuple, labels <: Tuple]
                                   (inline inputLabel: Text,
@@ -171,32 +179,33 @@ trait SumDerivationMethods[typeclass[_]]:
                                                   ?=> result)
   : Optional[result] =
 
-    inline erasedValue[variants] match
-      case _: (variant *: variants) => inline erasedValue[labels] match
-        case _: (label *: moreLabels) =>
-          type variant0 = variant & derivation
-          if index >= size then Unset else
-            (valueOf[label].asMatchable: @unchecked) match
-              case label: String =>
-                val index2: Int & VariantIndex[derivation] = VariantIndex[derivation](index)
+      inline erasedValue[variants] match
+        case _: (variant *: variants) => inline erasedValue[labels] match
+          case _: (label *: moreLabels) =>
+            type variant0 = variant & derivation
+            if index >= size then Unset else
+              (valueOf[label].asMatchable: @unchecked) match
+                case label: String =>
+                  val index2: Int & VariantIndex[derivation] = VariantIndex[derivation](index)
 
-                if predicate(using label.tt, index2)
-                then
-                  val index3: Int & VariantIndex[variant0] = VariantIndex[variant0](index)
-                  val context = requirement.wrap(summonInline[typeclass[variant0]])
-                  lambda[variant0](context)(using context, label.tt, index3)
-                else
-                  fold
-                    [derivation, variants, moreLabels]
-                    (inputLabel, size, index + 1, fallible)
-                    (predicate)
-                    (lambda)
+                  if predicate(using label.tt, index2)
+                  then
+                    val index3: Int & VariantIndex[variant0] = VariantIndex[variant0](index)
+                    val context = requirement.wrap(summonInline[typeclass[variant0]])
+                    lambda[variant0](context)(using context, label.tt, index3)
+                  else
+                    fold
+                      [derivation, variants, moreLabels]
+                      (inputLabel, size, index + 1, fallible)
+                      (predicate)
+                      (lambda)
 
-      case _ =>
-        inline if fallible
-        then summonInline[Tactic[VariantError]].give:
-          raise(VariantError[derivation](inputLabel)) yet Unset
-        else panic(m"Should be unreachable")
+        case _ =>
+          inline if fallible
+          then summonInline[Tactic[VariantError]].give:
+            raise(VariantError[derivation](inputLabel)) yet Unset
+          else panic(m"Should be unreachable")
+
 
   private transparent inline def fold[derivation, variants <: Tuple, labels <: Tuple]
                                   (inline sum:      derivation,
@@ -218,29 +227,30 @@ trait SumDerivationMethods[typeclass[_]]:
                                                   ?=> result)
   : Optional[result] =
 
-    inline erasedValue[variants] match
-      case _: (variant *: variants) => inline erasedValue[labels] match
-        case _: (label *: moreLabels) =>
-          type variant0 = variant & derivation
-          if index >= size then Unset else
-            (valueOf[label].asMatchable: @unchecked) match
-              case label: String =>
-                val index2: Int & VariantIndex[derivation] = VariantIndex[derivation](index)
+      inline erasedValue[variants] match
+        case _: (variant *: variants) => inline erasedValue[labels] match
+          case _: (label *: moreLabels) =>
+            type variant0 = variant & derivation
+            if index >= size then Unset else
+              (valueOf[label].asMatchable: @unchecked) match
+                case label: String =>
+                  val index2: Int & VariantIndex[derivation] = VariantIndex[derivation](index)
 
-                if predicate(using label.tt, index2)
-                then
-                  val index3: Int & VariantIndex[variant0] = VariantIndex[variant0](index)
-                  val variant: variant0 = sum.asInstanceOf[variant0]
-                  val context = requirement.wrap(summonInline[typeclass[variant0]])
-                  lambda[variant0](variant)(using context, label.tt, index3)
-                else
-                  fold[derivation, variants, moreLabels](sum, size, index + 1, fallible)(predicate)
-                   (lambda)
+                  if predicate(using label.tt, index2)
+                  then
+                    val index3: Int & VariantIndex[variant0] = VariantIndex[variant0](index)
+                    val variant: variant0 = sum.asInstanceOf[variant0]
+                    val context = requirement.wrap(summonInline[typeclass[variant0]])
+                    lambda[variant0](variant)(using context, label.tt, index3)
+                  else
+                    fold[derivation, variants, moreLabels](sum, size, index + 1, fallible)(predicate)
+                     (lambda)
 
-      case _ =>
-        inline if fallible
-        then summonInline[Tactic[VariantError]].give:
-          raise(VariantError[derivation]("".tt)) yet Unset
-        else panic(m"Should be unreachable")
+        case _ =>
+          inline if fallible
+          then summonInline[Tactic[VariantError]].give:
+            raise(VariantError[derivation]("".tt)) yet Unset
+          else panic(m"Should be unreachable")
+
 
   inline def split[derivation: SumReflection]: typeclass[derivation]

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -61,7 +61,7 @@ trait SumDerivationMethods[typeclass[_]]:
   protected transparent inline def complement[derivation, variant](sum: derivation)
                                     (using variantIndex: Int & VariantIndex[variant],
                                            reflection:   SumReflection[derivation])
-  :     Optional[variant] =
+  : Optional[variant] =
     type Labels = reflection.MirroredElemLabels
     type Variants = reflection.MirroredElemTypes
     val size: Int = valueOf[Tuple.Size[reflection.MirroredElemTypes]]
@@ -71,13 +71,13 @@ trait SumDerivationMethods[typeclass[_]]:
         if index == variantIndex then field.asInstanceOf[variant] else Unset
 
   protected inline def variantLabels[derivation](using reflection: SumReflection[derivation])
-  :     List[Text] =
+  : List[Text] =
 
     constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
 
   protected transparent inline def singleton[derivation](input: Text)
                                     (using reflection: SumReflection[derivation])
-  :     derivation =
+  : derivation =
 
     type Variants = reflection.MirroredElemTypes
     type Labels = reflection.MirroredElemLabels
@@ -89,7 +89,7 @@ trait SumDerivationMethods[typeclass[_]]:
   private transparent inline def singletonFold[derivation, variants <: Tuple, labels <: Tuple]
                                   (using reflection: SumReflection[derivation])
                                   (predicate: Text => Boolean)
-  :     Optional[derivation] =
+  : Optional[derivation] =
 
     inline erasedValue[variants] match
       case _: (variant *: variants) => inline erasedValue[labels] match
@@ -114,7 +114,7 @@ trait SumDerivationMethods[typeclass[_]]:
                                                 label:   Text,
                                                 index:   Int & VariantIndex[variant])
                                             ?=> result)
-  :     result =
+  : result =
 
     type Labels = reflection.MirroredElemLabels
     type Variants = reflection.MirroredElemTypes
@@ -139,7 +139,7 @@ trait SumDerivationMethods[typeclass[_]]:
                                                         label:   Text,
                                                         index:   Int & VariantIndex[variant])
                                                     ?=> result)
-  :     result =
+  : result =
 
     type Labels = reflection.MirroredElemLabels
     type Variants = reflection.MirroredElemTypes
@@ -169,7 +169,7 @@ trait SumDerivationMethods[typeclass[_]]:
                                                       label:   Text,
                                                       index:   Int & VariantIndex[variant])
                                                   ?=> result)
-  :     Optional[result] =
+  : Optional[result] =
 
     inline erasedValue[variants] match
       case _: (variant *: variants) => inline erasedValue[labels] match
@@ -216,7 +216,7 @@ trait SumDerivationMethods[typeclass[_]]:
                                                       label: Text,
                                                       index: Int & VariantIndex[variant])
                                                   ?=> result)
-  :     Optional[result] =
+  : Optional[result] =
 
     inline erasedValue[variants] match
       case _: (variant *: variants) => inline erasedValue[labels] match

--- a/lib/wisteria/src/core/wisteria.VariantError.scala
+++ b/lib/wisteria/src/core/wisteria.VariantError.scala
@@ -41,7 +41,7 @@ import scala.compiletime.*
 object VariantError:
   inline def apply[derivation](inputLabel: Text)
               (using reflection: SumReflection[derivation], diagnostics: Diagnostics)
-  :     VariantError =
+  : VariantError =
 
     val variants = constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
     val sum = constValue[reflection.MirroredLabel].tt

--- a/lib/wisteria/src/core/wisteria.VariantError.scala
+++ b/lib/wisteria/src/core/wisteria.VariantError.scala
@@ -43,10 +43,11 @@ object VariantError:
               (using reflection: SumReflection[derivation], diagnostics: Diagnostics)
   : VariantError =
 
-    val variants = constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
-    val sum = constValue[reflection.MirroredLabel].tt
+      val variants = constValueTuple[reflection.MirroredElemLabels].toList.map(_.toString.tt)
+      val sum = constValue[reflection.MirroredLabel].tt
 
-    VariantError(inputLabel, sum, variants)
+      VariantError(inputLabel, sum, variants)
+
 
 case class VariantError(inputLabel: Text, sum: Text, validVariants: List[Text])(using Diagnostics)
 extends Error

--- a/lib/wisteria/src/core/wisteria.Wisteria.scala
+++ b/lib/wisteria/src/core/wisteria.Wisteria.scala
@@ -40,21 +40,22 @@ object Wisteria:
   inline def default[product, field](index: Int): Optional[field] =
     ${getDefault[product, field]('index)}
 
+
   def getDefault[product: Type, field: Type](index: Expr[Int])(using Quotes)
   : Expr[Optional[field]] =
 
-    import quotes.reflect.*
+      import quotes.reflect.*
 
-    val methodName: String = "$lessinit$greater$default$"+(index.valueOrAbort + 1)
-    val productSymbol = TypeRepr.of[product].classSymbol
+      val methodName: String = "$lessinit$greater$default$"+(index.valueOrAbort + 1)
+      val productSymbol = TypeRepr.of[product].classSymbol
 
-    productSymbol.flatMap: symbol =>
-      symbol.companionClass.declaredMethod(methodName).headOption.map: method =>
-        Ref(symbol.companionModule).select(method)
+      productSymbol.flatMap: symbol =>
+        symbol.companionClass.declaredMethod(methodName).headOption.map: method =>
+          Ref(symbol.companionModule).select(method)
 
-    . map: selection =>
-        TypeRepr.of[product].typeArgs match
-          case Nil  => selection
-          case args => selection.appliedToTypes(args)
+      . map: selection =>
+          TypeRepr.of[product].typeArgs match
+            case Nil  => selection
+            case args => selection.appliedToTypes(args)
 
-    . map(_.asExprOf[field]).getOrElse('{Unset})
+      . map(_.asExprOf[field]).getOrElse('{Unset})

--- a/lib/wisteria/src/core/wisteria.Wisteria.scala
+++ b/lib/wisteria/src/core/wisteria.Wisteria.scala
@@ -41,7 +41,7 @@ object Wisteria:
     ${getDefault[product, field]('index)}
 
   def getDefault[product: Type, field: Type](index: Expr[Int])(using Quotes)
-  :     Expr[Optional[field]] =
+  : Expr[Optional[field]] =
 
     import quotes.reflect.*
 

--- a/lib/yossarian/src/core/yossarian.PtyState.scala
+++ b/lib/yossarian/src/core/yossarian.PtyState.scala
@@ -36,12 +36,12 @@ import anticipation.*
 import gossamer.*
 
 case class PtyState
-   (cursor:          Int     = 0,
-    savedCursor:     Int     = 0,
-    style:           Style   = Style(),
+   (cursor:             Int     = 0,
+    savedCursor:        Int     = 0,
+    style:              Style   = Style(),
     focusDetectionMode: Boolean = false,
-    focus:           Boolean = true,
+    focus:              Boolean = true,
     bracketedPasteMode: Boolean = false,
-    hideCursor:      Boolean = false,
-    title:           Text    = t"",
-    link:            Text    = t"")
+    hideCursor:         Boolean = false,
+    title:              Text    = t"",
+    link:               Text    = t"")


### PR DESCRIPTION
I've had a longstanding issue with the previous style for multiline signatures, which began their final line with `:     Type`. This meant that the alignment of the body beneath was to the left of the return type, `Type`.

This latest version reduces the five spaces between the `:` and the return type to one, and double-indents the method body, ensuring that there are two blank lines above and below the method.

With more indentation, this does not yet address the consequential long lines.