### PR TITLE
Schema-typed verify navigation and coherent Encodable & Schematic fusion

### DIFF
--- a/lib/anticipation/src/codec/anticipation.Schematic.scala
+++ b/lib/anticipation/src/codec/anticipation.Schematic.scala
@@ -30,83 +30,15 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package jacinta
+package anticipation
 
-import scala.annotation.*
-import scala.compiletime.summonInline
-
-import anticipation.*
 import prepositional.*
-import urticose.*
-import vacuous.*
-import wisteria.*
 
-// The third of the three derivations (encoder-only / schema-only / both): the
-// fused `Encodable & Schematic in Json over JsonSchema` for any product or sum.
-// It is deliberately a single intersection given (not a universal `(Encodable,
-// Schematic) => …` combinator), built by deriving the encoder and the schema from
-// the same structure. Kept at low priority (a supertrait of `Schematic`) so a
-// bare `Schematic over JsonSchema` summon never gets upgraded to require an
-// encoder — the combined given is chosen only when the intersection is requested.
-trait SchematicLow:
-  inline given encodableSchematic: [value: Reflection]
-  =>  value is Encodable & Schematic in Json over JsonSchema =
-    new Encodable with Schematic:
-      type Self = value
-      type Form = Json
-      type Transport = JsonSchema
-      def encoded(value: value): Json = summonInline[value is Encodable in Json].encoded(value)
-      def schema(): JsonSchema = JsonSchema.derived[value].schema()
-
-// `Schematic` describes the schema of a value's encoding; `Transport` is the
-// schema's own representation (e.g. `JsonSchema`), so an instance reads `X is
-// Schematic over JsonSchema`. It carries no `Form` of its own: when fused with an
-// encoder as `Encodable & Schematic in Json over JsonSchema`, the wire format
-// (`Form = Json`) comes from `Encodable`.
-object Schematic extends SchematicLow:
-  given byte: Byte is Schematic over JsonSchema = () => JsonSchema.Integer()
-  given short: Short is Schematic over JsonSchema = () => JsonSchema.Integer()
-  given int: Int is Schematic over JsonSchema = () => JsonSchema.Integer()
-  given long: Long is Schematic over JsonSchema = () => JsonSchema.Integer()
-  given float: Float is Schematic over JsonSchema = () => JsonSchema.Number()
-  given double: Double is Schematic over JsonSchema = () => JsonSchema.Number()
-  given text: Text is Schematic over JsonSchema = () => JsonSchema.String()
-  given email: EmailAddress is Schematic over JsonSchema = () => JsonSchema.String()
-  given boolean: Boolean is Schematic over JsonSchema = () => JsonSchema.Boolean()
-
-  given optional: [value: Schematic over JsonSchema]
-  =>  Optional[value] is Schematic over JsonSchema =
-    () =>
-      value.schema() match
-        case entity: JsonSchema.Object  => entity.copy(optional = true)
-        case entity: JsonSchema.Integer => entity.copy(optional = true)
-        case entity: JsonSchema.Number  => entity.copy(optional = true)
-        case entity: JsonSchema.String  => entity.copy(optional = true)
-        case entity: JsonSchema.Array   => entity.copy(optional = true)
-        case entity: JsonSchema.Boolean => entity.copy(optional = true)
-        case entity: JsonSchema.Null    => entity.copy(optional = true)
-
-  given list: [value: Schematic over JsonSchema]
-  =>  List[value] is Schematic over JsonSchema =
-    () => JsonSchema.Array(items = value.schema())
-
-  given set: [value: Schematic over JsonSchema]
-  =>  Set[value] is Schematic over JsonSchema =
-    () => JsonSchema.Array(items = value.schema())
-
-  given map: [key: Encodable in Text, value: Schematic over JsonSchema]
-  =>  Map[key, value] is Schematic over JsonSchema =
-    () => JsonSchema.Object(additionalProperties = true)
-
-  // Auto-derivation of a schema for any product or sum, mirroring the encoder /
-  // decoder auto-givens. Gated on `Reflection` so it never competes with the
-  // primitive givens above.
-  inline given derived: [value: Reflection] => value is Schematic over JsonSchema =
-    JsonSchema.derived
-
-// `Schematic` describes the schema of a value's encoding. `Transport` is the
-// schema's own representation (e.g. `JsonSchema`). The wire format the schema is
-// *for* is not recorded here — in the fused `Encodable & Schematic in Json over
-// JsonSchema` it comes from `Encodable`'s `Form`.
+// The schema of a value's encoding. `Transport` is the schema's own representation
+// (e.g. `JsonSchema` or a TEL `Tels.Type`), so an instance reads `X is Schematic
+// over JsonSchema`. It is a sibling of `Encodable`; the two are commonly fused as
+// `Encodable & Schematic in Json over JsonSchema`, where the wire format (`Form`)
+// comes from `Encodable`. Format-specific given instances live with their format
+// (e.g. in jacinta / stratiform), not here.
 trait Schematic extends Typeclass, Transportive:
   def schema(): Transport

--- a/lib/anticipation/src/codec/anticipation.Shape.scala
+++ b/lib/anticipation/src/codec/anticipation.Shape.scala
@@ -30,74 +30,33 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package jacinta
+package anticipation
 
-import anticipation.*
-import contingency.*
-import prepositional.*
-import rudiments.*
-import vacuous.*
+// A format-neutral description of the *shape* of an encoding. It is carried by a
+// codec (e.g. jacinta's `Json.Encodable`/`Json.Decodable`) so that the codec and
+// its schema are produced together — coherent by construction — and then *reified*
+// into a concrete, format-specific schema downstream (a `JsonSchema` in jacinta, a
+// `Tels.Type` in stratiform). Living here, upstream of every codec, is what lets a
+// codec carry its shape without depending on any particular schema representation.
+//
+// It captures only structure (the part that must stay coherent with the codec);
+// richer, format-specific annotations (descriptions, formats, bounds) remain the
+// concern of each format's own schema derivation.
+enum Shape:
+  // Whether a value of this shape may be absent (used to compute which record
+  // fields are required).
+  def optional: Boolean = this match
+    case Opt(_) => true
+    case _      => false
 
-import JsonError.Reason
-
-extension (json: Json)
-  // Runtime-checks `json` against the schema for `topic`, then re-types it as a
-  // schema-typed `Json of topic from topic`. The phantom `Topic` records the
-  // current position within the schema (initially the root, `topic`) and `Origin`
-  // records the root schema itself, so that the `Dynamic` navigation macros can
-  // resolve fields and array indices against `topic` at compile time — with no
-  // `dynamicJsonAccess.enabled` import required.
-  //
-  // The conformance check walks `schematic.schema(): JsonSchema` against the
-  // value, raising `JsonError` on the first structural mismatch (wrong type, or a
-  // required field absent).
-  def verify[topic](using decodable: topic is Json.Decodable)
-  :     (Json of topic from topic) raises JsonError =
-
-    conform(JsonSchema.reify(decodable.shape()), json.root)
-    json.asInstanceOf[Json of topic from topic]
-
-// Checks that a `Json.Ast` node conforms to a `JsonSchema`. An absent node is
-// permitted only where the schema is optional; otherwise each variant checks the
-// node's primitive type and recurses into object properties / array items.
-private def conform(schema: JsonSchema, ast: Json.Ast): Unit raises JsonError =
-  inline def mismatch(expected: JsonPrimitive): Unit =
-    raise(JsonError(Reason.NotType(ast.primitive, expected)))
-
-  if ast.isAbsent then (if !schema.optional then raise(JsonError(Reason.Absent)))
-  else schema match
-    case obj: JsonSchema.Object => obj.oneOf match
-      case variants: List[JsonSchema] =>
-        // A `oneOf` schema (e.g. a derived sum type) conforms if the node
-        // matches any one variant.
-        if !variants.exists { variant => safely(conform(variant, ast)).present }
-        then mismatch(JsonPrimitive.Object)
-
-      case _ =>
-        if !ast.isObject then mismatch(JsonPrimitive.Object) else
-          val absent = Json.Ast(Unset)
-
-          for (key, property) <- obj.properties do
-            val index = ast.objectIndexOf(key.s)
-            conform(property, if index < 0 then absent else ast.objectValue(index))
-
-    case array: JsonSchema.Array =>
-      if !ast.isArray then mismatch(JsonPrimitive.Array)
-      else if array.items.present then
-        val items = array.items.vouch
-        var index = 0
-        val length = ast.arrayLength
-
-        while index < length do
-          conform(items, ast.arrayElement(index))
-          index += 1
-
-    case _: JsonSchema.String  => if !ast.isString  then mismatch(JsonPrimitive.String)
-    case _: JsonSchema.Number  => if !ast.isNumber  then mismatch(JsonPrimitive.Number)
-    case _: JsonSchema.Integer => if !ast.isNumber  then mismatch(JsonPrimitive.Number)
-    case _: JsonSchema.Boolean => if !ast.isBoolean then mismatch(JsonPrimitive.Boolean)
-    case _: JsonSchema.Null    => if !ast.isNull    then mismatch(JsonPrimitive.Null)
-
-    // A `$ref` cannot be resolved without the root schema document, which is not
-    // yet threaded through; such nodes are left unchecked for now.
-    case _: JsonSchema.Ref => ()
+  case Str                                              // a string
+  case Whole                                            // an integer
+  case Real                                             // a (fractional) number
+  case Bool                                             // a boolean
+  case Empty                                            // null / unit
+  case Any                                              // unconstrained (e.g. a raw value)
+  case Opt(shape: Shape)                                // an optional value
+  case Arr(items: Shape)                                // a homogeneous sequence
+  case Dict(key: Shape, value: Shape)                   // a map of arbitrary keys to values
+  case Obj(fields: List[(Text, Shape)], required: List[Text]) // a record of named fields
+  case OneOf(variants: List[Shape])                     // a tagged disjunction

--- a/lib/anticipation/src/codec/soundness_anticipation_codec.scala
+++ b/lib/anticipation/src/codec/soundness_anticipation_codec.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anticipation.{bytestream, Data, Encodable, Schema, Schematic}
+export anticipation.{bytestream, Data, Encodable, Schema, Schematic, Shape}

--- a/lib/anticipation/src/codec/soundness_anticipation_codec.scala
+++ b/lib/anticipation/src/codec/soundness_anticipation_codec.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anticipation.{bytestream, Data, Encodable, Schema}
+export anticipation.{bytestream, Data, Encodable, Schema, Schematic}

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -64,8 +64,11 @@ object OpenApi:
 
     // Anchored (rather than derived inline at each use) so that `PathItem` and
     // `Operation`, which both embed `Parameter`, reference one cached instance.
