### PR TITLE
Make `Text` an `into` type

### DIFF
--- a/lib/anticipation/src/log/anticipation.Realm.scala
+++ b/lib/anticipation/src/log/anticipation.Realm.scala
@@ -35,6 +35,6 @@ package anticipation
 import language.experimental.into
 
 object Realm:
-  def make(name: Conversion.into[Text]): Realm = Realm(name)
+  def make(name: Text): Realm = Realm(name)
 
-case class Realm(name: Conversion.into[Text])
+case class Realm(name: Text)

--- a/lib/anticipation/src/text/anticipation.Anticipation.scala
+++ b/lib/anticipation/src/text/anticipation.Anticipation.scala
@@ -84,6 +84,8 @@ object Anticipation:
     given conversion: Conversion[String, Text] = identity(_)
 
     erased given canEqual: CanEqual[Text, Text] = erasedValue
+    erased given canEqual2: CanEqual[String, Text] = erasedValue
+    erased given canEqual3: CanEqual[Text, String] = erasedValue
 
     given typeable: Typeable[Text]:
       def unapply(value: Any): Option[value.type & Text] = value.asMatchable match

--- a/lib/anticipation/src/text/anticipation.Anticipation.scala
+++ b/lib/anticipation/src/text/anticipation.Anticipation.scala
@@ -41,7 +41,7 @@ import scala.reflect.*
 import scala.util.*
 
 object Anticipation:
-  opaque type Text <: Matchable = String
+  into opaque type Text <: Matchable = String
 
   object Text:
     def apply(string: String): Text = string

--- a/lib/fulminate/src/core/fulminate.TextEscapes.scala
+++ b/lib/fulminate/src/core/fulminate.TextEscapes.scala
@@ -42,7 +42,7 @@ object TextEscapes:
   import errorDiagnostics.stackTraces
 
 
-  def standardEscape(text: Conversion.into[Text], cur: Int, esc: Boolean)
+  def standardEscape(text: Text, cur: Int, esc: Boolean)
   : (Int, Int, Boolean) throws EscapeError =
 
       text.s.charAt(cur) match
@@ -72,7 +72,7 @@ object TextEscapes:
     then throw EscapeError(Message("the unicode escape is incomplete".tt))
     else Integer.parseInt(chars, 16).toChar
 
-  def escape(text: Conversion.into[Text]): Text throws EscapeError =
+  def escape(text: Text): Text throws EscapeError =
     val buf: StringBuilder = StringBuilder()
 
     @tailrec

--- a/lib/gossamer/src/core/gossamer-core.scala
+++ b/lib/gossamer/src/core/gossamer-core.scala
@@ -197,7 +197,7 @@ extension [textual: Textual](text: textual)
 
     recur(Prim, textual.empty)
 
-  def contains(substring: into[Text]): Boolean = textual.indexOf(text, substring).present
+  def contains(substring: Text): Boolean = textual.indexOf(text, substring).present
   def contains(char: Char): Boolean = textual.indexOf(text, char.show).present
 
   def search(regex: Regex, overlap: Boolean = false): Stream[textual] =
@@ -301,14 +301,14 @@ extension [textual: Textual](text: textual)
   def unkebab: List[textual] = text.cut("-".tt)
   def unsnake: List[textual] = text.cut("_".tt)
 
-  def starts(prefix: into[Text]): Boolean =
+  def starts(prefix: Text): Boolean =
     def recur(index: Ordinal): Boolean =
       index > (prefix.length - 1).z
       || textual.unsafeChar(text, index) == prefix.s.charAt(index.n0) && recur(index + 1)
 
     prefix.length <= text.length && recur(Prim)
 
-  def ends(suffix: into[Text]): Boolean = text.keep(suffix.length, Rtl) == suffix
+  def ends(suffix: Text): Boolean = text.keep(suffix.length, Rtl) == suffix
 
   inline def tr(from: Char, to: Char): textual =
     textual.map(text)(char => if char == from then to else char)
