### PR TITLE
stratiform: BinTEL §6 file framing + §9 textual encoding

### DIFF
--- a/lib/stratiform/src/binary/soundness_stratiform_binary.scala
+++ b/lib/stratiform/src/binary/soundness_stratiform_binary.scala
@@ -32,4 +32,5 @@
                                                                                                   */
 package soundness
 
-export stratiform.{Bintel, BintelError, Varint, VarintError, bintel, valueHash}
+export stratiform.{Bintel, BintelError, Varint, VarintError,
+                    bintel, bintelDocument, valueHash}

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -75,6 +75,14 @@ extension (tel: Tel)
   def valueHash(schema: Tels): Digest in Sha2[256] raises TelError =
     tel.bintel(schema).digest[Sha2[256]]
 
+  // Encode this document as a complete §6 BinTEL byte sequence —
+  // magic + signature length + signature + body. The signature must
+  // satisfy `length ≥ 32` and `(length − 30) mod 2 == 0`; otherwise
+  // raises `BintelError(BadSignatureLength)`.
+  def bintelDocument(schema: Tels, signature: Data)
+  :     Data raises TelError raises BintelError =
+    Bintel.frame(tel.bintel(schema), signature)
+
 extension (element: TelElement)
   // Encode a pre-assigned semantic-model element to BinTEL body bytes.
   def bintel: Data = Bintel.encode(element)
@@ -84,6 +92,21 @@ extension (element: TelElement)
 
 object Bintel:
 
+  // §6 magic number: the 4 bytes that prefix every BinTEL document.
+  // When viewed as BASE-256 text these are the four Greek letters
+  // `β τ ε λ` — visually evocative of "binary TEL".
+  val magic: Data =
+    Array[Byte](0xb2.toByte, 0xc4.toByte, 0xb5.toByte, 0xbb.toByte)
+      .asInstanceOf[IArray[Byte]]
+
+  // The result of unframing a complete §6 file: the carried schema
+  // signature bytes and the document-root body bytes.
+  case class Framed(signature: Data, body: Data)
+
+  // A fully decoded BinTEL document: the carried schema signature
+  // bytes and the recovered semantic-model `TelElement` root.
+  case class Document(signature: Data, root: TelElement)
+
   // Encode a `TelElement` tree to its BinTEL body bytes. The element is
   // expected to be the document root (a Node with `keywordIndex = Unset`
   // and `elementType = Tels.Struct`), as produced by `Tel.Type.assign`.
@@ -91,6 +114,85 @@ object Bintel:
     val out = new ByteArrayOutputStream
     encodeRoot(out, element)
     out.toByteArray.asInstanceOf[IArray[Byte]]
