### PR TITLE
Remember to include `austronesian-core` in the modules to publish

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1582,6 +1582,7 @@ object publishing extends Module {
     anticipation.time.publishLocal().t()
     anticipation.transport.publishLocal().t()
     anticipation.url.publishLocal().t()
+    austronesian.core.publishLocal().t()
     aviation.core.publishLocal().t()
     baroque.core.publishLocal().t()
     burdock.core.publishLocal().t()


### PR DESCRIPTION
Austronesian was added as a module, and is a dependency of Superlunary, but it wasn't being published. This adds it to the build.