### PR TITLE
denominative: represent Interval as first-ordinal + count

### DIFF
--- a/lib/denominative/src/core/denominative.internal.scala
+++ b/lib/denominative/src/core/denominative.internal.scala
@@ -78,10 +78,11 @@ object internal:
   extension (interval: Interval)
     inline def start: Ordinal = ((interval >> 32) & 0xffffffff).toInt
 
-    inline def end: Ordinal = (interval & 0xffffffff).toInt
-    inline def contains(ordinal: Ordinal): Boolean = start <= ordinal && ordinal <= end
-    inline def size: Int = (end - start) max 0
-    inline def next: Ordinal = end + 1
+    inline def size: Int = (interval & 0xffffffff).toInt
+    inline def end: Ordinal = start + size - 1
+    inline def limit: Ordinal = start + size
+    inline def contains(ordinal: Ordinal): Boolean = start <= ordinal && ordinal < limit
+    inline def next: Ordinal = limit
     inline def previous: Ordinal = start - 1
     inline def subsequent(size: Int): Interval = end.subsequent(size)
     inline def preceding(size: Int): Interval = start.preceding(size)
@@ -108,15 +109,17 @@ object internal:
       acc
 
 
-    inline def nil: Boolean = end < start
+    inline def nil: Boolean = size == 0
 
 
   object Interval:
-    inline def initial(size: Int): Interval = size.toLong
+    inline def sized(inline start: Int, inline count: Int): Interval =
+      if count <= 0 then 0L else (start.toLong & 0xffffffffL) << 32 | (count.toLong & 0xffffffffL)
+
+    inline def initial(size: Int): Interval = sized(0, size)
     inline def apply(): Interval = 0L
 
-    inline def zerary(inline start: Int, inline end: Int): Interval =
-      (start & 0xffffffffL) << 32 | end & 0xffffffffL
+    inline def zerary(inline start: Int, inline end: Int): Interval = sized(start, end - start)
 
     inline def apply(inline start: Ordinal, inline end: Ordinal): Interval =
-      (start & 0xffffffffL) << 32 | (end + 1) & 0xffffffffL
+      sized(start.n0, end.n0 - start.n0 + 1)

--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -50,7 +50,7 @@ extension (inline cardinal: Int)
   inline def upto(ordinal: Ordinal): Interval = (ordinal - cardinal) till ordinal
 
 extension [countable: Countable](value: countable)
-  inline def gamut: Interval = Interval(Prim, (countable.size(value) - 1).z)
+  inline def gamut: Interval = Interval.initial(countable.size(value))
   inline def nil: Boolean = countable.nil(value)
 
 export denominative.internal.{Ordinal, Interval}

--- a/lib/denominative/src/test/denominative_test.scala
+++ b/lib/denominative/src/test/denominative_test.scala
@@ -54,3 +54,52 @@ object Tests extends Suite(m"Denominative Tests"):
         val full = (Prim span 3).size
         skip == full
       . assert(identity(_))
+
+    suite(m"Interval-semantics tests"):
+      test(m"span preserves the start ordinal"):
+        (Sec span 3).start
+      . assert(_ == Sec)
+
+      test(m"span sets the inclusive end ordinal"):
+        (Sec span 3).end
+      . assert(_ == Quat)
+
+      test(m"span sets the exclusive limit ordinal"):
+        (Sec span 3).limit
+      . assert(_ == Quin)
+
+      test(m"interval contains an interior ordinal"):
+        (Sec span 3).contains(Quat)
+      . assert(identity(_))
+
+      test(m"interval does not contain the limit ordinal"):
+        (Sec span 3).contains(Quin)
+      . assert(_ == false)
+
+      test(m"each iterates exactly size times"):
+        var count = 0
+        (Sec span 3).each: _ =>
+          count += 1
+        count
+      . assert(_ == 3)
+
+    suite(m"Empty-interval tests"):
+      test(m"an empty interval has zero size"):
+        (Sec till Sec).size
+      . assert(_ == 0)
+
+      test(m"an empty interval is nil"):
+        (Sec till Sec).nil
+      . assert(identity(_))
+
+      test(m"an empty interval contains no ordinals"):
+        (Quat till Quat).contains(Quat)
+      . assert(_ == false)
+
+      test(m"empty intervals at different positions are equal"):
+        (Sec till Sec) == (Sept till Sept)
+      . assert(identity(_))
+
+      test(m"the canonical empty interval equals a degenerate range"):
+        Interval() == (Quat till Quat)
+      . assert(identity(_))