+
+  // §6 framing. Wrap a body byte sequence with the magic number, the
+  // signature length (varint), and the signature bytes. The signature
+  // length MUST be `30 + 2n` for some `n ≥ 1` — i.e. `≥ 32` and
+  // congruent to 30 mod 2 — per §6 field 2.
+  def frame(body: Data, signature: Data): Data raises BintelError =
+    if signature.length < 32 || (signature.length - 30) % 2 != 0
+    then abort(BintelError(BintelError.Reason.BadSignatureLength))
+
+    val out = new ByteArrayOutputStream(magic.length + 10 + signature.length + body.length)
+    out.write(magic.asInstanceOf[Array[Byte]])
+    val sigLen = new ByteArrayOutputStream(10)
+    var n = signature.length.toLong
+
+    while n >= 0x80L do
+      sigLen.write(((n & 0x7fL) | 0x80L).toInt)
+      n >>>= 7
+
+    sigLen.write(n.toInt)
+    out.write(sigLen.toByteArray)
+    out.write(signature.asInstanceOf[Array[Byte]])
+    out.write(body.asInstanceOf[Array[Byte]])
+    out.toByteArray.asInstanceOf[IArray[Byte]]
+
+  // §6 unframing. Parse a complete BinTEL byte sequence into its
+  // signature bytes and body bytes. Validates the magic number (B01),
+  // the signature length pattern (B03), and leaves trailing-byte (B08)
+  // detection to the caller (typically `Bintel.decode` over the body).
+  def unframe(data: Data): Framed raises BintelError =
+    if data.length < magic.length
+    then abort(BintelError(BintelError.Reason.BadMagic))
+
+    var i = 0
+
+    while i < magic.length do
+      if data(i) != magic(i) then abort(BintelError(BintelError.Reason.BadMagic))
+      i += 1
+
+    val sigLenDecoded =
+      import errorDiagnostics.empty
+      whereas:
+        case _: VarintError => BintelError(BintelError.Reason.VarintError)
+      . mitigate(Varint.decode(data, magic.length))
+
+    val sigLength = sigLenDecoded.value.toInt
+    if sigLength < 32 || (sigLength - 30) % 2 != 0
+    then abort(BintelError(BintelError.Reason.BadSignatureLength))
+
+    val sigStart = sigLenDecoded.next
+    val sigEnd   = sigStart + sigLength
+
+    if sigEnd > data.length then abort(BintelError(BintelError.Reason.UnexpectedEoi))
+
+    val sigBytes = new Array[Byte](sigLength)
+    System.arraycopy(data.asInstanceOf[Array[Byte]], sigStart, sigBytes, 0, sigLength)
+    val bodyBytes = new Array[Byte](data.length - sigEnd)
+    System.arraycopy(data.asInstanceOf[Array[Byte]], sigEnd, bodyBytes, 0, bodyBytes.length)
+
+    Framed(sigBytes.asInstanceOf[IArray[Byte]], bodyBytes.asInstanceOf[IArray[Byte]])
+
+  // §6 + §7.8 — decode a complete BinTEL document (magic + signature
+  // + body) into a `Document` carrying the signature bytes and the
+  // semantic-model `TelElement` tree under `schema`. This layer does
+  // not verify the signature against the schema (§8.2 palimpsest
+  // decoding is a follow-up).
+  def decodeDocument(data: Data, schema: Tels): Document raises BintelError =
+    val framed = unframe(data)
+    Document(framed.signature, decode(framed.body, schema))
+
+  // §9 textual encoding. The text form is one BASE-256 character per
+  // byte of the underlying BinTEL document; round-trips losslessly
+  // via `Base256.decode`. The text begins with `βτελ` — the four
+  // BASE-256 characters for the magic bytes.
+  def text(data: Data): Text = Base256.encode(data)
+
+  // §9 textual decoding. Permissively maps each character's code-point
+  // mod 256 back to a byte. Use `Base256.decodeStrict` first if the
+  // input may have come from an untrusted source.
+  def fromText(input: Text): Data = Base256.decode(input)
 
   // §7.8 decoder. Read BinTEL body bytes (no magic, no signature —
   // exactly what `encode` emits) under `schema`, recovering the

--- a/lib/stratiform/src/binary/stratiform.BintelError.scala
+++ b/lib/stratiform/src/binary/stratiform.BintelError.scala
@@ -39,21 +39,25 @@ object BintelError:
 
   object Reason:
     given communicable: Reason is Communicable =
+      case BadMagic            => m"the magic number is missing or does not match B2 C4 B5 BB"
+      case VarintError         => m"a variable-length integer in the stream is invalid"
+      case BadSignatureLength  => m"the schema signature length is not 30 + 2n for any n ≥ 1"
       case BadKeywordIndex     => m"a keyword index exceeds the parent's flat-keyword count"
       case ValueTruncated      => m"a Scalar value's byte length extends beyond end of input"
       case BadUtf8             => m"a Scalar value's bytes are not valid UTF-8"
       case TrailingBytes       => m"the document root completed with input bytes remaining"
       case UnexpectedEoi       => m"the decoder requested bytes beyond end of input"
-      case VarintError         => m"a variable-length integer in the stream is invalid"
       case ReferenceUnresolved => m"a Reference type in the schema does not resolve"
 
   enum Reason(val number: Int) extends Clarification:
