### PR TITLE
Simplify macro signatures

### DIFF
--- a/lib/abacist/src/core/abacist.Abacist.scala
+++ b/lib/abacist/src/core/abacist.Abacist.scala
@@ -50,7 +50,7 @@ given realm: Realm = realm"abacist"
 object Abacist:
   import Quantitative.*
 
-  def make[units <: Tuple: Type](values: Expr[Seq[Int]])(using Quotes): Expr[Quanta[units]] =
+  def make[units <: Tuple: Type](values: Expr[Seq[Int]]): Macro[Quanta[units]] =
     val inputs: List[Expr[Int]] = values.absolve match
       case Varargs(values) => values.to(List).reverse
 
@@ -87,8 +87,8 @@ object Abacist:
     '{Quanta.fromLong[units](${recur(multipliers[units].reverse, inputs, '{0L})})}
 
 
-  def describeQuanta[units <: Tuple: Type](count: Expr[Quanta[units]])(using Quotes)
-  : Expr[ListMap[Text, Long]] =
+  def describeQuanta[units <: Tuple: Type](count: Expr[Quanta[units]])
+  : Macro[ListMap[Text, Long]] =
 
       def recur(slices: List[Multiplier], expr: Expr[ListMap[Text, Long]])
       : Expr[ListMap[Text, Long]] =
@@ -111,15 +111,14 @@ object Abacist:
 
 
   def multiplyQuanta[units <: Tuple: Type]
-       (count: Expr[Quanta[units]], multiplier: Expr[Double], division: Boolean)(using Quotes)
-  : Expr[Any] =
+       (count: Expr[Quanta[units]], multiplier: Expr[Double], division: Boolean)
+  : Macro[Any] =
 
       if division then '{Quanta.fromLong[units](($count.longValue/$multiplier + 0.5).toLong)}
       else '{Quanta.fromLong[units](($count.longValue*$multiplier + 0.5).toLong)}
 
 
-  def toQuantity[units <: Tuple: Type](count: Expr[Quanta[units]])(using Quotes)
-  : Expr[Any] =
+  def toQuantity[units <: Tuple: Type](count: Expr[Quanta[units]]): Macro[Any] =
 
       val lastUnit = multipliers[units].last
       val quantityUnit = lastUnit.unitPower.ref.dimensionRef.principal
@@ -132,8 +131,7 @@ object Abacist:
 
   def fromQuantity[quantity <: Measure: Type, units <: Tuple: Type]
        (quantity: Expr[Quantity[quantity]])
-       (using Quotes)
-  : Expr[Quanta[units]] =
+  : Macro[Quanta[units]] =
 
       import quotes.reflect.*
 
@@ -145,8 +143,7 @@ object Abacist:
 
 
   def get[units <: Tuple: Type, unit <: Units[1, ? <: Dimension]: Type](value: Expr[Quanta[units]])
-       (using Quotes)
-  : Expr[Int] =
+  : Macro[Int] =
 
       import quotes.reflect.*
 

--- a/lib/adversaria/src/core/adversaria.Adversaria.scala
+++ b/lib/adversaria/src/core/adversaria.Adversaria.scala
@@ -39,8 +39,8 @@ import proscenium.*
 import scala.quoted.*
 
 object Adversaria:
-  def firstField[target <: Product: Type, annotation <: StaticAnnotation: Type](using Quotes)
-  : Expr[CaseField[target, annotation]] =
+  def firstField[target <: Product: Type, annotation <: StaticAnnotation: Type]
+  : Macro[CaseField[target, annotation]] =
 
       import quotes.reflect.*
 
@@ -58,8 +58,8 @@ object Adversaria:
       . head
 
 
-  def fields[target <: Product: Type, annotation <: StaticAnnotation: Type](using Quotes)
-  : Expr[List[CaseField[target, annotation]]] =
+  def fields[target <: Product: Type, annotation <: StaticAnnotation: Type]
+  : Macro[List[CaseField[target, annotation]]] =
 
       import quotes.reflect.*
 
@@ -80,8 +80,8 @@ object Adversaria:
       Expr.ofList(elements)
 
 
-  def fieldAnnotations[target: Type](lambda: Expr[target => Any])(using Quotes)
-  : Expr[List[StaticAnnotation]] =
+  def fieldAnnotations[target: Type](lambda: Expr[target => Any])
+  : Macro[List[StaticAnnotation]] =
 
       import quotes.reflect.*
 
@@ -100,8 +100,8 @@ object Adversaria:
           case '{ $annotation: StaticAnnotation } => annotation
 
 
-  def typeAnnotations[annotation <: StaticAnnotation: Type, target: Type](using Quotes)
-  : Expr[Annotations[annotation, target]] =
+  def typeAnnotations[annotation <: StaticAnnotation: Type, target: Type]
+  : Macro[Annotations[annotation, target]] =
 
       import quotes.reflect.*
 

--- a/lib/austronesian/src/core/austronesian.Austronesian2.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian2.scala
@@ -84,10 +84,7 @@ object Austronesian2:
       case other =>
         provide[Tactic[PojoError]](abort(PojoError()))
 
-  def isolated[result: Type](classloader: Expr[Classloader], invoke: Expr[result])
-     (using Quotes)
-  :     Expr[result] =
-
+  def isolated[result: Type](classloader: Expr[Classloader], invoke: Expr[result]): Macro[result] =
     import quotes.reflect.*
 
     invoke.asTerm match
@@ -102,8 +99,7 @@ object Austronesian2:
       arguments:   Expr[Seq[Any]],
       classloader: Expr[Classloader],
       singleton:   Expr[Boolean])
-     (using Quotes)
-  :     Expr[Any] =
+  : Macro[Any] =
 
     import quotes.reflect.*
 

--- a/lib/austronesian/src/core/austronesian.Restorable.scala
+++ b/lib/austronesian/src/core/austronesian.Restorable.scala
@@ -6,6 +6,7 @@ import scala.compiletime.*
 import anticipation.*
 import fulminate.*
 import hellenism.*
+import proscenium.*
 import rudiments.*
 import wisteria.*
 
@@ -14,25 +15,25 @@ object Restorable extends ProductDerivation[[entity] =>> entity is Restorable]:
   def apply[self](lambda: (Quotes, Classloader) ?=> Expr[Pojo] => Expr[self]): self is Restorable =
     new Restorable:
       type Self = self
-      def restore(value: Expr[Pojo])(using Quotes, Classloader) = lambda(value)
+      def restore(value: Expr[Pojo])(using Classloader) = lambda(value)
 
   given text: Text is Restorable:
