### PR TITLE
ci: run the test suite on JDK 25 to avoid virtual-thread pinning

### DIFF
--- a/etc/ci/run-tests.sh
+++ b/etc/ci/run-tests.sh
@@ -26,13 +26,23 @@ java -cp "$JAR" soundness.Tests &
 pid=$!
 
 # Watchdog: if the suite is still alive after $TIMEOUT, capture a full thread
-# dump (deadlock diagnosis) and kill it.
+# dump and kill it. We emit two dumps because the suite runs on virtual threads:
+#   * jstack — platform threads and carrier→virtual-thread mounting, readable.
+#   * jcmd Thread.dump_to_file -format=json — EVERY thread including *parked*
+#     virtual threads with their application stacks. jstack alone cannot show an
+#     unmounted virtual thread (e.g. a parasite daemon parked on a promise), so a
+#     deadlock among virtual threads is invisible without this.
 (
   sleep "$TIMEOUT"
   if kill -0 "$pid" 2>/dev/null; then
     echo >&2
-    echo "::: test suite exceeded ${TIMEOUT}s — assuming a hang; thread dump follows :::" >&2
+    echo "::: test suite exceeded ${TIMEOUT}s — assuming a hang; thread dumps follow :::" >&2
+    echo "::: --- jstack (platform threads + carrier mounting) --- :::" >&2
     jstack "$pid" >&2 2>/dev/null || jcmd "$pid" Thread.print >&2 2>/dev/null || true
+    echo "::: --- jcmd Thread.dump_to_file -format=json (all threads, incl. virtual) --- :::" >&2
+    if jcmd "$pid" Thread.dump_to_file -format=json -overwrite /tmp/threaddump.json >&2 2>/dev/null
+    then cat /tmp/threaddump.json >&2
+    fi
     kill -9 "$pid" 2>/dev/null
     exit 124
   fi

--- a/img/test
+++ b/img/test
@@ -10,8 +10,11 @@
 #
 # A successful build implies `./mill test.assembly && make ci` passed.
 
-ARG JDK=23
-FROM eclipse-temurin:${JDK}-jdk AS base
+ARG JDK=25
+# Pin the Ubuntu base to "noble" (24.04 LTS): the default `${JDK}-jdk` tag tracks
+# a newer Ubuntu for JDK 25 where the apt packages below (e.g. libicu74) no longer
+# exist. Noble keeps the userland this image's apt list targets, independent of JDK.
+FROM eclipse-temurin:${JDK}-jdk-noble AS base
 
 # Shells and tooling the tests exercise. We need the same userland as the
 # GitHub Actions ubuntu-latest runner image, which preinstalls many of these.


### PR DESCRIPTION
Fixes the intermittent CI hang that blocked attestation. Under JDK 23 (the previous CI image) a virtual thread pins its carrier whenever it runs inside a `synchronized` block; the codebase uses `synchronized` in pervasive low-level code (e.g. digression's diagnostics), so under load in Docker enough virtual threads pinned carriers to starve the scheduler — `parasite`'s daemon-based tests could never run the daemon that fulfils their promise, and the suite hung indefinitely (intermittently, and invisibly to jstack, since the blocked threads are unmounted virtual threads). JDK 24's JEP 491 removed `synchronized` pinning, so the CI image moves to JDK 25 (matching the local toolchain), pinned to the Ubuntu "noble" base because the default `25-jdk` tag tracks a newer Ubuntu lacking the apt packages this image installs. With JDK 25 the full suite passes in Docker (5622 passed, 0 failed). The hang dump in `etc/ci/run-tests.sh` also now emits a virtual-thread-aware `jcmd Thread.dump_to_file -format=json` alongside jstack.

## Release notes

CI reliability only — no library or API changes.

- The CI test image now runs on **JDK 25** (Ubuntu noble base), eliminating the JDK 23 virtual-thread `synchronized`-pinning that intermittently deadlocked the suite under Docker.
- `etc/ci/run-tests.sh` now captures a virtual-thread-aware thread dump on hang, so a future virtual-thread deadlock is actually diagnosable.