### PR TITLE
ethereal/profanity: forward terminal size and bg colour at startup

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1068,7 +1068,7 @@ object probably extends Library:
   object test extends Tests(cli)
 
 object profanity extends Library:
-  object core extends Component(eucalyptus.core, diuretic.core, iridescence.core, quantitative.units):
+  object core extends Component(ambience.core, eucalyptus.core, diuretic.core, iridescence.core, quantitative.units):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, exoskeleton.rig)

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -120,7 +120,14 @@ fn main() {
     let saved_tty = tty::save_tty_state();
     tty::set_raw_mode();
 
-    let info = ClientInfo::collect(&script, &args, tty::stdin_is_tty());
+    // Query the terminal's background colour while we still own stdin/stdout
+    // directly. Anything the user happens to type during the handshake is
+    // returned as `leftover` and chained ahead of stdin into the forwarder so
+    // no bytes are lost.
+    let (bg_color, leftover) = tty::query_bg_color(Duration::from_millis(150));
+    debug!("main: bg_color={:?} leftover={}bytes", bg_color, leftover.len());
+
+    let info = ClientInfo::collect(&script, &args, tty::stdin_is_tty(), bg_color.as_deref());
     debug!("main: connecting to daemon (pid={})", info.pid);
     let (main_socket, stderr_socket) = match connect_to_daemon(&socket_file, &info) {
         Ok(connections) => { debug!("main: connected to daemon"); connections },
@@ -131,8 +138,9 @@ fn main() {
         }
     };
 
+    let stdin_reader = std::io::Cursor::new(leftover).chain(std::io::stdin());
     spawn_forwarder(
-        std::io::stdin(),
+        stdin_reader,
         main_socket.try_clone().expect("clone main socket"),
         false,
     );
@@ -233,7 +241,7 @@ fn run_non_interactive(socket_file: &Path, script: &Path, args: &[String]) -> i3
         "run_non_interactive socket={} args={:?}", socket_file.display(), args,
     ));
 
