### PR TITLE
gossamer: add fuzzy method for closest-pattern dispatch

### DIFF
--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -325,3 +325,116 @@ object internal:
 
             step($start.n0)
           }
+
+
+  def fuzzyMacro[result: Type]
+    ( text:      Expr[Text],
+      threshold: Expr[Double],
+      cases:     Expr[Text ~> result],
+      proximity: Expr[Proximity { type Operand = Double }] )
+    ( using Quotes )
+  :   Expr[result] =
+
+    import quotes.reflect.*
+
+    def unwrap(term: Term): Term = term match
+      case Inlined(_, _, inner) => unwrap(inner)
+      case other                => other
+
+    val caseDefs: List[CaseDef] = unwrap(cases.asTerm) match
+      case Block(List(DefDef(_, _, _, Some(Match(_, cs)))), _) =>
+        cs
+
+      case _ =>
+        halt(m"fuzzy requires a partial-function literal")
+
+    def isWildcard(pattern: Tree): Boolean = pattern match
+      case Wildcard()          => true
+      case Bind(_, Wildcard()) => true
+      case _                   => false
+
+    // Find the first String literal anywhere in the pattern tree.
+    // Works for both `case "foo"` (Literal(StringConstant)) and `case t"foo"`
+    // (Unapply on a SimpleTExtractor built from the literal).
+    def findLiteral(tree: Tree): Option[String] =
+      var found: Option[String] = None
+
+      val finder = new TreeAccumulator[Unit]:
+        def foldTree(unit: Unit, t: Tree)(owner: Symbol): Unit =
+          if found.isDefined then () else t match
+            case Literal(StringConstant(s)) => found = Some(s)
+            case _                          => foldOverTree(unit, t)(owner)
+
+      finder.foldTree((), tree)(Symbol.spliceOwner)
+      found
+
+    val (nonWildcard, wildcard) =
+      if caseDefs.nonEmpty && isWildcard(caseDefs.last.pattern)
+      then (caseDefs.init, Some(caseDefs.last))
+      else (caseDefs, None)
+
+    nonWildcard.foreach: cd =>
+      if isWildcard(cd.pattern)
+      then halt(m"the wildcard case in a fuzzy match must be the last case")
+
+    val patternExprs: List[Expr[Text]] = nonWildcard.map: cd =>
+      findLiteral(cd.pattern) match
+        case Some(s) => '{Text(${Expr(s)})}
+        case None    => halt(m"fuzzy case patterns must be a string literal or `t\"…\"` literal")
+
+    val nonWildcardThunks: List[Expr[() => result]] = nonWildcard.map: cd =>
+      '{() => ${cd.rhs.asExprOf[result]}}
+
+    val wildcardThunk: Option[Expr[() => result]] = wildcard.map: cd =>
+      val matchTerm = Match(text.asTerm, List(cd))
+      '{() => ${matchTerm.asExprOf[result]}}
+
+    val patternsExpr = Expr.ofList(patternExprs)
+    val thunksExpr = Expr.ofList(nonWildcardThunks)
+
+    wildcardThunk match
+      case Some(wcThunk) =>
+        ' {
+            val scrutinee = $text
+            val limit = $threshold
+            val measure = $proximity
+            val patterns = $patternsExpr
+            val thunks = $thunksExpr
+            var bestIdx = -1
+            var bestDist = Double.PositiveInfinity
+            var i = 0
+
+            while i < patterns.length && bestDist > 0.0 do
+              val d = measure.distance(scrutinee, patterns(i))
+
+              if d <= limit && d < bestDist then
+                bestDist = d
+                bestIdx = i
+
+              i += 1
+
+            if bestIdx >= 0 then thunks(bestIdx)() else $wcThunk()
+          }
+
+      case None =>
+        ' {
+            val scrutinee = $text
+            val limit = $threshold
+            val measure = $proximity
+            val patterns = $patternsExpr
+            val thunks = $thunksExpr
+            var bestIdx = -1
+            var bestDist = Double.PositiveInfinity
+            var i = 0
+
+            while i < patterns.length && bestDist > 0.0 do
+              val d = measure.distance(scrutinee, patterns(i))
+
+              if d <= limit && d < bestDist then
+                bestDist = d
+                bestIdx = i
+
+              i += 1
+
+            if bestIdx >= 0 then thunks(bestIdx)() else throw new MatchError(scrutinee)
+          }

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -504,6 +504,19 @@ extension (text: Text)
   inline def data(using encoder: CharEncoder): IArray[Byte] = encoder.encode(text)
   inline def sysData: IArray[Byte] = CharEncoder.system.encode(text)
 
