### PR TITLE
xenophile: widen the C-header grammar and read struct fields at runtime

### DIFF
--- a/lib/xenophile/res/native/xenophile/library.h
+++ b/lib/xenophile/res/native/xenophile/library.h
@@ -10,9 +10,21 @@ typedef struct Point {
   int y;
 } Point;
 
+typedef int Counter;
+
+typedef enum { LEFT, RIGHT } Direction;
+
+typedef union {
+  int i;
+  float f;
+} Number;
+
 int abs(int n);
 double pow(double base, double exponent);
 size_t strlen(const char* s);
 const char* version(void);
+int32_t identity(int32_t value);
+Counter increment(Counter c);
+Direction flip(Direction d);
 
 #endif

--- a/lib/xenophile/src/core/xenophile.ForeignExpr.scala
+++ b/lib/xenophile/src/core/xenophile.ForeignExpr.scala
@@ -36,6 +36,9 @@ import anticipation.*
 
 enum ForeignExpr:
   case Reference(name: Text)
-  case Select(target: ForeignExpr, member: Text)
+  // `owner` is the foreign type the member is selected from — needed by backends (e.g. the native
+  // evaluator) that must locate the owning type's layout to read a field; self-describing backends
+  // (e.g. JSON) ignore it.
+  case Select(target: ForeignExpr, member: Text, owner: Text)
   case Apply(target: ForeignExpr, arguments: List[ForeignExpr])
   case Literal(value: Any)

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -230,7 +230,7 @@ object Xenophile:
 
     foreignType(signature.result, originRepr).asType.absolve match
       case '[type result <: Foreign; result] =>
-        val tree = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
+        val tree = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt, ${Expr(topic.s)}.tt)}
         '{Foreign.make($tree).asInstanceOf[result]}
 
   def applied(self: Expr[Foreign], field: Expr[String], arguments: Expr[Seq[Foreign]])
@@ -261,7 +261,7 @@ object Xenophile:
     val argTrees: List[Expr[ForeignExpr]] = args.zip(parameters).map: (arg, paramType) =>
       argTree(arg, paramType, fieldName)
 
-    val target = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt)}
+    val target = '{ForeignExpr.Select($self.expr, ${Expr(fieldName.s)}.tt, ${Expr(topic.s)}.tt)}
     val tree = '{ForeignExpr.Apply($target, ${Expr.ofList(argTrees)})}
 
     foreignType(signature.result, originRepr).asType.absolve match

--- a/lib/xenophile/src/native/xenophile.CHeaderDialect.scala
+++ b/lib/xenophile/src/native/xenophile.CHeaderDialect.scala
@@ -34,18 +34,22 @@ package xenophile
 
 import anticipation.*
 import gossamer.*
+import rudiments.*
 import vacuous.*
 
 // A minimal grammar for C header files (the `extern "C"` subset that Rust's `cbindgen`, and C/C++
-// public headers, expose): `struct` definitions become navigable foreign types whose members are
-// their fields, and top-level function prototypes become members of a synthetic `"library"` type
-// representing the loaded library. Preprocessor lines and comments are skipped; the rest of C is
-// not interpreted.
+// public headers, expose): `struct`/`union` definitions become navigable foreign types whose
+// members are their fields, top-level function prototypes become members of a synthetic `"library"`
+// type, `enum`s are treated as `int`, and `typedef` aliases are resolved. Preprocessor lines and
+// comments are skipped; the rest of C is not interpreted.
 object CHeaderDialect extends Dialect:
   val library: Text = t"library"
 
   def parse(source: Text): Map[Text, Map[Text, Signature]] =
-    declarations(tokenize(source.s), Map(), Map())
+    val (structs, functions, typedefs) = declarations(tokenize(source.s), Map(), Map(), Map())
+    val all = if functions.isEmpty then structs else structs.updated(library, functions)
+
+    resolve(all, typedefs)
 
   private def punctuation(char: Char): Boolean =
     char == '{' || char == '}' || char == '(' || char == ')' || char == ';' || char == ',' ||
@@ -86,6 +90,21 @@ object CHeaderDialect extends Dialect:
     case "double" | "float" | "void" | "bool" | "_Bool"            => true
     case _                                                         => false
 
