### PR TITLE
Make sure generic derivation works for recursive types

### DIFF
--- a/lib/cellulose/src/core/cellulose.Codl.scala
+++ b/lib/cellulose/src/core/cellulose.Codl.scala
@@ -46,7 +46,8 @@ import vacuous.*
 erased trait Codl
 
 object Codl:
-  def read[value: CodlDecoder](source: Any)(using readable: source.type is Readable by Text)
+  def read[value: CodlDecoder](using Void)[source](source: source)
+       (using readable: source is Readable by Text)
   : value raises CodlError raises CodlReadError =
 
       summon[CodlDecoder[value]].schema.parse(readable.stream(source)).as[value]

--- a/lib/cellulose/src/core/cellulose.CodlDecoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlDecoder.scala
@@ -75,13 +75,13 @@ object CodlDecoder:
     def decoded(nodes: List[Indexed]): Optional[value] raises CodlReadError =
       if nodes.isEmpty then Unset else value.decoded(nodes)
 
-  given option: [value: CodlDecoder] => CodlDecoder[Option[value]]:
+  given option: [value] => (value: => CodlDecoder[value]) => CodlDecoder[Option[value]]:
     def schema: CodlSchema = value.schema.optional
 
     def decoded(nodes: List[Indexed]): Option[value] raises CodlReadError =
       if nodes.isEmpty then None else Some(value.decoded(nodes))
 
-  given list: [element: CodlDecoder] => CodlDecoder[List[element]] =
+  given list: [element] => (element: => CodlDecoder[element]) => CodlDecoder[List[element]] =
     new CodlDecoder[List[element]]:
       def schema: CodlSchema = element.schema match
         case Field(_, validator) => Field(Arity.Many, validator)
@@ -95,7 +95,7 @@ object CodlDecoder:
           case struct: Struct =>
             value.map { v => element.decoded(List(v)) }
 
-  given set: [element: CodlDecoder] => CodlDecoder[Set[element]]:
+  given set: [element] => (element: => CodlDecoder[element]) => CodlDecoder[Set[element]]:
     def schema: CodlSchema = element.schema match
       case Field(_, validator) => Field(Arity.Many, validator)
       case struct: Struct      => struct.copy(structArity = Arity.Many)

--- a/lib/cellulose/src/core/cellulose.CodlEncoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoder.scala
@@ -66,7 +66,7 @@ object CodlEncoder extends CodlEncoder2:
   given boolean: CodlFieldWriter[Boolean] = if _ then t"yes" else t"no"
   given text: CodlFieldWriter[Text] = _.show
 
-  given optional: [encodable: CodlEncoder] => CodlEncoder[Optional[encodable]]:
+  given optional: [encodable] => (encodable: => CodlEncoder[encodable]) => CodlEncoder[Optional[encodable]]:
     def schema: CodlSchema = encodable.schema.optional
 
     def encode(value: Optional[encodable]): List[IArray[CodlNode]] =
@@ -79,7 +79,7 @@ object CodlEncoder extends CodlEncoder2:
       case None        => List()
       case Some(value) => encodable.encode(value)
 
-  given list: [element: CodlEncoder] => CodlEncoder[List[element]]:
+  given list: [element] => (element: => CodlEncoder[element]) => CodlEncoder[List[element]]:
     def schema: CodlSchema = element.schema match
       case Field(_, validator) => Field(Arity.Many, validator)
       case struct: Struct      => struct.copy(structArity = Arity.Many)


### PR DESCRIPTION
Generic derivation on self-referential types wasn't working because some references to recursive types were strict, which led to deadlock at runtime. (Or a compiletime failure, in some variations.)

That's now fixed, though similar changes still need to be made for several other typeclasses.