### PR TITLE
zephyrine: typed Cursor.buffer extension drops asInstanceOf cast

### DIFF
--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -543,7 +543,7 @@ object Html extends Tag.Container
     // backtracking via `cue`) the parser pushes `pos` to the cursor
     // first, then refreshes its snapshot from the cursor afterwards —
     // refill may compact the buffer, reallocate it, or reset `pos`.
-    private var bytes:  Array[Char] = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
+    private var bytes:  Array[Char] = cursor.buffer(using Unsafe)
     private var pos:    Int = cursor.unsafePos(using Unsafe)
     private var bufEnd: Int = cursor.unsafeWriteEnd(using Unsafe)
 
@@ -551,7 +551,7 @@ object Html extends Tag.Container
       cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
 
     private inline def syncFrom(): Unit =
-      bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
+      bytes  = cursor.buffer(using Unsafe)
       pos    = cursor.unsafePos(using Unsafe)
       bufEnd = cursor.unsafeWriteEnd(using Unsafe)
 

--- a/lib/jacinta/src/core/jacinta.JsonParser.scala
+++ b/lib/jacinta/src/core/jacinta.JsonParser.scala
@@ -324,7 +324,7 @@ private[jacinta] final class JsonParser:
   // refill compacts the buffer (bytes 0..old-pos are discarded; subsequent
   // walks would read different data).
   private inline def syncFrom(): Unit =
-    bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
+    bytes  = cursor.buffer(using Unsafe)
     pos    = cursor.unsafePos(using Unsafe)
     bufEnd = cursor.unsafeWriteEnd(using Unsafe)
     lineationPos = pos

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -440,7 +440,7 @@ private final class TelParser():
     cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
 
   private inline def syncFrom(): Unit =
-    bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
+    bytes  = cursor.buffer(using Unsafe)
     pos    = cursor.unsafePos(using Unsafe)
     bufEnd = cursor.unsafeWriteEnd(using Unsafe)
 

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1121,7 +1121,7 @@ object Xml extends Tag.Container
     // backtracking via `cue`) the parser pushes `pos` to the cursor first,
     // then refreshes its snapshot from the cursor afterwards — refill may
     // compact the buffer, reallocate it, or reset `pos`.
-    private var bytes:  Array[Char] = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
+    private var bytes:  Array[Char] = cursor.buffer(using Unsafe)
     private var pos:    Int = cursor.unsafePos(using Unsafe)
     private var bufEnd: Int = cursor.unsafeWriteEnd(using Unsafe)
 
@@ -1129,7 +1129,7 @@ object Xml extends Tag.Container
       cursor.unsafeAdvanceBy(pos - cursor.unsafePos(using Unsafe))(using Unsafe)
 
     private inline def syncFrom(): Unit =
-      bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
+      bytes  = cursor.buffer(using Unsafe)
       pos    = cursor.unsafePos(using Unsafe)
       bufEnd = cursor.unsafeWriteEnd(using Unsafe)
       lineationPos = pos

--- a/lib/ypsiloid/src/core/ypsiloid.YamlParser.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlParser.scala
@@ -264,7 +264,7 @@ private[ypsiloid] final class YamlParser:
   // a refill may have compacted the buffer (bytes 0..old-pos are
   // discarded; subsequent walks would read different data).
   private inline def syncFrom(): Unit =
-    bytes  = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
+    bytes  = cursor.buffer(using Unsafe)
     pos    = cursor.unsafePos(using Unsafe)
     bufEnd = cursor.unsafeWriteEnd(using Unsafe)
     lineationPos = pos

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -54,17 +54,13 @@ extension (cursor: Cursor[Data])
   @targetName("peekByte")
   inline def peek: Datum =
     if cursor.finished then Datum.End
-    else
-      val buffer = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
-      Datum.fromRaw(buffer(cursor.unsafePos(using Unsafe)) & 0xff)
+    else Datum.fromRaw(cursor.buffer(using Unsafe)(cursor.unsafePos(using Unsafe)) & 0xff)
 
 extension (cursor: Cursor[Text])
   @targetName("peekChar")
   inline def peek: Datum =
     if cursor.finished then Datum.End
-    else
-      val buffer = cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
-      Datum.fromRaw(buffer(cursor.unsafePos(using Unsafe)).toInt)
+    else Datum.fromRaw(cursor.buffer(using Unsafe)(cursor.unsafePos(using Unsafe)).toInt)
 
 // Match the cursor's current operand against `target`. On a match, advance
 // past it; on a mismatch (or EOF), raise `failure` via the ambient
@@ -106,6 +102,23 @@ extension [data](cursor: Cursor[data])
       val outcome: result = action
       cursor.cue(saved)
       outcome
+
+// Typed, allocation-free view of the cursor's current backing storage.
+// Returns the same array as `unsafeBuffer` but with its concrete element
+// type, so parsers that snapshot the buffer for a hot-loop scan don't have
+// to write `cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]`
+// themselves — the unsafe cast lives in one place inside zephyrine.
+// `Unsafe` is still required: the returned reference is only valid until
+// the next cursor operation that may compact or grow the buffer.
+extension (cursor: Cursor[Data])
+  @targetName("dataBuffer")
+  inline def buffer(using erased Unsafe): Array[Byte] =
+    cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]
+
+extension (cursor: Cursor[Text])
+  @targetName("textBuffer")
+  inline def buffer(using erased Unsafe): Array[Char] =
+    cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Char]]
 
 package lineation:
   inline given linefeedChars: Lineation:


### PR DESCRIPTION
Adds `cursor.buffer` extensions on `Cursor[Data]` and `Cursor[Text]` that return the typed `Array[Byte]` / `Array[Char]` directly, hiding the `cursor.unsafeBuffer.asInstanceOf[Array[…]]` cast inside zephyrine. Five parsers that snapshot the buffer for hot-loop scanning — Honeycomb, Xylophone, Ypsiloid, Jacinta, TelParser — drop the cast from their `syncFrom` / field initialisers. Zero perf overhead (the extension is inline); 1339 parser tests unchanged.

### `Cursor.buffer`

Two new inline extensions — `cursor.buffer: Array[Byte]` on `Cursor[Data]` and `cursor.buffer: Array[Char]` on `Cursor[Text]`. Returns the cursor's current backing array, typed correctly so parsers don't need to write `cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]` themselves.

```scala
// Before:
private var bytes: Array[Byte] =
  cursor.unsafeBuffer(using Unsafe).asInstanceOf[Array[Byte]]

// After:
private var bytes: Array[Byte] = cursor.buffer(using Unsafe)
```

`Unsafe` is still required — the returned reference is only valid until the next cursor operation that may compact or grow the buffer — but the parser-side code no longer carries the cast or has to remember the right `Array[…]` to cast to. The two extensions are disambiguated via `@targetName` since they erase to the same JVM signature.