### PR TITLE
rudiments: introduce Mutex and replace synchronized across libs

### DIFF
--- a/lib/anamnesis/src/core/anamnesis.Database.scala
+++ b/lib/anamnesis/src/core/anamnesis.Database.scala
@@ -58,6 +58,7 @@ class Database(size: Int) extends Findable:
   type AllRelations = Tuple.Union[Topic]
   type Has[relation <: Relation[?, ?]] = relation <:< AllRelations
 
+  private val mutex: Mutex = Mutex()
   private var references: Map[Any, Ref] = Map()
   private var dereferences: Map[Ref, Any] = Map()
 
@@ -75,7 +76,7 @@ class Database(size: Int) extends Findable:
   inline def store[left](left: left): Ref of left in this.type =
     references.at(left).or:
       allocate[left]().tap: ref =>
-        this.synchronized:
+        mutex:
           references = references.updated(left, ref)
           dereferences = dereferences.updated(ref, left)
 

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -58,9 +58,10 @@ object Scalac:
 
   case class Option[-version <: Versions](flags: Text*)
 
+  private val mutex: Mutex = Mutex()
   private var Scala3: dtd.Compiler = new dtd.Compiler()
 
-  def refresh(): Unit = synchronized { Scala3 = new dtd.Compiler() }
+  def refresh(): Unit = mutex { Scala3 = new dtd.Compiler() }
   def compiler(): dtd.Compiler = Scala3
 
 case class Scalac[version <: Scalac.Versions](options: List[Scalac.Option[version]]):

--- a/lib/camouflage/src/core/camouflage.Cache.scala
+++ b/lib/camouflage/src/core/camouflage.Cache.scala
@@ -50,10 +50,11 @@ object Cache:
   def apply[value](): Cache[value] = new Cache(Unset)
 
 class Cache[value](lifetime: Optional[Long]):
+  private val mutex: Mutex = Mutex()
   private var expiry: Long = Long.MaxValue
   private var value: Promise[value] = Promise()
 
-  def establish(block: => value): value = value.synchronized:
+  def establish(block: => value): value = mutex:
     if expiry < jl.System.currentTimeMillis then value = Promise()
 
     if value.ready then value().vouch else block.tap: result =>

--- a/lib/obligatory/src/core/obligatory.SseSource.scala
+++ b/lib/obligatory/src/core/obligatory.SseSource.scala
@@ -35,23 +35,25 @@ package obligatory
 import anticipation.*
 import contingency.*
 import prepositional.*
+import rudiments.*
 import spectacular.*
 import turbulence.*
 import vacuous.*
 
 class SseSource(capacity: Int):
+  private val mutex: Mutex = Mutex()
   private val buffer: Array[Sse] = new Array(capacity)
 
   private var current: Int = 0
   private var spool: Spool[Sse] = Spool()
 
-  def put[entity: Encodable in Sse](value: entity): Unit = synchronized:
+  def put[entity: Encodable in Sse](value: entity): Unit = mutex:
     val sse = value.encode.copy(id = current.show)
     buffer(current%capacity) = sse
     spool.put(sse)
     current += 1
 
-  def stream(start: Optional[Int] = Unset): Stream[Sse] raises SseError = synchronized:
+  def stream(start: Optional[Int] = Unset): Stream[Sse] raises SseError = mutex:
     start.let: start =>
       spool.stop()
       spool = Spool()

--- a/lib/phoenicia/src/core/phoenicia.Ttf.scala
+++ b/lib/phoenicia/src/core/phoenicia.Ttf.scala
@@ -160,9 +160,10 @@ case class Ttf(data: Data):
     case class GlyphEncoding(platformId: Int, encodingId: Int, offset: Int):
       val formatId: Int = B16(data, offset).u16.int
 
+      private val mutex: Mutex = Mutex()
       private var formatMemo: Optional[Format] = Unset
 
-      def format: Format raises FontError = synchronized:
+      def format: Format raises FontError = mutex:
         formatMemo.or:
           val format = formatId match
             case 0 =>

--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -93,15 +93,16 @@ class Report(using Environment)(using palette: TestPalette):
   def passed: Boolean = failure.absent && pass
 
   class TestsMap():
+    private val mutex: Mutex = Mutex()
     private var tests: ListMap[TestId, ReportLine] = ListMap()
 
-    def list: List[(TestId, ReportLine)] = synchronized(tests.to(List))
-    def apply(testId: TestId): ReportLine = synchronized(tests(testId))
+    def list: List[(TestId, ReportLine)] = mutex(tests.to(List))
+    def apply(testId: TestId): ReportLine = mutex(tests(testId))
 
-    def update(testId: TestId, reportLine: ReportLine) = synchronized:
+    def update(testId: TestId, reportLine: ReportLine) = mutex:
       tests = tests.updated(testId, reportLine)
 
-    def getOrElseUpdate(testId: TestId, reportLine: => ReportLine): ReportLine = synchronized:
+    def getOrElseUpdate(testId: TestId, reportLine: => ReportLine): ReportLine = mutex:
       if !tests.has(testId) then tests = tests.updated(testId, reportLine)
       tests(testId)
 

