### PR TITLE
Skip bytes at the start of executable ZIP files

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1549,7 +1549,7 @@ object zephyrine extends SoundnessModule {
 
 object zeppelin extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq(galilei.core)
+    def moduleDeps = Seq(galilei.core, zephyrine.core)
   }
 
   object test extends ProbablyTestModule {


### PR DESCRIPTION
Executable ZIP files contain content before the first entry: the program this is to be run to extract (or execute in some other way) the ZIP file's content. This makes it difficult to stream the entries in such a ZIP file, because there are some bytes at the start, before the first entry.

This scans a ZIP stream to cue zip streaming to the start of the entries before trying to read them.