### PR TITLE
xenophile: faithful WIT enum/flags via Hypotenuse; fix interface brace-skip

### DIFF
--- a/lib/xenophile/res/wit/xenophile/api.wit
+++ b/lib/xenophile/res/wit/xenophile/api.wit
@@ -14,11 +14,29 @@ interface api {
     blue,
   }
 
+  flags permissions {
+    read,
+    write,
+  }
+
+  variant shape {
+    circle(f64),
+    rectangle(point),
+  }
+
   type id = u64;
+
+  // A resource with a method body — the parser must skip its `{ … }` and still parse the functions
+  // that follow it.
+  resource file {
+    size: func() -> u64;
+  }
 
   greet: func(name: string) -> string;
   add: func(a: s32, b: s32) -> s32;
   origin: func() -> point;
   tags: func() -> list<string>;
   lookup: func(key: string) -> option<string>;
+  shade: func() -> color;
+  caps: func() -> permissions;
 }

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -192,12 +192,28 @@ object Tests extends Suite(m"Xenophile tests"):
         point.x.expr
       . assert(_ == Foreign.Expression.Select(Foreign.Expression.Reference(t"point"), t"x", t"point"))
 
-      test(m"a WIT function with a string argument is typed by its result"):
+      // `greet` is declared after a `resource { … }` in the interface, so this also checks that the
+      // resource's braces are skipped and the functions following it are still parsed.
+      test(m"a function declared after a `resource` is typed by its result"):
         val greeting: Foreign of "string" from Wit = api.greet(t"hi")
         greeting.expr
       . assert:
           case Foreign.Expression.Apply(Foreign.Expression.Select(_, m, _), List(_)) => m == t"greet"
           case _                                                                      => false
+
+      test(m"an `enum` is the unsigned discriminant sized to its cases"):
+        val shade: Foreign of "u8" from Wit = api.shade()
+        shade.expr
+      . assert:
+          case Foreign.Expression.Apply(Foreign.Expression.Select(_, m, _), Nil) => m == t"shade"
+          case _                                                                  => false
+
+      test(m"a `flags` type is a Hypotenuse bit-vector sized to its members"):
+        val caps: Foreign of "b8" from Wit = api.caps()
+        caps.expr
+      . assert:
+          case Foreign.Expression.Apply(Foreign.Expression.Select(_, m, _), Nil) => m == t"caps"
+          case _                                                                  => false
 
       test(m"a WIT `list<T>` result has an `over` foreign type"):
         val tags: Foreign of ("list" over "string") from Wit = api.tags()

--- a/lib/xenophile/src/wit/xenophile.Wit.scala
+++ b/lib/xenophile/src/wit/xenophile.Wit.scala
@@ -51,6 +51,12 @@ object Wit:
   given u64: (U64 is Interoperable in Wit of "u64") = Interoperable[U64, Wit, "u64"]()
   given f32: (F32 is Interoperable in Wit of "f32") = Interoperable[F32, Wit, "f32"]()
   given f64: (F64 is Interoperable in Wit of "f64") = Interoperable[F64, Wit, "f64"]()
+
+  // `flags` types resolve (in `WitDialect`) to a Hypotenuse bit-vector sized to hold their members.
+  given b8: (B8 is Interoperable in Wit of "b8") = Interoperable[B8, Wit, "b8"]()
+  given b16: (B16 is Interoperable in Wit of "b16") = Interoperable[B16, Wit, "b16"]()
+  given b32: (B32 is Interoperable in Wit of "b32") = Interoperable[B32, Wit, "b32"]()
+  given b64: (B64 is Interoperable in Wit of "b64") = Interoperable[B64, Wit, "b64"]()
   given boolean: (Boolean is Interoperable in Wit of "bool") = Interoperable[Boolean, Wit, "bool"]()
   given char: (Char is Interoperable in Wit of "char") = Interoperable[Char, Wit, "char"]()
   given string: (Text is Interoperable in Wit of "string") = Interoperable[Text, Wit, "string"]()

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -141,8 +141,10 @@ object WitDialect extends Dialect:
       case _ =>
         items(skipTo(tokens, t";"), types, typedefs)
 
