### PR TITLE
Year-based crypto permits and explicit initialization vectors

### DIFF
--- a/lib/enigmatic/src/core/enigmatic.Aes.scala
+++ b/lib/enigmatic/src/core/enigmatic.Aes.scala
@@ -41,14 +41,12 @@ object Aes:
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
-  =>  ( vector: InitializationVector )
   =>  ( crypto: Crypto )
   =>  ( Aes[bits] over mode against padding ) =
-    Aes(blockMode, blockPadding, vector, crypto.aes).asInstanceOf[Aes[bits] over mode against padding]
+    Aes(blockMode, blockPadding, crypto.aes).asInstanceOf[Aes[bits] over mode against padding]
 
 class Aes[bits <: 128 | 192 | 256: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
-    cipher: Crypto.SymmetricCipher )
-extends BlockCipher(t"AES", mode, padding, vector, cipher):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"AES", mode, padding, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -44,7 +44,6 @@ abstract class BlockCipher
   ( val algorithm: Text,
     mode:          BlockCipherMode,
     padding:       BlockCipherPadding,
-    vector:        InitializationVector,
     cipher:        Crypto.SymmetricCipher )
 extends Cipher, Encryption, Symmetric:
   type Transport
@@ -52,7 +51,9 @@ extends Cipher, Encryption, Symmetric:
 
   private def transformation: Text = t"$algorithm/${mode.name}/${padding.name}"
 
-  def encrypt(bytes: Data, key: Data): Data =
+  // The initialization vector is supplied explicitly by the caller; modes that
+  // don't use one (ECB) ignore it.
+  def encrypt(bytes: Data, key: Data, vector: InitializationVector): Data =
     val blockSize = cipher.blockSize(transformation)
     padding.verify(bytes.length, blockSize, mode.blockAligned)
     val iv: Optional[Data] = if mode.usesIv then vector(blockSize) else Unset
@@ -62,7 +63,7 @@ extends Cipher, Encryption, Symmetric:
   // mirroring `turbulence.Compression`. The IV (if any) is emitted as the first
   // chunk; the `NoPadding` alignment check happens at end-of-stream, where the
   // total length is finally known.
-  def encryptStream(stream: Stream[Data], key: Data): Stream[Data] =
+  def encryptStream(stream: Stream[Data], key: Data, vector: InitializationVector): Stream[Data] =
     val blockSize = cipher.blockSize(transformation)
     val iv: Optional[Data] = if mode.usesIv then vector(blockSize) else Unset
     val session = cipher.stream(transformation, key, iv)

--- a/lib/enigmatic/src/core/enigmatic.Blowfish.scala
+++ b/lib/enigmatic/src/core/enigmatic.Blowfish.scala
@@ -43,15 +43,13 @@ object Blowfish:
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
-  =>  ( vector: InitializationVector )
   =>  ( crypto: Crypto { def blowfish: Crypto.SymmetricCipher } )
   =>  ( Blowfish[bits] over mode against padding ) =
-    Blowfish(blockMode, blockPadding, vector, crypto.blowfish)
+    Blowfish(blockMode, blockPadding, crypto.blowfish)
     . asInstanceOf[Blowfish[bits] over mode against padding]
 
 class Blowfish[bits <: 128 | 256 | 448: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
-    cipher: Crypto.SymmetricCipher )
-extends BlockCipher(t"Blowfish", mode, padding, vector, cipher):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"Blowfish", mode, padding, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.Des.scala
+++ b/lib/enigmatic/src/core/enigmatic.Des.scala
@@ -43,14 +43,12 @@ object Des:
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
-  =>  ( vector: InitializationVector )
   =>  ( crypto: Crypto { def des: Crypto.SymmetricCipher } )
   =>  ( Des over mode against padding ) =
-    Des(blockMode, blockPadding, vector, crypto.des).asInstanceOf[Des over mode against padding]
+    Des(blockMode, blockPadding, crypto.des).asInstanceOf[Des over mode against padding]
 
 class Des
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
-    cipher: Crypto.SymmetricCipher )
-extends BlockCipher(t"DES", mode, padding, vector, cipher):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"DES", mode, padding, cipher):
   type Size = 56
   def keySize: 56 = 56

--- a/lib/enigmatic/src/core/enigmatic.Encryption.scala
+++ b/lib/enigmatic/src/core/enigmatic.Encryption.scala
@@ -35,5 +35,7 @@ package enigmatic
 import anticipation.*
 
 trait Encryption:
-  def encrypt(value: Data, privateKey: Data): Data
-  def decrypt(bytes: Data, publicKey: Data): Data
+  // `iv` is the explicitly-supplied initialization-vector strategy; ciphers and
+  // modes that don't use an IV (asymmetric, ECB) ignore it.
+  def encrypt(value: Data, key: Data, iv: InitializationVector): Data
+  def decrypt(bytes: Data, key: Data): Data

--- a/lib/enigmatic/src/core/enigmatic.InitializationVector.scala
+++ b/lib/enigmatic/src/core/enigmatic.InitializationVector.scala
@@ -33,11 +33,17 @@
 package enigmatic
 
 import anticipation.*
+import rudiments.*
+import vacuous.*
 
+// A strategy for producing an initialization vector of a given block size. It is
+// supplied *explicitly* at the encryption site (e.g. `data.encrypt(iv.random)`),
+// never resolved implicitly. `random` draws from the in-scope `Crypto` provider;
+// `fixed` reuses given bytes (deterministic); `zero` is an all-zero IV.
 object InitializationVector:
-  given random: (crypto: Crypto) => InitializationVector = size => crypto.random.bytes(size)
-
+  def random(using crypto: Crypto): InitializationVector = size => crypto.random.bytes(size)
   def fixed(iv: Data): InitializationVector = _ => iv
+  val zero: InitializationVector = size => Array.fill[Byte](size)(0).immutable(using Unsafe)
 
 trait InitializationVector:
   def apply(size: Int): Data

--- a/lib/enigmatic/src/core/enigmatic.Rc2.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rc2.scala
@@ -43,14 +43,12 @@ object Rc2:
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
-  =>  ( vector: InitializationVector )
   =>  ( crypto: Crypto { def rc2: Crypto.SymmetricCipher } )
   =>  ( Rc2[bits] over mode against padding ) =
-    Rc2(blockMode, blockPadding, vector, crypto.rc2).asInstanceOf[Rc2[bits] over mode against padding]
+    Rc2(blockMode, blockPadding, crypto.rc2).asInstanceOf[Rc2[bits] over mode against padding]
 
 class Rc2[bits <: 40 | 64 | 128: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
-    cipher: Crypto.SymmetricCipher )
-extends BlockCipher(t"RC2", mode, padding, vector, cipher):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"RC2", mode, padding, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic.Rsa.scala
+++ b/lib/enigmatic/src/core/enigmatic.Rsa.scala
@@ -43,5 +43,7 @@ class Rsa[bits <: 1024 | 2048: ValueOf](cipher: Crypto.PublicKeyCipher) extends 
   def keySize: bits = valueOf[bits]
   def privateToPublic(bytes: Data): Data = cipher.privateToPublic(bytes)
   def decrypt(bytes: Data, key: Data): Data = cipher.decrypt(bytes, key)
-  def encrypt(bytes: Data, key: Data): Data = cipher.encrypt(bytes, key)
+
+  // RSA uses no initialization vector; the explicit `iv` is ignored.
+  def encrypt(bytes: Data, key: Data, iv: InitializationVector): Data = cipher.encrypt(bytes, key)
   def genKey(): Data = cipher.generateKeyPair(keySize)

--- a/lib/enigmatic/src/core/enigmatic.TripleDes.scala
+++ b/lib/enigmatic/src/core/enigmatic.TripleDes.scala
@@ -43,15 +43,13 @@ object TripleDes:
   =>  ( blockMode: mode is BlockCipherMode )
   =>  ( blockPadding: padding is BlockCipherPadding )
   =>  ( mode Permits padding )
-  =>  ( vector: InitializationVector )
   =>  ( crypto: Crypto { def tripleDes: Crypto.SymmetricCipher } )
   =>  ( TripleDes[bits] over mode against padding ) =
-    TripleDes(blockMode, blockPadding, vector, crypto.tripleDes)
+    TripleDes(blockMode, blockPadding, crypto.tripleDes)
     . asInstanceOf[TripleDes[bits] over mode against padding]
 
 class TripleDes[bits <: 112 | 168: ValueOf]
-  ( mode: BlockCipherMode, padding: BlockCipherPadding, vector: InitializationVector,
-    cipher: Crypto.SymmetricCipher )
-extends BlockCipher(t"DESede", mode, padding, vector, cipher):
+  ( mode: BlockCipherMode, padding: BlockCipherPadding, cipher: Crypto.SymmetricCipher )
+extends BlockCipher(t"DESede", mode, padding, cipher):
   type Size = bits
   def keySize: bits = valueOf[bits]

