### PR TITLE
Fix longstanding challenges with deriving `Optional`s

### DIFF
--- a/lib/cellulose/src/core/cellulose.CodlEncoder.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoder.scala
@@ -67,13 +67,16 @@ object CodlEncoder extends CodlEncoder2:
   given text: CodlFieldWriter[Text] = _.show
 
 
-  given optional: [encodable] => (encodable: => CodlEncoder[encodable])
-  =>  CodlEncoder[Optional[encodable]]:
+  given optional: [inner, value >: Unset.type: Mandatable to inner]
+        => (encoder: => CodlEncoder[inner])
+        => CodlEncoder[value]:
 
-        def schema: CodlSchema = encodable.schema.optional
+    def schema: CodlSchema = encoder.schema.optional
 
-        def encode(value: Optional[encodable]): List[IArray[CodlNode]] =
-          value.let(encodable.encode(_)).or(List())
+    def encode(element: value): List[IArray[CodlNode]] =
+      element.let: element =>
+        encoder.encode(element.asInstanceOf[inner])
+      . or(List())
 
 
   given option: [encodable: CodlEncoder] => CodlEncoder[Option[encodable]]:

--- a/lib/cellulose/src/core/cellulose.CodlEncoderDerivation.scala
+++ b/lib/cellulose/src/core/cellulose.CodlEncoderDerivation.scala
@@ -43,7 +43,7 @@ object CodlEncoderDerivation extends ProductDerivation[CodlEncoder]:
       case relabelling: CodlRelabelling[derivation] => relabelling.relabelling()
       case _                                        => Map()
 
-    val schema: CodlSchema =
+    def schema: CodlSchema =
       val elements = contexts:
         [field] => context => CodlSchema.Entry(mapping.at(label).or(label), context.schema)
 

--- a/lib/cellulose/src/test/cellulose.Tests.scala
+++ b/lib/cellulose/src/test/cellulose.Tests.scala
@@ -1114,9 +1114,14 @@ object Tests2 extends Suite(m"Cellulose tests (Part 2)"):
       .assert(_ == List(t"hello", t"world"))
 
       case class Foo(alpha: Text, beta: Optional[Text])
-      // test(m"roundtrip a case class with an optional parameter"):
-      //   roundtrip(Foo(t"one", t"two"))
-      // .assert(_ == Foo(t"one", t"two"))
+      try
+        test(m"roundtrip a case class with an optional parameter"):
+          roundtrip(Foo(t"one", t"two"))
+        .assert(_ == Foo(t"one", t"two"))
+
+      catch
+        case throwable: Throwable =>
+          throwable.printStackTrace()
 
       test(m"roundtrip a case class with an optional parameter, unset"):
         roundtrip(Foo(t"one", Unset))
@@ -1129,11 +1134,11 @@ object Tests2 extends Suite(m"Cellulose tests (Part 2)"):
       val complex = Bar(List(Baz(t"a", 2, Unset), Baz(t"c", 6, 'e')), Quux(t"e", List(1, 2, 4)))
 
       // FIXME: Fails at runtime
-      // test(m"roundtrip a complex case class"):
-      //   summon[CodlDecoder[Baz]]
-      //   summon[CodlDecoder[List[Baz]]]
-      //   roundtrip(complex)
-      // .assert(_ == complex)
+      test(m"roundtrip a complex case class"):
+        summon[CodlDecoder[Baz]]
+        summon[CodlDecoder[List[Baz]]]
+        roundtrip(complex)
+      .assert(_ == complex)
 
       def print[T: CodlDecoder: CodlEncoder](value: T): Text =
         val writer = new ji.StringWriter()
@@ -1141,19 +1146,19 @@ object Tests2 extends Suite(m"Cellulose tests (Part 2)"):
         writer.toString().show
 
       // FIXME: Fails at runtime
-      // test(m"print a simple case class"):
-      //   print(Foo(t"one", t"two"))
-      // .assert(_ == t"alpha  one\nbeta  two\n")
+      test(m"print a simple case class"):
+        print(Foo(t"one", t"two"))
+      .assert(_ == t"alpha  one\nbeta  two\n")
 
       // FIXME: Fails at runtime
-      // test(m"print a complex case class"):
-      //   print(complex)
-      // .assert(_ == t"foo\n  gamma  a\n  delta  2\nfoo\n  gamma  c\n  delta  6\n  eta  e\nquux\n  alpha  e\n  beta  1\n  beta  2\n  beta  4\n")
+      test(m"print a complex case class"):
+        print(complex)
+      .assert(_ == t"foo\n  gamma  a\n  delta  2\nfoo\n  gamma  c\n  delta  6\n  eta  e\nquux\n  alpha  e\n  beta  1\n  beta  2\n  beta  4\n")
 
       // FIXME: Fails at runtime
