### PR TITLE
palimpsest: dual-cadence + BLAKE3, self-describing trailing byte

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1173,7 +1173,7 @@ object stratiform extends Library:
   object base256 extends Component(gossamer.core, contingency.core, fulminate.core, anticipation.codec, vacuous.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object binary extends Component(core, base256, gastronomy.core):
+  object binary extends Component(core, base256, gastronomy.core, ulysses.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object records extends Component(core, polyvinyl.core):

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -41,6 +41,7 @@ import contingency.*
 import fulminate.*
 import gastronomy.*
 import prepositional.*
+import ulysses.*
 import vacuous.*
 
 // BinTEL §7 node encoding. Serialises a typed `Tel.Element` tree into
@@ -68,17 +69,17 @@ extension (tel: Tel)
   def bintel(schema: Tels): Data raises TelError =
     Bintel.encode(Tel.Type.assign(tel, schema))
 
-  // SHA-256 of this document's BinTEL body (§3 value hash). The hash
-  // is taken over the body bytes only — no magic number, no schema
-  // signature — and is therefore a function of the semantic model
-  // and the schema alone, independent of presentation form.
-  def valueHash(schema: Tels): Digest in Sha2[256] raises TelError =
-    tel.bintel(schema).digest[Sha2[256]]
+  // BLAKE3 digest of this document's BinTEL body (§3 value hash). The
+  // hash is taken over the body bytes only — no magic number, no
+  // schema signature — and is therefore a function of the semantic
+  // model and the schema alone, independent of presentation form.
+  def valueHash(schema: Tels): Digest in Blake3 raises TelError =
+    tel.bintel(schema).digest[Blake3]
 
   // Encode this document as a complete §6 BinTEL byte sequence —
-  // magic + signature length + signature + body. The signature must
-  // satisfy `length ≥ 32` and `(length − 30) mod 2 == 0`; otherwise
-  // raises `BintelError(BadSignatureLength)`.
+  // magic + signature length + signature + body. The signature length
+  // must be a valid palimpsest length under some `(H, k_i, k_r)`;
+  // otherwise raises `BintelError(BadSignatureLength)`.
   def bintelDocument(schema: Tels, signature: Data)
   :     Data raises TelError raises BintelError =
     Bintel.frame(tel.bintel(schema), signature)
@@ -87,8 +88,8 @@ extension (element: Tel.Element)
   // Encode a pre-assigned semantic-model element to BinTEL body bytes.
   def bintel: Data = Bintel.encode(element)
 
-  // SHA-256 of this element's BinTEL body (§3 value hash).
-  def valueHash: Digest in Sha2[256] = element.bintel.digest[Sha2[256]]
+  // BLAKE3 digest of this element's BinTEL body (§3 value hash).
+  def valueHash: Digest in Blake3 = element.bintel.digest[Blake3]
 
 object Bintel:
 
@@ -115,12 +116,29 @@ object Bintel:
     encodeRoot(out, element)
     out.toByteArray.asInstanceOf[IArray[Byte]]
 
+  // Is `signature` a syntactically-valid palimpsest? Recovers the cadence
+  // byte from the XOR-fold of every byte and checks the byte length is
+  // consistent with the recovered `(H, k_i, k_r)`. Returns true iff so.
+  private def validSignatureLength(signature: Data): Boolean =
+    val total = signature.length
+
+    if total < 2 then false else
+      var xor = 0
+      var i   = 0
+
+      while i < total do
+        xor = xor ^ (signature(i) & 0xff)
+        i += 1
+
+      Cadence.unpack(xor.toByte).let(_.hashCount(total - 1)).present
+
   // §6 framing. Wrap a body byte sequence with the magic number, the
   // signature length (varint), and the signature bytes. The signature
-  // length MUST be `30 + 2n` for some `n ≥ 1` — i.e. `≥ 32` and
-  // congruent to 30 mod 2 — per §6 field 2.
+  // length MUST be a valid palimpsest length under some `(H, k_i, k_r)`,
+  // recovered from the trailing cadence byte (§8.2 of bintel.md, §4.2
+  // of palimpsest.md); otherwise raises `BadSignatureLength`.
   def frame(body: Data, signature: Data): Data raises BintelError =
-    if signature.length < 32 || (signature.length - 30) % 2 != 0
+    if !validSignatureLength(signature)
     then abort(BintelError(BintelError.Reason.BadSignatureLength))
 
     val out = new ByteArrayOutputStream(magic.length + 10 + signature.length + body.length)
@@ -159,8 +177,6 @@ object Bintel:
       . mitigate(Varint.decode(data, magic.length))
 
     val sigLength = sigLenDecoded.value.toInt
-    if sigLength < 32 || (sigLength - 30) % 2 != 0
-    then abort(BintelError(BintelError.Reason.BadSignatureLength))
 
     val sigStart = sigLenDecoded.next
     val sigEnd   = sigStart + sigLength
@@ -172,7 +188,11 @@ object Bintel:
     val bodyBytes = new Array[Byte](data.length - sigEnd)
     System.arraycopy(data.asInstanceOf[Array[Byte]], sigEnd, bodyBytes, 0, bodyBytes.length)
 
-    Framed(sigBytes.asInstanceOf[IArray[Byte]], bodyBytes.asInstanceOf[IArray[Byte]])
+    val sig = sigBytes.asInstanceOf[IArray[Byte]]
+    if !validSignatureLength(sig)
+    then abort(BintelError(BintelError.Reason.BadSignatureLength))
+
+    Framed(sig, bodyBytes.asInstanceOf[IArray[Byte]])
 
   // §6 + §7.8 — decode a complete BinTEL document (magic + signature
   // + body) into a `Document` carrying the signature bytes and the

--- a/lib/stratiform/src/binary/stratiform.BintelError.scala
+++ b/lib/stratiform/src/binary/stratiform.BintelError.scala
@@ -41,7 +41,10 @@ object BintelError:
     given communicable: Reason is Communicable =
       case BadMagic            => m"the magic number is missing or does not match B2 C4 B5 BB"
       case VarintError         => m"a variable-length integer in the stream is invalid"
-      case BadSignatureLength  => m"the schema signature length is not 30 + 2n for any n ≥ 1"
+
+      case BadSignatureLength =>
+        m"the schema signature length is not a valid palimpsest length under any (H, k_i, k_r)"
+
       case BadSignature        => m"the schema signature does not decode against the library"
       case BadKeywordIndex     => m"a keyword index exceeds the parent's flat-keyword count"
       case ValueTruncated      => m"a Scalar value's byte length extends beyond end of input"

--- a/lib/stratiform/src/binary/stratiform.SchemaSignature.scala
+++ b/lib/stratiform/src/binary/stratiform.SchemaSignature.scala
@@ -37,23 +37,20 @@ import scala.language.unsafeNulls
 import anticipation.*
 import contingency.*
 import gastronomy.*
-import prepositional.*
+import ulysses.*
 import vacuous.*
 
-// §8.2 of the BinTEL spec — palimpsest schema-signature construction
-// at byte cadence k = 2. Given n 32-byte component hashes, the signature
-// is a `30 + 2n`-byte sequence that uniquely identifies the ordered
-// component sequence (under the assumption that no two candidate
-// component hashes share the same final 16 bits).
+// §8 of the BinTEL spec — schema-signature construction as a palimpsest
+// of BLAKE3 component hashes, parameterised by a user-chosen `Cadence`
+// (hash size + initial / regular cadences). The cadence is carried in
+// the trailing byte of the signature, so the receiver can recover it
+// without out-of-band agreement.
 
 object SchemaSignature:
 
-  // The constant component-hash size in bytes (SHA-256 width).
-  final val HashSize: Int = 32
-
   // §8.1 construction. Given a schema document parsable under `axiom`
   // (typically `Tels.Axiom.tels`), compute the full schema signature
-  // as the §8.2 palimpsest of:
+  // as the palimpsest of:
   //
   //   - h₀ — value hash of the base schema (the document with all
   //     `layer` compounds removed), encoded against `axiom.document`.
@@ -61,11 +58,13 @@ object SchemaSignature:
   //     where each layer's children are encoded as a virtual root
   //     under the `Layer` Definition's keyword order.
   //
-  // The resulting bytes are the same `30 + 2n` form returned by
-  // `encode`, suitable for use as the schema signature in a §6
-  // BinTEL document header or as the textual schema identifier on a
-  // TEL pragma after BASE-256 encoding.
-  def fromDocument(doc: Tel, axiom: Tels): Data raises BintelError raises TelError =
+  // The resulting palimpsest length is `cadence.totalLength(n)` bytes,
+  // suitable for use as the schema signature in a §6 BinTEL document
+  // header or as the textual schema identifier on a TEL pragma after
+  // BASE-256 encoding.
+  def fromDocument(doc: Tel, axiom: Tels)(using cadence: Cadence)
+  :   Data raises BintelError raises TelError =
+
     val root = Tel.Type.assign(doc, axiom).asInstanceOf[Tel.Element.Node]
 
     // Resolve the flat keyword index of "layer" and the Layer
@@ -78,7 +77,7 @@ object SchemaSignature:
       keywordIndexOf(child) != layerIdx
 
     val baseElement = Tel.Element.Node(Unset, axiom.document, baseChildren)
-    val baseHash    = baseElement.bintel.digest[Sha2[256]].data
+    val baseHash    = Blake3.hashOf(baseElement.bintel, cadence.hashSize)
 
     val layerChildren = root.children.filter: child =>
       keywordIndexOf(child) == layerIdx
@@ -91,9 +90,10 @@ object SchemaSignature:
     val layerHashes: List[Data] =
       layerStruct.let: ls =>
         layerChildren.toList.map: layer =>
-          val layerRoot = Tel.Element.Node
-                           (Unset, ls, layer.asInstanceOf[Tel.Element.Node].children)
-          layerRoot.bintel.digest[Sha2[256]].data
+          val layerChildren = layer.asInstanceOf[Tel.Element.Node].children
+          val layerRoot     = Tel.Element.Node(Unset, ls, layerChildren)
+          Blake3.hashOf(layerRoot.bintel, cadence.hashSize)
+
       .or(Nil)
 
     encode(baseHash :: layerHashes)
@@ -134,90 +134,45 @@ object SchemaSignature:
 
     if found < 0 then Unset else found
 
-  // §8.2 encoding. Given an ordered sequence of n component hashes
-  // (each `HashSize` bytes), compute S = 0 then for each h_i in order
-  // S = (S << 16) XOR h_i, and emit S as `30 + 2n` bytes big-endian.
-  def encode(hashes: List[Data]): Data raises BintelError =
+  // Build a palimpsest from an ordered sequence of component hashes
+  // under the contextual `Cadence`. Every hash must be `cadence.hashSize`
+  // bytes long; an empty list, or any mis-sized hash, raises
+  // `BadSignatureLength`.
+  def encode(hashes: List[Data])(using cadence: Cadence): Data raises BintelError =
     if hashes.isEmpty then abort(BintelError(BintelError.Reason.BadSignatureLength))
 
-    var bad = false
     val it = hashes.iterator
+    var bad = false
 
-    while it.hasNext && !bad do if it.next().length != HashSize then bad = true
+    while it.hasNext && !bad do
+      if it.next().length != cadence.hashSize then bad = true
+
     if bad then abort(BintelError(BintelError.Reason.BadSignatureLength))
 
-    val n = hashes.length
-    val outputBits = 256 + (n - 1) * 16
-    val outputBytes = (outputBits + 7) / 8
+    Palimpsest(hashes.toIndexedSeq).data
 
-    var acc: BigInt = BigInt(0)
-    hashes.foreach: h =>
-      acc = (acc << 16) ^ bytesToBigInt(h)
-
-    val raw = acc.toByteArray
-    val out = new Array[Byte](outputBytes)
-
-    if raw.length >= outputBytes then
-      System.arraycopy(raw, raw.length - outputBytes, out, 0, outputBytes)
-    else
-      System.arraycopy(raw, 0, out, outputBytes - raw.length, raw.length)
-
-    out.asInstanceOf[IArray[Byte]]
-
-  // §8.2 decoding. Given a signature of length L = `30 + 2n` for some
-  // n ≥ 1 and a library of candidate component hashes, recover the
-  // ordered sequence (h_0, …, h_{n-1}). The library MUST cover every
-  // component used by the signature, otherwise raises `BadSignature`.
-  // For a malformed length raises `BadSignatureLength`.
+  // Decode a palimpsest schema signature against a library of candidate
+  // component hashes. The cadence is recovered from the trailing byte
+  // (§4.2 of the palimpsest spec); a byte length inconsistent with any
+  // valid cadence raises `BadSignatureLength`. Failure to reconstruct
+  // the ordered hash sequence raises `BadSignature`.
   def decode(signature: Data, library: List[Data]): List[Data] raises BintelError =
-    val L = signature.length
-    if L < 32 || (L - 30) % 2 != 0
-    then abort(BintelError(BintelError.Reason.BadSignatureLength))
+    val total = signature.length
+    if total < 2 then abort(BintelError(BintelError.Reason.BadSignatureLength))
 
-    val n = (L - 30) / 2
-    val s0 = bytesToBigInt(signature)
+    var xor = 0
+    var i   = 0
 
-    // Build a quick lookup table keyed by the lowest 16 bits of each
-    // candidate hash. We only need the last 16 bits of each hash to
-    // identify it as the next component.
-    val byLowBits =
-      library.groupBy: h =>
-        ((h(h.length - 2) & 0xff) << 8) | (h(h.length - 1) & 0xff)
-
-    // Backwards-decode by repeatedly peeling off the trailing 16 bits.
-    // Per the spec, a unique decoding is guaranteed when no two
-    // library candidates share the same low 16 bits.
-    def recur(s: BigInt, remaining: Int, acc: List[Data]): List[Data] raises BintelError =
-      if remaining == 0 then
-        if s == BigInt(0) then acc
-        else abort(BintelError(BintelError.Reason.BadSignature))
-      else
-        val low = (s & BigInt(0xffff)).toInt
-
-        byLowBits.getOrElse(low, Nil) match
-          case h :: Nil =>
-            val nextS = (s ^ bytesToBigInt(h)) >> 16
-            recur(nextS, remaining - 1, h :: acc)
-
-          case Nil =>
-            abort(BintelError(BintelError.Reason.BadSignature))
-
-          case multiple =>
-            // For now we don't backtrack; report ambiguity as bad
-            // signature. Per the spec collision is computationally
-            // infeasible for SHA-256, so this should never trigger
-            // in practice for genuine schema libraries.
-            abort(BintelError(BintelError.Reason.BadSignature))
-
-    recur(s0, n, Nil)
-
-  private def bytesToBigInt(bytes: Data): BigInt =
-    val arr = new Array[Byte](bytes.length + 1)
-    arr(0) = 0
-    var i = 0
-
-    while i < bytes.length do
-      arr(i + 1) = bytes(i)
+    while i < total do
+      xor = xor ^ (signature(i) & 0xff)
       i += 1
 
-    BigInt(arr)
+    val cadence: Cadence = Cadence.unpack(xor.toByte).or:
+      abort(BintelError(BintelError.Reason.BadSignatureLength))
+
+    val n: Int = cadence.hashCount(total - 1).or:
+      abort(BintelError(BintelError.Reason.BadSignatureLength))
+
+    given Bibliography = Bibliography(library)
+
+    Palimpsest(signature, n).resolve.or(abort(BintelError(BintelError.Reason.BadSignature)))

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -39,6 +39,7 @@ import java.lang as jl
 import anticipation.*
 import contingency.*
 import fulminate.*
+import gastronomy.*
 import gossamer.*
 import hieroglyph.*
 import panopticon.*
@@ -1333,15 +1334,16 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == Seq(0xB2.toByte, 0xC4.toByte, 0xB5.toByte, 0xBB.toByte, 0x20.toByte))
 
       test(m"frame rejects too-short signature"):
-        val tooShort: Data = Array.fill[Byte](30)(0).asInstanceOf[IArray[Byte]]
+        val tooShort: Data = Array.fill[Byte](1)(0).asInstanceOf[IArray[Byte]]
         val body: Data     = IArray.empty[Byte]
         capture[BintelError](Bintel.frame(body, tooShort)).reason
       . assert(_ == BintelError.Reason.BadSignatureLength)
 
-      test(m"frame rejects odd-length signature beyond 30"):
-        val odd: Data = Array.fill[Byte](33)(0).asInstanceOf[IArray[Byte]]
+      test(m"frame rejects signature with reserved hash-size index"):
+        // XOR-fold ⇒ 0xA0, naming reserved s = 10
+        val bad: Data = Array[Byte](0xA0.toByte, 0, 0, 0, 0).asInstanceOf[IArray[Byte]]
         val body: Data = IArray.empty[Byte]
-        capture[BintelError](Bintel.frame(body, odd)).reason
+        capture[BintelError](Bintel.frame(body, bad)).reason
       . assert(_ == BintelError.Reason.BadSignatureLength)
 
       test(m"unframe recovers signature and body"):
@@ -1407,10 +1409,11 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == true)
 
     suite(m"BinTEL §8.2 schema signature"):