-    def restore(value: Expr[Pojo])(using Quotes, Classloader): Expr[Text] =
+    def restore(value: Expr[Pojo])(using Classloader): Macro[Text] =
       '{  if $value.isInstanceOf[String] then $value.asInstanceOf[Text]
           else throw new RuntimeException()  }
 
   given int: Int is Restorable:
-    def restore(value: Expr[Pojo])(using Quotes, Classloader): Expr[Int] =
+    def restore(value: Expr[Pojo])(using Classloader): Macro[Int] =
       '{  if $value.isInstanceOf[Int] then $value.asInstanceOf[Int]
           else throw new RuntimeException()  }
 
   given long: Long is Restorable:
-    def restore(value: Expr[Pojo])(using Quotes, Classloader): Expr[Long] =
+    def restore(value: Expr[Pojo])(using Classloader): Macro[Long] =
       '{  if $value.isInstanceOf[Long] then $value.asInstanceOf[Long]
           else throw new RuntimeException()  }
 
   given boolean: Boolean is Restorable:
-    def restore(value: Expr[Pojo])(using Quotes, Classloader): Expr[Boolean] =
+    def restore(value: Expr[Pojo])(using Classloader): Macro[Boolean] =
       '{  if $value.isInstanceOf[Boolean] then $value.asInstanceOf[Boolean]
           else throw new RuntimeException()  }
 
@@ -60,4 +61,4 @@ object Restorable extends ProductDerivation[[entity] =>> entity is Restorable]:
 trait Restorable:
   type Self
 
-  def restore(value: Expr[Pojo])(using Quotes, Classloader): Expr[Self]
+  def restore(value: Expr[Pojo])(using Classloader): Macro[Self]

--- a/lib/aviation/src/core/aviation.Aviation.scala
+++ b/lib/aviation/src/core/aviation.Aviation.scala
@@ -127,7 +127,7 @@ object Aviation:
 
     given showable: Day is Showable = _.toString.tt
 
-  def validTime(time: Expr[Double], pm: Boolean)(using Quotes): Expr[Clockface] =
+  def validTime(time: Expr[Double], pm: Boolean): Macro[Clockface] =
     import quotes.reflect.*
 
     time.asTerm match

--- a/lib/cardinality/src/core/cardinality.Cardinality.scala
+++ b/lib/cardinality/src/core/cardinality.Cardinality.scala
@@ -38,6 +38,7 @@ import scala.quoted.*
 
 import anticipation.*
 import fulminate.*
+import proscenium.*
 
 object Cardinality:
   type Asym[value <: Double, truth <: Double, falsehood <: Double] <: Double =
@@ -56,8 +57,8 @@ object Cardinality:
   given realm: Realm = realm"cardinality"
 
 
-  def apply[left <: Double: Type, right <: Double: Type](digits: Expr[String])(using Quotes)
-  : Expr[left ~ right] =
+  def apply[left <: Double: Type, right <: Double: Type](digits: Expr[String])
+  : Macro[left ~ right] =
 
       import quotes.reflect.*
 

--- a/lib/cataclysm/src/core/cataclysm.Cataclysm.scala
+++ b/lib/cataclysm/src/core/cataclysm.Cataclysm.scala
@@ -40,13 +40,13 @@ import proscenium.*
 import scala.quoted.*
 
 object Cataclysm:
-  def rule(selector: Expr[Selector], props: Expr[Seq[(Label, Any)]])(using Quotes): Expr[CssRule] =
+  def rule(selector: Expr[Selector], props: Expr[Seq[(Label, Any)]]): Macro[CssRule] =
     '{CssRule($selector, ${read(props)})}
 
-  def keyframe(name: Expr[String], props: Expr[Seq[(Label, Any)]])(using Quotes): Expr[Keyframe] =
+  def keyframe(name: Expr[String], props: Expr[Seq[(Label, Any)]]): Macro[Keyframe] =
     '{Keyframe(Text($name), ${read(props)})}
 
-  def read(properties: Expr[Seq[(Label, Any)]])(using Quotes): Expr[CssStyle] =
+  def read(properties: Expr[Seq[(Label, Any)]]): Macro[CssStyle] =
     import quotes.reflect.*
 
     def recur(exprs: Seq[Expr[(Label, Any)]]): List[Expr[CssProperty]] = exprs match

--- a/lib/contextual/src/core/contextual.Interpolator.scala
+++ b/lib/contextual/src/core/contextual.Interpolator.scala
@@ -56,8 +56,8 @@ trait Interpolator[input, state, result]:
   extends Error(m"error $positionalMessage at position $start")
 
   def expand(context: Expr[StringContext], seq: Expr[Seq[Any]])(using thisType: Type[this.type])
-       (using Quotes, Type[input], Type[state], Type[result])
-  : Expr[result] =
+       (using Type[input], Type[state], Type[result])
+  : Macro[result] =
 
       expansion(context, seq)(1)
 

--- a/lib/contextual/src/core/contextual.Verifier.scala
+++ b/lib/contextual/src/core/contextual.Verifier.scala
@@ -35,6 +35,7 @@ package contextual
 import scala.quoted.*
 
 import anticipation.*
+import proscenium.*
 import vacuous.*
 
 trait Verifier[result]
@@ -47,8 +48,8 @@ extends Interpolator[Nothing, Optional[result], result]:
   protected def complete(value: Optional[result]): result = value.option.get
 
 
-  def expand(context: Expr[StringContext])(using Quotes, Type[result])
+  def expand(context: Expr[StringContext])(using Type[result])
        (using thisType: Type[this.type])