+    // Typed as the carrier `Json.Decodable` (not the plain `Decodable in Json`):
+    // the schema-carrying product derivation summons each field as `Json.Decodable`,
+    // so a plain-typed anchor would be bypassed and the type re-derived inline.
     given decodableJson: (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
-    =>  Parameter is Decodable in Json = Json.DecodableDerivation.derived
+    =>  Parameter is Json.Decodable = Json.DecodableDerivation.derived
 
     given decodableYaml: (Tactic[YamlError], Tactic[JsonPointerError], Tactic[OpenApiError])
     =>  Parameter is Decodable in Yaml = Yaml.DecodableDerivation.derived
@@ -82,12 +85,24 @@ object OpenApi:
 
   // An OpenAPI "Media Type Object": the value of a `content` entry keyed by a
   // media-type string such as `application/json`.
+  object MediaTypeObject:
+    given (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
+    =>  MediaTypeObject is Json.Decodable = Json.DecodableDerivation.derived
+
   case class MediaTypeObject(schema: Optional[JsonSchema] = Unset)
+
+  object RequestBody:
+    given (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
+    =>  RequestBody is Json.Decodable = Json.DecodableDerivation.derived
 
   case class RequestBody
     ( description: Optional[Text]             = Unset,
       required:    Optional[Boolean]          = Unset,
       content:     Map[Text, MediaTypeObject] = Map() )
+
+  object Response:
+    given (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
+    =>  Response is Json.Decodable = Json.DecodableDerivation.derived
 
   case class Response
     ( description: Optional[Text]             = Unset,
@@ -100,7 +115,7 @@ object OpenApi:
     // instance). Anchoring `Operation` derives it once and lets `PathItem`
     // simply reference it.
     given decodableJson: (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
-    =>  Operation is Decodable in Json = Json.DecodableDerivation.derived
+    =>  Operation is Json.Decodable = Json.DecodableDerivation.derived
 
     given decodableYaml: (Tactic[YamlError], Tactic[JsonPointerError], Tactic[OpenApiError])
     =>  Operation is Decodable in Yaml = Yaml.DecodableDerivation.derived
@@ -112,6 +127,10 @@ object OpenApi:
       parameters:  List[Parameter]       = Nil,
       requestBody: Optional[RequestBody] = Unset,
       responses:   Map[Text, Response]   = Map() )
+
+  object PathItem:
+    given (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
+    =>  PathItem is Json.Decodable = Json.DecodableDerivation.derived
 
   // The path-item object mixes HTTP-method keys with non-method keys, so each
   // verb is a fixed optional field rather than a `Map[Http.Method, Operation]`;
@@ -139,6 +158,10 @@ object OpenApi:
       verbs
       . collect { case (method, operation) if operation.present => method -> operation.vouch }
       . to(Map)
+
+  object Components:
+    given (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
+    =>  Components is Json.Decodable = Json.DecodableDerivation.derived
 
   case class Components(schemas: Map[Text, JsonSchema] = Map())
 
@@ -248,6 +271,13 @@ object OpenApi:
             Unset,
             yaml(t"additionalProperties").as[Optional[scala.Boolean]].or(false),
             field[List[JsonSchema]](t"oneOf") )
+
+  // Anchor the top-level model so `as[OpenApi]` (below) materialises its decoder
+  // once — with each nested type resolving to its own anchor — rather than inlining
+  // the entire OpenAPI graph at the call site (which, with schema-carrying codecs,
+  // overflows `-Xmax-inlines` and the JVM class-size limit).
+  given decodable: (Tactic[JsonError], Tactic[JsonPointerError], Tactic[OpenApiError])
+  =>  OpenApi is Json.Decodable = Json.DecodableDerivation.derived
 
   // `source.read[OpenApi]`: aggregate the source text, auto-detect JSON vs YAML
   // from the first non-whitespace character, decode through the shared model,

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -161,38 +161,41 @@ object Lsp:
   // is numbered from 0, so its ordinal is used directly.
 
   object DiagnosticSeverity:
-    given encodable: DiagnosticSeverity is Encodable in Json =
-      severity => (severity.ordinal + 1).json
+    given encodable: DiagnosticSeverity is Json.Encodable =
+      Json.Encodable(Shape.Whole)(severity => (severity.ordinal + 1).json)
 
-    given decodable: Tactic[JsonError] => DiagnosticSeverity is Decodable in Json =
-      json => DiagnosticSeverity.fromOrdinal(json.as[Int] - 1)
+    given decodable: Tactic[JsonError] => DiagnosticSeverity is Json.Decodable =
+      Json.Decodable(Shape.Whole)(json => DiagnosticSeverity.fromOrdinal(json.as[Int] - 1))
 
   enum DiagnosticSeverity:
     case Error, Warning, Information, Hint
 
   object MessageType:
-    given encodable: MessageType is Encodable in Json = level => (level.ordinal + 1).json
+    given encodable: MessageType is Json.Encodable =
+      Json.Encodable(Shape.Whole)(level => (level.ordinal + 1).json)
 
-    given decodable: Tactic[JsonError] => MessageType is Decodable in Json =
-      json => MessageType.fromOrdinal(json.as[Int] - 1)
+    given decodable: Tactic[JsonError] => MessageType is Json.Decodable =
+      Json.Decodable(Shape.Whole)(json => MessageType.fromOrdinal(json.as[Int] - 1))
 
   enum MessageType:
     case Error, Warning, Info, Log
 
   object TextDocumentSyncKind:
-    given encodable: TextDocumentSyncKind is Encodable in Json = kind => kind.ordinal.json
+    given encodable: TextDocumentSyncKind is Json.Encodable =
+      Json.Encodable(Shape.Whole)(kind => kind.ordinal.json)
 
-    given decodable: Tactic[JsonError] => TextDocumentSyncKind is Decodable in Json =
-      json => TextDocumentSyncKind.fromOrdinal(json.as[Int])
+    given decodable: Tactic[JsonError] => TextDocumentSyncKind is Json.Decodable =
+      Json.Decodable(Shape.Whole)(json => TextDocumentSyncKind.fromOrdinal(json.as[Int]))
 
   enum TextDocumentSyncKind:
     case None, Full, Incremental
 
   object CompletionItemKind:
-    given encodable: CompletionItemKind is Encodable in Json = kind => (kind.ordinal + 1).json
+    given encodable: CompletionItemKind is Json.Encodable =
+      Json.Encodable(Shape.Whole)(kind => (kind.ordinal + 1).json)
 
-    given decodable: Tactic[JsonError] => CompletionItemKind is Decodable in Json =
-      json => CompletionItemKind.fromOrdinal(json.as[Int] - 1)
+    given decodable: Tactic[JsonError] => CompletionItemKind is Json.Decodable =
+      Json.Decodable(Shape.Whole)(json => CompletionItemKind.fromOrdinal(json.as[Int] - 1))
 
   enum CompletionItemKind:
     case Text, Method, Function, Constructor, Field, Variable, Class, Interface, Module, Property,
@@ -200,10 +203,11 @@ object Lsp:
       Struct, Event, Operator, TypeParameter
 
   object SymbolKind:
-    given encodable: SymbolKind is Encodable in Json = kind => (kind.ordinal + 1).json
+    given encodable: SymbolKind is Json.Encodable =
+      Json.Encodable(Shape.Whole)(kind => (kind.ordinal + 1).json)
 
-    given decodable: Tactic[JsonError] => SymbolKind is Decodable in Json =
-      json => SymbolKind.fromOrdinal(json.as[Int] - 1)
+    given decodable: Tactic[JsonError] => SymbolKind is Json.Decodable =
+      Json.Decodable(Shape.Whole)(json => SymbolKind.fromOrdinal(json.as[Int] - 1))
 
   enum SymbolKind:
     case File, Module, Namespace, Package, Class, Method, Property, Field, Constructor, Enum,

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -37,25 +37,33 @@ import soundness.*
 import charEncoders.utf8
 import strategies.throwUnsafely
 
+// Kept as a top-level object (its own class) rather than nested in `Tests` so the
+// LSP codecs it inlines do not add to the `Tests` class, which — now that each
+// derived JSON codec also carries its `Shape` — would otherwise exceed the JVM
+// per-class size limit.
+object TestServer extends LspServer():
+  def name: Text = t"Test"
+  override def version: Optional[Text] = t"1.0"
+  def capabilities: Lsp.ServerCapabilities = Lsp.ServerCapabilities(hoverProvider = true)
+
+  override def hover(uri: Text, position: Lsp.Position): Optional[Lsp.Hover] =
+    Lsp.Hover(Lsp.MarkupContent(value = t"hi"))
+
+  override def onOpen(document: Lsp.TextDocumentItem)(using LspClient): Unit =
+    summon[LspClient].publishDiagnostics
+      ( document.uri,
+        List
+          ( Lsp.Diagnostic
+              ( range    = Lsp.Range(Lsp.Position(0, 0), Lsp.Position(0, 1)),
+                severity = Lsp.DiagnosticSeverity.Error,
+                message  = t"oops" ) ) )
+
+  // Expand the `serve` dispatch macro once, here, rather than at each test call
+  // site: each expansion inlines a codec (now schema-carrying) for every LSP
+  // method, which repeated would exceed the JVM per-class size limit in `Tests`.
+  lazy val dispatch: Json => Optional[Json] = JsonRpc.serve[Lsp](this)
+
 object Tests extends Suite(m"Exegesis Tests"):
-
-  object TestServer extends LspServer():
-    def name: Text = t"Test"
-    override def version: Optional[Text] = t"1.0"
-    def capabilities: Lsp.ServerCapabilities = Lsp.ServerCapabilities(hoverProvider = true)
-
-    override def hover(uri: Text, position: Lsp.Position): Optional[Lsp.Hover] =
-      Lsp.Hover(Lsp.MarkupContent(value = t"hi"))
-
-    override def onOpen(document: Lsp.TextDocumentItem)(using LspClient): Unit =
-      summon[LspClient].publishDiagnostics
-        ( document.uri,
-          List
-            ( Lsp.Diagnostic
-                ( range    = Lsp.Range(Lsp.Position(0, 0), Lsp.Position(0, 1)),
-                  severity = Lsp.DiagnosticSeverity.Error,
-                  message  = t"oops" ) ) )
-
   def run(): Unit =
     suite(m"Integer enum codecs"):
       test(m"DiagnosticSeverity encodes to its protocol number"):
@@ -85,7 +93,7 @@ object Tests extends Suite(m"Exegesis Tests"):
 
     suite(m"Dispatch"):
       test(m"a hover request is answered with the hover result"):
-        val dispatch = JsonRpc.serve[Lsp](TestServer)
+        val dispatch = TestServer.dispatch
 
         val request: Json =
           t"""{"jsonrpc":"2.0","id":1,"method":"textDocument/hover","params":{"textDocument":{"uri":"file:///x"},"position":{"line":0,"character":0}}}"""
@@ -95,7 +103,7 @@ object Tests extends Suite(m"Exegesis Tests"):
       . assert(_ == t"hi")
 
       test(m"opening a document publishes a diagnostic to the client"):
-        val dispatch = JsonRpc.serve[Lsp](TestServer)
+        val dispatch = TestServer.dispatch
 
         val request: Json =
           t"""{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"file:///x","languageId":"text","version":1,"text":"hello"}}}"""

--- a/lib/jacinta/src/core/jacinta.Jacinta.scala
+++ b/lib/jacinta/src/core/jacinta.Jacinta.scala
@@ -1,0 +1,191 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gigantism.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// Compile-time navigation for schema-typed `Json` values. A `Json of P from R`
+// carries a phantom *position* (`Topic = P`, a Scala model type) within a *root
+// schema* (`Origin = R`). The `Dynamic` methods on `Json` are `transparent
+// inline` and delegate here: when the receiver's position is bound and the field
+// name is a literal, the macro looks the field up in `P`'s structure and yields a
+// `Json of <field-type> from R`; otherwise it falls back to the plain
+// (`DynamicJsonEnabler`-gated) runtime access, exactly as before.
+object Jacinta:
+
+  // Every `type X = …` member of a (possibly nested) refinement, by name.
+  private def refinements(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :     Map[Text, quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
+      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
+      case AndType(left, right)                        => refinements(left) ++ refinements(right)
+      case _                                           => Map()
+
+  // Builds the refined type `Json of <position> from <root>`.
+  private def jsonType(using quotes: Quotes)
+      ( position: quotes.reflect.TypeRepr, root: quotes.reflect.TypeRepr )
+  :     quotes.reflect.TypeRepr =
+
+    import quotes.reflect.*
+
+    Refinement
+      ( Refinement(TypeRepr.of[Json], "Topic", TypeBounds(position, position)),
+        "Origin",
+        TypeBounds(root, root) )
+
+  // The single ordered-collection element type of `repr`, if it is one (`List`,
+  // `Vector`, `Seq`, `LazyList`, `Array`, `IArray`); `Set` is excluded as it has
+  // no positional index.
+  private def elementType(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :     Optional[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case AppliedType(constructor, List(element))
+      if repr <:< TypeRepr.of[Seq[Any]] || constructor.typeSymbol == defn.ArrayClass =>
+        element
+
+      case _ =>
+        Unset
+
+  // Reads `Topic` (position) and `Origin` (root) from a receiver, if present.
+  private def receiver(using quotes: Quotes)(self: Expr[Json])
+  :     Optional[(quotes.reflect.TypeRepr, quotes.reflect.TypeRepr)] =
+
+    import quotes.reflect.*
+    val members = refinements(self.asTerm.tpe.widen)
+
+    members.at(t"Topic").let: position =>
+      (position, members.at(t"Origin").or(position))
+
+  def select(self: Expr[Json], field: Expr[String]): Macro[Json] =
+    import quotes.reflect.*
+
+    // Plain (unverified) access: gate on the enabler (resolved at the call site),
+    // then read the field totally.
+    def plain: Expr[Json] =
+      if Expr.summon[DynamicJsonEnabler].isEmpty
+      then halt(m"""dynamic field access on an unverified `Json` requires
+                    `import dynamicJsonAccess.enabled` (or verify the value against a schema first)""")
+
+      '{$self.selectField($field)}
+
+    receiver(self) match
+      case (position, root) => field.value match
+        case Some(name) => position.typeSymbol.caseFields.find(_.name == name) match
+          case Some(member) =>
+            jsonType(position.memberType(member), root).asType.absolve match
+              case '[type result <: Json; result] =>
+                '{$self.selectField(${Expr(name)}).asInstanceOf[result]}
+
+          case None =>
+            halt(m"the schema position ${position.show} has no field $name")
+
+        case None =>
+          plain
+
+      case _ =>
+        plain
+
+  def index(self: Expr[Json], idx: Expr[Int]): Macro[Json] =
+    import quotes.reflect.*
+
+    receiver(self) match
+      case (position, root) =>
+        val element = elementType(position)
+
+        if element.absent
+        then halt(m"the schema position ${position.show} is not an indexable array type")
+
+        jsonType(element.vouch, root).asType.absolve match
+          case '[type result <: Json; result] =>
+            '{$self.selectIndex($idx).asInstanceOf[result]}
+
+      case _ => Expr.summon[Tactic[JsonError]] match
+        case Some(tactic) =>
+          '{$self.indexValue($idx)(using $tactic)}
+
+        case None =>
+          halt(m"""indexing a `Json` array may raise `JsonError`; a `Tactic[JsonError]`
+                   must be in scope (e.g. via `raises JsonError`)""")
+
+  def applied(self: Expr[Json], field: Expr[String], idx: Expr[Int]): Macro[Json] =
+    import quotes.reflect.*
+
+    def plain: Expr[Json] =
+      if Expr.summon[DynamicJsonEnabler].isEmpty
+      then halt(m"""dynamic field access on an unverified `Json` requires
+                    `import dynamicJsonAccess.enabled` (or verify the value against a schema first)""")
+
+      Expr.summon[Tactic[JsonError]] match
+        case Some(tactic) => '{$self.selectField($field).indexValue($idx)(using $tactic)}
+
+        case None =>
+          halt(m"""indexing a `Json` array may raise `JsonError`; a `Tactic[JsonError]`
+                   must be in scope (e.g. via `raises JsonError`)""")
+
+    receiver(self) match
+      case (position, root) => field.value match
+        case Some(name) => position.typeSymbol.caseFields.find(_.name == name) match
+          case Some(member) =>
+            val element = elementType(position.memberType(member))
+
+            if element.absent
+            then halt(m"the field $name of ${position.show} is not an indexable array")
+
+            jsonType(element.vouch, root).asType.absolve match
+              case '[type result <: Json; result] =>
+                '{$self.selectField(${Expr(name)}).selectIndex($idx).asInstanceOf[result]}
+
+          case None =>
+            halt(m"the schema position ${position.show} has no field $name")
+
+        case None =>
+          plain
+
+      case _ =>
+        plain

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -475,7 +475,7 @@ object Json extends Json2, Dynamic:
   given lens: [name <: Label: ValueOf] => (erased DynamicJsonEnabler) => Tactic[JsonError]
   =>  name is Lens from Json onto Json =
 
-    Lens(_.selectDynamic(valueOf[name]), _.modify(valueOf[name], _))
+    Lens(_.selectField(valueOf[name]), _.modify(valueOf[name], _))
 
 
   given ordinalOptical: [element] => Ordinal is Optical from Json onto Json =
@@ -714,23 +714,43 @@ object Json extends Json2, Dynamic:
     import dynamicJsonAccess.enabled
 
     def rewrite(kind: Text, json: Json): Json = unsafely(json.updateDynamic(key)(kind))
-    def discriminate(json: Json): Optional[Text] = safely(json.selectDynamic(key).as[Text])
+    def discriminate(json: Json): Optional[Text] = safely(json.selectField(key).as[Text])
     def variant(json: Json): Json = unsafely(json.updateDynamic(key)(Unset))
 
 class Json(rootValue: Any, positions: Optional[Json.PositionIndex] = Unset)
-extends Dynamic derives CanEqual:
+extends Dynamic, Topical, Original derives CanEqual:
   private[jacinta] def root: Json.Ast = rootValue.asInstanceOf[Json.Ast]
   def positionIndex: Optional[Json.PositionIndex] = positions
-  def apply(index: Int): Json raises JsonError = Json(root.array(index))
 
-  def selectDynamic(field: String)(using erased DynamicJsonEnabler): Json raises JsonError =
-    apply(field.tt)
+  // Total field access used by the schema-typed navigation macros and by
+  // internal optics: an absent `Json` for a missing key, never raising.
+  private[jacinta] def selectField(field: String): Json =
+    if root.isAbsent then Json.ast(Json.Ast(Unset))
+    else root.objectIndexOf(field) match
+      case -1    => Json.ast(Json.Ast(Unset))
+      case index => Json(root.objectValue(index))
 
+  // Total array access: an absent `Json` for an out-of-bounds index.
+  private[jacinta] def selectIndex(index: Int): Json =
+    if root.isArray && index >= 0 && index < root.arrayLength then Json(root.arrayElement(index))
+    else Json.ast(Json.Ast(Unset))
 
-  def applyDynamic(field: String)(index: Int)(using erased DynamicJsonEnabler)
-  :   Json raises JsonError =
+  // Raising array access, preserving the behaviour of plain `json(i)`.
+  private[jacinta] def indexValue(index: Int): Json raises JsonError = Json(root.array(index))
 
-    apply(field.tt)(index)
+  // Array indexing. For a schema-typed `Json of List[E] from R` the navigation
+  // macro yields `Json of E from R`; for a plain `Json` it indexes at runtime
+  // (raising on a non-array or out-of-bounds index), exactly as before.
+  transparent inline def apply(index: Int): Json = ${Jacinta.index('this, 'index)}
+
+  // Dynamic field selection. For a schema-typed `Json of P from R` the macro
+  // checks `P` has the field and yields `Json of <field-type> from R`; for a
+  // plain `Json` it requires a `DynamicJsonEnabler` (as before) and reads the
+  // field at runtime.
+  transparent inline def selectDynamic(field: String): Json = ${Jacinta.select('this, 'field)}
+
+  transparent inline def applyDynamic(field: String)(index: Int): Json =
+    ${Jacinta.applied('this, 'field, 'index)}
 
 
   def update[value: Encodable in Json](index: Int, value: value)(using erased DynamicJsonEnabler)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -86,59 +86,136 @@ trait Json2:
       def decoded(json: Json): value = inner.decoded(json)
 
   given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
-  =>  ( encodable: inner is Encodable in Json )
-  =>  value is Encodable in Json =
+  =>  ( encodable: inner is Json.Encodable )
+  =>  value is Json.Encodable =
 
-    new Encodable:
-      type Self = Optional[value]
-      type Form = Json
-
-      def encoded(value: Optional[value]): Json =
-        value.let(_.asInstanceOf[inner]).let(encodable.encode(_)).or(Json.ast(Json.Ast(Unset)))
+    Json.Encodable(Shape.Opt(encodable.shape())): value =>
+      value.let(_.asInstanceOf[inner]).let(encodable.encode(_)).or(Json.ast(Json.Ast(Unset)))
 
 
   given optional: [inner <: value, value >: Unset.type: Mandatable to inner] => Tactic[JsonError]
-  =>  ( decodable: => inner is Decodable in Json )
-  =>  value is Decodable in Json = json =>
+  =>  ( decodable: => inner is Json.Decodable )
+  =>  value is Json.Decodable =
 
-    if json.root.isAbsent then Unset else decodable.decoded(json)
+    Json.Decodable(Shape.Opt(decodable.shape())): json =>
+      if json.root.isAbsent then Unset else decodable.decoded(json)
 
 
-  given bytes: Tactic[JsonError] => Bytes is Decodable in Json = json => json.root.long.b
+  given bytes: Tactic[JsonError] => Bytes is Json.Decodable =
+    Json.Decodable(Shape.Whole)(json => json.root.long.b)
 
-  inline given decodable: [value] => value is Decodable in Json = summonFrom:
-    case given (`value` is Decodable in Text) =>
-      provide[Tactic[JsonError]](_.root.string.decode[value])
+  inline given decodable: [value] => value is Json.Decodable = summonFrom:
+    case given (`value` is distillate.Decodable in Text) =>
+      Json.Decodable(Shape.Str)(provide[Tactic[JsonError]](_.root.string.decode[value]))
 
     case given Reflection[`value`] =>
       DecodableDerivation.derived
 
-  inline given encodable: [value] => value is Encodable in Json = summonFrom:
-    case given (`value` is Encodable in Text) => value => Json.ast(Json.Ast(value.encode.s))
-    case given Reflection[`value`]            => EncodableDerivation.derived
+  inline given encodable: [value] => value is Json.Encodable = summonFrom:
+    case given (`value` is anticipation.Encodable in Text) =>
+      Json.Encodable(Shape.Str)(value => Json.ast(Json.Ast(value.encode.s)))
 
-  object DecodableDerivation extends Derivable[Decodable in Json]:
+    case given Reflection[`value`] =>
+      EncodableDerivation.derived
+
+  object DecodableDerivation extends Derivable[Json.Decodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Decodable in Json =
+    :   derivation is Json.Decodable =
 
-      json =>
-        provide[Foci[Json.Focus]]:
+      // The object `Shape` is built from the *field decoders'* own shapes, so it
+      // describes exactly what this decoder reads (a `… in Text`-branch field
+      // contributes a string shape, not its derived object shape), keeping a fused
+      // `Decodable & Schematic` coherent. A single `contexts` traversal (rather than
+      // one each for fields and required) keeps the inlined codegen within JVM class
+      // limits; it must be inlined here (not factored into a helper) so it does not
+      // perturb the `build` traversal below. Built by-name so recursive types compile.
+      Json.Decodable({
+        val fields: List[(Text, Shape)] =
+          contexts: [field] => context => (label, context.shape())
+          . to(List)
+
+        Shape.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
+      }):
+        json =>
+          provide[Foci[Json.Focus]]:
+            provide[Tactic[JsonError]]:
+              val root = json.root
+              val n = root.objectSize
+              val values = scm.HashMap.empty[String, Json.Ast]
+              var i = 0
+
+              while i < n do
+                values.update(root.objectKey(i), root.objectValue(i))
+                i += 1
+
+              // `@name[Json]` / bare `@name` renames: field name -> JSON key, read
+              // back the same way they are written.
+              val renames: Map[Text, Text] = relabelling[derivation, Json]
+
+              build: [field] =>
+                context =>
+                  val key: Text = renames.at(label).or(label)
+                  focus({
+                    val base = prior.let(_.pointer).or(JsonPointer())
+
+                    val newPointer =
+                      JsonPointer
+                        ( base.url,
+                          Path[JsonPointer, JsonPointer.type, Tuple]
+                            ( base.path.root, base.path.descent :+ key ) )
+
+                    Json.Focus(newPointer)
+                  }):
+                    values.get(key.s) match
+                      case Some(value) => context.decoded(new Json(value))
+                      case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
+
+    inline def disjunction[derivation: SumReflection]: derivation is Json.Decodable =
+      // A sum encodes as a discriminated object. Its precise per-variant schema is
+      // available from the standalone `Schematic` / `JsonSchema.derived`; the
+      // codec-carried shape is kept permissive (`Any`) because the only way to walk
+      // the variants here (`delegate`) is `fallible` and would leak a
+      // `Tactic[VariantError]` requirement onto every codec.
+      Json.Decodable(Shape.Any):
+        json =>
           provide[Tactic[JsonError]]:
-            val root = json.root
-            val n = root.objectSize
-            val values = scm.HashMap.empty[String, Json.Ast]
-            var i = 0
+            provide[Tactic[VariantError]]:
+              val discriminable = infer[derivation is Discriminable in Json]
 
-            while i < n do
-              values.update(root.objectKey(i), root.objectValue(i))
-              i += 1
+              // `@name[Json]` / bare `@name` variant renames: map the serialized
+              // discriminator back to the variant name before delegating.
+              val variantNames: Map[Text, Text] =
+                variantRelabelling[derivation, Json].map((variant, wire) => wire -> variant)
 
-            // `@name[Json]` / bare `@name` renames: field name -> JSON key, read
-            // back the same way they are written.
+              val wire: Text = discriminable.discriminate(json).or:
+                focus(prior.or(Json.Focus(JsonPointer())))(abort(JsonError(Reason.Absent)))
+
+              val discriminant: Text = variantNames.getOrElse(wire, wire)
+
+              delegate(discriminant): [variant <: derivation] =>
+                context => context.decoded(json)
+
+  object EncodableDerivation extends Derivable[Json.Encodable]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Json.Encodable =
+
+      Json.Encodable({
+        val fields: List[(Text, Shape)] =
+          contexts: [field] => context => (label, context.shape())
+          . to(List)
+
+        Shape.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
+      }):
+        value =>
+          provide[Foci[Json.Focus]]:
+            val labels: scm.ArrayBuffer[String] = scm.ArrayBuffer()
+            val values: scm.ArrayBuffer[Json.Ast] = scm.ArrayBuffer()
+
+            // `@name[Json]` / bare `@name` renames: field name -> JSON key.
             val renames: Map[Text, Text] = relabelling[derivation, Json]
 
-            build: [field] =>
-              context =>
+            fields(value): [field] =>
+              field =>
                 val key: Text = renames.at(label).or(label)
                 focus({
                   val base = prior.let(_.pointer).or(JsonPointer())
@@ -151,73 +228,29 @@ trait Json2:
 
                   Json.Focus(newPointer)
                 }):
-                  values.get(key.s) match
-                    case Some(value) => context.decoded(new Json(value))
-                    case None        => default.or(context.decoded(new Json(Json.Ast(Unset))))
+                  contextual.encode(field).root.tap: encoded =>
+                    if !encoded.isAbsent then
+                      labels += key.s
+                      values += encoded
 
-    inline def disjunction[derivation: SumReflection]: derivation is Decodable in Json =
-      json =>
-        provide[Tactic[JsonError]]:
-          provide[Tactic[VariantError]]:
-            val discriminable = infer[derivation is Discriminable in Json]
+            Json.ast
+              ( Json.Ast.obj
+                  ( unsafely(labels.toArray.immutable), unsafely(values.toArray.immutable) ) )
 
-            // `@name[Json]` / bare `@name` variant renames: map the serialized
-            // discriminator back to the variant name before delegating.
-            val variantNames: Map[Text, Text] =
-              variantRelabelling[derivation, Json].map((variant, wire) => wire -> variant)
+    inline def disjunction[derivation: SumReflection]: derivation is Json.Encodable =
+      // See the decoder disjunction: the codec-carried sum shape is permissive
+      // (`Any`); precise `oneOf` schemas come from the standalone `Schematic`.
+      Json.Encodable(Shape.Any):
+        value =>
+          val discriminable = infer[derivation is Discriminable in Json]
 
-            val wire: Text = discriminable.discriminate(json).or:
-              focus(prior.or(Json.Focus(JsonPointer())))(abort(JsonError(Reason.Absent)))
+          // `@name[Json]` / bare `@name` variant renames: variant name -> wire
+          // discriminator, read back the same way by the decoder.
+          val variantNames: Map[Text, Text] = variantRelabelling[derivation, Json]
 
-            val discriminant: Text = variantNames.getOrElse(wire, wire)
-
-            delegate(discriminant): [variant <: derivation] =>
-              context => context.decoded(json)
-
-  object EncodableDerivation extends Derivable[Encodable in Json]:
-    inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Encodable in Json =
-
-      value =>
-        provide[Foci[Json.Focus]]:
-          val labels: scm.ArrayBuffer[String] = scm.ArrayBuffer()
-          val values: scm.ArrayBuffer[Json.Ast] = scm.ArrayBuffer()
-
-          // `@name[Json]` / bare `@name` renames: field name -> JSON key.
-          val renames: Map[Text, Text] = relabelling[derivation, Json]
-
-          fields(value): [field] =>
-            field =>
-              val key: Text = renames.at(label).or(label)
-              focus({
-                val base = prior.let(_.pointer).or(JsonPointer())
-
-                val newPointer =
-                  JsonPointer
-                    ( base.url,
-                      Path[JsonPointer, JsonPointer.type, Tuple]
-                        ( base.path.root, base.path.descent :+ key ) )
-
-                Json.Focus(newPointer)
-              }):
-                contextual.encode(field).root.tap: encoded =>
-                  if !encoded.isAbsent then
-                    labels += key.s
-                    values += encoded
-
-          Json.ast
-            ( Json.Ast.obj
-                ( unsafely(labels.toArray.immutable), unsafely(values.toArray.immutable) ) )
-
-    inline def disjunction[derivation: SumReflection]: derivation is Encodable in Json = value =>
-      val discriminable = infer[derivation is Discriminable in Json]
-
-      // `@name[Json]` / bare `@name` variant renames: variant name -> wire
-      // discriminator, read back the same way by the decoder.
-      val variantNames: Map[Text, Text] = variantRelabelling[derivation, Json]
-
-      variant(value): [variant <: derivation] =>
-        value => discriminable.rewrite(variantNames.getOrElse(label, label), contextual.encode(value))
+          variant(value): [variant <: derivation] =>
+            value =>
+              discriminable.rewrite(variantNames.getOrElse(label, label), contextual.encode(value))
 
 object Json extends Json2, Dynamic:
   type JsonString  = String
@@ -226,6 +259,40 @@ object Json extends Json2, Dynamic:
   type JsonNull    = Null
   type JsonObject  = IArray[Any]
   type JsonArray   = IArray[Any] | Array[Long] | Array[Int]
+
+  // A JSON encoder that also carries the format-neutral `Shape` describing exactly
+  // what it produces. Making the shape travel *with* the codec is what lets a fused
+  // `Encodable & Schematic` (built by `jsonSchematics.encodable`) be coherent by
+  // construction — the shape is never resolved independently of the codec, so a
+  // gated or `… in Text`-branch encoder always pairs with its own matching shape.
+  // The `Shape` is reified into a concrete `JsonSchema` downstream (in the schema
+  // module), so the codec — and `jacinta.core` — need not know `JsonSchema` at all.
+  // It is deliberately *not* `Schematic` (that subtyping is what caused the earlier
+  // resolution ambiguity); it merely *has* a `shape()`.
+  trait Encodable extends anticipation.Encodable:
+    type Form = Json
+    def shape(): Shape
+
+  object Encodable:
+    def apply[value](shape0: => Shape)(lambda: value => Json): value is Json.Encodable =
+      new Json.Encodable:
+        type Self = value
+        def encoded(value: value): Json = lambda(value)
+        def shape(): Shape = shape0
+
+  // The decoding counterpart of `Json.Encodable`: a `Decodable in Json` that also
+  // carries the `Shape` of exactly what it reads, so `jsonSchematics.decodable` and
+  // `verify` get a schema that is guaranteed coherent with the decoder.
+  trait Decodable extends distillate.Decodable:
+    type Form = Json
+    def shape(): Shape
+
+  object Decodable:
+    def apply[value](shape0: => Shape)(lambda: Json => value): value is Json.Decodable =
+      new Json.Decodable:
+        type Self = value
+        def decoded(json: Json): value = lambda(json)
+        def shape(): Shape = shape0
 
   // All internal references in a `PositionIndex` are stored as offsets
   // relative to the start of the containing node descriptor, so any slice
@@ -535,18 +602,35 @@ object Json extends Json2, Dynamic:
           Json.Ast.arr(updated.asInstanceOf[IArray[Any]])
       else origin
 
-  given boolean: Json is Decodable in Json = identity(_)
-  given boolean: Tactic[JsonError] => Boolean is Decodable in Json = _.root.boolean
-  given double: Tactic[JsonError] => Double is Decodable in Json = _.root.double
-  given float: Tactic[JsonError] => Float is Decodable in Json = _.root.double.toFloat
-  given long: Tactic[JsonError] => Long is Decodable in Json = _.root.long
-  given int: Tactic[JsonError] => Int is Decodable in Json = _.root.long.toInt
-  given ordinalDecodable: Tactic[JsonError] => Ordinal is Decodable in Json = _.root.long.toInt.z
-  given text: Tactic[JsonError] => Text is Decodable in Json = _.root.string
-  given string: Tactic[JsonError] => String is Decodable in Json = _.root.string.s
+  given jsonDecodable: Json is Json.Decodable =
+    Json.Decodable(Shape.Any)(identity(_))
 
-  given unit: Tactic[JsonError] => Unit is Decodable in Json =
-    value =>
+  given boolean: Tactic[JsonError] => Boolean is Json.Decodable =
+    Json.Decodable(Shape.Bool)(_.root.boolean)
+
+  given double: Tactic[JsonError] => Double is Json.Decodable =
+    Json.Decodable(Shape.Real)(_.root.double)
+
+  given float: Tactic[JsonError] => Float is Json.Decodable =
+    Json.Decodable(Shape.Real)(_.root.double.toFloat)
+
+  given long: Tactic[JsonError] => Long is Json.Decodable =
+    Json.Decodable(Shape.Whole)(_.root.long)
+
+  given int: Tactic[JsonError] => Int is Json.Decodable =
+    Json.Decodable(Shape.Whole)(_.root.long.toInt)
+
+  given ordinalDecodable: Tactic[JsonError] => Ordinal is Json.Decodable =
+    Json.Decodable(Shape.Whole)(_.root.long.toInt.z)
+
+  given text: Tactic[JsonError] => Text is Json.Decodable =
+    Json.Decodable(Shape.Str)(_.root.string)
+
+  given string: Tactic[JsonError] => String is Json.Decodable =
+    Json.Decodable(Shape.Str)(_.root.string.s)
+
+  given unit: Tactic[JsonError] => Unit is Json.Decodable =
+    Json.Decodable(Shape.Empty): value =>
       if value.root.isNull then ()
       else
         val reason =
@@ -556,67 +640,81 @@ object Json extends Json2, Dynamic:
         raise(JsonError(reason))
 
 
-  given option: [value: Decodable in Json] => Tactic[JsonError]
-  =>  Option[value] is Decodable in Json =
+  given option: [value: Json.Decodable] => Tactic[JsonError]
+  =>  Option[value] is Json.Decodable =
 
-    json => if json.root.isAbsent then None else Some(value.decoded(json))
-
-
-  given optionEncodable: [value] => (encodable: value is Encodable in Json)
-  =>  Option[value] is Encodable in Json =
-
-    new Encodable:
-      type Self = Option[value]
-      type Form = Json
-
-      def encoded(value: Option[value]): Json = value match
-        case None        => Json.ast(Json.Ast(Unset))
-        case Some(value) => encodable.encode(value)
+    Json.Decodable(Shape.Opt(value.shape())): json =>
+      if json.root.isAbsent then None else Some(value.decoded(json))
 
 
-  given integralEncodable: [integral: Integral] => integral is Encodable in Json =
-    int => Json.ast(Json.Ast(integral.toLong(int)))
+  given optionEncodable: [value] => (encodable: value is Json.Encodable)
+  =>  Option[value] is Json.Encodable =
 
-  given textEncodableInJson: Text is Encodable in Json = text => Json.ast(Json.Ast(text.s))
-  given stringEncodable: String is Encodable in Json = string => Json.ast(Json.Ast(string))
-  given doubleEncodable: Double is Encodable in Json = double => Json.ast(Json.Ast(double))
-  given intEncodable: Int is Encodable in Json = int => Json.ast(Json.Ast(int.toLong))
-  given unitEncodable: Unit is Encodable in Json = unit => Json.ast(Json.Ast(null))
-
-  given ordinalEncodable: Ordinal is Encodable in Json =
-    ordinal => Json.ast(Json.Ast(ordinal.n0.toLong))
-
-  given longEncodable: Long is Encodable in Json = long => Json.ast(Json.Ast(long))
-  given booleanEncodable: Boolean is Encodable in Json = boolean => Json.ast(Json.Ast(boolean))
-  given jsonEncodable: Json is Encodable in Json = identity(_)
+    Json.Encodable(Shape.Opt(encodable.shape())):
+      case None        => Json.ast(Json.Ast(Unset))
+      case Some(value) => encodable.encode(value)
 
 
-  given listEncodable: [list <: List, element] => (encodable: => element is Encodable in Json)
-  =>  list[element] is Encodable in Json =
+  given integralEncodable: [integral: Integral] => integral is Json.Encodable =
+    Json.Encodable(Shape.Whole)(int => Json.ast(Json.Ast(integral.toLong(int))))
 
-    values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
+  given textEncodableInJson: Text is Json.Encodable =
+    Json.Encodable(Shape.Str)(text => Json.ast(Json.Ast(text.s)))
+
+  given stringEncodable: String is Json.Encodable =
+    Json.Encodable(Shape.Str)(string => Json.ast(Json.Ast(string)))
+
+  given doubleEncodable: Double is Json.Encodable =
+    Json.Encodable(Shape.Real)(double => Json.ast(Json.Ast(double)))
+
+  given intEncodable: Int is Json.Encodable =
+    Json.Encodable(Shape.Whole)(int => Json.ast(Json.Ast(int.toLong)))
+
+  given unitEncodable: Unit is Json.Encodable =
+    Json.Encodable(Shape.Empty)(unit => Json.ast(Json.Ast(null)))
+
+  given ordinalEncodable: Ordinal is Json.Encodable =
+    Json.Encodable(Shape.Whole)(ordinal => Json.ast(Json.Ast(ordinal.n0.toLong)))
+
+  given longEncodable: Long is Json.Encodable =
+    Json.Encodable(Shape.Whole)(long => Json.ast(Json.Ast(long)))
+
+  given booleanEncodable: Boolean is Json.Encodable =
+    Json.Encodable(Shape.Bool)(boolean => Json.ast(Json.Ast(boolean)))
+
+  given jsonEncodable: Json is Json.Encodable =
+    Json.Encodable(Shape.Any)(identity(_))
 
 
-  given setEncodable: [set <: Set, element] => (encodable: => element is Encodable in Json)
-  =>  set[element] is Encodable in Json =
+  given listEncodable: [list <: List, element] => (encodable: => element is Json.Encodable)
+  =>  list[element] is Json.Encodable =
 
-    values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
+    Json.Encodable(Shape.Arr(encodable.shape())):
+      values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
 
 
-  given seriesEncodable: [series <: Series, element] => (encodable: => element is Encodable in Json)
-  =>  series[element] is Encodable in Json =
+  given setEncodable: [set <: Set, element] => (encodable: => element is Json.Encodable)
+  =>  set[element] is Json.Encodable =
 
-    values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
+    Json.Encodable(Shape.Arr(encodable.shape())):
+      values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
+
+
+  given seriesEncodable: [series <: Series, element] => (encodable: => element is Json.Encodable)
+  =>  series[element] is Json.Encodable =
+
+    Json.Encodable(Shape.Arr(encodable.shape())):
+      values => Json.ast(Json.Ast.arr(IArray.from(values.map(encodable.encoded(_).root))))
 
 
   given array: [collection <: Iterable, element]
   =>  ( factory: Factory[element, collection[element]],
         tactic:  Tactic[JsonError],
         foci:    Foci[Json.Focus] )
-  =>  ( decodable: => element is Decodable in Json )
-  =>  collection[element] is Decodable in Json =
+  =>  ( decodable: => element is Json.Decodable )
+  =>  collection[element] is Json.Decodable =
 
-    value =>
+    Json.Decodable(Shape.Arr(decodable.shape())): value =>
       val builder = factory.newBuilder
 
       value.root.array.each: json =>
@@ -636,11 +734,12 @@ object Json extends Json2, Dynamic:
       builder.result()
 
 
-  given map: [key: Decodable in Text, element] => (decodable: => element is Decodable in Json)
+  given map: [key: distillate.Decodable in Text, element]
+  =>  (decodable: => element is Json.Decodable)
   =>  Tactic[JsonError]
-  =>  Map[key, element] is Decodable in Json =
+  =>  Map[key, element] is Json.Decodable =
 
-    value =>
+    Json.Decodable(Shape.Dict(Shape.Str, decodable.shape())): value =>
       val root = value.root
       val n = root.objectSize
       var i = 0
@@ -657,23 +756,25 @@ object Json extends Json2, Dynamic:
       acc
 
 
-  given mapEncodable: [key: Encodable in Text, element]
-  =>  ( encodable: element is Encodable in Json )
-  =>  Map[key, element] is Encodable in Json =
+  given mapEncodable: [key: anticipation.Encodable in Text, element]
+  =>  ( encodable: element is Json.Encodable )
+  =>  Map[key, element] is Json.Encodable =
 
-    map =>
+    Json.Encodable(Shape.Dict(Shape.Str, encodable.shape())): map =>
       val keys: List[key] = map.keys.to(List)
       val values = IArray.from(keys.map(map(_).encode.root))
       Json.ast(Json.Ast.obj(IArray.from(keys.map(_.encode.s)), values))
 
 
-  given jsonEncodableInText: Json is Encodable in Text = json => JsonPrinter.print(json.root, false)
+  given jsonEncodableInText: Json is anticipation.Encodable in Text =
+    json => JsonPrinter.print(json.root, false)
 
   given aggregable: Tactic[ParseError] => Json is Aggregable by Data =
     bytes => Json(bytes.read[Json.Ast])
 
 
-  given aggregableDirect: [value: Decodable in Json] => Tactic[ParseError] => Tactic[JsonError]
+  given aggregableDirect: [value: distillate.Decodable in Json] => Tactic[ParseError]
+  =>  Tactic[JsonError]
   =>  (value over Json) is Aggregable by Data =
 
     bytes => Json(bytes.read[Json.Ast]).as[value].asInstanceOf[value over Json]
@@ -694,7 +795,7 @@ object Json extends Json2, Dynamic:
         (t"application/json; charset=${encoder.encoding.name}", Stream(json.show.data))
 
 
-  given decodable: Tactic[ParseError] => Json is Decodable in Text =
+  given decodable: Tactic[ParseError] => Json is distillate.Decodable in Text =
     text => Stream(text.data(using charEncoders.utf8)).read[Json]
 
   given instantiable: Tactic[ParseError] => Json is Instantiable across HttpRequests from Text =
@@ -753,7 +854,8 @@ extends Dynamic, Topical, Original derives CanEqual:
     ${Jacinta.applied('this, 'field, 'index)}
 
 
-  def update[value: Encodable in Json](index: Int, value: value)(using erased DynamicJsonEnabler)
+  def update[value: anticipation.Encodable in Json](index: Int, value: value)
+    (using erased DynamicJsonEnabler)
   :   Json raises JsonError =
 
     if !root.isArray then raise(JsonError(Reason.NotType(root.primitive, JsonPrimitive.Array)))
@@ -771,7 +873,7 @@ extends Dynamic, Topical, Original derives CanEqual:
     Json.ast(Json.Ast.arr(updated.asInstanceOf[IArray[Any]]))
 
 
-  def updateDynamic(field: String)[value: Encodable in Json](value: value)
+  def updateDynamic(field: String)[value: anticipation.Encodable in Json](value: value)
     ( using erased DynamicJsonEnabler )
   :   Json raises JsonError =
 
@@ -1057,10 +1159,10 @@ extends Dynamic, Topical, Original derives CanEqual:
     case _ =>
       false
 
-  def as[value: Decodable in Json at Json.Focus]
+  def as[value: distillate.Decodable in Json at Json.Focus]
   :   value raises JsonError tracks Json.Focus =
 
-    val decodable = summon[value is Decodable in Json at Json.Focus]
+    val decodable = summon[value is distillate.Decodable in Json at Json.Focus]
     val result = decodable.decoded(this)
     val foci = summon[Foci[Json.Focus]]
     foci.supplement(foci.length, _.let(decodable.position(this, _)).vouch)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -111,6 +111,13 @@ trait Json2 extends Json3:
     Json.Decodable(Shape.Whole)(json => json.root.long.b)
 
   inline given decodable: [value] => value is Json.Decodable = summonFrom:
+    // `Json` decodes to itself. Handled here (not as a separate carrier given) so it
+    // does not compete — as a `Json.Decodable` subtype — with the plain
+    // `jsonDecodable` for a `Json is Decodable in Json` summon (which must beat
+    // distillate's `generic`).
+    case _: (`value` =:= Json) =>
+      Json.Decodable[Json](Shape.Any)(identity(_)).asInstanceOf[value is Json.Decodable]
+
     case given (`value` is distillate.Decodable in Text) =>
       Json.Decodable(Shape.Str)(provide[Tactic[JsonError]](_.root.string.decode[value]))
 
@@ -608,8 +615,14 @@ object Json extends Json2, Dynamic:
           Json.Ast.arr(updated.asInstanceOf[IArray[Any]])
       else origin
 
-  given jsonDecodable: Json is Json.Decodable =
-    Json.Decodable(Shape.Any)(identity(_))
+  // A `Json` value decodes to itself. Typed as the plain `Decodable in Json` (not
+  // the `Json.Decodable` carrier) so it is *exactly* the queried type and strictly
+  // beats distillate's universal `value is Decodable in value` identity given for a
+  // `Json is Decodable in Json` summon (e.g. `someJson.as[Json]`); a carrier subtype
+  // would be incomparable to `generic` and therefore ambiguous. `Json is
+  // Json.Decodable` (needed when `Json` nests in a collection/`Optional`) comes from
+  // the `Json` case in the `decodable` summonFrom above.
+  given jsonDecodable: Json is distillate.Decodable in Json = identity(_)
 
   given boolean: Tactic[JsonError] => Boolean is Json.Decodable =
     Json.Decodable(Shape.Bool)(_.root.boolean)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -63,32 +63,32 @@ import JsonError.Reason
 
 // Base mixin for Jacinta's decoder instances. Fixes the focus type to
 // `Json.Focus` and provides the position-enrichment hook that `Json#as[T]` runs
-// over the accumulated `Foci[Json.Focus]` after decoding. It extends the
-// schema-carrying `Json.Decodable`, carrying `inner`'s shape.
-private[jacinta] trait JsonDecodable[T] extends Json.Decodable:
+// over the accumulated `Foci[Json.Focus]` after decoding.
+private[jacinta] trait JsonDecodable[T] extends Decodable:
   type Self = T
+  type Form = Json
   type Locus = Json.Focus
   override def position(value: Json, focus: Json.Focus): Json.Focus =
     focus.withPosition(value)
 
-// Lowest-priority layer (extended by `Json2`), holding only the focus adapter.
-// Keeping it below the carrying decoders matters: a plain `summon[T is Decodable
-// in Json]` — as obligatory's / synesthesia's JsonRpc macros do via `Expr.summon`
-// — must resolve to a single carrying decoder, but the focus adapter's result
+// Lowest-priority layer (extended by `Json2`), holding only the focus adapter,
+// which lifts any `Decodable in Json` into one carrying `type Locus = Json.Focus`
+// (used by `as[T]`). Keeping it below the carrying decoders matters: its result
 // (`… at Json.Focus`) is itself a subtype of a plain `Decodable in Json`, so at
-// equal priority it competes and (now that both it and the carriers add members)
-// is incomparable, yielding an ambiguity. At lower priority it is ignored for the
-// plain summon, yet `as[T]` still finds it because it is the *only* given that
-// produces the `at Json.Focus` form. The lower priority also stops it feeding
-// itself as its own `inner`.
+// equal priority it would compete with — and be incomparable to (`Locus` vs
+// `shape`) — the carrying decoders for a plain `summon[T is Decodable in Json]`,
+// yielding an ambiguity. At lower priority it is ignored for plain/carrier
+// summons, yet `as[T]` still finds it because it is the *only* given producing the
+// `at Json.Focus` form. Deliberately broad (`Decodable in Json`, not
+// `Json.Decodable`) so generic `as[T]` callers bounded on `Decodable in Json`
+// still resolve.
 trait Json3:
   inline given decodableAtFocus: [value]
-  =>  (inner: value is Json.Decodable)
-  =>  value is Json.Decodable at Json.Focus =
+  =>  (inner: value is Decodable in Json)
+  =>  value is Decodable in Json at Json.Focus =
 
     new JsonDecodable[value]:
       def decoded(json: Json): value = inner.decoded(json)
-      def shape(): Shape = inner.shape()
 
 trait Json2 extends Json3:
   given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
@@ -779,7 +779,7 @@ object Json extends Json2, Dynamic:
     bytes => Json(bytes.read[Json.Ast])
 
 
-  given aggregableDirect: [value: Json.Decodable] => Tactic[ParseError]
+  given aggregableDirect: [value: distillate.Decodable in Json] => Tactic[ParseError]
   =>  Tactic[JsonError]
   =>  (value over Json) is Aggregable by Data =
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -61,30 +61,36 @@ import zephyrine.*
 
 import JsonError.Reason
 
-// Base mixin for Jacinta's `Decodable in Json` instances. Fixes the focus
-// type to `Json.Focus` and provides the position-enrichment hook that
-// `Json#as[T]` runs over the accumulated `Foci[Json.Focus]` after decoding.
-private[jacinta] trait JsonDecodable[T] extends Decodable:
+// Base mixin for Jacinta's decoder instances. Fixes the focus type to
+// `Json.Focus` and provides the position-enrichment hook that `Json#as[T]` runs
+// over the accumulated `Foci[Json.Focus]` after decoding. It extends the
+// schema-carrying `Json.Decodable`, carrying `inner`'s shape.
+private[jacinta] trait JsonDecodable[T] extends Json.Decodable:
   type Self = T
-  type Form = Json
   type Locus = Json.Focus
   override def position(value: Json, focus: Json.Focus): Json.Focus =
     focus.withPosition(value)
 
-trait Json2:
-  // Lower-priority adapter that lifts any `Decodable in Json` into one
-  // carrying `type Locus = Json.Focus`. Used by `as[T]` so it can call
-  // `.position` (delegating to `Json.Focus.withPosition`) over the
-  // accumulated `Foci[Json.Focus]` after decoding. Specific `Decodable in
-  // Json` givens stay unchanged; the wrapping happens only at the
-  // `at Json.Focus` boundary.
+// Lowest-priority layer (extended by `Json2`), holding only the focus adapter.
+// Keeping it below the carrying decoders matters: a plain `summon[T is Decodable
+// in Json]` — as obligatory's / synesthesia's JsonRpc macros do via `Expr.summon`
+// — must resolve to a single carrying decoder, but the focus adapter's result
+// (`… at Json.Focus`) is itself a subtype of a plain `Decodable in Json`, so at
+// equal priority it competes and (now that both it and the carriers add members)
+// is incomparable, yielding an ambiguity. At lower priority it is ignored for the
+// plain summon, yet `as[T]` still finds it because it is the *only* given that
+// produces the `at Json.Focus` form. The lower priority also stops it feeding
+// itself as its own `inner`.
+trait Json3:
   inline given decodableAtFocus: [value]
-  =>  (inner: value is Decodable in Json)
-  =>  value is Decodable in Json at Json.Focus =
+  =>  (inner: value is Json.Decodable)
+  =>  value is Json.Decodable at Json.Focus =
 
     new JsonDecodable[value]:
       def decoded(json: Json): value = inner.decoded(json)
+      def shape(): Shape = inner.shape()
 
+trait Json2 extends Json3:
   given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
   =>  ( encodable: inner is Json.Encodable )
   =>  value is Json.Encodable =
@@ -773,7 +779,7 @@ object Json extends Json2, Dynamic:
     bytes => Json(bytes.read[Json.Ast])
 
 
-  given aggregableDirect: [value: distillate.Decodable in Json] => Tactic[ParseError]
+  given aggregableDirect: [value: Json.Decodable] => Tactic[ParseError]
   =>  Tactic[JsonError]
   =>  (value over Json) is Aggregable by Data =
 

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -47,33 +47,34 @@ import vacuous.*
 import wisteria.*
 
 // Constructors for fused `Encodable & Schematic` / `Decodable & Schematic`
-// instances, built from a value's separate `Encodable`/`Decodable` and `Schematic`
-// instances. These are deliberately *methods*, not givens: a `Decodable &
-// Schematic` (or `Encodable & Schematic`) given is a subtype of both `Decodable`
-// (resp. `Encodable`) *and* `Schematic`, so as givens the two would be ambiguous
-// for any bare `Schematic` summon and would also be pulled into the recursive
-// `JsonSchema` codec. As methods they never enter implicit resolution; call them
-// where a fused instance is wanted (e.g. `given … = jsonSchematics.decodable[T]`).
+// instances. The schema is taken from the codec itself (`Json.Encodable` /
+// `Json.Decodable` *carry* a `schema()`), never resolved independently, so the
+// fused instance is coherent by construction: a gated or `… in Text`-branch codec
+// always pairs with the schema for exactly what it reads/writes.
+//
+// These are deliberately *methods*, not givens: a `Decodable & Schematic` (or
+// `Encodable & Schematic`) given is a subtype of both its codec typeclass *and*
+// `Schematic`, so as givens the two would be ambiguous for any bare `Schematic`
+// summon. As methods they never enter implicit resolution; call them where a fused
+// instance is wanted (e.g. `given … = jsonSchematics.decodable[T]`).
 object jsonSchematics:
-  def encodable[value](using encoder: value is Encodable in Json)
-                      (using schema0: value is Schematic over JsonSchema)
+  def encodable[value](using encoder: value is Json.Encodable)
   :     value is Encodable & Schematic in Json over JsonSchema =
     new Encodable with Schematic:
       type Self = value
       type Form = Json
       type Transport = JsonSchema
       def encoded(value: value): Json = encoder.encoded(value)
-      def schema(): JsonSchema = schema0.schema()
+      def schema(): JsonSchema = JsonSchema.reify(encoder.shape())
 
-  def decodable[value](using decoder: value is Decodable in Json)
-                      (using schema0: value is Schematic over JsonSchema)
+  def decodable[value](using decoder: value is Json.Decodable)
   :     value is Decodable & Schematic in Json over JsonSchema =
     new Decodable with Schematic:
       type Self = value
       type Form = Json
       type Transport = JsonSchema
       def decoded(json: Json): value = decoder.decoded(json)
-      def schema(): JsonSchema = schema0.schema()
+      def schema(): JsonSchema = JsonSchema.reify(decoder.shape())
 
 
 object JsonSchema extends Derivable[Schematic over JsonSchema]:
@@ -90,18 +91,44 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
   given emailSchematic: EmailAddress is Schematic over JsonSchema = () => JsonSchema.String()
   given booleanSchematic: scala.Boolean is Schematic over JsonSchema = () => JsonSchema.Boolean()
 
+  // Reifies a codec's format-neutral `Shape` (carried by `Json.Encodable` /
+  // `Json.Decodable`) into a concrete `JsonSchema`. This is the bridge that keeps
+  // `jacinta.core` free of any `JsonSchema` dependency while still letting a fused
+  // `Encodable & Schematic` / `Decodable & Schematic` expose a real schema that is
+  // coherent with the codec (since the `Shape` was produced by the codec itself).
+  def reify(shape: Shape): JsonSchema = shape match
+    case Shape.Str            => JsonSchema.String()
+    case Shape.Whole          => JsonSchema.Integer()
+    case Shape.Real           => JsonSchema.Number()
+    case Shape.Bool           => JsonSchema.Boolean()
+    case Shape.Empty          => JsonSchema.Null()
+    case Shape.Any            => JsonSchema.Object(additionalProperties = true)
+    case Shape.Opt(inner)     => JsonSchema.optional(reify(inner))
+    case Shape.Arr(items)     => JsonSchema.Array(items = reify(items))
+    case Shape.Dict(_, _)     => JsonSchema.Object(additionalProperties = true)
+    case Shape.OneOf(variants) =>
+      JsonSchema.Object(oneOf = variants.map(reify), required = List(t"kind"))
+
+    case Shape.Obj(fields, required) =>
+      JsonSchema.Object
+        ( properties = fields.map((label, shape) => (label, reify(shape))).to(Map),
+          required   = required )
+
+  // Marks a schema as optional (used both by the schema-only `Schematic` and by
+  // the schema-carrying `Json.Encodable`/`Json.Decodable` for `Optional`/`Option`).
+  def optional(schema: JsonSchema): JsonSchema = schema match
+    case entity: JsonSchema.Object  => entity.copy(optional = true)
+    case entity: JsonSchema.Integer => entity.copy(optional = true)
+    case entity: JsonSchema.Number  => entity.copy(optional = true)
+    case entity: JsonSchema.String  => entity.copy(optional = true)
+    case entity: JsonSchema.Array   => entity.copy(optional = true)
+    case entity: JsonSchema.Boolean => entity.copy(optional = true)
+    case entity: JsonSchema.Null    => entity.copy(optional = true)
+    case entity: JsonSchema.Ref     => entity.copy(optional = true)
+
   given optionalSchematic: [value: Schematic over JsonSchema]
   =>  Optional[value] is Schematic over JsonSchema =
-    () =>
-      value.schema() match
-        case entity: JsonSchema.Object  => entity.copy(optional = true)
-        case entity: JsonSchema.Integer => entity.copy(optional = true)
-        case entity: JsonSchema.Number  => entity.copy(optional = true)
-        case entity: JsonSchema.String  => entity.copy(optional = true)
-        case entity: JsonSchema.Array   => entity.copy(optional = true)
-        case entity: JsonSchema.Boolean => entity.copy(optional = true)
-        case entity: JsonSchema.Null    => entity.copy(optional = true)
-        case entity: JsonSchema.Ref     => entity.copy(optional = true)
+    () => JsonSchema.optional(value.schema())
 
   given listSchematic: [value: Schematic over JsonSchema]
   =>  List[value] is Schematic over JsonSchema =
@@ -130,21 +157,28 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
   private lazy val derivedEncodable: JsonSchema is Encodable in Json =
     Json.EncodableDerivation.derived
 
-  given encodable: JsonSchema is Encodable in Json = value => value match
-    case JsonSchema.Ref(pointer, _, _) =>
-      val ref = summon[JsonPointer is Encodable in Text].encoded(pointer).s
-      Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(ref))))
+  // A `Json.Encodable`/`Json.Decodable` (schema-carrying) rather than a plain
+  // codec, so that the `map`/collection codecs — which now require their element
+  // to be a `Json.Encodable`/`Json.Decodable` — resolve `JsonSchema` to *this*
+  // hand-written instance instead of recursively deriving a schema-of-schemas
+  // (which would diverge). The carried `schema()` is a fixed permissive object.
+  given encodable: JsonSchema is Json.Encodable =
+    Json.Encodable(Shape.Any):
+      case JsonSchema.Ref(pointer, _, _) =>
+        val ref = summon[JsonPointer is Encodable in Text].encoded(pointer).s
+        Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(ref))))
 
-    case other =>
-      derivedEncodable.encoded(other)
+      case other =>
+        derivedEncodable.encoded(other)
 
   // Hand-written rather than derived: a JSON-Schema object is discriminated by
   // the *value* of its `type` field (and may carry none, for `$ref`), which the
   // `type`-as-Scala-subtype derivation cannot model. Decoding by hand also
   // keeps the recursion on nested schemas pointed back at this same given.
   given decodable: (Tactic[JsonError], Tactic[JsonPointerError])
-  =>  JsonSchema is Decodable in Json = json =>
-    def field[value: Decodable in Json](name: Text): Optional[value] =
+  =>  JsonSchema is Json.Decodable =
+   Json.Decodable(Shape.Any): json =>
+    def field[value: Json.Decodable](name: Text): Optional[value] =
       json(name).as[Optional[value]]
 
     val reference = json("$ref".tt)

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -46,7 +46,7 @@ import vacuous.*
 import wisteria.*
 
 
-object JsonSchema extends Derivable[Schematic in JsonSchema]:
+object JsonSchema extends Derivable[Schematic over JsonSchema]:
   // `$ref` schemas have no `type` discriminator, so they are handled here
   // explicitly; every other variant is delegated to the `type`-discriminated
   // derivation. A `Ref` encodes to a bare `{"$ref": "…"}` object rather than
@@ -145,7 +145,7 @@ object JsonSchema extends Derivable[Schematic in JsonSchema]:
 
 
   inline def conjunction[derivation <: Product: ProductReflection]
-  :   derivation is Schematic in JsonSchema =
+  :   derivation is Schematic over JsonSchema =
 
     () =>
       val descriptions = infer[derivation is Annotated by memo] match
@@ -172,7 +172,7 @@ object JsonSchema extends Derivable[Schematic in JsonSchema]:
       Object(properties = map, required = required)
 
 
-  inline def disjunction[derivation: SumReflection]: derivation is Schematic in JsonSchema =
+  inline def disjunction[derivation: SumReflection]: derivation is Schematic over JsonSchema =
     () =>
       val descriptions = infer[Annotated by memo under derivation] match
         case annotated: Annotated.Subtypes => annotated.subtypes

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -33,7 +33,6 @@
 package jacinta
 
 import scala.annotation.*
-import scala.compiletime.summonInline
 
 import adversaria.*
 import anticipation.*
@@ -47,21 +46,37 @@ import urticose.*
 import vacuous.*
 import wisteria.*
 
-// Low-priority home for the fused `Encodable & Schematic` derivation (kept below
-// the single-capability givens in `object JsonSchema`, so a bare `Schematic` or
-// `Encodable` summon is never upgraded to demand the other capability).
-trait JsonSchema2:
-  inline given encodableSchematic: [value: Reflection]
-  =>  value is Encodable & Schematic in Json over JsonSchema =
+// Constructors for fused `Encodable & Schematic` / `Decodable & Schematic`
+// instances, built from a value's separate `Encodable`/`Decodable` and `Schematic`
+// instances. These are deliberately *methods*, not givens: a `Decodable &
+// Schematic` (or `Encodable & Schematic`) given is a subtype of both `Decodable`
+// (resp. `Encodable`) *and* `Schematic`, so as givens the two would be ambiguous
+// for any bare `Schematic` summon and would also be pulled into the recursive
+// `JsonSchema` codec. As methods they never enter implicit resolution; call them
+// where a fused instance is wanted (e.g. `given … = jsonSchematics.decodable[T]`).
+object jsonSchematics:
+  def encodable[value](using encoder: value is Encodable in Json)
+                      (using schema0: value is Schematic over JsonSchema)
+  :     value is Encodable & Schematic in Json over JsonSchema =
     new Encodable with Schematic:
       type Self = value
       type Form = Json
       type Transport = JsonSchema
-      def encoded(value: value): Json = summonInline[value is Encodable in Json].encoded(value)
-      def schema(): JsonSchema = JsonSchema.derived[value].schema()
+      def encoded(value: value): Json = encoder.encoded(value)
+      def schema(): JsonSchema = schema0.schema()
+
+  def decodable[value](using decoder: value is Decodable in Json)
+                      (using schema0: value is Schematic over JsonSchema)
+  :     value is Decodable & Schematic in Json over JsonSchema =
+    new Decodable with Schematic:
+      type Self = value
+      type Form = Json
+      type Transport = JsonSchema
+      def decoded(json: Json): value = decoder.decoded(json)
+      def schema(): JsonSchema = schema0.schema()
 
 
-object JsonSchema extends Derivable[Schematic over JsonSchema], JsonSchema2:
+object JsonSchema extends Derivable[Schematic over JsonSchema]:
   // Schema (`Schematic`) instances. Primitives and collections are single-capability
   // (schema-only); products/sums auto-derive; the fused `Encodable & Schematic`
   // lives at lower priority in `JsonSchema2`.
@@ -101,6 +116,11 @@ object JsonSchema extends Derivable[Schematic over JsonSchema], JsonSchema2:
     () => JsonSchema.Object(additionalProperties = true)
 
   inline given schematic: [value: Reflection] => value is Schematic over JsonSchema = derived
+
+  // A manual schema for `JsonSchema` itself (the recursive schema-of-schemas type),
+  // found in preference to the generic `schematic` derivation, so deriving a schema
+  // that nests `JsonSchema` terminates instead of recursing forever.
+  given jsonSchemaSchematic: JsonSchema is Schematic over JsonSchema = () => JsonSchema.Object()
 
   // `$ref` schemas have no `type` discriminator, so they are handled here
   // explicitly; every other variant is delegated to the `type`-discriminated

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -141,7 +141,7 @@ object JsonSchema extends Derivable[Schematic in JsonSchema]:
     def variant(json: Json): Json = unsafely(json.updateDynamic("type")(Unset))
 
     def discriminate(json: Json): Optional[Text] =
-      safely(json.selectDynamic("type").as[Text]).let(_.capitalize)
+      safely(json.selectField("type").as[Text]).let(_.capitalize)
 
 
   inline def conjunction[derivation <: Product: ProductReflection]

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -33,6 +33,7 @@
 package jacinta
 
 import scala.annotation.*
+import scala.compiletime.summonInline
 
 import adversaria.*
 import anticipation.*
@@ -42,11 +43,65 @@ import gossamer.*
 import prepositional.*
 import rudiments.*
 import turbulence.*
+import urticose.*
 import vacuous.*
 import wisteria.*
 
+// Low-priority home for the fused `Encodable & Schematic` derivation (kept below
+// the single-capability givens in `object JsonSchema`, so a bare `Schematic` or
+// `Encodable` summon is never upgraded to demand the other capability).
+trait JsonSchema2:
+  inline given encodableSchematic: [value: Reflection]
+  =>  value is Encodable & Schematic in Json over JsonSchema =
+    new Encodable with Schematic:
+      type Self = value
+      type Form = Json
+      type Transport = JsonSchema
+      def encoded(value: value): Json = summonInline[value is Encodable in Json].encoded(value)
+      def schema(): JsonSchema = JsonSchema.derived[value].schema()
 
-object JsonSchema extends Derivable[Schematic over JsonSchema]:
+
+object JsonSchema extends Derivable[Schematic over JsonSchema], JsonSchema2:
+  // Schema (`Schematic`) instances. Primitives and collections are single-capability
+  // (schema-only); products/sums auto-derive; the fused `Encodable & Schematic`
+  // lives at lower priority in `JsonSchema2`.
+  given byteSchematic: Byte is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given shortSchematic: Short is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given intSchematic: Int is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given longSchematic: Long is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given floatSchematic: Float is Schematic over JsonSchema = () => JsonSchema.Number()
+  given doubleSchematic: Double is Schematic over JsonSchema = () => JsonSchema.Number()
+  given textSchematic: Text is Schematic over JsonSchema = () => JsonSchema.String()
+  given emailSchematic: EmailAddress is Schematic over JsonSchema = () => JsonSchema.String()
+  given booleanSchematic: scala.Boolean is Schematic over JsonSchema = () => JsonSchema.Boolean()
+
+  given optionalSchematic: [value: Schematic over JsonSchema]
+  =>  Optional[value] is Schematic over JsonSchema =
+    () =>
+      value.schema() match
+        case entity: JsonSchema.Object  => entity.copy(optional = true)
+        case entity: JsonSchema.Integer => entity.copy(optional = true)
+        case entity: JsonSchema.Number  => entity.copy(optional = true)
+        case entity: JsonSchema.String  => entity.copy(optional = true)
+        case entity: JsonSchema.Array   => entity.copy(optional = true)
+        case entity: JsonSchema.Boolean => entity.copy(optional = true)
+        case entity: JsonSchema.Null    => entity.copy(optional = true)
+        case entity: JsonSchema.Ref     => entity.copy(optional = true)
+
+  given listSchematic: [value: Schematic over JsonSchema]
+  =>  List[value] is Schematic over JsonSchema =
+    () => JsonSchema.Array(items = value.schema())
+
+  given setSchematic: [value: Schematic over JsonSchema]
+  =>  Set[value] is Schematic over JsonSchema =
+    () => JsonSchema.Array(items = value.schema())
+
+  given mapSchematic: [key: Encodable in Text, value: Schematic over JsonSchema]
+  =>  Map[key, value] is Schematic over JsonSchema =
+    () => JsonSchema.Object(additionalProperties = true)
+
+  inline given schematic: [value: Reflection] => value is Schematic over JsonSchema = derived
+
   // `$ref` schemas have no `type` discriminator, so they are handled here
   // explicitly; every other variant is delegated to the `type`-discriminated
   // derivation. A `Ref` encodes to a bare `{"$ref": "…"}` object rather than
@@ -57,7 +112,8 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
 
   given encodable: JsonSchema is Encodable in Json = value => value match
     case JsonSchema.Ref(pointer, _, _) =>
-      Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(pointer.encode.s))))
+      val ref = summon[JsonPointer is Encodable in Text].encoded(pointer).s
+      Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(ref))))
 
     case other =>
       derivedEncodable.encoded(other)

--- a/lib/jacinta/src/schema/jacinta.Schematic.scala
+++ b/lib/jacinta/src/schema/jacinta.Schematic.scala
@@ -33,6 +33,7 @@
 package jacinta
 
 import scala.annotation.*
+import scala.compiletime.summonInline
 
 import anticipation.*
 import prepositional.*
@@ -40,12 +41,29 @@ import urticose.*
 import vacuous.*
 import wisteria.*
 
+// The third of the three derivations (encoder-only / schema-only / both): the
+// fused `Encodable & Schematic in Json over JsonSchema` for any product or sum.
+// It is deliberately a single intersection given (not a universal `(Encodable,
+// Schematic) => …` combinator), built by deriving the encoder and the schema from
+// the same structure. Kept at low priority (a supertrait of `Schematic`) so a
+// bare `Schematic over JsonSchema` summon never gets upgraded to require an
+// encoder — the combined given is chosen only when the intersection is requested.
+trait SchematicLow:
+  inline given encodableSchematic: [value: Reflection]
+  =>  value is Encodable & Schematic in Json over JsonSchema =
+    new Encodable with Schematic:
+      type Self = value
+      type Form = Json
+      type Transport = JsonSchema
+      def encoded(value: value): Json = summonInline[value is Encodable in Json].encoded(value)
+      def schema(): JsonSchema = JsonSchema.derived[value].schema()
+
 // `Schematic` describes the schema of a value's encoding; `Transport` is the
 // schema's own representation (e.g. `JsonSchema`), so an instance reads `X is
 // Schematic over JsonSchema`. It carries no `Form` of its own: when fused with an
 // encoder as `Encodable & Schematic in Json over JsonSchema`, the wire format
 // (`Form = Json`) comes from `Encodable`.
-object Schematic:
+object Schematic extends SchematicLow:
   given byte: Byte is Schematic over JsonSchema = () => JsonSchema.Integer()
   given short: Short is Schematic over JsonSchema = () => JsonSchema.Integer()
   given int: Int is Schematic over JsonSchema = () => JsonSchema.Integer()

--- a/lib/jacinta/src/schema/jacinta.Schematic.scala
+++ b/lib/jacinta/src/schema/jacinta.Schematic.scala
@@ -38,19 +38,26 @@ import anticipation.*
 import prepositional.*
 import urticose.*
 import vacuous.*
+import wisteria.*
 
+// `Schematic` describes the schema of a value's encoding; `Transport` is the
+// schema's own representation (e.g. `JsonSchema`), so an instance reads `X is
+// Schematic over JsonSchema`. It carries no `Form` of its own: when fused with an
+// encoder as `Encodable & Schematic in Json over JsonSchema`, the wire format
+// (`Form = Json`) comes from `Encodable`.
 object Schematic:
-  given byte: Byte is Schematic in JsonSchema = () => JsonSchema.Integer()
-  given short: Short is Schematic in JsonSchema = () => JsonSchema.Integer()
-  given int: Int is Schematic in JsonSchema = () => JsonSchema.Integer()
-  given long: Long is Schematic in JsonSchema = () => JsonSchema.Integer()
-  given float: Float is Schematic in JsonSchema = () => JsonSchema.Number()
-  given double: Double is Schematic in JsonSchema = () => JsonSchema.Number()
-  given text: Text is Schematic in JsonSchema = () => JsonSchema.String()
-  given email: EmailAddress is Schematic in JsonSchema = () => JsonSchema.String()
-  given boolean: Boolean is Schematic in JsonSchema = () => JsonSchema.Boolean()
+  given byte: Byte is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given short: Short is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given int: Int is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given long: Long is Schematic over JsonSchema = () => JsonSchema.Integer()
+  given float: Float is Schematic over JsonSchema = () => JsonSchema.Number()
+  given double: Double is Schematic over JsonSchema = () => JsonSchema.Number()
+  given text: Text is Schematic over JsonSchema = () => JsonSchema.String()
+  given email: EmailAddress is Schematic over JsonSchema = () => JsonSchema.String()
+  given boolean: Boolean is Schematic over JsonSchema = () => JsonSchema.Boolean()
 
-  given optional: [value: Schematic in JsonSchema] => Optional[value] is Schematic in JsonSchema =
+  given optional: [value: Schematic over JsonSchema]
+  =>  Optional[value] is Schematic over JsonSchema =
     () =>
       value.schema() match
         case entity: JsonSchema.Object  => entity.copy(optional = true)
@@ -61,18 +68,27 @@ object Schematic:
         case entity: JsonSchema.Boolean => entity.copy(optional = true)
         case entity: JsonSchema.Null    => entity.copy(optional = true)
 
-  given list: [value: Schematic in JsonSchema] => List[value] is Schematic in JsonSchema =
+  given list: [value: Schematic over JsonSchema]
+  =>  List[value] is Schematic over JsonSchema =
     () => JsonSchema.Array(items = value.schema())
 
-  given set: [value: Schematic in JsonSchema] => Set[value] is Schematic in JsonSchema =
+  given set: [value: Schematic over JsonSchema]
+  =>  Set[value] is Schematic over JsonSchema =
     () => JsonSchema.Array(items = value.schema())
 
-
-  given map: [key: Encodable in Text, value: Schematic in JsonSchema]
-  =>  Map[key, value] is Schematic in JsonSchema =
-
+  given map: [key: Encodable in Text, value: Schematic over JsonSchema]
+  =>  Map[key, value] is Schematic over JsonSchema =
     () => JsonSchema.Object(additionalProperties = true)
 
+  // Auto-derivation of a schema for any product or sum, mirroring the encoder /
+  // decoder auto-givens. Gated on `Reflection` so it never competes with the
+  // primitive givens above.
+  inline given derived: [value: Reflection] => value is Schematic over JsonSchema =
+    JsonSchema.derived
 
-trait Schematic extends Typeclass, Formal:
-  def schema(): Form
+// `Schematic` describes the schema of a value's encoding. `Transport` is the
+// schema's own representation (e.g. `JsonSchema`). The wire format the schema is
+// *for* is not recorded here — in the fused `Encodable & Schematic in Json over
+// JsonSchema` it comes from `Encodable`'s `Form`.
+trait Schematic extends Typeclass, Transportive:
+  def schema(): Transport

--- a/lib/jacinta/src/schema/jacinta.Verifiable.scala
+++ b/lib/jacinta/src/schema/jacinta.Verifiable.scala
@@ -33,8 +33,11 @@
 package jacinta
 
 import contingency.*
-import distillate.*
 import prepositional.*
+import rudiments.*
+import vacuous.*
+
+import JsonError.Reason
 
 extension (json: Json)
   // Runtime-checks `json` against the schema for `topic`, then re-types it as a
@@ -44,11 +47,56 @@ extension (json: Json)
   // resolve fields and array indices against `topic` at compile time — with no
   // `dynamicJsonAccess.enabled` import required.
   //
-  // The conformance check is, for now, a decode-and-discard against `topic`'s
-  // `Decodable` (so a nonconformant value raises `JsonError`); this is intended
-  // to be replaced by a dedicated walker over `schematic.schema(): JsonSchema`.
-  def verify[topic](using topic is Schematic in JsonSchema)(using topic is Decodable in Json)
+  // The conformance check walks `schematic.schema(): JsonSchema` against the
+  // value, raising `JsonError` on the first structural mismatch (wrong type, or a
+  // required field absent).
+  def verify[topic](using schematic: topic is Schematic in JsonSchema)
   :     (Json of topic from topic) raises JsonError =
 
-    json.as[topic]
+    conform(schematic.schema(), json.root)
     json.asInstanceOf[Json of topic from topic]
+
+// Checks that a `Json.Ast` node conforms to a `JsonSchema`. An absent node is
+// permitted only where the schema is optional; otherwise each variant checks the
+// node's primitive type and recurses into object properties / array items.
+private def conform(schema: JsonSchema, ast: Json.Ast): Unit raises JsonError =
+  inline def mismatch(expected: JsonPrimitive): Unit =
+    raise(JsonError(Reason.NotType(ast.primitive, expected)))
+
+  if ast.isAbsent then (if !schema.optional then raise(JsonError(Reason.Absent)))
+  else schema match
+    case obj: JsonSchema.Object => obj.oneOf match
+      case variants: List[JsonSchema] =>
+        // A `oneOf` schema (e.g. a derived sum type) conforms if the node
+        // matches any one variant.
+        if !variants.exists { variant => safely(conform(variant, ast)).present }
+        then mismatch(JsonPrimitive.Object)
+
+      case _ =>
+        if !ast.isObject then mismatch(JsonPrimitive.Object) else
+          val absent = Json.Ast(Unset)
+
+          for (key, property) <- obj.properties do
+            val index = ast.objectIndexOf(key.s)
+            conform(property, if index < 0 then absent else ast.objectValue(index))
+
+    case array: JsonSchema.Array =>
+      if !ast.isArray then mismatch(JsonPrimitive.Array)
+      else if array.items.present then
+        val items = array.items.vouch
+        var index = 0
+        val length = ast.arrayLength
+
+        while index < length do
+          conform(items, ast.arrayElement(index))
+          index += 1
+
+    case _: JsonSchema.String  => if !ast.isString  then mismatch(JsonPrimitive.String)
+    case _: JsonSchema.Number  => if !ast.isNumber  then mismatch(JsonPrimitive.Number)
+    case _: JsonSchema.Integer => if !ast.isNumber  then mismatch(JsonPrimitive.Number)
+    case _: JsonSchema.Boolean => if !ast.isBoolean then mismatch(JsonPrimitive.Boolean)
+    case _: JsonSchema.Null    => if !ast.isNull    then mismatch(JsonPrimitive.Null)
+
+    // A `$ref` cannot be resolved without the root schema document, which is not
+    // yet threaded through; such nodes are left unchecked for now.
+    case _: JsonSchema.Ref => ()

--- a/lib/jacinta/src/schema/jacinta.Verifiable.scala
+++ b/lib/jacinta/src/schema/jacinta.Verifiable.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package jacinta
 
+import anticipation.*
 import contingency.*
 import prepositional.*
 import rudiments.*

--- a/lib/jacinta/src/schema/jacinta.Verifiable.scala
+++ b/lib/jacinta/src/schema/jacinta.Verifiable.scala
@@ -1,0 +1,54 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+import contingency.*
+import distillate.*
+import prepositional.*
+
+extension (json: Json)
+  // Runtime-checks `json` against the schema for `topic`, then re-types it as a
+  // schema-typed `Json of topic from topic`. The phantom `Topic` records the
+  // current position within the schema (initially the root, `topic`) and `Origin`
+  // records the root schema itself, so that the `Dynamic` navigation macros can
+  // resolve fields and array indices against `topic` at compile time — with no
+  // `dynamicJsonAccess.enabled` import required.
+  //
+  // The conformance check is, for now, a decode-and-discard against `topic`'s
+  // `Decodable` (so a nonconformant value raises `JsonError`); this is intended
+  // to be replaced by a dedicated walker over `schematic.schema(): JsonSchema`.
+  def verify[topic](using topic is Schematic in JsonSchema)(using topic is Decodable in Json)
+  :     (Json of topic from topic) raises JsonError =
+
+    json.as[topic]
+    json.asInstanceOf[Json of topic from topic]

--- a/lib/jacinta/src/schema/jacinta.Verifiable.scala
+++ b/lib/jacinta/src/schema/jacinta.Verifiable.scala
@@ -50,7 +50,7 @@ extension (json: Json)
   // The conformance check walks `schematic.schema(): JsonSchema` against the
   // value, raising `JsonError` on the first structural mismatch (wrong type, or a
   // required field absent).
-  def verify[topic](using schematic: topic is Schematic in JsonSchema)
+  def verify[topic](using schematic: topic is Schematic over JsonSchema)
   :     (Json of topic from topic) raises JsonError =
 
     conform(schematic.schema(), json.root)

--- a/lib/jacinta/src/schema/soundness_jacinta_schema.scala
+++ b/lib/jacinta/src/schema/soundness_jacinta_schema.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export jacinta.{JsonPointerError, JsonSchema, memo, Schematic}
+export jacinta.{JsonPointerError, JsonSchema, memo}
 
 package jsonPointerRegistries:
   export jacinta.jsonPointerRegistries.{fetching, standalone}

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -46,6 +46,17 @@ case class Workplace(street: Text, city: Text) derives CanEqual
 case class Posting(employee: Employee, workplace: Workplace) derives CanEqual
 case class Squad(lead: Text, members: List[Employee]) derives CanEqual
 
+// A type whose JSON codec routes through its `… in Text` codec (it encodes as a
+// string), even though structurally it would derive an object/`oneOf` schema.
+// Used to demonstrate that the *fused* schema is coherent with the codec — a
+// string — rather than the independently-derived object that the old fusion
+// (which summoned `Schematic` separately) would have paired with it.
+enum Hue derives CanEqual:
+  case Crimson, Viridian
+
+object Hue:
+  given encodable: Hue is Encodable in Text = _.toString.tt.lower
+
 object VerifyTests extends Suite(m"Jacinta verify tests"):
   def run(): Unit =
     suite(m"Encodable & Schematic fusion"):
@@ -86,6 +97,19 @@ object VerifyTests extends Suite(m"Jacinta verify tests"):
         given (Employee is Decodable & Schematic in Json over JsonSchema) =
           jsonSchematics.decodable[Employee]
         summon[Employee is Decodable & Schematic in Json over JsonSchema].schema()
+      . assert:
+          case _: JsonSchema.Object => true
+          case _                    => false
+
+    suite(m"Schema coherence (the carried shape tracks the codec)"):
+      test(m"A Text-branch encoder's fused schema is a String, matching the codec"):
+        jsonSchematics.encodable[Hue].schema()
+      . assert:
+          case _: JsonSchema.String => true
+          case _                    => false
+
+      test(m"The standalone Schematic still derives the structural Object schema"):
+        infer[Hue is Schematic over JsonSchema].schema()
       . assert:
           case _: JsonSchema.Object => true
           case _                    => false

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -47,12 +47,6 @@ case class Posting(employee: Employee, workplace: Workplace) derives CanEqual
 case class Squad(lead: Text, members: List[Employee]) derives CanEqual
 
 object VerifyTests extends Suite(m"Jacinta verify tests"):
-
-  given employeeSchematic: Employee is Schematic in JsonSchema = JsonSchema.derived[Employee]
-  given workplaceSchematic: Workplace is Schematic in JsonSchema = JsonSchema.derived[Workplace]
-  given postingSchematic: Posting is Schematic in JsonSchema = JsonSchema.derived[Posting]
-  given squadSchematic: Squad is Schematic in JsonSchema = JsonSchema.derived[Squad]
-
   def run(): Unit =
     suite(m"Runtime verification"):
       test(m"A conformant object verifies and still decodes"):

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -1,0 +1,120 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+import soundness.*
+
+import charEncoders.utf8
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
+
+// NB: `dynamicJsonAccess.enabled` is deliberately *not* imported here — verified
+// `Json of T` navigation must work without it.
+
+case class Employee(name: Text, age: Int, email: Text) derives CanEqual
+case class Workplace(street: Text, city: Text) derives CanEqual
+case class Posting(employee: Employee, workplace: Workplace) derives CanEqual
+case class Squad(lead: Text, members: List[Employee]) derives CanEqual
+
+object VerifyTests extends Suite(m"Jacinta verify tests"):
+
+  given employeeSchematic: Employee is Schematic in JsonSchema = JsonSchema.derived[Employee]
+  given workplaceSchematic: Workplace is Schematic in JsonSchema = JsonSchema.derived[Workplace]
+  given postingSchematic: Posting is Schematic in JsonSchema = JsonSchema.derived[Posting]
+  given squadSchematic: Squad is Schematic in JsonSchema = JsonSchema.derived[Squad]
+
+  def run(): Unit =
+    suite(m"Runtime verification"):
+      test(m"A conformant object verifies and still decodes"):
+        val json = t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json]
+        json.verify[Employee].as[Employee]
+      . assert(_ == Employee(t"Alice", 30, t"a@b.c"))
+
+      test(m"A nonconformant object fails to verify"):
+        val json = t"""{"name": "Bob"}""".read[Json]
+        safely(json.verify[Employee]).absent
+      . assert(_ == true)
+
+      test(m"A conformant object verifies successfully"):
+        val json = t"""{"name": "Bob", "age": 4, "email": "b@c.d"}""".read[Json]
+        safely(json.verify[Employee]).present
+      . assert(_ == true)
+
+    suite(m"Typed navigation (no enabler import)"):
+      test(m"Access a verified field"):
+        val json = t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json]
+        json.verify[Employee].name.as[Text]
+      . assert(_ == t"Alice")
+
+      test(m"Access a verified Int field"):
+        val json = t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json]
+        json.verify[Employee].age.as[Int]
+      . assert(_ == 30)
+
+      test(m"Access a nested verified field"):
+        val json = t"""{"employee": {"name": "Bob", "age": 2, "email": "b@c.d"},
+                        "workplace": {"street": "Main", "city": "Town"}}""".read[Json]
+        json.verify[Posting].workplace.city.as[Text]
+      . assert(_ == t"Town")
+
+      test(m"Index into a verified array field"):
+        val json = t"""{"lead": "Z",
+                        "members": [{"name": "A", "age": 1, "email": "a@a"},
+                                    {"name": "B", "age": 2, "email": "b@b"}]}""".read[Json]
+        json.verify[Squad].members(1).name.as[Text]
+      . assert(_ == t"B")
+
+    suite(m"Compile-time schema checks"):
+      test(m"An unknown field is rejected"):
+        demilitarize:
+          t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json].verify[Employee].nope
+        . head.message
+      . assert(_.contains("has no field"))
+
+      test(m"Indexing a non-array field is rejected"):
+        demilitarize:
+          t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json].verify[Employee].name(0)
+        . head.message
+      . assert(_.contains("not an indexable array"))
+
+      test(m"Field access on a scalar position is rejected"):
+        demilitarize:
+          t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json].verify[Employee].name.deeper
+        . head.message
+      . assert(_.contains("has no field"))
+
+      test(m"Plain (unverified) field access requires the enabler"):
+        demilitarize:
+          t"""{"name": "Alice"}""".read[Json].name
+        . head.message
+      . assert(_.contains("dynamicJsonAccess.enabled"))

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -51,12 +51,23 @@ object VerifyTests extends Suite(m"Jacinta verify tests"):
     suite(m"Encodable & Schematic fusion"):
       val person = Employee(t"Alice", 30, t"a@b.c")
 
