### PR TITLE
HTTP content-type integration for XML, Protobuf, CBOR and YAML (with a YAML serializer)

### DIFF
--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -43,6 +43,7 @@ import adversaria.*
 import anticipation.*
 import contingency.*
 import distillate.*
+import gossamer.*
 import prepositional.*
 import rudiments.*
 import turbulence.*
@@ -242,6 +243,19 @@ object Cbor extends Cbor2, Dynamic:
 
   given aggregable: Tactic[CborError] => Cbor is Aggregable by Data =
     bytes => Cbor.ast(bytes.read[Cbor.Ast])
+
+  // HTTP content-type integration: `Abstractable across HttpStreams` makes a
+  // `Cbor` value usable as an HTTP request/response body (telekinesis derives
+  // `Postable`/`Servable` from it). Decoding a response body back into `Cbor`
+  // is already covered by `aggregable` (`Aggregable by Data`).
+  given abstractable: Cbor is Abstractable across HttpStreams to HttpStreams.Content =
+    new Abstractable:
+      type Self = Cbor
+      type Domain = HttpStreams
+      type Result = HttpStreams.Content
+
+      def genericize(value: Cbor): HttpStreams.Content =
+        (t"application/cbor", Stream(CborPrinter.encode(Cbor.unseal(value))))
 
   // `source.read[Foo over Cbor]` shorthand for
   // `source.read[Cbor].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -44,6 +44,7 @@ import adversaria.*
 import anticipation.*
 import contingency.*
 import distillate.*
+import gossamer.*
 import hypotenuse.*
 import prepositional.*
 import rudiments.*
@@ -100,6 +101,19 @@ object Protobuf extends Protobuf2:
   // `Encodable`) — the same verb jacinta uses for `Json`. `serialize` is reserved
   // for monotonous's byte→text encodings (hex, base64, …).
   given encodableInData: Protobuf is Encodable in Data = _.payload
+
+  // HTTP content-type integration: `Abstractable across HttpStreams` makes a
+  // `Protobuf` message usable as an HTTP request/response body (telekinesis
+  // derives `Postable`/`Servable` from it). Decoding a response body back into
+  // `Protobuf` is already covered by `aggregable` (`Aggregable by Data`).
+  given abstractable: Protobuf is Abstractable across HttpStreams to HttpStreams.Content =
+    new Abstractable:
+      type Self = Protobuf
+      type Domain = HttpStreams
+      type Result = HttpStreams.Content
+
+      def genericize(value: Protobuf): HttpStreams.Content =
+        (t"application/protobuf", Stream(value.encode))
 
   // `bytes.read[Protobuf]` aggregates the byte stream and wraps it as a message.
   given aggregable: Protobuf is Aggregable by Data = bytes => message(bytes.read[Data])

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -220,3 +220,13 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
           decode(0x80.toByte, 0x80.toByte, 0x80.toByte, 0x80.toByte, 0x80.toByte, 0x80.toByte,
               0x80.toByte, 0x80.toByte, 0x80.toByte, 0x02)
       . assert(_ == ProtobufError(ProtobufError.Reason.Overflow(0)))
+
+    suite(m"HTTP content-type integration"):
+      test(m"serialises with the application/protobuf media type"):
+        Person(t"Alice", 30).protobuf.generic(0)
+      . assert(_ == t"application/protobuf")
+
+      test(m"request/response body round-trips"):
+        val message = Person(t"Alice", 30).protobuf
+        message.generic(1).read[Person over Protobuf]
+      . assert(_ == Person(t"Alice", 30))

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -464,6 +464,26 @@ object Xml extends Tag.Container
   given aggregable2: (schema: XmlSchema) => Tactic[ParseError] => Xml is Aggregable by Text =
     input => XmlParser.fromIterator(input.iterator).parseXml(headers0 = false)
 
+  // HTTP content-type integration. `Abstractable across HttpStreams` makes an
+  // `Xml` value usable as an HTTP request/response body (telekinesis derives
+  // `Postable`/`Servable` from it); `Instantiable across HttpRequests` reads a
+  // request/response body back into `Xml`.
+  given abstractable: (encoder: CharEncoder)
+  =>  Xml is Abstractable across HttpStreams to HttpStreams.Content =
+
+    new Abstractable:
+      type Self = Xml
+      type Domain = HttpStreams
+      type Result = HttpStreams.Content
+
+      def genericize(xml: Xml): HttpStreams.Content =
+        (t"application/xml; charset=${encoder.encoding.name}", Stream(xml.show.data))
+
+  given instantiable: (schema: XmlSchema) => Tactic[ParseError]
+  =>  Xml is Instantiable across HttpRequests from Text =
+
+    text => Stream(text).read[Xml]
+
   // `source.read[Foo over Xml]` shorthand for
   // `source.read[Xml].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
   // for `value over Json`. The `Transport` type-tag is added by an

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -947,6 +947,18 @@ object Tests extends Suite(m"Xylophone tests"):
         . map(_.focus.nonEmpty)
       . assert(_ == List(true))
 