+    case BadMagic            extends Reason(1)
+    case VarintError         extends Reason(2)
+    case BadSignatureLength  extends Reason(3)
     case BadKeywordIndex     extends Reason(5)
     case ValueTruncated      extends Reason(6)
     case BadUtf8             extends Reason(7)
     case TrailingBytes       extends Reason(8)
     case UnexpectedEoi       extends Reason(9)
-    case VarintError         extends Reason(2)
     case ReferenceUnresolved extends Reason(10)
 
 case class BintelError(reason: BintelError.Reason)(using Diagnostics)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1139,6 +1139,101 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[BintelError](Bintel.decode(bytes, nameSchema)).reason
       . assert(_ == BintelError.Reason.BadKeywordIndex)
 
+    suite(m"BinTEL §6 file framing"):
+      val sig32: Data = Array.fill[Byte](32)(0x55.toByte).asInstanceOf[IArray[Byte]]
+      val sig34: Data = Array.fill[Byte](34)(0xAA.toByte).asInstanceOf[IArray[Byte]]
+
+      test(m"magic number bytes are B2 C4 B5 BB"):
+        hex(Bintel.magic)
+      . assert(_ == "B2 C4 B5 BB")
+
+      test(m"frame prepends magic, signature-length varint, signature"):
+        val body: Data = Array[Byte](0x01, 0x02).asInstanceOf[IArray[Byte]]
+        val framed = Bintel.frame(body, sig32)
+        // magic (4) + sigLen varint (1: 0x20) + signature (32) + body (2) = 39
+        framed.length
+      . assert(_ == 39)
+
+      test(m"frame writes signature length immediately after magic"):
+        val body: Data = Array[Byte](0x01).asInstanceOf[IArray[Byte]]
+        val framed = Bintel.frame(body, sig32)
+        framed.slice(0, 5).toSeq
+      . assert(_ == Seq(0xB2.toByte, 0xC4.toByte, 0xB5.toByte, 0xBB.toByte, 0x20.toByte))
+
+      test(m"frame rejects too-short signature"):
+        val tooShort: Data = Array.fill[Byte](30)(0).asInstanceOf[IArray[Byte]]
+        val body: Data     = IArray.empty[Byte]
+        capture[BintelError](Bintel.frame(body, tooShort)).reason
+      . assert(_ == BintelError.Reason.BadSignatureLength)
+
+      test(m"frame rejects odd-length signature beyond 30"):
+        val odd: Data = Array.fill[Byte](33)(0).asInstanceOf[IArray[Byte]]
+        val body: Data = IArray.empty[Byte]
+        capture[BintelError](Bintel.frame(body, odd)).reason
+      . assert(_ == BintelError.Reason.BadSignatureLength)
+
+      test(m"unframe recovers signature and body"):
+        val body: Data = Array[Byte](0x01, 0x02, 0x03).asInstanceOf[IArray[Byte]]
+        val framed = Bintel.frame(body, sig32)
+        val Bintel.Framed(sig, recovered) = Bintel.unframe(framed)
+        (sig.toSeq, recovered.toSeq)
+      . assert(_ == (sig32.toSeq, Seq[Byte](0x01, 0x02, 0x03)))
+
+      test(m"unframe rejects bad magic"):
+        val bytes: Data = Array.fill[Byte](40)(0).asInstanceOf[IArray[Byte]]
+        capture[BintelError](Bintel.unframe(bytes)).reason
+      . assert(_ == BintelError.Reason.BadMagic)
+
+      test(m"unframe rejects truncated input"):
+        val bytes: Data =
+          Array[Byte](0xB2.toByte, 0xC4.toByte, 0xB5.toByte, 0xBB.toByte, 0x20.toByte)
+            .asInstanceOf[IArray[Byte]]
+        capture[BintelError](Bintel.unframe(bytes)).reason
+      . assert(_ == BintelError.Reason.UnexpectedEoi)
+
+      test(m"larger signatures of permitted lengths are accepted"):
+        val body: Data = Array[Byte](0x01).asInstanceOf[IArray[Byte]]
+        val framed = Bintel.frame(body, sig34)
+        Bintel.unframe(framed).signature.length
+      . assert(_ == 34)
+
+      test(m"frame ↔ unframe round-trip for non-trivial body"):
+        val original: Data = (0 to 99).map(_.toByte).toArray.asInstanceOf[IArray[Byte]]
+        val framed = Bintel.frame(original, sig32)
+        val recovered = Bintel.unframe(framed).body.toSeq
+        recovered == original.toSeq
+      . assert(_ == true)
+
+      test(m"tel.bintelDocument produces a file beginning with magic"):
+        val bytes = t"name Alice\n".read[Tel].bintelDocument(nameSchema, sig32)
+        bytes.slice(0, 4).toSeq
+      . assert(_ == Seq(0xB2.toByte, 0xC4.toByte, 0xB5.toByte, 0xBB.toByte))
+
+      test(m"decodeDocument round-trips through frame + decode"):
+        val bytes = t"name Alice\n".read[Tel].bintelDocument(nameSchema, sig32)
+        val doc = Bintel.decodeDocument(bytes, nameSchema)
+        doc.root match
+          case Tel.Element.Node(_, _, children) =>
+            children.toList.collect:
+              case Tel.Element.Value(_, _, t) => t
+          case _ => Nil
+      . assert(_ == List(t"Alice"))
+
+    suite(m"BinTEL §9 textual encoding"):
+      val sig32: Data = Array.fill[Byte](32)(0x55.toByte).asInstanceOf[IArray[Byte]]
+
+      test(m"text begins with βτελ (the four BASE-256 chars for the magic bytes)"):
+        val bytes = t"name Alice\n".read[Tel].bintelDocument(nameSchema, sig32)
+        Bintel.text(bytes).s.substring(0, 4)
+      . assert(_ == "βτελ")
+
+      test(m"text/fromText round-trip"):
+        val source = t"name Alice\n".read[Tel].bintelDocument(nameSchema, sig32)
+        val text = Bintel.text(source)
+        val recovered = Bintel.fromText(text)
+        recovered.toSeq == source.toSeq
+      . assert(_ == true)
+
     suite(m"BinTEL §3 value hash"):
       test(m"valueHash is deterministic"):
         val tel = t"name Alice\n".read[Tel]


