### PR TITLE
Support zsh prefixes

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -46,12 +46,12 @@ case class Argument(position: Int, value: Text, cursor: Optional[Int]):
     cli.suggest(this, update)
 
 
-  def select[operand](options: Seq[operand])
-       (using cli: Cli, interpreter: CliInterpreter, suggestible: operand is Suggestible)
+  def select[operand: Suggestible](options: Seq[operand])
+       (using cli: Cli, interpreter: CliInterpreter)
   : Optional[operand] =
 
       val mapping: Map[Text, operand] =
-        options.map { option => (suggestible.suggest(option).text, option) }.to(Map)
+        options.map { option => (operand.suggest(option).text, option) }.to(Map)
 
-      suggest(options.to(List).map(suggestible.suggest(_)))
+      suggest(options.to(List).map(operand.suggest(_)))
       mapping.at(this())

--- a/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Suggestion.scala
@@ -34,25 +34,33 @@ package exoskeleton
 
 import anticipation.*
 import escapade.*
+import gossamer.*
+import symbolism.*
 import vacuous.*
 
 import language.experimental.pureFunctions
 
 object Suggestion:
   def apply
-       (text: Text,
+       (core:        Text,
         description: Optional[Text | Teletype],
         hidden:      Boolean                   = false,
         incomplete:  Boolean                   = false,
-        aliases:     List[Text]                = Nil)
+        aliases:     List[Text]                = Nil,
+        prefix:      Text                      = t"",
+        suffix:      Text                      = t"")
   : Suggestion =
 
-      new Suggestion(text, description, hidden, incomplete, aliases)
+      new Suggestion(core, description, hidden, incomplete, aliases, prefix, suffix)
 
 
 case class Suggestion
-   (text:        Text,
+   (core:        Text,
     description: Optional[Text | Teletype],
     hidden:      Boolean,
     incomplete:  Boolean,
-    aliases:     List[Text])
+    aliases:     List[Text],
+    prefix:      Text,
+    suffix:      Text):
+
+  def text: Text = prefix+core+suffix

--- a/lib/exoskeleton/src/completions/exoskeleton-completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton-completions.scala
@@ -66,14 +66,16 @@ package executives:
     : Cli =
 
         arguments match
-          case t"{completions}" :: shellName :: As[Int](focus) :: As[Int](position) :: t"--"
-              :: command
-              :: rest =>
+          case t"{completions}" :: shellName :: As[Int](focus0) :: As[Int](position) :: t"--"
+               :: command
+               :: rest =>
 
             val shell = shellName match
               case t"zsh"  => Shell.Zsh
               case t"fish" => Shell.Fish
               case _       => Shell.Bash
