### PR TITLE
xenophile: generic List, Map and Optional interoperability instances

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1306,7 +1306,7 @@ object wisteria extends Library:
 
 object xenophile extends Library:
   object core extends Component(gossamer.core, prepositional.core, gigantism.core, fulminate.core,
-    vacuous.core, hellenism.core, jacinta.core):
+    vacuous.core, hellenism.core, jacinta.core, distillate.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/xenophile/res/core/xenophile/definitions.ts
+++ b/lib/xenophile/res/core/xenophile/definitions.ts
@@ -4,6 +4,7 @@ interface Foo {
   greet(name: string): string;
   link(other: Bar): Foo;
   tags: string[];
+  counts: number[];
   nickname?: string;
   id: string | number;
   lookup: Map<number, string>;

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -34,6 +34,7 @@ package xenophile
 
 import anticipation.*
 import contingency.*, strategies.throwUnsafely
+import distillate.*
 import jacinta.*
 import prepositional.*
 import vacuous.*
@@ -72,14 +73,19 @@ object Typescript:
       ( _.let(_.asInstanceOf[inner]).let(interoperable.operand(_)).or(Json(Unset)),
         _.as[Optional[Json]].let(interoperable.value(_)) )
 
-  // A TypeScript `Map<number, string>` maps to a Scala `Map[Int, Text]`, decoded with jacinta's
-  // map support (object keys parsed as numbers).
-  type NumberToString =
-    Map[Int, Text] is Interoperable in Typescript of ("Map" over ("number", "string")) by Json
+  // A TypeScript `Map<K, V>` maps to a Scala `Map`. Values are converted by their `Interoperable`;
+  // JSON object keys are textual, so the key type also needs `Text` codecs.
+  given map: [key, value, keyTopic, valueTopic]
+  =>  ( keyType:   key is Interoperable in Typescript of keyTopic by Json,
+        valueType: value is Interoperable in Typescript of valueTopic by Json,
+        keyEncode: key is Encodable in Text,
+        keyDecode: key is Decodable in Text )
+  =>  ( Map[key, value] is Interoperable in Typescript
+          of ("Map" over (keyTopic, valueTopic)) by Json ) =
 
-  given numberToString: NumberToString =
-    Interoperable[Map[Int, Text], Typescript, ("Map" over ("number", "string")), Json]
-      ( _.json, _.as[Map[Int, Text]] )
+    Interoperable[Map[key, value], Typescript, ("Map" over (keyTopic, valueTopic)), Json]
+      ( _.map { (k, v) => (k.encode, valueType.operand(v)) }.json,
+        _.as[Map[Text, Json]].map { (k, v) => (k.decode[key], valueType.value(v)) } )
 
   // A backend that evaluates a `ForeignExpr` against an in-memory JSON document: references and
   // selections navigate the document; literals yield their operand; function application is

--- a/lib/xenophile/src/core/xenophile.Typescript.scala
+++ b/lib/xenophile/src/core/xenophile.Typescript.scala
@@ -48,18 +48,29 @@ object Typescript:
   given boolean: (Boolean is Interoperable in Typescript of "boolean" by Json) =
     Interoperable[Boolean, Typescript, "boolean", Json](_.json, _.as[Boolean])
 
-  // A TypeScript `string[]` (i.e. `Array<string>`) maps to a Scala `List[Text]`.
-  type Strings =
-    List[Text] is Interoperable in Typescript of ("Array" over "string") by Json
-
-  given strings: Strings =
-    Interoperable[List[Text], Typescript, ("Array" over "string"), Json]
-      ( _.json, _.as[List[Text]] )
+  // A TypeScript `T[]` (i.e. `Array<T>`) maps to a Scala `List`, with each element converted by
+  // the element type's own `Interoperable`.
+  given list: [element, topic]
+  =>  ( interoperable: element is Interoperable in Typescript of topic by Json )
+  =>  ( List[element] is Interoperable in Typescript of ("Array" over topic) by Json ) =
+    Interoperable[List[element], Typescript, ("Array" over topic), Json]
+      ( _.map(interoperable.operand(_)).json,
+        _.as[List[Json]].map(interoperable.value(_)) )
 
   // TypeScript `undefined` (produced by reading `T?` as `T | undefined`) maps to the absent
-  // `Optional` value.
+  // `Optional` value; it also backs the `Unset.type` alternative when a union is decoded.
   given undefined: (Unset.type is Interoperable in Typescript of "undefined" by Json) =
     Interoperable[Unset.type, Typescript, "undefined", Json](_ => Json(Unset), _ => Unset)
+
+  // A TypeScript `T?` (read as `T | undefined`) maps to a Scala `Optional`. Mirroring jacinta's own
+  // optional codecs, the `Mandatable` constraint identifies the mandatory type `inner` and ensures
+  // this instance applies only to genuine optionals — so it never competes with `inner`'s instance.
+  given optional: [inner <: value, value >: Unset.type: Mandatable to inner, topic]
+  =>  ( interoperable: inner is Interoperable in Typescript of topic by Json )
+  =>  ( value is Interoperable in Typescript of (topic | "undefined") by Json ) =
+    Interoperable[value, Typescript, (topic | "undefined"), Json]
+      ( _.let(_.asInstanceOf[inner]).let(interoperable.operand(_)).or(Json(Unset)),
+        _.as[Optional[Json]].let(interoperable.value(_)) )
 
   // A TypeScript `Map<number, string>` maps to a Scala `Map[Int, Text]`, decoded with jacinta's
   // map support (object keys parsed as numbers).

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -40,8 +40,8 @@ type TsInterface = Interface in Typescript at "/xenophile/definitions.ts"
 given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.ts")
 
 val document: Json =
-  j"""{"Foo": {"baz": "hello", "bar": {"count": 42}, "tags": ["a", "b"], "nickname": "Bob",
-       "id": "abc123", "lookup": {"1": "one", "2": "two"}}}"""
+  j"""{"Foo": {"baz": "hello", "bar": {"count": 42}, "tags": ["a", "b"], "counts": [1, 2, 3],
+       "nickname": "Bob", "id": "abc123", "lookup": {"1": "one", "2": "two"}}}"""
 
 given Evaluator in Typescript by Json = Typescript.evaluator(document)
 
@@ -112,10 +112,25 @@ object Tests extends Suite(m"Xenophile tests"):
         tags.as[List[Text]]
       . assert(_ == List(t"a", t"b"))
 
+      test(m"the generic List instance decodes an `Array<number>` to a List[Int]"):
+        val counts: Foreign of ("Array" over "number") from Typescript = foo.counts
+        counts.as[List[Int]]
+      . assert(_ == List(1, 2, 3))
+
       test(m"an optional field is a union with `undefined` and decodes to an Optional"):
         val nickname: Foreign of ("string" | "undefined") from Typescript = foo.nickname
         nickname.as[Optional[Text]]
       . assert(_ == t"Bob")
+
+      test(m"a present Optional value converts to a `Foreign` literal and round-trips"):
+        val opt: Foreign of ("string" | "undefined") from Typescript = t"hi": Optional[Text]
+        opt.as[Optional[Text]]
+      . assert(_ == t"hi")
+
+      test(m"an absent Optional value converts to `undefined` and decodes to Unset"):
+        val opt: Foreign of ("string" | "undefined") from Typescript = Unset: Optional[Text]
+        opt.as[Optional[Text]]
+      . assert(_ == Unset)
 
       test(m"a union field has a bare-union foreign type and decodes to a Scala union"):
         val id: Foreign of ("string" | "number") from Typescript = foo.id

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -35,6 +35,8 @@ package xenophile
 import soundness.*
 import jacinta.*
 
+import strategies.throwUnsafely
+
 type TsInterface = Interface in Typescript at "/xenophile/definitions.ts"
 
 given tsInterface: TsInterface = Interface[Typescript](cp"/xenophile/definitions.ts")


### PR DESCRIPTION
Xenophile's TypeScript interoperability now derives `List`, `Map` and `Optional` instances generically from their element types' own `Interoperable` instances, replacing the previous fixed monomorphic ones (`List[Text]`, `Map[Int, Text]`). `Optional` works in both directions — encode and decode — using a `Mandatable` constraint so the instance applies only to genuine optionals and never competes with the underlying type's instance.

Collection and optional foreign types are no longer limited to specific element types.

**`List`** — any element type with an `Interoperable` instance now works (`List[Int]`, `List[Boolean]`, …):

```scala
val counts: Foreign of ("Array" over "number") from Typescript = foo.counts
counts.as[List[Int]]
```

**`Map`** — values convert via their `Interoperable`; because JSON object keys are textual, the key type additionally needs `Text` codecs (this adds a dependency on distillate):

```scala
val lookup: Foreign of ("Map" over ("number", "string")) from Typescript = foo.lookup
lookup.as[Map[Int, Text]]
```

**`Optional`** — a `T?` field works for both encode and decode. A present value is converted through the underlying type's instance; an absent one maps to `undefined` / `Unset`:

```scala
val nickname: Foreign of ("string" | "undefined") from Typescript = foo.nickname
nickname.as[Optional[Text]]                                           // decode
val opt: Foreign of ("string" | "undefined") from Typescript = t"hi": Optional[Text]  // encode
```
