### PR TITLE
Add a download-on-demand packaging method to ziggurat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ release:
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make release VERSION=X.Y.Z" >&2; exit 1; fi
 	./etc/ci/release.sh "$(VERSION)"
 
+xeq-release:
+	@if [ -z "$(VERSION)" ]; then echo "Usage: make xeq-release VERSION=X.Y.Z [REPO=owner/repo] [TAG=tag]" >&2; exit 1; fi
+	./etc/ci/xeq-release.sh "$(VERSION)" "$(REPO)" "$(TAG)"
+
 scala/%:
 	TAG=$(word 1, $(subst :, ,$*)); \
 	JDK=$(word 2, $(subst :, ,$*)); \
@@ -63,4 +67,4 @@ matrix:
 	    $(foreach scala,3.6.1 3.6.2 3.6.3 3.6.4 3.7.0 3.7.1 3.7.1 main, \
 			    $(MAKE) bootstrap/$(scala):$(jdk);))
 
-.PHONY: publishLocal build dev ci test matrix attest verify-attest push release
+.PHONY: publishLocal build dev ci test matrix attest verify-attest push release xeq-release

--- a/build.mill
+++ b/build.mill
@@ -1435,7 +1435,7 @@ object zeppelin extends Library:
   object test extends Tests(core, imperial.core, diuretic.core)
 
 object ziggurat extends Library:
-  object core extends Component(hellenism.core, monotonous.core, turbulence.core):
+  object core extends Component(hellenism.core, monotonous.core, turbulence.core, gastronomy.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -734,6 +734,40 @@ object ethereal extends Library:
       new java.io.File(target.toString).setExecutable(true)
       PathRef(target)
 
+    // The download-on-demand counterpart of `bin()`. Instead of embedding every
+    // platform's binary, this stages one self-contained executable per platform
+    // (the runner with the JAR appended — exactly the runner+data concatenation
+    // the installer performs at unpack time) and emits a small launcher that
+    // downloads the right one from `baseUrl` on first run. Outputs go to
+    // `./dist`: the `xeq-<label>-<version>` binaries to upload, plus the `hello`
+    // launcher whose embedded SHA-256s are computed from those same bytes.
+    def distributable(version: String, baseUrl: String): Command[PathRef] = Task.Command:
+      val jar = assembly().path
+      val runnersBase = core.rustRunners().path / "ethereal"
+
+      val dist = moduleDir / ".." / ".." / ".." / ".." / "dist"
+      os.makeDir.all(dist)
+      val staging = Task.dest / "staging"
+      os.makeDir.all(staging)
+
+      core.rustTargets.foreach: (_, label, binary) =>
+        val ext = if binary.endsWith(".exe") then ".exe" else ""
+        val runner = runnersBase / s"runner-$label$ext"
+        val complete = staging / s"runner-$label$ext"
+        os.write.over(complete, os.read.bytes(runner) ++ os.read.bytes(jar))
+        os.perms.set(complete, "rwxr-xr-x")
+        os.copy.over(complete, dist / s"xeq-$label-$version")
+
+      val base = if baseUrl.endsWith("/") then baseUrl else s"$baseUrl/"
+      val classpath =
+        ziggurat.core.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
+
+      os.proc("java", "-cp", classpath, "ziggurat.Xeq", "multidownloader",
+          (dist / "hello").toString, staging.toString, base, version)
+        .call(stdout = os.Inherit, stderr = os.Inherit)
+
+      PathRef(dist)
+
   object test extends Tests(core, exoskeleton.rig, quantitative.units)
 
 object eucalyptus extends Library:

--- a/etc/ci/xeq-release.sh
+++ b/etc/ci/xeq-release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Publish download-on-demand binaries for the ethereal-hello example to a GitHub
+# release, and generate the matching ziggurat launcher script.
+#
+# This is the network-facing half of the "download-on-demand" packaging method
+# (the deterministic, in-process half is `ethereal.example.distributable`, which
+# stages the binaries and emits the launcher). Keeping them separate means the
+# launcher's embedded SHA-256s are always computed from the exact bytes that get
+# uploaded.
+#
+# Usage: ./etc/ci/xeq-release.sh <version> [owner/repo] [tag]
+#         (or `make xeq-release VERSION=X.Y.Z`)
+#
+# Produces (under ./dist):
+#   - xeq-<label>-<version>   the self-contained per-platform binaries (uploaded)
+#   - hello                   the launcher script (distribute this)
+#
+# The launcher embeds, per platform, the asset URL and its SHA-256. On first run
+# it detects the platform, downloads the right binary, verifies it, overwrites
+# itself, and execs.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION="${1:-}"
+REPO="${2:-propensive/soundness}"
+TAG="${3:-$VERSION}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version> [owner/repo] [tag]" >&2; exit 1
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  echo "xeq-release: the GitHub CLI (gh) is required" >&2; exit 1
+fi
+
+BASE="https://github.com/$REPO/releases/download/$TAG/"
+
+# Build the per-platform binaries and the launcher into ./dist. The base URL
+# baked into the launcher must match where we upload to below.
+./mill ethereal.example.distributable "$VERSION" "$BASE"
+
+# Create the release if it doesn't exist yet, then upload (clobber on re-run so
+# the script is idempotent).
+if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+  gh release create "$TAG" --repo "$REPO" --title "$TAG" \
+    --notes "Ziggurat download-on-demand binaries for $TAG"
+fi
+gh release upload "$TAG" --repo "$REPO" --clobber dist/xeq-*
+
+count=$(find dist -maxdepth 1 -name 'xeq-*' | wc -l | tr -d ' ')
+echo "xeq-release: uploaded $count binaries to $REPO@$TAG"
+echo "xeq-release: launcher written to ./dist/hello"

--- a/lib/ziggurat/res/core/ziggurat/xeq-multidownloader.bat
+++ b/lib/ziggurat/res/core/ziggurat/xeq-multidownloader.bat
@@ -1,0 +1,30 @@
+setlocal enabledelayedexpansion
+set "arch=x64"
+if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "arch=arm64"
+if /i "%PROCESSOR_ARCHITECTURE%"=="x86" set "arch=x86"
+set "label=windows-!arch!"
+set "assets="
+for /f "tokens=1* delims=:" %%a in ('findstr /b /c:"assets:" "%~f0"') do if not defined assets set "assets=%%b"
+if not defined assets (echo No asset table>&2 & exit /b 1)
+set "value="
+for %%E in ("!assets:,=" "!") do (
+    for /f "tokens=1* delims==" %%K in (%%E) do (
+        if "%%K"=="!label!" set "value=%%L"
+    )
+)
+if not defined value (echo No binary for !label!>&2 & exit /b 1)
+for /f "tokens=1,2 delims=|" %%U in ("!value!") do (set "url=%%U" & set "hash=%%V")
+set "t=%TEMP%\~zigdl%RANDOM%.tmp"
+call :xeq_msg 33 ████████ 0 "Downloading…"
+where curl >nul 2>&1
+if %errorlevel% equ 0 (curl -fsSL "!url!" -o "!t!") else (powershell -NoProfile -Command "Invoke-WebRequest -Uri '!url!' -OutFile '!t!'")
+if not exist "!t!" exit /b 1
+for %%S in ("!t!") do set "size=%%~zS"
+call :xeq_msg 32 ████████ 1 "Downloaded !size! bytes"
+call :xeq_msg 33 ████████ 0 "Verifying SHA-256…"
+set "g="
+for /f "skip=1 tokens=*" %%H in ('certutil -hashfile "!t!" SHA256') do if not defined g set "g=%%H"
+set "g=!g: =!"
+if /i "!g!" neq "!hash!" (echo Hash mismatch>&2 & del "!t!" & exit /b 1)
+call :xeq_msg 32 ████████ 1 "Verified SHA-256"
+endlocal & move /y "%t%" "%~f0" >nul & call "%~f0" %*

--- a/lib/ziggurat/res/core/ziggurat/xeq-multidownloader.ps1
+++ b/lib/ziggurat/res/core/ziggurat/xeq-multidownloader.ps1
@@ -1,0 +1,42 @@
+$os = if ($IsWindows -or $env:OS) {
+    "windows"
+} elseif ($IsMacOS) { "macos"
+} else { "linux" }
+$raw = if ($env:PROCESSOR_ARCHITECTURE) {
+    $env:PROCESSOR_ARCHITECTURE
+} else {
+    [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+}
+$arch = switch ($raw) {
+    "AMD64"  { "x64" }
+    "X64"    { "x64" }
+    "x86"    { "x86" }
+    "ARM64"  { "arm64" }
+    default  { $raw.ToLower() }
+}
+$label = "${os}-${arch}"
+$s = $MyInvocation.MyCommand.Definition
+$lines = Get-Content -Path $s
+$assets = ($lines -match '^assets:' | Select-Object -First 1) -replace '^assets:'
+if (-not $assets) { [Console]::Error.WriteLine("No asset table"); exit 1 }
+$row = $assets.Split(',') | Where-Object { $_.StartsWith("$label=") } | Select-Object -First 1
+if (-not $row) { [Console]::Error.WriteLine("No binary for $label"); exit 1 }
+$value = $row.Substring($label.Length + 1)
+$parts = $value.Split('|')
+$url = $parts[0]
+$hash = $parts[1]
+$t = "$s.tmp"
+xeq_msg 33 '████████' 0 'Downloading…'
+try { Invoke-WebRequest -Uri $url -OutFile $t -UseBasicParsing } catch {
+    [Console]::Error.WriteLine("Download failed"); exit 1
+}
+$size = (Get-Item $t).Length
+xeq_msg 32 '████████' 1 "Downloaded $size bytes"
+xeq_msg 33 '████████' 0 'Verifying SHA-256…'
+$g = (Get-FileHash -Path $t -Algorithm SHA256).Hash
+if ($g -ine $hash) {
+    [Console]::Error.WriteLine("Hash mismatch"); Remove-Item $t; exit 1
+}
+xeq_msg 32 '████████' 1 'Verified SHA-256'
+Move-Item -Force $t $s
+& $s @args

--- a/lib/ziggurat/res/core/ziggurat/xeq-multidownloader.sh
+++ b/lib/ziggurat/res/core/ziggurat/xeq-multidownloader.sh
@@ -1,0 +1,42 @@
+os=$(uname -s)
+arch=$(uname -m)
+
+case "$os" in
+  Darwin) os=macos ;; Linux) os=linux ;;
+  *)      printf "Unsupported OS: %s\n" "$os" >&2; exit 1 ;;
+esac
+
+case "$arch" in
+  x86_64)         arch=x64 ;;
+  aarch64|arm64)  arch=arm64 ;;
+  *)              printf "Unsupported architecture: %s\n" "$arch" >&2; exit 1 ;;
+esac
+
+label="${os}-${arch}"
+s=$(realpath "$0")
+row=$(sed -n 's/^assets://p' "$s" | head -1 | tr ',' '\n' | grep "^${label}=" | head -1)
+if [ -z "$row" ]
+then printf "No binary for %s\n" "$label" >&2; exit 1
+fi
+value=${row#*=}
+url=${value%%|*}
+hash=${value#*|}
+t="$s.tmp"
+xeq_msg 33 ████████ 0 "Downloading…"
+if command -v curl >/dev/null 2>&1
+then curl -fsSL "$url" -o "$t" || exit 1
+elif command -v wget >/dev/null 2>&1
+then wget -qO "$t" "$url" || exit 1
+else printf 'Need curl or wget\n' >&2; exit 1
+fi
+size=$(wc -c < "$t" | tr -d ' ')
+xeq_msg 32 ████████ 1 "Downloaded $size bytes"
+xeq_msg 33 ████████ 0 "Verifying SHA-256…"
+g=$( { sha256sum "$t" 2>/dev/null || shasum -a 256 "$t"; } | cut -d' ' -f1)
+if [ "$g" != "$hash" ]
+then printf 'Hash mismatch\n' >&2; rm -f "$t"; exit 1
+fi
+xeq_msg 32 ████████ 1 "Verified SHA-256"
+chmod +x "$t"
+mv "$t" "$s"
+exec "$s" "$@"

--- a/lib/ziggurat/src/core/ziggurat.Xeq.scala
+++ b/lib/ziggurat/src/core/ziggurat.Xeq.scala
@@ -36,10 +36,11 @@ import anticipation.*
 import contingency.*
 import distillate.*
 import galilei.*
+import gastronomy.*, hashProviders.javaStdlibHashing
 import gossamer.*
 import hellenism.*
 import hieroglyph.*
-import monotonous.*, alphabets.base64.standard
+import monotonous.*, alphabets.base64.standard, alphabets.hex.lowerCase
 import prepositional.*
 import serpentine.*
 import turbulence.*
@@ -60,6 +61,7 @@ import textSanitizers.skip
 object Xeq:
   private val ChunkSize: Int = 8000
   private val RunnerPrefix = t"runner-"
+  private val AssetPrefix = t"xeq-"
   private val ExeSuffix = t".exe"
   private val DataName = t"data"
 
@@ -125,6 +127,28 @@ object Xeq:
     builder.text.data(using charEncoders.utf8)
 
 
+  def multiDownloader(entries: List[(Text, Text, Text)]): Data =
+    val template = cp"/ziggurat/xeq.tmpl".read[Text]
+    val bat      = cp"/ziggurat/xeq-multidownloader.bat".read[Text]
+    val ps1      = cp"/ziggurat/xeq-multidownloader.ps1".read[Text]
+    val sh       = cp"/ziggurat/xeq-multidownloader.sh".read[Text]
+
+    val prefix: Text =
+      template.cut(t"@@BAT@@").join(bat).cut(t"@@PS1@@").join(ps1).cut(t"@@SH@@").join(sh)
+
+    val rows: List[Text] = entries.map: (label, url, hash) =>
+      t"$label=$url|$hash"
+
+    val builder = StringBuilder()
+    builder.add(prefix)
+    if !prefix.ends(t"\n") then builder.add('\n')
+    builder.add(t"assets:")
+    builder.add(rows.join(t","))
+    builder.add('\n')
+    builder.add(t"#>\n")
+    builder.text.data(using charEncoders.utf8)
+
+
   private def write(output: Path on Linux, data: Data): Unit = unsafely:
     output.create[File]()
 
@@ -172,6 +196,33 @@ object Xeq:
     write(output.decode[Path on Linux], downloader(url, hash))
 
 
+  private def multiDownloaderMain(output: Text, stagingDir: Text, baseUrl: Text, version: Text)
+  :   Unit = unsafely:
+    val outputPath: Path on Linux = output.decode[Path on Linux]
+    val staging: Path on Linux = stagingDir.decode[Path on Linux]
+
+    val children: List[Path on Linux] = staging.children.to(List)
+
+    val entries: List[(Text, Text, Text)] =
+      children
+      . filter(_.name.starts(RunnerPrefix))
+      . sortBy(_.name.s)
+      . map: path =>
+          val name = path.name
+          val withoutPrefix = name.skip(RunnerPrefix.length)
+
+          val label =
+            if withoutPrefix.ends(ExeSuffix) then withoutPrefix.skip(ExeSuffix.length, Rtl)
+            else withoutPrefix
+
+          val data: Data = path.open(_.read[Data])
+          val hash: Text = data.digest[Sha2[256]].serialize[Hex]
+          val url: Text = t"$baseUrl$AssetPrefix$label-$version"
+          (label, url, hash)
+
+    write(outputPath, multiDownloader(entries))
+
+
   def main(args: Array[String]): Unit =
     args.iterator.toList match
       case "installer" :: output :: staging :: Nil =>
@@ -180,7 +231,12 @@ object Xeq:
       case "downloader" :: output :: url :: hash :: Nil =>
         downloaderMain(output.tt, url.tt, hash.tt)
 
+      case "multidownloader" :: output :: staging :: base :: version :: Nil =>
+        multiDownloaderMain(output.tt, staging.tt, base.tt, version.tt)
+
       case _ =>
         System.err.nn.println("usage: ziggurat.Xeq installer <output-file> <staging-dir>")
         System.err.nn.println("       ziggurat.Xeq downloader <output-file> <url> <sha256>")
+        System.err.nn.println(
+          "       ziggurat.Xeq multidownloader <output-file> <staging-dir> <base-url> <version>")
         System.exit(1)

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -44,6 +44,8 @@ import termcaps.environment
 
 import strategies.throwUnsafely
 import charEncoders.utf8
+import hashProviders.javaStdlibHashing
+import alphabets.hex.lowerCase
 
 import filesystemOptions.dereferenceSymlinks.enabled
 import filesystemOptions.readAccess.enabled
@@ -110,6 +112,55 @@ object Tests extends Suite(m"Ziggurat tests"):
         val (_, script) = stage()
         sh"$script".exec[Text]().trim
       .assert(_ == t"hello from $hostLabel")
+
+    def stageDownloader(entries: List[(Text, Text, Text)]): Path on Linux =
+      val dir = tempDir()
+      val script = dir / t"fetch"
+      script.create[File]()
+      script.open: handle =>
+        Stream(Xeq.multiDownloader(entries)).writeTo(handle)
+      script.executable() = true
+      script
+
+    // Serve the binaries as `file://` URLs so the generated downloader's curl
+    // path is exercised without standing up an HTTP server.
+    def fileEntry(dir: Path on Linux, label: Text, body: Text, hash: Optional[Text] = Unset)
+    :   (Text, Text, Text) =
+      val bin = dir / t"bin-$label"
+      bin.create[File]()
+      val bytes = body.data
+      bin.open: handle =>
+        Stream(bytes).writeTo(handle)
+      (label, t"file://$bin", hash.or(bytes.digest[Sha2[256]].serialize[Hex]))
+
+    suite(m"multiDownloader()"):
+      val entries = labels.map(fileEntry(tempDir(), _, t"#!/bin/sh\n"))
+      val script: Data = Xeq.multiDownloader(entries)
+
+      test(m"output starts with bash shebang"):
+        script.utf8.starts(t"#!/usr/bin/env bash")
+      .assert(_ == true)
+
+      test(m"assets line contains every label"):
+        val text = script.utf8
+        labels.forall { label => text.contains(t"$label=") }
+      .assert(_ == true)
+
+    suite(m"native macOS download"):
+      test(m"downloads, verifies and runs host binary"):
+        val dir = tempDir()
+        val entries = labels.map: label =>
+          fileEntry(dir, label, t"#!/bin/sh\necho 'fetched $label'\n")
+        sh"${stageDownloader(entries)}".exec[Text]().trim
+      .assert(_ == t"fetched $hostLabel")
+
+      test(m"rejects a binary whose hash does not match"):
+        val dir = tempDir()
+        val badHash = t"0"*64
+        val entries = labels.map: label =>
+          fileEntry(dir, label, t"#!/bin/sh\necho oops\n", badHash)
+        sh"${stageDownloader(entries)}".exec[Exit]()
+      .assert(_ != Exit.Ok)
 
     // Docker on macOS cannot run macOS containers, so macOS coverage is host-native only.
     if !dockerOk then Out.println(t"Docker unavailable; skipping Linux container tests")


### PR DESCRIPTION
Ziggurat can now build a small launcher script that downloads the right executable for the host platform from a URL (such as a GitHub release) on first run, instead of embedding every platform's binary in the script. The launcher detects the platform, fetches the matching binary, verifies its SHA-256, overwrites itself, and runs — keeping the distributed artifact tiny while still being a single self-contained file. A `make xeq-release` target packages the ethereal-hello example this way and publishes the binaries to a GitHub release.

## Download-on-demand executables

Alongside the existing `Xeq.installer` (which embeds every platform's binary) and the single-URL `Xeq.downloader`, ziggurat now offers `Xeq.multiDownloader` — a launcher that picks the right binary per platform and downloads it at runtime.

```scala
// label, download URL, and SHA-256 (lowercase hex) per platform
val script: Data = Xeq.multiDownloader(List(
  (t"linux-x64",   t"https://github.com/me/app/releases/download/v1/xeq-linux-x64-v1",   t"…"),
  (t"macos-arm64", t"https://github.com/me/app/releases/download/v1/xeq-macos-arm64-v1", t"…")))
```

The generated script works as bash, `cmd.exe`, and PowerShell. On first run it detects the OS/arch, looks up the matching `(url, sha256)` from an embedded `assets:` table, downloads the binary (curl/wget or `Invoke-WebRequest`), verifies the hash, overwrites itself, and execs.

The CLI gains a `multidownloader` subcommand that hashes the staged `runner-<label>` binaries and derives `xeq-<label>-<version>` asset URLs from a base URL:

```
ziggurat.Xeq multidownloader <output-file> <staging-dir> <base-url> <version>
```

Publishing is wired up end-to-end with `make xeq-release VERSION=X.Y.Z`, which builds one self-contained binary per platform, uploads them to a GitHub release via `gh`, and emits the launcher with matching hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)