### PR TITLE
Add source-position tracking to CSV and Protobuf parse errors

### DIFF
--- a/lib/caesura/src/core/caesura.DsvError.scala
+++ b/lib/caesura/src/core/caesura.DsvError.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package caesura
 
+import denominative.*
 import fulminate.*
 
 object DsvError:
@@ -41,5 +42,12 @@ object DsvError:
   enum Reason(val number: Int) extends Clarification:
     case MisplacedQuote extends Reason(1)
 
-case class DsvError(format: DsvFormat, reason: DsvError.Reason)(using Diagnostics)
-extends Error(364, reason.number)(m"could not parse row data because $reason")
+// `row` and `column` are the 1-based position of the offending cell, and `offset`
+// is the character (UTF-16 code-unit) offset into the input at which the failure
+// was detected. A byte offset is not available here because the parser operates on
+// already-decoded `Text`, the source bytes having been discarded upstream.
+case class DsvError
+  ( format: DsvFormat, reason: DsvError.Reason, row: Ordinal, column: Ordinal, offset: Int )
+  ( using Diagnostics )
+extends Error(364, reason.number)
+  ( m"could not parse row data at row ${row.n1}, column ${column.n1} because $reason" )

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -113,6 +113,8 @@ object Sheet:
     private var current: String = ""
     private var currentLen: Int = 0
     private var pos: Int = 0
+    private var consumed: Int = 0
+    private var rowOrdinal: Ordinal = Prim
     private val builder: jl.StringBuilder = new jl.StringBuilder(64)
     private val cellsBuf: scm.ArrayBuffer[Text] = new scm.ArrayBuffer[Text](16)
     private var state: State = State.Fresh
@@ -127,6 +129,7 @@ object Sheet:
       if pos < currentLen then true
       else content match
         case head #:: tail =>
+          consumed += currentLen
           current = head.s
           currentLen = current.length
           pos = 0
@@ -145,6 +148,7 @@ object Sheet:
       val arr = new Array[Text](n)
       cellsBuf.copyToArray(arr)
       cellsBuf.clear()
+      rowOrdinal = rowOrdinal.next
       Dsv(IArray.unsafeFromArray(arr), headings)
 
     // Scan ahead in Fresh state for the next delimiter, quote, or line-ending,
@@ -171,7 +175,8 @@ object Sheet:
             return Unset
           else if ch == q then
             if builder.length > 0 then
-              raise(DsvError(format, DsvError.Reason.MisplacedQuote))
+              val reason = DsvError.Reason.MisplacedQuote
+              raise(DsvError(format, reason, rowOrdinal, cellsBuf.length.z, consumed + p))
 
             state = State.Quoted
             return Unset

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -86,7 +86,11 @@ object Tests extends Suite(m"Caesura tests"):
 
       test(m"misplaced quote"):
         capture[DsvError](t"""hello,wo"rld""".read[Sheet])
-      . assert(_ == DsvError(summon[DsvFormat], DsvError.Reason.MisplacedQuote))
+      . assert(_ == DsvError(summon[DsvFormat], DsvError.Reason.MisplacedQuote, Prim, Sec, 8))
+
+      test(m"misplaced quote reports row and offset on a later row"):
+        capture[DsvError](t"""a,b\nc,d\nef,g"h""".read[Sheet].rows.to(List))
+      . assert(_ == DsvError(summon[DsvFormat], DsvError.Reason.MisplacedQuote, Prim.next.next, Sec, 12))
 
       test(m"multi-line CSV without trailing newline"):
         t"""foo,bar\nbaz,quux""".read[Sheet].rows

--- a/lib/locomotion/src/core/locomotion.ProtobufError.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufError.scala
@@ -37,17 +37,27 @@ import fulminate.*
 object ProtobufError:
   object Reason:
     given communicable: Reason is Communicable =
