### PR TITLE
ypsiloid: multi-error accrual in case-class decoders

### DIFF
--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -129,8 +129,14 @@ trait Yaml2:
                 Yaml.Focus(base.prepend(label))
               }):
                 if found != null then context.decoded(new Yaml(found))
-                else
-                  default.or(context.decoded(new Yaml(Yaml.Ast.Null)))
+                // Missing field: try the case-class declared default
+                // (Wisteria's `default`); if absent, hand the
+                // `Yaml.Ast(Unset)` sentinel to the field's decoder.
+                // Primitives detect it (via `isAbsent`) and `raise +
+                // continue` with a zero/empty sentinel, so sibling
+                // fields' errors accrue rather than the decode bailing
+                // on the first missing field.
+                else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
 
     inline def disjunction[derivation: SumReflection]: derivation is Decodable in Yaml = yaml =>
       provide[Foci[Yaml.Focus]]:
@@ -798,6 +804,12 @@ object Yaml extends Yaml2, Dynamic:
       else
         origin
 
+  // Single-error abort variant retained for non-primitive accessors
+  // (`yaml(t"foo")`, `yaml(0)`, etc.) that need to short-circuit on
+  // wrong-shape access. Primitive `Decodable in Yaml` instances no
+  // longer route through this — they use the raise+yet helper below
+  // so multi-error accrual can register each malformed field
+  // independently.
   private inline def typeMismatch[T]
     ( yaml: Yaml, expected: YamlPrimitive, default: T )
     ( using Tactic[YamlError] )
@@ -805,53 +817,69 @@ object Yaml extends Yaml2, Dynamic:
 
     abort(YamlError(Reason.NotType(primitive(yaml.root), expected)))
 
+  // Register a wrong-type / absent error and continue with `sentinel`
+  // instead of aborting — the raise+yet pattern that lets sibling
+  // fields in a case-class decode accrue their own errors rather than
+  // bailing on the first failure. Absent inputs (the `Yaml.Ast(Unset)`
+  // sentinel handed to a primitive decoder by `DecodableDerivation.
+  // conjunction` for a missing case-class field) raise `Reason.Absent`
+  // so error reports distinguish "field missing" from "field had the
+  // wrong shape".
+  private inline def primitiveFault[T]
+    ( yaml: Yaml, expected: YamlPrimitive, sentinel: T )
+    ( using Tactic[YamlError] )
+  :   T =
+
+    if yaml.root.isAbsent then raise(YamlError(Reason.Absent)) yet sentinel
+    else raise(YamlError(Reason.NotType(primitive(yaml.root), expected))) yet sentinel
+
   given int: Tactic[YamlError] => Int is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case n: Long   => n.toInt
       case d: Double => d.toInt
-      case _         => typeMismatch(yaml, YamlPrimitive.Integer, 0)
+      case _         => primitiveFault(yaml, YamlPrimitive.Integer, 0)
 
   given long: Tactic[YamlError] => Long is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case n: Long   => n
       case d: Double => d.toLong
-      case _         => typeMismatch(yaml, YamlPrimitive.Integer, 0L)
+      case _         => primitiveFault(yaml, YamlPrimitive.Integer, 0L)
 
   given double: Tactic[YamlError] => Double is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case d: Double => d
       case n: Long   => n.toDouble
-      case _         => typeMismatch(yaml, YamlPrimitive.Decimal, 0.0)
+      case _         => primitiveFault(yaml, YamlPrimitive.Decimal, 0.0)
 
   given float: Tactic[YamlError] => Float is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case d: Double => d.toFloat
       case n: Long   => n.toFloat
-      case _         => typeMismatch(yaml, YamlPrimitive.Decimal, 0.0f)
+      case _         => primitiveFault(yaml, YamlPrimitive.Decimal, 0.0f)
 
   given boolean: Tactic[YamlError] => Boolean is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case b: Boolean => b
-      case _          => typeMismatch(yaml, YamlPrimitive.Bool, false)
+      case _          => primitiveFault(yaml, YamlPrimitive.Bool, false)
 
   given text: Tactic[YamlError] => Text is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case s: String => s.tt
