### PR TITLE
locomotion: expose Protobuf wire bytes via encode

### DIFF
--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -96,6 +96,11 @@ object Protobuf extends Protobuf2:
 
   given protobuf: Protobuf is Decodable in Protobuf = identity(_)
 
+  // The wire bytes of a `Protobuf` message, reached with `.encode` (anticipation's
+  // `Encodable`) — the same verb jacinta uses for `Json`. `serialize` is reserved
+  // for monotonous's byte→text encodings (hex, base64, …).
+  given encodableInData: Protobuf is Encodable in Data = _.payload
+
   // `bytes.read[Protobuf]` aggregates the byte stream and wraps it as a message.
   given aggregable: Protobuf is Aggregable by Data = bytes => message(bytes.read[Data])
 
@@ -411,7 +416,5 @@ enum Protobuf:
     case Absent        => true
     case Repeated(Nil) => true
     case _             => false
-
-  def serialize: Data = payload
 
   def as[value: Decodable in Protobuf]: value raises ProtobufError = value.decoded(this)

--- a/lib/locomotion/src/core/locomotion_core.scala
+++ b/lib/locomotion/src/core/locomotion_core.scala
@@ -36,7 +36,7 @@ import anticipation.*
 import prepositional.*
 
 // Encodes any value with an `Encodable in Protobuf` instance to its `Protobuf` wire
-// form; `.serialize` then yields the message bytes. Decoding is `Protobuf.parse(
-// bytes).as[T]`.
+// form; `.encode` then yields the message bytes (`Data`). Decoding is
+// `bytes.read[Protobuf].as[T]` or the `bytes.read[T over Protobuf]` shorthand.
 extension [value: Encodable in Protobuf](value: value)
   def protobuf: Protobuf = value.encode

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -68,7 +68,7 @@ case class Counts(@field(1) counts: Map[Text, Int]) derives CanEqual
 object Tests extends Suite(m"Locomotion Protobuf Tests"):
   def run(): Unit =
     def wire[value: Encodable in Protobuf](value: value): List[Int] =
-      value.protobuf.serialize.to(List).map(_.toInt & 0xff)
+      value.protobuf.encode.to(List).map(_.toInt & 0xff)
 
     suite(m"Wire-format golden vectors"):
       test(m"a single varint field encodes to the canonical bytes"):
@@ -85,36 +85,36 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
     suite(m"Round-trips"):
       test(m"single int field"):
-        Stream(Sample(150).protobuf.serialize).read[Sample over Protobuf]
+        Stream(Sample(150).protobuf.encode).read[Sample over Protobuf]
       . assert(_ == Sample(150))
 
       test(m"two int fields, one at its default"):
-        Stream(Point(0, 5).protobuf.serialize).read[Point over Protobuf]
+        Stream(Point(0, 5).protobuf.encode).read[Point over Protobuf]
       . assert(_ == Point(0, 5))
 
       test(m"string and int fields"):
-        Stream(Person(t"Alice", 30).protobuf.serialize).read[Person over Protobuf]
+        Stream(Person(t"Alice", 30).protobuf.encode).read[Person over Protobuf]
       . assert(_ == Person(t"Alice", 30))
 
       test(m"read[Protobuf] then as[T] (two-step)"):
-        Stream(Person(t"Alice", 30).protobuf.serialize).read[Protobuf].as[Person]
+        Stream(Person(t"Alice", 30).protobuf.encode).read[Protobuf].as[Person]
       . assert(_ == Person(t"Alice", 30))
 
       test(m"nested message"):
-        Stream(Wrapper(Point(3, 4), t"origin").protobuf.serialize).read[Wrapper over Protobuf]
+        Stream(Wrapper(Point(3, 4), t"origin").protobuf.encode).read[Wrapper over Protobuf]
       . assert(_ == Wrapper(Point(3, 4), t"origin"))
 
       test(m"sparse field numbers"):
-        Stream(Sparse(9, t"x").protobuf.serialize).read[Sparse over Protobuf]
+        Stream(Sparse(9, t"x").protobuf.encode).read[Sparse over Protobuf]
       . assert(_ == Sparse(9, t"x"))
 
     suite(m"Repeated fields"):
       test(m"repeated strings round-trip in order"):
-        Stream(Tags(List(t"a", t"b", t"c")).protobuf.serialize).read[Tags over Protobuf]
+        Stream(Tags(List(t"a", t"b", t"c")).protobuf.encode).read[Tags over Protobuf]
       . assert(_ == Tags(List(t"a", t"b", t"c")))
 
       test(m"repeated ints round-trip, keeping default elements"):
