### PR TITLE
Decomposition performance

### DIFF
--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
@@ -52,22 +52,26 @@ trait Decomposable extends Typeclass:
   def decomposition(value: Self): Decomposition
 
 object Decomposable extends Decomposable2:
+  trait Base extends Decomposable:
+    def decomposition(value: Self): Decomposition
+
   given list: [element, collection <: List[element]]
         => (decomposable: => element is Decomposable)
-        => collection is Base =
-    collection =>
-      Decomposition.Sequence
-       (t"List", collection.map(decomposable.decomposition(_)).to(List), collection)
+        => collection is Decomposable =
+    list =>
+      Decomposition.Sequence(t"List", list.map(decomposable.decomposition(_)), list)
 
   given trie: [element, collection <: Trie[element]]
         => (decomposable: => element is Decomposable)
-        => collection is Base =
-    collection =>
-      Decomposition.Sequence
-       (t"Trie", collection.map(decomposable.decomposition(_)).to(Trie), collection)
+        => collection is Decomposable =
+    trie =>
+      Decomposition.Sequence(t"Trie", trie.map(decomposable.decomposition(_)).to(List), trie)
 
-  trait Base extends Decomposable:
-    def decomposition(value: Self): Decomposition
+  given iarray: [element]
+        => (decomposable: => element is Decomposable)
+        => IArray[element] is Decomposable =
+    iarray =>
+      Decomposition.Sequence(t"IArray", iarray.map(decomposable.decomposition(_)).to(List), iarray)
 
   object Base:
     given text: Text is Base =

--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
@@ -74,10 +74,10 @@ object Decomposable extends Decomposable2:
     case given (`entity` is Encodable in Text) =>
       value => Decomposition.Primitive(shortName[entity], value.encode, value)
 
-  inline def primitive[value](name: Text): value is Decomposable =
+  def primitive[value](name: Text): value is Decomposable =
     value => Decomposition.Primitive(name, value.toString.tt, value)
 
-  inline def any[value]: value is Decomposable =
+  def any[value]: value is Decomposable =
     value => Decomposition.Primitive(t"Any", value.toString.tt, value)
 
   trait Foundation extends Decomposable:
@@ -98,11 +98,12 @@ object Decomposable extends Decomposable2:
 
     given decomposition: Decomposition is Decomposable.Foundation = identity(_)
 
-    inline given sequence: [element: Decomposable, collection <: Iterable[element]]
+    inline given sequence: [element, collection <: Iterable[element]]
           => collection is Decomposable.Foundation =
       collection =>
-        Decomposition.Sequence
-         (shortName[collection], collection.map(_.decompose).to(List), collection)
+        provide[element is Decomposable]:
+          Decomposition.Sequence
+           (shortName[collection], collection.map(_.decompose).to(List), collection)
 
   private inline def shortName[entity]: Text = rewrite(typeName[entity])
 

--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposition.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposition.scala
@@ -51,7 +51,7 @@ object Decomposition:
 enum Decomposition:
   case Primitive(typeName: Text, value: Text, ref: Any)
   case Product(name: Text, values: Map[Text, Decomposition], ref: Any)
-  case Sequence(name: Text, values: List[Decomposition], ref: Any)
+  case Sequence(name: Text, values: Iterable[Decomposition], ref: Any)
   case Sum(name: Text, value: Decomposition, ref: Any)
 
   def ref: Any
@@ -67,7 +67,7 @@ enum Decomposition:
   def short: Text = this match
     case Primitive(_, text, _)  => text
     case Sum(name, value, _)    => t"$name:${value.short}"
-    case Sequence(_, values, _) => t"[..${values.length}..]"
+    case Sequence(_, values, _) => t"[..${values.size}..]"
     case Product(name, _, _)    => name
 
   def text: Text =
@@ -94,7 +94,7 @@ enum Decomposition:
           append(t"\n")
           append(space*indent)
 
-        val last = values.length
+        val last = values.size
 
         values.each: item =>
           append(ordinal.n0.show)

--- a/lib/punctuation/src/test/punctuation.Tests.scala
+++ b/lib/punctuation/src/test/punctuation.Tests.scala
@@ -35,6 +35,7 @@ package punctuation
 import soundness.*
 
 import strategies.throwUnsafely
+import testAutopsies.contrastExpectations
 
 case class Example(str: Text, int: Int)
 


### PR DESCRIPTION
Generic derivation for `Decomposable`s was taking a very long time. The problem appeared to be related to the recursive derivation on `Iterable` subtypes. After various attempts to shuffle the order and priority of the implicits, the changes here appear to work as desired.