### PR TITLE
Provide `provide[T]` as a shortcut for `infer[T].give`

### DIFF
--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -74,7 +74,7 @@ object Austronesian2:
           _.decoded(array(index))
 
       case other =>
-        infer[Tactic[PojoError]].give(abort(PojoError()))
+        provide[Tactic[PojoError]](abort(PojoError()))
 
     inline def split[derivation: SumReflection]: derivation is Decodable in Pojo =
       case Array(label: String @unchecked, pojo: Pojo @unchecked) =>
@@ -82,7 +82,7 @@ object Austronesian2:
           _.decoded(pojo)
 
       case other =>
-        infer[Tactic[PojoError]].give(abort(PojoError()))
+        provide[Tactic[PojoError]](abort(PojoError()))
 
   def isolated[result: Type](classloader: Expr[Classloader], invoke: Expr[result])
      (using Quotes)

--- a/lib/caesura/src/core/caesura.DsvDecodable.scala
+++ b/lib/caesura/src/core/caesura.DsvDecodable.scala
@@ -56,7 +56,7 @@ object DsvDecodable extends ProductDerivable[DsvDecodable]:
     var rowNumber: Ordinal = Prim
     var count = 0
 
-    infer[Foci[CellRef]].give:
+    provide[Foci[CellRef]]:
       DsvProductDecoder[derivation](sum, (row: Row) => construct:
         [field] => context =>
           val index = row.columns.let(_.at(label)).or(count)

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -81,7 +81,7 @@ object Contrastable extends Contrastable2:
       compareSeq[Char](decompose(left.chars), decompose(right.chars), left, right)
 
   inline def nothing[value]: value is Contrastable = (left, right) =>
-    infer[value is Decomposable].give:
+    provide[value is Decomposable]:
       Juxtaposition.Same(left.decompose.text)
 
   given decomposable: [value: Decomposable] => value is Contrastable = (left, right) =>

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -73,7 +73,7 @@ trait Json2:
 
   inline given decodable: [value] => value is Decodable in Json = summonFrom:
     case given (`value` is Decodable in Text) =>
-      infer[Tactic[JsonError]].give(_.root.string.decode[value])
+      provide[Tactic[JsonError]](_.root.string.decode[value])
 
     case given Reflection[`value`] =>
       DecodableDerivation.derived
@@ -85,8 +85,8 @@ trait Json2:
   object DecodableDerivation extends Derivable[Decodable in Json]:
     inline def join[derivation <: Product: ProductReflection]: derivation is Decodable in Json =
       json =>
-        infer[Foci[JsonPointer]].give:
-          infer[Tactic[JsonError]].give:
+        provide[Foci[JsonPointer]]:
+          provide[Tactic[JsonError]]:
             val keyValues = json.root.obj
             val values = keyValues(0).zip(keyValues(1)).to(Map)
 
@@ -99,8 +99,8 @@ trait Json2:
 
     inline def split[derivation: SumReflection]: derivation is Decodable in Json =
       json =>
-        infer[Tactic[JsonError]].give:
-          infer[Tactic[VariantError]].give:
+        provide[Tactic[JsonError]]:
+          provide[Tactic[VariantError]]:
             val values = json.root.obj
 
             values(0).indexOf("_type") match
@@ -117,7 +117,7 @@ trait Json2:
   object EncodableDerivation extends Derivable[Encodable in Json]:
     inline def join[derivation <: Product: ProductReflection]: derivation is Encodable in Json =
       value =>
-        infer[Foci[JsonPointer]].give:
+        provide[Foci[JsonPointer]]:
           val labels: scm.ArrayBuffer[String] = scm.ArrayBuffer()
           val values: scm.ArrayBuffer[JsonAst] = scm.ArrayBuffer()
 

--- a/lib/legerdemain/src/core/legerdemain.Query.scala
+++ b/lib/legerdemain/src/core/legerdemain.Query.scala
@@ -77,7 +77,7 @@ object Query extends Dynamic:
     inline def join[derivation <: Product: ProductReflection]
     : derivation is Decodable in Query =
 
-        infer[Foci[Pointer]].give:
+        provide[Foci[Pointer]]:
           value =>
             construct:
               [field] => context =>
@@ -102,7 +102,7 @@ object Query extends Dynamic:
   inline given decodable: [value] => value is Decodable in Query =
     summonFrom:
       case given (`value` is Decodable in Text) =>
-        infer[Tactic[QueryError]].give:
+        provide[Tactic[QueryError]]:
           summonFrom:
             case given Default[`value`] =>
               _().let(_.decode).or(raise(QueryError()) yet default[value])

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -89,7 +89,7 @@ object Nomenclature2:
                 TypeRepr.of[param] match
                   case ConstantType(StringConstant(string)) =>
                     '{  if $rule.check($name, ${Expr(string)}.tt) then $expr
-                        else infer[Tactic[NameError]].give:
+                        else provide[Tactic[NameError]]:
                           raise(NameError($name, $rule, ${Expr(string)}))  }
 
         '{$checks; $name.asInstanceOf[Name[system]]}

