### PR TITLE
Provide `summonInline` as `infer`

### DIFF
--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -74,7 +74,7 @@ object Austronesian2:
           _.decoded(array(index))
 
       case other =>
-        summonInline[Tactic[PojoError]].give(abort(PojoError()))
+        infer[Tactic[PojoError]].give(abort(PojoError()))
 
     inline def split[derivation: SumReflection]: derivation is Decodable in Pojo =
       case Array(label: String @unchecked, pojo: Pojo @unchecked) =>
@@ -82,7 +82,7 @@ object Austronesian2:
           _.decoded(pojo)
 
       case other =>
-        summonInline[Tactic[PojoError]].give(abort(PojoError()))
+        infer[Tactic[PojoError]].give(abort(PojoError()))
 
   def isolated[result: Type](classloader: Expr[Classloader], invoke: Expr[result])
      (using Quotes)

--- a/lib/austronesian/src/core/austronesian.Restorable.scala
+++ b/lib/austronesian/src/core/austronesian.Restorable.scala
@@ -42,7 +42,7 @@ object Restorable extends ProductDerivation[[entity] =>> entity is Restorable]:
 
   //     def restore(value: Expr[Pojo])(using quotes: Quotes, classloader: Classloader): Expr[Self] =
   //       import quotes.reflect.*
-  //       given Type[derivation] = compiletime.summonInline[Type[derivation]]
+  //       given Type[derivation] = infer[Type[derivation]]
 
 
   inline def join[derivation <: Product: ProductReflection]: derivation is Restorable =

--- a/lib/caesura/src/core/caesura.DsvDecodable.scala
+++ b/lib/caesura/src/core/caesura.DsvDecodable.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import distillate.*
 import prepositional.*
+import proscenium.*
 import rudiments.*
 import vacuous.*
 import wisteria.*
@@ -55,7 +56,7 @@ object DsvDecodable extends ProductDerivable[DsvDecodable]:
     var rowNumber: Ordinal = Prim
     var count = 0
 