-    let info = ClientInfo::collect(script, args, false);
+    let info = ClientInfo::collect(script, args, false, None);
     let (main_socket, stderr_socket) = match connect_to_daemon(socket_file, &info) {
         Ok(connections) => { debug_log("connected"); connections }
         Err(error) => {
@@ -255,14 +263,34 @@ fn run_non_interactive(socket_file: &Path, script: &Path, args: &[String]) -> i3
 }
 
 impl ClientInfo {
-    pub fn collect(script: &Path, args: &[String], is_tty: bool) -> Self {
-        let env: Vec<String> = env::vars_os().map(|(name, value)| {
-            let mut entry = OsString::new();
-            entry.push(&name);
-            entry.push("=");
-            entry.push(&value);
-            entry.to_string_lossy().into_owned()
-        }).collect();
+    pub fn collect(script: &Path, args: &[String], is_tty: bool, bg_color: Option<&str>) -> Self {
+        let size = tty::terminal_size();
+        let mut env: Vec<String> = env::vars_os()
+            .filter(|(name, _)| {
+                // Strip any inherited COLUMNS/LINES/TERMINAL_BG; if we detected real
+                // values from the tty, ours are authoritative for this client, and if
+                // we didn't, inherited values are unreliable across a shared-daemon
+                // pipeline.
+                let n = name.to_string_lossy();
+                let strip_size = size.is_some() && (n == "COLUMNS" || n == "LINES");
+                let strip_bg = bg_color.is_some() && n == "TERMINAL_BG";
+                !(strip_size || strip_bg)
+            })
+            .map(|(name, value)| {
+                let mut entry = OsString::new();
+                entry.push(&name);
+                entry.push("=");
+                entry.push(&value);
+                entry.to_string_lossy().into_owned()
+            })
+            .collect();
+        if let Some((cols, rows)) = size {
+            env.push(format!("COLUMNS={}", cols));
+            env.push(format!("LINES={}", rows));
+        }
+        if let Some(bg) = bg_color {
+            env.push(format!("TERMINAL_BG={}", bg));
+        }
         ClientInfo {
             pid: std::process::id(),
             user_id: user_info::uid(),

--- a/lib/ethereal/src/runner/src/tty.rs
+++ b/lib/ethereal/src/runner/src/tty.rs
@@ -1,4 +1,7 @@
 #[cfg(unix)]
+use std::io::Write;
+
+#[cfg(unix)]
 pub struct TtyState {
     termios: Option<libc::termios>,
     is_tty: bool,
@@ -23,6 +26,125 @@ pub fn stdin_is_tty() -> bool {
         let h = GetStdHandle(STD_INPUT_HANDLE);
         let mut mode: u32 = 0;
         GetConsoleMode(h, &mut mode) != 0
+    }
+}
+
+// The launcher must know the real terminal size so it can forward it to the
+// daemon (which only sees a socket and cannot query the tty itself). Querying
+// from the launcher avoids a fragile ANSI cursor-position handshake across
+// the socket pipeline.
+#[cfg(unix)]
+pub fn terminal_size() -> Option<(u16, u16)> {
+    if !stdin_is_tty() { return None; }
+    let mut ws: libc::winsize = unsafe { std::mem::zeroed() };
+    let result = unsafe { libc::ioctl(libc::STDIN_FILENO, libc::TIOCGWINSZ, &mut ws) };
+    if result == 0 && ws.ws_col > 0 && ws.ws_row > 0 {
+        Some((ws.ws_col, ws.ws_row))
+    } else {
+        None
+    }
+}
+
+// OSC 11 query (`\e]11;?\e\\`) asks the terminal to report its background
+// colour as `\e]11;rgb:RRRR/GGGG/BBBB\e\\`. Running this from the launcher
+// (before forwarders start) keeps the handshake confined to one process with
+// direct tty access — much more reliable than letting the daemon attempt it
+// across the socket pipeline. Any non-response bytes are returned so they can
+// be prepended to the daemon's stdin and not lost.
+#[cfg(unix)]
+pub fn query_bg_color(timeout: std::time::Duration) -> (Option<String>, Vec<u8>) {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::time::Instant;
+
+    if !stdin_is_tty() { return (None, Vec::new()); }
+
+    let mut stdout = std::io::stdout();
+    if stdout.write_all(b"\x1b]11;?\x1b\\").is_err() { return (None, Vec::new()); }
+    let _ = stdout.flush();
+
+    let mut buf: Vec<u8> = Vec::with_capacity(64);
+    let deadline = Instant::now() + timeout;
+    let fd = std::io::stdin().as_raw_fd();
+
+    loop {
+        let now = Instant::now();
+        if now >= deadline { break; }
+        let remaining = (deadline - now).as_millis() as i32;
+        let mut pfd = libc::pollfd { fd, events: libc::POLLIN, revents: 0 };
+        let r = unsafe { libc::poll(&mut pfd, 1, remaining.max(1)) };
+        if r <= 0 { break; }
+
+        let mut chunk = [0u8; 64];
+        match std::io::stdin().read(&mut chunk) {
+            Ok(0) | Err(_) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                // Stop as soon as we see a terminator that could end an OSC response.
+                if find_subseq(&buf, b"\x1b\\").is_some() || buf.contains(&0x07) {
+                    break;
+                }
+            }
+        }
+    }
+
+    parse_osc11(&buf)
+}
+
+#[cfg(windows)]
+pub fn query_bg_color(_timeout: std::time::Duration) -> (Option<String>, Vec<u8>) {
+    // Windows Console doesn't reliably support OSC 11 background queries.
+    (None, Vec::new())
+}
+
+#[cfg(unix)]
+fn parse_osc11(buf: &[u8]) -> (Option<String>, Vec<u8>) {
+    let prefix = b"\x1b]11;rgb:";
+    let Some(start) = find_subseq(buf, prefix) else {
+        return (None, buf.to_vec());
+    };
+    let after_prefix = start + prefix.len();
+    let rest = &buf[after_prefix..];
+
+    let term_st = find_subseq(rest, b"\x1b\\");
+    let term_bel = rest.iter().position(|&b| b == 0x07);
+    let (rgb_end, term_len) = match (term_st, term_bel) {
+        (Some(a), Some(b)) if a < b => (a, 2),
+        (Some(_), Some(b))           => (b, 1),
+        (Some(a), None)              => (a, 2),
+        (None, Some(b))              => (b, 1),
+        (None, None)                 => return (None, buf.to_vec()),
+    };
+
+    let rgb_str = std::str::from_utf8(&rest[..rgb_end]).ok().map(str::to_owned);
+
+    let mut leftover = buf[..start].to_vec();
+    leftover.extend_from_slice(&rest[rgb_end + term_len..]);
+
+    (rgb_str, leftover)
+}
+
+#[cfg(unix)]
+fn find_subseq(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() { return None; }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+#[cfg(windows)]
+pub fn terminal_size() -> Option<(u16, u16)> {
+    use windows_sys::Win32::System::Console::{
+        CONSOLE_SCREEN_BUFFER_INFO, GetConsoleScreenBufferInfo, GetStdHandle, STD_OUTPUT_HANDLE,
+    };
+    unsafe {
+        let handle = GetStdHandle(STD_OUTPUT_HANDLE);
+        let mut info: CONSOLE_SCREEN_BUFFER_INFO = std::mem::zeroed();
+        if GetConsoleScreenBufferInfo(handle, &mut info) != 0 {
+            let cols = (info.srWindow.Right - info.srWindow.Left + 1).max(0) as u16;
+            let rows = (info.srWindow.Bottom - info.srWindow.Top + 1).max(0) as u16;
+            if cols > 0 && rows > 0 { Some((cols, rows)) } else { None }
+        } else {
+            None
+        }
     }
 }
 

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -117,7 +117,7 @@ object Keyboard:
                       TerminalInfo.WindowSize(rows, cols) #:: process(tail)
 
                     case _ =>
-                      TerminalInfo.WindowSize(20, 30) #:: process(tail)
+                      process(tail)
 
                   case 'O' #:: tail =>
                     TerminalInfo.LoseFocus #:: process(tail)

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package profanity
 
+import ambience.*
 import anticipation.*
+import contingency.*
+import distillate.*
 import gossamer.*
 import iridescence.*
 import parasite.*
@@ -49,16 +52,26 @@ object Terminal:
   def enablePaste: Text = t"\e[?2004h"
   def disablePaste: Text = t"\e[?2004l"
 
-case class Terminal()(using console: Console, monitor: Monitor, codicil: Codicil)
+case class Terminal()
+  ( using console: Console, monitor: Monitor, codicil: Codicil, environment: Environment )
 extends Interactivity[TerminalEvent]:
 
   export console.stdio.{in, out, err}
 
   val keyboard: Keyboard.Standard = Keyboard.Standard()
 
-  var mode: Optional[Brightness] = Unset
-  var rows: Optional[Int] = Unset
-  var columns: Optional[Int] = Unset
+  var mode: Optional[Brightness] = safely:
+    def hex(text: Text): Int = Integer.parseInt(text.s, 16)
+
+    Environment.terminalBg.cut(t"/").to(List) match
+      case red :: green :: blue :: Nil =>
+        if dark(hex(red), hex(green), hex(blue)) then Brightness.Dark else Brightness.Light
+
+      case _ =>
+        abort(EnvironmentError(t"TERMINAL_BG"))
+
+  var rows: Optional[Int] = safely(Environment.lines.decode[Int])
+  var columns: Optional[Int] = safely(Environment.columns.decode[Int])
 
   def knownColumns: Int = columns.or(80)
   def knownRows: Int = rows.or(80)

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package profanity
 
+import ambience.*
 import anticipation.*
 import contingency.*
 import parasite.*
@@ -41,7 +42,10 @@ given stdio: (terminal: Terminal) => Stdio = terminal.stdio
 
 
 def interactive[result](block: (terminal: Terminal) ?=> result)
-  ( using console: Console, monitor: Monitor, codicil: Codicil )
+  ( using console:     Console,
+          monitor:     Monitor,
+          codicil:     Codicil,
+          environment: Environment )
   ( using BracketedPasteMode,
           LuminosityDetection,
           TerminalFocusDetection,


### PR DESCRIPTION
The ethereal launcher now detects the terminal's size (via `TIOCGWINSZ` on Unix, `GetConsoleScreenBufferInfo` on Windows) and queries its background colour (via OSC 11 on Unix) at startup, forwarding both to the daemon as `COLUMNS`, `LINES`, and `TERMINAL_BG` environment variables. profanity reads these on `Terminal` construction so the line editor renders with the correct width and brightness from the very first frame, instead of waiting for an ANSI cursor-position handshake that often never makes it back through the launcher's socket pipeline.

This follows up #1185 (which dropped the per-keystroke 50 ms await): with that fix in place, the daemon was still falling back to an 80-column default whenever the size-report response failed to arrive — visible as broken wrap rendering until the user resized the terminal.

The launcher captures the size synchronously and the bg colour via a brief (~150 ms) OSC 11 handshake that runs in the window where it still owns stdin/stdout directly, before the forwarder threads start. Any bytes the user happens to type during the handshake are chained ahead of stdin into the forwarder so nothing is lost.

`profanity.Terminal` now seeds its `columns`, `rows`, and `mode` fields from `COLUMNS`, `LINES`, and `TERMINAL_BG` (xterm hex `RRRR/GGGG/BBBB`). Existing dynamic update paths — `SIGWINCH` → `reportSize`, OSC 11 mid-session — continue to work and keep the values fresh.

Two incidental cleanups:

- The fabricated `TerminalInfo.WindowSize(20, 30)` fallback in `Keyboard.Standard.process` is removed; a malformed `\e[…R` response no longer clobbers a known-good size with bogus 30×20.
- `profanity.core` now depends on `ambience.core` for `Environment`.

In non-ethereal modes, `COLUMNS`/`LINES`/`TERMINAL_BG` are honoured exactly as any other shell-exported terminal env vars.