### PR TITLE
jacinta: encode source positions alongside the AST in a tracking mode

### DIFF
--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -94,6 +94,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
         ( target = 1*Second, operationSize = size1, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes1) }
 
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size1):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes1) }
+
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size1):
         ' {
             import org.typelevel.jawn.ast.JParser
@@ -113,6 +116,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
       bench(m"Parse file with Merino")
         ( target = 1*Second, operationSize = size2, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes2) }
+
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size2):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes2) }
 
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size2):
         ' {
@@ -134,6 +140,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
         ( target = 1*Second, operationSize = size3, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes3) }
 
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size3):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes3) }
+
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size3):
         ' {
             import org.typelevel.jawn.ast.JParser
@@ -154,6 +163,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
         ( target = 1*Second, operationSize = size4, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes4) }
 
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size4):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes4) }
+
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size4):
         ' {
             import org.typelevel.jawn.ast.JParser
@@ -173,6 +185,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
       bench(m"Parse file with Merino")
         ( target = 1*Second, operationSize = size5, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes5) }
+
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size5):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes5) }
 
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size5):
         ' {
@@ -196,6 +211,10 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
       bench(m"Parse file with Merino (Full / Bcd Array[Double])")
         ( target = 1*Second, operationSize = size6, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes6)(using jacinta.NumberMode.Full) }
+
+      bench(m"Parse file with Merino (Full, tracking)")
+        (target = 1*Second, operationSize = size6):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes6)(using jacinta.NumberMode.Full) }
 
       bench(m"Parse file with Merino (Bcd single Long)")
         (target = 1*Second, operationSize = size6):
@@ -231,6 +250,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
         ( target = 1*Second, operationSize = size7, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes7) }
 
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size7):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes7) }
+
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size7):
         ' {
             import org.typelevel.jawn.ast.JParser
@@ -252,6 +274,9 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
       bench(m"Parse file with Merino")
         ( target = 1*Second, operationSize = size8, baseline = Baseline(compare = Min) ):
         '{ Json.Ast.parse(jacinta.Benchmarks.jsonBytes8) }
+
+      bench(m"Parse file with Merino (tracking)")(target = 1*Second, operationSize = size8):
+        '{ Json.Ast.parseTracked(jacinta.Benchmarks.jsonBytes8) }
 
       bench(m"Parse file with Jawn")(target = 1*Second, operationSize = size8):
         ' {

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -368,6 +368,20 @@ object Json extends Json2, Dynamic:
   def apply(value: Any): Json = new Json(value)
   def apply(value: Any, positions: Optional[Json.PositionIndex]): Json = new Json(value, positions)
 
+  // Defined on the companion directly (not as a `Json.type` extension) because
+  // the companion's `Dynamic` parentage intercepts `Json.parseTracked(...)`
+  // before extension-method resolution gets a chance.
+  def parseTracked(source: Data)(using NumberMode): Json raises ParseError =
+    val (ast, index) = Json.Ast.parseTracked(source)
+    new Json(ast, index)
+
+  def parseTracked(input: Iterator[Data])(using NumberMode): Json raises ParseError =
+    val (ast, index) = Json.Ast.parseTracked(input)
+    new Json(ast, index)
+
+  def parseTracked(source: Text)(using NumberMode, CharEncoder): Json raises ParseError =
+    parseTracked(source.data)
+
   // Canonical external accessor for the underlying AST. The `root`
   // method on `class Json` is package-private so that breaking through
   // the `Json` abstraction is a deliberate, named action.

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -98,7 +98,7 @@ trait Json2:
     :   derivation is Decodable in Json =
 
       json =>
-        provide[Foci[JsonPointer]]:
+        provide[Foci[Json.Focus]]:
           provide[Tactic[JsonError]]:
             val root = json.root
             val n = root.objectSize
@@ -112,12 +112,15 @@ trait Json2:
             build: [field] =>
               context =>
                 focus({
-                  val base = prior.or(JsonPointer())
+                  val base = prior.let(_.pointer).or(JsonPointer())
 
-                  JsonPointer
-                    ( base.url,
-                      Path[JsonPointer, JsonPointer.type, Tuple]
-                        ( base.path.root, base.path.descent :+ label ) )
+                  val newPointer =
+                    JsonPointer
+                      ( base.url,
+                        Path[JsonPointer, JsonPointer.type, Tuple]
+                          ( base.path.root, base.path.descent :+ label ) )
+
+                  Json.Focus(newPointer)
                 }):
                   values.get(label.s) match
                     case Some(value) => context.decoded(new Json(value))
@@ -130,7 +133,7 @@ trait Json2:
             val discriminable = infer[derivation is Discriminable in Json]
 
             val discriminant: Text = discriminable.discriminate(json).or:
-              focus(prior.or(JsonPointer()))(abort(JsonError(Reason.Absent)))
+              focus(prior.or(Json.Focus(JsonPointer())))(abort(JsonError(Reason.Absent)))
 
             delegate(discriminant): [variant <: derivation] =>
               context => context.decoded(json)
@@ -140,19 +143,22 @@ trait Json2:
     :   derivation is Encodable in Json =
 
       value =>
-        provide[Foci[JsonPointer]]:
+        provide[Foci[Json.Focus]]:
           val labels: scm.ArrayBuffer[String] = scm.ArrayBuffer()
           val values: scm.ArrayBuffer[Json.Ast] = scm.ArrayBuffer()
 
           fields(value): [field] =>
             field =>
               focus({
-                val base = prior.or(JsonPointer())
+                val base = prior.let(_.pointer).or(JsonPointer())
 
-                JsonPointer
-                  ( base.url,
-                    Path[JsonPointer, JsonPointer.type, Tuple]
-                      ( base.path.root, base.path.descent :+ label ) )
+                val newPointer =
+                  JsonPointer
+                    ( base.url,
+                      Path[JsonPointer, JsonPointer.type, Tuple]
+                        ( base.path.root, base.path.descent :+ label ) )
+
+                Json.Focus(newPointer)
               }):
                 contextual.encode(field).root.tap: encoded =>
                   if !encoded.isAbsent then
@@ -187,6 +193,19 @@ object Json extends Json2, Dynamic:
 
   extension (positionIndex: PositionIndex)
     private[jacinta] def ints: IArray[Int] = positionIndex
+
+  // Focus value tracked by Jacinta's decoders / encoders. `pointer` is the
+  // JSON-pointer path to the current node. `position` is initially `Unset`
+  // and filled in by `withPosition(json)` against the root `Json` that
+  // produced the focus — typically at error-render time so the success
+  // path pays nothing for `locate` lookups. Constructed lazily inside
+  // `Foci.supplement`, only for actually-registered errors.
+  case class Focus
+                ( pointer:  JsonPointer,
+                  position: Optional[Json.Ast.Position] = Unset )
+  derives CanEqual:
+
+    def withPosition(json: Json): Focus = copy(position = json.locate(pointer))
 
   opaque type Ast =
     JsonString | JsonNumber | JsonBoolean | JsonNull | JsonObject | JsonArray | Unset.type
@@ -510,7 +529,7 @@ object Json extends Json2, Dynamic:
   given array: [collection <: Iterable, element]
   =>  ( factory: Factory[element, collection[element]],
         tactic:  Tactic[JsonError],
-        foci:    Foci[JsonPointer] )
+        foci:    Foci[Json.Focus] )
   =>  ( decodable: => element is Decodable in Json )
   =>  collection[element] is Decodable in Json =
 
@@ -519,12 +538,15 @@ object Json extends Json2, Dynamic:
 
       value.root.array.each: json =>
         focus({
-          val base = prior.or(JsonPointer())
+          val base = prior.let(_.pointer).or(JsonPointer())
 
-          JsonPointer
-            ( base.url,
-              Path[JsonPointer, JsonPointer.type, Tuple]
-                ( base.path.root, base.path.descent :+ ordinal.n0.toString.tt ) )
+          val newPointer =
+            JsonPointer
+              ( base.url,
+                Path[JsonPointer, JsonPointer.type, Tuple]
+                  ( base.path.root, base.path.descent :+ ordinal.n0.toString.tt ) )
+
+          Json.Focus(newPointer)
         }):
           builder += decodable.decoded(Json.ast(json))
 
@@ -932,5 +954,5 @@ extends Dynamic derives CanEqual:
     case _ =>
       false
 
-  def as[value: Decodable in Json]: value raises JsonError tracks JsonPointer =
+  def as[value: Decodable in Json]: value raises JsonError tracks Json.Focus =
     value.decoded(this)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -177,6 +177,17 @@ object Json extends Json2, Dynamic:
   type JsonObject  = IArray[Any]
   type JsonArray   = IArray[Any] | Array[Long] | Array[Int]
 
+  // All internal references in a `PositionIndex` are stored as offsets
+  // relative to the start of the containing node descriptor, so any slice
+  // extracted at a descriptor boundary is itself a valid `PositionIndex`.
+  opaque type PositionIndex = IArray[Int]
+
+  object PositionIndex:
+    private[jacinta] def apply(data: IArray[Int]): PositionIndex = data
+
+  extension (positionIndex: PositionIndex)
+    private[jacinta] def ints: IArray[Int] = positionIndex
+
   opaque type Ast =
     JsonString | JsonNumber | JsonBoolean | JsonNull | JsonObject | JsonArray | Unset.type
 
@@ -351,6 +362,11 @@ object Json extends Json2, Dynamic:
     def objectSize(json: Ast): Int = json.asInstanceOf[IArray[Any]].length/2
 
   def ast(value: Json.Ast): Json = new Json(value)
+
+  // `object Json` extends `Dynamic`, which suppresses the universal-apply
+  // synthesis for `Json(...)`; these forward to the constructor manually.
+  def apply(value: Any): Json = new Json(value)
+  def apply(value: Any, positions: Optional[Json.PositionIndex]): Json = new Json(value, positions)
 
   // Canonical external accessor for the underlying AST. The `root`
   // method on `class Json` is package-private so that breaking through
@@ -582,8 +598,10 @@ object Json extends Json2, Dynamic:
     def discriminate(json: Json): Optional[Text] = safely(json.selectDynamic(key).as[Text])
     def variant(json: Json): Json = unsafely(json.updateDynamic(key)(Unset))
 
