### PR TITLE
Make it possible to rename `Path`s and `Relative`s

### DIFF
--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -104,7 +104,7 @@ trait Classpath:
 
   def classloader(parent: Classloader = classloaders.platform): Classloader =
     val javaClassloader = new jn.URLClassLoader(array, parent.java):
-      override def loadClass(name: String | Null, resolve: Boolean): Class[_] | Null =
+      override def loadClass(name: String | Null, resolve: Boolean): Class[?] | Null =
         try findClass(name) catch case error: ClassNotFoundException =>
           super.loadClass(name, resolve)
 

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -189,6 +189,10 @@ case class Path(root: Text, descent: Text*):
     case _ =>
       root == right.root
 
+  transparent inline def rename(lambda: (prior: Text) ?=> Text): Optional[Path] =
+    parent.let: parent =>
+      descent.prim.let(parent / lambda(using _))
+
   transparent inline def conjunction(right: Path): Optional[Path] =
     inline sameRoot(right) match
       case true  => certain(right)

--- a/lib/serpentine/src/test/serpentine.Tests.scala
+++ b/lib/serpentine/src/test/serpentine.Tests.scala
@@ -497,19 +497,19 @@ object Tests extends Suite(m"Serpentine Benchmarks"):
       val path: Path on Linux = % / "home" / "work" / "data"
 
       test(m"Match root on a simple path"):
-        path match
+        path.only:
           case root /: right => root
 
       . assert(_ == t"/")
 
       test(m"Match root on a short path"):
-        shortPath match
+        shortPath.only:
           case root /: right => root
 
       . assert(_ == t"/")
 
       test(m"Match descent on a simple path"):
-        path match
+        path.only:
           case root /: right => right
 
       . assert(_ == ? / "home" / "work" / "data")
@@ -522,30 +522,29 @@ object Tests extends Suite(m"Serpentine Benchmarks"):
       . assert(identity(_))
 
       test(m"Match top elementon a simple path"):
-        path match
+        path.only:
           case root /: right0 /: right1 => right0
 
       . assert(_ == t"home")
 
 
       test(m"Match further descent on a simple path"):
-        path match
+        path.only:
           case root /: right0 /: right1 => right1
 
       . assert(_ == ? / "work" / "data")
 
 
       test(m"Match last descent on a simple path"):
-        path match
+        path.only:
           case root /: right0 /: right1 /: right2 => right2
 
       . assert(_ == t"data")
 
 
       test(m"Further elements don't match"):
-        path match
+        path.only:
           case root /: right0 /: right1 /: right2 /: right3 => right3
-          case _                                            => Unset
 
       . assert(_ == Unset)
 


### PR DESCRIPTION
It's now possible to rename `Path`s and `Relative`s to a new `Text` value, with,
```scala
val path2 = path.rename(t"quux")
```
or, to reuse the previous name in the new name, it can be referenced with `prior`, like so:
```scala
val path2 = path.rename(prior+t".bak")
```

Note that `rename` may return an `Optional` if it cannot be statically determined to be a non-root.