### PR TITLE
honeycomb: drop Tactic requirement from permissive HTML reader

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -39,6 +39,7 @@ import java.util as ju
 
 import scala.annotation.tailrec
 import scala.quoted.*
+import scala.util.NotGiven
 
 import anticipation.*
 import contextual.*
@@ -131,30 +132,78 @@ object Html extends Tag.Container
       Fragment(List(left, right).nodes*).of[leftTopic | rightTopic].in[dom]
 
 
-  private inline def permissive(using recovery: Html.Recovery): Boolean =
-    recovery eq Html.Recovery.Permissive
+  // Internal Tactic used by the permissive-variant givens. Recovery warnings
+  // (`raise`) are discarded; truly unrecoverable conditions (`abort`) still
+  // throw, since the caller hasn't supplied a way to handle them.
+  private def lenientTactic: Tactic[ParseError] = new Tactic[ParseError]:
+    given canThrow: CanThrow[Exception] = unsafeExceptions.canThrowAny
+    def diagnostics: Diagnostics = errorDiagnostics.stackTraces
+    def record(error: Diagnostics ?=> ParseError): Unit = ()
 
-  given aggregable: [content <: Label: Reifiable to List[String]] => (dom: Dom)
-  =>  ( Tactic[ParseError], Html.Recovery )
+    def abort(error: Diagnostics ?=> ParseError): Nothing =
+      throw error(using diagnostics)
+
+    def certify(): Unit = ()
+
+
+  given strictAggregable: [content <: Label: Reifiable to List[String]]
+  =>  (dom: Dom)
+  =>  Tactic[ParseError]
+  =>  NotGiven[Html.Recovery.Permissive]
   =>  (Html of content) is Aggregable by Text =
 
     input =>
       val root = Tag.root(content.reify.map(_.tt).to(Set))
-      HtmlParser.fromIterator(input.iterator, permissive).parseHtml(root).of[content]
+      HtmlParser.fromIterator(input.iterator, permissive = false).parseHtml(root).of[content]
 
-  given aggregable2: (dom: Dom)
-  =>  ( Tactic[ParseError], Html.Recovery )
+  given strictAggregable2: (dom: Dom)
+  =>  Tactic[ParseError]
+  =>  NotGiven[Html.Recovery.Permissive]
   =>  Html is Aggregable by Text =
     input =>
-      HtmlParser.fromIterator(input.iterator, permissive)
+      HtmlParser.fromIterator(input.iterator, permissive = false)
       . parseHtml(dom.generic, doctypes = false)
 
-  given loadable: (dom: Dom)
-  =>  ( Tactic[ParseError], Html.Recovery )
+  given strictLoadable: (dom: Dom)
+  =>  Tactic[ParseError]
+  =>  NotGiven[Html.Recovery.Permissive]
   =>  Html is Loadable by Text = stream =>
     val root = Tag.root(Set(t"html"))
 
-    HtmlParser.fromIterator(stream.iterator, permissive)
+    HtmlParser.fromIterator(stream.iterator, permissive = false)
+    . parseHtml(root, doctypes = true) match
+      case Fragment(Doctype(doctype), content) => Document(content, dom)
+      case html@Element("html", _, _, _)       => Document(html, dom)
+
+      case _ =>
+        abort(ParseError(Html, Position(1.u, 1.u), Issue.BadDocument))
+
+
+  given permissiveAggregable: [content <: Label: Reifiable to List[String]]
+  =>  (dom: Dom)
+  =>  Html.Recovery.Permissive
+  =>  (Html of content) is Aggregable by Text =
+
+    input =>
+      given Tactic[ParseError] = lenientTactic
+      val root = Tag.root(content.reify.map(_.tt).to(Set))
+      HtmlParser.fromIterator(input.iterator, permissive = true).parseHtml(root).of[content]
+
+  given permissiveAggregable2: (dom: Dom)
+  =>  Html.Recovery.Permissive
+  =>  Html is Aggregable by Text =
+    input =>
+      given Tactic[ParseError] = lenientTactic
+      HtmlParser.fromIterator(input.iterator, permissive = true)
+      . parseHtml(dom.generic, doctypes = false)
+
+  given permissiveLoadable: (dom: Dom)
+  =>  Html.Recovery.Permissive
+  =>  Html is Loadable by Text = stream =>
+    given Tactic[ParseError] = lenientTactic
+    val root = Tag.root(Set(t"html"))
+
+    HtmlParser.fromIterator(stream.iterator, permissive = true)
     . parseHtml(root, doctypes = true) match
       case Fragment(Doctype(doctype), content) => Document(content, dom)
       case html@Element("html", _, _, _)       => Document(html, dom)