@@ -385,11 +385,11 @@ package proximityMeasures:
   given normalizedLevenshteinDistance: Proximity = (left, right) =>
     levenshteinDistance.distance(left, right)/left.length.max(right.length)
 
-extension (text: into[Text])
-  inline def sub(from: into[Text], to: into[Text]): Text =
+extension (text: Text)
+  inline def sub(from: Text, to: Text): Text =
     text.s.replaceAll(jur.Pattern.quote(from.s).nn, to.s).nn.tt
 
-  inline def sub(from: Regex, to: into[Text]): Text = text.s.replaceAll(from.pattern.s, to.s).nn.tt
+  inline def sub(from: Regex, to: Text): Text = text.s.replaceAll(from.pattern.s, to.s).nn.tt
 
   inline def urlEncode: Text = URLEncoder.encode(text.s, "UTF-8").nn.tt
   inline def urlDecode: Text = URLDecoder.decode(text.s, "UTF-8").nn.tt
@@ -397,7 +397,7 @@ extension (text: into[Text])
   inline def bytes(using encoder: CharEncoder): IArray[Byte] = encoder.encode(text)
   inline def sysBytes: IArray[Byte] = CharEncoder.system.encode(text)
 
-  def proximity(other: into[Text])(using proximity: Proximity): Double =
+  def proximity(other: Text)(using proximity: Proximity): Double =
     proximity.distance(text, other)
 
 extension (iarray: IArray[Char]) def text: Text = String(iarray.mutable(using Unsafe)).tt
@@ -420,7 +420,7 @@ extension [textual: Joinable](values: Iterable[textual])
     Iterable(left, join(separator, penultimate), right).join
 
 extension (builder: StringBuilder)
-  def add(text: into[Text]): Unit = builder.append(text.s)
+  def add(text: Text): Unit = builder.append(text.s)
   def add(char: Char): Unit = builder.append(char)
   def text: Text = builder.toString.tt
 

--- a/lib/gossamer/src/core/gossamer.Pue.scala
+++ b/lib/gossamer/src/core/gossamer.Pue.scala
@@ -40,7 +40,7 @@ import language.experimental.pureFunctions
 import language.experimental.into
 
 object Pue:
-  def apply(text: into[Text]): Bytes =
+  def apply(text: Text): Bytes =
     val length = text.length
 
     IArray.create[Byte](length): array =>

--- a/lib/mercator/src/core/mercator-core.scala
+++ b/lib/mercator/src/core/mercator-core.scala
@@ -47,7 +47,7 @@ extension [value, monad[_]](using monad: Monad[monad])(value: monad[value])
   def bind[value2](lambda: value => monad[value2]): monad[value2] =
     monad.flatMap(value)(lambda)
 
-extension (text: Conversion.into[Text])
+extension (text: Text)
   def bind(lambda: Char => Text): Text =
     val builder: StringBuilder = StringBuilder()
     text.s.toCharArray.nn.foreach: char =>

--- a/lib/parasite/src/core/parasite-core.scala
+++ b/lib/parasite/src/core/parasite-core.scala
@@ -86,7 +86,7 @@ def async[result](using Codepoint)(evaluate: Worker ?=> result)(using Monitor, C
     Task(evaluate(using _), daemon = false, name = Unset)
 
 
-def task[result](using Codepoint)(name: into[Text])(evaluate: Worker ?=> result)
+def task[result](using Codepoint)(name: Text)(evaluate: Worker ?=> result)
      (using Monitor, Codicil)
 : Task[result] =
 


### PR DESCRIPTION
We can now make `Text` an `into type`, which means that `Text` parameters everywhere can automatically take `String`s without explicit conversion.

Previously, only a few uses of `Text` in parameter position were marked `into[Text]`, so those have now been removed and the automatic-conversion functionality is applied universally.