### PR TITLE
ypsiloid: introduce Yaml.Focus and auto-populate position via as[T]

### DIFF
--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -97,7 +97,7 @@ trait Yaml2:
   object DecodableDerivation extends Derivable[Decodable in Yaml]:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Decodable in Yaml = yaml =>
-      provide[Foci[YamlPath]]:
+      provide[Foci[Yaml.Focus]]:
         provide[Tactic[YamlError]]:
           val arr: IArray[Any] | Null = yaml.root.asMatchable match
             case xs: IArray[?] @unchecked if (xs.length & 1) == 0 =>
@@ -118,19 +118,28 @@ trait Yaml2:
                     case s: String if s == target => found = arr(i + 1).asInstanceOf[Yaml.Ast]
                     case _                        => ()
                   i += 2
-              focus(prior.or(YamlPath()) / label):
+              // Each outer `focus` runs *after* the inner one
+              // (contingency's try/finally order), so we extend
+              // `prior` at the root side via `prepend` so a nested
+              // case-class error lands at `/outer/inner` rather than
+              // `/inner/outer`. See `feedback-xml-decoder-split-design`
+              // lesson 4.
+              focus({
+                val base = prior.let(_.pointer).or(YamlPath())
+                Yaml.Focus(base.prepend(label))
+              }):
                 if found != null then context.decoded(new Yaml(found))
                 else
                   default.or(context.decoded(new Yaml(Yaml.Ast.Null)))
 
     inline def disjunction[derivation: SumReflection]: derivation is Decodable in Yaml = yaml =>
-      provide[Foci[YamlPath]]:
+      provide[Foci[Yaml.Focus]]:
         provide[Tactic[YamlError]]:
           provide[Tactic[VariantError]]:
             val discriminable = infer[derivation is Discriminable in Yaml]
 
             val discriminant: Text = discriminable.discriminate(yaml).or:
-              focus(prior.or(YamlPath()))(abort(YamlError(Reason.Absent)))
+              focus(prior.or(Yaml.Focus(YamlPath())))(abort(YamlError(Reason.Absent)))
 
             delegate(discriminant): [variant <: derivation] =>
               context => context.decoded(discriminable.variant(yaml))
@@ -138,14 +147,18 @@ trait Yaml2:
   object EncodableDerivation extends Derivable[Encodable in Yaml]:
     inline def conjunction[derivation <: Product: ProductReflection]
     :   derivation is Encodable in Yaml = value =>
-      provide[Foci[YamlPath]]:
+      provide[Foci[Yaml.Focus]]:
         val entries = scm.ArrayBuffer.empty[Any]
         fields(value): [field] =>
-          field => focus(prior.or(YamlPath()) / label):
-            val encoded = contextual.encode(field).root
-            if !(encoded.asInstanceOf[AnyRef] eq Unset) then
-              entries += Yaml.Ast.Str(label).asInstanceOf[Any]
-              entries += encoded.asInstanceOf[Any]
+          field =>
+            focus({
+              val base = prior.let(_.pointer).or(YamlPath())
+              Yaml.Focus(base.prepend(label))
+            }):
+              val encoded = contextual.encode(field).root
+              if !(encoded.asInstanceOf[AnyRef] eq Unset) then
+                entries += Yaml.Ast.Str(label).asInstanceOf[Any]
+                entries += encoded.asInstanceOf[Any]
         Yaml.ast(Yaml.Ast.mapFromAnyArray(entries.toArray))
 
     inline def disjunction[derivation: SumReflection]: derivation is Encodable in Yaml = value =>
@@ -204,6 +217,20 @@ object Yaml extends Yaml2, Dynamic:
 
   extension (positionIndex: PositionIndex)
     private[ypsiloid] def ints: IArray[Int] = positionIndex
+
+  // The focus carried by `Yaml#as[T]` — a YAML-pointer path plus an
+  // optional source position. The position is populated lazily by
+  // `withPosition(yaml)`, which delegates to `yaml.locate(pointer)`,
+  // so an untracked root (no `positionIndex`) leaves `position` Unset.
+  // Costs nothing on the success path because `Focus` instances are
+  // constructed inside `Foci.supplement` only for errors actually
+  // registered in a surrounding `focus` block.
+  case class Focus
+    ( pointer:  YamlPath,
+      position: Optional[Yaml.Ast.Position] = Unset )
+  derives CanEqual:
+
+    def withPosition(yaml: Yaml): Focus = copy(position = yaml.locate(pointer))
 
   object Ast extends Format:
     def name: Text = "YAML"
