### PR TITLE
xylophone: generic `Encodable in Xml` derivation with `@attribute` support

### DIFF
--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -41,6 +41,7 @@ import scala.collection.mutable as scm
 import scala.compiletime.*
 import scala.quoted.*
 
+import adversaria.*
 import anticipation.*
 import contextual.*
 import contingency.*
@@ -247,6 +248,13 @@ object Xml extends Tag.Container
       ( using Foci[Xml.Focus], Tactic[XmlError] )
     :   derivation =
 
+      // Fields marked `@attribute` are read from the element's attributes
+      // rather than its child elements, mirroring the encoder.
+      val attributeFields: Map[Text, Set[attribute]] =
+        infer[derivation is Annotated by attribute] match
+          case annotated: Annotated.Fields => annotated.fields
+          case _                           => Map()
+
       val children: scm.HashMap[String, Element] = scm.HashMap.empty
       var i = 0
       while i < element.children.length do
@@ -268,7 +276,13 @@ object Xml extends Tag.Container
             val base = prior.let(_.path).or(XPath())
             Xml.Focus(base.prepend(fieldLabel, 1))
           }):
-            children.get(fieldLabel.s) match
+            if attributeFields.contains(fieldLabel) then
+              // `@attribute` field: decode from the matching attribute as a
+              // `TextNode`; a missing attribute falls back to the declared
+              // default, else the `Absent` sentinel (raise + continue).
+              element.attributes.at(fieldLabel).lay(default.or(context.decoded(Absent))): text =>
+                context.decoded(TextNode(text))
+            else children.get(fieldLabel.s) match
               case Some(child) => context.decoded(child)
               // Missing field: fall back to the case-class declared
               // default (Wisteria's `default`); if absent, hand the
@@ -316,10 +330,10 @@ object Xml extends Tag.Container
   // resulting element to the variant name, so it round-trips through the
   // `Discriminable`-by-label default that `disjunction` reads back.
   //
-  // `@attribute` is intentionally NOT honoured here: the decoder reads only
-  // child elements (never attributes), so writing a field as an attribute
-  // would not round-trip. Every field is emitted as a child element; the
-  // annotation stays inert in both directions.
+  // A field marked `@attribute` is written to the element's attributes rather
+  // than as a child element, and read back the same way by the decoder, so it
+  // round-trips. The annotation is read at derivation time via adversaria's
+  // `Annotated by attribute`.
   //
   // As in `DecodableDerivation`, `wisteria.label[Text]` is used in place of the
   // bare `label` identifier, which `Tag.Container`'s `label = "xml"` shadows.
@@ -337,11 +351,29 @@ object Xml extends Tag.Container
     :   derivation is Encodable in Xml =
 
       value =>
-        val children: IArray[Node] =
-          fields(value): [field] =>
-            field => wrap(wisteria.label[Text], contextual.encode(field))
+        val attributeFields: Map[Text, Set[attribute]] =
+          infer[derivation is Annotated by attribute] match
+            case annotated: Annotated.Fields => annotated.fields
+            case _                           => Map()
 
-        Element(typeName[derivation], Attributes.empty, children)
+        val attributes: scm.ArrayBuffer[(Text, Text)] = scm.ArrayBuffer()
+        val children: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
+
+        fields(value): [field] =>
+          field =>
+            val fieldLabel: Text = wisteria.label[Text]
+            val encoded: Xml = contextual.encode(field)
+
+            // `@attribute` fields become attributes carrying the encoded leaf's
+            // text; every other field becomes a child element via `wrap`.
+            if attributeFields.contains(fieldLabel)
+            then attributes += fieldLabel -> textOf(encoded).or(t"")
+            else children += wrap(fieldLabel, encoded)
+
+        Element
+         (typeName[derivation],
+          Attributes(attributes.toSeq*),
+          children.toArray.immutable(using Unsafe))
 
     inline def disjunction[derivation: SumReflection]: derivation is Encodable in Xml =
       value =>

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -194,6 +194,18 @@ object Xml extends Tag.Container
     case given Reflection[`value`] =>
       DecodableDerivation.derived
 
+  // Single entry-point for resolving `Encodable in Xml`, the exact mirror of
+  // `decodable` above. Prefers a textual encoder when one exists (so any
+  // `Encodable in Text` value — `Text`, `Int`, `Long`, user identifiers, … —
+  // becomes a leaf `TextNode`); otherwise falls back to Wisteria-derived
+  // case-class / sealed-trait encoding via `EncodableDerivation`.
+  inline given encodable: [value] => value is Encodable in Xml = summonFrom:
+    case given (`value` is Encodable in Text) =>
+      value => TextNode(value.encode)
+
+    case given Reflection[`value`] =>
+      EncodableDerivation.derived
+
   // Wisteria-based derivation for case classes (conjunction) and sealed
   // traits / enums (disjunction). Each field is decoded from the first
   // child element whose label matches the field name; sum-type variants