-      // test(m"roundtrip a complex case class "):
-      //   read(print(complex)).as[Bar]
-      // .assert(_ == complex)
+      test(m"roundtrip a complex case class "):
+        read(print(complex)).as[Bar]
+      .assert(_ == complex)
 
       // test(m"Print a case class using positional parameters"):
       //   print(User(12, t"user@example.com", List(Privilege(t"read", true), Privilege(t"write", false))))

--- a/lib/vacuous/src/core/vacuous.Mandatable.scala
+++ b/lib/vacuous/src/core/vacuous.Mandatable.scala
@@ -30,35 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package cellulose
+package vacuous
 
-import contingency.*
-import rudiments.*
-import vacuous.*
-import wisteria.*
+import prepositional.*
 
-import scala.deriving.*
+object Mandatable:
+  transparent inline given mandatable: [typeRef] => typeRef is Mandatable =
+    ${Vacuous.mandatable[typeRef]}
 
-object CodlDecoderDerivation extends ProductDerivation[CodlDecoder]:
-  inline def join[derivation <: Product: ProductReflection]: CodlDecoder[derivation] =
-    def schema: CodlSchema =
-      val elements = contexts:
-        [field] => context =>
-          val label2 = compiletime.summonFrom:
-            case relabelling: CodlRelabelling[derivation] => relabelling(label).or(label)
-            case _                                        => label
-
-          CodlSchema.Entry(label2, context.schema)
-
-      Struct(elements.to(List), Arity.One)
-
-    def decode(values: List[Indexed]): derivation raises CodlReadError =
-      construct:
-        [field] => context =>
-          val label2 = compiletime.summonFrom:
-            case relabelling: CodlRelabelling[derivation] => relabelling(label).or(label)
-            case _                                        => label
-
-          context.decoded(values.prim.lest(CodlReadError(label2)).get(label2))
-
-    CodlDecoder[derivation](schema, decode)
+erased trait Mandatable extends Typeclass:
+  type Result <: Self

--- a/lib/vacuous/src/test/vacuous.Tests.scala
+++ b/lib/vacuous/src/test/vacuous.Tests.scala
@@ -38,118 +38,119 @@ import soundness.*
 
 object Tests extends Suite(m"Vacuous Tests"):
   def run(): Unit =
-   suite(m"Vacuous tests"):
-     test(m"String is concrete"):
-       erased val x = summon[String is Concrete]
-     . assert()
+    suite(m"Vacuous tests"):
+      test(m"String is concrete"):
+        erased val x = summon[String is Concrete]
+      . assert()
 
-     test(m"Abstract method type is not concrete"):
-       demilitarize:
-         def abstractType[notConcrete]: Unit =
-           summon[notConcrete is Concrete]
-       . map(_.message)
-     . assert(_ == List(t"vacuous: type notConcrete is abstract"))
+      test(m"Abstract method type is not concrete"):
+        demilitarize:
+          def abstractType[notConcrete]: Unit =
+            summon[notConcrete is Concrete]
+        . map(_.message)
+      . assert(_ == List(t"vacuous: type notConcrete is abstract"))
 
-     test(m"Unexpanded inlined abstract method type is not concrete"):
-       demilitarize:
-         inline def abstractType[notConcrete]: Unit =
-           summon[notConcrete is Concrete]
-       . map(_.message)
-     . assert(_ == Nil)
+      test(m"Unexpanded inlined abstract method type is not concrete"):
+        demilitarize:
+          inline def abstractType[notConcrete]: Unit =
+            summon[notConcrete is Concrete]
+        . map(_.message)
+      . assert(_ == Nil)
 
-     test(m"Expanded inlined abstract method type is not concrete"):
-       demilitarize:
-         inline def abstractType[notConcrete]: Unit =
-           summon[notConcrete is Concrete]
+      test(m"Expanded inlined abstract method type is not concrete"):
+        demilitarize:
+          inline def abstractType[notConcrete]: Unit =
+            summon[notConcrete is Concrete]
 
-         erased val x = abstractType[Int]
+          erased val x = abstractType[Int]
 
-       . map(_.message)
-     . assert(_ == Nil)
+        . map(_.message)
+      . assert(_ == Nil)
 
-     test(m"Int and String are distinct types"):
-       demilitarize:
-         erased val x = infer[Int is Distinct from String]
+      test(m"Int and String are distinct types"):
+        demilitarize:
+          erased val x = infer[Int is Distinct from String]
 
-       . map(_.message)
-     . assert(_ == Nil)
+        . map(_.message)
+      . assert(_ == Nil)
 
-     test(m"Int and (Int | String) are not distinct types"):
-       demilitarize:
-         erased val x = compiletime.summonInline[Int is Distinct from (Int | String)]
+      test(m"Int and (Int | String) are not distinct types"):
+        demilitarize:
+          erased val x = compiletime.summonInline[Int is Distinct from (Int | String)]
 
