### PR TITLE
xylophone: Wisteria-derived Decodable in Xml with focus tracking

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1277,7 +1277,7 @@ object wisteria extends Library:
     override def enabled = false
 
 object xylophone extends Library:
-  object core extends Component(zephyrine.core, adversaria.core, typonym.core, hellenism.core, urticose.core):
+  object core extends Component(zephyrine.core, adversaria.core, typonym.core, hellenism.core, urticose.core, wisteria.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -57,9 +57,11 @@ object XPath extends Root("/"):
     val self: Text = "."
     val separator: Text = "/"
 
+  // The underlying serpentine `Path` already encodes with the leading `/`
+  // separator (Path.encode = root + descent.reverse.join(sep)). Re-using
+  // it directly avoids the double-slash that `t"/${path.path}"` produced.
   given XPath is Encodable in Text = path =>
-    if path.path.descent.length == 0 then t"/"
-    else t"/${path.path}"
+    if path.path.descent.length == 0 then t"/" else path.path.encode
 
   // Parse a stored descent segment back into an addressable step. Returns
   // `Right(name, ordinal)` for an element step, `Left(name)` for an
@@ -86,3 +88,12 @@ case class XPath(path: Path on XPath = XPath):
 
   def attribute(name: Text): XPath =
     XPath(path / XPath.attributeStep(name))
+
+  // Prepend `name[ordinal]` at the root end of the path, leaving the rest
+  // of the descent intact. Used by `Xml`'s Wisteria derivation: each outer
+  // `focus` block runs *after* the inner one, and needs to push its label
+  // to the front of the accumulated XPath (so `/parent[1]/child[1]` lands
+  // root-first), not append at the leaf end like `element` does.
+  private[xylophone] def prepend(name: Text, ordinal: Int = 1): XPath =
+    val step = XPath.elementStep(name, ordinal)
+    XPath(Path[XPath, XPath.type, Tuple]("/", path.descent :+ step))

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -37,6 +37,8 @@ import language.dynamics
 import java.lang as jl
 import java.util as ju
 
+import scala.collection.mutable as scm
+import scala.compiletime.*
 import scala.quoted.*
 
 import anticipation.*
@@ -55,6 +57,7 @@ import spectacular.*
 import turbulence.*
 import typonym.*
 import vacuous.*
+import wisteria.*
 import zephyrine.*
 
 object Xml extends Tag.Container
@@ -66,10 +69,110 @@ object Xml extends Tag.Container
   sealed trait Decimal
   sealed trait Id
 
-  given textDecodable: [value: Decodable in Text] => Tactic[XmlError] => value is Decodable in Xml =
-    case TextNode(text)                        => value.decoded(text)
-    case Element(_, _, IArray(TextNode(text))) => value.decoded(text)
-    case _                                     => abort(XmlError())
+  // Default sum-type discriminator for XML: the element's label is the
+  // variant tag. A sealed trait with case classes `Book` and `Magazine` is
+  // therefore decoded from `<book .../>` and `<magazine .../>` respectively
+  // without any explicit discriminator field — the XML-idiomatic choice.
+  given xmlDiscriminable: [value] => value is Discriminable in Xml = new Discriminable:
+    type Form = Xml
+    type Self = value
+
+    def discriminate(xml: Xml): Optional[Text] = xml match
+      case Element(label, _, _)           => label
+      case Fragment(Element(label, _, _)) => label
+      case _                              => Unset
+
+    def rewrite(kind: Text, xml: Xml): Xml = xml match
+      case Element(_, attrs, children)           => Element(kind, attrs, children)
+      case Fragment(Element(_, attrs, children)) => Element(kind, attrs, children)
+      case other                                 => other
+
+    def variant(xml: Xml): Xml = xml
+
+  // Single entry-point for resolving `Decodable in Xml`. Prefers a textual
+  // decoder when one exists (so primitives like `Int`, `Text`, `Boolean`
+  // continue to extract from element text content). Otherwise falls back to
+  // Wisteria-derived case-class / sealed-trait decoding via
+  // `DecodableDerivation`.
+  inline given decodable: [value] => value is Decodable in Xml = summonFrom:
+    case given (`value` is Decodable in Text) =>
+      xml =>
+        provide[Tactic[XmlError]]:
+          val text: Text = xml match
+            case TextNode(text)                        => text
+            case Element(_, _, IArray(TextNode(text))) => text
+            case Element(_, _, IArray())               => t""
+            case Fragment(node: Node)                  => node match
+              case TextNode(text)                        => text
+              case Element(_, _, IArray(TextNode(text))) => text
+              case Element(_, _, IArray())               => t""
+              case _                                     => abort(XmlError())
+            case _                                     => abort(XmlError())
+
+          summon[`value` is Decodable in Text].decoded(text)
+
+    case given Reflection[`value`] =>
+      DecodableDerivation.derived
+
+  // Wisteria-based derivation for case classes (conjunction) and sealed
+  // traits / enums (disjunction). Each field is decoded from the first
+  // child element whose label matches the field name; sum-type variants
+  // are picked from the element's own label via the `Discriminable`
+  // default.
+  //
+  // `wisteria.label[Text]` is used in place of the bare `label` identifier
+  // because `Tag.Container`'s `label = "xml"` constructor argument shadows
+  // Wisteria's `label aka "label"` parameter inside this object.
+  object DecodableDerivation extends Derivable[Decodable in Xml]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Decodable in Xml =
+
+      xml =>
+        provide[Foci[Xml.Focus]]:
+          provide[Tactic[XmlError]]:
+            val element: Element = xml match
+              case e: Element           => e
+              case Fragment(e: Element) => e
+              case _                    => abort(XmlError())
+
+            val children: scm.HashMap[String, Element] = scm.HashMap.empty
+            var i = 0
+            while i < element.children.length do
+              element.children(i) match
+                case child: Element =>
+                  val childLabel = child.label.s
+                  if !children.contains(childLabel) then
+                    children.update(childLabel, child)
+                case _ => ()
+              i += 1
+
+            build: [field] =>
+              context =>
+                val fieldLabel: Text = wisteria.label[Text]
+                focus({
+                  // Each outer `focus` runs *after* the inner one, so
+                  // we extend `prior` at the root side (`/outer/inner`),
+                  // not the leaf side that `XPath#element` would use.
+                  val base = prior.let(_.path).or(XPath())
+                  Xml.Focus(base.prepend(fieldLabel, 1))
+                }):
+                  children.get(fieldLabel.s) match
+                    case Some(child) => context.decoded(child)
+                    case None        => default.or(abort(XmlError()))
+
+    inline def disjunction[derivation: SumReflection]
+    :   derivation is Decodable in Xml =
+
+      xml =>
+        provide[Tactic[XmlError]]:
+          provide[Tactic[VariantError]]:
+            val discriminable = infer[derivation is Discriminable in Xml]
+
+            val discriminant: Text = discriminable.discriminate(xml).or:
+              focus(prior.or(Xml.Focus(XPath())))(abort(XmlError()))
+
+            delegate(discriminant): [variant <: derivation] =>
+              context => context.decoded(xml)
 
   case class attribute() extends StaticAnnotation
 
@@ -525,6 +628,20 @@ object Xml extends Tag.Container
   case class Tracked(value: Xml, positionIndex: PositionIndex):
     def locate(path: XPath): Optional[Xml.Position] =
       Tracked.walk(value, positionIndex.ints, 0, path.path.descent.toIndexedSeq, 0)
+
+    // Decode like `Xml#as` but also populate `position` on every
+    // accumulated `Xml.Focus` by looking up its XPath against this
+    // tracked root's position index. Outside `validate[Xml.Focus]` the
+    // ambient `Foci` is a no-op and `supplement` does nothing, so this
+    // call stays cost-free.
+    def as[result: Decodable in Xml]: result tracks Xml.Focus =
+      val decoded = value match
+        case Fragment(inner) => result.decoded(inner)
+        case xml: Xml        => result.decoded(xml)
+      val foci = summon[Foci[Xml.Focus]]
+      val tracked = this
+      foci.supplement(foci.length, _.let(_.withPosition(tracked)).vouch)
+      decoded
 
   object Tracked:
     // `XPath.path.descent` is stored leaf-first (Serpentine's `/`
@@ -1946,7 +2063,13 @@ sealed into trait Xml extends Dynamic, Topical, Documentary, Formal:
   private[xylophone] def over[transport <: Label]: this.type over transport =
     asInstanceOf[this.type over transport]
 
-  def as[result: Decodable in Xml]: result = this match
+  // Decode this `Xml` to a `result` value. `Decodable in Xml` is resolved
+  // via the `decodable` summonFrom (textual decoder, else Wisteria
+  // derivation). Errors registered inside the decoder carry `Xml.Focus`
+  // values describing the XPath of the failing field. Position information
+  // stays `Unset`; use `Xml.Tracked#as` against a `parseTracked` root if
+  // you also want source line / column.
+  def as[result: Decodable in Xml]: result tracks Xml.Focus = this match
     case Fragment(value) => result.decoded(value)
     case xml: Xml        => result.decoded(xml)
 

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -1,0 +1,157 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import soundness.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
+
+case class DPerson(name: Text, age: Int, email: Text) derives CanEqual
+case class DContact(person: DPerson, company: Text) derives CanEqual
+
+enum DShape derives CanEqual:
+  case Circle(radius: Int)
+  case Square(side: Int)
+
+case class XmlIssues(items: List[(Text, XmlError)] = Nil)(using Diagnostics)
+extends Error(m"${items.length} XML decoding issues"):
+  def +(focus: Text, error: XmlError): XmlIssues = XmlIssues(items :+ (focus, error))
+
+
+object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
+
+  private def validateXml[result](xml: Xml)(decode: Xml => result raises XmlError tracks Xml.Focus)
+  :   XmlIssues =
+    validate[Xml.Focus](XmlIssues()):
+      case error: XmlError => accrual + (prior.let(_.path.encode).or(t"#"), error)
+    . within(decode(xml))
+
+  def run(): Unit =
+    given XmlSchema = XmlSchema.Freeform
+
+    suite(m"Simple product"):
+      test(m"Decode a flat case class"):
+        x"<root><name>Alice</name><age>30</age><email>a@b.c</email></root>".as[DPerson]
+      . assert(_ == DPerson(t"Alice", 30, t"a@b.c"))
+
+      test(m"Field order doesn't matter"):
+        x"<root><age>21</age><email>b@x</email><name>Bob</name></root>".as[DPerson]
+      . assert(_ == DPerson(t"Bob", 21, t"b@x"))
+
+    suite(m"Nested product"):
+      test(m"Decode a nested case class"):
+        x"""<root>
+              <person><name>Carol</name><age>40</age><email>c@x</email></person>
+              <company>Acme</company>
+            </root>""".as[DContact]
+      . assert(_ == DContact(DPerson(t"Carol", 40, t"c@x"), t"Acme"))
+
+    suite(m"Sum type by element label"):
+      test(m"Decode the Circle variant"):
+        x"<Circle><radius>5</radius></Circle>".as[DShape]
+      . assert(_ == DShape.Circle(5))
+
+      test(m"Decode the Square variant"):
+        x"<Square><side>4</side></Square>".as[DShape]
+      . assert(_ == DShape.Square(4))
+
+    suite(m"Validation accrual"):
+      // The conjunction aborts on the first missing field, so only the
+      // first accrued error is registered. Multi-error accumulation
+      // would need primitive decoders that `raise` (record + continue)
+      // rather than `abort` — a future refinement.
+      test(m"Fully-valid input accrues zero errors"):
+        val xml = x"<root><name>Alice</name><age>30</age><email>a@b.c</email></root>"
+        validateXml(xml)(_.as[DPerson]).items.length
+      . assert(_ == 0)
+
+      test(m"One missing field accrues one error"):
+        val xml = x"<root><name>Alice</name><age>30</age></root>"
+        validateXml(xml)(_.as[DPerson]).items.length
+      . assert(_ == 1)
+
+      test(m"Pointer identifies the missing field"):
+        val xml = x"<root><name>Alice</name><age>30</age></root>"
+        validateXml(xml)(_.as[DPerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("/email[1]"))
+
+      test(m"Nested missing field reports both segments"):
+        val xml = x"""<root>
+                       <person><name>Dave</name><age>22</age></person>
+                       <company>Acme</company>
+                     </root>"""
+        validateXml(xml)(_.as[DContact]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("/person[1]/email[1]"))
+
+    suite(m"Position-aware focus (tracked Xml)"):
+      def validateWithPositions[result]
+        ( tracked: Xml.Tracked )
+        ( decode: Xml.Tracked => result raises XmlError tracks Xml.Focus )
+      :   List[(Text, Optional[Int], Optional[Int])] =
+
+        case class Tagged(items: List[(Text, Optional[Int], Optional[Int])] = Nil)
+                         (using Diagnostics)
+        extends Error(m"${items.length} validation issues"):
+          def +(focus: Text, line: Optional[Int], column: Optional[Int]): Tagged =
+            Tagged(items :+ (focus, line, column))
+
+        validate[Xml.Focus](Tagged()):
+          case error: XmlError =>
+            val position = prior.let(_.position)
+            accrual + ( prior.let(_.path.encode).or(t"#"),
+                        position.let(_.line.n1),
+                        position.let(_.column.n1) )
+        . within(decode(tracked)).items
+
+      test(m"Missing-field error on a tracked Xml reports the parent's position"):
+        val source = t"<root>\n  <name>Alice</name>\n  <age>30</age>\n</root>"
+        val tracked = Xml.parseTracked(source)
+        val results = validateWithPositions(tracked)(_.as[DPerson])
+        results.find(_(0) == t"/email[1]").map(_(1))
+      . assert(_ == Some(Unset))
+
+      test(m"Non-tracked Xml has Unset positions"):
+        val xml = x"<root><name>Alice</name></root>"
+        case class Tagged(items: List[Optional[Int]] = Nil)(using Diagnostics)
+        extends Error(m"${items.length}"):
+          def +(line: Optional[Int]): Tagged = Tagged(items :+ line)
+
+        val lines: List[Optional[Int]] =
+          validate[Xml.Focus](Tagged()):
+            case error: XmlError =>
+              accrual + prior.let(_.position).let(_.line.n1)
+          . within(xml.as[DPerson]).items
+
+        lines.forall(_ == Unset)
+      . assert(identity)

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -898,3 +898,4 @@ object Tests extends Suite(m"Xylophone tests"):
             Header(t"1.0", Unset, Unset))
 
     PositionTests()
+    DecoderTests()


### PR DESCRIPTION
Adds case-class and sealed-trait decoding for XML, modeled on Jacinta's `DecodableDerivation`. Errors registered during decoding carry an `Xml.Focus` describing the XPath of the failing field, and `Xml.Tracked#as[T]` populates the focus's source position from a tracked root, so decoding errors land with line / column information automatically when the root came from `parseTracked`.

## Case-class decoding

```scala
case class Person(name: Text, age: Int, email: Text)

x"<person><name>Alice</name><age>30</age><email>a@b.c</email></person>".as[Person]
// = Person(t"Alice", 30, t"a@b.c")
```

Each field is decoded from the first child element whose label matches the field name. Field order in the XML doesn't have to match the case-class definition; primitives keep going through `Decodable in Text` so any `Decodable in Text` value works as a field type.

## Sealed traits

The element's own label is the variant tag — the XML-idiomatic discriminator. No `type="…"` attribute is needed.

```scala
sealed trait Shape
case class Circle(radius: Int) extends Shape
case class Square(side: Int) extends Shape

x"<Circle><radius>5</radius></Circle>".as[Shape] // = Circle(5)
x"<Square><side>4</side></Square>".as[Shape]     // = Square(4)
```

The default `Xml is Discriminable in Xml` does this; a different rule can be installed by providing a more specific `Discriminable in Xml` given.

## Focus / position tracking

Decode errors are accrued via the standard `validate[Xml.Focus] { … }.within(xml.as[T])` pattern. The focus's `path` is an `XPath` to the failing field; `position` is set automatically when the root XML was produced by `Xml.parseTracked` and decoded with `Xml.Tracked#as[T]`.

```scala
validate[Xml.Focus](Issues()):
  case error: XmlError =>
    val position = prior.let(_.position)
    accrual + ( prior.let(_.path.encode).or(t"#"),
                position.let(_.line.n1),
                position.let(_.column.n1),
                error )
. within(Xml.parseTracked(source).as[Person])
```

## Limitations

Two follow-up items are explicitly out of scope here and will need raise-based primitive decoders to support cleanly:

- **Multi-error accrual.** The conjunction aborts on the first missing field, so one error is registered per decode. Accumulating multiple field errors per call needs primitive decoders that `raise` and continue with a sentinel value, as Jacinta does via `_.root.long`-style methods.
- **Type-mismatch error mapping.** Wrong-type fields (e.g. text content that doesn't parse as an `Int`) raise the underlying `distillate.NumberError`, not `XmlError`, so they bypass `case error: XmlError =>` handlers. A `Mitigable to XmlError` adapter (or XML-aware primitive `Decodable in Xml` instances) would fix this.

## Other changes

- `XPath#prepend(name, ordinal)` adds a step at the *root* end of the descent. Required by the Wisteria derivation: contingency runs outer `focus` supplements after inner ones, so each outer must push to the root side to produce `/parent/child` instead of `/child/parent`.
- `XPath`'s `Encodable in Text` was double-prefixing the leading `/` (the underlying `Path.encode` already supplies it). Fixed.