### PR TITLE
Pluggable hashing providers and shared NIST permits in gastronomy

### DIFF
--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -41,7 +41,7 @@ import eucalyptus.*
 import exoskeleton.*
 import fulminate.*
 import galilei.*
-import gastronomy.*
+import gastronomy.*, hashProviders.javaStdlibHashing
 import gossamer.*
 import hellenism.*
 import hieroglyph.*

--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -41,7 +41,7 @@ import eucalyptus.*
 import exoskeleton.*
 import fulminate.*
 import galilei.*
-import gastronomy.*, hashProviders.javaStdlibHashing
+import gastronomy.*, hashProviders.javaStdlibHashing, crypto.permitDeprecatedCrypto
 import gossamer.*
 import hellenism.*
 import hieroglyph.*

--- a/lib/embarcadero/src/oci/embarcadero_oci.scala
+++ b/lib/embarcadero/src/oci/embarcadero_oci.scala
@@ -33,7 +33,7 @@
 package embarcadero
 
 import anticipation.*
-import gastronomy.*
+import gastronomy.*, hashProviders.javaStdlibHashing
 import gesticulate.*
 import gossamer.*
 import hieroglyph.*, charEncoders.utf8

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -35,6 +35,7 @@ package embarcadero
 import soundness.*
 import bitumen.fromGzip
 
+import hashProviders.javaStdlibHashing
 import alphabets.hex.lowerCase
 import charEncoders.utf8
 import jsonPrinters.minimal

--- a/lib/enigmatic/src/core/enigmatic.BlockCipherMode.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipherMode.scala
@@ -33,6 +33,7 @@
 package enigmatic
 
 import anticipation.*
+import gastronomy.{Permit, Concession}
 import gossamer.*
 import prepositional.*
 

--- a/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PrivateKey.scala
@@ -33,7 +33,7 @@
 package enigmatic
 
 import anticipation.*
-import gastronomy.*
+import gastronomy.*, hashProviders.javaStdlibHashing
 import gossamer.*
 import monotonous.*
 import prepositional.*

--- a/lib/enigmatic/src/core/enigmatic.PublicKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.PublicKey.scala
@@ -33,6 +33,7 @@
 package enigmatic
 
 import anticipation.*
+import gastronomy.ProcessingPermit
 import gossamer.*
 import monotonous.*
 import prepositional.*

--- a/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
@@ -33,6 +33,7 @@
 package enigmatic
 
 import anticipation.*
+import gastronomy.ProcessingPermit
 import prepositional.*
 
 object SymmetricKey:

--- a/lib/enigmatic/src/core/enigmatic.Weakness.scala
+++ b/lib/enigmatic/src/core/enigmatic.Weakness.scala
@@ -30,17 +30,29 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package enigmatic
 
-export
-  gastronomy
-  . { Algorithm, Blake3, checksum, Concession, Crc32, Digest, digest, Digester, Digestible,
-      Digestion, Feistel, Hash, Hashing, Md5, Permit, ProcessingPermit, Sha1, Sha2, Sha384,
-      Sha512 }
+import gastronomy.Concession
 
-package hashProviders:
-  export gastronomy.hashProviders.{javaStdlibHashing, soundnessHashing}
+// The cipher-side concession match types. The shared `Concession` markers, `Permit`
+// and the `crypto.permit…Crypto` aggregates live in gastronomy; these map a cipher
+// type to its concession.
 
-package crypto:
-  export gastronomy.crypto.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
-      permitDisallowedCrypto}
+// The algorithm/key-length concession of a cipher type, extracted by matching the
+// (possibly `over`/`against`-refined) cipher. Anything not named here — AES,
+// RSA-2048, HMAC — is `Acceptable` and needs no permission.
+type Weakness[cipher] = cipher match
+  case Des          => Concession.Des
+  case TripleDes[?] => Concession.TripleDes
+  case Rc2[?]       => Concession.Rc2
+  case Blowfish[?]  => Concession.Blowfish
+  case Rsa[1024]    => Concession.SmallRsa
+  case Dsa[?]       => Concession.Dsa
+  case _            => Concession.Acceptable
+
+// Every (non-AEAD) block cipher is unauthenticated; asymmetric ciphers are not
+// classified this way. When authenticated encryption is added, its ciphers will
+// fall through to `Acceptable` here.
+type Authentication[cipher] = cipher match
+  case BlockCipher => Concession.Unauthenticated
+  case _           => Concession.Acceptable

