### PR TITLE
Eliminate some uses of `Iterable` in recursive `given` definitions

### DIFF
--- a/lib/austronesian/src/core/austronesian.Austronesian.scala
+++ b/lib/austronesian/src/core/austronesian.Austronesian.scala
@@ -37,6 +37,7 @@ import contingency.*
 import distillate.*
 import prepositional.*
 import probably.*
+import proscenium.*
 import rudiments.*
 import wisteria.*
 
@@ -63,9 +64,11 @@ object Austronesian:
     given boolean: Boolean is Encodable in Pojo = identity(_)
     given byte: Byte is Encodable in Pojo = identity(_)
 
-    given list: [collection <: Iterable, element: Encodable in Pojo]
-          =>  collection[element] is Encodable in Pojo =
-      iterable => IArray.from(iterable.map(_.encode))
+    given list: [list <: List, element: Encodable in Pojo] => list[element] is Encodable in Pojo =
+      list => IArray.from(list.map(_.encode))
+
+    given trie: [trie <: Trie, element: Encodable in Pojo] => trie[element] is Encodable in Pojo =
+      trie => IArray.from(trie.map(_.encode))
 
     given text2: Tactic[PojoError] => Text is Decodable in Pojo =
       case string: String => string.tt

--- a/lib/gastronomy/src/core/gastronomy.Digestible.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestible.scala
@@ -62,8 +62,17 @@ object Digestible extends Derivable[Digestible]:
         =>  Optional[digestible] is Digestible =
     (acc, value) => value.let(digestible.digest(acc, _))
 
-  given iterable: [collection <: Iterable, value: Digestible] => collection[value] is Digestible =
-    (digestion, iterable) => iterable.each(value.digest(digestion, _))
+  given list: [list <: List, value: Digestible] => list[value] is Digestible =
+    (digestion, list) => list.each(value.digest(digestion, _))
+
+  given set: [set <: Set, value: Digestible] => set[value] is Digestible =
+    (digestion, set) => set.each(value.digest(digestion, _))
+
+  given trie: [trie <: Trie, value: Digestible] => trie[value] is Digestible =
+    (digestion, trie) => trie.each(value.digest(digestion, _))
+
+  given iarray: [value: Digestible] => IArray[value] is Digestible =
+    (digestion, iarray) => iarray.each(value.digest(digestion, _))
 
   given map: [digestible: Digestible, digestible2: Digestible]
         =>  Map[digestible, digestible2] is Digestible =

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -189,9 +189,17 @@ object Json extends Json2, Dynamic:
   given booleanEncodable: Boolean is Encodable in Json = boolean => Json.ast(JsonAst(boolean))
   given jsonEncodable: Json is Encodable in Json = identity(_)
 
-  given encodable: [collection <: Iterable, element: Encodable in Json as encodable]
-        =>  collection[element] is Encodable in Json =
-    values => Json.ast(JsonAst(IArray.from(values.map(encodable.encode(_).root))))
+  given listEncodable: [list <: List, element: Encodable in Json]
+        =>  list[element] is Encodable in Json =
+    values => Json.ast(JsonAst(IArray.from(values.map(element.encoded(_).root))))
+
+  given setEncodable: [set <: Set, element: Encodable in Json]
+        =>  set[element] is Encodable in Json =
+    values => Json.ast(JsonAst(IArray.from(values.map(element.encoded(_).root))))
+
+  given trieEncodable: [trie <: Trie, element: Encodable in Json]
+        =>  trie[element] is Encodable in Json =
+    values => Json.ast(JsonAst(IArray.from(values.map(element.encoded(_).root))))
 
   given array: [collection <: Iterable, element: Decodable in Json]
         => (factory:    Factory[element, collection[element]],

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -114,9 +114,6 @@ object Inspectable extends Inspectable2:
   given indexedSeq: [element: Inspectable] => IndexedSeq[element] is Inspectable =
     _.map(_.inspect).mkString("⟨ ", " ", " ⟩ᵢ").tt
 
-  given iterable: [element: Inspectable] => Iterable[element] is Inspectable =
-    _.map(_.inspect).mkString("⦗", ", ", "⦘").tt
-
   given list: [element: Inspectable] => List[element] is Inspectable =
     _.map(_.inspect).mkString("[", ", ", "]").tt
 


### PR DESCRIPTION
A recursive `given` definition in Chiaroscuro was causing very long compile times, and the cause _appears_ to be the use of `Iterable` as a type bound for the collection. As a precaution, this removes a few more `given` definitions that look similar.