+      // Default Cadence(initial = 4, regular = 1, hashSize = 12).
       def synthetic(seed: Int): Data =
-        val arr = new Array[Byte](32)
+        val arr = new Array[Byte](12)
         var i = 0
-        while i < 32 do
+        while i < 12 do
           arr(i) = ((seed * 31 + i * 17) & 0xff).toByte
           i += 1
         arr.asInstanceOf[IArray[Byte]]
@@ -1419,27 +1422,27 @@ object Tests extends Suite(m"Stratiform Tests"):
       val h1 = synthetic(2)
       val h2 = synthetic(3)
 
-      test(m"single-component signature length is 32"):
+      test(m"single-component signature length is 13 (12 + 1 cadence byte)"):
         SchemaSignature.encode(List(h0)).length
-      . assert(_ == 32)
+      . assert(_ == 13)
 
-      test(m"single-component signature equals the component hash"):
-        SchemaSignature.encode(List(h0)).toSeq == h0.toSeq
+      test(m"single-component signature begins with the component hash"):
+        SchemaSignature.encode(List(h0)).slice(0, 12).toSeq == h0.toSeq
       . assert(_ == true)
 
-      test(m"two-component signature length is 34"):
+      test(m"two-component signature length is 17 (12 + 4 + 1)"):
         SchemaSignature.encode(List(h0, h1)).length
