### PR TITLE
enigmatic: add COSE signing and verification

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -604,7 +604,10 @@ object enigmatic extends Library:
   object core extends Component(gastronomy.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core)
+  object cose extends Component(core, breviloquence.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core, cose)
 
 object escapade extends Library:
   object core extends Component(anticipation.gfx, gossamer.core, turbulence.core, anticipation.url, iridescence.core, escritoire.core):

--- a/lib/enigmatic/src/cose/enigmatic.cose.CanonicalCbor.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CanonicalCbor.scala
@@ -1,0 +1,85 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import breviloquence.*
+
+// Deterministic CBOR encoding per RFC 8949 §4.2.1, as required by RFC 9052 §9.
+// `CborPrinter` already emits shortest-form integers and definite-length items;
+// what's missing is map-key ordering (bytewise lexicographic order of the
+// encoded keys).
+object CanonicalCbor:
+  def encode(ast: Cbor.Ast): Data = CborPrinter.encode(canonicalise(ast))
+
+  private def canonicalise(ast: Cbor.Ast): Cbor.Ast =
+    if ast.isMap then
+      val n = ast.entries
+      val builder = scala.collection.mutable.ArrayBuffer.empty[(Data, Cbor.Ast, Cbor.Ast)]
+      var index = 0
+      while index < n do
+        val canonicalKey = canonicalise(ast.key(index))
+        val canonicalValue = canonicalise(ast.value(index))
+        builder += ((CborPrinter.encode(canonicalKey), canonicalKey, canonicalValue))
+        index += 1
+      val sorted = builder.sortWith((a, b) => compareBytes(a._1, b._1) < 0)
+      val keys = new Array[Any](n)
+      val values = new Array[Any](n)
+      var write = 0
+      while write < n do
+        keys(write) = sorted(write)._2
+        values(write) = sorted(write)._3
+        write += 1
+      Cbor.Ast.map(keys.asInstanceOf[IArray[Any]], values.asInstanceOf[IArray[Any]])
+    else if ast.isArray then
+      val n = ast.elements
+      val out = new Array[Any](n)
+      var index = 0
+      while index < n do
+        out(index) = canonicalise(ast.element(index))
+        index += 1
+      Cbor.Ast.array(out.asInstanceOf[IArray[Any]])
+    else if ast.isTag then
+      val tag = ast.asInstanceOf[Cbor.Tag]
+      Cbor.Ast(Cbor.Tag(tag.tag, canonicalise(tag.value.asInstanceOf[Cbor.Ast])))
+    else ast
+
+  private def compareBytes(a: Data, b: Data): Int =
+    val n = math.min(a.length, b.length)
+    var index = 0
+    while index < n do
+      val diff = (a(index) & 0xFF) - (b(index) & 0xFF)
+      if diff != 0 then return diff
+      index += 1
+    a.length - b.length

