### PR TITLE
stratiform: Polyvinyl records integration

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1176,13 +1176,16 @@ object stratiform extends Library:
   object binary extends Component(core, base256, gastronomy.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object records extends Component(core, polyvinyl.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object time extends Component(core, aviation.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object http extends Component(core, telekinesis.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, base256, binary, time, http, eucalyptus.core)
+  object test extends Tests(core, base256, binary, records, time, http, eucalyptus.core)
 
 object superlunary extends Library:
   object core extends Component(jacinta.core, gastronomy.core, anthology.scala, austronesian.core):

--- a/lib/stratiform/src/records/soundness_stratiform_records.scala
+++ b/lib/stratiform/src/records/soundness_stratiform_records.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export stratiform.RecordSchema

--- a/lib/stratiform/src/records/stratiform.RecordSchema.scala
+++ b/lib/stratiform/src/records/stratiform.RecordSchema.scala
@@ -1,0 +1,194 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import polyvinyl.*
+import prepositional.*
+import vacuous.*
+
+import strategies.throwUnsafely
+
+// `stratiform.records` — a Polyvinyl Specification over a TEL schema.
+// Each `RecordSchema` instance binds a `Tels` schema to a structurally-
+// typed `Record` whose accessor fields are derived from the schema's
+// document struct, one field per Field member at the root.
+//
+// Usage:
+//   object MyRecords extends RecordSchema(myTels):
+//     transparent inline def record(tel: Tel): Record = ${build('tel)}
+//
+//   val r = MyRecords.record(myTel)
+//   r.name: Text     // for a `field name String` Scalar
+//   r.`first-name`   // for a kebab-cased field
+//
+// The mapping from TEL validators to Scala types is provided by the
+// `Intensional` typeclass instances in this file: "string",
+// "identifier", "type-name" → `Text`; "sigil" → `Char`; "flag" →
+// `Boolean`. Optional variants of each (suffixed with "?") yield
+// `Optional[T]`.
+
+object RecordSchema:
+
+  // A Tel returned from `access` is "absent" iff its wrapped Compound
+  // has an empty keyword — `Tel.empty` is the sentinel returned when
+  // a field is missing. Concrete present-but-no-value cases (e.g. a
+  // Flag) have a non-empty keyword.
+  private def absent(tel: Tel): Boolean = tel.keyword.s.isEmpty
+
+  given string: ("string" is Intensional in RecordSchema from Tel to Text) =
+    RecordSchema.intensional(_.primaryAtom)
+
+  given optionalString: ("string?" is Intensional in RecordSchema from Tel to Optional[Text]) =
+    RecordSchema.intensional: tel =>
+      if absent(tel) then Unset else tel.primaryAtom
+
+  given identifier: ("identifier" is Intensional in RecordSchema from Tel to Text) =
+    RecordSchema.intensional(_.primaryAtom)
+
+  given optionalIdentifier
+  :   ("identifier?" is Intensional in RecordSchema from Tel to Optional[Text]) =
+    RecordSchema.intensional: tel =>
+      if absent(tel) then Unset else tel.primaryAtom
+
+  given typeName: ("type-name" is Intensional in RecordSchema from Tel to Text) =
+    RecordSchema.intensional(_.primaryAtom)
+
+  given optionalTypeName
+  :   ("type-name?" is Intensional in RecordSchema from Tel to Optional[Text]) =
+    RecordSchema.intensional: tel =>
+      if absent(tel) then Unset else tel.primaryAtom
+
+  given sigil: ("sigil" is Intensional in RecordSchema from Tel to Char) =
+    RecordSchema.intensional: tel =>
+      val text = tel.primaryAtom.s
+      if text.length == 1 then text.charAt(0) else '#'
+
+  given optionalSigil: ("sigil?" is Intensional in RecordSchema from Tel to Optional[Char]) =
+    RecordSchema.intensional: tel =>
+      if absent(tel) then Unset
+      else
+        val text = tel.primaryAtom.s
+        if text.length == 1 then (text.charAt(0): Optional[Char]) else Unset
+
+  // A Flag field is satisfied when the schema declares the keyword
+  // *and* the parsed document contains a compound with that keyword.
+  // Polyvinyl's accessor calls our `access` first, which returns
+  // `Tel.empty` for an absent field; the Intensional below maps an
+  // absent Tel to `false` and a present one to `true`.
+  given flag: ("flag" is Intensional in RecordSchema from Tel to Boolean) =
+    RecordSchema.intensional(tel => !absent(tel))
+
+  given tel: ("tel" is Intensional in RecordSchema from Tel to Tel) =
+    RecordSchema.intensional(identity)
+
+  // Helper constructor for `Intensional` instances that ignore params.
+  def intensional[name <: Label, value](accessor: Tel => value)
+  :     name is Intensional in RecordSchema from Tel to value =
+    new Intensional:
+      type Self = name
+      type Origin = Tel
+      type Form = RecordSchema
+      type Result = value
+
+      def access(tel: Tel): value = accessor(tel)
+      def transform(tel: Tel, params: List[Text]): value = access(tel)
+
+  // Build a polyvinyl Record from a Tel value and an accessor map.
+  def record(data0: Tel, access0: Text => Tel => Any): Record = new Record:
+    type Origin = Tel
+    val data: Tel = data0
+    def access: Text => Tel => Any = access0
+
+  // Walk a Tels.Struct to produce the polyvinyl `Member` map. Each
+  // Field at the top level contributes one entry whose `fieldType`
+  // names the Intensional instance to look up.
+  def fieldsOf(struct: Tels.Struct, schema: Tels): Map[Text, Member] =
+    val builder = scala.collection.mutable.LinkedHashMap.empty[Text, Member]
+    var i = 0
+
+    while i < struct.members.length do
+      struct.members(i) match
+        case f: Tels.Field => builder(f.keyword) = memberOf(f, schema)
+        case _             => ()
+
+      i += 1
+
+    builder.toMap
+
+  // Map a single Tels.Field to its polyvinyl Member representation.
+  // Scalar / Flag / Reference types are translated to a Value member
+  // with the validator name (or built-in tag) used as the Intensional
+  // lookup key. Optional fields (required = Loose) get the `?` suffix.
+  private def memberOf(field: Tels.Field, schema: Tels): Member =
+    val optional = field.required == Tels.Polarity.Loose
+    val suffix   = if optional then "?" else ""
+
+    field.fieldType match
+      case s: Tels.Scalar =>
+        val validator = s.validators.headOption.getOrElse(t"string")
+        Member.Value(Text(validator.s + suffix))
+
+      case Tels.Flag =>
+        Member.Value(t"flag")
+
+      case Tels.Reference(name) =>
+        schema.scalars.find(_.name == name) match
+          case Some(sc) =>
+            val validator = sc.validators.headOption.getOrElse(t"string")
+            Member.Value(Text(validator.s + suffix))
+
+          case None =>
+            schema.records.find(_.name == name) match
+              case Some(rec) =>
+                Member.Record(t"object", fieldsOf(Tels.Struct(rec.members, rec.validators), schema))
+
+              case None => Member.Value(t"tel")
+
+      case _: Tels.Struct =>
+        Member.Value(t"tel")
+
+abstract class RecordSchema(val tels: Tels) extends Specification:
+  type Origin = Tel
+  type Form = RecordSchema
+
+  def fields: Map[Text, Member] = RecordSchema.fieldsOf(tels.document, tels)
+
+  def access(name: Text, tel: Tel): Tel = tel.field(name).or(Tel.empty)
+
+  def build(data: Tel, access: Text => Tel => Any): Record =
+    RecordSchema.record(data, access)

--- a/lib/stratiform/src/test/stratiform.ContactRecords.scala
+++ b/lib/stratiform/src/test/stratiform.ContactRecords.scala
@@ -1,0 +1,83 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.quoted.*
+
+import anticipation.*
+import gossamer.*
+import polyvinyl.*
+import vacuous.*
+
+import Tels.{Field, Polarity, Scalar, Struct}
+
+// Hand-built TEL schema for the Polyvinyl `RecordSchema` tests:
+// a `Contact` record with a required `name` (String scalar), an
+// optional `email` (String scalar), and a required `age` (identifier).
+object ContactSchemaFixture:
+  val tels: Tels = Tels(
+    name     = t"contact",
+    document = Struct(
+      members = IArray(
+        Field(Polarity.Implicit, Polarity.Implicit, t"name",  Scalar(IArray(t"string")),     Unset),
+        Field(Polarity.Loose,    Polarity.Implicit, t"email", Scalar(IArray(t"string")),     Unset),
+        Field(Polarity.Implicit, Polarity.Implicit, t"age",   Scalar(IArray(t"identifier")), Unset)),
+      validators = IArray.empty),
+    layers   = IArray.empty,
+    sigil    = Unset,
+    records  = IArray.empty,
+    scalars  = IArray.empty,
+    selects  = IArray.empty)
+
+// User-defined RecordSchema with the polyvinyl `record` inline-macro
+// entry point. Lives in its own file so its macro can be expanded
+// without a cyclic dependency from the call-site test file.
+object ContactRecords extends RecordSchema(ContactSchemaFixture.tels):
+  transparent inline def record(tel: Tel): Record = ${build('tel)}
+
+// A second schema with a Flag-typed field for the boolean records test.
+object FeatureSchemaFixture:
+  val tels: Tels = Tels(
+    name     = t"feature",
+    document = Struct(
+      members    = IArray
+                    (Field(Polarity.Loose, Polarity.Implicit, t"enabled", Tels.Flag, Unset)),
+      validators = IArray.empty),
+    layers   = IArray.empty,
+    sigil    = Unset,
+    records  = IArray.empty,
+    scalars  = IArray.empty,
+    selects  = IArray.empty)
+
+object FeatureRecords extends RecordSchema(FeatureSchemaFixture.tels):
+  transparent inline def record(tel: Tel): Record = ${build('tel)}

--- a/lib/stratiform/src/test/stratiform.RecordsTests.scala
+++ b/lib/stratiform/src/test/stratiform.RecordsTests.scala
@@ -1,0 +1,86 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import hieroglyph.*
+import probably.*
+import turbulence.*
+import vacuous.*
+
+import strategies.throwUnsafely
+import charEncoders.utf8
+
+object RecordsTests extends Suite(m"Stratiform Records tests"):
+  def run(): Unit =
+    suite(m"RecordSchema field access"):
+      test(m"required String field is accessed as Text"):
+        val record = ContactRecords.record(t"name Alice\nage 30\n".read[Tel])
+        record.name
+      . assert(_ == t"Alice")
+
+      test(m"second required field is accessed as Text"):
+        val record = ContactRecords.record(t"name Alice\nage 30\n".read[Tel])
+        record.age
+      . assert(_ == t"30")
+
+      test(m"optional field is absent when missing"):
+        val record = ContactRecords.record(t"name Alice\nage 30\n".read[Tel])
+        record.email
+      . assert(_ == Unset)
+
+      test(m"optional field is present when supplied"):
+        val record = ContactRecords.record
+                      (t"name Alice\nemail alice@example.com\nage 30\n".read[Tel])
+        record.email
+      . assert(_ == (t"alice@example.com": Optional[Text]))
+
+      test(m"records derived from the same schema can be queried independently"):
+        val a = ContactRecords.record(t"name Alice\nage 30\n".read[Tel])
+        val b = ContactRecords.record(t"name Bob\nage 40\n".read[Tel])
+        (a.name, b.name)
+      . assert(_ == (t"Alice", t"Bob"))
+
+    suite(m"RecordSchema flag fields"):
+      test(m"present flag reads as true"):
+        val record = FeatureRecords.record(t"enabled\n".read[Tel])
+        record.enabled
+      . assert(_ == true)
+
+      test(m"absent flag reads as false"):
+        val record = FeatureRecords.record(t"".read[Tel])
+        record.enabled
+      . assert(_ == false)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1410,3 +1410,5 @@ object Tests extends Suite(m"Stratiform Tests"):
         val element  = Tel.Type.assign(telBytes.read[Tel], TelsAxiom.tels)
         element.bintel.toSeq == refBytes
       . assert(_ == true)
+
+    RecordsTests()


### PR DESCRIPTION
## Summary

New `stratiform.records` sub-component deriving structurally-typed
records from a TEL schema via Polyvinyl.

### Notes for users

```scala
import soundness.*, strategies.throwUnsafely

object Contacts extends RecordSchema(myTels):
  transparent inline def record(tel: Tel): Record = ${build('tel)}

val c = Contacts.record(myTel)
c.name:  Text             // required `field name String`
c.email: Optional[Text]   // optional (`required = Loose`) field
c.age:   Text             // `field age Identifier`
```

The fields and their types are derived from the schema's document
struct at compile time. `Intensional` instances map TEL's built-in
scalar validators — `string`, `identifier`, `type-name`, `sigil` — to
`Text` / `Char`; `?`-suffixed variants give `Optional[T]` for
Loose-required fields. Flag-typed members become `Boolean`. References
to ScalarDefinitions resolve via the validator chain; references to
RecordDefinitions become nested Polyvinyl `Member.Record` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)