### PR TITLE
xenophile: a compile-time provider for foreign type systems

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1294,7 +1294,7 @@ object wisteria extends Library:
 
 object xenophile extends Library:
   object core extends Component(gossamer.core, prepositional.core, gigantism.core, fulminate.core,
-    vacuous.core, hellenism.core):
+    vacuous.core, hellenism.core, jacinta.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -1292,6 +1292,13 @@ object wisteria extends Library:
   object test extends Tests(core):
     override def enabled = false
 
+object xenophile extends Library:
+  object core extends Component(gossamer.core, prepositional.core, gigantism.core, fulminate.core,
+    vacuous.core, hellenism.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core)
+
 object xylophone extends Library:
   object core extends Component(zephyrine.core, adversaria.core, typonym.core, hellenism.core, urticose.core, wisteria.core):
     override def scalacOptions = Task:
@@ -1377,6 +1384,6 @@ val allLibraries: Seq[Library] = Seq(
   proscenium, punctuation, quantitative, revolution, rudiments, satirical, savagery,
   scintillate, sedentary, serpentine, spectacular, stenography, stratiform, superlunary,
   surveillance, symbolism, synesthesia, tarantula, telekinesis, turbulence, typonym,
-  ulysses, umbrageous, urticose, vacuous, vexillology, vicarious, wisteria, xylophone,
+  ulysses, umbrageous, urticose, vacuous, vexillology, vicarious, wisteria, xenophile, xylophone,
   yossarian, ypsiloid, zephyrine, zeppelin, ziggurat
 )

--- a/lib/hellenism/src/core/hellenism.Resource.scala
+++ b/lib/hellenism/src/core/hellenism.Resource.scala
@@ -42,12 +42,14 @@ import turbulence.*
 import vacuous.*
 
 object Resource:
-  given streamable: (classloader: Classloader) => Resource is Streamable by Data =
+  given streamable: [resource <: Resource]
+        => (classloader: Classloader)
+        => resource is Streamable by Data =
     given Tactic[StreamError | ClasspathError] = strategies.throwUnsafely
 
     Streamable.inputStream.contramap: resource =>
       classloader.inputStream(resource.path.encode)
 
-  given nominable: Resource is Nominable = _.path.descent.prim.or(t"/")
+  given nominable: [resource <: Resource] => resource is Nominable = _.path.descent.prim.or(t"/")
 
-case class Resource private[hellenism](path: Path on Classpath)
+case class Resource private[hellenism](path: Path on Classpath) extends Locatable

--- a/lib/hellenism/src/core/hellenism.internal.scala
+++ b/lib/hellenism/src/core/hellenism.internal.scala
@@ -59,10 +59,12 @@ object internal extends Hellenism2:
 
 
   def classpath(context: Expr[StringContext]): Macro[Resource] =
+    import quotes.reflect.*
+
     val name: String = context.valueOrAbort.parts.head
 
     val path = safely(name.tt.decode[Path on Classpath]).or:
-      halt(m"the path $name is not a valid classpath path")
+      halt(m"hellenism: the path $name is not a valid classpath path")
 
     val relativeName = if name.startsWith("/") then name.substring(1) else name
     val contextLoader = Thread.currentThread.nn.getContextClassLoader()
@@ -72,13 +74,19 @@ object internal extends Hellenism2:
       else classOf[hellenism.internal.type].getResourceAsStream(name)
 
     Optional(stream).or:
-      halt(m"the path $name is not on the classpath")
+      halt(m"hellenism: the path $name is not on the classpath")
 
-    ' {
-        Resource:
-          Path[Classpath, Classpath.type, Tuple]
-            ( ${Expr(path.root)}, ${Varargs(path.descent.map(Expr(_)))} )
-      }
+    val resource =
+      ' {
+          Resource:
+            Path[Classpath, Classpath.type, Tuple]
+              ( ${Expr(path.root)}, ${Varargs(path.descent.map(Expr(_)))} )
+        }
+
+    val locus = ConstantType(StringConstant(name))
+
+    Refinement(TypeRepr.of[Resource], "Locus", TypeBounds(locus, locus)).asType.absolve match
+      case '[type result <: Resource; result] => '{$resource.asInstanceOf[result]}
 
 
 trait Hellenism2:

--- a/lib/hellenism/src/core/hellenism_core.scala
+++ b/lib/hellenism/src/core/hellenism_core.scala
@@ -39,4 +39,4 @@ package classloaders:
   given scala: Classloader = Classloader[List]
 
 extension (inline context: StringContext)
