### PR TITLE
gossamer/kaleidoscope: fix extract for multi-case partial functions

### DIFF
--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -39,6 +39,7 @@ import denominative.*
 import fulminate.*
 import gigantism.*
 import hieroglyph.*
+import kaleidoscope.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
@@ -206,3 +207,121 @@ object internal:
         case Nil          => expr
 
     recur(staticParts.tail.to(List), dynamicParts, staticParts.head)
+
+
+  def extractMacro[textual: Type, value: Type]
+    ( text:    Expr[textual],
+      start:   Expr[Ordinal],
+      lambda:  Expr[Scanner ?=> textual ~> value],
+      textual: Expr[textual is Textual] )
+    ( using Quotes )
+  :   Expr[Stream[value]] =
+
+    import quotes.reflect.*
+
+    def unwrap(term: Term): Term = term match
+      case Inlined(_, _, inner) => unwrap(inner)
+      case other                => other
+
+    val outer = unwrap(lambda.asTerm)
+
+    val decomposed: Option[(Symbol, List[CaseDef])] = outer match
+      case Block(List(DefDef(_, List(TermParamClause(List(scannerVal))), _, Some(body))), _) =>
+        val scannerSym = scannerVal.symbol
+
+        unwrap(body) match
+          case Block(List(DefDef(_, _, _, Some(Match(_, caseDefs)))), _) =>
+            Some((scannerSym, caseDefs))
+
+          case _ =>
+            None
+
+      case _ =>
+        None
+
+    decomposed match
+      case None =>
+        // Cannot decompose — fall back to a runtime driver that advances by matchEnd.
+        ' {
+            val input = $textual.text($text)
+
+            def step(from: Int): Stream[value] =
+              if from >= input.s.length then Stream() else
+                val scanner = Scanner(from)
+
+                $lambda(using scanner).lift($text) match
+                  case Some(head) =>
+                    head #:: step(scanner.matchEnd.or(input.s.length).max(from + 1))
+
+                  case _ =>
+                    Stream()
+
+            step($start.n0)
+          }
+
+      case Some((scannerSym, caseDefs)) =>
+        // Build one (Int, textual) => Option[(matchStart, matchEnd, value)] closure per case,
+        // substituting the outer scanner param with a fresh local in each.
+        val closures: List[Expr[(Int, textual) => Option[(Int, Int, value)]]] =
+          caseDefs.map: caseDef =>
+            '{ (from: Int, input: textual) =>
+                val scanner = Scanner(from)
+
+                $ {
+                    val scannerRef = 'scanner.asTerm
+                    val inputRef = 'input.asTerm
+
+                    object Subst extends TreeMap:
+                      override def transformTerm(tree: Term)(owner: Symbol): Term =
+                        tree match
+                          case Ident(_) if tree.symbol == scannerSym =>
+                            scannerRef
+
+                          case _ =>
+                            super.transformTerm(tree)(owner)
+
+                    val substituted = Subst.transformCaseDef(caseDef)(Symbol.spliceOwner)
+
+                    val rhsWrapped =
+                      ' {
+                          Some
+                            ( ( scanner.nextStart.or(Int.MaxValue),
+                                scanner.matchEnd.or(Int.MaxValue),
+                                ${substituted.rhs.asExprOf[value]} ) )
+                        }
+
+                      . asTerm
+
+                    val matchedCase = CaseDef(substituted.pattern, substituted.guard, rhsWrapped)
+                    val wildcard = CaseDef(Wildcard(), None, '{None}.asTerm)
+                    val matchTerm = Match(inputRef, List(matchedCase, wildcard))
+                    matchTerm.asExprOf[Option[(Int, Int, value)]]
+                  }
+              }
+
+        ' {
+            val input = $textual.text($text)
+            val length = input.s.length
+            val cases = ${Expr.ofList(closures)}
+
+            def step(from: Int): Stream[value] =
+              if from >= length then Stream() else
+                var best: Optional[(Int, Int, value)] = Unset
+                val it = cases.iterator
+
+                while it.hasNext do
+                  it.next()(from, $text) match
+                    case Some(candidate) =>
+                      best.let: existing =>
+                        if candidate(0) < existing(0) then best = candidate
+
+                      . or:
+                        best = candidate
+
+                    case _ =>
+
+                best.lay(Stream()): triple =>
+                  triple(2) #:: step(triple(1).max(from + 1))
+
+            step($start.n0)
+          }

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -200,16 +200,14 @@ extension [textual: Textual](text: textual)
   def search(regex: Regex, overlap: Boolean = false): Stream[textual] =
     regex.search(textual.text(text), overlap = overlap).map(text.segment(_))
 
-  def extract[value](start: Ordinal)(lambda: Scanner ?=> textual ~> value): Stream[value] =
+  inline def extract[value](inline start: Ordinal)
+    ( inline lambda: Scanner ?=> textual ~> value )
+  :   Stream[value] =
 
