### PR TITLE
honeycomb: add permissive HTML-recovery parsing mode

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -131,22 +131,31 @@ object Html extends Tag.Container
       Fragment(List(left, right).nodes*).of[leftTopic | rightTopic].in[dom]
 
 
+  private inline def permissive(using recovery: Html.Recovery): Boolean =
+    recovery eq Html.Recovery.Permissive
+
   given aggregable: [content <: Label: Reifiable to List[String]] => (dom: Dom)
-  =>  Tactic[ParseError]
+  =>  ( Tactic[ParseError], Html.Recovery )
   =>  (Html of content) is Aggregable by Text =
 
     input =>
       val root = Tag.root(content.reify.map(_.tt).to(Set))
-      HtmlParser.fromIterator(input.iterator).parseHtml(root).of[content]
+      HtmlParser.fromIterator(input.iterator, permissive).parseHtml(root).of[content]
 
-  given aggregable2: (dom: Dom) => Tactic[ParseError] => Html is Aggregable by Text =
+  given aggregable2: (dom: Dom)
+  =>  ( Tactic[ParseError], Html.Recovery )
+  =>  Html is Aggregable by Text =
     input =>
-      HtmlParser.fromIterator(input.iterator).parseHtml(dom.generic, doctypes = false)
+      HtmlParser.fromIterator(input.iterator, permissive)
+      . parseHtml(dom.generic, doctypes = false)
 
-  given loadable: (dom: Dom) => Tactic[ParseError] => Html is Loadable by Text = stream =>
+  given loadable: (dom: Dom)
+  =>  ( Tactic[ParseError], Html.Recovery )
+  =>  Html is Loadable by Text = stream =>
     val root = Tag.root(Set(t"html"))
 
-    HtmlParser.fromIterator(stream.iterator).parseHtml(root, doctypes = true) match
+    HtmlParser.fromIterator(stream.iterator, permissive)
+    . parseHtml(root, doctypes = true) match
       case Fragment(Doctype(doctype), content) => Document(content, dom)
       case html@Element("html", _, _, _)       => Document(html, dom)
 
@@ -401,6 +410,12 @@ object Html extends Tag.Container
   enum Mode:
     case Raw, Rcdata, Whitespace, Normal
 
+  object Recovery:
+    given default: Recovery = Strict
+
+  enum Recovery:
+    case Strict, Permissive
+
   enum Hole:
     case Text, Tagbody, Comment
     case Element(tag: Text)
@@ -434,12 +449,16 @@ object Html extends Tag.Container
     // scanning the currently-buffered chars from offset 0 to the error
     // position — an O(buffer) cost paid only on the failure path.
 
-    def fromText(text: Text)(using Dom): HtmlParser = new HtmlParser(Cursor[Text](text))
+    def fromText(text: Text, permissive: Boolean = false)(using Dom): HtmlParser =
+      new HtmlParser(Cursor[Text](text), permissive)
 
-    def fromIterator(input: Iterator[Text])(using Dom): HtmlParser =
-      new HtmlParser(Cursor[Text](input))
+    def fromIterator(input: Iterator[Text], permissive: Boolean = false)(using Dom): HtmlParser =
+      new HtmlParser(Cursor[Text](input), permissive)
 
-  private[honeycomb] final class HtmlParser(cursor: Cursor[Text])(using dom: Dom):
+  private[honeycomb] final class HtmlParser
+    ( cursor:        Cursor[Text],
+      val permissive: Boolean      = false )
+    ( using dom: Dom ):
     private var heldToken: Cursor.Held | Null = null
 
     type Region = Cursor.Mark
@@ -739,24 +758,50 @@ object Html extends Tag.Container
         case '\u0000'                                    => fail(BadInsertion, mark)
         case char                                        => fail(Unexpected(char), mark)
 
+      // Permissive recovery for `key`: drain the remaining attribute-name
+      // characters (letters, digits, hyphens) so the cursor lands on the
+      // terminator, then return a synthetic Attribute that targets every
+      // tag — keeping the InvalidAttributeUse check happy.
+      @tailrec
+      def keyTail(mark: Mark): Attribute =
+        lay(Attribute(slice(mark, begin()), Set(), true)):
+          case char if asciiLetter(char) || asciiDigit(char) || char == '-' =>
+            advance() yet keyTail(mark)
+          case _ =>
+            Attribute(slice(mark, begin()), Set(), true)
+
       @tailrec
       def key(mark: Mark, node: Int): Attribute =
         lay(fail(ExpectedMore, mark)):
           case char if asciiLetter(char) || char == '-' =>
             val step = dom.attributes.step(node, asciiLower(char))
