### PR TITLE
Allow absolute and relative links for path-like attributes in HTML

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -921,7 +921,7 @@ object hellenism extends SoundnessModule {
 
 object honeycomb extends SoundnessModule {
   object core extends SoundnessSubModule {
-    def moduleDeps = Seq(gossamer.core, anticipation.html, anticipation.css, anticipation.path, anticipation.url, gesticulate.core, xylophone.core, serpentine.core)
+    def moduleDeps = Seq(gossamer.core, anticipation.html, anticipation.css, anticipation.path, anticipation.url, gesticulate.core, xylophone.core, serpentine.core, nettlesome.url)
   }
 
   object test extends ProbablyTestModule {

--- a/lib/gossamer/src/core/soundness+gossamer-core.scala
+++ b/lib/gossamer/src/core/soundness+gossamer-core.scala
@@ -39,7 +39,8 @@ export gossamer
     uncapitalize, tail, init, empty, chars, snip, reverse, contains, trim, where, upto, dropWhile,
     mapChars, count, pad, center, fit, uncamel, unkebab, unsnake, starts, ends, tr, subscripts,
     superscripts, sub, urlEncode, urlDecode, punycode, bytes, sysBytes, proximity, join, add, words,
-    lines, appendln, spaced, slices, seek, search, Ascii, AsciiBuilder, Ltr, Rtl, erase }
+    lines, appendln, spaced, slices, seek, search, Ascii, AsciiBuilder, Ltr, Rtl, erase, before,
+    after, from }
 
 package decimalFormatters:
   export gossamer.decimalFormatters.java

--- a/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
+++ b/lib/honeycomb/src/core/honeycomb.HtmlAttribute.scala
@@ -37,8 +37,10 @@ import gesticulate.*
 import gossamer.*
 import hieroglyph.*
 import kaleidoscope.*
+import nettlesome.*
 import prepositional.*
 import proscenium.*
+import serpentine.*
 import spectacular.*
 import vacuous.*
 
@@ -164,6 +166,16 @@ object HtmlAttribute:
   given href2: [url: Abstractable across Urls into Text] => ("href" is HtmlAttribute[url]) =
     _.generic
 
+  inline given href3: [topic, path <: Path of topic under %.type] => Rfc3986 is System
+         => ("href" is HtmlAttribute[path]) =
+    _.on[Rfc3986].encode
+
+  inline given href4: [topic, path <: Path of topic] => Rfc3986 is System
+         => ("href" is HtmlAttribute[path]) =
+    _.on[Rfc3986].encode
+
+  inline given href4: [path <: Path on Rfc3986] => ("href" is HtmlAttribute[path]) = _.encode
+
   // Needs to be provided by Cosmopolite
   given hreflang: ("hreflang" is HtmlAttribute[Text]) = identity(_)
 
@@ -236,6 +248,16 @@ object HtmlAttribute:
     _.generic
 
   given src3: [url: Abstractable across Urls into Text] => ("src" is HtmlAttribute[url]) = _.generic
+
+  inline given src4: [topic, path <: Path of topic under %.type] => Rfc3986 is System
+         => ("src" is HtmlAttribute[path]) =
+    _.on[Rfc3986].encode
+
+  inline given src5: [topic, path <: Path of topic] => Rfc3986 is System
+         => ("src" is HtmlAttribute[path]) =
+    _.on[Rfc3986].encode
+
+
   given srcdoc: ("srcdoc" is HtmlAttribute[Html[?]]) = _.show
   given srclang: ("srclang" is HtmlAttribute[Text]) = identity(_)
 

--- a/lib/honeycomb/src/core/honeycomb.html5.scala
+++ b/lib/honeycomb/src/core/honeycomb.html5.scala
@@ -59,7 +59,7 @@ object html5:
     "accesskey" | "autocapitalize" | "autofocus" | "contenteditable" | "dir" | "draggable"
     | "enterkeyhint" | "class" | "hidden" | "id" | "inputmode" | "is" | "itemid" | "itemprop"
     | "itemref" | "itemscope" | "itemtype" | "lang" | "nonce" | "spellcheck" | "style" | "tabindex"
-    | "title" | "translate" | EventHandlers
+    | "title" | "translate" | "name" | EventHandlers
 
   type Flow =
     "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "bdi" | "bdo"

--- a/lib/nettlesome/src/url/nettlesome.Rfc3986.scala
+++ b/lib/nettlesome/src/url/nettlesome.Rfc3986.scala
@@ -42,8 +42,9 @@ import serpentine.*
 erased trait Rfc3986
 
 object Rfc3986:
-  type Rules = MustMatch["[A-Za-z0-9_.~-]+"]
+  type Rules = MustMatch["[%A-Za-z0-9_.~-]+"]
   erased given nominative: Rfc3986 is Nominative under Rules = !!
+  given submissible: (%.type is Submissible on Rfc3986) = void => ()
 
   given system: Rfc3986 is System:
     type UniqueRoot = false

--- a/lib/nettlesome/src/url/soundness+nettlesome-url.scala
+++ b/lib/nettlesome/src/url/soundness+nettlesome-url.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export nettlesome
-. { url, email, host, Authority, Scheme, Url, UrlError, HttpUrl, UrlFragment, Origin }
+. { url, email, host, Authority, Scheme, Url, UrlError, HttpUrl, UrlFragment, Origin, Rfc3986 }


### PR DESCRIPTION
We previously had to use `Text` values for paths in HTML, because we didn't have a good representation of paths. The recent updates to Serpentine fix that, and here we provide the typeclasses necessary to allow URL paths to be included in HTML attributes.