### PR TITLE
Enable the breviloquence test suite

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -444,8 +444,7 @@ object breviloquence extends Library:
   object core extends Component(urticose.url, panopticon.core, turbulence.core, adversaria.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, sedentary.core, eucalyptus.core):
-    override def enabled = false
+  object test extends Tests(core, sedentary.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):
     def mvnDeps = Seq(
       mvn"com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.2",

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -313,3 +313,13 @@ object Tests extends Suite(m"Breviloquence Tests"):
           val bytes = CborPrinter.encode(Cbor.unseal((status: CStatus).cbor))
           Cbor.ast(Cbor.Ast.parse(bytes)).as[CStatus]
       . assert(_ == List(CStatus.Active(5), CStatus.Removed(9), CStatus.Pending(1)))
+
+    suite(m"HTTP content-type integration"):
+      test(m"serialises with the application/cbor media type"):
+        Person(t"Alice", 30).cbor.generic(0)
+      . assert(_ == t"application/cbor")
+
+      test(m"request/response body round-trips"):
+        val body = Person(t"Alice", 30).cbor
+        body.generic(1).read[Person over Cbor]
+      . assert(_ == Person(t"Alice", 30))


### PR DESCRIPTION
The breviloquence (CBOR) module's test suite was disabled and so never ran in the build; it is now enabled, restoring 46 tests plus new coverage for using CBOR values as HTTP request and response bodies. This is a build/test-only change with no effect on the library's API.

No user-facing API changes. The CBOR test suite (`breviloquence.test`) is no longer skipped, and now includes a round-trip test for `Cbor` HTTP bodies — confirming the `application/cbor` integration added alongside the other format modules.