--- a/lib/enigmatic/src/core/enigmatic_core.scala
+++ b/lib/enigmatic/src/core/enigmatic_core.scala
@@ -61,12 +61,9 @@ package blockCipherPadding:
   // `Tactic[CryptoError]`, and re-exporting a context-function given trips a
   // compiler assertion ("bad adapt"). Use `against NoPadding` explicitly instead.
 
-package initializationVector:
-  // `random` is the default `InitializationVector` (in `InitializationVector`'s
-  // companion). It is not re-exported here: it is now a context-function given
-  // over `Crypto`, and re-exporting such a given trips a compiler assertion
-  // ("bad adapt") — see the note in `blockCipherPadding` above.
-  given zero: InitializationVector = size => Array.fill[Byte](size)(0).immutable(using Unsafe)
+// The initialization vector is now supplied explicitly at the encryption site —
+// `InitializationVector.random` / `.fixed(…)` / `.zero` — so there is no
+// `initializationVector` given namespace.
 
 // Crypto providers select the algorithmic backend. Pick one with an explicit
 // import, e.g. `import cryptoProviders.javaStdlibCrypto`. The given's type is the

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -49,14 +49,14 @@ import vacuous.*
 // failures are surfaced as a `CryptoError`.
 
 extension [value: Encodable in Data](value: value)
-  def encrypt[cipher <: Cipher]
+  def encrypt[cipher <: Cipher](iv: InitializationVector)
     ( using encryptor: Encryptor[cipher],
             algorithm: cipher & Encryption,
             erased weakness: Permit[Weakness[cipher]],
             erased authentication: Permit[Authentication[cipher]] )
   :   Data =
 
-    algorithm.encrypt(value.bytestream, encryptor.bytes)
+    algorithm.encrypt(value.bytestream, encryptor.bytes, iv)
 
 // Streaming encryption (block ciphers only) lazily transforms a `Stream`, driving
 // the JCE cipher through update/doFinal. The IV is emitted as the leading chunk
@@ -64,14 +64,14 @@ extension [value: Encodable in Data](value: value)
 // `expose` block — only the fixed ciphertext of `stream` could otherwise leak.
 
 extension (stream: Stream[Data])
-  def encrypt[cipher <: BlockCipher]
+  def encrypt[cipher <: BlockCipher](iv: InitializationVector)
     ( using encryptor: Encryptor[cipher],
             algorithm: cipher & Encryption,
             erased weakness: Permit[Weakness[cipher]],
             erased authentication: Permit[Authentication[cipher]] )
   :   Stream[Data] =
 
-    algorithm.encryptStream(stream, encryptor.bytes)
+    algorithm.encryptStream(stream, encryptor.bytes, iv)
 
 extension (data: Data)
   def decrypt[decodable: Decodable in Data, cipher <: Cipher]

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -49,10 +49,5 @@ package blockCipherMode:
 package blockCipherPadding:
   export enigmatic.blockCipherPadding.{iso10126, pkcs7}
 
-package initializationVector:
-  // `random` (the default) lives in `InitializationVector`'s companion; it is a
-  // context-function given over `Crypto` and is deliberately not re-exported here.
-  export enigmatic.initializationVector.zero
-
 package cryptoProviders:
   export enigmatic.cryptoProviders.javaStdlibCrypto

--- a/lib/enigmatic/src/test/enigmatic_compile_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_compile_test.scala
@@ -46,7 +46,7 @@ object CompileChecks:
   val key: SymmetricKey[Aes[256]] = SymmetricKey.generate[Aes[256]]()
 
   val ciphertext: Data = key.expose:
-    t"Hello world".encrypt
+    t"Hello world".encrypt(InitializationVector.random)
 
   // Validity regression: only cipher/mode/padding triples the JDK supports have a
   // `given`, so an invalid combination does not compile. CTR permits only
@@ -70,4 +70,4 @@ object CompileChecks:
   // that key generation is *not* gated; only the encryption operation is.
   //
   //   val desKey = SymmetricKey.generate[Des over Cbc against Pkcs7]()
-  //   val desText = desKey.expose(t"Hello world".encrypt)
+  //   val desText = desKey.expose(t"Hello world".encrypt(InitializationVector.random))

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -115,7 +115,7 @@ object Tests extends Suite(m"Gastronomy tests"):
     test(m"RSA roundtrip"):
       val privateKey: PrivateKey[Rsa[1024]] = PrivateKey.generate[Rsa[1024]]()
       val message: Data = privateKey.public.expose:
-        t"Hello world".encrypt
+        t"Hello world".encrypt(InitializationVector.random)
       privateKey.expose:
         message.decrypt.text
     . assert(_ == t"Hello world")
@@ -124,66 +124,69 @@ object Tests extends Suite(m"Gastronomy tests"):
       import blockCipherMode.cbc, blockCipherPadding.pkcs7
       val key: SymmetricKey[Aes[256]] = SymmetricKey.generate[Aes[256]]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"AES/CBC/PKCS7 roundtrip (mode and padding fully specified)"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"AES/ECB/ISO10126 roundtrip (mode and padding fully specified)"):
       val key = SymmetricKey.generate[Aes[256] over Ecb against Iso10126]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"AES/CTR/NoPadding roundtrip (mode and padding fully specified)"):
       val key = SymmetricKey.generate[Aes[128] over Ctr against NoPadding]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"AES/CBC with padding inferred as PKCS7 from import"):
       import blockCipherPadding.pkcs7
       val key = SymmetricKey.generate[Aes[256] over Cbc]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"AES with mode and padding inferred as CBC/PKCS7 from imports"):
       import blockCipherMode.cbc, blockCipherPadding.pkcs7
       val key = SymmetricKey.generate[Aes[256]]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"CBC encryption of the same plaintext differs run-to-run (random IV)"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]
+        val first = t"Hello world".encrypt(InitializationVector.random).serialize[Hex]
+        val second = t"Hello world".encrypt(InitializationVector.random).serialize[Hex]
+        first == second
     . assert(_ == false)
 
     test(m"A fixed IV makes CBC encryption deterministic"):
-      given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+      val iv = InitializationVector.fixed(t"0123456789abcdef".data)
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]
+        t"Hello world".encrypt(iv).serialize[Hex] == t"Hello world".encrypt(iv).serialize[Hex]
     . assert(_ == true)
 
     test(m"A fixed IV still round-trips"):
-      given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+      val iv = InitializationVector.fixed(t"0123456789abcdef".data)
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(iv).decrypt.text
     . assert(_ == t"Hello world")
 
-    test(m"An imported zero IV makes CBC encryption deterministic"):
-      import initializationVector.zero
+    test(m"A zero IV makes CBC encryption deterministic"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]
+        val first = t"Hello world".encrypt(InitializationVector.zero).serialize[Hex]
+        val second = t"Hello world".encrypt(InitializationVector.zero).serialize[Hex]
+        first == second
     . assert(_ == true)
 
     test(m"A custom Crypto provider can supply deterministic randomness"):
@@ -198,78 +201,80 @@ object Tests extends Suite(m"Gastronomy tests"):
 
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.serialize[Hex] == t"Hello world".encrypt.serialize[Hex]
+        val first = t"Hello world".encrypt(InitializationVector.random).serialize[Hex]
+        val second = t"Hello world".encrypt(InitializationVector.random).serialize[Hex]
+        first == second
     . assert(_ == true)
 
     test(m"DES/CBC/PKCS7 roundtrip"):
       val key = SymmetricKey.generate[Des over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"TripleDES/CBC/PKCS7 roundtrip"):
       val key = SymmetricKey.generate[TripleDes[168] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"Blowfish/CBC/PKCS7 roundtrip"):
       val key = SymmetricKey.generate[Blowfish[448] over Cbc against Pkcs7]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"RC2/CFB/ISO10126 roundtrip"):
       val key = SymmetricKey.generate[Rc2[128] over Cfb against Iso10126]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"DES/CTR/NoPadding roundtrip"):
       val key = SymmetricKey.generate[Des over Ctr against NoPadding]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"Decryption with the wrong key fails with a CryptoError"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       val wrongKey = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
