### PR TITLE
stratiform: truly streaming parser + atom-bytes arena + ThreadLocal cache

### DIFF
--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -635,19 +635,25 @@ object Tel extends Tel2:
 
   object Atom:
     // Inline is a regular class (not a case class) so its `text` can be
-    // materialised lazily. The parser constructs each atom with a freshly
-    // allocated byte array (an OWNED, exact-size copy of the atom's UTF-8
-    // bytes) and pays the UTF-8 decode only on first `text` access.
-    // Consumers that never inspect an atom (parser-throughput benchmarks,
-    // partial decoders) avoid the per-atom String allocation entirely.
-    // The byte array is private and never shared with the parser's
+    // materialised lazily. The parser writes each atom's UTF-8 bytes into
+    // a shared per-parse "arena" (a growing byte buffer); each Inline
+    // remembers the slice as `(arenaBytes, byteOff, byteLen)`. The
+    // String allocation and UTF-8 decode only happen on first `.text`
+    // access — consumers that never inspect an atom (parser-throughput
+    // benchmarks, partial decoders) skip the per-atom String allocation
+    // entirely. The arena array is not aliased with the parser's
     // streaming buffer, so the atom's lifetime is independent of the
-    // Cursor it was parsed from. Apply / unapply preserve the previous
-    // case-class construction and pattern-match syntax; equality and
-    // hashCode are derived manually to match the prior structural
-    // behaviour.
+    // Cursor it was parsed from. When the arena needs to grow the parser
+    // allocates a fresh array and leaves the old one alive via the
+    // Inlines that point at it; multiple arena arrays may therefore be
+    // kept alive across a parse, but no per-atom byte[] is allocated.
+    // Apply / unapply preserve the previous case-class construction and
+    // pattern-match syntax; equality and hashCode are derived manually
+    // to match the prior structural behaviour.
     final class Inline private[stratiform]
       ( private val bytes:           Array[Byte] | Null,
+        private val byteOff:         Int,
+        private val byteLen:         Int,
         private var _text:           String | Null,
         val precedingSpaces:         Int )
     extends Atom:
@@ -656,7 +662,7 @@ object Tel extends Tel2:
         val t = _text
         if t == null then
           val b = bytes.nn
-          val s = new String(b, 0, b.length, java.nio.charset.StandardCharsets.UTF_8)
+          val s = new String(b, byteOff, byteLen, java.nio.charset.StandardCharsets.UTF_8)
           _text = s
           Text(s)
         else Text(t)
@@ -671,13 +677,16 @@ object Tel extends Tel2:
 
     object Inline:
       def apply(text: Text, precedingSpaces: Int): Inline =
-        new Inline(null, text.s, precedingSpaces)
+        new Inline(null, 0, 0, text.s, precedingSpaces)
 
-      // Parser entry: takes ownership of `ownedBytes` (an exact-size copy
-      // of the atom's UTF-8 bytes) and defers the String allocation until
-      // the atom's `text` is first read.
-      private[stratiform] def fromBytes(ownedBytes: Array[Byte], precedingSpaces: Int): Inline =
-        new Inline(ownedBytes, null, precedingSpaces)
+      // Parser entry: references a slice of the per-parse atom arena. The
+      // arena array is shared with sibling atoms committed before the
+      // arena's next growth event. UTF-8 decode is deferred until
+      // `.text` is first accessed.
+      private[stratiform] def fromArena
+                    (arena: Array[Byte], off: Int, len: Int, precedingSpaces: Int)
+      :     Inline =
+        new Inline(arena, off, len, null, precedingSpaces)
 
       def unapply(i: Inline): (Text, Int) = (i.text, i.precedingSpaces)
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -634,7 +634,53 @@ object Tel extends Tel2:
   extends Subtree
 
   object Atom:
-    case class Inline(text: Text, precedingSpaces: Int) extends Atom
+    // Inline is a regular class (not a case class) so its `text` can be
+    // materialised lazily. The parser constructs each atom with a freshly
+    // allocated byte array (an OWNED, exact-size copy of the atom's UTF-8
+    // bytes) and pays the UTF-8 decode only on first `text` access.
+    // Consumers that never inspect an atom (parser-throughput benchmarks,
+    // partial decoders) avoid the per-atom String allocation entirely.
+    // The byte array is private and never shared with the parser's
+    // streaming buffer, so the atom's lifetime is independent of the
+    // Cursor it was parsed from. Apply / unapply preserve the previous
+    // case-class construction and pattern-match syntax; equality and
+    // hashCode are derived manually to match the prior structural
+    // behaviour.
+    final class Inline private[stratiform]
+      ( private val bytes:           Array[Byte] | Null,
+        private var _text:           String | Null,
+        val precedingSpaces:         Int )
+    extends Atom:
+
+      def text: Text =
+        val t = _text
+        if t == null then
+          val b = bytes.nn
+          val s = new String(b, 0, b.length, java.nio.charset.StandardCharsets.UTF_8)
+          _text = s
+          Text(s)
+        else Text(t)
+
+      override def equals(other: Any): Boolean = other match
+        case o: Inline => text == o.text && precedingSpaces == o.precedingSpaces
+        case _         => false
+
+      override def hashCode: Int = text.hashCode * 31 + precedingSpaces
+
+      override def toString: String = s"Inline($text,$precedingSpaces)"
+
+    object Inline:
+      def apply(text: Text, precedingSpaces: Int): Inline =
+        new Inline(null, text.s, precedingSpaces)
+
+      // Parser entry: takes ownership of `ownedBytes` (an exact-size copy
+      // of the atom's UTF-8 bytes) and defers the String allocation until
+      // the atom's `text` is first read.
+      private[stratiform] def fromBytes(ownedBytes: Array[Byte], precedingSpaces: Int): Inline =
+        new Inline(ownedBytes, null, precedingSpaces)
+
+      def unapply(i: Inline): (Text, Int) = (i.text, i.precedingSpaces)
+
     case class Source(text: Text)                       extends Atom
     case class Literal(delimiter: Text, text: Text)     extends Atom
 

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -159,7 +159,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // mark/slice/refill operation; resync after.
 
   private val cursor: Cursor[Data] = cursor0
-  private var heldToken: Cursor.Held | Null = null
   private var bytes:  Array[Byte] = null.asInstanceOf[Array[Byte]]
   private var pos:    Int = 0
   private var bufEnd: Int = 0
@@ -444,7 +443,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     if pos + n <= bufEnd then ()
     else
       syncTo()
-      val mk = cursor.mark(using heldToken.nn)
+      val mk = cursor.mark(using Cursor.shared)
       var steps = 0
       while steps < n && cursor.more do
         cursor.advance()
@@ -560,25 +559,24 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // never byte offsets into a particular buffer.
   //
   // `inHold` nests safely: an inner `inHold` does not change `holdStart`,
-  // it just acquires a fresh `Cursor.Held` token for the duration of the
-  // inner scope. `heldToken` is restored on exit so a method calling
-  // multiple sequential `inHold` scopes (or an outer method whose body
-  // delegates to inner `inHold`s) keeps a coherent view.
+  // it just executes inside the outer hold's protection. `Cursor.Held` is
+  // a witness type and `Cursor.shared` is a singleton we always pass to
+  // `cursor.mark` — there's no run-time tracking of "are we in a hold"
+  // inside the parser because no run-time decision depends on it; the
+  // compile-time `using Cursor.Held` requirement at every mark call site
+  // is the static guarantee that the code path is reachable only from
+  // inside a hold.
   private inline def inHold[T](inline body: => T): T =
     syncTo()
     cursor.hold:
-      val prev = heldToken
-      heldToken = summon[Cursor.Held]
       try
         syncFrom()
         body
-      finally
-        syncTo()
-        heldToken = prev
+      finally syncTo()
 
   private inline def beginMark(): Cursor.Mark =
     syncTo()
-    cursor.mark(using heldToken.nn)
+    cursor.mark(using Cursor.shared)
 
   // Materialise the byte range between `start` and the current position as
   // a UTF-8 `String`. The only allocation point in the keyword / atom path.
@@ -586,7 +584,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // resolves once here against `this.cursor`.
   private def sliceText(start: Cursor.Mark): String =
     syncTo()
-    val endMk = cursor.mark(using heldToken.nn)
+    val endMk = cursor.mark(using Cursor.shared)
     cursor.slice(start, endMk): (storage, off, len) =>
       val arr = storage.asInstanceOf[Array[Byte]]
       if len <= 0 then "" else new String(arr, off, len, StandardCharsets.UTF_8)
@@ -946,7 +944,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // path pays no per-line lineation cost. Runs inside its own hold so the
   // intermediate `consumeLineEnding` (which calls `peekNext` → `ensureLookahead`,
   // a mark-using lookahead) and `recoverOddIndent` (which calls `peekKeyword`,
-  // also mark-using) have a valid `heldToken`.
+  // also mark-using) execute inside an active `cursor.hold` scope.
   private def fillHead(): Unit raises TelError = inHold:
     head.startLine = lineNo
 

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -129,16 +129,19 @@ object TelParser:
   // Reused (mutated in place) across every line — single allocation per
   // parser instance.
   //
-  // Position is stored as a raw byte offset into the input buffer.
-  // Computing the 1-indexed source line is deferred to error-time
-  // (`errorAt` walks the buffer from 0 counting LFs) so the success path
-  // pays no per-line lineation cost.
+  // `startLine` is the 1-indexed source line number of this line. We store
+  // the line number directly (not a byte position) because the streaming
+  // parser uses narrow per-leaf holds: once a hold closes the cursor may
+  // compact the buffer, so a byte offset recorded earlier can no longer
+  // be used to compute a line number later. Line numbers are bumped
+  // incrementally at every LF-consumption point (consumeLineEnding plus
+  // the two raw LF advances in parseLiteralAtom).
   private final class LineHead:
     var leadingSpaces: Int = 0
     var indentLevels:  Int = 0      // (leadingSpaces - margin) / 2 or -1
     var blank:         Boolean = false
     var eof:           Boolean = false
-    var startBytePos:  Int = 0      // absolute byte position of line start
+    var startLine:     Int = 1      // 1-indexed source line of this line
 
 
 private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
@@ -156,11 +159,17 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   private var pos:    Int = 0
   private var bufEnd: Int = 0
 
-  // Local-buffer offset up to which the cursor's lineNo/columnNo are up to
-  // date. We use `linefeedByte` lineation on the cursor, but bypass its
-  // per-`advance()` track via direct `pos` increments, so the cursor only
-  // sees lineation updates when we manually reconcile here.
-  private var lineationPos: Int = 0
+  // Incrementally tracked 1-indexed source line number of the current
+  // cursor position. Bumped at every LF-consumption point — `consumeLineEnding`
+  // and the two raw `advance()` calls over LF in `parseLiteralAtom`. Stays
+  // valid across hold boundaries (and therefore across buffer compaction)
+  // because it doesn't depend on resident buffer bytes. The cursor's own
+  // `lineation` is left disabled on the hot path; we don't drive
+  // `cursor.unsafeBumpLine` because column reconstruction is done from the
+  // current buffer (always inside a hold containing the line's bytes) by
+  // `columnForCurrentBytePos`, which doesn't depend on the cursor's
+  // `columnNo`.
+  private var lineNo: Int = 1
 
   // ── Parser state ──────────────────────────────────────────────────────────
 
@@ -210,77 +219,35 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // Reusable string builder for source-atom / literal-atom payloads.
   private val sb: jl.StringBuilder = new jl.StringBuilder(256)
 
-  // Reusable Char[] buffer for inline-atom text. JsonParser uses the same
-  // pattern: append bytes-as-chars on the hot path, then `new String(chars,
-  // off, len)` once per atom — one allocation per atom instead of the two
-  // strings the previous `sliceText` + `sb.append` + `sb.toString` cycle
-  // produced.
-  private var atomChars: Array[Char] = new Array[Char](128)
-  private var atomCharCursor: Int    = 0
+  // Reusable byte accumulator for the inline-atom currently being parsed in
+  // parseCompoundLine. Atom bytes are copied into here as we read them, so
+  // they're independent of the cursor's buffer — refills inside the
+  // parseCompoundLine hold can compact and shift `bytes` without
+  // invalidating the in-flight atom. At commit time we snapshot the
+  // accumulator into a freshly allocated, exact-size `Array[Byte]` owned
+  // by the `Inline` atom.
+  private var atomBytes: Array[Byte] = new Array[Byte](64)
+  private var atomLen: Int = 0
 
-  private inline def resetAtomChars(): Unit = atomCharCursor = 0
+  private inline def resetAtom(): Unit = atomLen = 0
 
-  private inline def ensureAtomCharSpace(n: Int): Unit =
-    if atomCharCursor + n > atomChars.length then
-      var newLen = atomChars.length
-      while atomCharCursor + n > newLen do newLen *= 2
-      val grown = new Array[Char](newLen)
-      System.arraycopy(atomChars, 0, grown, 0, atomCharCursor)
-      atomChars = grown
+  private inline def atomReserve(n: Int): Unit =
+    if atomLen + n > atomBytes.length then
+      var newLen = atomBytes.length
+      while atomLen + n > newLen do newLen *= 2
+      val grown = new Array[Byte](newLen)
+      System.arraycopy(atomBytes, 0, grown, 0, atomLen)
+      atomBytes = grown
 
-  private inline def appendAtomChar(c: Char): Unit =
-    if atomCharCursor == atomChars.length then ensureAtomCharSpace(1)
-    atomChars(atomCharCursor) = c
-    atomCharCursor += 1
+  private inline def atomAppend(b: Byte): Unit =
+    atomReserve(1)
+    atomBytes(atomLen) = b
+    atomLen += 1
 