@@ -410,11 +459,12 @@ object Html extends Tag.Container
   enum Mode:
     case Raw, Rcdata, Whitespace, Normal
 
+  // Bringing a `Recovery.Permissive` into scope selects the permissive HTML
+  // reader, which recovers from a defined subset of malformed inputs instead
+  // of aborting and does not require a `Tactic[ParseError]`. To enable it,
+  // `import honeycomb.recoveries.permissive` (defined in honeycomb_core.scala).
   object Recovery:
-    given default: Recovery = Strict
-
-  enum Recovery:
-    case Strict, Permissive
+    class Permissive
 
   enum Hole:
     case Text, Tagbody, Comment
@@ -1542,10 +1592,10 @@ object Html extends Tag.Container
       callback:    Optional[(Ordinal, Hole) => Unit] = Unset,
       fastforward: Int                               = 0,
       doctypes:    Boolean                           = false )
-    ( using dom: Dom, recovery: Html.Recovery )
+    ( using dom: Dom )
   :   Html raises ParseError =
 
-    val parser = HtmlParser.fromIterator(input, permissive)
+    val parser = HtmlParser.fromIterator(input, permissive = false)
     parser.callback = callback
     parser.parseHtml(root, doctypes)
 

--- a/lib/honeycomb/src/core/honeycomb_core.scala
+++ b/lib/honeycomb/src/core/honeycomb_core.scala
@@ -60,3 +60,6 @@ package stylesheets:
 
     new Stylesheet(Set(valueOf[classname])):
       type Topic = classname
+
+package recoveries:
+  given permissive: Html.Recovery.Permissive = new Html.Recovery.Permissive

--- a/lib/honeycomb/src/test/honeycomb_test.scala
+++ b/lib/honeycomb/src/test/honeycomb_test.scala
@@ -929,19 +929,7 @@ object Tests extends Suite(m"Honeycombd Tests"):
         . assert(_ == h"<div><h1>title</h1><p>body</p><p>more</p></div>")
 
       suite(m"Permissive parsing"):
-        given Html.Recovery = Html.Recovery.Permissive
-
-        given lenient: Tactic[ParseError]:
-          given canThrow: CanThrow[Exception] = unsafeExceptions.canThrowAny
-
-          def diagnostics: Diagnostics = errorDiagnostics.stackTraces
-
-          def record(error: Diagnostics ?=> ParseError): Unit = ()
-
-          def abort(error: Diagnostics ?=> ParseError): Nothing =
-            throw error(using diagnostics)
-
-          def certify(): Unit = ()
+        import recoveries.permissive
 
         test(m"unknown attribute is accepted"):
           t"""<div bogus="x"></div>""".read[Html of "div"]
@@ -980,7 +968,7 @@ object Tests extends Suite(m"Honeycombd Tests"):
             case ParseError(_, _, Html.Issue.Incomplete("ul")) => true
             case _                                             => false
 
-        test(m"warnings are emitted into the Tactic"):
+        test(m"parser emits warnings via raise() when a Tactic is in scope"):
           val errors = scala.collection.mutable.ListBuffer[ParseError]()
 
           locally:
@@ -997,7 +985,9 @@ object Tests extends Suite(m"Honeycombd Tests"):
 
               def certify(): Unit = ()
 
-            t"""<img alt="a" alt="b">""".read[Html of "img"]
+            Html.HtmlParser.fromIterator
+             (Iterator(t"""<img alt="a" alt="b">"""), permissive = true)
+            . parseHtml(Tag.root(Set(t"img")))
 
           errors.toList.map(_.issue)
         . assert:


### PR DESCRIPTION
The permissive HTML reader no longer requires a `Tactic[ParseError]`: bringing `import honeycomb.recoveries.permissive` into scope is enough to resolve a reader that handles errors internally, removing the friction of declaring an error-handling capability when you just want best-effort parsing.

A second variant of the `Html` typeclass instances (`Aggregable`, `Loadable`) now resolves when `Html.Recovery.Permissive` is in scope — without needing a `Tactic[ParseError]`. The permissive variant provides its own internal Tactic that discards recoverable warnings; truly unrecoverable conditions still throw. The strict variant is unchanged.

Enable permissive parsing with a single import:

```scala
import honeycomb.*
import honeycomb.recoveries.permissive

t"""<img alt="a" alt="b">""".read[Html of "img"]
// Img(alt = "a") — no Tactic[ParseError] needed
```

The strict reader (the default everywhere `recoveries.permissive` is not imported) still requires a `Tactic[ParseError]` exactly as before, so existing code is unaffected. The previous `enum Recovery: Strict, Permissive` shape (introduced in #1180) is replaced by a single `class Html.Recovery.Permissive` marker — there is no separate `Strict` value and no default given; strict mode is simply "no Permissive in scope".