+  // Canonicalises a base type: `unsigned`/`signed` are dropped, and the width-exact fixed-width
+  // names are mapped to the primitive of the same size (so the FFM layout stays correct). Widths
+  // without a matching primitive (`int8_t`, `int16_t`, `short`) are left as-is.
+  private def canonical(words: List[String]): Text =
+    val cleaned = words.filterNot: word =>
+      word == "unsigned" || word == "signed"
+
+    val name = if cleaned.isEmpty then t"int" else cleaned.mkString(" ").tt
+
+    if name == t"int32_t" || name == t"uint32_t" then t"int"
+    else if name == t"int64_t" || name == t"uint64_t" || name == t"long long" then t"long"
+    else if name == t"intptr_t" || name == t"uintptr_t" then t"long"
+    else if name == t"size_t" || name == t"ssize_t" then t"long"
+    else name
+
   // Reads a type and an optional declarator name: `int x` → (int, "x"), `const char* s` →
   // (string, "s"), and an abstract `int` / `char*` → (…, Unset). The base type is its leading
   // keywords (`unsigned int`) or single identifier (`Point`, `size_t`), then trailing `*`s; a
@@ -116,7 +135,7 @@ object CHeaderDialect extends Dialect:
       case word :: more if isWord(word) => (word.tt, more)
       case _                            => (Unset, rest1)
 
-    val base = words.mkString(" ").tt
+    val base = canonical(words)
 
     val foreign =
       if pointers == 0 then ForeignType.Named(base)
@@ -125,40 +144,41 @@ object CHeaderDialect extends Dialect:
 
     (foreign, name, rest)
 
-  // Walks the top-level declarations, accumulating named types (`structs`) and the synthetic
-  // `"library"` type's function members (`functions`).
+  // Walks the top-level declarations, accumulating named types (`structs`), the synthetic
+  // `"library"` type's function members (`functions`), and `typedef` aliases (`typedefs`).
   private def declarations
     ( tokens:    List[String],
       structs:   Map[Text, Map[Text, Signature]],
-      functions: Map[Text, Signature] )
-  :   Map[Text, Map[Text, Signature]] =
+      functions: Map[Text, Signature],
+      typedefs:  Map[Text, ForeignType] )
+  :   (Map[Text, Map[Text, Signature]], Map[Text, Signature], Map[Text, ForeignType]) =
 
     tokens match
       case Nil =>
-        if functions.isEmpty then structs else structs.updated(library, functions)
+        (structs, functions, typedefs)
 
-      // `struct Name { … };` and `typedef struct Name? { … } Alias;`
-      case ("struct" | "typedef") :: rest =>
-        val rest1 = rest match
-          case "struct" :: more => more
-          case more             => more
+      case "typedef" :: rest =>
+        typedef(rest, structs, functions, typedefs)
 
-        rest1 match
-          case name :: "{" :: more =>
-            val (fields, after) = members(more, Map())
-            val (alias, after2) = aliasName(after)
+      case ("struct" | "union") :: name :: "{" :: more =>
+        val (fields, after) = members(more, Map())
+        declarations(skipStatement(after), structs.updated(name.tt, fields), functions, typedefs)
 
-            declarations(after2, structs.updated(alias.or(name.tt), fields), functions)
+      case ("struct" | "union") :: "{" :: more =>
+        declarations(skipStatement(skipBraces(more, 1)), structs, functions, typedefs)
 
-          case "{" :: more =>
-            val (fields, after) = members(more, Map())
-            val (alias, after2) = aliasName(after)
+      case "enum" :: rest =>
+        val (name, body) = rest match
+          case word :: "{" :: more if isWord(word) => (word.tt, more)
+          case "{" :: more                         => (Unset, more)
+          case _                                   => (Unset, rest)
 
-            alias.lay(declarations(after2, structs, functions)): name =>
-              declarations(after2, structs.updated(name, fields), functions)
+        val after = skipStatement(skipBraces(body, 1))
 
-          case _ =>
-            declarations(skipStatement(rest1), structs, functions)
+        val updated = name.lay(typedefs): word =>
+          typedefs.updated(word, ForeignType.Named(t"int"))
+
+        declarations(after, structs, functions, updated)
 
       // A top-level function prototype: `<type> <name> ( <params> ) ;`.
       case _ =>
@@ -166,18 +186,60 @@ object CHeaderDialect extends Dialect:
 
         rest match
           case "(" :: more =>