-  // Decode UTF-8 bytes at `bytes(off..off+len)` and append as Chars to the
-  // atom buffer. ASCII fast-path; multi-byte sequences are decoded inline.
-  private def appendBytesAsAtomChars(src: Array[Byte], off: Int, len: Int): Unit =
-    ensureAtomCharSpace(len)  // upper bound (chars ≤ bytes for UTF-8)
-    var i = 0
-    while i < len do
-      val b = src(off + i)
-      if (b & 0x80) == 0 then
-        atomChars(atomCharCursor) = (b & 0xFF).toChar
-        atomCharCursor += 1
-        i += 1
-      else
-        val u = b & 0xFF
-        if (u & 0xE0) == 0xC0 then
-          val b2 = src(off + i + 1) & 0x3F
-          atomChars(atomCharCursor) = (((u & 0x1F) << 6) | b2).toChar
-          atomCharCursor += 1
-          i += 2
-        else if (u & 0xF0) == 0xE0 then
-          val b2 = src(off + i + 1) & 0x3F
-          val b3 = src(off + i + 2) & 0x3F
-          atomChars(atomCharCursor) = (((u & 0x0F) << 12) | (b2 << 6) | b3).toChar
-          atomCharCursor += 1
-          i += 3
-        else if (u & 0xF8) == 0xF0 then
-          val b2 = src(off + i + 1) & 0x3F
-          val b3 = src(off + i + 2) & 0x3F
-          val b4 = src(off + i + 3) & 0x3F
-          val cp = ((u & 0x07) << 18) | (b2 << 12) | (b3 << 6) | b4
-          if cp >= 0x10000 then
-            val adj = cp - 0x10000
-            ensureAtomCharSpace(2)
-            atomChars(atomCharCursor) = (0xD800 | (adj >>> 10)).toChar
-            atomChars(atomCharCursor + 1) = (0xDC00 | (adj & 0x3FF)).toChar
-            atomCharCursor += 2
-          else
-            atomChars(atomCharCursor) = cp.toChar
-            atomCharCursor += 1
-          i += 4
-        else
-          atomChars(atomCharCursor) = '�'
-          atomCharCursor += 1
-          i += 1
-
-  // Materialise the atom buffer's [start..atomCharCursor) range as a Text,
-  // exactly one allocation.
-  private inline def atomCharsToText(start: Int): Text =
-    Text(new String(atomChars, start, atomCharCursor - start))
+  private inline def atomAppendRange(src: Array[Byte], off: Int, len: Int): Unit =
+    atomReserve(len)
+    System.arraycopy(src, off, atomBytes, atomLen, len)
+    atomLen += len
 
   // ── Keyword interning cache ───────────────────────────────────────────────
   // 64-slot two-Long fingerprint cache. The byte-level variant: the first
@@ -300,31 +267,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
     pos    = cursor.unsafePos(using Unsafe)
     bufEnd = cursor.unsafeWriteEnd(using Unsafe)
-    lineationPos = pos
-
-  // Walk the buffer bytes between `lineationPos` and the cursor's current
-  // position, bumping `cursor.lineNo` / `cursor.columnNo` accordingly. Must
-  // be called before any refill that may discard consumed bytes, and before
-  // any cursor read that needs accurate line/column (mark, error reporting).
-  private def reconcileLineation(): Unit =
-    val end = cursor.unsafePos(using Unsafe)
-    if lineationPos < end then
-      var i = lineationPos
-      var newlines = 0
-      var lastNewlineAt = -1
-      while i < end do
-        if bytes(i) == LF then
-          newlines += 1
-          lastNewlineAt = i
-        i += 1
-
-      if newlines > 0 then
-        cursor.unsafeBumpLine(newlines)(using Unsafe)
-        cursor.unsafeSetColumn(end - lastNewlineAt - 1)(using Unsafe)
-      else
-        cursor.unsafeBumpColumn(end - lineationPos)(using Unsafe)
-
-      lineationPos = end
 
   private inline def more: Boolean = pos < bufEnd || moreSlow()
 
@@ -432,20 +374,11 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // ── Errors ────────────────────────────────────────────────────────────────
 
-  // Compute the 1-indexed line number for a given absolute byte position by
-  // walking the held buffer from offset 0 and counting LFs. Outer-hold
-  // pins basePos at 0 so byte positions index directly into `bytes`.
-  // O(N) per error; never runs on the success path.
-  private def lineForBytePos(bytePos: Int): Int =
-    var i = 0
-    var line = 1
-    while i < bytePos do
-      if bytes(i) == LF then line += 1
-      i += 1
-    line
-
   // Compute the column corresponding to the current cursor position
-  // (1-indexed; 1 = first byte of line).
+  // (1-indexed; 1 = first byte of line). Walks the *current* buffer backwards
+  // looking for the most-recent LF. Because errors are always raised while a
+  // hold is active around the line being parsed, the line's starting LF (or
+  // start-of-stream) is always inside the resident region of the buffer.
   private def columnForCurrentBytePos(): Int =
     var i = pos - 1
     var col = 1
@@ -455,20 +388,42 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     col
 
   private def errorHere(reason: Reason): Nothing raises TelError =
-    syncTo()
-    val line = lineForBytePos(pos)
     val column = columnForCurrentBytePos()
-    abort(TelError(reason, TelError.Position(line, column)))
+    abort(TelError(reason, TelError.Position(lineNo, column)))
 
-  // `lineBytePos` is the absolute byte offset of the offending line's start
-  // (or anywhere on that line). The 1-indexed source line is computed
-  // lazily via `lineForBytePos`.
-  private def errorAt(reason: Reason, lineBytePos: Int, column: Int)
+  // Direct line-number variant: callers pass the 1-indexed source line of
+  // the offending location and its column.
+  private def errorAt(reason: Reason, line: Int, column: Int)
   :     Nothing raises TelError =
-    val line = lineForBytePos(lineBytePos)
     abort(TelError(reason, TelError.Position(line, column)))
 
   // ── Mark / hold plumbing ──────────────────────────────────────────────────
+  //
+  // The streaming parser uses narrow per-leaf holds: every method that takes
+  // a `cursor.mark` (or that calls down to one — `peekNext`, `ensureLookahead`,
+  // `consumeLineEnding`, `sliceText`, etc.) wraps its mark-using scope in
+  // `inHold`. Outside any hold, the cursor is free to compact away consumed
+  // bytes when a refill needs space; that's exactly the streaming property
+  // we want. State carried between holds is restricted to plain primitives
+  // — `head.*`, `lineNo`, `prevLineWasBoundary`, accumulated `sb` content —
+  // never byte offsets into a particular buffer.
+  //
+  // `inHold` nests safely: an inner `inHold` does not change `holdStart`,
+  // it just acquires a fresh `Cursor.Held` token for the duration of the
+  // inner scope. `heldToken` is restored on exit so a method calling
+  // multiple sequential `inHold` scopes (or an outer method whose body
+  // delegates to inner `inHold`s) keeps a coherent view.
+  private inline def inHold[T](inline body: => T): T =
+    syncTo()
+    cursor.hold:
+      val prev = heldToken
+      heldToken = summon[Cursor.Held]
+      try
+        syncFrom()
+        body
+      finally
+        syncTo()
+        heldToken = prev
 
   private inline def beginMark(): Cursor.Mark =
     syncTo()
@@ -489,24 +444,20 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   def parse(): Tel.Document raises TelError =
     syncFrom()
-    cursor.hold:
-      heldToken = summon[Cursor.Held]
-      try
-        checkBom()
-        val directive = parseInterpreterDirective()
-        val pragma = parsePragma()
-        fillHead()  // park head at the next line
-        if directive.absent && pragma.absent then determineMargin()
-        else
-          // A directive or pragma may be followed by blank lines before the
-          // first content line; consume them so parseChildren can dispatch
-          // on a real content line.
-          margin = 0
-          while head.blank && !head.eof do fillHead()
+    checkBom()
+    val directive = parseInterpreterDirective()
+    val pragma = parsePragma()
+    fillHead()  // park head at the next line
+    if directive.absent && pragma.absent then determineMargin()
+    else
+      // A directive or pragma may be followed by blank lines before the
+      // first content line; consume them so parseChildren can dispatch
+      // on a real content line.
+      margin = 0
+      while head.blank && !head.eof do fillHead()
 
-        val children = parseChildren(parentIndent = -1)
-        Tel.Document(directive, pragma, lineEndings, children)
-      finally heldToken = null
+    val children = parseChildren(parentIndent = -1)
+    Tel.Document(directive, pragma, lineEndings, children)
 
   // ── BOM ──────────────────────────────────────────────────────────────────
 
@@ -530,7 +481,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // Reads "#!..." line if present. The directive payload excludes the
   // "#!" prefix and the terminating LF.
-  private def parseInterpreterDirective(): Optional[Text] raises TelError =
+  private def parseInterpreterDirective(): Optional[Text] raises TelError = inHold:
     // We can peek the first two bytes without consuming.
     if !more then Unset
     else if peek != '#'.toByte then Unset
@@ -554,10 +505,17 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // non-blank line. Marks before consuming any blanks; if the first
   // non-blank line is NOT a pragma, cues back so the cursor remains at
   // the original position and the caller can run determineMargin from
-  // scratch.
-  private def parsePragma(): Optional[Tel.Pragma] raises TelError =
+  // scratch. The mark must survive the blank-line scan, so the entire
+  // body runs inside one hold.
+  private def parsePragma(): Optional[Tel.Pragma] raises TelError = inHold:
+    // `pragmaStartAbs` is the absolute byte position of the start of the
+    // first non-blank line, used to check the 4096-byte pragma cap (§3.5)
+    // against absolute stream position rather than the (possibly compacted)
+    // buffer-relative `pos`. Computed via cursor.position after syncTo so it
+    // remains correct once we narrow holds elsewhere in the parser.
     val mk = beginMark()
     val savedBoundary = prevLineWasBoundary
+    val savedLineNo = lineNo
 
     // Skip blank lines (consuming them; we may cue back).
     var foundPragma: Optional[Tel.Pragma] = Unset
@@ -570,18 +528,22 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       else
         // First non-blank line. Is it a pragma?
         if spaceCount == 0 && startsWithPragma() then
-          val pragmaLineBytePos = pos  // line start (no leading spaces consumed)
-          if pos >= 4096 then
-            errorAt(Reason.PragmaTooLong, pragmaLineBytePos, 1)
+          val pragmaLine = lineNo
+          syncTo()
+          val pragmaStartAbs = cursor.position.n0
+          if pragmaStartAbs >= 4096 then
+            errorAt(Reason.PragmaTooLong, pragmaLine, 1)
           val pragmaMk = beginMark()
           while more && peek != LF && peek != CR do advance()
           val payload = sliceText(pragmaMk)
-          if pos > 4096 then
-            errorAt(Reason.PragmaTooLong, pragmaLineBytePos, 1)
+          syncTo()
+          val pragmaEndAbs = cursor.position.n0
+          if pragmaEndAbs > 4096 then
+            errorAt(Reason.PragmaTooLong, pragmaLine, 1)
           consumeLineEnding()
           prevLineWasBoundary = true
           hasConsumedNonBlankLine = true
-          foundPragma = Optional(parsePragmaContent(payload, pragmaLineBytePos))
+          foundPragma = Optional(parsePragmaContent(payload, pragmaLine))
         done = true
 
     if foundPragma.present then foundPragma
@@ -591,6 +553,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       cursor.cue(mk)
       syncFrom()
       prevLineWasBoundary = savedBoundary
+      lineNo = savedLineNo
       Unset
 
   // Count leading spaces at the current position (does not consume the LF /
@@ -615,6 +578,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       if !lineEndingsDetected then detectLineEndingMode(crBefore = false)
       else if crlfMode then errorHere(Reason.BadLineEnding)
       advance()
+      lineNo += 1
       if !more then documentEndsWithLf = true
     else if peek == CR then
       val next = peekNext()
@@ -624,6 +588,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         else if !crlfMode then errorHere(Reason.BadLineEnding)
         advance()  // CR
         advance()  // LF
+        lineNo += 1
         if !more then documentEndsWithLf = true
     else
       // not at a line ending — caller error
@@ -643,15 +608,15 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       else true  // exactly "tel" at EOF
     else false
 
-  private def parsePragmaContent(content: String, lineBytePos: Int)
+  private def parsePragmaContent(content: String, line: Int)
   : Tel.Pragma raises TelError =
     val parts = splitPragmaPhrases(content)
-    if parts.head != "tel" then errorAt(Reason.PragmaNotFirst, lineBytePos, 1)
+    if parts.head != "tel" then errorAt(Reason.PragmaNotFirst, line, 1)
     val version =
-      if parts.length >= 2 then parseVersion(parts(1), lineBytePos)
+      if parts.length >= 2 then parseVersion(parts(1), line)
       else (1, 0)
 
-    if parts.length > 4 then errorAt(Reason.ExtraPragmaContent, lineBytePos, 1)
+    if parts.length > 4 then errorAt(Reason.ExtraPragmaContent, line, 1)
 
     val schemaText: Optional[Text] =
       if parts.length >= 3 then
@@ -661,30 +626,30 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
         val isBase256 = s.exists(_.toInt > 127)
         if !isUrl && !isHexHash && !isBase256
-        then errorAt(Reason.BadSchemaIdentifier, lineBytePos, 1)
+        then errorAt(Reason.BadSchemaIdentifier, line, 1)
         Text(s): Optional[Text]
       else Unset
 
     val pragmaSigil: Optional[Char] =
       if parts.length >= 4 && parts(3).length == 1 then
         val c = parts(3).charAt(0)
-        if c.isLetterOrDigit then errorAt(Reason.BadSigil, lineBytePos, 1)
+        if c.isLetterOrDigit then errorAt(Reason.BadSigil, line, 1)
         sigil = c.toByte
         c: Optional[Char]
       else Unset
 
     Tel.Pragma(version, schemaText, pragmaSigil)
 
-  private def parseVersion(s: String, lineBytePos: Int)
+  private def parseVersion(s: String, line: Int)
   : (Int, Int) raises TelError =
     val dot = s.indexOf('.')
-    if dot <= 0 || dot == s.length - 1 then errorAt(Reason.BadVersion, lineBytePos, 1)
+    if dot <= 0 || dot == s.length - 1 then errorAt(Reason.BadVersion, line, 1)
     try
       val major = s.substring(0, dot).toInt
       val minor = s.substring(dot + 1).toInt
-      if major < 0 || minor < 0 then errorAt(Reason.BadVersion, lineBytePos, 1)
+      if major < 0 || minor < 0 then errorAt(Reason.BadVersion, line, 1)
       (major, minor)
-    catch case _: NumberFormatException => errorAt(Reason.BadVersion, lineBytePos, 1)
+    catch case _: NumberFormatException => errorAt(Reason.BadVersion, line, 1)
 
   private def splitPragmaPhrases(content: String): List[String] =
     val parts = scala.collection.mutable.ListBuffer.empty[String]
@@ -799,7 +764,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // compute admissibility at both candidate depths via the current ancestor
   // stack and pick deeper if and only if shallower is invalid AND deeper is
   // valid; tie-break favours shallower.
-  private def recoverOddIndent(spaces: Int, lineBytePos: Int): Int raises TelError =
+  private def recoverOddIndent(spaces: Int, line: Int): Int raises TelError =
     val rel = spaces - margin
     schema.let: s =>
       val shallower = rel / 2
@@ -817,7 +782,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         deeperParent.let(p => keywordAdmissible(p, keyword, s)).or(false)
       if !shallowerValid && deeperValid then deeper else shallower
     .or:
-      errorAt(Reason.OddIndentation, lineBytePos, 1)
+      errorAt(Reason.OddIndentation, line, 1)
 
   // ── Line-head fill ───────────────────────────────────────────────────────
 
@@ -825,11 +790,14 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // byte (or LF/EOF for a blank line). Updates `head` in place. Always
   // advances past EOF cleanly: head.eof = true, head.blank = true.
   //
