### PR TITLE
Lift inline-block declarations into a Repl via a binding macro

### DIFF
--- a/lib/anthology/src/repl/anthology.Repl.scala
+++ b/lib/anthology/src/repl/anthology.Repl.scala
@@ -34,6 +34,7 @@ package anthology
 
 import java.nio.file as jnf
 
+import scala.quoted.*
 import scala.util.control as suc
 
 import ambience.*
@@ -75,14 +76,46 @@ object Repl:
     case Rejected(notices: List[Notice])
     case Crashed(notices: List[Notice], error: StackTrace)
 
+  // A value/variable lifted from an inline binding block: its REPL-visible name
+  // and the source rendering of its type, used to build a typed accessor.
+  case class Binding(mutable: Boolean, name: String, typeName: String)
+
+  object Prelude:
+    val empty: Prelude = Prelude(Nil, Nil, Nil)
+
+  // Declarations lifted from an inline binding block to seed the REPL context:
+  // `imports` are re-injected into every line; `definitions` and binding
+  // accessors are established once in a seed object.
+  case class Prelude
+    ( imports:     List[String],
+      definitions: List[String],
+      bindings:    List[Binding] )
+
+  def make[version <: Scalac.Versions]
+    ( prelude: Repl.Prelude )
+    ( using Scalac[version], Classloader, TemporaryDirectory )
+  :   Repl[version] =
+
+    new Repl[version](prelude = prelude)
+
+  inline def apply[version <: Scalac.Versions](inline body: Unit = ())
+    ( using scalac: Scalac[version], classloader: Classloader, temporary: TemporaryDirectory )
+  :   Repl[version] =
+
+    ${ReplMacro.bound[version]('body, 'scalac, 'classloader, 'temporary)}
+
 class Repl[version <: Scalac.Versions]
-  ( layout: Repl.Layout = Repl.Layout.Standard() )
+  ( layout:  Repl.Layout   = Repl.Layout.Standard(),
+    prelude: Repl.Prelude  = Repl.Prelude.empty )
   ( using scalac: Scalac[version], classloader: Classloader, temporary: TemporaryDirectory ):
 
   import Repl.Outcome
 
+  val session: Long = ReplBridge.freshSession()
+
   private var index:   Int        = 0
   private var history: List[Text] = Nil
+  private var seeded:  Boolean     = false
 
   private val out: Path on Linux = unsafely(temporaryDirectory/Uuid())
   locally(jnf.Files.createDirectories(jnf.Path.of(out.encode.s)).nn)
@@ -99,11 +132,11 @@ class Repl[version <: Scalac.Versions]
 
     LocalClasspath(entries*)
 
-  def interpret(line: Text)(using Monitor, System, Codicil)
+  private def run(code: Text)(using Monitor, System, Codicil)
   :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
 
     val name:    Text = layout.objectName(index)
-    val source:  Text = layout.wrap(index, history, line)
+    val source:  Text = layout.wrap(index, history, code)
     val process       = scalac(classpath)(Map(t"$name.scala" -> source), out)
     val result        = process.complete()
     val notices       = process.notices.to(List)
@@ -128,3 +161,34 @@ class Repl[version <: Scalac.Versions]
 
           case suc.NonFatal(error) =>
             Outcome.Threw(notices, error)
+
+  // The prelude's definitions and binding accessors are compiled once, as the
+  // first object (`rs$line$0`); later lines see them via the history import.
+  // Imports create no members, so they are re-injected into every line instead.
+  private def seedBody: Text =
+    val accessors = prelude.bindings.map: binding =>
+      val keyword:  Text = if binding.mutable then t"var" else t"val"
+      val name:     Text = binding.name.tt
+      val typeName: Text = binding.typeName.tt
+      val key:      Text = t"${session.toString.tt}L, \"$name\""
+
+      t"$keyword $name: $typeName = anthology.ReplBridge.fetch[$typeName]($key)"
+
+    (prelude.imports.map(_.tt) ::: prelude.definitions.map(_.tt) ::: accessors).join(t"\n")
+
+  private def ensureSeeded()(using Monitor, System, Codicil)
+  :   Optional[Outcome] logs CompileEvent raises CompilerError raises AsyncError =
+
+    if seeded || prelude.definitions.isEmpty && prelude.bindings.isEmpty then Unset
+    else
+      seeded = true
+      run(seedBody)
+
+  def interpret(line: Text)(using Monitor, System, Codicil)
+  :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
+
+    def lineOutcome: Outcome = run((prelude.imports.map(_.tt) :+ line).join(t"\n"))
+
+    ensureSeeded().lay(lineOutcome):
+      case _: Outcome.Ran => lineOutcome
+      case failure        => failure

