### PR TITLE
apoplexy: a typed OpenAPI HTTP client

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -403,7 +403,8 @@ object anticipation extends Library:
   object test extends Tests
 
 object apoplexy extends Library:
-  object core extends Component(jacinta.schema, ypsiloid.core, telekinesis.core, fulminate.core):
+  object core extends Component(jacinta.schema, jacinta.http, ypsiloid.core, telekinesis.core,
+    urticose.core, legerdemain.core, hellenism.core, fulminate.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -404,7 +404,7 @@ object anticipation extends Library:
 
 object apoplexy extends Library:
   object core extends Component(jacinta.schema, jacinta.http, ypsiloid.core, telekinesis.core,
-    urticose.core, legerdemain.core, hellenism.core, fulminate.core):
+    urticose.core, legerdemain.core, hellenism.core, fulminate.core, xylophone.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/apoplexy/res/core/apoplexy/petstore.json
+++ b/lib/apoplexy/res/core/apoplexy/petstore.json
@@ -1,0 +1,189 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Petstore", "version": "1.0.0" },
+  "servers": [{ "url": "https://api.example.com/v1" }],
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "listPets",
+        "parameters": [
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer" } },
+          { "name": "tag",   "in": "query", "required": false, "schema": { "type": "string"  } }
+        ],
+        "responses": {
+          "200": {
+            "description": "a list of pets",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Pet" } }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPet",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NewPet" } }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "created",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "operationId": "getPet",
+        "parameters": [
+          { "name": "petId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "a pet",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "replacePet",
+        "parameters": [
+          { "name": "petId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NewPet" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "replaced",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deletePet",
+        "parameters": [
+          { "name": "petId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": { "204": { "description": "deleted" } }
+      }
+    },
+    "/pets/{petId}/photos": {
+      "get": {
+        "operationId": "listPhotos",
+        "parameters": [
+          { "name": "petId",  "in": "path",  "required": true,  "schema": { "type": "integer" } },
+          { "name": "width",  "in": "query", "required": true,  "schema": { "type": "integer" } },
+          { "name": "height", "in": "query", "required": false, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "photos",
+            "content": {
+              "application/json": {
+                "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Photo" } }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "operationId": "login",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/Credentials" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "a session token",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Token" } }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{token}": {
+      "delete": {
+        "operationId": "logout",
+        "parameters": [
+          { "name": "token", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "204": { "description": "logged out" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NewPet": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "tag":  { "type": "string" }
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id":    { "type": "integer" },
+          "name":  { "type": "string" },
+          "tag":   { "type": "string" },
+          "owner": { "$ref": "#/components/schemas/Owner" }
+        }
+      },
+      "Owner": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "pet":  { "$ref": "#/components/schemas/Pet" }
+        }
+      },
+      "Photo": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url":    { "type": "string" },
+          "width":  { "type": "integer" },
+          "height": { "type": "integer" }
+        }
+      },
+      "Credentials": {
+        "type": "object",
+        "required": ["username", "password"],
+        "properties": {
+          "username": { "type": "string" },
+          "password": { "type": "string" }
+        }
+      },
+      "Token": {
+        "type": "object",
+        "required": ["token"],
+        "properties": {
+          "token":   { "type": "string" },
+          "expires": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/lib/apoplexy/res/core/apoplexy/petstore.json
+++ b/lib/apoplexy/res/core/apoplexy/petstore.json
@@ -121,6 +121,25 @@
         }
       }
     },
+    "/profile": {
+      "put": {
+        "operationId": "updateProfile",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": { "schema": { "$ref": "#/components/schemas/NewPet" } }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "updated",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Pet" } }
+            }
+          }
+        }
+      }
+    },
     "/sessions/{token}": {
       "delete": {
         "operationId": "logout",

--- a/lib/apoplexy/res/core/apoplexy/petstore.json
+++ b/lib/apoplexy/res/core/apoplexy/petstore.json
@@ -129,6 +129,12 @@
         ],
         "responses": { "204": { "description": "logged out" } }
       }
+    },
+    "/logout": {
+      "delete": {
+        "operationId": "logoutAll",
+        "responses": { "204": { "description": "logged out everywhere" } }
+      }
     }
   },
   "components": {

--- a/lib/apoplexy/res/core/apoplexy/xmlstore.json
+++ b/lib/apoplexy/res/core/apoplexy/xmlstore.json
@@ -1,0 +1,35 @@
+{
+  "openapi": "3.0.3",
+  "info": { "title": "Notes", "version": "1.0.0" },
+  "servers": [{ "url": "https://xml.example.com" }],
+  "paths": {
+    "/notes/{id}": {
+      "get": {
+        "operationId": "getNote",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "a note",
+            "content": {
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Note" } }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Note": {
+        "type": "object",
+        "required": ["id", "text"],
+        "properties": {
+          "id":   { "type": "integer" },
+          "text": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/lib/apoplexy/res/core/apoplexy/xmlstore.json
+++ b/lib/apoplexy/res/core/apoplexy/xmlstore.json
@@ -18,6 +18,25 @@
           }
         }
       }
+    },
+    "/notes": {
+      "post": {
+        "operationId": "addNote",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/xml": { "schema": { "$ref": "#/components/schemas/NewNote" } }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "created",
+            "content": {
+              "application/xml": { "schema": { "$ref": "#/components/schemas/Note" } }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -27,6 +46,13 @@
         "required": ["id", "text"],
         "properties": {
           "id":   { "type": "integer" },
+          "text": { "type": "string" }
+        }
+      },
+      "NewNote": {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
           "text": { "type": "string" }
         }
       }

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -1,0 +1,101 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import language.dynamics
+
+import anticipation.*
+import fulminate.*
+import hellenism.*
+import jacinta.*
+import prepositional.*
+import telekinesis.*
+import vacuous.*
+
+object Api:
+  // Root constructor: `Api(cp"/spec.json")` reads the spec resource's `Locus`,
+  // validates the spec at compile time, and returns `Api at "/"` carrying the
+  // spec source so navigation macros can re-read it.
+  transparent inline def apply(inline resource: Resource): Any = ${Apoplexy.root('resource)}
+
+  def make(apiRequest: Api.Request): Api = new Api:
+    def request: Api.Request = apiRequest
+
+  // The runtime description of a navigated/invoked call. `base` is the server
+  // URL from the spec; `path` is the still-templated path; `substitutions`
+  // binds path templates to concrete values; `query` is the query string;
+  // `body` is an optional JSON request body.
+  case class Request
+    ( method:        Http.Method,
+      base:          Text,
+      path:          Text,
+      substitutions: Map[Text, Text]    = Map(),
+      query:         List[(Text, Text)] = Nil,
+      body:          Optional[Json]     = Unset )
+
+  // The result of invoking an endpoint. Its refined type records `Result` (a
+  // JSON-pointer to the 2xx response schema) and `Form` (the spec source),
+  // which `as` reads to check a target type for conformance against the schema.
+  object Response:
+    def make(apiRequest: Api.Request): Api.Response = new Api.Response:
+      def request: Api.Request = apiRequest
+
+  trait Response:
+    type Result
+    type Form
+    def request: Api.Request
+
+    transparent inline def as[value]: value = ${Apoplexy.decode[value]('this)}
+
+  object Error:
+    object Reason:
+      given Reason is Communicable =
+        case Status(code) => m"the server responded with an unsuccessful status, $code"
+
+    enum Reason(val number: Int) extends Clarification:
+      case Status(code: Int) extends Reason(1)
+
+  case class Error(reason: Api.Error.Reason)(using Diagnostics)
+  extends fulminate.Error(914, reason.number)(m"the API request was not successful because $reason")
+
+trait Api extends Dynamic, Locatable:
+  def request: Api.Request
+
+  transparent inline def selectDynamic(field: String): Any =
+    ${Apoplexy.select('this, 'field)}
+
+  transparent inline def applyDynamic(field: String)(inline args: Any*): Any =
+    ${Apoplexy.applied('this, 'field, 'args)}
+
+  transparent inline def applyDynamicNamed(field: String)(inline args: (String, Any)*): Any =
+    ${Apoplexy.appliedNamed('this, 'field, 'args)}

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -47,8 +47,7 @@ import spectacular.*
 import telekinesis.*
 import urticose.*
 import vacuous.*
-
-import jacinta.postables.jsonIsPostable
+import xylophone.*
 
 object Api:
   // Root constructor: `Api(cp"/spec.json")` reads the spec resource's `Locus`,
@@ -60,17 +59,22 @@ object Api:
     def request: Api.Request = apiRequest
 
   // The runtime send (invoked by the code `.call` emits): assemble the URL (base +
-  // substituted path + query), build the `Http.Request`, and dispatch through the
-  // telekinesis `HttpClient` — which uses whichever `Http.Backend` is in scope.
-  def send(request: Api.Request)
+  // substituted path + query), serialize the request body to bytes in its wire
+  // format, set the `content-type` (from the body) and `accept` (the response
+  // format the caller passes) headers, and dispatch through the telekinesis
+  // `HttpClient` — which uses whichever `Http.Backend` is in scope. The body
+  // printers/encoders are fixed internal defaults (minimal JSON, UTF-8), resolved
+  // here, so callers never supply them.
+  def send(request: Api.Request, accept: Text)
     ( using Online,
             HttpEvent is Loggable,
             Tactic[ConnectError],
-            Tactic[UrlError],
-            CharEncoder,
-            JsonPrinter )
+            Tactic[UrlError] )
     ( using client: HttpClient onto Origin["http" | "https"] )
   :   Http.Response =
+
+    import jsonPrinters.minimal
+    import charEncoders.utf8
 
     val substituted =
       request.substitutions.foldLeft(request.path): (path, entry) =>
@@ -87,30 +91,42 @@ object Api:
 
     val url = full.decode[HttpUrl]
 
-    val headers: List[Http.Header] = request.body.lay(Nil): json =>
-      List(Http.Header(t"content-type", summon[Json is Postable].mediaType(json).show))
-
     val empty: () => Stream[Data] = () => Stream()
 
-    val body: () => Stream[Data] = request.body.lay(empty): json =>
-      () => summon[Json is Postable].stream(json)
+    val (contentType, body): (Optional[Text], () => Stream[Data]) = request.body match
+      case Api.Body.Empty       => (Unset, empty)
+      case Api.Body.Json(value) => (t"application/json", () => Stream(value.show.data))
+      case Api.Body.Xml(value)  => (t"application/xml", () => Stream(value.show.data))
+
+    val contentTypeHeader: List[Http.Header] = contentType.lay(Nil): media =>
+      List(Http.Header(t"content-type", media))
+
+    val headers: List[Http.Header] = Http.Header(t"accept", accept) :: contentTypeHeader
 
     val httpRequest =
       Http.Request(request.method, 1.1, url.host.vouch, url.requestTarget, headers, body)
 
     client.request(httpRequest, url.origin)
 
+  // A request body already encoded to its wire-format AST. The spec's media type
+  // for the operation decides which case is built (in the `invoke` macro); `.call`
+  // serializes it to bytes with the matching printer.
+  enum Body derives CanEqual:
+    case Empty
+    case Json(value: jacinta.Json)
+    case Xml(value: xylophone.Xml)
+
   // The runtime description of a navigated/invoked call. `base` is the server
   // URL from the spec; `path` is the still-templated path; `substitutions`
   // binds path templates to concrete values; `query` is the query string;
-  // `body` is an optional JSON request body.
+  // `body` is the encoded request body (`Body.Empty` when there is none).
   case class Request
     ( method:        Http.Method,
       base:          Text,
       path:          Text,
       substitutions: Map[Text, Text]    = Map(),
       query:         List[(Text, Text)] = Nil,
-      body:          Optional[Json]     = Unset )
+      body:          Api.Body           = Api.Body.Empty )
 
   // The result of invoking an endpoint. Its refined type records `Result` (a
   // JSON-pointer to the 2xx response schema) and `Form` (the spec source),
@@ -119,9 +135,10 @@ object Api:
     def make(apiRequest: Api.Request): Api.Response = new Api.Response:
       def request: Api.Request = apiRequest
 
-  trait Response:
+  trait Response extends Transportive:
     type Result
     type Form
+    // type Transport (the wire format) inherited from Transportive
     def request: Api.Request
 
     // Performs the request and decodes the response as `value`. The empty
@@ -130,29 +147,36 @@ object Api:
     // perform the request, check for a 2xx status, and discard the body — the
     // natural default for `delete` and other no-content endpoints.
     //
-    // First the macro checks (at compile time) that `value` conforms to the
-    // endpoint's response schema. Then we send and interpret the response in
-    // *inline* code, so `value` is concrete when the `Conformant` (and hence the
-    // jacinta `Decodable`) instance is summoned — which is what lets `List[T]` and
-    // other collections resolve their decoders.
+    // The `inline` match on `this.Transport` selects the JSON or XML arm by the
+    // spec-decided wire format, so only the matching format's givens are demanded
+    // at a concrete call site. The macro first checks `value` against the response
+    // schema; the send + decode run in *inline* code, so `value` is concrete when
+    // the `Conformant` (and hence the jacinta/xylophone `Decodable`) is summoned —
+    // which is what lets `List[T]` and other collections resolve their decoders.
     transparent inline def call[value]()
       ( using erased default: value is Defaulting to Unit )
-      ( using online:     Online,
-              loggable:   HttpEvent is Loggable,
-              connect:    Tactic[ConnectError],
-              urlError:   Tactic[UrlError],
-              encoder:    CharEncoder,
-              printer:    JsonPrinter,
-              client:     HttpClient onto Origin["http" | "https"],
-              conformant: value is Conformant )
+      ( using online:   Online,
+              loggable: HttpEvent is Loggable,
+              connect:  Tactic[ConnectError],
+              urlError: Tactic[UrlError],
+              client:   HttpClient onto Origin["http" | "https"] )
     :   value =
 
       Apoplexy.check[value](this)
 
-      conformant.read:
-        Api.send(request)(using online, loggable, connect, urlError, encoder, printer)(using client)
+      def dispatch(accept: Text): Http.Response =
+        Api.send(request, accept)(using online, loggable, connect, urlError)(using client)
 
-trait Api extends Dynamic, Locatable:
+      inline compiletime.erasedValue[this.Transport] match
+        case _: jacinta.Json =>
+          val response = dispatch(t"application/json")
+          compiletime.summonInline[(value is Conformant) over jacinta.Json].read(response)
+
+        case _: xylophone.Xml =>
+          val response = dispatch(t"application/xml")
+          compiletime.summonInline[(value is Conformant) over xylophone.Xml].read(response)
+
+trait Api extends Dynamic, Locatable, Transportive:
   def request: Api.Request
 
   transparent inline def selectDynamic(field: String): Any =

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -58,7 +58,7 @@ object Api:
   def make(apiRequest: Api.Request): Api = new Api:
     def request: Api.Request = apiRequest
 
-  // The runtime send (invoked by the code `.as` emits): assemble the URL (base +
+  // The runtime send (invoked by the code `.call` emits): assemble the URL (base +
   // substituted path + query), build the `Http.Request`, and dispatch through the
   // telekinesis `HttpClient` — which uses whichever `Http.Backend` is in scope.
   def send(request: Api.Request)
@@ -113,7 +113,7 @@ object Api:
 
   // The result of invoking an endpoint. Its refined type records `Result` (a
   // JSON-pointer to the 2xx response schema) and `Form` (the spec source),
-  // which `as` reads to check a target type for conformance against the schema.
+  // which `call` reads to check a target type for conformance against the schema.
   object Response:
     def make(apiRequest: Api.Request): Api.Response = new Api.Response:
       def request: Api.Request = apiRequest
@@ -123,12 +123,13 @@ object Api:
     type Form
     def request: Api.Request
 
-    // First, the macro checks (at compile time) that `value` conforms to the
-    // endpoint's response schema. Then we send and interpret the response in
-    // *inline* code, so `value` is concrete when the `Conformant` (and hence the
-    // jacinta `Decodable`) instance is summoned — which is what lets `List[T]`
-    // and other collections resolve their decoders.
-    transparent inline def as[value]
+    // Performs the request and decodes the response as `value`. First, the macro
+    // checks (at compile time) that `value` conforms to the endpoint's response
+    // schema. Then we send and interpret the response in *inline* code, so `value`
+    // is concrete when the `Conformant` (and hence the jacinta `Decodable`)
+    // instance is summoned — which is what lets `List[T]` and other collections
+    // resolve their decoders.
+    transparent inline def call[value]
       ( using online:     Online,
               loggable:   HttpEvent is Loggable,
               connect:    Tactic[ConnectError],

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -44,7 +44,6 @@ import jacinta.*
 import prepositional.*
 import spectacular.*
 import telekinesis.*
-import turbulence.*
 import urticose.*
 import vacuous.*
 
@@ -63,13 +62,13 @@ object Api:
   // substituted path + query), build the `Http.Request`, and dispatch through the
   // telekinesis `HttpClient` — which uses whichever `Http.Backend` is in scope.
   def send(request: Api.Request)
-      ( using Online,
-              HttpEvent is Loggable,
-              Tactic[ConnectError],
-              Tactic[UrlError],
-              CharEncoder,
-              JsonPrinter )
-      (using client: HttpClient onto Origin["http" | "https"])
+    ( using Online,
+            HttpEvent is Loggable,
+            Tactic[ConnectError],
+            Tactic[UrlError],
+            CharEncoder,
+            JsonPrinter )
+    ( using client: HttpClient onto Origin["http" | "https"] )
   :   Http.Response =
 
     val substituted =
@@ -79,7 +78,10 @@ object Api:
     val full =
       if request.query.isEmpty then t"${request.base}$substituted"
       else
-        val parameters = request.query.map((key, value) => t"${key.urlEncode}=${value.urlEncode}")
+        val parameters =
+          request.query.map: (key, value) =>
+            t"${key.urlEncode}=${value.urlEncode}"
+
         t"${request.base}$substituted?${parameters.join(t"&")}"
 
     val url = full.decode[HttpUrl]
@@ -87,8 +89,10 @@ object Api:
     val headers: List[Http.Header] = request.body.lay(Nil): json =>
       List(Http.Header(t"content-type", summon[Json is Postable].mediaType(json).show))
 
-    val body: () => Stream[Data] =
-      request.body.lay(() => Stream())(json => () => summon[Json is Postable].stream(json))
+    val empty: () => Stream[Data] = () => Stream()
+
+    val body: () => Stream[Data] = request.body.lay(empty): json =>
+      () => summon[Json is Postable].stream(json)
 
     val httpRequest =
       Http.Request(request.method, 1.1, url.host.vouch, url.requestTarget, headers, body)
@@ -125,16 +129,18 @@ object Api:
     // jacinta `Decodable`) instance is summoned — which is what lets `List[T]`
     // and other collections resolve their decoders.
     transparent inline def as[value]
-        ( using online:     Online,
-                loggable:   HttpEvent is Loggable,
-                connect:    Tactic[ConnectError],
-                urlError:   Tactic[UrlError],
-                encoder:    CharEncoder,
-                printer:    JsonPrinter,
-                client:     HttpClient onto Origin["http" | "https"],
-                conformant: value is Conformant )
+      ( using online:     Online,
+              loggable:   HttpEvent is Loggable,
+              connect:    Tactic[ConnectError],
+              urlError:   Tactic[UrlError],
+              encoder:    CharEncoder,
+              printer:    JsonPrinter,
+              client:     HttpClient onto Origin["http" | "https"],
+              conformant: value is Conformant )
     :   value =
+
       Apoplexy.check[value](this)
+
       conformant.read:
         Api.send(request)(using online, loggable, connect, urlError, encoder, printer)(using client)
 

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -42,6 +42,7 @@ import hellenism.*
 import hieroglyph.*
 import jacinta.*
 import prepositional.*
+import rudiments.*
 import spectacular.*
 import telekinesis.*
 import urticose.*
@@ -123,13 +124,19 @@ object Api:
     type Form
     def request: Api.Request
 
-    // Performs the request and decodes the response as `value`. First, the macro
-    // checks (at compile time) that `value` conforms to the endpoint's response
-    // schema. Then we send and interpret the response in *inline* code, so `value`
-    // is concrete when the `Conformant` (and hence the jacinta `Decodable`)
-    // instance is summoned — which is what lets `List[T]` and other collections
-    // resolve their decoders.
-    transparent inline def call[value]
+    // Performs the request and decodes the response as `value`. The empty
+    // parentheses mark the side effect. A bare `.call()` leaves `value`
+    // unconstrained, so `value is Defaulting to Unit` resolves it to `Unit`:
+    // perform the request, check for a 2xx status, and discard the body — the
+    // natural default for `delete` and other no-content endpoints.
+    //
+    // First the macro checks (at compile time) that `value` conforms to the
+    // endpoint's response schema. Then we send and interpret the response in
+    // *inline* code, so `value` is concrete when the `Conformant` (and hence the
+    // jacinta `Decodable`) instance is summoned — which is what lets `List[T]` and
+    // other collections resolve their decoders.
+    transparent inline def call[value]()
+      ( using erased default: value is Defaulting to Unit )
       ( using online:     Online,
               loggable:   HttpEvent is Loggable,
               connect:    Tactic[ConnectError],

--- a/lib/apoplexy/src/core/apoplexy.ApiError.scala
+++ b/lib/apoplexy/src/core/apoplexy.ApiError.scala
@@ -1,0 +1,48 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import fulminate.*
+
+object ApiError:
+  object Reason:
+    given Reason is Communicable =
+      case Status(code) => m"the server responded with an unsuccessful status, $code"
+      case Malformed    => m"the response body was not valid JSON"
+
+  enum Reason(val number: Int) extends Clarification:
+    case Status(code: Int) extends Reason(1)
+    case Malformed         extends Reason(2)
+
+case class ApiError(reason: ApiError.Reason)(using Diagnostics)
+extends Error(914, reason.number)(m"the API request was not successful because $reason")

--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -32,7 +32,6 @@
                                                                                                   */
 package apoplexy
 
-import anticipation.*
 import contingency.*
 import distillate.*
 import fulminate.*
@@ -40,16 +39,13 @@ import jacinta.*
 import prepositional.*
 import telekinesis.*
 import turbulence.*
-import zephyrine.ParseError
 
 import errorDiagnostics.empty
+import zephyrine.ParseError
 
 // Interprets an `Http.Response` as a value of `Self`. The instances decide how a
 // response body is read; the `.as[T]` macro performs the compile-time check that
 // `T` conforms to the endpoint's response schema before summoning one.
-trait Conformant extends Typeclass:
-  def read(response: Http.Response): Self
-
 object Conformant:
   // Raise `ApiError` unless the response status is in the 2xx range.
   def successful(response: Http.Response)(using Tactic[ApiError]): Unit =
@@ -82,3 +78,6 @@ object Conformant:
         case JsonError(_)        => ApiError(ApiError.Reason.Malformed)
 
       . mitigate(response.body.stream.read[Json].as[value])
+
+trait Conformant extends Typeclass:
+  def read(response: Http.Response): Self

--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -35,48 +35,33 @@ package apoplexy
 import contingency.*
 import distillate.*
 import fulminate.*
+import hieroglyph.*
 import jacinta.*
 import prepositional.*
 import telekinesis.*
 import turbulence.*
+import xylophone.*
 
 import errorDiagnostics.empty
 import zephyrine.ParseError
 
-// Interprets an `Http.Response` as a value of `Self`. The instances decide how a
-// response body is read; `Api.Response.call[T]` performs the compile-time check
-// that `T` conforms to the endpoint's response schema before summoning one.
-object Conformant:
-  // Raise `ApiError` unless the response status is in the 2xx range.
-  def successful(response: Http.Response)(using Tactic[ApiError]): Unit =
-    if response.status.category != Http.Status.Category.Successful
-    then abort(ApiError(ApiError.Reason.Status(response.status.code)))
-
-  // The escape hatch: the raw response, with no status check.
-  given response: Http.Response is Conformant = response => response
-
-  // Just check for success and discard the body — for no-content (204) endpoints
-  // such as `delete`, and the default target of a bare `.call()`. Unlike the
-  // `decodable` instance, this never reads the body, so an empty one is fine.
-  given unit: Tactic[ApiError] => Unit is Conformant = response => successful(response)
-
-  // The raw 2xx body as JSON.
-  given json: Tactic[ApiError] => Json is Conformant = response =>
-    successful(response)
-
-    whereas:
-      case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
-
-    . mitigate(response.body.stream.read[Json])
-
-  // A 2xx body decoded to any JSON-decodable type. The `.call[T]` inline method
-  // only summons this after the conformance macro has verified `T` matches the
-  // endpoint's response schema. Resolving `value is Decodable in Json` here, at
-  // the concrete call site, lets jacinta pick the collection decoder for
-  // `List[T]` etc. — which a macro-spliced summon over an abstract type cannot.
-  given decodable: [value: Decodable in Json] => Tactic[ApiError] => value is Conformant =
+// Interprets an `Http.Response` as a value of `Self`, reading the body in the wire
+// format `Transport` (`jacinta.Json` or `xylophone.Xml`) the spec dictates.
+// `Api.Response.call[T]()` checks at compile time that `T` conforms to the response
+// schema, then summons `(T is Conformant) over <Transport>` at the concrete call
+// site — so only the matching format's givens are demanded, and `List[T]`-style
+// collection decoders resolve.
+// The decodable instances are lower priority so that the exact-type givens
+// (`Http.Response`, `Unit`, raw `Json`, raw `Xml`) win — `Unit` and `Json` are
+// themselves `Decodable in Json`, so they would otherwise be ambiguous.
+trait LowPriorityConformant:
+  // A 2xx JSON body decoded to any JSON-decodable type. Resolving `Decodable in
+  // Json` here, at the concrete call site, lets jacinta pick the collection
+  // decoder for `List[T]` etc.
+  given jsonDecodable: [value: Decodable in Json] => Tactic[ApiError]
+  =>  (value is Conformant) over Json =
     response =>
-      successful(response)
+      Conformant.successful(response)
 
       whereas:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
@@ -84,5 +69,53 @@ object Conformant:
 
       . mitigate(response.body.stream.read[Json].as[value])
 
-trait Conformant extends Typeclass:
+  // A 2xx XML body decoded to any XML-decodable type.
+  given xmlDecodable: [value: Decodable in Xml]
+  =>  ( CharDecoder, XmlSchema, Tactic[ApiError] ) => (value is Conformant) over Xml =
+    response =>
+      Conformant.successful(response)
+
+      whereas:
+        case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
+        case _: XmlError         => ApiError(ApiError.Reason.Malformed)
+
+      . mitigate(summon[CharDecoder].decoded(response.body.stream).read[Xml].as[value])
+
+object Conformant extends LowPriorityConformant:
+  // Raise `ApiError` unless the response status is in the 2xx range.
+  def successful(response: Http.Response)(using Tactic[ApiError]): Unit =
+    if response.status.category != Http.Status.Category.Successful
+    then abort(ApiError(ApiError.Reason.Status(response.status.code)))
+
+  // The escape hatch: the raw response, with no status check (any transport).
+  given response: [transport] => (Http.Response is Conformant) over transport =
+    response => response
+
+  // Just check for success and discard the body — for no-content (204) endpoints
+  // such as `delete`, and the default target of a bare `.call()`. Never reads the
+  // body, so an empty one is fine; transport-agnostic.
+  given unit: [transport] => Tactic[ApiError] => (Unit is Conformant) over transport =
+    response => successful(response)
+
+  // The raw 2xx body as JSON.
+  given json: Tactic[ApiError] => (Json is Conformant) over Json = response =>
+    successful(response)
+
+    whereas:
+      case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
+
+    . mitigate(response.body.stream.read[Json])
+
+  // The raw 2xx body as XML. The body bytes are decoded to `Text` (via the
+  // `CharDecoder`) before xylophone parses them.
+  given xml: (CharDecoder, XmlSchema, Tactic[ApiError]) => (Xml is Conformant) over Xml =
+    response =>
+      successful(response)
+
+      whereas:
+        case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
+
+      . mitigate(summon[CharDecoder].decoded(response.body.stream).read[Xml])
+
+trait Conformant extends Typeclass, Transportive:
   def read(response: Http.Response): Self

--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -32,120 +32,53 @@
                                                                                                   */
 package apoplexy
 
-import language.dynamics
-
 import anticipation.*
 import contingency.*
 import distillate.*
-import gossamer.*
-import hellenism.*
-import hieroglyph.*
+import fulminate.*
 import jacinta.*
 import prepositional.*
-import spectacular.*
 import telekinesis.*
 import turbulence.*
-import urticose.*
-import vacuous.*
+import zephyrine.ParseError
 
-import jacinta.postables.jsonIsPostable
+import errorDiagnostics.empty
 
-object Api:
-  // Root constructor: `Api(cp"/spec.json")` reads the spec resource's `Locus`,
-  // validates the spec at compile time, and returns `Api at "/"` carrying the
-  // spec source so navigation macros can re-read it.
-  transparent inline def apply(inline resource: Resource): Any = ${Apoplexy.root('resource)}
+// Interprets an `Http.Response` as a value of `Self`. The instances decide how a
+// response body is read; the `.as[T]` macro performs the compile-time check that
+// `T` conforms to the endpoint's response schema before summoning one.
+trait Conformant extends Typeclass:
+  def read(response: Http.Response): Self
 
-  def make(apiRequest: Api.Request): Api = new Api:
-    def request: Api.Request = apiRequest
+object Conformant:
+  // Raise `ApiError` unless the response status is in the 2xx range.
+  def successful(response: Http.Response)(using Tactic[ApiError]): Unit =
+    if response.status.category != Http.Status.Category.Successful
+    then abort(ApiError(ApiError.Reason.Status(response.status.code)))
 
-  // The runtime send (invoked by the code `.as` emits): assemble the URL (base +
-  // substituted path + query), build the `Http.Request`, and dispatch through the
-  // telekinesis `HttpClient` — which uses whichever `Http.Backend` is in scope.
-  def send(request: Api.Request)
-      ( using Online,
-              HttpEvent is Loggable,
-              Tactic[ConnectError],
-              Tactic[UrlError],
-              CharEncoder,
-              JsonPrinter )
-      (using client: HttpClient onto Origin["http" | "https"])
-  :   Http.Response =
+  // The escape hatch: the raw response, with no status check.
+  given response: Http.Response is Conformant = response => response
 
-    val substituted =
-      request.substitutions.foldLeft(request.path): (path, entry) =>
-        path.sub(t"{${entry(0)}}", entry(1))
+  // The raw 2xx body as JSON.
+  given json: Tactic[ApiError] => Json is Conformant = response =>
+    successful(response)
 
-    val full =
-      if request.query.isEmpty then t"${request.base}$substituted"
-      else
-        val parameters = request.query.map((key, value) => t"${key.urlEncode}=${value.urlEncode}")
-        t"${request.base}$substituted?${parameters.join(t"&")}"
+    whereas:
+      case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
 
-    val url = full.decode[HttpUrl]
+    . mitigate(response.body.stream.read[Json])
 
-    val headers: List[Http.Header] = request.body.lay(Nil): json =>
-      List(Http.Header(t"content-type", summon[Json is Postable].mediaType(json).show))
+  // A 2xx body decoded to any JSON-decodable type. The `.as[T]` inline method
+  // only summons this after the conformance macro has verified `T` matches the
+  // endpoint's response schema. Resolving `value is Decodable in Json` here, at
+  // the concrete call site, lets jacinta pick the collection decoder for
+  // `List[T]` etc. — which a macro-spliced summon over an abstract type cannot.
+  given decodable: [value: Decodable in Json] => Tactic[ApiError] => value is Conformant =
+    response =>
+      successful(response)
 
-    val body: () => Stream[Data] =
-      request.body.lay(() => Stream())(json => () => summon[Json is Postable].stream(json))
+      whereas:
+        case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
+        case JsonError(_)        => ApiError(ApiError.Reason.Malformed)
 
-    val httpRequest =
-      Http.Request(request.method, 1.1, url.host.vouch, url.requestTarget, headers, body)
-
-    client.request(httpRequest, url.origin)
-
-  // The runtime description of a navigated/invoked call. `base` is the server
-  // URL from the spec; `path` is the still-templated path; `substitutions`
-  // binds path templates to concrete values; `query` is the query string;
-  // `body` is an optional JSON request body.
-  case class Request
-    ( method:        Http.Method,
-      base:          Text,
-      path:          Text,
-      substitutions: Map[Text, Text]    = Map(),
-      query:         List[(Text, Text)] = Nil,
-      body:          Optional[Json]     = Unset )
-
-  // The result of invoking an endpoint. Its refined type records `Result` (a
-  // JSON-pointer to the 2xx response schema) and `Form` (the spec source),
-  // which `as` reads to check a target type for conformance against the schema.
-  object Response:
-    def make(apiRequest: Api.Request): Api.Response = new Api.Response:
-      def request: Api.Request = apiRequest
-
-  trait Response:
-    type Result
-    type Form
-    def request: Api.Request
-
-    // First, the macro checks (at compile time) that `value` conforms to the
-    // endpoint's response schema. Then we send and interpret the response in
-    // *inline* code, so `value` is concrete when the `Conformant` (and hence the
-    // jacinta `Decodable`) instance is summoned — which is what lets `List[T]`
-    // and other collections resolve their decoders.
-    transparent inline def as[value]
-        ( using online:     Online,
-                loggable:   HttpEvent is Loggable,
-                connect:    Tactic[ConnectError],
-                urlError:   Tactic[UrlError],
-                encoder:    CharEncoder,
-                printer:    JsonPrinter,
-                client:     HttpClient onto Origin["http" | "https"],
-                conformant: value is Conformant )
-    :   value =
-      Apoplexy.check[value](this)
-      conformant.read:
-        Api.send(request)(using online, loggable, connect, urlError, encoder, printer)(using client)
-
-trait Api extends Dynamic, Locatable:
-  def request: Api.Request
-
-  transparent inline def selectDynamic(field: String): Any =
-    ${Apoplexy.select('this, 'field)}
-
-  transparent inline def applyDynamic(field: String)(inline args: Any*): Any =
-    ${Apoplexy.applied('this, 'field, 'args)}
-
-  transparent inline def applyDynamicNamed(field: String)(inline args: (String, Any)*): Any =
-    ${Apoplexy.appliedNamed('this, 'field, 'args)}
+      . mitigate(response.body.stream.read[Json].as[value])

--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -55,6 +55,11 @@ object Conformant:
   // The escape hatch: the raw response, with no status check.
   given response: Http.Response is Conformant = response => response
 
+  // Just check for success and discard the body — for no-content (204) endpoints
+  // such as `delete`, and the default target of a bare `.call()`. Unlike the
+  // `decodable` instance, this never reads the body, so an empty one is fine.
+  given unit: Tactic[ApiError] => Unit is Conformant = response => successful(response)
+
   // The raw 2xx body as JSON.
   given json: Tactic[ApiError] => Json is Conformant = response =>
     successful(response)

--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -44,8 +44,8 @@ import errorDiagnostics.empty
 import zephyrine.ParseError
 
 // Interprets an `Http.Response` as a value of `Self`. The instances decide how a
-// response body is read; the `.as[T]` macro performs the compile-time check that
-// `T` conforms to the endpoint's response schema before summoning one.
+// response body is read; `Api.Response.call[T]` performs the compile-time check
+// that `T` conforms to the endpoint's response schema before summoning one.
 object Conformant:
   // Raise `ApiError` unless the response status is in the 2xx range.
   def successful(response: Http.Response)(using Tactic[ApiError]): Unit =
@@ -64,7 +64,7 @@ object Conformant:
 
     . mitigate(response.body.stream.read[Json])
 
-  // A 2xx body decoded to any JSON-decodable type. The `.as[T]` inline method
+  // A 2xx body decoded to any JSON-decodable type. The `.call[T]` inline method
   // only summons this after the conformance macro has verified `T` matches the
   // endpoint's response schema. Resolving `value is Decodable in Json` here, at
   // the concrete call site, lets jacinta pick the collection decoder for

--- a/lib/apoplexy/src/core/apoplexy.Executor.scala
+++ b/lib/apoplexy/src/core/apoplexy.Executor.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import telekinesis.*
+
+// The transport seam: turns an `Api.Request` into a raw HTTP response. The
+// production given (requiring `Online`) sends a real request; tests provide a
+// recording implementation that returns canned responses without any network.
+trait Executor:
+  def execute(request: Api.Request): Http.Response

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -256,9 +256,9 @@ object OpenApi:
     summon[Text is Aggregable by Text].map: text =>
       val document =
         whereas:
-          case ParseError(_, _, _)  => OpenApiError(OpenApiError.Reason.Malformed)
-          case JsonError(_)         => OpenApiError(OpenApiError.Reason.Malformed)
-          case YamlError(_)         => OpenApiError(OpenApiError.Reason.Malformed)
+          case ParseError(_, _, _)    => OpenApiError(OpenApiError.Reason.Malformed)
+          case JsonError(_)           => OpenApiError(OpenApiError.Reason.Malformed)
+          case YamlError(_)           => OpenApiError(OpenApiError.Reason.Malformed)
           case JsonPointerError(_, _) => OpenApiError(OpenApiError.Reason.Malformed)
 
         . mitigate:

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -533,13 +533,13 @@ object Apoplexy:
     if !ok(value, schema)
     then halt(m"apoplexy: ${value.show} does not conform to the response schema")
 
-  // The inline entry point called from `Api.Response.as`: a splice cannot appear
+  // The inline entry point called from `Api.Response.call`: a splice cannot appear
   // as a mid-body statement in an inline method, so the macro is wrapped here.
   transparent inline def check[value](inline self: Api.Response): Unit =
     ${conform[value]('self)}
 
   // Compile-time only: verify `value` conforms to the endpoint's response
-  // schema. The actual send and decode happen in inline code in `Api.Response.as`
+  // schema. The actual send and decode happen in inline code in `Api.Response.call`
   // (where `value` is concrete), so this returns `Unit`. The raw `Http.Response`
   // and `Json` targets bypass the schema check.
   def conform[value: Type](self: Expr[Api.Response]): Macro[Unit] =

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -40,11 +40,13 @@ import fulminate.*
 import gigantism.*
 import gossamer.*
 import hellenism.*
+import hieroglyph.*
 import jacinta.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
 import strategies.throwUnsafely
+import charEncoders.utf8
 import telekinesis.*
 import turbulence.*
 import vacuous.*
@@ -454,5 +456,91 @@ object Apoplexy:
 
         shortcut(self, doc, source, newLocus, named, positional)
 
-  def decode[value: Type](self: Expr[Api.Response]): Macro[value] =
-    halt(m"apoplexy: .as is not implemented yet")
+  // --- response decoding ---------------------------------------------------
+
+  private val specJsons: scala.collection.mutable.HashMap[Text, Json] =
+    scala.collection.mutable.HashMap()
+
+  private def specJson(using Quotes)(source: Text): Json =
+    specJsons.synchronized:
+      specJsons.at(source).or:
+        val stream = Optional(getClass.getResourceAsStream(source.s)).or:
+          halt(m"apoplexy: could not read the OpenAPI spec at $source on the classpath")
+
+        val content = scala.io.Source.fromInputStream(stream).mkString.tt
+
+        val json =
+          try content.read[Json]
+          catch case error: Exception => halt(m"apoplexy: the OpenAPI spec at $source is not valid")
+
+        specJsons(source) = json
+        json
+
+  // Resolve the response-schema `JsonSchema` at a JSON-pointer into the spec.
+  private def resolveSchema(using Quotes)(source: Text, pointer: Text): JsonSchema =
+    val segments = pointer.cut(t"/").to(List).drop(1)
+
+    val node =
+      segments.foldLeft(specJson(source)): (node, segment) =>
+        try node(segment.sub(t"~1", t"/").sub(t"~0", t"~"))
+        catch case error: Exception => halt(m"apoplexy: could not resolve the schema at $pointer")
+
+    try node.as[JsonSchema]
+    catch case error: Exception => halt(m"apoplexy: the response schema at $pointer is not valid")
+
+  // Compile-time check that `value` structurally matches the response schema.
+  private def conformsTo(using quotes: Quotes)(value: quotes.reflect.TypeRepr, schema: JsonSchema)
+  :   Unit =
+    import quotes.reflect.*
+
+    def simpleName(repr: TypeRepr): Text = repr.dealias.typeSymbol.name.tt
+
+    def listElement(repr: TypeRepr): Optional[TypeRepr] = repr match
+      case AppliedType(_, List(element)) if repr <:< TypeRepr.of[List[Any]] => element
+      case _                                                                => Unset
+
+    def componentName(pointer: JsonPointer): Text = pointer.encode.cut(t"/").to(List).last
+
+    def ok(value: TypeRepr, schema: JsonSchema): Boolean = schema match
+      case ref: JsonSchema.Ref   => simpleName(value) == componentName(ref.pointer)
+      case _: JsonSchema.String  => value =:= TypeRepr.of[Text]
+      case _: JsonSchema.Integer => value =:= TypeRepr.of[Int]
+      case _: JsonSchema.Number  => value =:= TypeRepr.of[Double]
+      case _: JsonSchema.Boolean => value =:= TypeRepr.of[Boolean]
+      case _: JsonSchema.Object  => value.typeSymbol.flags.is(Flags.Case)
+
+      case array: JsonSchema.Array => listElement(value) match
+        case element: TypeRepr => array.items.lay(true)(ok(element, _))
+        case _                 => false
+
+      case _ => true
+
+    if !ok(value, schema)
+    then halt(m"apoplexy: ${value.show} does not conform to the response schema")
+
+  // The inline entry point called from `Api.Response.as`: a splice cannot appear
+  // as a mid-body statement in an inline method, so the macro is wrapped here.
+  transparent inline def check[value](inline self: Api.Response): Unit =
+    ${conform[value]('self)}
+
+  // Compile-time only: verify `value` conforms to the endpoint's response
+  // schema. The actual send and decode happen in inline code in `Api.Response.as`
+  // (where `value` is concrete), so this returns `Unit`. The raw `Http.Response`
+  // and `Json` targets bypass the schema check.
+  def conform[value: Type](self: Expr[Api.Response]): Macro[Unit] =
+    import quotes.reflect.*
+
+    val valueRepr = TypeRepr.of[value]
+
+    if !(valueRepr =:= TypeRepr.of[Http.Response]) && !(valueRepr =:= TypeRepr.of[Json]) then
+      val members = refinements(self.asTerm.tpe) ++ refinements(self.asTerm.tpe.widen)
+
+      val pointer =
+        members.at(t"Result").lay(halt(m"apoplexy: the response has no schema pointer"))(stringOf(_))
+
+      val source =
+        members.at(t"Form").lay(halt(m"apoplexy: the response has no spec source"))(stringOf(_))
+
+      conformsTo(valueRepr, resolveSchema(source, pointer))
+
+    '{()}

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -547,7 +547,12 @@ object Apoplexy:
 
     val valueRepr = TypeRepr.of[value]
 
-    if !(valueRepr =:= TypeRepr.of[Http.Response]) && !(valueRepr =:= TypeRepr.of[Json]) then
+    val raw =
+      valueRepr =:= TypeRepr.of[Http.Response]
+      || valueRepr =:= TypeRepr.of[Json]
+      || valueRepr =:= TypeRepr.of[Unit]
+
+    if !raw then
       val members = refinements(self.asTerm.tpe) ++ refinements(self.asTerm.tpe.widen)
 
       val pointer =

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -45,11 +45,12 @@ import jacinta.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
-import strategies.throwUnsafely
-import charEncoders.utf8
 import telekinesis.*
 import turbulence.*
 import vacuous.*
+
+import charEncoders.utf8
+import strategies.throwUnsafely
 
 object Apoplexy:
   // --- compile-time spec access -------------------------------------------
@@ -239,6 +240,7 @@ object Apoplexy:
       case Nil =>
         if operation.requestBody.let(_.required.or(false)).or(false)
         then halt(m"apoplexy: $verb $locus requires a request body")
+
         '{Unset}
 
       case List(argExpr) =>
@@ -259,8 +261,10 @@ object Apoplexy:
     val status =
       operation.responses.keys.filter(_.starts(t"2")).to(List).sortBy(_.s).prim.or(t"200")
 
+    val jsonContent = escape(t"application/json")
+
     val pointer =
-      t"#/paths/${escape(locus)}/$verb/responses/$status/content/${escape(t"application/json")}/schema"
+      t"#/paths/${escape(locus)}/$verb/responses/$status/content/$jsonContent/schema"
 
     val mExpr = methodExpr(method)
     val locusExpr = Expr(locus.s)
@@ -273,10 +277,13 @@ object Apoplexy:
 
     responseType.asType.absolve match
       case '[type result <: Api.Response; result] =>
-        '{
+        ' {
             val request =
               $self.request.copy
-               (method = $mExpr, path = $locusExpr.tt, query = $queryExpr, body = $bodyExpr)
+                ( method = $mExpr,
+                  path   = $locusExpr.tt,
+                  query  = $queryExpr,
+                  body   = $bodyExpr )
 
             Api.Response.make(request).asInstanceOf[result]
           }
@@ -350,7 +357,8 @@ object Apoplexy:
         navigate(self, source, doc, locus, name)
 
   private def navigate(using quotes: Quotes)
-    (self: Expr[Api], source: Text, doc: OpenApi, locus: Text, name: Text): Expr[Any] =
+    ( self: Expr[Api], source: Text, doc: OpenApi, locus: Text, name: Text )
+  :   Expr[Any] =
 
     val newLocus = join(locus, name)
     val newSegs = segments(newLocus)
@@ -384,18 +392,23 @@ object Apoplexy:
 
         if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
 
-        val following =
-          keys.filter { key => isPrefix(newSegs, key) && key.length > newSegs.length }
-           .map(_(newSegs.length))
-           .find(isTemplate)
+        def deeper(key: List[Text]): Boolean =
+          isPrefix(newSegs, key) && key.length > newSegs.length
+
+        val following = keys.filter(deeper).map(_(newSegs.length)).find(isTemplate)
 
         following match
           case Some(template) => fillTemplate(self, source, doc, newLocus, template, positional)
           case None           => shortcut(self, doc, source, newLocus, Nil, positional)
 
   private def fillTemplate(using quotes: Quotes)
-    (self: Expr[Api], source: Text, doc: OpenApi, newLocus: Text, template: Text,
-     positional: List[Expr[Any]]): Expr[Any] =
+    ( self:       Expr[Api],
+      source:     Text,
+      doc:        OpenApi,
+      newLocus:   Text,
+      template:   Text,
+      positional: List[Expr[Any]] )
+  :   Expr[Any] =
 
     import quotes.reflect.*
 
@@ -451,6 +464,7 @@ object Apoplexy:
         val keys = doc.paths.keys.map(segments).to(List)
 
         if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
+
         if doc.paths.at(newLocus).absent
         then halt(m"apoplexy: $newLocus is not a complete endpoint")
 
@@ -491,6 +505,7 @@ object Apoplexy:
   // Compile-time check that `value` structurally matches the response schema.
   private def conformsTo(using quotes: Quotes)(value: quotes.reflect.TypeRepr, schema: JsonSchema)
   :   Unit =
+
     import quotes.reflect.*
 
     def simpleName(repr: TypeRepr): Text = repr.dealias.typeSymbol.name.tt
@@ -509,9 +524,9 @@ object Apoplexy:
       case _: JsonSchema.Boolean => value =:= TypeRepr.of[Boolean]
       case _: JsonSchema.Object  => value.typeSymbol.flags.is(Flags.Case)
 
-      case array: JsonSchema.Array => listElement(value) match
-        case element: TypeRepr => array.items.lay(true)(ok(element, _))
-        case _                 => false
+      case array: JsonSchema.Array =>
+        listElement(value).lay(false): element =>
+          array.items.lay(true)(ok(element, _))
 
       case _ => true
 
@@ -536,10 +551,10 @@ object Apoplexy:
       val members = refinements(self.asTerm.tpe) ++ refinements(self.asTerm.tpe.widen)
 
       val pointer =
-        members.at(t"Result").lay(halt(m"apoplexy: the response has no schema pointer"))(stringOf(_))
+        members.at(t"Result").lay(halt(m"apoplexy: missing response schema pointer"))(stringOf(_))
 
       val source =
-        members.at(t"Form").lay(halt(m"apoplexy: the response has no spec source"))(stringOf(_))
+        members.at(t"Form").lay(halt(m"apoplexy: missing spec source"))(stringOf(_))
 
       conformsTo(valueRepr, resolveSchema(source, pointer))
 

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -1,0 +1,252 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gigantism.*
+import gossamer.*
+import hellenism.*
+import jacinta.*
+import rudiments.*
+import spectacular.*
+import strategies.throwUnsafely
+import telekinesis.*
+import turbulence.*
+import vacuous.*
+
+object Apoplexy:
+  // --- compile-time spec access -------------------------------------------
+
+  private val specs: scala.collection.mutable.HashMap[Text, OpenApi] =
+    scala.collection.mutable.HashMap()
+
+  private def spec(using Quotes)(source: Text): OpenApi =
+    specs.synchronized:
+      specs.at(source).or:
+        val stream = Optional(getClass.getResourceAsStream(source.s)).or:
+          halt(m"apoplexy: could not read the OpenAPI spec at $source on the classpath")
+
+        val content = scala.io.Source.fromInputStream(stream).mkString.tt
+
+        val doc =
+          try content.read[OpenApi]
+          catch case error: Exception => halt(m"apoplexy: the OpenAPI spec at $source is not valid")
+
+        specs(source) = doc
+        doc
+
+  // --- refinement-type helpers (mirroring xenophile) ----------------------
+
+  private def refinements(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :   Map[Text, quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
+      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
+      case AndType(left, right)                        => refinements(left) ++ refinements(right)
+      case _                                           => Map()
+
+  private def stringOf(using quotes: Quotes)(repr: quotes.reflect.TypeRepr): Text =
+    import quotes.reflect.*
+
+    repr.absolve match
+      case ConstantType(StringConstant(value)) => value.tt
+      case _                                   => halt(m"apoplexy: expected a string literal type")
+
+  private def literalType(using quotes: Quotes)(value: Text): quotes.reflect.TypeRepr =
+    import quotes.reflect.*
+
+    ConstantType(StringConstant(value.s))
+
+  private def apiType(using quotes: Quotes)(locus: Text, source: Text): quotes.reflect.TypeRepr =
+    import quotes.reflect.*
+
+    val withLocus =
+      Refinement(TypeRepr.of[Api], "Locus", TypeBounds(literalType(locus), literalType(locus)))
+
+    Refinement(withLocus, "Source", TypeBounds(literalType(source), literalType(source)))
+
+  private def receiver(using quotes: Quotes)(self: Expr[Api]): (Text, Text) =
+    import quotes.reflect.*
+
+    val members = refinements(self.asTerm.tpe.widen)
+    val locus = members.at(t"Locus").lay(t"/")(stringOf(_))
+    val source = members.at(t"Source").or(halt(m"apoplexy: the receiver has no spec `Source`"))
+
+    (locus, stringOf(source))
+
+  // --- path utilities ------------------------------------------------------
+
+  private def segments(path: Text): List[Text] = path.cut(t"/").filter(_ != t"").to(List)
+  private def isTemplate(segment: Text): Boolean = segment.starts(t"{") && segment.s.endsWith("}")
+  private def templateName(segment: Text): Text = segment.skip(1).keep(segment.length - 2)
+
+  private def isPrefix(short: List[Text], long: List[Text]): Boolean =
+    short.length <= long.length && short.zip(long).forall(_ == _)
+
+  private def join(locus: Text, segment: Text): Text =
+    if locus == t"/" then t"/$segment" else t"$locus/$segment"
+
+  // --- schema → Scala type -------------------------------------------------
+
+  private def schemaType(using quotes: Quotes)(doc: OpenApi, schema: JsonSchema)
+  :   quotes.reflect.TypeRepr =
+
+    import quotes.reflect.*
+
+    schema match
+      case _: JsonSchema.Integer => TypeRepr.of[Int]
+      case _: JsonSchema.Number  => TypeRepr.of[Double]
+      case _: JsonSchema.String  => TypeRepr.of[Text]
+      case _: JsonSchema.Boolean => TypeRepr.of[Boolean]
+
+      case array: JsonSchema.Array =>
+        array.items.lay(TypeRepr.of[Json])(schemaType(doc, _)).asType.absolve match
+          case '[element] => TypeRepr.of[List[element]]
+
+      case _ =>
+        TypeRepr.of[Json]
+
+  private def pathParamType(using quotes: Quotes)(doc: OpenApi, path: Text, parameter: Text)
+  :   quotes.reflect.TypeRepr =
+
+    import quotes.reflect.*
+
+    val params =
+      doc.paths.at(path).lay(List[OpenApi.Parameter]()): item =>
+        item.operations.values.flatMap(_.parameters).to(List)
+
+    params.find { p => p.name == parameter && p.`in` == OpenApi.Parameter.In.Path } match
+      case Some(param) => param.schema.lay(TypeRepr.of[Text])(schemaType(doc, _))
+      case None        => TypeRepr.of[Text]
+
+  // --- macros --------------------------------------------------------------
+
+  def root(resource: Expr[Resource]): Macro[Api] =
+    import quotes.reflect.*
+
+    val members = refinements(resource.asTerm.tpe) ++ refinements(resource.asTerm.tpe.widen)
+
+    val source =
+      members.at(t"Locus").lay(halt(m"apoplexy: the resource has no `Locus` path"))(stringOf(_))
+
+    val doc = spec(source)
+    val base = if doc.servers.isEmpty then t"" else doc.servers.head.url
+    val baseExpr = Expr(base.s)
+
+    apiType(t"/", source).asType.absolve match
+      case '[type result <: Api; result] =>
+        '{Api.make(Api.Request(Http.Get, $baseExpr.tt, t"/")).asInstanceOf[result]}
+
+  def select(self: Expr[Api], field: Expr[String]): Macro[Api] =
+    val name = field.valueOrAbort.tt
+    val (locus, source) = receiver(self)
+    val doc = spec(source)
+    val keys = doc.paths.keys.map(segments).to(List)
+    val newLocus = join(locus, name)
+    val newSegs = segments(newLocus)
+
+    if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
+
+    val locusExpr = Expr(newLocus.s)
+
+    apiType(newLocus, source).asType.absolve match
+      case '[type result <: Api; result] =>
+        '{Api.make($self.request.copy(path = $locusExpr.tt)).asInstanceOf[result]}
+
+  def applied(self: Expr[Api], field: Expr[String], args: Expr[Seq[Any]]): Macro[Api] =
+    import quotes.reflect.*
+
+    val name = field.valueOrAbort.tt
+    val (locus, source) = receiver(self)
+    val doc = spec(source)
+    val keys = doc.paths.keys.map(segments).to(List)
+    val newLocus = join(locus, name)
+    val newSegs = segments(newLocus)
+
+    if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
+
+    val children = keys.filter: key =>
+      isPrefix(newSegs, key) && key.length > newSegs.length
+
+    children.map(_(newSegs.length)).find(isTemplate) match
+      case None =>
+        halt(m"apoplexy: invocation is not implemented yet")
+
+      case Some(template) =>
+        val parameter = templateName(template)
+        val templatedLocus = join(newLocus, template)
+
+        val arg = args match
+          case Varargs(Seq(only)) => only
+          case Varargs(_)         => halt(m"apoplexy: path parameter $parameter needs one argument")
+          case _                  => halt(m"apoplexy: the path argument must be passed directly")
+
+        val expected = pathParamType(doc, templatedLocus, parameter)
+        val actual = arg.asTerm.tpe.widen
+
+        if !(actual <:< expected)
+        then halt(m"apoplexy: path parameter $parameter expects ${expected.show}")
+
+        val locusExpr = Expr(templatedLocus.s)
+        val paramExpr = Expr(parameter.s)
+
+        apiType(templatedLocus, source).asType.absolve match
+          case '[type result <: Api; result] => actual.asType.absolve match
+            case '[argType] =>
+              val valueExpr = arg.asExprOf[argType]
+
+              val showable = Expr.summon[argType is Showable].getOrElse:
+                halt(m"apoplexy: the path parameter $parameter cannot be rendered as text")
+
+              ' {
+                  val rendered = $showable.text($valueExpr)
+                  val updated = $self.request.substitutions.updated($paramExpr.tt, rendered)
+
+                  Api.make($self.request.copy(path = $locusExpr.tt, substitutions = updated))
+                  . asInstanceOf[result]
+                }
+
+  def appliedNamed(self: Expr[Api], field: Expr[String], args: Expr[Seq[(String, Any)]])
+  :   Macro[Api.Response] =
+
+    halt(m"apoplexy: invocation is not implemented yet")
+
+  def decode[value: Type](self: Expr[Api.Response]): Macro[value] =
+    halt(m"apoplexy: .as is not implemented yet")

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -48,6 +48,7 @@ import spectacular.*
 import telekinesis.*
 import turbulence.*
 import vacuous.*
+import xylophone.*
 
 import charEncoders.utf8
 import strategies.throwUnsafely
@@ -104,20 +105,24 @@ object Apoplexy:
     import quotes.reflect.*
     TypeBounds(repr, repr)
 
-  private def apiType(using quotes: Quotes)(locus: Text, source: Text): quotes.reflect.TypeRepr =
+  private def apiType(using quotes: Quotes)(locus: Text, source: Text, wire: Wire)
+  :   quotes.reflect.TypeRepr =
+
     import quotes.reflect.*
 
     val withLocus = Refinement(TypeRepr.of[Api], "Locus", bounds(literalType(locus)))
-    Refinement(withLocus, "Source", bounds(literalType(source)))
+    val withSource = Refinement(withLocus, "Source", bounds(literalType(source)))
+    Refinement(withSource, "Transport", bounds(transportRepr(wire)))
 
-  private def receiver(using quotes: Quotes)(self: Expr[Api]): (Text, Text) =
+  private def receiver(using quotes: Quotes)(self: Expr[Api]): (Text, Text, Wire) =
     import quotes.reflect.*
 
     val members = refinements(self.asTerm.tpe.widen)
     val locus = members.at(t"Locus").lay(t"/")(stringOf(_))
     val source = members.at(t"Source").or(halt(m"apoplexy: the receiver has no spec `Source`"))
+    val wire = members.at(t"Transport").lay(Wire.Json)(wireOfRepr(_))
 
-    (locus, stringOf(source))
+    (locus, stringOf(source), wire)
 
   // --- path utilities ------------------------------------------------------
 
@@ -186,6 +191,54 @@ object Apoplexy:
       case Some(param) => param.schema.lay(TypeRepr.of[Text])(schemaType(doc, _))
       case None        => TypeRepr.of[Text]
 
+  // --- wire format ---------------------------------------------------------
+
+  // The wire format an operation speaks, inferred from its `content` media types.
+  // The end-user never chooses this; the OpenAPI spec dictates it.
+  private enum Wire:
+    case Json, Xml
+
+  private def mediaOf(wire: Wire): Text = wire match
+    case Wire.Json => t"application/json"
+    case Wire.Xml  => t"application/xml"
+
+  // JSON wins ties (the OpenAPI default, and the historical behaviour).
+  private def wireOf(content: Map[Text, OpenApi.MediaTypeObject]): Optional[Wire] =
+    if content.isEmpty then Unset
+    else if content.contains(t"application/json") then Wire.Json
+    else if content.contains(t"application/xml") || content.contains(t"text/xml") then Wire.Xml
+    else Wire.Json
+
+  // The wire format of an operation's first 2xx response body, if any.
+  private def responseWire(operation: OpenApi.Operation): Optional[Wire] =
+    val status = operation.responses.keys.filter(_.starts(t"2")).to(List).sortBy(_.s).prim
+
+    status.let(operation.responses.at(_)).let: response =>
+      wireOf(response.content)
+
+  // The spec-wide wire format if every operation agrees, else `Json` as a neutral
+  // placeholder for navigation types. The authoritative format is always recomputed
+  // per operation by `invoke`.
+  private def uniformWire(doc: OpenApi): Wire =
+    val wires =
+      doc.paths.values.flatMap(_.operations.values).to(List).flatMap: operation =>
+        responseWire(operation).lay(List[Wire]())(List(_))
+
+    . to(Set)
+
+    if wires.size == 1 then wires.head else Wire.Json
+
+  private def transportRepr(using quotes: Quotes)(wire: Wire): quotes.reflect.TypeRepr =
+    import quotes.reflect.*
+
+    wire match
+      case Wire.Json => TypeRepr.of[Json]
+      case Wire.Xml  => TypeRepr.of[Xml]
+
+  private def wireOfRepr(using quotes: Quotes)(repr: quotes.reflect.TypeRepr): Wire =
+    import quotes.reflect.*
+    if repr =:= TypeRepr.of[Xml] then Wire.Xml else Wire.Json
+
   // --- invocation ----------------------------------------------------------
 
   // Builds the `Api.Response` for invoking `method` on the complete endpoint
@@ -236,12 +289,29 @@ object Apoplexy:
 
     val queryExpr = Expr.ofList(queryEntries)
 
-    val bodyExpr: Expr[Optional[Json]] = positional match
+    val status =
+      operation.responses.keys.filter(_.starts(t"2")).to(List).sortBy(_.s).prim.or(t"200")
+
+    // The wire format the spec dictates for this operation: the response body's
+    // media type, else the request body's, else JSON. An operation that mixes
+    // request and response media types is not supported.
+    val respWire = operation.responses.at(status).let: response =>
+      wireOf(response.content)
+
+    val reqWire = operation.requestBody.let: body =>
+      wireOf(body.content)
+
+    if respWire.present && reqWire.present && respWire.vouch != reqWire.vouch
+    then halt(m"apoplexy: $verb $locus mixes request and response media types")
+
+    val wire = respWire.or(reqWire.or(Wire.Json))
+
+    val bodyExpr: Expr[Api.Body] = positional match
       case Nil =>
         if operation.requestBody.let(_.required.or(false)).or(false)
         then halt(m"apoplexy: $verb $locus requires a request body")
 
-        '{Unset}
+        '{Api.Body.Empty}
 
       case List(argExpr) =>
         if operation.requestBody.absent then halt(m"apoplexy: $verb $locus takes no request body")
@@ -250,30 +320,38 @@ object Apoplexy:
           case '[bodyType] =>
             val value = argExpr.asExprOf[bodyType]
 
-            val encodable = Expr.summon[bodyType is Encodable in Json].getOrElse:
-              halt(m"apoplexy: the request body cannot be encoded as JSON")
+            wire match
+              case Wire.Json =>
+                val encodable = Expr.summon[bodyType is Encodable in Json].getOrElse:
+                  halt(m"apoplexy: the request body cannot be encoded as JSON")
 
-            '{$encodable.encoded($value)}
+                '{Api.Body.Json($encodable.encoded($value))}
+
+              case Wire.Xml =>
+                val encodable = Expr.summon[bodyType is Encodable in Xml].getOrElse:
+                  halt(m"apoplexy: the request body cannot be encoded as XML")
+
+                '{Api.Body.Xml($encodable.encoded($value))}
 
       case _ =>
         halt(m"apoplexy: $verb $locus takes a single request body")
 
-    val status =
-      operation.responses.keys.filter(_.starts(t"2")).to(List).sortBy(_.s).prim.or(t"200")
-
-    val jsonContent = escape(t"application/json")
+    val mediaContent = escape(mediaOf(wire))
 
     val pointer =
-      t"#/paths/${escape(locus)}/$verb/responses/$status/content/$jsonContent/schema"
+      t"#/paths/${escape(locus)}/$verb/responses/$status/content/$mediaContent/schema"
 
     val mExpr = methodExpr(method)
     val locusExpr = Expr(locus.s)
 
     val responseType =
       Refinement
-        ( Refinement(TypeRepr.of[Api.Response], "Result", bounds(literalType(pointer))),
-          "Form",
-          bounds(literalType(source)) )
+        ( Refinement
+           ( Refinement(TypeRepr.of[Api.Response], "Result", bounds(literalType(pointer))),
+             "Form",
+             bounds(literalType(source)) ),
+          "Transport",
+          bounds(transportRepr(wire)) )
 
     responseType.asType.absolve match
       case '[type result <: Api.Response; result] =>
@@ -339,14 +417,15 @@ object Apoplexy:
     val doc = spec(source)
     val base = if doc.servers.isEmpty then t"" else doc.servers.head.url
     val baseExpr = Expr(base.s)
+    val wire = uniformWire(doc)
 
-    apiType(t"/", source).asType.absolve match
+    apiType(t"/", source, wire).asType.absolve match
       case '[type result <: Api; result] =>
         '{Api.make(Api.Request(Http.Get, $baseExpr.tt, t"/")).asInstanceOf[result]}
 
   def select(self: Expr[Api], field: Expr[String]): Macro[Any] =
     val name = field.valueOrAbort.tt
-    val (locus, source) = receiver(self)
+    val (locus, source, wire) = receiver(self)
     val doc = spec(source)
 
     verbs.at(name) match
@@ -354,10 +433,10 @@ object Apoplexy:
         invoke(self, doc, source, locus, method, Nil, Nil)
 
       case _ =>
-        navigate(self, source, doc, locus, name)
+        navigate(self, source, doc, locus, name, wire)
 
   private def navigate(using quotes: Quotes)
-    ( self: Expr[Api], source: Text, doc: OpenApi, locus: Text, name: Text )
+    ( self: Expr[Api], source: Text, doc: OpenApi, locus: Text, name: Text, wire: Wire )
   :   Expr[Any] =
 
     val newLocus = join(locus, name)
@@ -368,13 +447,13 @@ object Apoplexy:
 
     val locusExpr = Expr(newLocus.s)
 
-    apiType(newLocus, source).asType.absolve match
+    apiType(newLocus, source, wire).asType.absolve match
       case '[type result <: Api; result] =>
         '{Api.make($self.request.copy(path = $locusExpr.tt)).asInstanceOf[result]}
 
   def applied(self: Expr[Api], field: Expr[String], args: Expr[Seq[Any]]): Macro[Any] =
     val name = field.valueOrAbort.tt
-    val (locus, source) = receiver(self)
+    val (locus, source, wire) = receiver(self)
     val doc = spec(source)
 
     val positional = args match
@@ -398,8 +477,10 @@ object Apoplexy:
         val following = keys.filter(deeper).map(_(newSegs.length)).find(isTemplate)
 
         following match
-          case Some(template) => fillTemplate(self, source, doc, newLocus, template, positional)
-          case None           => shortcut(self, doc, source, newLocus, Nil, positional)
+          case None => shortcut(self, doc, source, newLocus, Nil, positional)
+
+          case Some(template) =>
+            fillTemplate(self, source, doc, newLocus, template, positional, wire)
 
   private def fillTemplate(using quotes: Quotes)
     ( self:       Expr[Api],
@@ -407,7 +488,8 @@ object Apoplexy:
       doc:        OpenApi,
       newLocus:   Text,
       template:   Text,
-      positional: List[Expr[Any]] )
+      positional: List[Expr[Any]],
+      wire:       Wire )
   :   Expr[Any] =
 
     import quotes.reflect.*
@@ -428,7 +510,7 @@ object Apoplexy:
     val locusExpr = Expr(templatedLocus.s)
     val paramExpr = Expr(parameter.s)
 
-    apiType(templatedLocus, source).asType.absolve match
+    apiType(templatedLocus, source, wire).asType.absolve match
       case '[type result <: Api; result] => actual.asType.absolve match
         case '[argType] =>
           val value = arg.asExprOf[argType]
@@ -448,7 +530,7 @@ object Apoplexy:
   :   Macro[Any] =
 
     val name = field.valueOrAbort.tt
-    val (locus, source) = receiver(self)
+    val (locus, source, wire) = receiver(self)
     val doc = spec(source)
     val entries = pairs(args)
     val named = entries.filter(_(0) != t"")

--- a/lib/apoplexy/src/core/apoplexy.internal.scala
+++ b/lib/apoplexy/src/core/apoplexy.internal.scala
@@ -41,6 +41,7 @@ import gigantism.*
 import gossamer.*
 import hellenism.*
 import jacinta.*
+import prepositional.*
 import rudiments.*
 import spectacular.*
 import strategies.throwUnsafely
@@ -94,13 +95,17 @@ object Apoplexy:
 
     ConstantType(StringConstant(value.s))
 
+  private def bounds(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :   quotes.reflect.TypeBounds =
+
+    import quotes.reflect.*
+    TypeBounds(repr, repr)
+
   private def apiType(using quotes: Quotes)(locus: Text, source: Text): quotes.reflect.TypeRepr =
     import quotes.reflect.*
 
-    val withLocus =
-      Refinement(TypeRepr.of[Api], "Locus", TypeBounds(literalType(locus), literalType(locus)))
-
-    Refinement(withLocus, "Source", TypeBounds(literalType(source), literalType(source)))
+    val withLocus = Refinement(TypeRepr.of[Api], "Locus", bounds(literalType(locus)))
+    Refinement(withLocus, "Source", bounds(literalType(source)))
 
   private def receiver(using quotes: Quotes)(self: Expr[Api]): (Text, Text) =
     import quotes.reflect.*
@@ -122,6 +127,28 @@ object Apoplexy:
 
   private def join(locus: Text, segment: Text): Text =
     if locus == t"/" then t"/$segment" else t"$locus/$segment"
+
+  private def escape(text: Text): Text = text.sub(t"~", t"~0").sub(t"/", t"~1")
+
+  // --- HTTP method helpers -------------------------------------------------
+
+  private val verbs: Map[Text, Http.Method] =
+    Map(t"get" -> Http.Get, t"post" -> Http.Post, t"put" -> Http.Put, t"patch" -> Http.Patch,
+        t"delete" -> Http.Delete)
+
+  private def methodName(method: Http.Method): Text = method match
+    case Http.Post   => t"post"
+    case Http.Put    => t"put"
+    case Http.Patch  => t"patch"
+    case Http.Delete => t"delete"
+    case _           => t"get"
+
+  private def methodExpr(using Quotes)(method: Http.Method): Expr[Http.Method] = method match
+    case Http.Post   => '{Http.Post}
+    case Http.Put    => '{Http.Put}
+    case Http.Patch  => '{Http.Patch}
+    case Http.Delete => '{Http.Delete}
+    case _           => '{Http.Get}
 
   // --- schema → Scala type -------------------------------------------------
 
@@ -156,6 +183,140 @@ object Apoplexy:
       case Some(param) => param.schema.lay(TypeRepr.of[Text])(schemaType(doc, _))
       case None        => TypeRepr.of[Text]
 
+  // --- invocation ----------------------------------------------------------
+
+  // Builds the `Api.Response` for invoking `method` on the complete endpoint
+  // `locus`: typechecks named args against the query parameters, the single
+  // optional positional against the request body, and records the 2xx response
+  // schema's pointer in the result type.
+  private def invoke(using quotes: Quotes)
+    ( self:       Expr[Api],
+      doc:        OpenApi,
+      source:     Text,
+      locus:      Text,
+      method:     Http.Method,
+      named:      List[(Text, Expr[Any])],
+      positional: List[Expr[Any]] )
+  :   Expr[Any] =
+
+    import quotes.reflect.*
+
+    val verb = methodName(method)
+
+    val operation = doc.paths.at(locus).let(_.operations.at(method)).or:
+      halt(m"apoplexy: $locus defines no $verb operation")
+
+    val queryParams = operation.parameters.filter(_.`in` == OpenApi.Parameter.In.Query)
+
+    val queryEntries: List[Expr[(Text, Text)]] = named.map: (name, argExpr) =>
+      val param = queryParams.find(_.name == name).getOrElse:
+        halt(m"apoplexy: $verb $locus has no query parameter $name")
+
+      val expected = param.schema.lay(TypeRepr.of[Text])(schemaType(doc, _))
+      val actual = argExpr.asTerm.tpe.widen
+
+      if !(actual <:< expected)
+      then halt(m"apoplexy: the query parameter $name expects ${expected.show}")
+
+      actual.asType.absolve match
+        case '[argType] =>
+          val value = argExpr.asExprOf[argType]
+
+          val showable = Expr.summon[argType is Showable].getOrElse:
+            halt(m"apoplexy: the query parameter $name cannot be rendered as text")
+
+          '{(${Expr(name.s)}.tt, $showable.text($value))}
+
+    queryParams.filter(_.required.or(false)).each: param =>
+      if !named.exists(_(0) == param.name)
+      then halt(m"apoplexy: required query parameter ${param.name} is missing")
+
+    val queryExpr = Expr.ofList(queryEntries)
+
+    val bodyExpr: Expr[Optional[Json]] = positional match
+      case Nil =>
+        if operation.requestBody.let(_.required.or(false)).or(false)
+        then halt(m"apoplexy: $verb $locus requires a request body")
+        '{Unset}
+
+      case List(argExpr) =>
+        if operation.requestBody.absent then halt(m"apoplexy: $verb $locus takes no request body")
+
+        argExpr.asTerm.tpe.widen.asType.absolve match
+          case '[bodyType] =>
+            val value = argExpr.asExprOf[bodyType]
+
+            val encodable = Expr.summon[bodyType is Encodable in Json].getOrElse:
+              halt(m"apoplexy: the request body cannot be encoded as JSON")
+
+            '{$encodable.encoded($value)}
+
+      case _ =>
+        halt(m"apoplexy: $verb $locus takes a single request body")
+
+    val status =
+      operation.responses.keys.filter(_.starts(t"2")).to(List).sortBy(_.s).prim.or(t"200")
+
+    val pointer =
+      t"#/paths/${escape(locus)}/$verb/responses/$status/content/${escape(t"application/json")}/schema"
+
+    val mExpr = methodExpr(method)
+    val locusExpr = Expr(locus.s)
+
+    val responseType =
+      Refinement
+        ( Refinement(TypeRepr.of[Api.Response], "Result", bounds(literalType(pointer))),
+          "Form",
+          bounds(literalType(source)) )
+
+    responseType.asType.absolve match
+      case '[type result <: Api.Response; result] =>
+        '{
+            val request =
+              $self.request.copy
+               (method = $mExpr, path = $locusExpr.tt, query = $queryExpr, body = $bodyExpr)
+
+            Api.Response.make(request).asInstanceOf[result]
+          }
+
+  // Invokes the sole non-DELETE method of a complete endpoint (the `apply`
+  // shortcut). DELETE never participates: a sole-DELETE endpoint still requires
+  // an explicit `.delete()`.
+  private def shortcut(using quotes: Quotes)
+    ( self: Expr[Api], doc: OpenApi, source: Text, locus: Text,
+      named: List[(Text, Expr[Any])], positional: List[Expr[Any]] )
+  :   Expr[Any] =
+
+    val methods =
+      doc.paths.at(locus).lay(List[Http.Method]()): item =>
+        item.operations.keys.filter(_ != Http.Delete).to(List)
+
+    methods match
+      case List(method) =>
+        invoke(self, doc, source, locus, method, named, positional)
+
+      case Nil =>
+        halt(m"apoplexy: $locus has no invokable operation (use `.delete()` for a DELETE endpoint)")
+
+      case _ =>
+        halt(m"apoplexy: $locus has several operations; use `.get`, `.post`, `.put` or `.patch`")
+
+  // Extracts the (name, value) pairs from `applyDynamicNamed` arguments; a
+  // positional argument arrives with an empty name.
+  private def pairs(using quotes: Quotes)(args: Expr[Seq[(String, Any)]])
+  :   List[(Text, Expr[Any])] =
+
+    args match
+      case Varargs(exprs) => exprs.to(List).map:
+        case '{($key: String, $value)} => (key.valueOrAbort.tt, value)
+        case _                         => halt(m"apoplexy: arguments must be passed directly")
+
+      case _ =>
+        halt(m"apoplexy: arguments must be passed directly")
+
+  private def defines(using Quotes)(doc: OpenApi, locus: Text, method: Http.Method): Boolean =
+    doc.paths.at(locus).let(_.operations.contains(method)).or(false)
+
   // --- macros --------------------------------------------------------------
 
   def root(resource: Expr[Resource]): Macro[Api] =
@@ -174,13 +335,24 @@ object Apoplexy:
       case '[type result <: Api; result] =>
         '{Api.make(Api.Request(Http.Get, $baseExpr.tt, t"/")).asInstanceOf[result]}
 
-  def select(self: Expr[Api], field: Expr[String]): Macro[Api] =
+  def select(self: Expr[Api], field: Expr[String]): Macro[Any] =
     val name = field.valueOrAbort.tt
     val (locus, source) = receiver(self)
     val doc = spec(source)
-    val keys = doc.paths.keys.map(segments).to(List)
+
+    verbs.at(name) match
+      case method: Http.Method if defines(doc, locus, method) =>
+        invoke(self, doc, source, locus, method, Nil, Nil)
+
+      case _ =>
+        navigate(self, source, doc, locus, name)
+
+  private def navigate(using quotes: Quotes)
+    (self: Expr[Api], source: Text, doc: OpenApi, locus: Text, name: Text): Expr[Any] =
+
     val newLocus = join(locus, name)
     val newSegs = segments(newLocus)
+    val keys = doc.paths.keys.map(segments).to(List)
 
     if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
 
@@ -190,63 +362,97 @@ object Apoplexy:
       case '[type result <: Api; result] =>
         '{Api.make($self.request.copy(path = $locusExpr.tt)).asInstanceOf[result]}
 
-  def applied(self: Expr[Api], field: Expr[String], args: Expr[Seq[Any]]): Macro[Api] =
+  def applied(self: Expr[Api], field: Expr[String], args: Expr[Seq[Any]]): Macro[Any] =
+    val name = field.valueOrAbort.tt
+    val (locus, source) = receiver(self)
+    val doc = spec(source)
+
+    val positional = args match
+      case Varargs(exprs) => exprs.to(List)
+      case _              => halt(m"apoplexy: arguments must be passed directly")
+
+    verbs.at(name) match
+      case method: Http.Method if defines(doc, locus, method) =>
+        invoke(self, doc, source, locus, method, Nil, positional)
+
+      case _ =>
+        val newLocus = join(locus, name)
+        val newSegs = segments(newLocus)
+        val keys = doc.paths.keys.map(segments).to(List)
+
+        if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
+
+        val following =
+          keys.filter { key => isPrefix(newSegs, key) && key.length > newSegs.length }
+           .map(_(newSegs.length))
+           .find(isTemplate)
+
+        following match
+          case Some(template) => fillTemplate(self, source, doc, newLocus, template, positional)
+          case None           => shortcut(self, doc, source, newLocus, Nil, positional)
+
+  private def fillTemplate(using quotes: Quotes)
+    (self: Expr[Api], source: Text, doc: OpenApi, newLocus: Text, template: Text,
+     positional: List[Expr[Any]]): Expr[Any] =
+
     import quotes.reflect.*
+
+    val parameter = templateName(template)
+    val templatedLocus = join(newLocus, template)
+
+    val arg = positional match
+      case List(only) => only
+      case _          => halt(m"apoplexy: path parameter $parameter needs one argument")
+
+    val expected = pathParamType(doc, templatedLocus, parameter)
+    val actual = arg.asTerm.tpe.widen
+
+    if !(actual <:< expected)
+    then halt(m"apoplexy: path parameter $parameter expects ${expected.show}")
+
+    val locusExpr = Expr(templatedLocus.s)
+    val paramExpr = Expr(parameter.s)
+
+    apiType(templatedLocus, source).asType.absolve match
+      case '[type result <: Api; result] => actual.asType.absolve match
+        case '[argType] =>
+          val value = arg.asExprOf[argType]
+
+          val showable = Expr.summon[argType is Showable].getOrElse:
+            halt(m"apoplexy: the path parameter $parameter cannot be rendered as text")
+
+          ' {
+              val rendered = $showable.text($value)
+              val updated = $self.request.substitutions.updated($paramExpr.tt, rendered)
+
+              Api.make($self.request.copy(path = $locusExpr.tt, substitutions = updated))
+              . asInstanceOf[result]
+            }
+
+  def appliedNamed(self: Expr[Api], field: Expr[String], args: Expr[Seq[(String, Any)]])
+  :   Macro[Any] =
 
     val name = field.valueOrAbort.tt
     val (locus, source) = receiver(self)
     val doc = spec(source)
-    val keys = doc.paths.keys.map(segments).to(List)
-    val newLocus = join(locus, name)
-    val newSegs = segments(newLocus)
+    val entries = pairs(args)
+    val named = entries.filter(_(0) != t"")
+    val positional = entries.filter(_(0) == t"").map(_(1))
 
-    if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
+    verbs.at(name) match
+      case method: Http.Method if defines(doc, locus, method) =>
+        invoke(self, doc, source, locus, method, named, positional)
 
-    val children = keys.filter: key =>
-      isPrefix(newSegs, key) && key.length > newSegs.length
+      case _ =>
+        val newLocus = join(locus, name)
+        val newSegs = segments(newLocus)
+        val keys = doc.paths.keys.map(segments).to(List)
 
-    children.map(_(newSegs.length)).find(isTemplate) match
-      case None =>
-        halt(m"apoplexy: invocation is not implemented yet")
+        if !keys.exists(isPrefix(newSegs, _)) then halt(m"apoplexy: no path begins with $newLocus")
+        if doc.paths.at(newLocus).absent
+        then halt(m"apoplexy: $newLocus is not a complete endpoint")
 
-      case Some(template) =>
-        val parameter = templateName(template)
-        val templatedLocus = join(newLocus, template)
-
-        val arg = args match
-          case Varargs(Seq(only)) => only
-          case Varargs(_)         => halt(m"apoplexy: path parameter $parameter needs one argument")
-          case _                  => halt(m"apoplexy: the path argument must be passed directly")
-
-        val expected = pathParamType(doc, templatedLocus, parameter)
-        val actual = arg.asTerm.tpe.widen
-
-        if !(actual <:< expected)
-        then halt(m"apoplexy: path parameter $parameter expects ${expected.show}")
-
-        val locusExpr = Expr(templatedLocus.s)
-        val paramExpr = Expr(parameter.s)
-
-        apiType(templatedLocus, source).asType.absolve match
-          case '[type result <: Api; result] => actual.asType.absolve match
-            case '[argType] =>
-              val valueExpr = arg.asExprOf[argType]
-
-              val showable = Expr.summon[argType is Showable].getOrElse:
-                halt(m"apoplexy: the path parameter $parameter cannot be rendered as text")
-
-              ' {
-                  val rendered = $showable.text($valueExpr)
-                  val updated = $self.request.substitutions.updated($paramExpr.tt, rendered)
-
-                  Api.make($self.request.copy(path = $locusExpr.tt, substitutions = updated))
-                  . asInstanceOf[result]
-                }
-
-  def appliedNamed(self: Expr[Api], field: Expr[String], args: Expr[Seq[(String, Any)]])
-  :   Macro[Api.Response] =
-
-    halt(m"apoplexy: invocation is not implemented yet")
+        shortcut(self, doc, source, newLocus, named, positional)
 
   def decode[value: Type](self: Expr[Api.Response]): Macro[value] =
     halt(m"apoplexy: .as is not implemented yet")

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -48,6 +48,7 @@ case class NewPet(name: Text, tag: Optional[Text] = Unset)
 case class Photo(url: Text, width: Optional[Int] = Unset, height: Optional[Int] = Unset)
 case class Pet(id: Int, name: Text, tag: Optional[Text] = Unset)
 case class Note(id: Int, text: Text)
+case class NewNote(text: Text)
 
 // A test `Http.Backend` that captures the request it is given and replies with a
 // canned response, so `.call` can be exercised without any network access.
@@ -272,3 +273,16 @@ object ApiTests extends Suite(m"Api client tests"):
         xmlApi.notes(1).get.call[Note]()
         recorder.lastHeaders.filter(_.key == t"accept").map(_.value)
       . assert(_ == List(t"application/xml"))
+
+      test(m"the request body is encoded as XML"):
+        xmlApi.notes.post(NewNote(t"hi")).request.body match
+          case Api.Body.Xml(_) => true
+          case _               => false
+      . assert(_ == true)
+
+      test(m"an XML POST sends an XML body and content-type"):
+        val recorder = Recorder(() => Http.Response(Http.Created, contentType = media"application/xml")(noteXml))
+        given Http.Backend = recorder
+        xmlApi.notes.post(NewNote(t"hi")).call[Note]()
+        (recorder.lastHeaders.filter(_.key == t"content-type").map(_.value), recorder.lastBody.present)
+      . assert(_ == (List(t"application/xml"), true))

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -1,0 +1,57 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package apoplexy
+
+import soundness.*
+
+import strategies.throwUnsafely
+
+object ApiTests extends Suite(m"Api client tests"):
+  def run(): Unit =
+    val api = Api(cp"/apoplexy/petstore.json")
+
+    suite(m"navigation refines the path type"):
+      test(m"a literal segment refines Locus"):
+        val pets: Api at "/pets" = api.pets
+        pets.request.path
+      . assert(_ == t"/pets")
+
+      test(m"a positional arg fills the following path template"):
+        val one: Api at "/pets/{petId}" = api.pets(42)
+        one.request.substitutions
+      . assert(_ == Map(t"petId" -> t"42"))
+
+      test(m"nested templated navigation"):
+        val photos: Api at "/pets/{petId}/photos" = api.pets(42).photos
+        photos.request.path
+      . assert(_ == t"/pets/{petId}/photos")

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -101,6 +101,14 @@ object ApiTests extends Suite(m"Api client tests"):
         api.login(Credentials(t"jon", t"pw")).request
       . assert(request => request.method == Http.Post && request.path == t"/login" && request.body.present)
 
+      test(m"PUT sole method with a positional body (verb omitted)"):
+        api.profile(NewPet(t"Rex")).request
+      . assert(request => request.method == Http.Put && request.path == t"/profile" && request.body.present)
+
+      test(m"the verb is still explicitly usable on a sole-method endpoint"):
+        api.profile.put(NewPet(t"Rex")).request.method
+      . assert(_ == Http.Put)
+
       test(m"an optional query parameter may be omitted"):
         api.pets(42).photos(width = 10).request.query
       . assert(_ == List(t"width" -> t"10"))

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -124,15 +124,15 @@ object ApiTests extends Suite(m"Api client tests"):
 
     suite(m"delete is always explicit"):
       test(m"DELETE /pets/{petId}"):
-        api.pets(42).delete().request.method
+        api.pets(42).delete.request.method
       . assert(_ == Http.Delete)
 
       test(m"a DELETE-only endpoint with a path parameter"):
-        api.sessions(t"abc").delete().request
+        api.sessions(t"abc").delete.request
       . assert(request => request.method == Http.Delete && request.substitutions == Map(t"token" -> t"abc"))
 
       test(m"a DELETE-only endpoint reached by a bare segment"):
-        api.logout.delete().request.method
+        api.logout.delete.request.method
       . assert(_ == Http.Delete)
 
     suite(m"compile-time safety"):
@@ -165,48 +165,60 @@ object ApiTests extends Suite(m"Api client tests"):
       . assert(_ > 0)
 
     suite(m"sending and decoding responses"):
-      test(m".call[Pet] decodes a single pet"):
+      test(m".call[Pet]() decodes a single pet"):
         given Http.Backend = Recorder(() => ok(petJson))
-        api.pets(42).get.call[Pet]
+        api.pets(42).get.call[Pet]()
       . assert(_ == Pet(42, t"Milo", t"cat"))
 
-      test(m".call[List[Pet]] decodes a list of pets"):
+      test(m".call[List[Pet]]() decodes a list of pets"):
         given Http.Backend = Recorder(() => ok(petsJson))
-        api.pets.get(limit = 10).call[List[Pet]]
+        api.pets.get(limit = 10).call[List[Pet]]()
       . assert(_ == List(Pet(1, t"Ada"), Pet(2, t"Bea")))
 
-      test(m".call[Json] returns the raw body"):
+      test(m".call[Json]() returns the raw body"):
         given Http.Backend = Recorder(() => ok(petJson))
-        api.pets(42).get.call[Json]
+        api.pets(42).get.call[Json]()
       . assert(_.as[Pet] == Pet(42, t"Milo", t"cat"))
 
-      test(m".call[Http.Response] returns the raw response"):
+      test(m".call[Http.Response]() returns the raw response"):
         given Http.Backend = Recorder(() => ok(petJson))
-        api.pets(42).get.call[Http.Response].status
+        api.pets(42).get.call[Http.Response]().status
       . assert(_ == Http.Ok)
+
+      test(m".call[Unit]() on a DELETE checks success and discards the body"):
+        given Http.Backend = Recorder(() => Http.Response(Http.NoContent)())
+        api.sessions(t"abc").delete.call[Unit]()
+      . assert(_ == ())
+
+      test(m"a bare .call() defaults to Unit"):
+        val recorder = Recorder(() => Http.Response(Http.NoContent)())
+        given Http.Backend = recorder
+        api.logout.delete.call()
+        recorder.lastMethod
+      . assert(_ == Http.Delete)
 
       test(m"the request URL and method are sent as navigated"):
         val recorder = Recorder(() => ok(petJson))
         given Http.Backend = recorder
-        api.pets(42).get.call[Pet]
+        api.pets(42).get.call[Pet]()
         (recorder.lastUrl, recorder.lastMethod)
       . assert(_ == (t"https://api.example.com/v1/pets/42", Http.Get))
 
       test(m"a POST sends its body"):
         val recorder = Recorder(() => ok(petJson))
         given Http.Backend = recorder
-        api.pets.post(NewPet(t"Milo", tag = t"cat")).call[Pet]
+        api.pets.post(NewPet(t"Milo", tag = t"cat")).call[Pet]()
         (recorder.lastMethod, recorder.lastBody.present)
       . assert(_ == (Http.Post, true))
 
       test(m"a non-2xx response raises ApiError"):
         given Http.Backend = Recorder(() => Http.Response(Http.NotFound)(t"{}"))
-        capture[ApiError](api.pets(42).get.call[Pet]).reason
+        capture[ApiError](api.pets(42).get.call[Pet]()).reason
       . assert(_ == ApiError.Reason.Status(404))
 
       test(m"a type that does not conform to the schema is rejected"):
         demilitarize:
           given Http.Backend = Recorder(() => ok(petJson))
-          api.pets(42).get.call[Photo]
+          api.pets(42).get.call[Photo]()
         . length
       . assert(_ > 0)

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -38,6 +38,8 @@ import strategies.throwUnsafely
 import logging.silent
 import internetAccess.enabled
 import charEncoders.utf8
+import charDecoders.utf8
+import textSanitizers.skip
 import jsonPrinters.minimal
 import errorDiagnostics.stackTraces
 
@@ -45,13 +47,15 @@ case class Credentials(username: Text, password: Text)
 case class NewPet(name: Text, tag: Optional[Text] = Unset)
 case class Photo(url: Text, width: Optional[Int] = Unset, height: Optional[Int] = Unset)
 case class Pet(id: Int, name: Text, tag: Optional[Text] = Unset)
+case class Note(id: Int, text: Text)
 
 // A test `Http.Backend` that captures the request it is given and replies with a
-// canned response, so `.as` can be exercised without any network access.
+// canned response, so `.call` can be exercised without any network access.
 class Recorder(canned: () => Http.Response) extends Http.Backend:
-  var lastUrl:    Optional[Text]        = Unset
-  var lastMethod: Optional[Http.Method] = Unset
-  var lastBody:   Optional[IArray[Byte]] = Unset
+  var lastUrl:     Optional[Text]        = Unset
+  var lastMethod:  Optional[Http.Method] = Unset
+  var lastBody:    Optional[IArray[Byte]] = Unset
+  var lastHeaders: List[Http.Header]     = Nil
 
   def request
      ( url: Text, method: Http.Method, headers: List[Http.Header], body: () => Stream[Data] )
@@ -59,12 +63,15 @@ class Recorder(canned: () => Http.Response) extends Http.Backend:
   :   Http.Response =
     lastUrl = url
     lastMethod = method
+    lastHeaders = headers
     val chunks = body().to(List)
     lastBody = if chunks.isEmpty then Unset else chunks.head
     canned()
 
 object ApiTests extends Suite(m"Api client tests"):
   def run(): Unit =
+    given XmlSchema = XmlSchema.Freeform
+
     val api = Api(cp"/apoplexy/petstore.json")
 
     val petJson  = t"""{"id": 42, "name": "Milo", "tag": "cat"}"""
@@ -99,11 +106,11 @@ object ApiTests extends Suite(m"Api client tests"):
 
       test(m"POST sole method with a positional body"):
         api.login(Credentials(t"jon", t"pw")).request
-      . assert(request => request.method == Http.Post && request.path == t"/login" && request.body.present)
+      . assert(request => request.method == Http.Post && request.path == t"/login" && (request.body != Api.Body.Empty))
 
       test(m"PUT sole method with a positional body (verb omitted)"):
         api.profile(NewPet(t"Rex")).request
-      . assert(request => request.method == Http.Put && request.path == t"/profile" && request.body.present)
+      . assert(request => request.method == Http.Put && request.path == t"/profile" && (request.body != Api.Body.Empty))
 
       test(m"the verb is still explicitly usable on a sole-method endpoint"):
         api.profile.put(NewPet(t"Rex")).request.method
@@ -120,7 +127,7 @@ object ApiTests extends Suite(m"Api client tests"):
 
       test(m"POST /pets via explicit .post with a body"):
         api.pets.post(NewPet(t"Milo", tag = t"cat")).request
-      . assert(request => request.method == Http.Post && request.body.present)
+      . assert(request => request.method == Http.Post && (request.body != Api.Body.Empty))
 
       test(m"GET /pets/{petId} via explicit .get with no arguments"):
         api.pets(42).get.request
@@ -230,3 +237,38 @@ object ApiTests extends Suite(m"Api client tests"):
           api.pets(42).get.call[Photo]()
         . length
       . assert(_ > 0)
+
+    suite(m"the spec decides the wire format (Api over Json / over Xml)"):
+      val xmlApi = Api(cp"/apoplexy/xmlstore.json")
+      val noteXml = t"<Note><id>1</id><text>hello</text></Note>"
+
+      def okXml(body: Text): Http.Response =
+        Http.Response(Http.Ok, contentType = media"application/xml")(body)
+
+      test(m"a uniform JSON spec is tracked as `Api over Json`"):
+        val typed: Api over Json = api
+        typed.request.path
+      . assert(_ == t"/")
+
+      test(m"a uniform XML spec is tracked as `Api over Xml`"):
+        val typed: Api over Xml = xmlApi
+        typed.request.path
+      . assert(_ == t"/")
+
+      test(m"an XML endpoint's response is `Api.Response over Xml`"):
+        given Http.Backend = Recorder(() => okXml(noteXml))
+        val typed: Api.Response over Xml = xmlApi.notes(1).get
+        typed.request.method
+      . assert(_ == Http.Get)
+
+      test(m".call[Note]() decodes an XML response body"):
+        given Http.Backend = Recorder(() => okXml(noteXml))
+        xmlApi.notes(1).get.call[Note]()
+      . assert(_ == Note(1, t"hello"))
+
+      test(m"an XML GET sends `Accept: application/xml`"):
+        val recorder = Recorder(() => okXml(noteXml))
+        given Http.Backend = recorder
+        xmlApi.notes(1).get.call[Note]()
+        recorder.lastHeaders.filter(_.key == t"accept").map(_.value)
+      . assert(_ == List(t"application/xml"))

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -34,13 +34,44 @@ package apoplexy
 
 import soundness.*
 
+import strategies.throwUnsafely
+import logging.silent
+import internetAccess.enabled
+import charEncoders.utf8
+import jsonPrinters.minimal
+import errorDiagnostics.stackTraces
+
 case class Credentials(username: Text, password: Text)
 case class NewPet(name: Text, tag: Optional[Text] = Unset)
 case class Photo(url: Text, width: Optional[Int] = Unset, height: Optional[Int] = Unset)
+case class Pet(id: Int, name: Text, tag: Optional[Text] = Unset)
+
+// A test `Http.Backend` that captures the request it is given and replies with a
+// canned response, so `.as` can be exercised without any network access.
+class Recorder(canned: () => Http.Response) extends Http.Backend:
+  var lastUrl:    Optional[Text]        = Unset
+  var lastMethod: Optional[Http.Method] = Unset
+  var lastBody:   Optional[IArray[Byte]] = Unset
+
+  def request
+     ( url: Text, method: Http.Method, headers: List[Http.Header], body: () => Stream[Data] )
+     ( using Tactic[ConnectError] )
+  :   Http.Response =
+    lastUrl = url
+    lastMethod = method
+    val chunks = body().to(List)
+    lastBody = if chunks.isEmpty then Unset else chunks.head
+    canned()
 
 object ApiTests extends Suite(m"Api client tests"):
   def run(): Unit =
     val api = Api(cp"/apoplexy/petstore.json")
+
+    val petJson  = t"""{"id": 42, "name": "Milo", "tag": "cat"}"""
+    val petsJson = t"""[{"id": 1, "name": "Ada"}, {"id": 2, "name": "Bea"}]"""
+
+    def ok(body: Text): Http.Response =
+      Http.Response(Http.Ok, contentType = media"application/json")(body)
 
     suite(m"navigation refines the path type"):
       test(m"a literal segment refines Locus"):
@@ -131,4 +162,51 @@ object ApiTests extends Suite(m"Api client tests"):
 
       test(m"omitting a required query parameter is rejected"):
         demilitarize(api.pets(42).photos(height = 20)).length
+      . assert(_ > 0)
+
+    suite(m"sending and decoding responses"):
+      test(m".as[Pet] decodes a single pet"):
+        given Http.Backend = Recorder(() => ok(petJson))
+        api.pets(42).get.as[Pet]
+      . assert(_ == Pet(42, t"Milo", t"cat"))
+
+      test(m".as[List[Pet]] decodes a list of pets"):
+        given Http.Backend = Recorder(() => ok(petsJson))
+        api.pets.get(limit = 10).as[List[Pet]]
+      . assert(_ == List(Pet(1, t"Ada"), Pet(2, t"Bea")))
+
+      test(m".as[Json] returns the raw body"):
+        given Http.Backend = Recorder(() => ok(petJson))
+        api.pets(42).get.as[Json]
+      . assert(_.as[Pet] == Pet(42, t"Milo", t"cat"))
+
+      test(m".as[Http.Response] returns the raw response"):
+        given Http.Backend = Recorder(() => ok(petJson))
+        api.pets(42).get.as[Http.Response].status
+      . assert(_ == Http.Ok)
+
+      test(m"the request URL and method are sent as navigated"):
+        val recorder = Recorder(() => ok(petJson))
+        given Http.Backend = recorder
+        api.pets(42).get.as[Pet]
+        (recorder.lastUrl, recorder.lastMethod)
+      . assert(_ == (t"https://api.example.com/v1/pets/42", Http.Get))
+
+      test(m"a POST sends its body"):
+        val recorder = Recorder(() => ok(petJson))
+        given Http.Backend = recorder
+        api.pets.post(NewPet(t"Milo", tag = t"cat")).as[Pet]
+        (recorder.lastMethod, recorder.lastBody.present)
+      . assert(_ == (Http.Post, true))
+
+      test(m"a non-2xx response raises ApiError"):
+        given Http.Backend = Recorder(() => Http.Response(Http.NotFound)(t"{}"))
+        capture[ApiError](api.pets(42).get.as[Pet]).reason
+      . assert(_ == ApiError.Reason.Status(404))
+
+      test(m"a type that does not conform to the schema is rejected"):
+        demilitarize:
+          given Http.Backend = Recorder(() => ok(petJson))
+          api.pets(42).get.as[Photo]
+        . length
       . assert(_ > 0)

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -34,7 +34,9 @@ package apoplexy
 
 import soundness.*
 
-import strategies.throwUnsafely
+case class Credentials(username: Text, password: Text)
+case class NewPet(name: Text, tag: Optional[Text] = Unset)
+case class Photo(url: Text, width: Optional[Int] = Unset, height: Optional[Int] = Unset)
 
 object ApiTests extends Suite(m"Api client tests"):
   def run(): Unit =
@@ -55,3 +57,78 @@ object ApiTests extends Suite(m"Api client tests"):
         val photos: Api at "/pets/{petId}/photos" = api.pets(42).photos
         photos.request.path
       . assert(_ == t"/pets/{petId}/photos")
+
+    suite(m"the apply shortcut invokes the sole non-DELETE method"):
+      test(m"GET sole method with query params (the user's example shape)"):
+        api.pets(42).photos(width = 10, height = 20).request
+      . assert: request =>
+          request.method == Http.Get && request.path == t"/pets/{petId}/photos"
+          && request.substitutions == Map(t"petId" -> t"42")
+          && request.query == List(t"width" -> t"10", t"height" -> t"20")
+
+      test(m"POST sole method with a positional body"):
+        api.login(Credentials(t"jon", t"pw")).request
+      . assert(request => request.method == Http.Post && request.path == t"/login" && request.body.present)
+
+      test(m"an optional query parameter may be omitted"):
+        api.pets(42).photos(width = 10).request.query
+      . assert(_ == List(t"width" -> t"10"))
+
+    suite(m"explicit terminals for multi-method endpoints"):
+      test(m"GET /pets via explicit .get with a query parameter"):
+        api.pets.get(limit = 10).request
+      . assert(request => request.method == Http.Get && request.query == List(t"limit" -> t"10"))
+
+      test(m"POST /pets via explicit .post with a body"):
+        api.pets.post(NewPet(t"Milo", tag = t"cat")).request
+      . assert(request => request.method == Http.Post && request.body.present)
+
+      test(m"GET /pets/{petId} via explicit .get with no arguments"):
+        api.pets(42).get.request
+      . assert(request => request.method == Http.Get && request.path == t"/pets/{petId}")
+
+      test(m"PUT /pets/{petId} via explicit .put with a body"):
+        api.pets(42).put(NewPet(t"Rex")).request.method
+      . assert(_ == Http.Put)
+
+    suite(m"delete is always explicit"):
+      test(m"DELETE /pets/{petId}"):
+        api.pets(42).delete().request.method
+      . assert(_ == Http.Delete)
+
+      test(m"a DELETE-only endpoint with a path parameter"):
+        api.sessions(t"abc").delete().request
+      . assert(request => request.method == Http.Delete && request.substitutions == Map(t"token" -> t"abc"))
+
+      test(m"a DELETE-only endpoint reached by a bare segment"):
+        api.logout.delete().request.method
+      . assert(_ == Http.Delete)
+
+    suite(m"compile-time safety"):
+      test(m"a nonexistent first segment is rejected"):
+        demilitarize(api.unicorns).length
+      . assert(_ > 0)
+
+      test(m"an undeclared path is rejected"):
+        demilitarize(api.pets(42).toys).length
+      . assert(_ > 0)
+
+      test(m"a path parameter of the wrong type is rejected"):
+        demilitarize(api.pets(t"notAnInt")).length
+      . assert(_ > 0)
+
+      test(m"the apply shortcut is rejected on a multi-method endpoint"):
+        demilitarize(api.pets(limit = 10)).length
+      . assert(_ > 0)
+
+      test(m"the apply shortcut cannot invoke a DELETE-only endpoint"):
+        demilitarize(api.logout()).length
+      . assert(_ > 0)
+
+      test(m"a query parameter of the wrong type is rejected"):
+        demilitarize(api.pets(42).photos(width = t"big")).length
+      . assert(_ > 0)
+
+      test(m"omitting a required query parameter is rejected"):
+        demilitarize(api.pets(42).photos(height = 20)).length
+      . assert(_ > 0)

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -165,48 +165,48 @@ object ApiTests extends Suite(m"Api client tests"):
       . assert(_ > 0)
 
     suite(m"sending and decoding responses"):
-      test(m".as[Pet] decodes a single pet"):
+      test(m".call[Pet] decodes a single pet"):
         given Http.Backend = Recorder(() => ok(petJson))
-        api.pets(42).get.as[Pet]
+        api.pets(42).get.call[Pet]
       . assert(_ == Pet(42, t"Milo", t"cat"))
 
-      test(m".as[List[Pet]] decodes a list of pets"):
+      test(m".call[List[Pet]] decodes a list of pets"):
         given Http.Backend = Recorder(() => ok(petsJson))
-        api.pets.get(limit = 10).as[List[Pet]]
+        api.pets.get(limit = 10).call[List[Pet]]
       . assert(_ == List(Pet(1, t"Ada"), Pet(2, t"Bea")))
 
-      test(m".as[Json] returns the raw body"):
+      test(m".call[Json] returns the raw body"):
         given Http.Backend = Recorder(() => ok(petJson))
-        api.pets(42).get.as[Json]
+        api.pets(42).get.call[Json]
       . assert(_.as[Pet] == Pet(42, t"Milo", t"cat"))
 
-      test(m".as[Http.Response] returns the raw response"):
+      test(m".call[Http.Response] returns the raw response"):
         given Http.Backend = Recorder(() => ok(petJson))
-        api.pets(42).get.as[Http.Response].status
+        api.pets(42).get.call[Http.Response].status
       . assert(_ == Http.Ok)
 
       test(m"the request URL and method are sent as navigated"):
         val recorder = Recorder(() => ok(petJson))
         given Http.Backend = recorder
-        api.pets(42).get.as[Pet]
+        api.pets(42).get.call[Pet]
         (recorder.lastUrl, recorder.lastMethod)
       . assert(_ == (t"https://api.example.com/v1/pets/42", Http.Get))
 
       test(m"a POST sends its body"):
         val recorder = Recorder(() => ok(petJson))
         given Http.Backend = recorder
-        api.pets.post(NewPet(t"Milo", tag = t"cat")).as[Pet]
+        api.pets.post(NewPet(t"Milo", tag = t"cat")).call[Pet]
         (recorder.lastMethod, recorder.lastBody.present)
       . assert(_ == (Http.Post, true))
 
       test(m"a non-2xx response raises ApiError"):
         given Http.Backend = Recorder(() => Http.Response(Http.NotFound)(t"{}"))
-        capture[ApiError](api.pets(42).get.as[Pet]).reason
+        capture[ApiError](api.pets(42).get.call[Pet]).reason
       . assert(_ == ApiError.Reason.Status(404))
 
       test(m"a type that does not conform to the schema is rejected"):
         demilitarize:
           given Http.Backend = Recorder(() => ok(petJson))
-          api.pets(42).get.as[Photo]
+          api.pets(42).get.call[Photo]
         . length
       . assert(_ > 0)

--- a/lib/apoplexy/src/test/apoplexy_test.scala
+++ b/lib/apoplexy/src/test/apoplexy_test.scala
@@ -196,3 +196,5 @@ components:
       capture[OpenApiError]:
         """{"openapi": "2.0", "info": {"title": "x", "version": "1"}}""".tt.read[OpenApi]
     .assert(_.reason == OpenApiError.Reason.UnsupportedVersion(t"2.0"))
+
+    ApiTests()

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -308,6 +308,28 @@ object Http:
       . to(Map)
 
 
+  // The swappable transport that physically sends a single request and returns
+  // its response. The URL is fully resolved (passed as `Text`) so non-JVM
+  // backends can parse it themselves; redirects are handled by `HttpClient`, not
+  // the backend. The JVM default (using `java.net.http`) is provided in
+  // `HttpClient`; other platforms or implementations (e.g. HTTP/2) supply their
+  // own given.
+  object Backend:
+    // The default transport. telekinesis is currently JVM-only, so this
+    // delegates to the `java.net.http` client; when the module is split for
+    // other platforms this default moves to a platform-specific source. A
+    // user-supplied `Http.Backend` given in scope overrides it.
+    given default: Backend = HttpClient.javaBackend
+
+  trait Backend:
+    def request
+      ( url:     Text,
+        method:  Http.Method,
+        headers: List[Http.Header],
+        body:    () => Stream[Data] )
+      ( using Tactic[ConnectError] )
+    :   Http.Response
+
   object Response extends Dynamic:
     transparent inline def applyDynamicNamed(id: "apply")(inline headers: (Label, Any)*)
     :   Prototype | Response =

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -44,6 +44,7 @@ import scala.util.NotGiven
 import anticipation.*
 import coaxial.*
 import contingency.*
+import gossamer.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
@@ -147,7 +148,25 @@ object HttpClient:
     case 301 | 302 | 303 | 307 | 308 => true
     case _                           => false
 
-  given httpStrict: Tactic[ConnectError] => Online => Redirects.Disabled => HttpClient:
+  // The JVM default transport, using `java.net.http`. Other platforms (e.g.
+  // Scala.js) or implementations (e.g. an HTTP/2 client) supply their own
+  // `Http.Backend` given instead.
+  val javaBackend: Http.Backend = new Http.Backend:
+    def request
+      ( url:     Text,
+        method:  Http.Method,
+        headers: List[Http.Header],
+        body:    () => Stream[Data] )
+      ( using Tactic[ConnectError] )
+    :   Http.Response =
+
+      buildResponse(send(buildJavaRequest(jn.URI.create(url.s).nn, method, headers, body)))
+
+  given httpStrict: Tactic[ConnectError]
+  =>  Online
+  =>  Redirects.Disabled
+  =>  ( backend: Http.Backend )
+  =>  HttpClient:
     type Target = Origin["http" | "https"]
 
     def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
@@ -156,19 +175,13 @@ object HttpClient:
       val url = httpRequest.on(origin)
       Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-      val javaRequest =
-        buildJavaRequest
-          ( jn.URI.create(url.show.s).nn,
-            httpRequest.method,
-            httpRequest.textHeaders,
-            httpRequest.body )
-
-      buildResponse(send(javaRequest))
+      backend.request(url.show, httpRequest.method, httpRequest.textHeaders, httpRequest.body)
 
   given http: Tactic[ConnectError]
   =>  Online
   =>  NotGiven[Redirects.Disabled]
   =>  ( redirection: HttpRedirection )
+  =>  ( backend: Http.Backend )
   =>  HttpClient:
     type Target = Origin["http" | "https"]
 
@@ -181,22 +194,25 @@ object HttpClient:
       def loop(uri: jn.URI, method: Http.Method, bodyFn: () => Stream[Data], remaining: Int)
       :   Http.Response =
 
-        val javaResponse = send(buildJavaRequest(uri, method, httpRequest.textHeaders, bodyFn))
-        val code = javaResponse.statusCode()
+        val response = backend.request(uri.toString.tt, method, httpRequest.textHeaders, bodyFn)
+        val code = response.status.code
 
-        if !isRedirect(code) || remaining <= 0 then buildResponse(javaResponse) else
-          val location = javaResponse.headers.nn.firstValue("Location").nn
+        if !isRedirect(code) || remaining <= 0 then response else
+          response.textHeaders.find(_.key.lower == t"location") match
+            case None =>
+              response
 
-          if !location.isPresent then buildResponse(javaResponse) else
-            try javaResponse.body().nn.close() catch case _: ji.IOException => ()
+            case Some(header) =>
+              // Drain the discarded intermediate body to free its connection.
+              safely(response.body.stream.each { _ => () })
 
-            val nextUri = uri.resolve(jn.URI.create(location.get.nn).nn).nn
-            val nextMethod = redirectMethod(code, method)
+              val nextUri = uri.resolve(jn.URI.create(header.value.s).nn).nn
+              val nextMethod = redirectMethod(code, method)
 
-            val nextBody: () => Stream[Data] =
-              if nextMethod == method then bodyFn else () => Stream()
+              val nextBody: () => Stream[Data] =
+                if nextMethod == method then bodyFn else () => Stream()
 
-            loop(nextUri, nextMethod, nextBody, remaining - 1)
+              loop(nextUri, nextMethod, nextBody, remaining - 1)
 
       loop(jn.URI.create(url.show.s).nn, httpRequest.method, httpRequest.body, redirection.value)
 


### PR DESCRIPTION
Apoplexy gains a compile-time-typechecked HTTP client generated directly from an OpenAPI definition: navigate an API's paths and invoke its operations as ordinary method calls, fully checked against the spec, with the wire format (JSON or XML) chosen per endpoint by the spec rather than the caller. Invalid paths, mistyped path or query parameters, wrong request bodies, and non-conforming response types are all reported as compile errors. This also adds a pluggable HTTP transport to telekinesis so the client (and any telekinesis user) can swap the underlying backend.

Given an OpenAPI definition on the classpath, construct a client and navigate it with ordinary selection and application syntax — every step is checked against the spec at compile time:

```scala
val api = Api(cp"/petstore.json")

// GET /pets/{petId} — `42` fills the path template, decoded as `Pet`
val pet: Pet = api.pets(42).get.call[Pet]()

// GET /pets?limit=10 — query parameters are named arguments
val pets: List[Pet] = api.pets.get(limit = 10).call[List[Pet]]()

// POST /pets with a JSON body
val created: Pet = api.pets.post(NewPet(t"Milo")).call[Pet]()
```

When an endpoint defines a single (non-`DELETE`) method, the verb may be omitted:

```scala
val token: Token = api.login(Credentials(t"user", t"pw")).call[Token]()
```

`.call[T]()` performs the request and decodes the 2xx response, raising `ApiError` on a non-2xx status. The empty parentheses mark the side effect, distinguishing it from the parenless navigation terminals. A bare `.call()` defaults to `Unit` — perform the request, check for success, and discard the body — which is the natural shape for `delete` and other no-content (204) endpoints:

```scala
api.sessions(token).delete.call()        // returns Unit
api.pets(42).get.call[Json]()            // the raw 2xx body
api.pets(42).get.call[Http.Response]()   // the raw response, no status check
```

The wire format is taken from each operation's `content` media types and surfaced in the types as `Api over Json` / `Api over Xml`; both request and response bodies are encoded and decoded in the format the spec declares (JSON via jacinta, XML via xylophone), with no change to the calling code:

```scala
val notes = Api(cp"/notes.json")            // an XML API
val note: Note = notes.notes(1).get.call[Note]()   // decodes application/xml
```

Telekinesis now resolves its HTTP transport through a `Http.Backend` given (defaulting to the `java.net.http` client), so an alternative implementation — an HTTP/2 client, a Scala.js runtime, or a test recorder — can be supplied by putting a different `Http.Backend` in scope.
