### PR TITLE
Use `into` for all `Duration` parameters

### DIFF
--- a/lib/aviation/src/core/aviation.Aviation2.scala
+++ b/lib/aviation/src/core/aviation.Aviation2.scala
@@ -143,9 +143,9 @@ object Aviation2:
 
         def milliseconds(duration: Quantity[units]): Long = (duration.normalize.value*1000).toLong
 
-  extension (instant: Instant)
+  extension (instant: into Instant)
     @targetName("to")
-    infix def ~ (that: Instant): Period = Period(instant, that)
+    infix def ~ (that: into Instant): Period = Period(instant, that)
 
     def tai: TaiInstant = LeapSeconds.tai(instant)
 
@@ -167,4 +167,4 @@ object Aviation2:
     def long: Long = instant
 
   extension (duration: into Duration)
-    def from(instant: Instant): Period = Period(instant, Instant.plus.add(instant, duration))
+    def from(instant: into Instant): Period = Period(instant, Instant.plus.add(instant, duration))

--- a/lib/aviation/src/core/aviation.Aviation2.scala
+++ b/lib/aviation/src/core/aviation.Aviation2.scala
@@ -166,5 +166,5 @@ object Aviation2:
 
     def long: Long = instant
 
-  extension (duration: Duration)
+  extension (duration: into Duration)
     def from(instant: Instant): Period = Period(instant, Instant.plus.add(instant, duration))

--- a/lib/aviation/src/core/aviation.Clock.scala
+++ b/lib/aviation/src/core/aviation.Clock.scala
@@ -41,7 +41,7 @@ object Clock:
   given current: Clock:
     def apply(): Instant = Instant.of(System.currentTimeMillis)
 
-  def fixed(instant: Instant): Clock = new Clock():
+  def fixed(instant: into Instant): Clock = new Clock():
     def apply(): Instant = instant
 
   def offset(diff: into Duration): Clock = new Clock():

--- a/lib/aviation/src/core/aviation.Clock.scala
+++ b/lib/aviation/src/core/aviation.Clock.scala
@@ -44,5 +44,5 @@ object Clock:
   def fixed(instant: Instant): Clock = new Clock():
     def apply(): Instant = instant
 
-  def offset(diff: Duration): Clock = new Clock():
+  def offset(diff: into Duration): Clock = new Clock():
     def apply(): Instant = Instant.of(System.currentTimeMillis) + diff

--- a/lib/aviation/src/core/aviation.Period.scala
+++ b/lib/aviation/src/core/aviation.Period.scala
@@ -36,7 +36,7 @@ import hypotenuse.*
 import symbolism.*
 import vacuous.*
 
-case class Period(start: Instant, finish: Instant):
+case class Period(start: into Instant, finish: into Instant):
   def duration = finish - start
 
   def intersect(period: Period): Optional[Period] =

--- a/lib/aviation/src/core/aviation.Tzdb.scala
+++ b/lib/aviation/src/core/aviation.Tzdb.scala
@@ -62,7 +62,7 @@ object Tzdb:
     case Zone(area: Text, location: Option[Text], info: Trie[ZoneInfo])
     case Link(from: Text, to: Text)
 
-  case class ZoneInfo(stdoff: Duration, rules: Text, format: Text => Text, until: Option[Text])
+  case class ZoneInfo(stdoff: into Duration, rules: Text, format: Text => Text, until: Option[Text])
 
   enum MonthDate:
     case Last(month: Month, day: Weekday)

--- a/lib/aviation/src/test/aviation.Tests.scala
+++ b/lib/aviation/src/test/aviation.Tests.scala
@@ -648,9 +648,5 @@ object Tests extends Suite(m"Aviation Tests"):
           test(m"Check there are 253 working days in a year"):
             import hebdomads.european
             import dateFormats.iso8601
-            for i <- 4 to 5 do
-              println("-----")
-              val d = (2025-Jan-1 + WorkingDays(i))
-              println(t"${d.weekday}, $d")
             2025-Jan-3 + WorkingDays(253)
           . assert(_ == 2026-Jan-1)

--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -87,7 +87,7 @@ object Bootstrapper:
 
   given burdockVerbosity: ("Burdock-Verbosity" is EncodableManifest of Text) = identity(_)
 
-  case class Requirement(url: HttpUrl, digest: Text):
+  case class Requirement(url: into HttpUrl, digest: Text):
     def text = t"$digest:$url"
 
   case class Entry(name: Text, data: Bytes)

--- a/lib/telekinesis/src/core/telekinesis-core.scala
+++ b/lib/telekinesis/src/core/telekinesis-core.scala
@@ -59,7 +59,7 @@ extension [fetchable: Fetchable](endpoint: fetchable)
   def submit: Http.Submit[fetchable.Target] =
     Http.Submit(fetchable.text(endpoint), fetchable.target(endpoint), fetchable.hostname(endpoint))
 
-extension (url: HttpUrl)
+extension (url: into HttpUrl)
   @targetName("withQuery")
   def query(query: Query): HttpUrl =
     val query2 = url.query.let(query ++ _.decode[Query]).or(query)

--- a/lib/telekinesis/src/core/telekinesis.HttpEvent.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpEvent.scala
@@ -39,7 +39,7 @@ import nettlesome.*
 enum HttpEvent:
   case Response(status: Http.Status)
   case Request(preview: Text)
-  case Send(method: Http.Method, url: HttpUrl, headers: Seq[Http.Header])
+  case Send(method: Http.Method, url: into HttpUrl, headers: Seq[Http.Header])
 
 object HttpEvent:
   given communicable: HttpEvent is Communicable =


### PR DESCRIPTION
This should make it possible to use alternative representations that are convertible to `Duration`s.