--- a/lib/probably/src/core/probably.Runner.scala
+++ b/lib/probably/src/core/probably.Runner.scala
@@ -49,6 +49,7 @@ object Runner:
   private[probably] val harnessThreadLocal: ThreadLocal[Option[Harness]] = ThreadLocal()
 
 class Runner[report]()(using reporter: Reporter[report]) extends Findable:
+  private val mutex: Mutex = Mutex()
   private var active: List[TestId] = Nil
   private val silent: Boolean = Ci.claudeCode || Ci()
 
@@ -69,7 +70,7 @@ class Runner[report]()(using reporter: Reporter[report]) extends Findable:
 
 
   def run[result](test: Test[result]): Trial[result] =
-    synchronized:
+    mutex:
       val size = active.size
       active ::= test.id
       redraw(size)
@@ -84,7 +85,7 @@ class Runner[report]()(using reporter: Reporter[report]) extends Findable:
       val ns: Long = System.nanoTime - ns0
 
       Trial.Returns(result, ns, context.captured.to(Map)).also:
-        synchronized:
+        mutex:
           val size = active.size
           active = active.filter(_ != test.id)
           redraw(size)
@@ -97,7 +98,7 @@ class Runner[report]()(using reporter: Reporter[report]) extends Findable:
         throw error
 
       Trial.Throws(lazyException, ns, context.captured.to(Map)).also:
-        synchronized:
+        mutex:
           val size = active.size
           active = active.filter(_ != test.id)
           redraw(size)
@@ -107,7 +108,7 @@ class Runner[report]()(using reporter: Reporter[report]) extends Findable:
 
   def suite(suite: Testable, block: Testable ?=> Unit): Unit =
     if !skip(suite.id) then
-      synchronized:
+      mutex:
         val size = active.size
         active ::= suite.id
         redraw(size)
@@ -115,12 +116,12 @@ class Runner[report]()(using reporter: Reporter[report]) extends Findable:
       reporter.declare(report, suite)
       block(using suite)
 
-      synchronized:
+      mutex:
         val size = active.size
         active = active.filter(_ != suite.id)
         redraw(size)
 
-  def terminate(error: Throwable): Unit = synchronized:
+  def terminate(error: Throwable): Unit = mutex:
     reporter.fail(report, error, active.to(Set))
     reporter.complete(report)
 

--- a/lib/rudiments/src/core/rudiments.Loop.scala
+++ b/lib/rudiments/src/core/rudiments.Loop.scala
@@ -37,13 +37,14 @@ object Loop:
     case Active, Stopping, Finished
 
 class Loop(iteration: () => Unit):
+  private val mutex: Mutex = Mutex()
   private var state: Loop.State = Loop.State.Active
 
-  def stop(): Unit = synchronized:
+  def stop(): Unit = mutex:
     if state == Loop.State.Active then state = Loop.State.Stopping
 
   def run(): Unit =
     while state == Loop.State.Active do iteration()
 
-    synchronized:
+    mutex:
       state = Loop.State.Finished

--- a/lib/rudiments/src/core/rudiments.Mutex.scala
+++ b/lib/rudiments/src/core/rudiments.Mutex.scala
@@ -30,14 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package rudiments
 
-export
-  rudiments
-  . { !!, &, all, also, and, annex, at, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,
-      DecimalConverter, Defaulting, Defaulting2, Digit, each, establish, Exit, fixpoint, fuse, gib,
-      give, has, immutable, Indexable, indexBy, intercalate, javaInputStream, kib, longestTrain,
-      Loop, loop, matchable, mean, mib, mutable, Mutex, next, occupied, ordinal, pipe, place, plus,
-      prim, prior, probe, product, reflectClass, repeat, runs, runsBy, sec, segment, Segmentable,
-      sift, snapshot, state, std, sumBy, tap, ter, that, tib, to, total, tri, triple, tuple, twin,
-      typed, typeName, unit, unwind, upsert, variance, waive, weave, when, yet }
+import java.util.concurrent.locks as juclo
+
+class Mutex():
+  private val lock: juclo.ReentrantLock = juclo.ReentrantLock()
+
+  inline def apply[result](inline block: => result): result =
+    lock.lock()
+    try block finally lock.unlock()

--- a/lib/surveillance/src/core/surveillance.Watch.scala
+++ b/lib/surveillance/src/core/surveillance.Watch.scala
@@ -54,10 +54,12 @@ object Watch:
 
     val async: Optional[Task[Unit]] = safely(supervise(task("surveillance".tt)(pollLoop.run())))
 
+  private val serviceMutex: Mutex = Mutex()
+  private val watchesMutex: Mutex = Mutex()
   private var serviceValue: Optional[WatchService] = Unset
 
   private def service: WatchService = serviceValue.or:
-    synchronized:
+    serviceMutex:
       jnf.FileSystems.getDefault.nn.newWatchService().nn.pipe: watchService =>
         WatchService(watchService, pollLoop(watchService)).tap: service =>
           serviceValue = service
