### PR TITLE
synesthesia: disable the manual MCP server runner in CI

### DIFF
--- a/lib/synesthesia/src/test/synesthesia_test.scala
+++ b/lib/synesthesia/src/test/synesthesia_test.scala
@@ -34,33 +34,37 @@ package synesthesia
 
 import soundness.*
 
-import strategies.throwUnsafely
-import charEncoders.utf8
-
 object Tests extends Suite(m"Synesthesia Tests"):
   def run(): Unit =
-    test(m"Remote server"):
-      import internetAccess.enabled
-      import supervisors.global
-      import codicils.cancel
-      import httpServers.stdlib
-      import logging.silent
-      import webserverErrorPages.stackTraces
-      import classloaders.threadContext
-
-      tcp"8080".serve:
-        request.path match
-          case % /: t"mcp" =>
-            try
-              unsafely:
-                TestMcpServer.serve
-            catch case throwable: Throwable =>
-              throwable.printStackTrace()
-              ???
-
-          case _ =>
-            Http.Response(Http.NotFound)(t"Error 404: Not found")
-
-      Thread.sleep(1000000)
-
-    . assert()
+    // Manual-only MCP server runner — NOT an automated test. It serves MCP on :8080
+    // and `Thread.sleep`s to keep the server alive for an external MCP client to
+    // connect to; it asserts nothing and blocked CI for ~16 minutes. Disabled here;
+    // uncomment (and restore the `strategies.throwUnsafely` / `charEncoders.utf8`
+    // imports) to run a live server by hand.
+    //
+    // test(m"Remote server"):
+    //   import internetAccess.enabled
+    //   import supervisors.global
+    //   import codicils.cancel
+    //   import httpServers.stdlib
+    //   import logging.silent
+    //   import webserverErrorPages.stackTraces
+    //   import classloaders.threadContext
+    //
+    //   tcp"8080".serve:
+    //     request.path match
+    //       case % /: t"mcp" =>
+    //         try
+    //           unsafely:
+    //             TestMcpServer.serve
+    //         catch case throwable: Throwable =>
+    //           throwable.printStackTrace()
+    //           ???
+    //
+    //       case _ =>
+    //         Http.Response(Http.NotFound)(t"Error 404: Not found")
+    //
+    //   Thread.sleep(1000000)
+    //
+    // . assert()
+    ()


### PR DESCRIPTION
`synesthesia.Tests` contained a single "Remote server" test that started an MCP
server on :8080 and `Thread.sleep(1000000)` (~16.7 min) to keep it alive for an
external MCP client to connect to by hand. It asserts nothing and is for manual
testing only, but it ran in the automated suite — so once the suite progressed
that far, the sleep dominated CI (~16 min), hanging `make attest` for every
branch based on main. This comments it out (preserved for manual use); `run()`
is now a no-op.

(Cherry-picked from `embarcadero-containerd`, where it was first written.)