### PR TITLE
Add apoplexy for reading OpenAPI definitions, plus jp/yp/xp path interpolators

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -402,6 +402,12 @@ object anticipation extends Library:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests
 
+object apoplexy extends Library:
+  object core extends Component(jacinta.schema, ypsiloid.core, telekinesis.core, fulminate.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core)
+
 object austronesian extends Library:
   object core extends Component(probably.core, hellenism.core):
     override def scalacOptions = Task:
@@ -1391,7 +1397,7 @@ object ziggurat extends Library:
 // directories.
 val allLibraries: Seq[Library] = Seq(
   abacist, acyclicity, adversaria, ambience, anamnesis, anthology, anticipation,
-  austronesian, aviation, baroque, beneficence, bitumen, breviloquence, burdock,
+  apoplexy, austronesian, aviation, baroque, beneficence, bitumen, breviloquence, burdock,
   cacophony, caduceus, caesura, camouflage, capricious, cardinality, cataclysm,
   cellulose, charisma, chiaroscuro, coaxial, contextual, contingency, cosmopolite,
   decorum, dendrology, denominative, digression, dissonance, distillate, diuretic,

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -1,0 +1,272 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import fulminate.*
+import gossamer.*
+import jacinta.*
+import prepositional.*
+import rudiments.*
+import spectacular.*
+import telekinesis.*
+import turbulence.*
+import vacuous.*
+import ypsiloid.*
+
+import errorDiagnostics.empty
+import zephyrine.ParseError
+
+object OpenApi:
+  case class Info(title: Text, version: Text, description: Optional[Text] = Unset)
+  case class Server(url: Text, description: Optional[Text] = Unset)
+
+  object Parameter:
+    object In:
+      given decodable: Tactic[OpenApiError] => In is Decodable in Text = _.lower match
+        case t"path"   => In.Path
+        case t"query"  => In.Query
+        case t"header" => In.Header
+        case t"cookie" => In.Cookie
+        case other     => abort(OpenApiError(OpenApiError.Reason.BadParameterLocation(other)))
+
+    // Anchored (rather than derived inline at each use) so that `PathItem` and
+    // `Operation`, which both embed `Parameter`, reference one cached instance.
+    given decodableJson: (Tactic[JsonError], Tactic[OpenApiError])
+    =>  Parameter is Decodable in Json = Json.DecodableDerivation.derived
+
+    given decodableYaml: (Tactic[YamlError], Tactic[OpenApiError])
+    =>  Parameter is Decodable in Yaml = Yaml.DecodableDerivation.derived
+
+    enum In:
+      case Path, Query, Header, Cookie
+
+  case class Parameter
+    ( name:        Text,
+      `in`:        Parameter.In,
+      required:    Optional[Boolean]    = Unset,
+      description: Optional[Text]       = Unset,
+      schema:      Optional[JsonSchema] = Unset )
+
+  // An OpenAPI "Media Type Object": the value of a `content` entry keyed by a
+  // media-type string such as `application/json`.
+  case class MediaTypeObject(schema: Optional[JsonSchema] = Unset)
+
+  case class RequestBody
+    ( description: Optional[Text]             = Unset,
+      required:    Optional[Boolean]          = Unset,
+      content:     Map[Text, MediaTypeObject] = Map() )
+
+  case class Response
+    ( description: Optional[Text]             = Unset,
+      content:     Map[Text, MediaTypeObject] = Map() )
+
+  object Operation:
+    // `PathItem` carries eight `Optional[Operation]` fields, so deriving it
+    // inline would expand the whole `Operation` graph eight times and overflow
+    // `-Xmax-inlines` (which surfaces, misleadingly, as a missing `Decodable`
+    // instance). Anchoring `Operation` derives it once and lets `PathItem`
+    // simply reference it.
+    given decodableJson: (Tactic[JsonError], Tactic[OpenApiError])
+    =>  Operation is Decodable in Json = Json.DecodableDerivation.derived
+
+    given decodableYaml: (Tactic[YamlError], Tactic[OpenApiError])
+    =>  Operation is Decodable in Yaml = Yaml.DecodableDerivation.derived
+
+  case class Operation
+    ( operationId: Optional[Text]        = Unset,
+      summary:     Optional[Text]        = Unset,
+      description: Optional[Text]        = Unset,
+      parameters:  List[Parameter]       = Nil,
+      requestBody: Optional[RequestBody] = Unset,
+      responses:   Map[Text, Response]   = Map() )
+
+  // The path-item object mixes HTTP-method keys with non-method keys, so each
+  // verb is a fixed optional field rather than a `Map[Http.Method, Operation]`;
+  // `operations` rebuilds that map for consumers that want it.
+  case class PathItem
+    ( summary:     Optional[Text]      = Unset,
+      description: Optional[Text]      = Unset,
+      get:         Optional[Operation] = Unset,
+      put:         Optional[Operation] = Unset,
+      post:        Optional[Operation] = Unset,
+      delete:      Optional[Operation] = Unset,
+      options:     Optional[Operation] = Unset,
+      head:        Optional[Operation] = Unset,
+      patch:       Optional[Operation] = Unset,
+      trace:       Optional[Operation] = Unset,
+      parameters:  List[Parameter]     = Nil ):
+
+    def operations: Map[Http.Method, Operation] =
+      val verbs =
+        List
+          ( Http.Get -> get, Http.Put -> put, Http.Post -> post, Http.Delete -> delete,
+            Http.Options -> options, Http.Head -> head, Http.Patch -> patch,
+            Http.Trace -> trace )
+
+      verbs
+      . collect { case (method, operation) if operation.present => method -> operation.vouch }
+      . to(Map)
+
+  case class Components(schemas: Map[Text, JsonSchema] = Map())
+
+  // The `responses` map is keyed by status text (`"200"`, `"2XX"`, `"default"`),
+  // not all of which are valid `Http.Status` codes; `response` interprets a
+  // concrete status against those keys.
+  extension (operation: Operation)
+    def response(status: Http.Status): Optional[Response] =
+      operation.responses.at(status.code.show)
+      . or(operation.responses.at(t"${status.code/100}XX"))
+      . or(operation.responses.at(t"default"))
+
+  // Resolve a single `$ref` hop against the document's component schemas.
+  // Resolving one hop at a time (never inlining recursively) keeps cyclic
+  // schema graphs from looping; the consumer drives the walk.
+  extension (schema: JsonSchema)
+    def dereference(using doc: OpenApi): JsonSchema raises OpenApiError = schema match
+      case JsonSchema.Ref(pointer, _, _) =>
+        val prefix = t"#/components/schemas/"
+
+        if pointer.starts(prefix) then
+          val name = pointer.skip(prefix.length)
+
+          doc.components.let(_.schemas.at(name)).or:
+            abort(OpenApiError(OpenApiError.Reason.UnresolvableRef(pointer)))
+        else
+          abort(OpenApiError(OpenApiError.Reason.UnsupportedRef(pointer)))
+
+      case other =>
+        other
+
+  // Mirror of jacinta's `JsonSchema is Decodable in Json`, over the `Yaml` AST.
+  // jacinta cannot depend on ypsiloid, so the YAML decoder for `JsonSchema`
+  // lives here, in scope of the model's own decoders. Kept distinct from the
+  // private method so that recursive summons for nested schemas (`items`,
+  // `properties`, …) resolve to this fully-defined given rather than to the
+  // instance currently being initialised.
+  given jsonSchemaYaml: Tactic[YamlError] => JsonSchema is Decodable in Yaml =
+    decodeYamlSchema(_)
+
+  private def decodeYamlSchema(yaml: Yaml)(using Tactic[YamlError]): JsonSchema =
+    def field[value: Decodable in Yaml](name: Text): Optional[value] =
+      yaml(name).as[Optional[value]]
+
+    val reference = field[Text]("$ref".tt)
+
+    if !reference.absent
+    then JsonSchema.Ref(reference.vouch, field[Text](t"description"))
+    else field[Text](t"type") match
+      case t"array" =>
+        JsonSchema.Array
+          ( field[Text](t"description"),
+            field[JsonSchema](t"items"),
+            field[Int](t"minItems"),
+            field[Int](t"maxItems"),
+            false,
+            field[Int](t"maxContains"),
+            field[Int](t"minContains") )
+
+      case t"string" =>
+        JsonSchema.String
+          ( field[Text](t"description"),
+            field[Int](t"minLength"),
+            field[Int](t"maxLength"),
+            field[Text](t"pattern"),
+            field[JsonSchema.Format](t"format"),
+            false )
+
+      case t"number" =>
+        JsonSchema.Number
+          ( field[Text](t"description"),
+            field[Double](t"multipleOf"),
+            field[Double](t"maximum"),
+            field[Double](t"minimum"),
+            field[Double](t"exclusiveMinimum"),
+            field[Double](t"exclusiveMaximum"),
+            false )
+
+      case t"integer" =>
+        JsonSchema.Integer
+          ( field[Text](t"description"),
+            field[Int](t"maximum"),
+            field[Int](t"minimum"),
+            field[Int](t"exclusiveMinimum"),
+            field[Int](t"exclusiveMaximum"),
+            false )
+
+      case t"boolean" =>
+        JsonSchema.Boolean(field[Text](t"description"), false)
+
+      case t"null" =>
+        JsonSchema.Null(field[Text](t"description"), false)
+
+      case _ =>
+        JsonSchema.Object
+          ( field[Text](t"description"),
+            field[Map[Text, JsonSchema]](t"properties").or(Map()),
+            false,
+            field[List[Text]](t"required"),
+            // `enum` holds raw `Json` values, and there is no `Yaml`->`Json`
+            // bridge, so enum constraint values are not carried through the YAML
+            // path; they do not affect endpoint structure.
+            Unset,
+            yaml(t"additionalProperties").as[Optional[scala.Boolean]].or(false),
+            field[List[JsonSchema]](t"oneOf") )
+
+  // `source.read[OpenApi]`: aggregate the source text, auto-detect JSON vs YAML
+  // from the first non-whitespace character, decode through the shared model,
+  // then check the document declares an OpenAPI 3.x version.
+  given aggregable: Tactic[OpenApiError] => OpenApi is Aggregable by Text =
+    summon[Text is Aggregable by Text].map: text =>
+      val document =
+        whereas:
+          case ParseError(_, _, _) => OpenApiError(OpenApiError.Reason.Malformed)
+          case JsonError(_)        => OpenApiError(OpenApiError.Reason.Malformed)
+          case YamlError(_)        => OpenApiError(OpenApiError.Reason.Malformed)
+
+        . mitigate:
+            if text.trim.starts(t"{") || text.trim.starts(t"[")
+            then text.decode[Json].as[OpenApi]
+            else text.decode[Yaml].as[OpenApi]
+
+      if document.openapi.starts(t"3.") then document
+      else abort(OpenApiError(OpenApiError.Reason.UnsupportedVersion(document.openapi)))
+
+case class OpenApi
+  ( openapi:    Text,
+    info:       OpenApi.Info,
+    servers:    List[OpenApi.Server]        = Nil,
+    paths:      Map[Text, OpenApi.PathItem] = Map(),
+    components: Optional[OpenApi.Components] = Unset )

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -64,10 +64,10 @@ object OpenApi:
 
     // Anchored (rather than derived inline at each use) so that `PathItem` and
     // `Operation`, which both embed `Parameter`, reference one cached instance.
-    given decodableJson: (Tactic[JsonError], Tactic[OpenApiError])
+    given decodableJson: (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
     =>  Parameter is Decodable in Json = Json.DecodableDerivation.derived
 
-    given decodableYaml: (Tactic[YamlError], Tactic[OpenApiError])
+    given decodableYaml: (Tactic[YamlError], Tactic[JsonPointerError], Tactic[OpenApiError])
     =>  Parameter is Decodable in Yaml = Yaml.DecodableDerivation.derived
 
     enum In:
@@ -99,10 +99,10 @@ object OpenApi:
     // `-Xmax-inlines` (which surfaces, misleadingly, as a missing `Decodable`
     // instance). Anchoring `Operation` derives it once and lets `PathItem`
     // simply reference it.
-    given decodableJson: (Tactic[JsonError], Tactic[OpenApiError])
+    given decodableJson: (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
     =>  Operation is Decodable in Json = Json.DecodableDerivation.derived
 
-    given decodableYaml: (Tactic[YamlError], Tactic[OpenApiError])
+    given decodableYaml: (Tactic[YamlError], Tactic[JsonPointerError], Tactic[OpenApiError])
     =>  Operation is Decodable in Yaml = Yaml.DecodableDerivation.derived
 
   case class Operation
@@ -151,21 +151,23 @@ object OpenApi:
       . or(operation.responses.at(t"${status.code/100}XX"))
       . or(operation.responses.at(t"default"))
 
-  // Resolve a single `$ref` hop against the document's component schemas.
-  // Resolving one hop at a time (never inlining recursively) keeps cyclic
-  // schema graphs from looping; the consumer drives the walk.
+  // Resolve a single `$ref` hop against the document's component schemas, via
+  // `ref()`. Resolving one hop at a time (never inlining recursively) keeps
+  // cyclic schema graphs from looping; the consumer drives the walk. A
+  // non-reference schema resolves to itself.
   extension (schema: JsonSchema)
-    def dereference(using doc: OpenApi): JsonSchema raises OpenApiError = schema match
+    def apply()(using doc: OpenApi): JsonSchema raises OpenApiError = schema match
       case JsonSchema.Ref(pointer, _, _) =>
+        val reference = pointer.encode
         val prefix = t"#/components/schemas/"
 
-        if pointer.starts(prefix) then
-          val name = pointer.skip(prefix.length)
+        if reference.starts(prefix) then
+          val name = reference.skip(prefix.length)
 
           doc.components.let(_.schemas.at(name)).or:
-            abort(OpenApiError(OpenApiError.Reason.UnresolvableRef(pointer)))
+            abort(OpenApiError(OpenApiError.Reason.UnresolvableRef(reference)))
         else
-          abort(OpenApiError(OpenApiError.Reason.UnsupportedRef(pointer)))
+          abort(OpenApiError(OpenApiError.Reason.UnsupportedRef(reference)))
 
       case other =>
         other
@@ -176,17 +178,19 @@ object OpenApi:
   // private method so that recursive summons for nested schemas (`items`,
   // `properties`, …) resolve to this fully-defined given rather than to the
   // instance currently being initialised.
-  given jsonSchemaYaml: Tactic[YamlError] => JsonSchema is Decodable in Yaml =
-    decodeYamlSchema(_)
+  given jsonSchemaYaml: (Tactic[YamlError], Tactic[JsonPointerError])
+  =>  JsonSchema is Decodable in Yaml = decodeYamlSchema(_)
 
-  private def decodeYamlSchema(yaml: Yaml)(using Tactic[YamlError]): JsonSchema =
+  private def decodeYamlSchema(yaml: Yaml)(using Tactic[YamlError], Tactic[JsonPointerError])
+  :   JsonSchema =
+
     def field[value: Decodable in Yaml](name: Text): Optional[value] =
       yaml(name).as[Optional[value]]
 
     val reference = field[Text]("$ref".tt)
 
     if !reference.absent
-    then JsonSchema.Ref(reference.vouch, field[Text](t"description"))
+    then JsonSchema.Ref(reference.vouch.decode[JsonPointer], field[Text](t"description"))
     else field[Text](t"type") match
       case t"array" =>
         JsonSchema.Array
@@ -252,9 +256,10 @@ object OpenApi:
     summon[Text is Aggregable by Text].map: text =>
       val document =
         whereas:
-          case ParseError(_, _, _) => OpenApiError(OpenApiError.Reason.Malformed)
-          case JsonError(_)        => OpenApiError(OpenApiError.Reason.Malformed)
-          case YamlError(_)        => OpenApiError(OpenApiError.Reason.Malformed)
+          case ParseError(_, _, _)  => OpenApiError(OpenApiError.Reason.Malformed)
+          case JsonError(_)         => OpenApiError(OpenApiError.Reason.Malformed)
+          case YamlError(_)         => OpenApiError(OpenApiError.Reason.Malformed)
+          case JsonPointerError(_)  => OpenApiError(OpenApiError.Reason.Malformed)
 
         . mitigate:
             if text.trim.starts(t"{") || text.trim.starts(t"[")

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -259,7 +259,7 @@ object OpenApi:
           case ParseError(_, _, _)  => OpenApiError(OpenApiError.Reason.Malformed)
           case JsonError(_)         => OpenApiError(OpenApiError.Reason.Malformed)
           case YamlError(_)         => OpenApiError(OpenApiError.Reason.Malformed)
-          case JsonPointerError(_)  => OpenApiError(OpenApiError.Reason.Malformed)
+          case JsonPointerError(_, _) => OpenApiError(OpenApiError.Reason.Malformed)
 
         . mitigate:
             if text.trim.starts(t"{") || text.trim.starts(t"[")

--- a/lib/apoplexy/src/core/apoplexy.OpenApiError.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApiError.scala
@@ -1,0 +1,64 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import anticipation.*
+import fulminate.*
+
+object OpenApiError:
+  object Reason:
+    given Reason is Communicable =
+      case Malformed =>
+        m"the OpenAPI document could not be parsed"
+
+      case UnsupportedVersion(version) =>
+        m"the OpenAPI version $version is not supported; only 3.x is supported"
+
+      case UnresolvableRef(pointer) =>
+        m"the reference $pointer could not be resolved"
+
+      case UnsupportedRef(pointer) =>
+        m"the reference $pointer is not supported; only #/components/schemas references work"
+
+      case BadParameterLocation(value) =>
+        m"$value is not a valid parameter location; expected one of path, query, header or cookie"
+
+  enum Reason(val number: Int) extends Clarification:
+    case Malformed                         extends Reason(1)
+    case UnsupportedVersion(version: Text) extends Reason(2)
+    case UnresolvableRef(pointer: Text)    extends Reason(3)
+    case UnsupportedRef(pointer: Text)     extends Reason(4)
+    case BadParameterLocation(value: Text) extends Reason(5)
+
+case class OpenApiError(reason: OpenApiError.Reason)(using Diagnostics)
+extends Error(846, reason.number)(m"the OpenAPI document was not valid because $reason")

--- a/lib/apoplexy/src/core/soundness_apoplexy_core.scala
+++ b/lib/apoplexy/src/core/soundness_apoplexy_core.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export apoplexy.{OpenApi, OpenApiError}

--- a/lib/apoplexy/src/test/apoplexy_test.scala
+++ b/lib/apoplexy/src/test/apoplexy_test.scala
@@ -174,20 +174,20 @@ components:
     .assert:
       case JsonSchema.Object(_, properties, _, _, _, _, _) =>
         properties.at(t"owner").vouch match
-          case JsonSchema.Ref(pointer, _, _) => pointer == t"#/components/schemas/Owner"
+          case JsonSchema.Ref(pointer, _, _) => pointer.encode == t"#/components/schemas/Owner"
           case _                             => false
       case _ => false
 
     test(m"a component reference resolves to its schema"):
       given OpenApi = fromJson
-      JsonSchema.Ref(t"#/components/schemas/Pet").dereference
+      JsonSchema.Ref(t"#/components/schemas/Pet".decode[JsonPointer])()
     .assert:
       case _: JsonSchema.Object => true
       case _                    => false
 
     test(m"a cyclic reference resolves one hop without looping"):
       given OpenApi = fromJson
-      JsonSchema.Ref(t"#/components/schemas/Owner").dereference
+      JsonSchema.Ref(t"#/components/schemas/Owner".decode[JsonPointer])()
     .assert:
       case _: JsonSchema.Object => true
       case _                    => false

--- a/lib/apoplexy/src/test/apoplexy_test.scala
+++ b/lib/apoplexy/src/test/apoplexy_test.scala
@@ -1,0 +1,198 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import soundness.*
+import apoplexy.OpenApi.*
+
+import errorDiagnostics.empty
+import strategies.throwUnsafely
+
+object Tests extends Suite(m"OpenAPI tests"):
+  val jsonSpec: Text =
+    """{
+      "openapi": "3.0.3",
+      "info": { "title": "Petstore", "version": "1.0.0" },
+      "paths": {
+        "/pets": {
+          "get": {
+            "operationId": "listPets",
+            "responses": {
+              "200": {
+                "description": "a list of pets",
+                "content": {
+                  "application/json": {
+                    "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "/pets/{id}": {
+          "get": {
+            "operationId": "getPet",
+            "parameters": [
+              { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+            ],
+            "responses": {
+              "200": {
+                "description": "a pet",
+                "content": {
+                  "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } }
+                }
+              }
+            }
+          }
+        }
+      },
+      "components": {
+        "schemas": {
+          "Pet": {
+            "type": "object",
+            "required": ["id", "name"],
+            "properties": {
+              "id": { "type": "integer" },
+              "name": { "type": "string" },
+              "owner": { "$ref": "#/components/schemas/Owner" }
+            }
+          },
+          "Owner": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "pet": { "$ref": "#/components/schemas/Pet" }
+            }
+          }
+        }
+      }
+    }""".tt
+
+  val yamlSpec: Text =
+    """openapi: "3.0.3"
+info:
+  title: Petstore
+  version: "1.0.0"
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        "200":
+          description: a list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+  /pets/{id}:
+    get:
+      operationId: getPet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: a pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        owner:
+          $ref: "#/components/schemas/Owner"
+    Owner:
+      type: object
+      properties:
+        name:
+          type: string
+        pet:
+          $ref: "#/components/schemas/Pet"
+""".tt
+
+  def run(): Unit =
+    val fromJson = jsonSpec.read[OpenApi]
+    val fromYaml = yamlSpec.read[OpenApi]
+
+    test(m"JSON and YAML specs decode to the same model")(fromYaml).assert(_ == fromJson)
+
+    test(m"the operationId of GET /pets is read"):
+      fromJson.paths.at(t"/pets").vouch.get.vouch.operationId.vouch
+    .assert(_ == t"listPets")
+
+    test(m"the path parameter location is decoded as Path"):
+      fromJson.paths.at(t"/pets/{id}").vouch.get.vouch.parameters.head.in
+    .assert(_ == OpenApi.Parameter.In.Path)
+
+    test(m"a reference property is kept lazy"):
+      fromJson.components.vouch.schemas.at(t"Pet").vouch
+    .assert:
+      case JsonSchema.Object(_, properties, _, _, _, _, _) =>
+        properties.at(t"owner").vouch match
+          case JsonSchema.Ref(pointer, _, _) => pointer == t"#/components/schemas/Owner"
+          case _                             => false
+      case _ => false
+
+    test(m"a component reference resolves to its schema"):
+      given OpenApi = fromJson
+      JsonSchema.Ref(t"#/components/schemas/Pet").dereference
+    .assert:
+      case _: JsonSchema.Object => true
+      case _                    => false
+
+    test(m"a cyclic reference resolves one hop without looping"):
+      given OpenApi = fromJson
+      JsonSchema.Ref(t"#/components/schemas/Owner").dereference
+    .assert:
+      case _: JsonSchema.Object => true
+      case _                    => false
+
+    test(m"an unsupported OpenAPI version is rejected"):
+      capture[OpenApiError]:
+        """{"openapi": "2.0", "info": {"title": "x", "version": "1"}}""".tt.read[OpenApi]
+    .assert(_.reason == OpenApiError.Reason.UnsupportedVersion(t"2.0"))

--- a/lib/jacinta/src/core/jacinta.JsonPointer.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPointer.scala
@@ -37,6 +37,7 @@ import scala.collection.mutable as scm
 
 import anticipation.*
 import beneficence.*
+import contextual.*
 import contingency.*
 import denominative.*
 import distillate.*
@@ -77,19 +78,38 @@ object JsonPointer extends Root(""):
     if pointer.path.descent.length == 0 then t"$url#"
     else t"$url#/${pointer.path}"
 
-  // Parses a same-document JSON reference (`#`, `#/`, `#/a/b`). URL-bearing or
-  // fragmentless references are reported as `Malformed`; same-document refs are
-  // all OpenAPI's component `$ref`s use, and JSON Pointer fragments per RFC 6901.
+  inline given interpolable: JsonPointer is Interpolable:
+    transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+      ( inline insertions: Any* )
+    :   JsonPointer =
+
+      ${jacinta.JsonPointerInterpolator.expand[parts, origins]('insertions)}
+
+  // Parses a same-document JSON reference (`#`, `#/`, `#/a/b`), reporting the
+  // offset of any error. URL-bearing references begin with a non-`#` character
+  // and so are rejected as `ExpectedHash`; same-document refs are all OpenAPI's
+  // `$ref`s use, and are JSON Pointer fragments per RFC 6901.
   given decodable: Tactic[JsonPointerError] => JsonPointer is Decodable in Text = text =>
-    val parts = text.cut(t"#")
+    val string = text.s
 
-    if parts.length != 2 || parts.head != t""
-    then abort(JsonPointerError(JsonPointerError.Reason.Malformed(text)))
+    if string.isEmpty || string.charAt(0) != '#'
+    then abort(JsonPointerError(JsonPointerError.Reason.ExpectedHash, 0))
+    else if string.length > 1 && string.charAt(1) != '/'
+    then abort(JsonPointerError(JsonPointerError.Reason.ExpectedSlash, 1))
     else
-      val segments = parts.last.cut(t"/").filter(_ != t"")
+      var index = 1
 
-      segments.foldLeft(JsonPointer(): JsonPointer): (pointer, segment) =>
-        pointer(filesystem.unescape(segment))
+      while index < string.length do
+        if string.charAt(index) == '~' then
+          val next = if index + 1 < string.length then string.charAt(index + 1) else ' '
+
+          if next != '0' && next != '1'
+          then abort(JsonPointerError(JsonPointerError.Reason.BadEscape, index))
+
+        index += 1
+
+      text.skip(1).cut(t"/").filter(_ != t"").foldLeft(JsonPointer(): JsonPointer):
+        (pointer, segment) => pointer(filesystem.unescape(segment))
 
   given divisible: JsonPointer is Divisible by Text to JsonPointer =
     (pointer, segment) => JsonPointer(pointer.url, pointer.path / segment)
@@ -99,7 +119,7 @@ object JsonPointer extends Root(""):
 
 case class JsonPointer(url: Optional[HttpUrl] = Unset, path: Path on JsonPointer = JsonPointer):
   def apply(using registry: JsonPointer.Registry)(document: Json): Json raises JsonPointerError =
-    url.let(registry(_).lest(JsonPointerError(JsonPointerError.Reason.UnknownDocument)))
+    url.let(registry(_).lest(JsonPointerError(JsonPointerError.Reason.UnknownDocument, 0)))
     . or(document)
 
   def apply(ordinal: Ordinal): JsonPointer = JsonPointer(url, path / ordinal)

--- a/lib/jacinta/src/core/jacinta.JsonPointer.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPointer.scala
@@ -39,6 +39,7 @@ import anticipation.*
 import beneficence.*
 import contingency.*
 import denominative.*
+import distillate.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
@@ -75,6 +76,20 @@ object JsonPointer extends Root(""):
 
     if pointer.path.descent.length == 0 then t"$url#"
     else t"$url#/${pointer.path}"
+
+  // Parses a same-document JSON reference (`#`, `#/`, `#/a/b`). URL-bearing or
+  // fragmentless references are reported as `Malformed`; same-document refs are
+  // all OpenAPI's component `$ref`s use, and JSON Pointer fragments per RFC 6901.
+  given decodable: Tactic[JsonPointerError] => JsonPointer is Decodable in Text = text =>
+    val parts = text.cut(t"#")
+
+    if parts.length != 2 || parts.head != t""
+    then abort(JsonPointerError(JsonPointerError.Reason.Malformed(text)))
+    else
+      val segments = parts.last.cut(t"/").filter(_ != t"")
+
+      segments.foldLeft(JsonPointer(): JsonPointer): (pointer, segment) =>
+        pointer(filesystem.unescape(segment))
 
   given divisible: JsonPointer is Divisible by Text to JsonPointer =
     (pointer, segment) => JsonPointer(pointer.url, pointer.path / segment)

--- a/lib/jacinta/src/core/jacinta.JsonPointerError.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPointerError.scala
@@ -32,14 +32,17 @@
                                                                                                   */
 package jacinta
 
+import anticipation.*
 import fulminate.*
 
 object JsonPointerError:
   enum Reason(val number: Int) extends Clarification:
-    case UnknownDocument extends Reason(1)
+    case UnknownDocument    extends Reason(1)
+    case Malformed(ref: Text) extends Reason(2)
 
   given communicable: Reason is Communicable =
     case Reason.UnknownDocument => m"the registry contains no document at the pointer's URL"
+    case Reason.Malformed(ref)  => m"$ref is not a valid JSON reference"
 
 case class JsonPointerError(reason: JsonPointerError.Reason)(using Diagnostics)
 extends Error(415, reason.number)

--- a/lib/jacinta/src/core/jacinta.JsonPointerInterpolator.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPointerInterpolator.scala
@@ -32,23 +32,57 @@
                                                                                                   */
 package jacinta
 
+import scala.quoted.*
+
+import anticipation.*
+import contextual.*
+import contingency.*
+import distillate.*
 import fulminate.*
+import gigantism.*
+import rudiments.*
+import vacuous.*
 
-object JsonPointerError:
-  enum Reason(val number: Int) extends Clarification:
-    case UnknownDocument extends Reason(1)
-    case ExpectedHash    extends Reason(2)
-    case ExpectedSlash   extends Reason(3)
-    case BadEscape       extends Reason(4)
+object JsonPointerInterpolator:
+  // Reuses `JsonPointer`'s own `Decodable` for validation: the literal is
+  // decoded at macro-expansion time and, if it fails, the `JsonPointerError`'s
+  // offset is mapped back to a source position so the error points exactly at
+  // the offending character.
+  def expand[parts <: Tuple: Type, origins <: Tuple: Type](insertions: Expr[Seq[Any]])
+  :   Macro[JsonPointer] =
 
-  given communicable: Reason is Communicable =
-    case Reason.UnknownDocument => m"the registry contains no document at the reference's URL"
-    case Reason.ExpectedHash    => m"a JSON reference must begin with '#'"
-    case Reason.ExpectedSlash   => m"a JSON reference fragment must begin with '/'"
-    case Reason.BadEscape       => m"a '~' in a JSON reference must be followed by '0' or '1'"
+    import quotes.reflect.*
 
-// `offset` is the character index, within the reference text, where the error
-// was detected; consumers (e.g. the `jp"…"` interpolator) use it to position a
-// compile-time error precisely.
-case class JsonPointerError(reason: JsonPointerError.Reason, offset: Int)(using Diagnostics)
-extends Error(415, reason.number)(m"the JSON reference was not valid because $reason")
+    def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case _               => strings
+
+    def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
+      case '[head *: tail] => TypeRepr.of[head].dealias match
+        case AppliedType(_, ConstantType(IntConstant(start)) :: _) => start
+        case _                                                     => 0
+
+      case _ => 0
+
+    val parts = recur[parts](Nil)
+    if parts.length != 1 then halt(m"a JSON pointer literal cannot have substitutions")
+    val raw: String = parts.head
+    val start: Int = firstOrigin[origins]
+
+    try unsafely(raw.tt.decode[JsonPointer]) catch
+      case error: JsonPointerError =>
+        val sourceFile = Position.ofMacroExpansion.sourceFile
+
+        val position = sourceFile.content match
+          case Some(content: String) if start > 0 && start < content.length =>
+            val upper = (start + raw.length*6 + 16).min(content.length)
+            val mapping = Interpolation.buildMapping(content.substring(start, upper).nn, raw)
+            val at = (start + mapping(error.offset.min(raw.length))).min(content.length - 1)
+            Position(sourceFile, at, (at + 1).min(content.length))
+
+          case _ =>
+            Position.ofMacroExpansion
+
+        halt(error.message, position)
+
+    '{unsafely(${Expr(raw)}.tt.decode[JsonPointer])}

--- a/lib/jacinta/src/core/jacinta_core.scala
+++ b/lib/jacinta/src/core/jacinta_core.scala
@@ -229,6 +229,7 @@ extension [entity: Encodable in Json](value: entity) def json: Json = value.enco
 
 extension (inline context: StringContext)
   transparent inline def j: Interpolation = interpolation[Json](context)
+  transparent inline def jp: Interpolation = interpolation[JsonPointer](context)
 
 package jsonPrinters:
   given indented: JsonPrinter = JsonPrinter.print(_, true)

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -47,7 +47,88 @@ import wisteria.*
 
 
 object JsonSchema extends Derivable[Schematic in JsonSchema]:
-  given encodable: JsonSchema is Encodable in Json = Json.EncodableDerivation.derived
+  // `$ref` schemas have no `type` discriminator, so they are handled here
+  // explicitly; every other variant is delegated to the `type`-discriminated
+  // derivation. A `Ref` encodes to a bare `{"$ref": "…"}` object rather than
+  // the (meaningless) `{"type": "ref", …}` the discriminated encoder would
+  // produce.
+  private lazy val derivedEncodable: JsonSchema is Encodable in Json =
+    Json.EncodableDerivation.derived
+
+  given encodable: JsonSchema is Encodable in Json = value => value match
+    case JsonSchema.Ref(pointer, _, _) =>
+      Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(pointer.s))))
+
+    case other =>
+      derivedEncodable.encoded(other)
+
+  // Hand-written rather than derived: a JSON-Schema object is discriminated by
+  // the *value* of its `type` field (and may carry none, for `$ref`), which the
+  // `type`-as-Scala-subtype derivation cannot model. Decoding by hand also
+  // keeps the recursion on nested schemas pointed back at this same given.
+  given decodable: Tactic[JsonError] => JsonSchema is Decodable in Json = json =>
+    def field[value: Decodable in Json](name: Text): Optional[value] =
+      json(name).as[Optional[value]]
+
+    val reference = json("$ref".tt)
+
+    if !reference.root.isAbsent
+    then JsonSchema.Ref(reference.as[Text], field[Text](t"description"))
+    else field[Text](t"type") match
+      case t"array" =>
+        JsonSchema.Array
+          ( field[Text](t"description"),
+            field[JsonSchema](t"items"),
+            field[Int](t"minItems"),
+            field[Int](t"maxItems"),
+            false,
+            field[Int](t"maxContains"),
+            field[Int](t"minContains") )
+
+      case t"string" =>
+        JsonSchema.String
+          ( field[Text](t"description"),
+            field[Int](t"minLength"),
+            field[Int](t"maxLength"),
+            field[Text](t"pattern"),
+            field[JsonSchema.Format](t"format"),
+            false )
+
+      case t"number" =>
+        JsonSchema.Number
+          ( field[Text](t"description"),
+            field[Double](t"multipleOf"),
+            field[Double](t"maximum"),
+            field[Double](t"minimum"),
+            field[Double](t"exclusiveMinimum"),
+            field[Double](t"exclusiveMaximum"),
+            false )
+
+      case t"integer" =>
+        JsonSchema.Integer
+          ( field[Text](t"description"),
+            field[Int](t"maximum"),
+            field[Int](t"minimum"),
+            field[Int](t"exclusiveMinimum"),
+            field[Int](t"exclusiveMaximum"),
+            false )
+
+      case t"boolean" =>
+        JsonSchema.Boolean(field[Text](t"description"), false)
+
+      case t"null" =>
+        JsonSchema.Null(field[Text](t"description"), false)
+
+      case _ =>
+        // `object`, or an untyped schema (treated as an object).
+        JsonSchema.Object
+          ( field[Text](t"description"),
+            field[Map[Text, JsonSchema]](t"properties").or(Map()),
+            false,
+            field[List[Text]](t"required"),
+            field[List[Json]](t"enum"),
+            json(t"additionalProperties").as[Optional[scala.Boolean]].or(false),
+            field[List[JsonSchema]](t"oneOf") )
 
   given discriminatedUnion: JsonSchema is Discriminable:
     type Form = Json
@@ -124,6 +205,7 @@ enum JsonSchema extends Documentary:
     case entity: Integer => entity.copy(description = description)
     case entity: Boolean => entity.copy(description = description)
     case entity: Null    => entity.copy(description = description)
+    case entity: Ref     => entity.copy(description = description)
 
   case Object
     ( description:          Optional[Text]             = Unset,
@@ -170,3 +252,10 @@ enum JsonSchema extends Documentary:
 
   case Boolean(description: Optional[Text] = Unset, optional: scala.Boolean = false)
   case Null(description: Optional[Text] = Unset, optional: scala.Boolean = false)
+
+  // A JSON Reference (`{"$ref": "#/…"}`). The pointer is retained verbatim and
+  // resolved lazily by the consumer, so cyclic schema graphs stay finite.
+  case Ref
+    ( pointer:     Text,
+      description: Optional[Text] = Unset,
+      optional:    scala.Boolean  = false )

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -57,7 +57,7 @@ object JsonSchema extends Derivable[Schematic in JsonSchema]:
 
   given encodable: JsonSchema is Encodable in Json = value => value match
     case JsonSchema.Ref(pointer, _, _) =>
-      Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(pointer.s))))
+      Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(pointer.encode.s))))
 
     case other =>
       derivedEncodable.encoded(other)