-            if step < 0 then fail(UnknownAttributeStart(slice(mark, begin())), mark)
-            else next() yet key(mark, step)
+            if step < 0 then
+              if permissive then
+                warn(UnknownAttributeStart(slice(mark, begin())))
+                keyTail(mark)
+              else
+                fail(UnknownAttributeStart(slice(mark, begin())), mark)
+            else
+              next() yet key(mark, step)
 
           case ' ' | '\f' | '\n' | '\r' | '\t' | '=' | '>' =>
             val attr = dom.attributes.value(node)
             if attr != null then attr.nn else
               val end = begin()
               val name = slice(mark, end)
-              reset(mark)
-              fail(UnknownAttribute(name), mark, end)
+              if permissive then
+                warn(UnknownAttribute(name))
+                Attribute(name, Set(), true)
+              else
+                reset(mark)
+                fail(UnknownAttribute(name), mark, end)
 
           case char =>
-            fail(Unexpected(char), mark)
+            if permissive then
+              warn(Unexpected(char))
+              keyTail(mark)
+            else
+              fail(Unexpected(char), mark)
 
       @tailrec
       def foreignKey(mark: Mark): Text = lay(fail(ExpectedMore, mark)):
@@ -796,7 +841,10 @@ object Html extends Tag.Container
       @tailrec
       def unquoted(mark: Mark): Text = lay(fail(ExpectedMore, mark)):
         case '>' | ' ' | '\f' | '\n' | '\r' | '\t' => slice(mark, begin())
-        case char@('"' | '\'' | '<' | '=' | '`')   => fail(ForbiddenUnquoted(char), mark)
+        case char@('"' | '\'' | '<' | '=' | '`')   =>
+          if permissive then warn(ForbiddenUnquoted(char)) yet next() yet unquoted(mark)
+          else fail(ForbiddenUnquoted(char), mark)
+
         case '\u0000'                              => fail(BadInsertion, mark)
         case char                                  => next() yet unquoted(mark)
 
@@ -854,7 +902,9 @@ object Html extends Tag.Container
             case _ =>
               val key2 = if foreign then foreignKey(begin()) else
                 key(begin(), 0).tap: key =>
-                  if !key.targets(tag) then fail(InvalidAttributeUse(key.label, tag))
+                  if !key.targets(tag) then
+                    if permissive then warn(InvalidAttributeUse(key.label, tag))
+                    else fail(InvalidAttributeUse(key.label, tag))
 
                 . label
 
@@ -864,12 +914,21 @@ object Html extends Tag.Container
               // Bloom-style fast-skip; only fall back to a linear scan when
               // the new hashcode's bits are entirely within the accumulated
               // envelope (i.e. it might match a prior key).
+              var isDuplicate = false
+
               if (hashOr | h) == hashOr then
                 var dup = 0
 
                 while dup < 2*n do
-                  if attrInterleaved(dup) == key2Str then fail(DuplicateAttribute(key2))
-                  dup += 2
+                  if attrInterleaved(dup) == key2Str then
+                    if permissive then
+                      warn(DuplicateAttribute(key2))
+                      isDuplicate = true
+                      dup = 2*n
+                    else
+                      fail(DuplicateAttribute(key2))
+                  else
+                    dup += 2
 
               hashOr |= h
 
@@ -885,10 +944,11 @@ object Html extends Tag.Container
                   case _ =>
                     unquoted(begin()) // FIXME: Only alphanumeric characters
 
-              ensureCapacity()
-              attrInterleaved(2*n) = key2Str
-              attrInterleaved(2*n + 1) = assignment.lay(null: String | Null)(_.s)
-              n += 1
+              if !isDuplicate then
+                ensureCapacity()
+                attrInterleaved(2*n) = key2Str
+                attrInterleaved(2*n + 1) = assignment.lay(null: String | Null)(_.s)
+                n += 1
 
         if n == 0 then Attributes.empty
         else
@@ -1226,9 +1286,12 @@ object Html extends Tag.Container
 
                 case Token.Cdata =>
                   current =
-                    if parent.foreign then TextNode(content) else
-                      fail(InvalidCdata, mark)
+                    if parent.foreign then TextNode(content)
+                    else if permissive then
+                      warn(InvalidCdata)
                       Comment(t"[CDATA[${content}]]")
+                    else
+                      fail(InvalidCdata, mark)
 
                 case Token.Empty =>
                   if admit(content) then empty() else infer:
@@ -1479,10 +1542,10 @@ object Html extends Tag.Container
       callback:    Optional[(Ordinal, Hole) => Unit] = Unset,
       fastforward: Int                               = 0,
       doctypes:    Boolean                           = false )
-    ( using dom: Dom )
+    ( using dom: Dom, recovery: Html.Recovery )
   :   Html raises ParseError =
 
-    val parser = HtmlParser.fromIterator(input)
+    val parser = HtmlParser.fromIterator(input, permissive)
     parser.callback = callback
     parser.parseHtml(root, doctypes)
 

