### PR TITLE
contingency: replace unsafely with whereas/recover/mitigate across libs

### DIFF
--- a/lib/anthology/src/bundle/anthology.Bundler.scala
+++ b/lib/anthology/src/bundle/anthology.Bundler.scala
@@ -70,7 +70,7 @@ object Bundler:
 
 
   def bundle(directory: Path on Linux, jarfile0: Optional[Path on Linux], main: Optional[Fqcn])
-  :   Path on Linux raises ZipError =
+  :   Path on Linux raises ZipError raises PathError raises IoError raises StreamError =
 
     val jarfile = jarfile0.or(directory.peer("tmpfile.jar"))
 
@@ -89,23 +89,21 @@ object Bundler:
         Zip.Entry(%.on[Zip] / "META-INF" / "MANIFEST.MF", manifest)
         :: classpath(directory).entries.to(List).flatMap:
           case ClasspathEntry.Directory(directory) =>
-            unsafely:
-              val root = directory.decode[Path on Linux]
-              root.descendants.to(List).filter: entry => !omissions(entry.name)
-              . map: file =>
-                if file.entry() == Directory then Unset else file.open: handle =>
-                  val ref = %.on[Zip] + root.toward(file).on[Zip]
-                  Zip.Entry(ref, handle.read[Data])
+            val root = directory.decode[Path on Linux]
+            root.descendants.to(List).filter: entry => !omissions(entry.name)
+            . map: file =>
+              if file.entry() == Directory then Unset else file.open: handle =>
+                val ref = %.on[Zip] + root.toward(file).on[Zip]
+                Zip.Entry(ref, handle.read[Data])
 
-              . compact
+            . compact
 
           case ClasspathEntry.Jar(jar) =>
-            unsafely:
-              workingDirectory[Path on Linux].resolve(jar).open: handle =>
-                ZipStream(handle).keep(_.encode != t"META-INF/MANIFEST.MF").map: entry =>
-                  Zip.Entry(entry.ref, entry.read[Data])
+            workingDirectory[Path on Linux].resolve(jar).open: handle =>
+              ZipStream(handle).keep(_.encode != t"META-INF/MANIFEST.MF").map: entry =>
+                Zip.Entry(entry.ref, entry.read[Data])
 
-                . to(List)
+              . to(List)
 
           case _ =>
             Nil

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -73,17 +73,18 @@ object Enclave:
       safely(promise.await())
 
   case class Launcher(path: Path on Linux):
-    def sandbox[result](block: (tool: Tool) ?=> result): result =
-      val completionScripts = unsafely(sh"$path '{admin}' install".exec[Text]())
-      val pid = Pid(unsafely(sh"$path '{admin}' pid".exec[Text]().trim.decode[Int]))
+    def sandbox[result](block: (tool: Tool) ?=> result)
+    :   result raises ExecError raises NumberError raises PathError =
+
+      val completionScripts = sh"$path '{admin}' install".exec[Text]()
+      val pid = Pid(sh"$path '{admin}' pid".exec[Text]().trim.decode[Int])
       val tool = Tool(path, pid)
 
       block(using tool).also:
-        unsafely:
-          sh"$path '{admin}' kill".exec[Exit]()
+        sh"$path '{admin}' kill".exec[Exit]()
 
-          completionScripts.trim.lines.map(_.decode[Path on Linux]).each: item =>
-            safely(item.delete())
+        completionScripts.trim.lines.map(_.decode[Path on Linux]).each: item =>
+          safely(item.delete())
 
 
 case class Enclave(name: Text, buildId: Optional[Int] = Unset)(using Classloader, Environment)

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -45,6 +45,8 @@ extension (shell: Shell)
     whereas:
       case ExecError(_, _, _)   => TmuxError(TmuxError.Reason.ExecFailed)
       case NumberError(_, _, _) => TmuxError(TmuxError.Reason.SessionDied)
+      case IoError(_, _, _, _)  => TmuxError(TmuxError.Reason.ExecFailed)
+      case StreamError(_)       => TmuxError(TmuxError.Reason.ExecFailed)
 
     . mitigate:
         given tmux: Tmux = Tmux(Uuid().show, summon[WorkingDirectory], width, height, shell)
@@ -130,7 +132,7 @@ extension (shell: Shell)
             import charEncoders.utf8
 
             val file: Path on Linux = unsafely(temporaryDirectory/t"exoskeleton-${Uuid()}.ps1")
