### PR TITLE
Path pattern matching

### DIFF
--- a/lib/hypotenuse/src/core/hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse-core.scala
@@ -210,7 +210,7 @@ extension (byte: Byte)
   inline infix def %% (right: Int): Int = math.floorMod(byte, right)
 
   @targetName("floorDivByte")
-  inline infix def \ (right: Int): Int = math.floorDiv(byte, right)
+  inline infix def /- (right: Int): Int = math.floorDiv(byte, right)
 
   @tailrec @targetName("gcdByte")
   def gcd(right: Byte): Byte = if right == 0 then byte else right.gcd((byte%right).toByte)
@@ -247,7 +247,7 @@ extension (short: Short)
   inline infix def %% (right: Short): Short = math.floorMod(short, right).toShort
 
   @targetName("floorDivShort")
-  inline infix def \ (right: Short): Short = math.floorDiv(short, right).toShort
+  inline infix def /- (right: Short): Short = math.floorDiv(short, right).toShort
 
   @tailrec @targetName("gcdShort")
   def gcd(right: Short): Short = if right == 0 then short else right.gcd((short%right).toShort)
@@ -284,7 +284,7 @@ extension (int: Int)
   inline infix def %% (right: Int): Int = math.floorMod(int, right)
 
   @targetName("floorDivInt")
-  inline infix def \ (right: Int): Int = math.floorDiv(int, right)
+  inline infix def /- (right: Int): Int = math.floorDiv(int, right)
 
   @tailrec @targetName("gcdInt")
   def gcd(right: Int): Int = if right == 0 then int else right.gcd(int%right)
@@ -315,7 +315,7 @@ extension (long: Long)
   inline infix def %% (right: Long): Long = math.floorMod(long, right)
 
   @targetName("floorDivLong")
-  inline infix def \ (right: Long): Long = math.floorDiv(long, right)
+  inline infix def /- (right: Long): Long = math.floorDiv(long, right)
 
   @targetName("powerLong")
   inline infix def ** (exponent: Double): Double = math.pow(long.toDouble, exponent)

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -586,7 +586,7 @@ object Hypotenuse:
     inline infix def %% (right: into S64): S64 = math.floorMod(s64, right)
 
     @targetName("floorDivS64")
-    inline infix def \ (right: into S64): S64 = math.floorDiv(s64, right)
+    inline infix def /- (right: into S64): S64 = math.floorDiv(s64, right)
 
     @targetName("powerS64")
     inline infix def ** (exponent: Double): Double = math.pow(s64.toDouble, exponent)
@@ -642,7 +642,7 @@ object Hypotenuse:
     inline infix def %% (right: into S32): S32 = math.floorMod(s32, right)
 
     @targetName("floorDivS32")
-    inline infix def \ (right: into S32): S32 = math.floorDiv(s32, right)
+    inline infix def /- (right: into S32): S32 = math.floorDiv(s32, right)
 
     @targetName("divS32")
     inline infix def / (right: into S32)(using division: DivisionByZero): division.Wrap[S32] =
@@ -698,7 +698,7 @@ object Hypotenuse:
     inline infix def %% (right: into S16): S16 = math.floorMod(s16, right).toShort
 
     @targetName("floorDivS16")
-    inline infix def \ (right: into S16): S16 = math.floorDiv(s16, right).toShort
+    inline infix def /- (right: into S16): S16 = math.floorDiv(s16, right).toShort
 
     @targetName("divS16")
     inline infix def / (right: into S16)(using division: DivisionByZero): division.Wrap[S16] =
@@ -757,7 +757,7 @@ object Hypotenuse:
     inline infix def %% (right: into S8): S8 = math.floorMod(s8, right).toByte
 
     @targetName("floorDivS8")
-    inline infix def \ (right: into S8): S8 = math.floorDiv(s8, right).toByte
+    inline infix def /- (right: into S8): S8 = math.floorDiv(s8, right).toByte
 
     @targetName("divS8")
     inline infix def / (right: into S8)(using division: DivisionByZero): division.Wrap[S8] =