-            name.lay(declarations(skipStatement(more), structs, functions)): function =>
+            name.lay(declarations(skipStatement(more), structs, functions, typedefs)): function =>
               val (params, after) = parameters(more, Nil)
 
               declarations
                 ( skipStatement(after),
                   structs,
-                  functions.updated(function, Signature(params, result)) )
+                  functions.updated(function, Signature(params, result)),
+                  typedefs )
 
           case _ =>
-            declarations(skipStatement(tokens), structs, functions)
+            declarations(skipStatement(tokens), structs, functions, typedefs)
 
-  // Reads a struct body's fields up to the closing `}`.
+  // Handles a `typedef`: a wrapped `struct`/`union` (a named type), a wrapped `enum` (treated as
+  // `int`), or a simple `typedef <type> Alias;` alias.
+  private def typedef
+    ( tokens:    List[String],
+      structs:   Map[Text, Map[Text, Signature]],
+      functions: Map[Text, Signature],
+      typedefs:  Map[Text, ForeignType] )
+  :   (Map[Text, Map[Text, Signature]], Map[Text, Signature], Map[Text, ForeignType]) =
+
+    tokens match
+      case ("struct" | "union") :: name :: "{" :: more =>
+        val (fields, after) = members(more, Map())
+        val (alias, after2) = aliasName(after)
+        declarations(after2, structs.updated(alias.or(name.tt), fields), functions, typedefs)
+
+      case ("struct" | "union") :: "{" :: more =>
+        val (fields, after) = members(more, Map())
+        val (alias, after2) = aliasName(after)
+
+        alias.lay(declarations(after2, structs, functions, typedefs)): name =>
+          declarations(after2, structs.updated(name, fields), functions, typedefs)
+
+      case "enum" :: rest =>
+        val body = rest match
+          case _ :: "{" :: more => more
+          case "{" :: more      => more
+          case _                => rest
+
+        val (alias, after) = aliasName(skipBraces(body, 1))
+
+        val updated = alias.lay(typedefs): word =>
+          typedefs.updated(word, ForeignType.Named(t"int"))
+
+        declarations(after, structs, functions, updated)
+
+      case _ =>
+        val (kind, name, after) = declarator(tokens)
+
+        name.lay(declarations(skipStatement(tokens), structs, functions, typedefs)): alias =>
+          declarations(skipStatement(after), structs, functions, typedefs.updated(alias, kind))
+
+  // Reads a struct or union body's fields up to the closing `}`.
   private def members(tokens: List[String], acc: Map[Text, Signature])
   :   (Map[Text, Signature], List[String]) =
 
@@ -224,8 +286,36 @@ object CHeaderDialect extends Dialect:
           case ")" :: more => ((kind :: acc).reverse, more)
           case _           => (acc.reverse, skipStatement(rest))
 
+  // Resolves every `typedef` alias appearing in a type, transitively.
+  private def resolve
+    ( definitions: Map[Text, Map[Text, Signature]], typedefs: Map[Text, ForeignType] )
+  :   Map[Text, Map[Text, Signature]] =
+
+    def expand(foreign: ForeignType): ForeignType = foreign match
+      case ForeignType.Named(name) =>
+        typedefs.at(name).lay(foreign)(expand)
+
+      case ForeignType.Union(members) =>
+        ForeignType.Union(members.map(expand))
+
+      case ForeignType.Applied(constructor, arguments) =>
+        ForeignType.Applied(constructor, arguments.map(expand))
+
+    def signature(sig: Signature): Signature =
+      Signature(sig.parameters.let(_.map(expand)), expand(sig.result))
+
+    definitions.map: (name, members) =>
+      (name, members.map { (member, sig) => (member, signature(sig)) })
+
   // Skips tokens up to and including the next `;` (to recover from constructs we do not model).
   private def skipStatement(tokens: List[String]): List[String] = tokens match
     case Nil         => Nil
     case ";" :: rest => rest
     case _ :: rest   => skipStatement(rest)
+
+  // Skips a balanced `{ … }` block, given the tokens just inside the opening brace (depth 1).
+  private def skipBraces(tokens: List[String], depth: Int): List[String] = tokens match
+    case Nil         => Nil
+    case "{" :: rest => skipBraces(rest, depth + 1)
+    case "}" :: rest => if depth <= 1 then rest else skipBraces(rest, depth - 1)
+    case _ :: rest   => skipBraces(rest, depth)

