### PR TITLE
Add `Redraft`: human-writable context-anchored diffs

### DIFF
--- a/lib/dissonance/src/core/dissonance.Redraft.scala
+++ b/lib/dissonance/src/core/dissonance.Redraft.scala
@@ -1,0 +1,296 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package dissonance
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import rudiments.*
+import turbulence.*
+import vacuous.*
+
+import RedraftError.Reason
+
+object Redraft:
+
+  /* A single line of a `Redraft`. `Keep` is unambiguous context; `Add`/`Cut` are edits forced with
+     the alternate `>`/`<` markers; `Mark` is a primary `+`/`-` line, whose meaning (an edit of its
+     payload, or context matching the literal marker line) is resolved against the original. */
+  enum Directive:
+    case Keep(line: Text)
+    case Add(line: Text)
+    case Cut(line: Text)
+    case Mark(line: Text, insert: Boolean)
+
+  /* A place where a `Redraft` cannot be unambiguously applied to a particular original; `line` is
+     the zero-based directive index in the redraft. */
+  case class Anomaly(line: Int, text: Text, reason: Reason)
+
+  /* How much unchanged context to include when rendering a `Diff` as a `Redraft`. */
+  enum Context:
+    case Minimal, Full
+    case Fixed(lines: Int)
+
+  private def marker(text: Text): Boolean =
+    val s = text.s
+    s == "+" || s == "-" || s == "<" || s == ">" || s.startsWith("+ ") || s.startsWith("- ")
+    || s.startsWith("< ") || s.startsWith("> ")
+
+  private def needsEscape(text: Text): Boolean = marker(text) || text.s.startsWith("\\")
+
+  private def payload(text: Text): Text =
+    (if text.s.length >= 2 then text.s.substring(2).nn else "").tt
+
+  def parse(lines: Stream[Text]): Redraft =
+    val directives = lines.map: line =>
+      val s = line.s
+      if s == "+" || s.startsWith("+ ") then Directive.Mark(payload(line), insert = true)
+      else if s == "-" || s.startsWith("- ") then Directive.Mark(payload(line), insert = false)
+      else if s == ">" || s.startsWith("> ") then Directive.Add(payload(line))
+      else if s == "<" || s.startsWith("< ") then Directive.Cut(payload(line))
+      else if s.startsWith("\\") then Directive.Keep(s.substring(1).nn.tt)
+      else Directive.Keep(line)
+
+    Redraft(directives.to(List)*)
+
+  private def render1(directive: Directive): Text = directive match
+    case Directive.Keep(line)        => if needsEscape(line) then ("\\"+line.s).tt else line
+    case Directive.Add(line)         => ("> "+line.s).tt
+    case Directive.Cut(line)         => ("< "+line.s).tt
+    case Directive.Mark(line, true)  => ("+ "+line.s).tt
+    case Directive.Mark(line, false) => ("- "+line.s).tt
+
+  /* The result of aligning the matcher lines (`Keep`/`Cut` and resolved `Mark`s) against the
+     original, recording for each matcher its text, the leftmost index it matched, and the directive
+     index that produced it. */
+  private case class Matcher(text: Text, index: Int, line: Int)
+
+  /* Apply a redraft's directives to an original by leftmost subsequence matching, producing the full
+     `Edit` list together with any anomalies (no-match, ambiguity, or insufficient anchoring). This
+     never raises; `resolve` and `verify` interpret the anomalies. */
+  private def analyze
+              (directives: List[Directive],
+               original:   IndexedSeq[Text],
+               compare:    (Text, Text) => Boolean)
+  :   (List[Edit[Text]], List[Anomaly]) =
+
+    val n = original.length
+
+    def seek(from: Int, text: Text): Int =
+      var j = from
+      while j < n && !compare(original(j), text) do j += 1
+      if j < n then j else -1
+
+    var cursor = 0
+    var right = 0
+    var edits: List[Edit[Text]] = Nil
+    var matchers: List[Matcher] = Nil
+    var anomalies: List[Anomaly] = Nil
+
+    def keepUpTo(target: Int): Unit =
+      var k = cursor
+      while k < target do
+        edits = Par(k, right, original(k)) :: edits
+        right += 1
+        k += 1
+      cursor = target
+
+    def keep(index: Int, text: Text, line: Int): Unit =
+      keepUpTo(index)
+      edits = Par(index, right, original(index)) :: edits
+      matchers = Matcher(text, index, line) :: matchers
+      right += 1
+      cursor = index + 1
+
+    def cut(index: Int, text: Text, line: Int): Unit =
+      keepUpTo(index)
+      edits = Del(index, original(index)) :: edits
+      matchers = Matcher(text, index, line) :: matchers
+      cursor = index + 1
+
+    def add(text: Text): Unit =
+      edits = Ins(right, text) :: edits
+      right += 1
+
+    directives.zipWithIndex.each: (directive, line) =>
+      directive match
+        case Directive.Keep(text) =>
+          val index = seek(cursor, text)
+          if index < 0 then anomalies = Anomaly(line, text, Reason.NoMatch) :: anomalies
+          else keep(index, text, line)
+
+        case Directive.Add(text) =>
+          add(text)
+
+        case Directive.Cut(text) =>
+          val index = seek(cursor, text)
+          if index < 0 then anomalies = Anomaly(line, text, Reason.NoMatch) :: anomalies
+          else cut(index, text, line)
+
+        case Directive.Mark(load, insert) =>
+          val literal = ((if insert then "+ " else "- ")+load.s).tt
+          val contextIndex = seek(cursor, literal)
+          val editIndex = if insert then cursor else seek(cursor, load)
+          val contextViable = contextIndex >= 0
+          val editViable = insert || editIndex >= 0
+
+          if contextViable && editViable
+          then anomalies = Anomaly(line, literal, Reason.Ambiguous) :: anomalies
+          else if contextViable then keep(contextIndex, literal, line)
+          else if editViable then (if insert then add(load) else cut(editIndex, load, line))
+          else anomalies = Anomaly(line, literal, Reason.NoMatch) :: anomalies
+
+    keepUpTo(n)
+
+    val ordered = matchers.reverse
+
+    // Rightmost greedy alignment of the same matcher texts; where it disagrees with the leftmost
+    // alignment, the matcher is under-anchored.
+    @tailrec
+    def alignRight(todo: List[Matcher], limit: Int, acc: List[Int]): Optional[List[Int]] =
+      todo match
+        case Nil => acc
+        case matcher :: rest =>
+          var j = limit
+          while j >= 0 && !compare(original(j), matcher.text) do j -= 1
+          if j < 0 then Unset else alignRight(rest, j - 1, j :: acc)
+
+    alignRight(ordered.reverse, n - 1, Nil).let: rightmost =>
+      ordered.zip(rightmost).each: (matcher, rightIndex) =>
+        if matcher.index != rightIndex
+        then anomalies = Anomaly(matcher.line, matcher.text, Reason.Unanchored) :: anomalies
+
+    (edits.reverse, anomalies.sortBy(_.line))
+
+  def render(diff: Diff[Text], context: Context): Redraft =
+    val original: IndexedSeq[Text] = diff.edits.collect:
+      case Par(_, _, value) => value.vouch
+      case Del(_, value)    => value.vouch
+    . to(IndexedSeq)
+
+    val full: List[Directive] = diff.edits.to(List).flatMap:
+      case Par(_, _, value) => List(Directive.Keep(value.vouch))
+      case Del(_, value)    => List(Directive.Mark(value.vouch, insert = false))
+      case Ins(_, value)    => List(Directive.Mark(value, insert = true))
+
+    // Promote any ambiguous primary `+`/`-` marker to the forced `>`/`<` spelling.
+    def deambiguate(directives: List[Directive]): List[Directive] =
+      val ambiguous =
+        analyze(directives, original, _ == _)(1).collect:
+          case Anomaly(line, _, Reason.Ambiguous) => line
+
+      . to(Set)
+
+      if ambiguous.isEmpty then directives
+      else deambiguate:
+        directives.zipWithIndex.map: (directive, index) =>
+          if !ambiguous.contains(index) then directive else directive match
+            case Directive.Mark(load, true)  => Directive.Add(load)
+            case Directive.Mark(load, false) => Directive.Cut(load)
+            case other                       => other
+
+    val resolved = deambiguate(full)
+
+    context match
+      case Context.Full     => Redraft(resolved*)
+      case Context.Fixed(k) => Redraft(trim(resolved, k)*)
+      case Context.Minimal  => Redraft(minimize(resolved, original, diff.patch(original).to(List))*)
+
+  /* Keep only unchanged lines within `k` directives of a change. */
+  private def trim(directives: List[Directive], k: Int): List[Directive] =
+    val keep = directives.map { case Directive.Keep(_) => false; case _ => true }.to(Array)
+    val n = keep.length
+
+    def near(index: Int): Boolean =
+      (1 to k).exists: d =>
+        (index - d >= 0 && keep(index - d)) || (index + d < n && keep(index + d))
+
+    directives.zipWithIndex.collect:
+      case (directive, index) if !directive.isInstanceOf[Directive.Keep] || near(index) => directive
+
+  /* Greedily drop unchanged context, preferring lines furthest from any change, retaining a drop
+     only while the redraft still reproduces the target and stays unambiguous. */
+  private def minimize
+              (directives: List[Directive], original: IndexedSeq[Text], target: List[Text])
+  :   List[Directive] =
+
+    val array = directives.to(Array)
+    val dropped = scala.collection.mutable.Set[Int]()
+
+    def remaining: List[Directive] =
+      array.indices.to(List).filter(!dropped.contains(_)).map(array(_))
+
+    def valid(candidate: List[Directive]): Boolean =
+      val (edits, anomalies) = analyze(candidate, original, _ == _)
+      anomalies.isEmpty && Diff(edits*).patch(original).to(List) == target
+
+    val changes = array.indices.filter(i => !array(i).isInstanceOf[Directive.Keep])
+
+    def distance(index: Int): Int =
+      if changes.isEmpty then 0 else changes.map(c => (c - index).abs).min
+
+    val order = array.indices
+                . filter(array(_).isInstanceOf[Directive.Keep])
+                . sortBy(index => -distance(index))
+
+    order.each: index =>
+      dropped += index
+      if !valid(remaining) then dropped -= index
+
+    remaining
+
+case class Redraft(directives: Redraft.Directive*):
+  def serialize: Stream[Text] = directives.map(Redraft.render1).to(Stream)
+
+  def resolve(original: IndexedSeq[Text], compare: (Text, Text) => Boolean = _ == _)
+  :   Diff[Text] raises RedraftError =
+
+    val (edits, anomalies) = Redraft.analyze(directives.to(List), original, compare)
+
+    anomalies match
+      case anomaly :: _ => abort(RedraftError(anomaly.line, anomaly.text, anomaly.reason))
+      case Nil          => Diff(edits*)
+
+  def verify(original: IndexedSeq[Text], compare: (Text, Text) => Boolean = _ == _)
+  :   List[Redraft.Anomaly] =
+
+    Redraft.analyze(directives.to(List), original, compare)(1)
+
+  def patch(original: IndexedSeq[Text], compare: (Text, Text) => Boolean = _ == _)
+  :   Stream[Text] raises RedraftError =
+
+    resolve(original, compare).patch(original)
+
+extension (diff: Diff[Text])
+  def redraft(context: Redraft.Context = Redraft.Context.Minimal): Redraft =
+    Redraft.render(diff, context)

