### PR TITLE
Provide simple implementation of a `Poset` with conversion to `Dag`s

### DIFF
--- a/lib/acyclicity/src/core/acyclicity.Dag.scala
+++ b/lib/acyclicity/src/core/acyclicity.Dag.scala
@@ -61,7 +61,7 @@ object Dag:
   @targetName("fromNodes")
   def apply[node](nodes: (node, Set[node])*): Dag[node] = Dag(Map(nodes*))
 
-case class Dag[node] private(edgeMap: Map[node, Set[node]] = Map()):
+case class Dag[node] private[acyclicity](edgeMap: Map[node, Set[node]] = Map()):
   private val reachableCache: scm.HashMap[node, Set[node]] = scm.HashMap()
 
   def keys: Set[node] = edgeMap.keySet

--- a/lib/acyclicity/src/core/acyclicity.PartiallyOrdered.scala
+++ b/lib/acyclicity/src/core/acyclicity.PartiallyOrdered.scala
@@ -30,6 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package acyclicity
 
-export acyclicity.{Dag, Digraph, Dot, Graph, NodeParser, Subgraph, dot, Poset, PartiallyOrdered}
+import scala.collection.mutable as scm
+
+import proscenium.*
+import rudiments.*
+
+trait PartiallyOrdered:
+  type Self
+  def compare(left: Self, right: Self): Boolean

--- a/lib/acyclicity/src/core/acyclicity.Poset.scala
+++ b/lib/acyclicity/src/core/acyclicity.Poset.scala
@@ -30,6 +30,23 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package acyclicity
 
-export acyclicity.{Dag, Digraph, Dot, Graph, NodeParser, Subgraph, dot, Poset, PartiallyOrdered}
+import scala.collection.mutable as scm
+
+import proscenium.*
+import rudiments.*
+
+object Poset:
+  def apply[element: PartiallyOrdered](elements: element*): Poset[element] =
+    new Poset(elements.to(Set))
+
+case class Poset[element: PartiallyOrdered](elements: Set[element]):
+  def dag: Dag[element] =
+    val map: scm.HashMap[element, scm.HashSet[element]] =
+      elements.map(_ -> scm.HashSet()).to(scm.HashMap)
+
+    for left <- elements; right <- elements
+    do if element.compare(left, right) then map(left) += right
+
+    Dag(map.view.mapValues(_.to(Set)).to(Map)).reduction


### PR DESCRIPTION
You can now construct a `Poset`, a partially-ordered set, and convert it to a `Dag`. This is useful for constructing Hasse Diagrams.