### PR TITLE
Provide an `effectful` block which allows side-effects

### DIFF
--- a/lib/exoskeleton/src/core/exoskeleton-core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton-core.scala
@@ -108,6 +108,9 @@ package executives:
       catch case error: Throwable => handler.handle(error)(using cli.stdio)
       //handler.handle(exitStatus(using cli))(using cli.stdio)
 
+inline def effectful[result](lambda: (erased Effectful) ?=> result): result =
+  lambda(using !![Effectful])
+
 def application(using executive: Executive, interpreter: CliInterpreter)
    (arguments: Iterable[Text], signals: List[Signal] = Nil)
    (block: Cli ?=> executive.Return)

--- a/lib/exoskeleton/src/core/soundness+exoskeleton-core.scala
+++ b/lib/exoskeleton/src/core/soundness+exoskeleton-core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export exoskeleton
 . { application, Application, CliInvocation, Effectful, Executive, InstallError, ShellContext,
-    UnhandledErrorHandler }
+    UnhandledErrorHandler, effectful }
 
 package unhandledErrors:
   export exoskeleton.unhandledErrors.{silent, genericErrorMessage, exceptionMessage, stackTrace}


### PR DESCRIPTION
When writing a CLI application, inside the `cli` block, you can't normally do anything that's marked as "effectful" with `(using Effectful)`. That's to save you from doing it by accident.

But sometimes you need to, so the `effectful` block is provided for that purpose.