### PR TITLE
Generalize CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Install shells
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y bash zsh fish
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y bash zsh fish
+        touch ~/.zshrc
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/lib/exoskeleton/src/rig/exoskeleton-rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton-rig.scala
@@ -64,7 +64,7 @@ extension (shell: Shell)
             case Shell.Zsh  =>
               sh"""tmux send-keys -t ${tmux.id} "PS1='> '" C-m""".exec[Unit]()
               sh"""tmux send-keys -t ${tmux.id} "path+=(\"$path\")" C-m""".exec[Unit]()
-              sh"""tmux send-keys -t ${tmux.id} "autoload -Uz compinit; compinit" C-m""".exec[Unit]()
+              sh"""tmux send-keys -t ${tmux.id} "autoload -Uz compinit; compinit -u" C-m""".exec[Unit]()
               Tmux.attend:
                 sh"""tmux send-keys -t ${tmux.id} C-l""".exec[Unit]()
 

--- a/lib/exoskeleton/src/rig/exoskeleton-rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton-rig.scala
@@ -62,7 +62,7 @@ extension (shell: Shell)
 
           shell match
             case Shell.Zsh  =>
-              sh"""tmux send-keys -t ${tmux.id} "PS1='> '" C-m""".exec[Unit]()
+              sh"""tmux send-keys -t ${tmux.id} 'precmd_functions=() preexec_functions=() PROMPT="> " RPROMPT=""' C-m""".exec[Unit]()
               sh"""tmux send-keys -t ${tmux.id} "path+=(\"$path\")" C-m""".exec[Unit]()
               sh"""tmux send-keys -t ${tmux.id} "autoload -Uz compinit; compinit -u" C-m""".exec[Unit]()
               Tmux.attend:

--- a/lib/exoskeleton/src/test/exoskeleton.Tests.scala
+++ b/lib/exoskeleton/src/test/exoskeleton.Tests.scala
@@ -54,7 +54,7 @@ import stdioSources.virtualMachine.ansi
 import Shell.*
 
 object Tests extends Suite(m"Exoskeleton Tests"):
-  def run(): Unit = if !githubActions then
+  def run(): Unit = if !Ci.githubActions then
     val foo: Text = "hello"
     Sandbox(t"abcd").dispatch:
       '{  import executives.completions

--- a/lib/exoskeleton/src/test/exoskeleton.Tests.scala
+++ b/lib/exoskeleton/src/test/exoskeleton.Tests.scala
@@ -54,7 +54,7 @@ import stdioSources.virtualMachine.ansi
 import Shell.*
 
 object Tests extends Suite(m"Exoskeleton Tests"):
-  def run(): Unit = if !Ci.githubActions then
+  def run(): Unit =
     val foo: Text = "hello"
     Sandbox(t"abcd").dispatch:
       '{  import executives.completions

--- a/lib/exoskeleton/src/test/exoskeleton.Tests.scala
+++ b/lib/exoskeleton/src/test/exoskeleton.Tests.scala
@@ -98,7 +98,11 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           t"finished"  }
 
     . sandbox:
-        println(summon[Sandbox.Tool].path.encode)
+        // Warmup runs to avoid timing issues in CI
+        Bash.tmux()(Tmux.completions(t""))
+        Zsh.tmux()(Tmux.completions(t""))
+        Fish.tmux(width = 120)(Tmux.completions(t""))
+
         test(m"Test subcommands on bash"):
           Bash.tmux()(Tmux.completions(t""))
         . assert(_ == t"alpha         beta          distribution")

--- a/lib/probably/src/core/probably-core.scala
+++ b/lib/probably/src/core/probably-core.scala
@@ -92,8 +92,6 @@ extension [test](test: Test[test])
 extension [value](inline value: value)(using inline test: Harness)
   inline def debug: value = ${Probably.debug('value, 'test)}
 
-def githubActions(using Environment): Boolean = safely(Environment.githubActions[Text]).present
-
 package harnesses:
   given threadLocal: Harness:
     private val delegate: Option[Harness] =

--- a/lib/probably/src/core/probably.Ci.scala
+++ b/lib/probably/src/core/probably.Ci.scala
@@ -30,15 +30,27 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package probably
 
-export probably
-. { Baseline, Benchmark, Inclusion, Verdict, Runner, Test, Harness, TestId, Report,
-    Reporter, Trial, Testable, Tolerance, Min, Mean, Max, BySpeed, ===, !==, ByTime, Geometric,
-    Arithmetic, +/-, test, suite, aspire, assert, check, matches, debug, Checkable, Ci }
+import ambience.*
+import anticipation.*
+import contingency.*
+import vacuous.*
 