@@ -66,14 +66,15 @@ object JsonSchema extends Derivable[Schematic in JsonSchema]:
   // the *value* of its `type` field (and may carry none, for `$ref`), which the
   // `type`-as-Scala-subtype derivation cannot model. Decoding by hand also
   // keeps the recursion on nested schemas pointed back at this same given.
-  given decodable: Tactic[JsonError] => JsonSchema is Decodable in Json = json =>
+  given decodable: (Tactic[JsonError], Tactic[JsonPointerError])
+  =>  JsonSchema is Decodable in Json = json =>
     def field[value: Decodable in Json](name: Text): Optional[value] =
       json(name).as[Optional[value]]
 
     val reference = json("$ref".tt)
 
     if !reference.root.isAbsent
-    then JsonSchema.Ref(reference.as[Text], field[Text](t"description"))
+    then JsonSchema.Ref(reference.as[JsonPointer], field[Text](t"description"))
     else field[Text](t"type") match
       case t"array" =>
         JsonSchema.Array
@@ -253,9 +254,9 @@ enum JsonSchema extends Documentary:
   case Boolean(description: Optional[Text] = Unset, optional: scala.Boolean = false)
   case Null(description: Optional[Text] = Unset, optional: scala.Boolean = false)
 
-  // A JSON Reference (`{"$ref": "#/…"}`). The pointer is retained verbatim and
-  // resolved lazily by the consumer, so cyclic schema graphs stay finite.
+  // A JSON Reference (`{"$ref": "#/…"}`). The pointer is retained unresolved and
+  // dereferenced lazily by the consumer, so cyclic schema graphs stay finite.
   case Ref