@@ -1081,8 +1108,19 @@ extends Dynamic derives CanEqual:
   // and for any `Yaml` built from a decoded/computed value.
   def positionIndex: Optional[Yaml.PositionIndex] = positions
 
-  def as[value: Decodable in Yaml]: value raises YamlError tracks YamlPath =
-    value.decoded(this)
+  def as[value: Decodable in Yaml]: value raises YamlError tracks Yaml.Focus =
+    val result = value.decoded(this)
+    // Auto-populate the source position on every accumulated focus so
+    // error handlers can read both `.pointer` and `.position` without
+    // calling `withPosition` themselves. `withPosition` on a `Yaml`
+    // without a `positionIndex` leaves the position `Unset`, so this
+    // costs nothing for untracked roots and only one `locate` per
+    // registered error for tracked roots. Mirrors xylophone
+    // `Tracked#as` (PR #1151).
+    val foci = summon[Foci[Yaml.Focus]]
+    val yaml = this
+    foci.supplement(foci.length, _.let(_.withPosition(yaml)).vouch)
+    result
 
   // Sequence indexing: `yaml(0)` returns the first element of a sequence,
   // raising `YamlError` (with `Reason.NotType`) if the root is not a

--- a/lib/ypsiloid/src/test/ypsiloid.FocusTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.FocusTests.scala
@@ -32,75 +32,103 @@
                                                                                                   */
 package ypsiloid
 
-import scala.collection.mutable as scm
+import soundness.*
 
-import anticipation.*
-import beneficence.*
-import contingency.*
-import denominative.*
-import gossamer.*
-import prepositional.*
-import rudiments.*
-import serpentine.*
-import symbolism.*
-import urticose.*
-import vacuous.*
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
 
-// A YAML Path identifies a node within a YAML document. Modelled on
-// `jacinta.JsonPointer` and using the same RFC 6901 escaping (`~0`
-// for `~`, `~1` for `/`) so paths interoperate cleanly with JSON
-// Pointers when YAML is treated as JSON. Non-string mapping keys are
-// not addressable; attempting to navigate through one is undefined.
-object YamlPath extends Root(""):
-  type Plane = YamlPath
+case class FPerson(name: Text, age: Int, email: Text) derives CanEqual
+case class FAddress(street: Text, city: Text, zip: Text) derives CanEqual
+case class FContact(person: FPerson, address: FAddress) derives CanEqual
 
-  trait Registry extends Findable:
-    private val documents: scm.HashMap[HttpUrl, Yaml] = scm.HashMap()
+object FocusTests extends Suite(m"Ypsiloid focus + position tests"):
 
-    def update(url: HttpUrl, document: Yaml): Unit = documents(url) = document
-    def apply(url: HttpUrl): Optional[Yaml] = documents.at(url).or(lookup(url))
-    protected def lookup(url: HttpUrl): Optional[Yaml]
+  case class Captured
+    ( items: List[(Text, Optional[Int], Optional[Int])] = Nil )
+    ( using Diagnostics )
+  extends Error(m"${items.length} validation issues"):
+    def +(focus: Text, line: Optional[Int], column: Optional[Int]): Captured =
+      Captured(items :+ (focus, line, column))
 
-  given navigable: [ordinal <: Ordinal] => ordinal is Navigable on YamlPath = _.n0.toString.tt
-  given admissible: [ordinal <: Ordinal] => ordinal is Admissible on YamlPath = _ => ()
-  given admissible2: [text <: Text] => text is Admissible on YamlPath = _ => ()
+  private def captureFoci[result](yaml: Yaml)
+                                 (decode: Yaml => result raises YamlError tracks Yaml.Focus)
+  :   List[(Text, Optional[Int], Optional[Int])] =
+    validate[Yaml.Focus](Captured()):
+      case error: YamlError =>
+        val position = prior.let(_.position)
+        accrual + ( prior.let(_.pointer.encode).or(t"#"),
+                    position.let(_.line),
+                    position.let(_.column) )
+    . within(decode(yaml)).items
 
-  given filesystem: YamlPath is Filesystem:
-    override def escape(text: Text): Text = text.sub("~", "~0").sub("/", "~1")
-    override def unescape(text: Text): Text = text.sub("~1", "/").sub("~0", "~")
+  def run(): Unit =
+    suite(m"Pointer-only focus (untracked Yaml)"):
+      test(m"Missing field reports the focus pointer (no position)"):
+        val yaml = t"name: Alice\nage: 30".read[Yaml]
+        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
+      . assert(_ == Set("#/email"))
 
