### PR TITLE
ethereal: signed self-upgrade with ML-DSA-44 verification

### DIFF
--- a/lib/ethereal/Cargo.lock
+++ b/lib/ethereal/Cargo.lock
@@ -27,6 +27,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "crypto-common",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,13 +99,25 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -89,6 +144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "ctutils",
+ "typenum",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,6 +176,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -152,10 +227,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "ml-dsa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67011732d2747886c7b64f2eceef9d6eb2645a0aa528a26828b949ece257285"
+dependencies = [
+ "crypto-common",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "shake",
+ "signature",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -187,15 +305,58 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "runner"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "ml-dsa",
+ "rand",
  "uds_windows",
  "windows-sys 0.59.0",
 ]
@@ -262,6 +423,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,11 +467,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds_windows"
@@ -540,6 +734,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/lib/ethereal/Cargo.toml
+++ b/lib/ethereal/Cargo.toml
@@ -8,6 +8,15 @@ edition = "2024"
 name = "runner"
 path = "src/runner/src/main.rs"
 
+[[bin]]
+name = "ethereal-sign"
+path = "src/sign/src/main.rs"
+required-features = ["sign"]
+
+[features]
+default = []
+sign = ["ml-dsa/rand_core", "dep:rand"]
+
 [profile.release]
 opt-level = "z"
 lto = true
@@ -16,6 +25,8 @@ panic = "abort"
 strip = true
 
 [dependencies]
+ml-dsa = { version = "0.1", default-features = false }
+rand = { version = "0.9", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/lib/ethereal/doc/signing.md
+++ b/lib/ethereal/doc/signing.md
@@ -1,0 +1,152 @@
+### Signing a Release
+
+Ethereal applications can be shipped with a baked-in ML-DSA-44 public key
+that the launcher uses to verify any candidate upgrade dropped at
+`{XDG_DATA_HOME}/{app-name}/.pending` before swapping it into place.
+Verification happens in the Rust launcher wrapper — before the JVM starts —
+so the trust boundary is not crossed by any Scala code in the running
+application.
+
+This document walks through the one-time key setup and the per-release
+signing workflow.
+
+#### One-time: generate a signing keypair
+
+The `ethereal-sign` CLI lives alongside the launcher under
+`lib/ethereal/src/sign/`. Build it once:
+
+```sh
+cargo build --release --bin ethereal-sign --features sign \
+            --manifest-path lib/ethereal/Cargo.toml
+```
+
+Generate a keypair:
+
+```sh
+./out/rust/release/ethereal-sign keygen --out release-keys/myapp
+```
+
+This produces two files:
+
+- `release-keys/myapp.seed` — 32 bytes of FIPS-204 signing-key seed.
+  **Keep this offline.** Anyone with this seed can ship a binary that
+  end-users' launchers will accept as a legitimate upgrade.
+- `release-keys/myapp.pub` — 1312 bytes of ML-DSA-44 public key. This is
+  what gets baked into the published binary.
+
+Treat the seed like any other release-signing key — store it on offline
+media or in an HSM, never in a CI variable, and rotate it deliberately.
+**Lost or compromised seeds cannot be revoked at the launcher level**: the
+public key is baked into every shipped binary, and only a fresh release
+with a new public key updates that. Plan accordingly.
+
+#### Per-release: build a signed binary
+
+A signed release is produced in two steps. First, build the application
+binary with the public key baked into its ETHRCFG block:
+
+```sh
+java -Dbuild.executable=dist/myapp \
+     -Dbuild.id=42 \
+     -Dethereal.publicKey=release-keys/myapp.pub \
+     -jar dist/myapp.jar '[]'
+```
+
+The relevant arguments:
+
+- `-Dbuild.executable=<path>` — output path for the runner+JAR file. Same
+  as any unsigned Ethereal build.
+- `-Dbuild.id=<u64>` — monotonically-increasing build identifier. The
+  signed-upgrade verifier rejects downgrades by comparing this against
+  the running launcher's own `build_id`.
+- `-Dethereal.publicKey=<path>` — the 1312-byte raw public-key file
+  produced by `ethereal-sign keygen`. **Without this property the build
+  emits a binary whose launcher will reject every upgrade** (the safe
+  default for `make install`–style local builds where the upgrade path
+  is never exercised).
+
+The output at `dist/myapp` is a normal executable, but its signature slot
+is all zero. Sign it in place to a new path:
+
+```sh
+./out/rust/release/ethereal-sign sign \
+    --key release-keys/myapp.seed \
+    --in  dist/myapp \
+    --out dist/myapp.signed
+```
+
+`dist/myapp.signed` is byte-for-byte the file your distribution channel
+should hand to end users — it's both a valid executable and a valid
+`.pending` for the launcher to apply on a future upgrade.
+
+#### Per-release: signing a downgrade
+
+If a release needs to be installable over a newer build (e.g. you've
+shipped 43 and discovered it's broken; you want users still on 42 to
+*not* upgrade to 43, and users already on 43 to roll back to 42), sign
+the rollback with `--allow-downgrade`:
+
+```sh
+./out/rust/release/ethereal-sign sign \
+    --key release-keys/myapp.seed \
+    --in  dist/myapp \
+    --out dist/myapp.signed \
+    --allow-downgrade
+```
+
+The flag lives in a byte inside the signed payload, so an attacker cannot
+flip it on a binary you signed without it. The launcher honours it only
+when the signature verifies.
+
+#### What users see
+
+End users install your application however they normally would. When the
+application later receives a signed upgrade — typically via the
+application's own `Upgrade(source)` call, where `source` could be a URL,
+a file path, or any other `Readable by Bytes`:
+
+```scala
+Upgrade(url"https://releases.example.com/myapp.signed")
+```
+
+— the launcher writes the bytes to `.pending`, spawns a fresh launcher,
+and exits. The fresh launcher reads `.pending`, verifies the ML-DSA-44
+signature against the public key it has baked in, checks the embedded
+`build_id` against its own, and either swaps the new binary into place
+(re-execing into it) or silently deletes `.pending` and continues running
+the existing binary. The runner's debug-trace output explains rejections
+when `ETHEREAL_DEBUG=1` is set.
+
+#### What's actually signed
+
+The launcher's verifier zeroes the 2420-byte signature slot in a working
+copy of the candidate binary and verifies the FIPS-204 ML-DSA-44
+signature over the result. The signed payload therefore covers:
+
+- the launcher's executable code (any tampering invalidates the
+  signature),
+- the entire bundled JAR appended to it,
+- the embedded `build_id` (defeats replay of an older legitimately-signed
+  release),
+- the `flags` byte that controls per-upgrade downgrade permission
+  (attackers cannot opt into downgrades on a binary you signed without
+  the flag),
+- the baked-in public key itself (defeats substituting a different
+  release key into an otherwise-legitimate binary).
+
+The FIPS-204 `ctx` parameter is empty, per the COSE algorithm registration
+in RFC 9964.
+
+#### Key rotation
+
+There is no in-launcher mechanism to switch keys. To rotate:
+
+1. Generate a new keypair as above.
+2. Ship one final release signed with the **old** seed whose embedded
+   public key is the **new** one. Users on existing installs apply this
+   release through the normal signed-upgrade path, and from that point
+   on their launchers trust only the new key.
+3. Subsequent releases are signed with the new seed.
+
+Skipping the bridging release strands existing installs — they hold the
+old public key and will reject everything you sign with the new seed.

