### PR TITLE
xylophone: Default-driven sentinels for missing fields and unknown variants

### DIFF
--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -210,64 +210,91 @@ object Xml extends Tag.Container
       xml =>
         provide[Foci[Xml.Focus]]:
           provide[Tactic[XmlError]]:
-            // A non-Element root (including the `Absent` sentinel passed
-            // by an outer conjunction for a missing nested case-class
-            // field) raises an error at the *current* focus and then
-            // continues with an empty children map. `build` then sees
-            // every field as missing and accrues per-field errors at
-            // `/parent/child` paths.
-            val element: Optional[Element] = xml match
-              case e: Element           => e
-              case Fragment(e: Element) => e
-              case _                    => raise(XmlError()) yet Unset
+            xml match
+              case e: Element           => buildWith(e)
+              case Fragment(e: Element) => buildWith(e)
+              case _                    =>
+                // Wrong-shape input (including the `Absent` sentinel an
+                // outer conjunction passes in for a missing nested case-
+                // class field). If the user supplied `Default[derivation]`
+                // we register one error at the current focus and continue
+                // with the sentinel — a missing nested case class lands
+                // as a single error rather than expanding per sub-field.
+                // Without a `Default`, we fall back to running `build`
+                // against an empty children map so each sub-field accrues
+                // its own missing-field error.
+                summonFrom:
+                  case derivationDefault: Default[`derivation`] =>
+                    raise(XmlError()) yet derivationDefault()
+                  case _                                        =>
+                    raise(XmlError())
+                    buildWith(Element(t"", Attributes.empty, IArray.empty))
 
-            val children: scm.HashMap[String, Element] = scm.HashMap.empty
-            element.let: el =>
-              var i = 0
-              while i < el.children.length do
-                el.children(i) match
-                  case child: Element =>
-                    val childLabel = child.label.s
-                    if !children.contains(childLabel) then
-                      children.update(childLabel, child)
-                  case _ => ()
-                i += 1
+    private inline def buildWith[derivation <: Product: ProductReflection]
+      ( element: Element )
+      ( using Foci[Xml.Focus], Tactic[XmlError] )
+    :   derivation =
 
-            build: [field] =>
-              context =>
-                val fieldLabel: Text = wisteria.label[Text]
-                focus({
-                  // Each outer `focus` runs *after* the inner one, so
-                  // we extend `prior` at the root side (`/outer/inner`),
-                  // not the leaf side that `XPath#element` would use.
-                  val base = prior.let(_.path).or(XPath())
-                  Xml.Focus(base.prepend(fieldLabel, 1))
-                }):
-                  children.get(fieldLabel.s) match
-                    case Some(child) => context.decoded(child)
-                    // Missing field: hand the `Absent` sentinel to the
-                    // field's decoder. Primitives and nested conjunctions
-                    // each detect it and `raise + continue` so the
-                    // surrounding `build` keeps iterating.
-                    case None        => default.or(context.decoded(Absent))
+      val children: scm.HashMap[String, Element] = scm.HashMap.empty
+      var i = 0
+      while i < element.children.length do
+        element.children(i) match
+          case child: Element =>
+            val childLabel = child.label.s
+            if !children.contains(childLabel) then
+              children.update(childLabel, child)
+          case _ => ()
+        i += 1
 
-    // Sealed-trait disjunction stays in single-error mode: a missing or
-    // unrecognised discriminant has no obvious sentinel variant to
-    // continue with, so it `abort`s. Same-level multi-error accrual
-    // applies inside the chosen variant via its product decoder.
+      build: [field] =>
+        context =>
+          val fieldLabel: Text = wisteria.label[Text]
+          focus({
+            // Each outer `focus` runs *after* the inner one, so we
+            // extend `prior` at the root side (`/outer/inner`), not the
+            // leaf side that `XPath#element` would use.
+            val base = prior.let(_.path).or(XPath())
+            Xml.Focus(base.prepend(fieldLabel, 1))
+          }):
+            children.get(fieldLabel.s) match
+              case Some(child) => context.decoded(child)
+              // Missing field: fall back to the case-class declared
+              // default (Wisteria's `default`); if absent, hand the
+              // `Absent` sentinel to the field's decoder. Primitives
+              // detect it and `raise + continue`; nested conjunctions
+              // detect it and may further short-circuit via a
+              // user-supplied `Default[Nested]`.
+              case None        => default.or(context.decoded(Absent))
+
+    // Sealed-trait disjunction picks a variant by element label. We screen
+    // the discriminator against `variantLabels` *before* `delegate`-ing so
+    // an unrecognised label doesn't punch through as `VariantError` — it
+    // gets the same `Default[derivation]`-or-abort treatment as a missing
+    // discriminator. When the user supplies `Default[derivation]` we
+    // register one error at the current focus and continue with the
+    // sentinel; without one we abort.
     inline def disjunction[derivation: SumReflection]
     :   derivation is Decodable in Xml =
 
       xml =>
