### PR TITLE
xylophone: multi-error accrual in case-class / sealed-trait decoders

### DIFF
--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -89,25 +89,105 @@ object Xml extends Tag.Container
 
     def variant(xml: Xml): Xml = xml
 
+  // Identity-checked sentinel used by `DecodableDerivation.conjunction` to
+  // signal "this field was absent from the XML". The textual decoder and
+  // the primitive `Decodable in Xml` instances detect it by reference
+  // equality and `raise` an `XmlError` while continuing with a zero / empty
+  // sentinel, so multi-error accrual can register every missing field in
+  // one decode rather than aborting at the first.
+  private[xylophone] val Absent: Xml = new Fragment()
+
+  // Extract the textual content of a leaf-shaped Xml node. Returns `Unset`
+  // for non-text shapes (other Elements, Comments, the `Absent` sentinel,
+  // etc.). Used by the primitive decoders so they can decide whether to
+  // parse the content or `raise` for a missing / wrong-shape input.
+  private def textOf(xml: Xml): Optional[Text] = xml match
+    case _ if xml eq Absent                    => Unset
+    case TextNode(text)                        => text
+    case Element(_, _, IArray(TextNode(text))) => text
+    case Element(_, _, IArray())               => t""
+    case Fragment(node: Node)                  => textOf(node)
+    case _                                     => Unset
+
+  // Explicit `Decodable in Xml` for the common primitive scalars. These
+  // *raise + continue* (record an `XmlError` on the ambient `Foci` and
+  // return a zero / false sentinel) rather than `abort`ing, so a case
+  // class with multiple bad fields accrues one error per field instead of
+  // bailing at the first.
+  //
+  // Specific givens here shadow the generic `decodable` summonFrom below
+  // for these types — that branch's `summon[Decodable in Text]` for
+  // `Int` would otherwise `abort` with `NumberError` and break accrual.
+  given int: Tactic[XmlError] => Int is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      try Integer.parseInt(text.s).nn
+      catch case _: NumberFormatException => raise(XmlError()) yet 0
+    . or:
+        raise(XmlError()) yet 0
+
+  given long: Tactic[XmlError] => Long is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      try jl.Long.parseLong(text.s).nn
+      catch case _: NumberFormatException => raise(XmlError()) yet 0L
+    . or:
+        raise(XmlError()) yet 0L
+
+  given short: Tactic[XmlError] => Short is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      try jl.Short.parseShort(text.s).nn
+      catch case _: NumberFormatException => raise(XmlError()) yet 0.toShort
+    . or:
+        raise(XmlError()) yet 0.toShort
+
+  given byte: Tactic[XmlError] => Byte is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      try jl.Byte.parseByte(text.s).nn
+      catch case _: NumberFormatException => raise(XmlError()) yet 0.toByte
+    . or:
+        raise(XmlError()) yet 0.toByte
+
+  given double: Tactic[XmlError] => Double is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      try jl.Double.parseDouble(text.s).nn
+      catch case _: NumberFormatException => raise(XmlError()) yet 0.0
+    . or:
+        raise(XmlError()) yet 0.0
+
+  given float: Tactic[XmlError] => Float is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      try jl.Float.parseFloat(text.s).nn
+      catch case _: NumberFormatException => raise(XmlError()) yet 0.0f
+    . or:
+        raise(XmlError()) yet 0.0f
+
+  given boolean: Tactic[XmlError] => Boolean is Decodable in Xml = xml =>
+    textOf(xml).let: text =>
+      text.s match
+        case "true"  => true
+        case "false" => false
+        case _       => raise(XmlError()) yet false
+    . or:
+        raise(XmlError()) yet false
+
   // Single entry-point for resolving `Decodable in Xml`. Prefers a textual
-  // decoder when one exists (so primitives like `Int`, `Text`, `Boolean`
-  // continue to extract from element text content). Otherwise falls back to
-  // Wisteria-derived case-class / sealed-trait decoding via
-  // `DecodableDerivation`.
+  // decoder when one exists (so any `Decodable in Text` value works as a
+  // field type); otherwise falls back to Wisteria-derived case-class /
+  // sealed-trait decoding via `DecodableDerivation`.
+  //
+  // The textual branch raises `XmlError` (and continues with `""`) on the
+  // `Absent` sentinel and on wrong-shape input. The inner
+  // `Decodable in Text` is then called with that sentinel `""`; primitive
+  // numerics have explicit `Decodable in Xml` givens above that pre-empt
+  // this branch entirely, so the surviving callers here are types whose
+  // textual decoders accept the empty string (e.g., `Text` itself,
+  // user-defined identifiers).
   inline given decodable: [value] => value is Decodable in Xml = summonFrom:
     case given (`value` is Decodable in Text) =>
       xml =>
         provide[Tactic[XmlError]]:
-          val text: Text = xml match
-            case TextNode(text)                        => text
-            case Element(_, _, IArray(TextNode(text))) => text
-            case Element(_, _, IArray())               => t""
-            case Fragment(node: Node)                  => node match
-              case TextNode(text)                        => text
-              case Element(_, _, IArray(TextNode(text))) => text
-              case Element(_, _, IArray())               => t""
-              case _                                     => abort(XmlError())
-            case _                                     => abort(XmlError())
+          val text: Text =
+            if xml eq Absent then raise(XmlError()) yet t""
+            else textOf(xml).or(raise(XmlError()) yet t"")
 
           summon[`value` is Decodable in Text].decoded(text)
 
@@ -130,21 +210,28 @@ object Xml extends Tag.Container
       xml =>
         provide[Foci[Xml.Focus]]:
           provide[Tactic[XmlError]]:
-            val element: Element = xml match
+            // A non-Element root (including the `Absent` sentinel passed
+            // by an outer conjunction for a missing nested case-class
+            // field) raises an error at the *current* focus and then
+            // continues with an empty children map. `build` then sees
+            // every field as missing and accrues per-field errors at
+            // `/parent/child` paths.
+            val element: Optional[Element] = xml match
               case e: Element           => e
               case Fragment(e: Element) => e
-              case _                    => abort(XmlError())
+              case _                    => raise(XmlError()) yet Unset
 
             val children: scm.HashMap[String, Element] = scm.HashMap.empty
-            var i = 0
-            while i < element.children.length do
-              element.children(i) match
-                case child: Element =>
-                  val childLabel = child.label.s
-                  if !children.contains(childLabel) then
-                    children.update(childLabel, child)
-                case _ => ()
-              i += 1
+            element.let: el =>
+              var i = 0
+              while i < el.children.length do
+                el.children(i) match
+                  case child: Element =>
+                    val childLabel = child.label.s
+                    if !children.contains(childLabel) then
+                      children.update(childLabel, child)
+                  case _ => ()
+                i += 1
 
             build: [field] =>
               context =>
@@ -158,8 +245,16 @@ object Xml extends Tag.Container
                 }):
                   children.get(fieldLabel.s) match
                     case Some(child) => context.decoded(child)
-                    case None        => default.or(abort(XmlError()))
+                    // Missing field: hand the `Absent` sentinel to the
+                    // field's decoder. Primitives and nested conjunctions
+                    // each detect it and `raise + continue` so the
+                    // surrounding `build` keeps iterating.
+                    case None        => default.or(context.decoded(Absent))
 
+    // Sealed-trait disjunction stays in single-error mode: a missing or
+    // unrecognised discriminant has no obvious sentinel variant to
+    // continue with, so it `abort`s. Same-level multi-error accrual
+    // applies inside the chosen variant via its product decoder.
     inline def disjunction[derivation: SumReflection]
     :   derivation is Decodable in Xml =
 

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -87,10 +87,6 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
       . assert(_ == DShape.Square(4))
 
     suite(m"Validation accrual"):
-      // The conjunction aborts on the first missing field, so only the
-      // first accrued error is registered. Multi-error accumulation
-      // would need primitive decoders that `raise` (record + continue)
-      // rather than `abort` — a future refinement.
       test(m"Fully-valid input accrues zero errors"):
         val xml = x"<root><name>Alice</name><age>30</age><email>a@b.c</email></root>"
         validateXml(xml)(_.as[DPerson]).items.length
@@ -106,13 +102,52 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
         validateXml(xml)(_.as[DPerson]).items.map(_(0).s).to(Set)
       . assert(_ == Set("/email[1]"))
 