-    val name: Text = "YAML"
-    val parent: Text = ".."
-    val self: Text = "#"
-    val separator: Text = "/"
+      test(m"Wrong-type field reports the focus pointer (no position)"):
+        val yaml = t"name: Alice\nage: thirty\nemail: a@b".read[Yaml]
+        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
+      . assert(_ == Set("#/age"))
 
-  given YamlPath is Encodable in Text = path =>
-    t"${path.url.let(_.encode).or(t"")}#${path.path}"
+      test(m"Nested case-class missing field reports root-first path"):
+        val yaml = t"""
+person:
+  name: X
+  age: 1
+  email: x@y
+address:
+  street: S
+""".read[Yaml]
+        // address is missing `city` (and zip); decoding aborts on the
+        // first missing, registering one error at #/address/city.
+        captureFoci(yaml)(_.as[FContact]).map(_(0).s).to(Set)
+      . assert(_ == Set("#/address/city"))
 
-  given divisible: YamlPath is Divisible by Text to YamlPath =
-    (path, segment) => YamlPath(path.url, path.path / segment)
+      test(m"Untracked roots leave the focus position Unset"):
+        val yaml = t"name: Alice\nage: 30".read[Yaml]
+        captureFoci(yaml)(_.as[FPerson]).forall((_, line, _) => line == Unset)
+      . assert(identity)
 
-  given divisible2: YamlPath is Divisible by Ordinal to YamlPath =
-    (path, segment) => YamlPath(path.url, path.path / segment)
+    suite(m"Position-aware focus (tracked Yaml)"):
+      given Yaml.Tracking = Yaml.Tracking.On
 
-case class YamlPath(url: Optional[HttpUrl] = Unset, path: Path on YamlPath = YamlPath):
-  def apply(using registry: YamlPath.Registry)(document: Yaml): Yaml raises YamlPathError =
-    url.let(registry(_).lest(YamlPathError(YamlPathError.Reason.UnknownDocument)))
-    . or(document)
+      test(m"Tracked root: focus pointers are still correct"):
+        // The decoder still aborts on first error (raise+yet is a PR 3
+        // change), so position population via `as[T]`'s Foci.supplement
+        // doesn't fire when an error short-circuits the decode. The
+        // focus *path* is registered by the focus block's try/finally
+        // either way, so we verify that path here and exercise the
+        // `withPosition` plumbing in a separate direct test below.
+        val yaml = t"name: Alice\nage: 30".read[Yaml]
+        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
+      . assert(_ == Set("#/email"))
 
-  def apply(ordinal: Ordinal): YamlPath = YamlPath(url, path / ordinal)
-  def apply(text: Text): YamlPath = YamlPath(url, path / text)
+      test(m"Nested missing field reports root-first path on a tracked root"):
+        val source = t"""person:
+  name: C
+  age: 25
+  email: c@x
+address:
+  street: X
+"""
+        captureFoci(source.read[Yaml])(_.as[FContact]).map(_(0).s).to(Set)
+      . assert(_ == Set("#/address/city"))
 
-  // Append `segment` at the root end of the path, leaving the rest of
-  // the descent intact. Used by `Yaml`'s Wisteria derivation: each
-  // outer `focus` block runs *after* the inner one (contingency's
-  // try/finally order), and needs to push its label to the root side
-  // of the accumulated path so `/parent/child` lands root-first. The
-  // `apply(text)` / `apply(ordinal)` methods above go through
-  // Serpentine's `/`, which adds at the leaf side — the wrong
-  // direction for focus supplementing.
-  private[ypsiloid] def prepend(segment: Text): YamlPath =
-    YamlPath(url, Path[YamlPath, YamlPath.type, Tuple]("/", path.descent :+ segment))
+      test(m"withPosition on a tracked Yaml resolves the pointer to a real position"):
+        // Direct exercise of `Yaml.Focus#withPosition`. Even though the
+        // current decoder aborts before `as[T]`'s `Foci.supplement` can
+        // run, the plumbing is wired correctly — once primitive
+        // decoders gain raise+yet sentinels in PR 3, wrong-type errors
+        // will land with `position` populated through this same path.
+        val source = t"name: Alice\nage: 30\nemail: a@b\n"
+        val yaml = source.read[Yaml]
+        Yaml.Focus(YamlPath()(t"age")).withPosition(yaml).position.let(_.line)
+      . assert(_ == 2)
 