--- a/lib/ethereal/src/core/ethereal.Upgrade.scala
+++ b/lib/ethereal/src/core/ethereal.Upgrade.scala
@@ -30,12 +30,94 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ethereal
 
-export
-  ethereal
-  . { cli, Client, DaemonEvent, DaemonLogEvent, daemonLogEvent, DaemonService, Installer,
-      LazyEnvironment, service, Stdin, Upgrade, UpgradeError }
+import java.lang as jl
 
-package workingDirectories:
-  export ambience.workingDirectories.daemonClient
+import ambience.*, systems.java
+import anticipation.*
+import contingency.*
+import fulminate.*
+import galilei.*
+import gossamer.*
+import nomenclature.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import spectacular.*
+import turbulence.*
+import vacuous.*
+
+import filesystemOptions.createNonexistent.enabled
+import filesystemOptions.createNonexistentParents.enabled
+import filesystemOptions.deleteRecursively.disabled
+import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.readAccess.enabled
+import filesystemOptions.writeAccess.enabled
+
+// Apply an upgrade to the running ethereal application. The given `source`
+// must yield the bytes of a complete signed runner+JAR binary — exactly
+// what `ethereal-sign` produces. The Scala side performs no verification;
+// the freshly-spawned launcher's `check_updates` (in `update.rs`) verifies
+// the ML-DSA-44 signature against the public key baked into the running
+// launcher before swapping anything into place.
+//
+// On success this function does not return — it spawns a new launcher and
+// `System.exit(0)`s the current JVM. The new launcher picks up `.pending`,
+// verifies, swaps, and re-execs into the upgraded binary.
+//
+// If the signature is bad, the new launcher silently deletes `.pending` and
+// continues with the existing binary. The caller's exit was still effective.
+// There is no synchronous success/failure signal because the verifying
+// process is, by design, not the calling one.
+object Upgrade:
+  inline def apply[source]
+    (source: source)
+    ( using environment: Environment,
+            system:      System,
+            diagnostics: Diagnostics )
+  :   Nothing raises UpgradeError =
+
+    applyBytes(source.read[Data])
+
+
+  def applyBytes(bytes: Data)
+    ( using environment: Environment,
+            system:      System,
+            diagnostics: Diagnostics )
+  :   Nothing raises UpgradeError =
+
+    whereas:
+      case PathError(_, _)     => UpgradeError(UpgradeError.Reason.CannotResolveLauncher)
+      case PropertyError(_)    => UpgradeError(UpgradeError.Reason.CannotResolveLauncher)
+      case IoError(_, _, _, _) => UpgradeError(UpgradeError.Reason.CannotWritePending)
+      case NameError(_, _, _)  => UpgradeError(UpgradeError.Reason.CannotWritePending)
+      case StreamError(_)      => UpgradeError(UpgradeError.Reason.CannotReadSource)
+
+    . mitigate:
+        val name: Text = System.properties.ethereal.name[Text]()
+
+        val dataHome: Path on Linux =
+          if isWindows then Directories.cacheHome[Path on Linux]
+          else Xdg.dataHome[Path on Linux]
+
+        val pendingDir: Path on Linux = dataHome/name
+        pendingDir.create[Directory]()
+        val pendingPath: Path on Linux = pendingDir/t".pending"
+
+        pendingPath.open: file =>
+          Stream(bytes).writeTo(file)
+
+        val launcher: Text = System.properties.ethereal.script[Text]()
+
+        try new jl.ProcessBuilder(launcher.s).inheritIO().nn.start()
+        catch case _: jl.Throwable =>
+          abort(UpgradeError(UpgradeError.Reason.CannotRespawnLauncher))
+
+        jl.System.exit(0)
+        throw new jl.AssertionError("unreachable: System.exit returned")
+
+
+  private def isWindows(using system: System): Boolean =
+    safely(System.properties.os.name[Text]().lower.contains(t"win")).or(false)

--- a/lib/ethereal/src/core/ethereal.UpgradeError.scala
+++ b/lib/ethereal/src/core/ethereal.UpgradeError.scala
@@ -30,12 +30,24 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ethereal
 
