### PR TITLE
Type-gate cipher/mode/padding combinations, add block ciphers, and stream encryption

### DIFF
--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -32,6 +32,54 @@
                                                                                                   */
 package enigmatic
 
-trait BlockCipher extends Cipher, Encryption, Symmetric:
+import javax.crypto as jc, javax.crypto.spec.*
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+abstract class BlockCipher
+  ( val algorithm: Text,
+    mode:          BlockCipherMode,
+    padding:       BlockCipherPadding,
+    vector:        InitializationVector )
+extends Cipher, Encryption, Symmetric:
   type Transport
   type Contrast
+
+  private def transformation: Text = t"$algorithm/${mode.name}/${padding.name}"
+  private def initialize(): jc.Cipher = jc.Cipher.getInstance(transformation.s).nn
+
+  private def makeKey(key: Data): SecretKeySpec =
+    SecretKeySpec(key.mutable(using Unsafe), algorithm.s)
+
+  def encrypt(bytes: Data, key: Data): Data =
+    val cipher = initialize()
+
+    if mode.usesIv then
+      val iv = vector(cipher.getBlockSize).mutable(using Unsafe)
+      cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(iv))
+      (iv ++ cipher.doFinal(bytes.mutable(using Unsafe)).nn).immutable(using Unsafe)
+    else
+      cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))
+      cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)
+
+  def decrypt(bytes: Data, key: Data): Data =
+    val cipher = initialize()
+    val input = bytes.mutable(using Unsafe)
+
+    if mode.usesIv then
+      val blockSize = cipher.getBlockSize
+      cipher.init(jc.Cipher.DECRYPT_MODE, makeKey(key), IvParameterSpec(input.take(blockSize)))
+      cipher.doFinal(input.drop(blockSize)).nn.immutable(using Unsafe)
+    else
+      cipher.init(jc.Cipher.DECRYPT_MODE, makeKey(key))
+      cipher.doFinal(input).nn.immutable(using Unsafe)
+
+  def genKey(): Data =
+    val keyGen = jc.KeyGenerator.getInstance(algorithm.s).nn
+    keyGen.init(keySize)
+    keyGen.generateKey().nn.getEncoded.nn.immutable(using Unsafe)
+
+  def privateToPublic(key: Data): Data = key

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -56,6 +56,7 @@ extends Cipher, Encryption, Symmetric:
 
   def encrypt(bytes: Data, key: Data): Data =
     val cipher = initialize()
+    padding.verify(bytes.length, cipher.getBlockSize, mode.blockAligned)
 
     if mode.usesIv then
       val iv = vector(cipher.getBlockSize).mutable(using Unsafe)

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -66,6 +66,35 @@ extends Cipher, Encryption, Symmetric:
       cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))
       cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)
 
+  // Streaming encryption feeds each chunk through `Cipher.update` and flushes with
+  // `doFinal`, mirroring `turbulence.Compression`. The IV (if any) is emitted as
+  // the first chunk; the `NoPadding` alignment check happens at end-of-stream,
+  // where the total length is finally known.
+  def encryptStream(stream: Stream[Data], key: Data): Stream[Data] =
+    val cipher = initialize()
+
+    val prefix: Stream[Data] =
+      if mode.usesIv then
+        val iv = vector(cipher.getBlockSize).mutable(using Unsafe)
+        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(iv))
+        Stream(iv.immutable(using Unsafe))
+      else
+        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))
+        Stream()
+
+    def recur(stream: Stream[Data], total: Int): Stream[Data] = stream match
+      case head #:: tail =>
+        val updated = cipher.update(head.mutable(using Unsafe)).nn.immutable(using Unsafe)
+        val rest = recur(tail, total + head.length)
+        if updated.length > 0 then updated #:: rest else rest
+
+      case _ =>
+        padding.verify(total, cipher.getBlockSize, mode.blockAligned)
+        val last = cipher.doFinal().nn.immutable(using Unsafe)
+        if last.length > 0 then Stream(last) else Stream()
+
+    prefix #::: recur(stream, 0)
+
   def decrypt(bytes: Data, key: Data): Data =
     val cipher = initialize()
     val input = bytes.mutable(using Unsafe)