-  : Expr[result] =
+  : Macro[result] =
 
       expand(context, '{Nil})(using thisType)

--- a/lib/contingency/src/core/contingency.Contingency.scala
+++ b/lib/contingency/src/core/contingency.Contingency.scala
@@ -75,11 +75,13 @@ object Contingency:
       object RepeatedParam:
         def unapply(using quotes: Quotes)(param: quotes.reflect.Symbol)
         : Option[quotes.reflect.TypeRepr] =
-          import quotes.reflect.*
-          param.info match
-            case AnnotatedType(repr, Apply(Select(New(annotation), _), _))
-            if annotation.symbol == defn.RepeatedAnnot                  => Some(repr)
-            case _                                                      => None
+
+            import quotes.reflect.*
+
+            param.info match
+              case AnnotatedType(repr, Apply(Select(New(annotation), _), _))
+              if annotation.symbol == defn.RepeatedAnnot                  => Some(repr)
+              case _                                                      => None
 
       def exhaustive(pattern: Tree, patternType: TypeRepr): Boolean = pattern match
         case Wildcard()          => true
@@ -150,8 +152,7 @@ object Contingency:
       case other                              => List(other)
 
 
-  def mitigate[errors <: Exception: Type](handler: Expr[Exception ~> errors])(using Quotes)
-  : Expr[Any] =
+  def mitigate[errors <: Exception: Type](handler: Expr[Exception ~> errors]): Macro[Any] =
 
       import quotes.reflect.*
 
@@ -171,8 +172,7 @@ object Contingency:
 
   def track[accrual <: Exception: Type, focus: Type]
        (accrual: Expr[accrual], handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
-       (using Quotes)
-  : Expr[Any] =
+  : Macro[Any] =
 
       import quotes.reflect.*
 
@@ -194,8 +194,7 @@ object Contingency:
 
   def validate[accrual: Type, focus: Type]
        (accrual: Expr[accrual], handler: Expr[(Optional[focus], accrual) ?=> Exception ~> accrual])
-       (using Quotes)
-  : Expr[Any] =
+  : Macro[Any] =
 
       import quotes.reflect.*
 
@@ -217,8 +216,7 @@ object Contingency:
 
   def accrue[accrual <: Exception: Type]
        (accrual: Expr[accrual], handler: Expr[accrual ?=> Exception ~> accrual])
-       (using Quotes)
-  : Expr[Any] =
+  : Macro[Any] =
 
       import quotes.reflect.*
 
@@ -237,7 +235,7 @@ object Contingency:
           '{Accrue[accrual, typeLambda]($accrual, accrual ?=> $handler(using accrual))}
 
 
-  def recover[result: Type](handler: Expr[Exception ~> result])(using Quotes): Expr[Any] =
+  def recover[result: Type](handler: Expr[Exception ~> result]): Macro[Any] =
     import quotes.reflect.*
 
     val errors = mapping(handler.asTerm)
@@ -256,8 +254,7 @@ object Contingency:
 
   def mitigateWithin[context[_]: Type, result: Type]
        (mitigate: Expr[Mitigation[context]], lambda: Expr[context[result]])
-       (using Quotes)
-    : Expr[result] =
+    : Macro[result] =
 
         import quotes.reflect.*
 
@@ -283,8 +280,7 @@ object Contingency:
 
   def recoverWithin[context[_]: Type, result: Type]
        (recovery: Expr[Recovery[?, context]], lambda: Expr[context[result]])
-       (using Quotes)
-  : Expr[result] =
+  : Macro[result] =
 
       type ContextResult = context[result]
 
@@ -319,8 +315,7 @@ object Contingency:
         lambda:      Expr[context[result]],
         tactic:      Expr[Tactic[accrual]],
         diagnostics: Expr[Diagnostics])
-     (using Quotes)
-  : Expr[result] =
+  : Macro[result] =
 
       '{  val ref: juca.AtomicReference[accrual] = juca.AtomicReference(null)
           val result = boundary[Option[result]]: label ?=>
@@ -360,8 +355,7 @@ object Contingency:
         lambda:      Expr[Foci[focus] ?=> context[result]],
         tactic:      Expr[Tactic[accrual]],
         diagnostics: Expr[Diagnostics])
-       (using Quotes)
-  : Expr[result] =
+  : Macro[result] =
 
       '{  val foci: Foci[focus] = TrackFoci()
 
@@ -403,8 +397,7 @@ object Contingency:
        (validate:    Expr[Validate[accrual, context, focus]],
         lambda:      Expr[Foci[focus] ?=> context[Any]],
         diagnostics: Expr[Diagnostics])
-       (using Quotes)
-  : Expr[accrual] =
+  : Macro[accrual] =
 
       '{  val foci: Foci[focus] = TrackFoci()
 