--- a/lib/enigmatic/src/core/enigmatic_core.scala
+++ b/lib/enigmatic/src/core/enigmatic_core.scala
@@ -39,7 +39,8 @@ import rudiments.*
 import vacuous.*
 
 extension [encodable: Encodable in Data](value: encodable)
-  def hmac[algorithm <: Algorithm](key: Data)(using hash: Hash in algorithm, crypto: Crypto)
+  def hmac[algorithm <: Algorithm](key: Data)
+      (using hash: Hash in algorithm, crypto: Crypto, erased weakness: Permit[HashWeakness[algorithm]])
   :   Hmac in algorithm =
 
     Hmac(crypto.hmac(hash.hmacName).mac(key, encodable.encode(value)))
@@ -74,35 +75,6 @@ package initializationVector:
 package cryptoProviders:
   given javaStdlibCrypto: JavaStdlibCrypto.type = JavaStdlibCrypto
 
-// Opt-in permits for sub-optimal cryptography, named after NIST SP 800-131A's
-// algorithm statuses. Each is an (erased) intersection of fine-grained `Permit`s,
-// so the named levels and any future year-based levels compose from the same
-// primitives. The levels nest by inclusion: `permitDisallowedCrypto` contains
-// every other permit, and since `Permit <: ProcessingPermit` it also covers
-// "legacy use". Import the weakest level that covers what you need.
-package crypto:
-  // Unauthenticated (non-AEAD) encryption — currently every block-cipher mode.
-  erased given permitUnauthenticatedCrypto: Permit[Concession.Unauthenticated] =
-    caps.unsafe.unsafeErasedValue
-
-  // "Deprecated": usable but transitional (e.g. Triple-DES).
-  erased given permitDeprecatedCrypto: Permit[Concession.TripleDes] =
-    caps.unsafe.unsafeErasedValue
-
-  // "Legacy use": processing already-protected data only (decrypt/verify).
-  erased given permitLegacyCrypto
-      : ProcessingPermit[Concession.TripleDes] & ProcessingPermit[Concession.Dsa] =
-    caps.unsafe.unsafeErasedValue
-
-  // "Disallowed": broken or non-approved algorithms, key lengths and modes;
-  // subsumes every weaker permit above.
-  erased given permitDisallowedCrypto
-      : Permit[Concession.Des]
-      & Permit[Concession.Rc2]
-      & Permit[Concession.Blowfish]
-      & Permit[Concession.TripleDes]
-      & Permit[Concession.Dsa]
-      & Permit[Concession.SmallRsa]
-      & Permit[Concession.Ecb]
-      & Permit[Concession.Unauthenticated] =
-    caps.unsafe.unsafeErasedValue
+// The `Permit`/`Concession` machinery and the `crypto.permit…Crypto` aggregates
+// live in gastronomy (shared with hashing); the cipher concessions they cover are
+// mapped from cipher types by `Weakness`/`Authentication` in `enigmatic.Weakness`.

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -38,6 +38,7 @@ import javax.crypto as jc
 import anticipation.*
 import contingency.*
 import distillate.*
+import gastronomy.{Permit, ProcessingPermit}
 import gossamer.*
 import prepositional.*
 import vacuous.*

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -32,13 +32,15 @@
                                                                                                   */
 package soundness
 
+// `Concession`, `Permit`, `ProcessingPermit` and the `crypto.permit…Crypto`
+// aggregates are re-exported by gastronomy (where they now live).
 export
   enigmatic
   . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
-      CipherSession, Concession, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence,
+      CipherSession, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence,
       Dsa, Ecb, encrypt, Encryptor, Encryption, expose,
-      Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel, Permit,
-      Permits, Pkcs7, PrivateKey, ProcessingPermit, PublicKey, Rc2, Rsa, Signature, Signing,
+      Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel,
+      Permits, Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing,
       Symmetric, SymmetricKey, TripleDes }
 
 package blockCipherMode:
@@ -54,7 +56,3 @@ package initializationVector:
 
 package cryptoProviders:
   export enigmatic.cryptoProviders.javaStdlibCrypto
