### PR TITLE
Support an optional binary prefix on ZIP archives

### DIFF
--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -60,11 +60,11 @@ object Zipfile:
   given streamable: Zipfile is Streamable by Data = _.serialize
 
   def write[path: Abstractable across Paths to Text]
-     (path: path)(entries: Iterable[Zip.Entry])
+     (path: path, prefix: Optional[Data] = Unset)(entries: Iterable[Zip.Entry])
   :   Unit raises ZipError =
     checkDuplicates(entries)
     val out = ji.FileOutputStream(ji.File(path.generic.s))
-    try Zipfile(entries.to(LazyList)).serialize.each: chunk =>
+    try Zipfile(entries.to(LazyList), Unset, prefix).serialize.each: chunk =>
       out.write(chunk.mutable(using Unsafe))
     finally out.close()
 
@@ -126,6 +126,7 @@ object Zipfile:
     var entryCount = Zip.u16(window, i + 10).toLong
     var cdSize = Zip.u32(window, i + 12)
     var cdOffset = Zip.u32(window, i + 16)
+    var cdEnd = eocdOffset // the central directory abuts the end-of-central-directory trailer
     val commentLength = Zip.u16(window, i + 20)
     val comment: Optional[Text] =
       if commentLength == 0 then Unset
@@ -136,18 +137,39 @@ object Zipfile:
       if eocdOffset >= 20 then
         val locator = source.read(eocdOffset - 20, 20)
         if Zip.u32(locator, 0) == (Zip.zip64LocatorSig.toLong & 0xffffffffL) then
-          val zip64Offset = Zip.u64(locator, 8)
-          val record = source.read(zip64Offset, 56)
+          val recorded = Zip.u64(locator, 8)
+
+          // The ZIP64 EOCD record abuts the locator; prefer the recorded offset, but if a
+          // prepended prefix has shifted it, fall back to its physical position.
+          val atRecorded =
+            if recorded >= 0 && recorded + 56 <= size then source.read(recorded, 56)
+            else IArray.empty[Byte]
+
+          val recordOffset =
+            if atRecorded.length == 56
+               && Zip.u32(atRecorded, 0) == (Zip.zip64EocdSig.toLong & 0xffffffffL)
+            then recorded else eocdOffset - 20 - 56
+
+          val record = source.read(recordOffset, 56)
           if Zip.u32(record, 0) == (Zip.zip64EocdSig.toLong & 0xffffffffL) then
             entryCount = Zip.u64(record, 32)
             cdSize = Zip.u64(record, 40)
             cdOffset = Zip.u64(record, 48)
+            cdEnd = recordOffset
           else raise(ZipError(ZipError.Reason.Zip64Error))
 
-    val central = source.read(cdOffset, cdSize.toInt)
+    // The central directory physically precedes the trailer; any gap between its actual start
+    // and the recorded offset is data prepended before the archive (a binary/self-extracting
+    // prefix), and every recorded offset must be shifted by that delta.
+    val cdActualStart = cdEnd - cdSize
+    if cdActualStart < 0 then raise(ZipError(ZipError.Reason.TruncatedArchive))
+    val prefixDelta = cdActualStart - cdOffset
+
+    val central = source.read(cdActualStart, cdSize.toInt)
     val builder = List.newBuilder[Zip.Entry]
     var p = 0
     var count = 0L
+    var earliestEntry = Long.MaxValue
 
     while count < entryCount && p + 46 <= central.length do
       if Zip.u32(central, p) != (Zip.centralHeaderSig.toLong & 0xffffffffL)
@@ -204,7 +226,8 @@ object Zipfile:
           case NameError(_, _, _) => ZipError(ZipError.Reason.InvalidName(cleanName))
         . mitigate(cleanName.decode[Path on Zip])
 
-      val payloadOffset = localOffset
+      val payloadOffset = localOffset + prefixDelta
+      if payloadOffset < earliestEntry then earliestEntry = payloadOffset
       val payloadSize = compressedSize
       val storedBytes: () => Stream[Data] = () =>
         val header = source.read(payloadOffset, 30)
@@ -219,7 +242,13 @@ object Zipfile:
       p = commentStart + entryCommentLength
       count += 1
 
-    Zipfile(builder.result().to(LazyList), comment)
+    // Anything before the earliest entry (or before the central directory, for an empty
+    // archive) is otherwise-unassigned data: a binary prefix.
+    val prefixSize = if count > 0 then earliestEntry else cdActualStart
+    val prefix: Optional[Data] =
+      if prefixSize > 0 then source.read(0, prefixSize.toInt) else Unset
+
+    Zipfile(builder.result().to(LazyList), comment, prefix)
 
   private def decodeText(bytes: Data): Text =
     String(bytes.mutable(using Unsafe), jncs.StandardCharsets.UTF_8).nn.tt
@@ -349,13 +378,17 @@ object Zipfile:
 
       List(record, locator, eocd)
 
-case class Zipfile(entries: LazyList[Zip.Entry], comment: Optional[Text] = Unset):
+case class Zipfile
+   (entries: LazyList[Zip.Entry], comment: Optional[Text] = Unset, prefix: Optional[Data] = Unset):
   def entry(ref: Path on Zip): Zip.Entry raises ZipError =
     entries.find(_.ref == ref).getOrElse(abort(ZipError(ZipError.Reason.NotFound(ref))))
 
   def serialize: Stream[Data] =
