### PR TITLE
Pluggable crypto providers and NIST-status permits for enigmatic

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -635,7 +635,12 @@ object enigmatic extends Library:
   object cose extends Component(core, breviloquence.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, cose)
+  object openssl extends Component(core, xenophile.native):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core, cose, openssl):
+    override def forkArgs: T[Seq[String]] = Task:
+      super.forkArgs() ++ Seq("--enable-native-access=ALL-UNNAMED")
 
 object escapade extends Library:
   object core extends Component(anticipation.gfx, gossamer.core, turbulence.core, anticipation.url, iridescence.core, escritoire.core):

--- a/lib/enigmatic/src/core/enigmatic.Aes.scala
+++ b/lib/enigmatic/src/core/enigmatic.Aes.scala
@@ -42,11 +42,13 @@ object Aes:
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
+  =>  ( crypto: Crypto )
   =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector).asInstanceOf[Aes[bits] over mode against padding]
+    Aes(blockMode, blockPadding, vector, crypto.aes).asInstanceOf[Aes[bits] over mode against padding]
 
 class Aes[bits <: 128 | 192 | 256: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"AES", mode, padding, vector):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
+    cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"AES", mode, padding, vector, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -32,84 +32,59 @@
                                                                                                   */
 package enigmatic
 
-import javax.crypto as jc, javax.crypto.spec.*
-
 import anticipation.*
 import gossamer.*
-import rudiments.*
 import vacuous.*
 
+// A block cipher's type-level *policy* (which mode and padding apply, whether an
+// IV is needed and how input length is checked) lives here; the byte-level
+// *mechanics* are delegated to the in-scope `Crypto` provider's
+// `Crypto.SymmetricCipher`, captured at construction by the algorithm's given.
 abstract class BlockCipher
   ( val algorithm: Text,
     mode:          BlockCipherMode,
     padding:       BlockCipherPadding,
-    vector:        InitializationVector )
+    vector:        InitializationVector,
+    cipher:        Crypto.SymmetricCipher )
 extends Cipher, Encryption, Symmetric:
   type Transport
   type Contrast
 
   private def transformation: Text = t"$algorithm/${mode.name}/${padding.name}"
-  private def initialize(): jc.Cipher = jc.Cipher.getInstance(transformation.s).nn
-
-  private def makeKey(key: Data): SecretKeySpec =
-    SecretKeySpec(key.mutable(using Unsafe), algorithm.s)
 
   def encrypt(bytes: Data, key: Data): Data =
-    val cipher = initialize()
-    padding.verify(bytes.length, cipher.getBlockSize, mode.blockAligned)
+    val blockSize = cipher.blockSize(transformation)
+    padding.verify(bytes.length, blockSize, mode.blockAligned)
+    val iv: Optional[Data] = if mode.usesIv then vector(blockSize) else Unset
+    cipher.encrypt(transformation, key, iv, bytes)
 
-    if mode.usesIv then
-      val iv = vector(cipher.getBlockSize).mutable(using Unsafe)
-      cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(iv))
-      (iv ++ cipher.doFinal(bytes.mutable(using Unsafe)).nn).immutable(using Unsafe)
-    else
-      cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))
-      cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)
-
-  // Streaming encryption feeds each chunk through `Cipher.update` and flushes with
-  // `doFinal`, mirroring `turbulence.Compression`. The IV (if any) is emitted as
-  // the first chunk; the `NoPadding` alignment check happens at end-of-stream,
-  // where the total length is finally known.
+  // Streaming encryption feeds each chunk through the provider's `CipherSession`,
+  // mirroring `turbulence.Compression`. The IV (if any) is emitted as the first
+  // chunk; the `NoPadding` alignment check happens at end-of-stream, where the
+  // total length is finally known.
   def encryptStream(stream: Stream[Data], key: Data): Stream[Data] =
-    val cipher = initialize()
-
-    val prefix: Stream[Data] =
-      if mode.usesIv then
-        val iv = vector(cipher.getBlockSize).mutable(using Unsafe)
-        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(iv))
-        Stream(iv.immutable(using Unsafe))
-      else
-        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))
-        Stream()
+    val blockSize = cipher.blockSize(transformation)
+    val iv: Optional[Data] = if mode.usesIv then vector(blockSize) else Unset
+    val session = cipher.stream(transformation, key, iv)
+    val prefix: Stream[Data] = iv.lay(Stream())(Stream(_))
 
     def recur(stream: Stream[Data], total: Int): Stream[Data] = stream match
       case head #:: tail =>
-        val updated = cipher.update(head.mutable(using Unsafe)).nn.immutable(using Unsafe)
+        val updated = session.update(head)
         val rest = recur(tail, total + head.length)
         if updated.length > 0 then updated #:: rest else rest
 
       case _ =>
-        padding.verify(total, cipher.getBlockSize, mode.blockAligned)
-        val last = cipher.doFinal().nn.immutable(using Unsafe)
+        padding.verify(total, blockSize, mode.blockAligned)
+        val last = session.finish()
         if last.length > 0 then Stream(last) else Stream()
 
     prefix #::: recur(stream, 0)
 
   def decrypt(bytes: Data, key: Data): Data =
-    val cipher = initialize()
-    val input = bytes.mutable(using Unsafe)
+    val ivSize: Optional[Int] = if mode.usesIv then cipher.blockSize(transformation) else Unset
+    cipher.decrypt(transformation, key, ivSize, bytes)
 
-    if mode.usesIv then
-      val blockSize = cipher.getBlockSize
-      cipher.init(jc.Cipher.DECRYPT_MODE, makeKey(key), IvParameterSpec(input.take(blockSize)))
-      cipher.doFinal(input.drop(blockSize)).nn.immutable(using Unsafe)
-    else
-      cipher.init(jc.Cipher.DECRYPT_MODE, makeKey(key))
-      cipher.doFinal(input).nn.immutable(using Unsafe)
-
-  def genKey(): Data =
-    val keyGen = jc.KeyGenerator.getInstance(algorithm.s).nn
-    keyGen.init(keySize)
-    keyGen.generateKey().nn.getEncoded.nn.immutable(using Unsafe)
+  def genKey(): Data = cipher.generateKey(keySize)
 
   def privateToPublic(key: Data): Data = key

--- a/lib/enigmatic/src/core/enigmatic.BlockCipherMode.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipherMode.scala
@@ -61,7 +61,10 @@ object Cbc:
 sealed trait Cbc
 
 object Ecb:
-  given mode: Ecb is BlockCipherMode = BlockCipherMode(t"ECB", false, true)
+  // ECB reveals plaintext structure and is gated as a "disallowed" mode: summoning
+  // its mode evidence (for either direction, or even key generation) needs a permit.
+  given mode: (erased Permit[Concession.Ecb]) => (Ecb is BlockCipherMode) =
+    BlockCipherMode(t"ECB", false, true)
 
 sealed trait Ecb
 