-       . map(_.message)
-     . assert(_.nonEmpty)
+        . map(_.message)
+      . assert(_.nonEmpty)
 
-     test(m"String is not distinct from itself"):
-       demilitarize:
-         erased val x = compiletime.summonInline[String is Distinct from String]
+      test(m"String is not distinct from itself"):
+        demilitarize:
+          erased val x = compiletime.summonInline[String is Distinct from String]
 
-       . map(_.message)
-     . assert(_.nonEmpty)
+        . map(_.message)
+      . assert(_.nonEmpty)
 
-     test(m"Abstract type is not proven distinct from anything, e.g. String"):
-       demilitarize:
-         def foo[T]: Unit = infer[T is Distinct from String].unit
-         foo[String]
+      test(m"Abstract type is not proven distinct from anything, e.g. String"):
+        demilitarize:
+          def foo[T]: Unit = infer[T is Distinct from String].unit
+          foo[String]
 
-       . map(_.message)
-     . assert(_.contains(t"vacuous: type T is abstract"))
+        . map(_.message)
+      . assert(_.contains(t"vacuous: type T is abstract"))
 
-     test(m"Abstract type is not proven distinct from anything, e.g. Int"):
-       demilitarize:
-         def foo[T]: Unit = infer[T is Distinct from String].unit
-         foo[Int]
+      test(m"Abstract type is not proven distinct from anything, e.g. Int"):
+        demilitarize:
+          def foo[T]: Unit = infer[T is Distinct from String].unit
+          foo[Int]
 
-       . map(_.message)
-     . assert(_.contains(t"vacuous: type T is abstract"))
+        . map(_.message)
+      . assert(_.contains(t"vacuous: type T is abstract"))
 
-     test(m"Inline abstract type is not proven distinct from anything, e.g. Int"):
-       demilitarize:
-         inline def foo[T]: Unit =
-           erased val x = infer[T is Distinct from String]
+      test(m"Inline abstract type is not proven distinct from anything, e.g. Int"):
+        demilitarize:
+          inline def foo[T]: Unit =
+            erased val x = infer[T is Distinct from String]
 
-         foo[Int]
+          foo[Int]
 
-       . map(_.message)
-     . assert(_ == Nil)
+        . map(_.message)
+      . assert(_ == Nil)
 
-     test(m"Inline abstract type is not proven distinct from anything, e.g. String"):
-       demilitarize:
-         inline def foo[T]: Unit =
-           erased val x = infer[T is Distinct from String]
+      test(m"Inline abstract type is not proven distinct from anything, e.g. String"):
+        demilitarize:
+          inline def foo[T]: Unit =
+            erased val x = infer[T is Distinct from String]
 
-         foo[String]
+          foo[String]
 
-       . map(_.message)
-     . assert(_.nonEmpty)
+        . map(_.message)
+      . assert(_.nonEmpty)
 
-     test(m"String is not distinct from String | Int"):
-       demilitarize:
-         inline def foo[T]: Unit =
-           erased val x = infer[T is Distinct from (String | Int)]
+      test(m"String is not distinct from String | Int"):
+        demilitarize:
+          inline def foo[T]: Unit =
+            erased val x = infer[T is Distinct from (String | Int)]
 
-         foo[String]
+          foo[String]
 
-       . map(_.message)
-     . assert(_.nonEmpty)
+        . map(_.message)
+      . assert(_.nonEmpty)
 
-     test(m"String singleton is not distinct from String"):
-       demilitarize:
-         inline def foo[T]: Unit =
-           erased val x = infer[T is Distinct from (String | Int)]
+      test(m"String singleton is not distinct from String"):
+        demilitarize:
+          inline def foo[T]: Unit =
+            erased val x = infer[T is Distinct from (String | Int)]
 
-         foo[""]
+          foo[""]
 
-       . map(_.message)
-     . assert(_.nonEmpty)
+        . map(_.message)
+      . assert(_.nonEmpty)
 
-     test(m"String singleton is not distinct from different String singleton"):
-       demilitarize:
-         inline def foo[T]: Unit =
-           erased val x = infer[T is Distinct from "foo"]
 
-         foo[""]
+      test(m"String singleton is not distinct from different String singleton"):
+        demilitarize:
+          inline def foo[T]: Unit =
+            erased val x = infer[T is Distinct from "foo"]
 
-       . map(_.message)
-     . assert(_ == Nil)
+          foo[""]
+
+        . map(_.message)
+      . assert(_ == Nil)


### PR DESCRIPTION
For a long time, it's been very difficult to write `given` instances for deriving `Optional`s, because they so frequently get caught in a recursive derivation loop. This has been fixed with a `Mandatable` typeclass.

See the `CodlDecoder` and `CodlEncoder` implementations for usage. The last remaining Cellulose tests have been fixed as a consequence.
