### PR TITLE
Rename sum-type variants with `@name`

### DIFF
--- a/lib/adversaria/src/core/adversaria_core.scala
+++ b/lib/adversaria/src/core/adversaria_core.scala
@@ -67,3 +67,25 @@ inline def relabelling[self, format]: Map[Text, Text] =
     fieldAnnotations[self, name[format]].map((field, set) => field -> set.head.name)
 
   general ++ specific
+
+// Like `fieldAnnotations`, but reads the `annotation`-typed annotations on the
+// subtypes (enum cases / sealed variants) of `self`, keyed by variant name,
+// keeping only variants that carry one. Used for renaming sum-type variants.
+inline def subtypeAnnotations[self, annotation <: StaticAnnotation]
+:   Map[Text, Set[annotation]] =
+
+  summonInline[Annotated by annotation under self] match
+    case annotated: Annotated.Subtypes => annotated.subtypes.filter(_(1).nonEmpty)
+    case _                             => Map()
+
+// The serialization renames for the variants of a sum type `self`: exactly like
+// `relabelling` but for `@name`-annotated enum cases / sealed variants. Maps each
+// renamed variant's name to its serialized discriminator.
+inline def variantRelabelling[self, format]: Map[Text, Text] =
+  val general:  Map[Text, Text] =
+    subtypeAnnotations[self, name[Any]].map((variant, set) => variant -> set.head.name)
+
+  val specific: Map[Text, Text] =
+    subtypeAnnotations[self, name[format]].map((variant, set) => variant -> set.head.name)
+
+  general ++ specific

--- a/lib/adversaria/src/test/adversaria_test.scala
+++ b/lib/adversaria/src/test/adversaria_test.scala
@@ -34,6 +34,14 @@ package adversaria
 
 import soundness.*
 
+// A sum type with `@name`-annotated variants, for `subtypeAnnotations` /
+// `variantRelabelling`. `Accept` is renamed for one type argument, `Reject` by a
+// bare `@name` (i.e. `name[Any]`), and `Defer` is unannotated.
+sealed trait Decision
+@name[Person](t"yes") case object Accept extends Decision
+@name(t"no")          case object Reject extends Decision
+                      case object Defer  extends Decision
+
 object Tests extends Suite(m"Adversaria tests"):
 
   def run(): Unit =
@@ -88,6 +96,14 @@ object Tests extends Suite(m"Adversaria tests"):
     test(m"a bare annotation is not read by a specific type-argument query"):
       fieldAnnotations[Tagged, marker[Person]]
     . assert(_ == Map(t"specific" -> Set(marker[Person](3))))
+
+    test(m"subtypeAnnotations reads @name on sum-type variants"):
+      subtypeAnnotations[Decision, name[Person]]
+    . assert(_ == Map(t"Accept" -> Set(adversaria.name[Person](t"yes"))))
+
+    test(m"variantRelabelling merges per-format and bare variant renames"):
+      variantRelabelling[Decision, Person]
+    . assert(_ == Map(t"Accept" -> t"yes", t"Reject" -> t"no"))
 
     test(m"List map of fields of an object"):
       summon[Example1.type is Dereferenceable to Int].members(Example1)

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -116,8 +116,15 @@ trait Cbor2:
           provide[Tactic[VariantError]]:
             val discriminable = infer[derivation is Discriminable in Cbor]
 
-            val discriminant: Text =
+            // `@name[Cbor]` / bare `@name` variant renames: map the serialized
+            // discriminator back to the variant name before delegating.
+            val variantNames: Map[Text, Text] =
+              variantRelabelling[derivation, Cbor].map((variant, wire) => wire -> variant)
+
+            val wire: Text =
               discriminable.discriminate(cbor).lest(CborError(Reason.Absent))
+
+            val discriminant: Text = variantNames.getOrElse(wire, wire)
 
             delegate(discriminant): [variant <: derivation] =>
               context => context.decoded(cbor)
@@ -145,8 +152,12 @@ trait Cbor2:
     inline def disjunction[derivation: SumReflection]: derivation is Encodable in Cbor = value =>
       val discriminable = infer[derivation is Discriminable in Cbor]
 
