### PR TITLE
xenophile: convert foreign method arguments through the public Converter

### DIFF
--- a/lib/xenophile/src/core/xenophile.Foreign.scala
+++ b/lib/xenophile/src/core/xenophile.Foreign.scala
@@ -55,7 +55,14 @@ trait Foreign extends Dynamic, Topical, Original:
   transparent inline def selectDynamic(field: String): Foreign =
     ${Xenophile.select('this, 'field)}
 
-  transparent inline def applyDynamic(field: String)(inline arguments: Any*): Foreign =
+  // Arguments are typed `Foreign from Origin` — i.e. a foreign value from this receiver's own
+  // source language. A Scala value with an `Interoperable` instance for that language is converted
+  // to a `Foreign` literal at the call site by the `converter` `Conversion` above (pinning the
+  // ecosystem to `Origin` is what lets the conversion infer its type parameters); the macro then
+  // checks each argument's foreign type against the declared parameter type.
+  transparent inline def applyDynamic(field: String)(inline arguments: (Foreign from Origin)*)
+  :   Foreign =
+
     ${Xenophile.applied('this, 'field, 'arguments)}
 
   inline def as[ScalaType]: ScalaType = ${Xenophile.convert[ScalaType]('this)}

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -180,40 +180,23 @@ object Xenophile:
         "Origin",
         TypeBounds(origin, origin) )
 
-  // Builds the `ForeignExpr` for a single method argument, checking it against the declared
-  // parameter type: a `Foreign` argument must already have that foreign type (`Topic`); any other
-  // value must have an `Interoperable` instance mapping it to exactly that foreign type.
+  // Builds the `ForeignExpr` for a single method argument. Every argument arrives as a `Foreign`
+  // (either already, or converted from a Scala value at the call site by the `converter`
+  // `Conversion`), so we need only check its foreign type (`Topic`) against the parameter type.
   private def argTree(using quotes: Quotes)
-    ( arg: Expr[Any], paramType: ForeignType, originRepr: quotes.reflect.TypeRepr, method: Text )
+    ( arg: Expr[Foreign], paramType: ForeignType, method: Text )
   :   Expr[ForeignExpr] =
 
     import quotes.reflect.*
 
     val paramTopic = reprOf(paramType)
+    val argRepr = arg.asTerm.tpe.widen
 
-    arg.asTerm.tpe.widen.asType.absolve match
-      case '[argument] =>
-        val argRepr = TypeRepr.of[argument]
+    val argTopic = refinements(argRepr).at(t"Topic").or:
+      halt(m"xenophile: the foreign type of an argument to $method is not known")
 
-        if argRepr <:< TypeRepr.of[Foreign] then
-          val argTopic = refinements(argRepr).at(t"Topic").or:
-            halt(m"xenophile: the foreign type of an argument to $method is not known")
-
-          if argTopic =:= paramTopic then '{${arg.asExprOf[Foreign]}.expr}
-          else halt(m"xenophile: $method expects an argument of foreign type ${paramType.text}")
-        else
-          val base = Refinement(TypeRepr.of[Interoperable], "Self", TypeBounds(argRepr, argRepr))
-          val withForm = Refinement(base, "Form", TypeBounds(originRepr, originRepr))
-          val interopType = Refinement(withForm, "Topic", TypeBounds(paramTopic, paramTopic))
-
-          interopType.asType.absolve match
-            case '[type interop <: Interoperable { type Self = argument }; interop] =>
-              Expr.summon[interop].absolve match
-                case Some(instance) =>
-                  '{ForeignExpr.Literal($instance.operand(${arg.asExprOf[argument]}))}
-
-                case _ =>
-                  halt(m"xenophile: cannot pass this argument as ${paramType.text} to $method")
+    if argTopic =:= paramTopic then '{$arg.expr}
+    else halt(m"xenophile: $method expects an argument of foreign type ${paramType.text}")
 
   def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =
     val fieldName = field.valueOrAbort.tt
@@ -234,7 +217,9 @@ object Xenophile:
         val tree = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
         '{Foreign.make($tree).asInstanceOf[result]}
 
-  def applied(self: Expr[Foreign], field: Expr[String], arguments: Expr[Seq[Any]]): Macro[Foreign] =
+  def applied(self: Expr[Foreign], field: Expr[String], arguments: Expr[Seq[Foreign]])
+  :   Macro[Foreign] =
+
     val fieldName = field.valueOrAbort.tt
     val (topicRepr, originRepr) = receiver(self)
     val topic = topicName(topicRepr)
@@ -258,7 +243,7 @@ object Xenophile:
       halt(m"xenophile: $fieldName expects ${parameters.length} arguments, not ${args.length}")
 
     val argTrees: List[Expr[ForeignExpr]] = args.zip(parameters).map: (arg, paramType) =>
-      argTree(arg, paramType, originRepr, fieldName)
+      argTree(arg, paramType, fieldName)
 
     val target = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
     val tree = '{ForeignExpr.Apply($target, ${Expr.ofList(argTrees)})}

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -86,6 +86,12 @@ object Tests extends Suite(m"Xenophile tests"):
           case ForeignExpr.Literal(_) => true
           case _                      => false
 
+      test(m"a Scala argument is converted to a `Foreign` literal upon application"):
+        foo.greet(t"hi").expr
+      . assert:
+          case ForeignExpr.Apply(_, List(ForeignExpr.Literal(_))) => true
+          case _                                                  => false
+
       test(m"a foreign literal converts back to a Scala value via `as`"):
         val text: Foreign of "string" from Typescript = t"hello"
         text.as[Text]
@@ -132,4 +138,4 @@ object Tests extends Suite(m"Xenophile tests"):
 
       test(m"passing an argument of the wrong foreign type is a compile error"):
         demilitarize(foo.greet(42)).map(_.message)
-      . assert(_ == List(t"xenophile: cannot pass this argument as string to greet"))
+      . assert(_ == List(t"xenophile: greet expects an argument of foreign type string"))


### PR DESCRIPTION
When a foreign method is applied, Scala arguments are now converted to `Foreign` values by the same `Conversion` that already governs assignment — so any type with an `Interoperable` instance for the receiver's source language can be passed directly, and only values that can be converted correctly are accepted. Previously the conversion logic at application sites was duplicated inside the macro; it now flows through one converter.

Passing a Scala value to a foreign method no longer requires wrapping it by hand — if there is an `Interoperable` instance for the receiver's source language, the value is converted to a `Foreign` literal at the call site:

```scala
val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]

foo.greet(t"hello")     // Text converted to `Foreign of "string"` and passed
foo.link(foo.bar)       // an existing `Foreign` value passed through unchanged
```

Conversion only succeeds when it is both possible and correct: a value with no `Interoperable` for that language is a compile error, and a value whose foreign type doesn't match the parameter (e.g. passing a number where a string is expected) is rejected by the type-checker.