-      test(m"A fused instance encodes (and round-trips) as Json"):
-        infer[Employee is Encodable & Schematic in Json over JsonSchema].encoded(person).as[Employee]
+      test(m"A fused encoder encodes (and round-trips) as Json"):
+        jsonSchematics.encodable[Employee].encoded(person).as[Employee]
       . assert(_ == person)
 
-      test(m"A fused instance yields a schema"):
-        infer[Employee is Encodable & Schematic in Json over JsonSchema].schema()
+      test(m"A fused encoder yields a schema"):
+        jsonSchematics.encodable[Employee].schema()
+      . assert:
+          case _: JsonSchema.Object => true
+          case _                    => false
+
+      test(m"A fused decoder decodes from Json"):
+        val json = t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json]
+        jsonSchematics.decodable[Employee].decoded(json)
+      . assert(_ == person)
+
+      test(m"A fused decoder yields a schema"):
+        jsonSchematics.decodable[Employee].schema()
       . assert:
           case _: JsonSchema.Object => true
           case _                    => false
@@ -67,6 +78,14 @@ object VerifyTests extends Suite(m"Jacinta verify tests"):
 
       test(m"The schema-only instance still resolves"):
         infer[Employee is Schematic over JsonSchema].schema()
+      . assert:
+          case _: JsonSchema.Object => true
+          case _                    => false
+
+      test(m"A fused instance can be promoted to a local given"):
+        given (Employee is Decodable & Schematic in Json over JsonSchema) =
+          jsonSchematics.decodable[Employee]
+        summon[Employee is Decodable & Schematic in Json over JsonSchema].schema()
       . assert:
           case _: JsonSchema.Object => true
           case _                    => false

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -48,6 +48,29 @@ case class Squad(lead: Text, members: List[Employee]) derives CanEqual
 
 object VerifyTests extends Suite(m"Jacinta verify tests"):
   def run(): Unit =