### PR DESCRIPTION
## Summary

- `Bintel.frame(body, signature)` wraps a body in the §6 file layout —
  magic number (`B2 C4 B5 BB`) + signature length varint + signature
  bytes + body. Validates the §6 signature-length pattern
  (`length = 30 + 2n` for `n ≥ 1`).
- `Bintel.unframe(data): Framed` recovers `(signature, body)` from a
  complete BinTEL byte sequence; validates the magic (B01) and the
  signature-length pattern (B03).
- `Bintel.decodeDocument(data, schema): Document` composes unframing
  with the §7.8 body decoder.
- `Bintel.text(data): Text` / `Bintel.fromText(text): Data` — §9
  textual form (BASE-256 wrap; every BinTEL document in textual form
  begins with `βτελ`).
- `tel.bintelDocument(schema, signature)` — user-facing entry that
  type-assigns, body-encodes, and frames in one call.

### Notes for users

```scala
import soundness.*, strategies.throwUnsafely

val bytes = tel.bintelDocument(schema, signature)
val text  = Bintel.text(bytes)             // textual form, starts βτελ…
val back  = Bintel.fromText(text)          // recovers the bytes
val doc   = Bintel.decodeDocument(back, schema)
// doc.signature, doc.root: TelElement
```

With this PR, BinTEL has its complete write/read cycle minus the
schema-signature construction itself (§8.1 palimpsest hashing), which
remains a follow-up. Signatures are currently passed as opaque byte
sequences by callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)