+    suite(m"HTTP content-type integration"):
+      import charEncoders.utf8
+
+      test(m"serialises with an application/xml media type"):
+        x"<doc/>".generic(0)
+      . assert(_.starts(t"application/xml"))
+
+      test(m"request body parses back via Instantiable"):
+        val instantiable = summon[Xml is Instantiable across HttpRequests from Text]
+        instantiable(t"<doc><a>1</a></doc>").show
+      . assert(_ == t"<doc><a>1</a></doc>".read[Xml].show)
+
     PositionTests()
     DecoderTests()
     EncoderTests()

--- a/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export ypsiloid.{Yaml, YamlError, YamlParser, YamlPrimitive}
+export ypsiloid.{Yaml, YamlError, YamlParser, YamlPrimitive, YamlPrinter}
+
+package yamlPrinters:
+  export ypsiloid.yamlPrinters.block

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -46,6 +46,7 @@ import denominative.*
 import distillate.*
 import fulminate.*
 import gossamer.*
+import hieroglyph.CharEncoder
 import jacinta.Bcd
 import panopticon.*
 import prepositional.*
@@ -1187,6 +1188,28 @@ object Yaml extends Yaml2, Dynamic:
           new Yaml(ast, Yaml.PositionIndex(ints))
         case Yaml.Tracking.Off =>
           Yaml(YamlParser.parse(text))
+
+  // HTTP content-type integration. `Abstractable across HttpStreams` makes a
+  // `Yaml` value usable as an HTTP request/response body (telekinesis derives
+  // `Postable`/`Servable` from it); `Instantiable across HttpRequests` reads a
+  // request/response body back into `Yaml`. Encoding needs a `YamlPrinter` (see
+  // `yamlPrinters`).
+  given abstractable: (encoder: CharEncoder, printer: YamlPrinter)
+  =>  Yaml is Abstractable across HttpStreams to HttpStreams.Content =
+
+    new Abstractable:
+      type Self = Yaml
+      type Domain = HttpStreams
+      type Result = HttpStreams.Content
+
+      def genericize(value: Yaml): HttpStreams.Content =
+        ( t"application/yaml; charset=${encoder.encoding.name}",
+          Stream(printer.print(Yaml.unseal(value)).data) )
+
+  given instantiable: (Tactic[ParseError], Yaml.Tracking)
+  =>  Yaml is Instantiable across HttpRequests from Text =
+
+    text => Stream(text).read[Yaml]
 
   // `source.read[Foo over Yaml]` shorthand for
   // `source.read[Yaml].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`

