### PR TITLE
stratiform: BinTEL §7 node encoder

### DIFF
--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -30,6 +30,107 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package stratiform
 
-export stratiform.{Bintel, Varint, VarintError, bintel}
+import java.io.ByteArrayOutputStream
+
+import scala.language.unsafeNulls
+
+import anticipation.*
+import contingency.*
+import vacuous.*
+
+// BinTEL §7 node encoding. Serialises a typed `TelElement` tree into
+// the binary form defined by `spec/bintel.md` — no magic number, no
+// schema signature; the output is exactly the document-root body
+// described in §7.1, suitable for §3 value-hashing.
+//
+// §7.1 forms:
+//   - Document root (TelElement.Node with keywordIndex = Unset):
+//       child-count : varint, then each child in canonical order.
+//   - Struct node (Node with elementType = Tels.Struct):
+//       keyword-index : varint, child-count : varint, recursive children.
+//   - Flag node (Node with elementType = Tels.Flag):
+//       keyword-index : varint.
+//   - Scalar node (TelElement.Value):
+//       keyword-index : varint, byte-length : varint, UTF-8 value bytes.
+//
+// Reference types do not appear: the type-assignment phase resolves
+// them to Struct / Scalar / Flag before producing TelElement.
+
+extension (tel: Tel)
+  // Encode this document's semantic model to BinTEL body bytes (no
+  // magic number, no schema signature). Type-assigns `tel` against
+  // `schema` first; raises `TelError` on type-assignment failures.
+  def bintel(schema: Tels): Data raises TelError =
+    Bintel.encode(Tel.Type.assign(tel, schema))
+
+extension (element: TelElement)
+  // Encode a pre-assigned semantic-model element to BinTEL body bytes.
+  def bintel: Data = Bintel.encode(element)
+
+object Bintel:
+
+  // Encode a `TelElement` tree to its BinTEL body bytes. The element is
+  // expected to be the document root (a Node with `keywordIndex = Unset`
+  // and `elementType = Tels.Struct`), as produced by `Tel.Type.assign`.
+  def encode(element: TelElement): Data =
+    val out = new ByteArrayOutputStream
+    encodeRoot(out, element)
+    out.toByteArray.asInstanceOf[IArray[Byte]]
+
+  private def encodeRoot(out: ByteArrayOutputStream, element: TelElement): Unit = element match
+    case TelElement.Node(_, _, children) =>
+      writeVarint(out, children.length.toLong)
+      var i = 0
+
+      while i < children.length do
+        encodeElement(out, children(i))
+        i += 1
+
+    case _: TelElement.Value =>
+      writeVarint(out, 1L)
+      encodeElement(out, element)
+
+  private def encodeElement(out: ByteArrayOutputStream, element: TelElement): Unit =
+    element match
+      case node: TelElement.Node   => encodeNode(out, node)
+      case value: TelElement.Value => encodeValue(out, value)
+
+  private def encodeNode(out: ByteArrayOutputStream, node: TelElement.Node): Unit =
+    val kidx = node.keywordIndex.or(0).toLong
+    writeVarint(out, kidx)
+
+    node.elementType match
+      case _: Tels.Struct =>
+        writeVarint(out, node.children.length.toLong)
+        var i = 0
+
+        while i < node.children.length do
+          encodeElement(out, node.children(i))
+          i += 1
+
+      case Tels.Flag =>
+        // Flag nodes carry no children and no length.
+        ()
+
+      case _: Tels.Scalar | _: Tels.Reference =>
+        // Should not appear in a well-formed TelElement.Node after type
+        // assignment — scalars are TelElement.Value and references are
+        // resolved during assignment. Encode no further bytes.
+        ()
+
+  private def encodeValue(out: ByteArrayOutputStream, value: TelElement.Value): Unit =
+    writeVarint(out, value.keywordIndex.toLong)
+    val bytes = value.text.s.getBytes("UTF-8")
+    writeVarint(out, bytes.length.toLong)
+    out.write(bytes)
+
+  private def writeVarint(out: ByteArrayOutputStream, value: Long): Unit =
+    var n = value
+
+    while n >= 0x80L do
+      out.write(((n & 0x7fL) | 0x80L).toInt)
+      n >>>= 7
+
+    out.write(n.toInt)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -870,3 +870,96 @@ object Tests extends Suite(m"Stratiform Tests"):
           false
         catch case _: IllegalArgumentException => true
       . assert(identity)
