### PR TITLE
profanity: drop blocking await from knownColumns/knownRows

### DIFF
--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -33,11 +33,9 @@
 package profanity
 
 import anticipation.*
-import contingency.*
 import gossamer.*
 import iridescence.*
 import parasite.*
-import quantitative.*
 import rudiments.*
 import symbolism.*
 import turbulence.*
@@ -57,15 +55,13 @@ extends Interactivity[TerminalEvent]:
   export console.stdio.{in, out, err}
 
   val keyboard: Keyboard.Standard = Keyboard.Standard()
-  val rows0: Promise[Int] = Promise()
-  val columns0: Promise[Int] = Promise()
 
   var mode: Optional[Brightness] = Unset
   var rows: Optional[Int] = Unset
   var columns: Optional[Int] = Unset
 
-  def knownColumns: Int = columns.or(safely(columns0.await(50.0*Milli(Second)))).or(80)
-  def knownRows: Int = rows.or(safely(rows0.await(50.0*Milli(Second)))).or(80)
+  def knownColumns: Int = columns.or(80)
+  def knownRows: Int = rows.or(80)
 
   val cap: Termcap = new Termcap:
     def ansi: Boolean = true
@@ -99,9 +95,7 @@ extends Interactivity[TerminalEvent]:
     keyboard.process(In.stream[Char]).each:
       case resize@TerminalInfo.WindowSize(rows2, columns2) =>
         rows = rows2
-        rows0.offer(rows2)
         columns = columns2
-        columns0.offer(columns2)
         events.put(resize)
 
       case bgColor@TerminalInfo.BgColor(red, green, blue) =>


### PR DESCRIPTION
`LineEditor` inside `interactive { … }` no longer stalls for up to 50 ms per keystroke when the terminal's size-report handshake fails to round-trip — fixing the input lag previously visible in daemon (ethereal) mode.

`Terminal#knownColumns` and `Terminal#knownRows` are now non-blocking. They return the most recently observed window size, or 80 if none has been reported yet; an asynchronous `WindowSize` event — from the initial reportSize handshake, a `SIGWINCH` reflow, or a direct `terminal.columns = …` assignment — updates the cached value for subsequent reads at zero extra cost.

Previously these methods awaited an internal `Promise` for up to 50 ms before falling back to 80. When the terminal's response to the `\e[6n` handshake never made it back through the stdin pipeline — the typical case in daemon mode — every `LineEditor.render` call (one per keystroke) paid that 50 ms tax, turning a one-time startup failure into permanent per-keystroke latency.

The undocumented `Terminal#columns0` and `Terminal#rows0` promise fields have been removed.