### PR TITLE
xenophile: load and call functions from a named shared library

### DIFF
--- a/lib/xenophile/res/native/xenophile/library.h
+++ b/lib/xenophile/res/native/xenophile/library.h
@@ -20,6 +20,7 @@ typedef union {
 } Number;
 
 int abs(int n);
+int add(int a, int b);
 double pow(double base, double exponent);
 size_t strlen(const char* s);
 const char* version(void);

--- a/lib/xenophile/src/native/xenophile.Native.scala
+++ b/lib/xenophile/src/native/xenophile.Native.scala
@@ -33,6 +33,7 @@
 package xenophile
 
 import java.lang.foreign.*, ValueLayout.*
+import java.nio.file.Path
 
 import anticipation.*
 import gossamer.*
@@ -80,16 +81,23 @@ object Native:
 
   private val address: AddressLayout = ADDRESS.nn
 
-  // An evaluator that performs real FFM downcalls against the platform's default (libc) symbol
-  // lookup. Each function's call descriptor is built from its signature, read by re-parsing
-  // `header`. Function application (scalar/pointer arguments, scalar results) and struct field
-  // reads (returning the field's slice of the struct's memory) are supported.
+  // An evaluator that resolves symbols through the platform's default (libc) lookup.
   def evaluator(header: Text): Evaluator in Native by MemorySegment =
+    evaluator(header, Linker.nativeLinker().nn.defaultLookup().nn)
+
+  // An evaluator that loads the shared library at `library` (a `.so` / `.dylib` path — e.g. a Rust
+  // crate built as a `cdylib`) for the lifetime of the JVM, resolving symbols within it.
+  def evaluator(header: Text, library: Text): Evaluator in Native by MemorySegment =
+    evaluator(header, SymbolLookup.libraryLookup(Path.of(library.s), Arena.global().nn).nn)
+
+  // The shared evaluator: it performs real FFM downcalls, building each function's call descriptor
+  // from its signature (read by re-parsing `header`) and resolving the symbol through `lookup`.
+  // Function application (scalar/pointer arguments, scalar results) and struct field reads
+  // (returning the field's slice of the struct's memory) are supported.
+  private def evaluator(header: Text, lookup: SymbolLookup): Evaluator in Native by MemorySegment =
     val definitions = CHeaderDialect.parse(header)
     val functions = definitions.at(CHeaderDialect.library).or(Map[Text, Signature]())
-
     val linker = Linker.nativeLinker().nn
-    val lookup = linker.defaultLookup().nn
 
     def layout(foreign: ForeignType): MemoryLayout = foreign match
       case ForeignType.Named(name) =>

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -36,6 +36,7 @@ import soundness.*
 import jacinta.*
 
 import java.lang.foreign.{Arena, MemorySegment}, java.lang.foreign.ValueLayout.JAVA_INT
+import java.nio.file.Files
 
 import strategies.throwUnsafely
 
@@ -237,3 +238,24 @@ object Tests extends Suite(m"Xenophile tests"):
 
         (point.x.as[Int], point.y.as[Int])
       . assert(_ == (3, 4))
+
+      // Builds a tiny C `cdylib` (the same C ABI a Rust crate's `extern "C"` API exposes), loads it
+      // by path, and calls into it — the path Scala↔Rust interop would take.
+      test(m"a function in a loaded shared library is called through FFM"):
+        val directory = Files.createTempDirectory("xenophile").nn
+        val source = directory.resolve("add.c").nn
+        Files.writeString(source, "int add(int a, int b) { return a + b; }")
+        val target = directory.resolve("libadd.so").nn
+
+        // If `cc` fails, the library is not produced and `libraryLookup` below raises, failing
+        // the test with a clear native-loading error.
+        val _ =
+          ProcessBuilder("cc", "-shared", "-fPIC", "-o", target.toString.nn, source.toString.nn)
+            .inheritIO().nn.start().nn.waitFor()
+
+        given Evaluator in Native by MemorySegment =
+          Native.evaluator(t"int add(int a, int b);", target.toString.nn.tt)
+
+        val library: Foreign of "library" from Native = Foreign["library", Native]
+        library.add(2, 3).as[Int]
+      . assert(_ == 5)


### PR DESCRIPTION
Adds the ability to load and call functions from a named shared library, the step that makes the `native` ecosystem usable for real Scala↔Rust (and C/C++) interoperability rather than only the platform's libc.

`Native.evaluator(header, library)` loads the shared library at the given `.so` / `.dylib` path through `SymbolLookup.libraryLookup` — for the lifetime of the JVM — and resolves foreign functions within it. The existing one-argument `Native.evaluator(header)` continues to use the platform's default (libc) lookup.

```scala
// `library` is a path to a compiled cdylib (e.g. from `cargo build --crate-type cdylib`)
given Evaluator in Native by MemorySegment = Native.evaluator(headerSource, library)

val lib: Foreign of "library" from Native = Foreign["library", Native]
lib.add(2, 3).as[Int]   // a real FFM downcall into the loaded library
```

The end-to-end test compiles a tiny C `cdylib` with `cc` (the same C ABI that a Rust crate's `extern "C"` API exposes), loads it by path, and calls into it — exercising the complete path from a parsed header through a typed `Foreign` value to a native downcall. The test toolchain (`cc`) is present in the CI image's `build-essential`.
