### PR TITLE
Render REPL expression results via Inspectable

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -360,7 +360,7 @@ object anthology extends Library:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     def mvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
-  object test extends Tests(`scala`, `java`, core, repl)
+  object test extends Tests(`scala`, `java`, core, repl, spectacular.core)
 
 object anticipation extends Library:
   object generic extends Component(prepositional.core):

--- a/lib/anthology/src/repl/anthology.Repl.scala
+++ b/lib/anthology/src/repl/anthology.Repl.scala
@@ -71,7 +71,7 @@ object Repl:
     def wrap(index: Int, history: List[Text], code: Text): Text
 
   enum Outcome:
-    case Ran(notices: List[Notice])
+    case Ran(notices: List[Notice], value: Optional[Text])
     case Threw(notices: List[Notice], error: Throwable)
     case Rejected(notices: List[Notice])
     case Crashed(notices: List[Notice], error: StackTrace)
@@ -114,6 +114,7 @@ class Repl[version <: Scalac.Versions]
   val session: Long = ReplBridge.freshSession()
 
   private var index:   Int        = 0
+  private var result:  Int        = 0
   private var history: List[Text] = Nil
   private var seeded:  Boolean     = false
 
@@ -132,16 +133,20 @@ class Repl[version <: Scalac.Versions]
 
     LocalClasspath(entries*)
 
-  private def run(code: Text)(using Monitor, System, Codicil)
+  // Compiles `code` as the next wrapper object and, on success, loads it (which
+  // runs its body). `rendered` is evaluated after a successful run to supply the
+  // `Outcome.Ran` value — `Unset` for statements, or the inspected result for an
+  // expression line.
+  private def compile(code: Text)(rendered: => Optional[Text])(using Monitor, System, Codicil)
   :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
 
     val name:    Text = layout.objectName(index)
     val source:  Text = layout.wrap(index, history, code)
     val process       = scalac(classpath)(Map(t"$name.scala" -> source), out)
-    val result        = process.complete()
+    val outcome       = process.complete()
     val notices       = process.notices.to(List)
 
-    result match
+    outcome match
       case CompileResult.Crash(trace) =>
         Outcome.Crashed(notices, trace)
 
@@ -154,13 +159,53 @@ class Repl[version <: Scalac.Versions]
 
         try
           loader.on(t"$name$$")
-          Outcome.Ran(notices)
+          Outcome.Ran(notices, rendered)
         catch
           case error: ExceptionInInitializerError =>
             Outcome.Threw(notices, Optional(error.getCause).or(error))
 
           case suc.NonFatal(error) =>
             Outcome.Threw(notices, error)
+
+  private def statementCode(line: Text): Text =
+    (prelude.imports.map(_.tt) :+ line).join(t"\n")
+
+  // Wraps an expression line as `val resN = <line>`, then renders the bound value
+  // through `Inspectable` and stashes the rendering in `ReplBridge`. The renderer
+  // sits in an `@experimental` scope because `Inspectable` is `@experimental`, so
+  // this compiles even when the contextual `Scalac` is not in experimental mode.
+  private def expressionCode(name: Text, key: Text, line: Text): Text =
+    val put: Text = t"anthology.ReplBridge.put(${session.toString.tt}L, \"$key\", $name.inspect)"
+
+    val lines: List[Text] =
+      List
+        ( t"val $name = $line",
+          t"@scala.annotation.experimental private val ${name}_inspected: scala.Unit =",
+          t"  { import spectacular.inspect; $put }" )
+
+    (prelude.imports.map(_.tt) ::: lines).join(t"\n")
+
+  private def evaluate(line: Text)(using Monitor, System, Codicil)
+  :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
+
+    val name: Text = t"res${result.toString.tt}"
+    val key:  Text = t"result:${session.toString.tt}:${index.toString.tt}"
+
+    // Try the line as an expression first; a definition or import fails to parse
+    // as `val resN = …` and falls back to being compiled as a plain statement.
+    val expression: Outcome = compile(expressionCode(name, key, line)):
+      Optional(ReplBridge.fetch[String](session, key.s)).let(_.tt)
+
+    expression match
+      case _: Outcome.Rejected =>
+        compile(statementCode(line))(Unset)
+
+      case ran: Outcome.Ran =>
+        result += 1
+        ran
+
+      case other =>
+        other
 
   // The prelude's definitions and binding accessors are compiled once, as the
   // first object (`rs$line$0`); later lines see them via the history import.
