### PR TITLE
octogenarian: git notes API + GitRefs Serpentine path scheme

### DIFF
--- a/lib/octogenarian/src/core/octogenarian.GitError.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitError.scala
@@ -60,6 +60,8 @@ object GitError:
     case RemoteFailed       extends Reason(22)
     case CheckoutFailed     extends Reason(23)
     case PushFailed         extends Reason(24)
+    case NotesFailed        extends Reason(25)
+    case NoteNotFound       extends Reason(26)
 
   import Reason.*
 
@@ -88,6 +90,8 @@ object GitError:
     case RemoteFailed       => m"the remote operation failed"
     case CheckoutFailed     => m"the checkout could not be completed"
     case PushFailed         => m"the push operation failed"
+    case NotesFailed        => m"the notes operation failed"
+    case NoteNotFound       => m"no note was attached to the given object"
 
 case class GitError(reason: GitError.Reason)(using Diagnostics)
 extends Error(685, reason.number)

--- a/lib/octogenarian/src/core/octogenarian.GitRefs.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRefs.scala
@@ -34,65 +34,69 @@ package octogenarian
 
 import anticipation.*
 import contingency.*
-import denominative.*
-import distillate.*
 import gossamer.*
-import guillotine.*
-import kaleidoscope.*
 import prepositional.*
-import rudiments.*
-import spectacular.*
+import serpentine.*
 
-object internal:
-  opaque type Refspec = anticipation.Text
-  opaque type GitTag <: Refspec = anticipation.Text
-  opaque type GitBranch <: Refspec = anticipation.Text
-  opaque type GitHash <: Refspec = anticipation.Text
+// `GitRefs` is the Serpentine path scheme for Git references. Every fully-
+// qualified reference (`refs/heads/main`, `refs/notes/commits`, …) is rooted
+// at `refs/` and is slash-separated, so it maps cleanly onto a Serpentine
+// path. Component-level validation reproduces the rules `git check-ref-format`
+// enforces, expressed as an `Admissible` typeclass.
+object GitRefs extends Root(t"refs/"):
+  type Plane = GitRefs
 
-  object Refspec:
-    def head(n: Int = 0): Refspec = t"HEAD~$n"
+  // Construct a notes-namespace ref path of the form `refs/notes/<namespace>`.
+  // The namespace is validated against `git check-ref-format`'s per-segment
+  // rules; an invalid namespace raises `GitRefError`.
+  def notes(namespace: Text)(using Tactic[GitRefError]): Path on GitRefs =
+    validateSegment(namespace)
+    GitRefs / t"notes" / namespace
 
-    def unsafe(text: Text): Refspec = text
+  // Construct a branch ref path of the form `refs/heads/<branch>`.
+  def heads(branch: Text)(using Tactic[GitRefError]): Path on GitRefs =
+    validateSegment(branch)
+    GitRefs / t"heads" / branch
 
-    def parse(text: Text)(using Tactic[GitRefError]): Text =
-      def fail(reason: GitRefError.Reason): Text = abort(GitRefError(text, reason))
+  // Construct a tag ref path of the form `refs/tags/<tag>`.
+  def tags(tag: Text)(using Tactic[GitRefError]): Path on GitRefs =
+    validateSegment(tag)
+    GitRefs / t"tags" / tag
 
-      text.cut(t"/").each: part =>
-        if part.starts(t".") || part.ends(t".") then fail(GitRefError.Reason.LeadingOrTrailingDot)
-        if part.ends(t".lock")                  then fail(GitRefError.Reason.ReservedSuffix)
-        if part.contains(t"@{")                 then fail(GitRefError.Reason.ReservedSequence)
-        if part.contains(t"..")                 then fail(GitRefError.Reason.DoubleDot)
-        if part.length == 0                     then fail(GitRefError.Reason.EmptySegment)
+  // The default notes namespace used by `git notes` when no `--ref` is given.
+  val defaultNotes: Path on GitRefs = unsafely(GitRefs.notes(t"commits"))
 
