### PR TITLE
stratiform: BinTEL §7.8 decoder

### DIFF
--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -38,6 +38,7 @@ import scala.language.unsafeNulls
 
 import anticipation.*
 import contingency.*
+import fulminate.*
 import gastronomy.*
 import prepositional.*
 import vacuous.*
@@ -90,6 +91,118 @@ object Bintel:
     val out = new ByteArrayOutputStream
     encodeRoot(out, element)
     out.toByteArray.asInstanceOf[IArray[Byte]]
+
+  // §7.8 decoder. Read BinTEL body bytes (no magic, no signature —
+  // exactly what `encode` emits) under `schema`, recovering the
+  // semantic-model `TelElement` tree. The schema must be the same
+  // composed schema used at encode time. Any framing or schema
+  // mismatch raises `BintelError`.
+  def decode(data: Data, schema: Tels): TelElement raises BintelError =
+    val cursor = Cursor(data, 0)
+    val root = decodeStructBody(cursor, schema.document, schema, keywordIndex = Unset)
+    if cursor.offset != data.length then abort(BintelError(BintelError.Reason.TrailingBytes))
+    root
+
+  private def decodeStructBody
+       (cursor: Cursor, struct: Tels.Struct, schema: Tels,
+        keywordIndex: Optional[Int])
+  :     TelElement raises BintelError =
+    val flat = flattenKeywords(struct, schema)
+    val childCount = readVarint(cursor)
+    val children = new Array[TelElement](childCount.toInt)
+    var i = 0
+
+    while i < childCount.toInt do
+      children(i) = decodeElement(cursor, flat, schema)
+      i += 1
+
+    TelElement.Node(keywordIndex, struct, children.asInstanceOf[IArray[TelElement]])
+
+  private def decodeElement
+       (cursor: Cursor, flat: IArray[(Text, Tels.Type)], schema: Tels)
+  :     TelElement raises BintelError =
+    val kidx = readVarint(cursor)
+    if kidx < 0 || kidx >= flat.length then abort(BintelError(BintelError.Reason.BadKeywordIndex))
+    val (_, memberType) = flat(kidx.toInt)
+    val resolved = resolveType(memberType, schema)
+
+    resolved match
+      case s: Tels.Struct =>
+        decodeStructBody(cursor, s, schema, keywordIndex = kidx.toInt)
+
+      case s: Tels.Scalar =>
+        val len = readVarint(cursor)
+        if cursor.offset + len > cursor.data.length
+        then abort(BintelError(BintelError.Reason.ValueTruncated))
+        val bytes = new Array[Byte](len.toInt)
+        var j = 0
+
+        while j < len.toInt do
+          bytes(j) = cursor.data(cursor.offset + j)
+          j += 1
+
+        cursor.offset += len.toInt
+        val text =
+          try Text(new String(bytes, "UTF-8"))
+          catch case _: Exception => abort(BintelError(BintelError.Reason.BadUtf8))
+        TelElement.Value(kidx.toInt, s, text)
+
+      case Tels.Flag =>
+        TelElement.Node(kidx.toInt, Tels.Flag, IArray.empty)
+
+      case _: Tels.Reference =>
+        abort(BintelError(BintelError.Reason.ReferenceUnresolved))
+
+  private def readVarint(cursor: Cursor): Long raises BintelError =
+    import errorDiagnostics.empty
+    if cursor.offset >= cursor.data.length
+    then abort(BintelError(BintelError.Reason.UnexpectedEoi))
+
+    whereas:
+      case _: VarintError => BintelError(BintelError.Reason.VarintError)
+    . mitigate:
+        val decoded = Varint.decode(cursor.data, cursor.offset)
+        cursor.offset = decoded.next
+        decoded.value
+
+  // Flatten a Struct's members into a parallel keyword/type sequence
+  // per §5. Fields contribute one entry; SelectRefs contribute one
+  // entry per variant in the referenced SelectDefinition. Excludes
+  // contribute none.
+  private def flattenKeywords(struct: Tels.Struct, schema: Tels)
+  :     IArray[(Text, Tels.Type)] =
+    val buf = scala.collection.mutable.ArrayBuffer.empty[(Text, Tels.Type)]
+    var i = 0
+
+    while i < struct.members.length do
+      struct.members(i) match
+        case f: Tels.Field =>
+          buf += ((f.keyword, f.fieldType))
+
+        case s: Tels.SelectRef =>
+          schema.selects.find(_.name == s.reference).foreach: selectDef =>
+            var v = 0
+            while v < selectDef.variants.length do
+              val variant = selectDef.variants(v)
+              buf += ((variant.keyword, variant.variantType))
+              v += 1
+
+        case _: Tels.Exclude =>
+          ()
+
+      i += 1
+
+    IArray.from(buf)
+
+  private def resolveType(t: Tels.Type, schema: Tels): Tels.Type = t match
+    case Tels.Reference(name) =>
+      schema.records.find(_.name == name) match
+        case Some(rec) => Tels.Struct(rec.members, rec.validators)
+        case None      => t
+
+    case other => other
+
+  private final class Cursor(val data: Data, var offset: Int)
 
   private def encodeRoot(out: ByteArrayOutputStream, element: TelElement): Unit = element match
     case TelElement.Node(_, _, children) =>