-class Json(rootValue: Any) extends Dynamic derives CanEqual:
+class Json(rootValue: Any, positions: Optional[Json.PositionIndex] = Unset)
+extends Dynamic derives CanEqual:
   private[jacinta] def root: Json.Ast = rootValue.asInstanceOf[Json.Ast]
+  def positionIndex: Optional[Json.PositionIndex] = positions
   def apply(index: Int): Json raises JsonError = Json(root.array(index))
 
   def selectDynamic(field: String)(using erased DynamicJsonEnabler): Json raises JsonError =

--- a/lib/jacinta/src/core/jacinta.JsonParser.scala
+++ b/lib/jacinta/src/core/jacinta.JsonParser.scala
@@ -137,7 +137,6 @@ private[jacinta] object JsonParser:
 
 private[jacinta] final class JsonParser:
   import JsonParser.*
-  import Lineation.untrackedData
 
   // The cursor remains the source of truth at refill, mark, slice and error
   // points, but for the per-byte hot loops (`peek`, `advance`, `more`) the
@@ -164,6 +163,11 @@ private[jacinta] final class JsonParser:
   private var bufEnd: Int = 0
 
   protected[jacinta] var holes: Boolean = false
+
+  // When true, the cursor is built with a line-feed-tracking `Lineation` so
+  // `cursor.line` / `cursor.column` reflect real source coordinates, and the
+  // parser emits a parallel `PositionIndex`.
+  protected[jacinta] var tracking: Boolean = false
 
   // Storage shape `parseNumber` uses for each parsed JSON number. See
   // `NumberMode` for semantics. Reset before each `parse()` call.
@@ -201,7 +205,7 @@ private[jacinta] final class JsonParser:
   private val keyCacheHigh: Array[Long]         = new Array(KeyCacheSize)
 
   def resetData(input: Data): Unit =
-    cursor = Cursor[Data](input)
+    cursor = makeCursor(input)
     syncFrom()
     stringCursor = 0
     arrayBufferId = -1
@@ -210,13 +214,29 @@ private[jacinta] final class JsonParser:
     heldToken = null
 
   def resetIterator(input: Iterator[Data]): Unit =
-    cursor = Cursor[Data](input)
+    cursor = makeCursor(input)
     syncFrom()
     stringCursor = 0
     arrayBufferId = -1
     bcdLongBufferId = -1
     bcdIntBufferId = -1
     heldToken = null
+
+  private def makeCursor(input: Data): Cursor[Data] =
+    if tracking then
+      import zephyrine.lineation.linefeedByte
+      Cursor[Data](input)
+    else
+      import Lineation.untrackedData
+      Cursor[Data](input)
+
+  private def makeCursor(input: Iterator[Data]): Cursor[Data] =
+    if tracking then
+      import zephyrine.lineation.linefeedByte
+      Cursor[Data](input)
+    else
+      import Lineation.untrackedData
+      Cursor[Data](input)
 
   // ──────────────────────────────────────────────────────────────────────────
   // Substrate.

--- a/lib/jacinta/src/core/jacinta.JsonParser.scala
+++ b/lib/jacinta/src/core/jacinta.JsonParser.scala
@@ -109,6 +109,7 @@ private[jacinta] object JsonParser:
 
   def parse(source: Data, mode: NumberMode = NumberMode.Full): Raw raises ParseError =
     val parser = pool.get.nn
+    parser.tracking = false
     parser.resetData(source)
     parser.holes = false
     parser.numberMode = mode
@@ -116,6 +117,7 @@ private[jacinta] object JsonParser:
 
   def parse(source: Data, holes: Boolean, mode: NumberMode): Raw raises ParseError =
     val parser = pool.get.nn
+    parser.tracking = false
     parser.resetData(source)
     parser.holes = holes
     parser.numberMode = mode
@@ -123,6 +125,7 @@ private[jacinta] object JsonParser:
 
   def parse(input: Iterator[Data], mode: NumberMode): Raw raises ParseError =
     val parser = pool.get.nn
+    parser.tracking = false
     parser.resetIterator(input)
     parser.holes = false
     parser.numberMode = mode
@@ -130,10 +133,31 @@ private[jacinta] object JsonParser:
 
   def parse(input: Iterator[Data], holes: Boolean, mode: NumberMode): Raw raises ParseError =
     val parser = pool.get.nn
+    parser.tracking = false
     parser.resetIterator(input)
     parser.holes = holes
     parser.numberMode = mode
     parser.parse()
+
+  def parseTracked(source: Data, mode: NumberMode = NumberMode.Full)
+  :   (Raw, IArray[Int]) raises ParseError =
+    val parser = pool.get.nn
+    parser.tracking = true
+    parser.resetData(source)
+    parser.holes = false
+    parser.numberMode = mode
+    val raw = parser.parse()
+    (raw, parser.rootIndex.nn)
+
+  def parseTracked(input: Iterator[Data], mode: NumberMode)
+  :   (Raw, IArray[Int]) raises ParseError =
+    val parser = pool.get.nn
+    parser.tracking = true
+    parser.resetIterator(input)
+    parser.holes = false
+    parser.numberMode = mode
+    val raw = parser.parse()
+    (raw, parser.rootIndex.nn)
 
 private[jacinta] final class JsonParser:
   import JsonParser.*
@@ -182,6 +206,12 @@ private[jacinta] final class JsonParser:
   protected val bcdLongBuffers:      ArrayBuffer[ArrayBuffer[Long]] = ArrayBuffer.empty
   protected var bcdIntBufferId:      Int = -1
   protected val bcdIntBuffers:       ArrayBuffer[ArrayBuffer[Int]]  = ArrayBuffer.empty
+  protected var indexBufferId:       Int = -1
+  protected val indexBuffers:        ArrayBuffer[ArrayBuffer[Int]]  = ArrayBuffer.empty
+
+  // Finalised root-level position index produced by the previous `parse()`
+  // call when `tracking` was on. Reset to `null` at the start of every parse.
+  protected[jacinta] var rootIndex: IArray[Int] | Null = null
 
   // Small open-addressed cache of recently-seen object keys. Index is
   // `hash & (KeyCacheSize - 1)`; on a hash collision the existing entry is
@@ -211,6 +241,8 @@ private[jacinta] final class JsonParser:
     arrayBufferId = -1
     bcdLongBufferId = -1
     bcdIntBufferId = -1
+    indexBufferId = -1
+    rootIndex = null
     heldToken = null
 
   def resetIterator(input: Iterator[Data]): Unit =
@@ -220,6 +252,8 @@ private[jacinta] final class JsonParser:
     arrayBufferId = -1
     bcdLongBufferId = -1
     bcdIntBufferId = -1
+    indexBufferId = -1
+    rootIndex = null
     heldToken = null
 
   private def makeCursor(input: Data): Cursor[Data] =
@@ -406,6 +440,55 @@ private[jacinta] final class JsonParser:
       buffer
 
   protected inline def relinquishBcdIntBuffer(): Unit = bcdIntBufferId -= 1
+
+  protected inline def getIndexBuffer(): ArrayBuffer[Int] =
+    indexBufferId += 1
+
+    if indexBuffers.length <= indexBufferId then
+      val newBuffer = ArrayBuffer.empty[Int]
+      indexBuffers += newBuffer
+      newBuffer
+    else
+      val buffer = indexBuffers(indexBufferId)
+      buffer.clear()
+      buffer
+
+  protected inline def relinquishIndexBuffer(): Unit = indexBufferId -= 1
+
+  // Assemble a composite (array or object) descriptor in `indexOut`. `scratch`
+  // holds the concatenated entry descriptors back-to-back (an entry is a
+  // child for arrays, or `[keyLine, keyColumn, keyLength, value descriptor]`
+  // for objects). `ends(i)` is the position in `scratch` immediately after
+  // the i-th entry, so the i-th entry's size is `ends(i) - ends(i-1)`.
+  protected def emitCompositeDescriptor
+    ( indexOut:    ArrayBuffer[Int],
+      scratch:     ArrayBuffer[Int],
+      ends:        ArrayBuffer[Int],
+      startLine:   Int,
+      startColumn: Int,
+      startMark:   Long )
+  :   Unit =
+
+    val n = ends.length
+    val sourceLength = (cursor.position.n0 - startMark).toInt
+    val sizeSlot = indexOut.length
+
+    indexOut += 0
+    indexOut += startLine
+    indexOut += startColumn
+    indexOut += sourceLength
+    indexOut += n
+
+    val headerSize = 5 + n
+    var i = 0
+
+    while i < n do
+      val childStart = if i == 0 then 0 else ends(i - 1)
+      indexOut += headerSize + childStart
+      i += 1
+
+    indexOut ++= scratch
+    indexOut(sizeSlot) = indexOut.length - sizeSlot
 
   // ──────────────────────────────────────────────────────────────────────────
   // Parser body (unchanged from the previous abstract base).
@@ -844,31 +927,75 @@ private[jacinta] final class JsonParser:
   // parsed from an array context still short-circuits the Double path.
   // The flag has no effect on non-number values, so we don't need to
   // propagate it to `parseObject` / `parseArray` / `parseString`.
-  private def parseValue(minus: Boolean = false, bcdOnly: Boolean = false)
-                        (using Tactic[ParseError]): Raw =
+  //
+  // `indexOut` is the destination position-index buffer for the surrounding
+  // composite (or `null` outside tracking mode). For primitives the outer
+  // call writes a 4-int descriptor; for composites `parseArray` /
+  // `parseObject` write their own composite descriptor. The recursive
+  // `Minus` call passes `null` so the descriptor is emitted once, by the
+  // outer call, with the leading `-` included in its source length.
+  private def parseValue
+    ( minus:    Boolean = false,
+      bcdOnly:  Boolean = false,
+      indexOut: ArrayBuffer[Int] | Null = null )
+    ( using Tactic[ParseError] )
+  :   Raw =
     if !more then errorAt(Issue.PrematureEnd)