--- a/lib/cosmopolite/src/core/cosmopolite.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.scala
@@ -54,8 +54,7 @@ case class Polyglot[+value, +localization <: Localization](value: Map[String, va
 
 object Cosmopolite:
   def access[value: Type, localization <: Localization: Type](value: Expr[Map[String, value]])
-     (using Quotes)
-  : Expr[value] =
+  : Macro[value] =
 
     import quotes.reflect.*
 
@@ -75,7 +74,7 @@ object Cosmopolite:
 
 //   private inline def reifyToSet[L <: String]: Set[String] = ${reifyToSetMacro[L]}
 
-//   private def reifyToSetMacro[L <: String: Type](using Quotes): Expr[Set[String]] =
+//   private def reifyToSetMacro[L <: String: Type]: Macro[Set[String]] =
 //     import quotes.reflect.*
 
 //     def langs(t: TypeRepr): Set[String] = t.dealias.asMatchable match

--- a/lib/digression/src/core/digression.Digression.scala
+++ b/lib/digression/src/core/digression.Digression.scala
@@ -34,13 +34,14 @@ package digression
 
 import anticipation.*
 import contingency.*
+import proscenium.*
 
 import scala.quoted.*
 
 import language.experimental.pureFunctions
 
 object Digression:
-  def location(using Quotes): Expr[Codepoint] =
+  def location: Macro[Codepoint] =
     import quotes.*, reflect.*
     val path = Expr(Position.ofMacroExpansion.sourceFile.path)
     val line = Expr(Position.ofMacroExpansion.startLine + 1)
@@ -55,5 +56,5 @@ object Digression:
       "final", "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile",
       "const", "float", "native", "super", "while")
 
-  def fqcn(context: Expr[StringContext])(using Quotes): Expr[Fqcn] =
+  def fqcn(context: Expr[StringContext]): Macro[Fqcn] =
     abortive('{new Fqcn(${Expr(Fqcn(context.valueOrAbort.parts.head.tt).parts)})})

--- a/lib/distillate/src/core/distillate.Distillate.scala
+++ b/lib/distillate/src/core/distillate.Distillate.scala
@@ -40,7 +40,7 @@ import proscenium.*
 
 object Distillate:
   given realm: Realm = realm"distillate"
-  def enumerable[enumeration <: reflect.Enum: Type](using Quotes): Expr[enumeration is Enumerable] =
+  def enumerable[enumeration <: reflect.Enum: Type]: Macro[enumeration is Enumerable] =
     import quotes.reflect.*
 
     val companion = Ref(TypeRepr.of[enumeration].typeSymbol.companionModule).asExpr

--- a/lib/eucalyptus/src/core/tmp-eucalyptus.scala
+++ b/lib/eucalyptus/src/core/tmp-eucalyptus.scala
@@ -50,8 +50,7 @@ package eucalyptus
 //         realm:          Expr[Realm],
 //         presentational: Expr[text is Presentational],
 //         show:           Expr[Any])
-//        (using Quotes)
-//   :     Expr[Unit] =
+//   : Macro[Unit] =
 
 //     '{  val time = System.currentTimeMillis
 //         val presentationalValue = $presentational
@@ -71,8 +70,7 @@ package eucalyptus
 //       (routes:         Expr[PartialFunction[Entry[text], Any]],
 //        monitor:        Expr[Monitor],
 //        presentational: Expr[text is Presentational])
-//       (using Quotes)
-//   :     Expr[Log[text]] =
+//   : Macro[Log[text]] =
 
 //     import quotes.reflect.*
 

--- a/lib/fulminate/src/core/fulminate.Fulminate.scala
+++ b/lib/fulminate/src/core/fulminate.Fulminate.scala
@@ -37,6 +37,7 @@ import language.experimental.into
 import scala.quoted.*
 
 import anticipation.*
+import proscenium.*
 
 object Fulminate:
   opaque type Diagnostics = Boolean
@@ -47,7 +48,7 @@ object Fulminate:
 
   extension (diagnostics: Diagnostics) def captureStack: Boolean = diagnostics
 
-  def realm(context: Expr[StringContext])(using Quotes): Expr[Realm] =
+  def realm(context: Expr[StringContext]): Macro[Realm] =
     val name: String = context.valueOrAbort.parts.head
     if !name.matches("[a-z]+")
     then halt(m"the realm name should contain only lowercase letters")(using Realm("fulminate"))

--- a/lib/gossamer/src/core/gossamer.Gossamer.scala
+++ b/lib/gossamer/src/core/gossamer.Gossamer.scala
@@ -87,7 +87,7 @@ object Gossamer:
         def segment(ascii: Ascii, interval: Interval): Ascii =
           ascii.slice(interval.start.n0, interval.end.n0)
 
-  def ascii(context: Expr[StringContext], parts: Expr[Seq[Ascii]])(using Quotes): Expr[Ascii] =
+  def ascii(context: Expr[StringContext], parts: Expr[Seq[Ascii]]): Macro[Ascii] =
     val dynamicParts: List[Expr[Ascii]] = parts.absolve match
       case Varargs(parts) => parts.to(List)
 

--- a/lib/guillotine/src/core/guillotine.Guillotine.scala
+++ b/lib/guillotine/src/core/guillotine.Guillotine.scala
@@ -39,7 +39,7 @@ import scala.quoted.*
 import proscenium.*
 
 object Guillotine:
-  def sh(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes): Expr[Command] =
+  def sh(context: Expr[StringContext], parts: Expr[Seq[Any]]): Macro[Command] =
     import quotes.reflect.*
 
     val execType = ConstantType(StringConstant(context.value.get.parts.head.split(" ").nn.head.nn))

--- a/lib/hellenism/src/core/hellenism.Hellenism.scala
+++ b/lib/hellenism/src/core/hellenism.Hellenism.scala
@@ -34,6 +34,7 @@ package hellenism
 
 import scala.quoted.*
 
+import proscenium.*
 import vacuous.*
 
 object Hellenism extends Hellenism2:
@@ -52,7 +53,7 @@ object Hellenism extends Hellenism2:
 export Hellenism.ClassRef
 
 trait Hellenism2:
-  def makeClass[template <: AnyKind: Type](using Quotes): Expr[ClassRef] =
+  def makeClass[template <: AnyKind: Type]: Macro[ClassRef] =
     import quotes.reflect.*
 
     '{ClassRef(Class.forName(${Expr(TypeRepr.of[template].classSymbol.get.fullName)}).nn)}

--- a/lib/hieroglyph/src/core/hieroglyph.Hieroglyph.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.Hieroglyph.scala
@@ -36,6 +36,7 @@ import scala.quoted.*
 
 import anticipation.*
 import fulminate.*
+import proscenium.*
 
 object Hieroglyph:
   given realm: Realm = realm"hieroglyph"
@@ -55,7 +56,7 @@ object Hieroglyph:
     def to: Int = range.toInt
     def contains(char: Char): Boolean = char.toInt >= from && char.toInt <= to
 
-  def encoding(contextExpr: Expr[StringContext])(using Quotes): Expr[Encoding] =
+  def encoding(contextExpr: Expr[StringContext]): Macro[Encoding] =
     import quotes.reflect.*
 
     val context: StringContext = contextExpr.valueOrAbort
@@ -73,7 +74,7 @@ object Hieroglyph:
         if encoding.charset.canEncode then '{Encoding.codecs(${Expr(name)}.tt)}
         else '{Encoding.decodeOnly(${Expr(name)}.tt)}
 
-  def char(contextExpr: Expr[StringContext])(using Quotes): Expr[Char | Text] =
+  def char(contextExpr: Expr[StringContext]): Macro[Char | Text] =
     val name: Text = contextExpr.valueOrAbort.parts.head.toUpperCase.nn.tt
 
     Unicode(name) match

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -49,8 +49,7 @@ object Honeycomb:
         className:  Expr[String],
         name:       Expr[name],
         attributes: Expr[Seq[(Label, Any)]])
-       (using Quotes)
-  : Expr[StartTag[name, result]] =
+  : Macro[StartTag[name, result]] =
 
       import quotes.reflect.*
 

--- a/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
+++ b/lib/hyperbole/src/core/hyperbole.Hyperbole.scala
@@ -51,6 +51,7 @@ import inimitable.*
 import iridescence.*
 import nomenclature.*
 import prepositional.*
+import proscenium.*
 import rudiments.*
 import serpentine.*
 import spectacular.*
@@ -63,7 +64,7 @@ import dotty.tools.*, dotc.util as dtdu
 import syntaxHighlighting.teletypeable
 
 object Hyperbole:
-  def introspection[value](value: Expr[value], inlining: Expr[Boolean])(using Quotes): Expr[Text] =
+  def introspection[value](value: Expr[value], inlining: Expr[Boolean]): Macro[Text] =
     Expr(introspect(value, inlining).render(termcapDefinitions.xterm256))
 
   def introspect[value](expr: Expr[value], inlining0: Expr[Boolean])(using Quotes): Teletype =

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse2.scala
@@ -40,12 +40,13 @@ import scala.quoted.*
 
 import anticipation.*
 import fulminate.*
+import proscenium.*
 import rudiments.*
 
 object Hypotenuse2:
   given realm: Realm = realm"hypotenuse"
 
-  def bin(expr: Expr[StringContext])(using Quotes): Expr[AnyVal] =
+  def bin(expr: Expr[StringContext]): Macro[AnyVal] =
     import quotes.reflect.*
     val bits = expr.valueOrAbort.parts.head
 
@@ -68,7 +69,7 @@ object Hypotenuse2:
       case 64 => Expr[Long](long)
       case _  => halt(m"a binary literal must be 8, 16, 32 or 64 bits long")
 
-  def hex(expr: Expr[StringContext])(using Quotes): Expr[IArray[Byte]] =
+  def hex(expr: Expr[StringContext]): Macro[IArray[Byte]] =
     import quotes.reflect.*
 
     val startPos = expr.asTerm.pos
@@ -94,23 +95,23 @@ object Hypotenuse2:
 
     '{IArray.from(${Expr(bytes)})}
 
-  def parseU64(digits: Expr[String])(using Quotes): Expr[Long] = digits.value match
+  def parseU64(digits: Expr[String]): Macro[Long] = digits.value match
     case None         => '{JLong.parseUnsignedLong($digits)}
     case Some(digits) => Expr(JLong.parseUnsignedLong(digits))
 
-  def parseS64(digits: Expr[String])(using Quotes): Expr[Long] = digits.value match
+  def parseS64(digits: Expr[String]): Macro[Long] = digits.value match
     case None         => '{JLong.parseLong($digits)}
     case Some(digits) => Expr(JLong.parseLong(digits))
 
-  def parseU32(digits: Expr[String])(using Quotes): Expr[Int] = digits.value match
+  def parseU32(digits: Expr[String]): Macro[Int] = digits.value match
     case None         => '{JInt.parseUnsignedInt($digits)}
     case Some(digits) => Expr(JInt.parseUnsignedInt(digits))
 
-  def parseS32(digits: Expr[String])(using Quotes): Expr[Int] = digits.value match
+  def parseS32(digits: Expr[String]): Macro[Int] = digits.value match
     case None         => '{JInt.parseInt($digits)}
     case Some(digits) => Expr(JInt.parseInt(digits))
 
-  def parseU16(digits: Expr[String])(using Quotes): Expr[Short] = digits.value match
+  def parseU16(digits: Expr[String]): Macro[Short] = digits.value match
     case None => '{JInt.parseInt($digits).toShort}
 
     case Some(digits) =>
@@ -120,7 +121,7 @@ object Hypotenuse2:
 
       Expr(int.toShort)
 
-  def parseS16(digits: Expr[String])(using Quotes): Expr[Short] = digits.value match
+  def parseS16(digits: Expr[String]): Macro[Short] = digits.value match
     case None => '{JInt.parseInt($digits).toShort}
 
     case Some(digits) =>
@@ -130,7 +131,7 @@ object Hypotenuse2:
 
       Expr(int.toShort)
 
-  def parseU8(digits: Expr[String])(using Quotes): Expr[Byte] = digits.value match
+  def parseU8(digits: Expr[String]): Macro[Byte] = digits.value match
     case None => '{JInt.parseInt($digits).toByte}
 
     case Some(digits) =>
@@ -140,7 +141,7 @@ object Hypotenuse2:
 
       Expr(int.toByte)
 
-  def parseS8(digits: Expr[String])(using Quotes): Expr[Byte] = digits.value match
+  def parseS8(digits: Expr[String]): Macro[Byte] = digits.value match
     case None => '{JInt.parseInt($digits).toByte}
 
     case Some(digits) =>
@@ -156,8 +157,7 @@ object Hypotenuse2:
         bound: Expr[Int | Double | Char | Byte | Short | Long | Float],
         strict: Expr[Boolean],
         greaterThan: Expr[Boolean])
