### PR TITLE
xylophone + ypsiloid: `read[T over Format]` decoder shorthand

### DIFF
--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -361,6 +361,19 @@ object Xml extends Tag.Container
   given aggregable2: (schema: XmlSchema) => Tactic[ParseError] => Xml is Aggregable by Text =
     input => XmlParser.fromIterator(input.iterator).parseXml(headers0 = false)
 
+  // `source.read[Foo over Xml]` shorthand for
+  // `source.read[Xml].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
+  // for `value over Json`. The `Transport` type-tag is added by an
+  // `asInstanceOf` cast — `value over Xml` is just `value { type
+  // Transport = Xml }` so the cast is a no-op at runtime.
+  given aggregableOver: [value: Decodable in Xml] => (schema: XmlSchema)
+  =>  (Tactic[ParseError], Tactic[XmlError])
+  =>  (value over Xml) is Aggregable by Text =
+
+    input =>
+      XmlParser.fromIterator(input.iterator).parseXml(headers0 = false).as[value]
+      . asInstanceOf[value over Xml]
+
   given loadable: (schema: XmlSchema) => Tactic[ParseError] => Xml is Loadable by Text = stream =>
     XmlParser.fromIterator(stream.iterator).parseXml(headers0 = true) match
       case Fragment((header: Header), rest*) =>

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -80,6 +80,16 @@ object Tests extends Suite(m"Xylophone tests"):
           unsafely(t"""<?xml  version="1.0"?><message>hello world</message>""".load[Xml].read[Text])
       . assert(_ == t"""<?xml version="1.0"?><message>hello world</message>""")
 
+    suite(m"`over Xml` decoder shorthand"):
+      test(m"`read[T over Xml]` resolves a value directly from text"):
+        t"<Worker><name>Alice</name><age>30</age></Worker>".read[Worker over Xml]
+      . assert(_ == Worker(t"Alice", 30))
+
+      test(m"`read[T over Xml]` works for nested case classes"):
+        t"<Firm><name>Acme</name><ceo><name>Alice</name><age>30</age></ceo></Firm>"
+          . read[Firm over Xml]
+      . assert(_ == Firm(t"Acme", Worker(t"Alice", 30)))
+
     test(m"extract integer"):
       x"""<message>1</message>""".as[Int]
     . assert(_ == 1)

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -1165,6 +1165,24 @@ object Yaml extends Yaml2, Dynamic:
         case Yaml.Tracking.Off =>
           Yaml(YamlParser.parse(text))
 
+  // `source.read[Foo over Yaml]` shorthand for
+  // `source.read[Yaml].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
+  // for `value over Json`. The `Transport` type-tag is added by an
+  // `asInstanceOf` cast — `value over Yaml` is just `value { type
+  // Transport = Yaml }` so the cast is a no-op at runtime.
+  given aggregableOver: [value: Decodable in Yaml]
+  =>  (Tactic[ParseError], Tactic[YamlError], Yaml.Tracking)
+  =>  (value over Yaml) is Aggregable by Text =
+
+    summon[Text is Aggregable by Text].map: text =>
+      val yaml = summon[Yaml.Tracking] match
+        case Yaml.Tracking.On =>
+          val (ast, ints) = YamlParser.parseTracked(text)
+          new Yaml(ast, Yaml.PositionIndex(ints))
+        case Yaml.Tracking.Off =>
+          Yaml(YamlParser.parse(text))
+      yaml.as[value].asInstanceOf[value over Yaml]
+
   def primitive(ast: Yaml.Ast): YamlPrimitive =
     if ast.asInstanceOf[AnyRef] == null then YamlPrimitive.Null
     else ast.asMatchable match

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -299,6 +299,19 @@ object Tests extends Suite(m"Ypsiloid Tests"):
           case _                        => -1
       . assert(_ == 2)
 
+    suite(m"`over Yaml` decoder shorthand"):
+      test(m"`read[T over Yaml]` resolves a value directly from text"):
+        t"{name: Alice, age: 30}".read[Person over Yaml]
+      . assert(_ == Person(t"Alice", 30))
+
+      test(m"`read[T over Yaml]` works for nested case classes"):
+        t"{inner: {n: 7}}".read[Outer over Yaml]
+      . assert(_ == Outer(Inner(7)))
+
+      test(m"`read[List[T] over Yaml]` decodes a sequence directly"):
+        t"[{name: Alice, age: 30}, {name: Bob, age: 25}]".read[List[Person] over Yaml]
+      . assert(_ == List(Person(t"Alice", 30), Person(t"Bob", 25)))
+
     suite(m"Case-class derivation"):
       test(m"Decode a flat case class from a flow mapping"):
         t"{name: Alice, age: 30}".read[Yaml].as[Person]


### PR DESCRIPTION
Mirrors `jacinta`'s `aggregableDirect` for `value over Json`: lets `source.read[Foo over Yaml]` and `source.read[Foo over Xml]` work as shorthand for `source.read[Format].as[Foo]`, so the same one-step decode is available across all three formats.

## Before / after

```scala
// Before — explicit two-step:
val band1 = beatles.read[Json].as[Band]
val config = configYaml.read[Yaml].as[Config]
val doc = docXml.read[Xml].as[Document]

// After — one-step via `over Format`:
val band2 = beatles.read[Band over Json]   // already worked, via jacinta
val config2 = configYaml.read[Config over Yaml]
val doc2 = docXml.read[Document over Xml]
```

`value over Format` is a refinement alias (`value { type Transport = Format }`) from `prepositional`, so the `Transport` type-tag is added by a no-op `asInstanceOf` cast — there's no runtime overhead beyond the underlying parse + decode that you'd be doing anyway.

For `Yaml`, the contextual `Yaml.Tracking` mode is honoured: with `given Yaml.Tracking = Yaml.Tracking.On` in scope the intermediate `Yaml` carries a `positionIndex`, so position-aware error focus works through the shorthand too.

## What changed

- `xylophone.Xml`: new `aggregableOver` given that produces `(value over Xml) is Aggregable by Text` for any `value: Decodable in Xml`.
- `ypsiloid.Yaml`: new `aggregableOver` given that produces `(value over Yaml) is Aggregable by Text` for any `value: Decodable in Yaml`, threading `Yaml.Tracking` through the parse.
- Tests in `ypsiloid_test.scala` and `xylophone_test.scala` exercise flat case classes, nested case classes, and (for Yaml) sequences through the new shorthand.

Single PR touching both formats because the change is the same shape in each module.