-        provide[Tactic[XmlError]]:
-          provide[Tactic[VariantError]]:
-            val discriminable = infer[derivation is Discriminable in Xml]
+        provide[Foci[Xml.Focus]]:
+          provide[Tactic[XmlError]]:
+            provide[Tactic[VariantError]]:
+              val discriminable = infer[derivation is Discriminable in Xml]
+              val labels: List[Text]    = variantLabels[derivation]
+              val resolved: Optional[Text] =
+                discriminable.discriminate(xml).let: discriminant =>
+                  if labels.contains(discriminant) then discriminant else Unset
 
-            val discriminant: Text = discriminable.discriminate(xml).or:
-              focus(prior.or(Xml.Focus(XPath())))(abort(XmlError()))
-
-            delegate(discriminant): [variant <: derivation] =>
-              context => context.decoded(xml)
+              resolved.let: discriminant =>
+                delegate(discriminant): [variant <: derivation] =>
+                  context => context.decoded(xml)
+              . or:
+                  summonFrom:
+                    case derivationDefault: Default[`derivation`] =>
+                      raise(XmlError()) yet derivationDefault()
+                    case _ =>
+                      abort(XmlError())
 
   case class attribute() extends StaticAnnotation
 

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -48,6 +48,39 @@ case class XmlIssues(items: List[(Text, XmlError)] = Nil)(using Diagnostics)
 extends Error(m"${items.length} XML decoding issues"):
   def +(focus: Text, error: XmlError): XmlIssues = XmlIssues(items :+ (focus, error))
 
+// Wrapped in an object so the `given Default[DPerson]` is in lexical scope
+// *at the conjunction call site* — the `summonFrom` inside the inlined
+// `Xml.DecodableDerivation.conjunction` body resolves against the call
+// site's implicit context.
+object DefaultPersonScope:
+  given XmlSchema = XmlSchema.Freeform
+  given Default[DPerson] = () => DPerson(t"", 0, t"")
+
+  def run(): Set[String] =
+    val xml = x"<root><company>Acme</company></root>"
+    validate[Xml.Focus](XmlIssues()):
+      case error: XmlError => accrual + (prior.let(_.path.encode).or(t"#"), error)
+    . within(xml.as[DContact]).items.map(_(0).s).to(Set)
+
+case class DDrawing(shape: DShape, label: Text) derives CanEqual
+
+// Sealed-trait Default test: when the discriminator doesn't match any
+// variant, `Default[DShape]` lets the decode return a sentinel rather
+// than aborting. The error registered carries whatever focus the
+// enclosing scope set — here at the top level it's `Unset`, so the
+// `or(t"#")` fallback fires for the path.
+object DefaultShapeScope:
+  given XmlSchema = XmlSchema.Freeform
+  given Default[DShape] = () => DShape.Circle(-1)
+
+  def run(): (Set[String], Int) =
+    val xml = x"<Triangle><foo>bar</foo></Triangle>"
+    val accrued = validate[Xml.Focus](XmlIssues()):
+      case error: XmlError => accrual + (prior.let(_.path.encode).or(t"#"), error)
+    . within(xml.as[DShape])
+
+    (accrued.items.map(_(0).s).to(Set), accrued.items.length)
+
 
 object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
 
@@ -140,6 +173,41 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
         // raise+continue at `/person[1]` and then every sub-field's
         // missing-field raise at `/person[1]/<field>[1]` — the same
         // accrual rule that handles same-level missing fields.
