### PR TITLE
xenophile: rename the ecosystem evaluator factory to apply

### DIFF
--- a/lib/xenophile/src/native/xenophile.Native.scala
+++ b/lib/xenophile/src/native/xenophile.Native.scala
@@ -82,19 +82,19 @@ object Native:
   private val address: AddressLayout = ADDRESS.nn
 
   // An evaluator that resolves symbols through the platform's default (libc) lookup.
-  def evaluator(header: Text): Evaluator in Native by MemorySegment =
-    evaluator(header, Linker.nativeLinker().nn.defaultLookup().nn)
+  def apply(header: Text): Evaluator in Native by MemorySegment =
+    apply(header, Linker.nativeLinker().nn.defaultLookup().nn)
 
   // An evaluator that loads the shared library at `library` (a `.so` / `.dylib` path — e.g. a Rust
   // crate built as a `cdylib`) for the lifetime of the JVM, resolving symbols within it.
-  def evaluator(header: Text, library: Text): Evaluator in Native by MemorySegment =
-    evaluator(header, SymbolLookup.libraryLookup(Path.of(library.s), Arena.global().nn).nn)
+  def apply(header: Text, library: Text): Evaluator in Native by MemorySegment =
+    apply(header, SymbolLookup.libraryLookup(Path.of(library.s), Arena.global().nn).nn)
 
   // The shared evaluator: it performs real FFM downcalls, building each function's call descriptor
   // from its signature (read by re-parsing `header`) and resolving the symbol through `lookup`.
   // Function application (scalar/pointer arguments, scalar results) and struct field reads
   // (returning the field's slice of the struct's memory) are supported.
-  private def evaluator(header: Text, lookup: SymbolLookup): Evaluator in Native by MemorySegment =
+  private def apply(header: Text, lookup: SymbolLookup): Evaluator in Native by MemorySegment =
     val definitions = CHeaderDialect.parse(header)
     val functions = definitions.at(CHeaderDialect.library).or(Map[Text, Signature]())
     val linker = Linker.nativeLinker().nn

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -48,14 +48,14 @@ val document: Json =
   j"""{"Foo": {"baz": "hello", "bar": {"count": 42}, "tags": ["a", "b"], "counts": [1, 2, 3],
        "nickname": "Bob", "id": "abc123", "lookup": {"1": "one", "2": "two"}}}"""
 
-given Evaluator in Typescript by Json = Typescript.evaluator(document)
+given Evaluator in Typescript by Json = Typescript(document)
 
 type NativeLibrary = Interface in Native at "/xenophile/library.h"
 
 given nativeLibrary: NativeLibrary = Interface[Native](cp"/xenophile/library.h")
 
 given Evaluator in Native by MemorySegment =
-  Native.evaluator(t"typedef struct Point { int x; int y; } Point; int abs(int n);")
+  Native(t"typedef struct Point { int x; int y; } Point; int abs(int n);")
 
 object Tests extends Suite(m"Xenophile tests"):
   def run(): Unit =
@@ -254,7 +254,7 @@ object Tests extends Suite(m"Xenophile tests"):
             .inheritIO().nn.start().nn.waitFor()
 
         given Evaluator in Native by MemorySegment =
-          Native.evaluator(t"int add(int a, int b);", target.toString.nn.tt)
+          Native(t"int add(int a, int b);", target.toString.nn.tt)
 
         val library: Foreign of "library" from Native = Foreign["library", Native]
         library.add(2, 3).as[Int]

--- a/lib/xenophile/src/typescript/xenophile.Typescript.scala
+++ b/lib/xenophile/src/typescript/xenophile.Typescript.scala
@@ -90,7 +90,7 @@ object Typescript:
   // A backend that evaluates a `Foreign.Expression` against an in-memory JSON document:
   // references and selections navigate the document; literals yield their operand; function
   // application is unsupported (a static document has no callable members).
-  def evaluator(document: Json): Evaluator in Typescript by Json =
+  def apply(document: Json): Evaluator in Typescript by Json =
     new Evaluator:
       type Form = Typescript
       type Operand = Json


### PR DESCRIPTION
A small API tidy-up, no behaviour change: the evaluator factory on each ecosystem object is now its `apply`, so constructing an evaluator reads more naturally.

- `Typescript.evaluator(document)` → `Typescript(document)`
- `Native.evaluator(header)` → `Native(header)`
- `Native.evaluator(header, library)` → `Native(header, library)`