--- a/lib/enigmatic/src/core/enigmatic.Blowfish.scala
+++ b/lib/enigmatic/src/core/enigmatic.Blowfish.scala
@@ -36,17 +36,22 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 object Blowfish:
   given value: [bits <: 128 | 256 | 448: ValueOf, mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
+  =>  ( crypto: Crypto { def blowfish: Crypto.SymmetricCipher } )
   =>  ( Blowfish[bits] over mode against padding ) =
-    Blowfish(blockMode, blockPadding, vector).asInstanceOf[Blowfish[bits] over mode against padding]
+    Blowfish(blockMode, blockPadding, vector, crypto.blowfish)
+    . asInstanceOf[Blowfish[bits] over mode against padding]
 
 class Blowfish[bits <: 128 | 256 | 448: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"Blowfish", mode, padding, vector):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
+    cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"Blowfish", mode, padding, vector, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.CipherSession.scala
+++ b/lib/enigmatic/src/core/enigmatic.CipherSession.scala
@@ -33,41 +33,10 @@
 package enigmatic
 
 import anticipation.*
-import gastronomy.*
-import prepositional.*
-import rudiments.*
-import vacuous.*
 
-extension [encodable: Encodable in Data](value: encodable)
-  def hmac[algorithm <: Algorithm](key: Data)(using hash: Hash in algorithm, crypto: Crypto)
-  :   Hmac in algorithm =
-
-    Hmac(crypto.hmac(hash.hmacName).mac(key, encodable.encode(value)))
-
-package blockCipherMode:
-  export Cbc.mode as cbc
-  export Ecb.mode as ecb
-  export Ctr.mode as ctr
-  export Cfb.mode as cfb
-  export Ofb.mode as ofb
-
-package blockCipherPadding:
-  export Pkcs7.padding as pkcs7
-  export Iso10126.padding as iso10126
-  // `NoPadding` is not re-exported for import-based inference: its `given` takes a
-  // `Tactic[CryptoError]`, and re-exporting a context-function given trips a
-  // compiler assertion ("bad adapt"). Use `against NoPadding` explicitly instead.
-
-package initializationVector:
-  // `random` is the default `InitializationVector` (in `InitializationVector`'s
-  // companion). It is not re-exported here: it is now a context-function given
-  // over `Crypto`, and re-exporting such a given trips a compiler assertion
-  // ("bad adapt") — see the note in `blockCipherPadding` above.
-  given zero: InitializationVector = size => Array.fill[Byte](size)(0).immutable(using Unsafe)
-
-// Crypto providers select the algorithmic backend. Pick one with an explicit
-// import, e.g. `import cryptoProviders.javaStdlibCrypto`. The given's type is the
-// provider object's singleton type, so the optional (structurally-typed)
-// algorithms it offers remain visible to consumers that require them.
-package cryptoProviders:
-  given javaStdlibCrypto: JavaStdlibCrypto.type = JavaStdlibCrypto
+// A stateful streaming-encryption session owned by a `Crypto` provider. The IV
+// (if any) has already been applied at construction; `update` feeds successive
+// plaintext chunks and `finish` flushes the final block.
+trait CipherSession:
+  def update(chunk: Data): Data
+  def finish(): Data

--- a/lib/enigmatic/src/core/enigmatic.Concession.scala
+++ b/lib/enigmatic/src/core/enigmatic.Concession.scala
@@ -32,89 +32,35 @@
                                                                                                   */
 package enigmatic
 
-import java.security as js
-import javax.crypto as jc
+// A "concession" is a specific cryptographic weakness a caller must explicitly
+// accept (via a `crypto.permit…Crypto` import) before the corresponding algorithm,
+// key length or mode can be used. `Acceptable` is the absence of any weakness.
+object Concession:
+  sealed trait Acceptable
+  sealed trait Des
+  sealed trait TripleDes
+  sealed trait Rc2
+  sealed trait Blowfish
+  sealed trait SmallRsa       // RSA with a key shorter than 2048 bits
+  sealed trait Dsa
+  sealed trait Ecb
+  sealed trait Unauthenticated
 
-import anticipation.*
-import contingency.*
-import distillate.*
-import gossamer.*
-import prepositional.*
-import vacuous.*
+// The algorithm/key-length concession of a cipher type, extracted by matching the
+// (possibly `over`/`against`-refined) cipher. Anything not named here — AES,
+// RSA-2048, HMAC — is `Acceptable` and needs no permission.
+type Weakness[cipher] = cipher match
+  case Des          => Concession.Des
+  case TripleDes[?] => Concession.TripleDes
+  case Rc2[?]       => Concession.Rc2
+  case Blowfish[?]  => Concession.Blowfish
+  case Rsa[1024]    => Concession.SmallRsa
+  case Dsa[?]       => Concession.Dsa
+  case _            => Concession.Acceptable
 
-// Encryption is total: a valid transformation is guaranteed by the static types
-// (see `Permits`), so `encrypt` cannot fail. Only `decrypt` can fail at runtime —
-// from a wrong key, corrupted ciphertext, or malformed input — and those JCE
-// failures are surfaced as a `CryptoError`.
-
-extension [value: Encodable in Data](value: value)
-  def encrypt[cipher <: Cipher]
-    ( using encryptor: Encryptor[cipher],
-            algorithm: cipher & Encryption,
-            erased weakness: Permit[Weakness[cipher]],
-            erased authentication: Permit[Authentication[cipher]] )
-  :   Data =
-
-    algorithm.encrypt(value.bytestream, encryptor.bytes)
-
-// Streaming encryption (block ciphers only) lazily transforms a `Stream`, driving
-// the JCE cipher through update/doFinal. The IV is emitted as the leading chunk
-// and the `NoPadding` alignment check runs at end-of-stream. Drain it within the
-// `expose` block — only the fixed ciphertext of `stream` could otherwise leak.
-
-extension (stream: Stream[Data])
-  def encrypt[cipher <: BlockCipher]
-    ( using encryptor: Encryptor[cipher],
-            algorithm: cipher & Encryption,
-            erased weakness: Permit[Weakness[cipher]],
-            erased authentication: Permit[Authentication[cipher]] )
-  :   Stream[Data] =
-
-    algorithm.encryptStream(stream, encryptor.bytes)
-
-extension (data: Data)
-  def decrypt[decodable: Decodable in Data, cipher <: Cipher]
-    ( using decryptor: Decryptor[cipher],
-            algorithm: cipher & Encryption,
-            erased weakness: ProcessingPermit[Weakness[cipher]],
-            erased authentication: ProcessingPermit[Authentication[cipher]] )
-  :   decodable raises CryptoError =
-
-    def detail(error: Throwable): Optional[Text] = error.getMessage match
-      case null         => Unset
-      case text: String => text.tt
-
-    val plaintext =
-      try algorithm.decrypt(data, decryptor.bytes) catch
-        case error: jc.AEADBadTagException =>
-          abort(CryptoError(CryptoError.Reason.BadPadding, detail(error)))
-
-        case error: jc.BadPaddingException =>
-          abort(CryptoError(CryptoError.Reason.BadPadding, detail(error)))
-
-        case error: jc.IllegalBlockSizeException =>
-          abort(CryptoError(CryptoError.Reason.IllegalBlockSize, detail(error)))
-
-        case error: js.InvalidKeyException =>
-          abort(CryptoError(CryptoError.Reason.InvalidKey, detail(error)))
-
-        case error: js.GeneralSecurityException =>
-          abort(CryptoError(CryptoError.Reason.IoFailure, detail(error)))
-
-    decodable.decoded(plaintext)
-
-// `expose` lends the key to the block as an `Encryptor`/`Decryptor` capability.
-// Capture checking (which would confine the capability to this scope) is not yet
-// enabled; the capability types are kept so it can be turned on as an enhancement.
-
-extension [cipher <: Cipher](key: PublicKey[cipher])
-  def expose[result](block: Encryptor[cipher] ?=> result): result =
-    block(using Encryptor(key.bytes))
-
-extension [cipher <: Cipher](key: PrivateKey[cipher])
-  def expose[result](block: Decryptor[cipher] ?=> result): result =
-    block(using Decryptor(key.privateData))
-
-extension [cipher <: Cipher](key: SymmetricKey[cipher])
-  def expose[result](block: (Encryptor[cipher], Decryptor[cipher]) ?=> result): result =
-    block(using Encryptor(key.bytes), Decryptor(key.bytes))
+// Every (non-AEAD) block cipher is unauthenticated; asymmetric ciphers are not
+// classified this way. When authenticated encryption is added, its ciphers will
+// fall through to `Acceptable` here.
+type Authentication[cipher] = cipher match
+  case BlockCipher => Concession.Unauthenticated
+  case _           => Concession.Acceptable

--- a/lib/enigmatic/src/core/enigmatic.Crypto.scala
+++ b/lib/enigmatic/src/core/enigmatic.Crypto.scala
@@ -33,41 +33,56 @@
 package enigmatic
 
 import anticipation.*
-import gastronomy.*
-import prepositional.*
-import rudiments.*
 import vacuous.*
 
-extension [encodable: Encodable in Data](value: encodable)
-  def hmac[algorithm <: Algorithm](key: Data)(using hash: Hash in algorithm, crypto: Crypto)
-  :   Hmac in algorithm =
+// A pluggable cryptographic provider: it supplies the raw algorithmic
+// implementations (the JDK's JCE, BouncyCastle, OpenSSL, …) that the typed
+// enigmatic API delegates to. Pick one with an explicit import, e.g.
+// `import cryptoProviders.javaStdlibCrypto`.
+//
+// Every provider must implement the mandatory baseline below — the modern,
+// universally-supported primitives. Legacy or provider-specific algorithms (DES,
+// Blowfish, RC2, DSA, …) are contributed as additional members and reached
+// through a structural refinement, so an algorithm a provider does not offer is a
+// compile error at the use site rather than a runtime failure.
+//
+// All inputs and outputs are byte arrays (`Data`) and string descriptors
+// (`Text`); no platform crypto types appear in this contract. Key material
+// follows JCE-compatible encodings: symmetric keys are raw bytes; asymmetric
+// private keys are PKCS#8, public keys X.509 (SubjectPublicKeyInfo); a symmetric
+// ciphertext is `iv ++ rawCiphertext` when the mode uses an IV.
 
-    Hmac(crypto.hmac(hash.hmacName).mac(key, encodable.encode(value)))
+trait Crypto:
+  def random: Crypto.Random
+  def aes: Crypto.SymmetricCipher
+  def rsa: Crypto.PublicKeyCipher
+  def hmac(algorithm: Text): Crypto.Mac
 
-package blockCipherMode:
-  export Cbc.mode as cbc
-  export Ecb.mode as ecb
-  export Ctr.mode as ctr
-  export Cfb.mode as cfb
-  export Ofb.mode as ofb
+object Crypto:
+  // A symmetric block cipher. `transformation` is the full JCE-style spec
+  // (e.g. `t"AES/CBC/PKCS5Padding"`); `encrypt`/`decrypt` frame the IV as the
+  // leading block of the ciphertext when one is supplied.
+  trait SymmetricCipher:
+    def encrypt(transformation: Text, key: Data, iv: Optional[Data], data: Data): Data
+    def decrypt(transformation: Text, key: Data, ivSize: Optional[Int], data: Data): Data
+    def blockSize(transformation: Text): Int
+    def generateKey(bits: Int): Data
+    def stream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession
 
-package blockCipherPadding:
-  export Pkcs7.padding as pkcs7
-  export Iso10126.padding as iso10126
-  // `NoPadding` is not re-exported for import-based inference: its `given` takes a
-  // `Tactic[CryptoError]`, and re-exporting a context-function given trips a
-  // compiler assertion ("bad adapt"). Use `against NoPadding` explicitly instead.
+  trait PublicKeyCipher:
+    def encrypt(input: Data, publicKey: Data): Data
+    def decrypt(input: Data, privateKey: Data): Data
+    def generateKeyPair(bits: Int): Data
+    def privateToPublic(privateKey: Data): Data
 
-package initializationVector:
-  // `random` is the default `InitializationVector` (in `InitializationVector`'s
-  // companion). It is not re-exported here: it is now a context-function given
-  // over `Crypto`, and re-exporting such a given trips a compiler assertion
-  // ("bad adapt") — see the note in `blockCipherPadding` above.
-  given zero: InitializationVector = size => Array.fill[Byte](size)(0).immutable(using Unsafe)
+  trait SignatureScheme:
+    def sign(data: Data, privateKey: Data): Data
+    def verify(data: Data, signature: Data, publicKey: Data): Boolean
+    def generateKeyPair(bits: Int): Data
+    def privateToPublic(privateKey: Data): Data
 
-// Crypto providers select the algorithmic backend. Pick one with an explicit
-// import, e.g. `import cryptoProviders.javaStdlibCrypto`. The given's type is the
-// provider object's singleton type, so the optional (structurally-typed)
-// algorithms it offers remain visible to consumers that require them.
-package cryptoProviders:
-  given javaStdlibCrypto: JavaStdlibCrypto.type = JavaStdlibCrypto
+  trait Mac:
+    def mac(key: Data, data: Data): Data
+
+  trait Random:
+    def bytes(size: Int): Data

--- a/lib/enigmatic/src/core/enigmatic.Des.scala
+++ b/lib/enigmatic/src/core/enigmatic.Des.scala
@@ -36,17 +36,21 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 object Des:
   given value: [mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
+  =>  ( crypto: Crypto { def des: Crypto.SymmetricCipher } )
   =>  ( Des over mode against padding ) =
-    Des(blockMode, blockPadding, vector).asInstanceOf[Des over mode against padding]
+    Des(blockMode, blockPadding, vector, crypto.des).asInstanceOf[Des over mode against padding]
 
 class Des
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"DES", mode, padding, vector):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
+    cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"DES", mode, padding, vector, cipher):
   type Size = 56
   def keySize: 56 = 56