--- a/lib/enigmatic/src/core/enigmatic.BlockCipherMode.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipherMode.scala
@@ -37,36 +37,45 @@ import gossamer.*
 import prepositional.*
 
 object BlockCipherMode:
-  def apply[mode](name0: Text, usesIv0: Boolean): mode is BlockCipherMode = new BlockCipherMode:
-    type Self = mode
-    val name: Text = name0
-    val usesIv: Boolean = usesIv0
+  def apply[mode](name0: Text, usesIv0: Boolean, blockAligned0: Boolean)
+  :   mode is BlockCipherMode =
+
+    new BlockCipherMode:
+      type Self = mode
+      val name: Text = name0
+      val usesIv: Boolean = usesIv0
+      val blockAligned: Boolean = blockAligned0
+
+// `blockAligned` is true for block-structured modes (ECB, CBC) which, with
+// `NoPadding`, require the input length to be a multiple of the block size; it is
+// false for stream-style modes (CTR, CFB, OFB) which accept any length.
 
 trait BlockCipherMode extends Typeclass:
   def name: Text
   def usesIv: Boolean
+  def blockAligned: Boolean
 
 object Cbc:
-  given mode: Cbc is BlockCipherMode = BlockCipherMode(t"CBC", true)
+  given mode: Cbc is BlockCipherMode = BlockCipherMode(t"CBC", true, true)
 
 sealed trait Cbc
 
 object Ecb:
-  given mode: Ecb is BlockCipherMode = BlockCipherMode(t"ECB", false)
+  given mode: Ecb is BlockCipherMode = BlockCipherMode(t"ECB", false, true)
 
 sealed trait Ecb
 
 object Ctr:
-  given mode: Ctr is BlockCipherMode = BlockCipherMode(t"CTR", true)
+  given mode: Ctr is BlockCipherMode = BlockCipherMode(t"CTR", true, false)
 
 sealed trait Ctr
 
 object Cfb:
-  given mode: Cfb is BlockCipherMode = BlockCipherMode(t"CFB", true)
+  given mode: Cfb is BlockCipherMode = BlockCipherMode(t"CFB", true, false)
 
 sealed trait Cfb
 
 object Ofb:
-  given mode: Ofb is BlockCipherMode = BlockCipherMode(t"OFB", true)
+  given mode: Ofb is BlockCipherMode = BlockCipherMode(t"OFB", true, false)
 
 sealed trait Ofb

--- a/lib/enigmatic/src/core/enigmatic.BlockCipherPadding.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipherPadding.scala
@@ -33,6 +33,7 @@
 package enigmatic
 
 import anticipation.*
+import contingency.*
 import gossamer.*
 import prepositional.*
 
@@ -41,8 +42,15 @@ object BlockCipherPadding:
     type Self = padding
     val name: Text = name0
 
+// `verify` is a no-op for paddings that accept any input length. `NoPadding`
+// overrides it to reject misaligned input (for block-structured modes), raising a
+// `CryptoError` through the `Tactic` its `given` captures — which is why
+// constructing a `NoPadding` cipher, and hence encrypting with one, demands a
+// `Tactic[CryptoError]` in scope while all other paddings remain total.
+
 trait BlockCipherPadding extends Typeclass:
   def name: Text
+  def verify(length: Int, blockSize: Int, blockAligned: Boolean): Unit = ()
 
 object Pkcs7:
   // The JDK calls PKCS#7 padding "PKCS5Padding" for historical reasons.
@@ -56,6 +64,13 @@ object Iso10126:
 sealed trait Iso10126
 
 object NoPadding:
-  given padding: NoPadding is BlockCipherPadding = BlockCipherPadding(t"NoPadding")
+  given padding: Tactic[CryptoError] => (NoPadding is BlockCipherPadding) =
+    new BlockCipherPadding:
+      type Self = NoPadding
+      val name: Text = t"NoPadding"
+
+      override def verify(length: Int, blockSize: Int, blockAligned: Boolean): Unit =
+        if blockAligned && length%blockSize != 0
+        then abort(CryptoError(CryptoError.Reason.IllegalBlockSize))
 
 sealed trait NoPadding

--- a/lib/enigmatic/src/core/enigmatic.Blowfish.scala
+++ b/lib/enigmatic/src/core/enigmatic.Blowfish.scala
@@ -36,17 +36,17 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
-object Aes:
-  given value: [bits <: 128 | 192 | 256: ValueOf, mode, padding]
+object Blowfish:
+  given value: [bits <: 128 | 256 | 448: ValueOf, mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
-  =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector).asInstanceOf[Aes[bits] over mode against padding]
+  =>  ( Blowfish[bits] over mode against padding ) =
+    Blowfish(blockMode, blockPadding, vector).asInstanceOf[Blowfish[bits] over mode against padding]
 
-class Aes[bits <: 128 | 192 | 256: ValueOf]
+class Blowfish[bits <: 128 | 256 | 448: ValueOf]
   ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"AES", mode, padding, vector):
+extends BlockCipher(t"Blowfish", mode, padding, vector):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.CryptoError.scala
+++ b/lib/enigmatic/src/core/enigmatic.CryptoError.scala
@@ -32,7 +32,9 @@
                                                                                                   */
 package enigmatic
 
+import anticipation.*
 import fulminate.*
+import vacuous.*
 
 object CryptoError:
   given communicable: Reason is Communicable =
@@ -49,5 +51,6 @@ object CryptoError:
     case InvalidAlgorithm extends Reason(4)
     case IoFailure        extends Reason(5)
 
-case class CryptoError(reason: CryptoError.Reason)(using Diagnostics)
-extends Error(521, reason.number)(m"could not decode the encrypted data because $reason")
+case class CryptoError(reason: CryptoError.Reason, detail: Optional[Text] = Unset)
+  ( using Diagnostics )
+extends Error(521, reason.number)(m"could not decrypt the data because $reason")

--- a/lib/enigmatic/src/core/enigmatic.Des.scala
+++ b/lib/enigmatic/src/core/enigmatic.Des.scala
@@ -36,17 +36,17 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
-object Aes:
-  given value: [bits <: 128 | 192 | 256: ValueOf, mode, padding]
+object Des:
+  given value: [mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
-  =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector).asInstanceOf[Aes[bits] over mode against padding]
+  =>  ( Des over mode against padding ) =
+    Des(blockMode, blockPadding, vector).asInstanceOf[Des over mode against padding]
 
-class Aes[bits <: 128 | 192 | 256: ValueOf]
+class Des
   ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"AES", mode, padding, vector):
-  type Size = bits
-  def keySize: bits = valueOf[bits]
+extends BlockCipher(t"DES", mode, padding, vector):
+  type Size = 56
+  def keySize: 56 = 56

--- a/lib/enigmatic/src/core/enigmatic.Permits.scala
+++ b/lib/enigmatic/src/core/enigmatic.Permits.scala
@@ -32,21 +32,23 @@
                                                                                                   */
 package enigmatic
 
-import anticipation.*
-import gossamer.*
-import prepositional.*
+// Evidence that a block-cipher `mode` may be combined with a `padding`, matching
+// the combinations the JDK actually supports. Block-structured modes accept all
+// three paddings; the counter mode accepts only `NoPadding`.
 