-    ( pointer:     Text,
+    ( pointer:     JsonPointer,
       description: Optional[Text] = Unset,
       optional:    scala.Boolean  = false )

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -769,7 +769,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(identity)
 
       test(m"JsonPointerError reason describes itself"):
-        val err = JsonPointerError(JsonPointerError.Reason.UnknownDocument)
+        val err = JsonPointerError(JsonPointerError.Reason.UnknownDocument, 0)
         err.message.text.s.contains("registry")
       . assert(identity)
 
@@ -1088,6 +1088,33 @@ object Tests extends Suite(m"Jacinta Tests"):
           j"""[$bad*]"""
         . map(_.focus)
       . assert(_ == List("bad"))
+
+    suite(m"JSON pointer interpolator"):
+      test(m"a same-document pointer parses"):
+        jp"#/foo/bar".encode
+      . assert(_ == t"#/foo/bar")
+
+      test(m"the whole-document pointer parses"):
+        jp"#".encode
+      . assert(_ == t"#")
+
+      test(m"a pointer not beginning with '#' is rejected at the first character"):
+        demilitarize:
+          jp"/foo/bar"
+        . map(_.focus)
+      . assert(_ == List("/"))
+
+      test(m"a fragment not beginning with '/' is rejected after the '#'"):
+        demilitarize:
+          jp"#foo"
+        . map(_.focus)
+      . assert(_ == List("f"))
+
+      test(m"a malformed '~' escape is rejected at the '~'"):
+        demilitarize:
+          jp"#/foo~2bar"
+        . map(_.focus)
+      . assert(_ == List("~"))
 
     ValidationTests()
     PositionTests()

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -33,6 +33,9 @@
 package xylophone
 
 import anticipation.*
+import contextual.*
+import contingency.*
+import distillate.*
 import gossamer.*
 import prepositional.*
 import serpentine.*
@@ -62,6 +65,39 @@ object XPath extends Root("/"):
   // it directly avoids the double-slash that `t"/${path.path}"` produced.
   given XPath is Encodable in Text = path =>
     if path.path.descent.length == 0 then t"/" else path.path.encode
+
+  inline given interpolable: XPath is Interpolable:
+    transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+      ( inline insertions: Any* )
+    :   XPath =
+
+      ${xylophone.XPathInterpolator.expand[parts, origins]('insertions)}
+
+  // Parses an absolute XPath (`/`, `/root[1]/child[2]`, `/root/@attr`),
+  // reporting the offset of any error. Each step is interpreted by `parseStep`;
+  // an unrecognised (e.g. empty, or `name[x]` with a non-numeric ordinal) step
+  // is a `BadStep`.
+  given decodable: Tactic[XPathError] => XPath is Decodable in Text = text =>
+    val string = text.s
+
+    if string.isEmpty || string.charAt(0) != '/'
+    then abort(XPathError(XPathError.Reason.ExpectedSlash, 0))
+    else
+      var xpath: XPath = XPath()
+      var offset = 1
+
+      while offset < string.length do
+        val slash = string.indexOf('/', offset)
+        val end = if slash < 0 then string.length else slash
+
+        parseStep(string.substring(offset, end).nn.tt) match
+          case Left(name)       => xpath = xpath.attribute(name)
+          case Right((name, n)) => xpath = xpath.element(name, n)
+          case Unset            => abort(XPathError(XPathError.Reason.BadStep, offset))
+
+        offset = end + 1
+
+      xpath
 
   // Parse a stored descent segment back into an addressable step. Returns
   // `Right(name, ordinal)` for an element step, `Left(name)` for an

--- a/lib/xylophone/src/core/xylophone.XPathError.scala
+++ b/lib/xylophone/src/core/xylophone.XPathError.scala
@@ -32,20 +32,19 @@
                                                                                                   */
 package xylophone
 
-import language.dynamics
+import fulminate.*
 
-import scala.annotation.*
+object XPathError:
+  enum Reason(val number: Int) extends Clarification:
+    case ExpectedSlash extends Reason(1)
+    case BadStep       extends Reason(2)
 
-import anticipation.*
-import contextual.*
-import prepositional.*
+  given communicable: Reason is Communicable =
+    case Reason.ExpectedSlash => m"an XPath must begin with '/'"
+    case Reason.BadStep       => m"the path step is not a valid XPath step"
 
-export Xml.attribute
-
-extension [encodable: Encodable in Xml](value: encodable)
-  def xml: Xml = encodable.encoded(value)
-
-extension (inline context: StringContext)
-  transparent inline def x: Interpolation = interpolation[Xml](context)
-  transparent inline def xp: Interpolation = interpolation[XPath](context)
-
+// `offset` is the character index, within the path text, where the error was
+// detected; consumers (e.g. the `xp"…"` interpolator) use it to position a
+// compile-time error precisely.
+case class XPathError(reason: XPathError.Reason, offset: Int)(using Diagnostics)
+extends Error(562, reason.number)(m"the XPath was not valid because $reason")

--- a/lib/xylophone/src/core/xylophone.XPathInterpolator.scala
+++ b/lib/xylophone/src/core/xylophone.XPathInterpolator.scala
@@ -32,20 +32,57 @@
                                                                                                   */
 package xylophone
 
-import language.dynamics
-
-import scala.annotation.*
+import scala.quoted.*
 
 import anticipation.*
 import contextual.*
-import prepositional.*
+import contingency.*
+import distillate.*
+import fulminate.*
+import gigantism.*
+import rudiments.*
+import vacuous.*
 
-export Xml.attribute
+object XPathInterpolator:
+  // Reuses `XPath`'s own `Decodable` for validation: the literal is decoded at
+  // macro-expansion time and, if it fails, the `XPathError`'s offset is mapped
+  // back to a source position so the error points exactly at the offending
+  // character. Mirrors `jacinta.JsonPointerInterpolator`.
+  def expand[parts <: Tuple: Type, origins <: Tuple: Type](insertions: Expr[Seq[Any]])
+  :   Macro[XPath] =
 
-extension [encodable: Encodable in Xml](value: encodable)
-  def xml: Xml = encodable.encoded(value)
+    import quotes.reflect.*
 
-extension (inline context: StringContext)
-  transparent inline def x: Interpolation = interpolation[Xml](context)
-  transparent inline def xp: Interpolation = interpolation[XPath](context)
+    def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case _               => strings
 
+    def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
+      case '[head *: tail] => TypeRepr.of[head].dealias match
+        case AppliedType(_, ConstantType(IntConstant(start)) :: _) => start
+        case _                                                     => 0
+
+      case _ => 0
+
+    val parts = recur[parts](Nil)
+    if parts.length != 1 then halt(m"an XPath literal cannot have substitutions")
+    val raw: String = parts.head
+    val start: Int = firstOrigin[origins]
+
+    try unsafely(raw.tt.decode[XPath]) catch
+      case error: XPathError =>
+        val sourceFile = Position.ofMacroExpansion.sourceFile
+
+        val position = sourceFile.content match
+          case Some(content: String) if start > 0 && start < content.length =>
+            val upper = (start + raw.length*6 + 16).min(content.length)
+            val mapping = Interpolation.buildMapping(content.substring(start, upper).nn, raw)
+            val at = (start + mapping(error.offset.min(raw.length))).min(content.length - 1)
+            Position(sourceFile, at, (at + 1).min(content.length))
+
+          case _ =>
+            Position.ofMacroExpansion
+
+        halt(error.message, position)
+
+    '{unsafely(${Expr(raw)}.tt.decode[XPath])}

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -912,5 +912,40 @@ object Tests extends Suite(m"Xylophone tests"):
             elem(t"root", elem(t"child")),
             Header(t"1.0", Unset, Unset))
 
+    suite(m"xp\"...\" interpolator"):
+      test(m"an absolute path with ordinals parses"):
+        xp"/root[1]/child[2]".encode
+      . assert(_ == t"/root[1]/child[2]")
+
+      test(m"an attribute step parses"):
+        xp"/root[1]/@id".encode
+      . assert(_ == t"/root[1]/@id")
+
+      test(m"a step without an ordinal defaults to [1]"):
+        xp"/root/child".encode
+      . assert(_ == t"/root[1]/child[1]")
+
+      test(m"the root path parses"):
+        xp"/".encode
+      . assert(_ == t"/")
+
+      test(m"a path not beginning with '/' is rejected at the first character"):
+        demilitarize:
+          xp"root/child"
+        . map(_.focus)
+      . assert(_ == List("r"))
+
+      test(m"an empty step is rejected at the offending separator"):
+        demilitarize:
+          xp"/root//child"
+        . map(_.focus)
+      . assert(_ == List("/"))
+
+      test(m"a non-numeric ordinal is rejected"):
+        demilitarize:
+          xp"/root[x]"
+        . map(_.focus.nonEmpty)
+      . assert(_ == List(true))
+
     PositionTests()
     DecoderTests()

--- a/lib/ypsiloid/src/core/ypsiloid.YamlPath.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlPath.scala
@@ -36,8 +36,10 @@ import scala.collection.mutable as scm
 
 import anticipation.*
 import beneficence.*
+import contextual.*
 import contingency.*
 import denominative.*
+import distillate.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
@@ -77,6 +79,45 @@ object YamlPath extends Root(""):
   given YamlPath is Encodable in Text = path =>
     t"${path.url.let(_.encode).or(t"")}#${path.path}"
 
+  inline given interpolable: YamlPath is Interpolable:
+    transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+      ( inline insertions: Any* )
+    :   YamlPath =
+
+      ${ypsiloid.YamlPathInterpolator.expand[parts, origins]('insertions)}
+
+  // Parses a same-document YAML path (`#`, `#/`, `#/a/b`), reporting the offset
+  // of any error. Modelled on `jacinta.JsonPointer`'s decoder, with the same
+  // RFC 6901 escaping.
+  given decodable: Tactic[YamlPathError] => YamlPath is Decodable in Text = text =>
+    val string = text.s
+
+    if string.isEmpty || string.charAt(0) != '#'
+    then abort(YamlPathError(YamlPathError.Reason.ExpectedHash, 0))
+    else if string.length > 1 && string.charAt(1) != '/'
+    then abort(YamlPathError(YamlPathError.Reason.ExpectedSlash, 1))
+    else
+      var index = 1
+
+      while index < string.length do
+        if string.charAt(index) == '~' then
+          val next = if index + 1 < string.length then string.charAt(index + 1) else ' '
+
+          if next != '0' && next != '1'
+          then abort(YamlPathError(YamlPathError.Reason.BadEscape, index))
+
+        index += 1
+
+      val segments = text.skip(1).cut(t"/").filter(_ != t"")
+
+      // Build with root `/`, matching the derivation's `prepend`, so the
+      // slashless encoder (`#${path}`) renders `#/a/b`. The whole-document path
+      // (`#`) keeps the default empty root so it encodes back to `#`.
+      if segments.isEmpty then YamlPath()
+      else
+        val descent = segments.reverse.map(filesystem.unescape)
+        YamlPath(Unset, Path[YamlPath, YamlPath.type, Tuple]("/", descent))
+
   given divisible: YamlPath is Divisible by Text to YamlPath =
     (path, segment) => YamlPath(path.url, path.path / segment)
 
@@ -85,7 +126,7 @@ object YamlPath extends Root(""):
 
 case class YamlPath(url: Optional[HttpUrl] = Unset, path: Path on YamlPath = YamlPath):
   def apply(using registry: YamlPath.Registry)(document: Yaml): Yaml raises YamlPathError =
-    url.let(registry(_).lest(YamlPathError(YamlPathError.Reason.UnknownDocument)))
+    url.let(registry(_).lest(YamlPathError(YamlPathError.Reason.UnknownDocument, 0)))
     . or(document)
 
   def apply(ordinal: Ordinal): YamlPath = YamlPath(url, path / ordinal)

--- a/lib/ypsiloid/src/core/ypsiloid.YamlPathInterpolator.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlPathInterpolator.scala
@@ -32,23 +32,57 @@
                                                                                                   */
 package ypsiloid
 
+import scala.quoted.*
+
+import anticipation.*
+import contextual.*
+import contingency.*
+import distillate.*
 import fulminate.*
+import gigantism.*
+import rudiments.*
+import vacuous.*
 
-object YamlPathError:
-  enum Reason(val number: Int) extends Clarification:
-    case UnknownDocument extends Reason(1)
-    case ExpectedHash    extends Reason(2)
-    case ExpectedSlash   extends Reason(3)
-    case BadEscape       extends Reason(4)
+object YamlPathInterpolator:
+  // Reuses `YamlPath`'s own `Decodable` for validation: the literal is decoded
+  // at macro-expansion time and, if it fails, the `YamlPathError`'s offset is
+  // mapped back to a source position so the error points exactly at the
+  // offending character. Mirrors `jacinta.JsonPointerInterpolator`.
+  def expand[parts <: Tuple: Type, origins <: Tuple: Type](insertions: Expr[Seq[Any]])
+  :   Macro[YamlPath] =
 
-  given communicable: Reason is Communicable =
-    case Reason.UnknownDocument => m"the registry contains no document at the path's URL"
-    case Reason.ExpectedHash    => m"a YAML path must begin with '#'"
-    case Reason.ExpectedSlash   => m"a YAML path fragment must begin with '/'"
-    case Reason.BadEscape       => m"a '~' in a YAML path must be followed by '0' or '1'"
+    import quotes.reflect.*
 
-// `offset` is the character index, within the path text, where the error was
-// detected; consumers (e.g. the `yp"…"` interpolator) use it to position a
-// compile-time error precisely.
-case class YamlPathError(reason: YamlPathError.Reason, offset: Int)(using Diagnostics)
-extends Error(546, reason.number)(m"the YAML path was not valid because $reason")
+    def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case _               => strings
+
+    def firstOrigin[tuple: Type]: Int = Type.of[tuple] match
+      case '[head *: tail] => TypeRepr.of[head].dealias match
+        case AppliedType(_, ConstantType(IntConstant(start)) :: _) => start
+        case _                                                     => 0
+
+      case _ => 0
+
+    val parts = recur[parts](Nil)
+    if parts.length != 1 then halt(m"a YAML path literal cannot have substitutions")
+    val raw: String = parts.head
+    val start: Int = firstOrigin[origins]
+
+    try unsafely(raw.tt.decode[YamlPath]) catch
+      case error: YamlPathError =>
+        val sourceFile = Position.ofMacroExpansion.sourceFile
+
+        val position = sourceFile.content match
+          case Some(content: String) if start > 0 && start < content.length =>
+            val upper = (start + raw.length*6 + 16).min(content.length)
+            val mapping = Interpolation.buildMapping(content.substring(start, upper).nn, raw)
+            val at = (start + mapping(error.offset.min(raw.length))).min(content.length - 1)
+            Position(sourceFile, at, (at + 1).min(content.length))
+
+          case _ =>
+            Position.ofMacroExpansion
+
+        halt(error.message, position)
+
+    '{unsafely(${Expr(raw)}.tt.decode[YamlPath])}

--- a/lib/ypsiloid/src/core/ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/ypsiloid_core.scala
@@ -51,6 +51,7 @@ extension [entity: Encodable in Yaml](value: entity) def yaml: Yaml = value.enco
 
 extension (inline context: StringContext)
   transparent inline def y: Interpolation = interpolation[Yaml](context)
+  transparent inline def yp: Interpolation = interpolation[YamlPath](context)
 
 // AST predicates and accessors mirroring Jacinta's `Json.Ast` extensions.
 // `isObject` / `isArray` distinguish mappings (even-length flat array of

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -954,9 +954,30 @@ object Tests extends Suite(m"Ypsiloid Tests"):
       . assert(identity)
 
       test(m"YamlPathError reason describes itself"):
-        val err = YamlPathError(YamlPathError.Reason.UnknownDocument)
+        val err = YamlPathError(YamlPathError.Reason.UnknownDocument, 0)
         err.message.text.s.contains("registry")
       . assert(identity)
+
+    suite(m"yp\"...\" interpolator"):
+      test(m"a same-document path parses"):
+        yp"#/foo/bar".encode
+      . assert(_ == t"#/foo/bar")
+
+      test(m"the whole-document path parses"):
+        yp"#".encode
+      . assert(_ == t"#")
+
+      test(m"a path not beginning with '#' is rejected at the first character"):
+        demilitarize:
+          yp"/foo/bar"
+        . map(_.focus)
+      . assert(_ == List("/"))
+
+      test(m"a malformed '~' escape is rejected at the '~'"):
+        demilitarize:
+          yp"#/foo~2bar"
+        . map(_.focus)
+      . assert(_ == List("~"))
 
     suite(m"Lens"):
       import dynamicYamlAccess.enabled


### PR DESCRIPTION
This adds a new `apoplexy` module for reading OpenAPI 3.x definitions, in either JSON or YAML, into a typed in-memory model that can be navigated and is suitable for compile-time use; along the way it extends Jacinta's JSON-Schema support with JSON references (`$ref`), gives `JsonPointer` a textual decoder, and introduces compile-time-checked interpolators for JSON-pointer, YAML-path and XPath literals.

Read an OpenAPI definition with `read[OpenApi]`, which auto-detects JSON or YAML:

```scala
import apoplexy.*
val api = spec.read[OpenApi]          // spec: Text (or any readable source)
api.paths.at(t"/pets").vouch.get      // the GET operation, if present
```

Schemas reuse Jacinta's `JsonSchema`, which now models JSON references. A `$ref` decodes to `JsonSchema.Ref` holding a typed `JsonPointer`, and is resolved one hop at a time (so cyclic schemas stay finite) with `ref()`:

```scala
given OpenApi = api
val pet = JsonSchema.Ref(jp"#/components/schemas/Pet")()   // the resolved schema
```

Finally, three string interpolators produce path values that are checked at compile time, reporting a precise error focused on the offending character if the literal is malformed:

```scala
jp"#/components/schemas/Pet"   // JsonPointer (jacinta)
yp"#/spec/replicas"            // YamlPath (ypsiloid)
xp"/library/book[2]/@isbn"     // XPath (xylophone)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)