--- a/lib/dissonance/src/core/dissonance.RedraftError.scala
+++ b/lib/dissonance/src/core/dissonance.RedraftError.scala
@@ -30,9 +30,23 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package dissonance
 
-export
-  dissonance
-  . { Change, Chunk, Del, Diff, diff, DiffError, Edit, Evolution, evolve, Ins, Par, RDiff, Redraft,
-      RedraftError, Region, Sub }
+import anticipation.*
+import fulminate.*
+
+object RedraftError:
+  object Reason:
+    given communicable: Reason is Communicable =
+      case NoMatch    => m"no matching line could be found in the original"
+      case Ambiguous  => m"the change could be interpreted in more than one way"
+      case Unanchored => m"there is not enough context to locate the change unambiguously"
+
+  enum Reason(val number: Int) extends Clarification:
+    case NoMatch    extends Reason(1)
+    case Ambiguous  extends Reason(2)
+    case Unanchored extends Reason(3)
+
+case class RedraftError(line: Int, text: Text, reason: RedraftError.Reason)(using Diagnostics)
+extends Error(472, reason.number)
+  ( m"the redraft could not be applied at line $line ($text) because $reason" )

--- a/lib/dissonance/src/test/dissonance_test.scala
+++ b/lib/dissonance/src/test/dissonance_test.scala
@@ -37,6 +37,9 @@ import soundness.*
 import proximities.levenshteinDistance
 import caseSensitivity.sensitive
 import strategies.throwUnsafely