--- a/lib/enigmatic/src/core/enigmatic.Dsa.scala
+++ b/lib/enigmatic/src/core/enigmatic.Dsa.scala
@@ -32,56 +32,23 @@
                                                                                                   */
 package enigmatic
 
-import java.security as js, js.spec as jss, js.interfaces as jsi
-
 import anticipation.*
-import fulminate.*
-import rudiments.*
-import vacuous.*
+
+import scala.reflect.Selectable.reflectiveSelectable
 
 object Dsa:
-  given value: [bits <: 512 | 1024 | 2048 | 3072: ValueOf] => Dsa[bits] = Dsa()
+  given value: [bits <: 512 | 1024 | 2048 | 3072: ValueOf]
+  =>  ( crypto: Crypto { def dsa: Crypto.SignatureScheme } )
+  =>  Dsa[bits] = Dsa(crypto.dsa)
 
-class Dsa[bits <: 512 | 1024 | 2048 | 3072: ValueOf]() extends Cipher, Signing:
+class Dsa[bits <: 512 | 1024 | 2048 | 3072: ValueOf](scheme: Crypto.SignatureScheme)
+extends Cipher, Signing:
   type Size = bits
 
   def keySize: bits = valueOf[bits]
-
-  def genKey(): Data =
-    val generator = js.KeyPairGenerator.getInstance("DSA").nn
-    val random = js.SecureRandom()
-    generator.initialize(keySize, random)
-    val keyPair = generator.generateKeyPair().nn
-
-    val pubKey = keyPair.getPublic.nn match
-      case key: jsi.DSAPublicKey => key
-      case key: js.PublicKey     => panic(m"unexpected public key type")
-
-    keyPair.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
-
-  def sign(data: Data, keyData: Data): Data =
-    val sig = initialize()
-    val key = keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(keyData.to(Array)))
-    sig.initSign(key)
-    sig.update(data.to(Array))
-    sig.sign().nn.immutable(using Unsafe)
+  def genKey(): Data = scheme.generateKeyPair(keySize)
+  def sign(data: Data, keyData: Data): Data = scheme.sign(data, keyData)
+  def privateToPublic(keyData: Data): Data = scheme.privateToPublic(keyData)
 
   def verify(data: Data, signature: Data, keyData: Data): Boolean =
-    val sig = initialize()
-    val key = keyFactory().generatePublic(jss.X509EncodedKeySpec(keyData.to(Array)))
-    sig.initVerify(key)
-    sig.update(data.to(Array))
-    sig.verify(signature.to(Array))
-
-  def privateToPublic(keyData: Data): Data =
-    val key = keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(keyData.to(Array))).nn match
-      case key: jsi.DSAPrivateKey => key
-      case key: js.PrivateKey     => panic(m"unexpected private key type")
-
-    val params = key.getParams.nn
-    val y = params.getG.nn.modPow(key.getX, params.getP)
-    val spec = jss.DSAPublicKeySpec(y, params.getP, params.getQ, params.getG)
-    keyFactory().generatePublic(spec).nn.getEncoded.nn.immutable(using Unsafe)
-
-  private def initialize(): js.Signature = js.Signature.getInstance("DSA").nn
-  private def keyFactory(): js.KeyFactory = js.KeyFactory.getInstance("DSA").nn
+    scheme.verify(data, signature, keyData)

--- a/lib/enigmatic/src/core/enigmatic.InitializationVector.scala
+++ b/lib/enigmatic/src/core/enigmatic.InitializationVector.scala
@@ -32,17 +32,10 @@
                                                                                                   */
 package enigmatic
 
-import java.security as js
-
 import anticipation.*
-import rudiments.*
-import vacuous.*
 
 object InitializationVector:
-  given random: InitializationVector = size =>
-    val iv = new Array[Byte](size)
-    js.SecureRandom().nextBytes(iv)
-    iv.immutable(using Unsafe)
+  given random: (crypto: Crypto) => InitializationVector = size => crypto.random.bytes(size)
 
   def fixed(iv: Data): InitializationVector = _ => iv
 

--- a/lib/enigmatic/src/core/enigmatic.JavaStdlibCrypto.scala
+++ b/lib/enigmatic/src/core/enigmatic.JavaStdlibCrypto.scala
@@ -1,0 +1,175 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import java.security as js, js.spec as jss, js.interfaces as jsi
+import javax.crypto as jc, javax.crypto.spec.*
+
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// The default `Crypto` provider, backed by the JDK's standard crypto (JCE /
+// `java.security`). This is the single home of all `javax.crypto.*` and
+// `java.security.*` usage in enigmatic; every other module reaches these
+// algorithms only through the `Crypto` contract.
+object JavaStdlibCrypto extends Crypto:
+  def random: Crypto.Random = new Crypto.Random:
+    def bytes(size: Int): Data =
+      val output = new Array[Byte](size)
+      js.SecureRandom().nextBytes(output)
+      output.immutable(using Unsafe)
+
+  def aes:       Crypto.SymmetricCipher = symmetric(t"AES")
+  def des:       Crypto.SymmetricCipher = symmetric(t"DES")
+  def tripleDes: Crypto.SymmetricCipher = symmetric(t"DESede")
+  def blowfish:  Crypto.SymmetricCipher = symmetric(t"Blowfish")
+  def rc2:       Crypto.SymmetricCipher = symmetric(t"RC2")
+
+  def hmac(algorithm: Text): Crypto.Mac = new Crypto.Mac:
+    def mac(key: Data, data: Data): Data =
+      val mac = jc.Mac.getInstance(algorithm.s).nn
+      mac.init(SecretKeySpec(key.to(Array), algorithm.s))
+      mac.doFinal(data.to(Array)).nn.immutable(using Unsafe)
+
+  def rsa: Crypto.PublicKeyCipher = new Crypto.PublicKeyCipher:
+    private def keyFactory(): js.KeyFactory = js.KeyFactory.getInstance("RSA").nn
+    private def cipher(): jc.Cipher = jc.Cipher.getInstance("RSA").nn
+
+    def encrypt(input: Data, publicKey: Data): Data =
+      val instance = cipher()
+      val key = keyFactory().generatePublic(jss.X509EncodedKeySpec(publicKey.mutable(using Unsafe)))
+      instance.init(jc.Cipher.ENCRYPT_MODE, key)
+      instance.doFinal(input.mutable(using Unsafe)).nn.immutable(using Unsafe)
+
+    def decrypt(input: Data, privateKey: Data): Data =
+      val instance = cipher()
+      val key = keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(privateKey.mutable(using Unsafe)))
+      instance.init(jc.Cipher.DECRYPT_MODE, key)
+      instance.doFinal(input.mutable(using Unsafe)).nn.immutable(using Unsafe)
+
+    def generateKeyPair(bits: Int): Data =
+      val generator = js.KeyPairGenerator.getInstance("RSA").nn
+      generator.initialize(bits)
+      generator.generateKeyPair().nn.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
+
+    def privateToPublic(privateKey: Data): Data =
+      val javaKey =
+        keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(privateKey.mutable(using Unsafe))).nn
+
+      val key = javaKey match
+        case key: jsi.RSAPrivateCrtKey => key
+        case key: js.PrivateKey        => panic(m"unexpected private key type")
+
+      val spec = jss.RSAPublicKeySpec(key.getModulus, key.getPublicExponent)
+      keyFactory().generatePublic(spec).nn.getEncoded.nn.immutable(using Unsafe)
+
+  def dsa: Crypto.SignatureScheme = new Crypto.SignatureScheme:
+    private def signature(): js.Signature = js.Signature.getInstance("DSA").nn
+    private def keyFactory(): js.KeyFactory = js.KeyFactory.getInstance("DSA").nn
+
+    def sign(data: Data, privateKey: Data): Data =
+      val sig = signature()
+      sig.initSign(keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(privateKey.to(Array))))
+      sig.update(data.to(Array))
+      sig.sign().nn.immutable(using Unsafe)
+
+    def verify(data: Data, signature0: Data, publicKey: Data): Boolean =
+      val sig = signature()
+      sig.initVerify(keyFactory().generatePublic(jss.X509EncodedKeySpec(publicKey.to(Array))))
+      sig.update(data.to(Array))
+      sig.verify(signature0.to(Array))
+
+    def generateKeyPair(bits: Int): Data =
+      val generator = js.KeyPairGenerator.getInstance("DSA").nn
+      generator.initialize(bits, js.SecureRandom())
+      generator.generateKeyPair().nn.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
+
+    def privateToPublic(privateKey: Data): Data =
+      val key = keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(privateKey.to(Array))).nn match
+        case key: jsi.DSAPrivateKey => key
+        case key: js.PrivateKey     => panic(m"unexpected private key type")
+
+      val params = key.getParams.nn
+      val y = params.getG.nn.modPow(key.getX, params.getP)
+      val spec = jss.DSAPublicKeySpec(y, params.getP, params.getQ, params.getG)
+      keyFactory().generatePublic(spec).nn.getEncoded.nn.immutable(using Unsafe)
+
+  // Shared implementation for all JCE block ciphers; `algorithm` is the bare key
+  // algorithm (e.g. `t"AES"`), used for `SecretKeySpec` and `KeyGenerator`, while
+  // the full `transformation` (e.g. `t"AES/CBC/PKCS5Padding"`) drives the cipher.
+  private def symmetric(algorithm: Text): Crypto.SymmetricCipher = new Crypto.SymmetricCipher:
+    private def makeKey(key: Data): SecretKeySpec = SecretKeySpec(key.mutable(using Unsafe), algorithm.s)
+
+    def blockSize(transformation: Text): Int = jc.Cipher.getInstance(transformation.s).nn.getBlockSize
+
+    def generateKey(bits: Int): Data =
+      val keyGen = jc.KeyGenerator.getInstance(algorithm.s).nn
+      keyGen.init(bits)
+      keyGen.generateKey().nn.getEncoded.nn.immutable(using Unsafe)
+
+    def encrypt(transformation: Text, key: Data, iv: Optional[Data], data: Data): Data =
+      val cipher = jc.Cipher.getInstance(transformation.s).nn
+
+      iv.lay:
+        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))
+        cipher.doFinal(data.mutable(using Unsafe)).nn.immutable(using Unsafe)
+      .apply: iv =>
+        val ivBytes = iv.mutable(using Unsafe)
+        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(ivBytes))
+        (ivBytes ++ cipher.doFinal(data.mutable(using Unsafe)).nn).immutable(using Unsafe)
+
+    def decrypt(transformation: Text, key: Data, ivSize: Optional[Int], data: Data): Data =
+      val cipher = jc.Cipher.getInstance(transformation.s).nn
+      val input = data.mutable(using Unsafe)
+
+      ivSize.lay:
+        cipher.init(jc.Cipher.DECRYPT_MODE, makeKey(key))
+        cipher.doFinal(input).nn.immutable(using Unsafe)
+      .apply: size =>
+        cipher.init(jc.Cipher.DECRYPT_MODE, makeKey(key), IvParameterSpec(input.take(size)))
+        cipher.doFinal(input.drop(size)).nn.immutable(using Unsafe)
+
+    def stream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession =
+      val cipher = jc.Cipher.getInstance(transformation.s).nn
+
+      iv.lay(cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))): iv =>
+        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(iv.mutable(using Unsafe)))
+
+      new CipherSession:
+        def update(chunk: Data): Data =
+          cipher.update(chunk.mutable(using Unsafe)).nn.immutable(using Unsafe)
+
+        def finish(): Data = cipher.doFinal().nn.immutable(using Unsafe)