+    suite(m"Encodable & Schematic fusion"):
+      val person = Employee(t"Alice", 30, t"a@b.c")
+
+      test(m"A fused instance encodes (and round-trips) as Json"):
+        infer[Employee is Encodable & Schematic in Json over JsonSchema].encoded(person).as[Employee]
+      . assert(_ == person)
+
+      test(m"A fused instance yields a schema"):
+        infer[Employee is Encodable & Schematic in Json over JsonSchema].schema()
+      . assert:
+          case _: JsonSchema.Object => true
+          case _                    => false
+
+      test(m"The encoder-only instance still resolves"):
+        infer[Employee is Encodable in Json].encoded(person).as[Employee]
+      . assert(_ == person)
+
+      test(m"The schema-only instance still resolves"):
+        infer[Employee is Schematic over JsonSchema].schema()
+      . assert:
+          case _: JsonSchema.Object => true
+          case _                    => false
+
     suite(m"Runtime verification"):
       test(m"A conformant object verifies and still decodes"):
         val json = t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json]

--- a/lib/jacinta/src/test/jacinta.VerifyTests.scala
+++ b/lib/jacinta/src/test/jacinta.VerifyTests.scala
@@ -70,6 +70,17 @@ object VerifyTests extends Suite(m"Jacinta verify tests"):
         safely(json.verify[Employee]).present
       . assert(_ == true)
 
+      test(m"A wrong-typed field fails to verify"):
+        val json = t"""{"name": "Bob", "age": "old", "email": "b@c.d"}""".read[Json]
+        safely(json.verify[Employee]).absent
+      . assert(_ == true)
+
+      test(m"A wrong-typed nested array element fails to verify"):
+        val json = t"""{"lead": "Z", "members": [{"name": "A", "age": "x", "email": "a@a"}]}"""
+                     .read[Json]
+        safely(json.verify[Squad]).absent
+      . assert(_ == true)
+
     suite(m"Typed navigation (no enabler import)"):
       test(m"Access a verified field"):
         val json = t"""{"name": "Alice", "age": 30, "email": "a@b.c"}""".read[Json]

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -872,45 +872,45 @@ object Tests extends Suite(m"Jacinta Tests"):
 
     suite(m"JsonSchema tests"):
       test(m"Schematic for Int yields an Integer schema"):
-        infer[Int is Schematic in JsonSchema].schema()
+        infer[Int is Schematic over JsonSchema].schema()
       . assert(_ == JsonSchema.Integer())
 
       test(m"Schematic for Long yields an Integer schema"):
-        infer[Long is Schematic in JsonSchema].schema()
+        infer[Long is Schematic over JsonSchema].schema()
       . assert(_ == JsonSchema.Integer())
 
       test(m"Schematic for Text yields a String schema"):