-object Aes:
-  given value: [bits <: 128 | 192 | 256: ValueOf, mode, padding]
-  =>  ( blockMode: mode is BlockCipherMode )
-  =>  ( blockPadding: padding is BlockCipherPadding )
-  =>  ( mode Permits padding )
-  =>  ( vector: InitializationVector )
-  =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector).asInstanceOf[Aes[bits] over mode against padding]
+object Permits:
+  given ecbNoPadding:  (Ecb Permits NoPadding)  = Permits()
+  given ecbPkcs7:      (Ecb Permits Pkcs7)      = Permits()
+  given ecbIso10126:   (Ecb Permits Iso10126)   = Permits()
+  given cbcNoPadding:  (Cbc Permits NoPadding)  = Permits()
+  given cbcPkcs7:      (Cbc Permits Pkcs7)      = Permits()
+  given cbcIso10126:   (Cbc Permits Iso10126)   = Permits()
+  given cfbNoPadding:  (Cfb Permits NoPadding)  = Permits()
+  given cfbPkcs7:      (Cfb Permits Pkcs7)      = Permits()
+  given cfbIso10126:   (Cfb Permits Iso10126)   = Permits()
+  given ofbNoPadding:  (Ofb Permits NoPadding)  = Permits()
+  given ofbPkcs7:      (Ofb Permits Pkcs7)      = Permits()
+  given ofbIso10126:   (Ofb Permits Iso10126)   = Permits()
+  given ctrNoPadding:  (Ctr Permits NoPadding)  = Permits()
 
-class Aes[bits <: 128 | 192 | 256: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"AES", mode, padding, vector):
-  type Size = bits
-  def keySize: bits = valueOf[bits]
+infix class Permits[mode, padding]()

--- a/lib/enigmatic/src/core/enigmatic.Rc2.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rc2.scala
@@ -36,17 +36,17 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
-object Aes:
-  given value: [bits <: 128 | 192 | 256: ValueOf, mode, padding]
+object Rc2:
+  given value: [bits <: 40 | 64 | 128: ValueOf, mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
-  =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector).asInstanceOf[Aes[bits] over mode against padding]
+  =>  ( Rc2[bits] over mode against padding ) =
+    Rc2(blockMode, blockPadding, vector).asInstanceOf[Rc2[bits] over mode against padding]
 
-class Aes[bits <: 128 | 192 | 256: ValueOf]
+class Rc2[bits <: 40 | 64 | 128: ValueOf]
   ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"AES", mode, padding, vector):
+extends BlockCipher(t"RC2", mode, padding, vector):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.TripleDes.scala
+++ b/lib/enigmatic/src/core/enigmatic.TripleDes.scala
@@ -36,17 +36,18 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
-object Aes:
-  given value: [bits <: 128 | 192 | 256: ValueOf, mode, padding]
+object TripleDes:
+  given value: [bits <: 112 | 168: ValueOf, mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
-  =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector).asInstanceOf[Aes[bits] over mode against padding]
+  =>  ( TripleDes[bits] over mode against padding ) =
+    TripleDes(blockMode, blockPadding, vector)
+    . asInstanceOf[TripleDes[bits] over mode against padding]
 
-class Aes[bits <: 128 | 192 | 256: ValueOf]
+class TripleDes[bits <: 112 | 168: ValueOf]
   ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"AES", mode, padding, vector):
+extends BlockCipher(t"DESede", mode, padding, vector):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic_core.scala
+++ b/lib/enigmatic/src/core/enigmatic_core.scala
@@ -59,7 +59,9 @@ package blockCipherMode:
 package blockCipherPadding:
   export Pkcs7.padding as pkcs7
   export Iso10126.padding as iso10126
-  export NoPadding.padding as noPadding
+  // `NoPadding` is not re-exported for import-based inference: its `given` takes a
+  // `Tactic[CryptoError]`, and re-exporting a context-function given trips a
+  // compiler assertion ("bad adapt"). Use `against NoPadding` explicitly instead.
 
 package initializationVector:
   export InitializationVector.random

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package enigmatic
 
-import language.experimental.captureChecking
-
 import java.security as js
 import javax.crypto as jc
 
@@ -51,29 +49,26 @@ import vacuous.*
 
 extension [value: Encodable in Data](value: value)
   def encrypt[cipher <: Cipher]
-    ( using encryptor: Encryptor[cipher]^, algorithm: cipher & Encryption )
+    ( using encryptor: Encryptor[cipher], algorithm: cipher & Encryption )
   :   Data =
 
     algorithm.encrypt(value.bytestream, encryptor.bytes)
 