-      val ciphertext = key.expose(t"Hello world".encrypt)
+      val ciphertext = key.expose(t"Hello world".encrypt(InitializationVector.random))
       capture[CryptoError](wrongKey.expose(ciphertext.decrypt.text)).reason
     . assert(_ == CryptoError.Reason.BadPadding)
 
     test(m"AES/CBC/NoPadding round-trips block-aligned input"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
       key.expose:
-        t"0123456789abcdef".encrypt.decrypt.text
+        t"0123456789abcdef".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"0123456789abcdef")
 
     test(m"AES/CBC/NoPadding rejects misaligned input with a CryptoError"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
-      capture[CryptoError](key.expose(t"Hello world".encrypt)).reason
+      capture[CryptoError](key.expose(t"Hello world".encrypt(InitializationVector.random))).reason
     . assert(_ == CryptoError.Reason.IllegalBlockSize)
 
     test(m"AES/CTR/NoPadding (stream mode) accepts any length"):
       val key = SymmetricKey.generate[Aes[256] over Ctr against NoPadding]()
       key.expose:
-        t"Hello world".encrypt.decrypt.text
+        t"Hello world".encrypt(InitializationVector.random).decrypt.text
     . assert(_ == t"Hello world")
 
     test(m"Streaming encryption round-trips via one-shot decryption"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
         val chunks = Stream(t"Hello, ".data, t"streaming ".data, t"world!".data)
-        chunks.encrypt.reduce(_ ++ _).decrypt.text
+        chunks.encrypt(InitializationVector.random).reduce(_ ++ _).decrypt.text
     . assert(_ == t"Hello, streaming world!")
 
     test(m"Streaming and one-shot encryption agree for a fixed IV"):
-      given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+      val iv = InitializationVector.fixed(t"0123456789abcdef".data)
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:
         val streamed =
-          Stream(t"Hello, ".data, t"streaming ".data, t"world!".data).encrypt.reduce(_ ++ _)
+          Stream(t"Hello, ".data, t"streaming ".data, t"world!".data).encrypt(iv).reduce(_ ++ _)
 
-        streamed.serialize[Hex] == t"Hello, streaming world!".data.encrypt.serialize[Hex]
+        streamed.serialize[Hex] == t"Hello, streaming world!".data.encrypt(iv).serialize[Hex]
     . assert(_ == true)
 
     test(m"Sign some data with DSA"):
@@ -361,23 +366,27 @@ object Tests extends Suite(m"Gastronomy tests"):
       . assert(_ == true)
 
       test(m"AES-256-CBC ciphertext agrees with the JDK provider (fixed IV)"):
-        given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+        val iv = InitializationVector.fixed(t"0123456789abcdef".data)
         val key: SymmetricKey[Aes[256] over Cbc against Pkcs7] = SymmetricKey(key32)
-        val jdk = key.expose(t"Hello world".encrypt.serialize[Hex])
-        val openssl = { given Crypto = OpensslCrypto; key.expose(t"Hello world".encrypt.serialize[Hex]) }
+        val jdk = key.expose(t"Hello world".encrypt(iv).serialize[Hex])
+
+        val openssl =
+          given Crypto = OpensslCrypto
+          key.expose(t"Hello world".encrypt(iv).serialize[Hex])
+
         jdk == openssl
       . assert(_ == true)
 
       test(m"AES-256-CBC round-trips under the OpenSSL provider"):
         given Crypto = OpensslCrypto
         val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
-        key.expose(t"Hello world".encrypt.decrypt.text)
+        key.expose(t"Hello world".encrypt(InitializationVector.random).decrypt.text)
       . assert(_ == t"Hello world")
 
       test(m"OpenSSL decrypts what the JDK encrypted (CBC, fixed IV)"):
-        given InitializationVector = InitializationVector.fixed(t"0123456789abcdef".data)
+        val iv = InitializationVector.fixed(t"0123456789abcdef".data)
         val key: SymmetricKey[Aes[256] over Cbc against Pkcs7] = SymmetricKey(key32)
-        val ciphertext = key.expose(t"Interoperable!".encrypt)
+        val ciphertext = key.expose(t"Interoperable!".encrypt(iv))
         val plaintext = { given Crypto = OpensslCrypto; key.expose(ciphertext.decrypt.text) }
         plaintext
       . assert(_ == t"Interoperable!")
@@ -385,7 +394,7 @@ object Tests extends Suite(m"Gastronomy tests"):
       test(m"AES-128-CTR/NoPadding round-trips under the OpenSSL provider"):
         given Crypto = OpensslCrypto
         val key = SymmetricKey.generate[Aes[128] over Ctr against NoPadding]()
-        key.expose(t"Hello world".encrypt.decrypt.text)
+        key.expose(t"Hello world".encrypt(InitializationVector.random).decrypt.text)
       . assert(_ == t"Hello world")
 
       test(m"OpenSSL streaming encryption round-trips via one-shot decryption"):
@@ -393,5 +402,5 @@ object Tests extends Suite(m"Gastronomy tests"):
         val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
         key.expose:
           val chunks = Stream(t"Hello, ".data, t"streaming ".data, t"world!".data)
-          chunks.encrypt.reduce(_ ++ _).decrypt.text
+          chunks.encrypt(InitializationVector.random).reduce(_ ++ _).decrypt.text
       . assert(_ == t"Hello, streaming world!")

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -80,6 +80,45 @@ package crypto:
       & Permit[Concession.Sha1] =
     caps.unsafe.unsafeErasedValue
 
+  // Year-based permits: an alternative to the named levels, composed from the same
+  // fine-grained `Permit`s. `permitCryptoThrough<year>` permits every algorithm
+  // NIST disallowed on or before that year, so a later year is strictly more
+  // permissive. (Unauthenticated/ECB are not date-based and are not included.)
+
+  // Through 2014: DES, the never-approved MD5/RC2/Blowfish, and RSA/DSA key
+  // lengths below 2048 bits (disallowed at the end of 2013).
+  erased given permitCryptoThrough2014
+      : Permit[Concession.Des]
+      & Permit[Concession.Md5]
+      & Permit[Concession.Rc2]
+      & Permit[Concession.Blowfish]
+      & Permit[Concession.SmallRsa] =
+    caps.unsafe.unsafeErasedValue
+
+  // Through 2024: also Triple-DES (encryption disallowed after 2023) and DSA
+  // signatures (removed in FIPS 186-5).
+  erased given permitCryptoThrough2024
+      : Permit[Concession.Des]
+      & Permit[Concession.Md5]
+      & Permit[Concession.Rc2]
+      & Permit[Concession.Blowfish]
+      & Permit[Concession.SmallRsa]
+      & Permit[Concession.TripleDes]
+      & Permit[Concession.Dsa] =
+    caps.unsafe.unsafeErasedValue
+
+  // Through 2030: also SHA-1 (NIST's planned phase-out by 2030).
+  erased given permitCryptoThrough2030
+      : Permit[Concession.Des]
+      & Permit[Concession.Md5]
+      & Permit[Concession.Rc2]
+      & Permit[Concession.Blowfish]
+      & Permit[Concession.SmallRsa]
+      & Permit[Concession.TripleDes]
+      & Permit[Concession.Dsa]
+      & Permit[Concession.Sha1] =
+    caps.unsafe.unsafeErasedValue
+
 extension [digestible: Digestible](value: digestible)
   def digest[hash <: Algorithm]
       (using hashed: Hash in hash, erased weakness: Permit[HashWeakness[hash]])

--- a/lib/gastronomy/src/core/soundness_gastronomy_core.scala
+++ b/lib/gastronomy/src/core/soundness_gastronomy_core.scala
@@ -43,4 +43,5 @@ package hashProviders:
 
 package crypto:
   export gastronomy.crypto.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
-      permitDisallowedCrypto}
+      permitDisallowedCrypto, permitCryptoThrough2014, permitCryptoThrough2024,
+      permitCryptoThrough2030}


