### PR TITLE
stratiform: BASE-256 binary-to-text codec

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1170,13 +1170,16 @@ object stratiform extends Library:
   object core extends Component(zephyrine.core, turbulence.core, panopticon.core, gossamer.core, contingency.core, anticipation.codec, distillate.core, wisteria.core, prepositional.core, contextual.core, gigantism.core, fulminate.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object base256 extends Component(gossamer.core, contingency.core, fulminate.core, anticipation.codec, vacuous.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object time extends Component(core, aviation.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object http extends Component(core, telekinesis.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, time, http, eucalyptus.core)
+  object test extends Tests(core, base256, time, http, eucalyptus.core)
 
 object superlunary extends Library:
   object core extends Component(jacinta.core, gastronomy.core, anthology.scala, austronesian.core):

--- a/lib/stratiform/src/base256/soundness_stratiform_base256.scala
+++ b/lib/stratiform/src/base256/soundness_stratiform_base256.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export stratiform.{Base256, Base256Error}

--- a/lib/stratiform/src/base256/stratiform.Base256.scala
+++ b/lib/stratiform/src/base256/stratiform.Base256.scala
@@ -1,0 +1,149 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.language.unsafeNulls
+
+import anticipation.*
+import contingency.*
+
+// BASE-256 binary-to-text codec. The alphabet of §4 of the spec assigns
+// each byte value `b` (0..255) a Unicode character `A[b]` whose code
+// point is congruent to `b` mod 256. Encoding is a single array index;
+// decoding is a single modulo operation per character.
+
+object Base256:
+
+  // §4 alphabet, in byte-value order. The 256 code points are drawn
+  // from Basic Latin, Latin Supplements A/B, Greek, Cyrillic, Latin
+  // Extended Additional, and Greek Extended — all in the BMP, so each
+  // is one UTF-16 code unit. The defining property
+  // `codepoint(alphabet(b)) ≡ b (mod 256)` is verified at module load
+  // by `verifyAlphabet` below.
+  val alphabetString: String =
+    "ḀḁЂЃĄąĆćȈȉЊḋЌḍĎďȐȑĒГДȕЖЗĘęȚțĜĝḞḟḠḡḢḣḤĥȦȧШḩЪЫЬЭĮį" +
+      "0123456789ĺĻļĽľĿŀABCDEFGHIJKLMNOPQRSTUVWXYZṛќѝŞşŠ" +
+      "abcdefghijklmnopqrstuvwxyzŻżṽžſẀẁẂẃẄẅẆẇẈẉΊẋẌẍΎƏҐґƒẓΔƕƖẗẘẙҚқƜƝΞƟ" +
+      "ƠơҢңƤƥΦƧƨΩΪΫάέήίưᾱβγδεζҷᾸικλμẽξοπӁӂÃτÅÆÇψωϊϋỌύώϏ" +
+      "ÐǑǒǓÔϕӖϗῘÙῚӛӜӝÞӟàῡǢǣӤåæçǨῩӪӫìíӮӯðñỲỳôỵǶỷӸùῺûǼǽþǿ"
+
+  val alphabet: IArray[Char] =
+    val arr = new Array[Char](256)
+    var i = 0
+
+    while i < 256 do
+      arr(i) = alphabetString.charAt(i)
+      i += 1
+
+    arr.asInstanceOf[IArray[Char]]
+
+  private val membership: Array[Boolean] =
+    val table = new Array[Boolean](Char.MaxValue.toInt + 1)
+    var i = 0
+
+    while i < 256 do
+      table(alphabet(i).toInt) = true
+      i += 1
+
+    table
+
+  // Self-check the alphabet's defining property — every implementation
+  // MUST verify it per §4. We do it at module load so a transcription
+  // error fails fast rather than surfacing as silent decode corruption.
+  locally:
+    if alphabetString.length != 256 then
+      sys.error(s"BASE-256 alphabet has ${alphabetString.length} chars, expected 256")
+
+    var i = 0
+
+    while i < 256 do
+      val c = alphabet(i)
+
+      if c.toInt % 256 != i then
+        val hex = String.format("%04X", Integer.valueOf(c.toInt))
+        sys.error(s"BASE-256 alphabet[$i] = U+$hex (mod 256 = ${c.toInt % 256}, expected $i)")
+
+      i += 1
+
+    val seen = new Array[Boolean](Char.MaxValue.toInt + 1)
+    var j = 0
+
+    while j < 256 do
+      val ord = alphabet(j).toInt
+      if seen(ord) then sys.error(s"BASE-256 alphabet has duplicate char at index $j")
+      seen(ord) = true
+      j += 1
+
+  // Encode a byte sequence to its BASE-256 textual form. Each byte
+  // becomes one Unicode character; the result has the same length in
+  // characters as the input has in bytes.
+  def encode(data: Data): Text =
+    val sb = new java.lang.StringBuilder(data.length * 2)
+    var i = 0
+
+    while i < data.length do
+      sb.append(alphabet(data(i) & 0xff))
+      i += 1
+
+    Text(sb.toString)
+
+  // Permissive decode (§9). Every input character is mapped to
+  // `codepoint(c) mod 256`. Characters outside the alphabet are not
+  // rejected; their residue is taken as-is.
+  def decode(text: Text): Data =
+    val s = text.s
+    val out = new Array[Byte](s.length)
+    var i = 0
+
+    while i < s.length do
+      out(i) = (s.charAt(i).toInt % 256).toByte
+      i += 1
+
+    out.asInstanceOf[IArray[Byte]]
+
+  // Strict decode (§9). Verifies every input character is a member of
+  // the alphabet; raises a `Base256Error` listing the first offending
+  // character's position and code point. Successful decoding behaves
+  // identically to `decode`.
+  def decodeStrict(text: Text): Data raises Base256Error =
+    val s = text.s
+    val out = new Array[Byte](s.length)
+    var i = 0
+
+    while i < s.length do
+      val c = s.charAt(i)
+      if !membership(c.toInt) then abort(Base256Error(Base256Error.Reason.NotInAlphabet(i, c)))
+      out(i) = (c.toInt % 256).toByte
+      i += 1
+
+    out.asInstanceOf[IArray[Byte]]

--- a/lib/stratiform/src/base256/stratiform.Base256Error.scala
+++ b/lib/stratiform/src/base256/stratiform.Base256Error.scala
@@ -1,0 +1,50 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import fulminate.*
+
+object Base256Error:
+
+  object Reason:
+    given communicable: Reason is Communicable =
+      case NotInAlphabet(position, character) =>
+        val cp = String.format("U+%04X", Integer.valueOf(character.toInt)).nn
+        m"the character `$character` ($cp) at position $position is not in the BASE-256 alphabet"
+
+  enum Reason(val number: Int) extends Clarification:
+    case NotInAlphabet(position: Int, character: Char) extends Reason(1)
+
+case class Base256Error(reason: Base256Error.Reason)(using Diagnostics)
+extends Error(607, reason.number)(m"the BASE-256 string is invalid because $reason")

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -755,3 +755,60 @@ object Tests extends Suite(m"Stratiform Tests"):
           test(m"raises an expected E1xx error on ${testcase.stem}"):
             codes.contains(capture[TelError](testcase.source.read[Tel]).reason.number)
           . assert(_ == true)
+
+    suite(m"BASE-256 codec"):
+      test(m"alphabet has 256 entries"):
+        Base256.alphabet.length
+      . assert(_ == 256)
+
+      test(m"alphabet satisfies codepoint ≡ index (mod 256)"):
+        (0 until 256).forall(i => Base256.alphabet(i).toInt % 256 == i)
+      . assert(_ == true)
+
+      test(m"alphabet entries are pairwise distinct"):
+        Base256.alphabet.toSet.size
+      . assert(_ == 256)
+
+      test(m"ASCII digits encode to themselves"):
+        (0x30 to 0x39).forall(b => Base256.alphabet(b) == b.toChar)
+      . assert(_ == true)
+
+      test(m"ASCII uppercase letters encode to themselves"):
+        (0x41 to 0x5A).forall(b => Base256.alphabet(b) == b.toChar)
+      . assert(_ == true)
+
+      test(m"ASCII lowercase letters encode to themselves"):
+        (0x61 to 0x7A).forall(b => Base256.alphabet(b) == b.toChar)
+      . assert(_ == true)
+
+      test(m"round-trip all 256 byte values"):
+        val data: Data = (0 to 255).map(_.toByte).toArray.asInstanceOf[IArray[Byte]]
+        Base256.decode(Base256.encode(data)).toSeq
+      . assert(_ == (0 to 255).map(_.toByte))
+
+      test(m"empty bytes round-trip to empty text"):
+        Base256.encode(IArray.empty[Byte])
+      . assert(_ == t"")
+
+      test(m"empty text round-trips to empty bytes"):
+        Base256.decode(t"").length
+      . assert(_ == 0)
+
+      test(m"encoded length in characters equals input length in bytes"):
+        val data: Data = (0 to 255).map(_.toByte).toArray.asInstanceOf[IArray[Byte]]
+        Base256.encode(data).s.length
+      . assert(_ == 256)
+
+      test(m"permissive decode accepts non-alphabet chars by residue"):
+        Base256.decode(t"A ").toSeq
+      . assert(_ == Seq(0x41.toByte, 0x20.toByte))
+
+      test(m"strict decode accepts the alphabet"):
+        val data: Data = (0 to 255).map(_.toByte).toArray.asInstanceOf[IArray[Byte]]
+        Base256.decodeStrict(Base256.encode(data)).toSeq
+      . assert(_ == (0 to 255).map(_.toByte))
+
+      test(m"strict decode rejects a non-alphabet char"):
+        capture[Base256Error](Base256.decodeStrict(t"A B")).reason match
+          case Base256Error.Reason.NotInAlphabet(pos, ch) => (pos, ch)
+      . assert(_ == (1, ' '))


### PR DESCRIPTION
## Summary

- New `stratiform.base256` sub-component implementing the BASE-256 codec
  from `spec/base256.md` — each byte maps to one Unicode character whose
  code point is congruent to the byte value modulo 256, so decoding is a
  constant-time modulo operation per character.
- The alphabet (256 BMP letters and the ten ASCII digits) is drawn from
  Unicode blocks where every code point is `Lu`/`Ll`/`Lt`/`Nd`, so an
  encoded string is one word under the Unicode default segmentation and
  is selectable by double-click.
- Self-checks the alphabet's defining property and 256-char distinctness
  at module load, so a transcription error fails fast rather than
  silently corrupting decode.

### Notes for users

```scala
import soundness.{Base256, Base256Error}

val text = Base256.encode(myBytes)
val bytes = Base256.decode(text)                          // permissive
val bytes = unsafely(Base256.decodeStrict(text))          // raises Base256Error
```

The codec has no TEL dependencies and is reusable on its own; the
forthcoming `binary` (BinTEL) component will compose with it for the
text-safe wire form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)