-        infer[Text is Schematic in JsonSchema].schema()
+        infer[Text is Schematic over JsonSchema].schema()
       . assert(_ == JsonSchema.String())
 
       test(m"Schematic for Double yields a Number schema"):
-        infer[Double is Schematic in JsonSchema].schema()
+        infer[Double is Schematic over JsonSchema].schema()
       . assert(_ == JsonSchema.Number())
 
       test(m"Schematic for Boolean yields a Boolean schema"):
-        infer[Boolean is Schematic in JsonSchema].schema()
+        infer[Boolean is Schematic over JsonSchema].schema()
       . assert(_ == JsonSchema.Boolean())
 
       test(m"Schematic for Optional[Int] is an optional Integer"):
-        infer[Optional[Int] is Schematic in JsonSchema].schema()
+        infer[Optional[Int] is Schematic over JsonSchema].schema()
       . assert:
           case s: JsonSchema.Integer => s.optional
           case _                     => false
 
       test(m"Schematic for List[Int] is an Array of Integers"):
-        infer[List[Int] is Schematic in JsonSchema].schema()
+        infer[List[Int] is Schematic over JsonSchema].schema()
       . assert:
           case JsonSchema.Array(_, JsonSchema.Integer(_, _, _, _, _, _), _, _, _, _, _) => true
           case _                                                                         => false
 
       test(m"Schematic for Set[Text] is an Array of Strings"):
-        infer[Set[Text] is Schematic in JsonSchema].schema()
+        infer[Set[Text] is Schematic over JsonSchema].schema()
       . assert:
           case JsonSchema.Array(_, JsonSchema.String(_, _, _, _, _, _), _, _, _, _, _) => true
           case _                                                                         => false
 
       test(m"Schematic for Map[Text, Int] is an object with additionalProperties"):
-        infer[Map[Text, Int] is Schematic in JsonSchema].schema()
+        infer[Map[Text, Int] is Schematic over JsonSchema].schema()
       . assert:
           case s: JsonSchema.Object => s.additionalProperties
           case _                    => false

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1169,3 +1169,4 @@ object Tests extends Suite(m"Jacinta Tests"):
 
     ValidationTests()
     PositionTests()
+    VerifyTests()

--- a/lib/jacinta/src/time/jacinta_time.scala
+++ b/lib/jacinta/src/time/jacinta_time.scala
@@ -39,17 +39,17 @@ import distillate.*
 import prepositional.*
 
 package jsonEncodables:
-  given encodeInstantsAsUnixEpochMilliseconds: Instant is Encodable in Json =
-    instant => Json(instant.long)
+  given encodeInstantsAsUnixEpochMilliseconds: Instant is Json.Encodable =
+    Json.Encodable(Shape.Whole)(instant => Json(instant.long))
 
-  given encodeDurationsAsMilliseconds: Duration is Encodable in Json =
-    duration => Json((duration.value*1000).toLong)
+  given encodeDurationsAsMilliseconds: Duration is Json.Encodable =
+    Json.Encodable(Shape.Whole)(duration => Json((duration.value*1000).toLong))
 
 package jsonDecodables:
-  given decodeInstantsAsUnixEpochMilliseconds: Tactic[JsonError] => Instant is Decodable in Json =
-    json =>
+  given decodeInstantsAsUnixEpochMilliseconds: Tactic[JsonError] => Instant is Json.Decodable =
+    Json.Decodable(Shape.Whole): json =>
       import abstractables.instantIsAbstractable
       Instant(json.as[Long])
 
-  given decodeDurationsAsMilliseconds: Tactic[JsonError] => Duration is Decodable in Json =
-    json => Duration(json.as[Long])
+  given decodeDurationsAsMilliseconds: Tactic[JsonError] => Duration is Json.Decodable =
+    Json.Decodable(Shape.Whole)(json => Duration(json.as[Long]))

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -82,7 +82,11 @@ object internal:
                   val cases = rpcMethods.map: method =>
                     val params = method.paramSymss.head.map: param =>
                       param.info.asType.absolve match
-                        case '[param] => Expr.summon[param is Decodable in Json] match
+                        // Summon the schema-carrying `Json.Decodable` rather than a
+                        // plain `Decodable in Json`: for a `Json`-typed parameter the
+                        // latter is ambiguous between jacinta's carrier and
+                        // distillate's universal `generic` identity decoder.
+                        case '[param] => Expr.summon[param is Json.Decodable] match
                           case Some(decoder) =>
                             '{$decoder.decoded(request.params(${Expr(param.name)}))}
                             . asTerm
@@ -232,7 +236,7 @@ object internal:
 
                     . asTerm
                   else result.asType.absolve match
-                    case '[result] => Expr.summon[result is Decodable in Json] match
+                    case '[result] => Expr.summon[result is Json.Decodable] match
                       case Some(decoder) =>
                         Some:
                           ' {
@@ -342,7 +346,7 @@ object internal:
 
             . asTerm
           else result.asType.absolve match
-            case '[result] => Expr.summon[result is Decodable in Json] match
+            case '[result] => Expr.summon[result is Json.Decodable] match
               case Some(decoder) =>
                 Some:
                   ' {

--- a/lib/stratiform/src/core/stratiform.Schematic.scala
+++ b/lib/stratiform/src/core/stratiform.Schematic.scala
@@ -70,6 +70,21 @@ object Schematic:
   given series: [value: Schematic] => Series[value] is Schematic =
     () => collectionType(value.schema())
 
+  // A `Map` is a series of repeatable `entries`, each a struct of a `key` and a
+  // `value` field — matching the `entries`/`key`/`value` encoding.
+  given map: [key: Schematic, value: Schematic] => Map[key, value] is Schematic =
+    () =>
+      val entry =
+        Tels.Struct
+          ( IArray
+              ( Tels.Field(Polarity.Tight, Polarity.Implicit, t"key", key.schema(), Unset),
+                Tels.Field(Polarity.Tight, Polarity.Implicit, t"value", value.schema(), Unset) ),
+            IArray.empty )
+
+      Tels.Struct
+        ( IArray(Tels.Field(Polarity.Implicit, Polarity.Loose, t"entries", entry, Unset)),
+          IArray.empty )
+
   // A collection encodes as a wrapping compound whose repeatable `item` children
   // are the elements, so its schema is a `Struct` with a single repeatable `item`
   // field of the element type.

--- a/lib/stratiform/src/core/stratiform.Schematic.scala
+++ b/lib/stratiform/src/core/stratiform.Schematic.scala
@@ -32,25 +32,83 @@
                                                                                                   */
 package stratiform
 
-import contingency.*
-import distillate.*
+import adversaria.*
+import anticipation.*
+import gossamer.*
 import prepositional.*
+import vacuous.*
+import wisteria.*
 
-extension (tel: Tel)
-  // Runtime-checks `tel` against `topic`, then re-types it as a schema-typed
-  // `Tel of topic from topic`. The phantom `Topic` records the current position
-  // within the schema (initially the root, `topic`) and `Origin` records the
-  // root schema, so the `Dynamic` navigation macros can resolve fields and
-  // child indices against `topic` at compile time — with no `dynamicTelAccess`
-  // import required.
-  //
-  // `topic` must have a derivable TEL schema (`Schematic`) — mirroring jacinta's
-  // `verify`, which requires a `JsonSchema`. The runtime conformance check itself
-  // is a decode-and-discard against `topic`'s `Decodable` (a nonconformant value
-  // raises `TelError`): TEL scalars are untyped text, so a structural walk over
-  // the derived `Tels` cannot catch type mismatches (e.g. a non-numeric `Int`
-  // field) that decoding does — hence decoding remains the strict check.
-  def verify[topic](using topic is Schematic)(using topic is Decodable in Tel)
-  :     (Tel of topic from topic) raises TelError =
-    tel.as[topic]
-    tel.asInstanceOf[Tel of topic from topic]
+import Tels.Polarity
+
+// Derives a TEL schema (`Tels.Type`) from a Scala type, mirroring jacinta's
+// `Schematic`/`JsonSchema` derivation. A scalar maps to `Tels.Scalar`, a product
+// to a `Tels.Struct` of `Field`s (one per case-class field, keyed by the
+// camel→kebab field name and respecting `@name[Tel]` renames), a collection to a
+// `Struct` carrying a single repeatable `item` field — matching the `item`-keyword
+// collection encoding — and `Optional` loosens the enclosing field's `required`
+// polarity. A full schema document is assembled by `Schematic.tels`.
+object Schematic:
+  given text: Text is Schematic = () => Tels.Scalar(IArray.empty)
+  given string: String is Schematic = () => Tels.Scalar(IArray.empty)
+  given int: Int is Schematic = () => Tels.Scalar(IArray.empty)
+  given long: Long is Schematic = () => Tels.Scalar(IArray.empty)
+  given double: Double is Schematic = () => Tels.Scalar(IArray.empty)
+  given boolean: Boolean is Schematic = () => Tels.Scalar(IArray.empty)
+
+  given optional: [value: Schematic] => Optional[value] is Schematic = new Schematic:
+    type Self = Optional[value]
+    def schema(): Tels.Type = value.schema()
+    override def required: Polarity = Polarity.Loose
+
+  given list: [value: Schematic] => List[value] is Schematic =
+    () => collectionType(value.schema())
+
+  given set: [value: Schematic] => Set[value] is Schematic =
+    () => collectionType(value.schema())
+
+  given series: [value: Schematic] => Series[value] is Schematic =
+    () => collectionType(value.schema())
+
+  // A collection encodes as a wrapping compound whose repeatable `item` children
+  // are the elements, so its schema is a `Struct` with a single repeatable `item`
+  // field of the element type.
+  private def collectionType(element: Tels.Type): Tels.Type =
+    Tels.Struct
+      ( IArray(Tels.Field(Polarity.Implicit, Polarity.Loose, t"item", element, Unset)),
+        IArray.empty )
+
+  inline given schematic: [value: Reflection] => value is Schematic = TelsDerivation.derived
+
+  // Assembles a full, self-contained `Tels` document whose root struct is the
+  // schema of `value`.
+  def tels[value: Schematic](name: Text): Tels = value.schema().absolve match
+    case struct: Tels.Struct =>
+      Tels(name, struct, IArray.empty, Unset, IArray.empty, IArray.empty, IArray.empty)
+
+object TelsDerivation extends Derivable[Schematic]:
+  inline def conjunction[derivation <: Product: ProductReflection]: derivation is Schematic =
+    () =>
+      val renames: Map[Text, Text] = relabelling[derivation, Tel]
+
+      val members =
+        contexts:
+          [field] => schematic =>
+            val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
+            Tels.Field(schematic.required, Polarity.Implicit, keyword, schematic.schema(), Unset)
+
+        . to(List)
+
+      Tels.Struct(IArray.from(members), IArray.empty)
+
+  // TEL sums (selects) are not yet derived structurally; a permissive empty
+  // struct is produced so a containing type can still derive a schema.
+  inline def disjunction[derivation: SumReflection]: derivation is Schematic =
+    () => Tels.Struct(IArray.empty, IArray.empty)
+
+trait Schematic extends Typeclass:
+  def schema(): Tels.Type
+
+  // The field-level `required` polarity contributed by this type when it appears
+  // as a case-class field; `Optional` loosens it.
+  def required: Tels.Polarity = Tels.Polarity.Tight

--- a/lib/stratiform/src/core/stratiform.Stratiform.scala
+++ b/lib/stratiform/src/core/stratiform.Stratiform.scala
@@ -146,7 +146,7 @@ object Stratiform:
 
             telType(element.vouch, root).asType.absolve match
               case '[type result <: Tel; result] =>
-                '{$self.selectFieldIndex(${Expr(name)}, $idx).asInstanceOf[result]}
+                '{$self.selectRepeatedField(${Expr(name)}, $idx).asInstanceOf[result]}
 
           case None =>
             halt(m"the schema position ${position.show} has no field $name")