-package harnesses:
-  export probably.harnesses.threadLocal
+object Ci:
+  def githubActions(using Environment): Boolean = safely(Environment.githubActions[Text]).present
+  def gitlabCi(using Environment): Boolean = safely(Environment.gitlabCi[Text]).present
+  def circleCi(using Environment): Boolean = safely(Environment.circleci[Text]).present
+  def travisCi(using Environment): Boolean = safely(Environment.travis[Text]).present
+  def jenkins(using Environment): Boolean = safely(Environment.jenkinsUrl[Text]).present
+  def azurePipelines(using Environment): Boolean = safely(Environment.tfBuild[Text]).present
+  def teamCity(using Environment): Boolean = safely(Environment.teamcityVersion[Text]).present
 
-package autopsies:
-  export probably.autopsies.{none, contrastExpectations}
+  def bitbucketPipelines(using Environment): Boolean =
+    safely(Environment.bitbucketBuildNumber[Text]).present
+
+  def buildkite(using Environment): Boolean = safely(Environment.buildkite[Text]).present
+  def appVeyor(using Environment): Boolean = safely(Environment.appveyor[Text]).present
+  def drone(using Environment): Boolean = safely(Environment.drone[Text]).present
+  def semaphore(using Environment): Boolean = safely(Environment.semaphore[Text]).present
+  def buddy(using Environment): Boolean = safely(Environment.buddyWorkspaceId[Text]).present

--- a/lib/probably/src/core/probably.Ci.scala
+++ b/lib/probably/src/core/probably.Ci.scala
@@ -35,22 +35,25 @@ package probably
 import ambience.*
 import anticipation.*
 import contingency.*
+import gossamer.*
 import vacuous.*
 
 object Ci:
-  def githubActions(using Environment): Boolean = safely(Environment.githubActions[Text]).present
-  def gitlabCi(using Environment): Boolean = safely(Environment.gitlabCi[Text]).present
-  def circleCi(using Environment): Boolean = safely(Environment.circleci[Text]).present
-  def travisCi(using Environment): Boolean = safely(Environment.travis[Text]).present
-  def jenkins(using Environment): Boolean = safely(Environment.jenkinsUrl[Text]).present
-  def azurePipelines(using Environment): Boolean = safely(Environment.tfBuild[Text]).present
-  def teamCity(using Environment): Boolean = safely(Environment.teamcityVersion[Text]).present
+  import environments.jre
+  def apply(): Boolean =
+    githubActions || gitlabCi || circleCi || travisCi || jenkins || azurePipelines || teamCity
+    || bitbucketPipelines || buildkite || appVeyor || drone || semaphore || buddy
 
-  def bitbucketPipelines(using Environment): Boolean =
-    safely(Environment.bitbucketBuildNumber[Text]).present
-
-  def buildkite(using Environment): Boolean = safely(Environment.buildkite[Text]).present
-  def appVeyor(using Environment): Boolean = safely(Environment.appveyor[Text]).present
-  def drone(using Environment): Boolean = safely(Environment.drone[Text]).present
-  def semaphore(using Environment): Boolean = safely(Environment.semaphore[Text]).present
-  def buddy(using Environment): Boolean = safely(Environment.buddyWorkspaceId[Text]).present
+  def githubActions: Boolean = safely(Environment.githubActions[Text]) == t"true"
+  def gitlabCi: Boolean = safely(Environment.gitlabCi[Text]) == t"true"
+  def circleCi: Boolean = safely(Environment.circleci[Text]) == t"true"
+  def travisCi: Boolean = safely(Environment.travis[Text]) == t"true"
+  def jenkins: Boolean = safely(Environment.jenkinsUrl[Text]).present
+  def azurePipelines: Boolean = safely(Environment.tfBuild[Text]) == t"true"
+  def teamCity: Boolean = safely(Environment.teamcityVersion[Text]).present
+  def bitbucketPipelines: Boolean = safely(Environment.bitbucketBuildNumber[Text]).present
+  def buildkite: Boolean = safely(Environment.buildkite[Text]) == t"true"
+  def appVeyor: Boolean = safely(Environment.appveyor[Text]) == t"true"
+  def drone: Boolean = safely(Environment.drone[Text]) == t"true"
+  def semaphore: Boolean = safely(Environment.semaphore[Text]) == t"true"
+  def buddy: Boolean = safely(Environment.buddyWorkspaceId[Text]).present


### PR DESCRIPTION
We gave special privilege to Github Actions by giving it its own special method to check if its the host environment. But other CI systems exist, so the `githubActions` method has been moved into the `Ci` object, and several other tests have been added for other CI services.
