### PR TITLE
ypsiloid: Default-driven sentinels for missing fields and unknown variants

### DIFF
--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -105,50 +105,101 @@ trait Yaml2:
 
             case _ => null
 
-          build: [field] =>
-            context =>
-              val target = label.s
-              var found: Yaml.Ast | Null = null
-              if arr != null then
-                val n = arr.length
-                var i = 0
-                while i < n && found == null do
-                  val key = arr(i).asInstanceOf[Yaml.Ast]
-                  key.asMatchable match
-                    case s: String if s == target => found = arr(i + 1).asInstanceOf[Yaml.Ast]
-                    case _                        => ()
-                  i += 2
-              // Each outer `focus` runs *after* the inner one
-              // (contingency's try/finally order), so we extend
-              // `prior` at the root side via `prepend` so a nested
-              // case-class error lands at `/outer/inner` rather than
-              // `/inner/outer`. See `feedback-xml-decoder-split-design`
-              // lesson 4.
-              focus({
-                val base = prior.let(_.pointer).or(YamlPath())
-                Yaml.Focus(base.prepend(label))
-              }):
-                if found != null then context.decoded(new Yaml(found))
-                // Missing field: try the case-class declared default
-                // (Wisteria's `default`); if absent, hand the
-                // `Yaml.Ast(Unset)` sentinel to the field's decoder.
-                // Primitives detect it (via `isAbsent`) and `raise +
-                // continue` with a zero/empty sentinel, so sibling
-                // fields' errors accrue rather than the decode bailing
-                // on the first missing field.
-                else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
+          if arr != null then buildWith(arr)
+          else
+            // Wrong-shape input (including the `Yaml.Ast(Unset)`
+            // sentinel an outer conjunction passes in for a missing
+            // nested case-class field). If the user supplied
+            // `Default[derivation]` we register one error at the
+            // current focus and continue with the sentinel — a
+            // missing nested case class lands as a single error
+            // rather than expanding per sub-field.
+            //
+            // Without a `Default`, we fall back to running `build`
+            // against a null mapping so each sub-field accrues its
+            // own missing-field error (the PR-3 behaviour).
+            //
+            // The `Default[derivation]` summon must reference the
+            // *outer* conjunction parameter `derivation` (concrete at
+            // the inlining site). Pushing it into Wisteria's per-
+            // field polymorphic lambda doesn't resolve reliably; see
+            // xylophone #1157.
+            summonFrom:
+              case derivationDefault: Default[`derivation`] =>
+                val reason =
+                  if yaml.root.isAbsent then Reason.Absent
+                  else Reason.NotType(primitive(yaml.root), YamlPrimitive.Mapping)
+                raise(YamlError(reason)) yet derivationDefault()
+              case _ =>
+                buildWith(null)
 
+    private inline def buildWith[derivation <: Product: ProductReflection]
+      ( arr: IArray[Any] | Null )
+      ( using Foci[Yaml.Focus], Tactic[YamlError] )
+    :   derivation =
+
+      build: [field] =>
+        context =>
+          val target = label.s
+          var found: Yaml.Ast | Null = null
+          if arr != null then
+            val n = arr.length
+            var i = 0
+            while i < n && found == null do
+              val key = arr(i).asInstanceOf[Yaml.Ast]
+              key.asMatchable match
+                case s: String if s == target => found = arr(i + 1).asInstanceOf[Yaml.Ast]
+                case _                        => ()
+              i += 2
+          // Each outer `focus` runs *after* the inner one
+          // (contingency's try/finally order), so we extend
+          // `prior` at the root side via `prepend` so a nested
+          // case-class error lands at `/outer/inner` rather than
+          // `/inner/outer`. See `feedback-xml-decoder-split-design`
+          // lesson 4.
+          focus({
+            val base = prior.let(_.pointer).or(YamlPath())
+            Yaml.Focus(base.prepend(label))
+          }):
+            if found != null then context.decoded(new Yaml(found))
+            // Missing field: try the case-class declared default
+            // (Wisteria's `default`); if absent, hand the
+            // `Yaml.Ast(Unset)` sentinel to the field's decoder.
+            // Primitives detect it (via `isAbsent`) and `raise +
+            // continue` with a zero/empty sentinel; nested
+            // conjunctions detect wrong-shape and may further
+            // short-circuit via a user-supplied `Default[Nested]`.
+            else default.or(context.decoded(new Yaml(Yaml.Ast(Unset))))
+
+    // Sealed-trait disjunction picks a variant by mapping discriminator
+    // (`type:` key). We screen the discriminator against
+    // `variantLabels` *before* `delegate`-ing so an unrecognised label
+    // doesn't punch through as `VariantError` (which `validate
+    // [Yaml.Focus]` doesn't catch) — it gets the same
+    // `Default[derivation]`-or-abort treatment as a missing
+    // discriminator. When the user supplies `Default[derivation]` we
+    // register one error at the current focus and continue with the
+    // sentinel; without one we abort.
     inline def disjunction[derivation: SumReflection]: derivation is Decodable in Yaml = yaml =>
       provide[Foci[Yaml.Focus]]:
         provide[Tactic[YamlError]]:
           provide[Tactic[VariantError]]:
             val discriminable = infer[derivation is Discriminable in Yaml]
