### PR TITLE
Generically-derive contrasts

### DIFF
--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
@@ -81,7 +81,6 @@ object Decomposable extends Decomposable2:
     value => Decomposition.Primitive(t"Any", value.toString.tt, value)
 
   trait Foundation extends Decomposable:
-    type Self
     def decomposition(value: Self): Decomposition
 
   object Foundation:


### PR DESCRIPTION
When contrasting one type with another, if no "native" `Contrastable` instance could be found, a `Contrastable` would be created from a `Decomposable` instance—which would be derived. Once going down the "decomposable" route, nested types like sets, doubles or ints (which have native `Contrastable` instances) would always be decomposed, because `Decomposable` derivation does not know anything about `Contrastable`s.

So now we do generic derivation on `Contrastable` instances too so that for every nested type, we first search for a `Contrastable` instance, and only then fall back on its decomposition.