-  // No reconcileLineation: the line number is recovered lazily from
-  // head.startBytePos at error-time. The success path runs through fillHead
-  // without paying any per-line lineation cost.
-  private def fillHead(): Unit raises TelError =
-    head.startBytePos = pos
+  // The 1-indexed line number is read from the incrementally-maintained
+  // `lineNo` counter (bumped at every LF-consumption point), so the success
+  // path pays no per-line lineation cost. Runs inside its own hold so the
+  // intermediate `consumeLineEnding` (which calls `peekNext` → `ensureLookahead`,
+  // a mark-using lookahead) and `recoverOddIndent` (which calls `peekKeyword`,
+  // also mark-using) have a valid `heldToken`.
+  private def fillHead(): Unit raises TelError = inHold:
+    head.startLine = lineNo
 
     val spaces = countLeadingSpaces()
     head.leadingSpaces = spaces
@@ -852,9 +820,9 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       val rel = spaces - margin
       head.indentLevels =
         if rel < 0 then
-          errorAt(Reason.LessThanMargin, head.startBytePos, 1)
+          errorAt(Reason.LessThanMargin, head.startLine, 1)
         else if rel % 2 == 0 then rel / 2
-        else recoverOddIndent(spaces, head.startBytePos)
+        else recoverOddIndent(spaces, head.startLine)
 
   // ── parseChildren ────────────────────────────────────────────────────────
 
@@ -870,7 +838,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       // After consuming children at `expected`, a remaining non-blank line
       // more indented than `expected` is an error.
       if !head.eof && head.indentLevels > expected then
-        val line = head.startBytePos
+        val line = head.startLine
         builder.lastOption match
           case Some(last) if last.tabulation.present && last.compounds.isEmpty =>
             errorAt(Reason.RowWrongIndent, line, 1)
@@ -900,7 +868,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       // content line (compound / tabulation) at indent ≥ this comment's.
       if !prevLineWasBoundary && prevContentLeadingSpaces >= 0
          && prevContentLeadingSpaces >= margin + indent * 2
-      then errorAt(Reason.CommentNotPreceded, head.startBytePos, 1)
+      then errorAt(Reason.CommentNotPreceded, head.startLine, 1)
 
       val text = parseCommentLine()
       comments += Tel.Comment(text)
@@ -935,7 +903,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       if isCommentBody() || isTabulationBody() then keepLoop = false
       else
         val compoundLeadingSpaces = head.leadingSpaces
-        val compoundLine = head.startBytePos
+        val compoundLine = head.startLine
         // §16.2: validate tabulated rows BEFORE parseCompoundLine consumes
         // the row's bytes. validateTabulatedRowInline uses mark + cue so the
         // cursor remains parked at the row start for parseCompoundLine.
@@ -973,13 +941,15 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // After the comment-group, consume blank lines if the next non-blank line
   // is a content (not comment) line at the same `indent`. Otherwise leave
-  // the blanks for the enclosing block. Uses mark+cue.
+  // the blanks for the enclosing block. Uses mark+cue. The hold spans the
+  // entire probe so the mark survives every nested fillHead.
   private def skipInteriorBlanksIfFollowedByContentAtIndent(indent: Int)
-  : Unit raises TelError =
+  : Unit raises TelError = inHold:
     val mk = beginMark()
     val savedHeadSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
-                             head.eof, head.startBytePos)
+                             head.eof, head.startLine)
     val savedBoundary = prevLineWasBoundary
+    val savedLineNo = lineNo
     while !head.eof && head.blank do fillHead()
     val keep =
       !head.eof && head.indentLevels == indent && !isCommentBody()
@@ -992,8 +962,9 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       head.indentLevels  = savedHeadSnapshot._2
       head.blank         = savedHeadSnapshot._3
       head.eof           = savedHeadSnapshot._4
-      head.startBytePos     = savedHeadSnapshot._5
+      head.startLine     = savedHeadSnapshot._5
       prevLineWasBoundary = savedBoundary
+      lineNo = savedLineNo
       // Re-park: skip leading spaces of the line we just rewound to.
       var i = 0
       while i < savedHeadSnapshot._1 && more && peek == SP do
@@ -1015,11 +986,12 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         1
       else 0
     else if !head.blank then 0
-    else
+    else inHold:
       val mk = beginMark()
       val firstBlankSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
-                                head.eof, head.startBytePos)
+                                head.eof, head.startLine)
       val savedBoundary = prevLineWasBoundary
+      val savedLineNo = lineNo
       var count = 0
       while !head.eof && head.blank do
         count += 1
@@ -1038,8 +1010,9 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         head.indentLevels  = firstBlankSnapshot._2
         head.blank         = firstBlankSnapshot._3
         head.eof           = firstBlankSnapshot._4
-        head.startBytePos     = firstBlankSnapshot._5
+        head.startLine     = firstBlankSnapshot._5
         prevLineWasBoundary = savedBoundary
+        lineNo = savedLineNo
         var i = 0
         while i < firstBlankSnapshot._1 && more && peek == SP do
           advance()
@@ -1051,7 +1024,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // True iff the parked head's first content byte is the sigil and the
   // line is a comment (sigil-only or sigil + soft space + text), as opposed
   // to a tabulation line or `#foo`-style keyword.
-  private def isCommentBody(): Boolean raises TelError =
+  private def isCommentBody(): Boolean raises TelError = inHold:
     if !more || peek != sigil then false
     else
       // Peek the rest of the line to decide between comment and tabulation.
@@ -1070,7 +1043,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // Returns true iff the parked head's line, when read forward from current
   // position, contains a 2-space-or-more run followed by sigil somewhere
   // before the next LF. Uses mark+cue.
-  private def lineHasTabulationMarker(): Boolean raises TelError =
+  private def lineHasTabulationMarker(): Boolean raises TelError = inHold:
     val mk = beginMark()
     var found = false
     var done = false
@@ -1094,14 +1067,14 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     syncFrom()
     found
 
-  private def isTabulationBody(): Boolean raises TelError =
+  private def isTabulationBody(): Boolean raises TelError = inHold:
     if !more || peek != sigil then false
     else lineHasTabulationMarker()
 
   // ── Comment parsing ──────────────────────────────────────────────────────
 
   // Cursor is at the sigil. Returns the comment text, advancing past LF.
-  private def parseCommentLine(): Text raises TelError =
+  private def parseCommentLine(): Text raises TelError = inHold:
     // Consume the sigil.
     advance()
     if !more || peek == LF || peek == CR then
@@ -1128,7 +1101,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // Cursor is at the sigil. Reads marker offsets + headings, advances past
   // LF.
-  private def parseTabulationLine(): Tel.Tabulation raises TelError =
+  private def parseTabulationLine(): Tel.Tabulation raises TelError = inHold:
     val lineStartCol = head.leadingSpaces  // first marker offset (column 0 = sigil)
     val markers = scala.collection.mutable.ArrayBuffer.empty[Int]
     val headings = scala.collection.mutable.ArrayBuffer.empty[Text]
@@ -1150,7 +1123,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         headings += t""
         done = true
       else if peek != SP then
-        errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
+        errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
       else
         // peek == SP
         // Check if the next byte is also a space — if so, heading is empty
@@ -1174,7 +1147,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
             done = true
           else
             // E120: more spaces or non-sigil content after empty.
-            errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
+            errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
         else
           // One soft space — heading text follows.
           advance(); lineCol += 1
@@ -1186,7 +1159,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               headingEnd = lineCol
               stop = true
             else if peek == sigil then
-              errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
+              errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
             else if peek == SP then
               // Hard space check: two spaces in a row?
               val nb = peekNext()
@@ -1211,7 +1184,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               // Loop continues.
             else if !more || peek == LF || peek == CR then done = true
             else
-              errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
+              errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
 
     consumeLineEnding()
     Tel.Tabulation(IArray.from(markers), IArray.from(headings))
@@ -1225,7 +1198,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // parseCompoundLine call.
   private def validateTabulatedRowInline
     ( rowLeadingSpaces: Int, tabulation: Tel.Tabulation, lineNumber: Int )
-  : Unit raises TelError =
+  : Unit raises TelError = inHold:
     val markers = tabulation.markerOffsets
     val mk = beginMark()
     var col = rowLeadingSpaces
@@ -1292,9 +1265,9 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       // §10.4 / §11.1: at most one source / literal atom per compound.
       if first.present && !head.eof && !head.blank then
         if head.leadingSpaces == literalIndent
-        then errorAt(Reason.DuplicateLiteral, head.startBytePos, 1)
+        then errorAt(Reason.DuplicateLiteral, head.startLine, 1)
         else if head.leadingSpaces == sourceIndent
-        then errorAt(Reason.DuplicateSource, head.startBytePos, 1)
+        then errorAt(Reason.DuplicateSource, head.startLine, 1)
 
       first
 
@@ -1321,35 +1294,41 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           documentEndsWithLf = false
         done = true
       else if head.blank then
-        // Probe across blanks to see if more source follows.
-        val mk = beginMark()
-        val firstBlankSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
-                                  head.eof, head.startBytePos)
-        val savedBoundary = prevLineWasBoundary
-        var blanks = 0
-        while !head.eof && head.blank do
-          blanks += 1
-          fillHead()
-        val keep = head.eof || head.leadingSpaces >= sourceIndent
-        if keep then
-          // Emit `blanks` empty lines.
-          var i = 0
-          while i < blanks do { sb.append('\n'); i += 1 }
-        else
-          // Rewind.
-          syncTo()
-          cursor.cue(mk)
-          syncFrom()
-          head.leadingSpaces = firstBlankSnapshot._1
-          head.indentLevels  = firstBlankSnapshot._2
-          head.blank         = firstBlankSnapshot._3
-          head.eof           = firstBlankSnapshot._4
-          head.startBytePos     = firstBlankSnapshot._5
-          prevLineWasBoundary = savedBoundary
-          var i = 0
-          while i < firstBlankSnapshot._1 && more && peek == SP do
-            advance(); i += 1
-          done = true
+        // Probe across blanks to see if more source follows. The mark must
+        // survive several nested fillHead calls so the probe runs inside its
+        // own hold; the cursor is free to compact again once the probe ends.
+        done = inHold:
+          val mk = beginMark()
+          val firstBlankSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
+                                    head.eof, head.startLine)
+          val savedBoundary = prevLineWasBoundary
+          val savedLineNo = lineNo
+          var blanks = 0
+          while !head.eof && head.blank do
+            blanks += 1
+            fillHead()
+          val keep = head.eof || head.leadingSpaces >= sourceIndent
+          if keep then
+            // Emit `blanks` empty lines.
+            var i = 0
+            while i < blanks do { sb.append('\n'); i += 1 }
+            false
+          else
+            // Rewind.
+            syncTo()
+            cursor.cue(mk)
+            syncFrom()
+            head.leadingSpaces = firstBlankSnapshot._1
+            head.indentLevels  = firstBlankSnapshot._2
+            head.blank         = firstBlankSnapshot._3
+            head.eof           = firstBlankSnapshot._4
+            head.startLine     = firstBlankSnapshot._5
+            prevLineWasBoundary = savedBoundary
+            lineNo = savedLineNo
+            var i = 0
+            while i < firstBlankSnapshot._1 && more && peek == SP do
+              advance(); i += 1
+            true
       else if head.leadingSpaces >= sourceIndent then
         // Read content: skip the first sourceIndent spaces — but wait, the
         // fillHead already consumed all leading spaces. We need to back up
@@ -1368,20 +1347,22 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         while i < excess do { sb.append(' '); i += 1 }
 
         // Now read the line content (until LF/CR), tracking trailing spaces
-        // so we can strip them.
-        val mk = beginMark()
-        while
-          scanUntil2(LF, CR, TelParser.LfRepl, TelParser.CrRepl)
-          pos == bufEnd && more
-        do ()
-        val payload = sliceText(mk)
-        // Strip trailing spaces.
-        var endIdx = payload.length
-        while endIdx > 0 && payload.charAt(endIdx - 1) == ' ' do endIdx -= 1
-        sb.append(payload, 0, endIdx)
-        sb.append('\n')
+        // so we can strip them. One hold per payload line so the cursor can
+        // compact between lines.
+        inHold:
+          val mk = beginMark()
+          while
+            scanUntil2(LF, CR, TelParser.LfRepl, TelParser.CrRepl)
+            pos == bufEnd && more
+          do ()
+          val payload = sliceText(mk)
+          // Strip trailing spaces.
+          var endIdx = payload.length
+          while endIdx > 0 && payload.charAt(endIdx - 1) == ' ' do endIdx -= 1
+          sb.append(payload, 0, endIdx)
+          sb.append('\n')
 
-        consumeLineEnding()
+          consumeLineEnding()
         fillHead()
       else done = true
 
@@ -1394,19 +1375,19 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // everything between the next LF and the first line whose content equals
   // the delimiter (at column 0 / flush left).
   private def parseLiteralAtom(literalIndent: Int): Tel.Atom.Literal raises TelError =
-    val openingLine = head.startBytePos
+    val openingLine = head.startLine
     // Read the delimiter — opening line, terminated by LF or CR per the
-    // document's line-ending mode.
-    val delimMk = beginMark()
-    while
-      scanUntil2(LF, CR, TelParser.LfRepl, TelParser.CrRepl)
-      pos == bufEnd && more
-    do ()
-    val delimiter = sliceText(delimMk)
-    // The opening line is now consumed up to but not including the LF.
-    // Empty-payload case: if next line is the closing delimiter exactly,
-    // payload is empty.
-    consumeLineEnding()
+    // document's line-ending mode. One hold for the opening line.
+    val delimiter: String = inHold:
+      val delimMk = beginMark()
+      while
+        scanUntil2(LF, CR, TelParser.LfRepl, TelParser.CrRepl)
+        pos == bufEnd && more
+      do ()
+      val d = sliceText(delimMk)
+      // The opening line is now consumed up to but not including the LF.
+      consumeLineEnding()
+      d
 
     sb.setLength(0)
     var done = false
@@ -1414,34 +1395,38 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       if !more then errorAt(Reason.UnclosedLiteral, openingLine, 1)
       // Read a line. Inside the literal payload, line endings are not
       // subject to the document's LF/CRLF mode (per §15 the payload is