+
+    suite(m"BinTEL §7 node encoder"):
+      def hex(data: Data): String =
+        val sb = new java.lang.StringBuilder
+        var i = 0
+        while i < data.length do
+          sb.append(f"${data(i) & 0xff}%02X")
+          if i + 1 < data.length then sb.append(' ')
+          i += 1
+        sb.toString
+
+      val nameSchema = Tels(
+        name     = t"contact",
+        document = Tels.Struct(
+          members = IArray(Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"name", Tels.Scalar(IArray(t"string")), Unset )),
+          validators = IArray.empty),
+        layers   = IArray.empty,
+        sigil    = Unset,
+        records  = IArray.empty,
+        scalars  = IArray.empty,
+        selects  = IArray.empty)
+
+      test(m"empty struct encodes as a single 00 child-count"):
+        val root = Tel.Element.Node(Unset, nameSchema.document, IArray.empty)
+        hex(root.bintel)
+      . assert(_ == "00")
+
+      test(m"single scalar child via tel.bintel(schema)"):
+        hex(t"name Alice\n".read[Tel].bintel(nameSchema))
+      . assert(_ == "01 00 05 41 6C 69 63 65")
+
+      test(m"empty scalar value encodes as zero-length"):
+        val scalar = Tels.Scalar(IArray.empty)
+        val value = Tel.Element.Value(0, scalar, t"")
+        val root = Tel.Element.Node(Unset, nameSchema.document, IArray(value))
+        hex(root.bintel)
+      . assert(_ == "01 00 00")
+
+      test(m"UTF-8 byte length is encoded, not character count"):
+        // "café" = 0x63 0x61 0x66 0xC3 0xA9 = 5 bytes, 4 chars
+        val scalar = Tels.Scalar(IArray.empty)
+        val value = Tel.Element.Value(0, scalar, t"café")
+        val root = Tel.Element.Node(Unset, nameSchema.document, IArray(value))
+        hex(root.bintel)
+      . assert(_ == "01 00 05 63 61 66 C3 A9")
+
+      test(m"flag node encodes as just its keyword index"):
+        val flagNode = Tel.Element.Node(0, Tels.Flag, IArray.empty)
+        val flagSchema = Tels(
+          name     = t"feature",
+          document = Tels.Struct(
+            members = IArray(Tels.Field
+             ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+               t"enabled", Tels.Flag, Unset )),
+            validators = IArray.empty),
+          layers   = IArray.empty,
+          sigil    = Unset,
+          records  = IArray.empty,
+          scalars  = IArray.empty,
+          selects  = IArray.empty)
+        val root = Tel.Element.Node(Unset, flagSchema.document, IArray(flagNode))
+        hex(root.bintel)
+      . assert(_ == "01 00")
+
+      test(m"nested struct emits kidx + count + children recursively"):
+        val innerScalar = Tels.Scalar(IArray.empty)
+        val innerStruct = Tels.Struct(
+          members = IArray(Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"host", innerScalar, Unset )),
+          validators = IArray.empty)
+        val outerStruct = Tels.Struct(
+          members = IArray(Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"config", innerStruct, Unset )),
+          validators = IArray.empty)
+
+        val configNode = Tel.Element.Node(
+          0, innerStruct,
+          IArray(Tel.Element.Value(0, innerScalar, t"example.com")))
+
+        val root = Tel.Element.Node(Unset, outerStruct, IArray(configNode))
+        hex(root.bintel)
+      . assert(_ == "01 00 01 00 0B 65 78 61 6D 70 6C 65 2E 63 6F 6D")
+
+      test(m"large keyword index uses multi-byte varint"):
+        val scalar = Tels.Scalar(IArray.empty)
+        val value = Tel.Element.Value(128, scalar, t"x")
+        val root = Tel.Element.Node(Unset, nameSchema.document, IArray(value))
+        hex(root.bintel)
+      . assert(_ == "01 80 01 01 78")


### PR DESCRIPTION
## Summary

- `tel.bintel(schema): Data` — extension method on `Tel` that
  type-assigns the document against the supplied schema and emits the
  BinTEL body bytes from §7.1 of `spec/bintel.md`.
- `element.bintel: Data` for callers who already hold a typed
  `Tel.Element`.
- Output is the §7.1 body only — no magic number, no schema signature.
  That bare body is what §3 hashes for the value-hash and what §8.1
  hashes per-component for schema signatures, both arriving in later
  PRs alongside the §6 framing.

### Notes for users

```scala
import soundness.*, strategies.throwUnsafely

val tel = source.read[Tel]
val bytes: Data = tel.bintel(schema)
```

Struct nodes emit keyword index + child count + recursively-encoded
children; Scalar nodes emit keyword index + UTF-8 byte length + value
bytes; Flag nodes emit just the keyword index. The document root omits
its keyword index and emits only the child count plus children. Tests
cover scalars, nested structs, flags, multi-byte UTF-8 length
accounting, and multi-byte keyword-index varints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)