--- a/lib/xenophile/src/native/xenophile.CHeaderDialect.scala
+++ b/lib/xenophile/src/native/xenophile.CHeaderDialect.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package xenophile
 
+import scala.collection.immutable.ListMap
+
 import anticipation.*
 import gossamer.*
 import rudiments.*
@@ -161,7 +163,7 @@ object CHeaderDialect extends Dialect:
         typedef(rest, structs, functions, typedefs)
 
       case ("struct" | "union") :: name :: "{" :: more =>
-        val (fields, after) = members(more, Map())
+        val (fields, after) = members(more, ListMap())
         declarations(skipStatement(after), structs.updated(name.tt, fields), functions, typedefs)
 
       case ("struct" | "union") :: "{" :: more =>
@@ -209,12 +211,12 @@ object CHeaderDialect extends Dialect:
 
     tokens match
       case ("struct" | "union") :: name :: "{" :: more =>
-        val (fields, after) = members(more, Map())
+        val (fields, after) = members(more, ListMap())
         val (alias, after2) = aliasName(after)
         declarations(after2, structs.updated(alias.or(name.tt), fields), functions, typedefs)
 
       case ("struct" | "union") :: "{" :: more =>
-        val (fields, after) = members(more, Map())
+        val (fields, after) = members(more, ListMap())
         val (alias, after2) = aliasName(after)
 
         alias.lay(declarations(after2, structs, functions, typedefs)): name =>

--- a/lib/xenophile/src/native/xenophile.Native.scala
+++ b/lib/xenophile/src/native/xenophile.Native.scala
@@ -82,11 +82,11 @@ object Native:
 
   // An evaluator that performs real FFM downcalls against the platform's default (libc) symbol
   // lookup. Each function's call descriptor is built from its signature, read by re-parsing
-  // `header`. Function application with scalar and pointer arguments and scalar results is
-  // supported; struct field reads are not yet evaluated at runtime.
+  // `header`. Function application (scalar/pointer arguments, scalar results) and struct field
+  // reads (returning the field's slice of the struct's memory) are supported.
   def evaluator(header: Text): Evaluator in Native by MemorySegment =
-    val functions =
-      CHeaderDialect.parse(header).at(CHeaderDialect.library).or(Map[Text, Signature]())
+    val definitions = CHeaderDialect.parse(header)
+    val functions = definitions.at(CHeaderDialect.library).or(Map[Text, Signature]())
 
     val linker = Linker.nativeLinker().nn
     val lookup = linker.defaultLookup().nn
@@ -129,6 +129,22 @@ object Native:
       case _ =>
         value.asInstanceOf[MemorySegment]
 
+    // The byte offset and size of a struct field, by folding over the fields in declaration order
+    // and aligning each to its layout (so it matches the C ABI for naturally-aligned structs).
+    def field(owner: Text, name: Text): (Long, Long) =
+      def recur(fields: List[(Text, Signature)], offset: Long): (Long, Long) = fields match
+        case Nil =>
+          throw RuntimeException(t"xenophile: the foreign type $owner has no field $name".s)
+
+        case (field, signature) :: rest =>
+          val memory = layout(signature.result)
+          val align = memory.byteAlignment
+          val start = (offset + align - 1)/align*align
+
+          if field == name then (start, memory.byteSize) else recur(rest, start + memory.byteSize)
+
+      recur(definitions.at(owner).or(Map[Text, Signature]()).to(List), 0L)
+
     new Evaluator:
       type Form = Native
       type Operand = MemorySegment
@@ -137,7 +153,11 @@ object Native:
         case ForeignExpr.Literal(value) =>
           value.asInstanceOf[MemorySegment]
 
-        case ForeignExpr.Apply(ForeignExpr.Select(_, function), arguments) =>
+        case ForeignExpr.Select(target, member, owner) =>
+          val (offset, size) = field(owner, member)
+          evaluate(target).asSlice(offset, size).nn
+
+        case ForeignExpr.Apply(ForeignExpr.Select(_, function, _), arguments) =>
           val signature = functions.at(function).or:
             throw RuntimeException(t"xenophile: unknown native function $function".s)
 

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -197,3 +197,29 @@ object Tests extends Suite(m"Xenophile tests"):
       test(m"a native function downcall through FFM returns the real result"):
         library.abs(-7).as[Int]
       . assert(_ == 7)