+import errorDiagnostics.empty
+
+import Redraft.Directive as D
 
 object Tests extends Suite(m"Dissonance tests"):
   def run(): Unit =
@@ -252,6 +255,87 @@ object Tests extends Suite(m"Dissonance tests"):
         val evolution = evolve(List(t"Jack and Jill", t"Jack with Jill", t"Jack und Jill").map(_.chars.to(List)))
         List(Prim, Sec, Ter).map(evolution(_).mkString)
       . assert(_ == List("Jack and Jill", "Jack with Jill", "Jack und Jill"))
+
+    val source = Vector(t"line1", t"line2", t"line3")
+    val dup = Vector(t"a", t"b", t"a")
+    val list = Vector(t"- alpha", t"- beta", t"- gamma")
+
+    suite(m"Redraft parsing tests"):
+      val roundtrip = Stream(t"line1", t"- line2", t"+ new", t"\\- escaped", t"< forced", t"> add")
+
+      test(m"Parse a simple redraft"):
+        Redraft.parse(Stream(t"line1", t"- line2", t"+ new line 2a", t"line3"))
+      . assert(_ == Redraft(D.Keep(t"line1"), D.Mark(t"line2", false), D.Mark(t"new line 2a", true),
+          D.Keep(t"line3")))
+
+      test(m"Parse forced and escaped directives"):
+        Redraft.parse(Stream(t"< forced", t"> add", t"\\- escaped"))
+      . assert(_ == Redraft(D.Cut(t"forced"), D.Add(t"add"), D.Keep(t"- escaped")))
+
+      test(m"Serialize round-trips through parse"):
+        Redraft.parse(roundtrip).serialize.to(List)
+      . assert(_ == roundtrip.to(List))
+
+    suite(m"Redraft application tests"):
+      test(m"Apply a simple redraft"):
+        Redraft.parse(Stream(t"- line2", t"+ new line 2a")).patch(source).to(Vector)
+      . assert(_ == Vector(t"line1", t"new line 2a", t"line3"))
+
+      test(m"Omitted unchanged lines are skipped"):
+        Redraft.parse(Stream(t"- line2")).patch(source).to(Vector)
+      . assert(_ == Vector(t"line1", t"line3"))
+
+      test(m"Insert before the first line"):
+        Redraft.parse(Stream(t"+ line0")).patch(source).to(Vector)
+      . assert(_ == Vector(t"line0", t"line1", t"line2", t"line3"))
+
+      test(m"Forced insert with the alternate marker"):
+        Redraft.parse(Stream(t"> line0")).patch(source).to(Vector)
+      . assert(_ == Vector(t"line0", t"line1", t"line2", t"line3"))
+
+      test(m"Deletion anchored by context"):
+        Redraft.parse(Stream(t"b", t"- a")).patch(dup).to(Vector)
+      . assert(_ == Vector(t"a", t"b"))
+
+      test(m"A verbatim marker line is kept as context"):
+        Redraft.parse(Stream(t"- alpha", t"< - beta", t"- gamma")).patch(list).to(Vector)
+      . assert(_ == Vector(t"- alpha", t"- gamma"))
+
+      test(m"Escaped context matches a literal marker line"):
+        Redraft.parse(Stream(t"\\- alpha")).patch(list).to(Vector)
+      . assert(_ == Vector(t"- alpha", t"- beta", t"- gamma"))
+
+      test(m"Delete a literal marker line with a doubled marker"):
+        Redraft.parse(Stream(t"- alpha", t"- - beta", t"- gamma")).patch(list).to(Vector)
+      . assert(_ == Vector(t"- alpha", t"- gamma"))
+
+    suite(m"Redraft ambiguity tests"):
+      test(m"An under-anchored deletion is rejected"):
+        capture[RedraftError](Redraft.parse(Stream(t"- a")).patch(dup))
+      . assert(_.reason == RedraftError.Reason.Unanchored)
+
+      test(m"verify reports the under-anchored line"):
+        Redraft.parse(Stream(t"- a")).verify(dup)
+      . assert(_ == List(Redraft.Anomaly(0, t"a", RedraftError.Reason.Unanchored)))
+
+      test(m"A non-matching context line is rejected"):
+        capture[RedraftError](Redraft.parse(Stream(t"absent", t"- line2")).patch(source))
+      . assert(_.reason == RedraftError.Reason.NoMatch)
+
+    suite(m"Redraft rendering tests"):
+      val target = Vector(t"line1", t"new", t"line3")
+
+      test(m"Render a minimal redraft, dropping all context"):
+        diff(source, Vector(t"line1", t"new line 2a", t"line3")).redraft().serialize.to(List)
+      . assert(_ == List(t"- line2", t"+ new line 2a"))
+
+      test(m"Render minimal context to anchor an ambiguous deletion"):
+        diff(dup, Vector(t"a", t"b")).redraft().serialize.to(List)
+      . assert(_ == List(t"b", t"- a"))
+
+      test(m"A rendered redraft reproduces the target when applied"):
+        diff(source, target).redraft().patch(source).to(Vector)
+      . assert(_ == target)
 
     // suite(m"Casual diff tests"):
     //   test(m"Parse a simple casual diff"):