-      // verbatim, with CRLF normalised to LF). SWAR-scan for LF; any
-      // preceding CR is captured in `raw` and stripped below.
-      val lineMk = beginMark()
-      while
-        scanUntil1(LF, TelParser.LfRepl)
-        pos == bufEnd && more
-      do ()
-      val raw = sliceText(lineMk)
-      val line = if raw.length > 0 && raw.charAt(raw.length - 1) == '\r'
-                 then raw.substring(0, raw.length - 1) else raw
-      if line == delimiter then
-        // Closing delimiter — the LF *before* the closing delimiter is the
-        // delimiter's leading separator, not part of the payload. Strip the
-        // trailing '\n' we appended for the previous payload line (if any),
-        // then consume the optional EOL after the delimiter.
-        if sb.length > 0 && sb.charAt(sb.length - 1) == '\n' then
-          sb.setLength(sb.length - 1)
-        if more then
-          advance()  // consume LF (may be absent at EOF)
+      // verbatim, with CRLF normalised to LF). One hold per payload line so
+      // the cursor can compact between lines.
+      done = inHold:
+        val lineMk = beginMark()
+        while
+          scanUntil1(LF, TelParser.LfRepl)
+          pos == bufEnd && more
+        do ()
+        val raw = sliceText(lineMk)
+        val line = if raw.length > 0 && raw.charAt(raw.length - 1) == '\r'
+                   then raw.substring(0, raw.length - 1) else raw
+        if line == delimiter then
+          // Closing delimiter — the LF *before* the closing delimiter is the
+          // delimiter's leading separator, not part of the payload. Strip the
+          // trailing '\n' we appended for the previous payload line (if any),
+          // then consume the optional EOL after the delimiter.
+          if sb.length > 0 && sb.charAt(sb.length - 1) == '\n' then
+            sb.setLength(sb.length - 1)
+          if more then
+            advance()  // consume LF (may be absent at EOF)
+            lineNo += 1
+            if !more then documentEndsWithLf = true
+          true
+        else
+          // Payload line — must have an LF terminator; EOF here is E115.
+          if !more then errorAt(Reason.UnclosedLiteral, openingLine, 1)
+          advance()  // consume LF
+          lineNo += 1
           if !more then documentEndsWithLf = true
-        done = true
-      else
-        // Payload line — must have an LF terminator; EOF here is E115.
-        if !more then errorAt(Reason.UnclosedLiteral, openingLine, 1)
-        advance()  // consume LF
-        if !more then documentEndsWithLf = true
-        sb.append(line)
-        sb.append('\n')
+          sb.append(line)
+          sb.append('\n')
+          false
 
     fillHead()
     // §15 normalises CRLF to LF inside the payload, but since we read line
@@ -1453,7 +1438,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // Cursor is at the first content byte (past leading spaces). Returns the
   // parsed compound (keyword + atoms + remark, children left empty for the
   // caller to fill in).
-  private def parseCompoundLine(lineNumber: Int): Tel.Compound raises TelError =
+  private def parseCompoundLine(lineNumber: Int): Tel.Compound raises TelError = inHold:
     val isAtColumnZero = head.leadingSpaces == 0
     val mayBeMisplacedPragma = isAtColumnZero && hasConsumedNonBlankLine
 
@@ -1469,16 +1454,25 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
     val atoms = scala.collection.mutable.ArrayBuffer.empty[Tel.Atom]
     var remark: Optional[Text] = Unset
-    resetAtomChars()
-    var atomStart = 0       // start index into atomChars for the open atom
+    // Accumulate atom bytes into the parser-owned `atomBytes` buffer rather
+    // than tracking buffer offsets into the cursor's `bytes`. With narrow
+    // holds, `parseCompoundLine`'s hold has `holdStart > 0`, so refills
+    // inside the line compact and shift `bytes`'s live content — buffer
+    // offsets recorded before the refill would no longer point at the right
+    // content. Copying bytes into a parser-local accumulator sidesteps that
+    // entirely; at commit we snapshot the accumulator into a freshly
+    // allocated, exact-size `Array[Byte]` owned by the `Inline` atom.
+    resetAtom()
     var precedingSpaces = 0
     var hardSpaceMode = false
     var atomOpen = false
 
     inline def commit(): Unit =
       if atomOpen then
-        atoms += Tel.Atom.Inline(atomCharsToText(atomStart), precedingSpaces)
-        atomStart = atomCharCursor
+        val owned = new Array[Byte](atomLen)
+        System.arraycopy(atomBytes, 0, owned, 0, atomLen)
+        atoms += Tel.Atom.Inline.fromBytes(owned, precedingSpaces)
+        resetAtom()
         atomOpen = false
 
     var stopped = false
@@ -1494,7 +1488,12 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               commit()
               precedingSpaces = run
             else
-              appendAtomChar(' ')
+              // Single space inside a hard-space-mode atom: the SP byte is
+              // part of the atom's content. atomOpen is necessarily already
+              // true here (hard-space-mode is only entered after a content
+              // commit, and hard-space-mode + run==1 only fires while
+              // reading content).
+              atomAppend(SP)
               atomOpen = true
           else
             if run == 1 then
@@ -1519,15 +1518,15 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
             while more && peek != LF && peek != CR do advance()
             remark = Text(sliceText(mk))
           else
-            appendAtomChar(ch.toChar)
-            atomOpen = true
+            atomAppend(ch)
             advance()
+            atomOpen = true
         else
-          // Read a run of non-space, non-sigil, non-LF, non-CR bytes
-          // directly into the char buffer — no intermediate String alloc.
-          // Atom runs in typical TEL are 2-12 bytes, too short for SWAR
-          // to amortise; we keep the byte loop and just direct-copy the
-          // range as UTF-8 → char in one shot.
+          // Read a run of non-space, non-sigil, non-LF, non-CR bytes,
+          // copying them into the parser-owned atom accumulator. After
+          // a refill compacts the cursor buffer, the source content stays
+          // valid because we read it out into our own array before the
+          // next refill can fire.
           val runStart = pos
           while pos < bufEnd
                 && bytes(pos) != SP
@@ -1537,13 +1536,14 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           do pos += 1
           val runLen = pos - runStart
           if runLen > 0 then
-            appendBytesAsAtomChars(bytes, runStart, runLen)
+            atomAppendRange(bytes, runStart, runLen)
             atomOpen = true
           else
-            // Could be a sigil while atomOpen — treat as content.
-            appendAtomChar(ch.toChar)
-            atomOpen = true
+            // Defensive: only reachable if the outer guards were ever
+            // relaxed. Treat the byte at `pos` as one atom byte.
+            atomAppend(ch)
             advance()
+            atomOpen = true
 
     commit()
 
@@ -1560,14 +1560,14 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // Read a keyword from the current position. The keyword runs until SP, LF,
   // CR, or EOF. Returns the interned `Text`. Uses the 64-slot fingerprint
-  // cache for ≤8-byte keywords (allocation-free on hit), one `grabText` on
-  // miss or for length > 8.
+  // cache for ≤8-byte keywords (allocation-free on hit). The keyword's
+  // start position is remembered via a `cursor.mark` (rather than a raw
+  // buffer offset) because the per-leaf hold under which `readKeyword`
+  // runs has `holdStart > 0`, so a refill inside the loop can compact the
+  // buffer and shift live content toward index 0 — the absolute-position
+  // mark survives that, a buffer-offset would not.
   private def readKeyword(): Text raises TelError =
-    // Track the byte offset directly instead of going through `cursor.mark`.
-    // With holdStart pinned at the outer hold's start (basePos stays 0),
-    // a refill never moves the byte at `startByte`; subsequent reads see
-    // the same data in the (possibly grown) buffer array.
-    val startByte = pos
+    val startMark = beginMark()
     var low:  Long = 0L
     var high: Long = 0L
     var len = 0
@@ -1585,7 +1585,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
     if len == 0 then t""
     else if len > 8 then
-      Text(new String(bytes, startByte, len, java.nio.charset.StandardCharsets.UTF_8))
+      Text(sliceText(startMark))
     else
       val hash = ((low ^ (low >>> 32)) ^ (high ^ (high >>> 17))).toInt
       var slot = hash & 0x3F
@@ -1594,7 +1594,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       while result == null && probes < 4 do
         val existing = keyCache(slot)
         if existing == null then
-          val s = new String(bytes, startByte, len, java.nio.charset.StandardCharsets.UTF_8)
+          val s = sliceText(startMark)
           keyCache(slot) = s
           keyCacheLow(slot) = low
           keyCacheHigh(slot) = high
@@ -1606,4 +1606,4 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           probes += 1
 
       if result != null then Text(result)
-      else Text(new String(bytes, startByte, len, java.nio.charset.StandardCharsets.UTF_8))
+      else Text(sliceText(startMark))

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -219,35 +219,64 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // Reusable string builder for source-atom / literal-atom payloads.
   private val sb: jl.StringBuilder = new jl.StringBuilder(256)
 
-  // Reusable byte accumulator for the inline-atom currently being parsed in
-  // parseCompoundLine. Atom bytes are copied into here as we read them, so
-  // they're independent of the cursor's buffer — refills inside the
-  // parseCompoundLine hold can compact and shift `bytes` without
-  // invalidating the in-flight atom. At commit time we snapshot the
-  // accumulator into a freshly allocated, exact-size `Array[Byte]` owned
-  // by the `Inline` atom.
-  private var atomBytes: Array[Byte] = new Array[Byte](64)
-  private var atomLen: Int = 0
+  // Atom-bytes arena: one growing byte buffer per parser instance into which
+  // every inline atom's UTF-8 bytes are written. Each `Tel.Atom.Inline`
+  // stores `(arenaArray, offset, length)` referring to a slice of the
+  // arena. When the arena's capacity is exhausted, the parser allocates a
+  // fresh, larger backing array; previously committed atoms keep the old
+  // arena array alive via their slice references. This replaces the prior
+  // "one freshly-allocated exact-size byte[] per atom" scheme: a workload
+  // with N atoms now performs O(log capacity) arena allocations instead of
+  // N per-atom allocations.
+  //
+  // `inFlightStart` is the arena offset where the currently-open atom
+  // started; -1 when no atom is open. On a mid-atom arena growth we carry
+  // the in-flight bytes (`atomArena(inFlightStart..arenaPos)`) into the
+  // new array at offset 0 so the atom remains contiguous; the old array
+  // (which still holds completed atoms) stays alive via their Inline
+  // references.
+  private var atomArena:     Array[Byte] = new Array[Byte](256)
+  private var arenaPos:      Int = 0
+  private var inFlightStart: Int = -1
 
-  private inline def resetAtom(): Unit = atomLen = 0
+  private inline def beginInFlightAtom(): Unit = inFlightStart = arenaPos
 
-  private inline def atomReserve(n: Int): Unit =
-    if atomLen + n > atomBytes.length then
-      var newLen = atomBytes.length
-      while atomLen + n > newLen do newLen *= 2
-      val grown = new Array[Byte](newLen)
-      System.arraycopy(atomBytes, 0, grown, 0, atomLen)
-      atomBytes = grown
+  private inline def endInFlightAtom(): Int =
+    val len = arenaPos - inFlightStart
+    inFlightStart = -1
+    len
 
-  private inline def atomAppend(b: Byte): Unit =
-    atomReserve(1)
-    atomBytes(atomLen) = b
-    atomLen += 1
+  private inline def arenaInFlightOffset: Int = inFlightStart
 
-  private inline def atomAppendRange(src: Array[Byte], off: Int, len: Int): Unit =
-    atomReserve(len)
-    System.arraycopy(src, off, atomBytes, atomLen, len)
-    atomLen += len
+  private inline def ensureArenaSpace(n: Int): Unit =
+    if arenaPos + n > atomArena.length then growArena(n)
+
+  // Non-inline: keep the slow path out of the inline budget. Allocates a
+  // fresh arena array sized to at least `arenaPos + n`, copies the
+  // in-flight atom's bytes (if any) into it starting at offset 0, and
+  // resets `arenaPos` accordingly. Already-committed atoms continue to
+  // reference the previous array.
+  private def growArena(n: Int): Unit =
+    val inFlightLen = if inFlightStart >= 0 then arenaPos - inFlightStart else 0
+    val needed = inFlightLen + n
+    var newCap = (atomArena.length * 2).max(256)
+    while newCap < needed do newCap *= 2
+    val newArena = new Array[Byte](newCap)
+    if inFlightLen > 0 then
+      System.arraycopy(atomArena, inFlightStart, newArena, 0, inFlightLen)
+    atomArena = newArena
+    if inFlightStart >= 0 then inFlightStart = 0
+    arenaPos = inFlightLen
+
+  private inline def appendToArena(b: Byte): Unit =
+    ensureArenaSpace(1)
+    atomArena(arenaPos) = b
+    arenaPos += 1
+
+  private inline def appendToArenaRange(src: Array[Byte], off: Int, len: Int): Unit =
+    ensureArenaSpace(len)
+    System.arraycopy(src, off, atomArena, arenaPos, len)
+    arenaPos += len
 
   // ── Honeycomb-style scratch buffers ───────────────────────────────────────
   // A single parser-lifetime array per child-collection type holds every
@@ -1589,25 +1618,21 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     hasConsumedNonBlankLine = true
 
     var remark: Optional[Text] = Unset
-    // Accumulate atom bytes into the parser-owned `atomBytes` buffer rather
-    // than tracking buffer offsets into the cursor's `bytes`. With narrow
-    // holds, `parseCompoundLine`'s hold has `holdStart > 0`, so refills
-    // inside the line compact and shift `bytes`'s live content — buffer
-    // offsets recorded before the refill would no longer point at the right
-    // content. Copying bytes into a parser-local accumulator sidesteps that
-    // entirely; at commit we snapshot the accumulator into a freshly
-    // allocated, exact-size `Array[Byte]` owned by the `Inline` atom.
-    resetAtom()
+    // Read atom bytes directly into the parser's atom-bytes arena. With
+    // narrow holds, parseCompoundLine's hold has holdStart > 0, so refills
+    // inside the line can compact and shift the cursor's `bytes` —
+    // we therefore copy bytes out into our own buffer (the arena) as we
+    // read them. Each Tel.Atom.Inline references its slice of the arena
+    // (arenaArray, offset, length); no per-atom byte[] is allocated.
     var precedingSpaces = 0
     var hardSpaceMode = false
     var atomOpen = false
 
     inline def commit(): Unit =
       if atomOpen then
-        val owned = new Array[Byte](atomLen)
-        System.arraycopy(atomBytes, 0, owned, 0, atomLen)
-        pushAtom(Tel.Atom.Inline.fromBytes(owned, precedingSpaces))
-        resetAtom()
+        val off = arenaInFlightOffset
+        val len = endInFlightAtom()
+        pushAtom(Tel.Atom.Inline.fromArena(atomArena, off, len, precedingSpaces))
         atomOpen = false
 
     var stopped = false
@@ -1628,7 +1653,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               // true here (hard-space-mode is only entered after a content
               // commit, and hard-space-mode + run==1 only fires while
               // reading content).
-              atomAppend(SP)
+              appendToArena(SP)
               atomOpen = true
           else
             if run == 1 then
@@ -1653,15 +1678,16 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
             while more && peek != LF && peek != CR do advance()
             remark = Text(sliceText(mk))
           else
-            atomAppend(ch)
+            beginInFlightAtom()
+            appendToArena(ch)
             advance()
             atomOpen = true
         else
           // Read a run of non-space, non-sigil, non-LF, non-CR bytes,
-          // copying them into the parser-owned atom accumulator. After
-          // a refill compacts the cursor buffer, the source content stays
-          // valid because we read it out into our own array before the
-          // next refill can fire.
+          // copying them into the parser's atom arena. After a refill
+          // compacts the cursor buffer, the source content stays valid
+          // because we read it out into our own arena before the next
+          // refill can fire.
           val runStart = pos
           while pos < bufEnd
                 && bytes(pos) != SP