-    val input = textual.text(text)
-
-    if start.n0 >= input.s.length then Stream() else
-      val scanner = Scanner(start.n0)
-
-      lambda(using scanner).lift(text) match
-        case Some(head) => head #:: extract(scanner.nextStart.or(0).z)(lambda)
-        case _          => Stream()
+    $ {
+        gossamer.internal.extractMacro[textual, value]
+          ( 'text, 'start, 'lambda, '{compiletime.summonInline[textual is Textual]} )
+      }
 
   def seek(regex: Regex): Optional[textual] = regex.seek(textual.text(text)).let(text.segment(_))
 

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -200,7 +200,7 @@ extension [textual: Textual](text: textual)
   def search(regex: Regex, overlap: Boolean = false): Stream[textual] =
     regex.search(textual.text(text), overlap = overlap).map(text.segment(_))
 
-  inline def extract[value](inline start: Ordinal)
+  inline def extract[value](inline start: Ordinal = Prim)
     ( inline lambda: Scanner ?=> textual ~> value )
   :   Stream[value] =
 

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1147,3 +1147,80 @@ object Tests extends Suite(m"Gossamer Tests"):
       test(m"Writing combining accent doesn't double-count"):
         Writing(Text("café")).metrics // c, a, f, é (e+combining)
       . assert(_ == 4)
+
+    suite(m"Regex extract"):
+      test(m"single case with capture extracts all groups"):
+        t"a=1; b=22; c=333".extract(Prim):
+          case r"$key([a-z])=$value([0-9]+)" => (key, value)
+
+        . to(List)
+
+      . assert(_ == List((t"a", t"1"), (t"b", t"22"), (t"c", t"333")))
+
+      test(m"single case finds no matches"):
+        t"hello world".extract(Prim):
+          case r"$digit([0-9])" => digit
+
+        . to(List)
+
+      . assert(_ == Nil)
+
+      test(m"start past end of input is empty"):
+        t"hello".extract(100.z):
+          case r"$any(.)" => any
+
+        . to(List)
+
+      . assert(_ == Nil)
+
+      test(m"multi-case picks earliest match across cases"):
+        t"bar foo bar foo".extract(Prim):
+          case r"$f(foo)" => 1
+          case r"$b(bar)" => 2
+
+        . to(List)
+
+      . assert(_ == List(2, 1, 2, 1))
+
+      test(m"multi-case where one case never matches"):
+        t"abc 123 def 456".extract(Prim):
+          case r"$d([0-9]+)" => d.length
+          case r"$x(zzz)"    => -1
+
+        . to(List)
+
+      . assert(_ == List(3, 3))
+
+      test(m"multi-case returns interleaved results"):
+        t"a1b2c3".extract(Prim):
+          case r"$l([a-z])" => Right(l)
+          case r"$n([0-9])" => Left(n)
+
+        . to(List)
+
+      . assert(_ == List(Right(t"a"), Left(t"1"), Right(t"b"), Left(t"2"), Right(t"c"), Left(t"3")))
+
+      test(m"no-capture pattern advances past match end"):
+        t"foo foo foo".extract(Prim):
+          case r"foo" => 1
+
+        . to(List)
+
+      . assert(_ == List(1, 1, 1))
+
+      test(m"no-capture multi-case picks earliest match"):
+        t"bar foo bar foo".extract(Prim):
+          case r"foo" => 1
+          case r"bar" => 2
+
+        . to(List)
+
+      . assert(_ == List(2, 1, 2, 1))
+
+      test(m"empty input returns empty stream"):
+        t"".extract(Prim):
+          case r"$any(.)" => any
+
+        . to(List)
+
+      . assert(_ == Nil)

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1150,7 +1150,7 @@ object Tests extends Suite(m"Gossamer Tests"):
 
     suite(m"Regex extract"):
       test(m"single case with capture extracts all groups"):
-        t"a=1; b=22; c=333".extract(Prim):
+        t"a=1; b=22; c=333".extract():
           case r"$key([a-z])=$value([0-9]+)" => (key, value)
 
         . to(List)
@@ -1158,7 +1158,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == List((t"a", t"1"), (t"b", t"22"), (t"c", t"333")))
 
       test(m"single case finds no matches"):
-        t"hello world".extract(Prim):
+        t"hello world".extract():
           case r"$digit([0-9])" => digit
 
         . to(List)
@@ -1174,7 +1174,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == Nil)
 
       test(m"multi-case picks earliest match across cases"):
-        t"bar foo bar foo".extract(Prim):
+        t"bar foo bar foo".extract():
           case r"$f(foo)" => 1
           case r"$b(bar)" => 2
 
