### PR TITLE
Add type-based completions to Harlequin

### DIFF
--- a/lib/harlequin/src/core/harlequin.Completion.scala
+++ b/lib/harlequin/src/core/harlequin.Completion.scala
@@ -32,59 +32,25 @@
                                                                                                   */
 package harlequin
 
-import soundness.*
+import anticipation.*
+import denominative.*
+import stenography.*
+import vacuous.*
 
-import ambience.systems.java
+object Completion:
+  enum Kind:
+    case Term, Method, Given, Extension, Type, Module, Package
 
-object Tests extends Suite(m"Harlequin Tests"):
-  def run(): Unit =
-    val snippet = t"val xs = List(1, 2, 3)"
+// A single completion candidate at a requested position. `name` is the text to
+// insert; `kind` distinguishes methods, extensions, types, etc.; `signature` is
+// the member's type rendered as a Stenography `Syntax` (a method's full
+// parameter/result signature, a value's type, …).
+case class Completion
+   ( name:          Text,
+     kind:          Completion.Kind,
+     signature:     Syntax,
+     documentation: Optional[Text] = Unset )
 
-    def typeOf(tokens: List[Token], text: Text): Optional[Text] =
-      tokens.find(_.text == text) match
-        case Some(Token(_, _, meta, _)) => meta.let(_.tpe.qualified)
-        case _                          => Unset
-
-    test(m"tokenized highlighting attaches no type metadata"):
-      Scala.highlight(snippet).lines.to(List).flatten.flatMap(_.meta.option)
-    .assert(_ == Nil)
-
-    test(m"each token carries its line and column position"):
-      val tokens = Scala.highlight(t"val n =\n  List").lines.to(List).flatten
-
-      tokens.map: token =>
-        (token.text, token.span.startLine.lay(-1)(_.n0), token.span.startColumn.lay(-1)(_.n0))
-    .assert(_.contains((t"List", 1, 2)))
-
-    test(m"typechecked highlighting resolves the type of a val"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
-      given LocalClasspath = unsafely(System.properties.java.`class`.path().decode[LocalClasspath])
-      import highlighting.typecheckedScala
-
-      typeOf(Scala.highlight(snippet).lines.to(List).flatten, t"xs").or(t"")
-    .assert { rendered => rendered.contains(t"List") && rendered.contains(t"Int") }
-
-    test(m"typechecked highlighting reports diagnostics for ill-typed code"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
-      given LocalClasspath = unsafely(System.properties.java.`class`.path().decode[LocalClasspath])
-      import highlighting.typecheckedScala
-
-      Scala.highlight(t"val n: Int = \"oops\"").diagnostics.length
-    .assert(_ > 0)
-
-    test(m"no completions are computed without a caret"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
-      given LocalClasspath = unsafely(System.properties.java.`class`.path().decode[LocalClasspath])
-      import highlighting.typecheckedScala
-
-      Scala.highlight(snippet).completions
-    .assert(_ == Unset)
-
-    test(m"completions at a member selection include the type's methods"):
-      given Scalac[3.8] = Scalac[3.8](Nil)
-      given LocalClasspath = unsafely(System.properties.java.`class`.path().decode[LocalClasspath])
-      import highlighting.typecheckedScala
-
-      val source = t"val xs = List(1, 2, 3)\nval y = xs.m"
-      Scala.highlight(source, caret = source.length.z).completions.lay(Nil)(_.items.map(_.name))
-    .assert(_.contains(t"map"))
+// The result of a completion request: `replace` is the source region the chosen
+// completion replaces (an `Offset`-mode `Span`), and `items` the candidates.
+case class Completions(replace: Span, items: List[Completion])

--- a/lib/harlequin/src/core/harlequin.ProgrammingLanguage.scala
+++ b/lib/harlequin/src/core/harlequin.ProgrammingLanguage.scala
@@ -33,6 +33,7 @@
 package harlequin
 
 import anticipation.*
+import denominative.*
 import gossamer.*
 import symbolism.*
 import vacuous.*
@@ -43,8 +44,11 @@ sealed trait ProgrammingLanguage:
   def preprocess(text: Text, context: Optional[Context]): Text = text
   def postprocess(code: SourceCode, context: Optional[Context]): SourceCode = code
 
-  def highlight(text: Text, context: Optional[Context] = Unset)(using Highlight): SourceCode =
-    postprocess(SourceCode(this, preprocess(text, context)), context)
+  def highlight(text: Text, context: Optional[Context] = Unset, caret: Optional[Ordinal] = Unset)
+     (using Highlight)
+  :   SourceCode =
+
+    postprocess(SourceCode(this, preprocess(text, context), caret), context)
 
 object Scala extends ProgrammingLanguage:
   enum Context:

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -65,23 +65,28 @@ object SourceCode:
   private val soft: Set[Text] =
     Set(t"inline", t"opaque", t"open", t"transparent", t"infix", t"update", t"erased", t"tracked")
 
-  def apply(language: ProgrammingLanguage, text: Text)(using highlighting: Highlight)
+  def apply(language: ProgrammingLanguage, text: Text, caret: Optional[Ordinal])
+     (using highlighting: Highlight)
   :   SourceCode =
 
     // For the typechecked/compiled pipelines, run the compiler frontend (and, for
-    // `Compiled`, the post-typer phases) to resolve types and collect diagnostics.
-    // Types are always read from the typer-stopped run, so they stay source-level.
-    val resolved: Optional[(Map[(Int, Int), Syntax], List[Diagnostic])] =
+    // `Compiled`, the post-typer phases) to resolve types, collect diagnostics, and
+    // — when a caret is given — compute completions. Types are always read from the
+    // typer-stopped run, so they stay source-level.
+    val resolved
+    :   Optional[(Map[(Int, Int), Syntax], List[Diagnostic], Optional[Completions])] =
       if highlighting.pipeline == Pipeline.Tokenized then Unset else
         (highlighting.scalac, highlighting.classpath) match
           case (scalac: Scalac[?], classpath: LocalClasspath) =>
-            resolveTypes(text, scalac, classpath, highlighting.pipeline == Pipeline.Compiled)
+            resolveTypes
+             (text, scalac, classpath, highlighting.pipeline == Pipeline.Compiled, caret)
 
           case _ =>
             Unset
 
-    val metaMap: Map[(Int, Int), Syntax] = resolved.let(_(0)).or(Map())
-    val diagnostics: List[Diagnostic] = resolved.let(_(1)).or(Nil)
+    val metaMap: Map[(Int, Int), Syntax] = resolved.lay(Map())(_(0))
+    val diagnostics: List[Diagnostic] = resolved.lay(Nil)(_(1))
+    val completions: Optional[Completions] = resolved.lay(Unset)(_(2))
 
     val source: SourceFile = SourceFile.virtual("<highlighting>", text.s)
     val context0 = Contexts.ContextBase().initialCtx.fresh.setReporter(Reporter.NoReporter)
@@ -170,7 +175,8 @@ object SourceCode:
       tokens.zip(tokens.scanLeft(0)(_ + _.length)).map: (token, column) =>
         token.copy(span = Span.line(index.z, column.z, token.length))
 
-    SourceCode(language, 1, IArray(positioned*), diagnostics = diagnostics)
+    SourceCode
+     (language, 1, IArray(positioned*), diagnostics = diagnostics, completions = completions)
 
   private class Trees() extends ast.untpd.UntypedTreeTraverser:
     import ast.*, untpd.*
@@ -217,8 +223,12 @@ object SourceCode:
     . join(java.io.File.pathSeparator.nn.tt)
 
   private def resolveTypes
-    ( text: Text, scalac: Scalac[?], classpath: LocalClasspath, full: Boolean )
-  :   (Map[(Int, Int), Syntax], List[Diagnostic]) =
+    ( text:      Text,
+      scalac:    Scalac[?],
+      classpath: LocalClasspath,
+      full:      Boolean,
+      caret:     Optional[Ordinal] )
+  :   (Map[(Int, Int), Syntax], List[Diagnostic], Optional[Completions]) =
 
     val cp = classpathText(classpath)
 
@@ -229,6 +239,7 @@ object SourceCode:
         context.setSetting(context.settings.YstopAfter, List("typer"))
 
     val metaMap = collectTypes(typerRun)
+    val completions = caret.let(collectCompletions(typerRun, _))
 
     // `Compiled` runs the post-typer phases (stopping before bytecode generation,
     // so nothing is written to disk) purely to surface later diagnostics.
@@ -239,7 +250,7 @@ object SourceCode:
 
         ._3
 
-    (metaMap, diagnostics)
+    (metaMap, diagnostics, completions)
 
   private def frontend
     ( text: Text, scalac: Scalac[?], cp: Text )
@@ -284,6 +295,36 @@ object SourceCode:
 
   private def syntaxOf(using quotes: scala.quoted.Quotes)(tpe: Types.Type): Syntax =
     Syntax(tpe.asInstanceOf[quotes.reflect.TypeRepr])
+
+  private def completionKind(symbol: Symbols.Symbol)(using Contexts.Context): Completion.Kind =
+    if symbol.is(Flags.Extension) then Completion.Kind.Extension
+    else if symbol.is(Flags.Package) then Completion.Kind.Package
+    else if symbol.is(Flags.Module) then Completion.Kind.Module
+    else if symbol.isType then Completion.Kind.Type
+    else if symbol.is(Flags.Given) then Completion.Kind.Given
+    else if symbol.is(Flags.Method) then Completion.Kind.Method
+    else Completion.Kind.Term
+
+  // Reuse the compiler's interactive completion engine over the typed tree, so we
+  // inherit its full behaviour — direct members, inherited members, extension
+  // methods (all four resolution routes), implicit-conversion members and givens.
+  private def collectCompletions(run: Run, caret: Ordinal): Completions =
+    val unit = run.units.head
+
+    given context: Contexts.Context =
+      dotty.tools.dotc.quoted.QuotesCache.init(run.runContext.fresh.setCompilationUnit(unit))
+
+    given quotes: scala.quoted.Quotes = scala.quoted.runtime.impl.QuotesImpl()(using context)
+
+    val position = SourcePosition(unit.source, Spans.Span(caret.n0))
+    val (offset, raw) = dotty.tools.dotc.interactive.Completion.completions(position)
+
+    val items = raw.flatMap: completion =>
+      completion.symbols.map: symbol =>
+        Completion
+         (completion.label.tt, completionKind(symbol), syntaxOf(symbol.info.widenTermRefExpr))
+
+    Completions(Span.offset(offset.z, 0), items)
 
   private def collectTypes(run: Run): Map[(Int, Int), Syntax] =
     // Use the run's own context: the compilation advanced the compiler's periods,
@@ -340,7 +381,8 @@ case class SourceCode
     offset:      Int,
     lines:       IArray[List[Token]],
     focus:       Optional[Span] = Unset,
-    diagnostics: List[Diagnostic] = Nil ):
+    diagnostics: List[Diagnostic] = Nil,
+    completions: Optional[Completions] = Unset ):
 
   def lastLine: Int = offset + lines.length - 1
   def apply(line: Int): List[Token] = lines(line - offset)

--- a/lib/harlequin/src/core/soundness_harlequin_core.scala
+++ b/lib/harlequin/src/core/soundness_harlequin_core.scala
@@ -32,5 +32,8 @@
                                                                                                   */
 package soundness
 
+// `Completion`/`Completions` are intentionally not re-exported here: those names
+// already belong to `exoskeleton` in the `soundness` namespace. Reach harlequin's
+// via `harlequin.Completion` / `harlequin.Completions`.
 export harlequin.{Accent, Diagnostic, Highlight, Java, Pipeline, ProgrammingLanguage, Scala,
     SourceCode, Token, highlighting}


### PR DESCRIPTION
Harlequin can now return code completions at an optional caret position, computed from the same typechecked run that resolves token types. `highlight`/`SourceCode.apply` take an optional caret offset; when supplied (on the `typecheckedScala`/`compiledScala` pipelines) the typed tree is queried through the compiler's own interactive completion engine, so the results include direct and inherited members, extension methods (all four resolution routes), implicit-conversion members, and givens — nothing is reimplemented. Each completion carries its name, a kind, and the member's signature rendered as a `stenography.Syntax`, and the result records the source `Span` the completion replaces.

## Requesting completions

```scala
import soundness.*
import highlighting.typecheckedScala

given Scalac[3.8] = Scalac[3.8](Nil)
given LocalClasspath = unsafely(System.properties.java.`class`.path().decode[LocalClasspath])

val source = t"val xs = List(1, 2, 3)\nval y = xs.m"

Scala.highlight(source, caret = source.length.z).completions.let: completions =>
  completions.items.each: completion =>
    Out.println(t"${completion.name}: ${completion.signature.qualified}")
```

Each `harlequin.Completion` exposes `name: Text`, `kind` (`Method`, `Extension`, `Given`, `Type`, …), `signature: Syntax`, and optional `documentation`; `Completions` adds the `replace: Span`. Without a caret, `completions` is `Unset`.