--- a/lib/enigmatic/src/cose/enigmatic.cose.Cose.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.Cose.scala
@@ -1,0 +1,208 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import breviloquence.*
+import contingency.*
+import enigmatic.*
+import gossamer.*
+import prepositional.*
+import turbulence.*
+
+object Cose:
+  private def emptyMapAst: Cbor.Ast =
+    Cbor.Ast.map(IArray.empty[Any], IArray.empty[Any])
+
+  private[cose] def emptyMap: Cbor = Cbor.ast(emptyMapAst)
+
+  private[cose] def unsealOrEmpty(cbor: Cbor): Cbor.Ast =
+    val ast = Cbor.unseal(cbor)
+    if ast.isMap then ast else emptyMapAst
+
+  private[cose] def toBeSigned
+    (context: String, bodyProtected: Data, externalAad: Data, payload: Data)
+  :   Data =
+
+    val sigStruct =
+      Cbor.Ast.array(IArray[Any](context, bodyProtected, externalAad, payload))
+
+    CanonicalCbor.encode(sigStruct)
+
+  private[cose] def readByteString(ast: Cbor.Ast)(using Tactic[CoseError]): Data =
+    if ast.isByteString then ast.asInstanceOf[Data]
+    else abort(CoseError(CoseError.Reason.MalformedStructure))
+
+  // Internal constructor that refines the phantom `Form` and `Operand` types.
+  def make[scheme <: CoseStructure, cipher <: Cipher]
+    (protectedHeader:   Data,
+     unprotectedHeader: Cbor,
+     payload:           Data,
+     contextString:     String,
+     cborTag:           Long,
+     recipients:        List[CoseRecipient])
+  :   Cose in scheme by cipher =
+
+    new Cose(protectedHeader, unprotectedHeader, payload, contextString, cborTag, recipients):
+      type Form    = scheme
+      type Operand = cipher
+
+
+  // User-facing constructor. The key's type selects the variant via
+  // `CoseAuthenticator` (asymmetric -> Sign1, symmetric -> Mac0). Inlined so
+  // `source.read[Data]` expands at the call site, picking up the caller's
+  // readability and tactic instances.
+  inline def apply[source, key]
+    (source: source, key: key)
+    (using auth: key is CoseAuthenticator, cborTactic: Tactic[CborError])
+  :   Cose in auth.Form by auth.Operand raises CoseError =
+
+    val payload: Data  = source.read[Data]
+    val algId          = auth.algId
+    val protectedAst   = Cbor.Ast.map(IArray[Any](1L), IArray[Any](algId))
+    val protectedBstr  = CanonicalCbor.encode(protectedAst)
+    val externalAad    = IArray.empty[Byte]
+    val tbs            = Cose.toBeSigned(auth.contextString, protectedBstr, externalAad, payload)
+    val authentication = auth.authenticate(tbs, key)
+    val recipient      = CoseRecipient(IArray.empty[Byte], Cose.emptyMap, authentication)
+
+    Cose.make[auth.Form, auth.Operand]
+     (protectedBstr,
+      Cose.emptyMap,
+      payload,
+      auth.contextString,
+      auth.cborTag,
+      List(recipient))
+
+
+  // Parse a tagged COSE envelope. The variant is determined from the CBOR
+  // tag; the returned phantom types are the most-general bounds.
+  def parse(bytes: Data)
+    (using cborTactic: Tactic[CborError])
+  :   Cose raises CoseError =
+
+    val ast = Cbor.Ast.parse(bytes)
+
+    if !ast.isTag then abort(CoseError(CoseError.Reason.MalformedStructure))
+
+    val tag       = ast.asInstanceOf[Cbor.Tag]
+    val tagNumber = tag.tag
+
+    val contextString = tagNumber match
+      case CoseTag.Sign1 => CoseContext.Signature1
+      case CoseTag.Mac0  => CoseContext.Mac0
+      case CoseTag.Sign  => CoseContext.Signature
+      case CoseTag.Mac   => CoseContext.Mac
+      case other         => abort(CoseError(CoseError.Reason.UnknownTag(other)))
+
+    val body = tag.value.asInstanceOf[Cbor.Ast]
+    if !body.isArray || body.elements != 4 then
+      abort(CoseError(CoseError.Reason.MalformedStructure))
+
+    val protectedHeader = readByteString(body.element(0))
+    val unprotectedAst  = body.element(1)
+    if !unprotectedAst.isMap then abort(CoseError(CoseError.Reason.MalformedStructure))
+
+    val payload = readByteString(body.element(2))
+
+    val recipients: List[CoseRecipient] = tagNumber match
+      case CoseTag.Sign1 | CoseTag.Mac0 =>
+        List(CoseRecipient(IArray.empty[Byte], emptyMap, readByteString(body.element(3))))
+
+      case _ =>
+        val recipArray = body.element(3)
+        if !recipArray.isArray then abort(CoseError(CoseError.Reason.MalformedStructure))
+        val builder = List.newBuilder[CoseRecipient]
+        var index = 0
+        while index < recipArray.elements do
+          val entry = recipArray.element(index)
+          if !entry.isArray || entry.elements != 3 then
+            abort(CoseError(CoseError.Reason.MalformedStructure))
+          val rp = readByteString(entry.element(0))
+          val ru = entry.element(1)
+          if !ru.isMap then abort(CoseError(CoseError.Reason.MalformedStructure))
+          val ra = readByteString(entry.element(2))
+          builder += CoseRecipient(rp, Cbor.ast(ru), ra)
+          index += 1
+        builder.result()
+
+    new Cose
+        (protectedHeader, Cbor.ast(unprotectedAst), payload, contextString, tagNumber, recipients):
+      type Form    = CoseStructure
+      type Operand = Cipher
+
+
+class Cose
+    (val protectedHeader:   Data,
+     val unprotectedHeader: Cbor,
+     val payload:           Data,
+     val contextString:     String,
+     val cborTag:           Long,
+     val recipients:        List[CoseRecipient]):
+  type Form    <: CoseStructure
+  type Operand <: Cipher
+
+  // Serialise this COSE message to its CBOR-tagged wire form.
+  def bytes: Data =
+    val unprotectedAst: Cbor.Ast = Cose.unsealOrEmpty(unprotectedHeader)
+
+    val envelope = cborTag match
+      case CoseTag.Sign1 | CoseTag.Mac0 =>
+        val auth = recipients.head.authentication
+        Cbor.Ast.array(IArray[Any](protectedHeader, unprotectedAst, payload, auth))
+
+      case _ =>
+        val recipAst: IArray[Any] = IArray.from(recipients.map: r =>
+          Cbor.Ast.array(IArray[Any](r.protectedHeader, Cose.unsealOrEmpty(r.unprotectedHeader),
+            r.authentication)))
+        Cbor.Ast.array(IArray[Any](protectedHeader, unprotectedAst, payload,
+          Cbor.Ast.array(recipAst)))
+
+    CborPrinter.encode(Cbor.Ast(Cbor.Tag(cborTag, envelope)))
+
+
+  def verifyWith[key]
+    (key: key)
+    (using verifier: key is CoseVerifier)
+  :   Boolean raises CoseError =
+
+    if verifier.contextString != contextString then
+      abort(CoseError(CoseError.Reason.VariantMismatch
+       (expected = verifier.contextString.tt, actual = contextString.tt)))
+
+    val externalAad = IArray.empty[Byte]
+    val tbs = Cose.toBeSigned(contextString, protectedHeader, externalAad, payload)
+
+    recipients.exists: recipient =>
+      verifier.check(tbs, recipient.authentication, key)