-export
-  ethereal
-  . { cli, Client, DaemonEvent, DaemonLogEvent, daemonLogEvent, DaemonService, Installer,
-      LazyEnvironment, service, Stdin, Upgrade, UpgradeError }
+import anticipation.*
+import fulminate.*
 
-package workingDirectories:
-  export ambience.workingDirectories.daemonClient
+object UpgradeError:
+  object Reason:
+    given communicable: Reason is Communicable =
+      case CannotReadSource     => m"the upgrade source could not be read"
+      case CannotWritePending   => m"the .pending file could not be written"
+      case CannotResolveLauncher => m"the running launcher's path is not available"
+      case CannotRespawnLauncher => m"the launcher could not be relaunched"
+
+  enum Reason(val number: Int) extends Clarification:
+    case CannotReadSource      extends Reason(1)
+    case CannotWritePending    extends Reason(2)
+    case CannotResolveLauncher extends Reason(3)
+    case CannotRespawnLauncher extends Reason(4)
+
+case class UpgradeError(reason: UpgradeError.Reason)(using Diagnostics)
+extends Error(631, reason.number)(m"could not apply the upgrade because $reason")

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -159,7 +159,11 @@ def cli[bus <: Matchable](using executive: Executive)
 
             val magic: Array[Byte] = Array[Byte](
               'E'.toByte, 'T'.toByte, 'H'.toByte, 'R'.toByte,
-              'C'.toByte, 'F'.toByte, 'G'.toByte, 1.toByte)
+              'C'.toByte, 'F'.toByte, 'G'.toByte, 2.toByte)
+
+            // v2 ETHRCFG layout — keep in sync with lib/ethereal/src/runner/src/config.rs.
+            val pubkeyLen: Int = 1312                       // ML-DSA-44 public key size
+            val pubkeyOffsetInBlock: Int = 32 - magic.length  // after the 24-byte meta region
 
             val magicOffset: Int =
               var found: Int = -1
@@ -177,20 +181,52 @@ def cli[bus <: Matchable](using executive: Executive)
                 i += 1
 
               if found < 0 then
-                Out.println(e"Runner binary does not contain the ETHRCFG magic marker")
+                Out.println(e"Runner binary does not contain the ETHRCFG\\x02 magic marker")
                 Exit.Fail(1).terminate()
 
               found
 
+            // ML-DSA-44 public key used by the runner to verify upgrades.
+            // When `ethereal.publicKey` is unset the slot stays zero and the
+            // runner's verifier rejects every upgrade — the safe default for
+            // dev builds where upgrades happen via `make install` rather
+            // than the .pending path. Releases that need signed upgrades
+            // pass `-Dethereal.publicKey=<path>` pointing at a 1312-byte raw
+            // ML-DSA-44 public key file.
+            val publicKeyBytes: Array[Byte] =
+              safely(System.properties.ethereal.publicKey[Text]()).absolve match
+                case Unset =>
+                  new Array[Byte](pubkeyLen)   // all zeros — upgrades blocked
+
+                case keyPath: Text =>
+                  val resolved: Path on Linux = safely(keyPath.decode[Path on Linux]).or:
+                    val work: Path on Linux = workingDirectory
+                    work + keyPath.decode[Relative on Linux]
+                  val raw = resolved.open(_.stream[Data].read[Data]).to(Array)
+                  if raw.length != pubkeyLen then
+                    Out.println(e"Public key at $keyPath is the wrong size (expected 1312 bytes)")
+                    Exit.Fail(1).terminate()
+                  raw
+
             val configOffset: Int = magicOffset + magic.length
             val patched: Array[Byte] = IArray.genericWrapArray(runnerBytes).toArray
-            val buf = jnio.ByteBuffer.wrap(patched, configOffset, 24).nn
-            buf.order(jnio.ByteOrder.LITTLE_ENDIAN).nn
-            buf.putLong(buildId)
-            buf.putShort(javaMinimum.toShort)
-            buf.putShort(javaPreferred.toShort)
-            buf.put((if jdk then 1 else 0).toByte)
-            while buf.hasRemaining do buf.put(0.toByte)
+
+            // Write the 24-byte metadata region.
+            val metaBuf = jnio.ByteBuffer.wrap(patched, configOffset, 24).nn
+            metaBuf.order(jnio.ByteOrder.LITTLE_ENDIAN).nn
+            metaBuf.putLong(buildId)
+            metaBuf.putShort(javaMinimum.toShort)
+            metaBuf.putShort(javaPreferred.toShort)
+            metaBuf.put((if jdk then 1 else 0).toByte)
+            while metaBuf.hasRemaining do metaBuf.put(0.toByte)
+
+            // Write the 1312-byte public-key region at offset 32 within the
+            // ETHRCFG block (8 magic + 24 metadata).
+            jl.System.arraycopy(publicKeyBytes, 0,
+                                patched, configOffset + 24,
+                                pubkeyLen)
+            // Signature slot at offset 1344 stays zero — populated later by
+            // the signer when this binary is itself shipped as an upgrade.
 
             path.open: file =>
               Stream(IArray.from(patched.iterator): IArray[Byte]).writeTo(file)

--- a/lib/ethereal/src/runner/src/config.rs
+++ b/lib/ethereal/src/runner/src/config.rs
@@ -1,52 +1,96 @@
 // Marker-patched static data. The Scala builder scans for the magic
-// `ETHRCFG\x01` and overwrites the 24 bytes that follow.
+// `ETHRCFG\x02` and overwrites the bytes that follow.
 //