@@ -1671,12 +1697,14 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           do pos += 1
           val runLen = pos - runStart
           if runLen > 0 then
-            atomAppendRange(bytes, runStart, runLen)
+            if !atomOpen then beginInFlightAtom()
+            appendToArenaRange(bytes, runStart, runLen)
             atomOpen = true
           else
             // Defensive: only reachable if the outer guards were ever
             // relaxed. Treat the byte at `pos` as one atom byte.
-            atomAppend(ch)
+            if !atomOpen then beginInFlightAtom()
+            appendToArena(ch)
             advance()
             atomOpen = true
 

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -249,6 +249,123 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     System.arraycopy(src, off, atomBytes, atomLen, len)
     atomLen += len
 
+  // ── Honeycomb-style scratch buffers ───────────────────────────────────────
+  // A single parser-lifetime array per child-collection type holds every
+  // pending child across the whole recursive descent. Each
+  // `parseBlock` / `parseCompoundLine` invocation snapshots the current
+  // index at scope-entry; on scope-exit it computes `count = current - start`,
+  // snapshots that range into a freshly allocated exact-size `Array` (wrapped
+  // as `IArray` via `.immutable(using Unsafe)`), and rewinds the index.
+  // Empty scopes return `IArray.empty` without any allocation.
+  //
+  // This replaces one `mutable.ArrayBuffer` (which itself allocates a backing
+  // array, grows geometrically, and copies on growth) + one `IArray.from`
+  // call per scope with a single exact-size `Array.copyOfRange` allocation
+  // per non-empty scope. For typical workloads (deep nesting, many siblings)
+  // it eliminates several thousand allocations per parse.
+
+  private var scratchAtoms:     Array[Tel.Atom]     = new Array[Tel.Atom](16)
+  private var atomScratchIx:    Int = 0
+
+  private var scratchComments:  Array[Tel.Comment]  = new Array[Tel.Comment](8)
+  private var commentScratchIx: Int = 0
+
+  private var scratchCompounds: Array[Tel.Compound] = new Array[Tel.Compound](8)
+  private var compoundScratchIx: Int = 0
+
+  private var scratchBlocks:    Array[Tel.Block]    = new Array[Tel.Block](16)
+  private var blockScratchIx:   Int = 0
+
+  private inline def reserveAtom(): Unit =
+    if atomScratchIx >= scratchAtoms.length then
+      val grown = new Array[Tel.Atom](scratchAtoms.length*2)
+      System.arraycopy(scratchAtoms, 0, grown, 0, atomScratchIx)
+      scratchAtoms = grown
+
+  private inline def reserveComment(): Unit =
+    if commentScratchIx >= scratchComments.length then
+      val grown = new Array[Tel.Comment](scratchComments.length*2)
+      System.arraycopy(scratchComments, 0, grown, 0, commentScratchIx)
+      scratchComments = grown
+
+  private inline def reserveCompound(): Unit =
+    if compoundScratchIx >= scratchCompounds.length then
+      val grown = new Array[Tel.Compound](scratchCompounds.length*2)
+      System.arraycopy(scratchCompounds, 0, grown, 0, compoundScratchIx)
+      scratchCompounds = grown
+
+  private inline def reserveBlock(): Unit =
+    if blockScratchIx >= scratchBlocks.length then
+      val grown = new Array[Tel.Block](scratchBlocks.length*2)
+      System.arraycopy(scratchBlocks, 0, grown, 0, blockScratchIx)
+      scratchBlocks = grown
+
+  private inline def pushAtom(atom: Tel.Atom): Unit =
+    reserveAtom()
+    scratchAtoms(atomScratchIx) = atom
+    atomScratchIx += 1
+
+  private inline def pushComment(c: Tel.Comment): Unit =
+    reserveComment()
+    scratchComments(commentScratchIx) = c
+    commentScratchIx += 1
+
+  private inline def pushCompound(c: Tel.Compound): Unit =
+    reserveCompound()
+    scratchCompounds(compoundScratchIx) = c
+    compoundScratchIx += 1
+
+  private inline def pushBlock(b: Tel.Block): Unit =
+    reserveBlock()
+    scratchBlocks(blockScratchIx) = b
+    blockScratchIx += 1
+
+  // Extract `count` items ending at the current index, rewind, and return
+  // them as an IArray. Empty scopes return the shared empty IArray with
+  // zero allocation.
+  private inline def takeAtoms(count: Int): IArray[Tel.Atom] =
+    if count == 0 then IArray.empty[Tel.Atom]
+    else
+      val result = new Array[Tel.Atom](count)
+      System.arraycopy(scratchAtoms, atomScratchIx - count, result, 0, count)
+      atomScratchIx -= count
+      result.asInstanceOf[IArray[Tel.Atom]]
+
+  private inline def takeComments(count: Int): IArray[Tel.Comment] =
+    if count == 0 then IArray.empty[Tel.Comment]
+    else
+      val result = new Array[Tel.Comment](count)
+      System.arraycopy(scratchComments, commentScratchIx - count, result, 0, count)
+      commentScratchIx -= count
+      result.asInstanceOf[IArray[Tel.Comment]]
+
+  private inline def takeCompounds(count: Int): IArray[Tel.Compound] =
+    if count == 0 then IArray.empty[Tel.Compound]
+    else
+      val result = new Array[Tel.Compound](count)
+      System.arraycopy(scratchCompounds, compoundScratchIx - count, result, 0, count)
+      compoundScratchIx -= count
+      result.asInstanceOf[IArray[Tel.Compound]]
+
+  private inline def takeBlocks(count: Int): IArray[Tel.Block] =
+    if count == 0 then IArray.empty[Tel.Block]
+    else
+      val result = new Array[Tel.Block](count)
+      System.arraycopy(scratchBlocks, blockScratchIx - count, result, 0, count)
+      blockScratchIx -= count
+      result.asInstanceOf[IArray[Tel.Block]]
+
+  // ── parseCompoundLine result channels ──────────────────────────────────────
+  // parseCompoundLine deposits its keyword + remark into these single-slot
+  // fields rather than returning a Tel.Compound. The atoms it reads remain
+  // on the scratchAtoms stack; the caller (parseBlock) optionally pushes
+  // an extra Source/Literal atom, then takes the entire atom run at once.
+  // This eliminates the prior `parsed.copy(atoms = finalAtoms, children = ...)`
+  // double-allocation: Tel.Compound is built exactly once with its final
+  // atoms and children set.
+  private var compoundLineKeyword: Text = t""
+  private var compoundLineRemark:  Optional[Text] = Unset
+
   // ── Keyword interning cache ───────────────────────────────────────────────
   // 64-slot two-Long fingerprint cache. The byte-level variant: the first
   // four bytes pack into `low` and the next four into `high`. ASCII keywords
@@ -831,36 +948,40 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
     if head.eof || head.indentLevels < expected then IArray.empty[Tel.Block]
     else
-      val builder = scala.collection.mutable.ArrayBuffer.empty[Tel.Block]
+      val start = blockScratchIx
       while !head.eof && head.indentLevels == expected do
-        builder += parseBlock(expected)
+        parseBlock(expected)  // pushes one block onto scratchBlocks
 
       // After consuming children at `expected`, a remaining non-blank line
       // more indented than `expected` is an error.
       if !head.eof && head.indentLevels > expected then
         val line = head.startLine
-        builder.lastOption match
-          case Some(last) if last.tabulation.present && last.compounds.isEmpty =>
+        val lastIx = blockScratchIx - 1
+        if lastIx >= start then
+          val last = scratchBlocks(lastIx)
+          if last.tabulation.present && last.compounds.isEmpty then
             errorAt(Reason.RowWrongIndent, line, 1)
-
-          case Some(last) if last.tabulation.present =>
+          else if last.tabulation.present then
             errorAt(Reason.ChildOfNonCompound, line, 1)
-
-          case Some(last) if last.compounds.isEmpty =>
+          else if last.compounds.isEmpty then
             errorAt(Reason.ChildOfNonCompound, line, 1)
+          else
+            errorAt(Reason.OverIndentation, line, 1)
+        else errorAt(Reason.OverIndentation, line, 1)
 
-          case _ => errorAt(Reason.OverIndentation, line, 1)
-
-      IArray.from(builder)
+      takeBlocks(blockScratchIx - start)
 
   // ── parseBlock ───────────────────────────────────────────────────────────
 
   // Parses one block at the given indent: leading comments, optional
   // tabulation header, a run of compounds (each possibly with source /
   // literal / children attached), then trailing blank lines (those that
-  // semantically belong to this block).
-  private def parseBlock(indent: Int): Tel.Block raises TelError =
-    val comments = scala.collection.mutable.ArrayBuffer.empty[Tel.Comment]
+  // semantically belong to this block). Pushes the resulting Tel.Block
+  // onto the parser's `scratchBlocks` stack; the caller (parseChildren)
+  // takes a contiguous range when its loop completes.
+  private def parseBlock(indent: Int): Unit raises TelError =
+    val commentStart  = commentScratchIx
+    val compoundStart = compoundScratchIx
 
     // Leading comments at this indent.
     while !head.eof && !head.blank && head.indentLevels == indent && isCommentBody() do
@@ -871,15 +992,17 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       then errorAt(Reason.CommentNotPreceded, head.startLine, 1)
 
       val text = parseCommentLine()
-      comments += Tel.Comment(text)
+      pushComment(Tel.Comment(text))
       prevLineWasBoundary = true
       hasConsumedNonBlankLine = true
       fillHead()
 
+    val hasComments = commentScratchIx > commentStart
+
     // Interior blanks: if we have comments and the next line is blank, look
     // ahead to see whether the blanks separate the comments from a compound
     // group at the same indent. If so, consume them as interior whitespace.
-    if comments.nonEmpty && !head.eof && head.blank then
+    if hasComments && !head.eof && head.blank then
       skipInteriorBlanksIfFollowedByContentAtIndent(indent)
 
     // Optional tabulation header.
@@ -895,8 +1018,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         Optional(tab)
       else Unset
 
-    val compounds = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
-
     // Compound loop.
     var keepLoop = true
     while keepLoop && !head.eof && !head.blank && head.indentLevels == indent do
@@ -909,7 +1030,17 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         // cursor remains parked at the row start for parseCompoundLine.
         if tabulation.present then
           validateTabulatedRowInline(compoundLeadingSpaces, tabulation.vouch, compoundLine)
-        val parsed = parseCompoundLine(compoundLine)
+
+        // parseCompoundLine pushes the compound's inline atoms onto
+        // scratchAtoms and deposits keyword + remark into the parser's
+        // compoundLine* fields. The atoms stay on the stack so we can
+        // append an optional source/literal extra atom alongside them
+        // and take the entire run at once into the final Tel.Compound,
+        // skipping the previous `parsed.copy(...)` double-allocation.
+        val atomsStart = atomScratchIx
+        parseCompoundLine(compoundLine)
+        val compoundKeyword = compoundLineKeyword
+        val compoundRemark  = compoundLineRemark
         prevContentLeadingSpaces = compoundLeadingSpaces
         prevLineWasBoundary = false
         // §19.5 recovery needs this compound's keyword on the ancestor
@@ -917,7 +1048,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         // there consults the ancestors. No-schema mode skips push/pop
         // entirely so the hot path is unaffected.
         val pushed = schema.present
-        if pushed then pushAncestor(parsed.keyword)
+        if pushed then pushAncestor(compoundKeyword)
         try
           fillHead()
 
@@ -925,19 +1056,21 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
             if tabulation.absent then parseSourceOrLiteralAtomIfPresent(compoundLeadingSpaces)
             else Unset
 
+          if extraAtom.present then pushAtom(extraAtom.vouch)
+
           val children =
             if extraAtom.absent && tabulation.absent then parseChildren(indent)
             else IArray.empty[Tel.Block]
 
-          val finalAtoms = extraAtom.lay(parsed.atoms): atom =>
-            parsed.atoms :+ atom
-
-          compounds += parsed.copy(atoms = finalAtoms, children = children)
+          val atoms = takeAtoms(atomScratchIx - atomsStart)
+          pushCompound(Tel.Compound(compoundKeyword, atoms, compoundRemark, children))
         finally if pushed then popAncestor()
 
     val trailingBlankLines = consumeTrailingBlanksFor(indent)
 
-    Tel.Block(IArray.from(comments), tabulation, IArray.from(compounds), trailingBlankLines)
+    val comments  = takeComments(commentScratchIx - commentStart)
+    val compounds = takeCompounds(compoundScratchIx - compoundStart)
+    pushBlock(Tel.Block(comments, tabulation, compounds, trailingBlankLines))
 
   // After the comment-group, consume blank lines if the next non-blank line
   // is a content (not comment) line at the same `indent`. Otherwise leave
@@ -1435,10 +1568,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // ── Compound line parsing ────────────────────────────────────────────────
 
-  // Cursor is at the first content byte (past leading spaces). Returns the
-  // parsed compound (keyword + atoms + remark, children left empty for the
-  // caller to fill in).
-  private def parseCompoundLine(lineNumber: Int): Tel.Compound raises TelError = inHold:
+  // Cursor is at the first content byte (past leading spaces). Reads the
+  // compound line's keyword, atoms, and remark, depositing the keyword and
+  // remark into `compoundLineKeyword` / `compoundLineRemark`. Atoms are
+  // pushed onto the `scratchAtoms` stack; the caller (parseBlock) is
+  // responsible for taking them — typically together with an optional
+  // source/literal extra atom — and constructing the final Tel.Compound.
+  private def parseCompoundLine(lineNumber: Int): Unit raises TelError = inHold:
     val isAtColumnZero = head.leadingSpaces == 0
     val mayBeMisplacedPragma = isAtColumnZero && hasConsumedNonBlankLine
 
@@ -1452,7 +1588,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       errorAt(Reason.PragmaNotFirst, lineNumber, 1)
     hasConsumedNonBlankLine = true
 
-    val atoms = scala.collection.mutable.ArrayBuffer.empty[Tel.Atom]
     var remark: Optional[Text] = Unset
     // Accumulate atom bytes into the parser-owned `atomBytes` buffer rather
     // than tracking buffer offsets into the cursor's `bytes`. With narrow
@@ -1471,7 +1606,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       if atomOpen then
         val owned = new Array[Byte](atomLen)
         System.arraycopy(atomBytes, 0, owned, 0, atomLen)
-        atoms += Tel.Atom.Inline.fromBytes(owned, precedingSpaces)
+        pushAtom(Tel.Atom.Inline.fromBytes(owned, precedingSpaces))
         resetAtom()
         atomOpen = false
 
@@ -1556,7 +1691,8 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     then errorAt(Reason.TrailingSpaces, lineNumber, head.leadingSpaces + 1)
 
     consumeLineEnding()
-    Tel.Compound(keyword, IArray.from(atoms), remark, IArray.empty)
+    compoundLineKeyword = keyword
+    compoundLineRemark  = remark
 
   // Read a keyword from the current position. The keyword runs until SP, LF,
   // CR, or EOF. Returns the interned `Text`. Uses the 64-slot fingerprint

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -128,12 +128,17 @@ object TelParser:
   // whether to continue at the current indent, descend, ascend, or stop.
   // Reused (mutated in place) across every line — single allocation per
   // parser instance.