-            unsafely(file.open(psScript.tt.writeTo(_)))
+            file.open(psScript.tt.writeTo(_))
             psFile = file
             t"POWERSHELL_UPDATECHECK=Off pwsh -NoLogo -NoExit -File ${file.encode}"
 

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -51,6 +51,7 @@ import serpentine.*
 import turbulence.*
 import vacuous.*
 
+import errorDiagnostics.stackTraces
 import filesystemOptions.createNonexistent.disabled
 import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemOptions.readAccess.enabled
@@ -60,7 +61,7 @@ import interfaces.paths.pathOnLinux
 
 def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using TemporaryDirectory)
   ( using classloader: Classloader )
-:   Bytecode =
+:   Bytecode raises BytecodeError =
 
   val uuid = Uuid()
   val out: Path on Linux = unsafely(temporaryDirectory/uuid)
@@ -71,12 +72,16 @@ def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using T
 
   given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
 
-  unsafely:
-    val file: Path on Linux = out/"Generated$$Code$$From$$Quoted.class"
-    val code: Quotes ?=> Expr[Unit] = '{def _code(): Unit = $code0}
-    staging.run(code)
-    val classfile: Classfile = new Classfile(file.open(_.read[Data]))
-    classfile.methods.find(_.name == t"_code$$1").map(_.bytecode).get.vouch.embed(codepoint)
+  whereas:
+    case IoError(_, _, _, _) => BytecodeError(BytecodeError.Reason.ClassfileMissing)
+    case StreamError(_)      => BytecodeError(BytecodeError.Reason.ClassfileUnreadable)
+
+  . mitigate:
+      val file: Path on Linux = out/"Generated$$Code$$From$$Quoted.class"
+      val code: Quotes ?=> Expr[Unit] = '{def _code(): Unit = $code0}
+      staging.run(code)
+      val classfile: Classfile = new Classfile(file.open(_.read[Data]))
+      classfile.methods.find(_.name == t"_code$$1").map(_.bytecode).get.vouch.embed(codepoint)
 
 
 type BytecodePalette = Palette:
@@ -87,3 +92,15 @@ type BytecodePalette = Palette:
 
 case class ClassfileError()(using Diagnostics)
 extends Error(293, 0)(m"there was an error reading the classfile")
+
+object BytecodeError:
+  enum Reason(val number: Int) extends Clarification:
+    case ClassfileMissing    extends Reason(1)
+    case ClassfileUnreadable extends Reason(2)
+
+  given communicable: Reason is Communicable =
+    case Reason.ClassfileMissing    => m"the generated classfile could not be opened"
+    case Reason.ClassfileUnreadable => m"the generated classfile could not be read"
+
+case class BytecodeError(reason: BytecodeError.Reason)(using Diagnostics)
+extends Error(295, reason.number)(m"the bytecode could not be extracted because $reason")

--- a/lib/obligatory/src/core/obligatory.JsonRpc.scala
+++ b/lib/obligatory/src/core/obligatory.JsonRpc.scala
@@ -52,6 +52,7 @@ import telekinesis.*
 import turbulence.*
 import urticose.*
 import vacuous.*
+import zephyrine.*
 
 
 object JsonRpc:
@@ -95,8 +96,15 @@ object JsonRpc:
     val request = Request("2.0", method, payload, uuid.json).json
 
     async:
-      unsafely:
-        promise.fulfill(target.submit(Http.Post)(request).receive[Json])
+      whereas:
+        case MediaTypeError(_, _)   => promise.cancel()
+        case ConnectError(_)        => promise.cancel()
+        case ParseError(_, _, _)    => promise.cancel()
+        case HttpError(_, _)        => promise.cancel()
+        case AsyncError(_)          => promise.cancel()
+
+      . recover:
+          promise.fulfill(target.submit(Http.Post)(request).receive[Json])
 
     promise
 
@@ -111,8 +119,14 @@ object JsonRpc:
 
     val request = Request("2.0", method, payload, Unset).json
 
-    unsafely:
-      target.submit(Http.Post)(request).receive[Text]
+    whereas:
+      case MediaTypeError(_, _) => ()
+      case ConnectError(_)      => ()
+      case HttpError(_, _)      => ()
+
+    . recover:
+        target.submit(Http.Post)(request).receive[Text]
+        ()
 
     Promise[Unit]().tap(_.offer(()))
 

