### PR TITLE
zephyrine: add Cursor.lookahead for non-consuming probe

### DIFF
--- a/lib/gesticulate/src/core/gesticulate.Multipart.scala
+++ b/lib/gesticulate/src/core/gesticulate.Multipart.scala
@@ -108,8 +108,7 @@ object Multipart:
         else if cursor.peek != '\r' then
           if !cursor.next() then continue = false
         else
-          val matched = cursor.hold:
-            val crMark = cursor.mark
+          val matched = cursor.lookahead:
             var ok = cursor.next() && cursor.peek == '\n'
             var i = 0
 
@@ -117,7 +116,6 @@ object Multipart:
               ok = cursor.next() && cursor.peek == boundary(i)
               i += 1
 
-            cursor.cue(crMark)
             ok
 
           if matched then

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -91,6 +91,22 @@ extension (cursor: Cursor[Text])
 
     if cursor.peek == target then cursor.next() else raise(failure)
 
+// Run `action` inside a hold and always restore the cursor position to
+// where it was on entry, regardless of the result — i.e. a non-consuming
+// lookahead. Marks taken inside the action are available via the implicit
+// `Cursor.Held`; the outer cursor is `cue`d back on exit so subsequent
+// processing sees the same bytes. Replaces the explicit
+// `hold { val mk = mark; … cue(mk); result }` idiom that parsers like
+// Multipart's boundary detector and Zeppelin's ZIP signature scanner
+// were writing.
+extension [data](cursor: Cursor[data])
+  inline def lookahead[result](inline action: Cursor.Held ?=> result): result =
+    cursor.hold:
+      val saved = cursor.mark
+      val outcome: result = action
+      cursor.cue(saved)
+      outcome
+
 package lineation:
   inline given linefeedChars: Lineation:
     type Operand = Char

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -492,3 +492,31 @@ object Tests extends Suite(m"Zephyrine tests"):
         cursor.peek == 'b'
       . assert(identity)
 
+    suite(m"lookahead tests"):
+      test(m"lookahead returns result without advancing on success"):
+        val cursor = Cursor[Text](Iterator(t"abcd"))
+        val ok = cursor.lookahead:
+          cursor.next() && cursor.peek == 'b'
+
+        (ok, cursor.peek == 'a')
+      . assert(_ == ((true, true)))
+
+      test(m"lookahead returns result without advancing on failure"):
+        val cursor = Cursor[Text](Iterator(t"abcd"))
+        val ok = cursor.lookahead:
+          cursor.next() && cursor.peek == 'z'
+
+        (ok, cursor.peek == 'a')
+      . assert(_ == ((false, true)))
+
+      test(m"lookahead inside an outer hold preserves the outer marks"):
+        val cursor = Cursor[Text](Iterator(t"abcd"))
+        cursor.hold:
+          val outer = cursor.mark
+          cursor.next()
+          val inner = cursor.lookahead:
+            cursor.next() && cursor.peek == 'c'
+
+          (inner, cursor.grab(outer, cursor.mark).s)
+      . assert(_ == ((true, "a")))
+

--- a/lib/zeppelin/src/core/zeppelin.ZipStream.scala
+++ b/lib/zeppelin/src/core/zeppelin.ZipStream.scala
@@ -70,16 +70,10 @@ class ZipStream(stream: () => Stream[Data], filter: (Path on Zip) => Boolean):
       while !done && !cursor.finished do
         if !cursor.seek(0x50.toByte) then done = true
         else
-          val matched = cursor.hold:
-            val start = cursor.mark
-
-            val ok =
-              cursor.next() && cursor.lay(false)(_ == 0x4b.toByte)
-              && cursor.next() && cursor.lay(false)(_ == 0x03.toByte)
-              && cursor.next() && cursor.lay(false)(_ == 0x04.toByte)
-
-            cursor.cue(start)
-            ok
+          val matched = cursor.lookahead:
+            cursor.next() && cursor.lay(false)(_ == 0x4b.toByte)
+            && cursor.next() && cursor.lay(false)(_ == 0x03.toByte)
+            && cursor.next() && cursor.lay(false)(_ == 0x04.toByte)
 
           if matched then
             found = true


### PR DESCRIPTION
Adds `Cursor.lookahead` — runs an action inside a `hold` and always restores the cursor position regardless of the result. Captures the hand-rolled `hold { val mk = mark; … cue(mk); ok }` idiom that Multipart's boundary detector and Zeppelin's ZIP signature scanner were writing. Bytecode-identical (the action is inline); 3 focused tests added to zephyrine; existing Multipart tests unchanged.

### `Cursor.lookahead`

A new inline extension on `Cursor[data]` for non-consuming probes. Runs `action` inside a hold, then `cue`s back to the entry position regardless of the result, and returns the action's value. Marks taken inside the action are valid via the implicit `Cursor.Held`.

```scala
val matched = cursor.lookahead:
  cursor.next() && cursor.peek == '\n' &&
  cursor.next() && cursor.peek == boundary(0)
  // … the cursor is always restored on return
```

Useful for "look without consuming" — checking whether a pattern follows the current position without committing to it. Distinct from a backtrack-on-failure: `lookahead` always restores; the caller separately decides what to do with the result.