+  inline def fuzzy[result]
+    ( inline threshold: Double = Double.PositiveInfinity )
+    ( inline cases: Text ~> result )
+  :   result =
+
+    $ {
+        gossamer.internal.fuzzyMacro[result]
+          ( 'text,
+            'threshold,
+            'cases,
+            '{compiletime.summonInline[Proximity { type Operand = Double }]} )
+      }
+
   def proximity(other: Text)(using proximity: Proximity): proximity.Operand =
     proximity.distance(text, other)
 

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -465,7 +465,9 @@ package proximities:
 
 
   given normalizedLevenshteinDistance: CaseSensitivity => Proximity by Double =
-    (left, right) => levenshteinDistance.distance(left, right)/left.length.max(right.length)
+    (left, right) =>
+      val span = left.length.max(right.length)
+      if span == 0 then 0.0 else levenshteinDistance.distance(left, right).toDouble/span
 
 extension (text: Text)
   inline def has(substring: Text): Boolean = text.contains(substring)

--- a/lib/gossamer/src/core/soundness_gossamer_core.scala
+++ b/lib/gossamer/src/core/soundness_gossamer_core.scala
@@ -36,8 +36,8 @@ export
   gossamer
   . { add, after, append, appendln, Ascii, ascii, AsciiBuilder, before, Bidi, blank, BoundsError,
       broken, build, Builder, builder, camel, capitalize, CaseSensitivity, center, chars, contains,
-      count, cut, Cuttable, data, Decimalizer, Dictionary, ends, erase, fill, fit, from, Grapheme,
-      init, join, Joinable, kebab, keep, length, Lexicon, lines, lower,
+      count, cut, Cuttable, data, Decimalizer, Dictionary, ends, erase, extract, fill, fit, from,
+      fuzzy, Grapheme, init, join, Joinable, kebab, keep, length, Lexicon, lines, lower,
       Ltr, Numerous, ossify, pad, pascal, plain, Proximity, proximity, Pue, pue, punycode,
       RangeError, reverse, Rtl, search, seek, SimpleTExtractor, skip, slices, snake, snip, spaced,
       starts, strip, sub, subscripts, superscripts, sysData, t, tail, text, TextBuilder, Textual,

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -1224,3 +1224,102 @@ object Tests extends Suite(m"Gossamer Tests"):
         . to(List)
 
       . assert(_ == Nil)
+
+    suite(m"Fuzzy match"):
+      import proximities.normalizedLevenshteinDistance
+
+      test(m"exact match returns that case's RHS"):
+        t"hello".fuzzy():
+          case "hello" => 1
+          case "world" => 2
+
+      . assert(_ == 1)
+
+      test(m"typo picks the nearest pattern"):
+        t"hlelo".fuzzy():
+          case t"hello"   => 1
+          case t"bonjour" => 2
+
+      . assert(_ == 1)
+
+      test(m"mixed String and Text literal patterns"):
+        t"world".fuzzy():
+          case "hello"  => 1
+          case t"world" => 2
+
+      . assert(_ == 2)
+
+      test(m"tie goes to the earlier source-order case"):
+        t"abc".fuzzy():
+          case "abd" => 1
+          case "abe" => 2
+
+      . assert(_ == 1)
+
+      test(m"single-case PF returns that case's RHS"):
+        t"anything".fuzzy():
+          case "only-option" => 42
+
+      . assert(_ == 42)
+
+      test(m"match within threshold returns that case's RHS"):
+        t"hlelo".fuzzy(0.5):
+          case t"hello"   => 1
+          case t"bonjour" => 2
+          case _          => 0
+
+      . assert(_ == 1)
+
+      test(m"all distances above threshold returns wildcard"):
+        t"xyzxyz".fuzzy(0.3):
+          case t"hello"   => 1
+          case t"bonjour" => 2
+          case _          => -1
+
+      . assert(_ == -1)
+
+      test(m"all above threshold without wildcard throws MatchError"):
+        try
+          t"xyzxyz".fuzzy(0.3):
+            case t"hello"   => 1
+            case t"bonjour" => 2
+          false
+        catch case _: MatchError => true
+
+      . assert(_ == true)
+
+      test(m"wildcard binds the scrutinee"):
+        t"unknown".fuzzy(0.1):
+          case t"hello"     => t"english"
+          case t"bonjour"   => t"french"
+          case other        => other
+
+      . assert(_ == t"unknown")
+
+      test(m"multiple cases within threshold — closest wins"):
+        t"hlelo".fuzzy(0.5):
+          case t"hello" => 1
+          case t"helxo" => 2
+          case _        => 0
+
+      . assert(_ == 1)
+
+    suite(m"Fuzzy compile errors"):
+      test(m"unsupported pattern shape errors"):
+        demilitarize:
+          t"hello".fuzzy():
+            case r"foo" => 1
+
+        . map(_.message)
+
+      . assert(!_.nil)
+
+      test(m"mid-list wildcard errors"):
+        demilitarize:
+          t"hello".fuzzy():
+            case _      => 0
+            case "good" => 1
+
+        . map(_.message)
+
+      . assert(!_.nil)


### PR DESCRIPTION
`text.fuzzy()` is a macro-driven match-like construct that dispatches to the case whose literal pattern has the smallest `Proximity` distance to the scrutinee. Cases use `case "foo"` or `case t"foo"`; the macro lifts each pattern's text at compile time, computes distances at runtime, and picks the closest case under a user-supplied `Double` threshold (default `Double.PositiveInfinity` — pick the closest unconditionally). A wildcard case is optional; without one, a scrutinee outside the threshold throws `MatchError` exactly as a normal `match` would. While adding this, a latent integer-division bug in `normalizedLevenshteinDistance` is also fixed so it actually returns fractional distances.

### `text.fuzzy()` — closest-pattern dispatch

A new `fuzzy` extension on `Text` matches a scrutinee against case patterns by closest `Proximity` distance and returns the winning case's RHS:

```scala
import gossamer.*, proximities.normalizedLevenshteinDistance, caseSensitivity.sensitive

t"hlelo".fuzzy():
  case t"hello"   => "en"
  case t"bonjour" => "fr"
  case t"hola"    => "es"
// → "en"
```

Pass a `Double` threshold to limit which cases are considered:

```scala
t"xyzxyz".fuzzy(0.3):
  case t"hello"   => "en"
  case t"bonjour" => "fr"
  case _          => "unknown"
// → "unknown"
```

The threshold defaults to `Double.PositiveInfinity`, so the no-arg form `fuzzy()` always picks the closest case. A wildcard case is optional; without one, a scrutinee outside the threshold raises `MatchError` like an ordinary `match`. Ties go to the earlier source-order case, and an exact match short-circuits the scan.

Case patterns must be `case "string-literal"` or `case t"text-literal"`; other shapes (regex extractors, binds, type tests) are rejected at compile time.

### `normalizedLevenshteinDistance` returns fractional distances

The given instance used integer division (`Int / Int`), silently truncating every distance to `0.0` unless it equalled the longer string's length. It now casts to `Double` before dividing and guards against division by zero when both inputs are empty.