--- a/lib/enigmatic/src/cose/enigmatic.cose.CoseAlgorithm.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CoseAlgorithm.scala
@@ -1,0 +1,56 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import gastronomy.*
+
+// Maps an enigmatic.Cipher to its COSE Algorithms registry identifier
+// (RFC 9053, https://www.iana.org/assignments/cose/cose.xhtml#algorithms).
+object CoseAlgorithm:
+  // HMAC 256/256 = 5, HMAC 384/384 = 6, HMAC 512/512 = 7
+  given hmacSha256: HmacCipher[Sha2[256]] is CoseAlgorithm = new CoseAlgorithm:
+    type Self = HmacCipher[Sha2[256]]
+    def algId: Long = 5L
+
+  given hmacSha384: HmacCipher[Sha2[384]] is CoseAlgorithm = new CoseAlgorithm:
+    type Self = HmacCipher[Sha2[384]]
+    def algId: Long = 6L
+
+  given hmacSha512: HmacCipher[Sha2[512]] is CoseAlgorithm = new CoseAlgorithm:
+    type Self = HmacCipher[Sha2[512]]
+    def algId: Long = 7L
+
+trait CoseAlgorithm:
+  type Self
+  def algId: Long

--- a/lib/enigmatic/src/cose/enigmatic.cose.CoseAuthenticator.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CoseAuthenticator.scala
@@ -1,0 +1,79 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import enigmatic.*
+import prepositional.*
+
+// Selects the COSE message variant from the key type:
+//   asymmetric (PrivateKey)        -> COSE_Sign1
+//   symmetric  (SymmetricKey)      -> COSE_Mac0
+// `SymmetricKey <: PrivateKey`, so resolution picks the more-specific
+// symmetric given for symmetric keys and falls back to asymmetric otherwise.
+object CoseAuthenticator:
+  given asymmetric: [cipher <: Cipher & Signing]
+                 => (algorithm: cipher & Signing, coseAlg: cipher is CoseAlgorithm)
+                 => PrivateKey[cipher] is CoseAuthenticator in Sign1 by cipher =
+    new CoseAuthenticator:
+      type Self    = PrivateKey[cipher]
+      type Form    = Sign1
+      type Operand = cipher
+      def algId:         Long   = coseAlg.algId
+      def contextString: String = CoseContext.Signature1
+      def cborTag:       Long   = CoseTag.Sign1
+      def authenticate(toBeSigned: Data, key: PrivateKey[cipher]): Data =
+        algorithm.sign(toBeSigned, key.privateData)
+
+  given symmetric: [cipher <: Cipher & Symmetric & Signing]
+                => (algorithm: cipher & Signing, coseAlg: cipher is CoseAlgorithm)
+                => SymmetricKey[cipher] is CoseAuthenticator in Mac0 by cipher =
+    new CoseAuthenticator:
+      type Self    = SymmetricKey[cipher]
+      type Form    = Mac0
+      type Operand = cipher
+      def algId:         Long   = coseAlg.algId
+      def contextString: String = CoseContext.Mac0
+      def cborTag:       Long   = CoseTag.Mac0
+      def authenticate(toBeSigned: Data, key: SymmetricKey[cipher]): Data =
+        algorithm.sign(toBeSigned, key.bytes)
+
+trait CoseAuthenticator:
+  type Self
+  type Form    <: CoseStructure
+  type Operand <: Cipher
+  def algId:         Long
+  def contextString: String
+  def cborTag:       Long
+  def authenticate(toBeSigned: Data, key: Self): Data