-
-package crypto:
-  export enigmatic.crypto.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
-      permitDisallowedCrypto}

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -38,6 +38,7 @@ import strategies.throwUnsafely
 import charDecoders.utf8, charEncoders.utf8, textSanitizers.skip
 import errorDiagnostics.stackTraces
 import cryptoProviders.javaStdlibCrypto
+import hashProviders.javaStdlibHashing
 import crypto.permitDisallowedCrypto   // the suite deliberately exercises weak crypto
 
 import alphabets.hex.upperCase

--- a/lib/gastronomy/src/core/gastronomy.Blake3.scala
+++ b/lib/gastronomy/src/core/gastronomy.Blake3.scala
@@ -33,7 +33,6 @@
 package gastronomy
 
 import java.nio.charset.StandardCharsets
-import javax.crypto as jc
 
 import anticipation.*
 import fulminate.*
@@ -41,6 +40,8 @@ import gossamer.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+
+import scala.reflect.Selectable.reflectiveSelectable
 
 object Blake3:
   private final val OutLen   = 32
@@ -291,15 +292,14 @@ object Blake3:
 
       current.rootOutputBytes(outLen).immutable(using Unsafe)
 
-  given hash: Hash in Blake3:
-    def name:     Text = t"BLAKE3"
-    def hmacName: Text = t"HMAC-BLAKE3"
-    def hmac0:    jc.Mac = panic(m"BLAKE3 HMAC is not implemented")
+  given hash: (hashing: Hashing { def blake3: Hashing.Function }) => Hash in Blake3 =
+    Hash(t"BLAKE3", t"HMAC-BLAKE3", hashing.blake3)
 
-    def initialize(): Digestion = new Digestion:
-      private val hasher: Hasher = Hasher(Iv, 0)
-      def append(bytes: Data): Unit = hasher.update(bytes)
-      def digest(): Data = hasher.complete(OutLen)
+  // The pure-Scala BLAKE3 `Digestion`, used by the Soundness hashing provider.
+  def digestion(): Digestion = new Digestion:
+    private val hasher: Hasher = Hasher(Iv, 0)
+    def append(bytes: Data): Unit = hasher.update(bytes)
+    def digest(): Data = hasher.complete(OutLen)
 
   def hashOf(input: IArray[Byte], length: Int = OutLen): IArray[Byte] =
     val hasher = Hasher(Iv, 0)

--- a/lib/gastronomy/src/core/gastronomy.Concession.scala
+++ b/lib/gastronomy/src/core/gastronomy.Concession.scala
@@ -30,13 +30,23 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package enigmatic
+package gastronomy
 
 // A "concession" is a specific cryptographic weakness a caller must explicitly
 // accept (via a `crypto.permit…Crypto` import) before the corresponding algorithm,
 // key length or mode can be used. `Acceptable` is the absence of any weakness.
+//
+// All concession markers live here in gastronomy (the lowest crypto module) so the
+// permit vocabulary is shared: the hash concessions are used by gastronomy itself,
+// while the cipher/mode concessions are used by enigmatic downstream.
 object Concession:
   sealed trait Acceptable
+
+  // hashing concessions (gastronomy)
+  sealed trait Md5
+  sealed trait Sha1
+
+  // cipher concessions (enigmatic)
   sealed trait Des
   sealed trait TripleDes
   sealed trait Rc2
@@ -46,21 +56,9 @@ object Concession:
   sealed trait Ecb
   sealed trait Unauthenticated
 
-// The algorithm/key-length concession of a cipher type, extracted by matching the
-// (possibly `over`/`against`-refined) cipher. Anything not named here — AES,
-// RSA-2048, HMAC — is `Acceptable` and needs no permission.
-type Weakness[cipher] = cipher match
-  case Des          => Concession.Des
-  case TripleDes[?] => Concession.TripleDes
-  case Rc2[?]       => Concession.Rc2
-  case Blowfish[?]  => Concession.Blowfish
-  case Rsa[1024]    => Concession.SmallRsa
-  case Dsa[?]       => Concession.Dsa
-  case _            => Concession.Acceptable
-
-// Every (non-AEAD) block cipher is unauthenticated; asymmetric ciphers are not
-// classified this way. When authenticated encryption is added, its ciphers will
-// fall through to `Acceptable` here.
-type Authentication[cipher] = cipher match
-  case BlockCipher => Concession.Unauthenticated
-  case _           => Concession.Acceptable
+// The concession of a hash algorithm: MD5 and SHA-1 are weak; everything else
+// (SHA-2, BLAKE3, CRC-32) is `Acceptable` and needs no permission.
+type HashWeakness[algorithm] = algorithm match
+  case Md5  => Concession.Md5
+  case Sha1 => Concession.Sha1
+  case _    => Concession.Acceptable