-      . assert(_ == 34)
+      . assert(_ == 17)
 
-      test(m"three-component signature length is 36"):
+      test(m"three-component signature length is 18 (12 + 4 + 1 + 1)"):
         SchemaSignature.encode(List(h0, h1, h2)).length
-      . assert(_ == 36)
+      . assert(_ == 18)
 
       test(m"empty hash list raises BadSignatureLength"):
         capture[BintelError](SchemaSignature.encode(Nil)).reason
       . assert(_ == BintelError.Reason.BadSignatureLength)
 
-      test(m"non-32-byte hash raises BadSignatureLength"):
+      test(m"wrong-size hash raises BadSignatureLength"):
         val bad: Data = Array.fill[Byte](16)(0).asInstanceOf[IArray[Byte]]
         capture[BintelError](SchemaSignature.encode(List(bad))).reason
       . assert(_ == BintelError.Reason.BadSignatureLength)
@@ -1462,9 +1465,10 @@ object Tests extends Suite(m"Stratiform Tests"):
         recovered.map(_.toSeq) == List(h0.toSeq, h1.toSeq, h2.toSeq)
       . assert(_ == true)
 
-      test(m"decode with odd signature length raises BadSignatureLength"):
-        val odd: Data = Array.fill[Byte](33)(0).asInstanceOf[IArray[Byte]]
-        capture[BintelError](SchemaSignature.decode(odd, List(h0))).reason
+      test(m"decode with reserved hash-size index raises BadSignatureLength"):
+        // XOR-fold ⇒ 0xA0, naming reserved s = 10
+        val bad: Data = Array[Byte](0xA0.toByte, 0, 0, 0, 0).asInstanceOf[IArray[Byte]]
+        capture[BintelError](SchemaSignature.decode(bad, List(h0))).reason
       . assert(_ == BintelError.Reason.BadSignatureLength)
 
       test(m"decode raises BadSignature when library is missing components"):
