### PR TITLE
xenophile: add a Wit ecosystem for WebAssembly Interface Types

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1331,7 +1331,10 @@ object xenophile extends Library:
   object native extends Component(core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(typescript, native)
+  object wit extends Component(core, jacinta.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(typescript, native, wit)
 
 object xylophone extends Library:
   object core extends Component(zephyrine.core, adversaria.core, typonym.core, hellenism.core, urticose.core, wisteria.core):

--- a/lib/xenophile/res/wit/xenophile/api.wit
+++ b/lib/xenophile/res/wit/xenophile/api.wit
@@ -1,0 +1,24 @@
+// Sample WIT (WebAssembly Component Model interface types).
+
+package example:demo@1.0.0;
+
+interface api {
+  record point {
+    x: u32,
+    y: u32,
+  }
+
+  enum color {
+    red,
+    green,
+    blue,
+  }
+
+  type id = u64;
+
+  greet: func(name: string) -> string;
+  add: func(a: s32, b: s32) -> s32;
+  origin: func() -> point;
+  tags: func() -> list<string>;
+  lookup: func(key: string) -> option<string>;
+}

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -57,6 +57,14 @@ given nativeLibrary: NativeLibrary = Interface[Native](cp"/xenophile/library.h")
 given Evaluator in Native by Memory =
   Native(t"typedef struct Point { int x; int y; } Point; int abs(int n);")
 
+type WitApi = Interface in Wit at "/xenophile/api.wit"
+
+given witApi: WitApi = Interface[Wit](cp"/xenophile/api.wit")
+
+val witDocument: Json = j"""{"point": {"x": 3, "y": 4}}"""
+
+given witEvaluator: (Evaluator in Wit by Json) = Wit(witDocument)
+
 object Tests extends Suite(m"Xenophile tests"):
   def run(): Unit =
     val foo: Foreign of "Foo" from Typescript = Foreign["Foo", Typescript]
@@ -259,3 +267,41 @@ object Tests extends Suite(m"Xenophile tests"):
         val library: Foreign of "library" from Native = Foreign["library", Native]
         library.add(2, 3).as[Int]
       . assert(_ == 5)
+
+    suite(m"Wit (WebAssembly Interface Types)"):
+      val api: Foreign of "api" from Wit = Foreign["api", Wit]
+
+      test(m"a WIT record field has the field's foreign type"):
+        val point: Foreign of "point" from Wit = Foreign["point", Wit]
+        point.x.expr
+      . assert(_ == Foreign.Expression.Select(Foreign.Expression.Reference(t"point"), t"x", t"point"))
+
+      test(m"a WIT record field decodes from the backend document"):
+        val point: Foreign of "point" from Wit = Foreign["point", Wit]
+        point.x.as[Int]
+      . assert(_ == 3)
+
+      test(m"a WIT function application is typed by its result"):
+        val sum: Foreign of "s32" from Wit = api.add(2, 3)
+        sum.expr
+      . assert:
+          case Foreign.Expression.Apply(Foreign.Expression.Select(_, m, _), List(_, _)) => m == t"add"
+          case _                                                                         => false
+
+      test(m"a WIT `list<T>` result has an `over` foreign type"):
+        val tags: Foreign of ("list" over "string") from Wit = api.tags()
+        tags.expr
+      . assert:
+          case Foreign.Expression.Apply(Foreign.Expression.Select(_, m, _), Nil) => m == t"tags"
+          case _                                                                  => false
+
+      test(m"a WIT `option<T>` result is a union with `none`"):
+        val found: Foreign of ("string" | "none") from Wit = api.lookup(t"k")
+        found.expr
+      . assert:
+          case Foreign.Expression.Apply(Foreign.Expression.Select(_, m, _), List(_)) => m == t"lookup"
+          case _                                                                      => false
+
+      test(m"passing a WIT argument of the wrong foreign type is a compile error"):
+        demilitarize(api.add(t"two", 3)).map(_.message)
+      . assert(_ == List(t"xenophile: add expects an argument of foreign type s32"))

--- a/lib/xenophile/src/wit/soundness_xenophile_wit.scala
+++ b/lib/xenophile/src/wit/soundness_xenophile_wit.scala
@@ -1,0 +1,35 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export xenophile.Wit

--- a/lib/xenophile/src/wit/xenophile.Wit.scala
+++ b/lib/xenophile/src/wit/xenophile.Wit.scala
@@ -1,0 +1,105 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import jacinta.*
+import prepositional.*
+import vacuous.*
+
+// The WIT (WebAssembly Interface Types) ecosystem. Foreign values are represented as `Json` (the
+// component model's textual value representation), grammars are read from `.wit` files by
+// `WitDialect`, and primitives map to the obvious Scala types.
+object Wit:
+  // WIT integers all canonicalise (in `WitDialect`) to `s32` (8/16/32-bit) or `s64` (64-bit), and
+  // `char` to `string`, so each Scala type maps to exactly one WIT primitive.
+  given s32: (Int is Interoperable in Wit of "s32" by Json) =
+    Interoperable[Int, Wit, "s32", Json](_.json, _.as[Int])
+
+  given s64: (Long is Interoperable in Wit of "s64" by Json) =
+    Interoperable[Long, Wit, "s64", Json](_.json, _.as[Long])
+
+  given f32: (Float is Interoperable in Wit of "f32" by Json) =
+    Interoperable[Float, Wit, "f32", Json](_.json, _.as[Float])
+
+  given f64: (Double is Interoperable in Wit of "f64" by Json) =
+    Interoperable[Double, Wit, "f64", Json](_.json, _.as[Double])
+
+  given boolean: (Boolean is Interoperable in Wit of "bool" by Json) =
+    Interoperable[Boolean, Wit, "bool", Json](_.json, _.as[Boolean])
+
+  given string: (Text is Interoperable in Wit of "string" by Json) =
+    Interoperable[Text, Wit, "string", Json](_.json, _.as[Text])
+
+  // A WIT `list<T>` maps to a Scala `List`, each element converted by its own `Interoperable`.
+  given list: [element, topic]
+  =>  ( interoperable: element is Interoperable in Wit of topic by Json )
+  =>  ( List[element] is Interoperable in Wit of ("list" over topic) by Json ) =
+    Interoperable[List[element], Wit, ("list" over topic), Json]
+      ( _.map(interoperable.operand(_)).json,
+        _.as[List[Json]].map(interoperable.value(_)) )
+
+  // WIT `none` (produced by reading `option<T>` as `T | none`) maps to the absent `Optional` value.
+  given none: (Unset.type is Interoperable in Wit of "none" by Json) =
+    Interoperable[Unset.type, Wit, "none", Json](_ => Json(Unset), _ => Unset)
+
+  // A WIT `option<T>` (read as `T | none`) maps to a Scala `Optional`. As in jacinta's own optional
+  // codecs, the `Mandatable` constraint identifies the mandatory type `inner` and ensures this
+  // instance applies only to genuine optionals, so it never competes with `inner`'s instance.
+  given optional: [inner <: value, value >: Unset.type: Mandatable to inner, topic]
+  =>  ( interoperable: inner is Interoperable in Wit of topic by Json )
+  =>  ( value is Interoperable in Wit of (topic | "none") by Json ) =
+    Interoperable[value, Wit, (topic | "none"), Json]
+      ( _.let(_.asInstanceOf[inner]).let(interoperable.operand(_)).or(Json(Unset)),
+        _.as[Optional[Json]].let(interoperable.value(_)) )
+
+  // A backend that evaluates a `Foreign.Expression` against an in-memory JSON document: references
+  // and selections navigate the document; literals yield their operand; function application is
+  // unsupported (a static document has no callable functions).
+  def apply(document: Json): Evaluator in Wit by Json =
+    new Evaluator:
+      type Form = Wit
+      type Operand = Json
+
+      def evaluate(expr: Foreign.Expression): Json = expr match
+        case Foreign.Expression.Literal(value)            => value.asInstanceOf[Json]
+        case Foreign.Expression.Reference(name)           => document(name)
+        case Foreign.Expression.Select(target, member, _) => evaluate(target)(member)
+
+        case Foreign.Expression.Apply(_, _) =>
+          throw RuntimeException("xenophile: a WIT document evaluator cannot call functions")
+
+trait Wit extends Ecosystem:
+  type Operand = Json
+  type Grammar = WitDialect.type

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -1,0 +1,279 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.collection.immutable.ListMap
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// A minimal grammar for WIT (the WebAssembly Component Model's interface-definition language).
+// `record`s become navigable foreign types whose members are their fields; an `interface`'s
+// functions become members of a type named after the interface; `enum`s and `flags` are treated as
+// `s32`; `type` aliases are resolved. `package`, `use`, `world`, `variant` and `resource`
+// declarations are recognised but their bodies are skipped. Line and block comments are ignored.
+object WitDialect extends Dialect:
+  def parse(source: Text): Map[Text, Map[Text, Signature]] =
+    val (types, typedefs) = items(tokenize(source.s), Map(), Map())
+
+    resolve(types, typedefs)
+
+  // WIT identifiers are kebab-case, so `-` is an identifier character — except in `->` (the
+  // return-type arrow). Other punctuation becomes single-character tokens; `//` and `/* … */`
+  // comments are skipped.
+  private def tokenize(source: String): List[String] =
+    def skipLine(index: Int): Int =
+      if index >= source.length || source.charAt(index) == '\n' then index + 1
+      else skipLine(index + 1)
+
+    def skipBlock(index: Int): Int =
+      if index + 1 >= source.length then source.length
+      else if source.charAt(index) == '*' && source.charAt(index + 1) == '/' then index + 2
+      else skipBlock(index + 1)
+
+    def ident(char: Char): Boolean =
+      char.isLetterOrDigit || char == '_' || char == '-'
+
+    def recur(index: Int, current: String, tokens: List[String]): List[String] =
+      val flushed = if current.isEmpty then tokens else current :: tokens
+
+      if index >= source.length then flushed.reverse else
+        val char = source.charAt(index)
+        val next = if index + 1 < source.length then source.charAt(index + 1) else ' '
+
+        if char == '/' && next == '/' then recur(skipLine(index), "", flushed)
+        else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed)
+        else if char == '-' && next == '>' then recur(index + 2, "", "->" :: flushed)
+        else if ident(char) then recur(index + 1, current + char, tokens)
+        else if char.isWhitespace then recur(index + 1, "", flushed)
+        else recur(index + 1, "", char.toString :: flushed)
+
+    recur(0, "", Nil)
+
+  // Maps WIT primitive names that share a Scala representation onto a single canonical name (so a
+  // Scala type has exactly one `Interoperable`): the 8/16/32-bit integers collapse to `s32`, the
+  // 64-bit integers to `s64`, and `char` to `string`. Floats, `bool` and `string` are unchanged.
+  private def canonical(name: String): Text = name match
+    case "s8" | "s16" | "s32" | "u8" | "u16" | "u32" => t"s32"
+    case "s64" | "u64"                               => t"s64"
+    case "char"                                      => t"string"
+    case other                                       => other.tt
+
+  // Parses a WIT type. `name<args>` is a generic application — `option<T>` becomes the union
+  // `T | none` (so it decodes to an `Optional`), and `list`/`tuple`/`result` stay applications.
+  private def typeOf(tokens: List[String]): (Foreign.Type, List[String]) = tokens match
+    case name :: "<" :: rest =>
+      val (args, after) = typeArguments(rest, Nil)
+
+      if name == "option" then args match
+        case inner :: Nil => (Foreign.Type.Union(List(inner, Foreign.Type.Named(t"none"))), after)
+        case _            => (Foreign.Type.Applied(t"option", args), after)
+      else (Foreign.Type.Applied(name.tt, args), after)
+
+    case name :: rest =>
+      (Foreign.Type.Named(canonical(name)), rest)
+
+    case Nil =>
+      (Foreign.Type.Named(t""), Nil)
+
+  private def typeArguments(tokens: List[String], acc: List[Foreign.Type])
+  :   (List[Foreign.Type], List[String]) =
+
+    tokens match
+      case ">" :: rest =>
+        (acc.reverse, rest)
+
+      case _ =>
+        val (arg, rest) = typeOf(tokens)
+
+        rest match
+          case "," :: more => typeArguments(more, arg :: acc)
+          case ">" :: more => ((arg :: acc).reverse, more)
+          case _           => (acc.reverse, skipTo(rest, t">"))
+
+  // Walks the top-level items, accumulating navigable types (records, and each interface's
+  // functions) and `type` aliases.
+  private def items
+    ( tokens:   List[String],
+      types:    Map[Text, Map[Text, Signature]],
+      typedefs: Map[Text, Foreign.Type] )
+  :   (Map[Text, Map[Text, Signature]], Map[Text, Foreign.Type]) =
+
+    tokens match
+      case Nil =>
+        (types, typedefs)
+
+      case "interface" :: name :: "{" :: rest =>
+        val (types2, typedefs2, after) = interface(rest, name.tt, types, typedefs)
+        items(after, types2, typedefs2)
+
+      case "type" :: name :: "=" :: rest =>
+        val (kind, after) = typeOf(rest)
+        items(skipTo(after, t";"), types, typedefs.updated(name.tt, kind))
+
+      case ("world" | "interface") :: _ :: "{" :: rest =>
+        items(skipBraces(rest, 1), types, typedefs)
+
+      case _ =>
+        items(skipTo(tokens, t";"), types, typedefs)
+
+  // Walks an interface body: `record`s and the interface's own functions become navigable types,
+  // `enum`/`flags` become `s32`, and `variant`/`resource` are registered as opaque types.
+  private def interface
+    ( tokens:   List[String],
+      name:     Text,
+      types:    Map[Text, Map[Text, Signature]],
+      typedefs: Map[Text, Foreign.Type] )
+  :   (Map[Text, Map[Text, Signature]], Map[Text, Foreign.Type], List[String]) =
+
+    def recur
+      ( todo:      List[String],
+        functions: Map[Text, Signature],
+        types:     Map[Text, Map[Text, Signature]],
+        typedefs:  Map[Text, Foreign.Type] )
+    :   (Map[Text, Map[Text, Signature]], Map[Text, Foreign.Type], List[String]) =
+
+      todo match
+        case "}" :: rest =>
+          (types.updated(name, functions), typedefs, rest)
+
+        case Nil =>
+          (types.updated(name, functions), typedefs, Nil)
+
+        case "record" :: record :: "{" :: rest =>
+          val (fields, after) = recordFields(rest, ListMap())
+          recur(after, functions, types.updated(record.tt, fields), typedefs)
+
+        case ("enum" | "flags") :: alias :: "{" :: rest =>
+          val updated = typedefs.updated(alias.tt, Foreign.Type.Named(t"s32"))
+          recur(skipBraces(rest, 1), functions, types, updated)
+
+        case "variant" :: variant :: "{" :: rest =>
+          val updated = types.updated(variant.tt, ListMap[Text, Signature]())
+          recur(skipBraces(rest, 1), functions, updated, typedefs)
+
+        case "type" :: alias :: "=" :: rest =>
+          val (kind, after) = typeOf(rest)
+          recur(skipTo(after, t";"), functions, types, typedefs.updated(alias.tt, kind))
+
+        case function :: ":" :: "func" :: "(" :: rest =>
+          val (parameters, after) = params(rest, Nil)
+
+          val (result, after2) = after match
+            case "->" :: more => typeOf(more)
+            case more         => (Foreign.Type.Named(t"unit"), more)
+
+          val signature = Signature(parameters, result)
+          recur(skipTo(after2, t";"), functions.updated(function.tt, signature), types, typedefs)
+
+        case _ :: rest =>
+          recur(rest, functions, types, typedefs)
+
+    recur(tokens, ListMap(), types, typedefs)
+
+  private def recordFields(tokens: List[String], acc: Map[Text, Signature])
+  :   (Map[Text, Signature], List[String]) =
+
+    tokens match
+      case "}" :: rest =>
+        (acc, rest)
+
+      case name :: ":" :: rest =>
+        val (kind, after) = typeOf(rest)
+        val updated = acc.updated(name.tt, Signature(Unset, kind))
+
+        after match
+          case "," :: more => recordFields(more, updated)
+          case _           => recordFields(after, updated)
+
+      case _ :: rest =>
+        recordFields(rest, acc)
+
+      case Nil =>
+        (acc, Nil)
+
+  private def params(tokens: List[String], acc: List[Foreign.Type])
+  :   (Optional[List[Foreign.Type]], List[String]) =
+
+    tokens match
+      case ")" :: rest =>
+        (acc.reverse, rest)
+
+      case name :: ":" :: rest =>
+        val (kind, after) = typeOf(rest)
+
+        after match
+          case "," :: more => params(more, kind :: acc)
+          case ")" :: more => ((kind :: acc).reverse, more)
+          case _           => (acc.reverse, skipTo(after, t")"))
+
+      case _ :: rest =>
+        params(rest, acc)
+
+      case Nil =>
+        (acc.reverse, Nil)
+
+  // Resolves every `type` alias appearing in a type, transitively.
+  private def resolve
+    ( definitions: Map[Text, Map[Text, Signature]], typedefs: Map[Text, Foreign.Type] )
+  :   Map[Text, Map[Text, Signature]] =
+
+    def expand(foreign: Foreign.Type): Foreign.Type = foreign match
+      case Foreign.Type.Named(name) =>
+        typedefs.at(name).lay(foreign)(expand)
+
+      case Foreign.Type.Union(members) =>
+        Foreign.Type.Union(members.map(expand))
+
+      case Foreign.Type.Applied(constructor, arguments) =>
+        Foreign.Type.Applied(constructor, arguments.map(expand))
+
+    def signature(sig: Signature): Signature =
+      Signature(sig.parameters.let(_.map(expand)), expand(sig.result))
+
+    definitions.map: (name, members) =>
+      (name, members.map { (member, sig) => (member, signature(sig)) })
+
+  // Skips tokens up to and including the next occurrence of `token`.
+  private def skipTo(tokens: List[String], token: Text): List[String] = tokens match
+    case Nil          => Nil
+    case head :: rest => if head == token.s then rest else skipTo(rest, token)
+
+  // Skips a balanced `{ … }` block, given the tokens just inside the opening brace (depth 1).
+  private def skipBraces(tokens: List[String], depth: Int): List[String] = tokens match
+    case Nil         => Nil
+    case "{" :: rest => skipBraces(rest, depth + 1)
+    case "}" :: rest => if depth <= 1 then rest else skipBraces(rest, depth - 1)
+    case _ :: rest   => skipBraces(rest, depth)


### PR DESCRIPTION
Adds a third xenophile ecosystem, `Wit`, for the WebAssembly Component Model's interface-definition language (WIT), alongside `Typescript` and `Native`. A `WitDialect` reads `.wit` syntax into the foreign-type graph, so WIT interfaces can be navigated and type-checked at compile time.

`WitDialect` parses the common WIT subset: an `interface` becomes a navigable type whose members are its functions; `record`s become field-typed foreign types; `enum`s and `flags` are treated as `s32`; `type` aliases are resolved; and types cover the primitives, `list<T>`, `option<T>` (read as `T | none`, decoding to `Optional`), `tuple<…>` and `result<…>`. The `Wit` ecosystem represents values as `Json` (the component model's textual value representation) with `Interoperable`s for the primitives and a JSON-document evaluator, mirroring `Typescript`. Integer widths canonicalise so each Scala type maps to one WIT primitive (`s32`/`s64`). A real Wasm-component runtime is future work, as the FFM evaluator was for `Native`.

```scala
given Interface in Wit at "/api.wit" = Interface[Wit](cp"/api.wit")
given Evaluator in Wit by Json = Wit(document)

val api:   Foreign of "api"   from Wit = Foreign["api", Wit]
val point: Foreign of "point" from Wit = Foreign["point", Wit]

point.x                                       // a record field, statically Foreign of "s32"
api.add(2, 3)                                 // Foreign of "s32"
api.tags()                                    // Foreign of ("list" over "string")
api.lookup(t"k")                              // Foreign of ("string" | "none")
```