@@ -71,7 +73,7 @@ object Watch:
     service.take().nn match
       case key: jnf.WatchKey =>
         key.pollEvents().nn.iterator.nn.asScala.each: event =>
-          watches.synchronized(watches(key)).each(_.put(event))
+          watchesMutex(watches(key)).each(_.put(event))
 
         key.reset()
 
@@ -90,6 +92,7 @@ object Watch:
       . to(Map)
 
 class Watch():
+  private val mutex: Mutex = Mutex()
   private val spool: Spool[WatchEvent] = Spool()
   private val watches: scm.HashSet[PathWatch] = scm.HashSet[PathWatch]()
 
@@ -134,13 +137,13 @@ class Watch():
           path.register(Watch.service.watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE).nn
 
         new PathWatch(key, path, spool, filter).tap: watch =>
-          Watch.watches.synchronized:
+          Watch.watchesMutex:
             Watch.watches(key) = Watch.watches.at(key).or(Set()) + watch
 
-    synchronized(watches ++= watches2)
+    mutex(watches ++= watches2)
 
   def unregister(): Unit =
-    Watch.watches.synchronized:
+    Watch.watchesMutex:
       watches.each: watch =>
         Watch.watches(watch.key) = Watch.watches.at(watch.key).or(Set()) - watch
 
@@ -148,7 +151,7 @@ class Watch():
           watch.key.cancel()
           Watch.watches.remove(watch.key)
 
-        if Watch.watches.nil then synchronized:
+        if Watch.watches.nil then mutex:
           Watch.serviceValue.let: service =>
             service.stop()
             Watch.serviceValue = Unset

--- a/lib/turbulence/src/core/turbulence.Err.scala
+++ b/lib/turbulence/src/core/turbulence.Err.scala
@@ -36,6 +36,8 @@ import anticipation.*
 import rudiments.*
 
 object Err:
+  private val mutex: Mutex = Mutex()
+
   def write(bytes: Data)(using stdio: Stdio): Unit = stdio.writeErr(bytes)
 
   def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio): Unit =
@@ -43,7 +45,7 @@ object Err:
 
   def println[textual: Printable](lines: Termcap ?=> textual*)(using stdio: Stdio): Unit =
     lines.map(_(using stdio.termcap)).pipe: lines =>
-      stdio.err.synchronized:
+      mutex:
         lines.foreach: line =>
           print(line)
           println()

--- a/lib/turbulence/src/core/turbulence.Out.scala
+++ b/lib/turbulence/src/core/turbulence.Out.scala
@@ -36,6 +36,8 @@ import anticipation.*
 import rudiments.*
 
 object Out:
+  private val mutex: Mutex = Mutex()
+
   def write(bytes: Data)(using stdio: Stdio): Unit = stdio.write(bytes)
 
   def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio): Unit =
@@ -45,7 +47,7 @@ object Out:
 
   def println[textual: Printable](lines: Termcap ?=> textual*)(using stdio: Stdio): Unit =
     lines.map(_(using stdio.termcap)).pipe: lines =>
-      stdio.out.synchronized:
+      mutex:
         lines.foreach: line =>
           print(line)
           println()


### PR DESCRIPTION
The fourteen `synchronized` call-sites in Soundness's libraries each used the JVM's intrinsic monitor to guard mutable state. Each has been replaced by a `Mutex` field whose `apply` method takes the protected block. `Mutex` is a thin new wrapper around `java.util.concurrent.locks.ReentrantLock` in `rudiments`, so the substitute lock provides the same mutual-exclusion and happens-before guarantees as `synchronized`, but no longer pins the carrier thread when run on a virtual thread and no longer relies on the intrinsic-monitor's biased-locking quirks.

### New: `rudiments.Mutex`

```scala
class Mutex():
  private val lock: ReentrantLock = ReentrantLock()

  inline def apply[result](inline block: => result): result =
    lock.lock()
    try block finally lock.unlock()
```

Use it where you would have used `synchronized` on a private monitor — `mutex:` is the brace-block call, identical to `synchronized:`:

```scala
class Foo:
  private val mutex: Mutex = Mutex()
  private var state = …

  def update() = mutex:
    state = …
```

### Migrated libraries

`rudiments.Loop`, `camouflage.Cache`, `anamnesis.Database`, `anthology.Scalac`, `obligatory.SseSource`, `phoenicia.Ttf`, `probably.Runner`, `probably.Report.TestsMap`, `surveillance.Watch`, `turbulence.Out`, `turbulence.Err`.

### Behavioural changes

- `camouflage.Cache.establish` used to synchronize on the `value` field, but the same block reassigns `value = Promise()` — meaning the lock target moved and two threads could enter the critical section concurrently. The dedicated `Mutex` field eliminates that race.
- `turbulence.Out.println` and `turbulence.Err.println` no longer share a monitor with the underlying `PrintStream`'s internal lock. Multi-line atomicity continues to hold between all Soundness writers (everything that goes through `Out`/`Err`), but a direct `System.out.println` from non-Soundness code could now interleave between Soundness-emitted lines.

### Library API changes

None. `Mutex` is a new public type in `rudiments`; existing public APIs are unchanged.