--- a/lib/honeycomb/src/test/honeycomb_test.scala
+++ b/lib/honeycomb/src/test/honeycomb_test.scala
@@ -928,6 +928,82 @@ object Tests extends Suite(m"Honeycombd Tests"):
           Div(H1("title")) +^ (P("body") + P("more"))
         . assert(_ == h"<div><h1>title</h1><p>body</p><p>more</p></div>")
 
+      suite(m"Permissive parsing"):
+        given Html.Recovery = Html.Recovery.Permissive
+
+        given lenient: Tactic[ParseError]:
+          given canThrow: CanThrow[Exception] = unsafeExceptions.canThrowAny
+
+          def diagnostics: Diagnostics = errorDiagnostics.stackTraces
+
+          def record(error: Diagnostics ?=> ParseError): Unit = ()
+
+          def abort(error: Diagnostics ?=> ParseError): Nothing =
+            throw error(using diagnostics)
+
+          def certify(): Unit = ()
+
+        test(m"unknown attribute is accepted"):
+          t"""<div bogus="x"></div>""".read[Html of "div"]
+        . assert:
+            case Element("div", _, _, _) => true
+            case _                       => false
+
+        test(m"unknown attribute on void tag is accepted"):
+          t"""<img mystery="y">""".read[Html of "img"]
+        . assert:
+            case Element("img", _, _, _) => true
+            case _                       => false
+
+        test(m"duplicate attribute keeps first value"):
+          t"""<img alt="first" alt="second">""".read[Html of "img"]
+        . assert(_ == Img(alt = "first"))
+
+        test(m"valid attribute used on wrong tag is accepted"):
+          t"""<div alt="caption"></div>""".read[Html of "div"]
+        . assert:
+            case Element("div", _, _, _) => true
+            case _                       => false
+
+        test(m"forbidden char in unquoted value is absorbed (per WHATWG)"):
+          t"""<img alt=a"b>""".read[Html of "img"]
+        . assert(_ == Img(alt = """a"b"""))
+
+        test(m"CDATA outside foreign content becomes a comment"):
+          t"""<div><![CDATA[xyz]]></div>""".read[Html of "div"]
+        . assert(_ == Div(Comment("[CDATA[xyz]]")))
+
+        test(m"permissive mode still aborts on unrecoverable structural errors"):
+          try t"""<ul><li>First item""".read[Html of Flow]
+          catch case exception: Exception => exception
+        . assert:
+            case ParseError(_, _, Html.Issue.Incomplete("ul")) => true
+            case _                                             => false
+
+        test(m"warnings are emitted into the Tactic"):
+          val errors = scala.collection.mutable.ListBuffer[ParseError]()
+
+          locally:
+            given Tactic[ParseError]:
+              given canThrow: CanThrow[Exception] = unsafeExceptions.canThrowAny
+
+              def diagnostics: Diagnostics = errorDiagnostics.stackTraces
+
+              def record(error: Diagnostics ?=> ParseError): Unit =
+                errors += error(using diagnostics)
+
+              def abort(error: Diagnostics ?=> ParseError): Nothing =
+                throw error(using diagnostics)
+
+              def certify(): Unit = ()
+
+            t"""<img alt="a" alt="b">""".read[Html of "img"]
+
+          errors.toList.map(_.issue)
+        . assert:
+            case List(Html.Issue.DuplicateAttribute(name)) => name == t"alt"
+            case _                                         => false
+
     Html4Tests()
 
 object Html4Tests extends Suite(m"HTML4 parsing tests"):


### PR DESCRIPTION
Honeycomb's HTML parser now supports an opt-in permissive mode that recovers from a defined subset of malformed inputs instead of aborting; bring `given Html.Recovery.Permissive` into scope to enable it, leaving `.read[Html]` strict by default.

A new `Html.Recovery` toggle controls whether the parser aborts on malformed input (the default `Strict`) or recovers and continues (`Permissive`). The user-facing API is unchanged — bringing one given into scope flips the behaviour:

```scala
import honeycomb.*
given Html.Recovery = Html.Recovery.Permissive

t"""<img alt="a" alt="b">""".read[Html of "img"]
// Img(alt = "a") — duplicate kept-first per spec, no exception
```

This first cut covers five conditions that real-world HTML routinely hits: unknown attribute name or prefix, valid attribute used on the wrong tag, duplicate attribute on a single tag, forbidden character in an unquoted attribute value (absorbed into the value, per WHATWG), and a `CDATA` block in HTML context (becomes a comment). Recovered errors are still emitted via `raise(...)` on `Tactic[ParseError]`, so a custom `Tactic` can collect them while parsing continues.

Structural recoveries — mismatched closing tags, inadmissible children, EOF mid-document — still abort and will be addressed in follow-ups.