### PR TITLE
contingency: document compiler bug blocking raising→raises

### DIFF
--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -157,6 +157,16 @@ def abortive[error <: Error](using Quotes)[success]
 
 infix type raises [success, error <: Exception] = Tactic[error] ?=> success
 
+// `raising` cannot replace `raises` until a Scala 3 compiler bug is fixed: when this match type
+// appears in a method's return type and reduces to a context function, PostTyper attaches
+// `@ContextResultCount` (see `ContextFunctionResults.annotateContextResults`), but TASTy stores
+// the unreduced `AppliedType`. At a cross-module use site, erasure runs
+// `ContextFunctionResults.integrateContextResults` (lines ~70-78) whose `tp.dealias match` has
+// no default case. `dealias` does not reduce match types during erasure because
+// `TypeApplications.appliedTo` short-circuits with `if (args.isEmpty || ctx.erasedTypes) self`,
+// so the unreduced `AppliedType` falls through every case and crashes with a `MatchError`.
+// Fix candidates: give the match a default case, or use `tryNormalize`/`superTypeNormalized`
+// in place of `dealias`.
 infix type raising[success, errors] = errors match
   case EmptyTuple.type => success
   case left *: right   => Tactic[left] ?=> raising[success, right]


### PR DESCRIPTION
Adds a code comment alongside the `raising` match type explaining why it cannot currently be promoted to be the new definition of `raises`. The Scala 3.8.3 compiler crashes during erasure when a match type that reduces to a context function appears in a method's return type and is consumed cross-module; the comment cites the specific compiler internals involved so a future contributor (or an upstream patch) can pick up where this left off.

### Comment added near `raising`

```scala
// `raising` cannot replace `raises` until a Scala 3 compiler bug is fixed: when this match type
// appears in a method's return type and reduces to a context function, PostTyper attaches
// `@ContextResultCount` (see `ContextFunctionResults.annotateContextResults`), but TASTy stores
// the unreduced `AppliedType`. At a cross-module use site, erasure runs
// `ContextFunctionResults.integrateContextResults` (lines ~70-78) whose `tp.dealias match` has
// no default case. `dealias` does not reduce match types during erasure because
// `TypeApplications.appliedTo` short-circuits with `if (args.isEmpty || ctx.erasedTypes) self`,
// so the unreduced `AppliedType` falls through every case and crashes with a `MatchError`.
// Fix candidates: give the match a default case, or use `tryNormalize`/`superTypeNormalized`
// in place of `dealias`.
```

No runtime or API change; documentation-only.