--- a/lib/gastronomy/src/core/gastronomy.Crc32.scala
+++ b/lib/gastronomy/src/core/gastronomy.Crc32.scala
@@ -32,30 +32,15 @@
                                                                                                   */
 package gastronomy
 
-import java.util as ju, ju.zip as juz
-import javax.crypto as jc
-
 import anticipation.*
-import fulminate.*
 import gossamer.*
 import prepositional.*
-import rudiments.*
-import vacuous.*
+
+import scala.reflect.Selectable.reflectiveSelectable
 
 object Crc32:
-  given hash: Hash in Crc32:
-    def initialize(): Digestion = new Digestion:
-      private val state: juz.CRC32 = juz.CRC32()
-
-      def append(bytes: Data): Unit = state.update(bytes.mutable(using Unsafe))
-
-      def digest(): Data =
-        val int = state.getValue()
-        IArray[Byte]((int >> 24).toByte, (int >> 16).toByte, (int >> 8).toByte, int.toByte)
-
-    def name: Text = t"CRC32"
-    def hmacName: Text = t"HMAC-CRC32"
-    def hmac0: jc.Mac = panic(m"this has not been implemented")
+  given hash: (hashing: Hashing { def crc32: Hashing.Function }) => Hash in Crc32 =
+    Hash(t"CRC32", t"HMAC-CRC32", hashing.crc32)
 
 sealed trait Crc32 extends Algorithm:
   type Bits = 32

--- a/lib/gastronomy/src/core/gastronomy.Digestion.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestion.scala
@@ -32,19 +32,10 @@
                                                                                                   */
 package gastronomy
 
-import java.security as js
-
 import anticipation.*
-import rudiments.*
-import vacuous.*
 
-object Digestion:
-  class Java(md: js.MessageDigest) extends Digestion:
-    private val messageDigest: js.MessageDigest = md
-
-    def append(bytes: Data): Unit = messageDigest.update(bytes.mutable(using Unsafe))
-    def digest(): Data = messageDigest.digest.nn.immutable(using Unsafe)
-
+// An incremental hash computation: feed bytes with `append`, then read the result
+// with `digest`. Implementations are supplied by `Hashing` providers.
 trait Digestion:
   def append(bytes: Data): Unit
   def digest(): Data

--- a/lib/gastronomy/src/core/gastronomy.Hash.scala
+++ b/lib/gastronomy/src/core/gastronomy.Hash.scala
@@ -32,22 +32,23 @@
                                                                                                   */
 package gastronomy
 
-import java.security as js
-import javax.crypto as jc
-
 import anticipation.*
 import beneficence.*
 import prepositional.*
 
 object Hash:
-  def apply[algorithm <: Algorithm](name0: Text, hmacName0: Text): Hash in algorithm = new Hash:
-    type Form = algorithm
+  // Builds a `Hash` for `algorithm` from the `Hashing.Function` an in-scope
+  // provider supplies. `name`/`hmacName` are the algorithm's JCE-style descriptors
+  // (the latter used by enigmatic's HMAC); the byte-level digesting is delegated to
+  // the provider's `Function`.
+  def apply[algorithm <: Algorithm](name0: Text, hmacName0: Text, function: Hashing.Function)
+  :   Hash in algorithm =
 
-    val name: Text = name0
-    val hmacName: Text = hmacName0
-
-    def initialize(): Digestion = new Digestion.Java(js.MessageDigest.getInstance(name0.s).nn)
-    def hmac0: jc.Mac = jc.Mac.getInstance(hmacName0.s).nn
+    new Hash:
+      type Form = algorithm
+      val name: Text = name0
+      val hmacName: Text = hmacName0
+      def initialize(): Digestion = function.digestion()
 
 trait Hash extends Findable:
   type Form <: Algorithm
