### PR TITLE
zephyrine: add Cursor.expect for advance-on-match parser combinator

### DIFF
--- a/lib/gesticulate/src/core/gesticulate.Multipart.scala
+++ b/lib/gesticulate/src/core/gesticulate.Multipart.scala
@@ -37,6 +37,7 @@ import scala.reflect.*
 import anticipation.*
 import contingency.*
 import denominative.*
+import fulminate.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
@@ -56,24 +57,23 @@ object Multipart:
 
     val cursor = Cursor[Data](input.stream[Data].filter(_.nonEmpty).iterator)
 
+    inline def expected(char: Char): Diagnostics ?=> MultipartError =
+      MultipartError(Reason.Expected(char))
+
     val boundary: Data = cursor.hold:
       val start = cursor.mark
-      if cursor.peek != '-' then raise(MultipartError(Reason.Expected('-')))
-      cursor.next()
-      if cursor.peek != '-' then raise(MultipartError(Reason.Expected('-')))
-      cursor.next()
+      cursor.expect('-')(expected('-'))
+      cursor.expect('-')(expected('-'))
       cursor.seek('\r'.toByte)
       cursor.grab(start, cursor.mark)
 
     cursor.next()
-    if cursor.peek != '\n' then raise(MultipartError(Reason.Expected('\n')))
-    cursor.next()
+    cursor.expect('\n')(expected('\n'))
 
     def headers(list: List[(Text, Text)]): Map[Text, Text] =
       if cursor.peek == '\r' then
         cursor.next()
-        if cursor.peek != '\n' then raise(MultipartError(Reason.Expected('\n')))
-        cursor.next()
+        cursor.expect('\n')(expected('\n'))
         list.to(Map)
 
       else
@@ -83,8 +83,7 @@ object Multipart:
           Text.ascii(cursor.grab(start, cursor.mark))
 
         cursor.next()
-        if cursor.peek != ' ' then raise(MultipartError(Reason.Expected(' ')))
-        cursor.next()
+        cursor.expect(' ')(expected(' '))
 
         val value: Text = cursor.hold:
           val start = cursor.mark
@@ -92,8 +91,7 @@ object Multipart:
           Text.ascii(cursor.grab(start, cursor.mark))
 
         cursor.next()
-        if cursor.peek != '\n' then raise(MultipartError(Reason.Expected('\n')))
-        cursor.next()
+        cursor.expect('\n')(expected('\n'))
         headers((key, value) :: list)
 
     inline def skipBytes(count: Int): Unit =
@@ -173,28 +171,24 @@ object Multipart:
       val part = parsePart(headers(Nil), body())
 
       if cursor.finished then
-        raise(MultipartError(Reason.Expected('-')))
+        raise(expected('-'))
         Stream()
       else if cursor.peek == '\r' then
-        if !cursor.next() || cursor.peek != '\n'
-        then raise(MultipartError(Reason.Expected('\n')))
+        cursor.next()
+        cursor.expect('\n')(expected('\n'))
 
-        part #:: { part.body.strict; cursor.next(); parts() }
+        part #:: { part.body.strict; parts() }
 
       else if cursor.peek == '-' then
-        if !cursor.next() || cursor.peek != '-'
-        then raise(MultipartError(Reason.Expected('-')))
-
-        if !cursor.next() || cursor.peek != '\r'
-        then raise(MultipartError(Reason.Expected('\r')))
-
-        if !cursor.next() || cursor.peek != '\n'
-        then raise(MultipartError(Reason.Expected('\n')))
+        cursor.next()
+        cursor.expect('-')(expected('-'))
+        cursor.expect('\r')(expected('\r'))
+        cursor.expect('\n')(expected('\n'))
 
         Stream(part)
 
       else
-        raise(MultipartError(Reason.Expected('-')))
+        raise(expected('-'))
         Stream()
 
     Multipart(parts())

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -36,6 +36,8 @@ import scala.annotation.targetName
 
 import anticipation.Data
 import anticipation.Text