@@ -295,6 +307,48 @@ object Xml extends Tag.Container
                       raise(XmlError()) yet derivationDefault()
                     case _ =>
                       abort(XmlError())
+
+  // Wisteria-based encoder, the mirror of `DecodableDerivation`. A product
+  // encodes to an `Element` labelled with the type's short name (`typeName`);
+  // each field becomes a child `Element` labelled with the field name via
+  // `wrap` — the exact inverse of the decoder reading a field from the child
+  // element of that name. A sum encodes its selected variant and relabels the
+  // resulting element to the variant name, so it round-trips through the
+  // `Discriminable`-by-label default that `disjunction` reads back.
+  //
+  // `@attribute` is intentionally NOT honoured here: the decoder reads only
+  // child elements (never attributes), so writing a field as an attribute
+  // would not round-trip. Every field is emitted as a child element; the
+  // annotation stays inert in both directions.
+  //
+  // As in `DecodableDerivation`, `wisteria.label[Text]` is used in place of the
+  // bare `label` identifier, which `Tag.Container`'s `label = "xml"` shadows.
+  object EncodableDerivation extends Derivable[Encodable in Xml]:
+
+    // Relabel an encoded field value to its field name and guarantee an
+    // `Element` wrapper, so it decodes back from `<fieldName>…</fieldName>`.
+    private def wrap(fieldName: Text, encoded: Xml): Node = encoded match
+      case Element(_, attributes, children)           => Element(fieldName, attributes, children)
+      case Fragment(Element(_, attributes, children)) => Element(fieldName, attributes, children)
+      case Fragment(nodes*)                           => Element(fieldName, Attributes.empty, nodes.toArray.immutable(using Unsafe))
+      case node: Node                                 => Element(fieldName, Attributes.empty, IArray(node))
+
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Encodable in Xml =
+
+      value =>
+        val children: IArray[Node] =
+          fields(value): [field] =>
+            field => wrap(wisteria.label[Text], contextual.encode(field))
+
+        Element(typeName[derivation], Attributes.empty, children)
+
+    inline def disjunction[derivation: SumReflection]: derivation is Encodable in Xml =
+      value =>
+        val discriminable = infer[derivation is Discriminable in Xml]
+
+        variant(value): [variant <: derivation] =>
+          value => discriminable.rewrite(wisteria.label[Text], contextual.encode(value))
 
   case class attribute() extends StaticAnnotation
 
@@ -658,7 +712,7 @@ object Xml extends Tag.Container
   given comment: [content <: Label] =>  Conversion[Comment, Xml of content] =
     _.of[content]
 
-  given encodable: [value: Encodable in Xml] => Conversion[value, Xml] =
+  given xmlConversion: [value: Encodable in Xml] => Conversion[value, Xml] =
     value.encoded(_)
 
   given sequences: [nodal, xml <: Xml] => (conversion: Conversion[nodal, xml])

--- a/lib/xylophone/src/test/xylophone.EncoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.EncoderTests.scala
@@ -1,0 +1,90 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import soundness.*
+
+import strategies.throwUnsafely
+
+// The `Encodable in Xml` derivation is the exact mirror of the decoder, so the
+// fixtures (`DPerson`/`DContact`/`DShape`) are shared with `DecoderTests`. A
+// product encodes to an element named after its type; each field becomes a
+// child element named after the field; a sum encodes its variant under an
+// element named after the variant. `@attribute` is intentionally not honoured
+// (the decoder cannot read attributes back), so an `@attribute` field still
+// encodes as a child element — locked in below.
+
+object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
+  def run(): Unit =
+    given XmlSchema = XmlSchema.Freeform
+
+    suite(m"Simple product"):
+      test(m"Encode a flat case class"):
+        DPerson(t"Alice", 30, t"a@b.c").xml
+      . assert(_ == x"<DPerson><name>Alice</name><age>30</age><email>a@b.c</email></DPerson>")
+
+      test(m"Flat case class round-trips"):
+        DPerson(t"Alice", 30, t"a@b.c").xml.as[DPerson]
+      . assert(_ == DPerson(t"Alice", 30, t"a@b.c"))
+
+    suite(m"Nested product"):
+      test(m"Encode a nested case class"):
+        DContact(DPerson(t"Carol", 40, t"c@x"), t"Acme").xml
+      . assert: xml =>
+          xml == x"""<DContact><person><name>Carol</name><age>40</age><email>c@x</email></person><company>Acme</company></DContact>"""
+
+      test(m"Nested case class round-trips"):
+        DContact(DPerson(t"Carol", 40, t"c@x"), t"Acme").xml.as[DContact]
+      . assert(_ == DContact(DPerson(t"Carol", 40, t"c@x"), t"Acme"))
+
+    suite(m"Sum type by element label"):
+      test(m"Encode the Circle variant"):
+        (DShape.Circle(5): DShape).xml
+      . assert(_ == x"<Circle><radius>5</radius></Circle>")
+
+      test(m"Encode the Square variant"):
+        (DShape.Square(4): DShape).xml
+      . assert(_ == x"<Square><side>4</side></Square>")
+
+      test(m"Circle variant round-trips"):
+        (DShape.Circle(5): DShape).xml.as[DShape]
+      . assert(_ == DShape.Circle(5))
+
+      test(m"Square variant round-trips"):
+        (DShape.Square(4): DShape).xml.as[DShape]
+      . assert(_ == DShape.Square(4))
+
+    suite(m"@attribute is not honoured (locked-in behaviour)"):
+      test(m"An @attribute field still encodes as a child element"):
+        Book(t"Dune", t"0441013597").xml
+      . assert(_ == x"<Book><title>Dune</title><isbn>0441013597</isbn></Book>")

