### PR TITLE
Support multiple tab presses for better completions

### DIFF
--- a/lib/aviation/src/core/aviation.Tzdb.scala
+++ b/lib/aviation/src/core/aviation.Tzdb.scala
@@ -62,7 +62,8 @@ object Tzdb:
     case Zone(area: Text, location: Option[Text], info: Trie[ZoneInfo])
     case Link(from: Text, to: Text)
 
-  case class ZoneInfo(stdoff: into[Duration], rules: Text, format: Text => Text, until: Option[Text])
+  case class ZoneInfo
+              (stdoff: into[Duration], rules: Text, format: Text => Text, until: Option[Text])
 
   enum MonthDate:
     case Last(month: Month, day: Weekday)

--- a/lib/cellulose/src/core/cellulose.CodlEncoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoder.scala
@@ -66,11 +66,15 @@ object CodlEncoder extends CodlEncoder2:
   given boolean: CodlFieldWriter[Boolean] = if _ then t"yes" else t"no"
   given text: CodlFieldWriter[Text] = _.show
 
-  given optional: [encodable] => (encodable: => CodlEncoder[encodable]) => CodlEncoder[Optional[encodable]]:
-    def schema: CodlSchema = encodable.schema.optional
 
-    def encode(value: Optional[encodable]): List[IArray[CodlNode]] =
-      value.let(encodable.encode(_)).or(List())
+  given optional: [encodable] => (encodable: => CodlEncoder[encodable])
+  =>  CodlEncoder[Optional[encodable]]:
+
+        def schema: CodlSchema = encodable.schema.optional
+
+        def encode(value: Optional[encodable]): List[IArray[CodlNode]] =
+          value.let(encodable.encode(_)).or(List())
+
 
   given option: [encodable: CodlEncoder] => CodlEncoder[Option[encodable]]:
     def schema: CodlSchema = encodable.schema.optional

--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -33,11 +33,12 @@
 package exoskeleton
 
 import anticipation.*
+import denominative.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
 
-case class Argument(position: Int, value: Text, cursor: Optional[Int]):
+case class Argument(position: Int, value: Text, cursor: Optional[Int], tab: Optional[Ordinal]):
   def apply(): Text = value
   def prefix: Optional[Text] = cursor.let(value.keep(_))
   def suffix: Optional[Text] = cursor.let(value.skip(_))

--- a/lib/exoskeleton/src/args/exoskeleton.Argument.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Argument.scala
@@ -46,8 +46,7 @@ case class Argument(position: Int, value: Text, cursor: Optional[Int]):
     cli.suggest(this, update)
 
 
-  def select[operand: Suggestible](options: Seq[operand])
-       (using cli: Cli, interpreter: Interpreter)
+  def select[operand: Suggestible](options: Seq[operand])(using cli: Cli, interpreter: Interpreter)
   : Optional[operand] =
 
       val mapping: Map[Text, operand] =

--- a/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Arguments.scala
@@ -35,7 +35,8 @@ package exoskeleton
 import vacuous.*
 
 case class Arguments(sequence: Argument*) extends Flags:
-  def read[operand: {Interpretable, Discoverable}](flag: Flag)(using Cli): Optional[operand] =
+  def read[operand: Interpretable](flag: Flag)(using Cli, (? <: operand) is Discoverable)
+  : Optional[operand] =
       Unset // FIXME
 
   def focus: Optional[Argument] = Unset

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -54,7 +54,10 @@ trait Cli extends Console:
   def arguments: List[Argument]
   def environment: Environment
   def workingDirectory: WorkingDirectory
-  def readParameter[operand: {Interpretable, Discoverable}](flag: Flag): Optional[operand]
+
+  def readParameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
+  : Optional[operand]
+
   def register(flag: Flag, discoverable: Discoverable): Unit = ()
   def present(flag: Flag): Unit = ()
   def explain(update: (prior: Optional[Text]) ?=> Optional[Text]): Unit = ()

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -55,7 +55,7 @@ trait Cli extends Console:
   def environment: Environment
   def workingDirectory: WorkingDirectory
 
