### PR TITLE
contingency: document inline-def limitation of whereas/mitigate

### DIFF
--- a/lib/contingency/src/core/contingency.whereas.scala
+++ b/lib/contingency/src/core/contingency.whereas.scala
@@ -65,7 +65,16 @@ class Whereas[lambda[_]](val handler: PartialFunction[Exception, Any])
 
 /** Capture a partial function describing how to handle errors. Returns a
  *  `Whereas` whose type lambda encodes the per-error `Tactic` parameters the
- *  body of a subsequent `.mitigate`/`.recover`/`.accrue` must accept. */
+ *  body of a subsequent `.mitigate`/`.recover`/`.accrue` must accept.
+ *
+ *  Note: this is a `transparent inline` whose declared return type
+ *  `Whereas[?]` is refined to a precise `Whereas[lambda]` by the macro, and
+ *  the `.mitigate`/`.recover`/`.accrue` extension methods depend on that
+ *  refinement to bind `lambda`. An enclosing `inline def` is expanded before
+ *  this refinement happens, so `whereas { … }.mitigate { … }` (and the
+ *  `.recover` / `.accrue` siblings) cannot appear directly in the body of an
+ *  `inline def`. Extract the call into a regular (non-inline) helper method.
+ *  See issue propensive/soundness#534. */
 transparent inline def whereas(inline handler: PartialFunction[Exception, Any])
 :   Whereas[?] =
   ${ contingency.internal.whereas('handler) }

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -146,6 +146,39 @@ object Tests extends Suite(m"Contingency"):
               "clean"
       . assert(_ == "clean")
 
+      test(m"whereas.recover inside `inline def` fails to compile (see #534)"):
+        demilitarize:
+          inline def inlineRecover: String =
+            whereas:
+              case ErrorA(n) => s"recovered:$n"
+            . recover(failA(7))
+          inlineRecover
+      . assert(_.nonEmpty)
+
+      test(m"whereas.mitigate inside `inline def` fails to compile (see #534)"):
+        demilitarize:
+          inline def inlineMitigate: Int =
+            whereas:
+              case ErrorB(n) => n
+            . recover:
+                whereas:
+                  case ErrorA(n) => ErrorB(n + 100)
+                . mitigate:
+                    raise(ErrorA(5))
+                    0
+          inlineMitigate
+      . assert(_.nonEmpty)
+
+      test(m"whereas.recover works inside `inline def` via a non-inline helper"):
+        def helperRecover: String =
+          whereas:
+            case ErrorA(n) => s"recovered:$n"
+          . recover(failA(7))
+
+        inline def inlineRecover: String = helperRecover
+        inlineRecover
+      . assert(_ == "recovered:7")
+
     suite(m"raise / abort / raises type"):
       test(m"Method with raises is callable under an in-scope Tactic"):
         whereas:

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -146,16 +146,16 @@ object Tests extends Suite(m"Contingency"):
               "clean"
       . assert(_ == "clean")
 
-      test(m"whereas.recover inside `inline def` fails to compile (see #534)"):
+      test(m"whereas.recover should compile inside `inline def` (see #534)"):
         demilitarize:
           inline def inlineRecover: String =
             whereas:
               case ErrorA(n) => s"recovered:$n"
             . recover(failA(7))
           inlineRecover
-      . assert(_.nonEmpty)
+      . aspire(_.isEmpty)
 
-      test(m"whereas.mitigate inside `inline def` fails to compile (see #534)"):
+      test(m"whereas.mitigate should compile inside `inline def` (see #534)"):
         demilitarize:
           inline def inlineMitigate: Int =
             whereas:
@@ -167,7 +167,7 @@ object Tests extends Suite(m"Contingency"):
                     raise(ErrorA(5))
                     0
           inlineMitigate
-      . assert(_.nonEmpty)
+      . aspire(_.isEmpty)
 
       test(m"whereas.recover works inside `inline def` via a non-inline helper"):
         def helperRecover: String =


### PR DESCRIPTION
Document the longstanding limitation that `whereas { … }.mitigate { … }` (and its `.recover` / `.accrue` siblings) cannot appear directly in the body of an enclosing `inline def`. The `whereas` macro is `transparent inline` and its precise return type is only known once the macro expands, but an outer `inline def` is expanded first, so the `mitigate` / `recover` / `accrue` extension method cannot bind its type parameter. Originally reported as #534 against the prior `mend`/`within` naming; the same root cause survives the rename. This PR amends the `whereas` docstring with the limitation and pins the current behaviour with `aspire`-style tests that will flip to passing if/when the underlying ordering issue is resolved.

### Workaround

If you need to call `whereas { … }.mitigate { … }` from an `inline def`, extract the call into a regular (non-inline) helper:

```scala
def handle: String =
  whereas:
    case ErrorA(n) => s"recovered:$n"
  . recover(failingOp())

inline def caller: String = handle
```