--- a/lib/stratiform/src/core/stratiform.Stratiform.scala
+++ b/lib/stratiform/src/core/stratiform.Stratiform.scala
@@ -1,0 +1,158 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.quoted.*
+
+import anticipation.*
+import fulminate.*
+import gigantism.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// Compile-time navigation for schema-typed `Tel` values. A `Tel of P from R`
+// carries a phantom *position* (`Topic = P`, a Scala model type) within a *root
+// schema* (`Origin = R`). The `Dynamic` methods on `Tel` are `transparent inline`
+// and delegate here: when the receiver's position is bound and the field name is a
+// literal, the macro looks the field up in `P`'s structure and yields a `Tel of
+// <field-type> from R`; otherwise it falls back to the plain
+// (`DynamicTelEnabler`-gated) runtime access. Mirrors `jacinta.Jacinta`.
+object Stratiform:
+
+  private def refinements(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :     Map[Text, quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
+      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
+      case AndType(left, right)                        => refinements(left) ++ refinements(right)
+      case _                                           => Map()
+
+  // Builds the refined type `Tel of <position> from <root>`.
+  private def telType(using quotes: Quotes)
+      ( position: quotes.reflect.TypeRepr, root: quotes.reflect.TypeRepr )
+  :     quotes.reflect.TypeRepr =
+
+    import quotes.reflect.*
+
+    Refinement
+      ( Refinement(TypeRepr.of[Tel], "Topic", TypeBounds(position, position)),
+        "Origin",
+        TypeBounds(root, root) )
+
+  // The single ordered-collection element type of `repr`, if it is one.
+  private def elementType(using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  :     Optional[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case AppliedType(constructor, List(element))
+      if repr <:< TypeRepr.of[Seq[Any]] || constructor.typeSymbol == defn.ArrayClass =>
+        element
+
+      case _ =>
+        Unset
+
+  // Reads `Topic` (position) and `Origin` (root) from a receiver, if present.
+  private def receiver(using quotes: Quotes)(self: Expr[Tel])
+  :     Optional[(quotes.reflect.TypeRepr, quotes.reflect.TypeRepr)] =
+
+    import quotes.reflect.*
+    val members = refinements(self.asTerm.tpe.widen)
+
+    members.at(t"Topic").let: position =>
+      (position, members.at(t"Origin").or(position))
+
+  def select(self: Expr[Tel], field: Expr[String]): Macro[Tel] =
+    import quotes.reflect.*
+
+    def plain: Expr[Tel] =
+      if Expr.summon[DynamicTelEnabler].isEmpty
+      then halt(m"""dynamic field access on an unverified `Tel` requires
+                    `import dynamicTelAccess.enabled` (or verify the value against a schema first)""")
+
+      '{$self.selectField($field)}
+
+    receiver(self) match
+      case (position, root) => field.value match
+        case Some(name) => position.typeSymbol.caseFields.find(_.name == name) match
+          case Some(member) =>
+            telType(position.memberType(member), root).asType.absolve match
+              case '[type result <: Tel; result] =>
+                '{$self.selectField(${Expr(name)}).asInstanceOf[result]}
+
+          case None =>
+            halt(m"the schema position ${position.show} has no field $name")
+
+        case None =>
+          plain
+
+      case _ =>
+        plain
+
+  def applied(self: Expr[Tel], field: Expr[String], idx: Expr[Int]): Macro[Tel] =
+    import quotes.reflect.*
+
+    def plain: Expr[Tel] =
+      if Expr.summon[DynamicTelEnabler].isEmpty
+      then halt(m"""dynamic field access on an unverified `Tel` requires
+                    `import dynamicTelAccess.enabled` (or verify the value against a schema first)""")
+
+      '{$self.selectFieldIndex($field, $idx)}
+
+    receiver(self) match
+      case (position, root) => field.value match
+        case Some(name) => position.typeSymbol.caseFields.find(_.name == name) match
+          case Some(member) =>
+            val element = elementType(position.memberType(member))
+
+            if element.absent
+            then halt(m"the field $name of ${position.show} is not an indexable collection")
+
+            telType(element.vouch, root).asType.absolve match
+              case '[type result <: Tel; result] =>
+                '{$self.selectFieldIndex(${Expr(name)}, $idx).asInstanceOf[result]}
+
+          case None =>
+            halt(m"the schema position ${position.show} has no field $name")
+
+        case None =>
+          plain
+
+      case _ =>
+        plain

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -68,9 +68,18 @@ extends scala.Dynamic, Documentary, Topical, Original:
     if match0.isEmpty then Tel.empty else Tel(match0.get)
 
   // Total child-by-index access under a field: an empty `Tel` when the index is
-  // out of range.
+  // out of range. Used by the positional optics / plain dynamic access, where a
+  // field compound contains the indexed children.
   private[stratiform] def selectFieldIndex(field: String, index: Int): Tel =
     val cs = selectField(field).childCompounds
+    if index < 0 || index >= cs.length then Tel.empty else Tel(cs(index))
+
+  // Indexed access into a *repeated* (collection) field: a `List`/`Set` field is
+  // encoded as repeated keyword compounds (per `#1291`), so index the n-th sibling
+  // sharing the field's keyword. Used by schema-typed navigation for collection
+  // positions. An empty `Tel` when the index is out of range.
+  private[stratiform] def selectRepeatedField(field: String, index: Int): Tel =
+    val cs = childCompounds.filter(_.keyword == Tel.camelToKebab(field))
     if index < 0 || index >= cs.length then Tel.empty else Tel(cs(index))
 
   // Dynamic field access: `tel.firstName` looks up the kebab-case keyword
@@ -153,6 +162,39 @@ object Tel extends Tel2:
   // `object Tel` below as their canonical location).
   type Error = TelError
   val Error: TelError.type = TelError
+
+  // A TEL encoder/decoder that also carries the format-neutral `Shape` of exactly
+  // what it reads/writes, so a fused `Encodable & Schematic` / `Decodable &
+  // Schematic` (built by `telSchematics`) is coherent by construction — the shape
+  // travels with the codec rather than being resolved independently. The `Shape` is
+  // reified into a concrete `Tels.Type` downstream. Mirrors jacinta's
+  // `Json.Encodable`/`Json.Decodable`. Not itself `Schematic`.
+  trait Encodable extends anticipation.Encodable:
+    type Form = Tel
+    def shape(): Shape
+
+  object Encodable:
+    def apply[value](shape0: => Shape)(lambda: value => Tel): value is Tel.Encodable =
+      new Tel.Encodable:
+        type Self = value
+        def encoded(value: value): Tel = lambda(value)
+        def shape(): Shape = shape0
+
+  trait Decodable extends distillate.Decodable:
+    type Form = Tel
+    def shape(): Shape
+
+    // True for collection decoders (`List`/`Set`): a repeated field. The product
+    // decoder gathers all same-keyword sibling compounds for such a field and hands
+    // them here as a Document; other fields read a single matching compound.
+    def repeatable: Boolean = false
+
+  object Decodable:
+    def apply[value](shape0: => Shape)(lambda: Tel => value): value is Tel.Decodable =
+      new Tel.Decodable:
+        type Self = value
+        def decoded(tel: Tel): value = lambda(tel)
+        def shape(): Shape = shape0
 
   // Type assignment algorithm per §20.2 of the TEL specification.
   object Type:
@@ -749,7 +791,7 @@ object Tel extends Tel2:
   // for `value over Json`. The `Transport` type-tag is added by an
   // `asInstanceOf` cast — `value over Tel` is just
   // `value { type Transport = Tel }` so the cast is a no-op at runtime.
-  given aggregableOver: [value: Decodable in Tel] => Tactic[TelError]
+  given aggregableOver: [value: distillate.Decodable in Tel] => Tactic[TelError]
   =>  (value over Tel) is Aggregable by Data =
     source => parse(concatenate(source)).as[value].asInstanceOf[value over Tel]
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -55,28 +55,35 @@ import vacuous.*
 // without case analysis.
 
 class Tel private[stratiform](private[stratiform] val subtree: Tel.Subtree)
-extends scala.Dynamic, Documentary:
+extends scala.Dynamic, Documentary, Topical, Original:
   type Self = Tel
   type Metadata = Tel.Metadata
 
   inline def as[value: Decodable in Tel]: value raises TelError = value.decoded(this)
 
-  // Dynamic field access: `tel.firstName` becomes a lookup for the kebab-
-  // case keyword "first-name". Gated by DynamicTelEnabler so opting in is
-  // explicit.
-  def selectDynamic(field: String)(using erased DynamicTelEnabler)
-  :     Tel raises TelError =
+  // Total field access used by the schema-typed navigation macros and by
+  // internal optics: an empty `Tel` for a missing field, never raising.
+  private[stratiform] def selectField(field: String): Tel =
     val match0 = childCompounds.find(_.keyword == Tel.camelToKebab(field))
     if match0.isEmpty then Tel.empty else Tel(match0.get)
 
-  // Chained access: `tel.contacts(0)` after the field lookup. Phase-2
-  // returns the n-th child compound (any keyword), matching list-style
-  // access.
-  def applyDynamic(field: String)(index: Int)(using erased DynamicTelEnabler)
-  :     Tel raises TelError =
-    val parent = selectDynamic(field)
-    val cs = parent.childCompounds
+  // Total child-by-index access under a field: an empty `Tel` when the index is
+  // out of range.
+  private[stratiform] def selectFieldIndex(field: String, index: Int): Tel =
+    val cs = selectField(field).childCompounds
     if index < 0 || index >= cs.length then Tel.empty else Tel(cs(index))
+
+  // Dynamic field access: `tel.firstName` looks up the kebab-case keyword
+  // "first-name". For a schema-typed `Tel of P from R` the macro checks `P` has
+  // the field and yields `Tel of <field-type> from R` (no `DynamicTelEnabler`
+  // import needed); for a plain `Tel` it requires the enabler, as before.
+  transparent inline def selectDynamic(field: String): Tel = ${Stratiform.select('this, 'field)}
+
+  // Chained access: `tel.contacts(0)`. For a schema-typed `Tel of P from R`
+  // where the field is a collection, the macro yields `Tel of <element> from R`;
+  // for a plain `Tel` it returns the n-th child compound, as before.
+  transparent inline def applyDynamic(field: String)(index: Int): Tel =
+    ${Stratiform.applied('this, 'field, 'index)}
 
   // Keyword of this node — empty for the document root, otherwise the
   // compound's keyword text.

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -64,7 +64,7 @@ trait Tel2:
   // new one. Mirrors jacinta's lens given.
   given lens: [name <: Label: ValueOf] => (erased DynamicTelEnabler) => Tactic[TelError]
   =>  name is Lens from Tel onto Tel =
-    Lens(_.selectDynamic(valueOf[name]), _.modify(valueOf[name], _))
+    Lens(_.selectField(valueOf[name]), _.modify(valueOf[name], _))
 
   // Positional optics over a node's child compounds (TEL has no positional arrays,
   // but a compound's children are ordered — this mirrors the read-side

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -33,6 +33,7 @@
 package stratiform
 
 import scala.compiletime.*
+import scala.collection.Factory
 
 import adversaria.*
 import anticipation.*
@@ -244,6 +245,43 @@ trait Tel2:
   given optionalDecodable: [value: Decodable in Tel] => Tactic[TelError]
   =>  Optional[value] is Decodable in Tel = telVal =>
     if telVal.childCompounds.isEmpty && telVal.atomTexts.isEmpty then Unset else value.decoded(telVal)
+
+  // Collection support — every element is encoded as an `item` compound, and the
+  // product encoder re-keys the wrapping compound with the field's label, so a
+  // `List[T]` field `xs` becomes an `xs` compound with one `item` child per
+  // element. Decoding reads back all `item` children, building the target
+  // collection via its `Factory`.
+
+  private def itemise(tel: Tel): Tel.Compound = tel.subtree match
+    case c: Tel.Compound => c.copy(keyword = t"item")
+    case d: Tel.Document => Tel.Compound(t"item", IArray.empty, Unset, d.children)
+
+  private def collectionTel[value]
+      (values: Iterable[value])(using encodable: value is Encodable in Tel)
+  :     Tel =
+    Tel.compound(t"", IArray.empty, IArray.from(values.map(v => itemise(encodable.encoded(v)))))
+
+  given listEncodable: [list <: List, element] => (encodable: => element is Encodable in Tel)
+  =>  list[element] is Encodable in Tel =
+    values => collectionTel(values)(using encodable)
+
+  given setEncodable: [set <: Set, element] => (encodable: => element is Encodable in Tel)
+  =>  set[element] is Encodable in Tel =
+    values => collectionTel(values)(using encodable)
+
+  given seriesEncodable: [series <: Series, element] => (encodable: => element is Encodable in Tel)
+  =>  series[element] is Encodable in Tel =
+    values => collectionTel(values)(using encodable)
+
+  given collectionDecodable: [collection <: Iterable, element]
+  =>  ( factory:   Factory[element, collection[element]],
+        decodable: => element is Decodable in Tel )
+  =>  Tactic[TelError]
+  =>  collection[element] is Decodable in Tel =
+    telVal =>
+      val builder = factory.newBuilder
+      for item <- telVal.fields(t"item") do builder += decodable.decoded(item)
+      builder.result()
 
   // Helpers used by encoders to construct Tel values.
 

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -252,14 +252,15 @@ trait Tel2:
   // element. Decoding reads back all `item` children, building the target
   // collection via its `Factory`.
 
-  private def itemise(tel: Tel): Tel.Compound = tel.subtree match
-    case c: Tel.Compound => c.copy(keyword = t"item")
-    case d: Tel.Document => Tel.Compound(t"item", IArray.empty, Unset, d.children)
+  // Re-keys an encoded value's compound (or wraps a document) under `keyword`.
+  private def reKey(tel: Tel, keyword: Text): Tel.Compound = tel.subtree match
+    case c: Tel.Compound => c.copy(keyword = keyword)
+    case d: Tel.Document => Tel.Compound(keyword, IArray.empty, Unset, d.children)
 
   private def collectionTel[value]
       (values: Iterable[value])(using encodable: value is Encodable in Tel)
   :     Tel =
-    Tel.compound(t"", IArray.empty, IArray.from(values.map(v => itemise(encodable.encoded(v)))))
+    Tel.compound(t"", IArray.empty, IArray.from(values.map(v => reKey(encodable.encoded(v), t"item"))))
 
   given listEncodable: [list <: List, element] => (encodable: => element is Encodable in Tel)
   =>  list[element] is Encodable in Tel =
@@ -282,6 +283,33 @@ trait Tel2:
       val builder = factory.newBuilder
       for item <- telVal.fields(t"item") do builder += decodable.decoded(item)
       builder.result()
+
+  // A `Map` encodes as a series of `entries` compounds, each carrying a `key`
+  // and a `value` child field. As with other collections the product encoder
+  // re-keys the wrapping compound with the field's label.
+
+  given mapEncodable: [key: Encodable in Tel, value: Encodable in Tel]
+  =>  Map[key, value] is Encodable in Tel =
+    map =>
+      val entries = IArray.from:
+        map.map: (k, v) =>
+          val keyChild   = reKey(key.encoded(k), t"key")
+          val valueChild = reKey(value.encoded(v), t"value")
+          reKey(Tel.compound(t"", IArray.empty, IArray(keyChild, valueChild)), t"entries")
+
+      Tel.compound(t"", IArray.empty, entries)
+
+  given mapDecodable: [key: Decodable in Tel, value: Decodable in Tel] => Tactic[TelError]
+  =>  Map[key, value] is Decodable in Tel =
+    telVal =>
+      var accumulator = Map.empty[key, value]
+
+      for entry <- telVal.fields(t"entries") do
+        val k = key.decoded(entry.field(t"key").or(Tel.empty))
+        val v = value.decoded(entry.field(t"value").or(Tel.empty))
+        accumulator = accumulator.updated(k, v)
+
+      accumulator
 
   // Helpers used by encoders to construct Tel values.
 

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -44,6 +44,7 @@ import distillate.*
 import gossamer.*
 import panopticon.*
 import prepositional.*
+import rudiments.*
 import vacuous.*
 import wisteria.*
 
@@ -116,181 +117,242 @@ trait Tel2:
 
       ${stratiform.internal.extractor[parts, origins]('scrutinee)}
 
-  inline given decodable: [value] => value is Decodable in Tel = summonFrom:
+  inline given decodable: [value] => value is Tel.Decodable = summonFrom:
     case given (`value` is Decodable in Text) =>
-      provide[Tactic[TelError]](_.primaryAtom.decode[value])
+      Tel.Decodable(Shape.Str)(provide[Tactic[TelError]](_.primaryAtom.decode[value]))
 
     case given Reflection[`value`] => DecodableDerivation.derived
 
-  inline given encodable: [value] => value is Encodable in Tel = summonFrom:
+  inline given encodable: [value] => value is Tel.Encodable = summonFrom:
     case given (`value` is Encodable in Text) =>
-      v => Tel.scalar(v.encode)
+      Tel.Encodable(Shape.Str)(v => Tel.scalar(v.encode))
 
     case given Reflection[`value`] => EncodableDerivation.derived
 
-  object DecodableDerivation extends Derivable[Decodable in Tel]:
+  object DecodableDerivation extends Derivable[Tel.Decodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Decodable in Tel =
-      telVal =>
-        provide[Tactic[TelError]]:
+    :   derivation is Tel.Decodable =
+      // The object `Shape` is built from the field decoders' own shapes (a single
+      // inlined `contexts` traversal — kept here, not factored out, so it does not
+      // perturb the `build` traversal), keeping a fused `Decodable & Schematic`
+      // coherent. Built by-name so recursive types compile.
+      Tel.Decodable({
+        val fields: List[(Text, Shape)] =
+          contexts: [field] => context => (label, context.shape())
+          . to(List)
+
+        Shape.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
+      }):
+        telVal =>
+          provide[Tactic[TelError]]:
+            // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
+            // verbatim; an unannotated field falls back to its camel→kebab form.
+            val renames: Map[Text, Text] = relabelling[derivation, Tel]
+
+            build: [field] =>
+              ctx =>
+                val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
+
+                // A `List`/`Set` field (`ctx.repeatable`) is encoded as repeated
+                // keyword compounds, so gather them all into a Document for the
+                // collection decoder. Every other field — scalar, nested product,
+                // `Optional`, `Map` (a single `entries` compound) — reads one match.
+                if ctx.repeatable then
+                  val compounds = telVal.childCompounds.filter(_.keyword == keyword)
+                  ctx.decoded:
+                    Tel.make
+                     (Tel.Document
+                       (Unset, Unset, Tel.LineEndings.Lf,
+                        IArray(Tel.Block(IArray.empty, Unset, compounds, 0))))
+                else
+                  val match0 = telVal.field(keyword)
+                  if match0.absent then default.or(ctx.decoded(Tel.empty))
+                  else ctx.decoded(match0.vouch)
+
+    inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
+      // A sum's precise per-variant schema is available from the standalone
+      // `Schematic` / `Tels.tels`; the codec-carried shape stays permissive (`Any`)
+      // because walking the variants (`delegate`) is `fallible` and would leak a
+      // `Tactic[VariantError]` requirement onto every codec.
+      Tel.Decodable(Shape.Any):
+        telVal =>
+          provide[Tactic[TelError]]:
+            provide[Tactic[VariantError]]:
+              val variantKeyword = telVal.primaryAtom
+              delegate(variantKeyword): [variant <: derivation] =>
+                ctx => ctx.decoded(telVal)
+
+  object EncodableDerivation extends Derivable[Tel.Encodable]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Tel.Encodable =
+      Tel.Encodable({
+        val fields: List[(Text, Shape)] =
+          contexts: [field] => context => (label, context.shape())
+          . to(List)
+
+        Shape.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
+      }):
+        value =>
+          val compounds = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
+
           // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
           // verbatim; an unannotated field falls back to its camel→kebab form.
           val renames: Map[Text, Text] = relabelling[derivation, Tel]
 
-          build: [field] =>
-            ctx =>
-              val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
-              val match0 = telVal.field(keyword)
-              if match0.absent then default.or(ctx.decoded(Tel.empty))
-              else ctx.decoded(match0.vouch)
+          fields(value): [field] =>
+            fieldValue =>
+              val encoded = contextual.encode(fieldValue)
+              val keyword = renames.getOrElse(label, Tel.camelToKebab(label.s))
+              encoded.subtree match
+                case c: Tel.Compound =>
+                  compounds += c.copy(keyword = keyword)
 
-    inline def disjunction[derivation: SumReflection]: derivation is Decodable in Tel =
-      telVal =>
-        provide[Tactic[TelError]]:
-          provide[Tactic[VariantError]]:
-            val variantKeyword = telVal.primaryAtom
-            delegate(variantKeyword): [variant <: derivation] =>
-              ctx => ctx.decoded(telVal)
+                // A list/set field encodes to a Document of element compounds;
+                // flatten them as repeated fields, each re-keyed to the field label
+                // (TEL's representation of a repeated field — see `#1291`).
+                case d: Tel.Document =>
+                  compounds ++= d.children.flatMap(_.compounds).map(_.copy(keyword = keyword))
 
-  object EncodableDerivation extends Derivable[Encodable in Tel]:
-    inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Encodable in Tel = value =>
-      val compounds = scala.collection.mutable.ArrayBuffer.empty[Tel.Compound]
+          Tel.compound(t"", IArray.empty, IArray.from(compounds))
 
-      // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
-      // verbatim; an unannotated field falls back to its camel→kebab form.
-      val renames: Map[Text, Text] = relabelling[derivation, Tel]
-
-      fields(value): [field] =>
-        fieldValue =>
-          val encoded = contextual.encode(fieldValue)
-          val keyword = renames.getOrElse(label, Tel.camelToKebab(label.s))
-          encoded.subtree match
-            case c: Tel.Compound =>
-              compounds += c.copy(keyword = keyword)
-
-            // A list-valued field encodes to a Document of element compounds;
-            // flatten them as repeated fields, each re-keyed to the field label.
-            case d: Tel.Document =>
-              compounds ++= d.children.flatMap(_.compounds).map(_.copy(keyword = keyword))
-
-      Tel.compound(t"", IArray.empty, IArray.from(compounds))
-
-    inline def disjunction[derivation: SumReflection]: derivation is Encodable in Tel =
-      value =>
-        variant(value): [variant <: derivation] =>
-          v => contextual.encode(v)
+    inline def disjunction[derivation: SumReflection]: derivation is Tel.Encodable =
+      Tel.Encodable(Shape.Any):
+        value =>
+          variant(value): [variant <: derivation] =>
+            v => contextual.encode(v)
 
   // Primitive instances: Text/Int/Long/Double/Boolean as Compound + inline
   // atom. These mirror jacinta.Json's primitive decoders but go through
   // the atom text rather than a JSON AST.
 
-  given textDecodable: Tactic[TelError] => Text is Decodable in Tel = _.primaryAtom
+  given textDecodable: Tactic[TelError] => Text is Tel.Decodable =
+    Tel.Decodable(Shape.Str)(_.primaryAtom)
 
-  given stringDecodable: Tactic[TelError] => String is Decodable in Tel =
-    _.primaryAtom.s
+  given stringDecodable: Tactic[TelError] => String is Tel.Decodable =
+    Tel.Decodable(Shape.Str)(_.primaryAtom.s)
 
-  given intDecodable: Tactic[TelError] => Int is Decodable in Tel = telVal =>
-    try telVal.primaryAtom.s.toInt
-    catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+  given intDecodable: Tactic[TelError] => Int is Tel.Decodable =
+    Tel.Decodable(Shape.Whole): telVal =>
+      try telVal.primaryAtom.s.toInt
+      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
 
-  given longDecodable: Tactic[TelError] => Long is Decodable in Tel = telVal =>
-    try telVal.primaryAtom.s.toLong
-    catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+  given longDecodable: Tactic[TelError] => Long is Tel.Decodable =
+    Tel.Decodable(Shape.Whole): telVal =>
+      try telVal.primaryAtom.s.toLong
+      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
 
-  given doubleDecodable: Tactic[TelError] => Double is Decodable in Tel = telVal =>
-    try telVal.primaryAtom.s.toDouble
-    catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+  given doubleDecodable: Tactic[TelError] => Double is Tel.Decodable =
+    Tel.Decodable(Shape.Real): telVal =>
+      try telVal.primaryAtom.s.toDouble
+      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
 
-  given booleanDecodable: Tactic[TelError] => Boolean is Decodable in Tel = telVal =>
-    telVal.primaryAtom.s match
-      case "true"  => true
-      case "false" => false
-      case _       => abort(TelError(TelError.Reason.BadVersion))
+  given booleanDecodable: Tactic[TelError] => Boolean is Tel.Decodable =
+    Tel.Decodable(Shape.Bool): telVal =>
+      telVal.primaryAtom.s match
+        case "true"  => true
+        case "false" => false
+        case _       => abort(TelError(TelError.Reason.BadVersion))
 
-  given telDecodable: Tel is Decodable in Tel = identity(_)
+  given telDecodable: Tel is Tel.Decodable = Tel.Decodable(Shape.Any)(identity(_))
 
-  given textEncodable: Text is Encodable in Tel = text => Tel.scalar(text)
-  given stringEncodable: String is Encodable in Tel = s => Tel.scalar(Text(s))
-  given intEncodable: Int is Encodable in Tel = i => Tel.scalar(Text(i.toString))
-  given longEncodable: Long is Encodable in Tel = l => Tel.scalar(Text(l.toString))
-  given doubleEncodable: Double is Encodable in Tel = d => Tel.scalar(Text(d.toString))
-  given booleanEncodable: Boolean is Encodable in Tel = b => Tel.scalar(Text(b.toString))
-  given telEncodable: Tel is Encodable in Tel = identity(_)
+  given textEncodable: Text is Tel.Encodable = Tel.Encodable(Shape.Str)(text => Tel.scalar(text))
+  given stringEncodable: String is Tel.Encodable =
+    Tel.Encodable(Shape.Str)(s => Tel.scalar(Text(s)))
+  given intEncodable: Int is Tel.Encodable =
+    Tel.Encodable(Shape.Whole)(i => Tel.scalar(Text(i.toString)))
+  given longEncodable: Long is Tel.Encodable =
+    Tel.Encodable(Shape.Whole)(l => Tel.scalar(Text(l.toString)))
+  given doubleEncodable: Double is Tel.Encodable =
+    Tel.Encodable(Shape.Real)(d => Tel.scalar(Text(d.toString)))
+  given booleanEncodable: Boolean is Tel.Encodable =
+    Tel.Encodable(Shape.Bool)(b => Tel.scalar(Text(b.toString)))
+  given telEncodable: Tel is Tel.Encodable = Tel.Encodable(Shape.Any)(identity(_))
 
   // Optional / List support — repeatable scalar fields produce multiple
   // compounds with the same keyword; we return a Document-rooted Tel
   // containing the list elements as siblings, which the product encoder
   // recognises and flattens with the field's label.
 
-  given optionalEncodable: [value: Encodable in Tel] => Optional[value] is Encodable in Tel =
-    opt => opt.lay(Tel.empty)(v => v.encode)
+  given optionalEncodable: [value: Tel.Encodable] => Optional[value] is Tel.Encodable =
+    Tel.Encodable(Shape.Opt(value.shape())): opt =>
+      opt.lay(Tel.empty)(v => v.encode)
 
-  // A `List` encodes to a Document-rooted Tel whose children are the elements'
-  // compounds; the product encoder recognises the Document and flattens those
-  // compounds into repeated fields keyed by the list's label — TEL's
-  // representation of a repeated field. `List[value]` is more specific than
-  // `value`, so this is preferred over the `encodable` derivation without
-  // ambiguity (exactly as `optionalEncodable` is for `Optional`).
-  given listEncodable: [value: Encodable in Tel] => List[value] is Encodable in Tel = list =>
-    val compounds: IArray[Tel.Compound] = IArray.from:
-      list.flatMap: element =>
-        element.encode.subtree match
-          case compound: Tel.Compound => List(compound)
-          case document: Tel.Document => document.children.flatMap(_.compounds).to(List)
-          case _                      => Nil
+  given optionalDecodable: [value: Tel.Decodable] => Tactic[TelError]
+  =>  Optional[value] is Tel.Decodable =
+    Tel.Decodable(Shape.Opt(value.shape())): telVal =>
+      if telVal.childCompounds.isEmpty && telVal.atomTexts.isEmpty then Unset
+      else value.decoded(telVal)
 
-    Tel(Tel.Document(Unset, Unset, Tel.LineEndings.Lf, IArray(Tel.Block(IArray.empty, Unset, compounds, 0))))
-
-  given optionalDecodable: [value: Decodable in Tel] => Tactic[TelError]
-  =>  Optional[value] is Decodable in Tel = telVal =>
-    if telVal.childCompounds.isEmpty && telVal.atomTexts.isEmpty then Unset else value.decoded(telVal)
-
-  // Collection support — every element is encoded as an `item` compound, and the
-  // product encoder re-keys the wrapping compound with the field's label, so a
-  // `List[T]` field `xs` becomes an `xs` compound with one `item` child per
-  // element. Decoding reads back all `item` children, building the target
-  // collection via its `Factory`.
+  // Collection support (aligned with `#1291`) — a `List`/`Set` encodes to a
+  // Document-rooted Tel whose children are the elements' compounds; the product
+  // encoder (`conjunction`) flattens those into repeated fields, each re-keyed to
+  // the field's label (TEL's representation of a repeated field). Decoding inverts
+  // this: the product decoder gathers all sibling compounds sharing the field's
+  // keyword into a Document and hands it here, where each child is decoded as an
+  // element via the target's `Factory`.
 
   // Re-keys an encoded value's compound (or wraps a document) under `keyword`.
   private def reKey(tel: Tel, keyword: Text): Tel.Compound = tel.subtree match
     case c: Tel.Compound => c.copy(keyword = keyword)
     case d: Tel.Document => Tel.Compound(keyword, IArray.empty, Unset, d.children)
 
-  private def collectionTel[value]
+  private def collectionDocument[value]
       (values: Iterable[value])(using encodable: value is Encodable in Tel)
   :     Tel =
-    Tel.compound(t"", IArray.empty, IArray.from(values.map(v => reKey(encodable.encoded(v), t"item"))))
+    val compounds: IArray[Tel.Compound] = IArray.from:
+      values.flatMap: element =>
+        encodable.encoded(element).subtree match
+          case compound: Tel.Compound => List(compound)
+          case document: Tel.Document => document.children.flatMap(_.compounds).to(List)
 
-  given listEncodable: [list <: List, element] => (encodable: => element is Encodable in Tel)
-  =>  list[element] is Encodable in Tel =
-    values => collectionTel(values)(using encodable)
+    Tel(Tel.Document(Unset, Unset, Tel.LineEndings.Lf,
+        IArray(Tel.Block(IArray.empty, Unset, compounds, 0))))
 
-  given setEncodable: [set <: Set, element] => (encodable: => element is Encodable in Tel)
-  =>  set[element] is Encodable in Tel =
-    values => collectionTel(values)(using encodable)
+  given listEncodable: [list <: List, element] => (encodable: => element is Tel.Encodable)
+  =>  list[element] is Tel.Encodable =
+    Tel.Encodable(Shape.Arr(encodable.shape())): values =>
+      collectionDocument(values)(using encodable)
 
-  given seriesEncodable: [series <: Series, element] => (encodable: => element is Encodable in Tel)
-  =>  series[element] is Encodable in Tel =
-    values => collectionTel(values)(using encodable)
+  given setEncodable: [set <: Set, element] => (encodable: => element is Tel.Encodable)
+  =>  set[element] is Tel.Encodable =
+    Tel.Encodable(Shape.Arr(encodable.shape())): values =>
+      collectionDocument(values)(using encodable)
+
+  given seriesEncodable: [series <: Series, element] => (encodable: => element is Tel.Encodable)
+  =>  series[element] is Tel.Encodable =
+    Tel.Encodable(Shape.Arr(encodable.shape())): values =>
+      collectionDocument(values)(using encodable)
 
   given collectionDecodable: [collection <: Iterable, element]
   =>  ( factory:   Factory[element, collection[element]],
-        decodable: => element is Decodable in Tel )
+        element0:  => element is Tel.Decodable )
   =>  Tactic[TelError]
-  =>  collection[element] is Decodable in Tel =
-    telVal =>
-      val builder = factory.newBuilder
-      for item <- telVal.fields(t"item") do builder += decodable.decoded(item)
-      builder.result()
+  =>  collection[element] is Tel.Decodable =
+    new Tel.Decodable:
+      type Self = collection[element]
+      def shape(): Shape = Shape.Arr(element0.shape())
+      override def repeatable: Boolean = true
+
+      def decoded(telVal: Tel): collection[element] =
+        val builder = factory.newBuilder
+
+        telVal.subtree.absolve match
+          case document: Tel.Document =>
+            document.children.flatMap(_.compounds).each: compound =>
+              builder += element0.decoded(Tel.make(compound))
+
+          case compound: Tel.Compound =>
+            builder += element0.decoded(telVal)
+
+        builder.result()
 
   // A `Map` encodes as a series of `entries` compounds, each carrying a `key`
   // and a `value` child field. As with other collections the product encoder
   // re-keys the wrapping compound with the field's label.
 
-  given mapEncodable: [key: Encodable in Tel, value: Encodable in Tel]
-  =>  Map[key, value] is Encodable in Tel =
-    map =>
+  given mapEncodable: [key: Tel.Encodable, value: Tel.Encodable]
+  =>  Map[key, value] is Tel.Encodable =
+    Tel.Encodable(Shape.Dict(key.shape(), value.shape())): map =>
       val entries = IArray.from:
         map.map: (k, v) =>
           val keyChild   = reKey(key.encoded(k), t"key")
@@ -299,9 +361,9 @@ trait Tel2:
 
       Tel.compound(t"", IArray.empty, entries)
 
-  given mapDecodable: [key: Decodable in Tel, value: Decodable in Tel] => Tactic[TelError]
-  =>  Map[key, value] is Decodable in Tel =
-    telVal =>
+  given mapDecodable: [key: Tel.Decodable, value: Tel.Decodable] => Tactic[TelError]
+  =>  Map[key, value] is Tel.Decodable =
+    Tel.Decodable(Shape.Dict(key.shape(), value.shape())): telVal =>
       var accumulator = Map.empty[key, value]
 
       for entry <- telVal.fields(t"entries") do

--- a/lib/stratiform/src/core/stratiform.Tels.scala
+++ b/lib/stratiform/src/core/stratiform.Tels.scala
@@ -64,7 +64,7 @@ case class Tels
      scalars:  IArray[Tels.ScalarDefinition],
      selects:  IArray[Tels.SelectDefinition] )
 
-object Tels:
+object Tels extends Tels2:
 
   // Per-axis polarity tristate from §20: "default" means no flag was
   // declared, "loose" means a loosening flag (optional / repeatable)

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -43,39 +43,41 @@ import wisteria.*
 import Tels.Polarity
 
 // Constructors for fused `Encodable & Schematic` / `Decodable & Schematic`
-// instances, built from a value's separate `Encodable`/`Decodable` and `Schematic`
-// instances. Deliberately *methods*, not givens: a fused given is a subtype of
-// both its codec typeclass and `Schematic`, so two such givens would be ambiguous
-// for any bare `Schematic` summon. Call them where a fused instance is wanted
-// (e.g. `given … = telSchematics.decodable[T]`). Mirrors jacinta's `jsonSchematics`.
+// instances. The schema is taken from the codec itself (`Tel.Encodable` /
+// `Tel.Decodable` *carry* a `Shape`), never resolved independently, so the fused
+// instance is coherent by construction — a gated or `… in Text`-branch codec
+// always pairs with the schema for exactly what it reads/writes. The carried
+// `Shape` is reified into a `Tels.Type` here. Deliberately *methods*, not givens
+// (a fused given is `<: Schematic`, so two would be ambiguous for a bare
+// `Schematic` summon). Mirrors jacinta's `jsonSchematics`.
 object telSchematics:
-  def encodable[value](using encoder: value is Encodable in Tel)
-                      (using schema0: value is Schematic over Tels.Type)
+  def encodable[value](using encoder: value is Tel.Encodable)
   :     value is Encodable & Schematic in Tel over Tels.Type =
     new Encodable with Schematic:
       type Self = value
       type Form = Tel
       type Transport = Tels.Type
       def encoded(value: value): Tel = encoder.encoded(value)
-      def schema(): Tels.Type = schema0.schema()
+      def schema(): Tels.Type = Tels2.reify(encoder.shape())
 
-  def decodable[value](using decoder: value is Decodable in Tel)
-                      (using schema0: value is Schematic over Tels.Type)
+  def decodable[value](using decoder: value is Tel.Decodable)
   :     value is Decodable & Schematic in Tel over Tels.Type =
     new Decodable with Schematic:
       type Self = value
       type Form = Tel
       type Transport = Tels.Type
       def decoded(tel: Tel): value = decoder.decoded(tel)
-      def schema(): Tels.Type = schema0.schema()
+      def schema(): Tels.Type = Tels2.reify(decoder.shape())
 
-// TEL refinement of the shared `anticipation.Schematic`: it adds a field-level
-// `polarity` so the product derivation can mark `Optional` fields as `Loose` (TEL
-// records optionality on the field, not on the schema node). The schema
-// representation (`Transport`) is a `Tels.Type`. `verify` / `tels` still require
-// only the shared `Schematic over Tels.Type`, which these givens satisfy.
+// TEL refinement of the shared `anticipation.Schematic`: it adds field-level
+// `polarity` (so the product derivation can mark `Optional` fields `Loose`) and
+// `repeatable` (so `List`/`Set` fields become repeatable fields — TEL records both
+// optionality and repeatability on the field, not on the schema node). The schema
+// representation (`Transport`) is a `Tels.Type`. `tels` still requires only the
+// shared `Schematic over Tels.Type`, which these givens satisfy.
 trait TelSchematic extends Schematic:
   def polarity: Tels.Polarity = Tels.Polarity.Tight
+  def repeatable: Tels.Polarity = Tels.Polarity.Implicit
 
 // Schema derivation for TEL: scalars map to `Tels.Scalar`, products to a
 // `Tels.Struct` of `Field`s, collections to a `Struct` with a repeatable `item`
@@ -97,14 +99,32 @@ trait Tels2:
       def schema(): Tels.Type = value.schema()
       override def polarity: Tels.Polarity = Polarity.Loose
 
+  // A `List`/`Set` field is a repeatable field whose type is the element's schema
+  // (TEL repeats the field rather than wrapping it), so the schema node is the
+  // element schema and the field is marked `Loose` (0+) and repeatable.
   given list: [value: Schematic over Tels.Type] => List[value] is TelSchematic over Tels.Type =
-    () => Tels2.itemType(value.schema())
+    new TelSchematic:
+      type Self = List[value]
+      type Transport = Tels.Type
+      def schema(): Tels.Type = value.schema()
+      override def polarity: Tels.Polarity = Polarity.Loose
+      override def repeatable: Tels.Polarity = Polarity.Loose
 
   given set: [value: Schematic over Tels.Type] => Set[value] is TelSchematic over Tels.Type =
-    () => Tels2.itemType(value.schema())
+    new TelSchematic:
+      type Self = Set[value]
+      type Transport = Tels.Type
+      def schema(): Tels.Type = value.schema()
+      override def polarity: Tels.Polarity = Polarity.Loose
+      override def repeatable: Tels.Polarity = Polarity.Loose
 
   given series: [value: Schematic over Tels.Type] => Series[value] is TelSchematic over Tels.Type =
-    () => Tels2.itemType(value.schema())
+    new TelSchematic:
+      type Self = Series[value]
+      type Transport = Tels.Type
+      def schema(): Tels.Type = value.schema()
+      override def polarity: Tels.Polarity = Polarity.Loose
+      override def repeatable: Tels.Polarity = Polarity.Loose
 
   given map: [key: Schematic over Tels.Type, value: Schematic over Tels.Type]
   =>  Map[key, value] is TelSchematic over Tels.Type =
@@ -130,12 +150,48 @@ trait Tels2:
       Tels(name, struct, IArray.empty, Unset, IArray.empty, IArray.empty, IArray.empty)
 
 object Tels2:
-  // A collection encodes as a wrapping compound with repeatable `item` children,
-  // so its schema is a `Struct` with a single repeatable `item` field.
-  private[stratiform] def itemType(element: Tels.Type): Tels.Type =
-    Tels.Struct
-      ( IArray(Tels.Field(Polarity.Implicit, Polarity.Loose, t"item", element, Unset)),
-        IArray.empty )
+  // Reifies a codec's format-neutral `Shape` (carried by `Tel.Encodable` /
+  // `Tel.Decodable`) into a concrete `Tels.Type`. TEL records optionality and
+  // repeatability on the *field*, so an `Opt` field becomes a `Loose` member and an
+  // `Arr` (list/set) field a `Loose`/repeatable member whose type is the element's
+  // schema (collections are repeated fields, per `#1291`, not wrapper structs).
+  // Field keywords are camel→kebab-cased to match the encoding. A sum carries a
+  // permissive `Any` shape; precise schemas come from the standalone `Schematic`.
+  private[stratiform] def reify(shape: Shape): Tels.Type = shape match
+    case Shape.Str | Shape.Whole | Shape.Real | Shape.Bool | Shape.Empty =>
+      Tels.Scalar(IArray.empty)
+
+    case Shape.Any        => Tels.Struct(IArray.empty, IArray.empty)
+    case Shape.OneOf(_)   => Tels.Struct(IArray.empty, IArray.empty)
+    case Shape.Opt(inner) => reify(inner)
+    case Shape.Arr(items) => reify(items)
+
+    case Shape.Dict(key, value) =>
+      val entry =
+        Tels.Struct
+          ( IArray
+              ( Tels.Field(Polarity.Tight, Polarity.Implicit, t"key", reify(key), Unset),
+                Tels.Field(Polarity.Tight, Polarity.Implicit, t"value", reify(value), Unset) ),
+            IArray.empty )
+
+      Tels.Struct
+        ( IArray(Tels.Field(Polarity.Implicit, Polarity.Loose, t"entries", entry, Unset)),
+          IArray.empty )
+
+    case Shape.Obj(fields, required) =>
+      val members = fields.map: (label, fieldShape) =>
+        val repeatable = fieldShape match
+          case Shape.Arr(_) => Polarity.Loose
+          case _            => Polarity.Implicit
+
+        val polarity = fieldShape match
+          case Shape.Arr(_) | Shape.Opt(_) => Polarity.Loose
+          case _ => if required.contains(label) then Polarity.Tight else Polarity.Loose
+
+        Tels.Field
+          (polarity, repeatable, Tel.camelToKebab(label.s), reify(fieldShape), Unset)
+
+      Tels.Struct(IArray.from(members), IArray.empty)
 
 object TelsDerivation extends Derivable[TelSchematic over Tels.Type]:
   inline def conjunction[derivation <: Product: ProductReflection]
@@ -148,7 +204,7 @@ object TelsDerivation extends Derivable[TelSchematic over Tels.Type]:
         contexts:
           [field] => schematic =>
             val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
-            Tels.Field(schematic.polarity, Polarity.Implicit, keyword, schematic.schema(), Unset)
+            Tels.Field(schematic.polarity, schematic.repeatable, keyword, schematic.schema(), Unset)
 
         . to(List)
 

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -32,10 +32,9 @@
                                                                                                   */
 package stratiform
 
-import scala.compiletime.summonInline
-
 import adversaria.*
 import anticipation.*
+import distillate.*
 import gossamer.*
 import prepositional.*
 import vacuous.*
@@ -43,18 +42,32 @@ import wisteria.*
 
 import Tels.Polarity
 
-// Low-priority home for the fused `Encodable & Schematic` derivation (below the
-// single-capability givens in `Tels2`/`object Tels`, so a bare `Schematic` or
-// `Encodable` summon is never upgraded to require the other capability).
-trait TelsLow:
-  inline given encodableSchematic: [value: Reflection]
-  =>  value is Encodable & Schematic in Tel over Tels.Type =
+// Constructors for fused `Encodable & Schematic` / `Decodable & Schematic`
+// instances, built from a value's separate `Encodable`/`Decodable` and `Schematic`
+// instances. Deliberately *methods*, not givens: a fused given is a subtype of
+// both its codec typeclass and `Schematic`, so two such givens would be ambiguous
+// for any bare `Schematic` summon. Call them where a fused instance is wanted
+// (e.g. `given … = telSchematics.decodable[T]`). Mirrors jacinta's `jsonSchematics`.
+object telSchematics:
+  def encodable[value](using encoder: value is Encodable in Tel)
+                      (using schema0: value is Schematic over Tels.Type)
+  :     value is Encodable & Schematic in Tel over Tels.Type =
     new Encodable with Schematic:
       type Self = value
       type Form = Tel
       type Transport = Tels.Type
-      def encoded(value: value): Tel = summonInline[value is Encodable in Tel].encoded(value)
-      def schema(): Tels.Type = TelsDerivation.derived[value].schema()
+      def encoded(value: value): Tel = encoder.encoded(value)
+      def schema(): Tels.Type = schema0.schema()
+
+  def decodable[value](using decoder: value is Decodable in Tel)
+                      (using schema0: value is Schematic over Tels.Type)
+  :     value is Decodable & Schematic in Tel over Tels.Type =
+    new Decodable with Schematic:
+      type Self = value
+      type Form = Tel
+      type Transport = Tels.Type
+      def decoded(tel: Tel): value = decoder.decoded(tel)
+      def schema(): Tels.Type = schema0.schema()
 
 // TEL refinement of the shared `anticipation.Schematic`: it adds a field-level
 // `polarity` so the product derivation can mark `Optional` fields as `Loose` (TEL
@@ -68,7 +81,7 @@ trait TelSchematic extends Schematic:
 // `Tels.Struct` of `Field`s, collections to a `Struct` with a repeatable `item`
 // field, and `Map` to repeatable `entries` of `key`/`value`. Mixed into `object
 // Tels` so the givens sit in the `Transport` companion's implicit scope.
-trait Tels2 extends TelsLow:
+trait Tels2:
   given text: Text is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
   given string: String is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
   given int: Int is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package stratiform
 
+import scala.compiletime.summonInline
+
 import adversaria.*
 import anticipation.*
 import gossamer.*
@@ -40,6 +42,19 @@ import vacuous.*
 import wisteria.*
 
 import Tels.Polarity
+
+// Low-priority home for the fused `Encodable & Schematic` derivation (below the
+// single-capability givens in `Tels2`/`object Tels`, so a bare `Schematic` or
+// `Encodable` summon is never upgraded to require the other capability).
+trait TelsLow:
+  inline given encodableSchematic: [value: Reflection]
+  =>  value is Encodable & Schematic in Tel over Tels.Type =
+    new Encodable with Schematic:
+      type Self = value
+      type Form = Tel
+      type Transport = Tels.Type
+      def encoded(value: value): Tel = summonInline[value is Encodable in Tel].encoded(value)
+      def schema(): Tels.Type = TelsDerivation.derived[value].schema()
 
 // TEL refinement of the shared `anticipation.Schematic`: it adds a field-level
 // `polarity` so the product derivation can mark `Optional` fields as `Loose` (TEL
@@ -53,7 +68,7 @@ trait TelSchematic extends Schematic:
 // `Tels.Struct` of `Field`s, collections to a `Struct` with a repeatable `item`
 // field, and `Map` to repeatable `entries` of `key`/`value`. Mixed into `object
 // Tels` so the givens sit in the `Transport` companion's implicit scope.
-trait Tels2:
+trait Tels2 extends TelsLow:
   given text: Text is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
   given string: String is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
   given int: Int is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -41,38 +41,45 @@ import wisteria.*
 
 import Tels.Polarity
 
-// Derives a TEL schema (`Tels.Type`) from a Scala type, mirroring jacinta's
-// `Schematic`/`JsonSchema` derivation. A scalar maps to `Tels.Scalar`, a product
-// to a `Tels.Struct` of `Field`s (one per case-class field, keyed by the
-// camel→kebab field name and respecting `@name[Tel]` renames), a collection to a
-// `Struct` carrying a single repeatable `item` field — matching the `item`-keyword
-// collection encoding — and `Optional` loosens the enclosing field's `required`
-// polarity. A full schema document is assembled by `Schematic.tels`.
-object Schematic:
-  given text: Text is Schematic = () => Tels.Scalar(IArray.empty)
-  given string: String is Schematic = () => Tels.Scalar(IArray.empty)
-  given int: Int is Schematic = () => Tels.Scalar(IArray.empty)
-  given long: Long is Schematic = () => Tels.Scalar(IArray.empty)
-  given double: Double is Schematic = () => Tels.Scalar(IArray.empty)
-  given boolean: Boolean is Schematic = () => Tels.Scalar(IArray.empty)
+// TEL refinement of the shared `anticipation.Schematic`: it adds a field-level
+// `polarity` so the product derivation can mark `Optional` fields as `Loose` (TEL
+// records optionality on the field, not on the schema node). The schema
+// representation (`Transport`) is a `Tels.Type`. `verify` / `tels` still require
+// only the shared `Schematic over Tels.Type`, which these givens satisfy.
+trait TelSchematic extends Schematic:
+  def polarity: Tels.Polarity = Tels.Polarity.Tight
 
-  given optional: [value: Schematic] => Optional[value] is Schematic = new Schematic:
-    type Self = Optional[value]
-    def schema(): Tels.Type = value.schema()
-    override def required: Polarity = Polarity.Loose
+// Schema derivation for TEL: scalars map to `Tels.Scalar`, products to a
+// `Tels.Struct` of `Field`s, collections to a `Struct` with a repeatable `item`
+// field, and `Map` to repeatable `entries` of `key`/`value`. Mixed into `object
+// Tels` so the givens sit in the `Transport` companion's implicit scope.
+trait Tels2:
+  given text: Text is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
+  given string: String is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
+  given int: Int is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
+  given long: Long is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
+  given double: Double is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
+  given boolean: Boolean is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
 
-  given list: [value: Schematic] => List[value] is Schematic =
-    () => collectionType(value.schema())
+  given optional: [value: Schematic over Tels.Type]
+  =>  Optional[value] is TelSchematic over Tels.Type =
+    new TelSchematic:
+      type Self = Optional[value]
+      type Transport = Tels.Type
+      def schema(): Tels.Type = value.schema()
+      override def polarity: Tels.Polarity = Polarity.Loose
 
-  given set: [value: Schematic] => Set[value] is Schematic =
-    () => collectionType(value.schema())
+  given list: [value: Schematic over Tels.Type] => List[value] is TelSchematic over Tels.Type =
+    () => Tels2.itemType(value.schema())
 
-  given series: [value: Schematic] => Series[value] is Schematic =
-    () => collectionType(value.schema())
+  given set: [value: Schematic over Tels.Type] => Set[value] is TelSchematic over Tels.Type =
+    () => Tels2.itemType(value.schema())
 
-  // A `Map` is a series of repeatable `entries`, each a struct of a `key` and a
-  // `value` field — matching the `entries`/`key`/`value` encoding.
-  given map: [key: Schematic, value: Schematic] => Map[key, value] is Schematic =
+  given series: [value: Schematic over Tels.Type] => Series[value] is TelSchematic over Tels.Type =
+    () => Tels2.itemType(value.schema())
+
+  given map: [key: Schematic over Tels.Type, value: Schematic over Tels.Type]
+  =>  Map[key, value] is TelSchematic over Tels.Type =
     () =>
       val entry =
         Tels.Struct
@@ -85,24 +92,27 @@ object Schematic:
         ( IArray(Tels.Field(Polarity.Implicit, Polarity.Loose, t"entries", entry, Unset)),
           IArray.empty )
 
-  // A collection encodes as a wrapping compound whose repeatable `item` children
-  // are the elements, so its schema is a `Struct` with a single repeatable `item`
-  // field of the element type.
-  private def collectionType(element: Tels.Type): Tels.Type =
+  inline given schematic: [value: Reflection] => value is TelSchematic over Tels.Type =
+    TelsDerivation.derived
+
+  // Assembles a self-contained `Tels` document whose root struct is the schema of
+  // `value`.
+  def tels[value: Schematic over Tels.Type](name: Text): Tels = value.schema().absolve match
+    case struct: Tels.Struct =>
+      Tels(name, struct, IArray.empty, Unset, IArray.empty, IArray.empty, IArray.empty)
+
+object Tels2:
+  // A collection encodes as a wrapping compound with repeatable `item` children,
+  // so its schema is a `Struct` with a single repeatable `item` field.
+  private[stratiform] def itemType(element: Tels.Type): Tels.Type =
     Tels.Struct
       ( IArray(Tels.Field(Polarity.Implicit, Polarity.Loose, t"item", element, Unset)),
         IArray.empty )
 
-  inline given schematic: [value: Reflection] => value is Schematic = TelsDerivation.derived
+object TelsDerivation extends Derivable[TelSchematic over Tels.Type]:
+  inline def conjunction[derivation <: Product: ProductReflection]
+  :   derivation is TelSchematic over Tels.Type =
 
-  // Assembles a full, self-contained `Tels` document whose root struct is the
-  // schema of `value`.
-  def tels[value: Schematic](name: Text): Tels = value.schema().absolve match
-    case struct: Tels.Struct =>
-      Tels(name, struct, IArray.empty, Unset, IArray.empty, IArray.empty, IArray.empty)
-
-object TelsDerivation extends Derivable[Schematic]:
-  inline def conjunction[derivation <: Product: ProductReflection]: derivation is Schematic =
     () =>
       val renames: Map[Text, Text] = relabelling[derivation, Tel]
 
@@ -110,20 +120,13 @@ object TelsDerivation extends Derivable[Schematic]:
         contexts:
           [field] => schematic =>
             val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
-            Tels.Field(schematic.required, Polarity.Implicit, keyword, schematic.schema(), Unset)
+            Tels.Field(schematic.polarity, Polarity.Implicit, keyword, schematic.schema(), Unset)
 
         . to(List)
 
       Tels.Struct(IArray.from(members), IArray.empty)
 
   // TEL sums (selects) are not yet derived structurally; a permissive empty
-  // struct is produced so a containing type can still derive a schema.
-  inline def disjunction[derivation: SumReflection]: derivation is Schematic =
+  // struct lets a containing type still derive a schema.
+  inline def disjunction[derivation: SumReflection]: derivation is TelSchematic over Tels.Type =
     () => Tels.Struct(IArray.empty, IArray.empty)
-
-trait Schematic extends Typeclass:
-  def schema(): Tels.Type
-
-  // The field-level `required` polarity contributed by this type when it appears
-  // as a case-class field; `Optional` loosens it.
-  def required: Tels.Polarity = Tels.Polarity.Tight

--- a/lib/stratiform/src/core/stratiform.Verifiable.scala
+++ b/lib/stratiform/src/core/stratiform.Verifiable.scala
@@ -45,13 +45,13 @@ extension (tel: Tel)
   // child indices against `topic` at compile time — with no `dynamicTelAccess`
   // import required.
   //
-  // `topic` must have a derivable TEL schema (`Schematic`) — mirroring jacinta's
-  // `verify`, which requires a `JsonSchema`. The runtime conformance check itself
-  // is a decode-and-discard against `topic`'s `Decodable` (a nonconformant value
-  // raises `TelError`): TEL scalars are untyped text, so a structural walk over
-  // the derived `Tels` cannot catch type mismatches (e.g. a non-numeric `Int`
-  // field) that decoding does — hence decoding remains the strict check.
-  def verify[topic](using topic is Schematic over Tels.Type)(using topic is Decodable in Tel)
+  // The runtime conformance check is a decode-and-discard against `topic`'s
+  // `Tel.Decodable` (a nonconformant value raises `TelError`): TEL scalars are
+  // untyped text, so a structural walk over the schema cannot catch type mismatches
+  // (e.g. a non-numeric `Int` field) that decoding does — hence decoding remains the
+  // strict check. The carrying `Tel.Decodable` also supplies the schema for the
+  // phantom anchor, so the schema is guaranteed coherent with the decoder used.
+  def verify[topic](using topic is Tel.Decodable)
   :     (Tel of topic from topic) raises TelError =
     tel.as[topic]
     tel.asInstanceOf[Tel of topic from topic]

--- a/lib/stratiform/src/core/stratiform.Verifiable.scala
+++ b/lib/stratiform/src/core/stratiform.Verifiable.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package stratiform
 
+import anticipation.*
 import contingency.*
 import distillate.*
 import prepositional.*
@@ -50,7 +51,7 @@ extension (tel: Tel)
   // raises `TelError`): TEL scalars are untyped text, so a structural walk over
   // the derived `Tels` cannot catch type mismatches (e.g. a non-numeric `Int`
   // field) that decoding does — hence decoding remains the strict check.
-  def verify[topic](using topic is Schematic)(using topic is Decodable in Tel)
+  def verify[topic](using topic is Schematic over Tels.Type)(using topic is Decodable in Tel)
   :     (Tel of topic from topic) raises TelError =
     tel.as[topic]
     tel.asInstanceOf[Tel of topic from topic]

--- a/lib/stratiform/src/core/stratiform.Verifiable.scala
+++ b/lib/stratiform/src/core/stratiform.Verifiable.scala
@@ -1,0 +1,54 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import contingency.*
+import distillate.*
+import prepositional.*
+
+extension (tel: Tel)
+  // Runtime-checks `tel` against `topic`, then re-types it as a schema-typed
+  // `Tel of topic from topic`. The phantom `Topic` records the current position
+  // within the schema (initially the root, `topic`) and `Origin` records the
+  // root schema, so the `Dynamic` navigation macros can resolve fields and
+  // child indices against `topic` at compile time — with no `dynamicTelAccess`
+  // import required.
+  //
+  // TEL has no schema-deriving typeclass (no analogue of jacinta's `Schematic`/
+  // `JsonSchema`), so conformance is a decode-and-discard against `topic`'s
+  // `Decodable` (a nonconformant value raises `TelError`). When a `Tels`-deriving
+  // typeclass is added this can switch to a dedicated schema walker, exactly as
+  // jacinta's `verify` did.
+  def verify[topic](using topic is Decodable in Tel): (Tel of topic from topic) raises TelError =
+    tel.as[topic]
+    tel.asInstanceOf[Tel of topic from topic]

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -138,12 +138,22 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
     suite(m"Encodable & Schematic fusion"):
       val worker = Worker(t"Alice", 30)
 
-      test(m"A fused instance encodes (and round-trips) as Tel"):
-        summon[Worker is Encodable & Schematic in Tel over Tels.Type].encoded(worker).as[Worker]
+      test(m"A fused encoder encodes (and round-trips) as Tel"):
+        telSchematics.encodable[Worker].encoded(worker).as[Worker]
       . assert(_ == worker)
 
-      test(m"A fused instance yields a schema"):
-        summon[Worker is Encodable & Schematic in Tel over Tels.Type].schema()
+      test(m"A fused encoder yields a schema"):
+        telSchematics.encodable[Worker].schema()
+      . assert:
+          case _: Tels.Struct => true
+          case _              => false
+
+      test(m"A fused decoder decodes from Tel"):
+        telSchematics.decodable[Worker].decoded(worker.encode)
+      . assert(_ == worker)
+
+      test(m"A fused decoder yields a schema"):
+        telSchematics.decodable[Worker].schema()
       . assert:
           case _: Tels.Struct => true
           case _              => false

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -1,0 +1,109 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import larceny.*
+import prepositional.*
+import probably.*
+import rudiments.*
+import vacuous.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
+import Tel.given
+
+// NB: `dynamicTelAccess.enabled` is deliberately *not* imported here — verified
+// `Tel of T` navigation must work without it.
+
+case class Worker(name: Text, age: Int) derives CanEqual
+case class Office(street: Text, city: Text) derives CanEqual
+case class Assignment(worker: Worker, office: Office) derives CanEqual
+case class TextAge(name: Text, age: Text) derives CanEqual
+
+object VerifyTests extends Suite(m"Stratiform verify tests"):
+  def run(): Unit =
+    suite(m"Runtime verification"):
+      test(m"A conformant value verifies and still decodes"):
+        Worker(t"Alice", 30).encode.verify[Worker].as[Worker]
+      . assert(_ == Worker(t"Alice", 30))
+
+      test(m"A conformant value verifies successfully"):
+        safely(Worker(t"Bob", 4).encode.verify[Worker]).present
+      . assert(_ == true)
+
+      test(m"A wrong-typed field fails to verify"):
+        safely(TextAge(t"Bob", t"old").encode.verify[Worker]).absent
+      . assert(_ == true)
+
+    suite(m"Typed navigation (no enabler import)"):
+      test(m"Access a verified field"):
+        Worker(t"Alice", 30).encode.verify[Worker].name.as[Text]
+      . assert(_ == t"Alice")
+
+      test(m"Access a verified Int field"):
+        Worker(t"Alice", 30).encode.verify[Worker].age.as[Int]
+      . assert(_ == 30)
+
+      test(m"Access a nested verified field"):
+        Assignment(Worker(t"Bob", 2), Office(t"Main", t"Town"))
+          .encode.verify[Assignment].office.city.as[Text]
+      . assert(_ == t"Town")
+
+    suite(m"Compile-time schema checks"):
+      test(m"An unknown field is rejected"):
+        demilitarize:
+          Worker(t"Alice", 30).encode.verify[Worker].nope
+        . head.message
+      . assert(_.contains("has no field"))
+
+      test(m"Indexing a non-collection field is rejected"):
+        demilitarize:
+          Worker(t"Alice", 30).encode.verify[Worker].name(0)
+        . head.message
+      . assert(_.contains("not an indexable collection"))
+
+      test(m"Field access on a scalar position is rejected"):
+        demilitarize:
+          Worker(t"Alice", 30).encode.verify[Worker].name.deeper
+        . head.message
+      . assert(_.contains("has no field"))
+
+      test(m"Plain (unverified) field access requires the enabler"):
+        demilitarize:
+          Worker(t"Alice", 30).encode.name
+        . head.message
+      . assert(_.contains("dynamicTelAccess.enabled"))

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -52,6 +52,7 @@ import Tel.given
 case class Worker(name: Text, age: Int) derives CanEqual
 case class Office(street: Text, city: Text) derives CanEqual
 case class Assignment(worker: Worker, office: Office) derives CanEqual
+case class Crew(lead: Text, members: List[Worker]) derives CanEqual
 case class TextAge(name: Text, age: Text) derives CanEqual
 
 object VerifyTests extends Suite(m"Stratiform verify tests"):
@@ -82,6 +83,16 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
         Assignment(Worker(t"Bob", 2), Office(t"Main", t"Town"))
           .encode.verify[Assignment].office.city.as[Text]
       . assert(_ == t"Town")
+
+      test(m"Index into a verified collection field"):
+        Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2)))
+          .encode.verify[Crew].members(1).name.as[Text]
+      . assert(_ == t"B")
+
+    suite(m"Collection round-trip"):
+      test(m"A list field round-trips through TEL"):
+        Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2))).encode.as[Crew]
+      . assert(_ == Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2))))
 
     suite(m"Compile-time schema checks"):
       test(m"An unknown field is rejected"):

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -105,28 +105,28 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
 
     suite(m"Schema derivation"):
       test(m"A product derives a Struct with kebab-cased field keywords"):