+            val labels: List[Text] = variantLabels[derivation]
+            val resolved: Optional[Text] =
+              discriminable.discriminate(yaml).let: discriminant =>
+                if labels.contains(discriminant) then discriminant else Unset
 
-            val discriminant: Text = discriminable.discriminate(yaml).or:
-              focus(prior.or(Yaml.Focus(YamlPath())))(abort(YamlError(Reason.Absent)))
-
-            delegate(discriminant): [variant <: derivation] =>
-              context => context.decoded(discriminable.variant(yaml))
+            resolved.let: discriminant =>
+              delegate(discriminant): [variant <: derivation] =>
+                context => context.decoded(discriminable.variant(yaml))
+            . or:
+                focus(prior.or(Yaml.Focus(YamlPath()))):
+                  summonFrom:
+                    case derivationDefault: Default[`derivation`] =>
+                      raise(YamlError(Reason.Absent)) yet derivationDefault()
+                    case _ =>
+                      abort(YamlError(Reason.Absent))
 
   object EncodableDerivation extends Derivable[Encodable in Yaml]:
     inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
@@ -1,0 +1,115 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ypsiloid
+
+import soundness.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
+import yamlDiscriminables.discriminatedUnionByType
+
+case class DPerson(name: Text, age: Int, email: Text) derives CanEqual
+case class DContact(person: DPerson, company: Text) derives CanEqual
+
+enum DShape derives CanEqual:
+  case Circle(radius: Int)
+  case Square(side: Int)
+
+case class Issues2(items: List[(Text, YamlError)] = Nil)(using Diagnostics)
+extends Error(m"${items.length} validation issues"):
+  def +(focus: Text, error: YamlError): Issues2 = Issues2(items :+ (focus, error))
+
+object DefaultPersonScope:
+  given Default[DPerson] = () => DPerson(t"", 0, t"")
+
+  def run(): Set[String] =
+    val yaml = t"company: Acme\n".read[Yaml]
+    validate[Yaml.Focus](Issues2()):
+      case error: YamlError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(yaml.as[DContact]).items.map(_(0).s).to(Set)
+
+object DefaultShapeScope:
+  given Default[DShape] = () => DShape.Circle(-1)
+
+  def runIssues(): (Set[String], Int) =
+    val yaml = t"type: Triangle\nfoo: bar\n".read[Yaml]
+    val issues = validate[Yaml.Focus](Issues2()):
+      case error: YamlError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(yaml.as[DShape])
+    (issues.items.map(_(0).s).to(Set), issues.items.length)
+
+object DefaultTests extends Suite(m"Ypsiloid Default-driven sentinel tests"):
+
+  private def validateYaml[result](yaml: Yaml)
+                                  (decode: Yaml => result raises YamlError tracks Yaml.Focus)
+  :   Issues2 =
+    validate[Yaml.Focus](Issues2()):
+      case error: YamlError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(decode(yaml))
+
+  def run(): Unit =
+    suite(m"Default-driven sentinels"):
+      test(m"Default[DPerson] collapses a missing nested into one error"):
+        DefaultPersonScope.run()
+      . assert(_ == Set("#/person"))
+
+      test(m"Default[DShape] handles an unknown discriminator at the top level"):
+        DefaultShapeScope.runIssues()
+      . assert((paths, count) => count == 1 && paths == Set("#"))
+
+      test(m"Without Default[DPerson], a missing nested still expands"):
+        // Confirms the existing (no-Default) PR-3 accrual semantics
+        // are unchanged for users who don't opt in.
+        val yaml = t"company: Acme\n".read[Yaml]
+        validateYaml(yaml)(_.as[DContact]).items.map(_(0).s).to(Set)
+      . assert: paths =>
+          paths == Set
+           ( "#/person/name",
+             "#/person/age",
+             "#/person/email" )
+
+      test(m"Without Default[DShape], unknown discriminator aborts cleanly"):
+        // Outside a `Default[DShape]`, the disjunction calls `abort`,
+        // which the surrounding `validate` captures as one accrual
+        // entry. No `VariantError` punches through.
+        val yaml = t"type: Triangle\nfoo: bar\n".read[Yaml]
+        validateYaml(yaml)(_.as[DShape]).items.length
+      . assert(_ == 1)
+
+      test(m"Without Default[DShape], absent discriminator aborts cleanly"):
+        val yaml = t"foo: bar\n".read[Yaml]
+        validateYaml(yaml)(_.as[DShape]).items.length
+      . assert(_ == 1)

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -971,3 +971,4 @@ object Tests extends Suite(m"Ypsiloid Tests"):
     PositionTests()
     FocusTests()
     AccrualTests()