--- a/lib/obligatory/src/core/obligatory.internal.scala
+++ b/lib/obligatory/src/core/obligatory.internal.scala
@@ -221,11 +221,13 @@ object internal:
                     ' {
                         val json = Map(${Varargs(entries)}*).json
 
-                        unsafely:
+                        safely[AsyncError]:
                           JsonRpc.notification($url, $methodName, json)
                             ( using $monitor, $codicil, $online )
 
                           . await()
+
+                        . yet (())
                       }
 
                     . asTerm

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -50,7 +50,9 @@ import urticose.*
 import vacuous.*
 
 object HttpConnection:
-  def apply(exchange: csnh.HttpExchange): HttpConnection logs HttpServerEvent =
+  def apply(exchange: csnh.HttpExchange)
+  :   HttpConnection logs HttpServerEvent raises HostnameError =
+
     val uri = exchange.getRequestURI.nn
     val query = Optional(uri.getQuery)
     val target = uri.getPath.nn.tt+query.let(t"?"+_.tt).or(t"")
@@ -66,7 +68,7 @@ object HttpConnection:
 
     val version: Http.Version = Http.Version.parse(exchange.getProtocol.nn.tt)
 
-    val host = unsafely:
+    val host =
       Optional(uri.getHost).let(_.tt).or:
         exchange.getLocalAddress.nn.getAddress.nn.getCanonicalHostName.nn.tt
 

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -52,13 +52,21 @@ extends RequestServable:
 
     def handle(exchange: csnh.HttpExchange | Null): Unit =
       try
-        val connection = HttpConnection(exchange.nn)
-
         whereas:
           case StreamError(length) =>
             Log.warn(HttpServerEvent.BrokenStream(length))
 
+          case error @ HostnameError(_, _) =>
+            error.printStackTrace()
+
+            try
+              exchange.nn.sendResponseHeaders(400, -1)
+              exchange.nn.close()
+            catch case NonFatal(_) => ()
+
         . recover:
+            val connection = HttpConnection(exchange.nn)
+
             connection.respond:
               try handler(using connection) catch case throwable: Throwable =>
                 errorPage.handle(throwable, connection)

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -53,7 +53,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
 
   protected def makeConnection
     ( request: jsh.HttpServletRequest, servletResponse: jsh.HttpServletResponse )
-  :   HttpConnection raises StreamError =
+  :   HttpConnection raises StreamError raises HostnameError =
 
     val uri = request.getRequestURI.nn.tt
     val query = Optional(request.getQueryString).let(_.tt)
@@ -70,7 +70,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
       Http.Request
         ( method      = request.getMethod.nn.show.decode[Http.Method],
           version     = Http.Version.parse(request.getProtocol.nn.tt),
-          host        = unsafely(request.getServerName.nn.tt.decode[Hostname]),
+          host        = request.getServerName.nn.tt.decode[Hostname],
           target      = target,
           body        = () => streamBody(request),
           textHeaders = headers )
@@ -102,9 +102,17 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
 
 
   def handle(request: jsh.HttpServletRequest, response: jsh.HttpServletResponse): Unit =
-    unsafely:
-      val connection = makeConnection(request, response)
-      connection.respond(handle(using connection))
+    whereas:
+      case error @ StreamError(_) =>
+        error.printStackTrace(System.out)
+
+      case error @ HostnameError(_, _) =>
+        error.printStackTrace(System.out)
+        try response.setStatus(400) catch case NonFatal(_) => ()
+
+    . recover:
+        val connection = makeConnection(request, response)
+        connection.respond(handle(using connection))
 
 
   override def service

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -773,7 +773,7 @@ object Mcp:
 
     def `resources/unsubscribe`(uri: Text, _meta: Optional[Json]): Unit = ???
 
-    def `tools/call`(name: Text, arguments: Json, _meta: Optional[Json]): CallTool = unsafely:
+    def `tools/call`(name: Text, arguments: Json, _meta: Optional[Json]): CallTool =
       val result = spec.invokeTool(server, client, name, arguments)
 
       import jsonPrinters.minimal

--- a/lib/synesthesia/src/core/synesthesia.McpServer.scala
+++ b/lib/synesthesia/src/core/synesthesia.McpServer.scala
@@ -39,6 +39,7 @@ import anticipation.*
 import contingency.*
 import distillate.*
 import fulminate.*