+
+      test(m"a `union` field has the field's foreign type"):
+        val number: Foreign of "Number" from Native = Foreign["Number", Native]
+        number.f.expr
+      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Number"), t"f"))
+
+      test(m"a `typedef` alias resolves to its underlying foreign type"):
+        val counter: Foreign of "int" from Native = library.increment(1)
+        counter.expr
+      . assert:
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(_)) => m == t"increment"
+          case _                                                    => false
+
+      test(m"an `enum`-typed parameter and result are treated as `int`"):
+        val direction: Foreign of "int" from Native = library.flip(0)
+        direction.expr
+      . assert:
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(_)) => m == t"flip"
+          case _                                                    => false
+
+      test(m"a fixed-width `int32_t` is canonicalised to `int`"):
+        val value: Foreign of "int" from Native = library.identity(42)
+        value.expr
+      . assert:
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(_)) => m == t"identity"
+          case _                                                    => false

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -35,7 +35,7 @@ package xenophile
 import soundness.*
 import jacinta.*
 
-import java.lang.foreign.MemorySegment
+import java.lang.foreign.{Arena, MemorySegment}, java.lang.foreign.ValueLayout.JAVA_INT
 
 import strategies.throwUnsafely
 
@@ -53,7 +53,8 @@ type NativeLibrary = Interface in Native at "/xenophile/library.h"
 
 given nativeLibrary: NativeLibrary = Interface[Native](cp"/xenophile/library.h")
 
-given Evaluator in Native by MemorySegment = Native.evaluator(t"int abs(int n);")
+given Evaluator in Native by MemorySegment =
+  Native.evaluator(t"typedef struct Point { int x; int y; } Point; int abs(int n);")
 
 object Tests extends Suite(m"Xenophile tests"):
   def run(): Unit =
@@ -63,26 +64,28 @@ object Tests extends Suite(m"Xenophile tests"):
       test(m"a member access has the precise refined static type"):
         val bar: Foreign of "Bar" from Typescript = foo.bar
         bar.expr
-      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar"))
+      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar", t"Foo"))
 
       test(m"navigate a cyclic foreign type graph"):
         val cyclic: Foreign of "Foo" from Typescript = foo.bar.qux
         cyclic.expr
-      . assert(_ == ForeignExpr.Select(ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar"), t"qux"))
+      . assert: expr =>
+          val inner = ForeignExpr.Select(ForeignExpr.Reference(t"Foo"), t"bar", t"Foo")
+          expr == ForeignExpr.Select(inner, t"qux", t"Bar")
 
     suite(m"Function application"):
       test(m"applyDynamic builds an `Apply` node typed by the method's result"):
         val greeting: Foreign of "string" from Typescript = foo.greet(t"hello")
         greeting.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, member), List(_)) => member == t"greet"
+          case ForeignExpr.Apply(ForeignExpr.Select(_, member, _), List(_)) => member == t"greet"
           case _                                                         => false
 
       test(m"a Foreign argument of the declared parameter type is accepted"):
         val linked: Foreign of "Foo" from Typescript = foo.link(foo.bar)
         linked.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(ForeignExpr.Select(_, b))) =>
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m, _), List(ForeignExpr.Select(_, b, _))) =>
             m == t"link" && b == t"bar"
 
           case _ =>
@@ -171,13 +174,13 @@ object Tests extends Suite(m"Xenophile tests"):
       test(m"a C struct field has the field's foreign type"):
         val point: Foreign of "Point" from Native = Foreign["Point", Native]
         point.x.expr
-      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Point"), t"x"))
+      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Point"), t"x", t"Point"))
 
       test(m"applying a C function builds an `Apply` node typed by its result"):
         val absolute: Foreign of "int" from Native = library.abs(5)
         absolute.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(ForeignExpr.Literal(_))) =>
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m, _), List(ForeignExpr.Literal(_))) =>
             m == t"abs"
 
           case _ =>
@@ -187,7 +190,7 @@ object Tests extends Suite(m"Xenophile tests"):
         val version: Foreign of "string" from Native = library.version()
         version.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), Nil) => m == t"version"
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m, _), Nil) => m == t"version"
           case _                                                => false
 
       test(m"passing a C argument of the wrong foreign type is a compile error"):