+
+    var startLine:   Int  = 0
+    var startColumn: Int  = 0
+    var startMark:   Long = 0L
+
+    if indexOut != null then
+      syncTo()
+      startLine   = cursor.line.n0
+      startColumn = cursor.column.n0
+      startMark   = cursor.position.n0.toLong
+
     val ch = peek
 
-    if (ch & 0xF8) == Num0 || (ch & 0xFE) == 0x38 then
-      advance()
-      parseNumber(ch & 0x0F, minus, bcdOnly)
-    else if minus then
-      errorAt(Issue.ExpectedDigit(ch.toChar))
-    else if holes && ch == 0 then
-      advance()
-      Unset
-    else
-      (ch: @switch) match
-        case Quote       => advance() yet parseString()
-        case Minus       => advance() yet parseValue(true, bcdOnly)
-        case OpenBracket => advance() yet parseArray()
-        case LowerF      => parseFalse()
-        case LowerN      => parseNull()
-        case LowerT      => parseTrue()
-        case OpenBrace   => advance() yet parseObject()
-        case other       => errorAt(Issue.ExpectedSomeValue(other.toChar))
+    val result: Raw =
+      if (ch & 0xF8) == Num0 || (ch & 0xFE) == 0x38 then
+        advance()
+        parseNumber(ch & 0x0F, minus, bcdOnly)
+      else if minus then
+        errorAt(Issue.ExpectedDigit(ch.toChar))
+      else if holes && ch == 0 then
+        advance()
+        Unset
+      else
+        (ch: @switch) match
+          case Quote       => advance() yet parseString()
+          case Minus       => advance() yet parseValue(true, bcdOnly, null)
+          case OpenBracket =>
+            advance()
+            parseArray(indexOut, startLine, startColumn, startMark)
+          case LowerF      => parseFalse()
+          case LowerN      => parseNull()
+          case LowerT      => parseTrue()
+          case OpenBrace   =>
+            advance()
+            parseObject(indexOut, startLine, startColumn, startMark)
+          case other       => errorAt(Issue.ExpectedSomeValue(other.toChar))
 
-  private def parseArray()(using Tactic[ParseError]): Raw =
+    // Composites have already written their descriptor; for everything else
+    // emit a 4-int primitive descriptor here.
+    if indexOut != null && ch != OpenBracket && ch != OpenBrace then
+      val length = (cursor.position.n0 - startMark).toInt
+      indexOut += 4
+      indexOut += startLine
+      indexOut += startColumn
+      indexOut += length
+
+    result
+
+  private def parseArray
+    ( indexOut:    ArrayBuffer[Int] | Null,
+      startLine:   Int,
+      startColumn: Int,
+      startMark:   Long )
+    ( using Tactic[ParseError] )
+  :   Raw =
     // The array starts in "undecided" mode. Each element is parsed with
     // `bcdOnly = true`, so a number comes back as either a single-Long
     // BCD packing (count + sign + nibbles encoded in the Long itself) or
@@ -889,6 +1016,14 @@ private[jacinta] final class JsonParser:
     var anyItems:  ArrayBuffer[Any]  | Null = null
     var first    = true
     var continue = true
+
+    // Tracking-mode scratch: `indexScratch` accumulates child descriptors
+    // back-to-back, `indexEnds` records each child's end position within
+    // `indexScratch` so offsets can be reconstructed at close.
+    val indexScratch: ArrayBuffer[Int] | Null =
+      if indexOut != null then getIndexBuffer() else null
+    val indexEnds:    ArrayBuffer[Int] | Null =
+      if indexOut != null then getIndexBuffer() else null
 
     inline def migrateIntToLong(): Unit =
       val src = intItems.nn
@@ -953,7 +1088,8 @@ private[jacinta] final class JsonParser:
           continue = false
 
         case _ =>
-          val value = parseValue(bcdOnly = true)
+          val value = parseValue(bcdOnly = true, indexOut = indexScratch)
+          if indexScratch != null then indexEnds.nn += indexScratch.length
           skip()
 
           val terminator: Byte = must()
@@ -1028,71 +1164,110 @@ private[jacinta] final class JsonParser:
 
       advance()
 
-    if first then
-      // Empty array — no buffer was ever allocated. The empty case has
-      // even (zero) length so the sentinel pad is required to keep arrays
-      // distinguishable from objects.
-      val out = new Array[Any](1)
-      out(0) = Json.Ast.arrayPad
-      out.asInstanceOf[IArray[Any]]
-    else
-      (mode: @switch) match
-        case ModeBcdInt =>
-          val src = intItems.nn
-          val out = new Array[Int](src.length)
-          src.copyToArray(out)
-          relinquishBcdIntBuffer()
-          out
+    val astValue: Raw =
+      if first then
+        // Empty array — no buffer was ever allocated. The empty case has
+        // even (zero) length so the sentinel pad is required to keep arrays
+        // distinguishable from objects.
+        val out = new Array[Any](1)
+        out(0) = Json.Ast.arrayPad
+        out.asInstanceOf[IArray[Any]]
+      else
+        (mode: @switch) match
+          case ModeBcdInt =>
+            val src = intItems.nn
+            val out = new Array[Int](src.length)
+            src.copyToArray(out)
+            relinquishBcdIntBuffer()
+            out
 
-        case ModeBcdLong =>
-          val src = longItems.nn
-          val out = new Array[Long](src.length)
-          src.copyToArray(out)
-          relinquishBcdLongBuffer()
-          out
+          case ModeBcdLong =>
+            val src = longItems.nn
+            val out = new Array[Long](src.length)
+            src.copyToArray(out)
+            relinquishBcdLongBuffer()
+            out
 
-        case _ =>
-          // Mixed/boxed array — stored as `IArray[Any]` and parity-padded
-          // when the element count is even, so arrays always have odd
-          // length and can be distinguished from objects (always even).
-          val src = anyItems.nn
-          val n = src.length
+          case _ =>
+            // Mixed/boxed array — stored as `IArray[Any]` and parity-padded
+            // when the element count is even, so arrays always have odd
+            // length and can be distinguished from objects (always even).
+            val src = anyItems.nn
+            val n = src.length
 
-          val out =
-            if (n & 1) == 1 then
-              val arr = new Array[Any](n)
-              src.copyToArray(arr)
-              arr
-            else
-              val arr = new Array[Any](n + 1)
-              src.copyToArray(arr)
-              arr(n) = Json.Ast.arrayPad
-              arr
+            val out =
+              if (n & 1) == 1 then
+                val arr = new Array[Any](n)
+                src.copyToArray(arr)
+                arr
+              else
+                val arr = new Array[Any](n + 1)
+                src.copyToArray(arr)
+                arr(n) = Json.Ast.arrayPad
+                arr
 
-          relinquishArrayBuffer()
-          out.asInstanceOf[IArray[Any]]
+            relinquishArrayBuffer()
+            out.asInstanceOf[IArray[Any]]
+
+    if indexOut != null then
+      emitCompositeDescriptor
+       ( indexOut, indexScratch.nn, indexEnds.nn,
+         startLine, startColumn, startMark )
+      relinquishIndexBuffer()
+      relinquishIndexBuffer()
+
+    astValue
 
   // Parse an object directly into the flat alternating-key/value layout. The
   // buffer always grows in pairs, so its length stays even, which is the
   // object/array parity invariant.
-  private def parseObject()(using Tactic[ParseError]): IArray[Any] =
+  private def parseObject
+    ( indexOut:    ArrayBuffer[Int] | Null,
+      startLine:   Int,
+      startColumn: Int,
+      startMark:   Long )
+    ( using Tactic[ParseError] )
+  :   IArray[Any] =
+
     val items: ArrayBuffer[Any] = getArrayBuffer()
     var continue = true
 
+    val indexScratch: ArrayBuffer[Int] | Null =
+      if indexOut != null then getIndexBuffer() else null
+    val indexEnds:    ArrayBuffer[Int] | Null =
+      if indexOut != null then getIndexBuffer() else null
+
+    var keyLine:   Int  = 0
+    var keyColumn: Int  = 0
+    var keyMark:   Long = 0L
+
     while continue do
       skip()
+
+      if indexOut != null then
+        syncTo()
+        keyLine   = cursor.line.n0
+        keyColumn = cursor.column.n0
+        keyMark   = cursor.position.n0.toLong
 
       must() match
         case Quote =>
           advance()
           val string = parseObjectKey()
+          val keyLength =
+            if indexOut != null then (cursor.position.n0 - keyMark).toInt else 0
           skip()
 
           must() match
             case Colon =>
               advance()
               skip()
-              val value = parseValue()
+              if indexScratch != null then
+                indexScratch += keyLine
+                indexScratch += keyColumn
+                indexScratch += keyLength
+              val value = parseValue(indexOut = indexScratch)
+              if indexEnds != null then indexEnds += indexScratch.nn.length
               skip()
 
               must() match
@@ -1114,13 +1289,19 @@ private[jacinta] final class JsonParser:
 
         case 0 if holes =>
           advance()
+          val keyLength = 1
           skip()
 
           must() match
             case Colon =>
               advance()
               skip()
-              val value = parseValue()
+              if indexScratch != null then
+                indexScratch += keyLine
+                indexScratch += keyColumn
+                indexScratch += keyLength
+              val value = parseValue(indexOut = indexScratch)
+              if indexEnds != null then indexEnds += indexScratch.nn.length
               skip()
 
               must() match
@@ -1139,12 +1320,36 @@ private[jacinta] final class JsonParser:
                 case ch => errorAt(Issue.UnexpectedChar(ch.toChar))
 
             case Comma =>
+              if indexScratch != null then
+                syncTo()
+                val unsetLine   = cursor.line.n0
+                val unsetColumn = cursor.column.n0
+                indexScratch += keyLine
+                indexScratch += keyColumn
+                indexScratch += keyLength
+                indexScratch += 4
+                indexScratch += unsetLine
+                indexScratch += unsetColumn
+                indexScratch += 0
+                indexEnds.nn += indexScratch.length
               advance()
               items += " "
               items += Unset
               skip()
 
             case CloseBrace =>
