### PR TITLE
locomotion: Protocol Buffers (proto3) codec

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -237,8 +237,8 @@ object groupCheck extends Module:
     "quantitative.units",
 
     "bitumen.core", "breviloquence.core", "distillate.core", "exegesis.core",
-    "gigantism.core", "proscenium.core", "satirical.core", "stenography.core",
-    "ypsiloid.core"
+    "gigantism.core", "locomotion.core", "proscenium.core", "satirical.core",
+    "stenography.core", "ypsiloid.core"
   )
 
   def validate(): Command[Unit] = Task.Command:
@@ -943,6 +943,14 @@ object mandible extends Library:
 
   object test extends Tests(core, revolution.core, quantitative.units)
 
+object locomotion extends Library:
+  object core
+      extends Component(turbulence.core, wisteria.core, adversaria.core, hypotenuse.core,
+        gossamer.core, spectacular.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core)
+
 object mercator extends Library:
   object core extends Component(fulminate.core):
     override def scalacOptions = Task:
@@ -1371,7 +1379,8 @@ val allLibraries: Seq[Library] = Seq(
   frontier, fulminate, galilei, gastronomy, geodesy, gesticulate, gigantism,
   gnossienne, gossamer, guillotine, hallucination, harlequin, hellenism, hieroglyph,
   honeycomb, hyperbole, hypotenuse, imperial, inimitable, iridescence, jacinta,
-  kaleidoscope, larceny, legerdemain, mandible, mercator, metamorphose, monotonous,
+  kaleidoscope, larceny, legerdemain, locomotion, mandible, mercator, metamorphose,
+  monotonous,
   mosquito, nomenclature, obligatory, octogenarian, orthodoxy, panopticon, parasite,
   phoenicia, plutocrat, polaris, polysyllabic, polyvinyl, prepositional, probably, profanity,
   proscenium, punctuation, quantitative, revolution, rudiments, satirical, savagery,

--- a/lib/locomotion/src/core/locomotion.Packable.scala
+++ b/lib/locomotion/src/core/locomotion.Packable.scala
@@ -1,0 +1,77 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import hypotenuse.*
+import prepositional.*
+
+// Marks a scalar type that participates in proto3 *packed* `repeated` encoding,
+// recording the wire type its values use. Only numeric scalars are packable;
+// strings, byte arrays and messages are always length-delimited and repeat as
+// separate fields, so they have no `Packable` instance.
+object Packable:
+  given int: Int is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given long: Long is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given boolean: Boolean is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given u32: U32 is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given u64: U64 is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given s32: S32 is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given s64: S64 is Packable:
+    def wireType: WireType = WireType.Varint
+
+  given float: Float is Packable:
+    def wireType: WireType = WireType.I32
+
+  given double: Double is Packable:
+    def wireType: WireType = WireType.I64
+
+  given b32: B32 is Packable:
+    def wireType: WireType = WireType.I32
+
+  given b64: B64 is Packable:
+    def wireType: WireType = WireType.I64
+
+trait Packable extends Typeclass:
+  def wireType: WireType

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -1,0 +1,417 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import language.experimental.pureFunctions
+
+import java.lang as jl
+import java.nio.charset.StandardCharsets.UTF_8
+
+import scala.collection.Factory
+import scala.compiletime.*
+
+import adversaria.*
+import anticipation.*
+import contingency.*
+import distillate.*
+import hypotenuse.*
+import prepositional.*
+import rudiments.*
+import turbulence.*
+import vacuous.*
+import wisteria.*
+
+import ProtobufError.Reason
+
+trait Protobuf2:
+  this: Protobuf.type =>
+
+  inline given encodable: [value] => value is Encodable in Protobuf = summonFrom:
+    case given Reflection[`value`] => EncodableDerivation.derived
+
+  inline given decodable: [value] => value is Decodable in Protobuf = summonFrom:
+    case given Reflection[`value`] => DecodableDerivation.derived
+
+  // Unpacked `repeated`: each element is emitted as a separate field (one tag per
+  // value). This is the fallback for elements with no `Packable` instance — strings,
+  // byte arrays and embedded messages. Numeric scalars are handled by the
+  // higher-priority packed givens in `object Protobuf`. Decoding accepts either
+  // form, so a packed field still round-trips here when no `Packable` is in scope.
+
+  given listEncodable: [collection <: Iterable, element]
+  =>  ( encodable: => element is Encodable in Protobuf )
+  =>  collection[element] is Encodable in Protobuf =
+
+    values =>
+      val occurrences = values.to(List).flatMap(encodable.encode(_).occurrences)
+      if occurrences.isEmpty then Protobuf.Absent else Protobuf.Repeated(occurrences)
+
+  given listDecodable: [collection <: Iterable, element]
+  =>  ( factory: Factory[element, collection[element]] )
+  =>  ( decodable: => element is Decodable in Protobuf )
+  =>  collection[element] is Decodable in Protobuf =
+
+    protobuf =>
+      val builder = factory.newBuilder
+
+      protobuf.occurrences.foreach: wire =>
+        builder += decodable.decoded(wire)
+
+      builder.result()
+
+object Protobuf extends Protobuf2:
+  // Wraps a complete message payload as a length-delimited wire value — the shape
+  // the derivations decode. Used by the `Aggregable` instances backing `read`.
+  private def message(bytes: Data): Protobuf = Wire(WireType.Len, bytes)
+
+  given protobuf: Protobuf is Decodable in Protobuf = identity(_)
+
+  // `bytes.read[Protobuf]` aggregates the byte stream and wraps it as a message.
+  given aggregable: Protobuf is Aggregable by Data = bytes => message(bytes.read[Data])
+
+  // `bytes.read[Foo over Protobuf]` shorthand for `bytes.read[Protobuf].as[Foo]`,
+  // mirroring jacinta's `value over Json` and breviloquence's `value over Cbor`.
+  // `value over Protobuf` is just `value { type Transport = Protobuf }`, so the
+  // cast is a no-op at runtime.
+  given aggregableOver: [value: Decodable in Protobuf] => Tactic[ProtobufError]
+  =>  (value over Protobuf) is Aggregable by Data =
+    bytes => message(bytes.read[Data]).as[value].asInstanceOf[value over Protobuf]
+
+  private def printed(lambda: ProtobufPrinter => Unit): Data =
+    val printer = ProtobufPrinter()
+    lambda(printer)
+    printer.result
+
+  private def readVarint(protobuf: Protobuf)(using Tactic[ProtobufError]): Long =
+    if protobuf.isAbsent then 0L else ProtobufParser(protobuf.payload).varint()
+
+  private def readFixed32(protobuf: Protobuf)(using Tactic[ProtobufError]): Int =
+    if protobuf.isAbsent then 0 else ProtobufParser(protobuf.payload).fixed32()
+
+  private def readFixed64(protobuf: Protobuf)(using Tactic[ProtobufError]): Long =
+    if protobuf.isAbsent then 0L else ProtobufParser(protobuf.payload).fixed64()
+
+  // Zig-zag maps signed integers to unsigned so small-magnitude negatives stay
+  // short as varints: 0→0, -1→1, 1→2, -2→3, …
+  private def zigzag(value: Long): Long = (value << 1) ^ (value >> 63)
+  private def unzigzag(value: Long): Long = (value >>> 1) ^ -(value & 1)
+
+  private def utf8(text: Text): Data = text.s.getBytes(UTF_8).nn.immutable(using Unsafe)
+
+  given intEncodable: Int is Encodable in Protobuf =
+    int => Wire(WireType.Varint, printed(_.varint(int.toLong)))
+
+  given longEncodable: Long is Encodable in Protobuf =
+    long => Wire(WireType.Varint, printed(_.varint(long)))
+
+  given booleanEncodable: Boolean is Encodable in Protobuf =
+    boolean => Wire(WireType.Varint, printed(_.varint(if boolean then 1L else 0L)))
+
+  given doubleEncodable: Double is Encodable in Protobuf =
+    double => Wire(WireType.I64, printed(_.fixed64(jl.Double.doubleToLongBits(double))))
+
+  given floatEncodable: Float is Encodable in Protobuf =
+    float => Wire(WireType.I32, printed(_.fixed32(jl.Float.floatToIntBits(float))))
+
+  given textEncodable: Text is Encodable in Protobuf = text => Wire(WireType.Len, utf8(text))
+  given dataEncodable: Data is Encodable in Protobuf = bytes => Wire(WireType.Len, bytes)
+
+  given intDecodable: Tactic[ProtobufError] => Int is Decodable in Protobuf =
+    readVarint(_).toInt
+
+  given longDecodable: Tactic[ProtobufError] => Long is Decodable in Protobuf =
+    readVarint(_)
+
+  given booleanDecodable: Tactic[ProtobufError] => Boolean is Decodable in Protobuf =
+    readVarint(_) != 0
+
+  given doubleDecodable: Tactic[ProtobufError] => Double is Decodable in Protobuf =
+    protobuf =>
+      if protobuf.isAbsent then 0.0
+      else jl.Double.longBitsToDouble(ProtobufParser(protobuf.payload).fixed64())
+
+  given floatDecodable: Tactic[ProtobufError] => Float is Decodable in Protobuf =
+    protobuf =>
+      if protobuf.isAbsent then 0.0f
+      else jl.Float.intBitsToFloat(ProtobufParser(protobuf.payload).fixed32())
+
+  given textDecodable: Text is Decodable in Protobuf =
+    protobuf => Text(jl.String(protobuf.payload.mutable(using Unsafe), UTF_8).nn)
+
+  given dataDecodable: Data is Decodable in Protobuf = _.payload
+
+  // hypotenuse typed integers select the protobuf integer encoding by type, with no
+  // annotation: U32/U64 → uint (plain varint), S32/S64 → sint (zig-zag varint),
+  // B32/B64 → fixed32/fixed64 (little-endian).
+
+  given u32Encodable: U32 is Encodable in Protobuf =
+    u32 => Wire(WireType.Varint, printed(_.varint(u32.long)))
+
+  given u64Encodable: U64 is Encodable in Protobuf =
+    u64 => Wire(WireType.Varint, printed(_.varint(u64.bits.s64.long)))
+
+  given s32Encodable: S32 is Encodable in Protobuf =
+    s32 => Wire(WireType.Varint, printed(_.varint(zigzag(s32.long))))
+
+  given s64Encodable: S64 is Encodable in Protobuf =
+    s64 => Wire(WireType.Varint, printed(_.varint(zigzag(s64.long))))
+
+  given b32Encodable: B32 is Encodable in Protobuf =
+    b32 => Wire(WireType.I32, printed(_.fixed32(b32.s32.int)))
+
+  given b64Encodable: B64 is Encodable in Protobuf =
+    b64 => Wire(WireType.I64, printed(_.fixed64(b64.s64.long)))
+
+  given u32Decodable: Tactic[ProtobufError] => U32 is Decodable in Protobuf =
+    readVarint(_).toInt.bits.u32
+
+  given u64Decodable: Tactic[ProtobufError] => U64 is Decodable in Protobuf =
+    readVarint(_).bits.u64
+
+  given s32Decodable: Tactic[ProtobufError] => S32 is Decodable in Protobuf =
+    protobuf => unzigzag(readVarint(protobuf)).toInt.bits.s32
+
+  given s64Decodable: Tactic[ProtobufError] => S64 is Decodable in Protobuf =
+    protobuf => unzigzag(readVarint(protobuf)).bits.s64
+
+  given b32Decodable: Tactic[ProtobufError] => B32 is Decodable in Protobuf =
+    readFixed32(_).bits
+
+  given b64Decodable: Tactic[ProtobufError] => B64 is Decodable in Protobuf =
+    readFixed64(_).bits
+
+  given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  ( encodable: inner is Encodable in Protobuf )
+  =>  value is Encodable in Protobuf =
+
+    new Encodable:
+      type Self = Optional[value]
+      type Form = Protobuf
+
+      def encoded(value: Optional[value]): Protobuf =
+        value.let(_.asInstanceOf[inner]).let(encodable.encode(_)).or(Absent)
+
+  given optionalDecodable: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  ( decodable: => inner is Decodable in Protobuf )
+  =>  value is Decodable in Protobuf =
+
+    protobuf => if protobuf.isAbsent then Unset else decodable.decoded(protobuf)
+
+  // Packed `repeated` for numeric scalars (proto3 default): all elements are
+  // concatenated into one length-delimited field. Higher priority than the unpacked
+  // givens in `Protobuf2` because `Packable` constrains the element type.
+
+  given packedEncodable: [collection <: Iterable, element]
+  =>  ( encodable: => element is Encodable in Protobuf, packable: element is Packable )
+  =>  collection[element] is Encodable in Protobuf =
+
+    values =>
+      val list = values.to(List)
+
+      if list.isEmpty then Absent else
+        val printer = ProtobufPrinter()
+        var rest = list
+
+        while rest.nonEmpty do
+          printer.raw(encodable.encode(rest.head).payload)
+          rest = rest.tail
+
+        Wire(WireType.Len, printer.result)
+
+  given packedDecodable: [collection <: Iterable, element]
+  =>  ( factory:   Factory[element, collection[element]],
+        decodable: => element is Decodable in Protobuf,
+        packable:  element is Packable )
+  =>  Tactic[ProtobufError]
+  =>  collection[element] is Decodable in Protobuf =
+
+    protobuf =>
+      val builder = factory.newBuilder
+
+      // Accept both packed (one Len field of concatenated values) and unpacked (a
+      // value per occurrence) wire forms, per the proto3 compatibility rule.
+      protobuf.occurrences.foreach: wire =>
+        if wire.wireKind == WireType.Len && packable.wireType != WireType.Len
+        then ProtobufParser(wire.payload).packed(packable.wireType).foreach: element =>
+          builder += decodable.decoded(element)
+        else builder += decodable.decoded(wire)
+
+      builder.result()
+
+  // `Map[K, V]` encodes as a `repeated` message of map entries, each a two-field
+  // message `{ key = 1; value = 2 }` — the proto3 map wire format.
+
+  given mapEncodable: [key, value]
+  =>  ( keyEncodable:   key is Encodable in Protobuf,
+        valueEncodable: value is Encodable in Protobuf )
+  =>  Map[key, value] is Encodable in Protobuf =
+
+    map =>
+      if map.isEmpty then Absent else
+        val entries = map.to(List).map: (key, value) =>
+          val printer = ProtobufPrinter()
+          printer.field(1, keyEncodable.encode(key))
+          printer.field(2, valueEncodable.encode(value))
+          Wire(WireType.Len, printer.result)
+
+        Repeated(entries)
+
+  given mapDecodable: [key, value]
+  =>  ( keyDecodable:   => key is Decodable in Protobuf,
+        valueDecodable: => value is Decodable in Protobuf )
+  =>  Tactic[ProtobufError]
+  =>  Map[key, value] is Decodable in Protobuf =
+
+    protobuf =>
+      val entries = protobuf.occurrences.map: entry =>
+        val fields = ProtobufParser(entry.payload).fields()
+        val key = keyDecodable.decoded(Repeated(fields.at(1).or(Nil)))
+        val value = valueDecodable.decoded(Repeated(fields.at(2).or(Nil)))
+        (key, value)
+
+      entries.to(Map)
+
+  object EncodableDerivation extends Derivable[Encodable in Protobuf]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Encodable in Protobuf =
+
+      val numbers = fieldNumbers[derivation]
+
+      value =>
+        val printer = ProtobufPrinter()
+
+        fields(value):
+          [field0] => fieldValue =>
+            printer.field(numbers(label), contextual.encode(fieldValue))
+
+        Protobuf.Wire(WireType.Len, printer.result)
+
+    inline def disjunction[derivation: SumReflection]: derivation is Encodable in Protobuf =
+      value =>
+        variant(value):
+          [variant <: derivation] => variantValue =>
+            val payload = printed(_.field(index + 1, contextual.encode(variantValue)))
+            Protobuf.Wire(WireType.Len, payload)
+
+    inline def fieldNumbers[derivation <: Product: ProductReflection]: Map[Text, Int] =
+      val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match
+        case annotated: Annotated.Fields => annotated.fields
+        case _                           => Map()
+
+      val pairs =
+        contexts:
+          [field0] => context =>
+            (label, annotated.at(label).let(_.head.number).or(index + 1))
+
+      pairs.to(Map)
+
+  object DecodableDerivation extends Derivable[Decodable in Protobuf]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Decodable in Protobuf =
+
+      val numbers = fieldNumbers[derivation]
+
+      protobuf =>
+        provide[Tactic[ProtobufError]]:
+          val map = ProtobufParser(protobuf.payload).fields()
+
+          build:
+            [field0] => context =>
+              map.at(numbers(label)).lay(default.or(context.decoded(Protobuf.Absent))): values =>
+                context.decoded(Protobuf.Repeated(values))
+
+    inline def disjunction[derivation: SumReflection]: derivation is Decodable in Protobuf =
+      protobuf =>
+        provide[Tactic[ProtobufError]]:
+          provide[Tactic[VariantError]]:
+            val map = ProtobufParser(protobuf.payload).fields()
+            val labels = variantLabels[derivation]
+
+            var index = 0
+            while index < labels.length && !map.contains(index + 1) do index += 1
+            if index >= labels.length then abort(ProtobufError(Reason.MissingField(0)))
+
+            delegate(labels(index)):
+              [variant <: derivation] => context =>
+                context.decoded(Protobuf.Repeated(map(index + 1)))
+
+    inline def fieldNumbers[derivation <: Product: ProductReflection]: Map[Text, Int] =
+      val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match
+        case annotated: Annotated.Fields => annotated.fields
+        case _                           => Map()
+
+      val pairs =
+        contexts:
+          [field0] => context =>
+            (label, annotated.at(label).let(_.head.number).or(index + 1))
+
+      pairs.to(Map)
+
+// A single Protocol Buffers wire value, tagged with its wire type — the `Form` of
+// `Encodable`/`Decodable in Protobuf`. `Repeated` carries every occurrence of a
+// field number (so repeated fields and last-wins scalars both work), and `Absent`
+// marks a field that was not present (decode) or should be omitted (encode).
+enum Protobuf:
+  case Absent
+  case Wire(wireType: WireType, bytes: Data)
+  case Repeated(values: List[Protobuf])
+
+  // The most recent single wire value (protobuf's last-one-wins rule for scalars).
+  def single: Protobuf = this match
+    case Repeated(values) => if values.isEmpty then Protobuf.Absent else values.last
+    case other            => other
+
+  // Every wire value recorded for this field — used to decode `repeated` fields.
+  def occurrences: List[Protobuf] = this match
+    case Repeated(values) => values
+    case Absent           => Nil
+    case wire             => wire :: Nil
+
+  def payload: Data = single match
+    case Wire(_, bytes) => bytes
+    case _              => IArray.empty[Byte]
+
+  // The wire type of the (single) value, or `Len` for absent — used to tell a packed
+  // scalar field (`Len`) from inline-encoded scalar values during repeated decoding.
+  def wireKind: WireType = single match
+    case Wire(wireType, _) => wireType
+    case _                 => WireType.Len
+
+  def isAbsent: Boolean = this match
+    case Absent        => true
+    case Repeated(Nil) => true
+    case _             => false
+
+  def serialize: Data = payload
+
+  def as[value: Decodable in Protobuf]: value raises ProtobufError = value.decoded(this)

--- a/lib/locomotion/src/core/locomotion.ProtobufError.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufError.scala
@@ -1,0 +1,54 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import fulminate.*
+
+object ProtobufError:
+  object Reason:
+    given communicable: Reason is Communicable =
+      case Truncated                 => m"the protobuf data ended unexpectedly"
+      case MalformedVarint           => m"a varint was malformed"
+      case UnexpectedWireType(found) => m"an unexpected wire type, $found, was encountered"
+      case Overflow                  => m"a numeric value was too large for its type"
+      case MissingField(number)      => m"the required field number $number was missing"
+
+  enum Reason:
+    case Truncated
+    case MalformedVarint
+    case UnexpectedWireType(found: Int)
+    case Overflow
+    case MissingField(number: Int)
+
+case class ProtobufError(reason: ProtobufError.Reason)(using Diagnostics)
+extends Error(700, 0)(m"the protobuf data was not valid: $reason")

--- a/lib/locomotion/src/core/locomotion.ProtobufParser.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufParser.scala
@@ -1,0 +1,139 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import contingency.*
+
+import ProtobufError.Reason
+
+// Reads Protocol Buffers wire bytes. `fields` parses a whole message payload into a
+// number-keyed map of (one or more) raw wire values, preserving repeats and unknown
+// fields — the structure the message decoder looks fields up in by number.
+class ProtobufParser(data: Data):
+  private var pos: Int = 0
+
+  def atEnd: Boolean = pos >= data.length
+
+  def varint(): Long raises ProtobufError =
+    var result = 0L
+    var shift = 0
+    var continue = true
+
+    while continue do
+      if pos >= data.length then abort(ProtobufError(Reason.Truncated))
+      val byte = data(pos) & 0xff
+      pos += 1
+      if shift < 64 then result |= (byte.toLong & 0x7f) << shift
+      shift += 7
+      if (byte & 0x80) == 0 then continue = false
+
+    result
+
+  def fixed32(): Int raises ProtobufError =
+    if pos + 4 > data.length then abort(ProtobufError(Reason.Truncated))
+    var result = 0
+    var i = 0
+
+    while i < 4 do
+      result |= (data(pos + i) & 0xff) << (i*8)
+      i += 1
+
+    pos += 4
+    result
+
+  def fixed64(): Long raises ProtobufError =
+    if pos + 8 > data.length then abort(ProtobufError(Reason.Truncated))
+    var result = 0L
+    var i = 0
+
+    while i < 8 do
+      result |= (data(pos + i).toLong & 0xff) << (i*8)
+      i += 1
+
+    pos += 8
+    result
+
+  def slice(length: Int): Data raises ProtobufError =
+    if length < 0 || pos + length > data.length then abort(ProtobufError(Reason.Truncated))
+    val result = data.slice(pos, pos + length)
+    pos += length
+    result
+
+  def fields(): Map[Int, List[Protobuf]] raises ProtobufError =
+    val accumulator = scm.LinkedHashMap.empty[Int, scm.ListBuffer[Protobuf]]
+
+    while !atEnd do
+      val tag = varint().toInt
+      val number = tag >>> 3
+      val code = tag & 0x7
+
+      val wireType =
+        WireType.fromId(code).lest(ProtobufError(Reason.UnexpectedWireType(code)))
+
+      val value = wireType match
+        case WireType.Varint =>
+          val start = pos
+          varint()
+          Protobuf.Wire(WireType.Varint, data.slice(start, pos))
+
+        case WireType.I64 => Protobuf.Wire(WireType.I64, slice(8))
+        case WireType.I32 => Protobuf.Wire(WireType.I32, slice(4))
+        case WireType.Len => Protobuf.Wire(WireType.Len, slice(varint().toInt))
+
+      accumulator.getOrElseUpdate(number, scm.ListBuffer()).addOne(value)
+
+    accumulator.view.mapValues(_.to(List)).to(Map)
+
+  // Splits a packed `repeated` payload (a single length-delimited field holding
+  // concatenated scalar values) into one wire value per element. `wireType` is the
+  // element encoding, supplied by the element's `Packable` instance.
+  def packed(wireType: WireType): List[Protobuf] raises ProtobufError =
+    val builder = List.newBuilder[Protobuf]
+
+    while !atEnd do
+      val value = wireType match
+        case WireType.Varint =>
+          val start = pos
+          varint()
+          Protobuf.Wire(WireType.Varint, data.slice(start, pos))
+
+        case WireType.I64 => Protobuf.Wire(WireType.I64, slice(8))
+        case WireType.I32 => Protobuf.Wire(WireType.I32, slice(4))
+        case WireType.Len => Protobuf.Wire(WireType.Len, slice(varint().toInt))
+
+      builder += value
+
+    builder.result()

--- a/lib/locomotion/src/core/locomotion.ProtobufPrinter.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufPrinter.scala
@@ -1,0 +1,93 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import rudiments.*
+import vacuous.*
+
+// Accumulates Protocol Buffers wire bytes. Varints are LEB128; fixed32/fixed64 are
+// little-endian; a field is its tag varint followed by the value (length-prefixed
+// for the length-delimited wire type).
+class ProtobufPrinter():
+  private val buffer = scm.ArrayBuilder.make[Byte]
+
+  def byte(value: Int): Unit = buffer.addOne(value.toByte)
+
+  def raw(data: Data): Unit =
+    var i = 0
+
+    while i < data.length do
+      buffer.addOne(data(i))
+      i += 1
+
+  def varint(value: Long): Unit =
+    var rest = value
+    var continue = true
+
+    while continue do
+      val septet = (rest & 0x7f).toInt
+      rest = rest >>> 7
+
+      if rest != 0 then byte(septet | 0x80) else
+        byte(septet)
+        continue = false
+
+  def fixed32(value: Int): Unit =
+    var i = 0
+
+    while i < 4 do
+      byte((value >>> (i*8)) & 0xff)
+      i += 1
+
+  def fixed64(value: Long): Unit =
+    var i = 0
+
+    while i < 8 do
+      byte(((value >>> (i*8)) & 0xff).toInt)
+      i += 1
+
+  def tag(number: Int, wireType: WireType): Unit = varint((number.toLong << 3) | wireType.id)
+
+  def field(number: Int, value: Protobuf): Unit = value match
+    case Protobuf.Absent           => ()
+    case Protobuf.Repeated(values) => values.foreach(field(number, _))
+
+    case Protobuf.Wire(wireType, bytes) =>
+      tag(number, wireType)
+      if wireType == WireType.Len then varint(bytes.length)
+      raw(bytes)
+
+  def result: Data = buffer.result().immutable(using Unsafe)

--- a/lib/locomotion/src/core/locomotion.WireType.scala
+++ b/lib/locomotion/src/core/locomotion.WireType.scala
@@ -1,0 +1,54 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import vacuous.*
+
+// The four Protocol Buffers wire types still in use (groups, 3 and 4, are
+// deprecated and unsupported). The `id` is the 3-bit code packed into a field tag.
+object WireType:
+  def fromId(id: Int): Optional[WireType] = id match
+    case 0 => Varint
+    case 1 => I64
+    case 2 => Len
+    case 5 => I32
+    case _ => Unset
+
+enum WireType:
+  case Varint, I64, Len, I32
+
+  def id: Int = this match
+    case Varint => 0
+    case I64    => 1
+    case Len    => 2
+    case I32    => 5

--- a/lib/locomotion/src/core/locomotion.field.scala
+++ b/lib/locomotion/src/core/locomotion.field.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import scala.annotation.StaticAnnotation
+
+// Annotates a case-class field (or enum case) with its Protocol Buffers field
+// number, e.g. `case class Point(@field(1) x: Int, @field(2) y: Int)`. Read during
+// derivation via adversaria. Fields without a `@field` annotation fall back to
+// their 1-based declaration order.
+case class field(number: Int) extends StaticAnnotation

--- a/lib/locomotion/src/core/locomotion_core.scala
+++ b/lib/locomotion/src/core/locomotion_core.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import anticipation.*
+import prepositional.*
+
+// Encodes any value with an `Encodable in Protobuf` instance to its `Protobuf` wire
+// form; `.serialize` then yields the message bytes. Decoding is `Protobuf.parse(
+// bytes).as[T]`.
+extension [value: Encodable in Protobuf](value: value)
+  def protobuf: Protobuf = value.encode

--- a/lib/locomotion/src/core/soundness_locomotion_core.scala
+++ b/lib/locomotion/src/core/soundness_locomotion_core.scala
@@ -1,0 +1,36 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export locomotion.{Protobuf, Protobuf2, ProtobufError, ProtobufParser, ProtobufPrinter,
+    Packable, WireType, field, protobuf}

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -1,0 +1,195 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import soundness.*
+
+import strategies.throwUnsafely
+
+case class Sample(@field(1) value: Int) derives CanEqual
+case class Point(@field(1) x: Int, @field(2) y: Int) derives CanEqual
+case class Person(@field(1) name: Text, @field(2) age: Int) derives CanEqual
+case class Wrapper(@field(1) point: Point, @field(2) label: Text) derives CanEqual
+case class Tags(@field(1) tags: List[Text]) derives CanEqual
+case class Numbers(@field(1) values: List[Int]) derives CanEqual
+case class MaybeName(@field(1) name: Optional[Text]) derives CanEqual
+case class Unnumbered(first: Int, second: Int) derives CanEqual
+case class Sparse(@field(3) a: Int, @field(7) b: Text) derives CanEqual
+
+enum Shape derives CanEqual:
+  case Circle(radius: Int)
+  case Rectangle(width: Int, height: Int)
+
+case class Typed
+   ( @field(1) unsigned:  U32,
+     @field(2) unsigned64: U64,
+     @field(3) signed:    S32,
+     @field(4) signed64:  S64,
+     @field(5) fixed:     B32,
+     @field(6) fixed64:   B64 )
+derives CanEqual
+
+case class Signed(@field(3) value: S32) derives CanEqual
+case class Fixed(@field(5) value: B32) derives CanEqual
+
+case class Labels(@field(1) entries: Map[Text, Text]) derives CanEqual
+case class Counts(@field(1) counts: Map[Text, Int]) derives CanEqual
+
+object Tests extends Suite(m"Locomotion Protobuf Tests"):
+  def run(): Unit =
+    def wire[value: Encodable in Protobuf](value: value): List[Int] =
+      value.protobuf.serialize.to(List).map(_.toInt & 0xff)
+
+    suite(m"Wire-format golden vectors"):
+      test(m"a single varint field encodes to the canonical bytes"):
+        wire(Sample(150))
+      . assert(_ == List(0x08, 0x96, 0x01))
+
+      test(m"a string field is length-delimited"):
+        wire(Person(t"AB", 0))
+      . assert(_ == List(0x0a, 0x02, 0x41, 0x42, 0x10, 0x00))
+
+      test(m"sparse field numbers produce the right tags"):
+        wire(Sparse(1, t"")).take(2)
+      . assert(_ == List(0x18, 0x01))
+
+    suite(m"Round-trips"):
+      test(m"single int field"):
+        Stream(Sample(150).protobuf.serialize).read[Sample over Protobuf]
+      . assert(_ == Sample(150))
+
+      test(m"two int fields, one at its default"):
+        Stream(Point(0, 5).protobuf.serialize).read[Point over Protobuf]
+      . assert(_ == Point(0, 5))
+
+      test(m"string and int fields"):
+        Stream(Person(t"Alice", 30).protobuf.serialize).read[Person over Protobuf]
+      . assert(_ == Person(t"Alice", 30))
+
+      test(m"read[Protobuf] then as[T] (two-step)"):
+        Stream(Person(t"Alice", 30).protobuf.serialize).read[Protobuf].as[Person]
+      . assert(_ == Person(t"Alice", 30))
+
+      test(m"nested message"):
+        Stream(Wrapper(Point(3, 4), t"origin").protobuf.serialize).read[Wrapper over Protobuf]
+      . assert(_ == Wrapper(Point(3, 4), t"origin"))
+
+      test(m"sparse field numbers"):
+        Stream(Sparse(9, t"x").protobuf.serialize).read[Sparse over Protobuf]
+      . assert(_ == Sparse(9, t"x"))
+
+    suite(m"Repeated fields"):
+      test(m"repeated strings round-trip in order"):
+        Stream(Tags(List(t"a", t"b", t"c")).protobuf.serialize).read[Tags over Protobuf]
+      . assert(_ == Tags(List(t"a", t"b", t"c")))
+
+      test(m"repeated ints round-trip, keeping default elements"):
+        Stream(Numbers(List(0, 1, 2)).protobuf.serialize).read[Numbers over Protobuf]
+      . assert(_ == Numbers(List(0, 1, 2)))
+
+      test(m"repeated ints are packed into one length-delimited field"):
+        wire(Numbers(List(3, 270, 86942))).take(2)
+      . assert(_ == List(0x0a, 0x06))
+
+      test(m"a packed field produced elsewhere decodes back to a List"):
+        // The canonical packed encoding of [3, 270, 86942] (matches `protoc`).
+        val packed = IArray[Byte](0x0a, 0x06, 0x03, 0x8e.toByte, 0x02, 0x9e.toByte, 0xa7.toByte, 0x05)
+        Stream(packed).read[Numbers over Protobuf]
+      . assert(_ == Numbers(List(3, 270, 86942)))
+
+      test(m"empty repeated field writes nothing"):
+        wire(Tags(Nil))
+      . assert(_ == Nil)
+
+    suite(m"Optional presence"):
+      test(m"a set optional round-trips"):
+        Stream(MaybeName(t"set").protobuf.serialize).read[MaybeName over Protobuf]
+      . assert(_ == MaybeName(t"set"))
+
+      test(m"an unset optional writes nothing and round-trips to Unset"):
+        Stream(MaybeName(Unset).protobuf.serialize).read[MaybeName over Protobuf]
+      . assert(_ == MaybeName(Unset))
+
+    suite(m"Sum types (oneof)"):
+      test(m"the Circle variant round-trips"):
+        val shape: Shape = Shape.Circle(5)
+        Stream(shape.protobuf.serialize).read[Shape over Protobuf]
+      . assert(_ == Shape.Circle(5))
+
+      test(m"the Rectangle variant round-trips"):
+        val shape: Shape = Shape.Rectangle(3, 4)
+        Stream(shape.protobuf.serialize).read[Shape over Protobuf]
+      . assert(_ == Shape.Rectangle(3, 4))
+
+    suite(m"Field-number fallback"):
+      test(m"unannotated fields use 1-based declaration order"):
+        wire(Unnumbered(150, 0)).take(2)
+      . assert(_ == List(0x08, 0x96))
+
+      test(m"unannotated message round-trips"):
+        Stream(Unnumbered(7, 9).protobuf.serialize).read[Unnumbered over Protobuf]
+      . assert(_ == Unnumbered(7, 9))
+
+    suite(m"Typed integer encodings"):
+      val typed = Typed(7.bits.u32, 8L.bits.u64, -3.bits.s32, -4L.bits.s64, 5.bits, 6L.bits)
+
+      test(m"all typed integers round-trip"):
+        Stream(typed.protobuf.serialize).read[Typed over Protobuf]
+      . assert(_ == typed)
+
+      test(m"sint32 uses zig-zag (field 3, -1 ⇒ tag 0x18, 0x01)"):
+        wire(Signed(-1.bits.s32))
+      . assert(_ == List(0x18, 0x01))
+
+      test(m"fixed32 is little-endian 4 bytes (field 5, value 5)"):
+        wire(Fixed(5.bits))
+      . assert(_ == List(0x2d, 0x05, 0x00, 0x00, 0x00))
+
+    suite(m"Maps"):
+      test(m"a string→string map round-trips"):
+        val labels = Labels(Map(t"a" -> t"1", t"b" -> t"2"))
+        Stream(labels.protobuf.serialize).read[Labels over Protobuf]
+      . assert(_ == Labels(Map(t"a" -> t"1", t"b" -> t"2")))
+
+      test(m"a string→int map round-trips"):
+        val counts = Counts(Map(t"x" -> 10, t"y" -> 20))
+        Stream(counts.protobuf.serialize).read[Counts over Protobuf]
+      . assert(_ == Counts(Map(t"x" -> 10, t"y" -> 20)))
+
+      test(m"an empty map writes nothing"):
+        wire(Labels(Map()))
+      . assert(_ == Nil)
+
+      test(m"a single entry encodes as a length-delimited message"):
+        wire(Labels(Map(t"a" -> t"b")))
+      . assert(_ == List(0x0a, 0x06, 0x0a, 0x01, 0x61, 0x12, 0x01, 0x62))


### PR DESCRIPTION
Locomotion is a new library for encoding and decoding Protocol Buffers (proto3) binary messages, with the same look and feel as Soundness's other format codecs: a `Protobuf` form type, Wisteria-derived `Encodable`/`Decodable` instances for case classes and enums, and `value.protobuf` / `read` entry points. Protobuf field numbers are supplied by an `@field` annotation read via Adversaria, and the protobuf integer encoding for each value is chosen by its Scala type using Hypotenuse's typed integers.

Locomotion provides Protocol Buffers (proto3) support that derives generically to and from your own case classes and enums.

```scala
import soundness.*

case class Point(@field(1) x: Int, @field(2) y: Int) derives CanEqual

val bytes = Point(3, 4).protobuf.serialize
val point = bytes.read[Point over Protobuf]
```

Field numbers come from the `@field(n)` annotation, falling back to 1-based declaration order when omitted. The protobuf integer encoding is selected by type, with no extra annotation:

- `Int`/`Long` → `int32`/`int64`, `Boolean` → `bool` (varint)
- `U32`/`U64` → `uint32`/`uint64` (varint)
- `S32`/`S64` → `sint32`/`sint64` (zig-zag varint)
- `B32`/`B64` → `fixed32`/`fixed64`
- `Float`/`Double` → `float`/`double`
- `Text` → `string`, `Bytes` → `bytes`

Nested messages, sum types (proto `enum` and synthetic `oneof`), `Optional` presence, packed `repeated` scalars, and `Map[K, V]` (as repeated map-entry messages) are all supported. Decoding accepts both packed and unpacked repeated fields. The output has been cross-validated byte-for-byte against `protoc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)