--- a/lib/enigmatic/src/core/enigmatic.Permit.scala
+++ b/lib/enigmatic/src/core/enigmatic.Permit.scala
@@ -32,89 +32,28 @@
                                                                                                   */
 package enigmatic
 
-import java.security as js
-import javax.crypto as jc
+import scala.annotation.implicitNotFound
 
-import anticipation.*
-import contingency.*
-import distillate.*
-import gossamer.*
-import prepositional.*
-import vacuous.*
+// Capability evidence that a `concession` (a weak algorithm, key length or mode)
+// is permitted. Following NIST SP 800-131A's apply-vs-process distinction:
+// `ProcessingPermit` allows *processing already-protected* data (decrypt/verify),
+// while `Permit` (a subtype) additionally allows *applying new protection*
+// (encrypt/sign). Both are erased — purely compile-time gates with no runtime cost.
+// Bring them into scope with a `crypto.permit…Crypto` import.
 
-// Encryption is total: a valid transformation is guaranteed by the static types
-// (see `Permits`), so `encrypt` cannot fail. Only `decrypt` can fail at runtime —
-// from a wrong key, corrupted ciphertext, or malformed input — and those JCE
-// failures are surfaced as a `CryptoError`.
+@implicitNotFound("this operation uses an algorithm whose status is \"legacy use\" or worse; "+
+    "import a permit (e.g. `crypto.permitLegacyCrypto` to process existing data, or "+
+    "`crypto.permitDisallowedCrypto`) to allow it")
+trait ProcessingPermit[concession]
 
-extension [value: Encodable in Data](value: value)
-  def encrypt[cipher <: Cipher]
-    ( using encryptor: Encryptor[cipher],
-            algorithm: cipher & Encryption,
-            erased weakness: Permit[Weakness[cipher]],
-            erased authentication: Permit[Authentication[cipher]] )
-  :   Data =
+@implicitNotFound("this operation uses a sub-optimal algorithm, key length or mode; import the "+
+    "matching permit (`crypto.permitUnauthenticatedCrypto`, `crypto.permitDeprecatedCrypto` or "+
+    "`crypto.permitDisallowedCrypto`) to allow it")
+trait Permit[concession] extends ProcessingPermit[concession]
 
-    algorithm.encrypt(value.bytestream, encryptor.bytes)
+object Permit:
+  // `Acceptable` crypto needs no permission, so this permit is always available.
+  erased given acceptable: Permit[Concession.Acceptable] = caps.unsafe.unsafeErasedValue
 
-// Streaming encryption (block ciphers only) lazily transforms a `Stream`, driving
-// the JCE cipher through update/doFinal. The IV is emitted as the leading chunk
-// and the `NoPadding` alignment check runs at end-of-stream. Drain it within the
-// `expose` block — only the fixed ciphertext of `stream` could otherwise leak.
-
-extension (stream: Stream[Data])
-  def encrypt[cipher <: BlockCipher]
-    ( using encryptor: Encryptor[cipher],
-            algorithm: cipher & Encryption,
-            erased weakness: Permit[Weakness[cipher]],
-            erased authentication: Permit[Authentication[cipher]] )
-  :   Stream[Data] =
-
-    algorithm.encryptStream(stream, encryptor.bytes)
-
-extension (data: Data)
-  def decrypt[decodable: Decodable in Data, cipher <: Cipher]
-    ( using decryptor: Decryptor[cipher],
-            algorithm: cipher & Encryption,
-            erased weakness: ProcessingPermit[Weakness[cipher]],
-            erased authentication: ProcessingPermit[Authentication[cipher]] )
-  :   decodable raises CryptoError =
-
-    def detail(error: Throwable): Optional[Text] = error.getMessage match
-      case null         => Unset
-      case text: String => text.tt
-
-    val plaintext =
-      try algorithm.decrypt(data, decryptor.bytes) catch
-        case error: jc.AEADBadTagException =>
-          abort(CryptoError(CryptoError.Reason.BadPadding, detail(error)))
-
-        case error: jc.BadPaddingException =>
-          abort(CryptoError(CryptoError.Reason.BadPadding, detail(error)))
-
-        case error: jc.IllegalBlockSizeException =>
-          abort(CryptoError(CryptoError.Reason.IllegalBlockSize, detail(error)))
-
-        case error: js.InvalidKeyException =>
-          abort(CryptoError(CryptoError.Reason.InvalidKey, detail(error)))
-
-        case error: js.GeneralSecurityException =>
-          abort(CryptoError(CryptoError.Reason.IoFailure, detail(error)))
-
-    decodable.decoded(plaintext)
-
-// `expose` lends the key to the block as an `Encryptor`/`Decryptor` capability.
-// Capture checking (which would confine the capability to this scope) is not yet
-// enabled; the capability types are kept so it can be turned on as an enhancement.
-
-extension [cipher <: Cipher](key: PublicKey[cipher])
-  def expose[result](block: Encryptor[cipher] ?=> result): result =
-    block(using Encryptor(key.bytes))
-
-extension [cipher <: Cipher](key: PrivateKey[cipher])
-  def expose[result](block: Decryptor[cipher] ?=> result): result =
-    block(using Decryptor(key.privateData))
-
-extension [cipher <: Cipher](key: SymmetricKey[cipher])
-  def expose[result](block: (Encryptor[cipher], Decryptor[cipher]) ?=> result): result =
-    block(using Encryptor(key.bytes), Decryptor(key.bytes))
+object ProcessingPermit:
+  erased given acceptable: ProcessingPermit[Concession.Acceptable] = caps.unsafe.unsafeErasedValue

--- a/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
@@ -52,7 +52,8 @@ class PrivateKey[cipher <: Cipher](private[enigmatic] val privateData: Data):
     PublicKey(cipher.privateToPublic(privateData))
 
 
-  def sign[encodable: Encodable in Data](value: encodable)(using cipher: cipher & Signing)
+  def sign[encodable: Encodable in Data](value: encodable)
+    (using cipher: cipher & Signing, erased weakness: Permit[Weakness[cipher]])
   :   Signature[cipher] =
 
     Signature(cipher.sign(encodable.encode(value), privateData))

--- a/lib/enigmatic/src/core/enigmatic.PublicKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PublicKey.scala
@@ -48,7 +48,7 @@ object PublicKey:
 
 case class PublicKey[cipher <: Cipher](bytes: Data):
   def verify[encodable: Encodable in Data](value: encodable, signature: Signature[cipher])