+              if indexScratch != null then
+                syncTo()
+                val unsetLine   = cursor.line.n0
+                val unsetColumn = cursor.column.n0
+                indexScratch += keyLine
+                indexScratch += keyColumn
+                indexScratch += keyLength
+                indexScratch += 4
+                indexScratch += unsetLine
+                indexScratch += unsetColumn
+                indexScratch += 0
+                indexEnds.nn += indexScratch.length
               advance()
               items += " "
               items += Unset
@@ -1163,17 +1368,32 @@ private[jacinta] final class JsonParser:
     val out = new Array[Any](items.length)
     items.copyToArray(out)
     relinquishArrayBuffer()
+
+    if indexOut != null then
+      emitCompositeDescriptor
+       ( indexOut, indexScratch.nn, indexEnds.nn,
+         startLine, startColumn, startMark )
+      relinquishIndexBuffer()
+      relinquishIndexBuffer()
+
     out.asInstanceOf[IArray[Any]]
 
   def parse()(using Tactic[ParseError]): Raw =
     bom()
     skip()
     if !more then abort(ParseError(Json.Ast, Position(0, 0), Issue.EmptyInput))
-    val result = parseValue()
+
+    val rootBuf: ArrayBuffer[Int] | Null =
+      if tracking then getIndexBuffer() else null
+    val result = parseValue(indexOut = rootBuf)
 
     while more do
       peek match
         case Tab | Return | Newline | Space => advance()
         case char                           => errorAt(Issue.SpuriousContent(char.toChar))
+
+    if rootBuf != null then
+      rootIndex = IArray.from(rootBuf)
+      relinquishIndexBuffer()
 
     result

--- a/lib/jacinta/src/core/jacinta.JsonParser.scala
+++ b/lib/jacinta/src/core/jacinta.JsonParser.scala
@@ -277,8 +277,34 @@ private[jacinta] final class JsonParser:
 
   // Push the parser's local `pos` back to the cursor. Required before any
   // cursor operation that consults `pos` (mark, slice, refill, position).
+  //
+  // `unsafeAdvanceBy` bypasses the cursor's lineation tracking, so in
+  // tracking mode the bypassed bytes are walked here to keep
+  // `cursor.line` / `cursor.column` accurate.
   private inline def syncTo(): Unit =
-    cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
+    if tracking then syncToTracked()
+    else cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
+
+  private def syncToTracked(): Unit =
+    val oldPos = cursor.unsafePos(using Unsafe)
+    val delta = pos - oldPos
+    if delta > 0 then
+      var i = oldPos
+      var newlines = 0
+      var lastNewlineAt = -1
+      while i < pos do
+        if bytes(i) == Newline then
+          newlines += 1
+          lastNewlineAt = i
+        i += 1
+
+      if newlines > 0 then
+        cursor.unsafeBumpLine(newlines)(using Unsafe)
+        cursor.unsafeSetColumn(pos - lastNewlineAt - 1)(using Unsafe)
+      else
+        cursor.unsafeBumpColumn(delta)(using Unsafe)
+
+      cursor.unsafeAdvanceBy(delta)(using Unsafe)
 
   // Refresh the parser's snapshot from the cursor. Required after any
   // cursor operation that may have changed the buffer reference, the read
@@ -293,9 +319,18 @@ private[jacinta] final class JsonParser:
   // Out-of-line slow path so the inline budget for `more` stays small enough
   // for the JIT to keep `pos < bufEnd` as a single register comparison in
   // hot loops.
+  //
+  // In tracking mode the parser later reads `cursor.position` to compute
+  // descriptor lengths; if `cursor.refill()` compacts the buffer here we
+  // must re-anchor the parser's local `pos` against the new buffer scale
+  // even when there's no more data, otherwise subsequent `syncTo()` calls
+  // would advance the cursor by a now-stale delta.
   private def moreSlow(): Boolean =
     syncTo()
-    if cursor.more then { syncFrom(); true } else false
+    if cursor.more then { syncFrom(); true }
+    else
+      if tracking then syncFrom()
+      false
 
   protected inline def peek: Byte = bytes(pos)
 
@@ -469,6 +504,7 @@ private[jacinta] final class JsonParser:
       startMark:   Long )
   :   Unit =
 
+    syncTo()
     val n = ends.length
     val sourceLength = (cursor.position.n0 - startMark).toInt
     val sizeSlot = indexOut.length
@@ -948,8 +984,8 @@ private[jacinta] final class JsonParser:
 
     if indexOut != null then
       syncTo()
-      startLine   = cursor.line.n0
-      startColumn = cursor.column.n0
+      startLine   = cursor.line.n1
+      startColumn = cursor.column.n1
       startMark   = cursor.position.n0.toLong
 
     val ch = peek
@@ -981,6 +1017,7 @@ private[jacinta] final class JsonParser:
     // Composites have already written their descriptor; for everything else
     // emit a 4-int primitive descriptor here.
     if indexOut != null && ch != OpenBracket && ch != OpenBrace then
+      syncTo()
       val length = (cursor.position.n0 - startMark).toInt
       indexOut += 4
       indexOut += startLine
@@ -1246,8 +1283,8 @@ private[jacinta] final class JsonParser:
 
       if indexOut != null then
         syncTo()
-        keyLine   = cursor.line.n0
-        keyColumn = cursor.column.n0
+        keyLine   = cursor.line.n1
+        keyColumn = cursor.column.n1
         keyMark   = cursor.position.n0.toLong
 
       must() match
@@ -1255,7 +1292,10 @@ private[jacinta] final class JsonParser:
           advance()
           val string = parseObjectKey()
           val keyLength =
-            if indexOut != null then (cursor.position.n0 - keyMark).toInt else 0
+            if indexOut != null then
+              syncTo()
+              (cursor.position.n0 - keyMark).toInt
+            else 0
           skip()
 
           must() match
@@ -1322,8 +1362,8 @@ private[jacinta] final class JsonParser:
             case Comma =>
               if indexScratch != null then
                 syncTo()
-                val unsetLine   = cursor.line.n0
-                val unsetColumn = cursor.column.n0
+                val unsetLine   = cursor.line.n1
+                val unsetColumn = cursor.column.n1
                 indexScratch += keyLine
                 indexScratch += keyColumn
                 indexScratch += keyLength
@@ -1340,8 +1380,8 @@ private[jacinta] final class JsonParser:
             case CloseBrace =>
               if indexScratch != null then
                 syncTo()
-                val unsetLine   = cursor.line.n0
-                val unsetColumn = cursor.column.n0
+                val unsetLine   = cursor.line.n1
+                val unsetColumn = cursor.column.n1
                 indexScratch += keyLine
                 indexScratch += keyColumn
                 indexScratch += keyLength

--- a/lib/jacinta/src/core/jacinta.JsonParser.scala
+++ b/lib/jacinta/src/core/jacinta.JsonParser.scala
@@ -213,6 +213,14 @@ private[jacinta] final class JsonParser:
   // call when `tracking` was on. Reset to `null` at the start of every parse.
   protected[jacinta] var rootIndex: IArray[Int] | Null = null
 
+  // Local-buffer offset up to which `cursor.lineNo` / `cursor.columnNo`
+  // have been brought up to date. The hot-loop `syncTo()` bypasses the
+  // cursor's lineation tracking via `unsafeAdvanceBy`, so the parser
+  // keeps track of how far ahead `cursor.pos` has been pushed and
+  // catches lineation up here only at tracking-mode capture points and
+  // before any refill discards consumed bytes.
+  private var lineationPos: Int = 0
+
   // Small open-addressed cache of recently-seen object keys. Index is
   // `hash & (KeyCacheSize - 1)`; on a hash collision the existing entry is
   // overwritten. Persisted across parses (per-thread, since the parser
@@ -277,22 +285,24 @@ private[jacinta] final class JsonParser:
 
   // Push the parser's local `pos` back to the cursor. Required before any
   // cursor operation that consults `pos` (mark, slice, refill, position).
-  //
-  // `unsafeAdvanceBy` bypasses the cursor's lineation tracking, so in
-  // tracking mode the bypassed bytes are walked here to keep
-  // `cursor.line` / `cursor.column` accurate.
+  // This must stay zero-branch on the hot path; tracking-mode callers
+  // separately invoke `reconcileLineation()` when they need accurate
+  // `cursor.line` / `cursor.column`.
   private inline def syncTo(): Unit =
-    if tracking then syncToTracked()
-    else cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
+    cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
 
-  private def syncToTracked(): Unit =
-    val oldPos = cursor.unsafePos(using Unsafe)
-    val delta = pos - oldPos
-    if delta > 0 then
-      var i = oldPos
+  // Walk the buffer bytes between the last lineation-reconciled position
+  // and `cursor.unsafePos`, bumping `cursor.lineNo` / `cursor.columnNo`
+  // accordingly. Called at tracking-mode capture points (`parseValue`,
+  // `parseObject`) and before any refill in `moreSlow()` so that
+  // consumed bytes are accounted for before they're discarded.
+  private def reconcileLineation(): Unit =
+    val end = cursor.unsafePos(using Unsafe)
+    if lineationPos < end then
+      var i = lineationPos
       var newlines = 0
       var lastNewlineAt = -1
-      while i < pos do
+      while i < end do
         if bytes(i) == Newline then
           newlines += 1
           lastNewlineAt = i
@@ -300,19 +310,24 @@ private[jacinta] final class JsonParser:
 
       if newlines > 0 then
         cursor.unsafeBumpLine(newlines)(using Unsafe)
-        cursor.unsafeSetColumn(pos - lastNewlineAt - 1)(using Unsafe)
+        cursor.unsafeSetColumn(end - lastNewlineAt - 1)(using Unsafe)
       else
-        cursor.unsafeBumpColumn(delta)(using Unsafe)
+        cursor.unsafeBumpColumn(end - lineationPos)(using Unsafe)
 
-      cursor.unsafeAdvanceBy(delta)(using Unsafe)
+      lineationPos = end
 
   // Refresh the parser's snapshot from the cursor. Required after any
   // cursor operation that may have changed the buffer reference, the read
   // position, or the write end (refill, cue).