-// Layout:
-//   [0..8]   magic: "ETHRCFG" + format version (1)
-//   [8..16]  build_id    (u64 little-endian)
-//   [16..18] java_min    (u16 little-endian)
-//   [18..20] java_pref   (u16 little-endian)
-//   [20]     bundle      (0 = jre, 1 = jdk)
-//   [21..32] reserved    (0)
+// Layout (3764 bytes total):
+//   [0..8]        magic: "ETHRCFG" + format version (2)
+//   [8..16]       build_id    (u64 little-endian)
+//   [16..18]      java_min    (u16 little-endian)
+//   [18..20]      java_pref   (u16 little-endian)
+//   [20]          bundle      (0 = jre, 1 = jdk)
+//   [21]          flags       (bit 0 = downgrade_permitted, others reserved)
+//   [22..32]      reserved    (0)
+//   [32..1344]    ml_dsa_44 public key (1312 bytes)
+//   [1344..3764]  ml_dsa_44 signature  (2420 bytes; zero in the running
+//                 binary, set only after build-time patching by the signer.
+//                 The verifier zeroes this region of the incoming .pending
+//                 binary before recomputing the signature.)
 
-const RECORD_LEN: usize = 32;
+pub const RECORD_LEN: usize        = 3764;
+pub const MAGIC_LEN: usize         = 8;
+pub const META_OFFSET: usize       = 8;
+pub const META_LEN: usize          = 24;          // build_id..reserved
+pub const PUBKEY_OFFSET: usize     = 32;
+pub const PUBKEY_LEN: usize        = 1312;        // ML-DSA-44 |pk|
+pub const SIGNATURE_OFFSET: usize  = 1344;
+pub const SIGNATURE_LEN: usize     = 2420;        // ML-DSA-44 |sig|
+
+pub const FLAG_DOWNGRADE_PERMITTED: u8 = 0x01;
+
+pub const MAGIC: [u8; MAGIC_LEN] =
+    [b'E', b'T', b'H', b'R', b'C', b'F', b'G', 2];
 
 #[used]
 #[unsafe(no_mangle)]
 #[cfg_attr(target_os = "macos",   unsafe(link_section = "__DATA,__ethereal"))]
 #[cfg_attr(target_os = "linux",   unsafe(link_section = ".ethereal"))]
 #[cfg_attr(target_os = "windows", unsafe(link_section = ".rdata$ether"))]
-pub static mut ETHEREAL_CONFIG: [u8; RECORD_LEN] = [
-    b'E', b'T', b'H', b'R', b'C', b'F', b'G', 1,
-    0, 0, 0, 0, 0, 0, 0, 0,
-    21, 0,
-    24, 0,
-    0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-];
+pub static mut ETHEREAL_CONFIG: [u8; RECORD_LEN] = {
+    let mut record = [0u8; RECORD_LEN];
+    record[0] = b'E'; record[1] = b'T'; record[2] = b'H'; record[3] = b'R';
+    record[4] = b'C'; record[5] = b'F'; record[6] = b'G'; record[7] = 2;
+    // build_id (8..16): zero by default.
+    // java_min (16..18) = 21.
+    record[16] = 21;
+    // java_pref (18..20) = 24.
+    record[18] = 24;
+    // bundle, flags, reserved, pubkey, sig: zero by default.
+    record
+};
 
 pub struct BuildConfig {
     pub build_id:  u64,
     pub java_min:  u16,
     pub java_pref: u16,
     pub bundle:    &'static str,
+    pub flags:     u8,
+}
+
+fn read_block() -> [u8; RECORD_LEN] {
+    // Volatile read so the compiler cannot constant-fold the initial values
+    // defined above — the bytes are patched at build time (or left as
+    // defaults when the runner is shipped unpatched).
+    unsafe { core::ptr::read_volatile(&raw const ETHEREAL_CONFIG) }
 }
 
 pub fn read_config() -> BuildConfig {
-    // Read via a volatile pointer so the compiler cannot constant-fold the
-    // initial values defined above — the bytes are patched at build time
-    // (or left as defaults when the runner is shipped unpatched).
-    let record: [u8; RECORD_LEN] = unsafe {
-        core::ptr::read_volatile(&raw const ETHEREAL_CONFIG)
-    };
-    let build_id = u64::from_le_bytes(record[8..16].try_into().unwrap());
+    let record = read_block();
+    let build_id     = u64::from_le_bytes(record[8..16].try_into().unwrap());
     let java_min_raw = u16::from_le_bytes(record[16..18].try_into().unwrap());
     let java_pref_raw = u16::from_le_bytes(record[18..20].try_into().unwrap());
     let bundle = if record[20] == 0 { "jre" } else { "jdk" };
+    let flags = record[21];
     BuildConfig {
         build_id,
         java_min:  if java_min_raw  == 0 { 21 } else { java_min_raw  },
         java_pref: if java_pref_raw == 0 { 24 } else { java_pref_raw },
         bundle,
+        flags,
     }
+}
+
+// Snapshot of the running binary's ML-DSA-44 public key. Returned as an owned
+// array because the caller may need to forward it across thread or FFI
+// boundaries; it's only 1312 bytes.
+pub fn public_key() -> [u8; PUBKEY_LEN] {
+    let record = read_block();
+    let mut out = [0u8; PUBKEY_LEN];
+    out.copy_from_slice(&record[PUBKEY_OFFSET..PUBKEY_OFFSET + PUBKEY_LEN]);
+    out
+}
+
+// True iff the baked-in public key is all zeros — the safe "no signing
+// configured" state. A runner in this state rejects every upgrade.
+pub fn public_key_is_unset() -> bool {
+    let record = read_block();
+    record[PUBKEY_OFFSET..PUBKEY_OFFSET + PUBKEY_LEN].iter().all(|&b| b == 0)
 }

--- a/lib/ethereal/src/runner/src/main.rs
+++ b/lib/ethereal/src/runner/src/main.rs
@@ -15,6 +15,7 @@ mod signals;
 mod tty;
 mod uds;
 mod update;
+mod verify;
 mod wrapper;
 mod xeq;
 