-        for char <- List('*', '[', '\\', ' ', '^', '~', ':', '?')
-        do if part.contains(char) then fail(GitRefError.Reason.InvalidCharacter)
+  // Serpentine's `/` operator does not invoke an `Admissible`'s `check` at
+  // construction time, so the per-segment rules live here and are invoked
+  // explicitly from the typed constructors above.
+  def validateSegment(segment: Text)(using Tactic[GitRefError]): Unit =
+    def fail(reason: GitRefError.Reason) = abort(GitRefError(segment, reason))
+    if segment.length == 0     then fail(GitRefError.Reason.EmptySegment)
+    if segment.starts(t".")    then fail(GitRefError.Reason.LeadingOrTrailingDot)
+    if segment.ends(t".")      then fail(GitRefError.Reason.LeadingOrTrailingDot)
+    if segment.ends(t".lock")  then fail(GitRefError.Reason.ReservedSuffix)
+    if segment.contains(t"@{") then fail(GitRefError.Reason.ReservedSequence)
+    if segment.contains(t"..") then fail(GitRefError.Reason.DoubleDot)
 
-      text
+    for ch <- List('*', '[', '\\', ' ', '^', '~', ':', '?', '/')
+    do if segment.contains(ch) then fail(GitRefError.Reason.InvalidCharacter)
 
-    given encodable: Refspec is Encodable in Text = identity(_)
-    given parameterizable: Refspec is Parameterizable = identity(_)
-    given showable: Refspec is Showable = identity(_)
+  // The default `text is Admissible on filesystem` from Serpentine already
+  // satisfies the typeclass slot for any plane; the marker here is for the
+  // benefit of `summonFrom` in Path's `/` operator, which treats the absence
+  // of an `Admissible` as evidence that the result should be unplatformed.
+  given admissible: [text <: Text] => text is Admissible on GitRefs = _ => ()
 
-  object GitTag:
-    def unsafe(text: Text): GitTag = text
-    def apply(text: Text)(using Tactic[GitRefError]): GitTag = Refspec.parse(text)
+  given filesystem: GitRefs is Filesystem:
+    val name: Text = t"GitRefs"
+    val separator: Text = t"/"
+    val self: Text = t"@"
+    val parent: Text = t".."
 
-    given decoder: Tactic[GitRefError] => GitTag is Decodable in Text = apply(_)
-    given showable: GitTag is Showable = identity(_)
+  // A validated `Path on GitRefs` already satisfies every rule git enforces,
+  // so it is safe to expose it as an opaque `Refspec` for any operation that
+  // accepts one.
+  given pathIsRefspec: Conversion[Path on GitRefs, Refspec] =
+    path => Refspec.unsafe(path.encode)
 
-  object GitBranch:
-    def unsafe(text: Text): GitBranch = text
-    def apply(text: Text)(using Tactic[GitRefError]): GitBranch = Refspec.parse(text)
-
-    given decoder: Tactic[GitRefError] => GitBranch is Decodable in Text = apply(_)
-    given showable: GitBranch is Showable = identity(_)
-
-  object GitHash:
-    def apply(text: Text)(using Tactic[GitRefError]): GitHash = text match
-      case r"[a-f0-9]{40}" => text
-      case _               => abort(GitRefError(text, GitRefError.Reason.BadHash))
-
-    def unsafe(text: Text): GitHash = text
-
-    given decoder: Tactic[GitRefError] => GitHash is Decodable in Text = apply(_)
-    given showable: GitHash is Showable = identity(_)
+trait GitRefs

--- a/lib/octogenarian/src/core/octogenarian.GitRepo.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitRepo.scala
@@ -276,6 +276,90 @@ case class GitRepo(gitDir: Path on Linux):
     GitHash.unsafe(sh"$git $repoOptions rev-parse $refspec".exec[Text]().trim)
 
 