--- a/lib/ypsiloid/src/core/ypsiloid.YamlPrinter.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlPrinter.scala
@@ -1,0 +1,184 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ypsiloid
+
+import scala.compiletime.asMatchable
+
+import anticipation.*
+import gossamer.*
+
+// Renders a `Yaml.Ast` back to YAML text in block style. Mirrors
+// `jacinta.JsonPrinter`. The emitter is deliberately conservative so that
+// the output re-parses (via `YamlParser`) to a structurally identical AST:
+//
+//   - scalars are emitted so the parser's `resolvePlainScalar` resolves them
+//     back to the same node type — integers as bare digits, decimals via
+//     `Double.toString` (or `.inf`/`-.inf`/`.nan`), booleans as `true`/`false`,
+//     null as `null`;
+//   - a string is emitted as a *plain* scalar only when it is unambiguously a
+//     string (a leading-letter run of `[A-Za-z0-9_-]` that is not a reserved
+//     word); otherwise it is double-quoted with escapes the parser accepts;
+//   - mappings and sequences are emitted as indented block collections (2-space
+//     step); empty collections use the flow forms `{}` / `[]`.
+//
+// `Yaml.Ast` node shapes (see `ypsiloid.Yaml.scala`): scalars are boxed JVM
+// values (`String`, `Long`, `Double`, `Boolean`, `null`); a high-precision
+// number is a `jacinta.Bcd` (`Array[Double]`); a mapping is an even-length
+// `IArray[Any]` of alternating key/value; a sequence is an odd-length
+// `IArray[Any]` (with a trailing `arrayPad` sentinel when the item count is
+// even). Mappings and sequences are told apart by length parity.
+object YamlPrinter:
+  def print(yaml: Yaml.Ast): Text = Text.build:
+    def spaces(n: Int): Unit =
+      var i = 0
+      while i < n do
+        append(' ')
+        i += 1
+
+    // A string is safe to emit as a plain scalar when it is a leading-letter
+    // run of `[A-Za-z0-9_-]` (no whitespace or indicator characters, never
+    // empty) that the parser would not resolve as a boolean or null.
+    def plainSafe(string: String): Boolean =
+      val length = string.length
+      if length == 0 then false else
+        val head = string.charAt(0)
+        if !((head >= 'A' && head <= 'Z') || (head >= 'a' && head <= 'z')) then false
+        else
+          var ok = true
+          var i = 0
+          while i < length && ok do
+            val c = string.charAt(i)
+            if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9') || c == '_' || c == '-')
+            then ok = false
+            i += 1
+
+          ok && (string match
+            case "null" | "Null" | "NULL" | "true" | "True" | "TRUE"
+                | "false" | "False" | "FALSE" => false
+            case _                            => true)
+
+    def appendString(string: String): Unit =
+      if plainSafe(string) then append(string) else
+        append('"')
+        var i = 0
+        while i < string.length do
+          string.charAt(i) match
+            case '"'  => append(t"\\\"")
+            case '\\' => append(t"\\\\")
+            case '\n' => append(t"\\n")
+            case '\r' => append(t"\\r")
+            case '\t' => append(t"\\t")
+
+            case c =>
+              if c < ' ' then
+                val hex = Integer.toHexString(c.toInt).nn
+                append(t"\\u")
+                var z = hex.length
+                while z < 4 do
+                  append('0')
+                  z += 1
+                append(hex.tt)
+              else append(c)
+
+          i += 1
+
+        append('"')
+
+    // Emit a scalar (or an empty collection) with no surrounding newlines.
+    def scalar(ast: Yaml.Ast): Unit = ast.asMatchable match
+      case bcd: Array[Double] @unchecked => append(bcd.asInstanceOf[jacinta.Bcd].text.tt)
+      case n: Long                       => append(n.toString)
+
+      case d: Double =>
+        if d.isNaN then append(t".nan")
+        else if d == Double.PositiveInfinity then append(t".inf")
+        else if d == Double.NegativeInfinity then append(t"-.inf")
+        else append(d.toString)
+
+      case b: Boolean => append(if b then t"true" else t"false")
+      case s: String  => appendString(s)
+
+      case xs: IArray[Any] @unchecked =>
+        if (xs.length & 1) == 0 then append(t"{}") else append(t"[]")
+
+      case _ => append(t"null")
+
+    // Scalars and empty collections render on one line; non-empty collections
+    // span multiple indented lines.
+    def inlineable(ast: Yaml.Ast): Boolean = ast.asMatchable match
+      case xs: IArray[Any] @unchecked =>
+        if (xs.length & 1) == 0 then xs.length == 0 else Yaml.Ast.sequenceLength(xs) == 0
+
+      case _ => true
+
+    // Emit the value after a `key:` or `- ` marker: inline when scalar/empty,
+    // otherwise on following lines indented one step deeper.
+    def value(ast: Yaml.Ast, indent: Int): Unit =
+      if inlineable(ast) then
+        append(' ')
+        scalar(ast)
+        append('\n')
+      else
+        append('\n')
+        block(ast, indent + 2)
+
+    def block(ast: Yaml.Ast, indent: Int): Unit = ast.asMatchable match
+      case xs: IArray[Any] @unchecked =>
+        if (xs.length & 1) == 0 then
+          val n = xs.length/2
+          var i = 0
+          while i < n do
+            spaces(indent)
+            scalar(xs(i*2).asInstanceOf[Yaml.Ast])
+            append(':')
+            value(xs(i*2 + 1).asInstanceOf[Yaml.Ast], indent)
+            i += 1
+        else
+          val n = Yaml.Ast.sequenceLength(xs)
+          var i = 0
+          while i < n do
+            spaces(indent)
+            append('-')
+            value(xs(i).asInstanceOf[Yaml.Ast], indent)
+            i += 1
+
+      case _ => ()
+
+    if inlineable(yaml) then
+      scalar(yaml)
+      append('\n')
+    else block(yaml, 0)
+
+trait YamlPrinter:
+  def print(yaml: Yaml.Ast): Text