--- a/lib/anthology/src/repl/anthology.ReplMacro.scala
+++ b/lib/anthology/src/repl/anthology.ReplMacro.scala
@@ -32,82 +32,73 @@
                                                                                                   */
 package anthology
 
-import soundness.*
+import scala.collection.mutable as scm
+import scala.quoted.*
 
-import classloaders.threadContext
-import codicils.await
-import logging.silent
-import strategies.throwUnsafely
-import systems.java
-import temporaryDirectories.system
-import threading.platform
+import ambience.*
+import hellenism.*
 
-object Tests extends Suite(m"Anthology Tests"):
-  def run(): Unit =
-    suite(m"REPL tests"):
-      given Scalac[3.8] = Scalac(Nil)
+// Macro support for `Repl.apply(inline body)`: it reads the inline binding
+// block's AST and lifts each statement into the REPL context. Imports/exports
+// and definitions are lifted as source text; `val`/`var` bindings capture the
+// runtime value of their right-hand side (evaluated in the host scope) into
+// `ReplBridge`, exposing it in the REPL via a typed accessor.
+object ReplMacro:
+  def bound[version <: Scalac.Versions: Type]
+    ( body:        Expr[Unit],
+      scalac:      Expr[Scalac[version]],
+      classloader: Expr[Classloader],
+      temporary:   Expr[TemporaryDirectory] )
+    ( using Quotes )
+  :   Expr[Repl[version]] =
 
-      test(m"a definition is visible on a later line"):
-        supervise:
-          val repl = Repl()
-          repl.interpret(t"val x = 40")
-          repl.interpret(t"println(x + 2)")
-      . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+    import quotes.reflect.*
 
-      test(m"a type error is reported as Rejected with notices"):
-        supervise:
-          Repl().interpret(t"val n: Int = \"forty\"")
-      . assert:
-          case Repl.Outcome.Rejected(notices) => notices.nonEmpty
-          case _                              => false
+    def statements(term: Term): List[Statement] = term match
+      case Inlined(_, _, inner)    => statements(inner)
+      case Literal(UnitConstant()) => Nil
+      case Block(stats, last)      => stats ++ statements(last)
+      case other                   => List(other)
 
-      test(m"a runtime exception is reported as Threw"):
-        supervise:
-          Repl().interpret(t"throw new RuntimeException(\"boom\")")
-      . assert:
-          case Repl.Outcome.Threw(_, _) => true
-          case _                        => false
+    def sourceText(tree: Tree): String = tree.pos.sourceCode.getOrElse(tree.show)
 
-    suite(m"REPL binding tests"):
-      given Scalac[3.8] = Scalac(Nil)
+    val imports:     scm.ListBuffer[String]                 = scm.ListBuffer()
+    val definitions: scm.ListBuffer[String]                 = scm.ListBuffer()
+    val bindings:    scm.ListBuffer[(Boolean, String, String)] = scm.ListBuffer()
+    val captures:    scm.ListBuffer[(String, Term)]         = scm.ListBuffer()
 
-      test(m"captured values and a lifted definition are usable in the REPL"):
-        supervise:
-          val greeting: String = "hello"
-          var counter:  Int    = 5
+    statements(body.asTerm).foreach:
+      case statement: Import => imports += sourceText(statement)
+      case statement: Export => imports += sourceText(statement)
 
-          val repl = Repl[3.8]:
-            val text  = greeting
-            val count = counter
-            def total: Int = text.length + count
+      case statement: ValDef if !statement.symbol.flags.is(Flags.Given) =>
+        val mutable: Boolean = statement.symbol.flags.is(Flags.Mutable)
+        bindings += ((mutable, statement.name, statement.tpt.tpe.show))
 
-          repl.interpret(t"println(total)")     // "hello".length + 5
-      . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+        statement.rhs.foreach: rhs =>
+          captures += ((statement.name, rhs))
 
-      test(m"a lifted import is in scope for REPL lines"):
-        supervise:
-          // the lifted import is consumed by the macro, so it reads as unused here
-          @annotation.nowarn val repl = Repl[3.8]:
-            import scala.collection.mutable.ListBuffer
+      case statement: Definition => definitions += sourceText(statement)
+      case _                     => ()
 