@@ -182,12 +227,12 @@ class Repl[version <: Scalac.Versions]
     if seeded || prelude.definitions.isEmpty && prelude.bindings.isEmpty then Unset
     else
       seeded = true
-      run(seedBody)
+      compile(seedBody)(Unset)
 
   def interpret(line: Text)(using Monitor, System, Codicil)
   :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
 
-    def lineOutcome: Outcome = run((prelude.imports.map(_.tt) :+ line).join(t"\n"))
+    def lineOutcome: Outcome = evaluate(line)
 
     ensureSeeded().lay(lineOutcome):
       case _: Outcome.Ran => lineOutcome

--- a/lib/anthology/src/test/anthology_test.scala
+++ b/lib/anthology/src/test/anthology_test.scala
@@ -53,8 +53,8 @@ object Tests extends Suite(m"Anthology Tests"):
           repl.interpret(t"val x = 40")
           repl.interpret(t"println(x + 2)")
       . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+          case Repl.Outcome.Ran(_, _) => true
+          case _                      => false
 
       test(m"a type error is reported as Rejected with notices"):
         supervise:
@@ -85,8 +85,8 @@ object Tests extends Suite(m"Anthology Tests"):
 
           repl.interpret(t"println(total)")     // "hello".length + 5
       . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+          case Repl.Outcome.Ran(_, _) => true
+          case _                      => false
 
       test(m"a lifted import is in scope for REPL lines"):
         supervise:
@@ -96,8 +96,8 @@ object Tests extends Suite(m"Anthology Tests"):
 
           repl.interpret(t"println(ListBuffer(1, 2, 3).sum)")
       . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+          case Repl.Outcome.Ran(_, _) => true
+          case _                      => false
 
       test(m"a captured value persists across several lines"):
         supervise:
@@ -109,5 +109,31 @@ object Tests extends Suite(m"Anthology Tests"):
           repl.interpret(t"val doubled = seed*2")
           repl.interpret(t"println(doubled + seed)")
       . assert:
-          case Repl.Outcome.Ran(_) => true
-          case _                   => false
+          case Repl.Outcome.Ran(_, _) => true
+          case _                      => false
+
+    suite(m"REPL result rendering"):
+      given Scalac[3.8] = Scalac(Nil)
+
+      test(m"an expression's value is rendered via Inspectable"):
+        supervise:
+          Repl().interpret(t"21 * 2")
+      . assert:
+          case Repl.Outcome.Ran(_, value) => value.let(_ == t"42").or(false)
+          case _                          => false
+
+      test(m"a definition renders no value"):
+        supervise:
+          Repl().interpret(t"val x = 5")
+      . assert:
+          case Repl.Outcome.Ran(_, value) => value.absent
+          case _                          => false
+
+      test(m"a rendered result is bound to res0 for later lines"):
+        supervise:
+          val repl = Repl()
+          repl.interpret(t"40 + 2")
+          repl.interpret(t"res0 + 1")
+      . assert:
+          case Repl.Outcome.Ran(_, value) => value.let(_ == t"43").or(false)
+          case _                          => false


### PR DESCRIPTION
The REPL now renders the result of an expression line: it binds the value to `res0`, `res1`, … and produces a `Text` rendering of it through the `Inspectable` typeclass, returned alongside the run outcome. Definitions, imports, and other non-expression statements render no value.

`Repl.Outcome.Ran` gains a `value: Optional[Text]` field carrying the rendered result:

```scala
import soundness.*
import classloaders.threadContext, temporaryDirectories.system, systems.java,
       codicils.await, threading.platform, logging.silent

given Scalac[3.8] = Scalac(Nil)

supervise:
  val repl = Repl()
  repl.interpret(t"21 * 2")    // Ran(_, value = Some(t"42"))
  repl.interpret(t"val x = 5") // Ran(_, value = Unset)  — a definition renders nothing
  repl.interpret(t"40 + 2")    // res0 = 42
  repl.interpret(t"res0 + 1")  // Ran(_, value = Some(t"43"))
```

`Inspectable` always resolves — types with no specific instance fall back to a `toString`-based rendering — so every expression yields a value. Results are bound to `resN` and remain visible to later lines, like the standard Scala REPL.

A line is treated as an expression when it compiles as `val resN = <line>`; definitions and imports fail that form and are compiled as plain statements instead. Rendering requires `spectacular` on the REPL's classpath; if it is absent the line still runs as a statement, just without a rendered value.