--- a/lib/ypsiloid/src/core/ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/ypsiloid_core.scala
@@ -38,11 +38,18 @@ import contingency.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
+import spectacular.{Showable, show}
 import vacuous.*
 import wisteria.*
 import zephyrine.*
 
 import YamlError.Reason
+
+// Render a `Yaml` / `Yaml.Ast` to YAML text using the `YamlPrinter` in scope.
+// Mirrors jacinta's `Json` / `Json.Ast` `Showable` givens. Bring a printer into
+// scope (e.g. `import yamlPrinters.block`) to enable `.show` and HTTP encoding.
+given astShowable: (printer: YamlPrinter) => Yaml.Ast is Showable = printer.print(_)
+given showable: YamlPrinter => Yaml is Showable = Yaml.unseal(_).show
 
 extension (text: Text)
   def readAll(using Tactic[ParseError]): List[Yaml] = Yaml.parseAll(text)
@@ -146,6 +153,11 @@ extension (yaml: Yaml.Ast)
     else expected(YamlPrimitive.Bool) yet false
 
   def primitive: YamlPrimitive = Yaml.primitive(yaml)
+
+package yamlPrinters:
+  // Block-style serializer. The default (and currently only) printer; flow
+  // style may be added later. Mirrors jacinta's `jsonPrinters.indented`.
+  given block: YamlPrinter = YamlPrinter.print(_)
 
 package yamlDiscriminables:
   given discriminatedUnionByType: [value] => value is Discriminable in Yaml =

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -1028,6 +1028,144 @@ object Tests extends Suite(m"Ypsiloid Tests"):
         updated.items.as[List[Int]]
       . assert(_ == List(99, 20, 30))
 
+    suite(m"Serializer roundtrip"):
+      import yamlPrinters.block
+
+      // Encode a value to `Yaml`, render it with the printer, parse the text
+      // back, and decode: the full encode → print → parse → decode loop.
+      def roundtrip[value: {Encodable in Yaml, Decodable in Yaml}](value: value): value =
+        value.yaml.show.read[Yaml].as[value]
+
+      // Print a parsed AST and re-parse it: print ∘ parse must be the identity
+      // on the structural AST (compared by `deepEquals`).
+      def astStable(source: Text): Boolean =
+        val original = source.read[Yaml]
+        Yaml.Ast.deepEquals(Yaml.unseal(original), Yaml.unseal(original.show.read[Yaml]))
+
+      test(m"Roundtrip a positive integer"):
+        roundtrip(42)
+      . assert(_ == 42)
+
+      test(m"Roundtrip a negative integer"):
+        roundtrip(-99)
+      . assert(_ == -99)
+
+      test(m"Roundtrip a long"):
+        roundtrip(1234567890123L)
+      . assert(_ == 1234567890123L)
+
+      test(m"Roundtrip a double"):
+        roundtrip(3.1415926)
+      . assert(_ == 3.1415926)
+
+      test(m"Roundtrip positive infinity"):
+        roundtrip(Double.PositiveInfinity)
+      . assert(_ == Double.PositiveInfinity)
+
+      test(m"Roundtrip negative infinity"):
+        roundtrip(Double.NegativeInfinity)
+      . assert(_ == Double.NegativeInfinity)
+
+      test(m"Roundtrip NaN"):
+        roundtrip(Double.NaN)
+      . assert(_.isNaN)
+
+      test(m"Roundtrip true"):
+        roundtrip(true)
+      . assert(identity)
+
+      test(m"Roundtrip false"):
+        roundtrip(false)
+      . assert(!_)
+
+      test(m"Roundtrip a simple string"):
+        roundtrip(t"hello")
+      . assert(_ == t"hello")
+
+      test(m"Roundtrip a string with a space"):
+        roundtrip(t"hello world")
+      . assert(_ == t"hello world")
+
+      test(m"Roundtrip a string that looks like an integer"):
+        roundtrip(t"42")
+      . assert(_ == t"42")
+
+      test(m"Roundtrip a string that looks like a boolean"):
+        roundtrip(t"true")
+      . assert(_ == t"true")
+
+      test(m"Roundtrip a string that looks like null"):
+        roundtrip(t"null")
+      . assert(_ == t"null")
+
+      test(m"Roundtrip an empty string"):
+        roundtrip(t"")
+      . assert(_ == t"")
+
+      test(m"Roundtrip a string with a colon"):
+        roundtrip(t"key: value")
+      . assert(_ == t"key: value")
+
+      test(m"Roundtrip a string with a newline"):
+        roundtrip(t"line1\nline2")
+      . assert(_ == t"line1\nline2")
+
+      test(m"Roundtrip a string with a quote and backslash"):
+        roundtrip(t"a\"b\\c")
+      . assert(_ == t"a\"b\\c")
+
+      test(m"Roundtrip a string with leading indicator"):
+        roundtrip(t"- not a list")
+      . assert(_ == t"- not a list")
+
+      test(m"Roundtrip a list of integers"):
+        roundtrip(List(1, 2, 3))
+      . assert(_ == List(1, 2, 3))
+
+      test(m"Roundtrip a list of strings"):
+        roundtrip(List(t"alice", t"bob"))
+      . assert(_ == List(t"alice", t"bob"))
+
+      test(m"Roundtrip an empty list"):
+        roundtrip(List[Int]())
+      . assert(_ == Nil)
+
+      test(m"Roundtrip a map"):
+        roundtrip(Map(t"a" -> 1, t"b" -> 2))
+      . assert(_ == Map(t"a" -> 1, t"b" -> 2))
+
+      test(m"Roundtrip a case class"):
+        roundtrip(Person(t"Jon", 42))
+      . assert(_ == Person(t"Jon", 42))
+
+      test(m"Roundtrip a nested case class"):
+        roundtrip(NamedOuter(t"a", Inner(7)))
+      . assert(_ == NamedOuter(t"a", Inner(7)))
+
+      test(m"Roundtrip a list of case classes"):
+        roundtrip(List(Person(t"a", 1), Person(t"b", 2)))
+      . assert(_ == List(Person(t"a", 1), Person(t"b", 2)))
+
+      test(m"Roundtrip a list of lists"):
+        roundtrip(List(List(1, 2), List(3, 4)))
+      . assert(_ == List(List(1, 2), List(3, 4)))
+
+      test(m"AST stable: nested mapping"):
+        astStable(t"outer:\n  inner: 1\n  other: two")
+      . assert(identity)
+
+      test(m"AST stable: sequence of mappings"):
+        astStable(t"- a: 1\n  b: 2\n- a: 3\n  b: 4")
+      . assert(identity)
+
+      test(m"AST stable: empty flow mapping"):
+        astStable(t"{}")
+      . assert(identity)
+
+      test(m"AST stable: empty flow sequence"):
+        astStable(t"[]")
+      . assert(identity)
+
     ConformanceTests.all()
 
     PositionTests()

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -1166,6 +1166,19 @@ object Tests extends Suite(m"Ypsiloid Tests"):
         astStable(t"[]")
       . assert(identity)
 