+  object notes:
+    def show(target: GitHash, ref: Path on GitRefs = GitRefs.defaultNotes)
+      ( using GitCommand, WorkingDirectory, Tactic[ExecError] )
+    :   Optional[Text] logs GitEvent =
+
+      val refArg = sh"--ref=${ref.encode}"
+
+      sh"$git $repoOptions notes $refArg show $target".exec[Exit]() match
+        case Exit.Ok =>
+          // `git notes show` appends a trailing newline to its output that is
+          // not part of the stored note; strip it to round-trip cleanly with
+          // bodies passed in to `add` / `append`.
+          val raw = sh"$git $repoOptions notes $refArg show $target".exec[Text]()
+          if raw.ends(t"\n") then raw.skip(1, Rtl) else raw
+
+        case _ =>
+          Unset
+
+
+    def add
+      ( target: GitHash, body: Text, force: Boolean = false,
+        ref:    Path on GitRefs = GitRefs.defaultNotes )
+      ( using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError] )
+    :   Unit logs GitEvent =
+
+      val refArg   = sh"--ref=${ref.encode}"
+      val forceOpt = if force then sh"-f" else sh""
+
+      sh"$git $repoOptions notes $refArg add $forceOpt -m $body $target".exec[Exit]() match
+        case Exit.Ok => ()
+        case _       => abort(GitError(NotesFailed))
+
+
+    def append
+      ( target: GitHash, body: Text, ref: Path on GitRefs = GitRefs.defaultNotes )
+      ( using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError] )
+    :   Unit logs GitEvent =
+
+      val refArg = sh"--ref=${ref.encode}"
+
+      sh"$git $repoOptions notes $refArg append -m $body $target".exec[Exit]() match
+        case Exit.Ok => ()
+        case _       => abort(GitError(NotesFailed))
+
+
+    def remove
+      ( target: GitHash, ignoreMissing: Boolean = false,
+        ref:    Path on GitRefs = GitRefs.defaultNotes )
+      ( using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError] )
+    :   Unit logs GitEvent =
+
+      val refArg     = sh"--ref=${ref.encode}"
+      val missingOpt = if ignoreMissing then sh"--ignore-missing" else sh""
+
+      sh"$git $repoOptions notes $refArg remove $missingOpt $target".exec[Exit]() match
+        case Exit.Ok => ()
+        case _       => abort(GitError(NotesFailed))
+
+
+    def list(ref: Path on GitRefs = GitRefs.defaultNotes)
+      ( using GitCommand, WorkingDirectory, Tactic[ExecError] )
+    :   Stream[(GitHash, GitHash)] logs GitEvent =
+
+      val refArg = sh"--ref=${ref.encode}"
+
+      sh"$git $repoOptions notes $refArg list".exec[Stream[Text]]().collect:
+        case r"$noteHash([a-f0-9]{40}) $target([a-f0-9]{40})" =>
+          (GitHash.unsafe(noteHash), GitHash.unsafe(target))
+
+
+    def copy
+      ( from: GitHash, to: GitHash, force: Boolean = false,
+        ref:  Path on GitRefs = GitRefs.defaultNotes )
+      ( using GitCommand, WorkingDirectory, Tactic[GitError], Tactic[ExecError] )
+    :   Unit logs GitEvent =
+
+      val refArg   = sh"--ref=${ref.encode}"
+      val forceOpt = if force then sh"-f" else sh""
+
+      sh"$git $repoOptions notes $refArg copy $forceOpt $from $to".exec[Exit]() match
+        case Exit.Ok => ()
+        case _       => abort(GitError(NotesFailed))
+
+
   // Lists every non-bare worktree attached to this object database.
   def worktrees()(using GitCommand, WorkingDirectory, Tactic[ExecError])
   :   List[Worktree] logs GitEvent raises GitError =

--- a/lib/octogenarian/src/core/octogenarian.Note.scala
+++ b/lib/octogenarian/src/core/octogenarian.Note.scala
@@ -30,13 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package octogenarian
 