### PR DESCRIPTION
Two refinements to the crypto permit and cipher APIs: year-based permit levels as an alternative to the named NIST statuses, and initialization vectors that are now always supplied explicitly at the encryption site rather than resolved from a contextual given.

The `crypto` permit package gains year-based levels alongside the named ones, composed from the same fine-grained permits. `permitCryptoThrough<year>` permits every algorithm NIST disallowed on or before that year, so a later year is strictly more permissive:

```scala
import crypto.permitCryptoThrough2030   // DES, MD5, RC2, Blowfish, RSA-1024, 3DES, DSA, SHA-1
```

`permitCryptoThrough2014` covers DES, MD5, RC2, Blowfish and sub-2048-bit RSA/DSA; `…2024` adds Triple-DES and DSA signatures; `…2030` adds SHA-1.

Initialization vectors are now explicit. Instead of an implicit `InitializationVector` given (with a `random` default), the IV strategy is passed at the call site:

```scala
data.encrypt(InitializationVector.random)        // a fresh random IV
data.encrypt(InitializationVector.fixed(bytes))  // deterministic
data.encrypt(InitializationVector.zero)
```

`random`/`fixed`/`zero` are plain values (no givens), and modes or ciphers that don't use an IV (ECB, RSA) ignore the argument. This makes IV selection visible and removes the implicit-resolution machinery (and its contextual-given edge cases) entirely.