-      case _         => typeMismatch(yaml, YamlPrimitive.Str, t"")
+      case _         => primitiveFault(yaml, YamlPrimitive.Str, t"")
 
   given string: Tactic[YamlError] => String is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
       case s: String => s
-      case _         => typeMismatch(yaml, YamlPrimitive.Str, "")
+      case _         => primitiveFault(yaml, YamlPrimitive.Str, "")
 
   given unit: Tactic[YamlError] => Unit is Decodable in Yaml = yaml =>
     if yaml.root.asInstanceOf[AnyRef] == null then ()
-    else typeMismatch(yaml, YamlPrimitive.Null, ())
+    else primitiveFault(yaml, YamlPrimitive.Null, ())
 
   given iterable: [collection <: Iterable, element]
   =>  ( factory:   Factory[element, collection[element]],
         tactic:    Tactic[YamlError],
-        foci:      Foci[YamlPath] )
+        foci:      Foci[Yaml.Focus] )
   =>  ( decodable: => element is Decodable in Yaml )
   =>  collection[element] is Decodable in Yaml = yaml =>
     yaml.root.asMatchable match
@@ -867,7 +895,10 @@ object Yaml extends Yaml2, Dynamic:
         var i = 0
         while i < effective do
           val ordinal = denominative.Ordinal.zerary(i)
-          focus(prior.or(YamlPath()) / ordinal):
+          focus({
+            val base = prior.let(_.pointer).or(YamlPath())
+            Yaml.Focus(base.prepend(ordinal))
+          }):
             builder += decodable.decoded(new Yaml(xs(i).asInstanceOf[Yaml.Ast]))
           i += 1
         builder.result()

--- a/lib/ypsiloid/src/test/ypsiloid.AccrualTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.AccrualTests.scala
@@ -37,100 +37,104 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 
-case class FPerson(name: Text, age: Int, email: Text) derives CanEqual
-case class FAddress(street: Text, city: Text, zip: Text) derives CanEqual
-case class FContact(person: FPerson, address: FAddress) derives CanEqual
+case class APerson(name: Text, age: Int, email: Text) derives CanEqual
+case class AContact(person: APerson, company: Text) derives CanEqual
 
-object FocusTests extends Suite(m"Ypsiloid focus + position tests"):
+object AccrualTests extends Suite(m"Ypsiloid multi-error accrual tests"):
 
-  case class Captured
-    ( items: List[(Text, Optional[Int], Optional[Int])] = Nil )
-    ( using Diagnostics )
+  case class Issues(items: List[(Text, YamlError)] = Nil)(using Diagnostics)
   extends Error(m"${items.length} validation issues"):
-    def +(focus: Text, line: Optional[Int], column: Optional[Int]): Captured =
-      Captured(items :+ (focus, line, column))
+    def +(focus: Text, error: YamlError): Issues = Issues(items :+ (focus, error))
 
-  private def captureFoci[result](yaml: Yaml)
-                                 (decode: Yaml => result raises YamlError tracks Yaml.Focus)
-  :   List[(Text, Optional[Int], Optional[Int])] =
-    validate[Yaml.Focus](Captured()):
+  private def validateYaml[result](yaml: Yaml)
+                                  (decode: Yaml => result raises YamlError tracks Yaml.Focus)
+  :   Issues =
+    validate[Yaml.Focus](Issues()):
       case error: YamlError =>
-        val position = prior.let(_.position)
-        accrual + ( prior.let(_.pointer.encode).or(t"#"),
-                    position.let(_.line),
-                    position.let(_.column) )
-    . within(decode(yaml)).items
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(decode(yaml))
 
   def run(): Unit =
-    suite(m"Pointer-only focus (untracked Yaml)"):
-      test(m"Missing field reports the focus pointer (no position)"):
-        val yaml = t"name: Alice\nage: 30".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/email"))
+    suite(m"Single-error decoding (sanity)"):
+      test(m"Fully-valid object: no errors accrued"):
+        val yaml = t"name: Alice\nage: 30\nemail: a@b.c\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.length
+      . assert(_ == 0)
 
-      test(m"Wrong-type field reports the focus pointer (no position)"):
-        val yaml = t"name: Alice\nage: thirty\nemail: a@b".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/age"))
+      test(m"Single missing field: one error"):
+        val yaml = t"name: Alice\nage: 30\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.length
+      . assert(_ == 1)
 