@@ -1183,7 +1183,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == List(2, 1, 2, 1))
 
       test(m"multi-case where one case never matches"):
-        t"abc 123 def 456".extract(Prim):
+        t"abc 123 def 456".extract():
           case r"$d([0-9]+)" => d.length
           case r"$x(zzz)"    => -1
 
@@ -1192,7 +1192,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == List(3, 3))
 
       test(m"multi-case returns interleaved results"):
-        t"a1b2c3".extract(Prim):
+        t"a1b2c3".extract():
           case r"$l([a-z])" => Right(l)
           case r"$n([0-9])" => Left(n)
 
@@ -1201,7 +1201,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == List(Right(t"a"), Left(t"1"), Right(t"b"), Left(t"2"), Right(t"c"), Left(t"3")))
 
       test(m"no-capture pattern advances past match end"):
-        t"foo foo foo".extract(Prim):
+        t"foo foo foo".extract():
           case r"foo" => 1
 
         . to(List)
@@ -1209,7 +1209,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == List(1, 1, 1))
 
       test(m"no-capture multi-case picks earliest match"):
-        t"bar foo bar foo".extract(Prim):
+        t"bar foo bar foo".extract():
           case r"foo" => 1
           case r"bar" => 2
 
@@ -1218,7 +1218,7 @@ object Tests extends Suite(m"Gossamer Tests"):
       . assert(_ == List(2, 1, 2, 1))
 
       test(m"empty input returns empty stream"):
-        t"".extract(Prim):
+        t"".extract():
           case r"$any(.)" => any
 
         . to(List)

--- a/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
@@ -400,4 +400,5 @@ case class Regex(pattern: Text, groups: List[Regex.Group]):
       case index: Int =>
         if !matcher.find(index) then None else
           scanner.nextStart = matcher.start + 1
+          scanner.matchEnd = matcher.end
           Some(IArray.from(recur(captureGroups, Nil, 0).reverse))

--- a/lib/kaleidoscope/src/core/kaleidoscope.Scanner.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Scanner.scala
@@ -38,4 +38,5 @@ import vacuous.*
 object Scanner:
   given default: (erased DummyImplicit) => Scanner = Scanner(Unset)
 
-class Scanner(var nextStart: Optional[Int] = Unset) extends Findable
+class Scanner(var nextStart: Optional[Int] = Unset, var matchEnd: Optional[Int] = Unset)
+extends Findable

--- a/lib/kaleidoscope/src/core/kaleidoscope.internal.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.internal.scala
@@ -94,7 +94,9 @@ object internal:
           val regex = Regex(List(pattern))(using Unsafe)
           val matcher = regex.javaPattern.matcher(scrutinee.s).nn
           val found = matcher.find(index)
-          if found then scanner.nextStart = matcher.start
+          if found then
+            scanner.nextStart = matcher.start + 1
+            scanner.matchEnd = matcher.end
           found
 
   class RExtractor[result](parts: Seq[String]):


### PR DESCRIPTION
`extract` previously walked the partial function once per stream position and returned whichever case appeared first in source order, so a later case could never match an earlier position in the input even when its pattern would have. It is now an inline macro that decomposes the partial function into per-case closures — each with its own fresh `Scanner` — and at each step picks the case whose pattern matches earliest in the input. The driver advances past `matcher.end` rather than from `matcher.start + 1`, which also fixes a latent infinite loop for no-capture patterns like `r"foo"`. The `start` argument now defaults to `Prim` so the common call shape is `text.extract():`.

### `extract` supports multi-case partial functions

Previously a multi-case `extract` always preferred the textually-first case, even when a later case would have matched earlier in the input. Results now appear in input order across all cases:

```scala
t"bar foo bar foo".extract():
  case r"$f(foo)" => 1
  case r"$b(bar)" => 2
. to(List)
// → List(2, 1, 2, 1)
```

### `extract`'s `start` defaults to `Prim`

The common case is to scan from the beginning, so the `start` argument now defaults to `Prim`. The two empty parens are still needed because the partial function lives in a second argument list:

```scala
// before
t"…".extract(Prim) { case … => … }
// now
t"…".extract() { case … => … }
```

### No-capture patterns no longer loop

`extract` with a no-capture pattern such as `case r"foo" => ...` used to spin forever (or OOM) because `NoExtraction.unapply` set `Scanner.nextStart = matcher.start`, so the driver re-found the same match indefinitely. Both extractors now set `nextStart = matcher.start + 1`.

### New `Scanner.matchEnd`

`Scanner` gains a `matchEnd: Optional[Int]` field, populated by both `NoExtraction.unapply` and `Regex.matchGroups` alongside `nextStart`. Drivers that want non-overlapping iteration can advance past `matchEnd` instead of overlapping from `nextStart`; the new `extract` macro uses this internally.