-  // Walks an interface body: `record`s and the interface's own functions become navigable types,
-  // `enum`/`flags` become `s32`, and `variant`/`resource` are registered as opaque types.
+  // Walks an interface body: `record`s and the interface's own functions become navigable types;
+  // an `enum` becomes the unsigned discriminant (`u8`/`u16`/`u32`) that holds its cases and `flags`
+  // a bit-vector (`b8`/`b16`/`b32`/`b64`) that holds its members; `variant` is an opaque type; and
+  // `resource`/`use` declarations are skipped (their `{ … }` bodies and statements bypassed).
   private def interface
     ( tokens:   List[String],
       name:     Text,
@@ -168,13 +170,32 @@ object WitDialect extends Dialect:
           val (fields, after) = recordFields(rest, ListMap())
           recur(after, functions, types.updated(record.tt, fields), typedefs)
 
-        case ("enum" | "flags") :: alias :: "{" :: rest =>
-          val updated = typedefs.updated(alias.tt, Foreign.Type.Named(t"s32"))
-          recur(skipBraces(rest, 1), functions, types, updated)
+        case "enum" :: alias :: "{" :: rest =>
+          val (count, after) = enumerators(rest, 0)
+          val topic = if count <= 256 then t"u8" else if count <= 65536 then t"u16" else t"u32"
+          recur(after, functions, types, typedefs.updated(alias.tt, Foreign.Type.Named(topic)))
+
+        case "flags" :: alias :: "{" :: rest =>
+          val (count, after) = enumerators(rest, 0)
+
+          val topic =
+            if count <= 8 then t"b8" else if count <= 16 then t"b16"
+            else if count <= 32 then t"b32" else t"b64"
+
+          recur(after, functions, types, typedefs.updated(alias.tt, Foreign.Type.Named(topic)))
 
         case "variant" :: variant :: "{" :: rest =>
           val updated = types.updated(variant.tt, ListMap[Text, Signature]())
           recur(skipBraces(rest, 1), functions, updated, typedefs)
+
+        case "resource" :: _ :: "{" :: rest =>
+          recur(skipBraces(rest, 1), functions, types, typedefs)
+
+        case "resource" :: _ :: ";" :: rest =>
+          recur(rest, functions, types, typedefs)
+
+        case "use" :: rest =>
+          recur(skipTo(rest, t";"), functions, types, typedefs)
 
         case "type" :: alias :: "=" :: rest =>
           val (kind, after) = typeOf(rest)
@@ -189,6 +210,11 @@ object WitDialect extends Dialect:
 
           val signature = Signature(parameters, result)
           recur(skipTo(after2, t";"), functions.updated(function.tt, signature), types, typedefs)
+
+        // Any unrecognised `{ … }` block is skipped wholesale rather than token-by-token, so its
+        // closing brace is never mistaken for the end of the interface.
+        case "{" :: rest =>
+          recur(skipBraces(rest, 1), functions, types, typedefs)
 
         case _ :: rest =>
           recur(rest, functions, types, typedefs)
@@ -269,3 +295,11 @@ object WitDialect extends Dialect:
     case "{" :: rest => skipBraces(rest, depth + 1)
     case "}" :: rest => if depth <= 1 then rest else skipBraces(rest, depth - 1)
     case _ :: rest   => skipBraces(rest, depth)
+
+  // Counts the case/flag names inside an `enum`/`flags` body (used to size the discriminant or
+  // bit-vector), returning the count and the tokens after the closing `}`.
+  private def enumerators(tokens: List[String], count: Int): (Int, List[String]) = tokens match
+    case "}" :: rest                          => (count, rest)
+    case Nil                                  => (count, Nil)
+    case name :: rest if name.head.isLetter   => enumerators(rest, count + 1)
+    case _ :: rest                            => enumerators(rest, count)


### PR DESCRIPTION
Extends WIT support using Hypotenuse's numeric and bit-vector types, and fixes an interface-parsing bug.

`enum` and `flags` are no longer both collapsed to `s32`:

- a WIT `enum` resolves to the unsigned Hypotenuse discriminant that holds its cases — `u8`, `u16` or `u32` by case count;
- a WIT `flags` resolves to a Hypotenuse bit-vector sized to its members — `b8`, `b16`, `b32` or `b64` (a bit-vector being the natural representation of a flag set).

The `B8`–`B64` interoperable markers are added alongside the existing `S8`–`U64`/`F32`/`F64`.

It also fixes a real parsing bug: a `resource { … }` (or a `use …{ … };`) declared inside an `interface` was recovered token-by-token, so its closing brace was mistaken for the end of the interface and every item declared after it was silently dropped. `resource` and `use` are now skipped explicitly, and any unrecognised `{ … }` block is brace-skipped wholesale, so declarations following them parse correctly.