--- a/lib/enigmatic/src/cose/enigmatic.cose.CoseError.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CoseError.scala
@@ -1,0 +1,62 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import fulminate.*
+
+object CoseError:
+  object Reason:
+    given communicable: Reason is Communicable =
+      case MalformedStructure              => m"the COSE structure was not well-formed"
+      case UnknownTag(tag)                 => m"the CBOR tag ${tag.toString} is not a COSE message tag"
+      case UnsupportedAlgorithm(id)        => m"the COSE algorithm identifier ${id.toString} is not supported"
+      case AlgorithmMismatch(want, got)    => m"expected COSE algorithm ${want.toString} but found ${got.toString}"
+      case VariantMismatch(want, got)      => m"expected a $want COSE message but found a $got"
+      case VerificationFailed              => m"the COSE signature or MAC did not verify"
+      case CborParseError                  => m"the COSE message contained malformed CBOR"
+      case DetachedPayloadRequired         => m"the COSE message has a detached payload"
+
+  enum Reason(val number: Int) extends Clarification:
+    case MalformedStructure                              extends Reason(1)
+    case UnknownTag(tag: Long)                           extends Reason(2)
+    case UnsupportedAlgorithm(id: Long)                  extends Reason(3)
+    case AlgorithmMismatch(expected: Long, actual: Long) extends Reason(4)
+    case VariantMismatch(expected: Text, actual: Text)   extends Reason(5)
+    case VerificationFailed                              extends Reason(6)
+    case CborParseError                                  extends Reason(7)
+    case DetachedPayloadRequired                         extends Reason(8)
+
+case class CoseError(reason: CoseError.Reason)(using Diagnostics)
+extends Error(596, reason.number)(m"could not process the COSE message because $reason")

--- a/lib/enigmatic/src/cose/enigmatic.cose.CoseRecipient.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CoseRecipient.scala
@@ -1,0 +1,39 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import breviloquence.*
+
+case class CoseRecipient(protectedHeader: Data, unprotectedHeader: Cbor, authentication: Data)

--- a/lib/enigmatic/src/cose/enigmatic.cose.CoseStructure.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CoseStructure.scala
@@ -1,0 +1,55 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+trait CoseStructure
+trait CoseSigned extends CoseStructure
+trait CoseMaced  extends CoseStructure
+
+trait Sign  extends CoseSigned   // multi-signer,        CBOR tag 98
+trait Sign1 extends CoseSigned   // single signer,       CBOR tag 18
+trait Mac   extends CoseMaced    // multi-recipient MAC, CBOR tag 97
+trait Mac0  extends CoseMaced    // single MAC,          CBOR tag 17
+
+object CoseTag:
+  inline val Sign1 = 18L
+  inline val Mac0  = 17L
+  inline val Sign  = 98L
+  inline val Mac   = 97L
+
+object CoseContext:
+  inline val Signature1 = "Signature1"
+  inline val Signature  = "Signature"
+  inline val Mac0       = "MAC0"
+  inline val Mac        = "MAC"