-export
-  octogenarian
-  . { ChangeKind, Commit, FastForward, FileDiff, Git, GitBranch, GitCommand, GitError, GitEvent,
-      GitHash, GitPathStatus, GitProcess, GitRefError, GitRefs, GitRepo, GitStatus, GitTag, Hunk,
-      Note, Patch, Progress, ReflogEntry, Refspec, Remote, ResetMode, SshUrl, Worktree }
+import anticipation.*
+import prepositional.*
+import serpentine.*
 
-package gitCommands:
-  export octogenarian.gitCommands.environmentDefault
+case class Note(target: GitHash, body: Text, ref: Path on GitRefs)

--- a/lib/octogenarian/src/core/octogenarian.NoteRef.scala
+++ b/lib/octogenarian/src/core/octogenarian.NoteRef.scala
@@ -30,13 +30,42 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package octogenarian
 
-export
-  octogenarian
-  . { ChangeKind, Commit, FastForward, FileDiff, Git, GitBranch, GitCommand, GitError, GitEvent,
-      GitHash, GitPathStatus, GitProcess, GitRefError, GitRefs, GitRepo, GitStatus, GitTag, Hunk,
-      Note, NoteRef, Patch, Progress, ReflogEntry, Refspec, Remote, ResetMode, SshUrl, Worktree }
+import ambience.*
+import anticipation.*
+import contingency.*
+import distillate.*
+import guillotine.*
+import prepositional.*
+import serpentine.*
+import symbolism.*
 
-package gitCommands:
-  export octogenarian.gitCommands.environmentDefault
+import GitError.Reason.*
+
+// A `NoteRef` names a specific git note: the commit it is attached to, plus
+// the ref path (e.g. `refs/notes/ci-attestation`) it lives under. The repo
+// is supplied implicitly at `.read` time.
+//
+// Constructed via Symbolism's `/` operator: `commit / t"foo"` lifts a
+// `GitHash` into a `NoteRef` (given lives on `GitHash`'s companion in
+// `octogenarian.internal`), and further chaining (`noteRef / t"bar"`)
+// extends the namespace path via the given below.
+object NoteRef:
+  given continuation: Tactic[GitRefError]
+  =>  NoteRef is Divisible by Text to NoteRef =
+
+    Divisible: (noteRef, segment) =>
+      GitRefs.validateSegment(segment)
+      NoteRef(noteRef.target, noteRef.ref / segment)
+
+case class NoteRef(target: GitHash, ref: Path on GitRefs):
+  def read[value: Decodable in Text]
+    ( using repo:    GitRepo,
+            command: GitCommand,
+            wd:      WorkingDirectory,
+            errors:  Tactic[GitError],
+            exec:    Tactic[ExecError] )
+  :   value logs GitEvent =
+
+    repo.notes.show(target, ref).lest(GitError(NoteNotFound)).decode[value]

--- a/lib/octogenarian/src/core/octogenarian.NoteRef.scala
+++ b/lib/octogenarian/src/core/octogenarian.NoteRef.scala
@@ -51,6 +51,11 @@ import GitError.Reason.*
 // `GitHash` into a `NoteRef` (given lives on `GitHash`'s companion in
 // `octogenarian.internal`), and further chaining (`noteRef / t"bar"`)
 // extends the namespace path via the given below.
+//
+// NB: this currently uses a `Divisible` instance for the entry-point lift
+// rather than a Serpentine-style `Conversion[GitHash, Path]`, because
+// Symbolism's generic `/` extension shadows any Conversion at method-
+// resolution time.  Revisit when Serpentine grows a first-class lift.
 object NoteRef:
   given continuation: Tactic[GitRefError]
   =>  NoteRef is Divisible by Text to NoteRef =

--- a/lib/octogenarian/src/core/octogenarian.internal.scala
+++ b/lib/octogenarian/src/core/octogenarian.internal.scala
@@ -42,6 +42,7 @@ import kaleidoscope.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 
 object internal:
   opaque type Refspec = anticipation.Text