-          repl.interpret(t"println(ListBuffer(1, 2, 3).sum)")
-      . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+    val importsExpr: Expr[List[String]] = Expr(imports.to(List))
+    val definitionsExpr: Expr[List[String]] = Expr(definitions.to(List))
 
-      test(m"a captured value persists across several lines"):
-        supervise:
-          val secret: Int = 42
+    val bindingsExpr: Expr[List[Repl.Binding]] = Expr.ofList:
+      bindings.to(List).map: (mutable, name, typeName) =>
+        '{Repl.Binding(${Expr(mutable)}, ${Expr(name)}, ${Expr(typeName)})}
 
-          val repl = Repl[3.8]:
-            val seed = secret
+    val preludeExpr: Expr[Repl.Prelude] =
+      '{Repl.Prelude($importsExpr, $definitionsExpr, $bindingsExpr)}
 
-          repl.interpret(t"val doubled = seed*2")
-          repl.interpret(t"println(doubled + seed)")
-      . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+    ' {
+        val repl: Repl[version] =
+          Repl.make[version]($preludeExpr)(using $scalac, $classloader, $temporary)
+
+        $ {
+            val puts: List[Expr[Unit]] = captures.to(List).map: (name, rhs) =>
+              '{ReplBridge.put(repl.session, ${Expr(name)}, ${rhs.asExprOf[Any]})}
+
+            Expr.block(puts, 'repl)
+          }
+      }

--- a/lib/anthology/src/repl/anthology/ReplBridge.java
+++ b/lib/anthology/src/repl/anthology/ReplBridge.java
@@ -1,0 +1,47 @@
+/*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0. © Copyright 2021-25 Jon Pretty, Propensive OÜ.                     ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+*/
+package anthology;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+// A process-global, session-keyed registry bridging runtime values from a host
+// program's scope into separately-compiled REPL code (see `Repl.apply`). Written
+// in Java deliberately: the surrounding Scala module is compiled with
+// experimental language features, which would mark a Scala equivalent
+// `@experimental` and make it unreferenceable from REPL code compiled without
+// experimental mode. A Java class carries no such marker.
+public final class ReplBridge {
+  private ReplBridge() {}
+
+  private static final ConcurrentHashMap<String, Object> registry = new ConcurrentHashMap<>();
+  private static final AtomicLong counter = new AtomicLong(0L);
+
+  private static String key(long session, String name) { return session + " " + name; }
+
+  public static long freshSession() { return counter.incrementAndGet(); }
+
+  public static void put(long session, String name, Object value) {
+    registry.put(key(session, name), value);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T fetch(long session, String name) {
+    return (T) registry.get(key(session, name));
+  }
+}


### PR DESCRIPTION
A `Repl` can now be constructed with an inline block whose declarations are lifted into the REPL's context, so code typed into the REPL can see imports, definitions, and values captured from the surrounding program scope — all type-checked at the construction site.

The companion `Repl.apply` takes an inline binding block and lifts each statement into the new REPL:

```scala
def session(label: String)(using Monitor, System, Codicil) =
  val base = 100

  val repl = Repl[3.8]:
    import scala.collection.mutable.*   // re-injected into every REPL line
    val tag = label                     // captured host value, typed in the REPL
    def doubled(n: Int): Int = n*2      // a real REPL definition

  repl.interpret(t"println(doubled(base) + tag.length)")
```

- **Imports/exports** are lifted as source text and re-injected into every interpreted line.
- **`def`/`class`/`type`/`given`** declarations seed the REPL once (as the first wrapper object) and are visible to every later line.
- **`val`/`var` bindings** evaluate their right-hand side in the host scope and expose the captured value in the REPL under the same name, with its real static type. Capture is by snapshot — later host mutations are not reflected, and reassigning the binding inside the REPL does not write back to the host.

This builds on the existing configurable wrapping: lifted declarations compose with the `Repl.Layout` rather than replacing it. The empty form `Repl()` continues to work as a REPL with no lifted context.

A binding's type is rendered into the REPL's source, so it must be nameable and resolvable there; lifting an `import` for the relevant package in the same block makes such names resolve. Because the block is type-checked at the call site, a lifted `import` reads as unused there — prefix the construction with `@nowarn` to silence it if needed.