-       (using Quotes)
-  : Expr[Boolean] =
+  : Macro[Boolean] =
 
       val errorMessage = m"this cannot be written as a range expression"
 

--- a/lib/inimitable/src/core/inimitable.Inimitable.scala
+++ b/lib/inimitable/src/core/inimitable.Inimitable.scala
@@ -37,10 +37,11 @@ import scala.quoted.*
 import anticipation.*
 import contingency.*
 import fulminate.*
+import proscenium.*
 
 object Inimitable:
   given realm: Realm = realm"inimitable"
 
-  def uuid(expr: Expr[StringContext])(using Quotes): Expr[Uuid] =
+  def uuid(expr: Expr[StringContext]): Macro[Uuid] =
     val uuid = abortive(Uuid.parse(expr.valueOrAbort.parts.head.tt))
     '{Uuid(${Expr(uuid.msb)}, ${Expr(uuid.lsb)})}

--- a/lib/kaleidoscope/src/core/kaleidoscope.Kaleidoscope.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Kaleidoscope.scala
@@ -41,20 +41,21 @@ import scala.quoted.*
 import anticipation.*
 import contingency.*
 import fulminate.*
+import proscenium.*
 import vacuous.*
 
 object Kaleidoscope:
   given realm: Realm = realm"kaleidoscope"
 
-  def glob(context: Expr[StringContext])(using Quotes): Expr[Any] =
+  def glob(context: Expr[StringContext]): Macro[Any] =
     val parts = context.value.get.parts.map(Text(_)).map(Glob.parse(_).regex.s).to(List)
 
     extractor(parts.head :: parts.tail.map("([^/\\\\]*)"+_))
 
-  def regex(context: Expr[StringContext])(using Quotes): Expr[Any] =
+  def regex(context: Expr[StringContext]): Macro[Any] =
     extractor(context.value.get.parts.to(List))
 
-  private def extractor(parts: List[String])(using Quotes): Expr[Any] =
+  private def extractor(parts: List[String]): Macro[Any] =
     import quotes.reflect.*
 
     val regex = abortive(Regex.parse(parts.map(Text(_))))

--- a/lib/legerdemain/src/core/legerdemain.Legerdemain.scala
+++ b/lib/legerdemain/src/core/legerdemain.Legerdemain.scala
@@ -40,7 +40,7 @@ import prepositional.*
 import proscenium.*
 
 object Legerdemain:
-  def query(values: Expr[Seq[(Label, Any)]])(using Quotes): Expr[Query] =
+  def query(values: Expr[Seq[(Label, Any)]]): Macro[Query] =
 
     def recur(exprs: List[Expr[(Label, Any)]], done: List[Expr[List[(Text, Text)]]] = Nil)
     : Expr[Query] =

--- a/lib/mandible/src/core/mandible.Mandible.scala
+++ b/lib/mandible/src/core/mandible.Mandible.scala
@@ -53,8 +53,7 @@ import vacuous.*
 
 object Mandible:
   def disassemble[target: Type](block: Expr[target => Any], classloader: Expr[Classloader])
