### PR TITLE
stratiform: schema-aware E107 recovery (§19.5)

### DIFF
--- a/lib/stratiform/doc/spec-notes.md
+++ b/lib/stratiform/doc/spec-notes.md
@@ -5,11 +5,11 @@ Implementation-discovered ambiguities, inconsistencies, and inadequacies in the 
 ## Open issues
 
 ### §18.1 / §19.1 vs §19.5 — schema-aware indentation recovery
-**Issue:** §18.1 and §19.1 say "the schema informs error recovery decisions (particularly for indentation errors, whose recovery algorithm is defined in §19.5)" — implying the parser consults the schema during recovery. But §19.5 defines the v1.0 recovery rule as the schema-independent **shallower-wins rule**, with the schema-aware variant "deliberately deferred" to a future revision.
+**Issue:** §18.1 and §19.1 say "the schema informs error recovery decisions (particularly for indentation errors, whose recovery algorithm is defined in §19.5)" — implying the parser consults the schema during recovery. But §19.5 originally defined the v1.0 recovery rule as the schema-independent **shallower-wins rule**.
 
-**Stratiform decision:** The parser is structured single-pass and schema-aware (per §18.1) but uses only the shallower-wins rule in phase 1. When schema integration lands in phase 3, the parser will consult the schema during recovery as the normative §18.1 wording allows, while still falling back to shallower-wins where the schema provides no signal.
+**Spec resolution:** **resolved.** §19.5 now defines two E107 recovery rules — a schema-independent shallower-wins rule (used when no schema is in scope) and a schema-aware rule (used when a schema is in scope) that picks between shallower and deeper based on keyword admissibility, falling back to shallower on a tie. §18.1 / §19.1 wording is now consistent.
 
-**Spec resolution:** open.
+**Stratiform implementation:** the schema-aware rule is implemented when the consumer calls `Tel.parse(bytes, schema)`; `bytes.read[Tel]` / `text.load[Tel]` (no schema in scope) continue to use shallower-wins (raising E107 in the absence of recovery). The parser maintains an `ancestors` stack of resolved struct types alongside the open-compound chain to enable the lookup.
 
 ### `tel-schema` self-validation circularity
 **Issue:** §20.5 specifies `tel-schema` as itself a TEL document conforming to `tel-schema`. A parser bootstrapping its first run has no `tel-schema` to validate the `tel-schema.tel` document against.

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -212,6 +212,13 @@ object Tel extends Tel2:
   private[stratiform] def parse(bytes: Data): Tel raises TelError =
     Tel(TelParser.parse(bytes))
 
+  // Schema-aware parse: the parser uses the §19.5 schema-aware E107
+  // recovery rule when it encounters an odd-indented line. Useful
+  // when the consumer wants tolerant parsing of indentation typos
+  // against a known schema.
+  def parse(bytes: Data, schema: Tels): Tel raises TelError =
+    Tel(TelParser.parse(bytes, schema))
+
   // `bytes.read[Tel]` for any Stream[Data] source: concatenates the
   // chunks and parses the result. The metadata (interpreter directive,
   // pragma, line-endings) is *not* surfaced — use `.load[Tel]` to

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -48,7 +48,15 @@ import TelError.Reason
 
 object TelParser:
 
-  def parse(input: Data): Tel.Document raises TelError = TelParser(input).parseDocument()
+  def parse(input: Data): Tel.Document raises TelError =
+    TelParser(input, Unset).parseDocument()
+
+  // Schema-aware parse: when an odd-indented line is encountered the
+  // parser uses §19.5's schema-aware E107 recovery to disambiguate
+  // shallower vs deeper. Without a schema the original shallower-wins
+  // rule still applies.
+  def parse(input: Data, schema: Tels): Tel.Document raises TelError =
+    TelParser(input, schema: Optional[Tels]).parseDocument()
 
   private final class Line
      ( val content:       String,
@@ -57,7 +65,7 @@ object TelParser:
        val start:         Int,
        val end:           Int )
 
-private final class TelParser(input: Data):
+private final class TelParser(input: Data, schema: Optional[Tels]):
   import TelParser.Line
 
   private val source: String =
@@ -126,6 +134,118 @@ private final class TelParser(input: Data):
   // this line as equivalent to "start of file" — comments immediately
   // after the prologue are valid.
   private var prologueEndLine: Int = -1
