### PR TITLE
Render stack traces

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Renderable.scala
+++ b/lib/honeycomb/src/core/honeycomb.Renderable.scala
@@ -33,10 +33,13 @@
 package honeycomb
 
 import anticipation.*
+import digression.*
 import fulminate.*
+import gossamer.*
 import prepositional.*
 import proscenium.*
 import spectacular.*
+import vacuous.*
 
 object Renderable:
   import html5.Phrasing
@@ -62,6 +65,20 @@ object Renderable:
 
       case Sgml.Element(label, attributes, children) =>
         Node(label, attributes.map(_.s -> _), children.map(convert(_)))
+
+  given StackTrace is Renderable into html5.Noninteractive = stackTrace =>
+    import html5.*
+
+    List:
+      Div.stack(H2(stackTrace.component),
+                H3(stackTrace.className),
+                H4(stackTrace.message.html),
+                Table(stackTrace.frames.map: frame =>
+                      Tr(Td.at(t"at"),
+                      Td.`class`(frame.method.className),
+                      Td.method(frame.method.method),
+                      Td.file(frame.file),
+                      Td.line(frame.line.let(_.show).or(t"")))))
 
 trait Renderable extends Typeclass:
   type Result <: Label

--- a/lib/honeycomb/src/core/honeycomb.Renderable.scala
+++ b/lib/honeycomb/src/core/honeycomb.Renderable.scala
@@ -66,7 +66,7 @@ object Renderable:
       case Sgml.Element(label, attributes, children) =>
         Node(label, attributes.map(_.s -> _), children.map(convert(_)))
 
-  given StackTrace is Renderable into html5.Noninteractive = stackTrace =>
+  given StackTrace is Renderable into html5.Flow = stackTrace =>
     import html5.*
 
     List:
@@ -74,11 +74,12 @@ object Renderable:
                 H3(stackTrace.className),
                 H4(stackTrace.message.html),
                 Table(stackTrace.frames.map: frame =>
-                      Tr(Td.at(t"at"),
-                      Td.`class`(frame.method.className),
-                      Td.method(frame.method.method),
-                      Td.file(frame.file),
-                      Td.line(frame.line.let(_.show).or(t"")))))
+                      Tr(Td.at(Code(t"at")),
+                      Td.`class`(Code(frame.method.className)),
+                      Td.method(Code(frame.method.method)),
+                      Td.file(Code(frame.file)),
+                      Td(Code(t":")),
+                      Td.line(Code(frame.line.let(_.show).or(t""))))))
 
 trait Renderable extends Typeclass:
   type Result <: Label

--- a/lib/honeycomb/src/core/honeycomb.html5.scala
+++ b/lib/honeycomb/src/core/honeycomb.html5.scala
@@ -44,7 +44,7 @@ object html5:
     "a" | "audio" | "button" | "details" | "embed" | "iframe" | "img" | "input" | "label" | "select"
     | "textarea" | "video"
 
-  type NonInteractive =
+  type Noninteractive =
     "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo"
     | "blockquote" | "br" | "canvas" | "cite" | "code" | "data" | "datalist" | "del" | "dfn"
     | "dialog" | "div" | "dl" | "em" | "fieldset" | "figure" | "footer" | "form" | "h1" | "h2"
@@ -111,7 +111,7 @@ object html5:
   type Sectioning = "article" | "aside" | "nav" | "section"
   type ScriptSupporting = "script" | "template"
 
-  val A = ClearTag["a", NonInteractive, Global | "href" | "target" | "download" | "ping" | "rel" |
+  val A = ClearTag["a", Noninteractive, Global | "href" | "target" | "download" | "ping" | "rel" |
       "hreflang" | "type" | "referrerpolicy"]("a")
 
   val Abbr = Tag["abbr", Phrasing, Global]("abbr")
@@ -152,7 +152,7 @@ object html5:
      ("button")
 
   // complicated
-  val Canvas = ClearTag["canvas", NonInteractive, Global | "width" | "height"]("canvas")
+  val Canvas = ClearTag["canvas", Noninteractive, Global | "width" | "height"]("canvas")
   val Caption = Tag["caption", Flow, Global]("caption") // no tables
   val Cite = Tag["cite", Phrasing, Global]("cite")
   val Code = Tag["code", Phrasing, Global]("code")

--- a/lib/punctuation/src/html/punctuation.HtmlTranslator.scala
+++ b/lib/punctuation/src/html/punctuation.HtmlTranslator.scala
@@ -142,12 +142,12 @@ open class HtmlTranslator(embeddings: Embedding*) extends Translator:
   def phrasing(node: Markdown.Ast.Inline): Seq[Html[Phrasing]] = node match
     case Markdown.Ast.Inline.Weblink(location, content) =>
 
-      def interactive(node: Html[Phrasing]): Html[NonInteractive] = node.absolve match
-        case node: Node[NonInteractive @unchecked] => node
+      def interactive(node: Html[Phrasing]): Html[Noninteractive] = node.absolve match
+        case node: Node[Noninteractive @unchecked] => node
         case text: Text                            => text
         case Unset                                 => t""
 
-      val children: Seq[Html[NonInteractive]] = nonInteractive(content).map(interactive(_))
+      val children: Seq[Html[Noninteractive]] = nonInteractive(content).map(interactive(_))
 
       List(A(href = location)(children))
 


### PR DESCRIPTION
We can now call `stackTrace.html` and get an HTML representation of the stack trace. This probably still requires some more styling, but it's a start.