+      // `@name[Cbor]` / bare `@name` variant renames: variant name -> wire
+      // discriminator, read back the same way by the decoder.
+      val variantNames: Map[Text, Text] = variantRelabelling[derivation, Cbor]
+
       variant(value): [variant <: derivation] =>
-        value => discriminable.rewrite(label, contextual.encode(value))
+        value => discriminable.rewrite(variantNames.getOrElse(label, label), contextual.encode(value))
 
 object Cbor extends Cbor2, Dynamic:
   // CBOR major-type representation in storage. Arrays are stored as an

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -48,6 +48,13 @@ enum Shape derives CanEqual:
   case Circle(radius: Double)
   case Square(side: Double)
 
+enum CStatus derives CanEqual:
+  @name[Cbor](t"ok") case Active(since: Int)
+  @name(t"gone")     case Removed(at: Int)
+                     case Pending(at: Int)
+
+given (CStatus is Discriminable in Cbor) = Cbor.discriminatedUnion(t"kind")
+
 private def hex(s: String): IArray[Byte] =
   val clean = s.filter(c => !c.isWhitespace)
   val out = new Array[Byte](clean.length/2)
@@ -293,3 +300,16 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val keys = (0 until ast.entries).map(ast.key(_).string).toSet
         keys == Set("values", "label")
       . assert(identity)
+
+      test(m"@name renames a variant's discriminator"):
+        val ast = Cbor.unseal((CStatus.Active(5): CStatus).cbor)
+        (0 until ast.entries).collectFirst:
+          case i if ast.key(i).string == "kind" => ast.value(i).string
+        . getOrElse("none")
+      . assert(_ == "ok")
+
+      test(m"@name variants round-trip"):
+        List(CStatus.Active(5), CStatus.Removed(9), CStatus.Pending(1)).map: status =>
+          val bytes = CborPrinter.encode(Cbor.unseal((status: CStatus).cbor))
+          Cbor.ast(Cbor.Ast.parse(bytes)).as[CStatus]
+      . assert(_ == List(CStatus.Active(5), CStatus.Removed(9), CStatus.Pending(1)))

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -161,8 +161,15 @@ trait Json2:
           provide[Tactic[VariantError]]:
             val discriminable = infer[derivation is Discriminable in Json]
 
-            val discriminant: Text = discriminable.discriminate(json).or:
+            // `@name[Json]` / bare `@name` variant renames: map the serialized
+            // discriminator back to the variant name before delegating.
+            val variantNames: Map[Text, Text] =
+              variantRelabelling[derivation, Json].map((variant, wire) => wire -> variant)
+
+            val wire: Text = discriminable.discriminate(json).or:
               focus(prior.or(Json.Focus(JsonPointer())))(abort(JsonError(Reason.Absent)))
+
+            val discriminant: Text = variantNames.getOrElse(wire, wire)
 
             delegate(discriminant): [variant <: derivation] =>
               context => context.decoded(json)
@@ -205,8 +212,12 @@ trait Json2:
     inline def disjunction[derivation: SumReflection]: derivation is Encodable in Json = value =>
       val discriminable = infer[derivation is Discriminable in Json]
 
+      // `@name[Json]` / bare `@name` variant renames: variant name -> wire
+      // discriminator, read back the same way by the decoder.
+      val variantNames: Map[Text, Text] = variantRelabelling[derivation, Json]
+
       variant(value): [variant <: derivation] =>
-        value => discriminable.rewrite(label, contextual.encode(value))
+        value => discriminable.rewrite(variantNames.getOrElse(label, label), contextual.encode(value))
 
 object Json extends Json2, Dynamic:
   type JsonString  = String

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -66,6 +66,11 @@ enum Shape:
   case Circle(radius: Double)
   case Square(side: Double)
 
+enum Status derives CanEqual:
+  @name[Json](t"ok") case Active(since: Int)
+  @name(t"gone")     case Removed(at: Int)
+                     case Pending(at: Int)
+
 object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
     suite(m"Parsing tests"):