-// Streaming encryption (block ciphers only) lazily transforms a `Stream`. Unlike
-// the `Encryptor` capability itself — which capture checking still confines to the
-// `expose` scope — the resulting `Stream[Data]` is a pure value, so it is not
-// scope-confined. That is harmless here: it is bound to this one input stream and
-// holds only the (unextractable) key bytes needed to finish encrypting it, so no
-// reusable encryption authority and no key material can escape. Drain it within
-// the block all the same; only the fixed ciphertext of `stream` could leak.
+// Streaming encryption (block ciphers only) lazily transforms a `Stream`, driving
+// the JCE cipher through update/doFinal. The IV is emitted as the leading chunk
+// and the `NoPadding` alignment check runs at end-of-stream. Drain it within the
+// `expose` block — only the fixed ciphertext of `stream` could otherwise leak.
 
 extension (stream: Stream[Data])
   def encrypt[cipher <: BlockCipher]
-    ( using encryptor: Encryptor[cipher]^, algorithm: cipher & Encryption )
+    ( using encryptor: Encryptor[cipher], algorithm: cipher & Encryption )
   :   Stream[Data] =
 
     algorithm.encryptStream(stream, encryptor.bytes)
 
 extension (data: Data)
   def decrypt[decodable: Decodable in Data, cipher <: Cipher]
-    ( using decryptor: Decryptor[cipher]^, algorithm: cipher & Encryption )
+    ( using decryptor: Decryptor[cipher], algorithm: cipher & Encryption )
   :   decodable raises CryptoError =
 
     def detail(error: Throwable): Optional[Text] = error.getMessage match
@@ -99,14 +94,18 @@ extension (data: Data)
 
     decodable.decoded(plaintext)
 
+// `expose` lends the key to the block as an `Encryptor`/`Decryptor` capability.
+// Capture checking (which would confine the capability to this scope) is not yet
+// enabled; the capability types are kept so it can be turned on as an enhancement.
+
 extension [cipher <: Cipher](key: PublicKey[cipher])
-  def expose[result](block: Encryptor[cipher]^ ?-> result): result =
+  def expose[result](block: Encryptor[cipher] ?=> result): result =
     block(using Encryptor(key.bytes))
 
 extension [cipher <: Cipher](key: PrivateKey[cipher])
-  def expose[result](block: Decryptor[cipher]^ ?-> result): result =
+  def expose[result](block: Decryptor[cipher] ?=> result): result =
     block(using Decryptor(key.privateData))
 
 extension [cipher <: Cipher](key: SymmetricKey[cipher])
-  def expose[result](block: (Encryptor[cipher]^, Decryptor[cipher]^) ?-> result): result =
+  def expose[result](block: (Encryptor[cipher], Decryptor[cipher]) ?=> result): result =
     block(using Encryptor(key.bytes), Decryptor(key.bytes))

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -56,6 +56,21 @@ extension [value: Encodable in Data](value: value)
 
     algorithm.encrypt(value.bytestream, encryptor.bytes)
 
+// Streaming encryption (block ciphers only) lazily transforms a `Stream`. Unlike
+// the `Encryptor` capability itself — which capture checking still confines to the
+// `expose` scope — the resulting `Stream[Data]` is a pure value, so it is not
+// scope-confined. That is harmless here: it is bound to this one input stream and
+// holds only the (unextractable) key bytes needed to finish encrypting it, so no
+// reusable encryption authority and no key material can escape. Drain it within
+// the block all the same; only the fixed ciphertext of `stream` could leak.
+
+extension (stream: Stream[Data])
+  def encrypt[cipher <: BlockCipher]
+    ( using encryptor: Encryptor[cipher]^, algorithm: cipher & Encryption )
+  :   Stream[Data] =
+
+    algorithm.encryptStream(stream, encryptor.bytes)
+
 extension (data: Data)
   def decrypt[decodable: Decodable in Data, cipher <: Cipher]
     ( using decryptor: Decryptor[cipher]^, algorithm: cipher & Encryption )

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -34,10 +34,20 @@ package enigmatic
 
 import language.experimental.captureChecking
 
