### PR TITLE
adversaria: add `@name` field-rename annotation, honoured by xylophone

### DIFF
--- a/lib/adversaria/src/core/adversaria.internal.scala
+++ b/lib/adversaria/src/core/adversaria.internal.scala
@@ -52,7 +52,20 @@ object internal:
       override def transformTypeTree(tree: TypeTree)(owner: Symbol): TypeTree =
         tree match
           case ident: TypeIdent => TypeIdent(tree.symbol)
-          case _                => throw jl.Error()
+
+          // A type-parameterized annotation (e.g. `@label[Xml](…)`) stores its
+          // type as an applied type tree. Re-root the type constructor and
+          // synthesise fresh argument trees from their types — the originals are
+          // loaded from another compilation unit's TASTy without usable source
+          // positions, which the later `typedTypeApply` asserts are present.
+          case Applied(constructor, arguments) =>
+            val arguments2 = arguments.map:
+              case argument: TypeTree => TypeTree.of(using argument.tpe.asType)
+              case argument           => argument
+
+            Applied(transformTypeTree(constructor)(owner), arguments2)
+
+          case _ => throw jl.Error()
 
       override def transformTerm(tree: Term)(sym: Symbol): Term =
         tree match
@@ -64,6 +77,16 @@ object internal:
 
           case Apply(fn, arguments) =>
             Apply(transformTerm(fn)(sym), transformTerms(arguments)(sym))
+
+          // The constructor of a type-parameterized annotation is applied to its
+          // type arguments before its value arguments. Synthesise fresh type-arg
+          // trees from their types (see `transformTypeTree` above).
+          case TypeApply(fn, arguments) =>
+            val arguments2 = arguments.map:
+              case argument: TypeTree => TypeTree.of(using argument.tpe.asType)
+              case argument           => argument
+
+            TypeApply(transformTerm(fn)(sym), arguments2)
 
           case _ =>
             throw jl.Error()

--- a/lib/adversaria/src/core/adversaria.internal.scala
+++ b/lib/adversaria/src/core/adversaria.internal.scala
@@ -52,20 +52,7 @@ object internal:
       override def transformTypeTree(tree: TypeTree)(owner: Symbol): TypeTree =
         tree match
           case ident: TypeIdent => TypeIdent(tree.symbol)
-
-          // A type-parameterized annotation (e.g. `@label[Xml](…)`) stores its
-          // type as an applied type tree. Re-root the type constructor and
-          // synthesise fresh argument trees from their types — the originals are
-          // loaded from another compilation unit's TASTy without usable source
-          // positions, which the later `typedTypeApply` asserts are present.
-          case Applied(constructor, arguments) =>
-            val arguments2 = arguments.map:
-              case argument: TypeTree => TypeTree.of(using argument.tpe.asType)
-              case argument           => argument
-
-            Applied(transformTypeTree(constructor)(owner), arguments2)
-
-          case _ => throw jl.Error()
+          case _                => throw jl.Error()
 
       override def transformTerm(tree: Term)(sym: Symbol): Term =
         tree match
@@ -75,18 +62,25 @@ object internal:
           case New(tpt)                => New(transformTypeTree(tpt)(sym))
           case Literal(constant)       => Literal(constant)
 
+          // A type-parameterized annotation constructor, e.g. `new name[Xml](…)`
+          // — or a bare `new name(…)`, whose type argument is inferred. Both
+          // carry their type arguments in a `TypeApply` around the constructor.
+          // Rebuild the constructor application from the fully-resolved
+          // annotation type, so an inferred argument (no syntactic tree) or one
+          // loaded from another unit's TASTy (no source position) is
+          // resynthesised cleanly and positioned.
+          case Apply(TypeApply(Select(New(_), _), _), arguments) =>
+            tree.tpe match
+              case AppliedType(constructor, typeArguments) =>
+                val newTree = New(TypeTree.ref(constructor.typeSymbol))
+                val typeTrees = typeArguments.map { argument => TypeTree.of(using argument.asType) }
+                Apply(TypeApply(Select(newTree, tree.symbol), typeTrees), transformTerms(arguments)(sym))
+
+              case _ =>
+                throw jl.Error()
+
           case Apply(fn, arguments) =>
             Apply(transformTerm(fn)(sym), transformTerms(arguments)(sym))
-
-          // The constructor of a type-parameterized annotation is applied to its
-          // type arguments before its value arguments. Synthesise fresh type-arg
-          // trees from their types (see `transformTypeTree` above).
-          case TypeApply(fn, arguments) =>
-            val arguments2 = arguments.map:
-              case argument: TypeTree => TypeTree.of(using argument.tpe.asType)
-              case argument           => argument
-
-            TypeApply(transformTerm(fn)(sym), arguments2)
 
           case _ =>
             throw jl.Error()
