### PR TITLE
Improvements to Gossamer, including `erase` method

### DIFF
--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -76,8 +76,9 @@ object Teletype:
     def text(teletype: Teletype): Text = teletype.plain
     def length(text: Teletype): Int = text.plain.s.length
     def apply(text: Text): Teletype = Teletype(text)
+    def apply(char: Char): Teletype = Teletype(char.show)
 
-    def map(text: Teletype, lambda: Char => Char): Teletype =
+    def map(text: Teletype)(lambda: Char => Char): Teletype =
       val array = text.plain.s.toCharArray.nn
 
       array.indices.each: index =>

--- a/lib/gossamer/src/core/gossamer.Gossamer.scala
+++ b/lib/gossamer/src/core/gossamer.Gossamer.scala
@@ -64,13 +64,14 @@ object Gossamer:
         val classTag: ClassTag[Ascii] = summon[ClassTag[Ascii]]
 
         def apply(text: Text): Ascii = text.sysBytes
+        def apply(char: Char): Ascii = IArray(char.toByte)
         def length(ascii: Ascii): Int = ascii.size
         def text(ascii: Ascii): Text = String(ascii.mutable(using Unsafe), "ASCII").nn.tt
         def unsafeChar(ascii: Ascii, index: Ordinal): Char = ascii(index.n0).toChar
         def builder(size: Optional[Int]): Builder[Ascii] = AsciiBuilder(size)
         def size(ascii: Ascii): Int = ascii.length
 
-        def map(ascii: Ascii, lambda: Char => Char): Ascii = ascii.map: byte =>
+        def map(ascii: Ascii)(lambda: Char => Char): Ascii = ascii.map: byte =>
           lambda(byte.toChar).toByte
 
         def concat(left: Ascii, right: Ascii): Ascii =

--- a/lib/gossamer/src/core/gossamer.Textual.scala
+++ b/lib/gossamer/src/core/gossamer.Textual.scala
@@ -46,10 +46,11 @@ trait Textual extends Typeclass, Concatenable, Countable, Segmentable, Zeroic:
 
   def show[value](value: value)(using show: Show[value]): Self
   def apply(text: Text): Self
+  def apply(char: Char): Self
   def classTag: ClassTag[Self]
   def length(text: Self): Int
   def text(text: Self): Text
-  def map(text: Self, lambda: Char => Char): Self
+  def map(text: Self)(lambda: Char => Char): Self
   def empty: Self
   def concat(left: Self, right: Self): Self
   def unsafeChar(text: Self, index: Ordinal): Char
@@ -65,10 +66,11 @@ object Textual:
     type Show[value] = value is spectacular.Showable
     val classTag: ClassTag[Text] = summon[ClassTag[Text]]
     def show[value](value: value)(using show: Show[value]): Text = show.text(value)
+    def apply(char: Char): Text = char.toString.tt
     def text(text: Text): Text = text
     def length(text: Text): Int = text.s.length
     def apply(text: Text): Text = text
-    def map(text: Text, lambda: Char => Char): Text = Text(text.s.map(lambda))
+    def map(text: Text)(lambda: Char => Char): Text = Text(text.s.map(lambda))
 
     def segment(text: Text, interval: Interval): Text =
       val limit = length(text)

--- a/lib/gossamer/src/core/soundness+gossamer-core.scala
+++ b/lib/gossamer/src/core/soundness+gossamer-core.scala
@@ -39,7 +39,7 @@ export gossamer
     uncapitalize, tail, init, empty, chars, snip, reverse, contains, trim, where, upto, dropWhile,
     mapChars, count, pad, center, fit, uncamel, unkebab, unsnake, starts, ends, tr, subscripts,
     superscripts, sub, urlEncode, urlDecode, punycode, bytes, sysBytes, proximity, join, add, words,
-    lines, appendln, spaced, slices, seek, search, Ascii, AsciiBuilder, Ltr, Rtl }
+    lines, appendln, spaced, slices, seek, search, Ascii, AsciiBuilder, Ltr, Rtl, erase }
 
 package decimalFormatters:
   export gossamer.decimalFormatters.java

--- a/lib/hieroglyph/src/core/hieroglyph-core.scala
+++ b/lib/hieroglyph/src/core/hieroglyph-core.scala
@@ -98,7 +98,7 @@ extension (char: Char)
   def superscript: Optional[Char] = Chars.superscript.applyOrElse(char, _ => Unset)
   def subscript: Optional[Char] = Chars.subscript.applyOrElse(char, _ => Unset)
   def description: Optional[Text] = Unicode.name(char)
-  def lower: Char = char.toLower
-  def upper: Char = char.toUpper
+  def minuscule: Char = char.toLower
+  def majuscule: Char = char.toUpper
 
 extension [measurable: Measurable](element: measurable) def metrics: Int = measurable.width(element)

--- a/lib/hieroglyph/src/core/soundness+hieroglyph-core.scala
+++ b/lib/hieroglyph/src/core/soundness+hieroglyph-core.scala
@@ -34,7 +34,8 @@ package soundness
 
 export hieroglyph
 . { Encoding, encoder, CharDecoder, CharEncoder, TextSanitizer, CharDecodeError, CharEncodeError,
-    enc, Unicode, metrics, Measurable, Chars, superscript, subscript, u, description }
+    enc, Unicode, metrics, Measurable, Chars, superscript, subscript, u, description, majuscule,
+    minuscule }
 
 package textSanitizers:
   export hieroglyph.textSanitizers.{strict, skip, substitute}


### PR DESCRIPTION
`Text` doesn't have a `filter` method, but it was useful to be able to erase certain characters (like whitespace), so I added an `erase` method for now.