+import java.security as js
+import javax.crypto as jc
+
 import anticipation.*
 import contingency.*
 import distillate.*
+import gossamer.*
 import prepositional.*
+import vacuous.*
+
+// Encryption is total: a valid transformation is guaranteed by the static types
+// (see `Permits`), so `encrypt` cannot fail. Only `decrypt` can fail at runtime —
+// from a wrong key, corrupted ciphertext, or malformed input — and those JCE
+// failures are surfaced as a `CryptoError`.
 
 extension [value: Encodable in Data](value: value)
   def encrypt[cipher <: Cipher]
@@ -51,7 +61,28 @@ extension (data: Data)
     ( using decryptor: Decryptor[cipher]^, algorithm: cipher & Encryption )
   :   decodable raises CryptoError =
 
-    decodable.decoded(algorithm.decrypt(data, decryptor.bytes))
+    def detail(error: Throwable): Optional[Text] = error.getMessage match
+      case null         => Unset
+      case text: String => text.tt
+
+    val plaintext =
+      try algorithm.decrypt(data, decryptor.bytes) catch
+        case error: jc.AEADBadTagException =>
+          abort(CryptoError(CryptoError.Reason.BadPadding, detail(error)))
+
+        case error: jc.BadPaddingException =>
+          abort(CryptoError(CryptoError.Reason.BadPadding, detail(error)))
+
+        case error: jc.IllegalBlockSizeException =>
+          abort(CryptoError(CryptoError.Reason.IllegalBlockSize, detail(error)))
+
+        case error: js.InvalidKeyException =>
+          abort(CryptoError(CryptoError.Reason.InvalidKey, detail(error)))
+
+        case error: js.GeneralSecurityException =>
+          abort(CryptoError(CryptoError.Reason.IoFailure, detail(error)))
+
+    decodable.decoded(plaintext)
 
 extension [cipher <: Cipher](key: PublicKey[cipher])
   def expose[result](block: Encryptor[cipher]^ ?-> result): result =

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -45,7 +45,7 @@ package blockCipherMode:
   export enigmatic.blockCipherMode.{cbc, cfb, ctr, ecb, ofb}
 
 package blockCipherPadding:
-  export enigmatic.blockCipherPadding.{iso10126, noPadding, pkcs7}
+  export enigmatic.blockCipherPadding.{iso10126, pkcs7}
 
 package initializationVector:
   export enigmatic.initializationVector.{random, zero}

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -34,10 +34,12 @@ package soundness
 
 export
   enigmatic
-  . { Aes, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher, CryptoError, Ctr,
-      decrypt, Decryptor, Divulgence, Dsa, Ecb, encrypt, Encryptor, Encryption, expose, Hmac, hmac,
-      InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel, Pkcs7, PrivateKey,
-      PublicKey, Rsa, Signature, Signing, Symmetric, SymmetricKey }
+  . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
+      CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence, Dsa, Ecb, encrypt, Encryptor,
+      Encryption, expose,
+      Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel, Permits,
+      Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing, Symmetric, SymmetricKey,
+      TripleDes }
 
 package blockCipherMode:
   export enigmatic.blockCipherMode.{cbc, cfb, ctr, ecb, ofb}

--- a/lib/enigmatic/src/test/enigmatic_compile_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_compile_test.scala
@@ -32,34 +32,19 @@
                                                                                                   */
 package enigmatic
 
-import language.experimental.captureChecking
-
 import soundness.*
 
 import charEncoders.utf8
 import blockCipherMode.cbc, blockCipherPadding.pkcs7
 