-        Stream(Numbers(List(0, 1, 2)).protobuf.serialize).read[Numbers over Protobuf]
+        Stream(Numbers(List(0, 1, 2)).protobuf.encode).read[Numbers over Protobuf]
       . assert(_ == Numbers(List(0, 1, 2)))
 
       test(m"repeated ints are packed into one length-delimited field"):
@@ -133,22 +133,22 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
     suite(m"Optional presence"):
       test(m"a set optional round-trips"):
-        Stream(MaybeName(t"set").protobuf.serialize).read[MaybeName over Protobuf]
+        Stream(MaybeName(t"set").protobuf.encode).read[MaybeName over Protobuf]
       . assert(_ == MaybeName(t"set"))
 
       test(m"an unset optional writes nothing and round-trips to Unset"):
-        Stream(MaybeName(Unset).protobuf.serialize).read[MaybeName over Protobuf]
+        Stream(MaybeName(Unset).protobuf.encode).read[MaybeName over Protobuf]
       . assert(_ == MaybeName(Unset))
 
     suite(m"Sum types (oneof)"):
       test(m"the Circle variant round-trips"):
         val shape: Shape = Shape.Circle(5)
-        Stream(shape.protobuf.serialize).read[Shape over Protobuf]
+        Stream(shape.protobuf.encode).read[Shape over Protobuf]
       . assert(_ == Shape.Circle(5))
 
       test(m"the Rectangle variant round-trips"):
         val shape: Shape = Shape.Rectangle(3, 4)
-        Stream(shape.protobuf.serialize).read[Shape over Protobuf]
+        Stream(shape.protobuf.encode).read[Shape over Protobuf]
       . assert(_ == Shape.Rectangle(3, 4))
 
     suite(m"Field-number fallback"):
@@ -157,14 +157,14 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       . assert(_ == List(0x08, 0x96))
 
       test(m"unannotated message round-trips"):
-        Stream(Unnumbered(7, 9).protobuf.serialize).read[Unnumbered over Protobuf]
+        Stream(Unnumbered(7, 9).protobuf.encode).read[Unnumbered over Protobuf]
       . assert(_ == Unnumbered(7, 9))
 
     suite(m"Typed integer encodings"):
       val typed = Typed(7.bits.u32, 8L.bits.u64, -3.bits.s32, -4L.bits.s64, 5.bits, 6L.bits)
 
       test(m"all typed integers round-trip"):
-        Stream(typed.protobuf.serialize).read[Typed over Protobuf]
+        Stream(typed.protobuf.encode).read[Typed over Protobuf]
       . assert(_ == typed)
 
       test(m"sint32 uses zig-zag (field 3, -1 ⇒ tag 0x18, 0x01)"):
@@ -178,12 +178,12 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
     suite(m"Maps"):
       test(m"a string→string map round-trips"):
         val labels = Labels(Map(t"a" -> t"1", t"b" -> t"2"))
-        Stream(labels.protobuf.serialize).read[Labels over Protobuf]
+        Stream(labels.protobuf.encode).read[Labels over Protobuf]
       . assert(_ == Labels(Map(t"a" -> t"1", t"b" -> t"2")))
 
       test(m"a string→int map round-trips"):
         val counts = Counts(Map(t"x" -> 10, t"y" -> 20))
-        Stream(counts.protobuf.serialize).read[Counts over Protobuf]
+        Stream(counts.protobuf.encode).read[Counts over Protobuf]
       . assert(_ == Counts(Map(t"x" -> 10, t"y" -> 20)))
 
       test(m"an empty map writes nothing"):


### PR DESCRIPTION
A `Protobuf` value's wire bytes are now obtained with `.encode`, via an `Encodable in Data` instance, matching how Jacinta encodes `Json`. The previous `serialize` method has been removed: `serialize`/`deserialize` are reserved for Monotonous's byte-to-text encodings (hex, base64), so reusing the name for a structured value's own bytes was misleading.

To get the wire bytes of an encoded message, use `.encode`:

```scala
case class Point(@field(1) x: Int, @field(2) y: Int) derives CanEqual

val bytes: Data = Point(3, 4).protobuf.encode
val point = bytes.read[Point over Protobuf]
```

This replaces the removed `.protobuf.serialize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)