--- a/lib/enigmatic/src/cose/enigmatic.cose.CoseVerifier.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.CoseVerifier.scala
@@ -1,0 +1,73 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import enigmatic.*
+import prepositional.*
+
+// Counterpart to CoseAuthenticator. Selects how the public/symmetric key is
+// used to verify a COSE signature or MAC.
+object CoseVerifier:
+  given asymmetric: [cipher <: Cipher & Signing]
+                 => (algorithm: cipher & Signing)
+                 => PublicKey[cipher] is CoseVerifier in Sign1 by cipher =
+    new CoseVerifier:
+      type Self    = PublicKey[cipher]
+      type Form    = Sign1
+      type Operand = cipher
+      def contextString: String = CoseContext.Signature1
+      def cborTag:       Long   = CoseTag.Sign1
+      def check(toBeSigned: Data, authentication: Data, key: PublicKey[cipher]): Boolean =
+        algorithm.verify(toBeSigned, authentication, key.bytes)
+
+  given symmetric: [cipher <: Cipher & Symmetric & Signing]
+                => (algorithm: cipher & Signing)
+                => SymmetricKey[cipher] is CoseVerifier in Mac0 by cipher =
+    new CoseVerifier:
+      type Self    = SymmetricKey[cipher]
+      type Form    = Mac0
+      type Operand = cipher
+      def contextString: String = CoseContext.Mac0
+      def cborTag:       Long   = CoseTag.Mac0
+      def check(toBeSigned: Data, authentication: Data, key: SymmetricKey[cipher]): Boolean =
+        algorithm.verify(toBeSigned, authentication, key.bytes)
+
+trait CoseVerifier:
+  type Self
+  type Form    <: CoseStructure
+  type Operand <: Cipher
+  def contextString: String
+  def cborTag:       Long
+  def check(toBeSigned: Data, authentication: Data, key: Self): Boolean

--- a/lib/enigmatic/src/cose/enigmatic.cose.HmacCipher.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.HmacCipher.scala
@@ -1,0 +1,82 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import javax.crypto.spec.SecretKeySpec
+
+import anticipation.*
+import enigmatic.*
+import gastronomy.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// Adapter that exposes HMAC as a `Cipher & Signing & Symmetric`, so that
+// `SymmetricKey[HmacCipher[Sha2[256]]]` plugs into the existing
+// `PrivateKey`/`SymmetricKey` machinery in enigmatic.core. Avoids a refactor
+// of `enigmatic.Hmac` (which is an output type, not a cipher).
+object HmacCipher:
+  given value: [algorithm <: Algorithm] => (hash: Hash in algorithm) => HmacCipher[algorithm] =
+    HmacCipher[algorithm]()
+
+class HmacCipher[algorithm <: Algorithm]()(using hash: Hash in algorithm)
+extends Cipher, Signing, Symmetric:
+  type Size = 256
+  def keySize: 256 = 256
+
+  def genKey(): Data =
+    val random = java.security.SecureRandom()
+    val bytes = new Array[Byte](32)
+    random.nextBytes(bytes)
+    bytes.immutable(using Unsafe)
+
+  def privateToPublic(key: Data): Data = key
+
+  def sign(data: Data, keyData: Data): Data =
+    val mac = hash.hmac0
+    mac.init(SecretKeySpec(keyData.to(Array), hash.name.s))
+    mac.doFinal(data.to(Array)).nn.immutable(using Unsafe)
+
+  def verify(data: Data, signature: Data, keyData: Data): Boolean =
+    val expected = sign(data, keyData)
+    constantTimeEquals(expected, signature)
+
+  private def constantTimeEquals(a: Data, b: Data): Boolean =
+    if a.length != b.length then false else
+      var diff = 0
+      var index = 0
+      while index < a.length do
+        diff |= (a(index) ^ b(index)) & 0xFF
+        index += 1
+      diff == 0

--- a/lib/enigmatic/src/cose/enigmatic_cose.scala
+++ b/lib/enigmatic/src/cose/enigmatic_cose.scala
@@ -1,0 +1,55 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+package cose
+
+import anticipation.*
+import breviloquence.*
+import contingency.*
+import turbulence.*
+
+// `bytes.verify[Cose](pubkey)` desugars to `(bytes.verify[Cose]).apply(pubkey)`.
+// The wrapper lets the user name the scheme as a type argument while still
+// allowing the key type to be inferred from the value argument.
+final class CoseVerify[source](val source: source):
+  inline def apply[K]
+    (key: K)
+    (using verifier:  K is CoseVerifier,
+           cborTactic: Tactic[CborError])
+  :   Boolean raises CoseError =
+
+    val bytes: Data = source.read[Data]
+    Cose.parse(bytes).verifyWith(key)
+
+extension [source](source: source)
+  inline def verify[scheme <: Cose]: CoseVerify[source] = new CoseVerify[source](source)