--- a/lib/gossamer/src/core/gossamer.Textual.scala
+++ b/lib/gossamer/src/core/gossamer.Textual.scala
@@ -63,7 +63,7 @@ object Textual:
     def segment(text: Text, interval: Interval): Text =
       val limit = length(text)
       val start = interval.start.n0.max(0).min(limit)
-      val end = interval.end.n0.max(start).min(limit)
+      val end = interval.limit.n0.max(start).min(limit)
 
       text.s.substring(start, end).nn.tt
 

--- a/lib/gossamer/src/core/gossamer.Writing.scala
+++ b/lib/gossamer/src/core/gossamer.Writing.scala
@@ -117,7 +117,7 @@ object Writing:
     def segment(writing: Writing, interval: Interval): Writing =
       val limit = length(writing)
       val s = interval.start.n0.max(0).min(limit)
-      val e = interval.end.n0.max(s).min(limit)
+      val e = interval.limit.n0.max(s).min(limit)
       val slice = writing.text.s.substring(writing.boundaries(s), writing.boundaries(e)).nn
       Writing(slice.tt)
 

--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -188,7 +188,7 @@ object internal:
           Ascii(show.text(value).sysData)
 
         def segment(ascii: Ascii, interval: Interval): Ascii =
-          ascii.slice(interval.start.n0, interval.end.n0)
+          ascii.slice(interval.start.n0, interval.limit.n0)
 
   def ascii(context: Expr[StringContext], parts: Expr[Seq[Ascii]]): Macro[Ascii] =
     val dynamicParts: List[Expr[Ascii]] = parts.absolve match

--- a/lib/rudiments/src/core/rudiments.Segmentable.scala
+++ b/lib/rudiments/src/core/rudiments.Segmentable.scala
@@ -38,14 +38,14 @@ import prepositional.*
 
 object Segmentable:
   given indexedSeq: [element] => IndexedSeq[element] is Segmentable =
-    (sequence, interval) => sequence.slice(interval.start.n0, interval.end.n0)
+    (sequence, interval) => sequence.slice(interval.start.n0, interval.limit.n0)
 
   given iarray: [element] => IArray[element] is Segmentable =
-    (iarray, interval) => iarray.slice(interval.start.n0, interval.end.n0)
+    (iarray, interval) => iarray.slice(interval.start.n0, interval.limit.n0)
 
   given text: Text is Segmentable = (text, interval) =>
     val min = interval.start.n0.max(0)
-    val max = interval.end.n0.min(text.s.length)
+    val max = interval.limit.n0.min(text.s.length)
     text.s.substring(min, max).nn.tt
 
 trait Segmentable extends Typeclass:


### PR DESCRIPTION
`Interval` now stores its first ordinal and element count rather than its first and (ambiguously exclusive) last ordinal, removing a class of off-by-one errors and giving empty intervals a single canonical representation.

### Release notes

`Interval` is now packed as a start ordinal plus an element count. The `end` accessor returns the **inclusive** final ordinal (as documented), and a new `limit` accessor returns the **exclusive** one-past-the-end ordinal — use `limit` where you previously relied on `end` for slicing. All empty intervals are now equal regardless of where they were constructed.

```scala
val interval = Sec span 3   // ordinals 1, 2, 3
interval.start   // Sec
interval.end     // Quat  (inclusive)
interval.limit   // Quin  (exclusive)
interval.size    // 3

(Sec till Sec) == (Sept till Sept)   // true — all empties are equal
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)