+    suite(m"HTTP content-type integration"):
+      import charEncoders.utf8
+      import yamlPrinters.block
+
+      test(m"serialises with an application/yaml media type"):
+        Person(t"Jon", 42).yaml.generic(0)
+      . assert(_.starts(t"application/yaml"))
+
+      test(m"request body parses back via Instantiable"):
+        val instantiable = summon[Yaml is Instantiable across HttpRequests from Text]
+        instantiable(t"name: Jon\nage: 42").as[Person]
+      . assert(_ == Person(t"Jon", 42))
+
     ConformanceTests.all()
 
     PositionTests()


### PR DESCRIPTION
The XML, Protobuf, CBOR and YAML format modules can now be used directly as HTTP request and response bodies, matching the integration JSON, TEL and CSV already had. YAML additionally gains a serializer — until now a `Yaml` value could be parsed and built but never rendered back to text — which both fixes that standalone gap and makes the YAML HTTP encoding possible.

Each format now wires up the `Abstractable`/`Instantiable` "across HTTP-streams" typeclasses, so values can be posted, served and received as bodies with the appropriate media type (`application/xml`, `application/protobuf`, `application/cbor`, `application/yaml`). The text formats (XML, YAML) decode request/response bodies through a new `Instantiable across HttpRequests from Text`; the binary formats (Protobuf, CBOR) already decode through their existing `Aggregable by Data`.

```scala
// Send a value as a typed request body, and read a typed response:
val person: Person = url.post(person.xml).receive[Person]

// Serialize a YAML value to text (new):
import yamlPrinters.block
val text: Text = myYaml.show
```

YAML serialization uses a new block-style `YamlPrinter` (with `Yaml is Showable`), available via the `yamlPrinters` package. The emitter is conservative so its output re-parses to the same structure: scalars are written in the form the parser resolves back to the same type, strings are quoted whenever a plain scalar would be ambiguous, and collections use indented block style.

Closes #1245.
Closes #1247.
