### PR TITLE
Dynamic element navigation for XML

### DIFF
--- a/lib/xylophone/src/core/xylophone.DynamicXmlEnabler.scala
+++ b/lib/xylophone/src/core/xylophone.DynamicXmlEnabler.scala
@@ -30,6 +30,17 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xylophone
 
-export xylophone.{Xml, XmlError, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess}
+import rudiments.*
+
+// Phantom-typed gate for `xml.selectDynamic("…")` and friends. Importing
+// `dynamicXmlAccess.enabled` brings the given into scope and unlocks the
+// dynamic navigation syntax (`xml.foo`, `xml.foo(Prim)`); without that import
+// the dynamic methods are inaccessible, mirroring jacinta's
+// `DynamicJsonEnabler` and stratiform's `DynamicTelEnabler`.
+
+sealed trait DynamicXmlEnabler
+
+object dynamicXmlAccess:
+  inline given enabled: DynamicXmlEnabler = !!

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -2331,6 +2331,49 @@ sealed into trait Xml extends Dynamic, Topical, Documentary, Formal:
     case Fragment(value) => result.decoded(value)
     case xml: Xml        => result.decoded(xml)
 
+  // Dynamic navigation. `xml.foo` selects every child element named `foo`,
+  // flattening across all element-nodes in the current `Fragment` (XML tags
+  // are not unique, so a dereference yields a `Fragment` of zero or more
+  // matches). `xml.foo(ordinal)` picks a single one; the ordinal defaults to
+  // `Prim`, so `xml.foo()` is the first match. Both are gated by an imported
+  // `DynamicXmlEnabler` (see `dynamicXmlAccess.enabled`).
+
+  private def selfNodes: IArray[Node] = this match
+    case Fragment(nodes*) => IArray.from(nodes)
+    case node: Node       => IArray(node)
+
+  private def childElements(name: String): IArray[Node] =
+    val buffer = scm.ArrayBuffer[Node]()
+    val nodes = selfNodes
+    var i = 0
+
+    while i < nodes.length do
+      nodes(i) match
+        case Element(_, _, children) =>
+          var j = 0
+
+          while j < children.length do
+            children(j) match
+              case child: Element if child.label == name.tt => buffer.append(child)
+              case _                                        => ()
+
+            j += 1
+
+        case _ =>
+          ()
+
+      i += 1
+
+    IArray.from(buffer)
+
+  def selectDynamic(name: String)(using erased DynamicXmlEnabler): Fragment =
+    new Fragment(childElements(name)*)
+
+  def applyDynamic(name: String)(ordinal: Ordinal = Prim)(using erased DynamicXmlEnabler)
+  :   Fragment =
+
+    childElements(name).at(ordinal).lay(new Fragment())(new Fragment(_))
+
 sealed trait Node extends Xml
 
 case class Comment(text: Text) extends Node:

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -959,6 +959,54 @@ object Tests extends Suite(m"Xylophone tests"):
         instantiable(t"<doc><a>1</a></doc>").show
       . assert(_ == t"<doc><a>1</a></doc>".read[Xml].show)
 
+    suite(m"Dynamic access"):
+      test(m"Dynamic dereference selects a child element's text"):
+        import dynamicXmlAccess.enabled
+        t"<root><foo>bar</foo></root>".read[Xml].foo().as[Text]
+      . assert(_ == t"bar")
+
+      test(m"Chained dynamic dereference navigates nested elements"):
+        import dynamicXmlAccess.enabled
+        t"<a><b><c>42</c></b></a>".read[Xml].b().c().as[Int]
+      . assert(_ == 42)
+
+      test(m"Dynamic dereference flattens non-unique tags into a Fragment"):
+        import dynamicXmlAccess.enabled
+        t"<r><x>1</x><x>2</x></r>".read[Xml].x.nodes.length
+      . assert(_ == 2)
+
+      test(m"Empty-parens dereference is the same as `(Prim)`"):
+        import dynamicXmlAccess.enabled
+        val xml = t"<r><x>1</x><x>2</x></r>".read[Xml]
+        xml.x() == xml.x(Prim)
+      . assert(_ == true)
+
+      test(m"An ordinal selects the nth matching element"):
+        import dynamicXmlAccess.enabled
+        t"<r><x>1</x><x>2</x></r>".read[Xml].x(Sec).as[Int]
+      . assert(_ == 2)
+
+      test(m"Dynamic dereference flattens across multiple parents"):
+        import dynamicXmlAccess.enabled
+        t"<r><a><b>1</b><b>2</b></a><a><b>3</b></a></r>".read[Xml].a.b.nodes.length
+      . assert(_ == 3)
+
+      test(m"A missing tag yields an empty Fragment"):
+        import dynamicXmlAccess.enabled
+        t"<r><x>1</x></r>".read[Xml].nope.nodes.isEmpty
+      . assert(_ == true)
+
+      test(m"An out-of-range ordinal yields an empty Fragment"):
+        import dynamicXmlAccess.enabled
+        t"<r><x>1</x></r>".read[Xml].x(Sec).nodes.isEmpty
+      . assert(_ == true)
+
+      test(m"Dynamic access does not compile without the enabler import"):
+        demilitarize:
+          t"<r><x>1</x></r>".read[Xml].x()
+        . nonEmpty
+      . assert(identity)
+
     PositionTests()
     DecoderTests()
     EncoderTests()


### PR DESCRIPTION
Xylophone now supports Scala's `Dynamic` syntax for navigating XML, bringing it to parity with the JSON, TEL, CSV, CBOR and YAML modules. The feature is opt-in via an imported enabler, and—because XML tags are not unique—every dereference produces a `Fragment` of all matching child elements rather than a single value.

Importing `dynamicXmlAccess.enabled` unlocks dynamic navigation on any `Xml` value. Because a tag may appear more than once, `xml.foo` collects *every* matching child element into a `Fragment`, flattening across all nodes in the current fragment:

```scala
import dynamicXmlAccess.enabled

val doc = t"<r><a><b>1</b><b>2</b></a><a><b>3</b></a></r>".read[Xml]

doc.a.b            // a Fragment of all three <b> elements
```

When you know (or want) a single element, apply parentheses. An empty pair selects the first match — it is exactly `(Prim)` — and any ordinal selects the *n*th:

```scala
doc.a().b().as[Int]   // 1  — first <a>, first <b>
doc.a(Sec).as[Xml]    // the second <a> element
```

A missing tag or an out-of-range ordinal yields an empty `Fragment` rather than an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)