+
+  // Ancestor stack of Struct types known for each open compound, used
+  // by the schema-aware E107 recovery rule of §19.5. The element at
+  // index `i` is the schema struct corresponding to the compound at
+  // depth `i+1` (so the document root at depth 0 is implicit and
+  // refers to `schema.document`). `Unset` entries mark compounds
+  // whose schema position couldn't be resolved (e.g. an unknown
+  // keyword in a permissive layer), in which case both shallower and
+  // deeper recovery treat that ancestor as "schema-blind".
+  private val ancestors =
+    scala.collection.mutable.ArrayBuffer.empty[Optional[Tels.Struct]]
+
+  // Push a child compound's resolved struct onto the ancestor stack.
+  // The compound is at depth `parentDepth + 1`; `parentDepth` is the
+  // length of the current ancestor stack (0 = document root). If we
+  // can resolve the compound's keyword to a Struct type inside the
+  // parent's schema struct, push it; otherwise push Unset.
+  private def pushAncestor(keyword: Text): Unit raises TelError =
+    schema.let: s =>
+      val parent: Optional[Tels.Struct] =
+        if ancestors.isEmpty then s.document else ancestors(ancestors.length - 1)
+
+      val resolved: Optional[Tels.Struct] = parent.let: p =>
+        resolveKeywordStruct(p, keyword, s)
+
+      ancestors += resolved
+    .or:
+      // Without a schema we still keep the depth alignment so pop
+      // works symmetrically, but the entries are always Unset.
+      ancestors += Unset
+
+  private def popAncestor(): Unit =
+    if ancestors.nonEmpty then ancestors.remove(ancestors.length - 1)
+
+  // Resolve `keyword` against `parent`'s direct Field / SelectRef
+  // members. Returns the Struct type if the keyword names a child
+  // whose resolved type is a Struct, or Unset otherwise (Scalar /
+  // Flag / unknown keyword / Reference to a non-struct).
+  private def resolveKeywordStruct(parent: Tels.Struct, keyword: Text, schema: Tels)
+  :     Optional[Tels.Struct] raises TelError =
+    val matched: Optional[Tels.Type] =
+      var found: Optional[Tels.Type] = Unset
+      var i = 0
+      while i < parent.members.length && found.absent do
+        parent.members(i) match
+          case f: Tels.Field =>
+            if f.keyword == keyword then found = f.fieldType
+
+          case s: Tels.SelectRef =>
+            // Expand the SelectRef's variants.
+            schema.selects.find(_.name == s.reference).foreach: selectDef =>
+              selectDef.variants.find(_.keyword == keyword).foreach: variant =>
+                found = variant.variantType
+
+          case _: Tels.Exclude => ()
+
+        i += 1
+
+      found
+
+    matched.let: t =>
+      resolveTypeToStruct(t, schema)
+    .or(Unset)
+
+  // Resolve a Type to a Struct (following one level of Reference) or
+  // Unset if it doesn't resolve to a Struct.
+  private def resolveTypeToStruct(t: Tels.Type, schema: Tels)
+  :     Optional[Tels.Struct] =
+    t match
+      case s: Tels.Struct =>
+        s
+
+      case Tels.Reference(name) =>
+        schema.records.find(_.name == name) match
+          case Some(rec) => Tels.Struct(rec.members, rec.validators)
+          case None      => Unset
+
+      case _ =>
+        Unset
+
+  // Does `parent` contain `keyword` in its direct Field/SelectRef
+  // keyword set?
+  private def keywordAdmissible(parent: Tels.Struct, keyword: Text, schema: Tels): Boolean =
+    var i = 0
+    while i < parent.members.length do
+      parent.members(i) match
+        case f: Tels.Field =>
+          if f.keyword == keyword then return true
+
+        case s: Tels.SelectRef =>
+          schema.selects.find(_.name == s.reference).foreach: selectDef =>
+            if selectDef.variants.exists(_.keyword == keyword) then return true
+
+        case _: Tels.Exclude => ()
+
+      i += 1
+
+    false
+
+  // Extract the keyword phrase from a non-blank, non-comment,
+  // non-tabulation line — used by the schema-aware E107 recovery to
+  // probe the schema. Falls back to the empty string if the line has
+  // no leading keyword.
+  private def extractKeyword(line: Line): Text =
+    val start = line.leadingSpaces
+    var end = start
+    while end < line.content.length
+      && line.content.charAt(end) != ' '
+      && line.content.charAt(end) != sigil
+    do end += 1
+
+    Text(line.content.substring(start, end))
 
   def parseDocument(): Tel.Document raises TelError =
     checkBom()
