### PR TITLE
stratiform: BinTEL §4 varint codec

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1173,13 +1173,16 @@ object stratiform extends Library:
   object base256 extends Component(gossamer.core, contingency.core, fulminate.core, anticipation.codec, vacuous.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object binary extends Component(core, base256):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object time extends Component(core, aviation.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object http extends Component(core, telekinesis.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, base256, time, http, eucalyptus.core)
+  object test extends Tests(core, base256, binary, time, http, eucalyptus.core)
 
 object superlunary extends Library:
   object core extends Component(jacinta.core, gastronomy.core, anthology.scala, austronesian.core):

--- a/lib/stratiform/src/binary/soundness_stratiform_binary.scala
+++ b/lib/stratiform/src/binary/soundness_stratiform_binary.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export stratiform.{Varint, VarintError}

--- a/lib/stratiform/src/binary/stratiform.Varint.scala
+++ b/lib/stratiform/src/binary/stratiform.Varint.scala
@@ -1,0 +1,92 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.language.unsafeNulls
+
+import anticipation.*
+import contingency.*
+
+// §4 of the BinTEL spec: variable-length unsigned integer encoding.
+// Seven payload bits per byte; bit 7 set marks a continuation byte;
+// bytes are emitted least-significant-first.
+
+object Varint:
+
+  // Result of decoding one varint from a byte stream: the value, and the
+  // index *past* the last consumed byte.
+  case class Decoded(value: Long, next: Int)
+
+  // Encode a non-negative integer to its BinTEL §4 byte sequence. Long
+  // accommodates every value BinTEL might emit — counts, byte lengths,
+  // and keyword indices in a single schema.
+  def encode(value: Long): Data =
+    if value < 0L then throw IllegalArgumentException(s"varint value must be non-negative: $value")
+    val buf = new Array[Byte](10)
+    var n = value
+    var i = 0
+
+    while n >= 0x80L do
+      buf(i) = ((n & 0x7fL) | 0x80L).toByte
+      n >>>= 7
+      i += 1
+
+    buf(i) = n.toByte
+    val out = new Array[Byte](i + 1)
+    System.arraycopy(buf, 0, out, 0, i + 1)
+    out.asInstanceOf[IArray[Byte]]
+
+  // Decode a varint from `data` starting at `offset`. Returns the decoded
+  // value and the next read position. Raises `Base256Error.Reason` is not
+  // applicable here — the equivalent failure for varint truncation /
+  // overflow lives in the BinTEL-level error type which this module does
+  // not yet introduce; we use a single dedicated exception for the
+  // foundational codec and let callers wrap it.
+  def decode(data: Data, offset: Int): Decoded raises VarintError =
+    var shift = 0
+    var acc = 0L
+    var i = offset
+
+    while true do
+      if i >= data.length then abort(VarintError(VarintError.Reason.Truncated))
+      val b = data(i) & 0xff
+
+      if shift >= 64 || (shift == 63 && (b & 0x7f) > 1)
+      then abort(VarintError(VarintError.Reason.Overflow))
+
+      acc |= (b & 0x7fL) << shift
+      i += 1
+      if (b & 0x80) == 0 then return Decoded(acc, i)
+      shift += 7
+
+    Decoded(0L, offset)

--- a/lib/stratiform/src/binary/stratiform.VarintError.scala
+++ b/lib/stratiform/src/binary/stratiform.VarintError.scala
@@ -1,0 +1,50 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import fulminate.*
+
+object VarintError:
+
+  object Reason:
+    given communicable: Reason is Communicable =
+      case Truncated => m"the varint is truncated — a continuation byte was expected"
+      case Overflow  => m"the varint encodes a value that does not fit in 64 bits"
+
+  enum Reason(val number: Int) extends Clarification:
+    case Truncated extends Reason(1)
+    case Overflow  extends Reason(2)
+
+case class VarintError(reason: VarintError.Reason)(using Diagnostics)
+extends Error(608, reason.number)(m"the varint is invalid because $reason")

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -812,3 +812,61 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[Base256Error](Base256.decodeStrict(t"A B")).reason match
           case Base256Error.Reason.NotInAlphabet(pos, ch) => (pos, ch)
       . assert(_ == (1, ' '))
+
+    suite(m"BinTEL §4 varint"):
+      def hex(data: Data): String =
+        val sb = new java.lang.StringBuilder
+        var i = 0
+        while i < data.length do
+          sb.append(f"${data(i) & 0xff}%02X")
+          if i + 1 < data.length then sb.append(' ')
+          i += 1
+        sb.toString
+
+      val vectors: List[(Long, String)] = List(
+        0L     -> "00",
+        1L     -> "01",
+        127L   -> "7F",
+        128L   -> "80 01",
+        255L   -> "FF 01",
+        16383L -> "FF 7F",
+        16384L -> "80 80 01"
+      )
+
+      vectors.foreach: (value, expected) =>
+        test(m"encodes $value as $expected"):
+          hex(Varint.encode(value))
+        . assert(_ == expected)
+
+        test(m"decodes $expected back to $value"):
+          val parts = expected.split(" ").map(java.lang.Integer.parseInt(_, 16).toByte)
+          Varint.decode(parts.asInstanceOf[IArray[Byte]], 0).value
+        . assert(_ == value)
+
+      test(m"round-trips every value in 0..1023"):
+        (0L to 1023L).forall: n =>
+          Varint.decode(Varint.encode(n), 0).value == n
+      . assert(identity)
+
+      test(m"round-trips powers of two up to 2^62"):
+        (0 to 62).map(_.toLong).forall: i =>
+          val n = 1L << i
+          Varint.decode(Varint.encode(n), 0).value == n
+      . assert(identity)
+
+      test(m"decode returns next offset"):
+        val data: Data = Array[Byte](0x80.toByte, 0x01, 0x42).asInstanceOf[IArray[Byte]]
+        Varint.decode(data, 0).next
+      . assert(_ == 2)
+
+      test(m"decode raises on truncated continuation"):
+        val data: Data = Array[Byte](0x80.toByte).asInstanceOf[IArray[Byte]]
+        capture[VarintError](Varint.decode(data, 0)).reason
+      . assert(_ == VarintError.Reason.Truncated)
+
+      test(m"encode rejects negative input"):
+        try
+          Varint.encode(-1L)
+          false
+        catch case _: IllegalArgumentException => true
+      . assert(identity)


### PR DESCRIPTION
## Summary

- Scaffolds the new `stratiform.binary` sub-component.
- Implements §4 of `spec/bintel.md` — variable-length unsigned
  integer encoding (LSB-first, 7 payload bits per byte, top bit a
  continuation flag).
- `Varint.encode(Long): Data` and `Varint.decode(Data, Int): Decoded`
  with `VarintError` for truncation and 64-bit overflow.

### Notes for users

```scala
import soundness.{Varint, VarintError}

val bytes = Varint.encode(16384)            // 80 80 01
val Varint.Decoded(value, next) = unsafely(Varint.decode(bytes, 0))
// value = 16384, next = 3
```

This is the foundational primitive everything else in BinTEL builds
on — keyword indices, byte-length prefixes, schema-signature framing
— so it lands first. All seven of the spec's normative test vectors
round-trip byte-exactly, plus 0..1023 inclusive and every power of
two up to 2^62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)