### PR TITLE
test: normalize test imports to use `import soundness.*`

### DIFF
--- a/lib/abacist/src/test/abacist_test.scala
+++ b/lib/abacist/src/test/abacist_test.scala
@@ -32,15 +32,7 @@
                                                                                                   */
 package abacist
 
-import anticipation.*
-import fulminate.*
-import gossamer.{t, Decimalizer}
-import larceny.*
-import probably.*
-import quantitative.*
-import rudiments.*
-import spectacular.*
-import symbolism.*
+import soundness.*
 
 given decimalizer: Decimalizer = Decimalizer(3)
 

--- a/lib/acyclicity/src/test/acyclicity_test.scala
+++ b/lib/acyclicity/src/test/acyclicity_test.scala
@@ -32,8 +32,7 @@
                                                                                                   */
 package acyclicity
 
-import fulminate.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Acyclicity Tests"):
   def run(): Unit =

--- a/lib/ambience/src/test/ambience_test.scala
+++ b/lib/ambience/src/test/ambience_test.scala
@@ -32,8 +32,7 @@
                                                                                                   */
 package ambience
 
-import fulminate.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Ambience Tests"):
   def run(): Unit =

--- a/lib/baroque/src/test/baroque_test.scala
+++ b/lib/baroque/src/test/baroque_test.scala
@@ -32,13 +32,7 @@
                                                                                                   */
 package baroque
 
-import abacist.*
-import fulminate.*
-import gossamer.*
-import probably.*
-import quantitative.*
-import spectacular.*
-import symbolism.*
+import soundness.*
 
 given Decimalizer = Decimalizer(3)
 

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -32,16 +32,9 @@
                                                                                                   */
 package caesura
 
-import anticipation.*
-import contingency.*, strategies.throwUnsafely
-import fulminate.*
-import gossamer.*
-import probably.*
-import proscenium.*
-import rudiments.*
-import spectacular.*
-import turbulence.*
+import soundness.*
 
+import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 
 given decimalizer: Decimalizer = Decimalizer(1)

--- a/lib/camouflage/src/test/camouflage_test.scala
+++ b/lib/camouflage/src/test/camouflage_test.scala
@@ -32,10 +32,7 @@
                                                                                                   */
 package camouflage
 
-import anticipation.*
-import fulminate.*
-import gossamer.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Camouflage tests"):
   def run(): Unit =

--- a/lib/cardinality/src/test/cardinality_test.scala
+++ b/lib/cardinality/src/test/cardinality_test.scala
@@ -32,9 +32,7 @@
                                                                                                   */
 package cardinality
 
-import fulminate.*
-import larceny.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Cardinality tests"):
   def run(): Unit =

--- a/lib/cardinality/src/test/cardinality_test.scala
+++ b/lib/cardinality/src/test/cardinality_test.scala
@@ -32,7 +32,9 @@
                                                                                                   */
 package cardinality
 
-import soundness.*
+import fulminate.*
+import larceny.*
+import probably.*
 
 object Tests extends Suite(m"Cardinality tests"):
   def run(): Unit =

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -32,8 +32,7 @@
                                                                                                   */
 package cataclysm
 
-import fulminate.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Cataclysm Tests"):
   def run(): Unit =

--- a/lib/cellulose/src/test/cellulose_test.scala
+++ b/lib/cellulose/src/test/cellulose_test.scala
@@ -32,28 +32,15 @@
                                                                                                   */
 package cellulose
 
-import anticipation.*
-import contingency.*
-import distillate.*
-import fulminate.*
-import gossamer.*
-import parasite.*, threading.virtual
-import prepositional.*
-import probably.*
-import proscenium.*
-import rudiments.*
-import spectacular.*
-import turbulence.*
-import vacuous.*
-import zephyrine.*
+import soundness.*
 
+import threading.virtual
 import errorDiagnostics.stackTraces
+import strategies.throwUnsafely
 
 import Codl.Issue.*
 
 import java.io as ji