--- a/lib/stratiform/src/binary/stratiform.BintelError.scala
+++ b/lib/stratiform/src/binary/stratiform.BintelError.scala
@@ -30,6 +30,31 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package stratiform
 
-export stratiform.{Bintel, BintelError, Varint, VarintError, bintel, valueHash}
+import anticipation.*
+import fulminate.*
+
+object BintelError:
+
+  object Reason:
+    given communicable: Reason is Communicable =
+      case BadKeywordIndex     => m"a keyword index exceeds the parent's flat-keyword count"
+      case ValueTruncated      => m"a Scalar value's byte length extends beyond end of input"
+      case BadUtf8             => m"a Scalar value's bytes are not valid UTF-8"
+      case TrailingBytes       => m"the document root completed with input bytes remaining"
+      case UnexpectedEoi       => m"the decoder requested bytes beyond end of input"
+      case VarintError         => m"a variable-length integer in the stream is invalid"
+      case ReferenceUnresolved => m"a Reference type in the schema does not resolve"
+
+  enum Reason(val number: Int) extends Clarification:
+    case BadKeywordIndex     extends Reason(5)
+    case ValueTruncated      extends Reason(6)
+    case BadUtf8             extends Reason(7)
+    case TrailingBytes       extends Reason(8)
+    case UnexpectedEoi       extends Reason(9)
+    case VarintError         extends Reason(2)
+    case ReferenceUnresolved extends Reason(10)
+
+case class BintelError(reason: BintelError.Reason)(using Diagnostics)
+extends Error(609, reason.number)(m"the BinTEL stream is invalid because $reason")

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1008,6 +1008,137 @@ object Tests extends Suite(m"Stratiform Tests"):
         hex(root.bintel)
       . assert(_ == "02 00 05 66 69 72 73 74 00 06 73 65 63 6F 6E 64")
 