@@ -96,3 +97,13 @@ object internal:
 
     given decoder: Tactic[GitRefError] => GitHash is Decodable in Text = apply(_)
     given showable: GitHash is Showable = identity(_)
+
+    // `commit / t"namespace"` lifts a `GitHash` into a `NoteRef` at the
+    // ref path `refs/notes/<namespace>`. Lives here (rather than on
+    // `NoteRef`'s companion) so that Symbolism's `/` implicit search,
+    // which visits the dividend type's companion, can find it.
+    given noteRefDivisible: Tactic[GitRefError]
+    =>  GitHash is Divisible by Text to NoteRef =
+
+      Divisible: (commit, namespace) =>
+        NoteRef(commit, GitRefs.notes(namespace))

--- a/lib/octogenarian/src/core/soundness_octogenarian_core.scala
+++ b/lib/octogenarian/src/core/soundness_octogenarian_core.scala
@@ -35,8 +35,8 @@ package soundness
 export
   octogenarian
   . { ChangeKind, Commit, FastForward, FileDiff, Git, GitBranch, GitCommand, GitError, GitEvent,
-      GitHash, GitPathStatus, GitProcess, GitRefError, GitRepo, GitStatus, GitTag, Hunk, Patch,
-      Progress, ReflogEntry, Refspec, Remote, ResetMode, SshUrl, Worktree }
+      GitHash, GitPathStatus, GitProcess, GitRefError, GitRefs, GitRepo, GitStatus, GitTag, Hunk,
+      Patch, Progress, ReflogEntry, Refspec, Remote, ResetMode, SshUrl, Worktree }
 
 package gitCommands:
   export octogenarian.gitCommands.environmentDefault

--- a/lib/octogenarian/src/test/octogenarian_test.scala
+++ b/lib/octogenarian/src/test/octogenarian_test.scala
@@ -991,3 +991,191 @@ object Tests extends Suite(m"Octogenarian Tests"):
         val cloned = Git.clone(bareDir, targetPath).complete()
         cloned.repo.log().to(List).length
       .assert(_ == 1)