-  def readParameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
+  def parameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
   : Optional[operand]
 
   def register(flag: Flag, discoverable: Discoverable): Unit = ()

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -34,6 +34,7 @@ package exoskeleton
 
 import ambience.*
 import anticipation.*
+import denominative.*
 import gossamer.*
 import profanity.*
 import rudiments.*
@@ -42,12 +43,13 @@ import vacuous.*
 object Cli:
   def arguments
        (textArguments: Iterable[Text],
-        focus:         Optional[Int] = Unset,
-        position:      Optional[Int] = Unset)
+        focus:         Optional[Int]     = Unset,
+        position:      Optional[Int]     = Unset,
+        tab:           Optional[Ordinal] = Unset)
   : List[Argument] =
 
       textArguments.to(List).padTo(focus.or(0) + 1, t"").zipWithIndex.map: (text, index) =>
-        Argument(index, text, if focus == index then position else Unset)
+        Argument(index, text, if focus == index then position else Unset, tab)
 
 
 trait Cli extends Console:

--- a/lib/exoskeleton/src/args/exoskeleton.Commandline.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Commandline.scala
@@ -45,7 +45,8 @@ case class Commandline
     focus:          Optional[Argument]            = Unset)
 extends Flags:
 
-  def read[operand: {Interpretable, Discoverable as discoverable}](flag: Flag)(using cli: Cli)
+  def read[operand: Interpretable](flag: Flag)
+       (using cli: Cli, discoverable: (? <: operand) is Discoverable)
   : Optional[operand] =
 
       cli.register(flag, discoverable)

--- a/lib/exoskeleton/src/args/exoskeleton.Discoverable.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Discoverable.scala
@@ -34,10 +34,11 @@ package exoskeleton
 
 import language.experimental.pureFunctions
 
+import denominative.*
 import prepositional.*
 
 object Discoverable:
-  def noSuggestions[operand]: operand is Discoverable = () => Nil
+  def noSuggestions[operand]: operand is Discoverable = _ => Nil
 
 trait Discoverable extends Typeclass:
-  def discover(): Iterable[Suggestion]
+  def discover(tab: Ordinal): Iterable[Suggestion]

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -77,7 +77,7 @@ case class Flag
   : Optional[operand] =
 
       cli.register(this, suggestions)
-      cli.readParameter(this)
+      cli.parameter(this)
 
 
   def select[operand](options: Iterable[operand])

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -48,7 +48,7 @@ object Flag:
     case char: Char => t"-$char"
     case text: Text => t"--$text"
 
-  given communicable: Flag is Showable = _.name.absolve match
+  given showable: Flag is Showable = _.name.absolve match
     case name: Text => t"--$name"
     case name: Char => t"-$name"
 
@@ -73,7 +73,7 @@ case class Flag
        (using cli:             Cli,
               interpreter:     Interpreter,
               interpretable:   operand is Interpretable,
-              suggestions:     operand is Discoverable   = Discoverable.noSuggestions)
+              suggestions:     (? <: operand) is Discoverable   = Discoverable.noSuggestions)
   : Optional[operand] =
 
       cli.register(this, suggestions)

--- a/lib/exoskeleton/src/args/exoskeleton.Flag.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flag.scala
@@ -91,6 +91,6 @@ case class Flag
         case List(value) => mapping.at(value())
         case _           => Unset
 
-      given suggestions: operand is Discoverable = () => options.map(suggestible.suggest(_))
+      given suggestions: operand is Discoverable = _ => options.map(suggestible.suggest(_))
 
       this()

--- a/lib/exoskeleton/src/args/exoskeleton.Flags.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Flags.scala
@@ -35,5 +35,7 @@ package exoskeleton
 import vacuous.*
 
 trait Flags:
-  def read[operand: {Interpretable, Discoverable}](flag: Flag)(using Cli): Optional[operand]
+  def read[operand: Interpretable](flag: Flag)(using Cli, (? <: operand) is Discoverable)
+  : Optional[operand]
+
   def focus: Optional[Argument]

--- a/lib/exoskeleton/src/completions/exoskeleton-completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton-completions.scala
@@ -34,6 +34,7 @@ package exoskeleton
 
 import ambience.*
 import anticipation.*
+import denominative.*
 import distillate.*
 import gossamer.*
 import profanity.*