-        keywords(Schematic.tels[Worker](t"worker").document)
+        keywords(Tels.tels[Worker](t"worker").document)
       . assert(_ == List(t"name", t"age"))
 
       test(m"A required field has Tight polarity"):
-        Schematic.tels[Worker](t"worker").document.members.to(List).collect:
+        Tels.tels[Worker](t"worker").document.members.to(List).collect:
           case field: Tels.Field if field.keyword == t"name" => field.required
       . assert(_ == List(Tels.Polarity.Tight))
 
       test(m"An Optional field loosens to Loose polarity"):
-        Schematic.tels[Nicked](t"nicked").document.members.to(List).collect:
+        Tels.tels[Nicked](t"nicked").document.members.to(List).collect:
           case field: Tels.Field if field.keyword == t"nick" => field.required
       . assert(_ == List(Tels.Polarity.Loose))
 
       test(m"A collection field's type is a Struct with a repeatable `item`"):
-        Schematic.tels[Crew](t"crew").document.members.to(List).collect:
+        Tels.tels[Crew](t"crew").document.members.to(List).collect:
           case field: Tels.Field if field.keyword == t"members" => field.fieldType
         . collect:
             case struct: Tels.Struct => keywords(struct)
       . assert(_ == List(List(t"item")))
 
       test(m"A map field's type is a Struct of repeatable `entries` of key/value"):
-        Schematic.tels[Config](t"config").document.members.to(List).collect:
+        Tels.tels[Config](t"config").document.members.to(List).collect:
           case field: Tels.Field if field.keyword == t"prefs" => field.fieldType
         . collect:
             case struct: Tels.Struct => struct.members.to(List).collect:

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -54,6 +54,10 @@ case class Office(street: Text, city: Text) derives CanEqual
 case class Assignment(worker: Worker, office: Office) derives CanEqual
 case class Crew(lead: Text, members: List[Worker]) derives CanEqual
 case class TextAge(name: Text, age: Text) derives CanEqual
+case class Nicked(name: Text, nick: Optional[Text]) derives CanEqual
+
+def keywords(struct: Tels.Struct): List[Text] = struct.members.to(List).collect:
+  case field: Tels.Field => field.keyword
 
 object VerifyTests extends Suite(m"Stratiform verify tests"):
   def run(): Unit =
@@ -93,6 +97,28 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
       test(m"A list field round-trips through TEL"):
         Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2))).encode.as[Crew]
       . assert(_ == Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2))))