-       (using Quotes)
-  : Expr[Optional[Bytecode]] =
+  : Macro[Optional[Bytecode]] =
 
       import quotes.reflect.*
       given Realm = realm"mandible"

--- a/lib/mercator/src/core/mercator.Mercator.scala
+++ b/lib/mercator/src/core/mercator.Mercator.scala
@@ -34,12 +34,13 @@ package mercator
 
 import anticipation.*
 import fulminate.*
+import proscenium.*
 
 import scala.compiletime.*
 import scala.quoted.*
 
 object Mercator:
-  def point[typeConstructor[_]: Type](using Quotes): Expr[Identity[typeConstructor]] =
+  def point[typeConstructor[_]: Type]: Macro[Identity[typeConstructor]] =
     import quotes.reflect.*
 
     val identityType = TypeRepr.of[typeConstructor].typeSymbol

--- a/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
+++ b/lib/nettlesome/src/core/nettlesome.EmailAddress.scala
@@ -61,7 +61,7 @@ object EmailAddress:
   given encodable: EmailAddress is Encodable in Text = _.text
   given showable: EmailAddress is Showable = _.text
 
-  def expand(context: Expr[StringContext])(using Quotes): Expr[EmailAddress] = abortive:
+  def expand(context: Expr[StringContext]): Macro[EmailAddress] = abortive:
     val text: Text = context.valueOrAbort.parts.head.tt
     val address = EmailAddress.parse(text)
 

--- a/lib/nettlesome/src/core/nettlesome.Hostname.scala
+++ b/lib/nettlesome/src/core/nettlesome.Hostname.scala
@@ -39,6 +39,7 @@ import denominative.*
 import fulminate.*
 import gossamer.*
 import hypotenuse.*
+import proscenium.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
@@ -53,7 +54,7 @@ object Hostname:
 
   given showable: Hostname is Showable = _.dnsLabels.map(_.show).join(t".")
 
-  def expand(context: Expr[StringContext])(using Quotes): Expr[Hostname] = abortive:
+  def expand(context: Expr[StringContext]): Macro[Hostname] = abortive:
     Expr(Hostname.parse(context.valueOrAbort.parts.head.tt))
 
   given toExpr: ToExpr[Hostname]:

--- a/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
+++ b/lib/nettlesome/src/core/nettlesome.Nettlesome.scala
@@ -235,8 +235,8 @@ object Nettlesome:
   case class Ipv6(highBits: Long, lowBits: Long)
 
 
-  def portService(context: Expr[StringContext], tcp: Boolean)(using Quotes)
-  : Expr[TcpPort | UdpPort] =
+  def portService(context: Expr[StringContext], tcp: Boolean)
+  : Macro[TcpPort | UdpPort] =
 
       import quotes.reflect.*
 
@@ -261,7 +261,7 @@ object Nettlesome:
                   else '{UdpPort.unsafe(${Expr(port)}).asInstanceOf[UdpPort of number]}
 
 
-  def ip(context: Expr[StringContext])(using Quotes): Expr[Ipv4 | Ipv6] =
+  def ip(context: Expr[StringContext]): Macro[Ipv4 | Ipv6] =
     val text = Text(context.valueOrAbort.parts.head)
 
     abortive:
@@ -273,7 +273,7 @@ object Nettlesome:
         val ipv6 = Ipv6.parse(text)
         '{Ipv6(${Expr(ipv6.highBits)}, ${Expr(ipv6.lowBits)})}
 
-  def mac(context: Expr[StringContext])(using Quotes): Expr[MacAddress] = abortive:
+  def mac(context: Expr[StringContext]): Macro[MacAddress] = abortive:
     val macAddress = MacAddress.parse(context.valueOrAbort.parts.head.tt)
     '{MacAddress(${Expr(macAddress.long)})}
 

--- a/lib/nettlesome/src/url/nettlesome.UrlInterpolator.scala
+++ b/lib/nettlesome/src/url/nettlesome.UrlInterpolator.scala
@@ -48,7 +48,7 @@ import errorDiagnostics.empty
 
 object UrlInterpolator extends contextual.Interpolator[UrlFragment, Text, Url[Label]]:
 
-  def refined(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes): Expr[Url[Label]] =
+  def refined(context: Expr[StringContext], parts: Expr[Seq[Any]]): Macro[Url[Label]] =
     import quotes.reflect.*
 
     val constant = context.value.get.parts.head.split(":").nn.head.nn

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature2.scala
@@ -61,13 +61,13 @@ object Nomenclature2:
       case AndType(left, right) => decompose(left) ++ decompose(right)
       case other                => Set(other)
 
-  def disintersection[intersection: Type](using Quotes): Expr[Tuple] =
+  def disintersection[intersection: Type]: Macro[Tuple] =
     import quotes.reflect.*
 
     build(decompose(TypeRepr.of[intersection].dealias).to(List)).asType.absolve match
       case '[type tupleType <: Tuple; tupleType] => '{null.asInstanceOf[tupleType]}
 
-  def extractor(context: Expr[StringContext])(using Quotes): Expr[Any] =
+  def extractor(context: Expr[StringContext]): Macro[Any] =
     import quotes.reflect.*
     val string = context.valueOrAbort.parts.head
 
@@ -77,7 +77,7 @@ object Nomenclature2:
         panic(m"StringContext did not contains Strings")
 
 
-  def makeName[system: Type](name: Expr[Text])(using Quotes): Expr[Name[system]] =
+  def makeName[system: Type](name: Expr[Text]): Macro[Name[system]] =
     import quotes.reflect.*
 
     Expr.summon[system is Nominative] match
@@ -97,8 +97,8 @@ object Nomenclature2:
       case None =>
         halt(m"Couldn't find a `Nominative` instance on ${Type.of[system]}")
 
-  def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])(using Quotes)
-  : Expr[Boolean] =
+  def parse2[platform: Type, name <: String: Type](scrutinee: Expr[Name[platform]])
+  : Macro[Boolean] =
 
       parse[platform, name]
       '{${Expr(constant[name])}.tt == $scrutinee}
@@ -114,7 +114,7 @@ object Nomenclature2:
       case module: `companion` => module
       case _                   => halt(m"The companion object did not have the expected type.")
 
-  def parse[platform: Type, name <: String: Type](using Quotes): Expr[Name[platform]] =
+  def parse[platform: Type, name <: String: Type]: Macro[Name[platform]] =
     import quotes.reflect.*
 
     val name: Text = constant[name].tt

--- a/lib/nomenclature/src/core/nomenclature.Nomenclature3.scala
+++ b/lib/nomenclature/src/core/nomenclature.Nomenclature3.scala
@@ -34,8 +34,10 @@ package nomenclature
 
 import scala.quoted.*
 