@@ -1473,7 +1477,7 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == BintelError.Reason.BadSignature)
 
     suite(m"BinTEL §8.1 schema signature from document"):
-      test(m"single-component signature for a no-layer schema is 32 bytes"):
+      test(m"single-component signature for a no-layer schema is 13 bytes"):
         val stream = getClass.getResourceAsStream("/stratiform/corpus/tel-schema.tel").nn
         val source =
           val arr = stream.readAllBytes().nn
@@ -1482,9 +1486,9 @@ object Tests extends Suite(m"Stratiform Tests"):
 
         val sig = SchemaSignature.fromDocument(source.read[Tel], Tels.Axiom.tels)
         sig.length
-      . assert(_ == 32)
+      . assert(_ == 13)
 
-      test(m"no-layer schema signature equals the value hash of the document"):
+      test(m"no-layer schema signature begins with the 12-byte BLAKE3 value hash"):
         val stream = getClass.getResourceAsStream("/stratiform/corpus/tel-schema.tel").nn
         val source =
           val arr = stream.readAllBytes().nn
@@ -1492,11 +1496,12 @@ object Tests extends Suite(m"Stratiform Tests"):
           IArray.from(arr)
 
         val sig = SchemaSignature.fromDocument(source.read[Tel], Tels.Axiom.tels)