--- a/lib/enigmatic/src/cose/soundness_enigmatic_cose.scala
+++ b/lib/enigmatic/src/cose/soundness_enigmatic_cose.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export enigmatic.cose
+  . { Cose, CoseStructure, CoseSigned, CoseMaced, Sign, Sign1, Mac, Mac0, CoseRecipient,
+      CoseAuthenticator, CoseVerifier, CoseAlgorithm, CoseError, HmacCipher, CoseTag, CoseContext,
+      verify }

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -156,3 +156,33 @@ object Tests extends Suite(m"Gastronomy tests"):
       import alphabets.base64.standard
       pangram.hmac[Sha2[512]](t"key".data).serialize[Base64]
     . assert(_ == t"tCrwkFe6weLUFwjkipAuCbX/fxKrQopP6GZTxz3SSPuC+UilSfe3kaW0GRXuTR7Dk1NX5OIxclDQNyr6Lr7rOg==")
+
+    suite(m"COSE Mac0 (HMAC-SHA-256)"):
+      val keyBytes: Data = t"a-32-byte-key-for-hmac-sha256!!!".data
+      val key: SymmetricKey[HmacCipher[Sha2[256]]] = SymmetricKey(keyBytes)
+      val payload: Data = pangram.data
+
+      test(m"Cose(payload, key) round-trips through verify[Cose](key)"):
+        val cose = Cose(payload, key)
+        cose.bytes.verify[Cose](key)
+      . assert(identity)
+
+      test(m"Cose envelope is tagged with CBOR tag 17 (Mac0)"):
+        val wire = Cose(payload, key).bytes
+        wire(0).toInt & 0xFF
+      . assert(_ == 0xD1)   // major type 6 (tag) | tag value 17 = 0xC0 | 17 = 0xD1
+
+      test(m"Verification fails with the wrong key"):
+        val wire = Cose(payload, key).bytes
+        val wrongKey: SymmetricKey[HmacCipher[Sha2[256]]] =
+          SymmetricKey(t"this-is-a-different-key-bytes!!!".data)
+        wire.verify[Cose](wrongKey)
+      . assert(!_)
+
+      test(m"Verification fails after tampering the wire bytes"):
+        val wire = Cose(payload, key).bytes
+        val tampered = wire.mutable(using Unsafe)
+        // Flip a bit in the MAC tag near the end of the envelope.
+        tampered(tampered.length - 5) = (tampered(tampered.length - 5) ^ 0xFF.toByte).toByte
+        tampered.immutable(using Unsafe).verify[Cose](key)
+      . assert(!_)


### PR DESCRIPTION
## Summary

- New `enigmatic.cose` submodule depending on `enigmatic.core` and `breviloquence.core`. Implements COSE (CBOR Object Signing and Encryption, RFC 9052) for signing and verifying binary blobs.
- API: `Cose(source, key)` produces a COSE message from anything readable as `Data`; `source.verify[Cose](key)` verifies one. Phantom types compose with `prepositional` infix types, so e.g. `Cose(payload, hmacKey)` has the static type `Cose in Mac0 by HmacCipher[Sha2[256]]`.
- Variant is selected from the key type: `PrivateKey` → `Sign1`, `SymmetricKey` → `Mac0`. The `SymmetricKey <: PrivateKey` ambiguity is resolved via most-specific-given resolution on a `CoseAuthenticator` typeclass.
- Includes a local `CanonicalCbor` helper that sorts map keys (RFC 8949 §4.2.1) on top of `breviloquence.CborPrinter`'s existing shortest-int encoding, and an `HmacCipher[A <: Algorithm]` adapter that exposes HMAC as a `Cipher & Signing & Symmetric` so it plugs into the existing key types without changing `enigmatic.core`.

## Scope flag

End-to-end is wired and tested for HMAC/Mac0. Sign1 / Sign / Mac variants compile but cannot yet be exercised — `enigmatic.Rsa` has no `Signing` instance and there's no `Ecdsa` cipher in `enigmatic.core`. Adding those is a follow-up enigmatic.core PR.

## Test plan

- [x] \`./mill enigmatic.cose.compile\` — clean compile
- [x] \`./mill enigmatic.test\` — 22 passed, 0 failed (4 new COSE tests: round-trip via \`verify[Cose]\`, tag-17 envelope byte, wrong-key rejection, tampered-bytes rejection)
- [ ] Round-trip against RFC 9052 Appendix C test vectors (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)