-    ( using algorithm: cipher & Signing )
+    ( using algorithm: cipher & Signing, erased weakness: ProcessingPermit[Weakness[cipher]] )
   :   Boolean =
 
     algorithm.verify(encodable.encode(value), signature.bytes, bytes)

--- a/lib/enigmatic/src/core/enigmatic.Rc2.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rc2.scala
@@ -36,17 +36,21 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 object Rc2:
   given value: [bits <: 40 | 64 | 128: ValueOf, mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
+  =>  ( crypto: Crypto { def rc2: Crypto.SymmetricCipher } )
   =>  ( Rc2[bits] over mode against padding ) =
-    Rc2(blockMode, blockPadding, vector).asInstanceOf[Rc2[bits] over mode against padding]
+    Rc2(blockMode, blockPadding, vector, crypto.rc2).asInstanceOf[Rc2[bits] over mode against padding]
 
 class Rc2[bits <: 40 | 64 | 128: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"RC2", mode, padding, vector):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
+    cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"RC2", mode, padding, vector, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.Rsa.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rsa.scala
@@ -32,53 +32,16 @@
                                                                                                   */
 package enigmatic
 
-import java.security as js, js.spec as jss, js.interfaces as jsi
-import javax.crypto as jc
-
 import anticipation.*
-import contingency.*
-import fulminate.*
-import rudiments.*
-import vacuous.*
 
 object Rsa:
-  given value: [bits <: 1024 | 2048: ValueOf] => Rsa[bits] = Rsa()
+  given value: [bits <: 1024 | 2048: ValueOf] => (crypto: Crypto) => Rsa[bits] = Rsa(crypto.rsa)
 
-class Rsa[bits <: 1024 | 2048: ValueOf]() extends Cipher, Encryption:
+class Rsa[bits <: 1024 | 2048: ValueOf](cipher: Crypto.PublicKeyCipher) extends Cipher, Encryption:
   type Size = bits
 
   def keySize: bits = valueOf[bits]
-
-  def privateToPublic(bytes: Data): Data =
-    val javaKey = keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(unsafely(bytes.mutable))).nn
-
-    val key = javaKey match
-      case key: jsi.RSAPrivateCrtKey => key
-      case key: js.PrivateKey        => panic(m"unexpected private key type")
-
-    val spec = jss.RSAPublicKeySpec(key.getModulus, key.getPublicExponent)
-    keyFactory().generatePublic(spec).nn.getEncoded.nn.immutable(using Unsafe)
-
-  def decrypt(bytes: Data, key: Data): Data =
-    val cipher = initialize()
-
-    val privateKey =
-      keyFactory().generatePrivate(jss.PKCS8EncodedKeySpec(key.mutable(using Unsafe)))
-
-    cipher.init(jc.Cipher.DECRYPT_MODE, privateKey)
-    cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)
-
-  def encrypt(bytes: Data, key: Data): Data =
-    val cipher = initialize()
-    val publicKey = keyFactory().generatePublic(jss.X509EncodedKeySpec(key.mutable(using Unsafe)))
-    cipher.init(jc.Cipher.ENCRYPT_MODE, publicKey)
-    cipher.doFinal(bytes.mutable(using Unsafe)).nn.immutable(using Unsafe)
-
-  def genKey(): Data =
-    val generator = js.KeyPairGenerator.getInstance("RSA").nn
-    generator.initialize(keySize)
-    val keyPair = generator.generateKeyPair().nn
-    keyPair.getPrivate.nn.getEncoded.nn.immutable(using Unsafe)
-
-  private def initialize(): jc.Cipher = jc.Cipher.getInstance("RSA").nn
-  private def keyFactory(): js.KeyFactory = js.KeyFactory.getInstance("RSA").nn
+  def privateToPublic(bytes: Data): Data = cipher.privateToPublic(bytes)
+  def decrypt(bytes: Data, key: Data): Data = cipher.decrypt(bytes, key)
+  def encrypt(bytes: Data, key: Data): Data = cipher.encrypt(bytes, key)
+  def genKey(): Data = cipher.generateKeyPair(keySize)

--- a/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
@@ -44,7 +44,7 @@ object SymmetricKey:
 class SymmetricKey[cipher <: Cipher](private[enigmatic] val bytes: Data)
 extends PrivateKey[cipher](bytes):
   def verify[value: Encodable in Data](value: value, signature: Signature[cipher])
-    ( using cipher & Signing )
+    ( using signing: cipher & Signing, erased weakness: ProcessingPermit[Weakness[cipher]] )
   :   Boolean =
 
     public.verify(value, signature)

--- a/lib/enigmatic/src/core/enigmatic.TripleDes.scala
+++ b/lib/enigmatic/src/core/enigmatic.TripleDes.scala
@@ -36,18 +36,22 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 object TripleDes:
   given value: [bits <: 112 | 168: ValueOf, mode, padding]
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
   =>  ( vector: InitializationVector )
+  =>  ( crypto: Crypto { def tripleDes: Crypto.SymmetricCipher } )
   =>  ( TripleDes[bits] over mode against padding ) =
-    TripleDes(blockMode, blockPadding, vector)
+    TripleDes(blockMode, blockPadding, vector, crypto.tripleDes)
     . asInstanceOf[TripleDes[bits] over mode against padding]
 
 class TripleDes[bits <: 112 | 168: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector )
-extends BlockCipher(t"DESede", mode, padding, vector):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
+    cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"DESede", mode, padding, vector, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic_core.scala
+++ b/lib/enigmatic/src/core/enigmatic_core.scala
@@ -46,10 +46,12 @@ extension [encodable: Encodable in Data](value: encodable)
 
 package blockCipherMode:
   export Cbc.mode as cbc
-  export Ecb.mode as ecb
   export Ctr.mode as ctr
   export Cfb.mode as cfb
   export Ofb.mode as ofb
+  // `Ecb.mode` is not re-exported: it is now a context-function given (it requires
+  // an erased `Permit[Concession.Ecb]`), and re-exporting such a given trips a
+  // compiler assertion. ECB is summoned from its own companion; use `over Ecb`.
 
 package blockCipherPadding:
   export Pkcs7.padding as pkcs7
@@ -71,3 +73,36 @@ package initializationVector:
 // algorithms it offers remain visible to consumers that require them.
 package cryptoProviders:
   given javaStdlibCrypto: JavaStdlibCrypto.type = JavaStdlibCrypto
+
+// Opt-in permits for sub-optimal cryptography, named after NIST SP 800-131A's
+// algorithm statuses. Each is an (erased) intersection of fine-grained `Permit`s,
+// so the named levels and any future year-based levels compose from the same
+// primitives. The levels nest by inclusion: `permitDisallowedCrypto` contains
+// every other permit, and since `Permit <: ProcessingPermit` it also covers
+// "legacy use". Import the weakest level that covers what you need.
+package crypto:
+  // Unauthenticated (non-AEAD) encryption — currently every block-cipher mode.
+  erased given permitUnauthenticatedCrypto: Permit[Concession.Unauthenticated] =
+    caps.unsafe.unsafeErasedValue
+
+  // "Deprecated": usable but transitional (e.g. Triple-DES).
+  erased given permitDeprecatedCrypto: Permit[Concession.TripleDes] =
+    caps.unsafe.unsafeErasedValue
+
+  // "Legacy use": processing already-protected data only (decrypt/verify).
+  erased given permitLegacyCrypto
+      : ProcessingPermit[Concession.TripleDes] & ProcessingPermit[Concession.Dsa] =
+    caps.unsafe.unsafeErasedValue
+
+  // "Disallowed": broken or non-approved algorithms, key lengths and modes;
+  // subsumes every weaker permit above.
+  erased given permitDisallowedCrypto
+      : Permit[Concession.Des]
+      & Permit[Concession.Rc2]
+      & Permit[Concession.Blowfish]
+      & Permit[Concession.TripleDes]
+      & Permit[Concession.Dsa]
+      & Permit[Concession.SmallRsa]
+      & Permit[Concession.Ecb]
+      & Permit[Concession.Unauthenticated] =
+    caps.unsafe.unsafeErasedValue

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -35,8 +35,8 @@ package soundness
 export
   enigmatic
   . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
-      CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence, Dsa, Ecb, encrypt, Encryptor,
-      Encryption, expose,
+      CipherSession, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence, Dsa, Ecb,
+      encrypt, Encryptor, Encryption, expose,
       Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel, Permits,
       Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing, Symmetric, SymmetricKey,
       TripleDes }
@@ -48,4 +48,9 @@ package blockCipherPadding:
   export enigmatic.blockCipherPadding.{iso10126, pkcs7}
 
 package initializationVector:
-  export enigmatic.initializationVector.{random, zero}
+  // `random` (the default) lives in `InitializationVector`'s companion; it is a
+  // context-function given over `Crypto` and is deliberately not re-exported here.
+  export enigmatic.initializationVector.zero
+
+package cryptoProviders:
+  export enigmatic.cryptoProviders.javaStdlibCrypto

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -35,14 +35,14 @@ package soundness
 export
   enigmatic
   . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
-      CipherSession, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence, Dsa, Ecb,
-      encrypt, Encryptor, Encryption, expose,
-      Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel, Permits,
-      Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing, Symmetric, SymmetricKey,
-      TripleDes }
+      CipherSession, Concession, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence,
+      Dsa, Ecb, encrypt, Encryptor, Encryption, expose,
+      Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel, Permit,
+      Permits, Pkcs7, PrivateKey, ProcessingPermit, PublicKey, Rc2, Rsa, Signature, Signing,
+      Symmetric, SymmetricKey, TripleDes }
 
 package blockCipherMode:
-  export enigmatic.blockCipherMode.{cbc, cfb, ctr, ecb, ofb}
+  export enigmatic.blockCipherMode.{cbc, cfb, ctr, ofb}
 
 package blockCipherPadding:
   export enigmatic.blockCipherPadding.{iso10126, pkcs7}
@@ -54,3 +54,7 @@ package initializationVector:
 
 package cryptoProviders:
   export enigmatic.cryptoProviders.javaStdlibCrypto
+
+package crypto:
+  export enigmatic.crypto.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
+      permitDisallowedCrypto}

--- a/lib/enigmatic/src/cose/enigmatic.cose.HmacCipher.scala
+++ b/lib/enigmatic/src/cose/enigmatic.cose.HmacCipher.scala
@@ -33,44 +33,32 @@
 package enigmatic
 package cose
 
-import javax.crypto.spec.SecretKeySpec
-
 import anticipation.*
 import enigmatic.*
 import gastronomy.*
 import prepositional.*
-import rudiments.*
-import vacuous.*
 
 // Adapter that exposes HMAC as a `Cipher & Signing & Symmetric`, so that
 // `SymmetricKey[HmacCipher[Sha2[256]]]` plugs into the existing
 // `PrivateKey`/`SymmetricKey` machinery in enigmatic.core. Avoids a refactor
-// of `enigmatic.Hmac` (which is an output type, not a cipher).
+// of `enigmatic.Hmac` (which is an output type, not a cipher). The HMAC and
+// secure-random work is delegated to the in-scope `Crypto` provider.
 object HmacCipher:
-  given value: [algorithm <: Algorithm] => (hash: Hash in algorithm) => HmacCipher[algorithm] =
+  given value: [algorithm <: Algorithm] => (hash: Hash in algorithm) => (crypto: Crypto)
+            => HmacCipher[algorithm] =
     HmacCipher[algorithm]()
 
-class HmacCipher[algorithm <: Algorithm]()(using hash: Hash in algorithm)
+class HmacCipher[algorithm <: Algorithm]()(using hash: Hash in algorithm, crypto: Crypto)
 extends Cipher, Signing, Symmetric:
   type Size = 256
   def keySize: 256 = 256
 
-  def genKey(): Data =
-    val random = java.security.SecureRandom()
-    val bytes = new Array[Byte](32)
-    random.nextBytes(bytes)
-    bytes.immutable(using Unsafe)
-
+  def genKey(): Data = crypto.random.bytes(32)
   def privateToPublic(key: Data): Data = key
-
-  def sign(data: Data, keyData: Data): Data =
-    val mac = hash.hmac0
-    mac.init(SecretKeySpec(keyData.to(Array), hash.name.s))
-    mac.doFinal(data.to(Array)).nn.immutable(using Unsafe)
+  def sign(data: Data, keyData: Data): Data = crypto.hmac(hash.hmacName).mac(keyData, data)
 
   def verify(data: Data, signature: Data, keyData: Data): Boolean =
-    val expected = sign(data, keyData)
-    constantTimeEquals(expected, signature)
+    constantTimeEquals(sign(data, keyData), signature)
 
   private def constantTimeEquals(a: Data, b: Data): Boolean =
     if a.length != b.length then false else

--- a/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
+++ b/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
@@ -1,0 +1,243 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package enigmatic
+
+import java.lang.foreign.*
+
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+import xenophile.*
+
+// A `Crypto` provider backed by OpenSSL's `libcrypto`, called through the
+// xenophile native FFM layer (`ForeignLibrary`): the C prototypes below are parsed
+// by `CHeaderDialect` and each call becomes a `java.lang.foreign` downcall.
+//
+// Native today: `random` (RAND_bytes), `hmac` (one-shot HMAC), and `aes` (the EVP
+// cipher API, for PKCS#7 and no-padding; ISO-10126 is a JCE-only scheme and is not
+// offered). `rsa` currently delegates to the JDK provider — native EVP_PKEY RSA
+// (DER key parsing + keygen) is future work.
+//
+// Select it with `import cryptoProviders.opensslCrypto`.
+object OpensslCrypto extends Crypto:
+  private val header: Text = t"""
+    int RAND_bytes(unsigned char* buf, int num);
+
+    const EVP_MD* EVP_sha1(void);
+    const EVP_MD* EVP_md5(void);
+    const EVP_MD* EVP_sha256(void);
+    const EVP_MD* EVP_sha384(void);
+    const EVP_MD* EVP_sha512(void);
+    unsigned char* HMAC(const EVP_MD* md, const void* key, int key_len, const unsigned char* d,
+        size_t n, unsigned char* out, unsigned int* out_len);
+
+    const EVP_CIPHER* EVP_get_cipherbyname(const char* name);
+    EVP_CIPHER_CTX* EVP_CIPHER_CTX_new(void);
+    void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX* ctx);
+    int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX* ctx, int pad);
+    int EVP_EncryptInit_ex(EVP_CIPHER_CTX* ctx, const EVP_CIPHER* type, void* impl,
+        const unsigned char* key, const unsigned char* iv);
+    int EVP_EncryptUpdate(EVP_CIPHER_CTX* ctx, unsigned char* out, int* outl,
+        const unsigned char* in, int inl);
+    int EVP_EncryptFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* out, int* outl);
+    int EVP_DecryptInit_ex(EVP_CIPHER_CTX* ctx, const EVP_CIPHER* type, void* impl,
+        const unsigned char* key, const unsigned char* iv);
+    int EVP_DecryptUpdate(EVP_CIPHER_CTX* ctx, unsigned char* out, int* outl,
+        const unsigned char* in, int inl);
+    int EVP_DecryptFinal_ex(EVP_CIPHER_CTX* ctx, unsigned char* out, int* outl);
+    """
+
+  private val paths: List[Text] = List
+   (t"/opt/homebrew/opt/openssl@3/lib/libcrypto.dylib",
+    t"/opt/homebrew/lib/libcrypto.dylib",
+    t"/usr/local/opt/openssl@3/lib/libcrypto.dylib",
+    t"libcrypto.so.3",
+    t"libcrypto.so",
+    t"libcrypto.dylib")
+
+  // The library outlives every call, so it is bound to the global arena.
+  private lazy val lib: ForeignLibrary = ForeignLibrary(header, paths)(using Arena.global().nn)
+
+  private val int: ValueLayout.OfInt = ValueLayout.JAVA_INT.nn
+
+  def random: Crypto.Random = new Crypto.Random:
+    def bytes(size: Int): Data =
+      val arena = Arena.ofConfined().nn
+
+      try
+        val buffer = arena.allocate(size.toLong).nn
+        lib.handle(t"RAND_bytes").invokeWithArguments(buffer, Integer.valueOf(size))
+        ForeignLibrary.bytes(buffer, size)
+      finally arena.close()
+
+  def hmac(algorithm: Text): Crypto.Mac = new Crypto.Mac:
+    def mac(key: Data, data: Data): Data =
+      val arena = Arena.ofConfined().nn
+
+      try
+        val md = digest(algorithm)
+        val keySegment = ForeignLibrary.segment(key)(using arena)
+        val dataSegment = ForeignLibrary.segment(data)(using arena)
+        val output = arena.allocate(64L).nn          // EVP_MAX_MD_SIZE
+        val outputLength = arena.allocate(int).nn
+
+        lib.handle(t"HMAC").invokeWithArguments(md, keySegment, Integer.valueOf(key.length),
+            dataSegment, java.lang.Long.valueOf(data.length.toLong), output, outputLength)
+
+        ForeignLibrary.bytes(output, outputLength.get(int, 0L))
+      finally arena.close()
+
+  def aes: Crypto.SymmetricCipher = symmetric(t"AES")
+
+  // RSA is not yet implemented natively (it needs EVP_PKEY DER parsing and keygen);
+  // delegate to the JDK provider so this remains a complete `Crypto`.
+  def rsa: Crypto.PublicKeyCipher = JavaStdlibCrypto.rsa
+
+  private def digest(algorithm: Text): MemorySegment =
+    val function = algorithm match
+      case t"HmacSHA256" => t"EVP_sha256"
+      case t"HmacSHA384" => t"EVP_sha384"
+      case t"HmacSHA512" => t"EVP_sha512"
+      case t"HmacSHA1"   => t"EVP_sha1"
+      case t"HmacMD5"    => t"EVP_md5"
+      case other         => panic(m"unsupported HMAC algorithm: $other")
+
+    lib.handle(function).invokeWithArguments().nn.asInstanceOf[MemorySegment]
+
+  // Maps a JCE-style cipher name (`AES`, `CBC`, key length) to OpenSSL's name, e.g.
+  // `aes-256-cbc`. Only AES is offered; other block ciphers would need their own
+  // key-length handling.
+  private def opensslCipher(algorithm: Text, mode: Text, keyLength: Int): Text = algorithm match
+    case t"AES" => t"aes-${keyLength*8}-${mode.lower}"
+    case other  => panic(m"unsupported OpenSSL cipher: $other")
+
+  private def cipher(name: Text)(using arena: Arena): MemorySegment =
+    val nameSegment = arena.allocateFrom(name.s).nn
+    val handle = lib.handle(t"EVP_get_cipherbyname").invokeWithArguments(nameSegment).nn
+    val result = handle.asInstanceOf[MemorySegment]
+    if result.address == 0L then panic(m"unknown OpenSSL cipher: $name") else result
+
+  private def symmetric(algorithm: Text): Crypto.SymmetricCipher = new Crypto.SymmetricCipher:
+    def blockSize(transformation: Text): Int = if algorithm == t"AES" then 16 else 8
+    def generateKey(bits: Int): Data = random.bytes(bits/8)
+
+    def encrypt(transformation: Text, key: Data, iv: Optional[Data], data: Data): Data =
+      val body = oneShot(encrypting = true, transformation, key, iv, data)
+      iv.lay(body)(_ ++ body)
+
+    def decrypt(transformation: Text, key: Data, ivSize: Optional[Int], data: Data): Data =
+      ivSize.lay(oneShot(encrypting = false, transformation, key, Unset, data)): size =>
+        oneShot(encrypting = false, transformation, key, data.take(size), data.drop(size))
+
+    def stream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession =
+      val arena = Arena.ofShared().nn
+      val parts = transformation.cut(t"/")
+      val context = newContext()
+      val cipher0 = cipher(opensslCipher(parts(0), parts(1), key.length))(using arena)
+      val keySegment = ForeignLibrary.segment(key)(using arena)
+      val ivSegment = iv.lay(MemorySegment.NULL)(ForeignLibrary.segment(_)(using arena))
+      lib.handle(t"EVP_EncryptInit_ex").invokeWithArguments
+       (context, cipher0, MemorySegment.NULL, keySegment, ivSegment)
+
+      if parts(2) == t"NoPadding"
+      then lib.handle(t"EVP_CIPHER_CTX_set_padding").invokeWithArguments(context, Integer.valueOf(0))
+
+      val block = if parts(0) == t"AES" then 16 else 8
+
+      new CipherSession:
+        def update(chunk: Data): Data =
+          val output = arena.allocate((chunk.length + block).toLong).nn
+          val length = arena.allocate(int).nn
+          val input = ForeignLibrary.segment(chunk)(using arena)
+          lib.handle(t"EVP_EncryptUpdate").invokeWithArguments
+           (context, output, length, input, Integer.valueOf(chunk.length))
+
+          ForeignLibrary.bytes(output, length.get(int, 0L))
+
+        def finish(): Data =
+          val output = arena.allocate(block.toLong).nn
+          val length = arena.allocate(int).nn
+          lib.handle(t"EVP_EncryptFinal_ex").invokeWithArguments(context, output, length)
+          val result = ForeignLibrary.bytes(output, length.get(int, 0L))
+          lib.handle(t"EVP_CIPHER_CTX_free").invokeWithArguments(context)
+          arena.close()
+          result
+
+  private def newContext(): MemorySegment =
+    lib.handle(t"EVP_CIPHER_CTX_new").invokeWithArguments().nn.asInstanceOf[MemorySegment]
+
+  // One-shot EVP encrypt/decrypt (init → update → final), returning the raw output
+  // without IV framing (the caller prepends/strips the IV).
+  private def oneShot(encrypting: Boolean, transformation: Text, key: Data, iv: Optional[Data],
+                      data: Data): Data =
+    val arena = Arena.ofConfined().nn
+
+    try
+      val parts = transformation.cut(t"/")
+      val cipher0 = cipher(opensslCipher(parts(0), parts(1), key.length))(using arena)
+      val context = newContext()
+
+      try
+        val keySegment = ForeignLibrary.segment(key)(using arena)
+        val ivSegment = iv.lay(MemorySegment.NULL)(ForeignLibrary.segment(_)(using arena))
+        val initFunction = if encrypting then t"EVP_EncryptInit_ex" else t"EVP_DecryptInit_ex"
+
+        lib.handle(initFunction).invokeWithArguments
+         (context, cipher0, MemorySegment.NULL, keySegment, ivSegment)
+
+        if parts(2) == t"NoPadding" then
+          lib.handle(t"EVP_CIPHER_CTX_set_padding").invokeWithArguments(context, Integer.valueOf(0))
+
+        val block = if parts(0) == t"AES" then 16 else 8
+        val output = arena.allocate((data.length + block).toLong).nn
+        val input = ForeignLibrary.segment(data)(using arena)
+        val length1 = arena.allocate(int).nn
+        val updateFunction = if encrypting then t"EVP_EncryptUpdate" else t"EVP_DecryptUpdate"
+
+        lib.handle(updateFunction).invokeWithArguments
+         (context, output, length1, input, Integer.valueOf(data.length))
+
+        val count1 = length1.get(int, 0L)
+        val length2 = arena.allocate(int).nn
+        val finalFunction = if encrypting then t"EVP_EncryptFinal_ex" else t"EVP_DecryptFinal_ex"
+
+        lib.handle(finalFunction).invokeWithArguments(context, output.asSlice(count1.toLong).nn, length2)
+
+        ForeignLibrary.bytes(output, count1 + length2.get(int, 0L))
+      finally lib.handle(t"EVP_CIPHER_CTX_free").invokeWithArguments(context)
+    finally arena.close()
+
+package cryptoProviders:
+  given opensslCrypto: OpensslCrypto.type = OpensslCrypto