+  //
+  // `lineationPos` is re-anchored to the cursor's current position because
+  // refill compacts the buffer (bytes 0..old-pos are discarded; subsequent
+  // walks would read different data).
   private inline def syncFrom(): Unit =
     bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
     pos    = cursor.unsafePos(using Unsafe)
     bufEnd = cursor.unsafeWriteEnd(using Unsafe)
+    lineationPos = pos
 
   protected inline def more: Boolean = pos < bufEnd || moreSlow()
 
@@ -324,9 +339,11 @@ private[jacinta] final class JsonParser:
   // descriptor lengths; if `cursor.refill()` compacts the buffer here we
   // must re-anchor the parser's local `pos` against the new buffer scale
   // even when there's no more data, otherwise subsequent `syncTo()` calls
-  // would advance the cursor by a now-stale delta.
+  // would advance the cursor by a now-stale delta. Lineation also needs
+  // to be reconciled before compaction discards the consumed bytes.
   private def moreSlow(): Boolean =
     syncTo()
+    if tracking then reconcileLineation()
     if cursor.more then { syncFrom(); true }
     else
       if tracking then syncFrom()
@@ -963,30 +980,49 @@ private[jacinta] final class JsonParser:
   // parsed from an array context still short-circuits the Double path.
   // The flag has no effect on non-number values, so we don't need to
   // propagate it to `parseObject` / `parseArray` / `parseString`.
-  //
-  // `indexOut` is the destination position-index buffer for the surrounding
-  // composite (or `null` outside tracking mode). For primitives the outer
-  // call writes a 4-int descriptor; for composites `parseArray` /
-  // `parseObject` write their own composite descriptor. The recursive
-  // `Minus` call passes `null` so the descriptor is emitted once, by the
-  // outer call, with the leading `-` included in its source length.
-  private def parseValue
-    ( minus:    Boolean = false,
-      bcdOnly:  Boolean = false,
-      indexOut: ArrayBuffer[Int] | Null = null )
+  private def parseValue(minus: Boolean = false, bcdOnly: Boolean = false)
+                        (using Tactic[ParseError]): Raw =
+    if !more then errorAt(Issue.PrematureEnd)
+    val ch = peek
+
+    if (ch & 0xF8) == Num0 || (ch & 0xFE) == 0x38 then
+      advance()
+      parseNumber(ch & 0x0F, minus, bcdOnly)
+    else if minus then
+      errorAt(Issue.ExpectedDigit(ch.toChar))
+    else if holes && ch == 0 then
+      advance()
+      Unset
+    else
+      (ch: @switch) match
+        case Quote       => advance() yet parseString()
+        case Minus       => advance() yet parseValue(true, bcdOnly)
+        case OpenBracket => advance() yet parseArray()
+        case LowerF      => parseFalse()
+        case LowerN      => parseNull()
+        case LowerT      => parseTrue()
+        case OpenBrace   => advance() yet parseObject()
+        case other       => errorAt(Issue.ExpectedSomeValue(other.toChar))
+
+  // Tracked-mode `parseValue`. Captures source position before dispatch,
+  // delegates composite cases to the `*Tracked` variants (so they emit
+  // their own descriptors into `indexOut`), and writes a 4-int primitive
+  // descriptor afterwards for everything else. The `Minus` recursion
+  // routes to the untracked variant since the outer call already owns
+  // the descriptor for the full `-N` span.
+  private def parseValueTracked
+    ( indexOut: ArrayBuffer[Int],
+      minus:    Boolean = false,
+      bcdOnly:  Boolean = false )
     ( using Tactic[ParseError] )
   :   Raw =
     if !more then errorAt(Issue.PrematureEnd)
 
-    var startLine:   Int  = 0
-    var startColumn: Int  = 0
-    var startMark:   Long = 0L
-
-    if indexOut != null then
-      syncTo()
-      startLine   = cursor.line.n1
-      startColumn = cursor.column.n1
-      startMark   = cursor.position.n0.toLong
+    syncTo()
+    reconcileLineation()
+    val startLine   = cursor.line.n1
+    val startColumn = cursor.column.n1
+    val startMark   = cursor.position.n0.toLong
 
     val ch = peek
 
@@ -1002,21 +1038,19 @@ private[jacinta] final class JsonParser:
       else
         (ch: @switch) match
           case Quote       => advance() yet parseString()
-          case Minus       => advance() yet parseValue(true, bcdOnly, null)
+          case Minus       => advance() yet parseValue(true, bcdOnly)
           case OpenBracket =>
             advance()
-            parseArray(indexOut, startLine, startColumn, startMark)
+            parseArrayTracked(indexOut, startLine, startColumn, startMark)
           case LowerF      => parseFalse()
           case LowerN      => parseNull()
           case LowerT      => parseTrue()
           case OpenBrace   =>
             advance()
-            parseObject(indexOut, startLine, startColumn, startMark)
+            parseObjectTracked(indexOut, startLine, startColumn, startMark)
           case other       => errorAt(Issue.ExpectedSomeValue(other.toChar))
 
-    // Composites have already written their descriptor; for everything else
-    // emit a 4-int primitive descriptor here.
-    if indexOut != null && ch != OpenBracket && ch != OpenBrace then
+    if ch != OpenBracket && ch != OpenBrace then
       syncTo()
       val length = (cursor.position.n0 - startMark).toInt
       indexOut += 4
@@ -1026,13 +1060,7 @@ private[jacinta] final class JsonParser:
 
     result
 
-  private def parseArray
-    ( indexOut:    ArrayBuffer[Int] | Null,
-      startLine:   Int,
-      startColumn: Int,
-      startMark:   Long )
-    ( using Tactic[ParseError] )
-  :   Raw =
+  private def parseArray()(using Tactic[ParseError]): Raw =
     // The array starts in "undecided" mode. Each element is parsed with
     // `bcdOnly = true`, so a number comes back as either a single-Long
     // BCD packing (count + sign + nibbles encoded in the Long itself) or
@@ -1053,14 +1081,6 @@ private[jacinta] final class JsonParser:
     var anyItems:  ArrayBuffer[Any]  | Null = null
     var first    = true
     var continue = true
-
-    // Tracking-mode scratch: `indexScratch` accumulates child descriptors
-    // back-to-back, `indexEnds` records each child's end position within
-    // `indexScratch` so offsets can be reconstructed at close.
-    val indexScratch: ArrayBuffer[Int] | Null =
-      if indexOut != null then getIndexBuffer() else null
-    val indexEnds:    ArrayBuffer[Int] | Null =
-      if indexOut != null then getIndexBuffer() else null
 
     inline def migrateIntToLong(): Unit =
       val src = intItems.nn
@@ -1125,8 +1145,7 @@ private[jacinta] final class JsonParser:
           continue = false
 
         case _ =>
-          val value = parseValue(bcdOnly = true, indexOut = indexScratch)
-          if indexScratch != null then indexEnds.nn += indexScratch.length
+          val value = parseValue(bcdOnly = true)
           skip()
 
           val terminator: Byte = must()
@@ -1201,11 +1220,200 @@ private[jacinta] final class JsonParser:
 
       advance()
 
+    if first then
+      // Empty array — no buffer was ever allocated. The empty case has
+      // even (zero) length so the sentinel pad is required to keep arrays
+      // distinguishable from objects.
+      val out = new Array[Any](1)
+      out(0) = Json.Ast.arrayPad
+      out.asInstanceOf[IArray[Any]]
+    else
+      (mode: @switch) match
+        case ModeBcdInt =>
+          val src = intItems.nn
+          val out = new Array[Int](src.length)
+          src.copyToArray(out)
+          relinquishBcdIntBuffer()
+          out
+
+        case ModeBcdLong =>
+          val src = longItems.nn
+          val out = new Array[Long](src.length)
+          src.copyToArray(out)
+          relinquishBcdLongBuffer()
+          out
+
+        case _ =>
+          // Mixed/boxed array — stored as `IArray[Any]` and parity-padded
+          // when the element count is even, so arrays always have odd
+          // length and can be distinguished from objects (always even).
+          val src = anyItems.nn
+          val n = src.length
+
+          val out =
+            if (n & 1) == 1 then
+              val arr = new Array[Any](n)
+              src.copyToArray(arr)
+              arr
+            else
+              val arr = new Array[Any](n + 1)
+              src.copyToArray(arr)
+              arr(n) = Json.Ast.arrayPad
+              arr
+
+          relinquishArrayBuffer()
+          out.asInstanceOf[IArray[Any]]
+
+  // Tracked-mode `parseArray`. Mirrors `parseArray` exactly but uses
+  // `parseValueTracked` for children and emits a composite descriptor
+  // into `indexOut` at close.
+  private def parseArrayTracked
+    ( indexOut:    ArrayBuffer[Int],
+      startLine:   Int,
+      startColumn: Int,
+      startMark:   Long )
+    ( using Tactic[ParseError] )
+  :   Raw =
+    var mode: Int = ModeUndecided
+    var intItems:  ArrayBuffer[Int]  | Null = null
+    var longItems: ArrayBuffer[Long] | Null = null
+    var anyItems:  ArrayBuffer[Any]  | Null = null
+    var first    = true
+    var continue = true
+
+    val indexScratch = getIndexBuffer()
+    val indexEnds    = getIndexBuffer()
+
+    inline def migrateIntToLong(): Unit =
+      val src = intItems.nn
+      val dst = getBcdLongBuffer()
+      val n = src.length
+      var i = 0
+
+      while i < n do
+        dst += Bcd.repackBcdIntAsLong(src(i))
+        i += 1
+
+      relinquishBcdIntBuffer()
+      intItems = null
+      longItems = dst
+      mode = ModeBcdLong
+
+    inline def migrateIntToBoxed(): Unit =
+      val src = intItems.nn
+      val dst = getArrayBuffer()
+      val n = src.length
+      var i = 0
+
+      while i < n do
+        dst += src(i)
+        i += 1
+
+      relinquishBcdIntBuffer()
+      intItems = null
+      anyItems = dst
+      mode = ModeBoxed
+
+    inline def migrateLongToBoxed(): Unit =
+      val src = longItems.nn
+      val dst = getArrayBuffer()
+      val n = src.length
+      var i = 0
+
+      while i < n do
+        val v = src(i)
+        val text = Bcd.bcdLongText(v)
+        val ast: Any =
+          try java.lang.Long.parseLong(text)
+          catch case _: NumberFormatException => java.lang.Double.parseDouble(text)
+
+        dst += ast
+        i += 1
+
+      relinquishBcdLongBuffer()
+      longItems = null
+      anyItems = dst
+      mode = ModeBoxed
+
+    while continue do
+      skip()
+
+      must() match
+        case CloseBracket =>
+          if !first then errorAt(Issue.ExpectedSomeValue(']'))
+          continue = false
+
+        case _ =>
+          val value = parseValueTracked(indexScratch, bcdOnly = true)
+          indexEnds += indexScratch.length
+          skip()
+
+          val terminator: Byte = must()
+
+          terminator match
+            case Comma | CloseBracket => ()
+            case char                 => errorAt(Issue.ExpectedSomeValue(char.toChar))
+
+          value match
+            case bcdLong: Long =>
+              val nibbles = ((bcdLong >>> 56) & 0x7FL).toInt
+
+              if first then
+                first = false
+                if nibbles <= Bcd.MaxBcdIntNibbles then
+                  mode = ModeBcdInt
+                  val buf = getBcdIntBuffer()
+                  intItems = buf
+                  buf += Bcd.packBcdIntFromLong(bcdLong)
+                else
+                  mode = ModeBcdLong
+                  val buf = getBcdLongBuffer()
+                  longItems = buf
+                  buf += bcdLong
+              else
+                (mode: @switch) match
+                  case ModeBcdInt =>
+                    if nibbles <= Bcd.MaxBcdIntNibbles then
+                      intItems.nn += Bcd.packBcdIntFromLong(bcdLong)
+                    else
+                      migrateIntToLong()
+                      longItems.nn += bcdLong
+
+                  case ModeBcdLong =>
+                    longItems.nn += bcdLong
+
+                  case _ =>
+                    if nibbles <= Bcd.MaxBcdIntNibbles then
+                      anyItems.nn += Bcd.packBcdIntFromLong(bcdLong)
+                    else
+                      anyItems.nn += bcdLong
+
+            case _ =>
+              if first then
+                first = false
+                mode = ModeBoxed
+                val buf = getArrayBuffer()
+                anyItems = buf
+                buf += value
+              else
+                (mode: @switch) match
+                  case ModeBcdInt =>
+                    migrateIntToBoxed()
+                    anyItems.nn += value
+
+                  case ModeBcdLong =>
+                    migrateLongToBoxed()
+                    anyItems.nn += value
+
+                  case _ =>
+                    anyItems.nn += value
+
+          if terminator == CloseBracket then continue = false
+
+      advance()
+
     val astValue: Raw =
       if first then