+    // Emit the prefix first; all subsequent offsets are absolute (they include the prefix), so
+    // any reader sees standard entries and the prefix as leading, otherwise-unassigned data.
+    val prefixBytes: Data = prefix.or(IArray.empty[Byte])
     val entryList = entries.to(List)
-    var offset = 0L
+    var offset = prefixBytes.length.toLong
     val builder = List.newBuilder[(Zip.Entry, Data, Data, Long)]
 
     entryList.foreach: entry =>
@@ -370,7 +403,10 @@ case class Zipfile(entries: LazyList[Zip.Entry], comment: Optional[Text] = Unset
     val cdSize = central.foldLeft(0L)(_ + _.length)
     val tail = Zipfile.endRecords(records.length.toLong, cdStart, cdSize, comment)
 
+    val prefixStream: Stream[Data] =
+      if prefixBytes.length == 0 then LazyList() else LazyList(prefixBytes)
+
     val local: Stream[Data] =
       records.to(LazyList).flatMap((entry, _, header, _) => header #:: entry.storedBytes())
 
-    local #::: central.to(LazyList) #::: tail.to(LazyList)
+    prefixStream #::: local #::: central.to(LazyList) #::: tail.to(LazyList)

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -299,3 +299,48 @@ object Tests extends Suite(m"Zeppelin tests"):
       test(m"the native reader counts all entries in a ZIP64 archive"):
         Zipfile.read(path).entries.length
       . assert(_ == 66000)
+
+    suite(m"Binary prefix"):
+      val prefix: Data = IArray.tabulate(64)(i => (i*7).toByte)
+
+      test(m"a binary prefix round-trips"):
+        val path = workDir/t"prefixed.zip"
+        Zipfile.write(path, prefix)(List(entry(t"a.txt", t"alpha"), entry(t"b.txt", t"beta")))
+        Zipfile.read(path).prefix.lay(Nil)(_.to(List))
+      . assert(_ == prefix.to(List))
+
+      test(m"entries in a prefixed archive remain readable"):
+        val path = workDir/t"prefixed2.zip"
+        Zipfile.write(path, prefix)(List(entry(t"a.txt", t"alpha"), entry(t"b.txt", t"beta")))
+        Zipfile.read(path).entries.map(_.read[Text]).to(List)
+      . assert(_ == List(t"alpha", t"beta"))
+
+      test(m"the prefix precedes the first local header"):
+        val path = workDir/t"prefixed3.zip"
+        Zipfile.write(path, prefix)(List(entry(t"a.txt", t"alpha")))
+        bytesOf(path).slice(0, 64).to(List)
+      . assert(_ == prefix.to(List))
+
+      test(m"the JDK reader reads a prefixed archive"):
+        val path = workDir/t"prefixed4.zip"
+        Zipfile.write(path, prefix)(List(entry(t"a.txt", t"alpha")))
+        jdkContent(path, t"a.txt").to(List)
+      . assert(_ == t"alpha".data.to(List))
+
+      test(m"an archive with no prefix reports no prefix"):
+        Zipfile.read(writeZip(t"noprefix.zip", entry(t"a.txt", t"x"))).prefix
+      . assert(_ == Unset)
+
+      test(m"detects and reads a prefix prepended to a JDK-written archive"):
+        // The JDK writes offsets relative to the archive start; prepending data makes a
+        // self-extracting archive whose offsets must be shifted by the prefix length.
+        val inner = bytesOf(writeRawZip(t"inner.zip", t"one.txt", t"two.txt"))
+        val stub: Data = t"STUB-PREFIX-DATA".data
+        val sfx = workDir/t"sfx.zip"
+        val out = ji.FileOutputStream(ji.File(sfx.encode.s))
+        out.write(stub.mutable(using Unsafe))
+        out.write(inner.mutable(using Unsafe))
+        out.close()
+        val zip = Zipfile.read(sfx)
+        (zip.prefix.lay(Nil)(_.to(List)), zip.entries.map(_.read[Text]).to(List))
+      . assert(_ == (t"STUB-PREFIX-DATA".data.to(List), List(t"data", t"data")))


### PR DESCRIPTION
Zeppelin's `Zipfile` can now carry an optional binary prefix written before the first entry, so it can produce and read self-extracting or stub-prefixed archives. On reading, the prefix is recovered as the otherwise-unassigned data before the earliest entry, and the reader correctly handles both archives Zeppelin writes (absolute offsets) and externally-produced self-extracting archives whose offsets are relative to the archive start.

## Binary prefixes (self-extracting archives)

`Zipfile` gains an optional `prefix`. When set, those bytes are written before the first entry; readers see a normal archive with the prefix as leading data:

```scala
Zipfile.write(path, prefix = stub)(entries)   // stub: Data, e.g. a launcher
// or: Zipfile(entries, prefix = stub).serialize
```

On read, it is recovered:

```scala
val zip = Zipfile.read(path)
zip.prefix   // Optional[Data] — the bytes before the earliest entry, or Unset
zip.entries  // the entries, exactly as before
```

The reader derives the archive's true start from the central directory (which always abuts the end-of-central-directory record), so it detects prefixes on archives Zeppelin wrote *and* correctly reads externally-produced self-extracting archives whose internal offsets are relative to the archive start (e.g. `cat stub app.zip > app.sfx`). An archive with no prefix reports `Unset`.