+  //
+  // Position is stored as a raw byte offset into the input buffer.
+  // Computing the 1-indexed source line is deferred to error-time
+  // (`errorAt` walks the buffer from 0 counting LFs) so the success path
+  // pays no per-line lineation cost.
   private final class LineHead:
     var leadingSpaces: Int = 0
     var indentLevels:  Int = 0      // (leadingSpaces - margin) / 2 or -1
     var blank:         Boolean = false
     var eof:           Boolean = false
-    var startLine:     Int = 1      // 1-indexed source line of this line
+    var startBytePos:  Int = 0      // absolute byte position of line start
 
 
 private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
@@ -325,7 +330,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   private def moreSlow(): Boolean =
     syncTo()
-    reconcileLineation()
     if cursor.more then { syncFrom(); true }
     else { syncFrom(); false }
 
@@ -347,7 +351,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     if pos + n <= bufEnd then ()
     else
       syncTo()
-      reconcileLineation()  // mark captures correct line/col
       val mk = cursor.mark(using heldToken.nn)
       var steps = 0
       while steps < n && cursor.more do
@@ -429,21 +432,46 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // ── Errors ────────────────────────────────────────────────────────────────
 
+  // Compute the 1-indexed line number for a given absolute byte position by
+  // walking the held buffer from offset 0 and counting LFs. Outer-hold
+  // pins basePos at 0 so byte positions index directly into `bytes`.
+  // O(N) per error; never runs on the success path.
+  private def lineForBytePos(bytePos: Int): Int =
+    var i = 0
+    var line = 1
+    while i < bytePos do
+      if bytes(i) == LF then line += 1
+      i += 1
+    line
+
+  // Compute the column corresponding to the current cursor position
+  // (1-indexed; 1 = first byte of line).
+  private def columnForCurrentBytePos(): Int =
+    var i = pos - 1
+    var col = 1
+    while i >= 0 && bytes(i) != LF do
+      col += 1
+      i -= 1
+    col
+
   private def errorHere(reason: Reason): Nothing raises TelError =
     syncTo()
-    reconcileLineation()
-    val line = cursor.line.n0 + 1
-    val column = cursor.column.n0 + 1
+    val line = lineForBytePos(pos)
+    val column = columnForCurrentBytePos()
     abort(TelError(reason, TelError.Position(line, column)))
 
-  private def errorAt(reason: Reason, line: Int, column: Int): Nothing raises TelError =
+  // `lineBytePos` is the absolute byte offset of the offending line's start
+  // (or anywhere on that line). The 1-indexed source line is computed
+  // lazily via `lineForBytePos`.
+  private def errorAt(reason: Reason, lineBytePos: Int, column: Int)
+  :     Nothing raises TelError =
+    val line = lineForBytePos(lineBytePos)
     abort(TelError(reason, TelError.Position(line, column)))
 
   // ── Mark / hold plumbing ──────────────────────────────────────────────────
 
   private inline def beginMark(): Cursor.Mark =
     syncTo()
-    reconcileLineation()
     cursor.mark(using heldToken.nn)
 
   // Materialise the byte range between `start` and the current position as
@@ -452,7 +480,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // resolves once here against `this.cursor`.
   private def sliceText(start: Cursor.Mark): String =
     syncTo()
-    reconcileLineation()
     val endMk = cursor.mark(using heldToken.nn)
     cursor.slice(start, endMk): (storage, off, len) =>
       val arr = storage.asInstanceOf[Array[Byte]]
@@ -543,25 +570,24 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       else
         // First non-blank line. Is it a pragma?
         if spaceCount == 0 && startsWithPragma() then
-          val pragmaLine = cursor.line.n0 + 1
-          if cursor.position.n0 >= 4096 then
-            errorAt(Reason.PragmaTooLong, pragmaLine, 1)
+          val pragmaLineBytePos = pos  // line start (no leading spaces consumed)
+          if pos >= 4096 then
+            errorAt(Reason.PragmaTooLong, pragmaLineBytePos, 1)
           val pragmaMk = beginMark()
           while more && peek != LF && peek != CR do advance()
           val payload = sliceText(pragmaMk)
-          if cursor.position.n0 > 4096 then
-            errorAt(Reason.PragmaTooLong, pragmaLine, 1)
+          if pos > 4096 then
+            errorAt(Reason.PragmaTooLong, pragmaLineBytePos, 1)
           consumeLineEnding()
           prevLineWasBoundary = true
           hasConsumedNonBlankLine = true
-          foundPragma = Optional(parsePragmaContent(payload, pragmaLine))
+          foundPragma = Optional(parsePragmaContent(payload, pragmaLineBytePos))
         done = true
 
     if foundPragma.present then foundPragma
     else
       // Not a pragma — cue back to before any blanks were consumed.
       syncTo()
-      reconcileLineation()
       cursor.cue(mk)
       syncFrom()
       prevLineWasBoundary = savedBoundary
@@ -617,15 +643,15 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       else true  // exactly "tel" at EOF
     else false
 
-  private def parsePragmaContent(content: String, lineIdx: Int)
+  private def parsePragmaContent(content: String, lineBytePos: Int)
   : Tel.Pragma raises TelError =
     val parts = splitPragmaPhrases(content)
-    if parts.head != "tel" then errorAt(Reason.PragmaNotFirst, lineIdx, 1)
+    if parts.head != "tel" then errorAt(Reason.PragmaNotFirst, lineBytePos, 1)
     val version =
-      if parts.length >= 2 then parseVersion(parts(1), lineIdx)
+      if parts.length >= 2 then parseVersion(parts(1), lineBytePos)
       else (1, 0)
 
-    if parts.length > 4 then errorAt(Reason.ExtraPragmaContent, lineIdx, 1)
+    if parts.length > 4 then errorAt(Reason.ExtraPragmaContent, lineBytePos, 1)
 
     val schemaText: Optional[Text] =
       if parts.length >= 3 then
@@ -635,30 +661,30 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
         val isBase256 = s.exists(_.toInt > 127)
         if !isUrl && !isHexHash && !isBase256
-        then errorAt(Reason.BadSchemaIdentifier, lineIdx, 1)
+        then errorAt(Reason.BadSchemaIdentifier, lineBytePos, 1)
         Text(s): Optional[Text]
       else Unset
 
     val pragmaSigil: Optional[Char] =
       if parts.length >= 4 && parts(3).length == 1 then
         val c = parts(3).charAt(0)
-        if c.isLetterOrDigit then errorAt(Reason.BadSigil, lineIdx, 1)
+        if c.isLetterOrDigit then errorAt(Reason.BadSigil, lineBytePos, 1)
         sigil = c.toByte
         c: Optional[Char]
       else Unset
 
     Tel.Pragma(version, schemaText, pragmaSigil)
 
-  private def parseVersion(s: String, lineIdx: Int)
+  private def parseVersion(s: String, lineBytePos: Int)
   : (Int, Int) raises TelError =
     val dot = s.indexOf('.')
-    if dot <= 0 || dot == s.length - 1 then errorAt(Reason.BadVersion, lineIdx, 1)
+    if dot <= 0 || dot == s.length - 1 then errorAt(Reason.BadVersion, lineBytePos, 1)
     try
       val major = s.substring(0, dot).toInt
       val minor = s.substring(dot + 1).toInt
-      if major < 0 || minor < 0 then errorAt(Reason.BadVersion, lineIdx, 1)
+      if major < 0 || minor < 0 then errorAt(Reason.BadVersion, lineBytePos, 1)
       (major, minor)
-    catch case _: NumberFormatException => errorAt(Reason.BadVersion, lineIdx, 1)
+    catch case _: NumberFormatException => errorAt(Reason.BadVersion, lineBytePos, 1)
 
   private def splitPragmaPhrases(content: String): List[String] =
     val parts = scala.collection.mutable.ListBuffer.empty[String]
@@ -705,7 +731,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     val outerMark = beginMark()
     val kw = readKeyword()
     syncTo()
-    reconcileLineation()
     cursor.cue(outerMark)
     syncFrom()
     kw
@@ -774,7 +799,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // compute admissibility at both candidate depths via the current ancestor
   // stack and pick deeper if and only if shallower is invalid AND deeper is
   // valid; tie-break favours shallower.
-  private def recoverOddIndent(spaces: Int, startLine: Int): Int raises TelError =
+  private def recoverOddIndent(spaces: Int, lineBytePos: Int): Int raises TelError =
     val rel = spaces - margin
     schema.let: s =>
       val shallower = rel / 2
@@ -792,18 +817,19 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         deeperParent.let(p => keywordAdmissible(p, keyword, s)).or(false)
       if !shallowerValid && deeperValid then deeper else shallower
     .or:
-      errorAt(Reason.OddIndentation, startLine, 1)
+      errorAt(Reason.OddIndentation, lineBytePos, 1)
 
   // ── Line-head fill ───────────────────────────────────────────────────────
 
   // Consume the next line's leading spaces and parks at the first content
   // byte (or LF/EOF for a blank line). Updates `head` in place. Always
   // advances past EOF cleanly: head.eof = true, head.blank = true.
+  //
+  // No reconcileLineation: the line number is recovered lazily from
+  // head.startBytePos at error-time. The success path runs through fillHead
+  // without paying any per-line lineation cost.
   private def fillHead(): Unit raises TelError =
-    syncTo()
-    reconcileLineation()
-    val startLine = cursor.line.n0 + 1
-    head.startLine = startLine
+    head.startBytePos = pos
 
     val spaces = countLeadingSpaces()
     head.leadingSpaces = spaces
@@ -826,9 +852,9 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       val rel = spaces - margin
       head.indentLevels =
         if rel < 0 then
-          errorAt(Reason.LessThanMargin, startLine, 1)
+          errorAt(Reason.LessThanMargin, head.startBytePos, 1)
         else if rel % 2 == 0 then rel / 2
-        else recoverOddIndent(spaces, startLine)
+        else recoverOddIndent(spaces, head.startBytePos)
 
   // ── parseChildren ────────────────────────────────────────────────────────
 
@@ -844,7 +870,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       // After consuming children at `expected`, a remaining non-blank line
       // more indented than `expected` is an error.
       if !head.eof && head.indentLevels > expected then
-        val line = head.startLine
+        val line = head.startBytePos
         builder.lastOption match
           case Some(last) if last.tabulation.present && last.compounds.isEmpty =>
             errorAt(Reason.RowWrongIndent, line, 1)
@@ -874,7 +900,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       // content line (compound / tabulation) at indent ≥ this comment's.
       if !prevLineWasBoundary && prevContentLeadingSpaces >= 0
          && prevContentLeadingSpaces >= margin + indent * 2
-      then errorAt(Reason.CommentNotPreceded, head.startLine, 1)
+      then errorAt(Reason.CommentNotPreceded, head.startBytePos, 1)
 
       val text = parseCommentLine()
       comments += Tel.Comment(text)
@@ -909,7 +935,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       if isCommentBody() || isTabulationBody() then keepLoop = false
       else
         val compoundLeadingSpaces = head.leadingSpaces
-        val compoundLine = head.startLine
+        val compoundLine = head.startBytePos
         // §16.2: validate tabulated rows BEFORE parseCompoundLine consumes
         // the row's bytes. validateTabulatedRowInline uses mark + cue so the
         // cursor remains parked at the row start for parseCompoundLine.
@@ -952,7 +978,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   : Unit raises TelError =
     val mk = beginMark()
     val savedHeadSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
-                             head.eof, head.startLine)
+                             head.eof, head.startBytePos)
     val savedBoundary = prevLineWasBoundary
     while !head.eof && head.blank do fillHead()
     val keep =
@@ -960,14 +986,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     if !keep then
       // Rewind.
       syncTo()
-      reconcileLineation()
       cursor.cue(mk)
       syncFrom()
       head.leadingSpaces = savedHeadSnapshot._1
       head.indentLevels  = savedHeadSnapshot._2
       head.blank         = savedHeadSnapshot._3
       head.eof           = savedHeadSnapshot._4
-      head.startLine     = savedHeadSnapshot._5
+      head.startBytePos     = savedHeadSnapshot._5
       prevLineWasBoundary = savedBoundary
       // Re-park: skip leading spaces of the line we just rewound to.
       var i = 0
@@ -993,7 +1018,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     else
       val mk = beginMark()
       val firstBlankSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
-                                head.eof, head.startLine)
+                                head.eof, head.startBytePos)
       val savedBoundary = prevLineWasBoundary
       var count = 0
       while !head.eof && head.blank do
@@ -1007,14 +1032,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       else
         // Rewind to the first blank.
         syncTo()
-        reconcileLineation()
         cursor.cue(mk)
         syncFrom()
         head.leadingSpaces = firstBlankSnapshot._1
         head.indentLevels  = firstBlankSnapshot._2
         head.blank         = firstBlankSnapshot._3
         head.eof           = firstBlankSnapshot._4
-        head.startLine     = firstBlankSnapshot._5
+        head.startBytePos     = firstBlankSnapshot._5
         prevLineWasBoundary = savedBoundary
         var i = 0
         while i < firstBlankSnapshot._1 && more && peek == SP do
@@ -1066,7 +1090,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
     // Rewind.
     syncTo()
-    reconcileLineation()
     cursor.cue(mk)
     syncFrom()
     found
@@ -1127,7 +1150,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         headings += t""
         done = true
       else if peek != SP then
-        errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
+        errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
       else
         // peek == SP
         // Check if the next byte is also a space — if so, heading is empty
@@ -1151,7 +1174,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
             done = true
           else
             // E120: more spaces or non-sigil content after empty.
-            errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
+            errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
         else
           // One soft space — heading text follows.
           advance(); lineCol += 1
@@ -1163,7 +1186,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               headingEnd = lineCol
               stop = true
             else if peek == sigil then
-              errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
+              errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
             else if peek == SP then
               // Hard space check: two spaces in a row?
               val nb = peekNext()
@@ -1188,7 +1211,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               // Loop continues.
             else if !more || peek == LF || peek == CR then done = true
             else
-              errorAt(Reason.BadTabulationHeading, head.startLine, lineCol + 1)
+              errorAt(Reason.BadTabulationHeading, head.startBytePos, lineCol + 1)
 
     consumeLineEnding()
     Tel.Tabulation(IArray.from(markers), IArray.from(headings))
@@ -1250,7 +1273,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
     // Cue back so parseCompoundLine reads the row from the start.
     syncTo()
-    reconcileLineation()
     cursor.cue(mk)
     syncFrom()
 
@@ -1270,9 +1292,9 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       // §10.4 / §11.1: at most one source / literal atom per compound.
       if first.present && !head.eof && !head.blank then
         if head.leadingSpaces == literalIndent