@@ -277,15 +397,58 @@ private final class TelParser(input: Data):
     while i < lines.length && lines(i).blank do i += 1
     if i < lines.length then i else Unset
 
-  // Returns the indent in levels (units of two spaces beyond the margin).
-  // Raises E106 if leading spaces fall short of the margin, E107 if the
-  // post-margin offset is odd. Phase-1 recovery is to bail on first error;
-  // a future phase will adopt §19.5's accumulating recovery.
+  // Returns the indent in levels (units of two spaces beyond the
+  // margin). Raises E106 if leading spaces fall short of the margin.
+  // Odd post-margin offsets go through E107 recovery: schema-aware
+  // when a schema is in scope (§19.5), schema-independent shallower-
+  // wins otherwise.
   private def indentOf(line: Line): Int raises TelError =
     val relative = line.leadingSpaces - margin
     if relative < 0 then abort(TelError(Reason.LessThanMargin))
-    else if relative % 2 != 0 then abort(TelError(Reason.OddIndentation))
-    else relative / 2
+    else if relative % 2 == 0 then relative / 2
+    else recoverOddIndent(line, relative)
+
+  // §19.5 E107 recovery. When no schema is in scope, return the
+  // shallower depth (the original v1.0 rule). When a schema is in
+  // scope, compute admissibility at both candidate depths via the
+  // current ancestor stack, then:
+  //   - both invalid or both valid → shallower (tie-break favours
+  //     the shallower interpretation; type assignment can later
+  //     report E306 against the chosen parent).
+  //   - only one valid → that one.
+  // Edge cases tracked in §19.5:
+  //   1. shallower over-dedents past the ancestor stack → shallower
+  //      invalid; deeper's parent doesn't exist either, so we fall
+  //      back to shallower (graceful degradation).
+  //   2. deeper's parent doesn't exist (no open compound at depth
+  //      `shallower`) → deeper invalid.
+  //   3. deeper's parent resolved to a non-Struct (Scalar/Flag) → it
+  //      wasn't pushed onto the ancestor stack at all, so deeperParent
+  //      is Unset → deeper invalid.
+  private def recoverOddIndent(line: Line, relative: Int): Int raises TelError =
+    schema.let: s =>
+      val shallower = relative / 2
+      val deeper    = shallower + 1
+      val keyword   = extractKeyword(line)
+
+      val shallowerParent: Optional[Tels.Struct] =
+        if shallower == 0 then s.document
+        else if shallower - 1 < ancestors.length then ancestors(shallower - 1)
+        else Unset
+
+      val deeperParent: Optional[Tels.Struct] =
+        if shallower < ancestors.length then ancestors(shallower)
+        else Unset
+
+      val shallowerValid =
+        shallowerParent.let(p => keywordAdmissible(p, keyword, s)).or(false)
+
+      val deeperValid =
+        deeperParent.let(p => keywordAdmissible(p, keyword, s)).or(false)
+
+      if !shallowerValid && deeperValid then deeper else shallower
+    .or:
+      abort(TelError(Reason.OddIndentation))
 
   private def checkTrailingSpaces(line: Line): Unit raises TelError =
     if line.content.length > 0 && line.content.charAt(line.content.length - 1) == ' '
@@ -392,7 +555,9 @@ private final class TelParser(input: Data):
         else Unset
 
       val children =
-        if extraAtom.absent && tabulation.absent then parseChildren(indent)
+        if extraAtom.absent && tabulation.absent then
+          pushAncestor(parsed.keyword)
+          try parseChildren(indent) finally popAncestor()
         else IArray.empty[Tel.Block]
 
       val withAtom = extraAtom.lay(parsed): atom =>

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -205,6 +205,80 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert: scalars =>
           scalars == Set(t"Identifier", t"TypeName", t"Sigil", t"String")
 