--- a/lib/enigmatic/src/openssl/soundness_enigmatic_openssl.scala
+++ b/lib/enigmatic/src/openssl/soundness_enigmatic_openssl.scala
@@ -32,4 +32,7 @@
                                                                                                   */
 package soundness
 
-export xenophile.{Native, ForeignLibrary}
+export enigmatic.OpensslCrypto
+
+package cryptoProviders:
+  export enigmatic.cryptoProviders.opensslCrypto

--- a/lib/enigmatic/src/test/enigmatic_compile_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_compile_test.scala
@@ -36,6 +36,7 @@ import soundness.*
 
 import charEncoders.utf8
 import blockCipherMode.cbc, blockCipherPadding.pkcs7
+import cryptoProviders.javaStdlibCrypto
 
 // Compile-time regressions for the cipher API. (Capture-checking confinement of
 // the exposed `Encryptor`/`Decryptor` capability is not yet enabled — see

--- a/lib/enigmatic/src/test/enigmatic_compile_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_compile_test.scala
@@ -37,6 +37,7 @@ import soundness.*
 import charEncoders.utf8
 import blockCipherMode.cbc, blockCipherPadding.pkcs7
 import cryptoProviders.javaStdlibCrypto
+import crypto.permitUnauthenticatedCrypto   // AES-CBC is unauthenticated
 
 // Compile-time regressions for the cipher API. (Capture-checking confinement of
 // the exposed `Encryptor`/`Decryptor` capability is not yet enabled — see
@@ -61,3 +62,12 @@ object CompileChecks:
   // compile, whereas every padded cipher is total (verified manually — uncomment).
   //
   //   val noTactic = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
+
+  // Permission regression: only `crypto.permitUnauthenticatedCrypto` is imported
+  // here, so AES (above) compiles, but reaching a "disallowed" algorithm without
+  // `crypto.permitDisallowedCrypto` does not — encrypting with DES fails with the
+  // `Permit` "no given instance" diagnostic (verified manually — uncomment). Note
+  // that key generation is *not* gated; only the encryption operation is.
+  //
+  //   val desKey = SymmetricKey.generate[Des over Cbc against Pkcs7]()
+  //   val desText = desKey.expose(t"Hello world".encrypt)

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -335,3 +335,61 @@ object Tests extends Suite(m"Gastronomy tests"):
         tampered(tampered.length - 5) = (tampered(tampered.length - 5) ^ 0xFF.toByte).toByte
         tampered.immutable(using Unsafe).verify[Cose](key)
       . assert(!_)
+
+    suite(m"OpenSSL provider (libcrypto via xenophile FFM)"):
+      // A local `given Crypto` outranks the file-level `javaStdlibCrypto` import,
+      // so each block unambiguously selects its provider; cross-validating the two
+      // proves the OpenSSL path agrees with the JDK on the wire.
+      val key32: Data = t"a-32-byte-key-for-aes-256-cbc!!!".data
+
+      test(m"RAND_bytes returns the requested number of bytes"):
+        OpensslCrypto.random.bytes(32).length
+      . assert(_ == 32)
+
+      test(m"HMAC-SHA256 agrees with the JDK provider"):
+        val jdk = pangram.hmac[Sha2[256]](t"key".data).serialize[Hex]
+        val openssl = { given Crypto = OpensslCrypto; pangram.hmac[Sha2[256]](t"key".data).serialize[Hex] }
+        jdk == openssl
+      . assert(_ == true)
+
+      test(m"HMAC-SHA512 agrees with the JDK provider"):
+        val jdk = pangram.hmac[Sha2[512]](t"key".data).serialize[Hex]
+        val openssl = { given Crypto = OpensslCrypto; pangram.hmac[Sha2[512]](t"key".data).serialize[Hex] }
+        jdk == openssl
+      . assert(_ == true)
+
+      test(m"AES-256-CBC ciphertext agrees with the JDK provider (fixed IV)"):
+        given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+        val key: SymmetricKey[Aes[256] over Cbc against Pkcs7] = SymmetricKey(key32)
+        val jdk = key.expose(t"Hello world".encrypt.serialize[Hex])
+        val openssl = { given Crypto = OpensslCrypto; key.expose(t"Hello world".encrypt.serialize[Hex]) }
+        jdk == openssl
+      . assert(_ == true)
+
+      test(m"AES-256-CBC round-trips under the OpenSSL provider"):
+        given Crypto = OpensslCrypto
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        key.expose(t"Hello world".encrypt.decrypt.text)
+      . assert(_ == t"Hello world")
+
+      test(m"OpenSSL decrypts what the JDK encrypted (CBC, fixed IV)"):
+        given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+        val key: SymmetricKey[Aes[256] over Cbc against Pkcs7] = SymmetricKey(key32)
+        val ciphertext = key.expose(t"Interoperable!".encrypt)
+        val plaintext = { given Crypto = OpensslCrypto; key.expose(ciphertext.decrypt.text) }
+        plaintext
+      . assert(_ == t"Interoperable!")
+
+      test(m"AES-128-CTR/NoPadding round-trips under the OpenSSL provider"):
+        given Crypto = OpensslCrypto
+        val key = SymmetricKey.generate[Aes[128] over Ctr against NoPadding]()
+        key.expose(t"Hello world".encrypt.decrypt.text)
+      . assert(_ == t"Hello world")
+
+      test(m"OpenSSL streaming encryption round-trips via one-shot decryption"):
+        given Crypto = OpensslCrypto
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        key.expose:
+          val chunks = Stream(t"Hello, ".data, t"streaming ".data, t"world!".data)
+          chunks.encrypt.reduce(_ ++ _).decrypt.text
+      . assert(_ == t"Hello, streaming world!")

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -37,6 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import charDecoders.utf8, charEncoders.utf8, textSanitizers.skip
 import errorDiagnostics.stackTraces