@@ -55,7 +56,6 @@ package executives:
     type Interface = Cli
     type Return = Execution
 
-
     def invocation
          (arguments:        Iterable[Text],
           environment:      Environment,
@@ -66,7 +66,7 @@ package executives:
     : Cli =
 
         arguments match
-          case t"{completions}" :: shellName :: As[Int](focus0) :: As[Int](position) :: t"--"
+          case t"{completions}" :: shellName :: As[Int](focus0) :: As[Int](position) :: tty :: t"--"
                :: command
                :: rest =>
 
@@ -77,16 +77,21 @@ package executives:
 
             val focus = if shell == Shell.Zsh then focus0 - 1 else focus0
 
-            Completion
-             (Cli.arguments(arguments, focus - 1, position),
-              Cli.arguments(rest, focus - 1, position),
-              environment,
-              workingDirectory,
-              shell,
-              focus - 1,
-              position,
-              stdio,
-              signals)
+            val completion =
+              Completion
+               (Cli.arguments(arguments, focus - 1, position),
+                Cli.arguments(rest, focus - 1, position),
+                environment,
+                workingDirectory,
+                shell,
+                focus - 1,
+                position,
+                stdio,
+                signals,
+                tty,
+                Prim)
+
+            completion.copy(tab = Completions.tab(completion))
 
           case other =>
             Invocation(Cli.arguments(arguments), environment, workingDirectory, stdio, signals)

--- a/lib/exoskeleton/src/completions/exoskeleton-completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton-completions.scala
@@ -77,21 +77,20 @@ package executives:
 
             val focus = if shell == Shell.Zsh then focus0 - 1 else focus0
 
-            val completion =
-              Completion
-               (Cli.arguments(arguments, focus - 1, position),
-                Cli.arguments(rest, focus - 1, position),
-                environment,
-                workingDirectory,
-                shell,
-                focus - 1,
-                position,
-                stdio,
-                signals,
-                tty,
-                Prim)
+            val tab = Completions.tab(tty, Completions.Tab(arguments.to(List), focus - 1, position))
 
-            completion.copy(tab = Completions.tab(completion))
+            Completion
+             (Cli.arguments(arguments, focus - 1, position, tab),
+              Cli.arguments(rest, focus - 1, position, tab),
+              environment,
+              workingDirectory,
+              shell,
+              focus - 1,
+              position,
+              stdio,
+              signals,
+              tty,
+              tab)
 
           case other =>
             Invocation(Cli.arguments(arguments), environment, workingDirectory, stdio, signals)

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -68,9 +68,10 @@ extends Cli:
   var cursorSuggestions: List[Suggestion] = Nil
 
 
-  def readParameter[operand: {Interpretable, Discoverable}](flag: Flag): Optional[operand] =
-    given cli: Cli = this
-    parameters.read(flag)
+  def readParameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
+  : Optional[operand] =
+      given cli: Cli = this
+      parameters.read(flag)
 
 
   def focus: Argument = arguments(currentArgument)

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -34,6 +34,7 @@ package exoskeleton
 
 import ambience.*
 import anticipation.*
+import denominative.*
 import escapade.*
 import gossamer.*
 import guillotine.*
@@ -57,7 +58,9 @@ case class Completion
     currentArgument:  Int,
     focusPosition:    Int,
     stdio:            Stdio,
-    signals:          Spool[Signal])
+    signals:          Spool[Signal],
+    tty:              Text,
+    tab:              Ordinal)
    (using interpreter: Interpreter)
 extends Cli:
   private lazy val parameters: interpreter.Parameters = interpreter.interpret(arguments)
@@ -79,7 +82,7 @@ extends Cli:
   override def register(flag: Flag, discoverable: Discoverable): Unit =
     parameters.focus.let: argument =>
       if flag.matches(argument) && currentArgument == argument.position + 1 then
-        val allSuggestions = discoverable.discover().to(List)
+        val allSuggestions = discoverable.discover(tab).to(List)
         if allSuggestions != Nil then cursorSuggestions = allSuggestions
 
     if !flag.secret then flags(flag) = discoverable