+
+            val focus = if shell == Shell.Zsh then focus0 - 1 else focus0
 
             CliCompletion
              (Cli.arguments(arguments, focus - 1, position),

--- a/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
@@ -121,27 +121,29 @@ extends Cli:
         val title = explanation.let { explanation => List(sh"'' -X $explanation") }.or(Nil)
         val termcap: Termcap = termcapDefinitions.xtermTrueColor
 
-        lazy val width = items.map(_.text.length).max
+        lazy val width = items.map(_.core.length).max
         lazy val aliasesWidth = items.map(_.aliases.join(t" ").length).max + 1
 
         val itemLines: List[Command] = items.flatMap:
           case Suggestion(core, description, hidden, incomplete, aliases, prefix, suffix) =>
             val hiddenParam = if hidden then sh"-n" else sh""
             val aliasText = aliases.join(t" ").fit(aliasesWidth)
-            val prefix2 = if prefix.empty then sh"" else sh"-P $prefix"
+            val prefix2 = if prefix.empty then sh"" else sh"-p $prefix"
+            val text = prefix+core+suffix
 
             val mainLine = description.absolve match
               case Unset =>
-                sh"'' $hiddenParam -- $core"
+                if prefix.empty then sh"'' $hiddenParam -- $core"
+                else sh"'' $hiddenParam -U $prefix2 -- $core"
 
               case description: Text =>
-                sh"'${core.fit(width)} $aliasText -- $description' -d desc -l $hiddenParam $prefix2 -- $core"
+                sh"'${core.fit(width)} $aliasText -U $prefix2 -- $description' -d desc -l $hiddenParam -- $core"
 
               case description: Teletype =>
                 val desc = description.render(termcap)
-                sh"'${core.fit(width)} $aliasText -- $desc' -d desc -l $hiddenParam $prefix2 -- $core"
+                sh"'${core.fit(width)} $aliasText -U $prefix2 -- $desc' -d desc -l $hiddenParam -- $core"
 
-            val duplicateLine = if !incomplete then List() else List(sh"'' -U -S '' $prefix2 -- $core")
+            val duplicateLine = if !incomplete then List() else List(sh"'' -U $prefix2 -S '' -- $core")
 
             val aliasLines = aliases.map: text =>
               description.absolve match
@@ -149,15 +151,15 @@ extends Cli:
                   sh"'' -n -- $text"
 
                 case description: Text =>
-                  sh"'${text.fit(width)} $aliasText -- $description' -d desc -l -n $prefix2 -- $core"
+                  sh"'${core.fit(width)} $aliasText -- $description' -d desc -l -n -- $core"
 
                 case description: Teletype =>
                   val desc = description.render(termcap)
-                  sh"'${text.fit(width)} $aliasText -- $desc' -d desc -l -n $prefix2 -- $core"
+                  sh"'${core.fit(width)} $aliasText -- $desc' -d desc -l -n -- $core"
 
             mainLine :: duplicateLine ::: aliasLines
 
-        (title ++ itemLines).map(_.arguments.join(t"\t"))
+        (title ++ itemLines).map(_.arguments.join(t"\u0000"))
 
       case Shell.Bash =>
         items.filter(!_.hidden).flatMap: suggestion =>

--- a/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.CliCompletion.scala
@@ -129,21 +129,24 @@ extends Cli:
             val hiddenParam = if hidden then sh"-n" else sh""
             val aliasText = aliases.join(t" ").fit(aliasesWidth)
             val prefix2 = if prefix.empty then sh"" else sh"-p $prefix"
+            val suffix2 = if suffix.empty then sh"" else sh"-s $suffix"
+
             val text = prefix+core+suffix
 
             val mainLine = description.absolve match
               case Unset =>
                 if prefix.empty then sh"'' $hiddenParam -- $core"
-                else sh"'' $hiddenParam -U $prefix2 -- $core"
+                else sh"'' $hiddenParam -U $prefix2 $suffix2 -- $core"
 
               case description: Text =>
-                sh"'${core.fit(width)} $aliasText -U $prefix2 -- $description' -d desc -l $hiddenParam -- $core"
+                sh"'${core.fit(width)} $aliasText -U $prefix2 $suffix2 -- $description' -d desc -l $hiddenParam -- $core"
 
               case description: Teletype =>
                 val desc = description.render(termcap)
-                sh"'${core.fit(width)} $aliasText -U $prefix2 -- $desc' -d desc -l $hiddenParam -- $core"
+                sh"'${core.fit(width)} $aliasText -U $prefix2 $suffix2 -- $desc' -d desc -l $hiddenParam -- $core"
 
-            val duplicateLine = if !incomplete then List() else List(sh"'' -U $prefix2 -S '' -- $core")
+            val duplicateLine =
+              if !incomplete then List() else List(sh"'' -U $prefix2 $suffix2 -S '' -- $core")
 
             val aliasLines = aliases.map: text =>
               description.absolve match

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -30,11 +30,57 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package exoskeleton
 
-export exoskeleton
-. { execute, explain, CliCompletion, Execution, SuggestionsState, TabCompletions,
-    TabCompletionsInstallation, Pathname }
+import anticipation.*
+import contingency.*
+import galilei.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import symbolism.*
+import vacuous.*
 
-package executives:
-  export exoskeleton.executives.completions
+import filesystemOptions.dereferenceSymlinks.enabled
+import interfaces.paths.pathOnLinux
+
+object Pathname:
+  def unapply(argument: Argument)(using WorkingDirectory, Cli): Option[Path on Linux] =
+    safely:
+      def suggest(path: Text): Suggestion =
+        val point = path.s.lastIndexOf('/', path.length - 2) + 1
+        val prefix = path.keep(point)
+        val core = path.skip(point)
+        Suggestion(core, Unset, incomplete = path != argument(), prefix = prefix)
+
+      if argument().empty then argument.suggest:
+        workingDirectory.children.to(List).map: path =>
+          suggest(path.name)
+      else
+        val absolute = argument().starts(t"/")
+        val directory = argument().ends(t"/")
+        val prototype = workingDirectory.resolve(argument())
+        val root = prototype.empty
+
+        val base: Optional[Path on Linux] = if directory then prototype else prototype.parent
+        val children0 = base.lay(Nil)(_.children.to(List))
+
+        val children =
+          if directory then children0 else children0.filter(_.name.starts(prototype.name))
+
+        argument.suggest:
+          children.map: path =>
+            val directory = safely(path.entry() == galilei.Directory).or(false)
+            val slash = if directory then t"/" else t""
+
+            if absolute then
+              val encoded = path.encode
+              val core = encoded+slash
+              suggest(core)
+            else
+              val encoded = path.relativeTo(workingDirectory).encode
+              val core = encoded+slash
+              suggest(core)
+
+    safely(workingDirectory.resolve(argument())).option

--- a/lib/exoskeleton/src/completions/exoskeleton.TabCompletions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.TabCompletions.scala
@@ -148,13 +148,11 @@ object TabCompletions:
       t"""|#compdef $command
           |local -a ln
           |_$command() {
-          |  oldIfs=$$IFS IFS=$$'\t'
-          |  $command '{completions}' zsh "$$CURRENT" "$${#PREFIX}" -- $$words | while read -r -A ln
+          |  $command '{completions}' zsh "$$CURRENT" "$${#PREFIX}" -- $$words | while IFS=$$'\\0' read -r -A ln
           |  do
           |    desc=($${ln[1]})
-          |    compadd -Q $${ln:1}
+          |    compadd -Q "$${(@)ln:1}"
           |  done
-          |  IFS=$$oldIfs
           |}
           |_$command
           |return 0

--- a/lib/exoskeleton/src/completions/exoskeleton.TabCompletions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.TabCompletions.scala
@@ -149,8 +149,7 @@ object TabCompletions:
           |local -a ln
           |_$command() {
           |  oldIfs=$$IFS IFS=$$'\t'
-          |  prev=$$((CURRENT-1))
-          |  $command '{completions}' zsh "$$prev" "$${#PREFIX}" -- $$words | while read -r -A ln
+          |  $command '{completions}' zsh "$$CURRENT" "$${#PREFIX}" -- $$words | while read -r -A ln
           |  do
           |    desc=($${ln[1]})
           |    compadd -Q $${ln:1}

--- a/lib/galilei/src/core/galilei-core.scala
+++ b/lib/galilei/src/core/galilei-core.scala
@@ -81,14 +81,14 @@ extension [plane: System](path: Path on plane)
       import Reason.*
 
       try block catch
-        // case break: boundary.Break[?]          => throw break
-        // case _: jnf.NoSuchFileException        => abort(IoError(path, operation, Nonexistent))
-        // case _: jnf.FileAlreadyExistsException => abort(IoError(path, operation, AlreadyExists))
-        // case _: jnf.DirectoryNotEmptyException => abort(IoError(path, operation, DirectoryNotEmpty))
-        // case _: jnf.AccessDeniedException      => abort(IoError(path, operation, PermissionDenied))
-        // case _: jnf.NotDirectoryException      => abort(IoError(path, operation, IsNotDirectory))
-        // case _: SecurityException              => abort(IoError(path, operation, PermissionDenied))
-        // case _: jnf.FileSystemLoopException    => abort(IoError(path, operation, Cycle))
+        case break: boundary.Break[?]          => throw break
+        case _: jnf.NoSuchFileException        => abort(IoError(path, operation, Nonexistent))
+        case _: jnf.FileAlreadyExistsException => abort(IoError(path, operation, AlreadyExists))
+        case _: jnf.DirectoryNotEmptyException => abort(IoError(path, operation, DirectoryNotEmpty))
+        case _: jnf.AccessDeniedException      => abort(IoError(path, operation, PermissionDenied))
+        case _: jnf.NotDirectoryException      => abort(IoError(path, operation, IsNotDirectory))
+        case _: SecurityException              => abort(IoError(path, operation, PermissionDenied))
+        case _: jnf.FileSystemLoopException    => abort(IoError(path, operation, Cycle))
         case other                             =>
           println(other)
           other.printStackTrace()

--- a/lib/serpentine/src/core/serpentine.Relative.scala
+++ b/lib/serpentine/src/core/serpentine.Relative.scala
@@ -79,11 +79,12 @@ object Relative:
     if text == system.self then ? else
       text.cut(system.separator).pipe: parts =>
         (if parts.last == t"" then parts.init else parts).pipe: parts =>
-          (if parts.head == system.self then parts.tail else parts).pipe: parts =>
-            val ascent = parts.takeWhile(_ == system.parent).length
-            val descent = parts.drop(ascent).reverse
+          if parts.isEmpty then Relative(0) else
+            (if parts.head == system.self then parts.tail else parts).pipe: parts =>
+              val ascent = parts.takeWhile(_ == system.parent).length
+              val descent = parts.drop(ascent).reverse
 
-            Relative(ascent, descent*)
+              Relative(ascent, descent*)
 
   inline given [topic, ascent <: Int, system]
          =>  Conversion[Relative of topic under ascent, Relative of topic under ascent on system] =
@@ -125,6 +126,8 @@ case class Relative(ascent: Int, descent: List[Text] = Nil) extends Planar, Topi
   type Limit <: Int
 
   def delta: Int = descent.length - ascent
+
+  def self: Boolean = ascent == 0 && descent == Nil
 
   transparent inline def rename(lambda: (prior: Text) ?=> Text): Optional[Relative] =
     descent.prim.let(parent / lambda(using _))


### PR DESCRIPTION
ZSH supports completion entries where the text that's on the commandline isn't necessarily included in full in the list of completion options. A typical example would be when calling `foo /home/<tab>` while the completions would be things like `/home/foo` and `/home/bar`, only `foo` and `bar` would be displayed in the list of completion options, because `/home/` would be specified as a "prefix".

For Bash and Fish, nothing changes: the completions are always shown in full.

Upon this, a new `Pathname` extractor has been provided which allows navigation of the filesystem.