-      case Truncated                 => m"the protobuf data ended unexpectedly"
-      case MalformedVarint           => m"a varint was malformed"
-      case UnexpectedWireType(found) => m"an unexpected wire type, $found, was encountered"
-      case Overflow                  => m"a numeric value was too large for its type"
-      case MissingField(number)      => m"the required field number $number was missing"
+      case Truncated(offset)       => m"the protobuf data ended unexpectedly at offset $offset"
+      case MalformedVarint(offset) => m"a varint was malformed at offset $offset"
+      case MissingField(number)    => m"the required field number $number was missing"
 
+      case UnexpectedWireType(found, offset) =>
+        m"an unexpected wire type, $found, was encountered at offset $offset"
+
+      case Overflow(offset) =>
+        m"a numeric value was too large for its type at offset $offset"
+
+  // The `offset` on the byte-level reasons is the position, in bytes, within the
+  // protobuf message (or sub-message payload) currently being parsed — not an
+  // absolute offset into the original input. Scalar fields and nested messages are
+  // each decoded with a fresh parser over their own payload slice, so only the
+  // top-level message's offsets are absolute. `MissingField` is a semantic
+  // (decode-level) failure and carries no offset.
   enum Reason:
-    case Truncated
-    case MalformedVarint
-    case UnexpectedWireType(found: Int)
-    case Overflow
+    case Truncated(offset: Int)
+    case MalformedVarint(offset: Int)
+    case UnexpectedWireType(found: Int, offset: Int)
+    case Overflow(offset: Int)
     case MissingField(number: Int)
 
 case class ProtobufError(reason: ProtobufError.Reason)(using Diagnostics)

--- a/lib/locomotion/src/core/locomotion.ProtobufParser.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufParser.scala
@@ -48,14 +48,19 @@ class ProtobufParser(data: Data):
   def atEnd: Boolean = pos >= data.length
 
   def varint(): Long raises ProtobufError =
+    val start = pos
     var result = 0L
     var shift = 0
     var continue = true
 
     while continue do
-      if pos >= data.length then abort(ProtobufError(Reason.Truncated))
+      if pos >= data.length then abort(ProtobufError(Reason.Truncated(pos)))
+      if shift >= 70 then abort(ProtobufError(Reason.MalformedVarint(start)))
       val byte = data(pos) & 0xff
       pos += 1
+      // The 10th byte (shift == 63) may only contribute bit 63; any higher bit set
+      // means the value does not fit in 64 bits.
+      if shift == 63 && (byte & 0x7f) > 1 then abort(ProtobufError(Reason.Overflow(start)))
       if shift < 64 then result |= (byte.toLong & 0x7f) << shift
       shift += 7
       if (byte & 0x80) == 0 then continue = false
@@ -63,7 +68,7 @@ class ProtobufParser(data: Data):
     result
 
   def fixed32(): Int raises ProtobufError =
-    if pos + 4 > data.length then abort(ProtobufError(Reason.Truncated))
+    if pos + 4 > data.length then abort(ProtobufError(Reason.Truncated(pos)))
     var result = 0
     var i = 0
 
@@ -75,7 +80,7 @@ class ProtobufParser(data: Data):
     result
 
   def fixed64(): Long raises ProtobufError =
-    if pos + 8 > data.length then abort(ProtobufError(Reason.Truncated))
+    if pos + 8 > data.length then abort(ProtobufError(Reason.Truncated(pos)))
     var result = 0L
     var i = 0
 
@@ -87,7 +92,7 @@ class ProtobufParser(data: Data):
     result
 
   def slice(length: Int): Data raises ProtobufError =
-    if length < 0 || pos + length > data.length then abort(ProtobufError(Reason.Truncated))
+    if length < 0 || pos + length > data.length then abort(ProtobufError(Reason.Truncated(pos)))
     val result = data.slice(pos, pos + length)
     pos += length
     result
@@ -96,12 +101,13 @@ class ProtobufParser(data: Data):
     val accumulator = scm.LinkedHashMap.empty[Int, scm.ListBuffer[Protobuf]]
 
     while !atEnd do
+      val tagStart = pos
       val tag = varint().toInt
       val number = tag >>> 3
       val code = tag & 0x7
 
       val wireType =