@@ -732,6 +737,14 @@ object Tests extends Suite(m"Jacinta Tests"):
         val s: Shape = Shape.Square(2.0)
         s.json.as[Shape]
       . assert(_ == Shape.Square(2.0))
+
+      test(m"@name renames a variant's discriminator"):
+        (Status.Active(5): Status).json.show
+      . assert(_ == t"""{"since":5,"kind":"ok"}""")
+
+      test(m"@name variants round-trip"):
+        List(Status.Active(5), Status.Removed(9), Status.Pending(1)).map(_.json.as[Status])
+      . assert(_ == List(Status.Active(5), Status.Removed(9), Status.Pending(1)))
 
       locally:
         import jsonDiscriminables.discriminatedUnionByType

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -310,8 +310,15 @@ object Xml extends Tag.Container
             provide[Tactic[VariantError]]:
               val discriminable = infer[derivation is Discriminable in Xml]
               val labels: List[Text]    = variantLabels[derivation]
+
+              // `@name[Xml]` / bare `@name` variant renames: map the serialized
+              // element label back to the variant name before delegating.
+              val variantNames: Map[Text, Text] =
+                variantRelabelling[derivation, Xml].map((variant, wire) => wire -> variant)
+
               val resolved: Optional[Text] =
-                discriminable.discriminate(xml).let: discriminant =>
+                discriminable.discriminate(xml).let: wire =>
+                  val discriminant = variantNames.getOrElse(wire, wire)
                   if labels.contains(discriminant) then discriminant else Unset
 
               resolved.let: discriminant =>
@@ -383,8 +390,14 @@ object Xml extends Tag.Container
       value =>
         val discriminable = infer[derivation is Discriminable in Xml]
 
+        // `@name[Xml]` / bare `@name` variant renames: variant name -> element
+        // label, read back the same way by the decoder.
+        val variantNames: Map[Text, Text] = variantRelabelling[derivation, Xml]
+
         variant(value): [variant <: derivation] =>
-          value => discriminable.rewrite(wisteria.label[Text], contextual.encode(value))
+          value =>
+            val label = wisteria.label[Text]
+            discriminable.rewrite(variantNames.getOrElse(label, label), contextual.encode(value))
 
   case class attribute() extends StaticAnnotation
 

--- a/lib/xylophone/src/test/xylophone.EncoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.EncoderTests.scala
@@ -58,6 +58,13 @@ case class Labelled
                                   pages:  Int)
 derives CanEqual
 
+// `Stop` is renamed for XML only; `Go` for all formats (a bare `@name`); `Wait`
+// is unannotated.
+enum Light derives CanEqual:
+  @name[Xml](t"red") case Stop(seconds: Int)
+  @name(t"green")    case Go(seconds: Int)
+                     case Wait(seconds: Int)
+
 object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform
@@ -116,3 +123,20 @@ object EncoderTests extends Suite(m"Xylophone case-class encoder tests"):
       test(m"@name fields round-trip"):
         Labelled(t"Dune", t"Herbert", t"sci-fi", 412).xml.as[Labelled]
       . assert(_ == Labelled(t"Dune", t"Herbert", t"sci-fi", 412))
+
+    suite(m"@name variants"):
+      test(m"@name[Xml] renames a variant's element"):
+        (Light.Stop(30): Light).xml
+      . assert(_ == x"<red><seconds>30</seconds></red>")
+
+      test(m"bare @name renames a variant's element"):
+        (Light.Go(45): Light).xml
+      . assert(_ == x"<green><seconds>45</seconds></green>")
+
+      test(m"an unannotated variant keeps its name"):
+        (Light.Wait(5): Light).xml
+      . assert(_ == x"<Wait><seconds>5</seconds></Wait>")
+
+      test(m"@name variants round-trip"):
+        List(Light.Stop(30), Light.Go(45), Light.Wait(5)).map(_.xml.as[Light])
+      . assert(_ == List(Light.Stop(30), Light.Go(45), Light.Wait(5)))

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -192,8 +192,15 @@ trait Yaml2:
           provide[Tactic[VariantError]]:
             val discriminable = infer[derivation is Discriminable in Yaml]
             val labels: List[Text] = variantLabels[derivation]
