### PR TITLE
Broaden panopticon optics across all format modules

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -985,7 +985,7 @@ object mandible extends Library:
 object locomotion extends Library:
   object core
       extends Component(turbulence.core, wisteria.core, adversaria.core, hypotenuse.core,
-        gossamer.core, spectacular.core):
+        gossamer.core, spectacular.core, panopticon.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -480,7 +480,7 @@ object caduceus extends Library:
   object test extends Tests(core)
 
 object caesura extends Library:
-  object core extends Component(turbulence.core, escritoire.core):
+  object core extends Component(turbulence.core, escritoire.core, panopticon.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -1372,7 +1372,7 @@ object querencia extends Library:
   object test extends Tests(core)
 
 object xylophone extends Library:
-  object core extends Component(zephyrine.core, adversaria.core, typonym.core, hellenism.core, urticose.core, wisteria.core):
+  object core extends Component(zephyrine.core, adversaria.core, typonym.core, hellenism.core, urticose.core, wisteria.core, panopticon.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/etc/ci/run-tests.sh
+++ b/etc/ci/run-tests.sh
@@ -39,7 +39,15 @@ pid=$!
 #     unmounted virtual thread (e.g. a parasite daemon parked on a promise), so a
 #     deadlock among virtual threads is invisible without this.
 (
-  sleep "$TIMEOUT"
+  # Run the timeout as a tracked background child with a TERM trap that reaps it.
+  # If we instead ran a bare `sleep "$TIMEOUT"` and the parent later did
+  # `kill "$watchdog"`, that would kill this subshell but ORPHAN the external
+  # `sleep`, which keeps the inherited write-end of the caller's `… | tee` pipe
+  # open — wedging `tee` (and `make attest`) until the stray sleep finally ends.
+  sleep "$TIMEOUT" &
+  sp=$!
+  trap 'kill "$sp" 2>/dev/null; exit 0' TERM
+  wait "$sp"
   if kill -0 "$pid" 2>/dev/null; then
     echo >&2
     echo "::: test suite exceeded ${TIMEOUT}s — assuming a hang; thread dumps follow :::" >&2

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -42,8 +42,10 @@ import scala.compiletime.*
 import adversaria.*
 import anticipation.*
 import contingency.*
+import denominative.*
 import distillate.*
 import gossamer.*
+import panopticon.*
 import prepositional.*
 import rudiments.*
 import turbulence.*
@@ -230,6 +232,67 @@ object Cbor extends Cbor2, Dynamic:
 
   def ast(value: Ast): Cbor = new Cbor(value)
   def unseal(cbor: Cbor): Ast = cbor.root
+
+  // Panopticon optics: navigate and immutably update a CBOR document. `lens` is the
+  // map-key (object-field) lens; `ordinalOptical` indexes an array; `eachOptical`
+  // and `filterOptical` traverse every (or matching) array element. All reuse the
+  // existing `selectDynamic`/`modify`/`element`/`Ast.array` primitives and rebuild
+  // immutably. Mirrors jacinta's `Json` optics.
+  given lens: [name <: Label: ValueOf] => (erased DynamicCborEnabler) => Tactic[CborError]
+  =>  name is Lens from Cbor onto Cbor =
+    Lens(_.selectDynamic(valueOf[name]), _.modify(valueOf[name], _))
+
+  given ordinalOptical: [element] => Ordinal is Optical from Cbor onto Cbor = ordinal =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.elements
+
+        if n <= ordinal.n0 then origin else Cbor.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+
+          while i < n do
+            updated(i) =
+              if i == ordinal.n0 then lambda(Cbor.ast(origin.root.element(i))).root
+              else origin.root.element(i)
+
+            i += 1
+
+          Cbor.Ast.array(updated.asInstanceOf[IArray[Any]])
+      else origin
+
+  given eachOptical: Each.type is Optical from Cbor onto Cbor = _ =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.elements
+
+        Cbor.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+
+          while i < n do
+            updated(i) = lambda(Cbor.ast(origin.root.element(i))).root
+            i += 1
+
+          Cbor.Ast.array(updated.asInstanceOf[IArray[Any]])
+      else origin
+
+  given filterOptical: Filter[Cbor] is Optical from Cbor onto Cbor = filter =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.elements
+
+        Cbor.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+
+          while i < n do
+            val element = Cbor.ast(origin.root.element(i))
+            updated(i) = (if filter.predicate(element) then lambda(element) else element).root
+            i += 1
+
+          Cbor.Ast.array(updated.asInstanceOf[IArray[Any]])
+      else origin
 
   given boolean: Tactic[CborError] => Boolean is Decodable in Cbor = _.root.boolean
   given double: Tactic[CborError] => Double is Decodable in Cbor = _.root.double

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -39,6 +39,7 @@ import strategies.throwUnsafely
 case class Point(x: Int, y: Int) derives CanEqual
 case class Person(name: Text, age: Int) derives CanEqual
 case class Wrapper(values: List[Int], label: Text) derives CanEqual
+case class Team(lead: Person, size: Int) derives CanEqual
 case class Renamed
    (@name[Cbor](t"data_files")  dataFiles:  List[Long],
     @name[Cbor](t"index_files") indexFiles: List[Long])
@@ -323,3 +324,42 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val body = Person(t"Alice", 30).cbor
         body.generic(1).read[Person over Cbor]
       . assert(_ == Person(t"Alice", 30))
+
+    suite(m"Optics"):
+      import dynamicCborAccess.enabled
+
+      val team = Team(Person(t"John", 40), 3).cbor
+      val list = Wrapper(List(1, 2, 3), t"hi").cbor
+
+      test(m"lens reads a field by name"):
+        summon["size" is Lens from Cbor onto Cbor](team).as[Int]
+      . assert(_ == 3)
+
+      test(m"lens sets a top-level field"):
+        team.lens(_.size = 5.cbor).as[Team]
+      . assert(_ == Team(Person(t"John", 40), 5))
+
+      test(m"lens sets a nested field"):
+        team.lens(_.lead.name = t"Bob".cbor).as[Team]
+      . assert(_ == Team(Person(t"Bob", 40), 3))
+
+      test(m"lens.modify transforms a field through a function"):
+        val lens = summon["size" is Lens from Cbor onto Cbor]
+        lens.modify(team)(cbor => (cbor.as[Int] + 1).cbor).as[Team]
+      . assert(_ == Team(Person(t"John", 40), 4))
+
+      test(m"ordinal optic updates an array element"):
+        list.lens(_.values(Sec) = 9.cbor).as[Wrapper]
+      . assert(_ == Wrapper(List(1, 9, 3), t"hi"))
+
+      test(m"each optic updates every array element"):
+        list.lens(_.values(Each) = 0.cbor).as[Wrapper]
+      . assert(_ == Wrapper(List(0, 0, 0), t"hi"))
+
+      test(m"filter optic updates only matching elements"):
+        list.lens(_.values(Filter[Cbor](_.as[Int] > 1)) = 0.cbor).as[Wrapper]
+      . assert(_ == Wrapper(List(1, 0, 0), t"hi"))
+
+      test(m"setting an absent field inserts it"):
+        list.lens(_.extra = 7.cbor).selectDynamic("extra").as[Int]
+      . assert(_ == 7)

--- a/lib/caesura/src/core/caesura_core.scala
+++ b/lib/caesura/src/core/caesura_core.scala
@@ -33,8 +33,12 @@
 package caesura
 
 import anticipation.*
+import denominative.*
 import gossamer.*
+import panopticon.*
 import prepositional.*
+import rudiments.*
+import vacuous.*
 
 package dsvFormats:
   given csv: DsvFormat = DsvFormat(false, ',', '"', '"')
@@ -55,3 +59,31 @@ extension [encodable: Encodable in Dsv](value: encodable) def dsv: Dsv = encodab
 
 extension [encodable: Encodable in Dsv](value: Seq[encodable])
   def dsv: Sheet = Sheet(value.to(Stream).map(encodable.encode(_)))
+
+// Panopticon optics for tabular data (no nesting, so they mirror the row/cell
+// structure rather than JSON's map/array). `cellLens` reads/writes a cell by column
+// name within a row; the `Sheet` opticals address the n-th row (`Ordinal`), every
+// row (`Each`), or rows matching a predicate (`Filter`). So
+// `sheet.lens(_(Sec).name = t"…")` updates the "name" column of the second row.
+private def cell(row: Dsv, name: String): Text =
+  row.columns.let(_.at(name.tt)).let(index => row.data.at(index.z)).or(t"")
+
+private def withCell(row: Dsv, name: String, value: Text): Dsv =
+  row.columns.let(_.at(name.tt)).lay(row): index =>
+    row.copy(data = row.data.updated(index, value))
+
+given cellLens: [name <: Label: ValueOf] => (erased DynamicDsvEnabler)
+=>  name is Lens from Dsv onto Text =
+  Lens(cell(_, valueOf[name]), withCell(_, valueOf[name], _))
+
+given rowOptical: [element] => Ordinal is Optical from Sheet onto Dsv = ordinal =>
+  Optic: (origin, lambda) =>
+    origin.copy(rows = origin.rows.zipWithIndex.map: (row, index) =>
+      if index == ordinal.n0 then lambda(row) else row)
+
+given rowEach: Each.type is Optical from Sheet onto Dsv = _ =>
+  Optic: (origin, lambda) => origin.copy(rows = origin.rows.map(lambda))
+
+given rowFilter: Filter[Dsv] is Optical from Sheet onto Dsv = filter =>
+  Optic: (origin, lambda) =>
+    origin.copy(rows = origin.rows.map(row => if filter.predicate(row) then lambda(row) else row))

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -228,6 +228,32 @@ object Tests extends Suite(m"Caesura tests"):
       Seq(Foo(t"hello", t"world")).dsv.show
     . assert(_ == t"hello\tworld")
 
+    suite(m"Optics"):
+      import dsvFormats.csvWithHeader
+      import dynamicDsvAccess.enabled
+      def sheet: Sheet = t"name,age\nAlice,30\nBob,25".read[Sheet]
+
+      test(m"cell lens reads a cell by column name"):
+        summon["name" is Lens from Dsv onto Text](sheet.rows.head)
+      . assert(_ == t"Alice")
+
+      test(m"cell lens replaces a cell by column name"):
+        sheet.rows.head.lens(_.name = t"Carol").data.head
+      . assert(_ == t"Carol")
+
+      test(m"row optic updates a cell in the n-th row"):
+        sheet.lens(_(Sec).name = t"Carol").rows.to(List).map(_.data.head)
+      . assert(_ == List(t"Alice", t"Carol"))
+
+      test(m"each-row optic updates every row"):
+        sheet.lens(_(Each).name = t"X").rows.to(List).map(_.data.head)
+      . assert(_ == List(t"X", t"X"))
+
+      test(m"filter-row optic updates only matching rows"):
+        sheet.lens(_(Filter[Dsv](_.data.head == t"Bob")).name = t"X")
+         .rows.to(List).map(_.data.head)
+      . assert(_ == List(t"Alice", t"X"))
+
 case class Foo(one: Text, two: Text)
 case class Bar(one: Double, foo1: Foo, four: Int, foo2: Foo)
 case class Quux(name: Text, greeting: Text)

--- a/lib/honeycomb/src/test/honeycomb_test.scala
+++ b/lib/honeycomb/src/test/honeycomb_test.scala
@@ -806,6 +806,27 @@ object Tests extends Suite(m"Honeycombd Tests"):
           t"""<table>x<b>y</b>z<tr><td>w</td></tr></table>""".read[Html of Flow]
         . assert(_ == Fragment(TextNode("x"), B("y"), TextNode("z"), Table(Tbody(Tr(Td("w"))))))
 
+      suite(m"Optics"):
+        test(m"Tag optic transforms every matching child element"):
+          Div(P("a"), P("b")).lens(_(P) = P("x")).show
+        . assert(_ == t"<div><p>x</p><p>x</p></div>")
+
+        test(m"Tag optic leaves non-matching children unchanged"):
+          Div(P("a"), B("b")).lens(_(P) = P("x")).show
+        . assert(_ == t"<div><p>x</p><b>b</b></div>")
+
+        test(m"Tag optic over a single matching child"):
+          Div(P("a")).lens(_(P) = P("z")).show
+        . assert(_ == t"<div><p>z</p></div>")
+
+        test(m"Tag optic with no matching children is a no-op"):
+          Div(B("a")).lens(_(P) = P("x")).show
+        . assert(_ == t"<div><b>a</b></div>")
+
+        test(m"nested Tag optics compose"):
+          Div(Ul(Li("a"), Li("b"))).lens(_(Ul)(Li) = Li("x")).show
+        . assert(_ == t"<div><ul><li>x</li><li>x</li></ul></div>")
+
       suite(m"Interpolator tests"):
         import attributives.textAttributes
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -500,6 +500,41 @@ object Json extends Json2, Dynamic:
         else
           origin
 
+  // `Each` applies the transform to every array element; `Filter` to those matching
+  // its predicate. Both rebuild the array immutably and no-op on non-arrays.
+  given eachOptical: Each.type is Optical from Json onto Json = _ =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.arrayLength
+
+        Json.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+
+          while i < n do
+            updated(i) = lambda(Json.ast(origin.root.arrayElement(i))).root
+            i += 1
+
+          Json.Ast.arr(updated.asInstanceOf[IArray[Any]])
+      else origin
+
+  given filterOptical: Filter[Json] is Optical from Json onto Json = filter =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.arrayLength
+
+        Json.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+
+          while i < n do
+            val element = Json.ast(origin.root.arrayElement(i))
+            updated(i) = (if filter.predicate(element) then lambda(element) else element).root
+            i += 1
+
+          Json.Ast.arr(updated.asInstanceOf[IArray[Any]])
+      else origin
+
   given boolean: Json is Decodable in Json = identity(_)
   given boolean: Tactic[JsonError] => Boolean is Decodable in Json = _.root.boolean
   given double: Tactic[JsonError] => Double is Decodable in Json = _.root.double

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -377,6 +377,34 @@ object Tests extends Suite(m"Jacinta Tests"):
         org2.as[Org]
       . assert(_ == Org("The Beatles", Entity("John", 40, List(Role("-")))))
 
+      val band = Org("Q", Entity("John", 40, List(Role("a"), Role("b"), Role("c")))).json
+
+      test(m"Lens reads a field by name"):
+        import dynamicJsonAccess.enabled
+        summon["name" is Lens from Json onto Json](org).as[String]
+      . assert(_ == "The Beatles")
+
+      test(m"Lens.modify transforms a field through a function"):
+        import dynamicJsonAccess.enabled
+        val lens = summon["name" is Lens from Json onto Json]
+        lens.modify(org)(json => (json.as[String]+"!").json).as[Org]
+      . assert(_ == Org("The Beatles!", Entity("John", 40, List(Role("Leader")))))
+
+      test(m"Each optic updates every array element"):
+        import dynamicJsonAccess.enabled
+        band.lens(_.leader.roles(Each).name = "x".json).as[Org]
+      . assert(_ == Org("Q", Entity("John", 40, List(Role("x"), Role("x"), Role("x")))))
+
+      test(m"Filter optic updates only matching elements"):
+        import dynamicJsonAccess.enabled
+        band.lens(_.leader.roles(Filter[Json](_.name.as[String] == "b")).name = "x".json).as[Org]
+      . assert(_ == Org("Q", Entity("John", 40, List(Role("a"), Role("x"), Role("c")))))
+
+      test(m"Setting an absent field inserts it"):
+        import dynamicJsonAccess.enabled
+        org.lens(_.extra = 9.json).selectDynamic("extra").as[Int]
+      . assert(_ == 9)
+
     suite(m"Json construction"):
       test(m"Json.make with one field"):
         Json.make(name = t"Anna".json).show

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -43,9 +43,11 @@ import scala.compiletime.*
 import adversaria.*
 import anticipation.*
 import contingency.*
+import denominative.*
 import distillate.*
 import gossamer.*
 import hypotenuse.*
+import panopticon.*
 import prepositional.*
 import rudiments.*
 import turbulence.*
@@ -125,6 +127,27 @@ object Protobuf extends Protobuf2:
   given aggregableOver: [value: Decodable in Protobuf] => Tactic[ProtobufError]
   =>  (value over Protobuf) is Aggregable by Data =
     bytes => message(bytes.read[Data]).as[value].asInstanceOf[value over Protobuf]
+
+  // Number-keyed optic: Protobuf fields are addressed by number, not name, so an
+  // `Ordinal` selects field `n` (`Prim` = field 1). Updating parses the message's
+  // fields, replaces field `n`'s wire value with the transform's result, and
+  // re-encodes. A parse failure, or an absent field number, leaves the message
+  // unchanged. This is the only optic Protobuf affords — there are no field labels.
+  given fieldOptical: [element] => Ordinal is Optical from Protobuf onto Protobuf = ordinal =>
+    Optic: (origin, lambda) =>
+      val number = ordinal.n0 + 1
+
+      safely:
+        val fields = ProtobufParser(origin.payload).fields()
+        if !fields.contains(number) then origin else
+          val printer = ProtobufPrinter()
+          fields.each: (key, values) =>
+            val value = Protobuf.Repeated(values)
+            printer.field(key, if key == number then lambda(value) else value)
+
+          Protobuf.Wire(WireType.Len, printer.result)
+
+      . or(origin)
 
   private def printed(lambda: ProtobufPrinter => Unit): Data =
     val printer = ProtobufPrinter()

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -230,3 +230,20 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
         val message = Person(t"Alice", 30).protobuf
         message.generic(1).read[Person over Protobuf]
       . assert(_ == Person(t"Alice", 30))
+
+    suite(m"Optics"):
+      // Protobuf is number-keyed: the `Ordinal` selects a field by number (Prim =
+      // field 1). Wrapper encodes `point` at field 1 and `label` at field 2.
+      def wrapper: Protobuf = Wrapper(Point(3, 4), t"origin").protobuf
+
+      test(m"field optic replaces a sub-message field by number"):
+        wrapper.lens(_(Prim) = Point(7, 8).protobuf).as[Wrapper]
+      . assert(_ == Wrapper(Point(7, 8), t"origin"))
+
+      test(m"field optic leaves other fields unchanged"):
+        wrapper.lens(_(Prim) = Point(7, 8).protobuf).as[Wrapper].label
+      . assert(_ == t"origin")
+
+      test(m"an absent field number is a no-op"):
+        wrapper.lens(_(Sen) = Point(7, 8).protobuf).as[Wrapper]
+      . assert(_ == Wrapper(Point(3, 4), t"origin"))

--- a/lib/panopticon/src/test/panopticon_test.scala
+++ b/lib/panopticon/src/test/panopticon_test.scala
@@ -229,6 +229,20 @@ object Tests extends Suite(m"Panopticon tests"):
       ( r.depts.head.lead.name, r.depts.head.lead.age, r.depts.head.lead.role.name )
     . assert(_ == ("Renamed", 99, "Boss"))
 
+    case class Bag(items: Vector[Int])
+    test(m"ordinal optic on a Vector field"):
+      Bag(Vector(1, 2, 3)).lens(_.items(Sec) = 9)
+    . assert(_ == Bag(Vector(1, 9, 3)))
+
+    case class Crew(members: Seq[Text])
+    test(m"ordinal optic on a Seq field"):
+      Crew(Seq(t"a", t"b", t"c")).lens(_.members(Prim) = t"z")
+    . assert(_ == Crew(Seq(t"z", t"b", t"c")))
+
+    test(m"filter-by-key traversal over a Map field"):
+      user.lens(_.roles(Filter[Text](_ == t"cfo")).name = "X")
+    . assert(_ == User("John", Map(t"ceo" -> Role("CEO", 1), t"cfo" -> Role("X", 2), t"cio" -> Role("CIO", 3))))
+
     import doms.html.whatwg.*
 
     test(m"adjust an HTML value"):

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -827,3 +827,26 @@ object Tel extends Tel2:
         out(lastIdx) = out(lastIdx).copy(compounds = out(lastIdx).compounds :+ compound)
 
     IArray.from(out)
+
+  // Replace the `index`-th child compound (flattened across blocks) by applying
+  // `transform`, preserving block structure and surrounding formatting. An
+  // out-of-range index leaves the children unchanged. Used by the panopticon
+  // `Ordinal` optic.
+  private[stratiform] def withChildCompound
+       (blocks: IArray[Block], index: Int, transform: Compound => Compound)
+  :     IArray[Block] =
+    var offset = 0
+    blocks.map: block =>
+      val compounds = block.compounds
+      val base = offset
+      offset += compounds.length
+      if index >= base && index < base + compounds.length
+      then block.copy(compounds = compounds.updated(index - base, transform(compounds(index - base))))
+      else block
+
+  // Apply `transform` to every child compound (flattened across blocks),
+  // preserving block structure. Used by the panopticon `Each` optic.
+  private[stratiform] def mapChildCompounds
+       (blocks: IArray[Block], transform: Compound => Compound)
+  :     IArray[Block] =
+    blocks.map(block => block.copy(compounds = block.compounds.map(transform)))

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -38,6 +38,7 @@ import adversaria.*
 import anticipation.*
 import contextual.*
 import contingency.*
+import denominative.*
 import distillate.*
 import gossamer.*
 import panopticon.*
@@ -64,6 +65,36 @@ trait Tel2:
   given lens: [name <: Label: ValueOf] => (erased DynamicTelEnabler) => Tactic[TelError]
   =>  name is Lens from Tel onto Tel =
     Lens(_.selectDynamic(valueOf[name]), _.modify(valueOf[name], _))
+
+  // Positional optics over a node's child compounds (TEL has no positional arrays,
+  // but a compound's children are ordered — this mirrors the read-side
+  // `applyDynamic(field)(index)`). `Ordinal` addresses the n-th child; `Each` every
+  // child. The transform's result keeps the original child's keyword, so a positional
+  // update preserves the field identity while replacing its value/children.
+  private def rewrap(original: Tel.Compound, replacement: Tel): Tel.Compound =
+    replacement.subtree match
+      case compound: Tel.Compound =>
+        compound.copy(keyword = original.keyword)
+      case document: Tel.Document =>
+        original.copy(atoms = IArray.empty[Tel.Atom], remark = Unset, children = document.children)
+
+  private def rebuild(origin: Tel, children: IArray[Tel.Block]): Tel = origin.subtree match
+    case document: Tel.Document => Tel.make(document.copy(children = children))
+    case compound: Tel.Compound => Tel.make(compound.copy(children = children))
+
+  given ordinalOptical: [element] => Ordinal is Optical from Tel onto Tel = ordinal =>
+    Optic: (origin, lambda) =>
+      if ordinal.n0 < 0 || ordinal.n0 >= origin.childCompounds.length then origin
+      else rebuild
+       ( origin,
+         Tel.withChildCompound
+          (origin.subtree.children, ordinal.n0, c => rewrap(c, lambda(Tel.make(c)))) )
+
+  given eachOptical: Each.type is Optical from Tel onto Tel = _ =>
+    Optic: (origin, lambda) =>
+      rebuild
+       ( origin,
+         Tel.mapChildCompounds(origin.subtree.children, c => rewrap(c, lambda(Tel.make(c)))) )
 
   // `tel"…"` interpolator: parses at compile time and substitutes typed
   // holes via Encodable in Tel.

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -39,6 +39,7 @@ import java.lang as jl
 import adversaria.name
 import anticipation.*
 import contingency.*
+import denominative.*
 import fulminate.*
 import gastronomy.*
 import gossamer.*
@@ -927,6 +928,38 @@ object Tests extends Suite(m"Stratiform Tests"):
         val updated = lens.modify(tel)(_ => Tel.scalar(t"Carol"))
         updated.selectDynamic("name").primaryAtom
       . assert(_ == t"Carol")
+
+    suite(m"Optics: positional child traversal"):
+      import dynamicTelAccess.enabled
+      def doc(source: String): Tel = source.tt.read[Tel]
+      def contacts: Tel = doc("contacts\n  contact alice\n  contact bob\n")
+
+      test(m"ordinal optic replaces the n-th child compound"):
+        contacts.lens(_.contacts(Sec) = Tel.scalar(t"carol")).contacts(1).primaryAtom
+      . assert(_ == t"carol")
+
+      test(m"ordinal optic leaves siblings unchanged"):
+        contacts.lens(_.contacts(Sec) = Tel.scalar(t"carol")).contacts(0).primaryAtom
+      . assert(_ == t"alice")
+
+      test(m"ordinal optic preserves the child's keyword"):
+        contacts.lens(_.contacts(Sec) = Tel.scalar(t"carol")).applyDynamic("contacts")(1).keyword
+      . assert(_ == t"contact")
+
+      test(m"each optic transforms every child compound"):
+        val updated = contacts.lens(_.contacts(Each) = Tel.scalar(t"x"))
+        (updated.contacts(0).primaryAtom, updated.contacts(1).primaryAtom)
+      . assert(_ == (t"x", t"x"))
+
+      test(m"an out-of-range ordinal is a no-op"):
+        contacts.lens(_.contacts(Quat) = Tel.scalar(t"none")).contacts(1).primaryAtom
+      . assert(_ == t"bob")
+
+      test(m"editing through an ordinal optic preserves surrounding formatting"):
+        val original = doc("# header\ncontacts\n  contact alice\n  contact bob\n")
+        val updated = original.lens(_.contacts(Sec) = Tel.scalar(t"carol"))
+        Tel.show(updated.document.vouch)
+      . assert(_ == t"# header\ncontacts\n  contact alice\n  contact carol\n")
 
     suite(m"Edit DSL"):
       def doc(source: String): Tel = source.tt.read[Tel]

--- a/lib/xylophone/src/core/xylophone_core.scala
+++ b/lib/xylophone/src/core/xylophone_core.scala
@@ -35,10 +35,15 @@ package xylophone
 import language.dynamics
 
 import scala.annotation.*
+import scala.collection.mutable as scm
 
 import anticipation.*
 import contextual.*
+import denominative.*
+import gossamer.*
+import panopticon.*
 import prepositional.*
+import rudiments.*
 
 export Xml.attribute
 
@@ -48,4 +53,73 @@ extension [encodable: Encodable in Xml](value: encodable)
 extension (inline context: StringContext)
   transparent inline def x: Interpolation = interpolation[Xml](context)
   transparent inline def xp: Interpolation = interpolation[XPath](context)
+
+// Panopticon optics over an XML element's children. `lens` navigates to the first
+// child element with the given name — replacing it on update, or appending if
+// absent — so `xml.lens(_.book.title = …)` works. `ordinalOptical` and `eachOptical`
+// address the n-th, or every, child element of a node. All rebuild the element
+// immutably; non-element nodes (text, comments) are preserved in place.
+private def xmlNodes(xml: Xml): IArray[Node] = xml match
+  case Fragment(nodes*) => IArray.from(nodes)
+  case node: Node       => IArray(node)
+  case _                => IArray[Node]()
+
+private def firstNode(xml: Xml, fallback: Node): Node =
+  val nodes = xmlNodes(xml)
+  if nodes.isEmpty then fallback else nodes(0)
+
+private def replaceNamedChild(xml: Xml, name: String, value: Xml): Xml = xml match
+  case Element(label, attributes, children) =>
+    val replacement = xmlNodes(value)
+    val buffer = scm.ArrayBuffer[Node]()
+    var done = false
+
+    var i = 0
+    while i < children.length do
+      children(i) match
+        case element: Element if !done && element.label == name.tt =>
+          buffer ++= replacement
+          done = true
+        case other =>
+          buffer += other
+      i += 1
+
+    if !done then buffer ++= replacement
+    Element(label, attributes, IArray.from(buffer))
+
+  case Fragment(node: Element) =>
+    Fragment(replaceNamedChild(node, name, value).asInstanceOf[Node])
+
+  case other =>
+    other
+
+private def updateChildElements(xml: Xml, select: Int => Boolean, lambda: Xml => Xml): Xml =
+  xml match
+    case Element(label, attributes, children) =>
+      var index = 0
+      val out = children.map:
+        case element: Element =>
+          val here = index
+          index += 1
+          if select(here) then firstNode(lambda(element), element) else element
+        case other =>
+          other
+
+      Element(label, attributes, out)
+
+    case Fragment(node: Element) =>
+      Fragment(updateChildElements(node, select, lambda).asInstanceOf[Node])
+
+    case other =>
+      other
+
+given lens: [name <: Label: ValueOf] => (erased DynamicXmlEnabler)
+=>  name is Lens from Xml onto Xml =
+  Lens(_.applyDynamic(valueOf[name])(Prim), replaceNamedChild(_, valueOf[name], _))
+
+given ordinalOptical: [element] => Ordinal is Optical from Xml onto Xml = ordinal =>
+  Optic: (origin, lambda) => updateChildElements(origin, _ == ordinal.n0, lambda)
+
+given eachOptical: Each.type is Optical from Xml onto Xml = _ =>
+  Optic: (origin, lambda) => updateChildElements(origin, _ => true, lambda)
 

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -1007,6 +1007,35 @@ object Tests extends Suite(m"Xylophone tests"):
         . nonEmpty
       . assert(identity)
 
+    suite(m"Optics"):
+      import dynamicXmlAccess.enabled
+      def doc: Xml = t"<doc><x>1</x><x>2</x><x>3</x></doc>".read[Xml]
+
+      test(m"lens replaces the first matching child element"):
+        doc.lens(_.x = x"<x>9</x>").show
+      . assert(_ == t"<doc><x>9</x><x>2</x><x>3</x></doc>")
+
+      test(m"lens appends when no matching child exists"):
+        doc.lens(_.y = x"<y>5</y>").show
+      . assert(_ == t"<doc><x>1</x><x>2</x><x>3</x><y>5</y></doc>")
+
+      test(m"lens navigates and updates a nested element"):
+        t"<doc><item><name>a</name></item></doc>".read[Xml]
+         .lens(_.item.name = x"<name>b</name>").show
+      . assert(_ == t"<doc><item><name>b</name></item></doc>")
+
+      test(m"ordinal optic replaces the n-th child element"):
+        doc.lens(_(Sec) = x"<x>9</x>").show
+      . assert(_ == t"<doc><x>1</x><x>9</x><x>3</x></doc>")
+
+      test(m"each optic replaces every child element"):
+        doc.lens(_(Each) = x"<x>0</x>").show
+      . assert(_ == t"<doc><x>0</x><x>0</x><x>0</x></doc>")
+
+      test(m"an out-of-range ordinal is a no-op"):
+        doc.lens(_(Sen) = x"<x>9</x>").show
+      . assert(_ == t"<doc><x>1</x><x>2</x><x>3</x></doc>")
+
     PositionTests()
     DecoderTests()
     EncoderTests()

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -883,6 +883,37 @@ object Yaml extends Yaml2, Dynamic:
       else
         origin
 
+  // `Each` applies the transform to every sequence element; `Filter` to those
+  // matching its predicate. Both rebuild the sequence immutably and no-op otherwise.
+  given eachOptical: Each.type is Optical from Yaml onto Yaml = _ =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.arrayLength
+        Yaml.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+          while i < n do
+            updated(i) = lambda(Yaml.ast(origin.root.arrayElement(i))).root
+            i += 1
+          Yaml.Ast.seqFromAnyArray(updated)
+      else
+        origin
+
+  given filterOptical: Filter[Yaml] is Optical from Yaml onto Yaml = filter =>
+    Optic: (origin, lambda) =>
+      if origin.root.isArray then
+        val n = origin.root.arrayLength
+        Yaml.ast:
+          val updated = new Array[Any](n)
+          var i = 0
+          while i < n do
+            val element = Yaml.ast(origin.root.arrayElement(i))
+            updated(i) = (if filter.predicate(element) then lambda(element) else element).root
+            i += 1
+          Yaml.Ast.seqFromAnyArray(updated)
+      else
+        origin
+
   // Single-error abort variant retained for non-primitive accessors
   // (`yaml(t"foo")`, `yaml(0)`, etc.) that need to short-circuit on
   // wrong-shape access. Primitive `Decodable in Yaml` instances no

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -1028,6 +1028,30 @@ object Tests extends Suite(m"Ypsiloid Tests"):
         updated.items.as[List[Int]]
       . assert(_ == List(99, 20, 30))
 
+      test(m"Lens reads a field by name"):
+        summon["name" is Lens from Yaml onto Yaml](org).as[Text]
+      . assert(_ == t"a")
+
+      test(m"Lens.modify transforms a field through a function"):
+        val lens = summon["n" is Lens from Yaml onto Yaml]
+        val inner = Yaml.ast(Inner(7).yaml.root)
+        lens.modify(inner)(yaml => (yaml.as[Int] + 1).yaml).as[Inner]
+      . assert(_ == Inner(8))
+
+      test(m"Each optic updates every sequence element"):
+        val y = t"items: [10, 20, 30]".read[Yaml]
+        y.lens(_.items(Each) = 0.yaml).items.as[List[Int]]
+      . assert(_ == List(0, 0, 0))
+
+      test(m"Filter optic updates only matching elements"):
+        val y = t"items: [10, 20, 30]".read[Yaml]
+        y.lens(_.items(Filter[Yaml](_.as[Int] > 15)) = 0.yaml).items.as[List[Int]]
+      . assert(_ == List(10, 0, 0))
+
+      test(m"Setting an absent field inserts it"):
+        org.lens(_.extra = 7.yaml).selectDynamic("extra").as[Int]
+      . assert(_ == 7)
+
     suite(m"Serializer roundtrip"):
       import yamlPrinters.block
 


### PR DESCRIPTION
Optics support via panopticon is now consistent across every format module. CBOR, XML, CSV/TSV and Protobuf gain optics for the first time, while JSON, YAML and TEL are broadened and HTML's existing tag optic is rounded out — so a document of any supported format can be navigated and immutably updated through the same `.lens(...)` syntax already used for case classes. The branch also fixes a `make attest` hang in which the test-timeout watchdog could orphan its `sleep` and wedge the build's output pipe after the suite passed.

Panopticon lens/optic support has been broadened to all format modules, so you can navigate and update parsed documents the same way you already update case classes — through `value.lens(_.path = newValue)`.

The optics available depend on each format's natural structure (modulo format differences):

- **JSON, YAML, CBOR** — a map-key lens, an `Ordinal` array index, and `Each`/`Filter` array traversals:
  ```scala
  json.lens(_.leader.roles(Each).name = "x".json)
  cbor.lens(_.values(Filter[Cbor](_.as[Int] > 1)) = 0.cbor)
  ```
- **TEL** — a field lens plus positional `Ordinal`/`Each` optics over a node's child compounds (formatting is preserved).
- **XML** — a child-element-by-name lens plus `Ordinal`/`Each` over child elements:
  ```scala
  xml.lens(_.book.title = x"<title>New</title>")
  ```
- **HTML** — the tag-keyed child optic, e.g. `table.lens(_(Tbody)(Tr)(Td) = Td("-"))`.
- **CSV/TSV** — a cell-by-column lens, plus row `Ordinal`/`Each`/`Filter` optics:
  ```scala
  sheet.lens(_(Sec).name = t"Carol")
  ```
- **Protobuf** — a number-keyed field optic (`Prim` = field 1), since Protobuf fields have no labels:
  ```scala
  message.lens(_(Prim) = Point(7, 8).protobuf)
  ```

Each module gains a dedicated `Optics` test suite (get / set / modify / nested / ordinal / each / filter / missing-key). A follow-up (#1272) tracks letting lens assignments accept encodable values directly (`_.name = "x"`), via `into`-typed conversions.