@@ -55,4 +56,3 @@ trait Hash extends Findable:
   def name: Text
   def hmacName: Text
   def initialize(): Digestion
-  def hmac0: jc.Mac

--- a/lib/gastronomy/src/core/gastronomy.Hashing.scala
+++ b/lib/gastronomy/src/core/gastronomy.Hashing.scala
@@ -32,15 +32,17 @@
                                                                                                   */
 package gastronomy
 
-import anticipation.*
-import gossamer.*
-import prepositional.*
+// A pluggable hashing provider: it supplies the implementation of each hash
+// function as a `Hashing.Function` (a factory for fresh `Digestion`s). Providers
+// are *disjoint* — the JDK provider handles MD5/SHA-1/SHA-2/CRC-32, while BLAKE3
+// (with no JDK implementation) is supplied by the pure-Scala Soundness provider —
+// so each algorithm is reached through a structural refinement rather than a
+// mandatory baseline. Select providers with explicit imports, e.g.
+// `import hashProviders.javaStdlibHashing, hashProviders.soundnessHashing`.
+trait Hashing
 
-import scala.reflect.Selectable.reflectiveSelectable
-
-object Sha1:
-  given hash: (hashing: Hashing { def sha1: Hashing.Function }) => Hash in Sha1 =
-    Hash(t"SHA1", t"HmacSHA1", hashing.sha1)
-
-sealed trait Sha1 extends Algorithm:
-  type Bits = 160
+object Hashing:
+  // One hash algorithm's implementation: a factory for a fresh incremental
+  // `Digestion`.
+  trait Function:
+    def digestion(): Digestion

--- a/lib/gastronomy/src/core/gastronomy.JavaStdlibHashing.scala
+++ b/lib/gastronomy/src/core/gastronomy.JavaStdlibHashing.scala
@@ -32,15 +32,34 @@
                                                                                                   */
 package gastronomy
 
+import java.security as js
+import java.util.zip as juz
+
 import anticipation.*
 import gossamer.*
-import prepositional.*
+import rudiments.*
+import vacuous.*
 
-import scala.reflect.Selectable.reflectiveSelectable
+// The default hashing provider, backed by the JDK: `MessageDigest` for the
+// cryptographic hashes and `java.util.zip.CRC32` for the checksum. This is the
+// single home of `java.security`/`java.util.zip` usage in gastronomy. It does not
+// offer BLAKE3 (the JDK has no implementation) — use the Soundness provider.
+object JavaStdlibHashing extends Hashing:
+  def md5:  Hashing.Function = messageDigest(t"MD5")
+  def sha1: Hashing.Function = messageDigest(t"SHA1")
+  def sha2(bits: Int): Hashing.Function = messageDigest(t"SHA-$bits")
 
-object Sha1:
-  given hash: (hashing: Hashing { def sha1: Hashing.Function }) => Hash in Sha1 =
-    Hash(t"SHA1", t"HmacSHA1", hashing.sha1)
+  def crc32: Hashing.Function = new Hashing.Function:
+    def digestion(): Digestion = new Digestion:
+      private val state: juz.CRC32 = juz.CRC32()
+      def append(bytes: Data): Unit = state.update(bytes.mutable(using Unsafe))
 
-sealed trait Sha1 extends Algorithm:
-  type Bits = 160
+      def digest(): Data =
+        val value = state.getValue()
+        IArray[Byte]((value >> 24).toByte, (value >> 16).toByte, (value >> 8).toByte, value.toByte)
+
+  private def messageDigest(name: Text): Hashing.Function = new Hashing.Function:
+    def digestion(): Digestion = new Digestion:
+      private val md: js.MessageDigest = js.MessageDigest.getInstance(name.s).nn
+      def append(bytes: Data): Unit = md.update(bytes.mutable(using Unsafe))
+      def digest(): Data = md.digest.nn.immutable(using Unsafe)

--- a/lib/gastronomy/src/core/gastronomy.Md5.scala
+++ b/lib/gastronomy/src/core/gastronomy.Md5.scala
@@ -36,8 +36,11 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 object Md5:
-  given hash: Hash in Md5 = Hash(t"MD5", t"HmacMD5")
+  given hash: (hashing: Hashing { def md5: Hashing.Function }) => Hash in Md5 =
+    Hash(t"MD5", t"HmacMD5", hashing.md5)
 
 sealed trait Md5 extends Algorithm:
   type Bits = 128