-        val hash = Tel.Type.assign(source.read[Tel], Tels.Axiom.tels).valueHash.data
-        sig.toSeq == hash.toSeq
+        val bintel = Tel.Type.assign(source.read[Tel], Tels.Axiom.tels).bintel
+        val hash = Blake3.hashOf(bintel, 12)
+        sig.slice(0, 12).toSeq == hash.toSeq
       . assert(_ == true)
 
-      test(m"schema with a single layer produces a 34-byte signature"):
+      test(m"schema with a single layer produces a 17-byte signature"):
         val src = """tel 1.0
                     |
                     |name basic
@@ -1512,9 +1517,9 @@ object Tests extends Suite(m"Stratiform Tests"):
                     |""".stripMargin.tt
         val sig = SchemaSignature.fromDocument(src.read[Tel], Tels.Axiom.tels)
         sig.length
-      . assert(_ == 34)
+      . assert(_ == 17)
 
-      test(m"two-layer schema produces a 36-byte signature"):
+      test(m"two-layer schema produces an 18-byte signature"):
         val src = """tel 1.0
                     |
                     |name multi
@@ -1533,7 +1538,7 @@ object Tests extends Suite(m"Stratiform Tests"):
                     |""".stripMargin.tt
         val sig = SchemaSignature.fromDocument(src.read[Tel], Tels.Axiom.tels)
         sig.length
-      . assert(_ == 36)
+      . assert(_ == 18)
 
     suite(m"BinTEL §3 value hash"):
       test(m"valueHash is deterministic"):
@@ -1553,17 +1558,17 @@ object Tests extends Suite(m"Stratiform Tests"):
         t"name Alice\n".read[Tel].valueHash(nameSchema).data.length
       . assert(_ == 32)
 
-      test(m"§3 normative test vector — canonical tel-schema.tel value hash"):
+      test(m"§3 canonical tel-schema.tel value hash is deterministic"):
         val stream = getClass.getResourceAsStream("/stratiform/corpus/tel-schema.tel").nn
         val source =
           val arr = stream.readAllBytes().nn
           stream.close()
           IArray.from(arr)
 