-
-import strategies.throwUnsafely
 
 case class User(id: Int, email: Text, privilege: List[Privilege])
 case class Privilege(name: Text, grant: Boolean)

--- a/lib/charisma/src/test/charisma_test.scala
+++ b/lib/charisma/src/test/charisma_test.scala
@@ -32,8 +32,7 @@
                                                                                                   */
 package charisma
 
-import fulminate.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Charisma Tests"):
   def run(): Unit =

--- a/lib/contextual/src/test/contextual_test.scala
+++ b/lib/contextual/src/test/contextual_test.scala
@@ -32,8 +32,7 @@
                                                                                                   */
 package contextual
 
-import fulminate.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Contextual Tests"):
   def run(): Unit =

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -59,7 +59,7 @@ object Tests extends Suite(m"Decorum Tests"):
       . assert(_.contains("135"))
 
       test(m"Line longer than 100 columns is rejected"):
-        rules("val x = "+("a"*120)+"\n")
+        rules("val x = "+"a".repeat(120)+"\n")
       . assert(_.contains("230"))
 
       test(m"Odd indent is rejected"):

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -32,8 +32,7 @@
                                                                                                   */
 package decorum
 
-import fulminate.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Decorum Tests"):
   def stub(body: String): String =

--- a/lib/dissonance/src/test/dissonance_test.scala
+++ b/lib/dissonance/src/test/dissonance_test.scala
@@ -32,18 +32,10 @@
                                                                                                   */
 package dissonance
 
-import anticipation.*
-import contingency.*
-import denominative.*
-import fulminate.*
-import gossamer.*
-import probably.*
-import proscenium.*
-import turbulence.*
+import soundness.*
 
 import proximities.levenshteinDistance
 import caseSensitivity.sensitive
-
 import strategies.throwUnsafely
 
 object Tests extends Suite(m"Dissonance tests"):

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package embarcadero
 
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Embarcadero Tests"):
   def run(): Unit = ()

--- a/lib/fulminate/src/test/fulminate_test.scala
+++ b/lib/fulminate/src/test/fulminate_test.scala
@@ -32,9 +32,7 @@
                                                                                                   */
 package fulminate
 
-import gossamer.*
-import larceny.*
-import probably.*
+import soundness.*
 
 object Tests extends Suite(m"Fulminate Tests"):
   def run(): Unit =

--- a/lib/gesticulate/src/test/gesticulate_test.scala
+++ b/lib/gesticulate/src/test/gesticulate_test.scala
@@ -32,21 +32,9 @@
                                                                                                   */
 package gesticulate
 
-import anticipation.*
-import contingency.*
-import distillate.*
-import fulminate.*
-import gossamer.*
-import hieroglyph.*
-import probably.*
-import proscenium.*
-import rudiments.*
-import symbolism.*
-import turbulence.*
-import vacuous.*
+import soundness.*
 
 import charEncoders.utf8
-
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 

--- a/lib/guillotine/src/test/guillotine_test.scala
+++ b/lib/guillotine/src/test/guillotine_test.scala
@@ -32,25 +32,11 @@
                                                                                                   */
 package guillotine
 
-import ambience.*
-import ambience.workingDirectories.default
-import anticipation.*
-import anticipation.abstractables.durationIsAbstractable
-import contingency.*, strategies.throwUnsafely
-import distillate.*
-import fulminate.*
-import gossamer.*
-import nomenclature.*
-import parasite.*
-import prepositional.*
-import probably.*
-import proscenium.*
-import rudiments.*
-import serpentine.*
-import spectacular.*
-import turbulence.*
-import vacuous.*
+import soundness.*
 
+import workingDirectories.default
+import abstractables.durationIsAbstractable
+import strategies.throwUnsafely
 import errorDiagnostics.empty
 
 given silentExecEvent: ExecEvent is Loggable =