--- a/lib/ethereal/src/runner/src/update.rs
+++ b/lib/ethereal/src/runner/src/update.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use crate::config::FLAG_DOWNGRADE_PERMITTED;
+
 pub fn check_updates(script: &Path, args: &[String], name: &str) {
     let data_home = crate::state::data_home();
     let pending = data_home.join(name).join(".pending");
@@ -10,6 +12,42 @@ pub fn check_updates(script: &Path, args: &[String], name: &str) {
     };
     crate::debug!("update: pending size={}", metadata.len());
     if metadata.len() == 0 { return; }
+
+    // Read the pending binary and verify its ML-DSA-44 signature against the
+    // public key baked into THIS running runner. A failure here means the
+    // file was either unsigned, signed by an unknown key, or tampered with;
+    // in any of those cases we delete `.pending` and continue with the
+    // existing binary. Verification is authoritative: nothing past this
+    // point should assume the file is benign on its own merits.
+    let pending_bytes = match std::fs::read(&pending) {
+        Ok(b) => b,
+        Err(e) => {
+            crate::debug!("update: read(pending) failed: {}", e);
+            return;
+        },
+    };
+
+    let pubkey = crate::config::public_key();
+    let build_config = crate::config::read_config();
+
+    let verified = match crate::verify::verify_pending(&pending_bytes, &pubkey) {
+        Ok(v) => v,
+        Err(e) => {
+            crate::debug!("update: verify rejected: {:?}", e);
+            let _ = std::fs::remove_file(&pending);
+            return;
+        },
+    };
+
+    let allow_downgrade = (verified.flags & FLAG_DOWNGRADE_PERMITTED) != 0;
+    if verified.build_id <= build_config.build_id && !allow_downgrade {
+        crate::debug!("update: downgrade rejected (embedded={} current={})",
+                      verified.build_id, build_config.build_id);
+        let _ = std::fs::remove_file(&pending);
+        return;
+    }
+    crate::debug!("update: verified build_id={} flags={:#x}",
+                  verified.build_id, verified.flags);
 
     #[cfg(unix)]
     {

--- a/lib/ethereal/src/runner/src/verify.rs
+++ b/lib/ethereal/src/runner/src/verify.rs
@@ -1,0 +1,241 @@
+use ml_dsa::{EncodedSignature, EncodedVerifyingKey, MlDsa44, Signature, VerifyingKey,
+             signature::Verifier};
+
+use crate::config::{
+    MAGIC, MAGIC_LEN, PUBKEY_LEN, RECORD_LEN, SIGNATURE_LEN, SIGNATURE_OFFSET,
+};
+
+#[derive(Debug)]
+pub enum VerifyError {
+    MagicMissing,
+    Truncated,
+    BadPublicKey,
+    BadSignature,
+    SignatureMismatch,
+    PublicKeyUnset,
+}
+
+#[derive(Debug)]
+pub struct VerifiedBinary {
+    pub build_id: u64,
+    pub flags:    u8,
+}
+
+// Locate the ETHRCFG magic in `binary`. Searches forwards; only the first
+// occurrence is honoured (the marker is rare enough in optimised binaries
+// that this is unambiguous in practice).
+fn find_magic(binary: &[u8]) -> Option<usize> {
+    if binary.len() < MAGIC_LEN { return None; }
+    binary.windows(MAGIC_LEN).position(|w| w == MAGIC)
+}
+
+// Verify a candidate upgrade binary against the runner's baked-in public key.
+//
+// Algorithm:
+//   1. Locate the ETHRCFG magic in `pending`.
+//   2. Extract the embedded signature bytes from that block.
+//   3. Make a working copy of the binary with the signature slot zeroed.
+//   4. Verify the signature over the zeroed copy using the running runner's
+//      public key.
+//
+// Returns the embedded `build_id` and `flags` on success so the caller can
+// enforce downgrade policy. The pending bytes themselves are unchanged and
+// ready to be swapped into place.
+pub fn verify_pending(
+    pending: &[u8],
+    pubkey:  &[u8; PUBKEY_LEN],
+) -> Result<VerifiedBinary, VerifyError> {
+
+    if pubkey.iter().all(|&b| b == 0) {
+        return Err(VerifyError::PublicKeyUnset);
+    }
+
+    let magic_offset = find_magic(pending).ok_or(VerifyError::MagicMissing)?;
+    let block_end = magic_offset + RECORD_LEN;
+    if pending.len() < block_end { return Err(VerifyError::Truncated); }
+
+    let block = &pending[magic_offset..block_end];
+    let build_id = u64::from_le_bytes(block[8..16].try_into().unwrap());
+    let flags    = block[21];
+
+    let sig_start_in_file = magic_offset + SIGNATURE_OFFSET;
+    let sig_end_in_file   = sig_start_in_file + SIGNATURE_LEN;
+    let mut sig_bytes = [0u8; SIGNATURE_LEN];
+    sig_bytes.copy_from_slice(&pending[sig_start_in_file..sig_end_in_file]);
+
+    // Mask the signature region to zero before recomputing the signature.
+    // Signing and verification must agree on this exact byte range.
+    let mut zeroed = pending.to_vec();
+    for b in &mut zeroed[sig_start_in_file..sig_end_in_file] { *b = 0; }
+
+    let encoded_pk = EncodedVerifyingKey::<MlDsa44>::try_from(&pubkey[..])
+        .map_err(|_| VerifyError::BadPublicKey)?;
+    let vk = VerifyingKey::<MlDsa44>::decode(&encoded_pk);
+
+    let encoded_sig = EncodedSignature::<MlDsa44>::try_from(&sig_bytes[..])
+        .map_err(|_| VerifyError::BadSignature)?;
+    let sig = Signature::<MlDsa44>::decode(&encoded_sig)
+        .ok_or(VerifyError::BadSignature)?;
+
+    vk.verify(&zeroed, &sig).map_err(|_| VerifyError::SignatureMismatch)?;
+
+    Ok(VerifiedBinary { build_id, flags })
+}
+
+#[cfg(all(test, feature = "sign"))]
+mod tests {
+    use super::*;
+    use ml_dsa::{B32, Keypair, SigningKey, signature::Signer};
+    use rand::{TryRngCore, rngs::OsRng};
+
+    fn fresh_keypair() -> (SigningKey<MlDsa44>, [u8; PUBKEY_LEN]) {
+        let mut seed = [0u8; 32];
+        OsRng.try_fill_bytes(&mut seed).unwrap();
+        let seed_b32: B32 = seed.into();
+        let sk: SigningKey<MlDsa44> = SigningKey::from_seed(&seed_b32);
+        let pk: [u8; PUBKEY_LEN] = sk.verifying_key().encode().into();
+        (sk, pk)
+    }
+
+    fn make_fake_binary(magic_offset: usize, build_id: u64, flags: u8,
+                        pk: &[u8; PUBKEY_LEN]) -> Vec<u8> {
+        let mut bin = vec![0xAAu8; magic_offset + RECORD_LEN + 1024];
+        bin[magic_offset..magic_offset + MAGIC_LEN].copy_from_slice(&MAGIC);
+        bin[magic_offset + 8 .. magic_offset + 16]
+            .copy_from_slice(&build_id.to_le_bytes());
+        bin[magic_offset + 21] = flags;
+        bin[magic_offset + 32 .. magic_offset + 32 + PUBKEY_LEN].copy_from_slice(pk);
+        bin
+    }
+
+    fn sign_in_place(bin: &mut [u8], sk: &SigningKey<MlDsa44>, magic_offset: usize) {
+        let sig_start = magic_offset + SIGNATURE_OFFSET;
+        let sig_end   = sig_start + SIGNATURE_LEN;
+        for b in &mut bin[sig_start..sig_end] { *b = 0; }
+        let sig = sk.sign(bin);
+        let sig_bytes: [u8; SIGNATURE_LEN] = sig.encode().into();
+        bin[sig_start..sig_end].copy_from_slice(&sig_bytes);
+    }
+
+    #[test]
+    fn round_trip() {
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 42, 0, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        let v = verify_pending(&bin, &pk).expect("verify");
+        assert_eq!(v.build_id, 42);
+        assert_eq!(v.flags, 0);
+    }
+
+    #[test]
+    fn signed_with_downgrade_flag_round_trips() {
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 7, 0x01, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        let v = verify_pending(&bin, &pk).expect("verify");
+        assert_eq!(v.build_id, 7);
+        assert_eq!(v.flags, 0x01);
+    }
+
+    #[test]
+    fn tampered_byte_outside_sig_rejected() {
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 42, 0, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        bin[0] ^= 0x01;       // flip a bit outside the signature slot
+        assert!(matches!(verify_pending(&bin, &pk),
+                         Err(VerifyError::SignatureMismatch)));
+    }
+
+    #[test]
+    fn tampered_sig_rejected() {
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 42, 0, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        let sig_start = 0x100 + SIGNATURE_OFFSET;
+        bin[sig_start] ^= 0x01;
+        assert!(matches!(verify_pending(&bin, &pk),
+                         Err(VerifyError::SignatureMismatch)));
+    }
+
+    #[test]
+    fn tampered_flags_byte_rejected() {
+        // The flags byte is inside the signed region. Flipping it after
+        // signing must invalidate the signature, so an attacker cannot
+        // turn on DOWNGRADE_PERMITTED by editing the binary.
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 42, 0, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        bin[0x100 + 21] = 0x01;
+        assert!(matches!(verify_pending(&bin, &pk),
+                         Err(VerifyError::SignatureMismatch)));
+    }
+
+    #[test]
+    fn tampered_build_id_rejected() {
+        // Same defence for build_id — flipping it after signing must
+        // invalidate the signature, so an attacker cannot lift a low
+        // build_id past the runner's downgrade gate.
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 1, 0, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        bin[0x100 + 8 .. 0x100 + 16].copy_from_slice(&999u64.to_le_bytes());
+        assert!(matches!(verify_pending(&bin, &pk),
+                         Err(VerifyError::SignatureMismatch)));
+    }
+
+    #[test]
+    fn wrong_key_rejected() {
+        let (sk_signer, _) = fresh_keypair();
+        let (_, pk_other)  = fresh_keypair();
+        let pk_signer: [u8; PUBKEY_LEN] = sk_signer.verifying_key().encode().into();
+        let mut bin = make_fake_binary(0x100, 42, 0, &pk_signer);
+        sign_in_place(&mut bin, &sk_signer, 0x100);
+
+        assert!(matches!(verify_pending(&bin, &pk_other),
+                         Err(VerifyError::SignatureMismatch)));
+    }
+
+    #[test]
+    fn missing_magic_rejected() {
+        let (_, pk) = fresh_keypair();
+        let junk = vec![0u8; 8 * 1024];
+        assert!(matches!(verify_pending(&junk, &pk),
+                         Err(VerifyError::MagicMissing)));
+    }
+
+    #[test]
+    fn unsigned_binary_rejected() {
+        // .pending file with all-zero signature slot but a real magic block.
+        // An all-zero signature may decode to a malformed-but-parseable
+        // value (BadSignature) or to a parseable-but-invalid one
+        // (SignatureMismatch) depending on which check fires first; either
+        // way the file does not get applied.
+        let (_, pk) = fresh_keypair();
+        let bin = make_fake_binary(0x100, 42, 0, &pk);
+        // No sign_in_place call — sig slot stays zero.
+        match verify_pending(&bin, &pk) {
+            Err(VerifyError::BadSignature) | Err(VerifyError::SignatureMismatch) => (),
+            other => panic!("unsigned binary should be rejected, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn unset_runner_public_key_rejects_everything() {
+        let (sk, pk) = fresh_keypair();
+        let mut bin = make_fake_binary(0x100, 42, 0, &pk);
+        sign_in_place(&mut bin, &sk, 0x100);
+
+        // The runner is configured with an all-zero pubkey (no signing
+        // configured): every upgrade is rejected upfront.
+        let zeros = [0u8; PUBKEY_LEN];
+        assert!(matches!(verify_pending(&bin, &zeros),
+                         Err(VerifyError::PublicKeyUnset)));
+    }
+}

--- a/lib/ethereal/src/sign/src/main.rs
+++ b/lib/ethereal/src/sign/src/main.rs
@@ -1,0 +1,143 @@
+// ethereal-sign: produce a signed `.pending` binary for ethereal self-upgrade.
+//
+// Usage:
+//   ethereal-sign keygen --out <key-prefix>
+//     Generates a fresh ML-DSA-44 keypair, writing <prefix>.pub (1312 B) and
+//     <prefix>.seed (32 B).  The seed is the FIPS-204 signing key seed; keep
+//     it offline.
+//
+//   ethereal-sign sign --key <seed-file> --in <binary> --out <signed>
+//                      [--allow-downgrade]
+//     Reads <binary> (a runner+JAR file produced by an ethereal build),
+//     locates the ETHRCFG\x02 marker, sets the per-upgrade flags byte and
+//     populates the ML-DSA-44 signature slot. Writes the result to <signed>,
+//     which is byte-for-byte the file that should be delivered as `.pending`
+//     to the target machine.
+
+use std::convert::TryInto;
+use std::path::PathBuf;
+
+use ml_dsa::{B32, Keypair, MlDsa44, Signature, SigningKey, signature::Signer};
+use rand::{TryRngCore, rngs::OsRng};
+
+// Layout — keep in sync with lib/ethereal/src/runner/src/config.rs.
+const MAGIC: [u8; 8]            = *b"ETHRCFG\x02";
+const RECORD_LEN: usize         = 3764;
+const SIGNATURE_OFFSET: usize   = 1344;
+const SIGNATURE_LEN: usize      = 2420;
+const PUBKEY_LEN: usize         = 1312;
+const SEED_LEN: usize           = 32;
+
+fn find_magic(binary: &[u8]) -> Option<usize> {
+    binary.windows(MAGIC.len()).position(|w| w == MAGIC)
+}
+
+fn die(msg: impl AsRef<str>) -> ! {
+    eprintln!("ethereal-sign: {}", msg.as_ref());
+    std::process::exit(1);
+}
+
+fn keygen(out_prefix: PathBuf) {
+    let mut seed_raw = [0u8; SEED_LEN];
+    OsRng.try_fill_bytes(&mut seed_raw)
+        .unwrap_or_else(|e| die(format!("could not read entropy from the OS RNG: {e}")));
+    let seed_b32: B32 = seed_raw.into();
+    let sk: SigningKey<MlDsa44> = SigningKey::from_seed(&seed_b32);
+    let vk = sk.verifying_key();
+    let seed_bytes: [u8; SEED_LEN] = seed_raw;
+    let pk_bytes: [u8; PUBKEY_LEN] = vk.encode().into();
+
+    let seed_path = out_prefix.with_extension("seed");
+    let pub_path  = out_prefix.with_extension("pub");
+    if let Err(e) = std::fs::write(&seed_path, seed_bytes) {
+        die(format!("could not write seed to {}: {e}", seed_path.display()));
+    }
+    if let Err(e) = std::fs::write(&pub_path, pk_bytes) {
+        die(format!("could not write public key to {}: {e}", pub_path.display()));
+    }
+    eprintln!("wrote {} ({} bytes) and {} ({} bytes)",
+              seed_path.display(), SEED_LEN, pub_path.display(), PUBKEY_LEN);
+}
+
+fn sign(seed_path: PathBuf, in_path: PathBuf, out_path: PathBuf, allow_downgrade: bool) {
+    let seed = std::fs::read(&seed_path)
+        .unwrap_or_else(|e| die(format!("could not read seed file {}: {e}", seed_path.display())));
+    if seed.len() != SEED_LEN {
+        die(format!("seed at {} is {} bytes; expected {SEED_LEN}",
+                    seed_path.display(), seed.len()));
+    }
+    let seed_arr: [u8; SEED_LEN] = seed.as_slice().try_into().unwrap();
+
+    let mut bin = std::fs::read(&in_path)
+        .unwrap_or_else(|e| die(format!("could not read input {}: {e}", in_path.display())));
+
+    let magic_offset = find_magic(&bin)
+        .unwrap_or_else(|| die("input binary does not contain the ETHRCFG\\x02 marker"));
+    let block_end = magic_offset + RECORD_LEN;
+    if bin.len() < block_end {
+        die(format!("input binary is truncated within the ETHRCFG block at offset {magic_offset}"));
+    }
+
+    // Set the per-upgrade flags byte before signing — it's part of the
+    // signed payload.
+    bin[magic_offset + 21] = if allow_downgrade { 0x01 } else { 0x00 };
+
+    // Zero the signature slot before signing. Verifier does the same.
+    let sig_start = magic_offset + SIGNATURE_OFFSET;
+    let sig_end   = sig_start + SIGNATURE_LEN;
+    for b in &mut bin[sig_start..sig_end] { *b = 0; }
+
+    let seed_b32: B32 = seed_arr.into();
+    let sk: SigningKey<MlDsa44> = SigningKey::from_seed(&seed_b32);
+    let sig: Signature<MlDsa44> = sk.sign(&bin);
+    let sig_bytes: [u8; SIGNATURE_LEN] = sig.encode().into();
+
+    bin[sig_start..sig_end].copy_from_slice(&sig_bytes);
+
+    if let Err(e) = std::fs::write(&out_path, &bin) {
+        die(format!("could not write {}: {e}", out_path.display()));
+    }
+    eprintln!("wrote signed binary to {} (allow_downgrade={allow_downgrade})",
+              out_path.display());
+}
+
+fn main() {
+    let argv: Vec<String> = std::env::args().collect();
+    let mut iter = argv.iter().skip(1);
+    let subcmd = iter.next().map(String::as_str).unwrap_or("");
+
+    match subcmd {
+        "keygen" => {
+            let mut out: Option<PathBuf> = None;
+            while let Some(arg) = iter.next() {
+                match arg.as_str() {
+                    "--out" => out = iter.next().map(PathBuf::from),
+                    _ => die(format!("unknown argument: {arg}")),
+                }
+            }
+            let out = out.unwrap_or_else(|| die("missing --out <prefix>"));
+            keygen(out);
+        }
+        "sign" => {
+            let mut seed: Option<PathBuf> = None;
+            let mut input: Option<PathBuf> = None;
+            let mut output: Option<PathBuf> = None;
+            let mut allow_downgrade = false;
+            while let Some(arg) = iter.next() {
+                match arg.as_str() {
+                    "--key" => seed = iter.next().map(PathBuf::from),
+                    "--in"  => input = iter.next().map(PathBuf::from),
+                    "--out" => output = iter.next().map(PathBuf::from),
+                    "--allow-downgrade" => allow_downgrade = true,
+                    _ => die(format!("unknown argument: {arg}")),
+                }
+            }
+            let seed   = seed.unwrap_or_else(|| die("missing --key <seed-file>"));
+            let input  = input.unwrap_or_else(|| die("missing --in <binary>"));
+            let output = output.unwrap_or_else(|| die("missing --out <signed>"));
+            sign(seed, input, output, allow_downgrade);
+        }
+        "" => die("usage: ethereal-sign <keygen|sign> [options]"),
+        other => die(format!("unknown subcommand: {other}")),
+    }
+}

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -596,15 +596,23 @@ object Tests extends Suite(m"Ethereal Tests"):
         }
 
     suite(m"Self-update"):
-      test(m"launcher swaps in pending binary before next invocation"):
+      // The Enclave-built runner has no public key baked in (its config
+      // block's pubkey slot is all zero), so `update::check_updates` rejects
+      // every candidate .pending file. Once the Enclave test rig grows a
+      // way to bake in a test public key the pair of "valid signed upgrade
+      // applies / tampered upgrade rejected" end-to-end tests can be added
+      // here; for now the cryptographic verifier is covered by the Rust
+      // unit tests in lib/ethereal/src/runner/src/verify.rs.
+
+      test(m"launcher rejects unsigned pending binary"):
         sh"mkdir -p $selfuDataDir".exec[Unit]()
         sh"cp ${selfuV2.path} $selfuDataDir/.pending".exec[Unit]()
         sh"${selfuV1.path} version".exec[Text]()
 
-      .assert(_ == t"v2")
+      .assert(_ == t"v1")
 
-      test(m"old binary is preserved after upgrade"):
-        sh"test -f ${Xdg.dataHome[Path on Local]}/selfu.old".exec[Exit]()
+      test(m"rejected pending binary is deleted"):
+        sh"test ! -e $selfuDataDir/.pending".exec[Exit]()
 
       .assert(_ == Exit.Ok)
 


### PR DESCRIPTION
## Summary

- The Rust launcher wrapper now verifies an ML-DSA-44 signature embedded in each `.pending` upgrade before the existing two-rename swap. The public key is baked into the launcher's `ETHRCFG` block (bumped from 32 to 3764 bytes; magic now `ETHRCFG\x02`) at build time via a new `-Dethereal.publicKey=<keyfile>` system property.
- The signed payload covers the executable, the embedded `build_id` (defeats downgrade replay), and a per-upgrade `allow_downgrade` flag the signer controls. The flag byte sits inside the signed region so an attacker can't flip it on a binary signed without it.
- New `Upgrade(source)` Scala API reads anything that's `Readable by Bytes`, drops it at `.pending`, spawns a fresh launcher, and exits. The Scala side performs no verification — the launcher is the sole trust boundary.
- New `ethereal-sign` Rust CLI (under `lib/ethereal/src/sign/`) handles keypair generation and binary signing.
- `lib/ethereal/doc/signing.md` walks through the release workflow: one-time keygen, per-release build + sign, downgrade-permitted signing, what's covered by the signature, and key rotation.

## Safe defaults

When `ethereal.publicKey` is unset at build time the slot stays zero and the launcher rejects every upgrade (verifier returns `PublicKeyUnset`). This is the right behaviour for `make install`–style dev builds and the existing test rig — both of which never exercise the `.pending` path.

## Tests

- **10 Rust unit tests** in `verify.rs` cover the full verifier matrix:
  - valid signature, valid signature with downgrade-permitted flag
  - tampered byte outside the sig slot, tampered sig bytes
  - tampered `flags` byte (attacker can't enable downgrade)
  - tampered `build_id` (attacker can't bypass the downgrade gate)
  - wrong signing key, missing ETHRCFG magic
  - unsigned binary (all-zero sig slot), unset runner public key
- **Scala selfu test updated** to assert the new behaviour — an unsigned `.pending` is rejected and deleted, leaving the existing binary running.

## Open follow-up

End-to-end Scala integration test for the happy path needs `exoskeleton.Enclave` to grow a `properties` parameter so the test rig can bake a test public key into the built runner. Noted in a comment in the selfu suite.

## Test plan

- [x] `cargo test --release --features sign` — 10/10 passed
- [x] `./mill ethereal.test` — 49/49 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)