-        // Empty array — no buffer was ever allocated. The empty case has
-        // even (zero) length so the sentinel pad is required to keep arrays
-        // distinguishable from objects.
         val out = new Array[Any](1)
         out(0) = Json.Ast.arrayPad
         out.asInstanceOf[IArray[Any]]
@@ -1226,9 +1434,6 @@ private[jacinta] final class JsonParser:
             out
 
           case _ =>
-            // Mixed/boxed array — stored as `IArray[Any]` and parity-padded
-            // when the element count is even, so arrays always have odd
-            // length and can be distinguished from objects (always even).
             val src = anyItems.nn
             val n = src.length
 
@@ -1246,20 +1451,111 @@ private[jacinta] final class JsonParser:
             relinquishArrayBuffer()
             out.asInstanceOf[IArray[Any]]
 
-    if indexOut != null then
-      emitCompositeDescriptor
-       ( indexOut, indexScratch.nn, indexEnds.nn,
-         startLine, startColumn, startMark )
-      relinquishIndexBuffer()
-      relinquishIndexBuffer()
+    emitCompositeDescriptor
+     ( indexOut, indexScratch, indexEnds, startLine, startColumn, startMark )
+    relinquishIndexBuffer()
+    relinquishIndexBuffer()
 
     astValue
 
   // Parse an object directly into the flat alternating-key/value layout. The
   // buffer always grows in pairs, so its length stays even, which is the
   // object/array parity invariant.