-  private[ypsiloid] def prepend(ordinal: Ordinal): YamlPath =
-    YamlPath(url, Path[YamlPath, YamlPath.type, Tuple]("/", path.descent :+ ordinal.n0.toString.tt))
+      test(m"withPosition leaves position Unset when the pointer doesn't resolve"):
+        val yaml = t"name: Alice".read[Yaml]
+        Yaml.Focus(YamlPath()(t"missing")).withPosition(yaml).position
+      . assert(_ == Unset)

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -969,3 +969,4 @@ object Tests extends Suite(m"Ypsiloid Tests"):
     ConformanceTests.all()
 
     PositionTests()
+    FocusTests()


### PR DESCRIPTION
Migrates `Yaml#as[T]` from `tracks YamlPath` to `tracks Yaml.Focus` — a small case class wrapping the YAML pointer plus an optional source position. The position is populated automatically by `as[T]` itself via `Foci.supplement(...)` after decoding, so error handlers reading `prior.position` see the source line/column for any error registered against a tracked root, with no extra work at the call site. Mirrors xylophone #1151's design (slimmer than jacinta #1148: no `Decodable.position` indirection, no `at Focus` adapter). Also fixes a latent path-direction bug in the existing focus blocks: nested case-class errors used to land at `/child/parent` because the conjunction extended the path via Serpentine's `/` (leaf-side prepend). The new `YamlPath#prepend` appends at the descent's root end, matching contingency's outer-runs-after-inner supplement order, so nested errors now land at `/parent/child` as expected.

## Validating against a tracked Yaml

```scala
import ypsiloid.*, soundness.*, strategies.throwUnsafely

case class Person(name: Text, age: Int, email: Text) derives CanEqual

case class Issues(items: List[(Text, Optional[Int])] = Nil)(using Diagnostics)
extends Error(m"${items.length} issues"):
  def +(focus: Text, line: Optional[Int]): Issues = Issues(items :+ (focus, line))

locally:
  given Yaml.Tracking = Yaml.Tracking.On
  val yaml = t"name: Alice\nage: thirty\nemail: a@b\n".read[Yaml]

  validate[Yaml.Focus](Issues()):
    case error: YamlError =>
      accrual + (prior.let(_.pointer.encode).or(t"#"),
                 prior.let(_.position).let(_.line))
  . within(yaml.as[Person])
  // → Issues with focus "#/age" and the line of the offending value
```

For untracked roots (the default), `withPosition` is called against a `Yaml` whose `positionIndex` is `Unset`, leaving `position` `Unset` too — no per-error lookup runs and the existing decode path keeps its current cost profile.

## Nested case classes accumulate the right path

```scala
case class Address(street: Text, city: Text, zip: Text)
case class Contact(person: Person, address: Address)

val yaml = t"""
person: { name: X, age: 1, email: x@y }
address: { street: S }
""".read[Yaml]
// validating yaml.as[Contact] reports "#/address/city" (not "#/city/address")
```

Previously, `prior / label` used Serpentine's leaf-side append, which built the inverse path under nested decoding because contingency's `focus` blocks run their supplement inner-first. The new `prepend(label)` appends at the descent's root end, so the supplements compose into the correct root-first path.

## Migration for `validate` callers

Any code that explicitly typed the focus carried by `Yaml#as[T]` needs a one-character switch — `validate[YamlPath]` → `validate[Yaml.Focus]`, and `prior` (formerly a `YamlPath`) now exposes `.pointer` and `.position` accessors:

```diff
-validate[YamlPath]:
+validate[Yaml.Focus]:
   case error: YamlError =>
-    accrual + (prior.let(_.encode).or(t"#"), error)
+    accrual + (prior.let(_.pointer.encode).or(t"#"), error)
```

No internal call sites in this repo needed the migration.

## Scope

Second of four PRs toward feature parity with `jacinta` and `xylophone`. PR 1 (#1163) set up the parser-level tracking infrastructure; this PR (PR 2) introduces `Yaml.Focus` and wires automatic position lookup into `as[T]`. Subsequent PRs:

- PR 3: multi-error accrual — convert primitive `Decodable in Yaml` instances to `raise + yet sentinel` so wrong-type errors don't abort the decode, letting the `Foci.supplement` in `as[T]` actually populate positions for them.
- PR 4: `Default`-driven sentinels for missing nested case-class fields and unknown sealed-trait discriminators.