@@ -201,25 +204,36 @@ object Tests extends Suite(m"Xenophile tests"):
       test(m"a `union` field has the field's foreign type"):
         val number: Foreign of "Number" from Native = Foreign["Number", Native]
         number.f.expr
-      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Number"), t"f"))
+      . assert(_ == ForeignExpr.Select(ForeignExpr.Reference(t"Number"), t"f", t"Number"))
 
       test(m"a `typedef` alias resolves to its underlying foreign type"):
         val counter: Foreign of "int" from Native = library.increment(1)
         counter.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(_)) => m == t"increment"
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m, _), List(_)) => m == t"increment"
           case _                                                    => false
 
       test(m"an `enum`-typed parameter and result are treated as `int`"):
         val direction: Foreign of "int" from Native = library.flip(0)
         direction.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(_)) => m == t"flip"
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m, _), List(_)) => m == t"flip"
           case _                                                    => false
 
       test(m"a fixed-width `int32_t` is canonicalised to `int`"):
         val value: Foreign of "int" from Native = library.identity(42)
         value.expr
       . assert:
-          case ForeignExpr.Apply(ForeignExpr.Select(_, m), List(_)) => m == t"identity"
+          case ForeignExpr.Apply(ForeignExpr.Select(_, m, _), List(_)) => m == t"identity"
           case _                                                    => false
+
+      test(m"struct fields are read from native memory at their computed offsets"):
+        val segment = Arena.ofConfined().nn.allocate(8L).nn
+        segment.set(JAVA_INT, 0L, 3)
+        segment.set(JAVA_INT, 4L, 4)
+
+        val point: Foreign of "Point" from Native =
+          Foreign.make(ForeignExpr.Literal(segment)).asInstanceOf[Foreign of "Point" from Native]
+
+        (point.x.as[Int], point.y.as[Int])
+      . assert(_ == (3, 4))

--- a/lib/xenophile/src/typescript/xenophile.Typescript.scala
+++ b/lib/xenophile/src/typescript/xenophile.Typescript.scala
@@ -96,9 +96,9 @@ object Typescript:
       type Operand = Json
 
       def evaluate(expr: ForeignExpr): Json = expr match
-        case ForeignExpr.Literal(value)         => value.asInstanceOf[Json]
-        case ForeignExpr.Reference(name)        => document(name)
-        case ForeignExpr.Select(target, member) => evaluate(target)(member)
+        case ForeignExpr.Literal(value)            => value.asInstanceOf[Json]
+        case ForeignExpr.Reference(name)           => document(name)
+        case ForeignExpr.Select(target, member, _) => evaluate(target)(member)
 
         case ForeignExpr.Apply(_, _) =>
           throw RuntimeException("xenophile: a JSON document evaluator cannot apply functions")


### PR DESCRIPTION
Extends the `xenophile.native` C-header support in two directions: a wider grammar and runtime struct-field reads.

**Wider C grammar.** `CHeaderDialect` now understands more of the `extern "C"` subset that Rust's `cbindgen` and C/C++ public headers emit:

- `union`s parse like structs — their fields become navigable members;
- `enum`s are treated as `int` (the C ABI), so enum-typed parameters and results accept and return integers;
- `typedef` aliases are recorded and resolved transitively;
- the width-exact fixed-width integer names (`int32_t`/`uint32_t` → `int`, `int64_t`/`uint64_t`/`size_t`/`intptr_t` → `long`) and `unsigned`/`signed` qualifiers are canonicalised, so the existing primitive interop and FFM layouts apply. Width-inexact names (`int8_t`, `int16_t`, `short`) are left as-is rather than silently mismatching the layout.

**Runtime struct-field reads.** `ForeignExpr.Select` now records the `owner` foreign type it selects from, which the native evaluator uses to locate the owning struct's layout. It folds over the struct's fields in declaration order — aligning each field to its `ValueLayout` to match the C ABI for naturally-aligned structs — to find the field's byte offset and size, then returns that slice of the struct's `MemorySegment` for the field's `Interoperable` to decode. (Self-describing backends, like the TypeScript/JSON evaluator, ignore `owner`.)

```scala
val point: Foreign of "Point" from Native = …   // backed by a native MemorySegment
point.x.as[Int]   // reads the `x` field from the struct's memory at its computed offset
```

C-header field maps are now insertion-ordered so the computed offsets are correct.
