### PR TITLE
ethereal: log TTY mode changes in runner under ETHEREAL_DEBUG

### DIFF
--- a/lib/ethereal/src/runner/src/tty.rs
+++ b/lib/ethereal/src/runner/src/tty.rs
@@ -30,13 +30,20 @@ pub fn stdin_is_tty() -> bool {
 pub fn save_tty_state() -> TtyState {
     let mut termios: libc::termios = unsafe { std::mem::zeroed() };
     let is_tty = stdin_is_tty();
-    if is_tty {
-        unsafe {
-            if libc::tcgetattr(libc::STDIN_FILENO, &mut termios) == 0 {
-                return TtyState { termios: Some(termios), is_tty: true };
-            }
+    if !is_tty {
+        crate::debug!("tty: save_tty_state — stdin is not a tty, nothing to save");
+        return TtyState { termios: None, is_tty: false };
+    }
+    unsafe {
+        if libc::tcgetattr(libc::STDIN_FILENO, &mut termios) == 0 {
+            crate::debug!("tty: save_tty_state — saved termios");
+            return TtyState { termios: Some(termios), is_tty: true };
         }
     }
+    crate::debug!(
+        "tty: save_tty_state — tcgetattr failed: {}",
+        std::io::Error::last_os_error(),
+    );
     TtyState { termios: None, is_tty }
 }
 
@@ -61,10 +68,19 @@ pub fn save_tty_state() -> TtyState {
 
 #[cfg(unix)]
 pub fn set_raw_mode() {
-    if !stdin_is_tty() { return; }
+    if !stdin_is_tty() {
+        crate::debug!("tty: set_raw_mode skipped — stdin is not a tty");
+        return;
+    }
     unsafe {
         let mut t: libc::termios = std::mem::zeroed();
-        if libc::tcgetattr(libc::STDIN_FILENO, &mut t) != 0 { return; }
+        if libc::tcgetattr(libc::STDIN_FILENO, &mut t) != 0 {
+            crate::debug!(
+                "tty: set_raw_mode — tcgetattr failed: {}",
+                std::io::Error::last_os_error(),
+            );
+            return;
+        }
         // Equivalent to: intr undef -echo icanon raw opost (keep opost)
         t.c_lflag &= !(libc::ICANON | libc::ECHO | libc::IEXTEN | libc::ISIG);
         t.c_iflag &= !(libc::IXON | libc::ICRNL | libc::BRKINT | libc::INPCK | libc::ISTRIP);
@@ -74,7 +90,14 @@ pub fn set_raw_mode() {
         t.c_cc[libc::VTIME] = 0;
         // intr undef
         t.c_cc[libc::VINTR] = 0;
-        libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &t);
+        if libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &t) != 0 {
+            crate::debug!(
+                "tty: set_raw_mode — tcsetattr failed: {}",
+                std::io::Error::last_os_error(),
+            );
+        } else {
+            crate::debug!("tty: set_raw_mode — raw mode set");
+        }
     }
 }
 
@@ -91,35 +114,86 @@ pub fn set_raw_mode() {
         if windows_sys::Win32::System::Console::GetConsoleMode(h_in, &mut in_mode) != 0 {
             in_mode &= !(ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT);
             in_mode |= ENABLE_VIRTUAL_TERMINAL_INPUT;
-            SetConsoleMode(h_in, in_mode);
+            if SetConsoleMode(h_in, in_mode) == 0 {
+                crate::debug!(
+                    "tty: set_raw_mode — SetConsoleMode(stdin) failed: {}",
+                    std::io::Error::last_os_error(),
+                );
+            } else {
+                crate::debug!("tty: set_raw_mode — stdin raw mode set");
+            }
+        } else {
+            crate::debug!(
+                "tty: set_raw_mode — GetConsoleMode(stdin) failed: {}",
+                std::io::Error::last_os_error(),
+            );
         }
         let h_out = GetStdHandle(STD_OUTPUT_HANDLE);
         let mut out_mode: u32 = 0;
         if windows_sys::Win32::System::Console::GetConsoleMode(h_out, &mut out_mode) != 0 {
             out_mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-            SetConsoleMode(h_out, out_mode);
+            if SetConsoleMode(h_out, out_mode) == 0 {
+                crate::debug!(
+                    "tty: set_raw_mode — SetConsoleMode(stdout) failed: {}",
+                    std::io::Error::last_os_error(),
+                );
+            } else {
+                crate::debug!("tty: set_raw_mode — stdout vt processing enabled");
+            }
+        } else {
+            crate::debug!(
+                "tty: set_raw_mode — GetConsoleMode(stdout) failed: {}",
+                std::io::Error::last_os_error(),
+            );
         }
     }
 }
 
 #[cfg(unix)]
 pub fn restore_tty_state(state: &TtyState) {
-    if !state.is_tty { return; }
+    if !state.is_tty {
+        crate::debug!("tty: restore_tty_state — stdin is not a tty, nothing to restore");
+        return;
+    }
     if let Some(termios) = state.termios {
-        unsafe { libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &termios); }
+        unsafe {
+            if libc::tcsetattr(libc::STDIN_FILENO, libc::TCSANOW, &termios) != 0 {
+                crate::debug!(
+                    "tty: restore_tty_state — tcsetattr failed: {}",
+                    std::io::Error::last_os_error(),
+                );
+            } else {
+                crate::debug!("tty: restore_tty_state — termios restored");
+            }
+        }
+    } else {
+        crate::debug!("tty: restore_tty_state — no saved termios available");
     }
 }
 
 #[cfg(windows)]
 pub fn restore_tty_state(state: &TtyState) {
-    if !state.is_tty { return; }
+    if !state.is_tty {
+        crate::debug!("tty: restore_tty_state — stdin is not a tty, nothing to restore");
+        return;
+    }
     use windows_sys::Win32::System::Console::{GetStdHandle, SetConsoleMode, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
     unsafe {
         if let Some(mode) = state.stdin_mode {
-            SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), mode);
+            if SetConsoleMode(GetStdHandle(STD_INPUT_HANDLE), mode) == 0 {
+                crate::debug!(
+                    "tty: restore_tty_state — SetConsoleMode(stdin) failed: {}",
+                    std::io::Error::last_os_error(),
+                );
+            }
         }
         if let Some(mode) = state.stdout_mode {
-            SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), mode);
+            if SetConsoleMode(GetStdHandle(STD_OUTPUT_HANDLE), mode) == 0 {
+                crate::debug!(
+                    "tty: restore_tty_state — SetConsoleMode(stdout) failed: {}",
+                    std::io::Error::last_os_error(),
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Ethereal's Rust launcher now emits diagnostic traces for every TTY-mode change (`tcgetattr`, `tcsetattr`, `SetConsoleMode`, raw-mode set, save/restore) when `ETHEREAL_DEBUG=1` is set, making it possible to pinpoint why an interactive Soundness CLI's terminal might fail to enter raw mode (issue #1142).

When troubleshooting an interactive Soundness CLI whose terminal stays in cooked mode (`Ctrl-C` echoing `^C`, arrow keys printing `^[[D`/`^[[C` verbatim, backspace doing nothing), re-run the command with `ETHEREAL_DEBUG=1` and the launcher will print a line for every step of the TTY-mode handshake:

```
[eth +123] tty: save_tty_state — saved termios
[eth +124] tty: set_raw_mode — raw mode set
…
[eth +9876] tty: restore_tty_state — termios restored
```

A failure — `stdin` not being a TTY at all, `tcgetattr`/`tcsetattr` returning a non-zero rc, or a premature restore that re-cooks the terminal — now produces a definite trace line identifying which precondition failed, replacing what used to be silent fall-throughs. There is no runtime cost when `ETHEREAL_DEBUG` is unset.