--- a/lib/xylophone/src/test/xylophone.EncoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.EncoderTests.scala
@@ -40,9 +40,9 @@ import strategies.throwUnsafely
 // fixtures (`DPerson`/`DContact`/`DShape`) are shared with `DecoderTests`. A
 // product encodes to an element named after its type; each field becomes a
 // child element named after the field; a sum encodes its variant under an
-// element named after the variant. `@attribute` is intentionally not honoured
-// (the decoder cannot read attributes back), so an `@attribute` field still
-// encodes as a child element — locked in below.
+// element named after the variant. A field marked `@attribute` (e.g. `Book`'s
+// `isbn`, defined in `xylophone_test.scala`) is written to / read from the
+// element's attributes, so it round-trips.
 
 object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
   def run(): Unit =
@@ -84,7 +84,11 @@ object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
         (DShape.Square(4): DShape).xml.as[DShape]
       . assert(_ == DShape.Square(4))
 
-    suite(m"@attribute is not honoured (locked-in behaviour)"):
-      test(m"An @attribute field still encodes as a child element"):
+    suite(m"@attribute fields"):
+      test(m"An @attribute field encodes as an attribute"):
         Book(t"Dune", t"0441013597").xml
-      . assert(_ == x"<Book><title>Dune</title><isbn>0441013597</isbn></Book>")
+      . assert(_ == x"""<Book isbn="0441013597"><title>Dune</title></Book>""")
+
+      test(m"An @attribute field round-trips"):
+        Book(t"Dune", t"0441013597").xml.as[Book]
+      . assert(_ == Book(t"Dune", t"0441013597"))

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -949,3 +949,4 @@ object Tests extends Suite(m"Xylophone tests"):
 
     PositionTests()
     DecoderTests()
+    EncoderTests()

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -42,8 +42,8 @@ import codicils.cancel
 case class Worker(name: Text, age: Int)
 case class Firm(name: Text, ceo: Worker)
 
-case class Book(title: Text, @attribute isbn: Text)
-case class Bibliography(author: Text, book: Book)
+case class Book(title: Text, @attribute isbn: Text) derives CanEqual
+case class Bibliography(author: Text, book: Book) derives CanEqual
 
 enum ColorVal:
   case Rgb(red: Int, green: Int, blue: Int)


### PR DESCRIPTION
Xylophone can now encode any case class or sealed hierarchy to XML, mirroring its
existing generic XML decoder, so a value can be round-tripped through XML without
a hand-written instance. A field annotated `@attribute` is serialised to — and
parsed back from — an element's attributes in both directions.

## Encoding to XML

A generic `Encodable in Xml` instance is now derived for products and sums, the
exact mirror of the existing `Decodable in Xml`. A product encodes to an element
named after its type, with each field as a child element named after the field; a
sealed hierarchy encodes its variant under an element named after the variant.

```scala
case class Book(title: Text, @attribute isbn: Text)

Book(t"Dune", t"0441013597").xml
// <Book isbn="0441013597"><title>Dune</title></Book>
```

A field marked `@attribute` is written to the element's attributes rather than as
a child element, and the decoder reads it back the same way, so the value
round-trips:

```scala
Book(t"Dune", t"0441013597").xml.as[Book]  // == Book(t"Dune", t"0441013597")
```

This also unblocks XML request bodies in the apoplexy OpenAPI client, whose
`invoke` macro already summons `Encodable in Xml` for the request body type.