-    summonInline[Foci[CellRef]].give:
+    infer[Foci[CellRef]].give:
       DsvProductDecoder[derivation](sum, (row: Row) => construct:
         [field] => context =>
           val index = row.columns.let(_.at(label)).or(count)

--- a/lib/capricious/src/core/capricious.Randomizable.scala
+++ b/lib/capricious/src/core/capricious.Randomizable.scala
@@ -70,11 +70,11 @@ object Randomizable extends Derivation[[derivation] =>> derivation is Randomizab
 
   inline def join[derivation <: Product: ProductReflection]: derivation is Randomizable =
     random =>
-      stochastic(using summonInline[Randomization]):
+      stochastic(using infer[Randomization]):
         construct { [field] => _.from(summon[Random]) }
 
   inline def split[derivation: SumReflection]: derivation is Randomizable = random =>
-    stochastic(using summonInline[Randomization]):
+    stochastic(using infer[Randomization]):
       delegate(variantLabels(random.long().abs.toInt%variantLabels.length)):
         [variant <: derivation] => _.from(summon[Random])
 

--- a/lib/capricious/src/core/capricious.Seed.scala
+++ b/lib/capricious/src/core/capricious.Seed.scala
@@ -38,6 +38,7 @@ import scala.compiletime.*
 
 import anticipation.*
 import hypotenuse.*
+import proscenium.*
 
 object Seed:
   def apply(long: Long): Seed = Seed(long.bits.bytes)
@@ -48,5 +49,5 @@ case class Seed(value: Bytes):
 
   inline def stochastic[result](block: Random ?=> result): result =
     given seed: Seed = this
-    val randomization = summonInline[Randomization]
+    val randomization = infer[Randomization]
     block(using new Random(randomization.make()))

--- a/lib/cataclysm/src/core/cataclysm.Cataclysm.scala
+++ b/lib/cataclysm/src/core/cataclysm.Cataclysm.scala
@@ -57,7 +57,7 @@ object Cataclysm:
             halt(m"no valid CSS element ${key.valueOrAbort} taking values of type $typeName exists")
 
         '{
-            CssProperty(Text($key).uncamel.kebab, compiletime.summonInline[ShowProperty[value]]
+            CssProperty(Text($key).uncamel.kebab, infer[ShowProperty[value]]
             . show($value))  }
         :: recur(tail)
 

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -81,7 +81,7 @@ object Contrastable extends Contrastable2:
       compareSeq[Char](decompose(left.chars), decompose(right.chars), left, right)
 
   inline def nothing[value]: value is Contrastable = (left, right) =>
-    compiletime.summonInline[value is Decomposable].give:
+    infer[value is Decomposable].give:
       Juxtaposition.Same(left.decompose.text)
 
   given decomposable: [value: Decomposable] => value is Contrastable = (left, right) =>

--- a/lib/fulminate/src/core/fulminate-core.scala
+++ b/lib/fulminate/src/core/fulminate-core.scala
@@ -107,7 +107,7 @@ extension (inline context: StringContext)
 
         Message
          (context.parts.map(_.tt).map(TextEscapes.escape(_)).to(List),
-          List(summonInline[(? >: other.type) is Communicable].message(other)))
+          List(infer[(? >: other.type) is Communicable].message(other)))
 
 extension (inline context: StringContext)
   inline def realm(): Realm = ${Fulminate.realm('context)}

--- a/lib/fulminate/src/core/fulminate.Message.scala
+++ b/lib/fulminate/src/core/fulminate.Message.scala
@@ -53,7 +53,7 @@ object Message:
         case _: (message *: tail) => messages.absolve match
           case message *: tail =>
             val message2 = message.asInstanceOf[message]
-            val communicable = summonInline[(? >: message) is Communicable]
+            val communicable = infer[(? >: message) is Communicable]
             make[tail](tail.asInstanceOf[tail], communicable.message(message2) :: done)
 
         case _ =>

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -73,7 +73,7 @@ trait Json2:
 
   inline given decodable: [value] => value is Decodable in Json = summonFrom:
     case given (`value` is Decodable in Text) =>
-      summonInline[Tactic[JsonError]].give(_.root.string.decode[value])
+      infer[Tactic[JsonError]].give(_.root.string.decode[value])
 
     case given Reflection[`value`] =>
       DecodableDerivation.derived
@@ -85,8 +85,8 @@ trait Json2:
   object DecodableDerivation extends Derivable[Decodable in Json]:
     inline def join[derivation <: Product: ProductReflection]: derivation is Decodable in Json =
       json =>
-        summonInline[Foci[JsonPointer]].give:
-          summonInline[Tactic[JsonError]].give:
+        infer[Foci[JsonPointer]].give:
+          infer[Tactic[JsonError]].give:
             val keyValues = json.root.obj
             val values = keyValues(0).zip(keyValues(1)).to(Map)
 
@@ -99,8 +99,8 @@ trait Json2:
 
     inline def split[derivation: SumReflection]: derivation is Decodable in Json =
       json =>
-        summonInline[Tactic[JsonError]].give:
-          summonInline[Tactic[VariantError]].give:
+        infer[Tactic[JsonError]].give:
+          infer[Tactic[VariantError]].give:
             val values = json.root.obj
 
             values(0).indexOf("_type") match
@@ -117,7 +117,7 @@ trait Json2:
   object EncodableDerivation extends Derivable[Encodable in Json]:
     inline def join[derivation <: Product: ProductReflection]: derivation is Encodable in Json =
       value =>
-        summonInline[Foci[JsonPointer]].give:
+        infer[Foci[JsonPointer]].give:
           val labels: scm.ArrayBuffer[String] = scm.ArrayBuffer()
           val values: scm.ArrayBuffer[JsonAst] = scm.ArrayBuffer()
 

--- a/lib/legerdemain/src/core/legerdemain.Query.scala
+++ b/lib/legerdemain/src/core/legerdemain.Query.scala
@@ -77,7 +77,7 @@ object Query extends Dynamic:
     inline def join[derivation <: Product: ProductReflection]
     : derivation is Decodable in Query =
 
-        summonInline[Foci[Pointer]].give:
+        infer[Foci[Pointer]].give:
           value =>
             construct:
               [field] => context =>
@@ -102,7 +102,7 @@ object Query extends Dynamic:
   inline given decodable: [value] => value is Decodable in Query =
     summonFrom:
       case given (`value` is Decodable in Text) =>
-        summonInline[Tactic[QueryError]].give:
+        infer[Tactic[QueryError]].give:
           summonFrom:
             case given Default[`value`] =>
               _().let(_.decode).or(raise(QueryError()) yet default[value])

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -89,7 +89,7 @@ object Nomenclature2:
                 TypeRepr.of[param] match
                   case ConstantType(StringConstant(string)) =>
                     '{  if $rule.check($name, ${Expr(string)}.tt) then $expr
-                        else summonInline[Tactic[NameError]].give:
+                        else infer[Tactic[NameError]].give:
                           raise(NameError($name, $rule, ${Expr(string)}))  }
 
         '{$checks; $name.asInstanceOf[Name[system]]}

--- a/lib/parasite/src/core/parasite-core.scala
+++ b/lib/parasite/src/core/parasite-core.scala
@@ -75,7 +75,7 @@ package retryTenacities:
   given fixedNoDelayFiveTimes: Tenacity = Tenacity.fixed(0L).limit(5)
   given fixedNoDelayTenTimes: Tenacity = Tenacity.fixed(0L).limit(10)
 
-transparent inline def monitor: Monitor = summonInline[Monitor]
+transparent inline def monitor: Monitor = infer[Monitor]
 
 def daemon(using Codepoint)(evaluate: Worker ?=> Unit)(using Monitor, Codicil): Daemon =
   Daemon(evaluate(using _))

--- a/lib/proscenium/src/core/proscenium-core.scala
+++ b/lib/proscenium/src/core/proscenium-core.scala
@@ -70,3 +70,5 @@ type Mono[value] = value *: Zero
 
 object Mono:
   inline def apply[value](value: value): Mono[value] = value *: Zero
+
+transparent inline def infer[context]: context = compiletime.summonInline[context]

--- a/lib/proscenium/src/core/soundness+proscenium-core.scala
+++ b/lib/proscenium/src/core/soundness+proscenium-core.scala
@@ -59,3 +59,5 @@ export scala.LazyList as Stream
 export scala.DummyImplicit as Void
 
 export proscenium.{Nat, Label, `~>`, Zero, Mono}
+
+transparent inline def infer[context]: context = compiletime.summonInline[context]

--- a/lib/scintillate/src/server/scintillate-core.scala
+++ b/lib/scintillate/src/server/scintillate-core.scala
@@ -91,7 +91,7 @@ def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.
         Http.Response(Http.Unauthorized, wwwAuthenticate = auth)()
 
 
-inline def request: Http.Request = compiletime.summonInline[Http.Request]
+inline def request: Http.Request = infer[Http.Request]
 
 given realm: Realm = realm"scintillate"
 

--- a/lib/serpentine/src/core/serpentine.Admissible.scala
+++ b/lib/serpentine/src/core/serpentine.Admissible.scala
@@ -52,7 +52,7 @@ object Admissible:
     inline !![text] match
       case _: Name[`system`] => unchecked[text, system]
 
-      case _ => compiletime.summonInline[Tactic[NameError]].give(Name[system](_))
+      case _ => infer[Tactic[NameError]].give(Name[system](_))
 
   inline given admissible: [string <: Label, system] => (nominative: system is Nominative) => string is Admissible on system =
     Admissible[string, system]({ void => Name.verify[string, system] })

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -158,12 +158,12 @@ case class Path(root: Text, descent: Text*):
       case _: Zero => ()
 
       case _: (head *: tail) =>
-        summonInline[head is Admissible on system].check(path.head)
+        infer[head is Admissible on system].check(path.head)
         check[tail, system](path.tail)
 
       case _ =>
         path.each: element =>
-          summonInline[Text is Admissible on system].check(element)
+          infer[Text is Admissible on system].check(element)
 
   inline def on[system]: Path of Subject under Constraint on system = summonFrom:
     case given (`system` =:= Platform) =>
@@ -176,7 +176,7 @@ case class Path(root: Text, descent: Text*):
         case constraint: (Constraint is Submissible on `system`)       => constraint.check(root)
         case radical: (Constraint is Radical on `system`)              => radical.decode(root)
         case system: (`system` is (System { type UniqueRoot = true })) =>
-          summonInline[Platform is (System { type UniqueRoot = true })]
+          infer[Platform is (System { type UniqueRoot = true })]
 
       this.asInstanceOf[Path of Subject under Constraint on system]
 
@@ -320,11 +320,11 @@ case class Path(root: Text, descent: Text*):
     summonFrom:
       case given ((? >: child.type) is Admissible on Platform) =>
         Path.of[Platform, Constraint, child.type *: Subject]
-          (root, summonInline[child.type is Navigable].follow(child) +: descent*)
+          (root, infer[child.type is Navigable].follow(child) +: descent*)
 
       case _ =>
         Path.unplatformed[Constraint, child.type *: Subject]
-          (root, summonInline[child.type is Navigable].follow(child) +: descent*)
+          (root, infer[child.type is Navigable].follow(child) +: descent*)
 
 
   transparent inline def peer(child: Any)(using child.type is Admissible on Platform)
@@ -332,11 +332,11 @@ case class Path(root: Text, descent: Text*):
     inline !![Subject] match
       case _: (head *: tail) =>
         Path.of[Platform, Constraint, child.type *: tail]
-         (root, summonInline[child.type is Navigable].follow(child) +: descent*)
+         (root, infer[child.type is Navigable].follow(child) +: descent*)
 
       case _ =>
         Path.of[Platform, Constraint, Tuple]
-         (root, summonInline[child.type is Navigable].follow(child) +: descent*)
+         (root, infer[child.type is Navigable].follow(child) +: descent*)
 
   transparent inline def + (relative: Relative): Path =
     type Base = Tuple.Reverse[Tuple.Take[Tuple.Reverse[Subject], relative.Constraint]]

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -128,14 +128,14 @@ case class Relative(ascent: Int, descent: List[Text] = Nil):
   private inline def check[subject, system](path: List[Text]): Unit =
     inline !![subject] match
       case _: (head *: tail) =>
-        summonInline[head is Admissible on system].check(path.head)
+        infer[head is Admissible on system].check(path.head)
         check[tail, system](path.tail).unit
 
       case EmptyTuple =>
         ()
 
       case _ =>
-        path.each(summonInline[Text is Admissible on system].check(_))
+        path.each(infer[Text is Admissible on system].check(_))
 
   inline def on[system]: Relative of Subject under Constraint on system =
     check[Subject, system](descent.to(List))

--- a/lib/superlunary/src/core/superlunary.Dispatchable.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatchable.scala
@@ -37,6 +37,7 @@ import contingency.*
 import distillate.*
 import jacinta.*
 import prepositional.*
+import proscenium.*
 import rudiments.*
 
 import interfaces.paths.pathOnLinux

--- a/lib/superlunary/src/core/superlunary.Dispatchable.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatchable.scala
@@ -58,11 +58,11 @@ object Dispatchable:
     inline def decode[value](value: Text): value = unsafely(value.decode[Json].as[value])
 
     inline def embed[entity](value: entity): Json =
-      compiletime.summonInline[entity is Encodable in Json].give(value.json)
+      infer[entity is Encodable in Json].give(value.json)
 
     inline def extract[entity](json: Json): entity =
-      compiletime.summonInline[Tactic[JsonError]].give:
-        compiletime.summonInline[entity is Decodable in Json].give(json.as[entity])
+      infer[Tactic[JsonError]].give:
+        infer[entity is Decodable in Json].give(json.as[entity])
 
 trait Dispatchable:
   type Carrier

--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -56,11 +56,11 @@ extension [value](value: value)
   inline def read[result]: result =
     compiletime.summonFrom:
       case aggregable: (`result` is Aggregable by Bytes) =>
-        compiletime.summonInline[value is Readable by Bytes].give:
+        infer[value is Readable by Bytes].give:
           aggregable.aggregate(value.stream[Bytes])
 
       case aggregable: (`result` is Aggregable by Text) =>
-        compiletime.summonInline[value is Readable by Text].give:
+        infer[value is Readable by Text].give:
           aggregable.aggregate(value.stream[Text])
 
 

--- a/lib/vacuous/src/core/vacuous-core.scala
+++ b/lib/vacuous/src/core/vacuous-core.scala
@@ -38,8 +38,9 @@ import scala.compiletime.*
 
 import anticipation.*
 import fulminate.*
+import proscenium.*
 
-inline def default[value]: value = summonInline[Default[value]]()
+inline def default[value]: value = infer[Default[value]]()
 
 inline def optimizable[value](lambda: Optional[value] => Optional[value]): Optional[value] =
   lambda(Unset)

--- a/lib/vacuous/src/test/vacuous.Tests.scala
+++ b/lib/vacuous/src/test/vacuous.Tests.scala
@@ -69,28 +69,28 @@ object Tests extends Suite(m"Vacuous Tests"):
 
      test(m"Int and String are distinct types"):
        demilitarize:
-         erased val x = summonInline[Int is Distinct from String]
+         erased val x = infer[Int is Distinct from String]
 
        . map(_.message)
      . assert(_ == Nil)
 
      test(m"Int and (Int | String) are not distinct types"):
        demilitarize:
-         erased val x = summonInline[Int is Distinct from (Int | String)]
+         erased val x = compiletime.summonInline[Int is Distinct from (Int | String)]
 
        . map(_.message)
      . assert(_.nonEmpty)
 
      test(m"String is not distinct from itself"):
        demilitarize:
-         erased val x = summonInline[String is Distinct from String]
+         erased val x = compiletime.summonInline[String is Distinct from String]
 
        . map(_.message)
      . assert(_.nonEmpty)
 
      test(m"Abstract type is not proven distinct from anything, e.g. String"):
        demilitarize:
-         def foo[T]: Unit = summonInline[T is Distinct from String].unit
+         def foo[T]: Unit = infer[T is Distinct from String].unit
          foo[String]
 
        . map(_.message)
@@ -98,7 +98,7 @@ object Tests extends Suite(m"Vacuous Tests"):
 
      test(m"Abstract type is not proven distinct from anything, e.g. Int"):
        demilitarize:
-         def foo[T]: Unit = summonInline[T is Distinct from String].unit
+         def foo[T]: Unit = infer[T is Distinct from String].unit
          foo[Int]
 
        . map(_.message)
@@ -107,7 +107,7 @@ object Tests extends Suite(m"Vacuous Tests"):
      test(m"Inline abstract type is not proven distinct from anything, e.g. Int"):
        demilitarize:
          inline def foo[T]: Unit =
-           erased val x = summonInline[T is Distinct from String]
+           erased val x = infer[T is Distinct from String]
 
          foo[Int]
 
@@ -117,7 +117,7 @@ object Tests extends Suite(m"Vacuous Tests"):
      test(m"Inline abstract type is not proven distinct from anything, e.g. String"):
        demilitarize:
          inline def foo[T]: Unit =
-           erased val x = summonInline[T is Distinct from String]
+           erased val x = infer[T is Distinct from String]
 
          foo[String]
 
@@ -127,7 +127,7 @@ object Tests extends Suite(m"Vacuous Tests"):
      test(m"String is not distinct from String | Int"):
        demilitarize:
          inline def foo[T]: Unit =
-           erased val x = summonInline[T is Distinct from (String | Int)]
+           erased val x = infer[T is Distinct from (String | Int)]
 
          foo[String]
 
@@ -137,7 +137,7 @@ object Tests extends Suite(m"Vacuous Tests"):
      test(m"String singleton is not distinct from String"):
        demilitarize:
          inline def foo[T]: Unit =
-           erased val x = summonInline[T is Distinct from (String | Int)]
+           erased val x = infer[T is Distinct from (String | Int)]
 
          foo[""]
 
@@ -147,7 +147,7 @@ object Tests extends Suite(m"Vacuous Tests"):
      test(m"String singleton is not distinct from different String singleton"):
        demilitarize:
          inline def foo[T]: Unit =
-           erased val x = summonInline[T is Distinct from "foo"]
+           erased val x = infer[T is Distinct from "foo"]
 
          foo[""]
 

--- a/lib/vicarious/src/core/vicarious.Proxy.scala
+++ b/lib/vicarious/src/core/vicarious.Proxy.scala
@@ -45,6 +45,6 @@ class Proxy[key, value, +id <: Nat]() extends Selectable:
       ${Vicarious.dereference[key, value, id]('key)}
 
 
-  inline def id: Int = compiletime.summonInline[ValueOf[id]].value
+  inline def id: Int = infer[ValueOf[id]].value
   inline def apply()(using catalog: Catalog[key, value]): value = catalog.values(id)
   inline def unapply(scrutinee: Proxy[key, value, Nat]): Boolean = scrutinee.id == id

--- a/lib/wisteria/src/core/wisteria.ContextRequirement.scala
+++ b/lib/wisteria/src/core/wisteria.ContextRequirement.scala
@@ -33,6 +33,7 @@
 package wisteria
 
 import anticipation.*
+import proscenium.*
 import rudiments.*
 import vacuous.*
 
@@ -55,6 +56,6 @@ trait ContextRequirement:
   def wrap[value](optional: Optional[value]): Optionality[value]
 
   inline def summon[context]: Optionality[context] =
-    inline if !![Required] then wrap(summonInline[context]) else summonFrom:
+    inline if !![Required] then wrap(infer[context]) else summonFrom:
       case contextual: `context` => wrap(contextual)
       case _                     => wrap(Unset)

--- a/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
@@ -116,7 +116,7 @@ trait ProductDerivationMethods[typeclass[_]]:
       type Fields = reflection.MirroredElemTypes
       type Labels = reflection.MirroredElemLabels
 
-      summonInline[ClassTag[result]].give:
+      infer[ClassTag[result]].give:
         IArray.create[result](valueOf[Tuple.Size[Fields]]): array =>
           fold[derivation, Fields, Labels, Unit]((), 0): accumulator =>
             [field] => context ?=> array(index) = lambda[field](context)
@@ -167,7 +167,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                     ?=> result)
   : IArray[result] =
 
-      summonInline[ClassTag[result]].give:
+      infer[ClassTag[result]].give:
         type Labels = reflection.MirroredElemLabels
         type Fields = reflection.MirroredElemTypes
         val tuple: Fields = Tuple.fromProductTyped(product)

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -87,7 +87,7 @@ trait SumDerivationMethods[typeclass[_]]:
       type Labels = reflection.MirroredElemLabels
 
       singletonFold[derivation, Variants, Labels](_ == input).or:
-        summonInline[Tactic[VariantError]].give:
+        infer[Tactic[VariantError]].give:
           abort(VariantError[derivation](input))
 
 
@@ -102,7 +102,7 @@ trait SumDerivationMethods[typeclass[_]]:
             type variant0 = variant & derivation
 
             if predicate(valueOf[label & String].tt)
-            then summonInline[Mirror.ProductOf[variant0]].fromProduct(Zero)
+            then infer[Mirror.ProductOf[variant0]].fromProduct(Zero)
             else singletonFold[derivation, variants, labelsType](predicate)
 
         case _  =>
@@ -191,7 +191,7 @@ trait SumDerivationMethods[typeclass[_]]:
                   if predicate(using label.tt, index2)
                   then
                     val index3: Int & VariantIndex[variant0] = VariantIndex[variant0](index)
-                    val context = requirement.wrap(summonInline[typeclass[variant0]])
+                    val context = requirement.wrap(infer[typeclass[variant0]])
                     lambda[variant0](context)(using context, label.tt, index3)
                   else
                     fold
@@ -202,7 +202,7 @@ trait SumDerivationMethods[typeclass[_]]:
 
         case _ =>
           inline if fallible
-          then summonInline[Tactic[VariantError]].give:
+          then infer[Tactic[VariantError]].give:
             raise(VariantError[derivation](inputLabel)) yet Unset
           else panic(m"Should be unreachable")
 
@@ -240,7 +240,7 @@ trait SumDerivationMethods[typeclass[_]]:
                   then
                     val index3: Int & VariantIndex[variant0] = VariantIndex[variant0](index)
                     val variant: variant0 = sum.asInstanceOf[variant0]
-                    val context = requirement.wrap(summonInline[typeclass[variant0]])
+                    val context = requirement.wrap(infer[typeclass[variant0]])
                     lambda[variant0](variant)(using context, label.tt, index3)
                   else
                     fold[derivation, variants, moreLabels](sum, size, index + 1, fallible)
@@ -249,7 +249,7 @@ trait SumDerivationMethods[typeclass[_]]:
 
         case _ =>
           inline if fallible
-          then summonInline[Tactic[VariantError]].give:
+          then infer[Tactic[VariantError]].give:
             raise(VariantError[derivation]("".tt)) yet Unset
           else panic(m"Should be unreachable")
 


### PR DESCRIPTION
The name `summonInline` is annoyingly long for a method that I'm using so regularly. I've provided it as `infer`.