@@ -108,12 +102,7 @@ object internal:
 
     def matching(annotations: List[Term]): Expr[List[operand]] =
       Expr.ofList:
-        annotations.map(_.asExpr).collect:
-          case '{$annotation: `operand`} => rebuild(annotation.asTerm)
-
-        . compact
-        . map(_.asExprOf[operand])
-        . reverse
+        annotations.filter(_.tpe <:< operand).map(rebuild(_)).compact.map(_.asExprOf[operand]).reverse
 
     if limit =:= TypeRepr.of[Any] then
       val annotations = matching(self.typeSymbol.annotations)

--- a/lib/adversaria/src/core/adversaria.name.scala
+++ b/lib/adversaria/src/core/adversaria.name.scala
@@ -30,6 +30,15 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package adversaria
 
-export adversaria.{Annotated, Dereferenceable, name}
+import anticipation.*
+
+// Renames a case-class field for serialization. The `format` type parameter
+// scopes the rename to one serialization format — e.g. `@name[Xml](t"Book")`
+// only affects XML — while a bare `@name(t"…")` (which infers `@name[Any]`)
+// applies to every format. A derivation reads the format-specific names first,
+// then the `Any` defaults, then falls back to the field's own name; see each
+// format's `relabelling` wiring. Multiple `@name`s with different `format`s may
+// sit on one field.
+case class name[format](name: Text) extends StaticAnnotation

--- a/lib/adversaria/src/core/adversaria_core.scala
+++ b/lib/adversaria/src/core/adversaria_core.scala
@@ -32,8 +32,24 @@
                                                                                                   */
 package adversaria
 
+import scala.compiletime.summonInline
+
+import anticipation.*
 import prepositional.*
+import vacuous.*
 
 extension [entity](entity: entity)
   def membersOfType[value](using deref: entity is Dereferenceable to value): Iterable[value] =
     deref.values(entity)
+
+// Read the `ann`-typed annotations on each field of `self`, keyed by field name,
+// keeping only fields that actually carry one (an `Annotated.Fields` lists every
+// field bearing *any* annotation, with an empty set for the others). Replaces the
+// `match { case _: Annotated.Fields => … case _ => Map() }` boilerplate callers
+// would otherwise repeat.
+inline def fieldAnnotations[self, annotation <: StaticAnnotation]
+:   Map[Text, Set[annotation]] =
+
+  summonInline[self is Annotated by annotation] match
+    case annotated: Annotated.Fields => annotated.fields.filter(_(1).nonEmpty)
+    case _                           => Map()

--- a/lib/adversaria/src/core/adversaria_core.scala
+++ b/lib/adversaria/src/core/adversaria_core.scala
@@ -53,3 +53,17 @@ inline def fieldAnnotations[self, annotation <: StaticAnnotation]
   summonInline[self is Annotated by annotation] match
     case annotated: Annotated.Fields => annotated.fields.filter(_(1).nonEmpty)
     case _                           => Map()
+
+// The serialization renames for `format`: a map from each `@name`-annotated
+// field's name to its serialized name, with a `@name[format]` overriding a bare
+// `@name` (i.e. `@name[Any]`) default on the same field. Fields without a `@name`
+// are absent (callers fall back to the field's own name). Used by each format's
+// derivation to honour `@name[Xml](t"…")` / `@name(t"…")` in encode and decode.
+inline def relabelling[self, format]: Map[Text, Text] =
+  val general:  Map[Text, Text] =
+    fieldAnnotations[self, name[Any]].map((field, set) => field -> set.head.name)
+
+  val specific: Map[Text, Text] =
+    fieldAnnotations[self, name[format]].map((field, set) => field -> set.head.name)
+
+  general ++ specific

--- a/lib/adversaria/src/examples/adversaria_examples.scala
+++ b/lib/adversaria/src/examples/adversaria_examples.scala
@@ -39,6 +39,14 @@ final case class unique() extends StaticAnnotation
 final case class number(number: Int) extends StaticAnnotation
 final case class ref(x: Int) extends StaticAnnotation
 
+// A type-parameterized annotation, used to check that adversaria can read and
+// filter annotations by their type argument (e.g. `@marker[Person]`).
+final case class marker[topic](id: Int) extends StaticAnnotation
+
+case class Marked
+   (@marker[Person](1) @marker[Company](2) one: Int,
+    @marker[Company](3)                    two: Int)
+
 case class Person(name: Text, @ident email: Text)
 
 @number(10)

--- a/lib/adversaria/src/examples/adversaria_examples.scala
+++ b/lib/adversaria/src/examples/adversaria_examples.scala
@@ -47,6 +47,14 @@ case class Marked
    (@marker[Person](1) @marker[Company](2) one: Int,
     @marker[Company](3)                    two: Int)
 