--- a/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completion.scala
@@ -71,7 +71,7 @@ extends Cli:
   var cursorSuggestions: List[Suggestion] = Nil
 
 
-  def readParameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
+  def parameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
   : Optional[operand] =
       given cli: Cli = this
       parameters.read(flag)

--- a/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Pathname.scala
@@ -62,7 +62,6 @@ object Pathname:
         val directory = argument().ends(t"/")
         val prototype = workingDirectory.resolve(argument())
         val root = prototype.empty
-
         val base: Optional[Path on Linux] = if directory then prototype else prototype.parent
         val children0 = base.lay(Nil)(_.children.to(List))
 

--- a/lib/exoskeleton/src/core/exoskeleton-core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton-core.scala
@@ -41,6 +41,7 @@ import hieroglyph.*, textMetrics.uniform
 import profanity.*
 import rudiments.*
 import turbulence.*
+import vacuous.*
 
 import sun.misc as sm
 
@@ -96,7 +97,7 @@ package executives:
     : Invocation =
 
         Invocation
-         (Cli.arguments(arguments),
+         (Cli.arguments(arguments, Unset, Unset, Unset),
           environments.jre,
           workingDirectories.jre,
           stdio,

--- a/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
@@ -53,6 +53,7 @@ extends Cli, Stdio:
   private lazy val parameters: interpreter.Parameters = interpreter.interpret(arguments)
 
 
-  def readParameter[operand: {Interpretable, Discoverable}](flag: Flag): Optional[operand] =
-    given cli: Cli = this
-    parameters.read(flag)
+  def readParameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
+  : Optional[operand] =
+      given cli: Cli = this
+      parameters.read(flag)

--- a/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Invocation.scala
@@ -53,7 +53,7 @@ extends Cli, Stdio:
   private lazy val parameters: interpreter.Parameters = interpreter.interpret(arguments)
 
 
-  def readParameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
+  def parameter[operand: Interpretable](flag: Flag)(using (? <: operand) is Discoverable)
   : Optional[operand] =
       given cli: Cli = this
       parameters.read(flag)

--- a/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Hypotenuse.scala
@@ -580,8 +580,9 @@ object Hypotenuse:
     inline infix def ** (exponent: Double): Double = math.pow(s64.toDouble, exponent)
 
     @targetName("divS64")
-    inline infix def / (right: Conversion.into[S64])(using division: DivisionByZero): division.Wrap[S64] =
-      division.divideS64(s64, right)
+    inline infix def / (right: Conversion.into[S64])(using division: DivisionByZero)
+    : division.Wrap[S64] =
+        division.divideS64(s64, right)
 
     @targetName("modS64")
     inline infix def % (right: Conversion.into[S64]): S64 = s64%right
@@ -599,8 +600,9 @@ object Hypotenuse:
 
   extension (s32: S32)
     @targetName("plusS32")
-    inline infix def + (right: Conversion.into[S32])(using overflow: CheckOverflow): overflow.Wrap[S32] =
-      overflow.addS32(s32, right)
+    inline infix def + (right: Conversion.into[S32])(using overflow: CheckOverflow)
+    : overflow.Wrap[S32] =
+        overflow.addS32(s32, right)
 
     @targetName("intS32")
     inline def int: Int = s32
@@ -633,8 +635,9 @@ object Hypotenuse:
     inline infix def /- (right: Conversion.into[S32]): S32 = math.floorDiv(s32, right)
 
     @targetName("divS32")
-    inline infix def / (right: Conversion.into[S32])(using division: DivisionByZero): division.Wrap[S32] =
-      division.divideS32(s32, right)
+    inline infix def / (right: Conversion.into[S32])(using division: DivisionByZero)
+    : division.Wrap[S32] =
+        division.divideS32(s32, right)
 
     @targetName("modS32")
     inline infix def % (right: Conversion.into[S32]): S32 = s32%right
@@ -652,8 +655,9 @@ object Hypotenuse:
 
   extension (s16: S16)
     @targetName("plusS16")
-    inline infix def + (right: Conversion.into[S16])(using overflow: CheckOverflow): overflow.Wrap[S16] =
-      overflow.addS16(s16, right)
+    inline infix def + (right: Conversion.into[S16])(using overflow: CheckOverflow)
+    : overflow.Wrap[S16] =
+        overflow.addS16(s16, right)
 
     @targetName("shortS16")
     inline def short: Short = s16
@@ -689,8 +693,9 @@ object Hypotenuse:
     inline infix def /- (right: Conversion.into[S16]): S16 = math.floorDiv(s16, right).toShort
 
     @targetName("divS16")
-    inline infix def / (right: Conversion.into[S16])(using division: DivisionByZero): division.Wrap[S16] =
-      division.divideS16(s16, right)
+    inline infix def / (right: Conversion.into[S16])(using division: DivisionByZero)
+    : division.Wrap[S16] =
+        division.divideS16(s16, right)
 
     @targetName("modS16")
     inline infix def % (right: Conversion.into[S16]): S16 = (s16%right).toShort
@@ -708,8 +713,9 @@ object Hypotenuse:
 
   extension (s8: S8)
     @targetName("plusS8")
-    inline infix def + (right: Conversion.into[S8])(using overflow: CheckOverflow): overflow.Wrap[S8] =
-      overflow.addS8(s8, right)
+    inline infix def + (right: Conversion.into[S8])(using overflow: CheckOverflow)
+    : overflow.Wrap[S8] =
+        overflow.addS8(s8, right)
 
     @targetName("byteS8")
     inline def byte: Byte = s8
@@ -748,8 +754,9 @@ object Hypotenuse:
     inline infix def /- (right: Conversion.into[S8]): S8 = math.floorDiv(s8, right).toByte
 
     @targetName("divS8")
-    inline infix def / (right: Conversion.into[S8])(using division: DivisionByZero): division.Wrap[S8] =
-      division.divideS8(s8, right)
+    inline infix def / (right: Conversion.into[S8])(using division: DivisionByZero)
+    : division.Wrap[S8] =
+        division.divideS8(s8, right)
 
     @targetName("modS8")
     inline infix def % (right: Conversion.into[S8]): S8 = (s8%right).toByte
@@ -1348,8 +1355,9 @@ object Hypotenuse:
     inline def binary: Text = JLong.toUnsignedString(u64, 2).nn.tt
 
     @targetName("divU64")
-    inline infix def / (right: Conversion.into[U64])(using division: DivisionByZero): division.Wrap[U64] =
-      division.divideU64(u64, right)
+    inline infix def / (right: Conversion.into[U64])(using division: DivisionByZero)
+    : division.Wrap[U64] =
+        division.divideU64(u64, right)
 
     @targetName("modU64")
     inline infix def % (right: Conversion.into[U64]): U64 = JLong.remainderUnsigned(u64, right)
@@ -1362,8 +1370,9 @@ object Hypotenuse:
 
   extension (u32: U32)
     @targetName("plusU32")
-    inline infix def + (right: Conversion.into[U32])(using overflow: CheckOverflow): overflow.Wrap[U32] =
-      overflow.addU32(u32, right)
+    inline infix def + (right: Conversion.into[U32])(using overflow: CheckOverflow)
+    : overflow.Wrap[U32] =
+        overflow.addU32(u32, right)
 
     @targetName("bitsU32")
     inline def bits: B32 = u32
@@ -1393,8 +1402,9 @@ object Hypotenuse:
     inline def long: Long = JInt.toUnsignedLong(u32)
 
     @targetName("divU32")
-    inline infix def / (right: Conversion.into[U32])(using division: DivisionByZero): division.Wrap[U32] =
-      division.divideU32(u32, right)
+    inline infix def / (right: Conversion.into[U32])(using division: DivisionByZero)
+    : division.Wrap[U32] =
+        division.divideU32(u32, right)
 
     @targetName("modU32")
     inline infix def % (right: Conversion.into[U32]): U32 = JInt.remainderUnsigned(u32, right)
@@ -1413,8 +1423,9 @@ object Hypotenuse:
 
   extension (u16: U16)
     @targetName("plusU16")
-    inline infix def + (right: Conversion.into[U16])(using overflow: CheckOverflow): overflow.Wrap[U16] =
-      overflow.addU16(u16, right)
+    inline infix def + (right: Conversion.into[U16])(using overflow: CheckOverflow)
+    : overflow.Wrap[U16] =
+        overflow.addU16(u16, right)
 
     @targetName("bitsU16")
     inline def bits: B16 = u16
@@ -1448,11 +1459,13 @@ object Hypotenuse:
     inline def int: Int = JShort.toUnsignedInt(u16)
 
     @targetName("divU16")
-    inline infix def / (right: Conversion.into[U16])(using division: DivisionByZero): division.Wrap[U16] =
-      division.divideU16(u16, right)
+    inline infix def / (right: Conversion.into[U16])(using division: DivisionByZero)
+    : division.Wrap[U16] =
+        division.divideU16(u16, right)
 
     @targetName("modU16")
-    inline infix def % (right: Conversion.into[U16]): U16 = JInt.remainderUnsigned(u16, right).toShort
+    inline infix def % (right: Conversion.into[U16]): U16 =
+      JInt.remainderUnsigned(u16, right).toShort
 
     @targetName("u16ToS32")
     inline def s32: S32 = JShort.toUnsignedInt(u16)
@@ -1476,8 +1489,9 @@ object Hypotenuse:
 
   extension (u8: U8)
     @targetName("plusU8")
-    inline infix def + (right: Conversion.into[U8])(using overflow: CheckOverflow): overflow.Wrap[U8] =
-      overflow.addU8(u8, right)
+    inline infix def + (right: Conversion.into[U8])(using overflow: CheckOverflow)
+    : overflow.Wrap[U8] =
+        overflow.addU8(u8, right)
 
     @targetName("bitsU8")
     inline def bits: B8 = u8
@@ -1513,8 +1527,9 @@ object Hypotenuse:
     inline def short: Short = JByte.toUnsignedInt(u8).toShort
 
     @targetName("divU8")
-    inline infix def / (right: Conversion.into[U8])(using division: DivisionByZero): division.Wrap[U8] =
-      division.divideU8(u8, right)
+    inline infix def / (right: Conversion.into[U8])(using division: DivisionByZero)
+    : division.Wrap[U8] =
+        division.divideU8(u8, right)
 
     @targetName("modU8")
     inline infix def % (right: Conversion.into[U8]): U8 = JInt.remainderUnsigned(u8, right).toByte

--- a/lib/larceny/src/plugin/larceny.CompileError.scala
+++ b/lib/larceny/src/plugin/larceny.CompileError.scala
@@ -38,7 +38,7 @@ object CompileError:
 
   enum Reason:
     case NoExplanation
-    case EmptyCatchOrFinallyBlock                                                          // inactive
+    case EmptyCatchOrFinallyBlock                                                          // old
     case EmptyCatchBlock
     case EmptyCatchAndFinallyBlock
     case DeprecatedWithOperator
@@ -48,11 +48,11 @@ object CompileError:
     case TypeMismatch
     case NotAMember
     case EarlyDefinitionsNotSupported
-    case TopLevelImplicitClass                                                             // inactive
+    case TopLevelImplicitClass                                                             // old
     case ImplicitCaseClass
     case ImplicitClassPrimaryConstructorArity
     case ObjectMayNotHaveSelfType
-    case TupleTooLong                                                                      // inactive
+    case TupleTooLong                                                                      // old
     case RepeatedModifier
     case InterpolatedStringError
     case UnboundPlaceholderParameter
@@ -74,7 +74,7 @@ object CompileError:
     case PkgDuplicateSymbol
     case ExistentialTypesNoLongerSupported
     case UnboundWildcardType
-    case DanglingThisInPath                                                                // inactive
+    case DanglingThisInPath                                                                // old
     case OverridesNothing
     case OverridesNothingButNameExists
     case ForwardReferenceExtendsOverDefinition
@@ -92,14 +92,14 @@ object CompileError:
     case AmbiguousOverload
     case ReassignmentToVal
     case TypeDoesNotTakeParameters
-    case ParameterizedTypeLacksArguments                                                   // inactive
+    case ParameterizedTypeLacksArguments                                                   // old
     case VarValParametersMayNotBeCallByName
     case MissingTypeParameterFor
     case DoesNotConformToBound
     case DoesNotConformToSelfType
     case DoesNotConformToSelfTypeCantBeInstantiated
     case AbstractMemberMayNotHaveModifier
-    case TopLevelCantBeImplicit                                                            // inactive
+    case TopLevelCantBeImplicit                                                            // old
     case TypesAndTraitsCantBeImplicit
     case OnlyClassesCanBeAbstract
     case AbstractOverrideOnlyInTraits
@@ -117,8 +117,8 @@ object CompileError:
     case ValueClassesMayNotWrapAnotherValueClass
     case ValueClassParameterMayNotBeAVar
     case ValueClassNeedsExactlyOneValParam
-    case OnlyCaseClassOrCaseObjectAllowed                                                  // inactive
-    case ExpectedTopLevelDef                                                               // inactive
+    case OnlyCaseClassOrCaseObjectAllowed                                                  // old
+    case ExpectedTopLevelDef                                                               // old
     case AnonymousFunctionMissingParamType
     case SuperCallsNotAllowedInlineable
     case NotAPath
@@ -193,7 +193,7 @@ object CompileError:
     case ExtensionCanOnlyHaveDefs
     case UnexpectedPatternForSummonFrom
     case AnonymousInstanceCannotBeEmpty
-    case TypeSpliceInValPattern                                                            // inactive
+    case TypeSpliceInValPattern                                                            // old
     case ModifierNotAllowedForDefinition
     case CannotExtendJavaEnum
     case InvalidReferenceInImplicitNotFoundAnnotation
@@ -201,7 +201,7 @@ object CompileError:
     case JavaEnumParentArgs
     case AlreadyDefined
     case CaseClassInInlinedCode
-    case OverrideTypeMismatchError                                                         // inactive
+    case OverrideTypeMismatchError                                                         // old
     case OverrideError
     case MatchableWarning
     case CannotExtendFunction

--- a/lib/probably/src/core/probably.Probably.scala
+++ b/lib/probably/src/core/probably.Probably.scala
@@ -66,7 +66,7 @@ object Probably:
 
           def lift(predicate: Expr[Any]): Option[Expr[Any]] = predicate.asTerm match
             case Inlined(_, _, predicate) => lift(predicate.asExpr)
-            case Block(List(DefDef(a1, _, _, Some(expression))), Closure(Ident(a2), _)) if a1 == a2 =>
+            case Block(List(DefDef(a, _, _, Some(expression))), Closure(Ident(b), _)) if a == b =>
               expression match
                 case Apply(Select(Ident(_), "=="), List(term)) => Some(term.asExpr)
                 case Apply(Select(term, "=="), List(Ident(_))) => Some(term.asExpr)

--- a/lib/wisteria/src/core/wisteria.ProductDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivation.scala
@@ -189,7 +189,10 @@ object ProductDerivation:
     // erasedness of the tuple.
 
     private transparent inline def fold
-                                    [derivation <: Product, fields <: Tuple, labels <: Tuple, result]
+                                    [derivation <: Product,
+                                     fields     <: Tuple,
+                                     labels     <: Tuple,
+                                     result]
                                     (using requirement: ContextRequirement)
                                     (inline tuple: fields, accumulator: result, index: Int)
                                     (inline lambda: result
@@ -226,7 +229,10 @@ object ProductDerivation:
 
 
     private transparent inline def fold
-                                    [derivation <: Product, fields <: Tuple, labels <: Tuple, result]
+                                    [derivation <: Product,
+                                     fields     <: Tuple,
+                                     labels     <: Tuple,
+                                     result]
                                     (using requirement: ContextRequirement)
                                     (inline accumulator: result, index: Int)
                                     (inline lambda: result


### PR DESCRIPTION
When using tab completions, sometimes we want to display a smaller list of options first, before
revealing a larger list. This is now possible by tracking the number of times `[tab]` has been
pressed on the same commandline.

This number is now passed as a parameter to every `Argument`, which means that it's available to
use wherever the `Argument` is, including in suggestions code.

- **Some fixes for inferring given `Discoverable`s**
- **Count the number of times `[tab]` is pressed**
- **Rename `readParameter` to `parameter`**
- **Support multi-tab completions for pathnames**