+
+    // ----- GitRefs (Serpentine ref paths) ---------------------------------
+
+    suite(m"GitRefs (Serpentine ref paths)"):
+
+      test(m"a branch ref path encodes as refs/heads/<name>"):
+        (GitRefs / t"heads" / t"main").encode
+      .assert(_ == t"refs/heads/main")
+
+      test(m"a notes ref path encodes as refs/notes/<namespace>"):
+        GitRefs.notes(t"ci-attestation").encode
+      .assert(_ == t"refs/notes/ci-attestation")
+
+      test(m"GitRefs.heads(name) matches manual construction"):
+        GitRefs.heads(t"main").encode
+      .assert(_ == t"refs/heads/main")
+
+      test(m"GitRefs.tags(name) encodes as refs/tags/<name>"):
+        GitRefs.tags(t"v1").encode
+      .assert(_ == t"refs/tags/v1")
+
+      test(m"the default notes ref is refs/notes/commits"):
+        GitRefs.defaultNotes.encode
+      .assert(_ == t"refs/notes/commits")
+
+      test(m"GitRefs.heads rejects a segment containing .."):
+        safely(GitRefs.heads(t"foo..bar")).let(_.encode)
+      .assert(_.absent)
+
+      test(m"GitRefs.heads rejects a segment ending in .lock"):
+        safely(GitRefs.heads(t"main.lock")).let(_.encode)
+      .assert(_.absent)
+
+      test(m"GitRefs.heads rejects a segment containing a space"):
+        safely(GitRefs.heads(t"two words")).let(_.encode)
+      .assert(_.absent)
+
+      test(m"GitRefs.heads rejects a segment containing a colon"):
+        safely(GitRefs.heads(t"a:b")).let(_.encode)
+      .assert(_.absent)
+
+      test(m"GitRefs.heads rejects an empty segment"):
+        safely(GitRefs.heads(t"")).let(_.encode)
+      .assert(_.absent)
+
+      test(m"GitRefs.notes rejects a segment containing @{"):
+        safely(GitRefs.notes(t"name@{0}")).let(_.encode)
+      .assert(_.absent)
+
+      test(m"a GitRefs path is usable as a Refspec via implicit conversion"):
+        val ref: Refspec = GitRefs.heads(t"main")
+        ref.show
+      .assert(_ == t"refs/heads/main")
+
+    // ----- git notes ------------------------------------------------------
+
+    suite(m"git notes"):
+
+      test(m"add then show a note in the default namespace"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"a note body")
+        worktree.repo.notes.show(hash)
+      .assert(_ == t"a note body")
+
+      test(m"show on a commit with no note returns Unset"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.show(hash)
+      .assert(_.absent)
+
+      test(m"add then show in a custom namespace"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        val ref  = GitRefs.notes(t"ci-attestation")
+        worktree.repo.notes.add(hash, t"signed envelope", ref = ref)
+        worktree.repo.notes.show(hash, ref = ref)
+      .assert(_ == t"signed envelope")
+
+      test(m"custom namespace and default namespace are independent"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"default note")
+        worktree.repo.notes.add(hash, t"custom note", ref = GitRefs.notes(t"alt"))
+        (worktree.repo.notes.show(hash), worktree.repo.notes.show(hash, GitRefs.notes(t"alt")))
+      .assert(_ == ((t"default note", t"custom note")))
+
+      test(m"add without force on an existing note aborts NotesFailed"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"first body")
+        capture[GitError](worktree.repo.notes.add(hash, t"second body")).reason
+      .assert(_ == GitError.Reason.NotesFailed)
+
+      test(m"add with force overwrites an existing note"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"first body")
+        worktree.repo.notes.add(hash, t"second body", force = true)
+        worktree.repo.notes.show(hash)
+      .assert(_ == t"second body")
+
+      test(m"append concatenates to an existing note"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"line one")
+        worktree.repo.notes.append(hash, t"line two")
+        val body = worktree.repo.notes.show(hash)
+        body.let(b => b.contains(t"line one") && b.contains(t"line two")).or(false)
+      .assert(_ == true)
+
+      test(m"remove deletes a note"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"a body")
+        worktree.repo.notes.remove(hash)
+        worktree.repo.notes.show(hash)
+      .assert(_.absent)
+
+      test(m"list on an empty namespace returns an empty stream"):
+        val worktree = freshWorktree()
+        commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.list().to(List)
+      .assert(_.isEmpty)
+
+      test(m"list yields one entry per annotated commit"):
+        val worktree = freshWorktree()
+        val first  = commitFile(worktree, t"a", t"a\n", t"first")
+        val second = commitFile(worktree, t"b", t"b\n", t"second")
+        worktree.repo.notes.add(first, t"note one")
+        worktree.repo.notes.add(second, t"note two")
+        worktree.repo.notes.list().to(List).map(_._2).to(Set) == Set(first, second)
+      .assert(_ == true)
+
+      test(m"copy duplicates a note onto another commit"):
+        val worktree = freshWorktree()
+        val first  = commitFile(worktree, t"a", t"a\n", t"first")
+        val second = commitFile(worktree, t"b", t"b\n", t"second")
+        worktree.repo.notes.add(first, t"shared body")
+        worktree.repo.notes.copy(first, second)
+        worktree.repo.notes.show(second)
+      .assert(_ == t"shared body")
+
+      test(m"a Path on GitRefs is usable as a Refspec for revParse"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"body", ref = GitRefs.notes(t"custom"))
+        // refs/notes/custom now exists; revParse via the path resolves to a hash.
+        val noteRefHash = worktree.repo.revParse(GitRefs.notes(t"custom"))
+        noteRefHash.show.length
+      .assert(_ == 40)
+
+    // ----- commit-rooted note access -------------------------------------
+
+    suite(m"commit-rooted note access"):
+
+      test(m"commit / namespace builds a NoteRef at refs/notes/<namespace>"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        (hash / t"foo").ref.encode
+      .assert(_ == t"refs/notes/foo")
+
+      test(m"chaining / extends the namespace path"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        (hash / t"foo" / t"bar").ref.encode
+      .assert(_ == t"refs/notes/foo/bar")
+
+      test(m"(commit / namespace).read[Text] returns the note body"):
+        val worktree = freshWorktree()
+        given GitRepo = worktree.repo
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        worktree.repo.notes.add(hash, t"hello", ref = GitRefs.notes(t"greeting"))
+        (hash / t"greeting").read[Text]
+      .assert(_ == t"hello")
+
+      test(m"read aborts NoteNotFound when no note exists"):
+        val worktree = freshWorktree()
+        given GitRepo = worktree.repo
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        capture[GitError]((hash / t"missing").read[Text]).reason
+      .assert(_ == GitError.Reason.NoteNotFound)
+
+      test(m"continuation / on NoteRef rejects an invalid segment"):
+        val worktree = freshWorktree()
+        val hash = commitFile(worktree, t"a", t"a\n", t"first")
+        safely(hash / t"foo" / t"bad..segment").let(_.ref.encode)
+      .assert(_.absent)


### PR DESCRIPTION
Adds first-class git notes support to Octogenarian, with all `git notes` subcommands (`show`, `add`, `append`, `remove`, `list`, `copy`) reachable through a typed namespace, plus a new `GitRefs` Serpentine path scheme that models any reference under `refs/` and a shorthand `commit / t"ns"` for note access on a commit.

## `GitRefs` — git references as Serpentine paths

`refs/heads/main`, `refs/notes/ci-attestation`, and any other ref now have a typed `Path on GitRefs` representation. Construct via the typed helpers, which validate each segment against `git check-ref-format`'s rules and raise `GitRefError` on failure; `Path on GitRefs` implicitly converts to `Refspec`, so the typed form fits anywhere the existing `Refspec` did:

```scala
val main:        Path on GitRefs = GitRefs.heads(t"main")
val ciAttest:    Path on GitRefs = GitRefs.notes(t"ci-attestation")
val release:     Path on GitRefs = GitRefs.tags(t"v1.0")
repo.revParse(release)         // Path on GitRefs flows in as Refspec
```

## `GitRepo.notes` — programmatic git notes

A nested `notes` namespace on `GitRepo` exposes `show`, `add`, `append`, `remove`, `list`, and `copy`. Each method takes a `ref: Path on GitRefs` (defaulting to `refs/notes/commits`), so the default namespace is ergonomic and custom namespaces like `refs/notes/ci-attestation` are first-class.

```scala
repo.notes.add(commitHash, t"a signed envelope", ref = GitRefs.notes(t"ci-attestation"))
val body: Optional[Text] = repo.notes.show(commitHash, ref = GitRefs.notes(t"ci-attestation"))
val entries: Stream[(GitHash, GitHash)] = repo.notes.list()
```

Multi-line bodies pass through as a single `-m` argument with no shell quoting issues; `show` strips git's trailing newline so bodies round-trip cleanly with `add`/`append`.

## `commit / t"ns"` — commit-rooted note access

`GitHash` divides by `Text` into a `NoteRef`, and a `NoteRef` itself divides further to nest the namespace:

```scala
import strategies.throwUnsafely
given GitRepo = repo
val envelope: Text = (commitHash / t"ci-attestation").read[Text]
val deeper:   Text = (commitHash / t"reviews" / t"alice").read[Text]
```

`.read[T]` decodes via `T is Decodable in Text` and aborts with `GitError(NoteNotFound)` when no note is attached.

## Notes on implementation

The `commit / t"ns"` lift currently goes through a Symbolism `Divisible` instance rather than the Serpentine-native `Conversion[GitHash, Path]` pattern, because Symbolism's generic `/` extension is selected before any implicit conversion can fire. A follow-up will revisit this on the Serpentine side.
