### PR TITLE
exoskeleton: make Completions.ensure idempotent

### DIFF
--- a/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
@@ -38,6 +38,7 @@ import ambience.*, environments.java, systems.java
 import anticipation.*
 import contingency.*
 import denominative.*
+import digression.idempotent
 import distillate.*
 import fulminate.*
 import galilei.*
@@ -111,7 +112,17 @@ object Completions:
   def ensure(force: Boolean = false)(using Entrypoint, WorkingDirectory, Diagnostics)
   :   List[Text] logs CliEvent =
 
-    safely(effectful(install(force))).let(_.paths).or(Nil)
+    if force then safely(effectful(install(force))).let(_.paths).or(Nil)
+    else
+      // The non-force path is meant to be a fire-and-forget "install if not
+      // already installed" check at startup. Each invocation otherwise spawns
+      // 5–7 subprocesses (including a `zsh -c 'source ~/.zshrc'`) — measured
+      // ~300 ms per call on macOS, dominating the launch time of any
+      // daemon-backed CLI that calls this on every invocation. Use
+      // `idempotent` so the work runs once per JVM lifetime; subsequent
+      // calls are a no-op.
+      idempotent(safely(effectful(install())))
+      Nil
 
 
   def install(force: Boolean = false)(using entrypoint: Entrypoint)(using erased Effectful)


### PR DESCRIPTION
## Summary

`Completions.ensure()` is the recommended call at the top of every `@main`-annotated cli body, but each call spawns 5–7 subprocesses to detect installed shells and locate fpath/profile directories — including a full \`zsh -c 'source ~/.zshrc'\`. Under a daemonised executive (\`ethereal\`) the cli body runs once per client invocation in the already-warm daemon JVM, so the subprocess fan-out is paid on every invocation.

Measured cost on amok (macOS, fish/zsh/bash/no-pwsh installed): **~300 ms per call**, dominating the launch time of a hot-daemon CLI whose work otherwise completes in <10 ms.

## Fix

Wrap the non-\`force\` body in \`digression.idempotent\` so the install attempt runs once per JVM lifetime; subsequent calls at the same codepoint are a no-op.

The \`force = true\` path (used by the \`{admin} install\` administrative command at \`exoskeleton_completions.scala:165\`) is unchanged and still returns the actual install paths. The \`force = false\` path's return value isn't used by any in-tree caller, so returning \`Nil\` after the idempotent block is harmless.

## Diff

\`\`\`scala
-    safely(effectful(install(force))).let(_.paths).or(Nil)
+    if force then safely(effectful(install(force))).let(_.paths).or(Nil)
+    else
+      idempotent(safely(effectful(install())))
+      Nil
\`\`\`

(Plus an \`import digression.idempotent\` and a comment explaining why.)

## Verification

Tested end-to-end against amok built from soundness \`main\` + this patch:

\`\`\`
=== before (force-disabled probe) ===
amok about > /dev/null  …  0.009 total      ← ~9 ms — the floor
=== before (real ensure() on every call) ===
amok about > /dev/null  …  0.304 total
amok about > /dev/null  …  0.304 total
=== after (idempotent ensure()) ===
amok about > /dev/null  …  2.484 total      ← first run, daemon cold-start
amok about > /dev/null  …  0.014 total
amok about > /dev/null  …  0.014 total
amok about > /dev/null  …  0.013 total
amok about > /dev/null  …  0.015 total
\`\`\`

>20× speed-up on hot-daemon invocations. First-invocation cost in each daemon lifetime is unchanged — the install attempt still runs on the first call.

\`mill exoskeleton.completions.compile\` and \`mill exoskeleton.test.compile\` both succeed.

## Notes

- The \`{admin} install\` command (force=true) still works as before and is the way to force a fresh install attempt — useful when the user moves the executable or adds a new shell after the daemon started.
- This change interacts well with the recently fixed #1113 \`await\` timeouts and #1114/#1117 fish completion fixes — they all touch the same daemon-launch hot path.