-  inline def cp(): Resource = ${internal.classpath('context)}
+  transparent inline def cp(): Resource = ${internal.classpath('context)}

--- a/lib/xenophile/res/core/xenophile/definitions.simple
+++ b/lib/xenophile/res/core/xenophile/definitions.simple
@@ -1,7 +1,7 @@
 Foo:
   bar Bar
-  baz Text
-  greet(string) Text
+  baz string
+  greet(string) string
 Bar:
   qux Foo
-  count Int
+  count number

--- a/lib/xenophile/res/core/xenophile/definitions.simple
+++ b/lib/xenophile/res/core/xenophile/definitions.simple
@@ -1,0 +1,6 @@
+Foo:
+  bar Bar
+  baz Text
+Bar:
+  qux Foo
+  count Int

--- a/lib/xenophile/res/core/xenophile/definitions.simple
+++ b/lib/xenophile/res/core/xenophile/definitions.simple
@@ -2,6 +2,7 @@ Foo:
   bar Bar
   baz string
   greet(string) string
+  link(Bar) Foo
 Bar:
   qux Foo
   count number

--- a/lib/xenophile/res/core/xenophile/definitions.simple
+++ b/lib/xenophile/res/core/xenophile/definitions.simple
@@ -1,8 +1,0 @@
-Foo:
-  bar Bar
-  baz string
-  greet(string) string
-  link(Bar) Foo
-Bar:
-  qux Foo
-  count number

--- a/lib/xenophile/res/core/xenophile/definitions.simple
+++ b/lib/xenophile/res/core/xenophile/definitions.simple
@@ -1,6 +1,7 @@
 Foo:
   bar Bar
   baz Text
+  greet(string) Text
 Bar:
   qux Foo
   count Int

--- a/lib/xenophile/res/core/xenophile/definitions.ts
+++ b/lib/xenophile/res/core/xenophile/definitions.ts
@@ -3,6 +3,8 @@ interface Foo {
   baz: string;
   greet(name: string): string;
   link(other: Bar): Foo;
+  tags: string[];
+  nickname?: string;
 }
 
 interface Bar {

--- a/lib/xenophile/res/core/xenophile/definitions.ts
+++ b/lib/xenophile/res/core/xenophile/definitions.ts
@@ -1,0 +1,11 @@
+interface Foo {
+  bar: Bar;
+  baz: string;
+  greet(name: string): string;
+  link(other: Bar): Foo;
+}
+
+interface Bar {
+  qux: Foo;
+  count: number;
+}

--- a/lib/xenophile/src/core/soundness_xenophile_core.scala
+++ b/lib/xenophile/src/core/soundness_xenophile_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export xenophile.{Ecosystem, Foreign, ForeignExpr, Interface, Interoperable, Typescript}
+export xenophile.{Ecosystem, Evaluator, Foreign, ForeignExpr, Interface, Interoperable, Typescript}

--- a/lib/xenophile/src/core/soundness_xenophile_core.scala
+++ b/lib/xenophile/src/core/soundness_xenophile_core.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export xenophile.{Foreign, Interface, Typescript}

--- a/lib/xenophile/src/core/xenophile.Dialect.scala
+++ b/lib/xenophile/src/core/xenophile.Dialect.scala
@@ -30,7 +30,16 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Dialect, Ecosystem, Evaluator, Foreign, ForeignExpr, Interface, Interoperable,
-    Signature, Typescript}
+import anticipation.*
+import vacuous.*
+
+// The signature of a member of a foreign type: a field has no parameters (`Unset`); a method
+// records the foreign type names of its parameters. `result` is the foreign type name produced.
+case class Signature(parameters: Optional[List[Text]], result: Text)
+
+// A grammar for a particular foreign type system: parses a definitions source into a map from each
+// foreign type name to its members' signatures. Keyed on an ecosystem so the macro stays agnostic.
+trait Dialect:
+  def parse(source: Text): Map[Text, Map[Text, Signature]]

--- a/lib/xenophile/src/core/xenophile.Ecosystem.scala
+++ b/lib/xenophile/src/core/xenophile.Ecosystem.scala
@@ -30,6 +30,8 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Ecosystem, Foreign, ForeignExpr, Interface, Interoperable, Typescript}
+import prepositional.*
+
+trait Ecosystem extends Operable

--- a/lib/xenophile/src/core/xenophile.Evaluator.scala
+++ b/lib/xenophile/src/core/xenophile.Evaluator.scala
@@ -36,3 +36,7 @@ import prepositional.*
 
 trait Evaluator extends Formal, Operable:
   def evaluate(expr: ForeignExpr): Operand
+
+  // Whether an evaluated operand represents an absent/null value in this ecosystem; used to decode
+  // optional foreign types.
+  def absent(operand: Operand): Boolean

--- a/lib/xenophile/src/core/xenophile.Evaluator.scala
+++ b/lib/xenophile/src/core/xenophile.Evaluator.scala
@@ -32,68 +32,7 @@
                                                                                                   */
 package xenophile
 
-import soundness.*
-import jacinta.*
+import prepositional.*
 
-type TsInterface = Interface in Typescript at "/xenophile/definitions.simple"
-
-given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.simple")
-
-val document: Json = j"""{"Foo": {"baz": "hello", "bar": {"count": 42}}}"""
-
-given Evaluator in Typescript by Json = Typescript.evaluator(document)
-
-object Tests extends Suite(m"Xenophile tests"):
-  def run(): Unit =
-    val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
-
-    suite(m"Foreign type navigation"):
-      test(m"a member access has the precise refined static type"):
-        val bar: Foreign of "Bar" from Typescript = foo.bar
-        bar.expr
-      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar"))
-
-      test(m"navigate a cyclic foreign type graph"):
-        val cyclic: Foreign of "Foo" from Typescript = foo.bar.qux
-        cyclic.expr
-      . assert(_ == ForeignExpr.Select(ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar"), t"qux"))
-
-    suite(m"Function application"):
-      test(m"applyDynamic builds an `Apply` node typed by the method's result"):
-        val greeting: Foreign of "string" from Typescript = foo.greet(t"hello")
-        greeting.expr
-      . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, member), List(_)) => member == t"greet"
-          case _                                                         => false
-
-      test(m"a Foreign argument of the declared parameter type is accepted"):
-        val linked: Foreign of "Foo" from Typescript = foo.link(foo.bar)
-        linked.expr
-      . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(ForeignExpr.Select(_, b))) =>
-            m == t"link" && b == t"bar"
-
-          case _ =>
-            false
-
-    suite(m"Interoperability"):
-      test(m"a Scala value converts into a `Foreign` literal"):
-        val text: Foreign of "string" from Typescript = t"hello"
-        text.expr
-      . assert:
-          case ForeignExpr.Literal(_) => true
-          case _                      => false
-
-      test(m"a foreign literal converts back to a Scala value via `as`"):
-        val text: Foreign of "string" from Typescript = t"hello"
-        text.as[Text]
-      . assert(_ == t"hello")
-
-    suite(m"Evaluation"):
-      test(m"evaluate a selected leaf field against the backend and decode it"):
-        foo.baz.as[Text]
-      . assert(_ == t"hello")
-
-      test(m"evaluate a nested selection against the backend and decode it"):
-        foo.bar.count.as[Int]
-      . assert(_ == 42)
+trait Evaluator extends Formal, Operable:
+  def evaluate(expr: ForeignExpr): Operand

--- a/lib/xenophile/src/core/xenophile.Foreign.scala
+++ b/lib/xenophile/src/core/xenophile.Foreign.scala
@@ -40,6 +40,13 @@ object Foreign:
   def make(tree: ForeignExpr): Foreign = new Foreign:
     def expr: ForeignExpr = tree
 
+  def unevaluated: Nothing =
+    throw RuntimeException("xenophile: this expression must be evaluated by a backend before `as`")
+
+  def operandOf(tree: ForeignExpr): Any = tree match
+    case ForeignExpr.Literal(value) => value
+    case _                          => unevaluated
+
   transparent inline def apply[name <: Label, origin]: Foreign = ${Xenophile.root[name, origin]}
 
   given converter: [value, ecosystem <: Ecosystem]
@@ -58,5 +65,4 @@ trait Foreign extends Dynamic, Topical, Original:
   transparent inline def applyDynamic(field: String)(inline arguments: Any*): Foreign =
     ${Xenophile.applied('this, 'field, 'arguments)}
 
-  inline def as[ScalaType]: ScalaType =
-    throw RuntimeException("xenophile: `as` is a proof-of-concept stub with no value to decode")
+  inline def as[ScalaType]: ScalaType = ${Xenophile.convert[ScalaType]('this)}

--- a/lib/xenophile/src/core/xenophile.Foreign.scala
+++ b/lib/xenophile/src/core/xenophile.Foreign.scala
@@ -34,23 +34,29 @@ package xenophile
 
 import scala.language.dynamics
 
-import anticipation.*
 import prepositional.*
 
 object Foreign:
-  def make(name: String): Foreign = new Foreign:
-    def topic: Text = name.tt
+  def make(tree: ForeignExpr): Foreign = new Foreign:
+    def expr: ForeignExpr = tree
 
   transparent inline def apply[name <: Label, origin]: Foreign = ${Xenophile.root[name, origin]}
 
+  given converter: [value, ecosystem <: Ecosystem]
+  =>  ( interoperable: value is Interoperable in ecosystem )
+  =>  Conversion[value, Foreign of interoperable.Topic from ecosystem] =
+    instance =>
+      val literal = ForeignExpr.Literal(interoperable.operand(instance))
+      Foreign.make(literal).asInstanceOf[Foreign of interoperable.Topic from ecosystem]
+
 trait Foreign extends Dynamic, Topical, Original:
-  def topic: Text
+  def expr: ForeignExpr
 
   transparent inline def selectDynamic(field: String): Foreign =
     ${Xenophile.select('this, 'field)}
 
-  transparent inline def applyDynamic(field: String)(arguments: Any*): Foreign =
-    ${Xenophile.select('this, 'field)}
+  transparent inline def applyDynamic(field: String)(inline arguments: Any*): Foreign =
+    ${Xenophile.applied('this, 'field, 'arguments)}
 
   inline def as[ScalaType]: ScalaType =
     throw RuntimeException("xenophile: `as` is a proof-of-concept stub with no value to decode")

--- a/lib/xenophile/src/core/xenophile.Foreign.scala
+++ b/lib/xenophile/src/core/xenophile.Foreign.scala
@@ -1,0 +1,56 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.language.dynamics
+
+import anticipation.*
+import prepositional.*
+
+object Foreign:
+  def make(name: String): Foreign = new Foreign:
+    def topic: Text = name.tt
+
+  transparent inline def apply[name <: Label, origin]: Foreign = ${Xenophile.root[name, origin]}
+
+trait Foreign extends Dynamic, Topical, Original:
+  def topic: Text
+
+  transparent inline def selectDynamic(field: String): Foreign =
+    ${Xenophile.select('this, 'field)}
+
+  transparent inline def applyDynamic(field: String)(arguments: Any*): Foreign =
+    ${Xenophile.select('this, 'field)}
+
+  inline def as[ScalaType]: ScalaType =
+    throw RuntimeException("xenophile: `as` is a proof-of-concept stub with no value to decode")

--- a/lib/xenophile/src/core/xenophile.Foreign.scala
+++ b/lib/xenophile/src/core/xenophile.Foreign.scala
@@ -40,13 +40,6 @@ object Foreign:
   def make(tree: ForeignExpr): Foreign = new Foreign:
     def expr: ForeignExpr = tree
 
-  def unevaluated: Nothing =
-    throw RuntimeException("xenophile: this expression must be evaluated by a backend before `as`")
-
-  def operandOf(tree: ForeignExpr): Any = tree match
-    case ForeignExpr.Literal(value) => value
-    case _                          => unevaluated
-
   transparent inline def apply[name <: Label, origin]: Foreign = ${Xenophile.root[name, origin]}
 
   given converter: [value, ecosystem <: Ecosystem]

--- a/lib/xenophile/src/core/xenophile.ForeignExpr.scala
+++ b/lib/xenophile/src/core/xenophile.ForeignExpr.scala
@@ -30,6 +30,12 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Ecosystem, Foreign, ForeignExpr, Interface, Interoperable, Typescript}
+import anticipation.*
+
+enum ForeignExpr:
+  case Reference(name: Text)
+  case Select(target: ForeignExpr, member: Text)
+  case Apply(target: ForeignExpr, arguments: List[ForeignExpr])
+  case Literal(value: Any)

--- a/lib/xenophile/src/core/xenophile.Interface.scala
+++ b/lib/xenophile/src/core/xenophile.Interface.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import hellenism.*
+import prepositional.*
+
+object Interface:
+  transparent inline def apply[form](inline resource: Resource): Interface =
+    ${Xenophile.interface[form]('resource)}
+
+trait Interface extends Formal, Locatable

--- a/lib/xenophile/src/core/xenophile.Interoperable.scala
+++ b/lib/xenophile/src/core/xenophile.Interoperable.scala
@@ -30,6 +30,22 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Ecosystem, Foreign, ForeignExpr, Interface, Interoperable, Typescript}
+import prepositional.*
+
+object Interoperable:
+  def apply[self, form <: Ecosystem, topic <: Label, operand](lambda: self => operand)
+  :   (self is Interoperable in form of topic by operand) =
+
+    new Interoperable:
+      type Self = self
+      type Form = form
+      type Topic = topic
+      type Operand = operand
+
+      def operand(value: self): operand = lambda(value)
+
+trait Interoperable extends Topical, Formal, Operable:
+  type Self
+  def operand(value: Self): Operand

--- a/lib/xenophile/src/core/xenophile.Interoperable.scala
+++ b/lib/xenophile/src/core/xenophile.Interoperable.scala
@@ -35,7 +35,8 @@ package xenophile
 import prepositional.*
 
 object Interoperable:
-  def apply[self, form <: Ecosystem, topic <: Label, operand](lambda: self => operand)
+  def apply[self, form <: Ecosystem, topic <: Label, operand]
+    ( encode: self => operand, decode: operand => self )
   :   (self is Interoperable in form of topic by operand) =
 
     new Interoperable:
@@ -44,8 +45,10 @@ object Interoperable:
       type Topic = topic
       type Operand = operand
 
-      def operand(value: self): operand = lambda(value)
+      def operand(value: self): operand = encode(value)
+      def value(data: operand): self = decode(data)
 
 trait Interoperable extends Topical, Formal, Operable:
   type Self
   def operand(value: Self): Operand
+  def value(operand: Operand): Self

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+trait Typescript

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -32,18 +32,20 @@
                                                                                                   */
 package xenophile
 
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
 import jacinta.*
 import prepositional.*
 
 object Typescript:
-  given string: (String is Interoperable in Typescript of "string" by Json) =
-    Interoperable[String, Typescript, "string", Json](_.json)
+  given text: (Text is Interoperable in Typescript of "string" by Json) =
+    Interoperable[Text, Typescript, "string", Json](_.json, _.as[Text])
 
   given int: (Int is Interoperable in Typescript of "number" by Json) =
-    Interoperable[Int, Typescript, "number", Json](_.json)
+    Interoperable[Int, Typescript, "number", Json](_.json, _.as[Int])
 
   given boolean: (Boolean is Interoperable in Typescript of "boolean" by Json) =
-    Interoperable[Boolean, Typescript, "boolean", Json](_.json)
+    Interoperable[Boolean, Typescript, "boolean", Json](_.json, _.as[Boolean])
 
 trait Typescript extends Ecosystem:
   type Operand = Json

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -32,4 +32,18 @@
                                                                                                   */
 package xenophile
 
-trait Typescript
+import jacinta.*
+import prepositional.*
+
+object Typescript:
+  given string: (String is Interoperable in Typescript of "string" by Json) =
+    Interoperable[String, Typescript, "string", Json](_.json)
+
+  given int: (Int is Interoperable in Typescript of "number" by Json) =
+    Interoperable[Int, Typescript, "number", Json](_.json)
+
+  given boolean: (Boolean is Interoperable in Typescript of "boolean" by Json) =
+    Interoperable[Boolean, Typescript, "boolean", Json](_.json)
+
+trait Typescript extends Ecosystem:
+  type Operand = Json

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -47,5 +47,21 @@ object Typescript:
   given boolean: (Boolean is Interoperable in Typescript of "boolean" by Json) =
     Interoperable[Boolean, Typescript, "boolean", Json](_.json, _.as[Boolean])
 
+  // A backend that evaluates a `ForeignExpr` against an in-memory JSON document: references and
+  // selections navigate the document; literals yield their operand; function application is
+  // unsupported (a static document has no callable members).
+  def evaluator(document: Json): Evaluator in Typescript by Json =
+    new Evaluator:
+      type Form = Typescript
+      type Operand = Json
+
+      def evaluate(expr: ForeignExpr): Json = expr match
+        case ForeignExpr.Literal(value)         => value.asInstanceOf[Json]
+        case ForeignExpr.Reference(name)        => document(name)
+        case ForeignExpr.Select(target, member) => evaluate(target)(member)
+
+        case ForeignExpr.Apply(_, _) =>
+          throw RuntimeException("xenophile: a JSON document evaluator cannot apply functions")
+
 trait Typescript extends Ecosystem:
   type Operand = Json

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import contingency.*, strategies.throwUnsafely
 import jacinta.*
 import prepositional.*
+import vacuous.*
 
 object Typescript:
   given text: (Text is Interoperable in Typescript of "string" by Json) =
@@ -59,6 +60,8 @@ object Typescript:
     new Evaluator:
       type Form = Typescript
       type Operand = Json
+
+      def absent(operand: Json): Boolean = operand.as[Optional[Json]] == Unset
 
       def evaluate(expr: ForeignExpr): Json = expr match
         case ForeignExpr.Literal(value)         => value.asInstanceOf[Json]

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -47,6 +47,11 @@ object Typescript:
   given boolean: (Boolean is Interoperable in Typescript of "boolean" by Json) =
     Interoperable[Boolean, Typescript, "boolean", Json](_.json, _.as[Boolean])
 
+  // A TypeScript `string[]` array maps to a Scala `List[Text]`, decoded with jacinta's own
+  // collection support.
+  given strings: (List[Text] is Interoperable in Typescript of "string[]" by Json) =
+    Interoperable[List[Text], Typescript, "string[]", Json](_.json, _.as[List[Text]])
+
   // A backend that evaluates a `ForeignExpr` against an in-memory JSON document: references and
   // selections navigate the document; literals yield their operand; function application is
   // unsupported (a static document has no callable members).

--- a/lib/xenophile/src/core/xenophile.TypescriptDialect.scala
+++ b/lib/xenophile/src/core/xenophile.TypescriptDialect.scala
@@ -30,7 +30,97 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Dialect, Ecosystem, Evaluator, Foreign, ForeignExpr, Interface, Interoperable,
-    Signature, Typescript}
+import anticipation.*
+import vacuous.*
+
+// A minimal grammar for TypeScript declaration files: enough to read `interface` blocks of fields
+// (`name: Type;`) and methods (`name(p: T, …): Type;`). It does not interpret the rest of the
+// language — unrecognised tokens between members are skipped.
+object TypescriptDialect extends Dialect:
+  def parse(source: Text): Map[Text, Map[Text, Signature]] = interfaces(tokenize(source.s), Map())
+
+  // Splits the source into identifier and single-character punctuation tokens, discarding
+  // whitespace; this is all the lexical structure the interface grammar needs.
+  private def punctuation(char: Char): Boolean =
+    char == '{' || char == '}' || char == '(' || char == ')' || char == ':' ||
+      char == ',' || char == ';'
+
+  private def tokenize(source: String): List[String] =
+    def recur(index: Int, current: String, tokens: List[String]): List[String] =
+      if index >= source.length
+      then (if current.isEmpty then tokens else current :: tokens).reverse
+      else
+        val char = source.charAt(index)
+
+        if char.isLetterOrDigit || char == '_' then recur(index + 1, current + char, tokens)
+        else
+          val flushed = if current.isEmpty then tokens else current :: tokens
+
+          if punctuation(char) then recur(index + 1, "", char.toString :: flushed)
+          else recur(index + 1, "", flushed)
+
+    recur(0, "", Nil)
+
+  private def interfaces(tokens: List[String], acc: Map[Text, Map[Text, Signature]])
+  :   Map[Text, Map[Text, Signature]] =
+
+    tokens match
+      case "interface" :: name :: "{" :: rest =>
+        val (members, rest2) = membersOf(rest, Map())
+        interfaces(rest2, acc.updated(name.tt, members))
+
+      case _ :: rest =>
+        interfaces(rest, acc)
+
+      case Nil =>
+        acc
+
+  private def membersOf(tokens: List[String], acc: Map[Text, Signature])
+  :   (Map[Text, Signature], List[String]) =
+
+    tokens match
+      case "}" :: rest =>
+        (acc, rest)
+
+      case name :: "(" :: rest =>
+        val (parameters, rest2) = params(rest, Nil)
+
+        rest2 match
+          case ":" :: result :: rest3 =>
+            val signature = Signature(parameters.map(_.tt), result.tt)
+            membersOf(semicolon(rest3), acc.updated(name.tt, signature))
+
+          case _ =>
+            (acc, rest2)
+
+      case name :: ":" :: result :: rest =>
+        membersOf(semicolon(rest), acc.updated(name.tt, Signature(Unset, result.tt)))
+
+      case _ :: rest =>
+        membersOf(rest, acc)
+
+      case Nil =>
+        (acc, Nil)
+
+  // Reads parameter declarations up to the closing `)`, keeping only each parameter's type name.
+  private def params(tokens: List[String], acc: List[String]): (List[String], List[String]) =
+    tokens match
+      case ")" :: rest =>
+        (acc.reverse, rest)
+
+      case name :: ":" :: kind :: rest =>
+        rest match
+          case "," :: more => params(more, kind :: acc)
+          case _           => params(rest, kind :: acc)
+
+      case _ :: rest =>
+        params(rest, acc)
+
+      case Nil =>
+        (acc.reverse, Nil)
+
+  private def semicolon(tokens: List[String]): List[String] = tokens match
+    case ";" :: rest => rest
+    case _           => tokens

--- a/lib/xenophile/src/core/xenophile.TypescriptDialect.scala
+++ b/lib/xenophile/src/core/xenophile.TypescriptDialect.scala
@@ -44,8 +44,8 @@ object TypescriptDialect extends Dialect:
   // Splits the source into identifier and single-character punctuation tokens, discarding
   // whitespace; this is all the lexical structure the interface grammar needs.
   private def punctuation(char: Char): Boolean =
-    char == '{' || char == '}' || char == '(' || char == ')' || char == ':' ||
-      char == ',' || char == ';'
+    char == '{' || char == '}' || char == '(' || char == ')' || char == ':' || char == ',' ||
+      char == ';' || char == '[' || char == ']' || char == '?' || char == '|'
 
   private def tokenize(source: String): List[String] =
     def recur(index: Int, current: String, tokens: List[String]): List[String] =
@@ -77,6 +77,24 @@ object TypescriptDialect extends Dialect:
       case Nil =>
         acc
 
+  // Parses a type expression into a foreign type name encoding its structure: `T[]` becomes "T[]";
+  // `T | null` and `T | undefined` become "T?"; any other union "A | B" becomes "A|B". These names
+  // are what `Interoperable` instances are keyed on.
+  private def typeOf(tokens: List[String]): (String, List[String]) = tokens match
+    case base :: rest =>
+      val (array, rest2) = rest match
+        case "[" :: "]" :: more => (base+"[]", more)
+        case _                  => (base, rest)
+
+      rest2 match
+        case "|" :: "null" :: more      => (array+"?", more)
+        case "|" :: "undefined" :: more => (array+"?", more)
+        case "|" :: other :: more       => (array+"|"+other, more)
+        case _                          => (array, rest2)
+
+    case Nil =>
+      ("", Nil)
+
   private def membersOf(tokens: List[String], acc: Map[Text, Signature])
   :   (Map[Text, Signature], List[String]) =
 
@@ -88,15 +106,21 @@ object TypescriptDialect extends Dialect:
         val (parameters, rest2) = params(rest, Nil)
 
         rest2 match
-          case ":" :: result :: rest3 =>
+          case ":" :: rest3 =>
+            val (result, rest4) = typeOf(rest3)
             val signature = Signature(parameters.map(_.tt), result.tt)
-            membersOf(semicolon(rest3), acc.updated(name.tt, signature))
+            membersOf(semicolon(rest4), acc.updated(name.tt, signature))
 
           case _ =>
             (acc, rest2)
 
-      case name :: ":" :: result :: rest =>
-        membersOf(semicolon(rest), acc.updated(name.tt, Signature(Unset, result.tt)))
+      case name :: "?" :: ":" :: rest =>
+        val (result, rest2) = typeOf(rest)
+        membersOf(semicolon(rest2), acc.updated(name.tt, Signature(Unset, (result+"?").tt)))
+
+      case name :: ":" :: rest =>
+        val (result, rest2) = typeOf(rest)
+        membersOf(semicolon(rest2), acc.updated(name.tt, Signature(Unset, result.tt)))
 
       case _ :: rest =>
         membersOf(rest, acc)
@@ -104,16 +128,18 @@ object TypescriptDialect extends Dialect:
       case Nil =>
         (acc, Nil)
 
-  // Reads parameter declarations up to the closing `)`, keeping only each parameter's type name.
+  // Reads parameter declarations up to the closing `)`, keeping only each parameter's type.
   private def params(tokens: List[String], acc: List[String]): (List[String], List[String]) =
     tokens match
       case ")" :: rest =>
         (acc.reverse, rest)
 
-      case name :: ":" :: kind :: rest =>
-        rest match
+      case name :: ":" :: rest =>
+        val (kind, rest2) = typeOf(rest)
+
+        rest2 match
           case "," :: more => params(more, kind :: acc)
-          case _           => params(rest, kind :: acc)
+          case _           => params(rest2, kind :: acc)
 
       case _ :: rest =>
         params(rest, acc)

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -52,13 +52,24 @@ object Xenophile:
     else halt(m"xenophile: no grammar is available for the foreign source language")
 
   // Reads the definitions resource at `path` and parses it with the grammar for `origin`.
+  // Parsed definitions are cached by resource path for the lifetime of a compilation run, so that
+  // navigating a chain like `foo.bar.qux` parses each resource only once instead of per access.
+  private val parsed: scala.collection.mutable.HashMap[Text, Map[Text, Map[Text, Signature]]] =
+    scala.collection.mutable.HashMap()
+
   def definitions(using quotes: Quotes)(origin: quotes.reflect.TypeRepr, path: Text)
   :   Map[Text, Map[Text, Signature]] =
 
-    val stream = Optional(getClass.getResourceAsStream(path.s)).or:
-      halt(m"xenophile: could not read foreign definitions at $path on the classpath")
+    parsed.synchronized:
+      parsed.at(path).or:
+        val stream = Optional(getClass.getResourceAsStream(path.s)).or:
+          halt(m"xenophile: could not read foreign definitions at $path on the classpath")
 
-    dialectFor(origin).parse(scala.io.Source.fromInputStream(stream).mkString.tt)
+        val content = scala.io.Source.fromInputStream(stream).mkString.tt
+        val result = dialectFor(origin).parse(content)
+        parsed(path) = result
+
+        result
 
   // Collects every `type X = …` member from a (possibly nested) refinement type into a map.
   private def refinements(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -44,19 +44,14 @@ import vacuous.*
 
 object Xenophile:
 
+  case class Signature(parameters: Optional[List[Text]], result: Text)
+
   // Parses the trivial line-based definitions format into a map from each foreign type name to a
-  // map from its member names to the names of their (foreign) types. For example:
-  //
-  //     Foo:
-  //       bar Bar
-  //       baz Text
-  //     Bar:
-  //       qux Foo
-  //
-  // becomes `Map(Foo -> Map(bar -> Bar, baz -> Text), Bar -> Map(qux -> Foo))`.
-  def parse(lines: List[Text]): Map[Text, Map[Text, Text]] =
-    def recur(todo: List[Text], current: Text, acc: Map[Text, Map[Text, Text]])
-    :   Map[Text, Map[Text, Text]] =
+  // map from member names to their signatures. A member is either a field (`bar Bar`) or a method
+  // (`greet(string) Text`); a method records its parameter type names and result type.
+  def parse(lines: List[Text]): Map[Text, Map[Text, Signature]] =
+    def recur(todo: List[Text], current: Text, acc: Map[Text, Map[Text, Signature]])
+    :   Map[Text, Map[Text, Signature]] =
 
       todo match
         case Nil =>
@@ -65,39 +60,49 @@ object Xenophile:
         case line :: tail =>
           val tokens = line.cut(t" ").to(List).filter(_ != t"")
 
-          if tokens.isEmpty then
-            recur(tail, current, acc)
+          if tokens.isEmpty then recur(tail, current, acc)
           else if !line.starts(t" ") && line.ends(t":") then
             val name = line.cut(t":").to(List).head
             recur(tail, name, acc.updated(name, Map()))
           else
-            tokens match
-              case member :: kind :: _ =>
-                val updated = acc.at(current).or(Map()).updated(member, kind)
-                recur(tail, current, acc.updated(current, updated))
+            val result = tokens.last
+            val segments = tokens.head.cut(t"(").to(List)
+            val name = segments.head
 
-              case _ =>
-                recur(tail, current, acc)
+            val signature =
+              if segments.length == 1 then Signature(Unset, result)
+              else
+                val inside = segments.tail.head.cut(t")").to(List).head
+                Signature(inside.cut(t",").to(List).filter(_ != t""), result)
+
+            val members = acc.at(current).or(Map()).updated(name, signature)
+            recur(tail, current, acc.updated(current, members))
 
     recur(lines, t"", Map())
 
-  def definitions(path: Text)(using Quotes): Map[Text, Map[Text, Text]] =
+  def definitions(path: Text)(using Quotes): Map[Text, Map[Text, Signature]] =
     val stream = Optional(getClass.getResourceAsStream(path.s)).or:
       halt(m"xenophile: could not read foreign definitions at $path on the classpath")
 
     parse(scala.io.Source.fromInputStream(stream).getLines().map(Text(_)).to(List))
 
-  def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =
+  // Collects every `type X = …` member from a (possibly nested) refinement type into a map.
+  private def refinements(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :   Map[Text, quotes.reflect.TypeRepr] =
+
     import quotes.reflect.*
 
-    val fieldName = field.valueOrAbort.tt
-
-    // Collects every `type X = …` member from a (possibly nested) refinement type into a map.
-    def refinements(repr: TypeRepr): Map[Text, TypeRepr] = repr.dealias match
+    repr.dealias match
       case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
       case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
       case AndType(left, right)                        => refinements(left) ++ refinements(right)
       case _                                           => Map()
+
+  // Reads the `Topic` (foreign type name) and `Origin` (source language) from a `Foreign` receiver.
+  private def receiver(using quotes: Quotes)(self: Expr[Foreign])
+  :   (Text, quotes.reflect.TypeRepr) =
+
+    import quotes.reflect.*
 
     val members = refinements(self.asTerm.tpe.widen)
 
@@ -110,59 +115,122 @@ object Xenophile:
       case _ =>
         halt(m"xenophile: the foreign type's `Topic` is not a string literal type")
 
-    val originRepr = members.at(t"Origin").or:
+    val origin = members.at(t"Origin").or:
       halt(m"xenophile: the receiver does not record its source language (it has no `Origin`)")
 
-    val interfaceType =
-      Refinement(TypeRepr.of[Interface], "Form", TypeBounds(originRepr, originRepr))
+    (topic, origin)
+
+  // Summons the `Interface` given for a source language and reads its definitions path (`Locus`).
+  private def locusOf(using quotes: Quotes)(origin: quotes.reflect.TypeRepr): Text =
+    import quotes.reflect.*
+
+    val interfaceType = Refinement(TypeRepr.of[Interface], "Form", TypeBounds(origin, origin))
 
     val interfaceTerm = interfaceType.asType.absolve match
       case '[interface] =>
-        val interface = Expr.summon[interface].getOrElse:
+        val found = Expr.summon[interface].getOrElse:
           halt(m"xenophile: no `Interface` is available for the foreign source language")
 
-        interface.asTerm
+        found.asTerm
 
-    val interfaceMembers =
-      refinements(interfaceTerm.tpe) ++ refinements(interfaceTerm.tpe.widen)
+    val members = refinements(interfaceTerm.tpe) ++ refinements(interfaceTerm.tpe.widen)
 
-    val locusRepr = interfaceMembers.at(t"Locus").or:
+    val locusRepr = members.at(t"Locus").or:
       halt(m"xenophile: the `Interface` does not specify a definitions path (it has no `Locus`)")
 
-    val locus = locusRepr.absolve match
+    locusRepr.absolve match
       case ConstantType(StringConstant(path)) => path.tt
 
       case _ =>
         halt(m"xenophile: the definitions path is not a string literal type")
 
-    val defs = definitions(locus)
+  // Builds the refined type `Foreign of <topic> from <origin>`.
+  private def foreignType(using quotes: Quotes)(topic: Text, origin: quotes.reflect.TypeRepr)
+  :   quotes.reflect.TypeRepr =
 
-    val typeMembers = defs.at(topic).or:
-      halt(m"xenophile: the foreign type $topic is not defined in $locus")
+    import quotes.reflect.*
 
-    val memberType = typeMembers.at(fieldName).or:
+    val topicType = ConstantType(StringConstant(topic.s))
+
+    Refinement
+      ( Refinement(TypeRepr.of[Foreign], "Topic", TypeBounds(topicType, topicType)),
+        "Origin",
+        TypeBounds(origin, origin) )
+
+  def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =
+    val fieldName = field.valueOrAbort.tt
+    val (topic, originRepr) = receiver(self)
+
+    val typeMembers = definitions(locusOf(originRepr)).at(topic).or:
+      halt(m"xenophile: the foreign type $topic is not defined")
+
+    val signature = typeMembers.at(fieldName).or:
       halt(m"xenophile: the foreign type $topic has no member $fieldName")
 
-    val topicType = ConstantType(StringConstant(memberType.s))
+    signature.parameters.let: _ =>
+      halt(m"xenophile: $fieldName is a method of $topic and must be called with arguments")
 
-    val resultType =
-      Refinement
-        ( Refinement(TypeRepr.of[Foreign], "Topic", TypeBounds(topicType, topicType)),
-          "Origin",
-          TypeBounds(originRepr, originRepr) )
-
-    resultType.asType.absolve match
+    foreignType(signature.result, originRepr).asType.absolve match
       case '[type result <: Foreign; result] =>
-        '{Foreign.make(${Expr(memberType.s)}).asInstanceOf[result]}
+        val tree = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
+        '{Foreign.make($tree).asInstanceOf[result]}
+
+  def applied(self: Expr[Foreign], field: Expr[String], arguments: Expr[Seq[Any]]): Macro[Foreign] =
+    import quotes.reflect.*
+
+    val fieldName = field.valueOrAbort.tt
+    val (topic, originRepr) = receiver(self)
+
+    val typeMembers = definitions(locusOf(originRepr)).at(topic).or:
+      halt(m"xenophile: the foreign type $topic is not defined")
+
+    val signature = typeMembers.at(fieldName).or:
+      halt(m"xenophile: the foreign type $topic has no member $fieldName")
+
+    val parameters = signature.parameters.or:
+      halt(m"xenophile: $fieldName is not a method of $topic")
+
+    val args = arguments match
+      case Varargs(exprs) => exprs.to(List)
+
+      case _ =>
+        halt(m"xenophile: the arguments to $fieldName must be passed directly")
+
+    if args.length != parameters.length then
+      halt(m"xenophile: $fieldName expects ${parameters.length} arguments, not ${args.length}")
+
+    val argTrees: List[Expr[ForeignExpr]] = args.map: arg =>
+      arg.asTerm.tpe.widen.asType.absolve match
+        case '[argument] =>
+          if TypeRepr.of[argument] <:< TypeRepr.of[Foreign] then '{${arg.asExprOf[Foreign]}.expr}
+          else
+            val interopType =
+              Refinement
+                ( Refinement
+                    ( TypeRepr.of[Interoperable],
+                      "Self",
+                      TypeBounds(TypeRepr.of[argument], TypeRepr.of[argument]) ),
+                  "Form",
+                  TypeBounds(originRepr, originRepr) )
+
+            interopType.asType.absolve match
+              case '[type interop <: Interoperable { type Self = argument }; interop] =>
+                Expr.summon[interop].absolve match
+                  case Some(instance) =>
+                    '{ForeignExpr.Literal($instance.operand(${arg.asExprOf[argument]}))}
+
+                  case _ =>
+                    halt(m"xenophile: no `Interoperable` instance for this argument to $fieldName")
+
+    val target = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
+    val tree = '{ForeignExpr.Apply($target, ${Expr.ofList(argTrees)})}
+
+    foreignType(signature.result, originRepr).asType.absolve match
+      case '[type result <: Foreign; result] =>
+        '{Foreign.make($tree).asInstanceOf[result]}
 
   def interface[form: Type](resource: Expr[Resource]): Macro[Interface] =
     import quotes.reflect.*
-
-    def refinements(repr: TypeRepr): Map[Text, TypeRepr] = repr.dealias match
-      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
-      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
-      case AndType(left, right)                        => refinements(left) ++ refinements(right)
-      case _                                           => Map()
 
     val members = refinements(resource.asTerm.tpe) ++ refinements(resource.asTerm.tpe.widen)
 
@@ -192,14 +260,6 @@ object Xenophile:
       case _ =>
         halt(m"xenophile: the foreign type name must be a string literal type")
 
-    val originRepr = TypeRepr.of[origin]
-
-    val resultType =
-      Refinement
-        ( Refinement(TypeRepr.of[Foreign], "Topic", TypeBounds(nameRepr, nameRepr)),
-          "Origin",
-          TypeBounds(originRepr, originRepr) )
-
-    resultType.asType.absolve match
+    foreignType(name.tt, TypeRepr.of[origin]).asType.absolve match
       case '[type result <: Foreign; result] =>
-        '{Foreign.make(${Expr(name)}).asInstanceOf[result]}
+        '{Foreign.make(ForeignExpr.Reference(${Expr(name)}.tt)).asInstanceOf[result]}

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -1,0 +1,205 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.quoted.*
+
+import anticipation.*
+import fulminate.*
+import gigantism.*
+import gossamer.*
+import hellenism.*
+import rudiments.*
+import vacuous.*
+
+object Xenophile:
+
+  // Parses the trivial line-based definitions format into a map from each foreign type name to a
+  // map from its member names to the names of their (foreign) types. For example:
+  //
+  //     Foo:
+  //       bar Bar
+  //       baz Text
+  //     Bar:
+  //       qux Foo
+  //
+  // becomes `Map(Foo -> Map(bar -> Bar, baz -> Text), Bar -> Map(qux -> Foo))`.
+  def parse(lines: List[Text]): Map[Text, Map[Text, Text]] =
+    def recur(todo: List[Text], current: Text, acc: Map[Text, Map[Text, Text]])
+    :   Map[Text, Map[Text, Text]] =
+
+      todo match
+        case Nil =>
+          acc
+
+        case line :: tail =>
+          val tokens = line.cut(t" ").to(List).filter(_ != t"")
+
+          if tokens.isEmpty then
+            recur(tail, current, acc)
+          else if !line.starts(t" ") && line.ends(t":") then
+            val name = line.cut(t":").to(List).head
+            recur(tail, name, acc.updated(name, Map()))
+          else
+            tokens match
+              case member :: kind :: _ =>
+                val updated = acc.at(current).or(Map()).updated(member, kind)
+                recur(tail, current, acc.updated(current, updated))
+
+              case _ =>
+                recur(tail, current, acc)
+
+    recur(lines, t"", Map())
+
+  def definitions(path: Text)(using Quotes): Map[Text, Map[Text, Text]] =
+    val stream = Optional(getClass.getResourceAsStream(path.s)).or:
+      halt(m"xenophile: could not read foreign definitions at $path on the classpath")
+
+    parse(scala.io.Source.fromInputStream(stream).getLines().map(Text(_)).to(List))
+
+  def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =
+    import quotes.reflect.*
+
+    val fieldName = field.valueOrAbort.tt
+
+    // Collects every `type X = …` member from a (possibly nested) refinement type into a map.
+    def refinements(repr: TypeRepr): Map[Text, TypeRepr] = repr.dealias match
+      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
+      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
+      case AndType(left, right)                        => refinements(left) ++ refinements(right)
+      case _                                           => Map()
+
+    val members = refinements(self.asTerm.tpe.widen)
+
+    val topicRepr = members.at(t"Topic").or:
+      halt(m"xenophile: the receiver is not a singleton foreign type (it has no `Topic`)")
+
+    val topic = topicRepr.absolve match
+      case ConstantType(StringConstant(name)) => name.tt
+
+      case _ =>
+        halt(m"xenophile: the foreign type's `Topic` is not a string literal type")
+
+    val originRepr = members.at(t"Origin").or:
+      halt(m"xenophile: the receiver does not record its source language (it has no `Origin`)")
+
+    val interfaceType =
+      Refinement(TypeRepr.of[Interface], "Form", TypeBounds(originRepr, originRepr))
+
+    val interfaceTerm = interfaceType.asType.absolve match
+      case '[interface] =>
+        val interface = Expr.summon[interface].getOrElse:
+          halt(m"xenophile: no `Interface` is available for the foreign source language")
+
+        interface.asTerm
+
+    val interfaceMembers =
+      refinements(interfaceTerm.tpe) ++ refinements(interfaceTerm.tpe.widen)
+
+    val locusRepr = interfaceMembers.at(t"Locus").or:
+      halt(m"xenophile: the `Interface` does not specify a definitions path (it has no `Locus`)")
+
+    val locus = locusRepr.absolve match
+      case ConstantType(StringConstant(path)) => path.tt
+
+      case _ =>
+        halt(m"xenophile: the definitions path is not a string literal type")
+
+    val defs = definitions(locus)
+
+    val typeMembers = defs.at(topic).or:
+      halt(m"xenophile: the foreign type $topic is not defined in $locus")
+
+    val memberType = typeMembers.at(fieldName).or:
+      halt(m"xenophile: the foreign type $topic has no member $fieldName")
+
+    val topicType = ConstantType(StringConstant(memberType.s))
+
+    val resultType =
+      Refinement
+        ( Refinement(TypeRepr.of[Foreign], "Topic", TypeBounds(topicType, topicType)),
+          "Origin",
+          TypeBounds(originRepr, originRepr) )
+
+    resultType.asType.absolve match
+      case '[type result <: Foreign; result] =>
+        '{Foreign.make(${Expr(memberType.s)}).asInstanceOf[result]}
+
+  def interface[form: Type](resource: Expr[Resource]): Macro[Interface] =
+    import quotes.reflect.*
+
+    def refinements(repr: TypeRepr): Map[Text, TypeRepr] = repr.dealias match
+      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
+      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
+      case AndType(left, right)                        => refinements(left) ++ refinements(right)
+      case _                                           => Map()
+
+    val members = refinements(resource.asTerm.tpe) ++ refinements(resource.asTerm.tpe.widen)
+
+    val locusRepr = members.at(t"Locus").or:
+      halt(m"xenophile: the resource does not carry a singleton path type (it has no `Locus`)")
+
+    val formRepr = TypeRepr.of[form]
+
+    val resultType =
+      Refinement
+        ( Refinement(TypeRepr.of[Interface], "Form", TypeBounds(formRepr, formRepr)),
+          "Locus",
+          TypeBounds(locusRepr, locusRepr) )
+
+    resultType.asType.absolve match
+      case '[type result <: Interface; result] =>
+        '{(new Interface {}).asInstanceOf[result]}
+
+  def root[name <: Label: Type, origin: Type]: Macro[Foreign] =
+    import quotes.reflect.*
+
+    val nameRepr = TypeRepr.of[name]
+
+    val name = nameRepr.absolve match
+      case ConstantType(StringConstant(string)) => string
+
+      case _ =>
+        halt(m"xenophile: the foreign type name must be a string literal type")
+
+    val originRepr = TypeRepr.of[origin]
+
+    val resultType =
+      Refinement
+        ( Refinement(TypeRepr.of[Foreign], "Topic", TypeBounds(nameRepr, nameRepr)),
+          "Origin",
+          TypeBounds(originRepr, originRepr) )
+
+    resultType.asType.absolve match
+      case '[type result <: Foreign; result] =>
+        '{Foreign.make(${Expr(name)}).asInstanceOf[result]}

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -226,33 +226,55 @@ object Xenophile:
     import quotes.reflect.*
 
     val (topic, originRepr) = receiver(self)
-    val selfRepr = TypeRepr.of[target]
-    val topicLiteral = ConstantType(StringConstant(topic.s))
 
     val operandRepr = originRepr.memberType(originRepr.typeSymbol.typeMember("Operand")) match
       case TypeBounds(_, hi) => hi
       case repr              => repr
 
-    val ioBase = Refinement(TypeRepr.of[Interoperable], "Self", TypeBounds(selfRepr, selfRepr))
-    val ioForm = Refinement(ioBase, "Form", TypeBounds(originRepr, originRepr))
-    val ioTopic = Refinement(ioForm, "Topic", TypeBounds(topicLiteral, topicLiteral))
-    val interopType = Refinement(ioTopic, "Operand", TypeBounds(operandRepr, operandRepr))
-
     val evalForm = Refinement(TypeRepr.of[Evaluator], "Form", TypeBounds(originRepr, originRepr))
     val evaluatorType = Refinement(evalForm, "Operand", TypeBounds(operandRepr, operandRepr))
 
     operandRepr.asType.absolve match
-      case '[operand] => interopType.asType.absolve match
-        case '[type interop <: Interoperable { type Operand = operand }; interop] =>
-          evaluatorType.asType.absolve match
-            case '[type evaluator <: Evaluator { type Operand = operand }; evaluator] =>
-              val io = Expr.summon[interop].getOrElse:
-                halt(m"xenophile: cannot read $topic as this type; no matching `Interoperable`")
+      case '[operand] => evaluatorType.asType.absolve match
+        case '[type evaluator <: Evaluator { type Operand = operand }; evaluator] =>
+          val ev = Expr.summon[evaluator].getOrElse:
+            halt(m"xenophile: no `Evaluator` is available for the foreign source language")
 
-              val ev = Expr.summon[evaluator].getOrElse:
-                halt(m"xenophile: no `Evaluator` is available for the foreign source language")
+          // Summons the `Interoperable` for `elementTopic` and decodes one operand value with it.
+          def element(elementRepr: TypeRepr, elementTopic: Text, data: Expr[operand]): Expr[Any] =
+            val literal = ConstantType(StringConstant(elementTopic.s))
+            val bounds = TypeBounds(elementRepr, elementRepr)
+            val withSelf = Refinement(TypeRepr.of[Interoperable], "Self", bounds)
+            val withForm = Refinement(withSelf, "Form", TypeBounds(originRepr, originRepr))
+            val withTopic = Refinement(withForm, "Topic", TypeBounds(literal, literal))
+            val full = Refinement(withTopic, "Operand", TypeBounds(operandRepr, operandRepr))
 
-              '{$io.value($ev.evaluate($self.expr)).asInstanceOf[target]}
+            full.asType.absolve match
+              case '[type io <: Interoperable { type Operand = operand }; io] =>
+                val instance = Expr.summon[io].getOrElse:
+                  halt(m"xenophile: cannot read $elementTopic; no matching `Interoperable`")
+
+                '{$instance.value($data)}.asExprOf[Any]
+
+          if topic.ends(t"?") then
+            val base = topic.cut(t"?").to(List).head
+
+            val innerRepr = TypeRepr.of[target].dealias match
+              case OrType(left, right) => if left =:= TypeRepr.of[Unset.type] then right else left
+
+              case _ =>
+                halt(m"xenophile: reading an optional foreign type needs an `Optional` Scala type")
+
+            val tree =
+              ' {
+                  val data: operand = $ev.evaluate($self.expr)
+                  if $ev.absent(data) then Unset else ${element(innerRepr, base, 'data)}
+                }
+
+            tree.asExprOf[target]
+
+          else
+            element(TypeRepr.of[target], topic, '{$ev.evaluate($self.expr)}).asExprOf[target]
 
   def interface[form: Type](resource: Expr[Resource]): Macro[Interface] =
     import quotes.reflect.*

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -44,47 +44,21 @@ import vacuous.*
 
 object Xenophile:
 
-  case class Signature(parameters: Optional[List[Text]], result: Text)
+  // Selects the grammar for a source language. New ecosystems register here.
+  private def dialectFor(using Quotes)(origin: quotes.reflect.TypeRepr): Dialect =
+    import quotes.reflect.*
 
-  // Parses the trivial line-based definitions format into a map from each foreign type name to a
-  // map from member names to their signatures. A member is either a field (`bar Bar`) or a method
-  // (`greet(string) Text`); a method records its parameter type names and result type.
-  def parse(lines: List[Text]): Map[Text, Map[Text, Signature]] =
-    def recur(todo: List[Text], current: Text, acc: Map[Text, Map[Text, Signature]])
-    :   Map[Text, Map[Text, Signature]] =
+    if origin =:= TypeRepr.of[Typescript] then TypescriptDialect
+    else halt(m"xenophile: no grammar is available for the foreign source language")
 
-      todo match
-        case Nil =>
-          acc
+  // Reads the definitions resource at `path` and parses it with the grammar for `origin`.
+  def definitions(using quotes: Quotes)(origin: quotes.reflect.TypeRepr, path: Text)
+  :   Map[Text, Map[Text, Signature]] =
 
-        case line :: tail =>
-          val tokens = line.cut(t" ").to(List).filter(_ != t"")
-
-          if tokens.isEmpty then recur(tail, current, acc)
-          else if !line.starts(t" ") && line.ends(t":") then
-            val name = line.cut(t":").to(List).head
-            recur(tail, name, acc.updated(name, Map()))
-          else
-            val result = tokens.last
-            val segments = tokens.head.cut(t"(").to(List)
-            val name = segments.head
-
-            val signature =
-              if segments.length == 1 then Signature(Unset, result)
-              else
-                val inside = segments.tail.head.cut(t")").to(List).head
-                Signature(inside.cut(t",").to(List).filter(_ != t""), result)
-
-            val members = acc.at(current).or(Map()).updated(name, signature)
-            recur(tail, current, acc.updated(current, members))
-
-    recur(lines, t"", Map())
-
-  def definitions(path: Text)(using Quotes): Map[Text, Map[Text, Signature]] =
     val stream = Optional(getClass.getResourceAsStream(path.s)).or:
       halt(m"xenophile: could not read foreign definitions at $path on the classpath")
 
-    parse(scala.io.Source.fromInputStream(stream).getLines().map(Text(_)).to(List))
+    dialectFor(origin).parse(scala.io.Source.fromInputStream(stream).mkString.tt)
 
   // Collects every `type X = …` member from a (possibly nested) refinement type into a map.
   private def refinements(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
@@ -200,7 +174,7 @@ object Xenophile:
     val fieldName = field.valueOrAbort.tt
     val (topic, originRepr) = receiver(self)
 
-    val typeMembers = definitions(locusOf(originRepr)).at(topic).or:
+    val typeMembers = definitions(originRepr, locusOf(originRepr)).at(topic).or:
       halt(m"xenophile: the foreign type $topic is not defined")
 
     val signature = typeMembers.at(fieldName).or:
@@ -218,7 +192,7 @@ object Xenophile:
     val fieldName = field.valueOrAbort.tt
     val (topic, originRepr) = receiver(self)
 
-    val typeMembers = definitions(locusOf(originRepr)).at(topic).or:
+    val typeMembers = definitions(originRepr, locusOf(originRepr)).at(topic).or:
       halt(m"xenophile: the foreign type $topic is not defined")
 
     val signature = typeMembers.at(fieldName).or:

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -229,6 +229,35 @@ object Xenophile:
       case '[type result <: Foreign; result] =>
         '{Foreign.make($tree).asInstanceOf[result]}
 
+  // Converts a foreign value to a Scala type, via the `Interoperable` instance registered for the
+  // receiver's foreign type (its `Topic`) — the same typeclass that converts Scala values inwards.
+  def convert[target: Type](self: Expr[Foreign]): Macro[target] =
+    import quotes.reflect.*
+
+    val (topic, originRepr) = receiver(self)
+    val selfRepr = TypeRepr.of[target]
+    val topicLiteral = ConstantType(StringConstant(topic.s))
+
+    val operandRepr = originRepr.memberType(originRepr.typeSymbol.typeMember("Operand")) match
+      case TypeBounds(_, hi) => hi
+      case repr              => repr
+
+    val base = Refinement(TypeRepr.of[Interoperable], "Self", TypeBounds(selfRepr, selfRepr))
+    val withForm = Refinement(base, "Form", TypeBounds(originRepr, originRepr))
+    val withTopic = Refinement(withForm, "Topic", TypeBounds(topicLiteral, topicLiteral))
+    val interopType = Refinement(withTopic, "Operand", TypeBounds(operandRepr, operandRepr))
+
+    operandRepr.asType.absolve match
+      case '[operand] => interopType.asType.absolve match
+        case '[type interop <: Interoperable { type Operand = operand }; interop] =>
+          Expr.summon[interop].absolve match
+            case Some(instance) =>
+              val operand = '{Foreign.operandOf($self.expr).asInstanceOf[operand]}
+              '{$instance.value($operand).asInstanceOf[target]}
+
+            case _ =>
+              halt(m"xenophile: cannot read $topic as this type; no matching `Interoperable`")
+
   def interface[form: Type](resource: Expr[Resource]): Macro[Interface] =
     import quotes.reflect.*
 

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -259,21 +259,26 @@ object Xenophile:
       case TypeBounds(_, hi) => hi
       case repr              => repr
 
-    val base = Refinement(TypeRepr.of[Interoperable], "Self", TypeBounds(selfRepr, selfRepr))
-    val withForm = Refinement(base, "Form", TypeBounds(originRepr, originRepr))
-    val withTopic = Refinement(withForm, "Topic", TypeBounds(topicLiteral, topicLiteral))
-    val interopType = Refinement(withTopic, "Operand", TypeBounds(operandRepr, operandRepr))
+    val ioBase = Refinement(TypeRepr.of[Interoperable], "Self", TypeBounds(selfRepr, selfRepr))
+    val ioForm = Refinement(ioBase, "Form", TypeBounds(originRepr, originRepr))
+    val ioTopic = Refinement(ioForm, "Topic", TypeBounds(topicLiteral, topicLiteral))
+    val interopType = Refinement(ioTopic, "Operand", TypeBounds(operandRepr, operandRepr))
+
+    val evalForm = Refinement(TypeRepr.of[Evaluator], "Form", TypeBounds(originRepr, originRepr))
+    val evaluatorType = Refinement(evalForm, "Operand", TypeBounds(operandRepr, operandRepr))
 
     operandRepr.asType.absolve match
       case '[operand] => interopType.asType.absolve match
         case '[type interop <: Interoperable { type Operand = operand }; interop] =>
-          Expr.summon[interop].absolve match
-            case Some(instance) =>
-              val operand = '{Foreign.operandOf($self.expr).asInstanceOf[operand]}
-              '{$instance.value($operand).asInstanceOf[target]}
+          evaluatorType.asType.absolve match
+            case '[type evaluator <: Evaluator { type Operand = operand }; evaluator] =>
+              val io = Expr.summon[interop].getOrElse:
+                halt(m"xenophile: cannot read $topic as this type; no matching `Interoperable`")
 
-            case _ =>
-              halt(m"xenophile: cannot read $topic as this type; no matching `Interoperable`")
+              val ev = Expr.summon[evaluator].getOrElse:
+                halt(m"xenophile: no `Evaluator` is available for the foreign source language")
+
+              '{$io.value($ev.evaluate($self.expr)).asInstanceOf[target]}
 
   def interface[form: Type](resource: Expr[Resource]): Macro[Interface] =
     import quotes.reflect.*

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -157,6 +157,45 @@ object Xenophile:
         "Origin",
         TypeBounds(origin, origin) )
 
+  // Builds the `ForeignExpr` for a single method argument, checking it against the declared
+  // parameter type: a `Foreign` argument must already have that foreign type (`Topic`); any other
+  // value must have an `Interoperable` instance mapping it to exactly that foreign type.
+  private def argTree(using quotes: Quotes)
+    ( arg: Expr[Any], paramType: Text, originRepr: quotes.reflect.TypeRepr, method: Text )
+  :   Expr[ForeignExpr] =
+
+    import quotes.reflect.*
+
+    val paramTopic = ConstantType(StringConstant(paramType.s))
+
+    arg.asTerm.tpe.widen.asType.absolve match
+      case '[argument] =>
+        val argRepr = TypeRepr.of[argument]
+
+        if argRepr <:< TypeRepr.of[Foreign] then
+          val argTopic = refinements(argRepr).at(t"Topic").or:
+            halt(m"xenophile: the foreign type of an argument to $method is not known")
+
+          val matches = argTopic.absolve match
+            case ConstantType(StringConstant(name)) => name.tt == paramType
+            case _                                  => false
+
+          if matches then '{${arg.asExprOf[Foreign]}.expr}
+          else halt(m"xenophile: $method expects an argument of foreign type $paramType")
+        else
+          val base = Refinement(TypeRepr.of[Interoperable], "Self", TypeBounds(argRepr, argRepr))
+          val withForm = Refinement(base, "Form", TypeBounds(originRepr, originRepr))
+          val interopType = Refinement(withForm, "Topic", TypeBounds(paramTopic, paramTopic))
+
+          interopType.asType.absolve match
+            case '[type interop <: Interoperable { type Self = argument }; interop] =>
+              Expr.summon[interop].absolve match
+                case Some(instance) =>
+                  '{ForeignExpr.Literal($instance.operand(${arg.asExprOf[argument]}))}
+
+                case _ =>
+                  halt(m"xenophile: cannot pass this argument as $paramType to $method")
+
   def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =
     val fieldName = field.valueOrAbort.tt
     val (topic, originRepr) = receiver(self)
@@ -176,8 +215,6 @@ object Xenophile:
         '{Foreign.make($tree).asInstanceOf[result]}
 
   def applied(self: Expr[Foreign], field: Expr[String], arguments: Expr[Seq[Any]]): Macro[Foreign] =
-    import quotes.reflect.*
-
     val fieldName = field.valueOrAbort.tt
     val (topic, originRepr) = receiver(self)
 
@@ -199,28 +236,8 @@ object Xenophile:
     if args.length != parameters.length then
       halt(m"xenophile: $fieldName expects ${parameters.length} arguments, not ${args.length}")
 
-    val argTrees: List[Expr[ForeignExpr]] = args.map: arg =>
-      arg.asTerm.tpe.widen.asType.absolve match
-        case '[argument] =>
-          if TypeRepr.of[argument] <:< TypeRepr.of[Foreign] then '{${arg.asExprOf[Foreign]}.expr}
-          else
-            val interopType =
-              Refinement
-                ( Refinement
-                    ( TypeRepr.of[Interoperable],
-                      "Self",
-                      TypeBounds(TypeRepr.of[argument], TypeRepr.of[argument]) ),
-                  "Form",
-                  TypeBounds(originRepr, originRepr) )
-
-            interopType.asType.absolve match
-              case '[type interop <: Interoperable { type Self = argument }; interop] =>
-                Expr.summon[interop].absolve match
-                  case Some(instance) =>
-                    '{ForeignExpr.Literal($instance.operand(${arg.asExprOf[argument]}))}
-
-                  case _ =>
-                    halt(m"xenophile: no `Interoperable` instance for this argument to $fieldName")
+    val argTrees: List[Expr[ForeignExpr]] = args.zip(parameters).map: (arg, paramType) =>
+      argTree(arg, paramType, originRepr, fieldName)
 
     val target = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
     val tree = '{ForeignExpr.Apply($target, ${Expr.ofList(argTrees)})}

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -109,3 +109,16 @@ object Tests extends Suite(m"Xenophile tests"):
         val nickname: Foreign of "string?" from Typescript = foo.nickname
         nickname.as[Optional[Text]]
       . assert(_ == t"Bob")
+
+    suite(m"Compile-time safety"):
+      test(m"selecting an undefined member is a compile error"):
+        demilitarize(foo.nonexistent).map(_.message)
+      . assert(_ == List(t"xenophile: the foreign type Foo has no member nonexistent"))
+
+      test(m"calling a method with the wrong arity is a compile error"):
+        demilitarize(foo.greet(t"a", t"b")).map(_.message)
+      . assert(_ == List(t"xenophile: greet expects 1 arguments, not 2"))
+
+      test(m"passing an argument of the wrong foreign type is a compile error"):
+        demilitarize(foo.greet(42)).map(_.message)
+      . assert(_ == List(t"xenophile: cannot pass this argument as string to greet"))

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -1,0 +1,61 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import soundness.*
+
+type TsInterface = Interface in Typescript at "/xenophile/definitions.simple"
+
+given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.simple")
+
+object Tests extends Suite(m"Xenophile tests"):
+  def run(): Unit =
+    val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
+
+    suite(m"Foreign type navigation"):
+      test(m"resolve a direct member's foreign type name"):
+        foo.bar.topic
+      . assert(_ == t"Bar")
+
+      test(m"resolve a leaf member's type name"):
+        foo.baz.topic
+      . assert(_ == t"Text")
+
+      test(m"navigate a cyclic foreign type graph"):
+        foo.bar.qux.topic
+      . assert(_ == t"Foo")
+
+      test(m"a member access has the precise refined static type"):
+        val bar: Foreign of "Bar" from Typescript = foo.bar
+        bar.topic
+      . assert(_ == t"Bar")

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -55,7 +55,7 @@ object Tests extends Suite(m"Xenophile tests"):
 
     suite(m"Function application"):
       test(m"applyDynamic builds an `Apply` node typed by the method's result"):
-        val greeting: Foreign of "Text" from Typescript = foo.greet("hello")
+        val greeting: Foreign of "string" from Typescript = foo.greet(t"hello")
         greeting.expr
       . assert:
           case ForeignExpr.Apply(ForeignExpr.Select(_, member), List(_)) => member == t"greet"
@@ -63,8 +63,13 @@ object Tests extends Suite(m"Xenophile tests"):
 
     suite(m"Interoperability"):
       test(m"a Scala value converts into a `Foreign` literal"):
-        val text: Foreign of "string" from Typescript = "hello"
+        val text: Foreign of "string" from Typescript = t"hello"
         text.expr
       . assert:
           case ForeignExpr.Literal(_) => true
           case _                      => false
+
+      test(m"a foreign literal converts back to a Scala value via `as`"):
+        val text: Foreign of "string" from Typescript = t"hello"
+        text.as[Text]
+      . assert(_ == t"hello")

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -35,9 +35,9 @@ package xenophile
 import soundness.*
 import jacinta.*
 
-type TsInterface = Interface in Typescript at "/xenophile/definitions.simple"
+type TsInterface = Interface in Typescript at "/xenophile/definitions.ts"
 
-given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.simple")
+given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.ts")
 
 val document: Json = j"""{"Foo": {"baz": "hello", "bar": {"count": 42}}}"""
 

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -61,6 +61,16 @@ object Tests extends Suite(m"Xenophile tests"):
           case ForeignExpr.Apply(ForeignExpr.Select(_, member), List(_)) => member == t"greet"
           case _                                                         => false
 
+      test(m"a Foreign argument of the declared parameter type is accepted"):
+        val linked: Foreign of "Foo" from Typescript = foo.link(foo.bar)
+        linked.expr
+      . assert:
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(ForeignExpr.Select(_, b))) =>
+            m == t"link" && b == t"bar"
+
+          case _ =>
+            false
+
     suite(m"Interoperability"):
       test(m"a Scala value converts into a `Foreign` literal"):
         val text: Foreign of "string" from Typescript = t"hello"

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -39,7 +39,8 @@ type TsInterface = Interface in Typescript at "/xenophile/definitions.ts"
 
 given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.ts")
 
-val document: Json = j"""{"Foo": {"baz": "hello", "bar": {"count": 42}}}"""
+val document: Json =
+  j"""{"Foo": {"baz": "hello", "bar": {"count": 42}, "tags": ["a", "b"], "nickname": null}}"""
 
 given Evaluator in Typescript by Json = Typescript.evaluator(document)
 
@@ -97,3 +98,16 @@ object Tests extends Suite(m"Xenophile tests"):
       test(m"evaluate a nested selection against the backend and decode it"):
         foo.bar.count.as[Int]
       . assert(_ == 42)
+
+    suite(m"Complex types"):
+      test(m"an array field has an array foreign type and decodes to a List"):
+        val tags: Foreign of "string[]" from Typescript = foo.tags
+        tags.as[List[Text]]
+      . assert(_ == List(t"a", t"b"))
+
+      test(m"an optional field is given an optional foreign type"):
+        val nickname: Foreign of "string?" from Typescript = foo.nickname
+        nickname.expr
+      . assert:
+          case ForeignExpr.Select(_, member) => member == t"nickname"
+          case _                              => false

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -40,7 +40,7 @@ type TsInterface = Interface in Typescript at "/xenophile/definitions.ts"
 given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.ts")
 
 val document: Json =
-  j"""{"Foo": {"baz": "hello", "bar": {"count": 42}, "tags": ["a", "b"], "nickname": null}}"""
+  j"""{"Foo": {"baz": "hello", "bar": {"count": 42}, "tags": ["a", "b"], "nickname": "Bob"}}"""
 
 given Evaluator in Typescript by Json = Typescript.evaluator(document)
 
@@ -105,9 +105,7 @@ object Tests extends Suite(m"Xenophile tests"):
         tags.as[List[Text]]
       . assert(_ == List(t"a", t"b"))
 
-      test(m"an optional field is given an optional foreign type"):
+      test(m"an optional field has an optional foreign type and decodes to an Optional"):
         val nickname: Foreign of "string?" from Typescript = foo.nickname
-        nickname.expr
-      . assert:
-          case ForeignExpr.Select(_, member) => member == t"nickname"
-          case _                              => false
+        nickname.as[Optional[Text]]
+      . assert(_ == t"Bob")

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -43,19 +43,28 @@ object Tests extends Suite(m"Xenophile tests"):
     val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
 
     suite(m"Foreign type navigation"):
-      test(m"resolve a direct member's foreign type name"):
-        foo.bar.topic
-      . assert(_ == t"Bar")
-
-      test(m"resolve a leaf member's type name"):
-        foo.baz.topic
-      . assert(_ == t"Text")
-
-      test(m"navigate a cyclic foreign type graph"):
-        foo.bar.qux.topic
-      . assert(_ == t"Foo")
-
       test(m"a member access has the precise refined static type"):
         val bar: Foreign of "Bar" from Typescript = foo.bar
-        bar.topic
-      . assert(_ == t"Bar")
+        bar.expr
+      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar"))
+
+      test(m"navigate a cyclic foreign type graph"):
+        val cyclic: Foreign of "Foo" from Typescript = foo.bar.qux
+        cyclic.expr
+      . assert(_ == ForeignExpr.Select(ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar"), t"qux"))
+
+    suite(m"Function application"):
+      test(m"applyDynamic builds an `Apply` node typed by the method's result"):
+        val greeting: Foreign of "Text" from Typescript = foo.greet("hello")
+        greeting.expr
+      . assert:
+          case ForeignExpr.Apply(ForeignExpr.Select(_, member), List(_)) => member == t"greet"
+          case _                                                         => false
+
+    suite(m"Interoperability"):
+      test(m"a Scala value converts into a `Foreign` literal"):
+        val text: Foreign of "string" from Typescript = "hello"
+        text.expr
+      . assert:
+          case ForeignExpr.Literal(_) => true
+          case _                      => false


### PR DESCRIPTION
Xenophile is a new module for using types that originate outside Scala — such as TypeScript interfaces — directly from Scala with full compile-time checking. A `Foreign` value navigates a foreign type system's definitions lazily, one member at a time, resolving each member's type by parsing the definitions resource during compilation; member and method accesses, their arities, and their argument types are all checked by the compiler, and a foreign value can be evaluated and decoded into a Scala value with `as`. The change also refines hellenism's `cp` classpath interpolator so that `cp"…"` now carries its validated path in its type.

## Xenophile: foreign type providers

`xenophile` lets you treat types defined in another type system as first-class, compile-time-checked Scala types. Point an `Interface` at a definitions resource for an ecosystem (e.g. a TypeScript `.d.ts`) and navigate it:

```scala
type TsInterface = Interface in Typescript at "/definitions.ts"
given TsInterface = Interface[Typescript](cp"/definitions.ts")

val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
val bar   = foo.bar              // : Foreign of "Bar" from Typescript
val cycle = foo.bar.qux          // : Foreign of "Foo" from Typescript
val hi    = foo.greet(t"world")  // : Foreign of "string" from Typescript
```

Each access resolves its foreign type by parsing the definitions during compilation, so selecting an undefined member, calling a method with the wrong arity, or passing an argument of the wrong foreign type are all compile errors.

A foreign value carries a typed `ForeignExpr` describing the navigation; an `Evaluator` for the ecosystem runs it against a backing document, and `as` decodes the result via an `Interoperable` instance:

```scala
given Evaluator in Typescript by Json = Typescript.evaluator(document)

foo.baz.as[Text]                 // a string field
foo.bar.count.as[Int]            // a nested numeric field
foo.tags.as[List[Text]]          // a `string[]` array
foo.nickname.as[Optional[Text]]  // an optional `string?`
```

`Interoperable` instances describe how Scala types map to and from an ecosystem's encoding (JSON for TypeScript), e.g. `String is Interoperable in Typescript of "string" by Json`. This is an early, fledgling module.

## hellenism: `cp` carries its path in its type

The `cp` classpath interpolator now returns a refined `Resource` whose type records the validated path — `cp"foo"` has type `Resource at "foo"`. This is backwards-compatible (a refined `Resource` is still a `Resource`) and lets macros read a resource's path statically.