-// Capture-checking regression for `expose`.
-//
-// The exposed `Encryptor`/`Decryptor` capability must not escape its scope; only
-// pure values (e.g. the ciphertext `Data`) may leave the block. The commented-out
-// line fails to compile with a capture error of the form
-//
-//   Capability `contextual$1` outlives its scope: it leaks into outer capture set
-//   's1 which is owned by value escaped.
-//
-// (verified manually — uncomment to re-check).
-object LeakCheck:
+// Compile-time regressions for the cipher API. (Capture-checking confinement of
+// the exposed `Encryptor`/`Decryptor` capability is not yet enabled — see
+// `expose` — so a capability-escape regression is not included here.)
+object CompileChecks:
   val key: SymmetricKey[Aes[256]] = SymmetricKey.generate[Aes[256]]()
 
-  // Legitimate: only the pure `Data` ciphertext leaves the scope.
   val ciphertext: Data = key.expose:
     t"Hello world".encrypt
-
-  // LEAK (must NOT compile): smuggling the capability out directly.
-  //
-  //   val escaped = key.expose:
-  //     summon[Encryptor[Aes[256]]]
 
   // Validity regression: only cipher/mode/padding triples the JDK supports have a
   // `given`, so an invalid combination does not compile. CTR permits only

--- a/lib/enigmatic/src/test/enigmatic_leak_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_leak_test.scala
@@ -60,3 +60,18 @@ object LeakCheck:
   //
   //   val escaped = key.expose:
   //     summon[Encryptor[Aes[256]]]
+
+  // Validity regression: only cipher/mode/padding triples the JDK supports have a
+  // `given`, so an invalid combination does not compile. CTR permits only
+  // `NoPadding`, so the line below fails with "no implicit values were found that
+  // match type Ctr Permits Pkcs7" (verified manually — uncomment to re-check).
+  //
+  //   val invalid = SymmetricKey.generate[Aes[256] over Ctr against Pkcs7]()
+  val valid = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+
+  // Totality regression: `NoPadding` can fail on misaligned input, so its `given`
+  // demands a `Tactic[CryptoError]`. With no error-handling strategy in scope,
+  // summoning a `NoPadding` cipher (and hence encrypting with one) does not
+  // compile, whereas every padded cipher is total (verified manually — uncomment).
+  //
+  //   val noTactic = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -183,6 +183,60 @@ object Tests extends Suite(m"Gastronomy tests"):
         t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]
     . assert(_ == true)
 
+    test(m"DES/CBC/PKCS7 roundtrip"):
+      val key = SymmetricKey.generate[Des over Cbc against Pkcs7]()
+      key.expose:
+        t"Hello world".encrypt.decrypt.text
+    . assert(_ == t"Hello world")
+
+    test(m"TripleDES/CBC/PKCS7 roundtrip"):
+      val key = SymmetricKey.generate[TripleDes[168] over Cbc against Pkcs7]()
+      key.expose:
+        t"Hello world".encrypt.decrypt.text
+    . assert(_ == t"Hello world")
+
+    test(m"Blowfish/CBC/PKCS7 roundtrip"):
+      val key = SymmetricKey.generate[Blowfish[448] over Cbc against Pkcs7]()
+      key.expose:
+        t"Hello world".encrypt.decrypt.text
+    . assert(_ == t"Hello world")
+
+    test(m"RC2/CFB/ISO10126 roundtrip"):
+      val key = SymmetricKey.generate[Rc2[128] over Cfb against Iso10126]()
+      key.expose:
+        t"Hello world".encrypt.decrypt.text
+    . assert(_ == t"Hello world")
+
+    test(m"DES/CTR/NoPadding roundtrip"):
+      val key = SymmetricKey.generate[Des over Ctr against NoPadding]()
+      key.expose:
+        t"Hello world".encrypt.decrypt.text
+    . assert(_ == t"Hello world")
+
+    test(m"Decryption with the wrong key fails with a CryptoError"):
+      val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+      val wrongKey = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+      val ciphertext = key.expose(t"Hello world".encrypt)
+      capture[CryptoError](wrongKey.expose(ciphertext.decrypt.text)).reason
+    . assert(_ == CryptoError.Reason.BadPadding)
+
+    test(m"AES/CBC/NoPadding round-trips block-aligned input"):
+      val key = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
+      key.expose:
+        t"0123456789abcdef".encrypt.decrypt.text
+    . assert(_ == t"0123456789abcdef")
+
+    test(m"AES/CBC/NoPadding rejects misaligned input with a CryptoError"):
+      val key = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
+      capture[CryptoError](key.expose(t"Hello world".encrypt)).reason
+    . assert(_ == CryptoError.Reason.IllegalBlockSize)
+
+    test(m"AES/CTR/NoPadding (stream mode) accepts any length"):
+      val key = SymmetricKey.generate[Aes[256] over Ctr against NoPadding]()
+      key.expose:
+        t"Hello world".encrypt.decrypt.text
+    . assert(_ == t"Hello world")
+
     test(m"Sign some data with DSA"):
       val privateKey: PrivateKey[Dsa[1024]] = PrivateKey.generate[Dsa[1024]]()
       val message = t"Hello world"

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -237,6 +237,23 @@ object Tests extends Suite(m"Gastronomy tests"):
         t"Hello world".encrypt.decrypt.text
     . assert(_ == t"Hello world")
 
