### PR TITLE
punctuation: markdown serializer and terminal renderer

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1080,7 +1080,8 @@ object punctuation extends Library:
   object html extends Component(core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object ansi extends Component(core, harlequin.core):
+  object ansi extends Component(core, harlequin.core, harlequin.ansi, escapade.core,
+      polysyllabic.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, html, ansi, jacinta.core, telekinesis.core, sedentary.core, quantitative.units)

--- a/lib/punctuation/src/ansi/punctuation.MarkdownPalette.scala
+++ b/lib/punctuation/src/ansi/punctuation.MarkdownPalette.scala
@@ -1,0 +1,50 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+
+object MarkdownPalette:
+  given default: MarkdownPalette = MarkdownPalette()
+
+// Terminal colours for the markdown renderer. Each field is a 24-bit `Chroma`
+// (RGB packed into an `Int`); the values below are chosen to read well on
+// both light and dark backgrounds in a true-colour terminal.
+case class MarkdownPalette
+  ( heading:  Chroma = Chroma(0x82, 0xaa, 0xff),
+    link:     Chroma = Chroma(0x80, 0xcb, 0xc4),
+    code:     Chroma = Chroma(0xff, 0xcb, 0x6b),
+    codeBg:   Chroma = Chroma(0x2a, 0x2a, 0x2a),
+    quoteBar: Chroma = Chroma(0x82, 0xaa, 0xff),
+    rule:     Chroma = Chroma(0x60, 0x60, 0x60),
+    subdued:  Chroma = Chroma(0x80, 0x80, 0x80) )

--- a/lib/punctuation/src/ansi/punctuation.Renderer.scala
+++ b/lib/punctuation/src/ansi/punctuation.Renderer.scala
@@ -1,0 +1,351 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+import escapade.*
+import frontier.*
+import gossamer.*
+import polysyllabic.*
+import prepositional.*
+import rudiments.*
+import symbolism.*
+import vacuous.*
+
+// Renders a parsed `Markdown` document into an Escapade `Teletype`, suitable
+// for printing to a terminal. Inline elements (emphasis, strong, code, links,
+// images) gain styling and OSC 8 hyperlinks; blocks (headings, lists,
+// blockquotes, thematic breaks) gain Unicode glyphs; paragraphs are wrapped
+// to the given column width using Polysyllabic for end-of-line hyphenation;
+// code blocks are syntax-highlighted via `TeletypeFormattable` givens.
+object Renderer:
+
+  // U+2010 HYPHEN — the visible-but-not-soft variant used at wrap points.
+  private val Hyphen: Teletype = Teletype(t"‐")
+  private val Space: Teletype = Teletype(t" ")
+  private val Newline: Teletype = Teletype(t"\n")
+
+  def render
+    ( markdown: Markdown of Layout, width: Int )
+    ( using hyphenation: Hyphenation,
+            formattables: Every[TeletypeFormattable],
+            palette: MarkdownPalette )
+  :   Teletype =
+
+    val blocks = markdown.children.map(layoutLines(_, width)).filter(_.nonEmpty)
+    blocks.map(joinLines(_)).to(Seq).join(e"\n\n")
+
+  // -- inline ---------------------------------------------------------------
+
+  // Renders inline `Prose` to a `Teletype` with the appropriate styling.
+  // Softbreaks become a literal space (the wrap pass treats them as word
+  // boundaries); linebreaks become the sentinel '\n' so the wrap pass can
+  // split on them.
+  private def inlineProse(node: Prose)(using palette: MarkdownPalette): Teletype = node match
+    case Prose.Textual(text) =>
+      Teletype(text)
+
+    case Prose.Softbreak =>
+      Space
+
+    case Prose.Linebreak =>
+      Newline
+
+    case Prose.Code(code) =>
+      e"${Bg(palette.codeBg)}(${Fg(palette.code)}($code))"
+
+    case Prose.Emphasis(children*) =>
+      val inner = children.map(inlineProse(_)).to(Seq).join
+      e"$Italic($inner)"
+
+    case Prose.Strong(children*) =>
+      val inner = children.map(inlineProse(_)).to(Seq).join
+      e"$Bold($inner)"
+
+    case Prose.Link(destination, _, children*) =>
+      val inner = children.map(inlineProse(_)).to(Seq).join
+      val link = Hyperlink(destination)
+      e"$link(${Fg(palette.link)}($Underline($inner)))"
+
+    case Prose.Image(destination, title, children*) =>
+      val alt = children.map(plainTextOf(_)).to(Seq).join
+      val label = if alt.length == 0 then title.or(t"image") else alt
+      val link = Hyperlink(destination)
+      e"$link(${Fg(palette.subdued)}([$label]))"
+
+    case Prose.HtmlInline(html) =>
+      e"${Fg(palette.subdued)}($html)"
+
+
+  // For image alt-text and similar uses where we need the plain text inside
+  // an inline subtree without any markup.
+  private def plainTextOf(node: Prose): Text = node match
+    case Prose.Textual(text)                  => text
+    case Prose.Code(code)                     => code
+    case Prose.Softbreak                      => t" "
+    case Prose.Linebreak                      => t" "
+    case Prose.HtmlInline(_)                  => t""
+    case Prose.Emphasis(children*)            => children.map(plainTextOf(_)).to(Seq).join
+    case Prose.Strong(children*)              => children.map(plainTextOf(_)).to(Seq).join
+    case Prose.Link(_, _, children*)          => children.map(plainTextOf(_)).to(Seq).join
+    case Prose.Image(_, title, children*)     =>
+      val inner = children.map(plainTextOf(_)).to(Seq).join
+      if inner.length == 0 then title.or(t"") else inner
+
+
+  // -- block ---------------------------------------------------------------
+
+  // Render a single block to a non-empty list of physical lines. Lines do
+  // NOT carry trailing newlines; the outer driver joins them.
+  private def layoutLines
+    ( node: Layout, width: Int )
+    ( using hyphenation: Hyphenation,
+            formattables: Every[TeletypeFormattable],
+            palette: MarkdownPalette )
+  :   List[Teletype] = node match
+
+    case Layout.Heading(_, level, children*) =>
+      val text = children.map(inlineProse(_)).to(Seq).join
+      val styled = e"$Bold(${Fg(palette.heading)}($text))"
+      val wrapped = wrap(styled, width)
+
+      level match
+        case 1 =>
+          val rule = e"${Fg(palette.heading)}(${t"━"*width})"
+          wrapped :+ rule
+
+        case 2 =>
+          val rule = e"${Fg(palette.heading)}(${t"─"*width})"
+          wrapped :+ rule
+
+        case _ =>
+          val prefix = e"${Fg(palette.subdued)}(${t"#"*level} )"
+          wrapped match
+            case Nil =>
+              List(prefix)
+
+            case head :: tail =>
+              (prefix + head) :: tail.map(indent(_, t" "*(level + 1)))
+
+    case Layout.Paragraph(_, children*) =>
+      val styled = children.map(inlineProse(_)).to(Seq).join
+      wrap(styled, width)
+
+    case Layout.ThematicBreak(_) =>
+      List(e"${Fg(palette.rule)}(${t"─"*width})")
+
+    case Layout.BlockQuote(_, children*) =>
+      val bar = e"${Fg(palette.quoteBar)}(▎)"
+      val innerWidth = (width - 2).max(1)
+      val innerBlocks = children.map(layoutLines(_, innerWidth)).filter(_.nonEmpty)
+      val joined = interleaveBlanks(innerBlocks.to(List))
+
+      joined.map: line =>
+        if line.plain.length == 0 then bar
+        else bar + Space + line
+
+    case Layout.BulletList(_, tight, items*) =>
+      renderList(items.to(List), tight, width, _ => bullet(palette))
+
+    case Layout.OrderedList(_, start, tight, delimiter, items*) =>
+      val delim = delimiter.or('.')
+      renderList(items.to(List), tight, width, n => e"${Fg(palette.subdued)}(${start + n}$delim)")
+
+    case Layout.CodeBlock(_, info, code) =>
+      val available = summon[Every[TeletypeFormattable]].values
+      val formatted = available.foldLeft(Unset: Optional[Teletype]):
+        (acc, fmt) => acc.or(fmt.format(info, code))
+
+      val body: Teletype = formatted.or:
+        e"${Fg(palette.subdued)}($code)"
+
+      val raw = body.cut(t"\n")
+      // Drop a trailing empty line that comes from a final '\n' in `code`.
+      val lines = if raw.lastOption.exists(_.plain.length == 0) then raw.dropRight(1) else raw
+
+      lines.map: line =>
+        e"  $line"
+
+    case Layout.HtmlBlock(_, html) =>
+      val text: Teletype = e"${Fg(palette.subdued)}($html)"
+
+      text.cut(t"\n") match
+        case Nil            => Nil
+        case lines @ _ :: _ => if lines.last.plain.length == 0 then lines.dropRight(1) else lines
+
+
+  private def bullet(palette: MarkdownPalette): Teletype =
+    e"${Fg(palette.subdued)}(•)"
+
+
+  // Renders a list, dispatching to the marker-generator `marker` (called with
+  // the zero-based index). Continuation lines of each item are hung off the
+  // marker by `markerWidth + 1` spaces. `tight` lists omit the blank line
+  // between items.
+  private def renderList
+    ( items:  List[List[Layout]],
+      tight:  Boolean,
+      width:  Int,
+      marker: Int => Teletype )
+    ( using hyphenation: Hyphenation,
+            formattables: Every[TeletypeFormattable],
+            palette: MarkdownPalette )
+  :   List[Teletype] =
+
+    if items.isEmpty then Nil
+    else
+      val rendered = items.zipWithIndex.map: (item, idx) =>
+        val mk = marker(idx)
+        val markerSize = mk.plain.length + 1   // marker + one space
+        val hang = t" "*markerSize
+        val inner = item.map(layoutLines(_, (width - markerSize).max(1))).filter(_.nonEmpty)
+        val joined = if tight then concatItems(inner) else interleaveBlanks(inner)
+
+        joined match
+          case Nil            => List(mk)
+          case head :: tail   =>
+            (mk + Space + head) :: tail.map(indent(_, hang))
+
+      if tight then rendered.flatten
+      else interleaveBlanks(rendered)
+
+
+  // -- helpers --------------------------------------------------------------
+
+  // Concatenate per-block line lists with no separator (used for tight lists).
+  private def concatItems(blocks: List[List[Teletype]]): List[Teletype] =
+    blocks.flatten
+
+
+  // Concatenate per-block line lists with a single blank line between blocks.
+  private def interleaveBlanks(blocks: List[List[Teletype]]): List[Teletype] =
+    blocks match
+      case Nil        => Nil
+      case head :: Nil => head
+      case head :: tail => head ::: Teletype.empty :: interleaveBlanks(tail)
+
+
+  // Prefix a single line's content with `prefix` (no newlines should appear
+  // in `line`).
+  private def indent(line: Teletype, prefix: Text): Teletype =
+    if line.plain.length == 0 then Teletype(prefix) else Teletype(prefix)+line
+
+
+  // Join a list of lines into one Teletype with embedded newlines.
+  private def joinLines(lines: List[Teletype]): Teletype =
+    lines.to(Seq).join(Newline)
+
+
+  // Wrap an inline `Teletype` into width-bounded lines, applying soft
+  // hyphenation via `polysyllabic` when a single word would overflow but a
+  // syllable break would fit.
+  private def wrap
+    ( content: Teletype, width: Int )
+    ( using hyphenation: Hyphenation )
+  :   List[Teletype] =
+
+    if width < 1 then return List(content)
+
+    // Hard line-breaks (Linebreak) embedded as '\n' produce a forced break.
+    // Split on them first, wrap each segment independently, then concatenate.
+    val segments = content.cut(t"\n")
+    segments.flatMap(wrapSegment(_, width))
+
+
+  private def wrapSegment
+    ( segment: Teletype, width: Int )
+    ( using hyphenation: Hyphenation )
+  :   List[Teletype] =
+
+    val out = scala.collection.mutable.ListBuffer[Teletype]()
+    var line: Teletype = Teletype.empty
+    var col: Int = 0
+
+    inline def flush(): Unit =
+      out += line
+      line = Teletype.empty
+      col = 0
+
+    def placeWord(word: Teletype): Unit =
+      val wlen = word.plain.length
+      if wlen == 0 then ()
+      else
+        val needsSpace = col > 0
+        val needed = if needsSpace then wlen + 1 else wlen
+
+        if col + needed <= width then
+          // Fits on current line.
+          if needsSpace then
+            line = line + Space
+            col += 1
+
+          line = line + word
+          col += wlen
+        else
+          // Doesn't fit. Try hyphenation.
+          val avail = if needsSpace then (width - col - 1).max(0) else width - col
+          val breaks = word.plain.breakPoints
+          var best = -1
+          var k = 0
+
+          while k < breaks.length do
+            val b = breaks(k)
+            // After break, prefix is `b` chars; we add a hyphen, total `b + 1`.
+            if b + 1 <= avail && b > best then best = b
+            k += 1
+
+          if best >= 1 then
+            if needsSpace then
+              line = line + Space
+              col += 1
+
+            line = line + word.takeChars(best) + Hyphen
+            flush()
+            placeWord(word.dropChars(best))
+          else if col > 0 then
+            // Move to a new line and try again.
+            flush()
+            placeWord(word)
+          else
+            // Word exceeds the width and has no break point. Emit it on its
+            // own line, overflowing if necessary.
+            line = word
+            col = wlen
+            flush()
+
+    segment.cut(t" ").each: word =>
+      placeWord(word)
+
+    if col > 0 then flush()
+
+    if out.isEmpty then List(Teletype.empty) else out.to(List)

--- a/lib/punctuation/src/ansi/punctuation.TeletypeFormattable.scala
+++ b/lib/punctuation/src/ansi/punctuation.TeletypeFormattable.scala
@@ -1,0 +1,45 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+import escapade.*
+import vacuous.*
+
+// Terminal counterpart of `punctuation.Formattable`. Returns `Unset` when the
+// formattable does not handle the code block's language so the renderer can
+// fall back to a plain (`Faint`-styled) presentation.
+trait TeletypeFormattable:
+  type Self
+
+  def format(language: List[Text], content: Text): Optional[Teletype]

--- a/lib/punctuation/src/ansi/punctuation_ansi.scala
+++ b/lib/punctuation/src/ansi/punctuation_ansi.scala
@@ -1,0 +1,90 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+import escapade.*
+import frontier.*
+import gossamer.*
+import harlequin.*
+import polysyllabic.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// Code-block formattables for the terminal renderer. Each one tries to match
+// the info-string against its claimed language and, on success, runs the
+// content through Harlequin's highlighter and out via the `unnumbered` token
+// stream. Callers supply a `ScalaSyntaxPalette` to colour the tokens.
+package teletypeFormattables:
+  given scala: (palette: ScalaSyntaxPalette)
+              => ("scala" is TeletypeFormattable) = new TeletypeFormattable:
+    type Self = "scala"
+
+    def format(meta: List[Text], content: Text): Optional[Teletype] =
+      if meta.prim != t"scala" then Unset
+      else
+        import syntaxHighlighting.unnumbered
+        Scala.highlight(content).teletype
+
+  given java: (palette: ScalaSyntaxPalette)
+            => ("java" is TeletypeFormattable) = new TeletypeFormattable:
+    type Self = "java"
+
+    def format(meta: List[Text], content: Text): Optional[Teletype] =
+      if meta.prim != t"java" then Unset
+      else
+        import syntaxHighlighting.unnumbered
+        Java.highlight(content).teletype
+
+extension (markdown: Markdown of Layout)
+  def terminal
+    ( width: Int = 80 )
+    ( using hyphenation: Hyphenation,
+            formattables: Every[TeletypeFormattable],
+            palette: MarkdownPalette )
+  :   Teletype =
+
+    Renderer.render(markdown, width)
+
+// Drives the markdown renderer from a `Termcap`. Reads the column width from
+// `termcap.width` (defaulting to 80 when no width is supplied — the built-in
+// `termcapDefinitions` leave the default `Int.MaxValue`, which would otherwise
+// produce mile-wide thematic-break rules), renders to a `Teletype`, then
+// emits ANSI escapes through the existing `Teletype is Printable` given.
+given (Hyphenation, Every[TeletypeFormattable], MarkdownPalette)
+   => (Markdown of Layout) is Printable =
+
+  (markdown, termcap) =>
+    val width = if termcap.width >= Int.MaxValue then 80 else termcap.width
+    Renderer.render(markdown, width).render(termcap)

--- a/lib/punctuation/src/ansi/soundness_punctuation_ansi.scala
+++ b/lib/punctuation/src/ansi/soundness_punctuation_ansi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export punctuation.{MarkdownPalette, Renderer, TeletypeFormattable, terminal}
+
+package teletypeFormattables:
+  export punctuation.teletypeFormattables.{scala, java}

--- a/lib/punctuation/src/core/punctuation.Serializer.scala
+++ b/lib/punctuation/src/core/punctuation.Serializer.scala
@@ -1,0 +1,388 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+import anticipation.*
+import denominative.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import symbolism.*
+import vacuous.*
+
+// Round-trips a `Markdown` AST back into CommonMark source text. The output is
+// not byte-identical to whatever the parser originally consumed, but is
+// guaranteed to re-parse to an equal AST (modulo `Ordinal` `line` metadata).
+object Serializer:
+  def apply(markdown: Markdown of Layout): Text =
+    val builder = StringBuilder()
+    layoutSeq(builder, markdown.children, t"")
+    appendLinkRefs(builder, markdown.linkRefs)
+    builder.text
+
+  @scala.annotation.targetName("applyProse")
+  def apply(markdown: Markdown of Prose): Text =
+    val builder = StringBuilder()
+    markdown.children.each(prose(builder, _))
+    builder.text
+
+  private def appendLinkRefs(builder: StringBuilder, refs: List[Markdown.LinkRef]): Unit =
+    if !refs.nil then
+      if builder.length > 0 && !builder.text.ends(t"\n") then builder.add(t"\n")
+
+      refs.each: ref =>
+        builder.add('[')
+        builder.add(escapeLinkLabel(ref.label))
+        builder.add(t"]: ")
+        builder.add(linkDestination(ref.destination))
+        ref.title.let: title =>
+          builder.add(t" \"")
+          builder.add(title.sub(t"\"", t"\\\""))
+          builder.add('"')
+        builder.add('\n')
+
+  // Characters that, if unescaped in a `Textual` node, could start a new
+  // inline construct when the output is re-parsed. We escape conservatively:
+  // every occurrence, not only "active" ones. CommonMark is happy to accept
+  // backslash escapes ahead of any ASCII punctuation character.
+  private inline def inlineSpecial(char: Char): Boolean = char match
+    case '\\' | '`' | '*' | '_' | '[' | ']' | '<' | '>' | '&' => true
+    case _                                                    => false
+
+  // Block-start characters: a paragraph whose first line begins with one of
+  // these would re-parse as a different block (heading, list, blockquote,
+  // thematic break, etc.). We rewrite the first character with a backslash
+  // escape so the round-trip lands on `Paragraph` again.
+  private inline def blockStart(char: Char): Boolean = char match
+    case '#' | '>' | '-' | '+' | '*' | '=' | '_' | '~' | '`' | '|' => true
+    case _                                                         => false
+
+  private def escapeTextual(text: Text): Text =
+    val s = text.s
+    val buf = StringBuilder()
+    var i = 0
+
+    while i < s.length do
+      val c = s.charAt(i)
+      if inlineSpecial(c) then buf.add('\\')
+      buf.add(c)
+      i += 1
+
+    buf.text
+
+  private def escapeLinkLabel(text: Text): Text =
+    val s = text.s
+    val buf = StringBuilder()
+    var i = 0
+
+    while i < s.length do
+      val c = s.charAt(i)
+      if c == '\\' || c == '[' || c == ']' then buf.add('\\')
+      buf.add(c)
+      i += 1
+
+    buf.text
+
+  // Choose the angle-bracket form `<…>` when the destination contains
+  // characters that would break the bare form, otherwise emit it directly.
+  // Inside angles, only `<` `>` and newline need escaping.
+  private def linkDestination(dest: Text): Text =
+    val s = dest.s
+    var needsAngles = s.isEmpty
+
+    var i = 0
+    while i < s.length && !needsAngles do
+      val c = s.charAt(i)
+      if c == ' ' || c == '\t' || c == '(' || c == ')' || c == '<' || c == '>' || c <= 0x20
+      then needsAngles = true
+      i += 1
+
+    if !needsAngles then dest else
+      val buf = StringBuilder()
+      buf.add('<')
+
+      var j = 0
+      while j < s.length do
+        val c = s.charAt(j)
+        if c == '<' || c == '>' || c == '\\' then buf.add('\\')
+        if c != '\n' then buf.add(c)
+        j += 1
+
+      buf.add('>')
+      buf.text
+
+  // Pick the smallest backtick-fence width that does not appear as a run
+  // inside `code`. CommonMark §6.1: at least one more backtick than the
+  // longest internal run.
+  private def codeSpanDelimiter(code: Text): Text =
+    val s = code.s
+    var longest = 0
+    var current = 0
+    var i = 0
+
+    while i < s.length do
+      if s.charAt(i) == '`' then
+        current += 1
+        if current > longest then longest = current
+      else
+        current = 0
+
+      i += 1
+
+    t"`"*(longest + 1)
+
+  // The needed extra-space padding for code spans whose content begins or
+  // ends with a backtick or is wholly whitespace.
+  private def codeSpanNeedsPadding(code: Text): Boolean =
+    val s = code.s
+
+    if s.isEmpty then false
+    else if s.charAt(0) == '`' || s.charAt(s.length - 1) == '`' then true
+    else
+      var blank = true
+      var i = 0
+      while i < s.length && blank do
+        val c = s.charAt(i)
+        if c != ' ' && c != '\n' then blank = false
+        i += 1
+      blank
+
+  private def codeBlockFence(code: Text): Text =
+    val s = code.s
+    var longestRun = 2
+    var current = 0
+    var i = 0
+
+    while i < s.length do
+      val c = s.charAt(i)
+      if c == '`' then
+        current += 1
+        if current > longestRun then longestRun = current
+      else
+        current = 0
+
+      i += 1
+
+    t"`"*(longestRun + 1)
+
+  private def prose(builder: StringBuilder, node: Prose): Unit = node match
+    case Prose.Textual(text) =>
+      builder.add(escapeTextual(text))
+
+    case Prose.Softbreak =>
+      builder.add('\n')
+
+    case Prose.Linebreak =>
+      builder.add(t"\\\n")
+
+    case Prose.Code(code) =>
+      val fence = codeSpanDelimiter(code)
+      builder.add(fence)
+      if codeSpanNeedsPadding(code) then builder.add(' ')
+      builder.add(code)
+      if codeSpanNeedsPadding(code) then builder.add(' ')
+      builder.add(fence)
+
+    case Prose.Emphasis(children*) =>
+      builder.add('*')
+      children.each(prose(builder, _))
+      builder.add('*')
+
+    case Prose.Strong(children*) =>
+      builder.add(t"**")
+      children.each(prose(builder, _))
+      builder.add(t"**")
+
+    case Prose.Link(destination, title, children*) =>
+      builder.add('[')
+      children.each(prose(builder, _))
+      builder.add(t"](")
+      builder.add(linkDestination(destination))
+      title.let: t =>
+        builder.add(t" \"")
+        builder.add(t.sub(t"\"", t"\\\""))
+        builder.add(t"\"")
+      builder.add(')')
+
+    case Prose.Image(destination, title, children*) =>
+      builder.add(t"![")
+      children.each(prose(builder, _))
+      builder.add(t"](")
+      builder.add(linkDestination(destination))
+      title.let: t =>
+        builder.add(t" \"")
+        builder.add(t.sub(t"\"", t"\\\""))
+        builder.add(t"\"")
+      builder.add(')')
+
+    case Prose.HtmlInline(html) =>
+      builder.add(html)
+
+  // Render the inline content of a paragraph or heading to a fresh `Text`,
+  // applying first-character block-start protection so a leading `#` etc.
+  // does not re-parse as a new block.
+  private def inlineLine(children: Seq[Prose]): Text =
+    val buf = StringBuilder()
+    children.each(prose(buf, _))
+    val out = buf.text
+
+    if out.length == 0 then out
+    else if blockStart(out.s.charAt(0)) then t"\\$out"
+    else out
+
+  private def layoutSeq(builder: StringBuilder, nodes: Seq[Layout], indent: Text): Unit =
+    var first = true
+
+    nodes.each: node =>
+      if !first then ensureBlankLine(builder)
+      first = false
+      layout(builder, node, indent)
+
+  private def ensureBlankLine(builder: StringBuilder): Unit =
+    val txt = builder.text
+
+    if txt.length == 0 then ()
+    else if txt.ends(t"\n\n") then ()
+    else if txt.ends(t"\n") then builder.add('\n')
+    else builder.add(t"\n\n")
+
+  private def writeWithIndent(builder: StringBuilder, text: Text, indent: Text): Unit =
+    val s = text.s
+    var lineStart = true
+    var i = 0
+
+    while i < s.length do
+      val c = s.charAt(i)
+      if lineStart && indent.length > 0 then builder.add(indent)
+      builder.add(c)
+      lineStart = c == '\n'
+      i += 1
+
+  private def layout(builder: StringBuilder, node: Layout, indent: Text): Unit = node match
+    case Layout.Heading(_, level, children*) =>
+      builder.add(indent)
+      builder.add(t"#"*level)
+      builder.add(' ')
+      builder.add(inlineLine(children))
+      builder.add('\n')
+
+    case Layout.Paragraph(_, children*) =>
+      writeWithIndent(builder, inlineLine(children), indent)
+      builder.add('\n')
+
+    case Layout.ThematicBreak(_) =>
+      builder.add(indent)
+      builder.add(t"---\n")
+
+    case Layout.CodeBlock(_, info, code) =>
+      val fence = codeBlockFence(code)
+      builder.add(indent)
+      builder.add(fence)
+      if !info.nil then builder.add(info.map(_.s).mkString(" ").tt)
+      builder.add('\n')
+      writeWithIndent(builder, code, indent)
+      if !code.ends(t"\n") then builder.add('\n')
+      builder.add(indent)
+      builder.add(fence)
+      builder.add('\n')
+
+    case Layout.BlockQuote(_, children*) =>
+      val inner = StringBuilder()
+      layoutSeq(inner, children, t"")
+      val text = inner.text
+      // Strip a single trailing newline so the loop doesn't emit a phantom
+      // empty final line.
+      val body = if text.ends(t"\n") then text.skip(1, Rtl) else text
+
+      body.cut(t"\n").each: line =>
+        builder.add(indent)
+        if line.length == 0 then builder.add('>')
+        else
+          builder.add(t"> ")
+          builder.add(line)
+        builder.add('\n')
+
+    case Layout.HtmlBlock(_, html) =>
+      writeWithIndent(builder, html, indent)
+      if !html.ends(t"\n") then builder.add('\n')
+
+    case Layout.BulletList(_, tight, items*) =>
+      var first = true
+
+      items.each: item =>
+        if !first && !tight then ensureBlankLine(builder)
+        first = false
+        builder.add(indent)
+        builder.add(t"- ")
+        renderItemBody(builder, item, t"$indent  ", tight)
+
+    case Layout.OrderedList(_, start, tight, delimiter, items*) =>
+      var n = start
+      var first = true
+
+      items.each: item =>
+        if !first && !tight then ensureBlankLine(builder)
+        first = false
+        val marker = t"$n${delimiter.or('.')} "
+        val hangingSpaces = t" "*marker.length
+        builder.add(indent)
+        builder.add(marker)
+        renderItemBody(builder, item, t"$indent$hangingSpaces", tight)
+        n += 1
+
+  // A list item is itself a sequence of `Layout` blocks. We emit the first
+  // block's first line right after the marker, then everything else with
+  // the hanging-indent applied. Tight lists collapse the inter-paragraph
+  // blank lines exactly as the parser does.
+  private def renderItemBody
+    ( builder: StringBuilder, item: List[Layout], hangingIndent: Text, tight: Boolean )
+  :   Unit =
+
+    if item.nil then builder.add('\n')
+    else
+      val inner = StringBuilder()
+      layoutSeq(inner, item, t"")
+      val rendered = inner.text.s
+
+      var i = 0
+      var lineStart = false
+
+      while i < rendered.length do
+        val c = rendered.charAt(i)
+        if lineStart then builder.add(hangingIndent)
+        builder.add(c)
+        lineStart = c == '\n'
+        i += 1
+
+      if rendered.isEmpty || rendered.charAt(rendered.length - 1) != '\n'
+      then builder.add('\n')

--- a/lib/punctuation/src/core/punctuation_core.scala
+++ b/lib/punctuation/src/core/punctuation_core.scala
@@ -30,6 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package punctuation
 
-export punctuation.{Formattable, Layout, Markdown, Parser, Prose, Serializer, Translator, source}
+import anticipation.*
+import prepositional.*
+
+extension (markdown: Markdown of Layout)
+  def source: Text = Serializer(markdown)
+
+extension (markdown: Markdown of Prose)
+  @scala.annotation.targetName("sourceProse")
+  def source: Text = Serializer(markdown)

--- a/lib/punctuation/src/test/punctuation_test.scala
+++ b/lib/punctuation/src/test/punctuation_test.scala
@@ -62,3 +62,98 @@ object Tests extends Suite(m"Punctuation tests"):
                 test(m"Commonmark test case ${testcase.example}"):
                   Parser.parse(testcase.markdown).html.show
                 . assert(_ == html.show)
+
+    suite(m"Serializer round-trip"):
+      def roundTrip(markdown: Text): Markdown of Layout =
+        Parser.parse(Parser.parse(markdown).source)
+
+      test(m"simple heading"):
+        roundTrip(t"# Title\n").children.head
+      . assert:
+          case Layout.Heading(_, 1, Prose.Textual(t"Title")) => true
+          case _                                             => false
+
+      test(m"emphasis and strong"):
+        roundTrip(t"Hello **bold** and *em* here.\n").children.head
+      . assert:
+          case Layout.Paragraph(_, prose*) =>
+            prose.exists:
+              case Prose.Strong(_*) => true
+              case _                => false
+            && prose.exists:
+              case Prose.Emphasis(_*) => true
+              case _                  => false
+
+          case _ => false
+
+      test(m"fenced code block preserves content"):
+        val src = t"```scala\nval x = 1\n```\n"
+        val first = Parser.parse(src).children.head
+        val again = Parser.parse(Parser.parse(src).source).children.head
+
+        (first, again).match
+          case (Layout.CodeBlock(_, a, b), Layout.CodeBlock(_, c, d)) => (a, b) == (c, d)
+          case _                                                     => false
+      . assert(_ == true)
+
+      test(m"link with title"):
+        val src = t"See [docs](https://example.org \"Docs\") here.\n"
+        Parser.parse(Parser.parse(src).source).children.head
+      . assert:
+          case Layout.Paragraph(_, _, Prose.Link(t"https://example.org", t"Docs", _*), _*) => true
+          case _                                                                          => false
+
+      test(m"blockquote nests paragraph"):
+        val src = t"> hello\n"
+        Parser.parse(Parser.parse(src).source).children.head
+      . assert:
+          case Layout.BlockQuote(_, Layout.Paragraph(_, Prose.Textual(t"hello"))) => true
+          case _                                                                  => false
+
+      test(m"bullet list with two items"):
+        val src = t"- one\n- two\n"
+        Parser.parse(Parser.parse(src).source).children.head
+      . assert:
+          case Layout.BulletList(_, true, items*) if items.size == 2 => true
+          case _                                                     => false
+
+      test(m"ordered list with two items"):
+        val src = t"1. one\n2. two\n"
+        Parser.parse(Parser.parse(src).source).children.head
+      . assert:
+          case Layout.OrderedList(_, 1, true, _, items*) if items.size == 2 => true
+          case _                                                            => false
+
+    suite(m"Terminal renderer"):
+      import hyphenations.englishHyphenation
+      import termcapDefinitions.xtermTrueColor
+
+      test(m"heading is styled and followed by a rule"):
+        val md = Parser.parse(t"# Hello\n")
+        md.terminal(width = 20).plain
+      . assert(_.s.contains("Hello"))
+
+      test(m"link content carries an OSC 8 escape"):
+        val md = Parser.parse(t"See [home](https://example.org/) here.\n")
+        md.terminal(width = 60).render(xtermTrueColor).s
+      . assert(_.contains("]8;;https://example.org/"))
+
+      test(m"long word hyphenates at width 20"):
+        val md = Parser.parse(t"supercalifragilisticexpialidocious is a word.\n")
+        md.terminal(width = 20).plain.s
+      . assert(_.contains("‐"))
+
+      test(m"thematic break is a horizontal rule of the requested width"):
+        val md = Parser.parse(t"---\n")
+        md.terminal(width = 10).plain.s
+      . assert(_.contains("──────────"))
+
+      test(m"Printable reads width from Termcap"):
+        given Termcap:
+          def ansi = false
+          def color = ColorDepth.NoColor
+          override def width = 12
+
+        val md = Parser.parse(t"---\n")
+        summon[(Markdown of Layout) is Printable].print(md, summon[Termcap]).s
+      . assert(_.contains("────────────"))


### PR DESCRIPTION
Punctuation now serialises its AST back to CommonMark source and
renders markdown to a styled `Teletype` for the terminal — italic
emphasis, bold strong, fg/bg-styled inline code, OSC 8 clickable
links, harlequin-highlighted fenced code blocks, Unicode glyphs for
bullets, blockquote bars and thematic rules, and Polysyllabic-driven
soft hyphenation when a long word would overflow the column width.
The renderer reads its width from `Termcap` via a new `Printable`
instance, matching the convention already used by Escritoire.

## Serializer

Turn a parsed `Markdown of Layout` (or `Markdown of Prose`) back into
CommonMark source with `.source`:

```scala
val md = Parser.parse(t"# Hello\n\nA **bold** word.\n")
val text: Text = md.source
```

Round-trip is AST-stable but not byte-identical: inline specials are
backslash-escaped, code-span/fence widths are picked to clear the
longest internal backtick run, link destinations switch to the
angle-bracket form when they contain spaces or parens, and paragraphs
whose first character would re-parse as a block marker (`#`, `>`, `-`,
etc.) get a leading backslash.

## Terminal renderer

Render markdown to a styled terminal output:

```scala
import soundness.*
import hyphenations.englishHyphenation
import teletypeFormattables.scala  // syntax-highlight ```scala blocks

val md = Parser.parse(markdown)
Out.println(md)  // uses Termcap.width
```

The new `(Markdown of Layout) is Printable` given reads the column
width from the ambient `Termcap`, falling back to 80 when none is
supplied. For an explicit width without going through `Termcap`, use
`.terminal(width)` to get a `Teletype` directly:

```scala
val tt: Teletype = md.terminal(width = 100)
```

Customise colours with `MarkdownPalette`:

```scala
given MarkdownPalette =
  MarkdownPalette(heading = Chroma(0xff, 0xaa, 0x33))
```

Fenced code blocks are delegated to `Every[TeletypeFormattable]`. The
bundled `scala` and `java` instances delegate to Harlequin, so you can
syntax-highlight by bringing them into scope and supplying a
`ScalaSyntaxPalette`.