--- a/lib/gastronomy/src/core/gastronomy.Permit.scala
+++ b/lib/gastronomy/src/core/gastronomy.Permit.scala
@@ -30,7 +30,7 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package enigmatic
+package gastronomy
 
 import scala.annotation.implicitNotFound
 
@@ -38,8 +38,10 @@ import scala.annotation.implicitNotFound
 // is permitted. Following NIST SP 800-131A's apply-vs-process distinction:
 // `ProcessingPermit` allows *processing already-protected* data (decrypt/verify),
 // while `Permit` (a subtype) additionally allows *applying new protection*
-// (encrypt/sign). Both are erased — purely compile-time gates with no runtime cost.
-// Bring them into scope with a `crypto.permit…Crypto` import.
+// (encrypt/sign/hash). Both are erased — purely compile-time gates with no runtime
+// cost. Bring them into scope with a `crypto.permit…Crypto` import. Defined here in
+// gastronomy so both gastronomy (weak hashes) and enigmatic (weak ciphers) share
+// one permit vocabulary.
 
 @implicitNotFound("this operation uses an algorithm whose status is \"legacy use\" or worse; "+
     "import a permit (e.g. `crypto.permitLegacyCrypto` to process existing data, or "+

--- a/lib/gastronomy/src/core/gastronomy.Sha2.scala
+++ b/lib/gastronomy/src/core/gastronomy.Sha2.scala
@@ -36,9 +36,13 @@ import anticipation.*
 import gossamer.*
 import prepositional.*
 
+import scala.reflect.Selectable.reflectiveSelectable
+
 object Sha2:
-  given hash: [bits <: 224 | 256 | 384 | 512: ValueOf] => Hash in Sha2[bits] =
-    Hash(t"SHA-${valueOf[bits]}", t"HmacSHA${valueOf[bits]}")
+  given hash: [bits <: 224 | 256 | 384 | 512: ValueOf]
+            => (hashing: Hashing { def sha2(bits: Int): Hashing.Function })
+            => Hash in Sha2[bits] =
+    Hash(t"SHA-${valueOf[bits]}", t"HmacSHA${valueOf[bits]}", hashing.sha2(valueOf[bits]))
 
 sealed trait Sha2[bits <: 224 | 256 | 384 | 512] extends Algorithm:
   type Bits = bits

--- a/lib/gastronomy/src/core/gastronomy.SoundnessHashing.scala
+++ b/lib/gastronomy/src/core/gastronomy.SoundnessHashing.scala
@@ -32,15 +32,9 @@
                                                                                                   */
 package gastronomy
 
-import anticipation.*
-import gossamer.*
-import prepositional.*
-
-import scala.reflect.Selectable.reflectiveSelectable
-
-object Sha1:
-  given hash: (hashing: Hashing { def sha1: Hashing.Function }) => Hash in Sha1 =
-    Hash(t"SHA1", t"HmacSHA1", hashing.sha1)
-
-sealed trait Sha1 extends Algorithm:
-  type Bits = 160
+// A pure-Scala hashing provider for algorithms with no JDK implementation. Today
+// that is just BLAKE3 (implemented in `Blake3`); other native-Scala hashes would
+// be added here. Select it with `import hashProviders.soundnessHashing`.
+object SoundnessHashing extends Hashing:
+  def blake3: Hashing.Function = new Hashing.Function:
+    def digestion(): Digestion = Blake3.digestion()

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -36,14 +36,14 @@ import anticipation.*
 import prepositional.*
 import turbulence.*
 
-package hashFunctions:
-  given blake3: Hash in Blake3 = Blake3.hash
-  given crc32: Hash in Crc32 = Crc32.hash
-  given md5: Hash in Md5 = Md5.hash
-  given sha1: Hash in Sha1 = Sha1.hash
-
-  given sha2: [bits <: 224 | 256 | 384 | 512: ValueOf] => Hash in Sha2[bits] =
-    Sha2.hash[bits]
+// Hashing providers supply the per-algorithm implementations. Pick one (or both)
+// with an explicit import, e.g. `import hashProviders.javaStdlibHashing` for the
+// JDK hashes and `import hashProviders.soundnessHashing` for BLAKE3. The given's
+// type is the provider object's singleton type, so the structurally-typed
+// algorithms it offers stay visible to the per-algorithm `Hash` givens.
+package hashProviders:
+  given javaStdlibHashing: JavaStdlibHashing.type = JavaStdlibHashing
+  given soundnessHashing: SoundnessHashing.type = SoundnessHashing
 
 extension [digestible: Digestible](value: digestible)
   def digest[hash <: Algorithm](using Hash in hash): Digest in hash =

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -45,11 +45,52 @@ package hashProviders:
   given javaStdlibHashing: JavaStdlibHashing.type = JavaStdlibHashing
   given soundnessHashing: SoundnessHashing.type = SoundnessHashing
 
+// Opt-in permits for sub-optimal cryptography, named after NIST SP 800-131A's
+// algorithm statuses. Each is an (erased) intersection of fine-grained `Permit`s,
+// covering both hashes (here) and ciphers (added downstream by enigmatic). The
+// levels nest by inclusion: `permitDisallowedCrypto` contains every other permit,
+// and since `Permit <: ProcessingPermit` it also covers "legacy use".
+package crypto:
+  // Unauthenticated (non-AEAD) encryption — every block-cipher mode (enigmatic).
+  erased given permitUnauthenticatedCrypto: Permit[Concession.Unauthenticated] =
+    caps.unsafe.unsafeErasedValue
+
+  // "Deprecated": usable but transitional — Triple-DES, and SHA-1 (still common in
+  // legacy formats such as Git).
+  erased given permitDeprecatedCrypto: Permit[Concession.TripleDes] & Permit[Concession.Sha1] =
+    caps.unsafe.unsafeErasedValue
+
+  // "Legacy use": processing already-protected data only (decrypt/verify).
+  erased given permitLegacyCrypto
+      : ProcessingPermit[Concession.TripleDes] & ProcessingPermit[Concession.Dsa] =
+    caps.unsafe.unsafeErasedValue
+
+  // "Disallowed": broken or non-approved algorithms, key lengths and modes (incl.
+  // MD5 and SHA-1); subsumes every weaker permit above.
+  erased given permitDisallowedCrypto
+      : Permit[Concession.Des]
+      & Permit[Concession.Rc2]
+      & Permit[Concession.Blowfish]
+      & Permit[Concession.TripleDes]
+      & Permit[Concession.Dsa]
+      & Permit[Concession.SmallRsa]
+      & Permit[Concession.Ecb]
+      & Permit[Concession.Unauthenticated]
+      & Permit[Concession.Md5]
+      & Permit[Concession.Sha1] =
+    caps.unsafe.unsafeErasedValue
+
 extension [digestible: Digestible](value: digestible)
-  def digest[hash <: Algorithm](using Hash in hash): Digest in hash =
+  def digest[hash <: Algorithm]
+      (using hashed: Hash in hash, erased weakness: Permit[HashWeakness[hash]])
+  :   Digest in hash =
+
     val digester = Digester(digestible.digest(_, value))
     digester.apply
 
 extension [source: Streamable by Data](source: source)
-  def checksum[hash <: Algorithm](using Hash in hash): Digest in hash =
+  def checksum[hash <: Algorithm]
+      (using hashed: Hash in hash, erased weakness: Permit[HashWeakness[hash]])
+  :   Digest in hash =
+
     source.stream[Data].digest[hash]

--- a/lib/gastronomy/src/core/soundness_gastronomy_core.scala
+++ b/lib/gastronomy/src/core/soundness_gastronomy_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   gastronomy
   . { Algorithm, Blake3, checksum, Crc32, Digest, digest, Digester, Digestible, Digestion, Feistel,
-      Hash, Md5, Sha1, Sha2, Sha384, Sha512 }
+      Hash, Hashing, Md5, Sha1, Sha2, Sha384, Sha512 }
 
