### PR TITLE
stratiform + breviloquence: `read[T over Format]` decoder shorthand

### DIFF
--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -230,6 +230,15 @@ object Cbor extends Cbor2, Dynamic:
   given aggregable: Tactic[CborError] => Cbor is Aggregable by Data =
     bytes => Cbor.ast(bytes.read[Cbor.Ast])
 
+  // `source.read[Foo over Cbor]` shorthand for
+  // `source.read[Cbor].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
+  // for `value over Json`. The `Transport` type-tag is added by an
+  // `asInstanceOf` cast — `value over Cbor` is just
+  // `value { type Transport = Cbor }` so the cast is a no-op at runtime.
+  given aggregableOver: [value: Decodable in Cbor] => Tactic[CborError]
+  =>  (value over Cbor) is Aggregable by Data =
+    bytes => Cbor.ast(bytes.read[Cbor.Ast]).as[value].asInstanceOf[value over Cbor]
+
   given unit: Tactic[CborError] => Unit is Decodable in Cbor =
     value =>
       if !value.root.nullary then

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -260,6 +260,19 @@ object Tests extends Suite(m"Breviloquence Tests"):
         Cbor.ast(Stream(bytes).read[Cbor.Ast]).as[Wrapper]
       . assert(_ == Wrapper(List(1, 2, 3), t"hi"))
 
+    suite(m"`over Cbor` decoder shorthand"):
+      test(m"`read[T over Cbor]` resolves a value directly from bytes"):
+        val original = Point(3, 4)
+        val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
+        Stream(bytes).read[Point over Cbor]
+      . assert(_ == Point(3, 4))
+
+      test(m"`read[T over Cbor]` works for nested case classes"):
+        val original = Wrapper(List(1, 2, 3), t"hi")
+        val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
+        Stream(bytes).read[Wrapper over Cbor]
+      . assert(_ == Wrapper(List(1, 2, 3), t"hi"))
+
     suite(m"Relabelling"):
       test(m"Encode renames fields to wire keys"):
         val cbor = Renamed(List(1L, 2L), List(3L)).cbor

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -667,6 +667,23 @@ object Tel extends Tel2:
 
     parse(acc)
 
+  // `source.read[Foo over Tel]` shorthand for
+  // `source.read[Tel].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
+  // for `value over Json`. The `Transport` type-tag is added by an
+  // `asInstanceOf` cast — `value over Tel` is just
+  // `value { type Transport = Tel }` so the cast is a no-op at runtime.
+  given aggregableOver: [value: Decodable in Tel] => Tactic[TelError]
+  =>  (value over Tel) is Aggregable by Data =
+    source =>
+      import denominative.nil
+      var acc    = IArray.empty[Byte]
+      var stream = source
+      while !stream.nil do
+        acc = acc ++ stream.head
+        stream = stream.tail
+
+      parse(acc).as[value].asInstanceOf[value over Tel]
+
   // `text.load[Tel]` for any Stream[Text] source: concatenates the
   // chunks, UTF-8 encodes, parses, and pairs the resulting Tel with a
   // `Tel.Metadata` carrying the document's prologue.

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -98,6 +98,11 @@ object Tests extends Suite(m"Stratiform Tests"):
         Tests.Person(t"Alice", 30).encode.as[Tests.Person]
       . assert(_ == Tests.Person(t"Alice", 30))
 
+    suite(m"`over Tel` decoder shorthand"):
+      test(m"`read[T over Tel]` resolves a value directly from text"):
+        t"name Alice\nage 30\n".read[Tests.Person over Tel]
+      . assert(_ == Tests.Person(t"Alice", 30))
+
     suite(m"tel\"…\" interpolator"):
       test(m"simple literal"):
         val parsed = tel"hello"


### PR DESCRIPTION
Generalises the `read[Foo over Format]` shorthand to TEL and CBOR — the same pattern jacinta has carried since the `over Json` adapter, and that PR #1172 ported to YAML and XML. With this PR, every text/binary format in Soundness exposes the same one-step decode:

```scala
source.read[Foo over Json]    // jacinta
source.read[Foo over Yaml]    // ypsiloid
source.read[Foo over Xml]     // xylophone
source.read[Foo over Tel]     // stratiform   (new)
source.read[Foo over Cbor]    // breviloquence (new)
```

## What it does

Each given parses through the format's existing `Aggregable by Data` path, calls `.as[value]`, then adds the `Transport` type-tag via an `asInstanceOf` cast. `value over Format` is a refinement alias from `prepositional` (`value { type Transport = Format }`), so the cast is a no-op at runtime — there's no overhead beyond the underlying parse + decode that you'd already be doing.

```scala
import stratiform.*, soundness.*, strategies.throwUnsafely

case class Person(name: Text, age: Int) derives CanEqual

// Before:
val person = t"name Alice\nage 30\n".read[Tel].as[Person]

// After:
val person = t"name Alice\nage 30\n".read[Person over Tel]
```

```scala
import breviloquence.*, soundness.*, strategies.throwUnsafely

case class Point(x: Int, y: Int) derives CanEqual

// Before:
val pt = Stream(bytes).read[Cbor].as[Point]

// After:
val pt = Stream(bytes).read[Point over Cbor]
```

## Tests

`stratiform_test.scala` and `breviloquence_test.scala` each gain a `\`over Format\` decoder shorthand` suite covering the shorthand against simple and nested case classes.