### PR DESCRIPTION
Dissonance gains `Redraft`, a human-writable diff format that locates changes purely by context rather than by line number, so a patch can be written (or generated) by lightly annotating an excerpt of a file with `+ ` and `- ` markers. A `Redraft` is the positionless counterpart to a `Diff`: rendering one erases line positions and drops redundant context down to the minimum needed to stay unambiguous, while applying one re-derives the positions by matching the context against the original. Application is strict — a redraft is only accepted when it locates a unique alignment — so an applied redraft is provably unambiguous, and `verify` reports under-anchored lines for editor tooling.

### Human-writable diffs with `Redraft`

You can now describe an edit to a text file without line numbers, by quoting context and marking changed lines. Given a file:

```
line1
line2
line3
```

the redraft:

```
- line2
+ new line 2a
```

applied to it yields `line1` / `new line 2a` / `line3`. Lines prefixed `- ` are deleted, `+ ` are inserted, and bare lines are unchanged context that must match (skipping over any intervening lines); unchanged lines you don't care about can simply be omitted.

```scala
import soundness.*

val patch = Redraft.parse(Stream(t"- line2", t"+ new line 2a"))
val result = patch.patch(Vector(t"line1", t"line2", t"line3"))   // line1 / new line 2a / line3
```

Where a line appears more than once, enough context must be given to pin the change down. This redraft is rejected as under-anchored, because `- a` could remove either `a`:

```
- a
```

but adding the preceding line resolves it:

```
b
- a
```

Going the other way, `diff(before, after).redraft()` renders a minimal redraft — including only as much surrounding context as is needed to keep the patch unambiguous:

```scala
diff(before, after).redraft().serialize   // the lines of the redraft
```

A line that begins with a marker character can still be used: `<`/`>` are alternative spellings of `- `/`+ ` that force a deletion or insertion, a leading `\` forces a line to be read as context, and a doubled marker (e.g. `- - foo`) edits a line that literally begins with `- `. Verbatim marker-looking lines (such as YAML `- item` list entries) are treated as context automatically wherever that reading is unambiguous.
