### PR TITLE
Rename `terminal` to `interactive`

### DIFF
--- a/lib/profanity/src/core/profanity-core.scala
+++ b/lib/profanity/src/core/profanity-core.scala
@@ -44,7 +44,7 @@ given realm: Realm = realm"profanity"
 given stdio: (terminal: Terminal) => Stdio = terminal.stdio
 
 
-def terminal[result](block: (terminal: Terminal) ?=> result)
+def interactive[result](block: (terminal: Terminal) ?=> result)
    (using context: ProcessContext, monitor: Monitor, codicil: Codicil)
    (using BracketedPasteMode,
           BackgroundColorDetection,

--- a/lib/profanity/src/core/soundness+profanity-core.scala
+++ b/lib/profanity/src/core/soundness+profanity-core.scala
@@ -36,7 +36,7 @@ export profanity
 . { BackgroundColorDetection, BracketedPasteMode, DismissError, Interaction, Interactivity,
     Keyboard, Keypress, LineEditor, ProcessContext, Question, SelectMenu, StandardKeyboard,
     Terminal, TerminalError, TerminalEvent, TerminalFocusDetection, TerminalMode,
-    TerminalSizeDetection, terminal }
+    TerminalSizeDetection, interactive }
 
 package keyboards:
   export profanity.keyboards.{raw, numeric, standard}


### PR DESCRIPTION
The method for introducing an interactive terminal environment had a name which conflicted with the `terminal` _value_, an interface to the actual terminal introduced by `terminal`. This was unnecessarily confusing. We fix it by renaming the first `terminal` to `interactive`.