+import contingency.*
+import fulminate.Diagnostics
 import vacuous.Unsafe
 
 // Safe, allocation-free single-element peek. Returns `Datum.End` when the
@@ -63,6 +65,31 @@ extension (cursor: Cursor[Text])
     else
       val buffer = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
       Datum.fromRaw(buffer(cursor.unsafePos(using Unsafe)).toInt)
+
+// Match the cursor's current operand against `target`. On a match, advance
+// past it; on a mismatch (or EOF), raise `failure` via the ambient
+// `Tactic`. Replaces the hand-rolled `if cursor.peek != X then raise(…);
+// cursor.next()` pair that every header / framer parser was writing. The
+// target is `Char` for both variants so callers don't need `'X'.toByte`
+// on `Cursor[Data]`; for ASCII targets the `Datum`-vs-`Char` comparison
+// compiles to a single primitive `int == int`.
+extension (cursor: Cursor[Data])
+  @targetName("expectByte")
+  inline def expect[error <: Exception](target: Char)
+    (inline failure: Diagnostics ?=> error)
+    ( using Tactic[error] )
+  :   Unit =
+
+    if cursor.peek == target then cursor.next() else raise(failure)
+
+extension (cursor: Cursor[Text])
+  @targetName("expectChar")
+  inline def expect[error <: Exception](target: Char)
+    (inline failure: Diagnostics ?=> error)
+    ( using Tactic[error] )
+  :   Unit =
+
+    if cursor.peek == target then cursor.next() else raise(failure)
 
 package lineation:
   inline given linefeedChars: Lineation:

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -466,3 +466,29 @@ object Tests extends Suite(m"Zephyrine tests"):
         cursor.peek == Datum.End
       . assert(identity)
 
+    suite(m"expect tests"):
+      import strategies.throwUnsafely
+      case class Mismatch() extends Exception
+
+      test(m"Cursor[Data].expect matching advances past the target"):
+        val cursor = Cursor[Data](Iterator(Data('a'.toByte, 'b'.toByte)))
+        cursor.expect('a')(Mismatch())
+        cursor.peek == 'b'
+      . assert(identity)
+
+      test(m"Cursor[Data].expect mismatching throws"):
+        val cursor = Cursor[Data](Iterator(Data('a'.toByte)))
+        try { cursor.expect('z')(Mismatch()); false } catch case _: Mismatch => true
+      . assert(identity)
+
+      test(m"Cursor[Data].expect at EOF throws"):
+        val cursor = Cursor[Data](Iterator(Data()))
+        try { cursor.expect('a')(Mismatch()); false } catch case _: Mismatch => true
+      . assert(identity)
+
+      test(m"Cursor[Text].expect matching advances past the target"):
+        val cursor = Cursor[Text](Iterator(t"ab"))
+        cursor.expect('a')(Mismatch())
+        cursor.peek == 'b'
+      . assert(identity)
+


### PR DESCRIPTION
Adds `Cursor.expect`, a small inline combinator that captures the `if cursor.peek != X then raise(...); cursor.next()` idiom every header / framer parser was writing as two statements per byte. On a match it advances past the target; on mismatch — including EOF — it `raise`s the supplied error via the ambient `Tactic`. The first user, `gesticulate.Multipart`, drops eleven such pairs to one line each.

### `Cursor.expect`

A new inline extension on `Cursor[Data]` and `Cursor[Text]` for the common pattern "consume the next byte/char if it matches, otherwise raise". The error argument is a `Diagnostics ?=> error` context function, so it can construct errors that need `Diagnostics` (e.g. from `fulminate`) inline at the call site:

```scala
def expected(char: Char): Diagnostics ?=> MultipartError =
  MultipartError(Reason.Expected(char))

cursor.expect('-')(expected('-'))
cursor.expect('-')(expected('-'))
cursor.expect('\r')(expected('\r'))
cursor.expect('\n')(expected('\n'))
```

On a match the cursor advances past the target. On mismatch — including end-of-stream — `failure` is `raise`d via the ambient `Tactic[error]`; the cursor position is unchanged, so the caller can attempt recovery.