-package hashFunctions:
-  export gastronomy.hashFunctions.{blake3, crc32, md5, sha1, sha2}
+package hashProviders:
+  export gastronomy.hashProviders.{javaStdlibHashing, soundnessHashing}

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -34,6 +34,8 @@ package gastronomy
 
 import soundness.*
 
+import hashProviders.javaStdlibHashing, hashProviders.soundnessHashing
+
 import alphabets.hex.upperCase
 
 object Tests extends Suite(m"Gastronomy tests"):

--- a/lib/gastronomy/src/test/gastronomy_test.scala
+++ b/lib/gastronomy/src/test/gastronomy_test.scala
@@ -35,6 +35,7 @@ package gastronomy
 import soundness.*
 
 import hashProviders.javaStdlibHashing, hashProviders.soundnessHashing
+import crypto.permitDisallowedCrypto   // the suite exercises MD5 and SHA-1
 
 import alphabets.hex.upperCase
 

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -39,7 +39,7 @@ import scala.language.unsafeNulls
 import anticipation.*
 import contingency.*
 import fulminate.*
-import gastronomy.*
+import gastronomy.*, hashProviders.soundnessHashing
 import prepositional.*
 import ulysses.*
 import vacuous.*

--- a/lib/ulysses/src/core/ulysses.BloomFilter.scala
+++ b/lib/ulysses/src/core/ulysses.BloomFilter.scala
@@ -45,7 +45,7 @@ import vacuous.*
 object BloomFilter:
   def apply[element: Digestible](approximateSize: Int, targetErrorRate: 0.0 ~ 1.0)
     [ algorithm <: Algorithm ]
