### PR TITLE
stratiform: BinTEL §8.1 schema-signature from document

### DIFF
--- a/lib/stratiform/src/binary/stratiform.SchemaSignature.scala
+++ b/lib/stratiform/src/binary/stratiform.SchemaSignature.scala
@@ -36,6 +36,9 @@ import scala.language.unsafeNulls
 
 import anticipation.*
 import contingency.*
+import gastronomy.*
+import prepositional.*
+import vacuous.*
 
 // §8.2 of the BinTEL spec — palimpsest schema-signature construction
 // at byte cadence k = 2. Given n 32-byte component hashes, the signature
@@ -47,6 +50,89 @@ object SchemaSignature:
 
   // The constant component-hash size in bytes (SHA-256 width).
   final val HashSize: Int = 32
+
+  // §8.1 construction. Given a schema document parsable under `axiom`
+  // (typically `Tels.Axiom.tels`), compute the full schema signature
+  // as the §8.2 palimpsest of:
+  //
+  //   - h₀ — value hash of the base schema (the document with all
+  //     `layer` compounds removed), encoded against `axiom.document`.
+  //   - h_i — value hash of each `layer` compound in source order,
+  //     where each layer's children are encoded as a virtual root
+  //     under the `Layer` Definition's keyword order.
+  //
+  // The resulting bytes are the same `30 + 2n` form returned by
+  // `encode`, suitable for use as the schema signature in a §6
+  // BinTEL document header or as the textual schema identifier on a
+  // TEL pragma after BASE-256 encoding.
+  def fromDocument(doc: Tel, axiom: Tels): Data raises BintelError raises TelError =
+    val root = Tel.Type.assign(doc, axiom).asInstanceOf[TelElement.Node]
+
+    // Resolve the flat keyword index of "layer" and the Layer
+    // RecordDefinition's struct from the axiom. If either is missing
+    // the axiom does not describe schemas-with-layers; we still
+    // proceed by treating the whole document as the base schema.
+    val layerIdx: Optional[Int] = layerKeywordIndex(axiom.document, axiom)
+
+    val baseChildren = root.children.filter: child =>
+      keywordIndexOf(child) != layerIdx
+
+    val baseElement = TelElement.Node(Unset, axiom.document, baseChildren)
+    val baseHash    = baseElement.bintel.digest[Sha2[256]].data
+
+    val layerChildren = root.children.filter: child =>
+      keywordIndexOf(child) == layerIdx
+
+    val layerStruct: Optional[Tels.Struct] =
+      axiom.records.find(_.name == Text("Layer")) match
+        case Some(rec) => Tels.Struct(rec.members, rec.validators)
+        case None      => Unset
+
+    val layerHashes: List[Data] =
+      layerStruct.let: ls =>
+        layerChildren.toList.map: layer =>
+          val layerRoot = TelElement.Node
+                           (Unset, ls, layer.asInstanceOf[TelElement.Node].children)
+          layerRoot.bintel.digest[Sha2[256]].data
+      .or(Nil)
+
+    encode(baseHash :: layerHashes)
+
+  private def keywordIndexOf(element: TelElement): Optional[Int] = element match
+    case TelElement.Node(idx, _, _)  => idx
+    case TelElement.Value(idx, _, _) => idx
+
+  // Flat-keyword-index lookup for the `layer` keyword inside the
+  // given struct, walking parent.members in declaration order and
+  // expanding SelectRef variants per §5.
+  private def layerKeywordIndex(struct: Tels.Struct, schema: Tels): Optional[Int] =
+    var idx   = 0
+    var i     = 0
+    var found = -1
+
+    while i < struct.members.length && found < 0 do
+      struct.members(i) match
+        case f: Tels.Field =>
+          if f.keyword == Text("layer") then found = idx else idx += 1
+
+        case s: Tels.SelectRef =>
+          schema.selects.find(_.name == s.reference) match
+            case Some(sd) =>
+              var v = 0
+
+              while v < sd.variants.length && found < 0 do
+                if sd.variants(v).keyword == Text("layer") then found = idx + v
+                v += 1
+
+              if found < 0 then idx += sd.variants.length
+
+            case None => ()
+
+        case _: Tels.Exclude => ()
+
+      i += 1
+
+    if found < 0 then Unset else found
 
   // §8.2 encoding. Given an ordered sequence of n component hashes
   // (each `HashSize` bytes), compute S = 0 then for each h_i in order

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1300,6 +1300,69 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[BintelError](SchemaSignature.decode(sig, List(h2))).reason
       . assert(_ == BintelError.Reason.BadSignature)
 