-  private def parseObject
-    ( indexOut:    ArrayBuffer[Int] | Null,
+  private def parseObject()(using Tactic[ParseError]): IArray[Any] =
+    val items: ArrayBuffer[Any] = getArrayBuffer()
+    var continue = true
+
+    while continue do
+      skip()
+
+      must() match
+        case Quote =>
+          advance()
+          val string = parseObjectKey()
+          skip()
+
+          must() match
+            case Colon =>
+              advance()
+              skip()
+              val value = parseValue()
+              skip()
+
+              must() match
+                case Comma =>
+                  advance()
+                  items += string
+                  items += value
+                  skip()
+
+                case CloseBrace =>
+                  advance()
+                  items += string
+                  items += value
+                  continue = false
+
+                case ch  => errorAt(Issue.UnexpectedChar(ch.toChar))
+
+            case ch => errorAt(Issue.ExpectedColon(ch.toChar))
+
+        case 0 if holes =>
+          advance()
+          skip()
+
+          must() match
+            case Colon =>
+              advance()
+              skip()
+              val value = parseValue()
+              skip()
+
+              must() match
+                case Comma =>
+                  advance()
+                  items += " "
+                  items += value
+                  skip()
+
+                case CloseBrace =>
+                  advance()
+                  items += " "
+                  items += value
+                  continue = false
+
+                case ch => errorAt(Issue.UnexpectedChar(ch.toChar))
+
+            case Comma =>
+              advance()
+              items += " "
+              items += Unset
+              skip()
+
+            case CloseBrace =>
+              advance()
+              items += " "
+              items += Unset
+              continue = false
+
+            case ch => errorAt(Issue.UnexpectedChar(ch.toChar))
+
+        case CloseBrace =>
+          if !items.nil then errorAt(Issue.ExpectedSomeValue('}'))
+          advance()
+          continue = false
+
+        case ch =>
+          errorAt(Issue.ExpectedString(ch.toChar))
+
+    val out = new Array[Any](items.length)
+    items.copyToArray(out)
+    relinquishArrayBuffer()
+    out.asInstanceOf[IArray[Any]]
+
+  // Tracked-mode `parseObject`. Mirrors `parseObject` exactly but captures
+  // key positions, runs values through `parseValueTracked`, and emits a
+  // composite descriptor into `indexOut` at close.
+  private def parseObjectTracked
+    ( indexOut:    ArrayBuffer[Int],
       startLine:   Int,
       startColumn: Int,
       startMark:   Long )
@@ -1269,10 +1565,8 @@ private[jacinta] final class JsonParser:
     val items: ArrayBuffer[Any] = getArrayBuffer()
     var continue = true
 
-    val indexScratch: ArrayBuffer[Int] | Null =
-      if indexOut != null then getIndexBuffer() else null
-    val indexEnds:    ArrayBuffer[Int] | Null =
-      if indexOut != null then getIndexBuffer() else null
+    val indexScratch = getIndexBuffer()
+    val indexEnds    = getIndexBuffer()
 
     var keyLine:   Int  = 0
     var keyColumn: Int  = 0
@@ -1280,34 +1574,29 @@ private[jacinta] final class JsonParser:
 
     while continue do
       skip()
-
-      if indexOut != null then
-        syncTo()
-        keyLine   = cursor.line.n1
-        keyColumn = cursor.column.n1
-        keyMark   = cursor.position.n0.toLong
+      syncTo()
+      reconcileLineation()
+      keyLine   = cursor.line.n1
+      keyColumn = cursor.column.n1
+      keyMark   = cursor.position.n0.toLong
 
       must() match
         case Quote =>
           advance()
           val string = parseObjectKey()
-          val keyLength =
-            if indexOut != null then
-              syncTo()
-              (cursor.position.n0 - keyMark).toInt
-            else 0
+          syncTo()
+          val keyLength = (cursor.position.n0 - keyMark).toInt
           skip()
 
           must() match
             case Colon =>
               advance()
               skip()
-              if indexScratch != null then
-                indexScratch += keyLine
-                indexScratch += keyColumn
-                indexScratch += keyLength
-              val value = parseValue(indexOut = indexScratch)
-              if indexEnds != null then indexEnds += indexScratch.nn.length
+              indexScratch += keyLine
+              indexScratch += keyColumn
+              indexScratch += keyLength
+              val value = parseValueTracked(indexScratch)
+              indexEnds += indexScratch.length
               skip()
 
               must() match
@@ -1336,12 +1625,11 @@ private[jacinta] final class JsonParser:
             case Colon =>
               advance()
               skip()
-              if indexScratch != null then
-                indexScratch += keyLine
-                indexScratch += keyColumn
-                indexScratch += keyLength
-              val value = parseValue(indexOut = indexScratch)
-              if indexEnds != null then indexEnds += indexScratch.nn.length
+              indexScratch += keyLine
+              indexScratch += keyColumn
+              indexScratch += keyLength
+              val value = parseValueTracked(indexScratch)
+              indexEnds += indexScratch.length
               skip()
 
               must() match
@@ -1360,36 +1648,36 @@ private[jacinta] final class JsonParser:
                 case ch => errorAt(Issue.UnexpectedChar(ch.toChar))
 
             case Comma =>
-              if indexScratch != null then
-                syncTo()
-                val unsetLine   = cursor.line.n1
-                val unsetColumn = cursor.column.n1
-                indexScratch += keyLine
-                indexScratch += keyColumn
-                indexScratch += keyLength
-                indexScratch += 4
-                indexScratch += unsetLine
-                indexScratch += unsetColumn
-                indexScratch += 0
-                indexEnds.nn += indexScratch.length
+              syncTo()
+              reconcileLineation()
+              val unsetLine   = cursor.line.n1
+              val unsetColumn = cursor.column.n1
+              indexScratch += keyLine
+              indexScratch += keyColumn
+              indexScratch += keyLength
+              indexScratch += 4
+              indexScratch += unsetLine
+              indexScratch += unsetColumn
+              indexScratch += 0
+              indexEnds += indexScratch.length
               advance()
               items += " "
               items += Unset
               skip()
 
             case CloseBrace =>
-              if indexScratch != null then
-                syncTo()
-                val unsetLine   = cursor.line.n1
-                val unsetColumn = cursor.column.n1
-                indexScratch += keyLine
-                indexScratch += keyColumn
-                indexScratch += keyLength
-                indexScratch += 4
-                indexScratch += unsetLine
-                indexScratch += unsetColumn
-                indexScratch += 0
-                indexEnds.nn += indexScratch.length
+              syncTo()
+              reconcileLineation()
+              val unsetLine   = cursor.line.n1
+              val unsetColumn = cursor.column.n1
+              indexScratch += keyLine
+              indexScratch += keyColumn
+              indexScratch += keyLength
+              indexScratch += 4
+              indexScratch += unsetLine
+              indexScratch += unsetColumn
+              indexScratch += 0
+              indexEnds += indexScratch.length
               advance()
               items += " "
               items += Unset
@@ -1409,12 +1697,10 @@ private[jacinta] final class JsonParser:
     items.copyToArray(out)
     relinquishArrayBuffer()
 
-    if indexOut != null then
-      emitCompositeDescriptor
-       ( indexOut, indexScratch.nn, indexEnds.nn,
-         startLine, startColumn, startMark )
-      relinquishIndexBuffer()
-      relinquishIndexBuffer()
+    emitCompositeDescriptor
+     ( indexOut, indexScratch, indexEnds, startLine, startColumn, startMark )
+    relinquishIndexBuffer()
+    relinquishIndexBuffer()
 
     out.asInstanceOf[IArray[Any]]
 
@@ -1423,17 +1709,18 @@ private[jacinta] final class JsonParser:
     skip()
     if !more then abort(ParseError(Json.Ast, Position(0, 0), Issue.EmptyInput))
 
-    val rootBuf: ArrayBuffer[Int] | Null =
-      if tracking then getIndexBuffer() else null
-    val result = parseValue(indexOut = rootBuf)
+    val result =
+      if tracking then
+        val rootBuf = getIndexBuffer()
+        val r = parseValueTracked(rootBuf)
+        rootIndex = IArray.from(rootBuf)
+        relinquishIndexBuffer()
+        r
+      else parseValue()
 
     while more do
       peek match
         case Tab | Return | Newline | Space => advance()
         case char                           => errorAt(Issue.SpuriousContent(char.toChar))
-
-    if rootBuf != null then
-      rootIndex = IArray.from(rootBuf)
-      relinquishIndexBuffer()
 
     result

--- a/lib/jacinta/src/core/jacinta_parser.scala
+++ b/lib/jacinta/src/core/jacinta_parser.scala
@@ -52,5 +52,24 @@ extension (json: Json.Ast.type)
   :   Json.Ast raises ParseError =
     Json.Ast(JsonParser.parse(input, holes, mode))
 
+  def parseTracked(source: Data)(using mode: NumberMode)
+  :   (Json.Ast, Json.PositionIndex) raises ParseError =
+    val (raw, ints) = JsonParser.parseTracked(source, mode)
+    (Json.Ast(raw), Json.PositionIndex(ints))
+
+  def parseTracked(input: Iterator[Data])(using mode: NumberMode)
+  :   (Json.Ast, Json.PositionIndex) raises ParseError =
+    val (raw, ints) = JsonParser.parseTracked(input, mode)
+    (Json.Ast(raw), Json.PositionIndex(ints))
+
+extension (json: Json.type)
+  def parseTracked(source: Data)(using NumberMode): Json raises ParseError =
+    val (ast, index) = Json.Ast.parseTracked(source)
+    new Json(ast, index)
+
+  def parseTracked(input: Iterator[Data])(using NumberMode): Json raises ParseError =
+    val (ast, index) = Json.Ast.parseTracked(input)
+    new Json(ast, index)
+
 given parserAggregable: Tactic[ParseError] => Json.Ast is Aggregable by Data =
   source => Json.Ast.parse(source.iterator)

--- a/lib/jacinta/src/core/jacinta_position.scala
+++ b/lib/jacinta/src/core/jacinta_position.scala
@@ -32,35 +32,61 @@
                                                                                                   */
 package jacinta
 
+import vacuous.*
 import anticipation.*
-import contingency.*
-import prepositional.*
-import turbulence.*
-import zephyrine.*
 
-extension (json: Json.Ast.type)
-  def parse(source: Data)(using mode: NumberMode): Json.Ast raises ParseError =
-    Json.Ast(JsonParser.parse(source, mode))
+extension (json: Json)
+  def locate(pointer: JsonPointer): Optional[Json.Ast.Position] =
+    json.positionIndex.let: posIndex =>
+      walkIndex(json.root, posIndex.ints, 0, pointer.path.descent.toIndexedSeq, 0, false)
 
-  def parse(source: Data, holes: Boolean)(using mode: NumberMode): Json.Ast raises ParseError =
-    Json.Ast(JsonParser.parse(source, holes, mode))
+  def locateKey(pointer: JsonPointer): Optional[Json.Ast.Position] =
+    json.positionIndex.let: posIndex =>
+      walkIndex(json.root, posIndex.ints, 0, pointer.path.descent.toIndexedSeq, 0, true)
 
-  def parse(input: Iterator[Data])(using mode: NumberMode): Json.Ast raises ParseError =
-    Json.Ast(JsonParser.parse(input, mode))
+private def walkIndex
+  ( ast:      Json.Ast,
+    data:     IArray[Int],
+    offset:   Int,
+    segments: IndexedSeq[Text],
+    i:        Int,
+    keyMode:  Boolean )
+:   Optional[Json.Ast.Position] =
 
-  def parse(input: Iterator[Data], holes: Boolean)(using mode: NumberMode)
-  :   Json.Ast raises ParseError =
-    Json.Ast(JsonParser.parse(input, holes, mode))
+  if i >= segments.length then
+    if keyMode then Unset
+    else Json.Ast.Position
+     ( line   = data(offset + 1),
+       column = data(offset + 2),
+       length = data(offset + 3) )
+  else
+    // `JsonPointer.path.descent` is stored leaf-first (Serpentine's `/`
+    // prepends), so iterate it in reverse to walk root-to-leaf.
+    val seg = segments(segments.length - 1 - i).s
 
-  def parseTracked(source: Data)(using mode: NumberMode)
-  :   (Json.Ast, Json.PositionIndex) raises ParseError =
-    val (raw, ints) = JsonParser.parseTracked(source, mode)
-    (Json.Ast(raw), Json.PositionIndex(ints))
+    if ast.isObject then
+      val k = ast.objectIndexOf(seg)
 
-  def parseTracked(input: Iterator[Data])(using mode: NumberMode)
-  :   (Json.Ast, Json.PositionIndex) raises ParseError =
-    val (raw, ints) = JsonParser.parseTracked(input, mode)
-    (Json.Ast(raw), Json.PositionIndex(ints))
+      if k < 0 then Unset
+      else
+        val entryOff = data(offset + 5 + k)
+        val isLast = i == segments.length - 1
 
-given parserAggregable: Tactic[ParseError] => Json.Ast is Aggregable by Data =
-  source => Json.Ast.parse(source.iterator)
+        if isLast && keyMode then
+          Json.Ast.Position
+           ( line   = data(offset + entryOff),
+             column = data(offset + entryOff + 1),
+             length = data(offset + entryOff + 2) )
+        else
+          walkIndex
+           ( ast.objectValue(k), data, offset + entryOff + 3, segments, i + 1, keyMode )
+    else if ast.isArray then
+      try
+        val k = Integer.parseInt(seg)
+        if k < 0 || k >= ast.arrayLength then Unset
+        else
+          val childOff = data(offset + 5 + k)
+          walkIndex
+           ( ast.arrayElement(k), data, offset + childOff, segments, i + 1, keyMode )
+      catch case _: NumberFormatException => Unset
+    else Unset

--- a/lib/jacinta/src/test/jacinta.PositionTests.scala
+++ b/lib/jacinta/src/test/jacinta.PositionTests.scala
@@ -1,0 +1,189 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+import soundness.*
+
+import charEncoders.utf8
+import strategies.throwUnsafely
+
+object PositionTests extends Suite(m"Jacinta position-index tests"):
+
+  private def at(line: Int, column: Int, length: Int): Json.Ast.Position =
+    Json.Ast.Position(line, column, length = length)
+
+  def run(): Unit =
+    suite(m"Single-line root primitives"):
+      test(m"Locate a root number"):
+        val json = Json.parseTracked(t"42")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 2))
+
+      test(m"Locate a root string"):
+        val json = Json.parseTracked(t""""hello"""")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 7))
+
+      test(m"Locate a root boolean"):
+        val json = Json.parseTracked(t"true")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 4))
+
+      test(m"Locate a root null"):
+        val json = Json.parseTracked(t"null")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 4))
+
+      test(m"Locate a negative number includes the minus sign in length"):
+        val json = Json.parseTracked(t"-42")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 3))
+
+    suite(m"Single-line objects"):
+      test(m"Locate the root object"):
+        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 13))
+
+      test(m"Locate the value at key 'a'"):
+        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        json.locate(JsonPointer()(t"a"))
+      . assert(_ == at(1, 6, 1))
+
+      test(m"Locate the value at key 'b'"):
+        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        json.locate(JsonPointer()(t"b"))
+      . assert(_ == at(1, 12, 1))
+
+      test(m"Locate the key 'a' itself"):
+        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        json.locateKey(JsonPointer()(t"a"))
+      . assert(_ == at(1, 2, 3))
+
+      test(m"Locate the key 'b' itself"):
+        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        json.locateKey(JsonPointer()(t"b"))
+      . assert(_ == at(1, 8, 3))
+
+      test(m"Missing key returns Unset"):
+        val json = Json.parseTracked(t"""{"a":1}""")
+        json.locate(JsonPointer()(t"missing"))
+      . assert(_ == Unset)
+
+    suite(m"Single-line arrays"):
+      test(m"Locate the root array"):
+        val json = Json.parseTracked(t"[10,20,30]")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 10))
+
+      test(m"Locate the first array element"):
+        val json = Json.parseTracked(t"[10,20,30]")
+        json.locate(JsonPointer()(Prim))
+      . assert(_ == at(1, 2, 2))
+
+      test(m"Locate the last array element"):
+        val json = Json.parseTracked(t"[10,20,30]")
+        json.locate(JsonPointer()(Ter))
+      . assert(_ == at(1, 8, 2))
+
+      test(m"Out-of-bounds index returns Unset"):
+        val json = Json.parseTracked(t"[10,20]")
+        json.locate(JsonPointer()(Ter))
+      . assert(_ == Unset)
+
+      test(m"Empty array locates only the root"):
+        val json = Json.parseTracked(t"[]")
+        json.locate(JsonPointer())
+      . assert(_ == at(1, 1, 2))
+
+    suite(m"Nested structures"):
+      test(m"Locate a key in a nested object"):
+        val json = Json.parseTracked(t"""{"a":{"b":42}}""")
+        json.locate(JsonPointer()(t"a")(t"b"))
+      . assert(_ == at(1, 11, 2))
+
+      test(m"Locate an element of a nested array"):
+        val json = Json.parseTracked(t"""{"xs":[1,2,3]}""")
+        json.locate(JsonPointer()(t"xs")(Sec))
+      . assert(_ == at(1, 10, 1))
+
+      test(m"Locate an object inside an array"):
+        val json = Json.parseTracked(t"""[{"id":1},{"id":2}]""")
+        json.locate(JsonPointer()(Sec)(t"id"))
+      . assert(_ == at(1, 17, 1))
+
+    suite(m"Multi-line input"):
+      test(m"Second-line key is on line 2"):
+        val source = t"{\n  \"a\": 42\n}"
+        val json = Json.parseTracked(source)
+        json.locate(JsonPointer()(t"a")).let(_.line)
+      . assert(_ == 2)
+
+      test(m"Second-line value column is past the indent"):
+        val source = t"{\n  \"a\": 42\n}"
+        val json = Json.parseTracked(source)
+        json.locate(JsonPointer()(t"a")).let(_.column)
+      . assert(_ == 8)
+
+      test(m"Third-line element is on line 3"):
+        val source = t"[\n  1,\n  2,\n  3\n]"
+        val json = Json.parseTracked(source)
+        json.locate(JsonPointer()(Sec)).let(_.line)
+      . assert(_ == 3)
+
+    suite(m"Number-array specialisations"):
+      test(m"Small-BCD array still has per-element positions"):
+        val json = Json.parseTracked(t"[1,2,3]")
+        json.locate(JsonPointer()(Sec))
+      . assert(_ == at(1, 4, 1))
+
+      test(m"BCD-Long array still has per-element positions"):
+        val json = Json.parseTracked(t"[12345678901234,1]")
+        json.locate(JsonPointer()(Prim)).let(_.length)
+      . assert(_ == 14)
+
+    suite(m"Subsequence property"):
+      test(m"A nested object's descriptor slice has length == slot 0"):
+        val json = Json.parseTracked(t"""{"a":{"b":42}}""")
+        val data = json.positionIndex.vouch.ints
+        val firstEntryOff = data(5)
+        val valueDescOff = firstEntryOff + 3
+        val valueSize = data(valueDescOff)
+        val slice = data.slice(valueDescOff, valueDescOff + valueSize)
+        slice.length == valueSize
+      . assert(identity)
+
+    suite(m"Non-tracking mode"):
+      test(m"Plain parse leaves positionIndex Unset"):
+        t"42".read[Json].positionIndex
+      . assert(_ == Unset)

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -50,10 +50,10 @@ extends Error(m"${items.length} validation issues"):
 
 object ValidationTests extends Suite(m"Jacinta validation tests"):
 