+import proscenium.*
+
 object Nomenclature3:
-  def staticCompanion[instance: Type](using Quotes): Expr[Matchable] =
+  def staticCompanion[instance: Type]: Macro[Matchable] =
     import quotes.reflect.*
     Ident(TypeRepr.of[instance].typeSymbol.companionModule.termRef).asExprOf[Matchable]
 

--- a/lib/panopticon/src/core/panopticon.Panopticon.scala
+++ b/lib/panopticon/src/core/panopticon.Panopticon.scala
@@ -92,7 +92,7 @@ object Panopticon:
           halt(m"unexpectedly did not match")
 
 
-  def get[from: Type, path <: Tuple: Type, to: Type](value: Expr[from])(using Quotes): Expr[to] =
+  def get[from: Type, path <: Tuple: Type, to: Type](value: Expr[from]): Macro[to] =
 
     import quotes.reflect.*
 
@@ -116,8 +116,7 @@ object Panopticon:
 
 
   def set[from: Type, path <: Tuple: Type, to: Type](value: Expr[from], newValue: Expr[to])
-       (using Quotes)
-  : Expr[from] =
+  : Macro[from] =
 
       import quotes.reflect.*
 
@@ -146,7 +145,7 @@ object Panopticon:
       rewrite(getPath[path](), value.asTerm).asExprOf[from]
 
 
-  def dereference[aim: Type, tuple <: Tuple: Type](member: Expr[String])(using Quotes): Expr[Any] =
+  def dereference[aim: Type, tuple <: Tuple: Type](member: Expr[String]): Macro[Any] =
     import quotes.reflect.*
 
     val fieldName = member.valueOrAbort

--- a/lib/polyvinyl/src/core/polyvinyl.Schema.scala
+++ b/lib/polyvinyl/src/core/polyvinyl.Schema.scala
@@ -45,9 +45,8 @@ trait Schema[data, record <: Record in data]:
   def access(name: String, value: data): data
 
 
-  def build(value: Expr[data])(using Quotes, Type[record], Type[data])
-       (using thisType: Type[this.type])
-  : Expr[record] =
+  def build(value: Expr[data])(using Type[record], Type[data])(using thisType: Type[this.type])
+  : Macro[record] =
 
       import quotes.reflect.*
 

--- a/lib/probably/src/core/probably.Probably.scala
+++ b/lib/probably/src/core/probably.Probably.scala
@@ -37,6 +37,7 @@ import chiaroscuro.*
 import denominative.*
 import fulminate.*
 import gossamer.*
+import proscenium.*
 import rudiments.*
 import spectacular.*
 
@@ -51,8 +52,7 @@ object Probably:
                   inc:       Expr[Inclusion[report, Verdict]],
                   inc2:      Expr[Inclusion[report, Verdict.Detail]],
                   action:    Expr[Trial[test] => result])
-                 (using Quotes)
-  : Expr[result] =
+  : Macro[result] =
 
       import quotes.reflect.*
 
@@ -110,8 +110,7 @@ object Probably:
         runner:    Expr[Runner[report]],
         inc:       Expr[Inclusion[report, Verdict]],
         inc2:      Expr[Inclusion[report, Verdict.Detail]])
-       (using Quotes)
-  : Expr[test] =
+  : Macro[test] =
 
       general[test, report, test]
        (test, predicate, runner, inc, inc2, '{ (t: Trial[test]) => t.get })
@@ -123,8 +122,7 @@ object Probably:
         runner:    Expr[Runner[report]],
         inc:       Expr[Inclusion[report, Verdict]],
         inc2:      Expr[Inclusion[report, Verdict.Detail]])
-       (using Quotes)
-  : Expr[Unit] =
+  : Macro[Unit] =
 
       general[test, report, Unit](test, predicate, runner, inc, inc2, '{ _ => () })
 
@@ -134,8 +132,7 @@ object Probably:
         runner: Expr[Runner[report]],
         inc:    Expr[Inclusion[report, Verdict]],
         inc2:   Expr[Inclusion[report, Verdict.Detail]])
-       (using Quotes)
-  : Expr[Unit] =
+  : Macro[Unit] =
 
       general[test, report, Unit](test, '{ _ => true }, runner, inc, inc2, '{ _ => () })
 
@@ -187,7 +184,7 @@ object Probably:
         result(run)
 
 
-  def debug[test: Type](expr: Expr[test], test: Expr[Harness])(using Quotes): Expr[test] =
+  def debug[test: Type](expr: Expr[test], test: Expr[Harness]): Macro[test] =
     import quotes.reflect.*
 
     val exprName: Text = expr.asTerm.pos match

--- a/lib/proscenium/src/core/proscenium-core.scala
+++ b/lib/proscenium/src/core/proscenium-core.scala
@@ -73,6 +73,8 @@ object Mono:
 
 transparent inline def infer[context]: context = compiletime.summonInline[context]
 
+type Macro[result] = scala.quoted.Quotes ?=> scala.quoted.Expr[result]
+
 transparent inline def provide[context](using erased Void)[result]
                         (inline lambda: context ?=> result)
 : result =

--- a/lib/punctuation/src/core/punctuation.Punctuation.scala
+++ b/lib/punctuation/src/core/punctuation.Punctuation.scala
@@ -33,12 +33,13 @@
 package punctuation
 
 import anticipation.*
+import proscenium.*
 
 import scala.quoted.*
 
 object Punctuation:
-  def md(context: Expr[StringContext], parts: Expr[Seq[Any]])(using Quotes)
-  : Expr[Markdown[Markdown.Ast.Node]] =
+  def md(context: Expr[StringContext], parts: Expr[Seq[Any]])
+  : Macro[Markdown[Markdown.Ast.Node]] =
 
       Md.Interpolator.expansion(context, parts) match
         case (Md.Input.Inline(_), result) => '{$result.asInstanceOf[InlineMd]}

--- a/lib/rudiments/src/core/rudiments.Rudiments.scala
+++ b/lib/rudiments/src/core/rudiments.Rudiments.scala
@@ -37,6 +37,7 @@ import scala.quoted.*
 import anticipation.*
 import fulminate.*
 import prepositional.*
+import proscenium.*
 import symbolism.*
 import vacuous.*
 
@@ -79,11 +80,11 @@ object Rudiments:
       def long: Long = left
       def text: Text = (left.toString+" bytes").tt
 
-  def probe[target: Type](using Quotes): Expr[Nothing] =
+  def probe[target: Type]: Macro[Nothing] =
     import quotes.reflect.*
     halt(m"the type is ${TypeRepr.of[target].dealias.widen}")
 