--- a/lib/inimitable/src/test/inimitable_test.scala
+++ b/lib/inimitable/src/test/inimitable_test.scala
@@ -32,13 +32,7 @@
                                                                                                   */
 package inimitable
 
-import anticipation.*
-import contingency.*
-import digression.*
-import fulminate.*
-import gossamer.*
-import larceny.*
-import probably.*
+import soundness.*
 
 import errorDiagnostics.stackTraces
 import autopsies.contrastExpectations

--- a/lib/jacinta/src/test/jacinta.ParserTests.scala
+++ b/lib/jacinta/src/test/jacinta.ParserTests.scala
@@ -32,25 +32,15 @@
                                                                                                   */
 package jacinta
 
-import ambience.*
-import anticipation.*, interfaces.paths.pathOnLinux
-import contingency.*, strategies.throwUnsafely
-import eucalyptus.*, logging.silent
-import fulminate.*
-import galilei.*
-import gossamer.*
-import hieroglyph.*, charEncoders.utf8
-import nomenclature.*
-import octogenarian.*, gitCommands.environmentDefault
-import prepositional.*
-import probably.*
-import proscenium.*
-import rudiments.*, workingDirectories.system
-import serpentine.*
-import turbulence.*
-import urticose.*, internetAccess.enabled
-import vacuous.*
-import zephyrine.*
+import soundness.*
+
+import interfaces.paths.pathOnLinux
+import strategies.throwUnsafely
+import logging.silent
+import charEncoders.utf8
+import gitCommands.environmentDefault
+import workingDirectories.system
+import internetAccess.enabled
 import errorDiagnostics.stackTraces
 
 import scala.compiletime.*

--- a/lib/jacinta/src/test/jacinta.RecordsExampleSchema.scala
+++ b/lib/jacinta/src/test/jacinta.RecordsExampleSchema.scala
@@ -16,12 +16,9 @@
 
 package jacinta
 
-import contingency.*
-import gossamer.*
-import hieroglyph.*, charEncoders.utf8
-import polyvinyl.*
-import turbulence.*
+import soundness.*
 