+import cryptoProviders.javaStdlibCrypto
 
 import alphabets.hex.upperCase
 
@@ -178,6 +179,21 @@ object Tests extends Suite(m"Gastronomy tests"):
 
     test(m"An imported zero IV makes CBC encryption deterministic"):
       import initializationVector.zero
+      val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+      key.expose:
+        t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]
+    . assert(_ == true)
+
+    test(m"A custom Crypto provider can supply deterministic randomness"):
+      // A provider that reuses the JDK's algorithms but fixes its randomness; the
+      // resulting all-zero IV makes CBC encryption repeatable, demonstrating that
+      // the provider seam (and its random source) is injectable.
+      given Crypto:
+        def random: Crypto.Random = size => IArray.fill[Byte](size)(0.toByte)
+        def aes: Crypto.SymmetricCipher = javaStdlibCrypto.aes
+        def rsa: Crypto.PublicKeyCipher = javaStdlibCrypto.rsa
+        def hmac(algorithm: Text): Crypto.Mac = javaStdlibCrypto.hmac(algorithm)
+
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
         t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -38,6 +38,7 @@ import strategies.throwUnsafely
 import charDecoders.utf8, charEncoders.utf8, textSanitizers.skip
 import errorDiagnostics.stackTraces
 import cryptoProviders.javaStdlibCrypto
+import crypto.permitDisallowedCrypto   // the suite deliberately exercises weak crypto
 
 import alphabets.hex.upperCase
 

--- a/lib/xenophile/src/native/xenophile.ForeignLibrary.scala
+++ b/lib/xenophile/src/native/xenophile.ForeignLibrary.scala
@@ -30,6 +30,83 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Native, ForeignLibrary}
+import java.lang.foreign.*
+import java.lang.invoke.MethodHandle
+
+import anticipation.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// A loaded native library, paired with the C signatures `CHeaderDialect` read from
+// a header. This is the runtime half of the `native` ecosystem — the Foreign /
+// Memory (FFM) "evaluator" that turns a navigated foreign function into an actual
+// downcall. The compile-time `Foreign` navigator type-checks calls against the same
+// header; this executes them.
+object ForeignLibrary:
+  private def linker: Linker = Linker.nativeLinker.nn
+
+  // Maps a C type (as canonicalised by `CHeaderDialect`) to an FFM memory layout.
+  // Every pointer and string is an `ADDRESS`; the numeric primitives map to their
+  // same-width FFM value layout. Opaque/unknown named types are assumed to be
+  // passed by pointer (the `extern "C"` convention for handles like `EVP_PKEY*`).
+  def layout(tpe: Foreign.Type): MemoryLayout = tpe match
+    case Foreign.Type.Named(t"int")    => ValueLayout.JAVA_INT.nn
+    case Foreign.Type.Named(t"long")   => ValueLayout.JAVA_LONG.nn
+    case Foreign.Type.Named(t"short")  => ValueLayout.JAVA_SHORT.nn
+    case Foreign.Type.Named(t"char")   => ValueLayout.JAVA_BYTE.nn
+    case Foreign.Type.Named(t"double") => ValueLayout.JAVA_DOUBLE.nn
+    case Foreign.Type.Named(t"float")  => ValueLayout.JAVA_FLOAT.nn
+    case Foreign.Type.Named(t"bool")   => ValueLayout.JAVA_BOOLEAN.nn
+    case _                             => ValueLayout.ADDRESS.nn
+
+  def descriptor(signature: Signature): FunctionDescriptor =
+    val parameters = signature.parameters.or(Nil).map(layout)
+
+    signature.result match
+      case Foreign.Type.Named(t"void") => FunctionDescriptor.ofVoid(parameters*).nn
+      case result                      => FunctionDescriptor.of(layout(result), parameters*).nn
+
+  // Loads the first of `paths` that resolves as a symbol lookup bound to `arena`,
+  // pairing it with the function signatures parsed from `header`.
+  def apply(header: Text, paths: List[Text])(using arena: Arena): ForeignLibrary =
+    def attempt(remaining: List[Text]): SymbolLookup = remaining match
+      case path :: rest =>
+        try SymbolLookup.libraryLookup(path.s, arena).nn catch case _: Throwable => attempt(rest)
+
+      case Nil =>
+        throw IllegalArgumentException(t"no native library could be loaded from $paths".s)
+
+    val signatures = CHeaderDialect.parse(header).getOrElse(CHeaderDialect.library, Map())
+    new ForeignLibrary(attempt(paths), signatures)
+
+  // The process-wide default lookup (the C standard library and already-loaded
+  // images); useful for `libc` symbols without naming a library file.
+  def system(header: Text): ForeignLibrary =
+    val signatures = CHeaderDialect.parse(header).getOrElse(CHeaderDialect.library, Map())
+    new ForeignLibrary(linker.defaultLookup.nn, signatures)
+
+  // Copies bytes into freshly-allocated native memory in `arena`.
+  def segment(bytes: Data)(using arena: Arena): MemorySegment =
+    val source = bytes.mutable(using Unsafe)
+    val target = arena.allocate(bytes.length.toLong).nn
+    MemorySegment.copy(source, 0, target, ValueLayout.JAVA_BYTE, 0L, bytes.length)
+    target
+
+  // Reads `length` bytes back out of a native segment.
+  def bytes(segment: MemorySegment, length: Int): Data =
+    val array = new Array[Byte](length)
+    MemorySegment.copy(segment, ValueLayout.JAVA_BYTE, 0L, array, 0, length)
+    array.immutable(using Unsafe)
+
+class ForeignLibrary(lookup: SymbolLookup, signatures: Map[Text, Signature]):
+  // A bound `MethodHandle` for the named function, built from its parsed C
+  // signature. Invoke it with `invokeWithArguments`, passing `MemorySegment`s for
+  // pointer parameters and boxed primitives for the rest.
+  def handle(function: Text): MethodHandle =
+    val signature = signatures.getOrElse(function, panic(m"no such foreign function: $function"))
+    val symbol = lookup.find(function.s).nn.orElseThrow().nn
+    ForeignLibrary.linker.downcallHandle(symbol, ForeignLibrary.descriptor(signature)).nn

--- a/lib/xenophile/src/test/xenophile_test.scala
+++ b/lib/xenophile/src/test/xenophile_test.scala
@@ -161,6 +161,13 @@ object Tests extends Suite(m"Xenophile tests"):
     suite(m"Native (C headers)"):
       val library: Foreign of "library" from Native = Foreign["library", Native]
 
+      test(m"FFM: call libc strlen through a parsed C header"):
+        val arena = java.lang.foreign.Arena.global().nn
+        val libc = ForeignLibrary.system(t"long strlen(const char* s);")
+        val text = arena.allocateFrom("hello, world").nn
+        libc.handle(t"strlen").invokeWithArguments(text).nn.asInstanceOf[Long]
+      . assert(_ == 12L)
+
       test(m"a C struct field has the field's foreign type"):
         val point: Foreign of "Point" from Native = Foreign["Point", Native]
         point.x.expr


### PR DESCRIPTION
Enigmatic's cryptography is no longer hardwired to the JDK: the algorithmic backend is now a pluggable `Crypto` provider chosen by an explicit import, with a JDK-backed default and a new OpenSSL provider that calls libcrypto through a `java.lang.foreign` layer in xenophile's native ecosystem, and sub-optimal algorithms, key lengths and modes are now gated at compile time behind erased permits named after NIST SP 800-131A statuses.

Cryptographic operations now require a `Crypto` provider in scope, selected with an explicit import such as `import cryptoProviders.javaStdlibCrypto` (the JDK-backed default):

```scala
import cryptoProviders.javaStdlibCrypto
import crypto.permitUnauthenticatedCrypto      // AES-CBC is unauthenticated

val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
key.expose(t"Hello world".encrypt.decrypt.text)
```

An OpenSSL-backed provider is also available via `import cryptoProviders.opensslCrypto`. It calls `libcrypto` for secure random, HMAC and AES (RSA still falls back to the JDK) through a new `ForeignLibrary` FFM layer in xenophile's native ecosystem, and produces byte-identical output to the JDK provider. The FFM layer parses a C header with `CHeaderDialect` and builds native downcall handles, so it is reusable for binding other C libraries.

Sub-optimal cryptography must now be opted into. Using a deprecated, legacy, disallowed or unauthenticated algorithm/mode requires importing the matching erased permit — named after NIST SP 800-131A statuses — or it fails to compile:

```scala
import crypto.permitDisallowedCrypto           // unlocks DES, RC2, ECB, RSA-1024, …

val key = SymmetricKey.generate[Des over Cbc against Pkcs7]()
```

`Permit` (encrypt/sign) extends `ProcessingPermit` (decrypt/verify), so `permitLegacyCrypto` allows reading already-protected data without allowing new protection to be applied. The permits are erased, so this safety is purely a compile-time gate with no runtime cost. Because all current block-cipher modes are unauthenticated, `permitUnauthenticatedCrypto` is needed for ordinary AES-CBC until authenticated encryption lands.
