### PR TITLE
zeppelin: run the ZIP test suite in CI

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1378,8 +1378,7 @@ object zeppelin extends Library:
   object core extends Component(galilei.core, zephyrine.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, imperial.core, diuretic.core):
-    override def enabled = false
+  object test extends Tests(core, imperial.core, diuretic.core)
 
 object ziggurat extends Library:
   object core extends Component(hellenism.core, monotonous.core, turbulence.core):

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -150,7 +150,7 @@ object Tests extends Suite(m"Soundness tests"):
     ypsiloid.Tests()
     yossarian.Tests()
     zephyrine.Tests()
-    //zeppelin.Tests()
+    zeppelin.Tests()
     //ziggurat.Tests() - ziggurat.test missing from build.mill test bundle
 
 object FailingTests extends Suite(m"Failing tests"):


### PR DESCRIPTION
Activates the Zeppelin ZIP test suite in CI. PR #1213 added the suite (`lib/zeppelin/src/test/zeppelin_test.scala`) but its tests did not actually run as part of the CI aggregate: the `zeppelin` test module was declared `enabled = false` (a leftover from when the suite was an empty placeholder) and the `zeppelin.Tests()` call in `soundness.Tests` was commented out. This change enables the module and invokes it, so the 24 ZIP tests now run with the rest of the suite.

## Notes

- The aggregate `test` module auto-collects every *enabled* `Tests` submodule, so enabling `zeppelin.test` is what makes `zeppelin.Tests` visible to `soundness.Tests`; both the build flag and the call had to change together.
- Confirmed via `make attest`: the suite total rose from 5451 to 5475 (the +24 Zeppelin tests), 0 failed.
