### PR TITLE
parasite: fix Timeout busy-loop that pegged a CPU and hung Ethereal tests

### DIFF
--- a/lib/parasite/src/core/parasite.Timeout.scala
+++ b/lib/parasite/src/core/parasite.Timeout.scala
@@ -52,7 +52,7 @@ object Timeout:
 
     def process(expiry: juca.AtomicLong): Task[Unit] = task("timeout".tt):
       while jl.System.currentTimeMillis < expiry.get()
-      do sleep(expiry.get() - jl.System.currentTimeMillis)
+      do sleep(expiry.get())
 
       expiry.set(Long.MinValue)
       action


### PR DESCRIPTION
parasite.Timeout passed the remaining duration to sleep, which expects an absolute instant; sleep computed a negative parkNanos value and returned immediately, so the timeout's wait loop spun a core at 100% for the entire timeout window instead of sleeping. In Ethereal's idle daemon (idleTimeout = 6h) this pinned a CPU and starved the tmux-timed profanity tests, hanging the test suite. The fix passes the absolute expiry instant so the loop sleeps until expiry.

Fixed a bug where `Timeout` would busy-wait at 100% CPU for the full timeout duration rather than sleeping. Code that relies on an inactivity/idle `Timeout` — such as Ethereal's idle-daemon shutdown — no longer pegs a CPU core while waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)