--- a/lib/proscenium/src/core/proscenium-core.scala
+++ b/lib/proscenium/src/core/proscenium-core.scala
@@ -72,3 +72,9 @@ object Mono:
   inline def apply[value](value: value): Mono[value] = value *: Zero
 
 transparent inline def infer[context]: context = compiletime.summonInline[context]
+
+transparent inline def provide[context](using erased Void)[result]
+                        (inline lambda: context ?=> result)
+: result =
+
+    lambda(using compiletime.summonInline[context])

--- a/lib/proscenium/src/core/soundness+proscenium-core.scala
+++ b/lib/proscenium/src/core/soundness+proscenium-core.scala
@@ -61,3 +61,5 @@ export scala.DummyImplicit as Void
 export proscenium.{Nat, Label, `~>`, Zero, Mono}
 
 transparent inline def infer[context]: context = compiletime.summonInline[context]
+
+export proscenium.provide

--- a/lib/serpentine/src/core/serpentine.Admissible.scala
+++ b/lib/serpentine/src/core/serpentine.Admissible.scala
@@ -52,7 +52,7 @@ object Admissible:
     inline !![text] match
       case _: Name[`system`] => unchecked[text, system]
 
-      case _ => infer[Tactic[NameError]].give(Name[system](_))
+      case _ => provide[Tactic[NameError]](Name[system](_))
 
   inline given admissible: [string <: Label, system] => (nominative: system is Nominative) => string is Admissible on system =
     Admissible[string, system]({ void => Name.verify[string, system] })

--- a/lib/superlunary/src/core/superlunary.Dispatchable.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatchable.scala
@@ -58,12 +58,10 @@ object Dispatchable:
     inline def encode(value: List[Json]): Text = value.json.encode
     inline def decode[value](value: Text): value = unsafely(value.decode[Json].as[value])
 
-    inline def embed[entity](value: entity): Json =
-      infer[entity is Encodable in Json].give(value.json)
+    inline def embed[entity](value: entity): Json = provide[entity is Encodable in Json](value.json)
 
-    inline def extract[entity](json: Json): entity =
-      infer[Tactic[JsonError]].give:
-        infer[entity is Decodable in Json].give(json.as[entity])
+    inline def extract[entity](json: Json): entity = provide[Tactic[JsonError]]:
+      provide[entity is Decodable in Json](json.as[entity])
 
 trait Dispatchable:
   type Carrier

--- a/lib/turbulence/src/core/turbulence-core.scala
+++ b/lib/turbulence/src/core/turbulence-core.scala
@@ -56,11 +56,11 @@ extension [value](value: value)
   inline def read[result]: result =
     compiletime.summonFrom:
       case aggregable: (`result` is Aggregable by Bytes) =>
-        infer[value is Readable by Bytes].give:
+        provide[value is Readable by Bytes]:
           aggregable.aggregate(value.stream[Bytes])
 
       case aggregable: (`result` is Aggregable by Text) =>
-        infer[value is Readable by Text].give:
+        provide[value is Readable by Text]:
           aggregable.aggregate(value.stream[Text])
 
 

--- a/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivationMethods.scala
@@ -116,7 +116,7 @@ trait ProductDerivationMethods[typeclass[_]]:
       type Fields = reflection.MirroredElemTypes
       type Labels = reflection.MirroredElemLabels
 
-      infer[ClassTag[result]].give:
+      provide[ClassTag[result]]:
         IArray.create[result](valueOf[Tuple.Size[Fields]]): array =>
           fold[derivation, Fields, Labels, Unit]((), 0): accumulator =>
             [field] => context ?=> array(index) = lambda[field](context)
@@ -167,7 +167,7 @@ trait ProductDerivationMethods[typeclass[_]]:
                                                     ?=> result)
   : IArray[result] =
 
-      infer[ClassTag[result]].give:
+      provide[ClassTag[result]]:
         type Labels = reflection.MirroredElemLabels
         type Fields = reflection.MirroredElemTypes
         val tuple: Fields = Tuple.fromProductTyped(product)

--- a/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivationMethods.scala
@@ -87,7 +87,7 @@ trait SumDerivationMethods[typeclass[_]]:
       type Labels = reflection.MirroredElemLabels
 
       singletonFold[derivation, Variants, Labels](_ == input).or:
-        infer[Tactic[VariantError]].give:
+        provide[Tactic[VariantError]]:
           abort(VariantError[derivation](input))
 
 
@@ -202,7 +202,7 @@ trait SumDerivationMethods[typeclass[_]]:
 
         case _ =>
           inline if fallible
-          then infer[Tactic[VariantError]].give:
+          then provide[Tactic[VariantError]]:
             raise(VariantError[derivation](inputLabel)) yet Unset
           else panic(m"Should be unreachable")
 
@@ -249,7 +249,7 @@ trait SumDerivationMethods[typeclass[_]]:
 
         case _ =>
           inline if fallible
-          then infer[Tactic[VariantError]].give:
+          then provide[Tactic[VariantError]]:
             raise(VariantError[derivation]("".tt)) yet Unset
           else panic(m"Should be unreachable")
 


### PR DESCRIPTION
This further simplifies code which uses `summonInline`.