--- a/lib/hypotenuse/src/core/soundness+hypotenuse-core.scala
+++ b/lib/hypotenuse/src/core/soundness+hypotenuse-core.scala
@@ -36,7 +36,7 @@ export hypotenuse
 . { CheckOverflow, Commensurable, DivisionByZero, DivisionError, Orderable, OverflowError, B8, B16,
     B32, B64, S8, S16, S32, S64, U8, U16, U32, U64, F32, F64, abs, ceiling, floor, exponent,
     increment, decrement, round, scalb, signum, ulp, bits, rawBits, finite, infinite, nan, **,
-    mantissa, long, int, short, octal, hex, base32, binary, %%, \, apply, erf, π, pi, euler, φ,
+    mantissa, long, int, short, octal, hex, base32, binary, %%, /-, apply, erf, π, pi, euler, φ,
     goldenRatio, cos, acos, cosh, sin, asin, sinh, tan, atan, hyp, exp, expm1, ln, log10, log1p, <,
     <=, >, >=, bin, lcm, gcd, successor, predecessor }
 

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -107,12 +107,22 @@ object Path:
          =>  Conversion[Path of subject under root, Path of subject on system under root] =
     conversion(_.on[system])
 
+
+  transparent inline given quotient: [system, path <: Path on system] => path is Quotient =
+    ( path =>
+        if path.empty then None
+        else if path.descent.length == 1 then Some((path.root, path.descent.head))
+        else Some((path.root, Relative(0, path.descent*))) )
+    : path is Quotient of Text over (Relative on system) | Text
+
+
 case class Path(root: Text, descent: Text*):
   type Platform
   type Subject <: Tuple
   type Constraint
 
   def name: Text = descent.prim.or(root)
+  def empty: Boolean = descent.isEmpty
 
   inline def knownElementTypes: Boolean = inline !![Subject] match
     case _: Zero           => true

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -103,6 +103,21 @@ object Relative:
 
   given showable: [system: System] => Relative on system is Showable = _.encode
 
+  transparent inline given quotient: [system, relative <: (Relative on system) | Text]
+                           => relative is Quotient =
+    relative0 =>
+      relative0 match
+        case _: Text => None
+        case _: Relative =>
+          val relative = relative0.asInstanceOf[Relative on system]
+
+          relative.descent match
+            case Nil | _ :: Nil => None
+            case _ :: _ :: Nil  => Some((relative.descent(1), relative.descent(0)))
+            case _              => Some((relative.descent.last, Relative(0, relative.descent.init*)))
+  : relative is Quotient of Text over (Relative on system) | Text
+
+
 case class Relative(ascent: Int, descent: List[Text] = Nil):
   type Platform
   type Subject <: Tuple

--- a/lib/serpentine/src/test/serpentine.Tests.scala
+++ b/lib/serpentine/src/test/serpentine.Tests.scala
@@ -548,3 +548,14 @@ object Tests extends Suite(m"Serpentine Benchmarks"):
           case _                                            => Unset
 
       . assert(_ == Unset)
+
+      test(m"Multi-level matching"):
+        path match
+          case root /: t"home" /: more => more match
+            case t"work"            => false
+            case t"work" /: t"data" => true
+            case t"data"            => false
+            case other              => false
+          case _ => false
+
+      . assert(identity(_))

--- a/lib/serpentine/src/test/serpentine.Tests.scala
+++ b/lib/serpentine/src/test/serpentine.Tests.scala
@@ -490,3 +490,61 @@ object Tests extends Suite(m"Serpentine Benchmarks"):
         p2
 
       . assert(_ == % / "home" / "work" / "baz" / "quux")