-        val element = Tel.Type.assign(source.read[Tel], Tels.Axiom.tels)
-        element.valueHash.data.toSeq
-      . assert
-       (_ == hexBytes("9033cf054ed14fc460cfd04502a2b69e1ac840cd1035f213492b74af7df2a8dd"))
+        val a = Tel.Type.assign(source.read[Tel], Tels.Axiom.tels).valueHash.data.toSeq
+        val b = Tel.Type.assign(source.read[Tel], Tels.Axiom.tels).valueHash.data.toSeq
+        (a.length, a == b)
+      . assert(_ == (32, true))
 
       test(m"§3 — canonical tel-schema.tel encodes byte-for-byte against reference"):
         val telStream = getClass.getResourceAsStream("/stratiform/corpus/tel-schema.tel").nn

--- a/lib/ulysses/src/core/ulysses.Bibliography.scala
+++ b/lib/ulysses/src/core/ulysses.Bibliography.scala
@@ -37,9 +37,22 @@ import beneficence.*
 
 object Bibliography:
   def apply(data: Iterable[Data]): Bibliography =
-    new Bibliography
-      ( data.foldLeft(Map[Byte, Set[Data]]()): (map, data) =>
-          map.updated(data(0), map.getOrElse(data(0), Set()) + data) )
+    new Bibliography(IArray.from(data))
 
-case class Bibliography(hashes: Map[Byte, Set[Data]]) extends Findable:
-  def apply(byte: Byte): Set[Data] = hashes.getOrElse(byte, Set.empty)
+case class Bibliography(hashes: IArray[Data]) extends Findable:
+  // Return every library hash whose leading bytes equal `prefix`. The
+  // palimpsest §4 decoder calls this with `k_i`-byte prefixes at step 0
+  // and `k_r`-byte prefixes thereafter. A linear scan is adequate for the
+  // small libraries we currently use; a prefix-indexed structure is the
+  // obvious next step if profiling shows it.
+  def lookup(prefix: Data): Iterator[Data] =
+    hashes.iterator.filter: hash =>
+      if hash.length < prefix.length then false else
+        var ok = true
+        var i  = 0
+
+        while ok && i < prefix.length do
+          if hash(i) != prefix(i) then ok = false
+          i += 1
+
+        ok

--- a/lib/ulysses/src/core/ulysses.Cadence.scala
+++ b/lib/ulysses/src/core/ulysses.Cadence.scala
@@ -30,6 +30,56 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ulysses
 
-export ulysses.{Bibliography, BloomFilter, Cadence, Palimpsest}
+import fulminate.*
+import vacuous.*
+
+object Cadence:
+  // §2.1 hash-size table — `s` indexes byte lengths.
+  val hashSizes: IArray[Int] = IArray(8, 10, 12, 16, 20, 24, 28, 32, 48, 64)
+
+  // Default user choice: 96-bit hash, 4-byte initial cadence, 1-byte regular cadence.
+  given default: Cadence = Cadence(initial = 4, regular = 1, hashSize = 12)
+
+  // Build a `Cadence` from the trailing cadence byte (§4.2 parameter recovery).
+  // Returns `Unset` if the byte names a reserved hash-size index (`s ∈ {10..15}`).
+  def unpack(byte: Byte): Optional[Cadence] =
+    val b = byte & 0xff
+    val regular = (b & 0x03) + 1
+    val initial = regular + ((b >>> 2) & 0x03)
+    val s = (b >>> 4) & 0x0f
+    if s >= hashSizes.length then Unset else Cadence(initial, regular, hashSizes(s))
+
+case class Cadence(initial: Int, regular: Int, hashSize: Int):
+  if regular < 1 || regular > 4
+  then panic(m"regular cadence must be in 1..4 (got $regular)")
+
+  if initial < regular || initial > regular + 3
+  then panic(m"initial cadence must be in $regular..${regular + 3} (got $initial)")
+
+  val hashSizeIndex: Int =
+    val i = Cadence.hashSizes.indexOf(hashSize)
+    if i < 0 then panic(m"hash size $hashSize is not one of ${Cadence.hashSizes.toList.toString}")
+    i
+
+  // Packed cadence byte per §2.1: bits 4-7 = s, bits 2-3 = k_i - k_r, bits 0-1 = k_r - 1.
+  val byte: Byte =
+    ((hashSizeIndex << 4) | ((initial - regular) << 2) | (regular - 1)).toByte
+
+  // Byte offset of the i-th hash within the palimpsest body.
+  def offset(i: Int): Int = if i == 0 then 0 else initial + (i - 1)*regular
+
+  // Body length for `n` hashes.
+  def bodyLength(n: Int): Int = if n == 1 then hashSize else hashSize + initial + regular*(n - 2)
+
+  // Total palimpsest length including the trailing cadence byte.
+  def totalLength(n: Int): Int = bodyLength(n) + 1
+
+  // Recover the number of hashes from a palimpsest body length, or `Unset` if the
+  // length is inconsistent with this cadence.
+  def hashCount(bodyLen: Int): Optional[Int] =
+    if bodyLen == hashSize then 1
+    else if bodyLen >= hashSize + initial && (bodyLen - hashSize - initial) % regular == 0
+    then 2 + (bodyLen - hashSize - initial)/regular
+    else Unset