-      test(m"Nested missing field reports both segments"):
+      test(m"Two missing primitive fields accrue two errors"):
+        val xml = x"<root><name>Alice</name></root>"
+        validateXml(xml)(_.as[DPerson]).items.length
+      . assert(_ == 2)
+
+      test(m"Pointers identify both missing primitive fields"):
+        val xml = x"<root><name>Alice</name></root>"
+        validateXml(xml)(_.as[DPerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("/age[1]", "/email[1]"))
+
+      test(m"Wrong-type primitive field accrues an error"):
+        val xml = x"<root><name>Alice</name><age>oldish</age><email>a@b.c</email></root>"
+        validateXml(xml)(_.as[DPerson]).items.length
+      . assert(_ == 1)
+
+      test(m"Wrong-type primitive field reports the field's path"):
+        val xml = x"<root><name>Alice</name><age>oldish</age><email>a@b.c</email></root>"
+        validateXml(xml)(_.as[DPerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("/age[1]"))
+
+      test(m"Wrong-type and missing-field errors mix"):
+        val xml = x"<root><name>Alice</name><age>oldish</age></root>"
+        validateXml(xml)(_.as[DPerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("/age[1]", "/email[1]"))
+
+      test(m"Nested missing primitive field reports both segments"):
         val xml = x"""<root>
                        <person><name>Dave</name><age>22</age></person>
                        <company>Acme</company>
                      </root>"""
         validateXml(xml)(_.as[DContact]).items.map(_(0).s).to(Set)
       . assert(_ == Set("/person[1]/email[1]"))
+
+      test(m"Missing nested case-class field expands per sub-field"):
+        // A missing `person` triggers the nested conjunction's
+        // raise+continue at `/person[1]` and then every sub-field's
+        // missing-field raise at `/person[1]/<field>[1]` — the same
+        // accrual rule that handles same-level missing fields.
+        val xml = x"<root><company>Acme</company></root>"
+        validateXml(xml)(_.as[DContact]).items.map(_(0).s).to(Set)
+      . assert: paths =>
+          paths == Set
+            ( "/person[1]",
+              "/person[1]/name[1]",
+              "/person[1]/age[1]",
+              "/person[1]/email[1]" )
 
     suite(m"Position-aware focus (tracked Xml)"):
       def validateWithPositions[result]

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -85,8 +85,13 @@ object Tests extends Suite(m"Xylophone tests"):
     . assert(_ == 1)
 
     test(m"fail to extract bad integer"):
-      capture[NumberError](x"""<message>ABC</message>""".as[Int])
-    . assert(_ == NumberError("ABC", Int, NumberError.Reason.Unparseable))
+      // The explicit `Int is Decodable in Xml` raises `XmlError` (not
+      // `NumberError`) so multi-error accrual can register and continue
+      // through every bad field of a case class; outside `validate`,
+      // `raise` still throws via the ambient `Tactic`.
+      capture[XmlError](x"""<message>ABC</message>""".as[Int])
+      true
+    . assert(identity)
 
     test(m"extract email address"):
       x"""<email>test@example.com</email>""".as[EmailAddress]


### PR DESCRIPTION
Decoding XML to case classes and sealed traits now records every missing or wrong-type field on the ambient `Foci[Xml.Focus]` and continues, instead of aborting at the first failure. Parsing is unchanged — a malformed document still produces exactly one `ParseError`.

```scala
case class Person(name: Text, age: Int, email: Text)

validate[Xml.Focus](Issues()):
  case error: XmlError =>
    accrual + (prior.let(_.path.encode).or(t"#"), error)
. within(x"<root><name>Alice</name><age>oldish</age></root>".as[Person])
// items = [("/age[1]", _), ("/email[1]", _)]
```

## How

- Explicit `Decodable in Xml` for `Int`, `Long`, `Short`, `Byte`, `Double`, `Float`, `Boolean` extract text content and parse with `raise + yet 0` (or `false`) instead of `abort`-ing. They shadow the generic `decodable` summonFrom for these types so the textual branch — which would otherwise propagate `NumberError` as a thrown exception — is bypassed.

- A private `Xml.Absent = Fragment()` sentinel signals "this field was missing from the XML". The Wisteria conjunction passes it to a field's decoder when the named child element is absent; primitives detect it via `textOf` returning `Unset`, and the textual decodable branch detects it via `xml eq Absent`. Both raise an error at the field's focus and continue with `0` / `""`.

- The conjunction's wrong-shape branch (non-Element root — e.g. the `Absent` sentinel passed by an outer conjunction for a missing nested case-class field) raises at the current focus and continues with an empty children map. `build` then registers each sub-field's missing-field error at `/parent[1]/child[1]` paths. So a missing nested case class expands recursively into per-sub-field errors at the right XPaths.

- Sum-type disjunction stays in single-error mode: a missing or unrecognised discriminant has no obvious sentinel variant to continue with, so it `abort`s. Multi-error accrual still applies inside the chosen variant via its product decoder.

## Behaviour change

`xylophone_test`'s "fail to extract bad integer" now expects `XmlError` rather than `NumberError`. The explicit `Int is Decodable in Xml` calls `raise(XmlError())` — which the ambient `throwUnsafely` Tactic still surfaces as a thrown exception outside `validate`, just with the XML-aware error type instead of the underlying parse error.