+// A bare `@marker(…)` (no explicit type argument) infers `marker[Any]`, so it is
+// read by a `marker[Any]` query alongside an explicit `@marker[Any]`, but not by
+// a `marker[Person]` query.
+case class Tagged
+   (@marker(1)         bare:     Int,
+    @marker[Any](2)    anyArg:   Int,
+    @marker[Person](3) specific: Int)
+
 case class Person(name: Text, @ident email: Text)
 
 @number(10)

--- a/lib/adversaria/src/test/adversaria_test.scala
+++ b/lib/adversaria/src/test/adversaria_test.scala
@@ -69,6 +69,18 @@ object Tests extends Suite(m"Adversaria tests"):
       summon[Annotated under Colored].subtypes
     . assert(_ == Map("Rgb" -> Set(unique()), "Hsv" -> Set(number(3))))
 
+    test(m"read a type-parameterized annotation, filtered by type argument"):
+      summon[Marked is Annotated by marker[Person]].fields
+    . assert(_ == Map("one" -> Set(marker[Person](1)), "two" -> Set()))
+
+    test(m"a different type argument selects different annotations"):
+      summon[Marked is Annotated by marker[Company]].fields
+    . assert(_ == Map("one" -> Set(marker[Company](2)), "two" -> Set(marker[Company](3))))
+
+    test(m"fieldAnnotations drops fields without the queried annotation"):
+      fieldAnnotations[Marked, marker[Person]]
+    . assert(_ == Map(t"one" -> Set(marker[Person](1))))
+
     test(m"List map of fields of an object"):
       summon[Example1.type is Dereferenceable to Int].members(Example1)
     . assert(_ == Map(t"foo" -> 42, t"baz" -> 12))

--- a/lib/adversaria/src/test/adversaria_test.scala
+++ b/lib/adversaria/src/test/adversaria_test.scala
@@ -81,6 +81,14 @@ object Tests extends Suite(m"Adversaria tests"):
       fieldAnnotations[Marked, marker[Person]]
     . assert(_ == Map(t"one" -> Set(marker[Person](1))))
 
+    test(m"a bare annotation (no type argument) is read as the `Any` instance"):
+      fieldAnnotations[Tagged, marker[Any]]
+    . assert(_ == Map(t"bare" -> Set(marker(1)), t"anyArg" -> Set(marker(2))))
+
+    test(m"a bare annotation is not read by a specific type-argument query"):
+      fieldAnnotations[Tagged, marker[Person]]
+    . assert(_ == Map(t"specific" -> Set(marker[Person](3))))
+
     test(m"List map of fields of an object"):
       summon[Example1.type is Dereferenceable to Int].members(Example1)
     . assert(_ == Map(t"foo" -> 42, t"baz" -> 12))

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -250,10 +250,11 @@ object Xml extends Tag.Container
 
       // Fields marked `@attribute` are read from the element's attributes
       // rather than its child elements, mirroring the encoder.
-      val attributeFields: Map[Text, Set[attribute]] =
-        infer[derivation is Annotated by attribute] match
-          case annotated: Annotated.Fields => annotated.fields
-          case _                           => Map()
+      val attributeFields: Map[Text, Set[attribute]] = fieldAnnotations[derivation, attribute]
+
+      // `@name[Xml]` / bare `@name` renames: field name -> element/attribute
+      // name on the wire. Read back the same way they are written.
+      val renames: Map[Text, Text] = relabelling[derivation, Xml]
 
       val children: scm.HashMap[String, Element] = scm.HashMap.empty
       var i = 0
@@ -269,20 +270,21 @@ object Xml extends Tag.Container
       build: [field] =>
         context =>
           val fieldLabel: Text = wisteria.label[Text]
+          val wireName: Text = renames.at(fieldLabel).or(fieldLabel)
           focus({
             // Each outer `focus` runs *after* the inner one, so we
             // extend `prior` at the root side (`/outer/inner`), not the
             // leaf side that `XPath#element` would use.
             val base = prior.let(_.path).or(XPath())
-            Xml.Focus(base.prepend(fieldLabel, 1))
+            Xml.Focus(base.prepend(wireName, 1))
           }):
             if attributeFields.contains(fieldLabel) then
               // `@attribute` field: decode from the matching attribute as a
               // `TextNode`; a missing attribute falls back to the declared
               // default, else the `Absent` sentinel (raise + continue).
-              element.attributes.at(fieldLabel).lay(default.or(context.decoded(Absent))): text =>
+              element.attributes.at(wireName).lay(default.or(context.decoded(Absent))): text =>
                 context.decoded(TextNode(text))
-            else children.get(fieldLabel.s) match
+            else children.get(wireName.s) match
               case Some(child) => context.decoded(child)
               // Missing field: fall back to the case-class declared
               // default (Wisteria's `default`); if absent, hand the