-  private def validateJson[result](json: Json)(decode: Json => result raises JsonError tracks JsonPointer)
+  private def validateJson[result](json: Json)(decode: Json => result raises JsonError tracks Json.Focus)
   :   Issues =
-    validate[JsonPointer](Issues()):
-      case error: JsonError => accrual + (prior.let(_.encode).or(t"#"), error)
+    validate[Json.Focus](Issues()):
+      case error: JsonError => accrual + (prior.let(_.pointer.encode).or(t"#"), error)
     . within(decode(json))
 
   def run(): Unit =
@@ -149,3 +149,48 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
                         "address": {"street": 2, "city": 3, "zip": 4}}""".read[Json]
         validateJson(json)(_.as[VContact]).items.length
       . assert(_ == 6)
+
+    suite(m"Position-aware focus (tracked Json)"):
+      // `withPosition` resolves the focus's pointer against the tracked
+      // Json's position index. Costs nothing on the success path because
+      // `Json.Focus` is constructed (and `withPosition` invoked) only
+      // for errors registered inside the surrounding `focus` block.
+      def validateWithPositions[result](json: Json)
+                                       (decode: Json => result raises JsonError tracks Json.Focus)
+      :   List[(Text, Optional[Int], Optional[Int])] =
+        case class Tagged(items: List[(Text, Optional[Int], Optional[Int])] = Nil)
+                         (using Diagnostics)
+        extends Error(m"${items.length} validation issues"):
+          def +(focus: Text, line: Optional[Int], column: Optional[Int]): Tagged =
+            Tagged(items :+ (focus, line, column))
+
+        validate[Json.Focus](Tagged()):
+          case error: JsonError =>
+            val focus = prior.let(_.withPosition(json))
+            val position = focus.let(_.position)
+            accrual + ( focus.let(_.pointer.encode).or(t"#"),
+                        position.let(_.line),
+                        position.let(_.column) )
+        . within(decode(json)).items
+
+      test(m"Missing field reports a position on a tracked Json"):
+        val source = t"""{"name": "Alice"}"""
+        val json = Json.parseTracked(source)
+        val results = validateWithPositions(json)(_.as[VPerson])
+        results.map(_(0).s).to(Set)
+      . assert(_ == Set("#/age", "#/email"))
+
+      test(m"Wrong-type field reports the value's line/column"):
+        val source = t"{\n  \"name\": 42,\n  \"age\": 30,\n  \"email\": \"x@y\"\n}"
+        val json = Json.parseTracked(source)
+        val results = validateWithPositions(json)(_.as[VPerson])
+        // `name` value 42 is on line 2; column points at the `4` of `42`.
+        results.find(_(0) == t"#/name").map((_, line, col) => (line, col))
+      . assert(_ == Some((2, 11)))
+
+      test(m"Non-tracking Json has Unset positions"):
+        val source = t"""{"name": "Alice"}"""
+        val json = source.read[Json]
+        val results = validateWithPositions(json)(_.as[VPerson])
+        results.forall((_, line, _) => line == Unset)
+      . assert(identity)

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1090,3 +1090,4 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == List("bad"))
 
     ValidationTests()
+    PositionTests()


### PR DESCRIPTION
Adds an opt-in "tracking" parse mode for Jacinta that builds a flat, source-position index alongside the AST so a `JsonPointer` path can be resolved back to a real line/column/length in the original source. The default parser is byte-identical to before — benchmarks stay within ±2% of `main` on every shape — and the tracked variant lives in parallel `parseValueTracked` / `parseArrayTracked` / `parseObjectTracked` methods that share the same input formats but emit a relative-offset descriptor for every node, including object keys. Two new entry points (`Json.parseTracked` and `Json.Ast.parseTracked`) return a `Json` whose `positionIndex` is populated; `Json#locate(pointer)` and `Json#locateKey(pointer)` walk it. Jacinta's decoders and encoders now track `Json.Focus` (pointer + optional position) instead of bare `JsonPointer`, so error sites can resolve positions on demand.

## Tracking-mode parsing

```scala
import jacinta.*, soundness.*, charEncoders.utf8, strategies.throwUnsafely

val source = t"""
  {
    "name": "Alice",
    "age":  30
  }
"""

val json = Json.parseTracked(source)
val ageAt = json.locate(JsonPointer()(t"age")) // Position(line=4, column=13, length=2)
val keyAt = json.locateKey(JsonPointer()(t"name")) // Position(line=3, column=5, length=6)
```

`positionIndex` is `Unset` when a value comes from the regular `read[Json]` path, so existing code doesn't change shape.

## Layout

Each node has a self-contained descriptor. Composites' offsets are relative to the descriptor's own start, so any slice at a descriptor boundary is itself a valid `PositionIndex`:

```
primitive: [size=4, line, column, sourceLength]
array:     [size, line, column, sourceLength, n, off_0..off_{n-1},
            <child descriptors concatenated>]
object:    [size, line, column, sourceLength, n, off_0..off_{n-1},
            <entries: keyLine, keyColumn, keyLength, value descriptor>]
```

## Integration with `Foci`

Jacinta's decoders and encoders now track `Json.Focus` — a small case class carrying both the JSON-pointer path and an optional source position — instead of `JsonPointer`. The pointer is populated by the existing focus blocks; the position is filled in on demand by `focus.withPosition(json)` against the root `Json`:

```scala
validate[Json.Focus](Issues()):
  case error: JsonError =>
    val focus = prior.let(_.withPosition(json))
    accrual + ( focus.let(_.pointer.encode).or(t"#"),
                focus.let(_.position).let(_.line),
                error )
. within(json.as[T])
```

`Json.Focus` instances are constructed lazily inside `Foci.supplement` — only for errors actually registered in the surrounding `focus` block — so success-path decoding pays nothing extra. `withPosition` is the same shape, invoking `locate` only when a focus is present (i.e. on errors).

Migration for existing call sites: `validate[JsonPointer]` → `validate[Json.Focus]`, plus a `.pointer` accessor where the underlying pointer is needed.

## Performance

The untracked path is preserved exactly — `Merino` rows in the benchmark stay within ±2% of `main` across all eight shapes (small / typical / rich / 100 records / 500 logs / 50 blockchain / 1000 ints / 1000 decimals). Tracking mode is roughly 2–2.5× slower because each node now writes a 4-int descriptor and composites materialise per-entry offsets; the cost is in the descriptor build, not in the AST. A `Merino (tracking)` row sits next to every Merino bench so future changes catch regressions in either path.