### PR TITLE
Make enumerations discoverable by default

### DIFF
--- a/lib/exoskeleton/src/args/exoskeleton.Discoverable.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Discoverable.scala
@@ -35,10 +35,16 @@ package exoskeleton
 import language.experimental.pureFunctions
 
 import denominative.*
+import distillate.*
 import prepositional.*
 
 object Discoverable:
   def noSuggestions[operand]: operand is Discoverable = _ => Nil
+
+  given enumerable: [value: {Enumerable, Identifiable}] => value is Discoverable = _ =>
+    value.values.to(List)
+    . map { element => value.encode(value.name(element)) }
+    . map(Suggestion(_))
 
 trait Discoverable extends Typeclass:
   def discover(tab: Ordinal): Iterable[Suggestion]


### PR DESCRIPTION
Tab-completion on a flag whose value is determined by an enumeration should now work out of the box.