+    suite(m"BinTEL §7.8 decoder"):
+      test(m"empty struct round-trips"):
+        val root = Tel.Element.Node(Unset, nameSchema.document, IArray.empty)
+        val bytes = root.bintel
+        val decoded = Bintel.decode(bytes, nameSchema)
+        decoded match
+          case Tel.Element.Node(_, _, c) => c.length
+          case _                          => -1
+      . assert(_ == 0)
+
+      test(m"single scalar value round-trips"):
+        val original = t"name Alice\n".read[Tel]
+        val bytes = original.bintel(nameSchema)
+        val decoded = Bintel.decode(bytes, nameSchema)
+        decoded match
+          case Tel.Element.Node(_, _, children) =>
+            children.toList.collect:
+              case Tel.Element.Value(_, _, t) => t
+          case _ => Nil
+      . assert(_ == List(t"Alice"))
+
+      test(m"empty scalar value round-trips"):
+        val scalar = Tels.Scalar(IArray.empty)
+        val root = Tel.Element.Node
+                    (Unset, nameSchema.document, IArray(Tel.Element.Value(0, scalar, t"")))
+        val bytes = root.bintel
+        val decoded = Bintel.decode(bytes, nameSchema)
+        decoded match
+          case Tel.Element.Node(_, _, children) =>
+            children.toList.collect:
+              case Tel.Element.Value(_, _, t) => t
+          case _ => Nil
+      . assert(_ == List(t""))
+
+      test(m"UTF-8 multi-byte scalar round-trips"):
+        val scalar = Tels.Scalar(IArray.empty)
+        val root = Tel.Element.Node
+                    (Unset, nameSchema.document, IArray(Tel.Element.Value(0, scalar, t"café")))
+        val bytes = root.bintel
+        val decoded = Bintel.decode(bytes, nameSchema)
+        decoded match
+          case Tel.Element.Node(_, _, children) =>
+            children.toList.collect:
+              case Tel.Element.Value(_, _, t) => t
+          case _ => Nil
+      . assert(_ == List(t"café"))
+
+      test(m"flag element round-trips"):
+        val flagSchema = Tels(
+          name     = t"feature",
+          document = Tels.Struct(
+            members = IArray(Tels.Field
+             ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+               t"enabled", Tels.Flag, Unset )),
+            validators = IArray.empty),
+          layers   = IArray.empty,
+          sigil    = Unset,
+          records  = IArray.empty,
+          scalars  = IArray.empty,
+          selects  = IArray.empty)
+        val root = Tel.Element.Node
+                    (Unset, flagSchema.document, IArray(Tel.Element.Node(0, Tels.Flag, IArray.empty)))
+        val bytes = root.bintel
+        val decoded = Bintel.decode(bytes, flagSchema)
+        decoded match
+          case Tel.Element.Node(_, _, IArray(Tel.Element.Node(_, Tels.Flag, _))) => true
+          case _                                                                  => false
+      . assert(identity)
+
+      test(m"nested struct round-trips"):
+        val innerScalar = Tels.Scalar(IArray.empty)
+        val innerStruct = Tels.Struct(
+          members = IArray(Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"host", innerScalar, Unset )),
+          validators = IArray.empty)
+        val outerStruct = Tels.Struct(
+          members = IArray(Tels.Field
+           ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+             t"config", innerStruct, Unset )),
+          validators = IArray.empty)
+        val outerSchema = Tels(
+          name = t"app", document = outerStruct, layers = IArray.empty,
+          sigil = Unset, records = IArray.empty, scalars = IArray.empty,
+          selects = IArray.empty)
+
+        val configNode = Tel.Element.Node(
+          0, innerStruct,
+          IArray(Tel.Element.Value(0, innerScalar, t"example.com")))
+        val root = Tel.Element.Node(Unset, outerStruct, IArray(configNode))
+
+        val bytes = root.bintel
+        val decoded = Bintel.decode(bytes, outerSchema)
+        decoded match
+          case Tel.Element.Node(_, _, IArray(Tel.Element.Node(_, _, inner))) =>
+            inner.toList.collect:
+              case Tel.Element.Value(_, _, t) => t
+          case _ => Nil
+      . assert(_ == List(t"example.com"))
+
+      test(m"trailing bytes after document root raise BintelError"):
+        val original = t"name Alice\n".read[Tel]
+        val bytes = original.bintel(nameSchema)
+        val padded = (bytes.toList :+ 0xff.toByte).toArray.asInstanceOf[IArray[Byte]]
+        capture[BintelError](Bintel.decode(padded, nameSchema)).reason
+      . assert(_ == BintelError.Reason.TrailingBytes)
+
+      test(m"truncated input raises BintelError"):
+        val original = t"name Alice\n".read[Tel]
+        val bytes = original.bintel(nameSchema)
+        val truncated = bytes.slice(0, bytes.length - 1)
+        // Either UnexpectedEoi or ValueTruncated depending on where the
+        // truncation lands; both are valid framing errors.
+        val reason = capture[BintelError](Bintel.decode(truncated, nameSchema)).reason
+        reason == BintelError.Reason.UnexpectedEoi ||
+          reason == BintelError.Reason.ValueTruncated
+      . assert(identity)
+
+      test(m"out-of-range keyword index raises BintelError"):
+        // Manually craft a body with one child whose keyword index is
+        // out of range for the schema. nameSchema has 1 flat-keyword
+        // entry (index 0); we use index 5.
+        val bytes: Data =
+          Array[Byte](
+            0x01,                   // child-count 1
+            0x05,                   // keyword index 5 (out of range)
+            0x00                    // scalar length 0
+          ).asInstanceOf[IArray[Byte]]
+        capture[BintelError](Bintel.decode(bytes, nameSchema)).reason
+      . assert(_ == BintelError.Reason.BadKeywordIndex)
+
     suite(m"BinTEL §3 value hash"):
       test(m"valueHash is deterministic"):
         val tel = t"name Alice\n".read[Tel]


### PR DESCRIPTION
## Summary

- `Bintel.decode(data: Data, schema: Tels): TelElement raises BintelError`
  reverses the §7 encoder, recovering the semantic-model `TelElement`
  tree from BinTEL body bytes.
- Errors per BinTEL §10: `BadKeywordIndex` (B05), `ValueTruncated`
  (B06), `BadUtf8` (B07), `TrailingBytes` (B08), `UnexpectedEoi`
  (B09), `VarintError` (B02), `ReferenceUnresolved` (B10).
- Round-trip tests cover scalars, nested structs, flags, multi-byte
  UTF-8, plus negative tests for trailing-byte, truncation, and
  out-of-range keyword-index conditions.

### Notes for users

```scala
import soundness.*, strategies.throwUnsafely

val bytes   = tel.bintel(schema)            // §7 encode
val element = Bintel.decode(bytes, schema)  // §7.8 decode
```

The decoder walks the byte cursor reading varint keyword indices,
looks each one up in the parent struct's flat keyword sequence
(Fields contribute one entry each, SelectRefs contribute one per
variant of the referenced SelectDefinition, Excludes contribute
none), then dispatches on the resolved type to recurse for Structs,
read length-prefixed UTF-8 for Scalars, or stop immediately for
Flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)