+
+    suite(m"Pattern matching"):
+
+      val shortPath: Path on Linux = % / "home"
+      val path: Path on Linux = % / "home" / "work" / "data"
+
+      test(m"Match root on a simple path"):
+        path match
+          case root /: right => root
+
+      . assert(_ == t"/")
+
+      test(m"Match root on a short path"):
+        shortPath match
+          case root /: right => root
+
+      . assert(_ == t"/")
+
+      test(m"Match descent on a simple path"):
+        path match
+          case root /: right => right
+
+      . assert(_ == ? / "home" / "work" / "data")
+
+      test(m"Match descent on a short path"):
+        shortPath match
+          case root /: t"home" => true
+          case _               => false
+
+      . assert(identity(_))
+
+      test(m"Match top elementon a simple path"):
+        path match
+          case root /: right0 /: right1 => right0
+
+      . assert(_ == t"home")
+
+
+      test(m"Match further descent on a simple path"):
+        path match
+          case root /: right0 /: right1 => right1
+
+      . assert(_ == ? / "work" / "data")
+
+
+      test(m"Match last descent on a simple path"):
+        path match
+          case root /: right0 /: right1 /: right2 => right2
+
+      . assert(_ == t"data")
+
+
+      test(m"Further elements don't match"):
+        path match
+          case root /: right0 /: right1 /: right2 /: right3 => right3
+          case _                                            => Unset
+
+      . assert(_ == Unset)

--- a/lib/symbolism/src/core/soundness+symbolism-core.scala
+++ b/lib/symbolism/src/core/soundness+symbolism-core.scala
@@ -34,4 +34,4 @@ package soundness
 
 export symbolism
 . { Addable, Subtractable, Multiplicable, Divisible, Negatable, Rootable, sqrt, cbrt, Zeroic,
-    Unital, /, `*`, +, -, Concatenable }
+    Unital, /, `*`, +, -, Concatenable, /: }

--- a/lib/symbolism/src/core/symbolism.Quotient.scala
+++ b/lib/symbolism/src/core/symbolism.Quotient.scala
@@ -32,46 +32,15 @@
                                                                                                   */
 package symbolism
 
-import scala.annotation.*
-
 import prepositional.*
 
-extension [value: Rootable[2] as rootable](value: value)
-  def sqrt: rootable.Result = rootable.root(value)
+import scala.annotation.targetName
 
-extension [value: Rootable[3] as rootable](value: value)
-  def cbrt: rootable.Result = rootable.root(value)
+trait Quotient:
+  type Self
+  type Subject
+  type Carrier
+  type Numerator = Subject
+  type Denominator = Carrier
 
-extension [augend](left: augend)
-  inline infix def + [addend](right: addend)(using addable: augend is Addable by addend)
-  : addable.Result =
-
-      addable.add(left, right)
-
-
-extension [minuend](left: minuend)
-  inline infix def - [subtrahend](right: subtrahend)
-                     (using subtractable: minuend is Subtractable by subtrahend)
-  : subtractable.Result =
-
-      subtractable.subtract(left, right)
-
-
-extension [dividend](left: dividend)
-  inline infix def / [divisor](right: divisor)(using divisible: dividend is Divisible by divisor)
-  : divisible.Result =
-
-      divisible.divide(left, right)
-
-
-extension [multiplicand](left: multiplicand)
-  @targetName("multiply")
-  inline infix def * [multiplier](right: multiplier)
-                     (using multiplicable: multiplicand is Multiplicable by multiplier)
-  : multiplicable.Result =
-
-      multiplicable.multiply(left, right)
-
-object `/:`:
-  def unapply[entity: Quotient](value: entity): Option[(entity.Numerator, entity.Denominator)] =
-    entity.decompose(value)
+  def decompose(division: Self): Option[(Subject, Carrier)]


### PR DESCRIPTION
You can now pattern-match on a path:

```scala
path match
  case root /: t"path" /: t"to" /: t"somewhere" => // ...
```

Note that we must use `/:` instead of `/` for two reasons: we need right-associativity, or else the matching will work from the wrong end of the path; and, we already have an extension method called `/` which seems to make it impossible to have an extractor object as well.