### PR TITLE
Include Superlunary in the tests

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -239,6 +239,7 @@ object test extends ScalaModule {
     sedentary.test,
     serpentine.test,
     spectacular.test,
+    superlunary.test,
     surveillance.test,
     symbolism.test,
     tarantula.test,

--- a/lib/superlunary/src/core/superlunary.Dispatchable.scala
+++ b/lib/superlunary/src/core/superlunary.Dispatchable.scala
@@ -63,7 +63,7 @@ object Dispatchable:
     inline def extract[entity](json: Json): entity = provide[Tactic[JsonError]]:
       provide[entity is Decodable in Json](json.as[entity])
 
-trait Dispatchable, Transportive, Formal:
+trait Dispatchable extends Transportive, Formal:
   def encoder[value: Type]: Macro[value => Form]
   def decoder: Macro[Form => List[Transport]]
 


### PR DESCRIPTION
An error with Superlunary became apparent during publishing which had not been caught during a normal CI run. This was because the `superlunary.test` module was omitted from the test build, while it was still being published.

Here, we include it in the build, and also fix the issue that wasn't caught.