### PR TITLE
ci: bound the test run with a timeout and serialize the build cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ dev:
 	./mill -w soundness.all
 
 ci:
-	java -cp out/test/assembly.dest/out.jar soundness.Tests
+	./etc/ci/run-tests.sh
 
 attest:
 	./etc/ci/attest.sh

--- a/etc/ci/run-tests.sh
+++ b/etc/ci/run-tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Run the umbrella test suite (soundness.Tests) with a hard wall-clock timeout.
+#
+# The `probably` table reporter buffers its output until the run completes, so a
+# hung or deadlocked test produces no output at all — it just stalls forever.
+# Inside `docker build` (img/test stage 3) that hangs the whole CI build with no
+# diagnostics. This wrapper bounds the run: if the suite exceeds the timeout, it
+# dumps every thread's stack (so a deadlock is pinpointed) and fails, instead of
+# hanging indefinitely.
+#
+# Environment:
+#   SOUNDNESS_CI_TEST_TIMEOUT   seconds before the suite is declared hung
+#                               (default: 1800 = 30 minutes)
+#
+# Exit codes:
+#   0    suite passed
+#   !=0  suite failed, or was killed after exceeding the timeout (124)
+
+set -uo pipefail
+
+JAR=out/test/assembly.dest/out.jar
+TIMEOUT="${SOUNDNESS_CI_TEST_TIMEOUT:-1800}"
+
+java -cp "$JAR" soundness.Tests &
+pid=$!
+
+# Watchdog: if the suite is still alive after $TIMEOUT, capture a full thread
+# dump (deadlock diagnosis) and kill it.
+(
+  sleep "$TIMEOUT"
+  if kill -0 "$pid" 2>/dev/null; then
+    echo >&2
+    echo "::: test suite exceeded ${TIMEOUT}s — assuming a hang; thread dump follows :::" >&2
+    jstack "$pid" >&2 2>/dev/null || jcmd "$pid" Thread.print >&2 2>/dev/null || true
+    kill -9 "$pid" 2>/dev/null
+    exit 124
+  fi
+) &
+watchdog=$!
+
+wait "$pid"
+rc=$?
+
+# Stop the watchdog if the suite finished on its own.
+kill "$watchdog" 2>/dev/null
+wait "$watchdog" 2>/dev/null
+watchdog_rc=$?
+
+# If the watchdog fired (exit 124), surface that as the failure.
+if [[ $watchdog_rc -eq 124 ]]; then
+  exit 124
+fi
+
+exit $rc

--- a/img/test
+++ b/img/test
@@ -94,7 +94,7 @@ RUN --mount=type=cache,target=/root/.cache/coursier \
     --mount=type=cache,target=/root/.cache/mill \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/src/out \
+    --mount=type=cache,target=/src/out,sharing=locked \
     CLAUDECODE=1 ./mill --ticker false soundness.all.compile
 
 # Stage 2: compile tests and assemble the fat test JAR. Mill sees the
@@ -104,10 +104,10 @@ RUN --mount=type=cache,target=/root/.cache/coursier \
     --mount=type=cache,target=/root/.cache/mill \
     --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/src/out \
+    --mount=type=cache,target=/src/out,sharing=locked \
     CLAUDECODE=1 ./mill --ticker false test.assembly
 
 # Stage 3: run the assembled test JAR. No mill JVM in this stage.
 FROM compile-tests AS run-tests
-RUN --mount=type=cache,target=/src/out \
+RUN --mount=type=cache,target=/src/out,sharing=locked \
     CLAUDECODE=1 make ci


### PR DESCRIPTION
Hardens the local-CI attestation pipeline against two harness-level failure modes that could stall `make attest` indefinitely, independent of any test. The umbrella test run is now wrapped in a wall-clock timeout that dumps every thread's stack on expiry (turning a silent hang into a bounded, diagnosable failure), and the three `/src/out` BuildKit cache mounts in `img/test` are switched from the default `sharing=shared` to `sharing=locked`, so two attests running concurrently (e.g. from separate worktrees) serialize on mill's non-concurrency-safe output cache instead of corrupting each other.

## Release notes

CI reliability only — no library or API changes.

- `make ci` now runs the suite via `etc/ci/run-tests.sh`, which enforces a timeout (`SOUNDNESS_CI_TEST_TIMEOUT`, default 30 min) and prints a full thread dump if the suite hangs, instead of stalling the build forever.
- `img/test` cache mounts use `sharing=locked`, preventing concurrent attests from clobbering the shared `/src/out` mill cache.