### PR TITLE
jacinta: refresh benchmark parser versions

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -907,9 +907,9 @@ object jacinta extends Library:
     def mvnDeps = Seq(
       mvn"org.typelevel::jawn-ast:1.6.0",
       mvn"io.circe::circe-parser:0.14.13",
-      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.30.7",
-      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-circe:2.30.7",
-      mvn"com.fasterxml.jackson.core:jackson-databind:2.18.2"
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.35.3",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-circe:2.35.3",
+      mvn"com.fasterxml.jackson.core:jackson-databind:2.21.3"
     )
 
 object kaleidoscope extends Library:


### PR DESCRIPTION
The Jacinta benchmark suite compares Merino against several third-party JSON parsers; this updates jsoniter-scala (2.30.7 → 2.35.3) and jackson-databind (2.18.2 → 2.21.3) to their latest Maven Central releases so the comparison reflects each library's current performance. jawn-ast (1.6.0) and circe-parser (0.14.13) were already on the latest versions.

No user-facing changes — only the benchmark module's `mvnDeps` were touched.