+    DefaultTests()


### PR DESCRIPTION
Mirrors xylophone #1157: lets the user opt into single-error accrual for an absent / wrong-shape nested case-class field, or an unknown sealed-trait discriminator, by providing a `vacuous.Default` instance for that type. Builds on PR #1169's `raise + yet sentinel` machinery — `Default[T]` is what lets a missing nested struct collapse to one error at the parent's focus instead of expanding into one error per sub-field.

## Missing nested case class

Without a `Default`, a missing nested case-class field expands into one error per sub-field (the PR #1169 behaviour):

```scala
case class Person(name: Text, age: Int, email: Text)
case class Contact(person: Person, company: Text)

t"company: Acme\n".read[Yaml].as[Contact]
// → 3 errors at #/person/name, #/person/age, #/person/email
```

With a user-supplied `Default[Person]` in scope, the same input collapses to one error and the decode returns the sentinel:

```scala
given Default[Person] = () => Person(t"", 0, t"")
t"company: Acme\n".read[Yaml].as[Contact]
// → 1 error at #/person; decode returns Contact(Person("", 0, ""), "Acme")
```

## Unknown sealed-trait discriminator

Previously, an unknown discriminator value punched through `validate[Yaml.Focus]` as a `VariantError` because Wisteria's `delegate(label)` aborts with that exception type — different from `YamlError`, so the `validate` handler doesn't catch it.

Now, `delegate` is gated by `variantLabels.contains(discriminant)`. Unknown discriminators get the same `Default[derivation]`-or-abort treatment as missing ones:

```scala
enum Shape derives CanEqual:
  case Circle(radius: Int)
  case Square(side: Int)

// With Default[Shape] in scope, an unknown variant raises one
// YamlError and decoding returns the sentinel.
given Default[Shape] = () => Shape.Circle(-1)
t"type: Triangle\nfoo: bar\n".read[Yaml].as[Shape]
// → 1 YamlError at #; decode returns Shape.Circle(-1)
```

Without `Default[Shape]`, the disjunction calls `abort(YamlError())`, which `validate[Yaml.Focus]` captures as a single accrued entry — no `VariantError` leaks.

## How

- `DecodableDerivation.conjunction` now branches at the top: if the input isn't a YAML mapping (including the `Yaml.Ast(Unset)` sentinel an outer conjunction hands in for a missing nested field), it tries `Default[derivation]`. With a `given` in scope, raises one error at the current focus and returns the sentinel. Without one, falls through to the previous behaviour (`build` against a null mapping → per-sub-field errors). The per-field code is factored into a `buildWith(arr)` helper.
- The `summonFrom` reliably resolves `Default[derivation]` because `derivation` is bound at the *outer* `inline def conjunction` parameter — concrete at the inlining site, where the user's local `given` is in scope. Pushing this into Wisteria's per-field polymorphic `build` lambda doesn't resolve reliably; see xylophone #1157.
- `DecodableDerivation.disjunction` screens the discriminator against `variantLabels[derivation]` before delegating, and the unknown / absent branch summons `Default[derivation]` for raise+yet or falls back to `abort`.

## Tests

`DefaultTests` exercises:
- `Default[DPerson]` collapses a missing nested into one error at `#/person`.
- Without `Default[DPerson]`, the prior per-sub-field expansion is preserved.
- `Default[DShape]` handles an unknown discriminator at the top level with one accrued `YamlError`.
- Without `Default[DShape]`, the disjunction aborts under `validate` (no `VariantError` leak), for both unknown and absent discriminators.

Fourth and final PR toward feature parity with `jacinta` and `xylophone`.