### PR TITLE
ethereal: expose per-client Environment as cli block context param

### DIFF
--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -82,7 +82,7 @@ given daemonLogEvent: Message transcribes DaemonLogEvent = _.communicate
 def service[bus <: Matchable](using service: DaemonService[bus]): DaemonService[bus] = service
 
 def cli[bus <: Matchable](using executive: Executive)
-  ( block: (DaemonService[bus], executive.Interface) ?=> executive.Return )
+  ( block: (DaemonService[bus], executive.Interface, Environment) ?=> executive.Return )
   ( using interpreter: Interpreter,
           threading:   Threading,
           handler:     Backstop )
@@ -419,7 +419,7 @@ def cli[bus <: Matchable](using executive: Executive)
             connection.invocation.offer(cli)
 
             if cli.proceed then
-              val result = block(using service, cli)
+              val result = block(using service, cli, environment)
               val exitStatus: Exit = executive.process(cli)(result)
 
               connection.exitPromise.fulfill(exitStatus)


### PR DESCRIPTION
The `cli[bus]` daemon block was typed as `(DaemonService[bus], executive.Interface) ?=> executive.Return` and invoked with just `service` and `cli` as context parameters. The per-client `LazyEnvironment` defined locally in the daemon's init handler was therefore never visible inside the user's block — any code that summoned `Environment` got whatever the user had imported at file level (typically `environments.java`, which reads `System.getenv` of the daemon's *own process* env, not the per-client env). That meant the `COLUMNS` / `LINES` / `TERMINAL_BG` env vars added by the launcher in #1187 were arriving at the daemon but never reaching `profanity.Terminal`, which kept falling back to 80 columns — exactly the bug #1187 was meant to fix. More broadly, *every* `Environment`-dependent lookup inside a `cli { … }` block has been silently reading the wrong env.

Add `Environment` to the block's contextual parameters and pass the local `LazyEnvironment` when invoking the block. In Scala 3 a context-function parameter outranks a file-level import in given resolution, so existing user imports of `environments.java` are shadowed *only* inside the block. Lambda-syntax callers (`cli: …`) are source-compatible.

```diff
-def cli[bus <: Matchable](using executive: Executive)
-  ( block: (DaemonService[bus], executive.Interface) ?=> executive.Return )
+def cli[bus <: Matchable](using executive: Executive)
+  ( block: (DaemonService[bus], executive.Interface, Environment) ?=> executive.Return )
   …
-              val result = block(using service, cli)
+              val result = block(using service, cli, environment)
```