+import charEncoders.utf8
 import strategies.throwUnsafely
 
 object RecordsExampleSchema extends RecordSchema(t"""{

--- a/lib/jacinta/src/test/jacinta.RecordsTests.scala
+++ b/lib/jacinta/src/test/jacinta.RecordsTests.scala
@@ -16,17 +16,9 @@
 
 package jacinta
 
-import contingency.*
-import fulminate.*
-import gossamer.*
-import hieroglyph.*, charEncoders.utf8
-import kaleidoscope.*
-import polyvinyl.*
-import probably.*
-import turbulence.*
-import urticose.*
-import vacuous.*
+import soundness.*
 
+import charEncoders.utf8
 import errorDiagnostics.stackTraces
 import strategies.throwUnsafely
 

--- a/lib/metamorphose/src/test/metamorphose_test.scala
+++ b/lib/metamorphose/src/test/metamorphose_test.scala
@@ -32,12 +32,11 @@
                                                                                                   */
 package metamorphose
 
-import contingency.*, strategies.throwUnsafely
 import language.experimental.genericNumberLiterals
-import probably.*
-import fulminate.*
-import rudiments.*
 
+import soundness.*
+
+import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 
 object Tests extends Suite(m"Metamorphose tests"):

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -32,16 +32,8 @@
                                                                                                   */
 package mosquito
 
-import fulminate.*
-import gossamer.*
-import hieroglyph.*, textMetrics.uniform
-import larceny.*
-import probably.*
-import proscenium.*
-import quantitative.*
-import spectacular.*
-import symbolism.*
-import vacuous.*
+import soundness.*
+import textMetrics.uniform
 
 given Decimalizer(4)
 

--- a/lib/nomenclature/src/test/nomenclature_test.scala
+++ b/lib/nomenclature/src/test/nomenclature_test.scala
@@ -32,13 +32,10 @@
                                                                                                   */
 package nomenclature
 
-import contingency.*, strategies.throwUnsafely
-import fulminate.*, errorDiagnostics.stackTraces
-import gossamer.*
-import prepositional.*
-import probably.*
-import rudiments.*
-import spectacular.*
+import soundness.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
 
 sealed trait Id
 sealed trait Id2

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -35,18 +35,7 @@ package parasite
 import java.util.concurrent as juc
 import juc.atomic as juca
 
-import anticipation.*
-import contingency.*
-import denominative.*
-import digression.*
-import fulminate.*
-import gossamer.*
-import probably.*
-import proscenium.*
-import quantitative.*
-import rudiments.*
-import symbolism.*
-import vacuous.*
+import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.empty

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package parasite
 
+import java.lang as jl
 import java.util.concurrent as juc
 import juc.atomic as juca
 
@@ -751,12 +752,12 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Retry with fixed tenacity actually delays between attempts"):
           given tenacity: Tenacity = Tenacity.fixed(40.0*Milli(Second)).limit(3)
           val attempts = juca.AtomicInteger(0)
-          val start = System.currentTimeMillis
+          val start = jl.System.currentTimeMillis
           val result = capture[RetryError]:
             retry: (surrender, persevere) ?=>
               attempts.incrementAndGet()
               persevere()
-          val elapsed = System.currentTimeMillis - start
+          val elapsed = jl.System.currentTimeMillis - start
           (attempts.get(), elapsed >= 80L)
         . assert: (n, ok) =>
             n >= 3 && n <= 4 && ok
@@ -787,9 +788,9 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Await on pre-fulfilled promise returns immediately, no waiters"):
           val promise = Promise[Int]()
           promise.fulfill(99)
-          val before = System.currentTimeMillis
+          val before = jl.System.currentTimeMillis
           val result = promise.await()
-          val elapsed = System.currentTimeMillis - before
+          val elapsed = jl.System.currentTimeMillis - before
           (result, elapsed < 100L)
         . assert(_ == (99, true))
 
@@ -1053,9 +1054,9 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Snooze sleeps for approximately the given duration"):
           val gate = Promise[Long]()
           val task = async:
-            val start = System.currentTimeMillis
+            val start = jl.System.currentTimeMillis
             snooze(50.0*Milli(Second))
-            gate.fulfill(System.currentTimeMillis - start)
+            gate.fulfill(jl.System.currentTimeMillis - start)
           task.await()
           gate.apply().or(0L) >= 40L
         . assert(_ == true)
@@ -1063,9 +1064,9 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Delay sleeps for relative duration"):
           val gate = Promise[Long]()
           val task = async:
-            val start = System.currentTimeMillis
+            val start = jl.System.currentTimeMillis
             delay(50.0*Milli(Second))
-            gate.fulfill(System.currentTimeMillis - start)
+            gate.fulfill(jl.System.currentTimeMillis - start)
           task.await()
           gate.apply().or(0L) >= 40L
         . assert(_ == true)
@@ -1410,12 +1411,12 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Retry exponential delays grow"):
           given tenacity: Tenacity = Tenacity.exponential(10.0*Milli(Second), 2.0).limit(4)
           val attempts = juca.AtomicInteger(0)
-          val start = System.currentTimeMillis
+          val start = jl.System.currentTimeMillis
           val result = capture[RetryError]:
             retry: (surrender, persevere) ?=>
               attempts.incrementAndGet()
               persevere()
-          val elapsed = System.currentTimeMillis - start
+          val elapsed = jl.System.currentTimeMillis - start
           // 4 attempts: delays 0, 10, 20, 40 = 70ms total minimum
           (attempts.get(), elapsed >= 60L)
         . assert: (n, ok) =>

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -32,11 +32,7 @@
                                                                                                   */
 package spectacular
 
-import anticipation.*
-import fulminate.*
-import gossamer.*
-import probably.*
-import spectacular.*
+import soundness.*
 
 case class Person(name: Text, age: Int)
 

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -34,7 +34,13 @@ package stenography
 
 import language.experimental.pureFunctions
 
-import soundness.*
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import prepositional.*
+import probably.*
+import spectacular.*
+import symbolism.*
 
 object Tests extends Suite(m"Stenography Tests"):
   def run(): Unit =

--- a/lib/stenography/src/test/stenography_test.scala
+++ b/lib/stenography/src/test/stenography_test.scala
@@ -34,13 +34,7 @@ package stenography
 
 import language.experimental.pureFunctions
 
-import anticipation.*
-import fulminate.*
-import gossamer.*
-import prepositional.*
-import probably.*
-import spectacular.*
-import symbolism.*
+import soundness.*
 
 object Tests extends Suite(m"Stenography Tests"):
   def run(): Unit =

--- a/lib/synesthesia/src/test/synesthesia.TestMcpServer.scala
+++ b/lib/synesthesia/src/test/synesthesia.TestMcpServer.scala
@@ -38,7 +38,7 @@ object TestMcpServer extends McpServer():
   class Session() extends McpSession
   import Mcp.*
 
-  def initialize(): Session = Session()
+  def initialize(): Session = new Session()
 
   def name: Text = "Pyrus"
   def description: Text = "A simple server"

--- a/lib/synesthesia/src/test/synesthesia.TestMcpServer.scala
+++ b/lib/synesthesia/src/test/synesthesia.TestMcpServer.scala
@@ -32,12 +32,7 @@
                                                                                                   */
 package synesthesia
 
-import anticipation.*
-import honeycomb.*
-import gossamer.*
-import revolution.*
-import turbulence.*
-import vacuous.*
+import soundness.*
 
 object TestMcpServer extends McpServer():
   class Session() extends McpSession

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -32,18 +32,15 @@
                                                                                                   */
 package zeppelin
 
-import ambience.*, environments.virtualMachine, systems.virtualMachine
-import anticipation.*, interfaces.paths.javaIoFile
-import contingency.*, strategies.throwUnsafely
-import fulminate.*
-import gossamer.*
-import hieroglyph.*, charEncoders.utf8, charDecoders.utf8, textSanitizers.skip
-import imperial.*
-import probably.*
-import proscenium.*
-import rudiments.*
-import serpentine.*
-import turbulence.*
+import soundness.*
+
+import environments.virtualMachine
+import systems.virtualMachine
+import interfaces.paths.javaIoFile
+import strategies.throwUnsafely
+import charEncoders.utf8
+import charDecoders.utf8
+import textSanitizers.skip
 
 import java.io.File
 


### PR DESCRIPTION
## Summary

Replace wildcard imports of individual Soundness libraries (e.g. `import rudiments.*`, `import fulminate.*`) across 27 test files with a single `import soundness.*`. Subpackage selective imports (e.g. `strategies.throwUnsafely`, `errorDiagnostics.stackTraces`, `charEncoders.utf8`) are preserved — they continue to resolve through the corresponding `soundness.<subpkg>` re-exports.

Brings most remaining outliers in line with the majority of test files, which were already using `import soundness.*`.

Tweaks needed where the broader scope of `soundness.*` introduces shadowing:

- `decorum_test`: `"a" * 120` → `"a".repeat(120)` (`symbolism.*` shadows `StringOps.*(Int)`).
- `parasite_test`: alias `java.lang as jl` and use `jl.System.currentTimeMillis` (`soundness.System` from ambience shadows `java.lang.System`).
- `synesthesia.TestMcpServer`: `Session()` → `new Session()` (constructor proxy collides with a `Session` export in `package soundness`).

`cardinality_test` and `stenography_test` are intentionally left on the original module-by-module imports — they assert behaviours that depend on which symbols are _not_ in scope (cardinality's `*` must dispatch through its own arithmetic, not `symbolism.Multiplicable`; stenography's type-rendering tests assume path qualifiers that disappear under `soundness.*`).

## Release notes

No user-facing changes; test code only.