-        WireType.fromId(code).lest(ProtobufError(Reason.UnexpectedWireType(code)))
+        WireType.fromId(code).lest(ProtobufError(Reason.UnexpectedWireType(code, tagStart)))
 
       val value = wireType match
         case WireType.Varint =>

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -35,6 +35,7 @@ package locomotion
 import soundness.*
 
 import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
 
 case class Sample(@field(1) value: Int) derives CanEqual
 case class Point(@field(1) x: Int, @field(2) y: Int) derives CanEqual
@@ -193,3 +194,29 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       test(m"a single entry encodes as a length-delimited message"):
         wire(Labels(Map(t"a" -> t"b")))
       . assert(_ == List(0x0a, 0x06, 0x0a, 0x01, 0x61, 0x12, 0x01, 0x62))
+
+    suite(m"Parse errors carry a byte offset"):
+      def decode(bytes: Byte*): Sample raises ProtobufError =
+        Stream(IArray.from(bytes)).read[Sample over Protobuf]
+
+      test(m"a truncated length-delimited payload reports the offset where data ran out"):
+        // field 1, wire type Len, length 5, but only one payload byte present.
+        capture[ProtobufError](decode(0x0a, 0x05, 0x41))
+      . assert(_ == ProtobufError(ProtobufError.Reason.Truncated(2)))
+
+      test(m"an unexpected wire type reports the offset of the tag"):
+        // field 1, wire type 3 (group-start) is not a valid proto3 wire type.
+        capture[ProtobufError](decode(0x0b))
+      . assert(_ == ProtobufError(ProtobufError.Reason.UnexpectedWireType(3, 0)))
+
+      test(m"a varint longer than ten bytes is malformed"):
+        capture[ProtobufError]:
+          Stream(IArray.fill(11)(0x80.toByte)).read[Sample over Protobuf]
+      . assert(_ == ProtobufError(ProtobufError.Reason.MalformedVarint(0)))
+
+      test(m"a varint whose value overflows 64 bits is rejected"):
+        // nine continuation bytes then a tenth byte contributing more than bit 63.
+        capture[ProtobufError]:
+          decode(0x80.toByte, 0x80.toByte, 0x80.toByte, 0x80.toByte, 0x80.toByte, 0x80.toByte,
+              0x80.toByte, 0x80.toByte, 0x80.toByte, 0x02)
+      . assert(_ == ProtobufError(ProtobufError.Reason.Overflow(0)))


### PR DESCRIPTION
Caesura's `DsvError` and locomotion's `ProtobufError` now pinpoint where a parse failure occurred: a malformed CSV/TSV cell reports its row, column and character offset, while a Protobuf decoding failure reports the byte offset within the message being parsed. As part of the same work, locomotion now rejects over-long and out-of-range varints that were previously accepted by silently discarding excess bits.

### Caesura: positioned `DsvError`

`DsvError` now carries the position of the offending cell, so failures point at *where* they happened rather than only *what* went wrong:

```scala
case class DsvError(format: DsvFormat, reason: DsvError.Reason, row: Ordinal, column: Ordinal, offset: Int)
```

`row` and `column` are the cell's position and `offset` is the character offset into the input. For example, parsing `hello,wo"rld` now reports a misplaced quote at row 1, column 2, offset 8. (A true byte offset isn't available at this layer, since the parser works on already-decoded text.)

### Locomotion: byte offsets on `ProtobufError`

The byte-level `ProtobufError.Reason` cases — `Truncated`, `MalformedVarint`, `UnexpectedWireType` and `Overflow` — now carry an `offset` giving the position within the message (or sub-message payload) being parsed, mirroring breviloquence's `CborError`. `MissingField` remains a semantic error with no offset.

**Behavioural change:** `MalformedVarint` and `Overflow`, previously defined but never raised, are now reported for varints longer than ten bytes or whose value exceeds 64 bits. Input that previously decoded by silently truncating such a varint will now fail with a `ProtobufError`. Valid encodings (including 10-byte sign-extended negative `int32`s) are unaffected.