+
+            // `@name[Yaml]` / bare `@name` variant renames: map the serialized
+            // discriminator back to the variant name before delegating.
+            val variantNames: Map[Text, Text] =
+              variantRelabelling[derivation, Yaml].map((variant, wire) => wire -> variant)
+
             val resolved: Optional[Text] =
-              discriminable.discriminate(yaml).let: discriminant =>
+              discriminable.discriminate(yaml).let: wire =>
+                val discriminant = variantNames.getOrElse(wire, wire)
                 if labels.contains(discriminant) then discriminant else Unset
 
             resolved.let: discriminant =>
@@ -231,8 +238,13 @@ trait Yaml2:
 
     inline def disjunction[derivation: SumReflection]: derivation is Encodable in Yaml = value =>
       val discriminable = infer[derivation is Discriminable in Yaml]
+
+      // `@name[Yaml]` / bare `@name` variant renames: variant name -> wire
+      // discriminator, read back the same way by the decoder.
+      val variantNames: Map[Text, Text] = variantRelabelling[derivation, Yaml]
+
       variant(value): [variant <: derivation] =>
-        value => discriminable.rewrite(label, contextual.encode(value))
+        value => discriminable.rewrite(variantNames.getOrElse(label, label), contextual.encode(value))
 
 object Yaml extends Yaml2, Dynamic:
   type YamlString    = String

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -51,6 +51,11 @@ enum Shape derives CanEqual:
   case Square(side: Double)
   case Triangle(a: Double, b: Double, c: Double)
 
+enum YStatus derives CanEqual:
+  @name[Yaml](t"ok") case Active(since: Int)
+  @name(t"gone")     case Removed(at: Int)
+                     case Pending(at: Int)
+
 object Tests extends Suite(m"Ypsiloid Tests"):
   def run(): Unit =
     suite(m"Plain scalar parsing"):
@@ -761,6 +766,19 @@ object Tests extends Suite(m"Ypsiloid Tests"):
             . getOrElse("none")
           case _ => "none"
       . assert(_ == "Circle")
+
+      test(m"@name renames a variant's `type` discriminator"):
+        (YStatus.Active(5): YStatus).yaml.root match
+          case Yaml.Ast.Mapping(entries) =>
+            entries.collectFirst:
+              case (Yaml.Ast.Str(k), Yaml.Ast.Str(v)) if k == t"type" => v.s
+            . getOrElse("none")
+          case _ => "none"
+      . assert(_ == "ok")
+
+      test(m"@name variants round-trip"):
+        List(YStatus.Active(5), YStatus.Removed(9), YStatus.Pending(1)).map(_.yaml.as[YStatus])
+      . assert(_ == List(YStatus.Active(5), YStatus.Removed(9), YStatus.Pending(1)))
 
       test(m"Decode a sum-type variant from a flow mapping"):
         t"{type: Circle, radius: 2.5}".read[Yaml].as[Shape]


### PR DESCRIPTION
The `@name` annotation, which renames serialized fields, now also renames enum
cases and sealed-trait variants — the discriminator a format writes and reads for
a sum type. As with fields, a `@name[Json](t"…")` (or `[Xml]`, `[Yaml]`, `[Cbor]`)
applies to one format and a bare `@name(t"…")` to all; an unannotated variant
keeps its own name.

## Renaming variants

```scala
enum Status:
  @name[Json](t"ok") case Active(since: Int)
  @name(t"gone")     case Removed(at: Int)
  case Pending(at: Int)

(Status.Active(5): Status).json.show
// {"since":5,"kind":"ok"}

(Status.Active(5): Status).json.as[Status]  // == Status.Active(5)
```

Supported in the XML, JSON, YAML and CBOR derivations, in both encoding and
decoding. TEL is excluded — its sum encoder does not emit a variant discriminator
today, so there is nothing to rename — and protobuf remains excluded for its
number-keyed wire format.

Internally, adversaria gains `subtypeAnnotations` and `variantRelabelling` (the
sum-variant analogues of `fieldAnnotations` and `relabelling`).