-  def reflectClass[target: Type](using Quotes): Expr[Class[target]] =
+  def reflectClass[target: Type]: Macro[Class[target]] =
     import quotes.reflect.*
     '{Class.forName(${Expr(TypeRepr.of[target].typeSymbol.fullName)}).asInstanceOf[Class[target]]}
 

--- a/lib/superlunary/src/core/superlunary.Dispatchable.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatchable.scala
@@ -49,10 +49,10 @@ object Dispatchable:
     type Carrier = Json
     type Format = Text
 
-    def encoder[value: Type](using Quotes): Expr[value => Text] =
+    def encoder[value: Type]: Macro[value => Text] =
       '{ value => value.json.encode }
 
-    def decoder(using Quotes): Expr[Text => List[Json]] =
+    def decoder: Macro[Text => List[Json]] =
       '{ text => unsafely(text.decode[Json].as[List[Json]]) }
 
     inline def encode(value: List[Json]): Text = value.json.encode
@@ -67,8 +67,8 @@ trait Dispatchable:
   type Carrier
   type Format
 
-  def encoder[value: Type](using Quotes): Expr[value => Format]
-  def decoder(using Quotes): Expr[Format => List[Carrier]]
+  def encoder[value: Type]: Macro[value => Format]
+  def decoder: Macro[Format => List[Carrier]]
 
   inline def encode(values: List[Carrier]): Format
   inline def decode[value](value: Format): value

--- a/lib/typonym/.github/readme.md
+++ b/lib/typonym/.github/readme.md
@@ -98,10 +98,10 @@ inline def printElements[ItemsType <: TypeList[?]]: Unit =
   reify[ItemsType].foreach(println)
 ```
 
-Similarly, within a macro, 
+Similarly, within a macro,
 ```scala
 
-def printLongest[ItemsType <: TypeList[?]: Type](using Quotes): Expr[Unit] =
+def printLongest[ItemsType <: TypeList[?]: Type]: Macro[Unit] =
   val items: List[String] = reify(Type.of[ItemsType])
   println(items.maxBy(_.length))
   '{()}
@@ -135,7 +135,7 @@ experimentation. They are provided only for the necessity of providing _some_
 answer to the question, "how can I try Typonym?".
 
 1. *Copy the sources into your own project*
-   
+
    Read the `fury` file in the repository root to understand Typonym's build
    structure, dependencies and source location; the file format should be short
    and quite intuitive. Copy the sources into a source directory in your own
@@ -152,7 +152,7 @@ answer to the question, "how can I try Typonym?".
    file in the project directory, and produce a collection of JAR files which can
    be added to a classpath, by compiling the project and all of its dependencies,
    including the Scala compiler itself.
-   
+
    Download the latest version of
    [`wrath`](https://github.com/propensive/wrath/releases/latest), make it
    executable, and add it to your path, for example by copying it to
@@ -213,4 +213,3 @@ The logo shows the square brackets which usually delimit a type in Scala.
 
 Typonym is copyright &copy; 2025 Jon Pretty & Propensive O&Uuml;, and
 is made available under the [Apache 2.0 License](/license.md).
-

--- a/lib/typonym/doc/basics.md
+++ b/lib/typonym/doc/basics.md
@@ -59,10 +59,10 @@ inline def printElements[ItemsType <: TypeList[?]]: Unit =
   reify[ItemsType].foreach(println)
 ```
 
-Similarly, within a macro, 
+Similarly, within a macro,
 ```scala
 
-def printLongest[ItemsType <: TypeList[?]: Type](using Quotes): Expr[Unit] =
+def printLongest[ItemsType <: TypeList[?]: Type]: Macro[Unit] =
   val items: List[String] = reify(Type.of[ItemsType])
   println(items.maxBy(_.length))
   '{()}

--- a/lib/typonym/src/core/typonym-core.scala
+++ b/lib/typonym/src/core/typonym-core.scala
@@ -34,9 +34,10 @@ package typonym
 
 import scala.quoted.*
 
+import proscenium.*
 //transparent inline def erase(inline value: Any): Any = ${Typonym.erase(value)}
 
 transparent inline def reify[phantom]: Any = ${Typonym.reify[phantom]}
 
-def reify[phantom](phantomType: Type[phantom])(using Quotes): Expr[Any] =
+def reify[phantom](phantomType: Type[phantom]): Macro[Any] =
   Typonym.reify[phantom](using phantomType)

--- a/lib/typonym/src/core/typonym.Typonym.scala
+++ b/lib/typonym/src/core/typonym.Typonym.scala
@@ -47,7 +47,7 @@ object Typonym:
       case _ =>
         Nil
 
-  def reify[phantom: Type](using Quotes): Expr[Any] =
+  def reify[phantom: Type]: Macro[Any] =
     import quotes.reflect.*
 
     Type.of[phantom] match

--- a/lib/vicarious/src/core/vicarious.Vicarious.scala
+++ b/lib/vicarious/src/core/vicarious.Vicarious.scala
@@ -43,8 +43,7 @@ object Vicarious:
        (lambda: Expr[[field] => (field: field) => value],
         value: Expr[key],
         classTag: Expr[ClassTag[value]])
-       (using Quotes)
-  : Expr[Catalog[key, value]] =
+  : Macro[Catalog[key, value]] =
 
       import quotes.reflect.*
 
@@ -65,8 +64,8 @@ object Vicarious:
         case '[fieldType] => label :: fieldNames[fieldType](label)
 
 
-  def dereference[key: Type, value: Type, id <: Nat: Type](key: Expr[String])(using Quotes)
-  : Expr[value | Proxy[key, value, Nat]] =
+  def dereference[key: Type, value: Type, id <: Nat: Type](key: Expr[String])
+  : Macro[value | Proxy[key, value, Nat]] =
 
       import quotes.reflect.*
 
@@ -80,7 +79,7 @@ object Vicarious:
         case '[ type id <: Nat; id ] => '{Proxy[key, value, id]()}
 
 
-  def proxy[key: Type, value: Type](using Quotes): Expr[Proxy[key, value, 0]] =
+  def proxy[key: Type, value: Type]: Macro[Proxy[key, value, 0]] =
     import quotes.reflect.*
 
     val fields = fieldNames[key]("")


### PR DESCRIPTION
Almost every macro takes the form `def <something>(using Quotes): Expr[T]`. With a simple type alias, we can simplify this to `def <something>: Macro[T]`.

This introduces the type alias in Proscenium, and applies it everywhere it's usable.