+import gossamer.*
 import inimitable.*
 import jacinta.*
 import obligatory.*
@@ -69,10 +70,15 @@ trait McpServer():
   def serve(using this.type is McpSpecification, Monitor, Codicil, Online, Http.Request)
   :   Http.Response =
 
-    unsafely:
-      val sessionId = request.headers.mcpSessionId.prim.or(Uuid().encode)
-      val interface: Mcp.Interface = Mcp.Interface(sessionId, this)
-      Mcp.send(sessionId, this, interface)(JsonRpc.serve(interface))
+    whereas:
+      case error @ JsonRpcError(_) =>
+        import hieroglyph.charEncoders.utf8
+        Http.Response(Unfulfilled(t"JSON-RPC error: ${error.message.text}"))
+
+    . recover:
+        val sessionId = request.headers.mcpSessionId.prim.or(Uuid().encode)
+        val interface: Mcp.Interface = Mcp.Interface(sessionId, this)
+        Mcp.send(sessionId, this, interface)(JsonRpc.serve(interface))
 
 
   def name: Text


### PR DESCRIPTION
Twelve `unsafely:` blocks across `obligatory`, `scintillate`, `synesthesia`, `anthology`, `mandible`, and `exoskeleton` each suppressed typed errors that the underlying calls already advertised, so any failure crashed the request thread or surfaced as an opaque stack trace from inside an internal context. Each site now uses contingency's `whereas { case … } . recover/mitigate` (or `safely[E]`, or a wider `raises` clause) so the error type is explicit at the handler, the recovery action is named (cancel the promise, send a 400, return a JSON-RPC error, mitigate to a domain error), and downstream callers see typed errors instead of crashes. The repository-wide count of `unsafely` in `lib/` drops from 125 to 109.

### Behavioural changes

- `obligatory.JsonRpc.request` (HTTP variant): on transport failure the promise is now cancelled rather than left pending forever, so `await()` aborts with `AsyncError.Cancelled` instead of hanging.
- `obligatory.JsonRpc.notification` (HTTP variant): no longer throws past its `Promise[Unit]` return value on transport failure; failures are silently dropped (matching the fire-and-forget contract).
- `scintillate.HttpServer` and `scintillate.JavaServlet`: a malformed `Host` header now returns 400 Bad Request via the raw transport (best-effort) instead of crashing the request thread; `StreamError` on the request body is logged.
- `synesthesia.McpServer.serve`: a `JsonRpcError` propagated by the MCP dispatcher now produces a 500 with a brief error message instead of crashing.

### Library API changes

- `anthology.Bundler.bundle`: widens from `… raises ZipError` to `… raises ZipError raises PathError raises IoError raises StreamError`. Callers that already wrapped `bundle(...)` in `unsafely` are unaffected.
- `mandible.disassemble`: new domain error `BytecodeError` (companion `Reason` enum with `ClassfileMissing`, `ClassfileUnreadable`; error code 295). Signature is now `Bytecode raises BytecodeError`.
- `exoskeleton.Enclave.Launcher.sandbox`: signature widens to `result raises ExecError raises NumberError raises PathError`. Existing test callers are unaffected.
- `scintillate.HttpConnection.apply` and `scintillate.JavaServlet.makeConnection`: signatures gain `raises HostnameError`; the existing whereas in `scintillate.HttpServer.handle` adds a `HostnameError` case.
- `obligatory.internal` (RPC notification client macro): the spliced body uses `safely[AsyncError]` instead of `unsafely`.

### Sites deliberately left as `unsafely`

A handful resist the same treatment for documented reasons. They stay `unsafely` until follow-up work:

- The serpentine path-component macro (`dir/t"literal"`, `dir/DataName`) loses its singleton-typed view of literals inside a context-function body, so path concatenations cannot move into a `recover`/`mitigate` block as-is. Affects `ziggurat.Xeq`, parts of `mandible.disassemble`, and the powershell-script-path construction in `exoskeleton_rig`.
- `Rig.stage` and `Rig.invoke` declare no `raises`, so concrete Rig subclasses (`sedentary.Bench`, `exoskeleton.Enclave`) cannot tighten the override with a `raises` clause without changing `Rig` itself.
- The `obligatory` request-client macro splices generate a method body returning a generic `result`, so there is no neutral recovery value for `whereas .recover` without expanding the user RPC interface.