+
+    suite(m"Schema derivation"):
+      test(m"A product derives a Struct with kebab-cased field keywords"):
+        keywords(Schematic.tels[Worker](t"worker").document)
+      . assert(_ == List(t"name", t"age"))
+
+      test(m"A required field has Tight polarity"):
+        Schematic.tels[Worker](t"worker").document.members.to(List).collect:
+          case field: Tels.Field if field.keyword == t"name" => field.required
+      . assert(_ == List(Tels.Polarity.Tight))
+
+      test(m"An Optional field loosens to Loose polarity"):
+        Schematic.tels[Nicked](t"nicked").document.members.to(List).collect:
+          case field: Tels.Field if field.keyword == t"nick" => field.required
+      . assert(_ == List(Tels.Polarity.Loose))
+
+      test(m"A collection field's type is a Struct with a repeatable `item`"):
+        Schematic.tels[Crew](t"crew").document.members.to(List).collect:
+          case field: Tels.Field if field.keyword == t"members" => field.fieldType
+        . collect:
+            case struct: Tels.Struct => keywords(struct)
+      . assert(_ == List(List(t"item")))
 
     suite(m"Compile-time schema checks"):
       test(m"An unknown field is rejected"):

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -55,6 +55,7 @@ case class Assignment(worker: Worker, office: Office) derives CanEqual
 case class Crew(lead: Text, members: List[Worker]) derives CanEqual
 case class TextAge(name: Text, age: Text) derives CanEqual
 case class Nicked(name: Text, nick: Optional[Text]) derives CanEqual
+case class Config(name: Text, prefs: Map[Text, Int]) derives CanEqual
 
 def keywords(struct: Tels.Struct): List[Text] = struct.members.to(List).collect:
   case field: Tels.Field => field.keyword
@@ -98,6 +99,10 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
         Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2))).encode.as[Crew]
       . assert(_ == Crew(t"Z", List(Worker(t"A", 1), Worker(t"B", 2))))
 
+      test(m"A map field round-trips through TEL"):
+        Config(t"c", Map(t"a" -> 1, t"b" -> 2)).encode.as[Config]
+      . assert(_ == Config(t"c", Map(t"a" -> 1, t"b" -> 2)))
+
     suite(m"Schema derivation"):
       test(m"A product derives a Struct with kebab-cased field keywords"):
         keywords(Schematic.tels[Worker](t"worker").document)
@@ -119,6 +124,16 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
         . collect:
             case struct: Tels.Struct => keywords(struct)
       . assert(_ == List(List(t"item")))
+
+      test(m"A map field's type is a Struct of repeatable `entries` of key/value"):
+        Schematic.tels[Config](t"config").document.members.to(List).collect:
+          case field: Tels.Field if field.keyword == t"prefs" => field.fieldType
+        . collect:
+            case struct: Tels.Struct => struct.members.to(List).collect:
+              case field: Tels.Field if field.keyword == t"entries" => field.fieldType
+        . flatten.collect:
+            case struct: Tels.Struct => keywords(struct)
+      . assert(_ == List(List(t"key", t"value")))
 
     suite(m"Compile-time schema checks"):
       test(m"An unknown field is rejected"):

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -135,6 +135,19 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
             case struct: Tels.Struct => keywords(struct)
       . assert(_ == List(List(t"key", t"value")))
 
+    suite(m"Encodable & Schematic fusion"):
+      val worker = Worker(t"Alice", 30)
+
+      test(m"A fused instance encodes (and round-trips) as Tel"):
+        summon[Worker is Encodable & Schematic in Tel over Tels.Type].encoded(worker).as[Worker]
+      . assert(_ == worker)
+
+      test(m"A fused instance yields a schema"):
+        summon[Worker is Encodable & Schematic in Tel over Tels.Type].schema()
+      . assert:
+          case _: Tels.Struct => true
+          case _              => false
+
     suite(m"Compile-time schema checks"):
       test(m"An unknown field is rejected"):
         demilitarize:

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -57,6 +57,15 @@ case class TextAge(name: Text, age: Text) derives CanEqual
 case class Nicked(name: Text, nick: Optional[Text]) derives CanEqual
 case class Config(name: Text, prefs: Map[Text, Int]) derives CanEqual
 
+// A type whose TEL codec routes through its `… in Text` codec (a scalar atom),
+// although structurally it would derive a `Struct`. Used to check the fused TEL
+// schema is coherent with the codec (a `Scalar`), not the derived structure.
+enum Tint derives CanEqual:
+  case Pale, Deep
+
+object Tint:
+  given encodable: Tint is Encodable in Text = _.toString.tt.lower
+
 def keywords(struct: Tels.Struct): List[Text] = struct.members.to(List).collect:
   case field: Tels.Field => field.keyword
 
@@ -135,6 +144,13 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
         . flatten.collect:
             case struct: Tels.Struct => keywords(struct)
       . assert(_ == List(List(t"key", t"value")))
+
+    suite(m"Schema coherence (the carried shape tracks the codec)"):
+      test(m"A Text-branch encoder's fused TEL schema is a Scalar, matching the codec"):
+        telSchematics.encodable[Tint].schema()
+      . assert:
+          case _: Tels.Scalar => true
+          case _              => false
 
     suite(m"Encodable & Schematic fusion"):
       val worker = Worker(t"Alice", 30)

--- a/lib/stratiform/src/test/stratiform.VerifyTests.scala
+++ b/lib/stratiform/src/test/stratiform.VerifyTests.scala
@@ -118,12 +118,13 @@ object VerifyTests extends Suite(m"Stratiform verify tests"):
           case field: Tels.Field if field.keyword == t"nick" => field.required
       . assert(_ == List(Tels.Polarity.Loose))
 
-      test(m"A collection field's type is a Struct with a repeatable `item`"):
+      test(m"A collection field is repeatable, typed as the element struct"):
         Tels.tels[Crew](t"crew").document.members.to(List).collect:
-          case field: Tels.Field if field.keyword == t"members" => field.fieldType
+          case field: Tels.Field if field.keyword == t"members" =>
+            field.repeatable -> field.fieldType
         . collect:
-            case struct: Tels.Struct => keywords(struct)
-      . assert(_ == List(List(t"item")))
+            case (repeatable, struct: Tels.Struct) => repeatable -> keywords(struct)
+      . assert(_ == List(Tels.Polarity.Loose -> List(t"name", t"age")))
 
       test(m"A map field's type is a Struct of repeatable `entries` of key/value"):
         Tels.tels[Config](t"config").document.members.to(List).collect:

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1751,3 +1751,4 @@ object Tests extends Suite(m"Stratiform Tests"):
       . assert(_ == BintelError.Reason.EmbeddedSchemaUndecodable)
 
     RecordsTests()
+    VerifyTests()

--- a/lib/stratiform/src/time/stratiform_time.scala
+++ b/lib/stratiform/src/time/stratiform_time.scala
@@ -45,20 +45,22 @@ import prepositional.*
 // clash with project-wide default encodings.
 
 package telEncodables:
-  given encodeInstantsAsUnixEpochMilliseconds: Instant is Encodable in Tel =
-    instant => Tel.scalar(instant.long.toString.tt)
+  given encodeInstantsAsUnixEpochMilliseconds: Instant is Tel.Encodable =
+    Tel.Encodable(Shape.Whole)(instant => Tel.scalar(instant.long.toString.tt))
 
-  given encodeDurationsAsMilliseconds: Duration is Encodable in Tel =
-    duration => Tel.scalar((duration.value*1000).toLong.toString.tt)
+  given encodeDurationsAsMilliseconds: Duration is Tel.Encodable =
+    Tel.Encodable(Shape.Whole)(duration => Tel.scalar((duration.value*1000).toLong.toString.tt))
 
 package telDecodables:
   given decodeInstantsAsUnixEpochMilliseconds: Tactic[TelError]
-  =>  Instant is Decodable in Tel = tel =>
-    import abstractables.instantIsAbstractable
-    try Instant(tel.primaryAtom.s.toLong)
-    catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+  =>  Instant is Tel.Decodable =
+    Tel.Decodable(Shape.Whole): tel =>
+      import abstractables.instantIsAbstractable
+      try Instant(tel.primaryAtom.s.toLong)
+      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
 
   given decodeDurationsAsMilliseconds: Tactic[TelError]
-  =>  Duration is Decodable in Tel = tel =>
-    try Duration(tel.primaryAtom.s.toLong)
-    catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+  =>  Duration is Tel.Decodable =
+    Tel.Decodable(Shape.Whole): tel =>
+      try Duration(tel.primaryAtom.s.toLong)
+      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -140,12 +140,13 @@ object Mcp:
   case class Error(code: Int, message: Text, data: Optional[Json] = Unset)
 
   object TextInt:
-    given encodable: TextInt is Encodable in Json = _.id.absolve match
-      case text: Text => text.json
-      case int: Int   => int.json
+    given encodable: TextInt is Json.Encodable = Json.Encodable(Shape.Any):
+      _.id.absolve match
+        case text: Text => text.json
+        case int: Int   => int.json
 
-    given decodable: Tactic[JsonError] => TextInt is Decodable in Json =
-      json => TextInt(safely(json.as[Int]).or(json.as[Text]))
+    given decodable: Tactic[JsonError] => TextInt is Json.Decodable =
+      Json.Decodable(Shape.Any)(json => TextInt(safely(json.as[Int]).or(json.as[Text])))
 
   case class TextInt(id: Text | Int)
 
@@ -233,12 +234,14 @@ object Mcp:
       tasks:        Optional[Tasks]           = Unset )
 
   object Contents:
-    given encodable: Contents is Encodable in Json = _.contents match
-      case text: TextResourceContents => text.json
-      case blob: BlobResourceContents => blob.json
+    given encodable: Contents is Json.Encodable = Json.Encodable(Shape.Any):
+      _.contents match
+        case text: TextResourceContents => text.json
+        case blob: BlobResourceContents => blob.json
 
-    given decodable: Tactic[JsonError] => Contents is Decodable in Json = json =>
-      Contents(safely(json.as[TextResourceContents]).or(json.as[BlobResourceContents]))
+    given decodable: Tactic[JsonError] => Contents is Json.Decodable =
+      Json.Decodable(Shape.Any): json =>
+        Contents(safely(json.as[TextResourceContents]).or(json.as[BlobResourceContents]))
 
   case class Contents(contents: TextResourceContents | BlobResourceContents)
   case class Context(arguments: Optional[Map[Text, Text]] = Unset)
@@ -292,46 +295,53 @@ object Mcp:
     ( values: List[Text] = Nil, total: Optional[Int] = Unset, hasMore: Optional[Boolean] = Unset )
 
   object Role:
-    given encodable: Role is Encodable in Json =
+    given encodable: Role is Json.Encodable = Json.Encodable(Shape.Str):
       case Role.User      => t"user".json
       case Role.Assistant => t"assistant".json
 
-    given decodable: Tactic[JsonError] => Role is Decodable in Json = _.as[Text] match
-      case t"user"      => Role.User
-      case t"assistant" => Role.Assistant
-      case _            => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => Role is Json.Decodable =
+      Json.Decodable(Shape.Str): json =>
+        json.as[Text] match
+          case t"user"      => Role.User
+          case t"assistant" => Role.Assistant
+          case _            => abort(JsonError(JsonError.Reason.OutOfRange))
 
   enum Role:
     case User, Assistant
 
   object TaskSupport:
-    given encodable: TaskSupport is Encodable in Json =
+    given encodable: TaskSupport is Json.Encodable = Json.Encodable(Shape.Str):
       case TaskSupport.Forbidden => t"forbidden".json
       case TaskSupport.Optional  => t"optional".json
       case TaskSupport.Required  => t"required".json
 
-    given decodable: Tactic[JsonError] => TaskSupport is Decodable in Json = _.as[Text] match
-      case t"forbidden" => TaskSupport.Forbidden
-      case t"optional"  => TaskSupport.Optional
-      case t"required"  => TaskSupport.Required
-      case _            => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => TaskSupport is Json.Decodable =
+      Json.Decodable(Shape.Str): json =>
+        json.as[Text] match
+          case t"forbidden" => TaskSupport.Forbidden
+          case t"optional"  => TaskSupport.Optional
+          case t"required"  => TaskSupport.Required
+          case _            => abort(JsonError(JsonError.Reason.OutOfRange))
 
   enum TaskSupport:
     case Forbidden, Optional, Required
 
   object LoggingLevel:
-    given encodable: LoggingLevel is Encodable in Json = _.toString.tt.lower.json
+    given encodable: LoggingLevel is Json.Encodable =
+      Json.Encodable(Shape.Str)(_.toString.tt.lower.json)
 
-    given decodable: Tactic[JsonError] => LoggingLevel is Decodable in Json = _.as[Text] match
-      case t"debug"     => LoggingLevel.Debug
-      case t"info"      => LoggingLevel.Info
-      case t"notice"    => LoggingLevel.Notice
-      case t"warning"   => LoggingLevel.Warning
-      case t"error"     => LoggingLevel.Error
-      case t"critical"  => LoggingLevel.Critical
-      case t"alert"     => LoggingLevel.Alert
-      case t"emergency" => LoggingLevel.Emergency
-      case _            => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => LoggingLevel is Json.Decodable =
+      Json.Decodable(Shape.Str): json =>
+        json.as[Text] match
+          case t"debug"     => LoggingLevel.Debug
+          case t"info"      => LoggingLevel.Info
+          case t"notice"    => LoggingLevel.Notice
+          case t"warning"   => LoggingLevel.Warning
+          case t"error"     => LoggingLevel.Error
+          case t"critical"  => LoggingLevel.Critical
+          case t"alert"     => LoggingLevel.Alert
+          case t"emergency" => LoggingLevel.Emergency
+          case _            => abort(JsonError(JsonError.Reason.OutOfRange))
 
   enum LoggingLevel:
     case Debug, Info, Notice, Warning, Error, Critical, Alert, Emergency
@@ -339,20 +349,22 @@ object Mcp:
   case class LoggingMessage(level: LoggingLevel, logger: Optional[Text] = Unset, data: Json)
 
   object TaskStatus:
-    given encodable: TaskStatus is Encodable in Json =
+    given encodable: TaskStatus is Json.Encodable = Json.Encodable(Shape.Str):
       case TaskStatus.Working       => t"working".json
       case TaskStatus.InputRequired => t"input_required".json
       case TaskStatus.Completed     => t"completed".json
       case TaskStatus.Failed        => t"failed".json
       case TaskStatus.Cancelled     => t"cancelled".json
 
-    given decodable: Tactic[JsonError] => TaskStatus is Decodable in Json = _.as[Text] match
-      case t"working"        => TaskStatus.Working
-      case t"input_required" => TaskStatus.InputRequired
-      case t"completed"      => TaskStatus.Completed
-      case t"failed"         => TaskStatus.Failed
-      case t"cancelled"      => TaskStatus.Cancelled
-      case _                 => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => TaskStatus is Json.Decodable =
+      Json.Decodable(Shape.Str): json =>
+        json.as[Text] match
+          case t"working"        => TaskStatus.Working
+          case t"input_required" => TaskStatus.InputRequired
+          case t"completed"      => TaskStatus.Completed
+          case t"failed"         => TaskStatus.Failed
+          case t"cancelled"      => TaskStatus.Cancelled
+          case _                 => abort(JsonError(JsonError.Reason.OutOfRange))
 
   enum TaskStatus:
     case Working, InputRequired, Completed, Failed, Cancelled
@@ -378,15 +390,16 @@ object Mcp:
 
     private val typeTag = Json.discriminatedUnion[Reference](t"type")
 
-    given encodable: Reference is Encodable in Json =
+    given encodable: Reference is Json.Encodable = Json.Encodable(Shape.Any):
       case ref: PromptReference           => typeTag.rewrite(t"ref/prompt", ref.json)
       case ref: ResourceTemplateReference => typeTag.rewrite(t"ref/resource", ref.json)
 
-    given decodable: Tactic[JsonError] => Reference is Decodable in Json = json =>
-      json.`type`.as[Text] match
-        case "ref/prompt"   => json.as[PromptReference]
-        case "ref/resource" => json.as[ResourceTemplateReference]
-        case _              => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => Reference is Json.Decodable =
+      Json.Decodable(Shape.Any): json =>
+        json.`type`.as[Text] match
+          case "ref/prompt"   => json.as[PromptReference]
+          case "ref/resource" => json.as[ResourceTemplateReference]
+          case _              => abort(JsonError(JsonError.Reason.OutOfRange))
 
   sealed trait Reference
 
@@ -427,16 +440,18 @@ object Mcp:
   case class ToolChoice(mode: Optional[Mode] = Unset)
 
   object Mode:
-    given encodable: Mode is Encodable in Json =
+    given encodable: Mode is Json.Encodable = Json.Encodable(Shape.Str):
       case Mode.Auto     => t"auto".json
       case Mode.Required => t"required".json
       case Mode.None     => t"none".json
 
-    given decodable: Tactic[JsonError] => Mode is Decodable in Json = _.as[Text] match
-      case t"auto"     => Mode.Auto
-      case t"required" => Mode.Required
-      case t"none"     => Mode.None
-      case _           => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => Mode is Json.Decodable =
+      Json.Decodable(Shape.Str): json =>
+        json.as[Text] match
+          case t"auto"     => Mode.Auto
+          case t"required" => Mode.Required
+          case t"none"     => Mode.None
+          case _           => abort(JsonError(JsonError.Reason.OutOfRange))
 
   enum Mode:
     case Auto, Required, None
@@ -449,21 +464,22 @@ object Mcp:
 
     private val typeTag = Json.discriminatedUnion[SamplingMessageContentBlock](t"type")
 
-    given encodable: SamplingMessageContentBlock is Encodable in Json =
+    given encodable: SamplingMessageContentBlock is Json.Encodable = Json.Encodable(Shape.Any):
       case content: TextContent       => typeTag.rewrite(t"text",        content.json)
       case content: ImageContent      => typeTag.rewrite(t"image",       content.json)
       case content: AudioContent      => typeTag.rewrite(t"audio",       content.json)
       case content: ToolUseContent    => typeTag.rewrite(t"tool_use",    content.json)
       case content: ToolResultContent => typeTag.rewrite(t"tool_result", content.json)
 
-    given decodable: Tactic[JsonError] => SamplingMessageContentBlock is Decodable in Json = json =>
-      json.`type`.as[Text] match
-        case "text"        => json.as[TextContent]
-        case "image"       => json.as[ImageContent]
-        case "audio"       => json.as[AudioContent]
-        case "tool_use"    => json.as[ToolUseContent]
-        case "tool_result" => json.as[ToolResultContent]
-        case _             => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => SamplingMessageContentBlock is Json.Decodable =
+      Json.Decodable(Shape.Any): json =>
+        json.`type`.as[Text] match
+          case "text"        => json.as[TextContent]
+          case "image"       => json.as[ImageContent]
+          case "audio"       => json.as[AudioContent]
+          case "tool_use"    => json.as[ToolUseContent]
+          case "tool_result" => json.as[ToolResultContent]
+          case _             => abort(JsonError(JsonError.Reason.OutOfRange))
 
   sealed trait SamplingMessageContentBlock
 
@@ -480,21 +496,22 @@ object Mcp:
 
     private val typeTag = Json.discriminatedUnion[ContentBlock](t"type")
 
-    given encodable: ContentBlock is Encodable in Json =
+    given encodable: ContentBlock is Json.Encodable = Json.Encodable(Shape.Any):
       case content: TextContent      => typeTag.rewrite(t"text",          content.json)
       case content: ImageContent     => typeTag.rewrite(t"image",         content.json)
       case content: AudioContent     => typeTag.rewrite(t"audio",         content.json)
       case content: ResourceLink     => typeTag.rewrite(t"resource_link", content.json)
       case content: EmbeddedResource => typeTag.rewrite(t"resource",      content.json)
 
-    given decodable: Tactic[JsonError] => ContentBlock is Decodable in Json = json =>
-      json.`type`.as[Text] match
-        case "text"          => json.as[TextContent]
-        case "image"         => json.as[ImageContent]
-        case "audio"         => json.as[AudioContent]
-        case "resource_link" => json.as[ResourceLink]
-        case "resource"      => json.as[EmbeddedResource]
-        case _               => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => ContentBlock is Json.Decodable =
+      Json.Decodable(Shape.Any): json =>
+        json.`type`.as[Text] match
+          case "text"          => json.as[TextContent]
+          case "image"         => json.as[ImageContent]
+          case "audio"         => json.as[AudioContent]
+          case "resource_link" => json.as[ResourceLink]
+          case "resource"      => json.as[EmbeddedResource]
+          case _               => abort(JsonError(JsonError.Reason.OutOfRange))
 
   sealed trait ContentBlock
 
@@ -553,16 +570,18 @@ object Mcp:
   case class CreateTaskResult(task: Task)
 
   object ElicitAction:
-    given encodable: ElicitAction is Encodable in Json =
+    given encodable: ElicitAction is Json.Encodable = Json.Encodable(Shape.Str):
       case ElicitAction.Accept  => t"accept".json
       case ElicitAction.Decline => t"decline".json
       case ElicitAction.Cancel  => t"cancel".json
 
-    given decodable: Tactic[JsonError] => ElicitAction is Decodable in Json = _.as[Text] match
-      case t"accept"  => ElicitAction.Accept
-      case t"decline" => ElicitAction.Decline
-      case t"cancel"  => ElicitAction.Cancel
-      case _          => abort(JsonError(JsonError.Reason.OutOfRange))
+    given decodable: Tactic[JsonError] => ElicitAction is Json.Decodable =
+      Json.Decodable(Shape.Str): json =>
+        json.as[Text] match
+          case t"accept"  => ElicitAction.Accept
+          case t"decline" => ElicitAction.Decline
+          case t"cancel"  => ElicitAction.Cancel
+          case _          => abort(JsonError(JsonError.Reason.OutOfRange))
 
   enum ElicitAction:
     case Accept, Decline, Cancel

--- a/lib/synesthesia/src/core/synesthesia.McpClient.scala
+++ b/lib/synesthesia/src/core/synesthesia.McpClient.scala
@@ -81,7 +81,7 @@ trait McpClient extends Findable:
   def log(message: Text): Unit =
     `notifications/message`(LoggingLevel.Info, "updates", Map("message" -> message).json)
 
-  def elicit[result: Schematic in JsonSchema](message: Text): Json =
+  def elicit[result: Schematic over JsonSchema](message: Text): Json =
     `elicitation/create`(t"form", message, result.schema().json)
 
   def sample(message: Text): Unit = ???

--- a/lib/synesthesia/src/core/synesthesia.internal.scala
+++ b/lib/synesthesia/src/core/synesthesia.internal.scala
@@ -362,7 +362,7 @@ object internal:
 
       val params = method.paramSymss.head.map: param =>
         param.info.asType.absolve match
-          case '[param] => Expr.summon[param is Schematic in JsonSchema] match
+          case '[param] => Expr.summon[param is Schematic over JsonSchema] match
             case Some(schematic) =>
               '{(${Expr(param.name)}.tt, $schematic.schema())}
 
@@ -376,7 +376,7 @@ object internal:
         case MethodType(_, _, result)                   => result
 
       result.asType.absolve match
-        case '[result] => Expr.summon[result is Schematic in JsonSchema] match
+        case '[result] => Expr.summon[result is Schematic over JsonSchema] match
           case Some(schematic) =>
             ' {
                 val inputSchema =
@@ -407,7 +407,7 @@ object internal:
 
           case None => halt:
             m"""
-              there was no contextual ${TypeRepr.of[result is Schematic in JsonSchema].show}
+              there was no contextual ${TypeRepr.of[result is Schematic over JsonSchema].show}
               instance for the return type of ${method.name}
             """
 

--- a/lib/synesthesia/src/core/synesthesia.internal.scala
+++ b/lib/synesthesia/src/core/synesthesia.internal.scala
@@ -124,10 +124,10 @@ object internal:
 
                       val params = method.paramSymss.head.map: param =>
                         param.info.asType.absolve match
-                          case '[param] => Expr.summon[param is Decodable in Json] match
+                          case '[param] => Expr.summon[param is Json.Decodable] match
                             case Some(decodable) =>
                               ' {
-                                  given param is Decodable in Json = $decodable
+                                  given param is Json.Decodable = $decodable
                                   request(${Expr(param.name)}).as[param]
                                 }
 


### PR DESCRIPTION
Adds runtime `verify` for JSON and TEL — re-typing a value to a phantom that carries its schema position so fields and array/collection indices can be navigated with compile-time checking and no `dynamic…Access` import — unifies schema generation onto a shared `anticipation.Schematic`, and lets a codec be fused with its schema as `Encodable & Schematic` / `Decodable & Schematic`. The schema is carried by the codec (built in the same derivation, via a format-neutral `anticipation.Shape` that each format reifies into its own representation), so a fused instance is coherent by construction: a gated or `… in Text`-branch codec always pairs with the schema for exactly what it reads/writes.

## Schema-typed navigation

`verify` checks a value against a type's schema and re-types it so subsequent field/index access is resolved (and checked) at compile time — no enabler import:

```scala
val person = json.verify[Employee]   // : (Json of Employee from Employee) raises JsonError
person.name.as[Text]                 // ok
person.members(1).age.as[Int]        // ok — indexing a collection field
person.nope                          // compile error: no such field
person.name(0)                       // compile error: not an indexable collection
```

The same works for TEL: `tel.verify[Worker].office.city.as[Text]`.

## Coherent `Encodable & Schematic` fusion

```scala
given (Employee is Decodable & Schematic in Json over JsonSchema) =
  jsonSchematics.decodable[Employee]
```

`jsonSchematics.encodable/decodable` (and `telSchematics.*`) take the schema from the codec itself, so it can no longer drift from what the codec actually reads/writes — including the previously-silent case of a `… in Text` codec (which encodes a string) being paired with a derived object schema.

## Shared `Schematic` and `Shape`

`Schematic` now lives in `anticipation` and is shared by JSON (`over JsonSchema`) and TEL (`over Tels.Type`). A new `anticipation.Shape` is the format-neutral schema description carried by codecs and reified per format. Collections reach parity across formats; TEL collections are encoded as repeated fields (consistent with the representation introduced in #1291), with decoding gathering the repeated siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