+        val xml = x"<root><company>Acme</company></root>"
+        validateXml(xml)(_.as[DContact]).items.map(_(0).s).to(Set)
+      . assert: paths =>
+          paths == Set
+            ( "/person[1]",
+              "/person[1]/name[1]",
+              "/person[1]/age[1]",
+              "/person[1]/email[1]" )
+
+    suite(m"Default-driven sentinels"):
+      // A user-supplied `Default[T]` short-circuits the conjunction's
+      // wrong-shape fallback and the disjunction's unknown-discriminator
+      // fallback: instead of running `build` against an empty children
+      // map (and accruing sub-field errors), or aborting, the focus
+      // raises the error once and continues with the supplied default.
+
+      test(m"Default[DPerson] collapses a missing nested into one error"):
+        DefaultPersonScope.run()
+      . assert(_ == Set("/person[1]"))
+
+      test(m"Default[DShape] handles an unknown discriminator at the top level"):
+        DefaultShapeScope.run()
+      . assert((paths, count) => count == 1 && paths == Set("#"))
+
+      test(m"Without Default[DShape], unknown discriminator aborts"):
+        // Outside a `Default[DShape]`, the disjunction calls `abort`,
+        // which the surrounding `validate` captures and reports as one
+        // accrual entry. No `VariantError` punches through.
+        val xml = x"<UnknownVariant><foo>bar</foo></UnknownVariant>"
+        validateXml(xml)(_.as[DShape]).items.length
+      . assert(_ == 1)
+
+      test(m"Without Default[DPerson], a missing nested still expands"):
+        // Confirms the existing (no-Default) accrual semantics from the
+        // previous PR are unchanged for users who don't opt in.
         val xml = x"<root><company>Acme</company></root>"
         validateXml(xml)(_.as[DContact]).items.map(_(0).s).to(Set)
       . assert: paths =>


### PR DESCRIPTION
Lets the user opt into single-error accrual for an absent nested case-class field or an unknown sealed-trait discriminator by providing a `vacuous.Default` instance for that type.

## Missing nested case class

Previously, a missing nested field expanded recursively into per-sub-field errors:

```scala
case class Person(name: Text, age: Int, email: Text)
case class Contact(person: Person, company: Text)

xml.as[Contact]  // xml has no <person>
// → 4 errors: /person[1], /person[1]/name[1], /person[1]/age[1], /person[1]/email[1]
```

With a user-supplied `Default[Person]` in scope:

```scala
given Default[Person] = () => Person(t"", 0, t"")
xml.as[Contact]
// → 1 error at /person[1]; decode returns the sentinel Person value
```

## Unknown sealed-trait discriminator

Previously, an unknown element label (`<Triangle/>` against `sealed trait Shape { Circle; Square }`) punched through `validate[Xml.Focus]` as a `VariantError`, bypassing `case error: XmlError =>` handlers.

Now, `delegate` is gated by `variantLabels.contains(discriminant)` so an unknown label gets the same `Default[derivation]`-or-`abort` treatment as a missing discriminator. With `Default[Shape]` in scope:

```scala
given Default[Shape] = () => Shape.Unknown
xml.as[Shape]
// → 1 error (XmlError) is captured by validate, decode returns Shape.Unknown
```

Without `Default[Shape]`, the disjunction calls `abort(XmlError())` — captured cleanly by `validate`; no `VariantError` leaks.

## How

* `DecodableDerivation.conjunction` now branches at the top: a non-Element input first tries `Default[derivation]`; if a given is in scope, raises one error at the current focus and returns the sentinel. Without a `Default`, the previous behaviour (run `build` against an empty children map and accrue per-sub-field errors) is preserved. The per-field code is factored into a `buildWith(element)` helper.
* `summonFrom` works for `Default[derivation]` because `derivation` is bound at the *outer* `inline def conjunction` parameter — concrete at the inlining site and the user's local given resolves against the call-site implicit scope. Pushing this into the per-field `build` lambda (where `field` lives behind Wisteria's polymorphic abstraction) wasn't reliable; keeping the `Default` check at the conjunction's surface sidesteps that.
* Conjunction's missing-field case is unchanged: `default.or(...)` passes `Absent` to the field's decoder, which a nested conjunction then short-circuits via its own top-level `Default[Nested]` check.

## Tests

`DecoderTests` exercises:

- Missing nested with `Default` collapses to one error at `/person[1]`.
- Unknown variant with `Default[Sum]` accrues one `XmlError` and the decode returns the sentinel.
- Without `Default[Sum]`, the disjunction aborts under `validate` (no `VariantError` leaks).
- Without `Default[Nested]`, the prior per-sub-field expansion is preserved.