-        then errorAt(Reason.DuplicateLiteral, head.startLine, 1)
+        then errorAt(Reason.DuplicateLiteral, head.startBytePos, 1)
         else if head.leadingSpaces == sourceIndent
-        then errorAt(Reason.DuplicateSource, head.startLine, 1)
+        then errorAt(Reason.DuplicateSource, head.startBytePos, 1)
 
       first
 
@@ -1302,7 +1324,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         // Probe across blanks to see if more source follows.
         val mk = beginMark()
         val firstBlankSnapshot = (head.leadingSpaces, head.indentLevels, head.blank,
-                                  head.eof, head.startLine)
+                                  head.eof, head.startBytePos)
         val savedBoundary = prevLineWasBoundary
         var blanks = 0
         while !head.eof && head.blank do
@@ -1316,14 +1338,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         else
           // Rewind.
           syncTo()
-          reconcileLineation()
           cursor.cue(mk)
           syncFrom()
           head.leadingSpaces = firstBlankSnapshot._1
           head.indentLevels  = firstBlankSnapshot._2
           head.blank         = firstBlankSnapshot._3
           head.eof           = firstBlankSnapshot._4
-          head.startLine     = firstBlankSnapshot._5
+          head.startBytePos     = firstBlankSnapshot._5
           prevLineWasBoundary = savedBoundary
           var i = 0
           while i < firstBlankSnapshot._1 && more && peek == SP do
@@ -1373,7 +1394,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // everything between the next LF and the first line whose content equals
   // the delimiter (at column 0 / flush left).
   private def parseLiteralAtom(literalIndent: Int): Tel.Atom.Literal raises TelError =
-    val openingLine = head.startLine
+    val openingLine = head.startBytePos
     // Read the delimiter — opening line, terminated by LF or CR per the
     // document's line-ending mode.
     val delimMk = beginMark()

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -88,6 +88,41 @@ object TelParser:
   private final val BOM1: Byte = 0xBB.toByte
   private final val BOM2: Byte = 0xBF.toByte
 
+  // ── SWAR (SIMD-within-a-register) byte scan helpers ──────────────────────
+  // The inner byte-scan loops in the parser read a `Long` of 8 bytes at a
+  // time from the buffer and use the classic "haszero" trick to detect a
+  // target byte across all 8 lanes in two arithmetic ops. On long content
+  // runs (literal payloads, source-atom lines, inline atoms) this replaces
+  // an 8-iteration byte loop with one Long load plus a couple of bitwise
+  // operations.
+
+  // `classOf[Array[Long]]` resolves to `java.lang.Object` under some Scala 3
+  // compilation paths (notably macro-expansion contexts) — and
+  // `byteArrayViewVarHandle` rejects that. Get `long[].class` directly from
+  // a runtime instance instead.
+  private val longView: java.lang.invoke.VarHandle =
+    java.lang.invoke.MethodHandles.byteArrayViewVarHandle
+     ( (new Array[Long](0)).getClass.nn, java.nio.ByteOrder.LITTLE_ENDIAN )
+
+  private final val OnesMask:     Long = 0x0101010101010101L
+  private final val HighBitsMask: Long = 0x8080808080808080L
+
+  // The byte `b` replicated across all 8 lanes of a Long.
+  private inline def replicate(b: Byte): Long = (b & 0xFFL) * OnesMask
+
+  // Pre-computed replications for the constant scan targets.
+  private final val SpRepl: Long = (SP & 0xFFL) * OnesMask
+  private final val LfRepl: Long = (LF & 0xFFL) * OnesMask
+  private final val CrRepl: Long = (CR & 0xFFL) * OnesMask
+
+  // Per-lane "is this byte zero?" mask: each 0x80 marks a zero byte in `v`.
+  private inline def haszero(v: Long): Long =
+    (v - OnesMask) & ~v & HighBitsMask
+
+  // Per-lane "does this byte equal the target?" mask.
+  private inline def matchByte(v: Long, replicated: Long): Long =
+    haszero(v ^ replicated)
+
   // Carries the look-ahead state for the next unconsumed line. Parsed once
   // by `fillHead`, then consulted by recursive-descent functions to decide
   // whether to continue at the current indent, descend, ascend, or stop.
@@ -169,6 +204,78 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
   // Reusable string builder for source-atom / literal-atom payloads.
   private val sb: jl.StringBuilder = new jl.StringBuilder(256)
+
+  // Reusable Char[] buffer for inline-atom text. JsonParser uses the same
+  // pattern: append bytes-as-chars on the hot path, then `new String(chars,
+  // off, len)` once per atom — one allocation per atom instead of the two
+  // strings the previous `sliceText` + `sb.append` + `sb.toString` cycle
+  // produced.
+  private var atomChars: Array[Char] = new Array[Char](128)
+  private var atomCharCursor: Int    = 0
+
+  private inline def resetAtomChars(): Unit = atomCharCursor = 0
+
+  private inline def ensureAtomCharSpace(n: Int): Unit =
+    if atomCharCursor + n > atomChars.length then
+      var newLen = atomChars.length
+      while atomCharCursor + n > newLen do newLen *= 2
+      val grown = new Array[Char](newLen)
+      System.arraycopy(atomChars, 0, grown, 0, atomCharCursor)
+      atomChars = grown
+
+  private inline def appendAtomChar(c: Char): Unit =
+    if atomCharCursor == atomChars.length then ensureAtomCharSpace(1)
+    atomChars(atomCharCursor) = c
+    atomCharCursor += 1
+
+  // Decode UTF-8 bytes at `bytes(off..off+len)` and append as Chars to the
+  // atom buffer. ASCII fast-path; multi-byte sequences are decoded inline.
+  private def appendBytesAsAtomChars(src: Array[Byte], off: Int, len: Int): Unit =
+    ensureAtomCharSpace(len)  // upper bound (chars ≤ bytes for UTF-8)
+    var i = 0
+    while i < len do
+      val b = src(off + i)
+      if (b & 0x80) == 0 then
+        atomChars(atomCharCursor) = (b & 0xFF).toChar
+        atomCharCursor += 1
+        i += 1
+      else
+        val u = b & 0xFF
+        if (u & 0xE0) == 0xC0 then
+          val b2 = src(off + i + 1) & 0x3F
+          atomChars(atomCharCursor) = (((u & 0x1F) << 6) | b2).toChar
+          atomCharCursor += 1
+          i += 2
+        else if (u & 0xF0) == 0xE0 then
+          val b2 = src(off + i + 1) & 0x3F
+          val b3 = src(off + i + 2) & 0x3F
+          atomChars(atomCharCursor) = (((u & 0x0F) << 12) | (b2 << 6) | b3).toChar
+          atomCharCursor += 1
+          i += 3
+        else if (u & 0xF8) == 0xF0 then
+          val b2 = src(off + i + 1) & 0x3F
+          val b3 = src(off + i + 2) & 0x3F
+          val b4 = src(off + i + 3) & 0x3F
+          val cp = ((u & 0x07) << 18) | (b2 << 12) | (b3 << 6) | b4
+          if cp >= 0x10000 then
+            val adj = cp - 0x10000
+            ensureAtomCharSpace(2)
+            atomChars(atomCharCursor) = (0xD800 | (adj >>> 10)).toChar
+            atomChars(atomCharCursor + 1) = (0xDC00 | (adj & 0x3FF)).toChar
+            atomCharCursor += 2
+          else
+            atomChars(atomCharCursor) = cp.toChar
+            atomCharCursor += 1
+          i += 4
+        else
+          atomChars(atomCharCursor) = '�'
+          atomCharCursor += 1
+          i += 1
+
+  // Materialise the atom buffer's [start..atomCharCursor) range as a Text,
+  // exactly one allocation.
+  private inline def atomCharsToText(start: Int): Text =
+    Text(new String(atomChars, start, atomCharCursor - start))
 
   // ── Keyword interning cache ───────────────────────────────────────────────
   // 64-slot two-Long fingerprint cache. The byte-level variant: the first
@@ -254,6 +361,71 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   private def peekNext(): Int =
     ensureLookahead(2)
     if pos + 1 < bufEnd then bytes(pos + 1) & 0xff else -1
+
+  // ── SWAR in-buffer scans ─────────────────────────────────────────────────
+  // Each `scanUntilN` method advances the parser-local `pos` until either a
+  // byte matching one of the targets is found, or `pos == bufEnd`. It does
+  // NOT refill the cursor — callers wrap the call in a refill loop when
+  // they need to scan across chunk boundaries.
+
+  // Advance pos until bytes(pos) == target1, or pos == bufEnd.
+  private def scanUntil1(target1: Byte, repl1: Long): Unit =
+    while pos + 8 <= bufEnd do
+      val v = TelParser.longView.get(bytes, pos).asInstanceOf[Long]
+      val mask = TelParser.matchByte(v, repl1)
+      if mask != 0L then
+        pos += (java.lang.Long.numberOfTrailingZeros(mask) >>> 3)
+        return
+      pos += 8
+    while pos < bufEnd && bytes(pos) != target1 do pos += 1
+
+  // Advance pos until bytes(pos) ∈ {target1, target2}, or pos == bufEnd.
+  private def scanUntil2(target1: Byte, target2: Byte, repl1: Long, repl2: Long): Unit =
+    while pos + 8 <= bufEnd do
+      val v = TelParser.longView.get(bytes, pos).asInstanceOf[Long]
+      val combined = TelParser.matchByte(v, repl1) | TelParser.matchByte(v, repl2)
+      if combined != 0L then
+        pos += (java.lang.Long.numberOfTrailingZeros(combined) >>> 3)
+        return
+      pos += 8
+    while pos < bufEnd && bytes(pos) != target1 && bytes(pos) != target2 do pos += 1
+
+  // Advance pos until bytes(pos) ∈ {a, b, c}, or pos == bufEnd.
+  private def scanUntil3
+                ( a: Byte, b: Byte, c: Byte,
+                  rA: Long, rB: Long, rC: Long )
+  : Unit =
+    while pos + 8 <= bufEnd do
+      val v = TelParser.longView.get(bytes, pos).asInstanceOf[Long]
+      val combined =
+        TelParser.matchByte(v, rA)
+        | TelParser.matchByte(v, rB)
+        | TelParser.matchByte(v, rC)
+      if combined != 0L then
+        pos += (java.lang.Long.numberOfTrailingZeros(combined) >>> 3)
+        return
+      pos += 8
+    while pos < bufEnd && bytes(pos) != a && bytes(pos) != b && bytes(pos) != c do pos += 1
+
+  // Advance pos until bytes(pos) ∈ {a, b, c, d}, or pos == bufEnd.
+  private def scanUntil4
+                ( a: Byte, b: Byte, c: Byte, d: Byte,
+                  rA: Long, rB: Long, rC: Long, rD: Long )
+  : Unit =
+    while pos + 8 <= bufEnd do
+      val v = TelParser.longView.get(bytes, pos).asInstanceOf[Long]
+      val combined =
+        TelParser.matchByte(v, rA)
+        | TelParser.matchByte(v, rB)
+        | TelParser.matchByte(v, rC)
+        | TelParser.matchByte(v, rD)
+      if combined != 0L then
+        pos += (java.lang.Long.numberOfTrailingZeros(combined) >>> 3)
+        return
+      pos += 8
+    while pos < bufEnd && bytes(pos) != a && bytes(pos) != b
+          && bytes(pos) != c && bytes(pos) != d
+    do pos += 1
 
   // ── Errors ────────────────────────────────────────────────────────────────
 
@@ -1177,7 +1349,10 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
         // Now read the line content (until LF/CR), tracking trailing spaces
         // so we can strip them.
         val mk = beginMark()
-        while more && peek != LF && peek != CR do advance()
+        while
+          scanUntil2(LF, CR, TelParser.LfRepl, TelParser.CrRepl)
+          pos == bufEnd && more
+        do ()
         val payload = sliceText(mk)
         // Strip trailing spaces.
         var endIdx = payload.length
@@ -1199,9 +1374,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // the delimiter (at column 0 / flush left).
   private def parseLiteralAtom(literalIndent: Int): Tel.Atom.Literal raises TelError =
     val openingLine = head.startLine
-    // Read the delimiter.
+    // Read the delimiter — opening line, terminated by LF or CR per the
+    // document's line-ending mode.
     val delimMk = beginMark()
-    while more && peek != LF && peek != CR do advance()
+    while
+      scanUntil2(LF, CR, TelParser.LfRepl, TelParser.CrRepl)
+      pos == bufEnd && more
+    do ()
     val delimiter = sliceText(delimMk)
     // The opening line is now consumed up to but not including the LF.
     // Empty-payload case: if next line is the closing delimiter exactly,
@@ -1214,11 +1393,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       if !more then errorAt(Reason.UnclosedLiteral, openingLine, 1)
       // Read a line. Inside the literal payload, line endings are not
       // subject to the document's LF/CRLF mode (per §15 the payload is
-      // verbatim, with CRLF normalised to LF). Read up to the next LF
-      // treating any preceding CR as part of the line, then strip a
-      // trailing CR for normalisation.
+      // verbatim, with CRLF normalised to LF). SWAR-scan for LF; any
+      // preceding CR is captured in `raw` and stripped below.
       val lineMk = beginMark()
-      while more && peek != LF do advance()
+      while
+        scanUntil1(LF, TelParser.LfRepl)
+        pos == bufEnd && more
+      do ()
       val raw = sliceText(lineMk)
       val line = if raw.length > 0 && raw.charAt(raw.length - 1) == '\r'
                  then raw.substring(0, raw.length - 1) else raw
@@ -1254,7 +1435,6 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   private def parseCompoundLine(lineNumber: Int): Tel.Compound raises TelError =
     val isAtColumnZero = head.leadingSpaces == 0
     val mayBeMisplacedPragma = isAtColumnZero && hasConsumedNonBlankLine
-    val lineStart = beginMark()
 
     // First phrase = keyword. Read until space or LF/CR.
     val keyword = readKeyword()
@@ -1268,15 +1448,16 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
 
     val atoms = scala.collection.mutable.ArrayBuffer.empty[Tel.Atom]
     var remark: Optional[Text] = Unset
-    sb.setLength(0)
+    resetAtomChars()
+    var atomStart = 0       // start index into atomChars for the open atom
     var precedingSpaces = 0
     var hardSpaceMode = false
     var atomOpen = false
 
     inline def commit(): Unit =
       if atomOpen then
-        atoms += Tel.Atom.Inline(Text(sb.toString), precedingSpaces)
-        sb.setLength(0)
+        atoms += Tel.Atom.Inline(atomCharsToText(atomStart), precedingSpaces)
+        atomStart = atomCharCursor
         atomOpen = false
 
     var stopped = false
@@ -1292,7 +1473,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
               commit()
               precedingSpaces = run
             else
-              sb.append(' ')
+              appendAtomChar(' ')
               atomOpen = true
           else
             if run == 1 then
@@ -1317,31 +1498,29 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
             while more && peek != LF && peek != CR do advance()
             remark = Text(sliceText(mk))
           else
