### PR TITLE
Rename the stdlib vector type to `Series`, and Mosquito's `Tensor` to `Vector`

### DIFF
--- a/lib/austronesian/src/core/austronesian.internal.scala
+++ b/lib/austronesian/src/core/austronesian.internal.scala
@@ -105,9 +105,9 @@ object internal:
     // => list[element] is Encodable in Pojo =
     //   list => IArray.from(list.map(_.encode))
 
-    // given trie: [trie <: Trie, element: Encodable in Pojo]
-    // => trie[element] is Encodable in Pojo =
-    //   trie => IArray.from(trie.map(_.encode))
+    // given series: [series <: Series, element: Encodable in Pojo]
+    // => series[element] is Encodable in Pojo =
+    //   series => IArray.from(series.map(_.encode))
 
     given list: [collection <: Iterable, element: Encodable in Pojo]
     =>  collection[element] is Encodable in Pojo =

--- a/lib/austronesian/src/test/austronesian_test.scala
+++ b/lib/austronesian/src/test/austronesian_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 sealed trait Something
 case class Person(name: Text, age: Int) extends Something
 case class Group(persons: List[Person], size: Int) extends Something
-case class Colors(colors: Trie[Color]) extends Something
+case class Colors(colors: Series[Color]) extends Something
 
 enum Color:
   case Red, Green, Blue
@@ -76,7 +76,7 @@ object Tests extends Suite(m"Austronesian tests"):
     // val data = List
     //             (Person(t"Jim", 19),
     //              Group(persons = List(Person(t"Jane", 25), Person(t"John", 30)), size = 2),
-    //              Colors(Trie(Color.Red, Color.Green)))
+    //              Colors(Series(Color.Red, Color.Green)))
 
     // test(m"Roundtrip a complex datatype"):
     //   recover:

--- a/lib/aviation/src/core/aviation.Tzdb.scala
+++ b/lib/aviation/src/core/aviation.Tzdb.scala
@@ -59,7 +59,7 @@ object Tzdb:
         letters: Option[Text] )
 
     case Leap(year: Int, month: Month, day: Int, time: Time, addition: Boolean)
-    case Zone(area: Text, location: Option[Text], info: Trie[ZoneInfo])
+    case Zone(area: Text, location: Option[Text], info: Series[ZoneInfo])
     case Link(from: Text, to: Text)
 
   case class ZoneInfo
@@ -125,10 +125,10 @@ object Tzdb:
       case name :: rest =>
         name.cut(t"/", 2).to(List) match
           case area :: location :: Nil =>
-            Tzdb.Entry.Zone(area, Some(location), Trie(parseZoneInfo(lineNo, rest)))
+            Tzdb.Entry.Zone(area, Some(location), Series(parseZoneInfo(lineNo, rest)))
 
           case simple :: Nil =>
-            Tzdb.Entry.Zone(simple, None, Trie(parseZoneInfo(lineNo, rest)))
+            Tzdb.Entry.Zone(simple, None, Series(parseZoneInfo(lineNo, rest)))
 
           case _ =>
             abort(TzdbError(TzdbError.Reason.BadName(name), lineNo))

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -384,8 +384,8 @@ object Cbor extends Cbor2, Dynamic:
     values => ast(Ast.array(IArray.from(values.map(encodable.encoded(_).root))))
 
 
-  given trieEncodable: [trie <: Trie, element] => (encodable: => element is Encodable in Cbor)
-  =>  trie[element] is Encodable in Cbor =
+  given seriesEncodable: [series <: Series, element] => (encodable: => element is Encodable in Cbor)
+  =>  series[element] is Encodable in Cbor =
 
     values => ast(Ast.array(IArray.from(values.map(encodable.encoded(_).root))))
 

--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposable.scala
@@ -73,12 +73,12 @@ object Decomposable extends Decomposable2:
       Decomposition.Sequence(t"List", list.map(decomposable.decomposition(_)), list)
 
 
-  given trie: [element, collection <: Trie[element]]
+  given series: [element, collection <: Series[element]]
   =>  ( decomposable: => element is Decomposable )
   =>  collection is Decomposable =
 
-    trie =>
-      Decomposition.Sequence(t"Trie", trie.map(decomposable.decomposition(_)).to(List), trie)
+    series =>
+      Decomposition.Sequence(t"Series", series.map(decomposable.decomposition(_)).to(List), series)
 
 
   given iarray: [element]

--- a/lib/dendrology/src/dag/dendrology.DagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.DagDiagram.scala
@@ -42,7 +42,7 @@ import spectacular.*
 
 object DagDiagram:
   def apply[node](dag: Dag[node]): DagDiagram[node] raises DagError =
-    val nodes = dag.sorted.to(Vector)
+    val nodes = dag.sorted.to(Series)
     val indexes: Map[node, Int] = nodes.zipWithIndex.to(Map)
 
     val layout: Array[Array[Int]] = Array.from:

--- a/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LaneDagDiagram.scala
@@ -75,7 +75,7 @@ object LaneDagDiagram:
         case _                            => Space
 
   def apply[node](dag: Dag[node]): LaneDagDiagram[node] raises DagError =
-    val nodes: Vector[node] = dag.sorted.to(Vector)
+    val nodes: Series[node] = dag.sorted.to(Series)
     val total: Int = nodes.length
 
     if total == 0 then LaneDagDiagram(Nil) else
@@ -84,7 +84,7 @@ object LaneDagDiagram:
 
       val nodeCol: Array[Int] = new Array[Int](total)
       val laneState: Array[Map[Int, Lane[node]]] = Array.fill(total + 1)(Map.empty[Int, Lane[node]])
-      val started: Array[Vector[Lane[node]]] = Array.fill(total)(Vector.empty[Lane[node]])
+      val started: Array[Series[Lane[node]]] = Array.fill(total)(Series.empty[Lane[node]])
       val directOut: Array[Boolean] = new Array[Boolean](total)
 
       for r <- 0 until total do
@@ -105,9 +105,9 @@ object LaneDagDiagram:
         nodeCol(r) = chosenCol
 
         val nextNode: Optional[node] = if r + 1 < total then nodes(r + 1) else Unset
-        val targets: Vector[node] = forward.getOrElse(current, Set.empty).to(Vector).sortBy(rowOf)
+        val targets: Series[node] = forward.getOrElse(current, Set.empty).to(Series).sortBy(rowOf)
 
-        val (directs, indirects) = nextNode.lay((Vector.empty[node], targets)): nx =>
+        val (directs, indirects) = nextNode.lay((Series.empty[node], targets)): nx =>
           targets.partition(_ == nx)
 
         directOut(r) = directs.nonEmpty