@@ -351,10 +353,11 @@ object Xml extends Tag.Container
     :   derivation is Encodable in Xml =
 
       value =>
-        val attributeFields: Map[Text, Set[attribute]] =
-          infer[derivation is Annotated by attribute] match
-            case annotated: Annotated.Fields => annotated.fields
-            case _                           => Map()
+        val attributeFields: Map[Text, Set[attribute]] = fieldAnnotations[derivation, attribute]
+
+        // `@name[Xml]` / bare `@name` renames: field name -> element/attribute
+        // name on the wire.
+        val renames: Map[Text, Text] = relabelling[derivation, Xml]
 
         val attributes: scm.ArrayBuffer[(Text, Text)] = scm.ArrayBuffer()
         val children: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
@@ -362,13 +365,14 @@ object Xml extends Tag.Container
         fields(value): [field] =>
           field =>
             val fieldLabel: Text = wisteria.label[Text]
+            val wireName: Text = renames.at(fieldLabel).or(fieldLabel)
             val encoded: Xml = contextual.encode(field)
 
             // `@attribute` fields become attributes carrying the encoded leaf's
             // text; every other field becomes a child element via `wrap`.
             if attributeFields.contains(fieldLabel)
-            then attributes += fieldLabel -> textOf(encoded).or(t"")
-            else children += wrap(fieldLabel, encoded)
+            then attributes += wireName -> textOf(encoded).or(t"")
+            else children += wrap(wireName, encoded)
 
         Element
          (typeName[derivation],

--- a/lib/xylophone/src/test/xylophone.EncoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.EncoderTests.scala
@@ -44,6 +44,20 @@ import strategies.throwUnsafely
 // `isbn`, defined in `xylophone_test.scala`) is written to / read from the
 // element's attributes, so it round-trips.
 
+// A stand-in for some other serialization format, to check that a `@name`
+// scoped to it is ignored by XML.
+sealed trait OtherFormat
+
+// `title` is renamed for XML only; `author` for all formats (a bare `@name`,
+// which infers `@name[Any]`); `note`'s rename is scoped to another format, so
+// XML must ignore it and use the field name.
+case class Labelled
+   (@name[Xml](t"Title")          title:  Text,
+    @name(t"writer")              author: Text,
+    @name[OtherFormat](t"n")      note:   Text,
+                                  pages:  Int)
+derives CanEqual
+
 object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform
@@ -92,3 +106,13 @@ object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
       test(m"An @attribute field round-trips"):
         Book(t"Dune", t"0441013597").xml.as[Book]
       . assert(_ == Book(t"Dune", t"0441013597"))
+
+    suite(m"@name fields"):
+      test(m"@name[Xml] and bare @name rename elements; other-format @name ignored"):
+        Labelled(t"Dune", t"Herbert", t"sci-fi", 412).xml
+      . assert: xml =>
+          xml == x"""<Labelled><Title>Dune</Title><writer>Herbert</writer><note>sci-fi</note><pages>412</pages></Labelled>"""
+
+      test(m"@name fields round-trip"):
+        Labelled(t"Dune", t"Herbert", t"sci-fi", 412).xml.as[Labelled]
+      . assert(_ == Labelled(t"Dune", t"Herbert", t"sci-fi", 412))


### PR DESCRIPTION
Soundness gains a `@name` annotation for renaming a case-class field in
serialized output. A rename can target one format — `@name[Xml](t"Title")` only
affects XML — or every format at once with a bare `@name(t"book_title")`.
Xylophone is the first format to honour it, in both encoding and decoding;
support for the other formats will follow. Reading such type-parameterized
annotations is also made robust in adversaria, so a rename whose type argument is
inferred or defined in another module is read reliably.

## Renaming serialized fields

Annotate a field with `@name` to change the element (or attribute) name xylophone
reads and writes for it. A bare `@name` applies to every serialization format; a
`@name[Xml]` applies to XML only and overrides the bare default.

```scala
case class Book(@name[Xml](t"Title") title: Text, @name(t"writer") author: Text)

Book(t"Dune", t"Herbert").xml
// <Book><Title>Dune</Title><writer>Herbert</writer></Book>

Book(t"Dune", t"Herbert").xml.as[Book]  // == Book(t"Dune", t"Herbert")
```

A `@name` scoped to a different format is ignored by XML, which falls back to the
field's own name.

## Reading type-parameterized annotations (adversaria)

`adversaria` can now read annotations parameterized by a type argument
(`@name[Xml](…)`), filtering by that argument, including the cases where the
argument is inferred (a bare `@name(…)`, which resolves to `@name[Any]`) or is
loaded from another compilation unit. A new `fieldAnnotations`/`relabelling`
helper exposes the per-field results without boilerplate.