-            sb.append(ch.toChar)
+            appendAtomChar(ch.toChar)
             atomOpen = true
             advance()
         else
-          // Read a run of non-space, non-sigil, non-LF, non-CR bytes into
-          // sb. This is the inner-loop hot path; we want bulk-copy.
-          val mk = beginMark()
-          var localPos = pos
-          while localPos < bufEnd
-                && bytes(localPos) != SP
-                && bytes(localPos) != LF
-                && bytes(localPos) != CR
-                && (atomOpen || bytes(localPos) != sigil)
-          do localPos += 1
-          val runLen = localPos - pos
+          // Read a run of non-space, non-sigil, non-LF, non-CR bytes
+          // directly into the char buffer — no intermediate String alloc.
+          // Atom runs in typical TEL are 2-12 bytes, too short for SWAR
+          // to amortise; we keep the byte loop and just direct-copy the
+          // range as UTF-8 → char in one shot.
+          val runStart = pos
+          while pos < bufEnd
+                && bytes(pos) != SP
+                && bytes(pos) != LF
+                && bytes(pos) != CR
+                && (atomOpen || bytes(pos) != sigil)
+          do pos += 1
+          val runLen = pos - runStart
           if runLen > 0 then
-            // Append via cursor.slice for a single zero-copy materialise →
-            // string concat.
-            pos = localPos
-            val piece = sliceText(mk)
-            sb.append(piece)
+            appendBytesAsAtomChars(bytes, runStart, runLen)
             atomOpen = true
           else
             // Could be a sigil while atomOpen — treat as content.
-            sb.append(ch.toChar)
+            appendAtomChar(ch.toChar)
             atomOpen = true
             advance()
 
@@ -1363,21 +1542,29 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // cache for ≤8-byte keywords (allocation-free on hit), one `grabText` on
   // miss or for length > 8.
   private def readKeyword(): Text raises TelError =
-    val startMk = beginMark()
+    // Track the byte offset directly instead of going through `cursor.mark`.
+    // With holdStart pinned at the outer hold's start (basePos stays 0),
+    // a refill never moves the byte at `startByte`; subsequent reads see
+    // the same data in the (possibly grown) buffer array.
+    val startByte = pos
     var low:  Long = 0L
     var high: Long = 0L
     var len = 0
-    while more && peek != SP && peek != LF && peek != CR do
-      val b = peek
-      if len < 4 then
-        low |= (b & 0xff).toLong << (len * 8)
-      else if len < 8 then
-        high |= (b & 0xff).toLong << ((len - 4) * 8)
-      len += 1
-      advance()
+    while
+      while pos < bufEnd && bytes(pos) != SP && bytes(pos) != LF && bytes(pos) != CR do
+        val b = bytes(pos)
+        if len < 4 then
+          low |= (b & 0xff).toLong << (len * 8)
+        else if len < 8 then
+          high |= (b & 0xff).toLong << ((len - 4) * 8)
+        len += 1
+        pos += 1
+      pos == bufEnd && more
+    do ()
 
     if len == 0 then t""
-    else if len > 8 then Text(sliceText(startMk))
+    else if len > 8 then
+      Text(new String(bytes, startByte, len, java.nio.charset.StandardCharsets.UTF_8))
     else
       val hash = ((low ^ (low >>> 32)) ^ (high ^ (high >>> 17))).toInt
       var slot = hash & 0x3F
@@ -1386,7 +1573,7 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
       while result == null && probes < 4 do
         val existing = keyCache(slot)
         if existing == null then
-          val s = sliceText(startMk)
+          val s = new String(bytes, startByte, len, java.nio.charset.StandardCharsets.UTF_8)
           keyCache(slot) = s
           keyCacheLow(slot) = low
           keyCacheHigh(slot) = high
@@ -1398,4 +1585,4 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
           probes += 1
 
       if result != null then Text(result)
-      else Text(sliceText(startMk))
+      else Text(new String(bytes, startByte, len, java.nio.charset.StandardCharsets.UTF_8))

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -71,14 +71,19 @@ object TelParser:
     new TelParser(cursor, schema: Optional[Tels]).parse()
 
   // Convenience overloads for callers that already have the whole input as
-  // a single byte chunk. The cursor is constructed with `linefeedByte`
-  // lineation so error positions carry accurate line/column.
+  // a single byte chunk. The cursor is constructed with `untrackedData`
+  // lineation: TelParser tracks the 1-indexed source line via its own
+  // `lineNo` field (bumped at every LF-consumption point) and never reads
+  // `cursor.line` / `cursor.column`. Driving cursor's lineation would
+  // record (line, column) on every `cursor.mark` call — for a parser that
+  // marks O(atoms + keywords + remarks + payloads) times per parse this is
+  // significant wasted work, since the recorded offsets are never consulted.
   def parse(input: Data): Tel.Document raises TelError =
-    import zephyrine.lineation.linefeedByte
+    import zephyrine.Lineation.untrackedData
     new TelParser(Cursor[Data](input), Unset).parse()
 
   def parse(input: Data, schema: Tels): Tel.Document raises TelError =
-    import zephyrine.lineation.linefeedByte
+    import zephyrine.Lineation.untrackedData
     new TelParser(Cursor[Data](input), schema: Optional[Tels]).parse()
 
   private final val SP: Byte = 0x20

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -64,11 +64,28 @@ import TelError.Reason
 
 object TelParser:
 
+  // Per-thread cached parser. The parser's mutable state (scratch buffers,
+  // keyword cache, StringBuilder, ArrayBuffer of ancestors, etc.) is
+  // expensive to allocate fresh on every call; reusing the same parser
+  // across calls on a thread amortises those allocations to ~one per
+  // thread-lifetime. `reset()` re-initialises all per-parse state at the
+  // start of each call. The atom arena is REPLACED (not reused) so any
+  // `Tel.Atom.Inline` instances returned from prior parses keep their
+  // backing bytes valid; the previous arena array stays alive via those
+  // Inlines and gets GC'd once all references to the prior Document are
+  // released.
+  private val cached: ThreadLocal[TelParser] =
+    ThreadLocal.withInitial(() => new TelParser())
+
   def parse(cursor: Cursor[Data]): Tel.Document raises TelError =
-    new TelParser(cursor, Unset).parse()
+    val p = cached.get.nn
+    p.reset(cursor, Unset)
+    p.parse()
 
   def parse(cursor: Cursor[Data], schema: Tels): Tel.Document raises TelError =
-    new TelParser(cursor, schema: Optional[Tels]).parse()
+    val p = cached.get.nn
+    p.reset(cursor, schema: Optional[Tels])
+    p.parse()
 
   // Convenience overloads for callers that already have the whole input as
   // a single byte chunk. The cursor is constructed with `untrackedData`
@@ -80,11 +97,15 @@ object TelParser:
   // significant wasted work, since the recorded offsets are never consulted.
   def parse(input: Data): Tel.Document raises TelError =
     import zephyrine.Lineation.untrackedData
-    new TelParser(Cursor[Data](input), Unset).parse()
+    val p = cached.get.nn
+    p.reset(Cursor[Data](input), Unset)
+    p.parse()
 
   def parse(input: Data, schema: Tels): Tel.Document raises TelError =
     import zephyrine.Lineation.untrackedData
-    new TelParser(Cursor[Data](input), schema: Optional[Tels]).parse()
+    val p = cached.get.nn
+    p.reset(Cursor[Data](input), schema: Optional[Tels])
+    p.parse()
 
   private final val SP: Byte = 0x20
   private final val LF: Byte = 0x0A
@@ -149,7 +170,7 @@ object TelParser:
     var startLine:     Int = 1      // 1-indexed source line of this line
 
 
-private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
+private final class TelParser():
   import TelParser.*
 
   // ── Local snapshot ────────────────────────────────────────────────────────
@@ -157,8 +178,13 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
   // buffer keeps `bytes`/`pos`/`bufEnd` as plain fields so the JIT can hold
   // them in registers across hot byte loops. Sync to the cursor before any
   // mark/slice/refill operation; resync after.
+  //
+  // `cursor` and `schema` are `var`s rather than constructor args because
+  // the parser is cached per-thread and reset across calls. `reset()`
+  // re-binds both before each `parse()` invocation.
 
-  private val cursor: Cursor[Data] = cursor0
+  private var cursor: Cursor[Data] = null.asInstanceOf[Cursor[Data]]
+  private var schema: Optional[Tels] = Unset
   private var bytes:  Array[Byte] = null.asInstanceOf[Array[Byte]]
   private var pos:    Int = 0
   private var bufEnd: Int = 0
@@ -588,6 +614,60 @@ private final class TelParser(cursor0: Cursor[Data], schema: Optional[Tels]):
     cursor.slice(start, endMk): (storage, off, len) =>
       val arr = storage.asInstanceOf[Array[Byte]]
       if len <= 0 then "" else new String(arr, off, len, StandardCharsets.UTF_8)
+
+  // ── Reset (per-thread reuse) ──────────────────────────────────────────────
+  //
+  // Re-initialise the parser for a new parse. Called by the cached factory
+  // in `object TelParser` before each `parse()` invocation. Every mutable
+  // field that survives across parses is reset here; reusable arrays
+  // (scratch buffers, ancestors, sb) are cleared in place so we don't pay
+  // their allocation again. The atom arena is REPLACED with a fresh array
+  // because previously-parsed Inlines reference the old one — we cannot
+  // overwrite their bytes. The keyword-fingerprint cache is preserved
+  // across resets so frequent keywords stay interned.
+  private[stratiform] def reset(c: Cursor[Data], s: Optional[Tels]): Unit =
+    cursor = c
+    schema = s
+    bytes  = null.asInstanceOf[Array[Byte]]
+    pos    = 0
+    bufEnd = 0
+    lineNo = 1
+    margin = 0
+    sigil  = '#'.toByte
+    crlfMode = false
+    lineEndingsDetected = false
+    lineEndings = Tel.LineEndings.Lf
+    head.leadingSpaces = 0
+    head.indentLevels  = 0
+    head.blank = false
+    head.eof   = false
+    head.startLine = 1
+    prevLineWasBoundary = true
+    prevContentLeadingSpaces = -1
+    hasConsumedNonBlankLine = false
+    documentEndsWithLf = false
+    ancestors.clear()
+    sb.setLength(0)
+    // Fresh arena: previous parse's Inlines hold the old array via their
+    // (arena, off, len) backing reference, so it stays alive as long as
+    // those Inlines are referenced.
+    atomArena     = new Array[Byte](256)
+    arenaPos      = 0
+    inFlightStart = -1
+    // Null out the scratch arrays so they don't pin references from the
+    // previous parse. Cheap (one pass over what are typically small arrays);
+    // worth it to let GC collect the previous Document's transient nodes
+    // promptly while the parser sits in the ThreadLocal between calls.
+    java.util.Arrays.fill(scratchAtoms.asInstanceOf[Array[AnyRef]], null)
+    atomScratchIx = 0
+    java.util.Arrays.fill(scratchComments.asInstanceOf[Array[AnyRef]], null)
+    commentScratchIx = 0
+    java.util.Arrays.fill(scratchCompounds.asInstanceOf[Array[AnyRef]], null)
+    compoundScratchIx = 0
+    java.util.Arrays.fill(scratchBlocks.asInstanceOf[Array[AnyRef]], null)
+    blockScratchIx = 0
+    compoundLineKeyword = t""
+    compoundLineRemark  = Unset
 
   // ── Top-level parse ───────────────────────────────────────────────────────
 

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -41,7 +41,14 @@ object Cursor:
   opaque type Mark = Long
   opaque type Offset = Long
 
-  class Held()
+  // `Held` is a witness type — it has no per-instance state, and the marker
+  // APIs (`mark`, `cue`) only consult its type to gate access. Share a
+  // single instance across all `cursor.hold` calls instead of allocating a
+  // fresh one each time; parsers using narrow per-leaf holds open one
+  // `cursor.hold` per line and would otherwise pay one tiny `Held`
+  // allocation per line.
+  final class Held private[zephyrine] ()
+  val shared: Held = new Held()
 
   type Loader[data] = () => Optional[data]
 
@@ -435,7 +442,7 @@ final class Cursor[data]
     val wasHeld = holdStart >= 0
     if !wasHeld then holdStart = pos
 
-    action(using new Cursor.Held()).also:
+    action(using Cursor.shared).also:
       if !wasHeld then
         holdStart = -1
         marksSize = 0


### PR DESCRIPTION
The TelParser no longer buffers its entire input. Holds are narrowed to per-leaf scope so the cursor can compact away consumed bytes between lines, atom bytes are written into a single growing per-parse arena referenced by lazy Tel.Atom.Inline instances (so per-atom byte arrays are gone), the parser itself is reused across calls via a ThreadLocal cache, and a few small zephyrine.Cursor optimisations (Cursor.Held singleton; `untrackedData` lineation for the bundled-input fast path) round out the cycle. Net throughput on the eight benchmark documents is up 4-18% on five cases, flat on two, and down 8-12% on two; ex1 hits 199k op/s ≈ 610 MB/s, ex2 hits 1.53M op/s ≈ 313 MB/s. The chunk-boundary fuzz suite (parse sizes {1,7,64,1024,full}) now genuinely exercises refill+compact round-trips — under the old design all chunk sizes collapsed to "input resident in one buffer".

## Streaming TEL parsing

`stratiform.Tel.parse(...)` is now a true streaming reader: it does not hold the entire input resident in memory while parsing. Per-leaf `cursor.hold` scopes mean the underlying `zephyrine.Cursor` can reclaim consumed bytes between lines. There is no API change — a `Cursor[Data]` constructed from an `Iterator[Data]` chunked at any granularity now parses with bounded buffer memory.

## `Tel.Atom.Inline` lazy decode

`Tel.Atom.Inline` is now a regular class (not a case class) that stores the atom's UTF-8 bytes (as a slice of a per-parse arena) and materialises its `text: Text` lazily on first access. Consumers that read every atom's text behave identically. Consumers that only inspect some atoms (e.g. partial decoders, schema validation that short-circuits) skip the UTF-8 decode and String allocation for the atoms they never touch. Pattern-match syntax and \`apply\`/\`unapply\` are preserved:

\`\`\`scala
atom match
  case Tel.Atom.Inline(text, precedingSpaces) => ...
\`\`\`

## ThreadLocal parser reuse

\`TelParser\` instances are now cached per thread. Tight loops calling \`Tel.parse(bytes)\` no longer allocate the parser's scratch buffers, keyword cache, and StringBuilder on every call. The cached parser is reset (not re-allocated) between calls; the atom arena is replaced on each reset so previously-parsed atoms keep their backing bytes valid.

## zephyrine.Cursor.Held singleton

\`zephyrine.Cursor.hold\` no longer allocates a fresh \`Cursor.Held\` witness per invocation. A shared \`Cursor.shared: Cursor.Held\` singleton is used instead. The constructor is now \`private[zephyrine]\`; user code that called \`new Cursor.Held()\` directly (none on this codebase) will need to use \`Cursor.shared\` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)