### PR TITLE
Allow and correctly handle `pm`/`am` times where the hour is `12`

### DIFF
--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -270,6 +270,14 @@ object Tests extends Suite(m"Aviation Tests"):
         demilitarize(7.585.am)
       .assert(_.nonEmpty)
 
+      test(m"Specify afternoon time with hour `12`"):
+        12.25.pm
+      .assert(_ == Clockface(12, 25, 0))
+
+      test(m"Specify morning time with hour `12`"):
+        12.25.am
+      .assert(_ == Clockface(0, 25, 0))
+
       import calendars.gregorian
 
       test(m"Specify datetime"):


### PR DESCRIPTION
Times between `12` and `1` were being assigned to the wrong side of midday, and times after 12.pm were not being permitted at all. This is now fixed.