-    ( using Hash in algorithm )
+    ( using hash0: Hash in algorithm, erased weakness: Permit[HashWeakness[algorithm]] )
   :   BloomFilter[element, algorithm] =
 
     val bitSize: Int = (-1.44*approximateSize*ln(targetErrorRate.double).double).toInt
@@ -55,7 +55,7 @@ object BloomFilter:
 
 case class BloomFilter[element: Digestible, algorithm <: Algorithm]
   ( bitSize: Int, hashCount: Int, bits: sci.BitSet )
-  ( using Hash in algorithm ):
+  ( using hash0: Hash in algorithm, erased weakness: Permit[HashWeakness[algorithm]] ):
 
   private val requiredEntropyBits = ln(bitSize ** hashCount).double.toInt + 1
 

--- a/lib/ulysses/src/test/ulysses_test.scala
+++ b/lib/ulysses/src/test/ulysses_test.scala
@@ -34,7 +34,8 @@ package ulysses
 
 import soundness.*
 
-import hashFunctions.blake3
+import hashProviders.soundnessHashing
+import Blake3.hash   // a concrete `Hash in Blake3` in scope, so BloomFilter infers BLAKE3
 
 object Tests extends Suite(m"Ulysses tests"):
   def run(): Unit =


### PR DESCRIPTION
Gastronomy's hashing is now pluggable in the same way as enigmatic's ciphers: hash functions are supplied by a `Hashing` provider chosen by an explicit import, with the JDK hashes and the pure-Scala BLAKE3 in separate providers; and the NIST SP 800-131A permit machinery has moved down into gastronomy so both modules share one vocabulary for gating sub-optimal cryptography, with weak hashes (MD5, SHA-1) now gated too.

Computing a hash now requires a `Hashing` provider in scope, selected with an explicit import:

```scala
import hashProviders.javaStdlibHashing      // MD5/SHA-1/SHA-2/CRC-32 (JDK)
import hashProviders.soundnessHashing       // BLAKE3 (pure Scala)

t"Hello world".digest[Sha2[256]].serialize[Hex]
data.digest[Blake3]
```

The providers are disjoint and structurally typed — the JDK has no BLAKE3, and BLAKE3 is the only pure-Scala implementation — so importing both is unambiguous, and asking a provider for an algorithm it doesn't offer is a compile error. BLAKE3 now has a proper "Soundness" provider, and all `java.security`/`java.util.zip` use is confined to `JavaStdlibHashing`.

The `Permit`/`ProcessingPermit`/`Concession` types and the `crypto.permit…Crypto` levels now live in gastronomy and are shared with enigmatic, so weak hashes are gated like weak ciphers — MD5 is disallowed and SHA-1 is deprecated:

```scala
import crypto.permitDeprecatedCrypto        // needed for SHA-1
data.digest[Sha1]
```

By default only acceptable hashes (SHA-2, BLAKE3) compile; reaching for MD5 or SHA-1 (in a digest or an HMAC) requires the matching erased permit, exactly as for ciphers.