-      test(m"Nested case-class missing field reports root-first path"):
-        val yaml = t"""
-person:
-  name: X
-  age: 1
-  email: x@y
-address:
-  street: S
-""".read[Yaml]
-        // address is missing both `city` and `zip`; primitive
-        // decoders raise+yet on the `Unset` sentinel so both accrue
-        // their own errors rather than the first one aborting the
-        // whole decode.
-        captureFoci(yaml)(_.as[FContact]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/address/city", "#/address/zip"))
+      test(m"Single wrong-type field: one error"):
+        val yaml = t"name: Alice\nage: thirty\nemail: a@b\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.length
+      . assert(_ == 1)
 
-      test(m"Untracked roots leave the focus position Unset"):
-        val yaml = t"name: Alice\nage: 30".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).forall((_, line, _) => line == Unset)
-      . assert(identity)
-
-    suite(m"Position-aware focus (tracked Yaml)"):
-      given Yaml.Tracking = Yaml.Tracking.On
-
-      test(m"Tracked root: focus pointers are still correct"):
-        // The decoder still aborts on first error (raise+yet is a PR 3
-        // change), so position population via `as[T]`'s Foci.supplement
-        // doesn't fire when an error short-circuits the decode. The
-        // focus *path* is registered by the focus block's try/finally
-        // either way, so we verify that path here and exercise the
-        // `withPosition` plumbing in a separate direct test below.
-        val yaml = t"name: Alice\nage: 30".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/email"))
-
-      test(m"Nested missing field reports root-first path on a tracked root"):
-        val source = t"""person:
-  name: C
-  age: 25
-  email: c@x
-address:
-  street: X
-"""
-        captureFoci(source.read[Yaml])(_.as[FContact]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/address/city", "#/address/zip"))
-
-      test(m"withPosition on a tracked Yaml resolves the pointer to a real position"):
-        // Direct exercise of `Yaml.Focus#withPosition`. Even though the
-        // current decoder aborts before `as[T]`'s `Foci.supplement` can
-        // run, the plumbing is wired correctly — once primitive
-        // decoders gain raise+yet sentinels in PR 3, wrong-type errors
-        // will land with `position` populated through this same path.
-        val source = t"name: Alice\nage: 30\nemail: a@b\n"
-        val yaml = source.read[Yaml]
-        Yaml.Focus(YamlPath()(t"age")).withPosition(yaml).position.let(_.line)
+    suite(m"Multiple missing fields"):
+      test(m"Two missing primitive fields accrue two errors"):
+        val yaml = t"name: Alice\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.length
       . assert(_ == 2)
 
-      test(m"withPosition leaves position Unset when the pointer doesn't resolve"):
-        val yaml = t"name: Alice".read[Yaml]
-        Yaml.Focus(YamlPath()(t"missing")).withPosition(yaml).position
-      . assert(_ == Unset)
+      test(m"Pointers identify the missing fields"):
+        val yaml = t"name: Alice\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/age", "#/email"))
+
+      test(m"Each missing-field error has reason Absent"):
+        val yaml = t"name: Alice\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.all:
+          case (_, err) => err.reason == YamlError.Reason.Absent
+      . assert(identity)
+
+      test(m"Three missing fields: three errors accrued"):
+        val yaml = t"{}".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.length
+      . assert(_ == 3)
+
+    suite(m"Multiple wrong-type fields"):
+      test(m"Two wrong types accrue two errors"):
+        val yaml = t"name: 42\nage: thirty\nemail: x@y\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.length
+      . assert(_ == 2)
+
+      test(m"Pointers identify the wrong-type fields"):
+        val yaml = t"name: 42\nage: thirty\nemail: x@y\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/name", "#/age"))
+
+      test(m"Wrong-type errors have reason NotType"):
+        val yaml = t"name: 42\nage: thirty\nemail: x@y\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.all:
+          case (_, err) => err.reason match
+            case YamlError.Reason.NotType(_, _) => true
+            case _                              => false
+      . assert(identity)
+
+    suite(m"Missing + wrong-type mixed"):
+      test(m"One wrong-type plus two missing: three errors at the right pointers"):
+        val yaml = t"name: 42\n".read[Yaml]
+        validateYaml(yaml)(_.as[APerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/name", "#/age", "#/email"))
+
+    suite(m"Nested case-class errors"):
+      test(m"Missing nested case-class field expands per sub-field"):
+        // Without a `Default[APerson]` (PR 4), a missing nested case
+        // class hits the wrong-shape branch of the inner conjunction,
+        // which builds against an empty mapping and lets each sub-
+        // field raise its own missing-field error.
+        val yaml = t"company: Acme\n".read[Yaml]
+        validateYaml(yaml)(_.as[AContact]).items.map(_(0).s).to(Set)
+      . assert: paths =>
+          paths == Set
+           ( "#/person/name",
+             "#/person/age",
+             "#/person/email" )
+
+      test(m"Mixed errors at different depths accrue together"):
+        val yaml = t"person:\n  name: D\ncompany: Acme\n".read[Yaml]
+        // person is present but missing `age` and `email`; company is
+        // present.
+        validateYaml(yaml)(_.as[AContact]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/person/age", "#/person/email"))

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -970,3 +970,4 @@ object Tests extends Suite(m"Ypsiloid Tests"):
 
     PositionTests()
     FocusTests()
+    AccrualTests()


### PR DESCRIPTION
Mirrors xylophone #1153: primitive `Decodable in Yaml` instances now use `raise + yet sentinel` instead of `abort`, so all malformed fields in a case-class decode are reported together rather than the first failure aborting the rest. Combined with PR #1167's `Yaml.Focus` machinery, a single `validate[Yaml.Focus]` block now sees every error with the correct pointer (and, on a tracked root, position) instead of just the first.

## Validation accrual

```scala
import ypsiloid.*, soundness.*, strategies.throwUnsafely

case class Person(name: Text, age: Int, email: Text) derives CanEqual

case class Issues(items: List[(Text, YamlError)] = Nil)(using Diagnostics)
extends Error(m"${items.length}"):
  def +(focus: Text, error: YamlError): Issues = Issues(items :+ (focus, error))

val yaml = t"name: 42\n".read[Yaml]

validate[Yaml.Focus](Issues()):
  case error: YamlError =>
    accrual + (prior.let(_.pointer.encode).or(t"#"), error)
. within(yaml.as[Person])
// → 3 errors:
//   #/name  → NotType(Integer → Str)
//   #/age   → Absent
//   #/email → Absent
```

Previously the same input produced a single error and `.as[Person]` threw.

## What changed

- New `primitiveFault` helper alongside the existing `typeMismatch`. Same `Reason.NotType` / `Reason.Absent` distinction, but `raise + yet sentinel` instead of `abort` — primitives detect `Yaml.Ast(Unset)` (the missing-field sentinel an outer conjunction now hands them) via `isAbsent` and register `Reason.Absent`, otherwise register `Reason.NotType(actual, expected)`. Sentinels are the obvious zero / empty / false for each type so the surrounding case class still constructs.
- `Int`, `Long`, `Double`, `Float`, `Boolean`, `Text`, `String`, `Unit` decoders all route through `primitiveFault`.
- `DecodableDerivation.conjunction`'s missing-field branch now passes `Yaml.Ast(Unset)` (was `Yaml.Ast.Null`) to the field decoder. The previous `Yaml.Ast.Null` collided with YAML's actual `null` value and aborted the whole decode through the catch-all `Decodable in Text` branch.
- `typeMismatch` is retained for the non-primitive accessor helpers (`yaml(t"foo")`, `yaml(0)`), which still short-circuit on wrong-shape access.
- Stray `Foci[YamlPath]` parameter on the `iterable` decoder is migrated to `Foci[Yaml.Focus]`, with the focus block updated to use `Yaml.Focus(base.prepend(ordinal))` — same fix as PR #1167.

## Scope

Disjunction's missing-discriminator and unknown-discriminator cases still abort in this PR. PR 4 wires the `Default[derivation]` fallback for both, plus the same `Default`-based collapse for missing nested case classes when callers want one-error semantics for an absent struct.

Third of four PRs toward feature parity with `jacinta` and `xylophone`.