@@ -162,7 +162,7 @@ object LaneDagDiagram:
 
   private def connectorRow[node]
     ( state:        Map[Int, Lane[node]],
-      justStarted:  Vector[Lane[node]],
+      justStarted:  Series[Lane[node]],
       prevNodeCol:  Int,
       curNodeCol:   Int,
       directEdge:   Boolean,

--- a/lib/dendrology/src/dag/dendrology.LayeredDagDiagram.scala
+++ b/lib/dendrology/src/dag/dendrology.LayeredDagDiagram.scala
@@ -79,7 +79,7 @@ object LayeredDagDiagram:
         case _                            => Space
 
   def apply[node](dag: Dag[node]): LayeredDagDiagram[node] raises DagError =
-    val nodes: Vector[node] = dag.sorted.to(Vector)
+    val nodes: Series[node] = dag.sorted.to(Series)
 
     if nodes.isEmpty then LayeredDagDiagram(Nil) else
       val parents: Map[node, Set[node]] = dag.edgeMap
@@ -93,8 +93,8 @@ object LayeredDagDiagram:
 
       val maxLevel: Int = level.values.max
 
-      val byLevel: Vector[Vector[node]] =
-        (0 to maxLevel).to(Vector).map: l =>
+      val byLevel: Series[Series[node]] =
+        (0 to maxLevel).to(Series).map: l =>
           nodes.filter(level(_) == l)
 
       val state: scm.HashMap[Int, Lane[node]] = scm.HashMap()
@@ -107,14 +107,14 @@ object LayeredDagDiagram:
         val terminating = state.toMap.filter: (_, lane) => level(lane.target) == l
         val continuing = state.toMap -- terminating.keys
 
-        val incomingByNode: Map[node, Vector[Int]] =
+        val incomingByNode: Map[node, Series[Int]] =
           terminating
             . groupBy(_._2.target)
             . map: (n, m) =>
-                n -> m.keys.to(Vector).sorted
+                n -> m.keys.to(Series).sorted
 
         val desired: Map[node, Int] = levelNodes.map: n =>
-          val incoming = incomingByNode.getOrElse(n, Vector.empty)
+          val incoming = incomingByNode.getOrElse(n, Series.empty)
 
           val centre =
             if incoming.nonEmpty then incoming(incoming.length/2)
@@ -143,7 +143,7 @@ object LayeredDagDiagram:
 
         for n <- ordered do
           val outgoing = forward.getOrElse(n, Set.empty).filter(level(_) > l)
-          val sortedOut = outgoing.to(Vector).sortBy(level)
+          val sortedOut = outgoing.to(Series).sortBy(level)
 
           for target <- sortedOut do
             var col = nodeCol(n)

--- a/lib/denominative/src/test/denominative_test.scala
+++ b/lib/denominative/src/test/denominative_test.scala
@@ -327,7 +327,7 @@ object Tests extends Suite(m"Denominative Tests"):
       . assert(_ == 4)
 
       test(m"an indexed sequence's gamut spans all its elements"):
-        val sequence: IndexedSeq[Int] = Vector(1, 2)
+        val sequence: IndexedSeq[Int] = Series(1, 2)
         sequence.gamut.size
       . assert(_ == 2)
 

--- a/lib/dissonance/src/test/dissonance_test.scala
+++ b/lib/dissonance/src/test/dissonance_test.scala
@@ -134,8 +134,8 @@ object Tests extends Suite(m"Dissonance tests"):
         diff(IArray(t"A", t"B"), IArray(t"B", t"C", t"D"))
       . assert(_ == Diff(Del(0, t"A"), Par(1, 0, t"B"), Ins(1, t"C"), Ins(2, t"D")))
 
-    val start = Vector(t"foo", t"bar", t"baz")
-    val end = Vector(t"foo", t"quux", t"bop", t"baz")
+    val start = Series(t"foo", t"bar", t"baz")
+    val end = Series(t"foo", t"quux", t"bop", t"baz")
 
     suite(m"Diff parsing tests"):
       val diffStream = Stream(t"2c2,3", t"< bar", t"---", t"> quux", t"> bop")
@@ -162,15 +162,15 @@ object Tests extends Suite(m"Dissonance tests"):
       val reverseChanges = diff(end, start)
 
       test(m"Serialize a trivial diff"):
-        diff(Vector(), Vector(t"a")).serialize.to(List)
+        diff(Series(), Series(t"a")).serialize.to(List)
       . assert(_ == List(t"0a1", t"> a"))
 
       test(m"Serialize a trivial deletion diff"):
-        diff(Vector(t"a", t"b", t"c", t"d"), Vector(t"a", t"d")).serialize.to(List)
+        diff(Series(t"a", t"b", t"c", t"d"), Series(t"a", t"d")).serialize.to(List)
       . assert(_ == List(t"2,3d1", t"< b", t"< c"))
 
       test(m"Serialize another trivial diff"):
-        diff(Vector(t"a"), Vector()).serialize.to(List)
+        diff(Series(t"a"), Series()).serialize.to(List)
       . assert(_ == List(t"1d0", t"< a"))
 
       test(m"Serialize a simple diff"):
@@ -182,19 +182,19 @@ object Tests extends Suite(m"Dissonance tests"):
       . assert(_ == List(t"2,3c2", t"< quux", t"< bop", t"---", t"> bar"))
 
       test(m"Experimental diff"):
-        diff(Vector(t"one"), Vector(t"two")).serialize.to(List)
+        diff(Series(t"one"), Series(t"two")).serialize.to(List)
       . assert(_ == List(t"1c1", t"< one", t"---", t"> two"))
 
       test(m"Experimental diff 2"):
-        diff(Vector(t"zero", t"one"), Vector(t"two")).serialize.to(List)
+        diff(Series(t"zero", t"one"), Series(t"two")).serialize.to(List)
       . assert(_ == List(t"1,2c1", t"< zero", t"< one", t"---", t"> two"))
 
       test(m"Experimental diff 3"):
-        diff(Vector(t"zero", t"one"), Vector(t"zero", t"two")).serialize.to(List)
+        diff(Series(t"zero", t"one"), Series(t"zero", t"two")).serialize.to(List)
       . assert(_ == List(t"2c2", t"< one", t"---", t"> two"))
 
-    val italian = Vector(t"zero", t"uno", t"due", t"tre", t"quattro", t"cinque", t"sei", t"sette")
-    val spanish = Vector(t"cero", t"uno", t"dos", t"tres", t"cuatro", t"cinco", t"seis", t"siete")
+    val italian = Series(t"zero", t"uno", t"due", t"tre", t"quattro", t"cinque", t"sei", t"sette")
+    val spanish = Series(t"cero", t"uno", t"dos", t"tres", t"cuatro", t"cinco", t"seis", t"siete")
 
     suite(m"Rdiff tests"):
       val italianToSpanish = test(m"Do a normal diff on Italian/Spanish numbers"):
@@ -256,9 +256,9 @@ object Tests extends Suite(m"Dissonance tests"):
         List(Prim, Sec, Ter).map(evolution(_).mkString)
       . assert(_ == List("Jack and Jill", "Jack with Jill", "Jack und Jill"))
 
-    val source = Vector(t"line1", t"line2", t"line3")
-    val dup = Vector(t"a", t"b", t"a")
-    val list = Vector(t"- alpha", t"- beta", t"- gamma")
+    val source = Series(t"line1", t"line2", t"line3")
+    val dup = Series(t"a", t"b", t"a")
+    val list = Series(t"- alpha", t"- beta", t"- gamma")
 
     suite(m"Redraft parsing tests"):
       val roundtrip = Stream(t"line1", t"- line2", t"+ new", t"\\- escaped", t"< forced", t"> add")
@@ -278,36 +278,36 @@ object Tests extends Suite(m"Dissonance tests"):
 
     suite(m"Redraft application tests"):
       test(m"Apply a simple redraft"):
-        Redraft.parse(Stream(t"- line2", t"+ new line 2a")).patch(source).to(Vector)
-      . assert(_ == Vector(t"line1", t"new line 2a", t"line3"))
+        Redraft.parse(Stream(t"- line2", t"+ new line 2a")).patch(source).to(Series)
+      . assert(_ == Series(t"line1", t"new line 2a", t"line3"))
 
       test(m"Omitted unchanged lines are skipped"):
-        Redraft.parse(Stream(t"- line2")).patch(source).to(Vector)
-      . assert(_ == Vector(t"line1", t"line3"))
+        Redraft.parse(Stream(t"- line2")).patch(source).to(Series)
+      . assert(_ == Series(t"line1", t"line3"))
 
       test(m"Insert before the first line"):
-        Redraft.parse(Stream(t"+ line0")).patch(source).to(Vector)
-      . assert(_ == Vector(t"line0", t"line1", t"line2", t"line3"))
+        Redraft.parse(Stream(t"+ line0")).patch(source).to(Series)
+      . assert(_ == Series(t"line0", t"line1", t"line2", t"line3"))
 
       test(m"Forced insert with the alternate marker"):
-        Redraft.parse(Stream(t"> line0")).patch(source).to(Vector)
-      . assert(_ == Vector(t"line0", t"line1", t"line2", t"line3"))
+        Redraft.parse(Stream(t"> line0")).patch(source).to(Series)
+      . assert(_ == Series(t"line0", t"line1", t"line2", t"line3"))
 
       test(m"Deletion anchored by context"):
-        Redraft.parse(Stream(t"b", t"- a")).patch(dup).to(Vector)
-      . assert(_ == Vector(t"a", t"b"))
+        Redraft.parse(Stream(t"b", t"- a")).patch(dup).to(Series)
+      . assert(_ == Series(t"a", t"b"))
 
       test(m"A verbatim marker line is kept as context"):
-        Redraft.parse(Stream(t"- alpha", t"< - beta", t"- gamma")).patch(list).to(Vector)
-      . assert(_ == Vector(t"- alpha", t"- gamma"))
+        Redraft.parse(Stream(t"- alpha", t"< - beta", t"- gamma")).patch(list).to(Series)
+      . assert(_ == Series(t"- alpha", t"- gamma"))
 
       test(m"Escaped context matches a literal marker line"):
-        Redraft.parse(Stream(t"\\- alpha")).patch(list).to(Vector)
-      . assert(_ == Vector(t"- alpha", t"- beta", t"- gamma"))
+        Redraft.parse(Stream(t"\\- alpha")).patch(list).to(Series)
+      . assert(_ == Series(t"- alpha", t"- beta", t"- gamma"))
 
       test(m"Delete a literal marker line with a doubled marker"):
-        Redraft.parse(Stream(t"- alpha", t"- - beta", t"- gamma")).patch(list).to(Vector)
-      . assert(_ == Vector(t"- alpha", t"- gamma"))
+        Redraft.parse(Stream(t"- alpha", t"- - beta", t"- gamma")).patch(list).to(Series)
+      . assert(_ == Series(t"- alpha", t"- gamma"))
 
     suite(m"Redraft ambiguity tests"):
       test(m"An under-anchored deletion is rejected"):
@@ -323,18 +323,18 @@ object Tests extends Suite(m"Dissonance tests"):
       . assert(_.reason == RedraftError.Reason.NoMatch)
 
     suite(m"Redraft rendering tests"):
-      val target = Vector(t"line1", t"new", t"line3")
+      val target = Series(t"line1", t"new", t"line3")
 
       test(m"Render a minimal redraft, dropping all context"):
-        diff(source, Vector(t"line1", t"new line 2a", t"line3")).redraft().serialize.to(List)
+        diff(source, Series(t"line1", t"new line 2a", t"line3")).redraft().serialize.to(List)
       . assert(_ == List(t"- line2", t"+ new line 2a"))
 
       test(m"Render minimal context to anchor an ambiguous deletion"):
-        diff(dup, Vector(t"a", t"b")).redraft().serialize.to(List)
+        diff(dup, Series(t"a", t"b")).redraft().serialize.to(List)
       . assert(_ == List(t"b", t"- a"))
 
       test(m"A rendered redraft reproduces the target when applied"):
-        diff(source, target).redraft().patch(source).to(Vector)
+        diff(source, target).redraft().patch(source).to(Series)
       . assert(_ == target)
 
     // suite(m"Casual diff tests"):
@@ -369,10 +369,10 @@ object Tests extends Suite(m"Dissonance tests"):
     //   def allPermutations(n: Int): List[List[Text]] =
     //     if n == 0 then Nil else permutations(n) ++ allPermutations(n - 1)
 
-    //   allPermutations(3).map(_.to(Vector)).each: perm1 =>
-    //     allPermutations(3).map(_.to(Vector)).each: perm2 =>
+    //   allPermutations(3).map(_.to(Series)).each: perm1 =>
+    //     allPermutations(3).map(_.to(Series)).each: perm2 =>
     //       import unsafeExceptions.canThrowAny
     //       val d = diff(perm1, perm2).casual
     //       test(m"Check differences"):
-    //         d.patch(perm1).to(Vector)
+    //         d.patch(perm1).to(Series)
     //       . assert(_ == perm2)

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -224,7 +224,7 @@ package columnar:
           (0 until count).each: index =>
             result = line.segment((width*index).z span width) :: result
 
-        result.reverse.to(Vector)
+        result.reverse.to(Series)
 
   case class Fixed(fixedWidth: Int, ellipsis: Text = t"…") extends Columnar:
     def width[text: Textual](lines: IArray[text], maxWidth: Int, slack: Double)

--- a/lib/gastronomy/src/core/gastronomy.Digestible.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestible.scala
@@ -73,10 +73,10 @@ object Digestible extends Derivable[Digestible]:
     (digestion, set) => set.each(digestible.digest(digestion, _))
 
 
-  given trie: [trie <: Trie, value] => (digestible: => value is Digestible)
-  =>  trie[value] is Digestible =
+  given series: [series <: Series, value] => (digestible: => value is Digestible)
+  =>  series[value] is Digestible =
 
-    (digestion, trie) => trie.each(digestible.digest(digestion, _))
+    (digestion, series) => series.each(digestible.digest(digestion, _))
 
 
   given iarray: [value] => (digestible: => value is Digestible) => IArray[value] is Digestible =

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -603,8 +603,8 @@ object Json extends Json2, Dynamic:
     values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
 
 
-  given trieEncodable: [trie <: Trie, element] => (encodable: => element is Encodable in Json)
-  =>  trie[element] is Encodable in Json =
+  given seriesEncodable: [series <: Series, element] => (encodable: => element is Encodable in Json)
+  =>  series[element] is Encodable in Json =
 
     values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
 

--- a/lib/mercator/src/test/mercator_test.scala
+++ b/lib/mercator/src/test/mercator_test.scala
@@ -51,9 +51,9 @@ object Tests extends Suite(m"Mercator tests"):
       summon[Identity[Set]].point(1)
     . assert(_ == Set(1))
 
-    test(m"Identity for Vector"):
-      summon[Identity[Vector]].point(1)
-    . assert(_ == Vector(1))
+    test(m"Identity for Series"):
+      summon[Identity[Series]].point(1)
+    . assert(_ == Series(1))
 
     test(m"Identity for Try"):
       summon[Identity[scala.util.Try]].point(1)
@@ -78,10 +78,10 @@ object Tests extends Suite(m"Mercator tests"):
       functor.map(Set(1, 3, 5))(_ + 1)
     . assert(_ == Set(2, 4, 6))
 
-    test(m"Functor for Vector"):
-      val functor = summon[Functor[Vector]]
-      functor.map(Vector(1, 2, 3))(_ + 1)
-    . assert(_ == Vector(2, 3, 4))
+    test(m"Functor for Series"):
+      val functor = summon[Functor[Series]]
+      functor.map(Series(1, 2, 3))(_ + 1)
+    . assert(_ == Series(2, 3, 4))
 
     test(m"Functor for Try"):
       val functor = summon[Functor[scala.util.Try]]
@@ -108,10 +108,10 @@ object Tests extends Suite(m"Mercator tests"):
       monad.flatMap(Set(1, 3, 5)) { v => Set(v + 1) }
     . assert(_ == Set(2, 4, 6))
 
-    test(m"Monad for Vector"):
-      val monad = summon[Monad[Vector]]
-      monad.flatMap(Vector(1, 2, 3)) { v => Vector(v + 1, v + 1) }
-    . assert(_ == Vector(2, 2, 3, 3, 4, 4))
+    test(m"Monad for Series"):
+      val monad = summon[Monad[Series]]
+      monad.flatMap(Series(1, 2, 3)) { v => Series(v + 1, v + 1) }
+    . assert(_ == Series(2, 2, 3, 3, 4, 4))
 
     test(m"Monad for Try"):
       val monad = summon[Monad[scala.util.Try]]
@@ -122,9 +122,9 @@ object Tests extends Suite(m"Mercator tests"):
       List(Try(1), Try(2), Try(3)).sequence
     . assert(_ == Success(List(1, 2, 3)))
 
-    // test(m"Sequence on Vector/Try"):
-    //   Vector(Try(1), Try(2), Try(3)).sequence
-    // .assert(_ == Success(Vector(1, 2, 3)))
+    // test(m"Sequence on Series/Try"):
+    //   Series(Try(1), Try(2), Try(3)).sequence
+    // .assert(_ == Success(Series(1, 2, 3)))
 
     test(m"Sequence on List/Set"):
       List(Set(1), Set(2), Set(3)).sequence

--- a/lib/metamorphose/.github/readme.md
+++ b/lib/metamorphose/.github/readme.md
@@ -44,7 +44,7 @@ import soundness.*
 There are two ways to construct a new `Permutation`. Firstly, from an ordered
 sequence of distinct indexes, for example,
 ```scala
-val permutation = Permutation(Vector(1, 4, 2, 3, 0))
+val permutation = Permutation(Series(1, 4, 2, 3, 0))
 ```
 which interprets the ordering of the indexes to yield the permutation with
 factoradic number 45, i.e. `Permutation(Factoradic(45))`.

--- a/lib/metamorphose/doc/basics.md
+++ b/lib/metamorphose/doc/basics.md
@@ -12,7 +12,7 @@ import soundness.*
 There are two ways to construct a new `Permutation`. Firstly, from an ordered
 sequence of distinct indexes, for example,
 ```scala
-val permutation = Permutation(Vector(1, 4, 2, 3, 0))
+val permutation = Permutation(Series(1, 4, 2, 3, 0))
 ```
 which interprets the ordering of the indexes to yield the permutation with
 factoradic number 45, i.e. `Permutation(Factoradic(45))`.

--- a/lib/metamorphose/src/test/metamorphose_test.scala
+++ b/lib/metamorphose/src/test/metamorphose_test.scala
@@ -100,35 +100,35 @@ object Tests extends Suite(m"Metamorphose tests"):
 
     suite(m"Permutations"):
       test(m"Construct an identity permutation"):
-        Permutation(Vector(0, 1, 2, 3, 4, 5))
+        Permutation(Series(0, 1, 2, 3, 4, 5))
       . assert(_ == Permutation(Factoradic(0)))
 
       test(m"Construct a reversal permutation"):
-        Permutation(Vector(5, 4, 3, 2, 1, 0))
+        Permutation(Series(5, 4, 3, 2, 1, 0))
       . assert(_ == Permutation(Factoradic(719)))
 
       test(m"Reverse a list of numbers"):
-        Permutation(Vector(5, 4, 3, 2, 1, 0))(List("one", "two", "three", "four", "five", "six"))
+        Permutation(Series(5, 4, 3, 2, 1, 0))(List("one", "two", "three", "four", "five", "six"))
       . assert(_ == List("six", "five", "four", "three", "two", "one"))
 
       test(m"Reorder a list of numbers"):
-        Permutation(Vector(3, 1, 4, 2, 0, 5))(List("zero", "one", "two", "three", "four", "five"))
+        Permutation(Series(3, 1, 4, 2, 0, 5))(List("zero", "one", "two", "three", "four", "five"))
       . assert(_ == List("three", "one", "four", "two", "zero", "five"))
 
       test(m"Check duplicate indexes are caught"):
-        capture[PermutationError](Permutation(Vector(3, 1, 4, 2, 3, 5)))
+        capture[PermutationError](Permutation(Series(3, 1, 4, 2, 3, 5)))
       . assert(_ == PermutationError(PermutationError.Reason.DuplicateIndex(3, 4)))
 
       test(m"Check negative indexes are caught"):
-        capture[PermutationError](Permutation(Vector(3, 1, 4, 2, -3, 5)))
+        capture[PermutationError](Permutation(Series(3, 1, 4, 2, -3, 5)))
       . assert(_ == PermutationError(PermutationError.Reason.InvalidIndex(-3, 5)))
 
       test(m"Check high indexes are caught"):
-        capture[PermutationError](Permutation(Vector(3, 1, 4, 6, 0, 5)))
+        capture[PermutationError](Permutation(Series(3, 1, 4, 6, 0, 5)))
       . assert(_ == PermutationError(PermutationError.Reason.InvalidIndex(6, 5)))
 
       test(m"Check input is long enough"):
-        val permutation = Permutation(Vector(3, 1, 4, 2, 0, 5))
+        val permutation = Permutation(Series(3, 1, 4, 2, 0, 5))
         capture[PermutationError](permutation(List(1, 2, 3)))
       . assert(_ == PermutationError(PermutationError.Reason.TooShort(3, 6)))
 
@@ -146,7 +146,7 @@ object Tests extends Suite(m"Metamorphose tests"):
         . assert(_ == list)
 
 
-      val indices = Vector(6, 2, 1, 0, 3, 5, 4)
+      val indices = Series(6, 2, 1, 0, 3, 5, 4)
       val permutation = Permutation(indices)
       for i <- 0 to 6 do
         test(m"Apply permutation indexwise"):

--- a/lib/mosquito/.github/readme.md
+++ b/lib/mosquito/.github/readme.md
@@ -8,11 +8,11 @@ __Typesafe vector algebra__
 
 Euclidean vectors, in contrast to scalars and arbitrary collections, represent
 values in _a fixed multiple_ number of dimensions. _Mosquito_ provides a
-representation of vectors, `Euclidean`, whose generic type encapsulates both
-its element type and size. In some sense, a `Euclidean` can be considered a
+representation of vectors, `Vector`, whose generic type encapsulates both
+its element type and size. In some sense, a `Vector` can be considered a
 hybrid of a `Tuple` (whose size in known) and a collection (whose elements are
 homogeneous). Mosquito supports the use case of _generic programming_ with
-`Euclidean` vectors, but facilitates linear algebra operations, including
+`Vector`s, but facilitates linear algebra operations, including
 working with matrices and scalar and vector products.
 
 ## Features
@@ -43,22 +43,23 @@ import mosquito.*
 
 ### Constructing vectors
 
-A Euclidean vector, primarily to distinguish it from Scala's `Vector`
-collection type, is called `Euclidean`. It represents an ordered, generic
+A Euclidean vector is represented by the type `Vector`. (Soundness exports
+Scala's standard-library vector collection as `Series`, leaving the name `Vector`
+free for this Euclidean vector.) It represents an ordered, generic
 collection of elements whose length is known, and furthermore encoded in its
 type. So a three-dimensional vector of `Double` values would have the type,
-`Euclidean[Double, 3]`.
+`Vector[Double, 3]`.
 
 But since both the element type and the size of a Euclidean vector can be
 inferred from its values, we can create such a vector with just,
 ```scala
-val vector = Euclidean(2.7, -0.3, 0.8)
+val vector = Vector(2.7, -0.3, 0.8)
 ```
-and it's type will be known to be `Euclidean[Double, 3]`.
+and it's type will be known to be `Vector[Double, 3]`.
 
 ### Constructing matrices
 
-A matrix has the type `Matrix`, and like a `Euclidean`, contains homogeneous
+A matrix has the type `Matrix`, and like a `Vector`, contains homogeneous
 elements, and encodes its size in its type. However, a `Matrix`'s size is
 determined by a number of rows and a number of columns. So a 3×4 matrix of
 `Int`s would have the type, `Matrix[Int, 3, 4]`. Conventionally for matrices,
@@ -96,18 +97,18 @@ will be a new vector, of the same dimension, and elements of the type resulting
 from multiplying the original element types by the scalar value.
 
 Often, as for `Double`s, this would be the same type: the product of a
-`Euclidean[Double, 3]` and a `Double` will be another `Euclidean[Double, 3]`.
+`Vector[Double, 3]` and a `Double` will be another `Vector[Double, 3]`.
 But this will not always be the case.
 
 If using [Quantitative](https://github.com/propensive/quantitative/) with
 Mosquito, a vector of values in metres per second, multiplied by a time value,
-would yield a vector distance. Specifically, a `Euclidean[Quantity[Metres[1] &
+would yield a vector distance. Specifically, a `Vector[Quantity[Metres[1] &
 Seconds[-1]]]` multiplied by a `Quantity[Seconds[1]]` would produce a
-`Euclidean[Quantity[Metres[1]]]`.
+`Vector[Quantity[Metres[1]]]`.
 
 #### Dot Products
 
-The extension method `dot` is available for combining two `Euclidean` instances
+The extension method `dot` is available for combining two `Vector` instances
 of equal dimension, and whose scalar elements have a `*` operation defined,
 whose result type has a `+` operation that returns the same type. Although
 slightly complex, these criteria correspond closely to the low-level operations
@@ -121,7 +122,7 @@ value in square metres.
 #### Cross Products
 
 The cross product is only defined for vectors of dimension 3 or 7. Currently,
-_Mosquito_ only provides an implementation for 3-dimensional `Euclidean`
+_Mosquito_ only provides an implementation for 3-dimensional `Vector`
 values, but cross products between 7-dimensional vectors will be provided at a
 later date.
 

--- a/lib/mosquito/doc/basics.md
+++ b/lib/mosquito/doc/basics.md
@@ -7,22 +7,23 @@ import mosquito.*
 
 ### Constructing vectors
 
-A Euclidean vector, primarily to distinguish it from Scala's `Vector`
-collection type, is called `Euclidean`. It represents an ordered, generic
+A Euclidean vector is represented by the type `Vector`. (Soundness exports
+Scala's standard-library vector collection as `Series`, leaving the name `Vector`
+free for this Euclidean vector.) It represents an ordered, generic
 collection of elements whose length is known, and furthermore encoded in its
 type. So a three-dimensional vector of `Double` values would have the type,
-`Euclidean[Double, 3]`.
+`Vector[Double, 3]`.
 
 But since both the element type and the size of a Euclidean vector can be
 inferred from its values, we can create such a vector with just,
 ```scala
-val vector = Euclidean(2.7, -0.3, 0.8)
+val vector = Vector(2.7, -0.3, 0.8)
 ```
-and it's type will be known to be `Euclidean[Double, 3]`.
+and it's type will be known to be `Vector[Double, 3]`.
 
 ### Constructing matrices
 
-A matrix has the type `Matrix`, and like a `Euclidean`, contains homogeneous
+A matrix has the type `Matrix`, and like a `Vector`, contains homogeneous
 elements, and encodes its size in its type. However, a `Matrix`'s size is
 determined by a number of rows and a number of columns. So a 3×4 matrix of
 `Int`s would have the type, `Matrix[Int, 3, 4]`. Conventionally for matrices,
@@ -60,18 +61,18 @@ will be a new vector, of the same dimension, and elements of the type resulting
 from multiplying the original element types by the scalar value.
 
 Often, as for `Double`s, this would be the same type: the product of a
-`Euclidean[Double, 3]` and a `Double` will be another `Euclidean[Double, 3]`.
+`Vector[Double, 3]` and a `Double` will be another `Vector[Double, 3]`.
 But this will not always be the case.
 
 If using [Quantitative](https://github.com/propensive/quantitative/) with
 Mosquito, a vector of values in metres per second, multiplied by a time value,
-would yield a vector distance. Specifically, a `Euclidean[Quantity[Metres[1] &
+would yield a vector distance. Specifically, a `Vector[Quantity[Metres[1] &
 Seconds[-1]]]` multiplied by a `Quantity[Seconds[1]]` would produce a
-`Euclidean[Quantity[Metres[1]]]`.
+`Vector[Quantity[Metres[1]]]`.
 
 #### Dot Products
 
-The extension method `dot` is available for combining two `Euclidean` instances
+The extension method `dot` is available for combining two `Vector` instances
 of equal dimension, and whose scalar elements have a `*` operation defined,
 whose result type has a `+` operation that returns the same type. Although
 slightly complex, these criteria correspond closely to the low-level operations
@@ -85,7 +86,7 @@ value in square metres.
 #### Cross Products
 
 The cross product is only defined for vectors of dimension 3 or 7. Currently,
-_Mosquito_ only provides an implementation for 3-dimensional `Euclidean`
+_Mosquito_ only provides an implementation for 3-dimensional `Vector`
 values, but cross products between 7-dimensional vectors will be provided at a
 later date.
 

--- a/lib/mosquito/doc/intro.md
+++ b/lib/mosquito/doc/intro.md
@@ -1,9 +1,9 @@
 Euclidean vectors, in contrast to scalars and arbitrary collections, represent
 values in _a fixed multiple_ number of dimensions. _Mosquito_ provides a
-representation of vectors, `Euclidean`, whose generic type encapsulates both
-its element type and size. In some sense, a `Euclidean` can be considered a
+representation of vectors, `Vector`, whose generic type encapsulates both
+its element type and size. In some sense, a `Vector` can be considered a
 hybrid of a `Tuple` (whose size in known) and a collection (whose elements are
 homogeneous). Mosquito supports the use case of _generic programming_ with
-`Euclidean` vectors, but facilitates linear algebra operations, including
+`Vector`s, but facilitates linear algebra operations, including
 working with matrices and scalar and vector products.
 

--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -44,7 +44,7 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
-import mosquito.internal.Tensor
+import mosquito.internal.Vector
 
 object Matrix:
   given showable: [element: Showable] => Text is Measurable => Matrix[element, ?, ?] is Showable =
@@ -305,13 +305,13 @@ object Matrix:
       if (row + column) % 2 == 0 then minorValue else zeroic.zero - minorValue
 
 
-    def solve(rhs: Tensor[element, n])
+    def solve(rhs: Vector[element, n])
       ( using zeroic:         element is Zeroic,
               subtraction:    element is Subtractable by element to element,
               multiplication: element is Multiplicable by element to element,
               divisible:      element is Divisible by element to element,
               classTag:       ClassTag[element] )
-    :   Optional[Tensor[element, n]] =
+    :   Optional[Vector[element, n]] =
 
       val size = matrix.rows
       val zero = zeroic.zero
@@ -381,14 +381,14 @@ object Matrix:
           x(i) = sum/a(size*i + i)
           i -= 1
 
-        val tensorData = IArray.build[Any](size): array =>
+        val vectorData = IArray.build[Any](size): array =>
           var k = 0
 
           while k < size do
             array(k) = x(k)
             k += 1
 
-        new Tensor[element, n](tensorData)
+        new Vector[element, n](vectorData)
 
 
     def adjugate
@@ -478,7 +478,7 @@ object Matrix:
 
   extension [n <: Int](matrix: Matrix[Double, n, n])
     def eigensystem(using ValueOf[n])
-    :   Optional[(Tensor[Double, n], Matrix[Double, n, n])] =
+    :   Optional[(Vector[Double, n], Matrix[Double, n, n])] =
 
       val dimension = matrix.rows
       val tolerance = 1.0e-12
@@ -597,12 +597,12 @@ object Matrix:
               array(i) = vec(i)
               i += 1
 
-          val eigvals = new Tensor[Double, n](eigvalArr)
+          val eigvals = new Vector[Double, n](eigvalArr)
           val eigvecs = new Matrix[Double, n, n](dimension, dimension, eigvecArr)
           (eigvals, eigvecs)
 
 
-    def eigenvalues(using ValueOf[n]): Optional[Tensor[Double, n]] =
+    def eigenvalues(using ValueOf[n]): Optional[Vector[Double, n]] =
       matrix.eigensystem.let(_(0))
 
 
@@ -615,7 +615,7 @@ class Matrix[element, rows <: Int, columns <: Int]
 
   def apply(row: Int, column: Int): element = elements(columns*row + column)
 
-  def row(index: Int): Tensor[element, columns] =
+  def row(index: Int): Vector[element, columns] =
     val cols = columns
 
     val arr = IArray.build[Any](cols): array =>
@@ -625,10 +625,10 @@ class Matrix[element, rows <: Int, columns <: Int]
         array(i) = elements(cols*index + i)
         i += 1
 
-    new Tensor[element, columns](arr)
+    new Vector[element, columns](arr)
 
 
-  def column(index: Int): Tensor[element, rows] =
+  def column(index: Int): Vector[element, rows] =
     val arr = IArray.build[Any](rows): array =>
       var i = 0
 
@@ -636,7 +636,7 @@ class Matrix[element, rows <: Int, columns <: Int]
         array(i) = elements(columns*i + index)
         i += 1
 
-    new Tensor[element, rows](arr)
+    new Vector[element, rows](arr)
 
 
   def transpose(using ClassTag[element]): Matrix[element, columns, rows] =
@@ -821,12 +821,12 @@ class Matrix[element, rows <: Int, columns <: Int]
 
   @targetName("mulVec")
   def * [right]
-    ( right: Tensor[right, columns] )
+    ( right: Vector[right, columns] )
     ( using multiplication: element is Multiplicable by right,
             addition:       multiplication.Result is Addable by multiplication.Result,
             equality:       addition.Result =:= multiplication.Result,
             columnValue:    ValueOf[columns] )
-  :   Tensor[multiplication.Result, rows] =
+  :   Vector[multiplication.Result, rows] =
 
     val inner = valueOf[columns]
 
@@ -846,4 +846,4 @@ class Matrix[element, rows <: Int, columns <: Int]
         array(row) = sum
         row += 1
 
-    new Tensor[multiplication.Result, rows](arr)
+    new Vector[multiplication.Result, rows](arr)

--- a/lib/mosquito/src/core/mosquito.internal.scala
+++ b/lib/mosquito/src/core/mosquito.internal.scala
@@ -45,11 +45,11 @@ import symbolism.*
 import vacuous.*
 
 object internal:
-  object Tensor:
-    def apply(tuple: Tuple): Tensor[Tuple.Union[tuple.type], Tuple.Size[tuple.type]] =
-      new Tensor(tuple.toIArray)
+  object Vector:
+    def apply(tuple: Tuple): Vector[Tuple.Union[tuple.type], Tuple.Size[tuple.type]] =
+      new Vector(tuple.toIArray)
 
-    def take[element](list: List[element], size: Int): Optional[Tensor[element, size.type]] =
+    def take[element](list: List[element], size: Int): Optional[Vector[element, size.type]] =
       val array: Array[Any] = new Array(size)
       var i = 0
       var rest = list
@@ -64,23 +64,23 @@ object internal:
             rest = tail
             i += 1
 
-      new Tensor[element, size.type](array.immutable(using Unsafe))
+      new Vector[element, size.type](array.immutable(using Unsafe))
 
 
     given addable
     :   [ value,
           size   <: Int,
-          left   <: Tensor[value, size],
+          left   <: Vector[value, size],
           value2,
-          right  <: Tensor[value2, size],
+          right  <: Vector[value2, size],
           result ]
     =>  ( addable: value is Addable by value2 to result )
     =>  left is Addable:
 
       type Operand = right
-      type Result = Tensor[result, size]
+      type Result = Vector[result, size]
 
-      def add(left: left, right: right): Tensor[result, size] =
+      def add(left: left, right: right): Vector[result, size] =
         val length = left.data.length
 
         val arr = IArray.build[Any](length): array =>
@@ -92,33 +92,33 @@ object internal:
 
             i += 1
 
-        new Tensor[result, size](arr)
+        new Vector[result, size](arr)
 
 
-    given negatable: [value, size <: Int, tensor <: Tensor[value, size], result]
+    given negatable: [value, size <: Int, vector <: Vector[value, size], result]
     =>  ( negatable: value is Negatable to result )
-    =>  tensor is Negatable:
+    =>  vector is Negatable:
 
-      type Result = Tensor[result, size]
+      type Result = Vector[result, size]
 
-      def negate(operand: tensor): Tensor[result, size] = operand.map(negatable.negate(_))
+      def negate(operand: vector): Vector[result, size] = operand.map(negatable.negate(_))
 
 
     given subtractable
     :   [ value,
           size   <: Int,
-          left   <: Tensor[value, size],
+          left   <: Vector[value, size],
           value2,
-          right  <: Tensor[value2, size],
+          right  <: Vector[value2, size],
           result ]
     =>  ( subtractable: value is Subtractable by value2 to result )
     =>  left is Subtractable:
 
       type Self = left
       type Operand = right
-      type Result = Tensor[result, size]
+      type Result = Vector[result, size]
 
-      def subtract(left: left, right: right): Tensor[result, size] =
+      def subtract(left: left, right: right): Vector[result, size] =
         val length = left.data.length
 
         val arr = IArray.build[Any](length): array =>
@@ -131,14 +131,14 @@ object internal:
 
             i += 1
 
-        new Tensor[result, size](arr)
+        new Vector[result, size](arr)
 
 
     given showable: [size <: Int: ValueOf, element: Showable] => Text is Measurable
-    =>  Tensor[element, size] is Showable =
+    =>  Vector[element, size] is Showable =
 
-      tensor =>
-        val items = tensor.list.map(_.show)
+      vector =>
+        val items = vector.list.map(_.show)
         val width = items.maxBy(_.length).length
         val size = valueOf[size]
 
@@ -151,29 +151,29 @@ object internal:
           (top :: middle ::: bottom :: Nil).join(t"\n")
 
 
-  extension [left](left: Tensor[left, 3])
-    def cross[right](right: Tensor[right, 3])
+  extension [left](left: Vector[left, 3])
+    def cross[right](right: Vector[right, 3])
       ( using multiplication: left is Multiplicable by right,
               addition:       multiplication.Result is Addable by multiplication.Result,
               subtraction:    multiplication.Result is Subtractable by multiplication.Result )
-    :   Tensor[addition.Result, 3] =
+    :   Vector[addition.Result, 3] =
 
       val first = left.element(1)*right.element(2) - left.element(2)*right.element(1)
       val second = left.element(2)*right.element(0) - left.element(0)*right.element(2)
       val third = left.element(0)*right.element(1) - left.element(1)*right.element(0)
 
-      new Tensor[addition.Result, 3](IArray[Any](first, second, third))
+      new Vector[addition.Result, 3](IArray[Any](first, second, third))
 
 
-  extension [left](left: Tensor[left, 7])
+  extension [left](left: Vector[left, 7])
     @targetName("cross7")
-    def cross[right](right: Tensor[right, 7])
+    def cross[right](right: Vector[right, 7])
       ( using multiplication: left is Multiplicable by right,
               addition:       multiplication.Result is Addable by multiplication.Result,
               subtraction:    multiplication.Result is Subtractable by multiplication.Result,
               addEq:          addition.Result =:= multiplication.Result,
               subEq:          subtraction.Result =:= multiplication.Result )
-    :   Tensor[addition.Result, 7] =
+    :   Vector[addition.Result, 7] =
 
       val a0 = left.element(0); val a1 = left.element(1); val a2 = left.element(2)
       val a3 = left.element(3); val a4 = left.element(4); val a5 = left.element(5)
@@ -205,10 +205,10 @@ object internal:
       val c5 = combine(a6*b1, a1*b6, a0*b4, a4*b0, a2*b3, a3*b2)
       val c6 = combine(a0*b2, a2*b0, a1*b5, a5*b1, a3*b4, a4*b3)
 
-      new Tensor[addition.Result, 7](IArray[Any](c0, c1, c2, c3, c4, c5, c6))
+      new Vector[addition.Result, 7](IArray[Any](c0, c1, c2, c3, c4, c5, c6))
 
 
-  extension [size <: Int, left](left: Tensor[left, size])
+  extension [size <: Int, left](left: Vector[left, size])
     def element(index: Int): left = left.data(index).asInstanceOf[left]
 
     def apply(index: Int): left = left.data(index).asInstanceOf[left]
@@ -232,7 +232,7 @@ object internal:
       recur(left.element(0)*left.element(0), left.data.length - 1)
 
 
-    def map[left2](fn: left => left2): Tensor[left2, size] =
+    def map[left2](fn: left => left2): Vector[left2, size] =
       val length = left.data.length
 
       val arr = IArray.build[Any](length): array =>
@@ -242,7 +242,7 @@ object internal:
           array(i) = fn(left.data(i).asInstanceOf[left])
           i += 1
 
-      new Tensor[left2, size](arr)
+      new Vector[left2, size](arr)
 
 
     def unitary[square]
@@ -250,7 +250,7 @@ object internal:
               addable:       square is Addable by square to square,
               rootable:      square is Rootable[2] to left,
               divisible:     left is Divisible by left to Double )
-    :   Tensor[Double, size] =
+    :   Vector[Double, size] =
 
       val magnitude: left = left.norm
       val length = left.data.length
@@ -262,10 +262,10 @@ object internal:
           array(i) = left.data(i).asInstanceOf[left]/magnitude
           i += 1
 
-      new Tensor[Double, size](arr)
+      new Vector[Double, size](arr)
 
 
-    def dot[right](right: Tensor[right, size])
+    def dot[right](right: Vector[right, size])
       ( using multiply: left is Multiplicable by right,
               size:     ValueOf[size],
               addable:  multiply.Result is Addable by multiply.Result,
@@ -279,12 +279,12 @@ object internal:
       val start = size.value - 1
       recur(start - 1, left.element(start)*right.element(start))
 
-  class Tensor[value, size <: Int](val data: IArray[Any]):
+  class Vector[value, size <: Int](val data: IArray[Any]):
     override def equals(right: Any): Boolean = right.asMatchable match
-      case that: Tensor[?, ?] => data.sameElements(that.data)
+      case that: Vector[?, ?] => data.sameElements(that.data)
       case _                  => false
 
     override def hashCode: Int =
       scala.util.hashing.MurmurHash3.arrayHash(data.mutable(using Unsafe))
 
-    override def toString: String = data.mkString("Tensor(", ", ", ")")
+    override def toString: String = data.mkString("Vector(", ", ", ")")

--- a/lib/mosquito/src/core/mosquito_core.scala
+++ b/lib/mosquito/src/core/mosquito_core.scala
@@ -34,9 +34,9 @@ package mosquito
 
 import vacuous.*
 
-export mosquito.internal.Tensor
+export mosquito.internal.Vector
 
 extension [element](list: List[element])
-  def slide(size: Int): Stream[Tensor[element, size.type]] = list match
+  def slide(size: Int): Stream[Vector[element, size.type]] = list match
     case Nil          => Stream()
-    case head :: tail => Tensor.take(list, size).lay(Stream())(_ #:: tail.slide(size))
+    case head :: tail => Vector.take(list, size).lay(Stream())(_ #:: tail.slide(size))

--- a/lib/mosquito/src/core/soundness_mosquito_core.scala
+++ b/lib/mosquito/src/core/soundness_mosquito_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export mosquito.{Matrix, slide, Tensor}
+export mosquito.{Matrix, slide, Vector}

--- a/lib/mosquito/src/test/mosquito_test.scala
+++ b/lib/mosquito/src/test/mosquito_test.scala
@@ -39,173 +39,173 @@ given Decimalizer(4)
 
 object Tests extends Suite(m"Mosquito tests"):
   def run(): Unit =
-    test(m"Create a Tensor of Ints"):
-      Tensor(1, 2, 3)
-    . assert(_ == Tensor(1, 2, 3))
+    test(m"Create a Vector of Ints"):
+      Vector(1, 2, 3)
+    . assert(_ == Vector(1, 2, 3))
 
-    test(m"A Tensor of Ints infers the correct size"):
+    test(m"A Vector of Ints infers the correct size"):
       demilitarize:
-        val tensor: Tensor[Int, 3] = Tensor(1, 3, 4)
+        val vector: Vector[Int, 3] = Vector(1, 3, 4)
       .map(_.message)
     . assert(_ == Nil)
 
     test(m"Type error if size is incorrect"):
       demilitarize:
-        val tensor: Tensor[Int, 2] = Tensor(1, 3, 4)
+        val vector: Vector[Int, 2] = Vector(1, 3, 4)
     . assert(_.nonEmpty)
 
     test(m"Type error if type is incorrect"):
       demilitarize:
-        val tensor: Tensor[String, 3] = Tensor(1, 3, 4)
+        val vector: Vector[String, 3] = Vector(1, 3, 4)
     . assert(_.nonEmpty)
 
     test(m"Calculate integer dot-product"):
-      Tensor(1, 2, 3).dot(Tensor(4, 3, 7))
+      Vector(1, 2, 3).dot(Vector(4, 3, 7))
     . assert(_ == 31)
 
     test(m"Calculate Double dot-product"):
-      Tensor(0.1, 0.2, 0.3).dot(Tensor(0.4, 0.3, 0.7))
+      Vector(0.1, 0.2, 0.3).dot(Vector(0.4, 0.3, 0.7))
     . assert(_ === 0.31 +/- 0.000001)
 
     test(m"Calculate integer cross-product"):
-      Tensor(1, 2, 3).cross(Tensor(4, 3, 7))
-    . assert(_ == Tensor(5, 5, -5))
+      Vector(1, 2, 3).cross(Vector(4, 3, 7))
+    . assert(_ == Vector(5, 5, -5))
 
     test(m"Calculate Double cross-product"):
-      Tensor(1.4, 2.4, 3.8).cross(Tensor(4.9, 3.6, 0.7))
-    . assert(_ == Tensor(-12.0, 17.64, -6.72))
+      Vector(1.4, 2.4, 3.8).cross(Vector(4.9, 3.6, 0.7))
+    . assert(_ == Vector(-12.0, 17.64, -6.72))
 
-    test(m"Show Tensor 3-tensor"):
-      Tensor(1, 3, 6).show
+    test(m"Show Vector 3-vector"):
+      Vector(1, 3, 6).show
     . assert(_ == t"\u239b 1 \u239e\n\u239c 3 \u239f\n\u239d 6 \u23a0")
 
-    test(m"Show Tensor 1-tensor"):
-      Tensor(Mono(42)).show
+    test(m"Show Vector 1-vector"):
+      Vector(Mono(42)).show
     . assert(_ == t"( 42 )")
 
-    test(m"Show Tensor 2-tensor"):
-      Tensor(1, 2).show
+    test(m"Show Vector 2-vector"):
+      Vector(1, 2).show
     . assert(_ == t"\u239b 1 \u239e\n\u239d 2 \u23a0")
 
     test(m"Add two tensors"):
-      Tensor(1, 2, 3) + Tensor(3, 4, 5)
-    . assert(_ == Tensor(4, 6, 8))
+      Vector(1, 2, 3) + Vector(3, 4, 5)
+    . assert(_ == Vector(4, 6, 8))
 
     test(m"Subtract two tensors"):
-      Tensor(5, 7, 9) - Tensor(1, 2, 3)
-    . assert(_ == Tensor(4, 5, 6))
+      Vector(5, 7, 9) - Vector(1, 2, 3)
+    . assert(_ == Vector(4, 5, 6))
 
-    test(m"Negate a tensor"):
-      -Tensor(1, -2, 3)
-    . assert(_ == Tensor(-1, 2, -3))
+    test(m"Negate a vector"):
+      -Vector(1, -2, 3)
+    . assert(_ == Vector(-1, 2, -3))
 
     suite(m"Element access and conversions"):
-      test(m"element(0) on a 3-tensor"):
-        Tensor(10, 20, 30).element(0)
+      test(m"element(0) on a 3-vector"):
+        Vector(10, 20, 30).element(0)
       . assert(_ == 10)
 
-      test(m"element(1) on a 3-tensor"):
-        Tensor(10, 20, 30).element(1)
+      test(m"element(1) on a 3-vector"):
+        Vector(10, 20, 30).element(1)
       . assert(_ == 20)
 
-      test(m"element(2) on a 3-tensor"):
-        Tensor(10, 20, 30).element(2)
+      test(m"element(2) on a 3-vector"):
+        Vector(10, 20, 30).element(2)
       . assert(_ == 30)
 
       test(m"apply(i) accessor matches element(i)"):
-        Tensor(10, 20, 30)(1)
+        Vector(10, 20, 30)(1)
       . assert(_ == 20)
 
       test(m"list conversion"):
-        Tensor(1, 2, 3).list
+        Vector(1, 2, 3).list
       . assert(_ == List(1, 2, 3))
 
       test(m"iarray conversion"):
-        Tensor("a", "b", "c").iarray.toList
+        Vector("a", "b", "c").iarray.toList
       . assert(_ == List("a", "b", "c"))
 
-      test(m"size of a 4-tensor"):
-        Tensor(1, 2, 3, 4).size
+      test(m"size of a 4-vector"):
+        Vector(1, 2, 3, 4).size
       . assert(_ == 4)
 
     suite(m"Map operations"):
       test(m"Map increment over Ints"):
-        Tensor(1, 2, 3).map(_ + 1)
-      . assert(_ == Tensor(2, 3, 4))
+        Vector(1, 2, 3).map(_ + 1)
+      . assert(_ == Vector(2, 3, 4))
 
       test(m"Map type-changing (Int to String)"):
-        Tensor(1, 2, 3).map(_.toString)
-      . assert(_ == Tensor("1", "2", "3"))
+        Vector(1, 2, 3).map(_.toString)
+      . assert(_ == Vector("1", "2", "3"))
 
     suite(m"Vector magnitude operations"):
       test(m"Norm of a 3-4 right triangle"):
-        Tensor(3.0, 4.0).norm
+        Vector(3.0, 4.0).norm
       . assert(_ === 5.0 +/- 0.000001)
 
       test(m"Norm of a 2-3-6 vector"):
-        Tensor(2.0, 3.0, 6.0).norm
+        Vector(2.0, 3.0, 6.0).norm
       . assert(_ === 7.0 +/- 0.000001)
 
       test(m"Unitary of a 3-4 vector x-component"):
-        Tensor(3.0, 4.0).unitary.element(0)
+        Vector(3.0, 4.0).unitary.element(0)
       . assert(_ === 0.6 +/- 0.000001)
 
       test(m"Unitary of a 3-4 vector y-component"):
-        Tensor(3.0, 4.0).unitary.element(1)
+        Vector(3.0, 4.0).unitary.element(1)
       . assert(_ === 0.8 +/- 0.000001)
 
-    suite(m"Tensor.take and List.slide"):
-      test(m"Tensor.take takes the first N elements"):
-        Tensor.take(List(1, 2, 3), 3)
-      . assert(_ == Tensor(1, 2, 3))
+    suite(m"Vector.take and List.slide"):
+      test(m"Vector.take takes the first N elements"):
+        Vector.take(List(1, 2, 3), 3)
+      . assert(_ == Vector(1, 2, 3))
 
-      test(m"Tensor.take returns Unset when list is too short"):
-        Tensor.take(List(1, 2), 3)
+      test(m"Vector.take returns Unset when list is too short"):
+        Vector.take(List(1, 2), 3)
       . assert(_ == Unset)
 
-      test(m"Tensor.take of size 0 with empty list is defined"):
-        Tensor.take(Nil: List[Int], 0)
+      test(m"Vector.take of size 0 with empty list is defined"):
+        Vector.take(Nil: List[Int], 0)
       . assert(_ != Unset)
 
       test(m"List.slide produces a stream of 2-tensors"):
         List(1, 2, 3, 4).slide(2).to(List)
-      . assert(_ == List(Tensor(1, 2), Tensor(2, 3), Tensor(3, 4)))
+      . assert(_ == List(Vector(1, 2), Vector(2, 3), Vector(3, 4)))
 
     suite(m"Tensors of various sizes"):
-      test(m"1-tensor list"):
-        Tensor(Mono(42)).list
+      test(m"1-vector list"):
+        Vector(Mono(42)).list
       . assert(_ == List(42))
 
-      test(m"2-tensor list"):
-        Tensor(1, 2).list
+      test(m"2-vector list"):
+        Vector(1, 2).list
       . assert(_ == List(1, 2))
 
-      test(m"4-tensor list"):
-        Tensor(1, 2, 3, 4).list
+      test(m"4-vector list"):
+        Vector(1, 2, 3, 4).list
       . assert(_ == List(1, 2, 3, 4))
 
-      test(m"5-tensor element access"):
-        Tensor(10, 20, 30, 40, 50).element(4)
+      test(m"5-vector element access"):
+        Vector(10, 20, 30, 40, 50).element(4)
       . assert(_ == 50)
 
-      test(m"5-tensor size"):
-        Tensor(10, 20, 30, 40, 50).size
+      test(m"5-vector size"):
+        Vector(10, 20, 30, 40, 50).size
       . assert(_ == 5)
 
-      test(m"4-tensor iarray length"):
-        Tensor("a", "b", "c", "d").iarray.length
+      test(m"4-vector iarray length"):
+        Vector("a", "b", "c", "d").iarray.length
       . assert(_ == 4)
 
     suite(m"Vector identities"):
-      val a = Tensor(1, 2, 3)
-      val b = Tensor(4, 5, 6)
+      val a = Vector(1, 2, 3)
+      val b = Vector(4, 5, 6)
 
       test(m"Cross product is anti-commutative"):
         a.cross(b)
       . assert(_ == -b.cross(a))
 
       test(m"Dot product of orthogonal unit vectors is zero"):
-        Tensor(1, 0, 0).dot(Tensor(0, 1, 0))
+        Vector(1, 0, 0).dot(Vector(0, 1, 0))
       . assert(_ == 0)
 
       test(m"Dot product is commutative"):
@@ -214,16 +214,16 @@ object Tests extends Suite(m"Mosquito tests"):
 
     suite(m"Quantity operations"):
       test(m"Add two quantity tensors"):
-        Tensor(1.0*Metre, 2.0*Metre, 3.0*Metre) + Tensor(3.0*Metre, 4.0*Metre, 5.0*Metre)
-      . assert(_ == Tensor(4.0*Metre, 6.0*Metre, 8.0*Metre))
+        Vector(1.0*Metre, 2.0*Metre, 3.0*Metre) + Vector(3.0*Metre, 4.0*Metre, 5.0*Metre)
+      . assert(_ == Vector(4.0*Metre, 6.0*Metre, 8.0*Metre))
 
       test(m"Add two mixed-quantity tensors"):
-        Tensor(1.0*Foot, 1.0*Foot, 1.0*Foot) + Tensor(3.0*Metre, 4.0*Metre, 5.0*Metre)
-      . assert(_ == Tensor(3.3048*Metre, 4.3048*Metre, 5.3048*Metre))
+        Vector(1.0*Foot, 1.0*Foot, 1.0*Foot) + Vector(3.0*Metre, 4.0*Metre, 5.0*Metre)
+      . assert(_ == Vector(3.3048*Metre, 4.3048*Metre, 5.3048*Metre))
 
       test(m"Map from m to m²"):
-        Tensor(1.0*Metre, 2.0*Metre, 3.0*Metre, 4.0*Metre).map(_*Metre)
-      . assert(_ == Tensor(1.0*Metre*Metre, 2.0*Metre*Metre, 3.0*Metre*Metre, 4.0*Metre*Metre))
+        Vector(1.0*Metre, 2.0*Metre, 3.0*Metre, 4.0*Metre).map(_*Metre)
+      . assert(_ == Vector(1.0*Metre*Metre, 2.0*Metre*Metre, 3.0*Metre*Metre, 4.0*Metre*Metre))
 
     suite(m"Matrix tests"):
       val m1 = Matrix[2, 3]((1, 2, 3), (4, 5, 6))
@@ -337,12 +337,12 @@ object Tests extends Suite(m"Mosquito tests"):
       . assert(_.nonEmpty)
 
     suite(m"Seven-dimensional cross product"):
-      val a7 = Tensor(1, 2, 3, 4, 5, 6, 7)
-      val b7 = Tensor(2, 1, 4, 3, 6, 5, 0)
+      val a7 = Vector(1, 2, 3, 4, 5, 6, 7)
+      val b7 = Vector(2, 1, 4, 3, 6, 5, 0)
 
       test(m"e0 cross e1 = e3"):
-        Tensor(1, 0, 0, 0, 0, 0, 0).cross(Tensor(0, 1, 0, 0, 0, 0, 0))
-      . assert(_ == Tensor(0, 0, 0, 1, 0, 0, 0))
+        Vector(1, 0, 0, 0, 0, 0, 0).cross(Vector(0, 1, 0, 0, 0, 0, 0))
+      . assert(_ == Vector(0, 0, 0, 1, 0, 0, 0))
 
       test(m"7D cross product is anti-commutative"):
         a7.cross(b7)
@@ -350,7 +350,7 @@ object Tests extends Suite(m"Mosquito tests"):
 
       test(m"7D cross of vector with itself is zero"):
         a7.cross(a7)
-      . assert(_ == Tensor(0, 0, 0, 0, 0, 0, 0))
+      . assert(_ == Vector(0, 0, 0, 0, 0, 0, 0))
 
       test(m"7D cross product is orthogonal to first operand"):
         a7.dot(a7.cross(b7))
@@ -361,8 +361,8 @@ object Tests extends Suite(m"Mosquito tests"):
       . assert(_ == 0)
 
       test(m"7D Pythagorean identity |a x b|^2 = |a|^2 |b|^2 - (a.b)^2"):
-        val ad = Tensor(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
-        val bd = Tensor(2.0, 1.0, 4.0, 3.0, 6.0, 5.0, 0.0)
+        val ad = Vector(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0)
+        val bd = Vector(2.0, 1.0, 4.0, 3.0, 6.0, 5.0, 0.0)
         val cross = ad.cross(bd)
         val crossNormSquared = cross.dot(cross)
         val aDotA = ad.dot(ad)
@@ -371,33 +371,33 @@ object Tests extends Suite(m"Mosquito tests"):
         crossNormSquared - (aDotA*bDotB - aDotB*aDotB)
       . assert(d => math.abs(d) < 0.000001)
 
-      test(m"Type error if cross called on 4-tensor"):
+      test(m"Type error if cross called on 4-vector"):
         demilitarize:
-          Tensor(1, 2, 3, 4).cross(Tensor(5, 6, 7, 8))
+          Vector(1, 2, 3, 4).cross(Vector(5, 6, 7, 8))
       . assert(_.nonEmpty)
 
     suite(m"Interesting types"):
-      test(m"Dot product of a tensor of quantities"):
-        val v1 = Tensor(5*Inch, 2*Inch, Inch)
-        val v2 = Tensor(2*Inch, 3*Inch, 6*Inch)
+      test(m"Dot product of a vector of quantities"):
+        val v1 = Vector(5*Inch, 2*Inch, Inch)
+        val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
         v1.dot(v2)
       . assert(_ == 22*Inch*Inch)
 
-      test(m"Cross product of a tensor of quantities"):
-        val v1 = Tensor(5*Inch, 2*Inch, Inch)
-        val v2 = Tensor(2*Inch, 3*Inch, 6*Inch)
+      test(m"Cross product of a vector of quantities"):
+        val v1 = Vector(5*Inch, 2*Inch, Inch)
+        val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
         v1.cross(v2)
-      . assert(_ == Tensor(9*Inch, -28*Inch, 11*Inch))
+      . assert(_ == Vector(9*Inch, -28*Inch, 11*Inch))
 
       test(m"Sum of two tensors of quantities"):
-        val v1 = Tensor(5*Inch, 2*Inch, Inch)
-        val v2 = Tensor(2*Inch, 3*Inch, 6*Inch)
+        val v1 = Vector(5*Inch, 2*Inch, Inch)
+        val v2 = Vector(2*Inch, 3*Inch, 6*Inch)
         v1 + v2
-      . assert(_ == Tensor(7*Inch, 5*Inch, 7*Inch))
+      . assert(_ == Vector(7*Inch, 5*Inch, 7*Inch))
 
       test(m"Sum of two tensors of different quantities"):
-        val v1 = Tensor(5*Inch, 2*Inch, Inch)
-        val v2 = Tensor(2*Metre, 3*Metre, 6*Metre)
+        val v1 = Vector(5*Inch, 2*Inch, Inch)
+        val v2 = Vector(2*Metre, 3*Metre, 6*Metre)
 
         val sum = v1 + v1
       . assert()
@@ -407,19 +407,19 @@ object Tests extends Suite(m"Mosquito tests"):
 
       test(m"row(0) of a 2x3 matrix"):
         mat.row(0)
-      . assert(_ == Tensor(1, 2, 3))
+      . assert(_ == Vector(1, 2, 3))
 
       test(m"row(1) of a 2x3 matrix"):
         mat.row(1)
-      . assert(_ == Tensor(4, 5, 6))
+      . assert(_ == Vector(4, 5, 6))
 
       test(m"column(0) of a 2x3 matrix"):
         mat.column(0)
-      . assert(_ == Tensor(1, 4))
+      . assert(_ == Vector(1, 4))
 
       test(m"column(2) of a 2x3 matrix"):
         mat.column(2)
-      . assert(_ == Tensor(3, 6))
+      . assert(_ == Vector(3, 6))
 
       test(m"row size matches column count"):
         mat.row(0).size
@@ -515,12 +515,12 @@ object Tests extends Suite(m"Mosquito tests"):
 
     suite(m"Matrix-vector multiplication"):
       test(m"2x3 matrix times 3-vector"):
-        Matrix[2, 3]((1, 2, 3), (4, 5, 6))*Tensor(7, 8, 9)
-      . assert(_ == Tensor(50, 122))
+        Matrix[2, 3]((1, 2, 3), (4, 5, 6))*Vector(7, 8, 9)
+      . assert(_ == Vector(50, 122))
 
       test(m"Identity matrix times vector is the vector"):
-        Matrix.identity[Int, 3]*Tensor(2, 3, 5)
-      . assert(_ == Tensor(2, 3, 5))
+        Matrix.identity[Int, 3]*Vector(2, 3, 5)
+      . assert(_ == Vector(2, 3, 5))
 
     suite(m"Identity and zero constructors"):
       test(m"Identity 3x3 of Int"):
@@ -646,38 +646,38 @@ object Tests extends Suite(m"Mosquito tests"):
     suite(m"Solve linear system"):
       test(m"Solve 2x2 system"):
         val mat = Matrix[2, 2]((2.0, 1.0), (1.0, 3.0))
-        val rhs = Tensor(3.0, 4.0)
+        val rhs = Vector(3.0, 4.0)
         val solution = mat.solve(rhs).vouch
         math.abs(solution(0) - 1.0) + math.abs(solution(1) - 1.0)
       . assert(_ < 0.000001)
 
       test(m"Solve identity system returns RHS"):
-        val solution = Matrix.identity[Double, 3].solve(Tensor(7.0, 8.0, 9.0)).vouch
+        val solution = Matrix.identity[Double, 3].solve(Vector(7.0, 8.0, 9.0)).vouch
         solution
-      . assert(_ == Tensor(7.0, 8.0, 9.0))
+      . assert(_ == Vector(7.0, 8.0, 9.0))
 
       test(m"Solve 3x3 system"):
         val mat = Matrix[3, 3]((1.0, 1.0, 1.0), (0.0, 2.0, 5.0), (2.0, 5.0, -1.0))
-        val rhs = Tensor(6.0, -4.0, 27.0)
+        val rhs = Vector(6.0, -4.0, 27.0)
         val solution = mat.solve(rhs).vouch
-        val expected = Tensor(5.0, 3.0, -2.0)
+        val expected = Vector(5.0, 3.0, -2.0)
         (0 until 3).map(i => math.abs(solution(i) - expected(i))).max
       . assert(_ < 0.000001)
 
       test(m"Solve verifies A * x = b"):
         val mat = Matrix[3, 3]((4.0, 1.0, 2.0), (1.0, 5.0, 3.0), (2.0, 3.0, 6.0))
-        val rhs = Tensor(7.0, 8.0, 9.0)
+        val rhs = Vector(7.0, 8.0, 9.0)
         val solution = mat.solve(rhs).vouch
         val recovered = mat*solution
         (0 until 3).map(i => math.abs(recovered(i) - rhs(i))).max
       . assert(_ < 0.000001)
 
       test(m"Solve singular system returns Unset"):
-        Matrix[2, 2]((1.0, 2.0), (2.0, 4.0)).solve(Tensor(3.0, 6.0))
+        Matrix[2, 2]((1.0, 2.0), (2.0, 4.0)).solve(Vector(3.0, 6.0))
       . assert(_ == Unset)
 
       test(m"Solve requires row swap (zero in pivot)"):
         val mat = Matrix[2, 2]((0.0, 1.0), (1.0, 0.0))
-        val solution = mat.solve(Tensor(2.0, 3.0)).vouch
+        val solution = mat.solve(Vector(2.0, 3.0)).vouch
         math.abs(solution(0) - 3.0) + math.abs(solution(1) - 2.0)
       . assert(_ < 0.000001)

--- a/lib/panopticon/src/core/panopticon.Optical.scala
+++ b/lib/panopticon/src/core/panopticon.Optical.scala
@@ -46,7 +46,7 @@ object Optical:
         if origin.length > ordinal.n0 then origin.updated(ordinal.n0, lambda(origin(ordinal.n0)))
         else origin
 
-  given ordinalVector: [element] => Ordinal is Optical from Vector[element] onto element =
+  given ordinalSeries: [element] => Ordinal is Optical from Series[element] onto element =
     ordinal =>
       Optic: (origin, lambda) =>
         if origin.length > ordinal.n0 then origin.updated(ordinal.n0, lambda(origin(ordinal.n0)))

--- a/lib/panopticon/src/test/panopticon_test.scala
+++ b/lib/panopticon/src/test/panopticon_test.scala
@@ -229,10 +229,10 @@ object Tests extends Suite(m"Panopticon tests"):
       ( r.depts.head.lead.name, r.depts.head.lead.age, r.depts.head.lead.role.name )
     . assert(_ == ("Renamed", 99, "Boss"))
 
-    case class Bag(items: Vector[Int])
-    test(m"ordinal optic on a Vector field"):
-      Bag(Vector(1, 2, 3)).lens(_.items(Sec) = 9)
-    . assert(_ == Bag(Vector(1, 9, 3)))
+    case class Bag(items: Series[Int])
+    test(m"ordinal optic on a Series field"):
+      Bag(Series(1, 2, 3)).lens(_.items(Sec) = 9)
+    . assert(_ == Bag(Series(1, 9, 3)))
 
     case class Crew(members: Seq[Text])
     test(m"ordinal optic on a Seq field"):

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -485,7 +485,7 @@ object Tests extends Suite(m"Parasite tests"):
         test(m"Race returns first completed result"):
           val gate = Promise[Unit]()
           val winner = Promise[Unit]()
-          val tasks = Vector(
+          val tasks = Series(
             async { winner.await(); t"first" },
             async { gate.await(); t"second" },
             async { gate.await(); t"third" } )
@@ -986,7 +986,7 @@ object Tests extends Suite(m"Parasite tests"):
           val later = async:
             snooze(1.0*Second)
             -1
-          val result = async(Vector(ready, later).race()).await()
+          val result = async(Series(ready, later).race()).await()
           later.cancel()
           result
         . assert(_ == 99)
@@ -1085,7 +1085,7 @@ object Tests extends Suite(m"Parasite tests"):
       suite(m"Race extension"):
         test(m"Race propagates result of fastest"):
           val gate = Promise[Unit]()
-          val tasks = Vector(
+          val tasks = Series(
             async:
               snooze(200.0*Milli(Second))
               t"slow",
@@ -1107,7 +1107,7 @@ object Tests extends Suite(m"Parasite tests"):
           val winner = async:
             winnerGate.await()
             t"winner"
-          val tasks = Vector(winner, loser)
+          val tasks = Series(winner, loser)
           val raceTask = async(tasks.race())
           winnerGate.fulfill(())
           raceTask.await()

--- a/lib/proscenium/src/core/proscenium_core.scala
+++ b/lib/proscenium/src/core/proscenium_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package proscenium
 
-export scala.collection.immutable.Vector as Trie
+export scala.collection.immutable.Vector as Series
 export Predef.runtimeChecked as absolve
 export scala.reflect.{ClassTag, Typeable}
 export scala.collection.immutable.{Set, List, ListMap, Map, TreeSet, TreeMap}

--- a/lib/proscenium/src/core/soundness_proscenium_core.scala
+++ b/lib/proscenium/src/core/soundness_proscenium_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export scala.collection.immutable.Vector as Trie
+export scala.collection.immutable.Vector as Series
 export Predef.runtimeChecked as absolve
 export scala.reflect.{ClassTag, Typeable}
 export scala.collection.immutable.{List, ListMap, Map, Set, TreeMap, TreeSet}

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -60,8 +60,8 @@ object Tests extends Suite(m"Rudiments Tests"):
         List(1, 2, 3).has(4)
       . assert(_ == false)
 
-      test(m"Vector[Int] has is membership, not index validity"):
-        Vector(10, 20, 30).has(2)
+      test(m"Series[Int] has is membership, not index validity"):
+        Series(10, 20, 30).has(2)
       . assert(_ == false)
 
       test(m"Range has is membership, not index validity"):

--- a/lib/savagery/src/core/savagery.Delta.scala
+++ b/lib/savagery/src/core/savagery.Delta.scala
@@ -42,7 +42,7 @@ import spectacular.*
 import symbolism.*
 
 object Delta:
-  def apply(dx: Float, dy: Float): Delta = Delta(Tensor((dx, dy)))
+  def apply(dx: Float, dy: Float): Delta = Delta(Vector((dx, dy)))
 
   given showable: Delta is Showable = delta =>
     t"${delta.dx.toString} ${delta.dy.toString}"
@@ -74,9 +74,9 @@ object Delta:
   given multiplicableByInt: Delta is Multiplicable by Int to Delta = Multiplicable:
     (delta, scalar) => Delta(delta.dx*scalar, delta.dy*scalar)
 
-final case class Delta(tensor: Tensor[Float, 2]):
-  def dx: Float = tensor.element(0)
-  def dy: Float = tensor.element(1)
+final case class Delta(vector: Vector[Float, 2]):
+  def dx: Float = vector.element(0)
+  def dy: Float = vector.element(1)
 
 val Up:    Delta = Delta(0.0f, -1.0f)
 val Down:  Delta = Delta(0.0f, 1.0f)

--- a/lib/savagery/src/core/savagery.Point.scala
+++ b/lib/savagery/src/core/savagery.Point.scala
@@ -42,7 +42,7 @@ import spectacular.*
 import symbolism.*
 
 object Point:
-  def apply(x: Float, y: Float): Point = Point(Tensor((x, y)))
+  def apply(x: Float, y: Float): Point = Point(Vector((x, y)))
 
   given showable: Point is Showable = point =>
     t"${point.x.toString} ${point.y.toString}"
@@ -63,6 +63,6 @@ object Point:
     Subtractable: (left, right) =>
       Delta(left.x - right.x, left.y - right.y)
 
-final case class Point(tensor: Tensor[Float, 2]):
-  def x: Float = tensor.element(0)
-  def y: Float = tensor.element(1)
+final case class Point(vector: Vector[Float, 2]):
+  def x: Float = vector.element(0)
+  def y: Float = vector.element(1)

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -109,8 +109,8 @@ object Inspectable extends Inspectable2:
     _.map(inspectable.text(_)).mkString("{", ", ", "}").tt
 
 
-  given vector: [element] => (inspectable: => element is Inspectable)
-  =>  Trie[element] is Inspectable =
+  given series: [element] => (inspectable: => element is Inspectable)
+  =>  Series[element] is Inspectable =
 
     _.map(inspectable.text(_)).mkString("⟨ ", " ", " ⟩").tt
 

--- a/lib/spectacular/src/core/spectacular.Showable.scala
+++ b/lib/spectacular/src/core/spectacular.Showable.scala
@@ -66,7 +66,7 @@ object Showable:
   given list: [element: Showable] => List[element] is Showable =
     _.map(_.show).mkString("[", ", ", "]").tt
 
-  given trie: [element: Showable] => Trie[element] is Showable =
+  given series: [element: Showable] => Series[element] is Showable =
     _.map(_.show).mkString("[ ", " ", " ]").tt
 
   given none: None.type is Showable = none => "none".tt

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -181,8 +181,8 @@ object Tests extends Suite(m"Spectacular Tests"):
         Array(1, 2, 3).inspect
       . assert(_ == t"""⦋🅸₀1∣₁2∣₂3⦌""")
 
-      test(m"serialize Vector of shorts"):
-        Vector(1.toShort, 2.toShort, 3.toShort).inspect
+      test(m"serialize Series of shorts"):
+        Series(1.toShort, 2.toShort, 3.toShort).inspect
       . assert(_ == t"""⟨ 1.toShort 2.toShort 3.toShort ⟩""")
 
       test(m"serialize Array of Longs"):

--- a/lib/symbolism/.github/readme.md
+++ b/lib/symbolism/.github/readme.md
@@ -50,7 +50,7 @@ abstract over the arithmetic operations. That means it's possible to write code
 against these typeclasses which will work on any type which implements them.
 
 For example, [Mosquito](https://github.com/propensive/mosquito/) is a library
-for working with Euclidean vectors (called `Euclidean`) and matrices of
+for working with Euclidean vectors (called `Vector`) and matrices of
 arbitrary types, such as `Double`s or even `Exception`s. With Mosquito, you can
 add two vectors if, and only if, you can add their elements. So you can add two
 vectors of `Double` (as long as they have the same dimension), but you can't

--- a/lib/symbolism/doc/basics.md
+++ b/lib/symbolism/doc/basics.md
@@ -13,7 +13,7 @@ abstract over the arithmetic operations. That means it's possible to write code
 against these typeclasses which will work on any type which implements them.
 
 For example, [Mosquito](https://github.com/propensive/mosquito/) is a library
-for working with Euclidean vectors (called `Euclidean`) and matrices of
+for working with Euclidean vectors (called `Vector`) and matrices of
 arbitrary types, such as `Double`s or even `Exception`s. With Mosquito, you can
 add two vectors if, and only if, you can add their elements. So you can add two
 vectors of `Double` (as long as they have the same dimension), but you can't

--- a/lib/vacuous/src/core/vacuous.Default.scala
+++ b/lib/vacuous/src/core/vacuous.Default.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package vacuous
 
-import scala.collection.immutable as sci
-
 import anticipation.*
 import beneficence.*
 
@@ -47,7 +45,7 @@ object Default:
   given string: Default[String] = () => ""
   given list: [element] => Default[List[element]] = () => Nil
   given set: [element] => Default[Set[element]] = () => Set()
-  given vector: [element] => Default[sci.Vector[element]] = () => sci.Vector()
+  given series: [element] => Default[Series[element]] = () => Series()
 
 trait Default[+value] extends Findable:
   def apply(): value

--- a/lib/xylophone/.github/readme.md
+++ b/lib/xylophone/.github/readme.md
@@ -149,7 +149,7 @@ a book from the _library_ example above could be read with:
 library.book().as[Book]
 ```
 
-The `as` method can also extract collection types (e.g. `Set`, `List` or `Vector`) from an `Xml` value, so
+The `as` method can also extract collection types (e.g. `Set`, `List` or `Series`) from an `Xml` value, so
 _all_ the books in the library could be accessed with,
 ```scala
 library.book.as[Set[Book]]

--- a/lib/xylophone/doc/basics.md
+++ b/lib/xylophone/doc/basics.md
@@ -119,7 +119,7 @@ a book from the _library_ example above could be read with:
 library.book().as[Book]
 ```
 
-The `as` method can also extract collection types (e.g. `Set`, `List` or `Vector`) from an `Xml` value, so
+The `as` method can also extract collection types (e.g. `Set`, `List` or `Series`) from an `Xml` value, so
 _all_ the books in the library could be accessed with,
 ```scala
 library.book.as[Set[Book]]

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -241,9 +241,9 @@ object Tests extends Suite(m"Ypsiloid Tests"):
         t"[\"a,b\", \"c,d\"]".read[Yaml].as[List[Text]]
       . assert(_ == List(t"a,b", t"c,d"))
 
-      test(m"Parse a flow sequence into a Vector"):
-        t"[10, 20, 30]".read[Yaml].as[Vector[Int]]
-      . assert(_ == Vector(10, 20, 30))
+      test(m"Parse a flow sequence into a Series"):
+        t"[10, 20, 30]".read[Yaml].as[Series[Int]]
+      . assert(_ == Series(10, 20, 30))
 
       test(m"Parse a flow sequence into a Set"):
         t"[1, 2, 3]".read[Yaml].as[Set[Int]]


### PR DESCRIPTION
The standard-library vector collection was referred to inconsistently across Soundness — exported by Proscenium as `Trie` but also used directly as `Vector`. It now has a single name, `Series`, exported once from Proscenium and used everywhere. With `Vector` freed up, Mosquito's `Tensor` type — which was never a tensor, but a fixed-size Euclidean vector — has been renamed to `Vector`, which describes it accurately.

The standard-library immutable vector is now exported by Proscenium (and `soundness`) as `Series`:

```scala
val xs: Series[Int] = Series(1, 2, 3)
```

The name `Trie` and bare uses of `Vector` for this type are gone.

Mosquito's fixed-size Euclidean vector is now `Vector` (formerly `Tensor`):

```scala
import mosquito.*

val v: Vector[Double, 3] = Vector(2.7, -0.3, 0.8)
val w = Vector(1, 0, 0).cross(Vector(0, 1, 0))
```

`scala.collection.concurrent.TrieMap`, cryptographic initialization vectors, and other unrelated uses of "vector"/"trie" are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)