### PR TITLE
Parse sequences of TEL documents

### DIFF
--- a/lib/stratiform/res/test/stratiform/corpus/pos.index
+++ b/lib/stratiform/res/test/stratiform/corpus/pos.index
@@ -113,6 +113,7 @@ tabulation-row-with-remark
 tabulation-second-replaces-first
 tabulation-terminated-by-blank
 tabulation-three-columns
+tel-header-then-garbage
 unicode-keyword
 word-separation-resets-per-line
 zero-bytes

--- a/lib/stratiform/res/test/stratiform/corpus/pos/tel-header-then-garbage.check
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/tel-header-then-garbage.check
@@ -1,0 +1,74 @@
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "title",
+                    atoms: [
+                        Inline {
+                            text: "Document",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "with",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "a",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "TEL",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "header",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+                Compound {
+                    keyword: "author",
+                    atoms: [
+                        Inline {
+                            text: "Ada",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+        Block {
+            comments: [
+                Comment {
+                    text: "The single-document parser stops at the separator below, so none of the",
+                },
+                Comment {
+                    text: "non-TEL content that follows is parsed or validated.",
+                },
+            ],
+            tabulation: None,
+            compounds: [],
+            trailing_blank_lines: 0,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/pos/tel-header-then-garbage.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/tel-header-then-garbage.tel
@@ -1,0 +1,12 @@
+tel 1.0
+
+title Document with a TEL header
+author Ada
+
+# The single-document parser stops at the separator below, so none of the
+# non-TEL content that follows is parsed or validated.
+##
+This is not TEL at all. It might be base64, CSV, or a binary blob:
+  - { unbalanced brackets ][
+	tabs and	whatever  ## even a stray double-sigil here is ignored
+%%% &&& not a pragma: tel 9.9 nonsense

--- a/lib/stratiform/res/test/stratiform/corpus/stream.index
+++ b/lib/stratiform/res/test/stratiform/corpus/stream.index
@@ -1,0 +1,7 @@
+empty-between
+literal-contains-separator
+non-default-sigil
+pragmaless-document
+three-documents
+trailing-separator
+two-documents

--- a/lib/stratiform/res/test/stratiform/corpus/stream/empty-between.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/empty-between.check
@@ -1,0 +1,77 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "alpha",
+                    atoms: [
+                        Inline {
+                            text: "1",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}
+=== document 1 ===
+Document {
+    interpreter_directive: None,
+    pragma: None,
+    line_endings: LF,
+    children: [],
+}
+=== document 2 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "beta",
+                    atoms: [
+                        Inline {
+                            text: "2",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/empty-between.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/empty-between.tel
@@ -1,0 +1,8 @@
+tel 1.0
+
+alpha 1
+##
+##
+tel 1.0
+
+beta 2

--- a/lib/stratiform/res/test/stratiform/corpus/stream/literal-contains-separator.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/literal-contains-separator.check
@@ -1,0 +1,46 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "code",
+                    atoms: [
+                        Literal {
+                            delimiter: "END",
+                            text: "      line one\n##\n      line three",
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+                Compound {
+                    keyword: "after",
+                    atoms: [
+                        Inline {
+                            text: "plain",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/literal-contains-separator.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/literal-contains-separator.tel
@@ -1,0 +1,9 @@
+tel 1.0
+
+code
+      END
+      line one
+##
+      line three
+END
+after plain

--- a/lib/stratiform/res/test/stratiform/corpus/stream/non-default-sigil.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/non-default-sigil.check
@@ -1,0 +1,100 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: Some(
+                "https://example.org/notes",
+            ),
+            sigil: Some(
+                '%',
+            ),
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "##",
+                    atoms: [],
+                    remark: None,
+                    children: [],
+                },
+                Compound {
+                    keyword: "note",
+                    atoms: [
+                        Inline {
+                            text: "this",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "document",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "uses",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "a",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "percent",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "sigil",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}
+=== document 1 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "second",
+                    atoms: [
+                        Inline {
+                            text: "document",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/non-default-sigil.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/non-default-sigil.tel
@@ -1,0 +1,8 @@
+tel 1.0 https://example.org/notes %
+
+##
+note this document uses a percent sigil
+%%
+tel 1.0
+
+second document

--- a/lib/stratiform/res/test/stratiform/corpus/stream/pragmaless-document.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/pragmaless-document.check
@@ -1,0 +1,80 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: None,
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "loose",
+                    atoms: [
+                        Inline {
+                            text: "content",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+                Compound {
+                    keyword: "no",
+                    atoms: [
+                        Inline {
+                            text: "pragma",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "here",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}
+=== document 1 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "second",
+                    atoms: [
+                        Inline {
+                            text: "has",
+                            preceding_spaces: 1,
+                        },
+                        Inline {
+                            text: "pragma",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/pragmaless-document.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/pragmaless-document.tel
@@ -1,0 +1,6 @@
+loose content
+no pragma here
+##
+tel 1.0
+
+second has pragma

--- a/lib/stratiform/res/test/stratiform/corpus/stream/three-documents.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/three-documents.check
@@ -1,0 +1,105 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "ordinal",
+                    atoms: [
+                        Inline {
+                            text: "first",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}
+=== document 1 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "ordinal",
+                    atoms: [
+                        Inline {
+                            text: "second",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}
+=== document 2 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "ordinal",
+                    atoms: [
+                        Inline {
+                            text: "third",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/three-documents.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/three-documents.tel
@@ -1,0 +1,11 @@
+tel 1.0
+
+ordinal first
+##
+tel 1.0
+
+ordinal second
+##
+tel 1.0
+
+ordinal third

--- a/lib/stratiform/res/test/stratiform/corpus/stream/trailing-separator.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/trailing-separator.check
@@ -1,0 +1,35 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "only",
+                    atoms: [
+                        Inline {
+                            text: "document",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/trailing-separator.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/trailing-separator.tel
@@ -1,0 +1,6 @@
+tel 1.0
+
+only document
+##
+
+

--- a/lib/stratiform/res/test/stratiform/corpus/stream/two-documents.check
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/two-documents.check
@@ -1,0 +1,70 @@
+=== document 0 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "greeting",
+                    atoms: [
+                        Inline {
+                            text: "hello",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 0,
+        },
+    ],
+}
+=== document 1 ===
+Document {
+    interpreter_directive: None,
+    pragma: Some(
+        Pragma {
+            version: (
+                1,
+                0,
+            ),
+            schema: None,
+            sigil: None,
+        },
+    ),
+    line_endings: LF,
+    children: [
+        Block {
+            comments: [],
+            tabulation: None,
+            compounds: [
+                Compound {
+                    keyword: "greeting",
+                    atoms: [
+                        Inline {
+                            text: "world",
+                            preceding_spaces: 1,
+                        },
+                    ],
+                    remark: None,
+                    children: [],
+                },
+            ],
+            trailing_blank_lines: 1,
+        },
+    ],
+}

--- a/lib/stratiform/res/test/stratiform/corpus/stream/two-documents.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/two-documents.tel
@@ -1,0 +1,7 @@
+tel 1.0
+
+greeting hello
+##
+tel 1.0
+
+greeting world

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -708,11 +708,18 @@ object Tel extends Tel2:
   def parse(bytes: Data, schema: Tels): Tel raises TelError =
     Tel(TelParser.parse(bytes, schema))
 
-  // `bytes.read[Tel]` for any Stream[Data] source: concatenates the
-  // chunks and parses the result. The metadata (interpreter directive,
-  // pragma, line-endings) is *not* surfaced — use `.load[Tel]` to
-  // recover those alongside the value.
-  given aggregable: Tactic[TelError] => Tel is Aggregable by Data = source =>
+  // Parse a multi-document source (§6.1) into its sequence of documents.
+  // `parseAll` is eager; `parseStream` parses lazily on demand. Used internally
+  // by the collection Aggregable typeclasses; user code should prefer
+  // `bytes.read[List[Tel]]` or `bytes.read[Stream[Tel]]`.
+  def parseAll(bytes: Data): List[Tel] raises TelError =
+    TelParser.parseDocuments(bytes).map(Tel(_))
+
+  def parseStream(bytes: Data): Stream[Tel] raises TelError =
+    TelParser.parseStream(bytes).map(Tel(_))
+
+  // Concatenate the chunks of a `Stream[Data]` source into a single byte array.
+  private def concatenate(source: Stream[Data]): Data =
     import denominative.nil
     var acc    = IArray.empty[Byte]
     var stream = source
@@ -720,7 +727,15 @@ object Tel extends Tel2:
       acc = acc ++ stream.head
       stream = stream.tail
 
-    parse(acc)
+    acc
+
+  // `bytes.read[Tel]` for any Stream[Data] source: concatenates the
+  // chunks and parses the result. The metadata (interpreter directive,
+  // pragma, line-endings) is *not* surfaced — use `.load[Tel]` to
+  // recover those alongside the value. Per §6.1, single-document parsing
+  // stops at the first document separator; content after it is ignored.
+  given aggregable: Tactic[TelError] => Tel is Aggregable by Data =
+    source => parse(concatenate(source))
 
   // `source.read[Foo over Tel]` shorthand for
   // `source.read[Tel].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
@@ -729,15 +744,18 @@ object Tel extends Tel2:
   // `value { type Transport = Tel }` so the cast is a no-op at runtime.
   given aggregableOver: [value: Decodable in Tel] => Tactic[TelError]
   =>  (value over Tel) is Aggregable by Data =
-    source =>
-      import denominative.nil
-      var acc    = IArray.empty[Byte]
-      var stream = source
-      while !stream.nil do
-        acc = acc ++ stream.head
-        stream = stream.tail
+    source => parse(concatenate(source)).as[value].asInstanceOf[value over Tel]
 
-      parse(acc).as[value].asInstanceOf[value over Tel]
+  // `source.read[List[Tel]]` / `read[Stream[Tel]]` for a multi-document source
+  // (§6.1). `List[Tel]` parses every document eagerly; `Stream[Tel]` parses
+  // them lazily on demand (the more specific instance wins over turbulence's
+  // generic `Stream` Aggregable, which would otherwise wrap the whole source as
+  // a single element).
+  given listAggregable: Tactic[TelError] => List[Tel] is Aggregable by Data =
+    source => parseAll(concatenate(source))
+
+  given streamAggregable: Tactic[TelError] => Stream[Tel] is Aggregable by Data =
+    source => parseStream(concatenate(source))
 
   // `text.load[Tel]` for any Stream[Text] source: concatenates the
   // chunks, UTF-8 encodes, parses, and pairs the resulting Tel with a

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -107,6 +107,22 @@ object TelParser:
     p.reset(Cursor[Data](input), schema: Optional[Tels])
     p.parse()
 
+  // Streaming parse (§6.1) of a multi-document source into the documents it
+  // contains. `parseDocuments` is eager; `parseStream` parses lazily on demand.
+  def parseDocuments(input: Data): List[Tel.Document] raises TelError =
+    import zephyrine.Lineation.untrackedData
+    val p = cached.get.nn
+    p.reset(Cursor[Data](input), Unset)
+    p.parseAllDocuments()
+
+  def parseStream(input: Data): Stream[Tel.Document] raises TelError =
+    import zephyrine.Lineation.untrackedData
+    // A dedicated parser instance, not the shared per-thread cache: the lazy
+    // tail parses later document(s) on demand and must own its parser state.
+    val p = new TelParser()
+    p.reset(Cursor[Data](input), Unset)
+    p.documentStream(first = true)
+
   private final val SP: Byte = 0x20
   private final val LF: Byte = 0x0A
   private final val CR: Byte = 0x0D
@@ -168,6 +184,12 @@ object TelParser:
     var blank:         Boolean = false
     var eof:           Boolean = false
     var startLine:     Int = 1      // 1-indexed source line of this line
+    // §5/§6.1: this line is a document separator — exactly two resolved-sigil
+    // characters at column zero and nothing else. It ends the current document
+    // (like EOF) and the next document begins on the following line. Recognised
+    // only at the structural level, so it is computed only for non-blank,
+    // non-EOF, zero-indent lines.
+    var separator:     Boolean = false
 
 
 private final class TelParser():
@@ -642,6 +664,7 @@ private final class TelParser():
     head.blank = false
     head.eof   = false
     head.startLine = 1
+    head.separator = false
     prevLineWasBoundary = true
     prevContentLeadingSpaces = -1
     hasConsumedNonBlankLine = false
@@ -669,11 +692,56 @@ private final class TelParser():
     compoundLineKeyword = t""
     compoundLineRemark  = Unset
 
+  // Soft reset between documents in a stream (§6.1). Re-initialises only
+  // per-document state; preserves the live cursor position, the continuous
+  // `lineNo` counter, and the whole-source line-ending mode (§4). The BOM is
+  // significant only at the true start of the source, so it is not re-checked.
+  // A fresh `atomArena` is allocated per document because each parsed
+  // document's `Inline` atoms keep their own arena alive.
+  private[stratiform] def resetForNextDocument(): Unit =
+    margin = 0
+    sigil  = '#'.toByte
+    head.leadingSpaces = 0
+    head.indentLevels  = 0
+    head.blank = false
+    head.eof   = false
+    head.startLine = lineNo
+    head.separator = false
+    prevLineWasBoundary = true
+    prevContentLeadingSpaces = -1
+    hasConsumedNonBlankLine = false
+    documentEndsWithLf = false
+    ancestors.clear()
+    sb.setLength(0)
+    atomArena     = new Array[Byte](256)
+    arenaPos      = 0
+    inFlightStart = -1
+    java.util.Arrays.fill(scratchAtoms.asInstanceOf[Array[AnyRef]], null)
+    atomScratchIx = 0
+    java.util.Arrays.fill(scratchComments.asInstanceOf[Array[AnyRef]], null)
+    commentScratchIx = 0
+    java.util.Arrays.fill(scratchCompounds.asInstanceOf[Array[AnyRef]], null)
+    compoundScratchIx = 0
+    java.util.Arrays.fill(scratchBlocks.asInstanceOf[Array[AnyRef]], null)
+    blockScratchIx = 0
+    compoundLineKeyword = t""
+    compoundLineRemark  = Unset
+
   // ── Top-level parse ───────────────────────────────────────────────────────
 
+  // Single-document parse (§6.1): reads exactly one document and stops at the
+  // first document separator. Any content after the separator is left
+  // unconsumed and need not be valid TEL.
   def parse(): Tel.Document raises TelError =
     syncFrom()
     checkBom()
+    parseOneDocument()
+
+  // Parse one document from the current cursor position, stopping at the first
+  // document separator or at end of input. The caller has already synced from
+  // the cursor and (for the first document only) checked the BOM. On return,
+  // `head` is parked either on a separator (`head.separator`) or at EOF.
+  private def parseOneDocument(): Tel.Document raises TelError =
     val directive = parseInterpreterDirective()
     val pragma = parsePragma()
     fillHead()  // park head at the next line
@@ -687,6 +755,70 @@ private final class TelParser():
 
     val children = parseChildren(parentIndent = -1)
     Tel.Document(directive, pragma, lineEndings, children)
+
+  // ── Document streams (§6.1) ────────────────────────────────────────────────
+
+  // Streaming parse: yield each document of the source in order, parsed
+  // independently. Eager — all documents are parsed (and any TelError raised)
+  // before returning. A separator followed only by blank lines or nothing
+  // yields no trailing empty document; two consecutive separators yield one
+  // empty document between them.
+  def parseAllDocuments(): List[Tel.Document] raises TelError =
+    syncFrom()
+    checkBom()
+    val buffer = scala.collection.mutable.ListBuffer.empty[Tel.Document]
+    var first = true
+    var continue = true
+    while continue do
+      if !first then resetForNextDocument()
+      first = false
+      val doc = parseOneDocument()
+      val terminatedBySeparator = head.separator
+      if terminatedBySeparator then consumeSeparatorLine()
+      // A document terminated by a separator is always emitted (even when
+      // empty — the empty document between two separators). A document
+      // terminated by EOF is dropped if empty: this is the trailing
+      // separator-then-blanks case, and the entirely-blank source.
+      if terminatedBySeparator || !documentIsEmpty(doc) then buffer += doc
+      if !terminatedBySeparator then continue = false
+
+    buffer.to(List)
+
+  // Lazy streaming parse: documents are parsed on demand as the returned
+  // `Stream` is forced. Mirrors turbulence's deferred `Streamable` readers,
+  // which likewise capture the error capability in the lazy tail; the consumer
+  // must drive the stream within the `raises TelError` handler's scope. Uses a
+  // dedicated parser instance (never the shared per-thread cache) so the
+  // parser state survives across element demands.
+  private def documentStream(first: Boolean): Stream[Tel.Document] raises TelError =
+    if first then
+      syncFrom()
+      checkBom()
+    else resetForNextDocument()
+
+    val doc = parseOneDocument()
+    if head.separator then
+      consumeSeparatorLine()
+      doc #:: documentStream(first = false)
+    else if documentIsEmpty(doc) then Stream.empty
+    else Stream(doc)
+
+  // A document with no prologue and no children: the empty document yielded
+  // between two separators, or the absence of any document at the end of a
+  // stream.
+  private def documentIsEmpty(doc: Tel.Document): Boolean =
+    doc.children.isEmpty && doc.interpreterDirective.absent && doc.pragma.absent
+
+  // `head` is parked on a separator (the cursor sits on its first sigil).
+  // Consume both sigil bytes and the terminating line-ending so the next
+  // document begins on the following line. At true EOF the separator has no
+  // line-ending and `consumeLineEnding` is a no-op.
+  private def consumeSeparatorLine(): Unit raises TelError = inHold:
+    ensureLookahead(2)
+    advance()  // first sigil
+    advance()  // second sigil
+    consumeLineEnding()
+    prevLineWasBoundary = true
 
   // ── BOM ──────────────────────────────────────────────────────────────────
 
@@ -1032,6 +1164,7 @@ private final class TelParser():
   // also mark-using) execute inside an active `cursor.hold` scope.
   private def fillHead(): Unit raises TelError = inHold:
     head.startLine = lineNo
+    head.separator = false
 
     val spaces = countLeadingSpaces()
     head.leadingSpaces = spaces
@@ -1051,6 +1184,12 @@ private final class TelParser():
     else
       head.blank = false
       head.eof = false
+      // A document separator is recognised only at column zero (§5). The
+      // resolved sigil is already in `sigil` (the pragma, if any, was parsed
+      // before any body fillHead). When the line is a separator we leave the
+      // cursor parked on its first sigil; the multi-document driver consumes
+      // the separator line, and the body-parsing loops treat it like EOF.
+      head.separator = spaces == 0 && headLineIsSeparator()
       val rel = spaces - margin
       head.indentLevels =
         if rel < 0 then
@@ -1058,20 +1197,32 @@ private final class TelParser():
         else if rel % 2 == 0 then rel / 2
         else recoverOddIndent(spaces, head.startLine)
 
+  // True iff the cursor is parked on the first byte of a document separator:
+  // exactly two `sigil` bytes followed immediately by a line-ending or EOF —
+  // no third character and (given the zero-indent precondition) no leading or
+  // trailing spaces. Does not consume.
+  private def headLineIsSeparator(): Boolean =
+    ensureLookahead(3)
+    pos + 1 < bufEnd
+    && bytes(pos) == sigil && bytes(pos + 1) == sigil
+    && (pos + 2 >= bufEnd || bytes(pos + 2) == LF || bytes(pos + 2) == CR)
+
   // ── parseChildren ────────────────────────────────────────────────────────
 
   private def parseChildren(parentIndent: Int): IArray[Tel.Block] raises TelError =
     val expected = parentIndent + 1
 
-    if head.eof || head.indentLevels < expected then IArray.empty[Tel.Block]
+    if head.eof || head.separator || head.indentLevels < expected
+    then IArray.empty[Tel.Block]
     else
       val start = blockScratchIx
-      while !head.eof && head.indentLevels == expected do
+      while !head.eof && !head.separator && head.indentLevels == expected do
         parseBlock(expected)  // pushes one block onto scratchBlocks
 
       // After consuming children at `expected`, a remaining non-blank line
-      // more indented than `expected` is an error.
-      if !head.eof && head.indentLevels > expected then
+      // more indented than `expected` is an error. A document separator
+      // (always at column zero) is never over-indented, so it is excluded.
+      if !head.eof && !head.separator && head.indentLevels > expected then
         val line = head.startLine
         val lastIx = blockScratchIx - 1
         if lastIx >= start then
@@ -1101,7 +1252,9 @@ private final class TelParser():
     val compoundStart = compoundScratchIx
 
     // Leading comments at this indent.
-    while !head.eof && !head.blank && head.indentLevels == indent && isCommentBody() do
+    while !head.eof && !head.separator && !head.blank && head.indentLevels == indent
+          && isCommentBody()
+    do
       // §9 E109 check — fires only if the immediately preceding line was a
       // content line (compound / tabulation) at indent ≥ this comment's.
       if !prevLineWasBoundary && prevContentLeadingSpaces >= 0
@@ -1124,7 +1277,8 @@ private final class TelParser():
 
     // Optional tabulation header.
     val tabulation: Optional[Tel.Tabulation] =
-      if !head.eof && !head.blank && head.indentLevels == indent && isTabulationBody()
+      if !head.eof && !head.separator && !head.blank && head.indentLevels == indent
+         && isTabulationBody()
       then
         val ls = head.leadingSpaces
         val tab = parseTabulationLine()
@@ -1137,7 +1291,9 @@ private final class TelParser():
 
     // Compound loop.
     var keepLoop = true
-    while keepLoop && !head.eof && !head.blank && head.indentLevels == indent do
+    while keepLoop && !head.eof && !head.separator && !head.blank
+          && head.indentLevels == indent
+    do
       if isCommentBody() || isTabulationBody() then keepLoop = false
       else
         val compoundLeadingSpaces = head.leadingSpaces
@@ -1202,7 +1358,7 @@ private final class TelParser():
     val savedLineNo = lineNo
     while !head.eof && head.blank do fillHead()
     val keep =
-      !head.eof && head.indentLevels == indent && !isCommentBody()
+      !head.eof && !head.separator && head.indentLevels == indent && !isCommentBody()
     if !keep then
       // Rewind.
       syncTo()

--- a/lib/stratiform/src/test/stratiform.CheckFormat.scala
+++ b/lib/stratiform/src/test/stratiform.CheckFormat.scala
@@ -68,6 +68,18 @@ object CheckFormat:
 
     CheckFile(tree, errors)
 
+  // Parse a multi-document stream `.check` fixture (§6.1): a sequence of
+  // `=== document N ===` header lines, each followed by a `Document { … }`
+  // value and an optional per-document `errors:` block. Each section is parsed
+  // independently with `parse`.
+  def parseStream(source: Text): List[CheckFile] =
+    val sections = scala.collection.mutable.ListBuffer.empty[StringBuilder]
+    source.s.split('\n').foreach: line =>
+      if line.startsWith("=== document ") then sections += new StringBuilder()
+      else if sections.nonEmpty then sections.last.append(line).append('\n')
+
+    sections.toList.map(section => parse(Text(section.toString)))
+
   private def parseValue(cursor: Cursor): CheckTree =
     cursor.skipWhitespace()
     val c = cursor.peek()

--- a/lib/stratiform/src/test/stratiform.CorpusLoader.scala
+++ b/lib/stratiform/src/test/stratiform.CorpusLoader.scala
@@ -50,11 +50,18 @@ object CorpusLoader:
   def positive: List[Case] = load(t"pos")
   def negative: List[Case] = load(t"neg")
 
+  // Multi-document stream fixtures (§6.1): `.check` files hold a sequence of
+  // `=== document N ===` sections (see CheckFormat.parseStream).
+  def streaming: List[Case] = load(t"stream")
+
   private def load(category: Text): List[Case] =
-    readIndex(category).filterNot(_.s.startsWith("_")).map: stem =>
-      val source = readResource(t"/stratiform/corpus/$category/$stem.tel")
-      val check = readResourceText(t"/stratiform/corpus/$category/$stem.check")
-      Case(stem, IArray.from(source), check)
+    readIndex(category).filterNot(_.s.startsWith("_")).map(caseByStem(category, _))
+
+  // Load a single corpus case by category and stem (e.g. an off-index fixture).
+  def caseByStem(category: Text, stem: Text): Case =
+    val source = readResource(t"/stratiform/corpus/$category/$stem.tel")
+    val check = readResourceText(t"/stratiform/corpus/$category/$stem.check")
+    Case(stem, IArray.from(source), check)
 
   // Extract the expected E-code from a negative case's stem name. Filenames
   // follow the upstream convention `e<n>-<description>.tel`; cases without

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -143,6 +143,43 @@ object Tests extends Suite(m"Stratiform Tests"):
             tree == baseline
         . assert(identity)
 
+    suite(m"Document streams (§6.1)"):
+      // Each `.check` fixture holds a `=== document N ===` sequence; the parsed
+      // documents must match it document-for-document.
+      CorpusLoader.streaming.each: testcase =>
+        test(m"read[List[Tel]] parses ${testcase.stem}"):
+          testcase.source.read[List[Tel]].map(TelCheckTree.of)
+        . assert(_ == CheckFormat.parseStream(testcase.check).map(_.tree))
+
+        // `LazyList[Tel]` is proscenium's `Stream[Tel]`; this file doesn't
+        // import the predef alias, so spell it out.
+        test(m"read[Stream[Tel]] parses ${testcase.stem}"):
+          testcase.source.read[LazyList[Tel]].map(TelCheckTree.of).to(List)
+        . assert(_ == CheckFormat.parseStream(testcase.check).map(_.tree))
+
+      test(m"two documents yield a list of two"):
+        CorpusLoader.caseByStem(t"stream", t"two-documents").source.read[List[Tel]].length
+      . assert(_ == 2)
+
+      test(m"a trailing separator yields no empty trailing document"):
+        CorpusLoader.caseByStem(t"stream", t"trailing-separator").source.read[List[Tel]].length
+      . assert(_ == 1)
+
+      test(m"two consecutive separators yield an empty document between them"):
+        CorpusLoader.caseByStem(t"stream", t"empty-between").source.read[List[Tel]].length
+      . assert(_ == 3)
+
+      test(m"a malformed document in a stream raises (fail-fast)"):
+        // The second document has an odd indentation (E107); reading the whole
+        // list eagerly surfaces it.
+        capture[TelError](t"a 1\n##\nparent\n   bad".read[List[Tel]]).reason.number
+      . assert(_ == 107)
+
+      test(m"read[Stream[Tel]] is lazy past a malformed later document"):
+        val source = t"first ok\n##\nparent\n   bad"
+        TelCheckTree.of(source.read[LazyList[Tel]].head)
+      . assert(_ == TelCheckTree.of(t"first ok".read[Tel]))
+
     suite(m"Encode/decode primitives"):
       test(m"Text round-trip"):
         t"hello".encode.as[Text]


### PR DESCRIPTION
Stratiform can now read a TEL source that contains more than one document. The TEL specification (§6.1) lets a source carry a sequence of documents separated by a document-separator line — two of the document's sigil characters alone on a line — and stratiform now understands them: single-document reads stop at the first separator, and new `read[List[Tel]]` and `read[Stream[Tel]]` decoders return the whole sequence.

## Reading a sequence of TEL documents

A TEL source may now contain several documents, one after another, separated by a *document separator*: a line consisting of exactly two of the document's sigil characters (`##` by default). Read them all at once with `read[List[Tel]]`, or lazily with `read[Stream[Tel]]`:

```scala
val source = t"tel 1.0\n\ngreeting hello\n##\ntel 1.0\n\ngreeting world"

val docs: List[Tel]       = source.read[List[Tel]]    // two documents
val lazyDocs: Stream[Tel] = source.read[Stream[Tel]]  // parsed on demand
```

Each document is independent — it has its own interpreter directive, pragma, resolved sigil and margin — while the byte-order mark and line-ending mode are fixed once for the whole source. A document whose pragma sets the sigil to `%` is terminated by `%%`, and a `##` line within it is ordinary content.

Single-document `read[Tel]` now stops at the first separator instead of consuming the rest of the source, so a TEL document can serve as a header in front of arbitrary, possibly non-TEL, content:

```scala
// only the header is parsed; everything after the `##` separator is ignored
header.read[Tel]
```

`read[List[Tel]]` parses eagerly and raises on the first malformed document; `read[Stream[Tel]]` parses each document on demand as the stream is consumed.