+    suite(m"E107 schema-aware recovery (§19.5)"):
+      // A schema where a root-level `parent` field references a
+      // `Parent` record, and the `Parent` record contains a field
+      // `child`. The keyword `child` is admissible inside Parent but
+      // NOT at the document root, so an odd-indented `child` line
+      // following a `parent` line must be recovered to the deeper
+      // candidate.
+      val recoverSchema = Tels(
+        name     = t"recover",
+        document = Tels.Struct(
+          members = IArray(
+            Tels.Field
+             ( Tels.Polarity.Implicit, Tels.Polarity.Loose,
+               t"parent",
+               Tels.Reference(t"Parent"),
+               Unset )),
+          validators = IArray.empty),
+        layers   = IArray.empty,
+        sigil    = Unset,
+        records  = IArray(Tels.RecordDefinition(
+          t"Parent",
+          IArray(Tels.Field
+                 ( Tels.Polarity.Loose, Tels.Polarity.Loose,
+                   t"child", Tels.Scalar(IArray(t"string")), Unset )),
+          IArray.empty)),
+        scalars  = IArray.empty,
+        selects  = IArray.empty)
+
+      test(m"picks deeper when only deeper is valid"):
+        // `child` at one space of indent (=odd) is invalid as a root
+        // sibling but valid as a child of `parent`; the parser
+        // recovers to the deeper interpretation, and the printer
+        // re-emits at the canonical two-space indent.
+        val src = summon[CharEncoder].encoded(t"parent\n child Alice\n")
+        val tel = Tel.parse(src, recoverSchema)
+        Tel.show(tel.document.vouch)
+      . assert(_ == t"parent\n  child Alice\n")
+
+      test(m"prefers shallower on tie"):
+        // A `thing` keyword admissible at both depths via a
+        // self-referential record; shallower must win.
+        val tieSchema = Tels(
+          name     = t"tie",
+          document = Tels.Struct(
+            members = IArray(Tels.Field
+                            ( Tels.Polarity.Loose, Tels.Polarity.Loose,
+                              t"thing", Tels.Reference(t"Thing"), Unset )),
+            validators = IArray.empty),
+          layers   = IArray.empty,
+          sigil    = Unset,
+          records  = IArray(Tels.RecordDefinition(
+            t"Thing",
+            IArray(Tels.Field
+                   ( Tels.Polarity.Loose, Tels.Polarity.Loose,
+                     t"thing", Tels.Reference(t"Thing"), Unset )),
+            IArray.empty)),
+          scalars  = IArray.empty,
+          selects  = IArray.empty)
+
+        // Open one level (`thing`), then an odd-indented `thing`.
+        // Both depths admit `thing`; shallower wins per the
+        // tie-breaker.
+        val src = summon[CharEncoder].encoded(t"thing\n thing\n")
+        val tel = Tel.parse(src, tieSchema)
+        // The output's child compound is the shallower interpretation
+        // (sibling at root) — its keyword is "thing".
+        tel.childCompounds.length
+      . assert(_ == 2)
+
+      test(m"without schema, original shallower-wins still raises E107"):
+        // The schema-independent parse path still aborts on odd indent.
+        capture[TelError](t"parent\n child Alice\n".read[Tel]).reason
+      . assert(_ == TelError.Reason.OddIndentation)
+
     suite(m"Type assignment"):
       // A small hand-built schema for a `person` document with required
       // name (Scalar String) and optional age (Scalar Identifier).


### PR DESCRIPTION
Implements the new schema-aware E107 (OddIndentation) recovery rule from the updated §19.5 of the TEL specification. When a schema is in scope at parse time, an odd post-margin offset is no longer a hard error: the parser instead picks between the shallower and deeper candidate depths by querying the schema for keyword admissibility.

## API

A new `Tel.parse(bytes, schema)` entry point activates the schema-aware rule:

```scala
import soundness.*, contingency.*, strategies.throwUnsafely, charEncoders.utf8

val src    = encoder.encoded(t"parent\n child Alice\n")
val schema = mySchema  // a Tels with a `Parent` record containing `child`
val tel    = Tel.parse(src, schema)
// `child` is recovered to depth 1 (parent's child), not E107.
```

The existing `bytes.read[Tel]` / `text.load[Tel]` (no schema) continue to use the original v1.0 shallower-wins rule — they still raise E107 on odd indents.

## Algorithm

The parser maintains an `ancestors` stack of resolved struct types alongside the open-compound chain. On an odd post-margin offset of `relative`:

  - `shallower = ⌊relative/2⌋`, `deeper = shallower + 1`
  - Look up the line's keyword in the struct at each candidate depth.
  - Pick the only valid candidate; on tie (both / neither admissible), pick shallower per the spec's tiebreaker.

Edge cases handled per §19.5:

  - `shallower` over-dedents past the ancestor stack → shallower invalid; deeper's parent doesn't exist either, so fall back to shallower (graceful degradation).
  - `deeper`'s parent missing → deeper invalid.
  - `deeper`'s parent resolves to a non-Struct (Scalar / Flag) → it never made it onto the ancestor stack, so deeper is invalid.