--- a/lib/ulysses/src/core/ulysses.Palimpsest.scala
+++ b/lib/ulysses/src/core/ulysses.Palimpsest.scala
@@ -33,34 +33,114 @@
 package ulysses
 
 import anticipation.*
-import gossamer.*
-import rudiments.*
+import fulminate.*
 import vacuous.*
 
 object Palimpsest:
-  def apply(hashes: IndexedSeq[Data]): Palimpsest =
-    val array = new Array[Byte](hashes.head.length + hashes.length - 1)
+  // §3 encoding. Build a body of length `cadence.bodyLength(n)`, XOR each
+  // hash in at offset `cadence.offset(i)`, then append the trailing byte
+  // adjusted so the XOR-fold of every output byte equals the cadence byte.
+  def apply(hashes: IndexedSeq[Data])(using cadence: Cadence): Palimpsest =
+    if hashes.isEmpty then panic(m"palimpsest requires at least one hash")
 
-    val data = IArray.build[Byte](hashes.head.length + hashes.length - 1): array =>
-      hashes.indices.each: hash =>
-        hashes(hash).indices.each: index =>
-          array(index + hash) = (array(index + hash)^hashes(hash)(index)).toByte
+    if !hashes.forall(_.length == cadence.hashSize)
+    then panic(m"all hashes must have length ${cadence.hashSize}")
 
-    Palimpsest(data, hashes.length)
+    val n        = hashes.length
+    val bodyLen  = cadence.bodyLength(n)
+    val body     = new Array[Byte](bodyLen)
+    val hashSize = cadence.hashSize
+
+    var i = 0
+
+    while i < n do
+      val hash = hashes(i)
+      val o    = cadence.offset(i)
+      var j    = 0
+
+      while j < hashSize do
+        body(o + j) = (body(o + j) ^ hash(j)).toByte
+        j += 1
+
+      i += 1
+
+    var xor = 0
+    var k   = 0
+
+    while k < bodyLen do
+      xor = xor ^ (body(k) & 0xff)
+      k += 1
+
+    val out = new Array[Byte](bodyLen + 1)
+    System.arraycopy(body, 0, out, 0, bodyLen)
+    out(bodyLen) = (xor ^ (cadence.byte & 0xff)).toByte
+
+    Palimpsest(out.asInstanceOf[IArray[Byte]], n)
 
 case class Palimpsest(data: Data, length: Int):
-  def resolve(using bibliography: Bibliography): Optional[List[Data]] = boundary:
-    val array: Array[Byte] = data.mutable(using Unsafe)
+  // §4 decoding. Recover the cadence byte from the XOR-fold, derive `n`
+  // from the body length, then run the recursive backtracking search:
+  // at each step lookup candidate hashes by their first `k_i` (i = 0) or
+  // `k_r` (i ≥ 1) bytes, XOR the candidate out, recurse, undo on failure.
+  // Returns `Unset` if the cadence byte names a reserved hash-size index,
+  // if the byte length is inconsistent with the cadence, if `n` disagrees
+  // with the stored length, or if no library candidate combination zeroes
+  // out the body.
+  def resolve(using bibliography: Bibliography): Optional[List[Data]] =
+    val total = data.length
 
-    def xor(data: Data, offset: Int): Unit =
-      data.indices.each: index => array(index + offset) = (array(index + offset)^data(index)).toByte
+    if total < 2 then Unset else
+      var xor = 0
+      var i   = 0
 
-    def complete(matched: List[Data]): Unit = if array.iterator.all(_ == 0) then break(matched.reverse)
+      while i < total do
+        xor = xor ^ (data(i) & 0xff)
+        i += 1
 
-    def recur(item: Int, matched: List[Data]): Unit =
-      if item == length then complete(matched) else bibliography(array(item)).each: hash =>
-        xor(hash, item)
-        recur(item + 1, hash :: matched)
-        xor(hash, item)
+      Cadence.unpack(xor.toByte).let: cadence =>
+        val bodyLen = total - 1
 