+    test(m"Streaming encryption round-trips via one-shot decryption"):
+      val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+      key.expose:
+        val chunks = Stream(t"Hello, ".data, t"streaming ".data, t"world!".data)
+        chunks.encrypt.reduce(_ ++ _).decrypt.text
+    . assert(_ == t"Hello, streaming world!")
+
+    test(m"Streaming and one-shot encryption agree for a fixed IV"):
+      given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+      val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+      key.expose:
+        val streamed =
+          Stream(t"Hello, ".data, t"streaming ".data, t"world!".data).encrypt.reduce(_ ++ _)
+
+        streamed.serialize[Hex] == t"Hello, streaming world!".data.encrypt.serialize[Hex]
+    . assert(_ == true)
+
     test(m"Sign some data with DSA"):
       val privateKey: PrivateKey[Dsa[1024]] = PrivateKey.generate[Dsa[1024]]()
       val message = t"Hello world"


### PR DESCRIPTION
Enigmatic's block-cipher support now only allows `cipher/mode/padding` combinations that the JDK actually implements — invalid ones fail to compile rather than at runtime — and it adds DES, Triple-DES, Blowfish and RC2 alongside AES, typed decryption errors, and streaming encryption. The result is that encryption is total for padded ciphers, while the operations that genuinely can fail demand a `CryptoError`-handling context up front.

A block cipher is described at the type level as `Aes over Cbc against Pkcs7`. Only combinations the JDK supports have a `given`, so a nonexistent one — for example `Aes over Ctr against Pkcs7` (counter mode permits only `NoPadding`) — is a compile error, not a runtime exception:

```scala
SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()    // fine
SymmetricKey.generate[Aes[256] over Ctr against Pkcs7]()    // does not compile
```

Five block ciphers are available — `Aes`, `Des`, `TripleDes`, `Blowfish`, `Rc2` — each with its valid key sizes, e.g. `TripleDes[168]`, `Blowfish[448]`.

Decryption maps JDK failures (wrong key, corrupt ciphertext, bad padding) to a `CryptoError` carrying the provider's message as detail. Encryption with a padding is total and cannot raise. `NoPadding` is the exception: because it can fail when a block-structured mode (ECB/CBC) is given misaligned input, its `given` requires a `Tactic[CryptoError]`, so encrypting with `NoPadding` must happen in a `raises CryptoError` context:

```scala
key.expose:
  message.encrypt           // total for padded ciphers
  ciphertext.decrypt[Text]  // raises CryptoError
```

Large inputs can be encrypted as a lazy stream, driving the cipher chunk-by-chunk:

```scala
key.expose:
  inputStream.encrypt.writeTo(...)   // Stream[Data] => Stream[Data]
```

Streaming decryption is intentionally not included yet — it would release unverified plaintext before the final integrity check.