+    suite(m"BinTEL §8.1 schema signature from document"):
+      test(m"single-component signature for a no-layer schema is 32 bytes"):
+        val stream = getClass.getResourceAsStream("/stratiform/corpus/tel-schema.tel").nn
+        val source =
+          val arr = stream.readAllBytes().nn
+          stream.close()
+          IArray.from(arr)
+
+        val sig = SchemaSignature.fromDocument(source.read[Tel], TelsAxiom.tels)
+        sig.length
+      . assert(_ == 32)
+
+      test(m"no-layer schema signature equals the value hash of the document"):
+        val stream = getClass.getResourceAsStream("/stratiform/corpus/tel-schema.tel").nn
+        val source =
+          val arr = stream.readAllBytes().nn
+          stream.close()
+          IArray.from(arr)
+
+        val sig = SchemaSignature.fromDocument(source.read[Tel], TelsAxiom.tels)
+        val hash = Tel.Type.assign(source.read[Tel], TelsAxiom.tels).valueHash.data
+        sig.toSeq == hash.toSeq
+      . assert(_ == true)
+
+      test(m"schema with a single layer produces a 34-byte signature"):
+        val src = """tel 1.0
+                    |
+                    |name basic
+                    |
+                    |record Item
+                    |  field key Identifier
+                    |
+                    |document
+                    |  field key Identifier
+                    |
+                    |layer ext
+                    |  scalar Number identifier
+                    |""".stripMargin.tt
+        val sig = SchemaSignature.fromDocument(src.read[Tel], TelsAxiom.tels)
+        sig.length
+      . assert(_ == 34)
+
+      test(m"two-layer schema produces a 36-byte signature"):
+        val src = """tel 1.0
+                    |
+                    |name multi
+                    |
+                    |record Item
+                    |  field key Identifier
+                    |
+                    |document
+                    |  field key Identifier
+                    |
+                    |layer ext1
+                    |  scalar Number identifier
+                    |
+                    |layer ext2
+                    |  scalar Symbol identifier
+                    |""".stripMargin.tt
+        val sig = SchemaSignature.fromDocument(src.read[Tel], TelsAxiom.tels)
+        sig.length
+      . assert(_ == 36)
+
     suite(m"BinTEL §3 value hash"):
       test(m"valueHash is deterministic"):
         val tel = t"name Alice\n".read[Tel]


### PR DESCRIPTION
## Summary

- `SchemaSignature.fromDocument(doc, axiom): Data raises BintelError
  | TelError` constructs the full schema signature for a TEL schema
  document per §8.1.
- The base component (the document with all `layer` compounds
  removed) is hashed under the axiom's `document` struct; each layer
  is hashed as a virtual root under the `Layer` Definition struct.
- The component hashes are then composed via the §8.2 palimpsest
  already in place.

### Notes for users

```scala
import soundness.*, strategies.throwUnsafely

val signature = SchemaSignature.fromDocument(schemaTel, Tels.Axiom.tels)
// 32 bytes for a no-layer schema; 30 + 2(n+1) bytes for n layers.
val pragmaId  = Base256.encode(signature)
```

A schema with no layers signs to its 32-byte value hash. A schema
with n layers signs to a `30 + 2(n+1)` byte sequence; the single-
and two-layer cases produce 34 and 36 byte signatures respectively.

This closes the full BinTEL §3 / §5 / §6 / §7 / §8 / §9 cycle for
stratiform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)