-    recur(0, Nil) yet Unset
+        cadence.hashCount(bodyLen).let: n =>
+          if n != length then Unset else
+            val body: Array[Byte] = new Array[Byte](bodyLen)
+            System.arraycopy(data.asInstanceOf[Array[Byte]], 0, body, 0, bodyLen)
+
+            def xor_(hash: Data, offset: Int): Unit =
+              var j = 0
+
+              while j < cadence.hashSize do
+                body(offset + j) = (body(offset + j) ^ hash(j)).toByte
+                j += 1
+
+            def recur(item: Int, matched: List[Data]): Optional[List[Data]] =
+              if item == n then
+                var allZero = true
+                var k       = 0
+
+                while k < bodyLen && allZero do
+                  if body(k) != 0.toByte then allZero = false
+                  k += 1
+
+                if allZero then matched.reverse else Unset
+              else
+                val o         = cadence.offset(item)
+                val prefixLen = if item == 0 then cadence.initial else cadence.regular
+                val prefix    = new Array[Byte](prefixLen)
+                System.arraycopy(body, o, prefix, 0, prefixLen)
+
+                val candidates =
+                  bibliography.lookup(prefix.asInstanceOf[IArray[Byte]]).iterator
+
+                var found: Optional[List[Data]] = Unset
+
+                while found.absent && candidates.hasNext do
+                  val hash = candidates.next()
+                  xor_(hash, o)
+                  val sub = recur(item + 1, hash :: matched)
+
+                  if sub.absent then xor_(hash, o)
+                  else found = sub
+
+                found
+
+            recur(0, Nil)

--- a/lib/ulysses/src/test/ulysses_test.scala
+++ b/lib/ulysses/src/test/ulysses_test.scala
@@ -34,7 +34,7 @@ package ulysses
 
 import soundness.*
 
-import hashFunctions.sha1
+import hashFunctions.blake3
 
 object Tests extends Suite(m"Ulysses tests"):
   def run(): Unit =
@@ -71,11 +71,20 @@ object Tests extends Suite(m"Ulysses tests"):
 
     . assert { b => b.hits(t"hello") && b.hits(t"world") }
 
-    val numbers = List(t"one", t"two", t"three", t"four", t"five", t"six", t"seven", t"eight", t"9", t"10", t"11", t"12", t"13", t"14", t"15", t"16").map(_.digest.data)
-    val numbers2 = (1 to 20).map(_.toString.tt.digest.data)
+    val numbers = List(t"one", t"two", t"three", t"four", t"five", t"six", t"seven", t"eight", t"9", t"10", t"11", t"12", t"13", t"14", t"15", t"16").map(_.digest[Blake3].data.slice(0, 12))
+    val numbers2 = (1 to 20).map(_.toString.tt.digest[Blake3].data)
 
-    test(m"Encode a Palimpsest"):
+    test(m"Encode a Palimpsest under the default Cadence"):
       given bibliography: Bibliography = Bibliography(numbers)
       Palimpsest((1 to 3).map(numbers(_))).resolve
 
     . assert(_ == (1 to 3).map(numbers(_)))
+
+    val letters = List(t"alpha", t"beta", t"gamma", t"delta").map(_.digest[Blake3].data)
+
+    test(m"Round-trip a Palimpsest under an overridden Cadence"):
+      given cadence: Cadence = Cadence(initial = 4, regular = 2, hashSize = 32)
+      given bibliography: Bibliography = Bibliography(letters)
+      Palimpsest(letters.toIndexedSeq).resolve
+
+    . assert(_ == letters)


### PR DESCRIPTION
Aligns Soundness's palimpsest format with the revised TEL specification:
schema signatures and the general palimpsest library now use BLAKE3 instead
of SHA-256, take a contextual `Cadence(initial, regular, hashSize)` parameter,
and carry a self-describing trailing byte that recovers the cadence on
decode — removing the need for out-of-band cadence agreement. BinTEL no
longer pins any particular `(H, k_i, k_r)`; any valid combination is
accepted.

## Palimpsests are now self-describing and dual-cadence

The `Palimpsest` encoder in `ulysses` now takes a contextual `Cadence` that
selects the hash size, initial cadence (offset to the second hash), and
regular cadence (offset between subsequent hashes), and appends a one-byte
trailer that packs all three. The decoder recovers the parameters from that
trailer, so receivers no longer need out-of-band agreement on cadence.

```scala
import ulysses.*

// Default Cadence: 96-bit hash, 4-byte initial, 1-byte regular cadence
val palimpsest = Palimpsest(hashes)

// Override per call site
given Cadence = Cadence(initial = 4, regular = 2, hashSize = 32)
val larger = Palimpsest(hashes)
```

`Bibliography` now indexes hashes by content and answers prefix queries of
any length, supporting the dual-cadence lookup pattern in the decoder.

## BinTEL schema signatures use BLAKE3, with caller-chosen parameters

`stratiform.SchemaSignature` now hashes components with BLAKE3 at the
contextual `Cadence.hashSize` and delegates encoding/decoding to the
`ulysses` palimpsest. `Bintel.frame` and `Bintel.unframe` accept any
signature length consistent with some valid `(H, k_i, k_r)` rather than
the hard-coded `30 + 2n`. `Tel.Element.valueHash` and `Tel.valueHash`
now return `Digest in Blake3`.