### PR TITLE
Add fullscreen and inline rendering modes to ultimatum

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1391,7 +1391,7 @@ object typonym extends Library:
   object test extends Tests(core)
 
 object ultimatum extends Library:
-  object core extends Component(profanity.core):
+  object core extends Component(profanity.core, escapade.csi):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/ultimatum/src/core/soundness_ultimatum_core.scala
+++ b/lib/ultimatum/src/core/soundness_ultimatum_core.scala
@@ -32,5 +32,6 @@
                                                                                                   */
 package soundness
 
-export ultimatum.{Rect, Extent, FlowExtent, Axis, Sizing, Limits, Frame, Placement, Pane, panel,
-    file, rank, layout, paint, Focus, EditorField, MenuField, Form, dirtyCells, editor, menu, form}
+export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, Axis, Sizing, Limits, Frame, Placement,
+    Pane, Mode, panel, file, rank, layout, paint, Focus, EditorField, MenuField, Form, dirtyCells,
+    editor, menu, form}

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -39,9 +39,11 @@ import rudiments.*
 // terminal events — TAB cycles focus between widgets, Escape/Ctrl-C exits, and
 // every other event is folded into the focused widget. After each edit (or a
 // terminal resize) the layout is re-solved using each widget's live intrinsic
-// size, and only the panels whose rectangle or content actually changed are
-// repainted.
-class Form(root: Canvas, fullScreen: Boolean, pane: Pane):
+// size and the root is presented. In `Fullscreen` mode only the panels whose
+// rectangle or content changed are repainted (the root composites straight to the
+// screen); in `Inline` mode the grid is re-sized to the measured block height each
+// frame and the whole block is re-presented at the cursor.
+class Form(root: Canvas, mode: Mode, pane: Pane):
   private val leaves: IndexedSeq[Pane] = pane.leaves.to(IndexedSeq)
   private val focuses: IndexedSeq[Focus] = leaves.collect { case Pane.Widget(_, focus) => focus }
 
@@ -78,9 +80,19 @@ class Form(root: Canvas, fullScreen: Boolean, pane: Pane):
 
     project(pane)
 
+  // Re-solve the layout; in inline mode also reframe the root grid to the measured
+  // block height (clamped to the terminal). Returns the new panel rectangles.
   private def solve(): IndexedSeq[Rect] =
     val frame = liveFrame
-    val height = if fullScreen then root.height else frame.measure(Axis.Rank).min
+
+    val height = mode match
+      case Mode.Fullscreen => root.height
+      case Mode.Inline     => frame.measure(Axis.Rank).min
+
+    root match
+      case inline: InlineRoot => inline.reframe(root.width, height)
+      case _                  => ()
+
     frame.arrange(Rect(0, 0, root.width, height)).cells.to(IndexedSeq)
 
   private def paint(index: Int): Unit =
@@ -97,45 +109,59 @@ class Form(root: Canvas, fullScreen: Boolean, pane: Pane):
       case _ =>
         ()
 
-  // Paint every panel, then repaint the focused widget last so the hardware
-  // caret is left in it.
-  private def paintAll(): Unit =
-    rects.indices.each(paint(_))
+  // Re-solve and repaint, then present the root. Inline always repaints every
+  // panel (its grid was just reframed and blanked); fullscreen repaints only the
+  // cells whose rectangle or content changed. The focused widget is painted last
+  // so the caret rests in it.
+  private def refresh(changed: Set[Int]): Unit =
+    val updated = solve()
+
+    mode match
+      case Mode.Inline =>
+        rects = updated
+        rects.indices.each(paint(_))
+
+      case Mode.Fullscreen =>
+        val dirty = dirtyCells(rects, updated, changed)
+        rects = updated
+        dirty.each(paint(_))
+
     if focuses.nonEmpty then paint(focusLeaf(focus))
+    root.flush()
 
   def run(events: Iterator[TerminalEvent]): Unit =
-    rects = solve()
-    paintAll()
+    refresh(Set())
     var running = true
 
     while running && events.hasNext do events.next() match
       case Keypress.Tab =>
         if focuses.nonEmpty then
           focus = (focus + 1)%focuses.length
-          paintAll()
+          refresh(Set())
 
       case Keypress.Escape | Keypress.Ctrl('C' | 'D') =>
         running = false
 
-      // The terminal reports its new size after a resize (the `Winch` signal,
-      // handled below, is what prompts the report). Clear the screen and re-tile
-      // against the now-current dimensions, repainting every panel.
+      // The terminal reports its new size after a resize. Fullscreen clears the
+      // whole screen and forces a full re-tile; inline must NOT clear the screen
+      // (that would wipe scrollback) — its reframe + present reconcile the change.
       case _: TerminalInfo.WindowSize =>
-        root.clear()
-        rects = solve()
-        paintAll()
+        mode match
+          case Mode.Fullscreen => root.clear()
+          case Mode.Inline     => ()
 
-      // A bare resize signal arrives before the new size is known, so there is
-      // nothing useful to do yet; the `WindowSize` event that follows re-tiles.
-      // Swallow all signals here — they are never widget input.
+        rects = IndexedSeq()
+        refresh(Set())
+
+      // Signals are never widget input; the WindowSize event above does the work.
       case _: Signal =>
         ()
 
       case event =>
         if focuses.nonEmpty then
           focuses(focus).handle(event)
-          val updated = solve()
-          val dirty = dirtyCells(rects, updated, Set(focusLeaf(focus)))
-          rects = updated
-          dirty.each(paint(_))
-          paint(focusLeaf(focus))
+          refresh(Set(focusLeaf(focus)))
+
+    root match
+      case inline: InlineRoot => inline.finish()
+      case _                  => ()

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -34,44 +34,95 @@ package ultimatum
 
 import anticipation.*
 import denominative.*
+import escapade.*
 import profanity.*
-import turbulence.*
 
-// A `Canvas` confined to a `Rect` of a parent surface, backed by the shared
-// character grid (`GridSurface`). Writes flow and wrap within the rectangle;
-// `flush` paints the grid onto the parent surface, one row at a time, via the
-// parent's `move`/`put` (so positioning is always expressed through the `Canvas`
-// interface, never as inline escapes). It is also an `Stdio`, so bare
-// `Out.println` in a panel body flows into it.
-class FlowExtent(parent: Canvas, val rect: Rect)
-extends GridSurface(rect.width, rect.height), Extent:
-  def cursor(visible: Boolean): Unit = parent.cursor(visible)
+// The shared character-grid mechanics behind `FlowExtent` (a clipped sub-rectangle
+// that composites onto a parent) and `InlineRoot` (the inline-mode root that
+// presents its grid at the cursor). Writes flow within the grid: text wraps at
+// the grid width and, once the last row fills, the grid scrolls up — like a
+// miniature terminal. Subclasses supply `cursor`, `showCaret` and `flush`.
+private[ultimatum] abstract class GridSurface(initialWidth: Int, initialHeight: Int)
+extends Canvas:
+  protected var gridWidth: Int = initialWidth
+  protected var gridHeight: Int = initialHeight
+  protected var cells: Array[Char] = Array.fill(gridWidth*gridHeight)(' ')
+  protected var col: Int = 0
+  protected var row: Int = 0
 
-  def showCaret(column: Ordinal, row2: Ordinal): Unit =
-    parent.showCaret((rect.left + column.n0).z, (rect.top + row2.n0).z)
+  def width: Int = gridWidth
+  def height: Int = gridHeight
 
-  // Paint the whole grid onto the parent surface, one row at a time. The parent
-  // is not itself flushed here — the caller presents the root once after every
-  // panel has composited, so an inline root emits a complete frame rather than
-  // once per panel.
-  def flush(): Unit =
+  // Reallocate the grid to a new size, blanking it and homing the cursor. Used by
+  // `InlineRoot` to resize to the measured block height each frame.
+  protected def reshape(width2: Int, height2: Int): Unit =
+    gridWidth = width2
+    gridHeight = height2
+    cells = Array.fill(gridWidth*gridHeight)(' ')
+    col = 0
+    row = 0
+
+  protected def scrollUp(): Unit =
+    System.arraycopy(cells, gridWidth, cells, 0, gridWidth*(gridHeight - 1))
+    var i = gridWidth*(gridHeight - 1)
+
+    while i < gridWidth*gridHeight do
+      cells(i) = ' '
+      i += 1
+
+  protected def newline(): Unit =
+    col = 0
+    if row < gridHeight - 1 then row += 1 else scrollUp()
+
+  protected def putChar(char: Char): Unit =
+    if char == '\n' then newline()
+    else
+      if col >= gridWidth then newline()
+      cells(row*gridWidth + col) = char
+      col += 1
+
+  protected def rowText(r: Int): Text = String(cells, r*gridWidth, gridWidth).tt
+
+  def move(column: Ordinal, row2: Ordinal): Unit =
+    col = column.n0.min(gridWidth - 1).max(0)
+    row = row2.n0.min(gridHeight - 1).max(0)
+
+  def put(text: Text): Unit =
+    val string = text.s
+    var i = 0
+
+    while i < string.length do
+      putChar(string.charAt(i))
+      i += 1
+
+  def put(text: Teletype): Unit = put(text.plain)
+
+  def clear(): Unit =
+    var i = 0
+
+    while i < cells.length do
+      cells(i) = ' '
+      i += 1
+
+    col = 0
+    row = 0
+
+  def clearLine(): Unit =
+    var c = col
+
+    while c < gridWidth do
+      cells(row*gridWidth + c) = ' '
+      c += 1
+
+  // A plain-text snapshot of the grid (rows joined by newlines), for testing and
+  // for content-change detection.
+  def render: Text =
+    val builder = StringBuilder()
     var r = 0
 
-    while r < height do
-      parent.move(rect.left.z, (rect.top + r).z)
-      parent.put(rowText(r))
+    while r < gridHeight do
+      builder.append(String(cells, r*gridWidth, gridWidth))
+      if r < gridHeight - 1 then builder.append('\n')
       r += 1
 
-  // `Stdio` members: routing `Out` output (and other `Stdio` writes) into this
-  // extent. `print` lays text out through the same cursor model as `put`; the
-  // underlying streams are muted because all rendering goes via `flush`.
-  val termcap: Termcap = new Termcap:
-    def ansi: Boolean = true
-    def color: ColorDepth = ColorDepth.TrueColor
-    override def width: Int = rect.width
-
-  val out = Stdio.MutePrintStream
-  val err = Stdio.MutePrintStream
-  val in = Stdio.MuteInputStream
-
-  override def print(text: Text): Unit = put(text)
+    builder.toString.tt

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -34,44 +34,88 @@ package ultimatum
 
 import anticipation.*
 import denominative.*
+import escapade.*
+import gossamer.*
 import profanity.*
 import turbulence.*
 
-// A `Canvas` confined to a `Rect` of a parent surface, backed by the shared
-// character grid (`GridSurface`). Writes flow and wrap within the rectangle;
-// `flush` paints the grid onto the parent surface, one row at a time, via the
-// parent's `move`/`put` (so positioning is always expressed through the `Canvas`
-// interface, never as inline escapes). It is also an `Stdio`, so bare
-// `Out.println` in a panel body flows into it.
-class FlowExtent(parent: Canvas, val rect: Rect)
-extends GridSurface(rect.width, rect.height), Extent:
-  def cursor(visible: Boolean): Unit = parent.cursor(visible)
+object InlineRoot:
+  // The root for inline mode over a real terminal: width and the height clamp are
+  // read live, so a resize is reflected on the next frame.
+  def apply(terminal: Terminal): InlineRoot =
+    new InlineRoot(() => terminal.knownColumns, () => terminal.knownRows)(using terminal.stdio)
 
-  def showCaret(column: Ordinal, row2: Ordinal): Unit =
-    parent.showCaret((rect.left + column.n0).z, (rect.top + row2.n0).z)
+  def apply(width: Int, height: Int)(using Stdio): InlineRoot =
+    new InlineRoot(() => width, () => height)
 
-  // Paint the whole grid onto the parent surface, one row at a time. The parent
-  // is not itself flushed here — the caller presents the root once after every
-  // panel has composited, so an inline root emits a complete frame rather than
-  // once per panel.
+// The root `Canvas` for INLINE mode: panels composite into its character grid
+// (inherited from `GridSurface`), and `flush` presents the whole grid at the
+// terminal's current cursor using relative motion plus CR/LF. Because a `\n` on
+// the bottom line scrolls a fresh row in (whereas a relative `cud` clamps), the
+// block grows downward without needing the alternate screen buffer or any
+// pre-reserved space; on shrink the freed rows are cleared. The cursor is tracked
+// relative to its own resting row within the block, never an absolute screen row,
+// so the present stays correct after the terminal scrolls. `widthFn`/`heightFn`
+// supply the live terminal columns and the height clamp (an oversize block
+// degrades to a bottom-anchored window).
+class InlineRoot(widthFn: () => Int, heightFn: () => Int)(using Stdio)
+extends GridSurface(widthFn(), 0):
+  private var presentedRows: Int = 0
+  private var cursorRow: Int = 0
+  private var caretColumn: Int = 0
+  private var caretRow: Int = 0
+
+  override def width: Int = widthFn()
+
+  // Resize the grid to the measured block height, clamped to the live terminal
+  // height; called by the driver before compositing each frame.
+  def reframe(width: Int, height: Int): Unit = reshape(width, height.min(heightFn()))
+
+  def cursor(visible: Boolean): Unit = Out.print(csi.dectcem(visible))
+
+  // Inline carets are deferred: record the block-local target and let `flush`
+  // position it relative to the block, since mid-composite the cursor is wherever
+  // the last panel left it.
+  override def showCaret(column: Ordinal, row2: Ordinal): Unit =
+    caretColumn = column.n0
+    caretRow = row2.n0
+
   def flush(): Unit =
+    Out.print(csi.dectcem(false))
+    if cursorRow > 0 then Out.print(csi.cuu(cursorRow))
+    Out.print(t"\r")
+
     var r = 0
 
     while r < height do
-      parent.move(rect.left.z, (rect.top + r).z)
-      parent.put(rowText(r))
+      Out.print(csi.el(2))
+      Out.print(rowText(r))
+      Out.print(t"\r")
+      if r < height - 1 then Out.print(t"\n")
       r += 1
 
-  // `Stdio` members: routing `Out` output (and other `Stdio` writes) into this
-  // extent. `print` lays text out through the same cursor model as `put`; the
-  // underlying streams are muted because all rendering goes via `flush`.
-  val termcap: Termcap = new Termcap:
-    def ansi: Boolean = true
-    def color: ColorDepth = ColorDepth.TrueColor
-    override def width: Int = rect.width
+    if presentedRows > height then
+      var k = height
 
-  val out = Stdio.MutePrintStream
-  val err = Stdio.MutePrintStream
-  val in = Stdio.MuteInputStream
+      while k < presentedRows do
+        Out.print(t"\n")
+        Out.print(csi.el(2))
+        k += 1
 
-  override def print(text: Text): Unit = put(text)
+      Out.print(csi.cuu(presentedRows - height))
+
+    val up = (height - 1) - caretRow
+    if up > 0 then Out.print(csi.cuu(up))
+    Out.print(csi.cha(caretColumn + 1))
+
+    presentedRows = height
+    cursorRow = caretRow
+    Out.print(csi.dectcem(true))
+
+  // On exit, drop the cursor onto a fresh line below the block and re-show it, so
+  // subsequent output continues after the rendered block (like a submitted prompt).
+  def finish(): Unit =
+    val down = (height - 1) - cursorRow
+    if down > 0 then Out.print(csi.cud(down))
+    Out.print(t"\r\n")
+    Out.print(csi.dectcem(true))

--- a/lib/ultimatum/src/core/ultimatum.Mode.scala
+++ b/lib/ultimatum/src/core/ultimatum.Mode.scala
@@ -32,46 +32,9 @@
                                                                                                   */
 package ultimatum
 
-import anticipation.*
-import denominative.*
-import profanity.*
-import turbulence.*
-
-// A `Canvas` confined to a `Rect` of a parent surface, backed by the shared
-// character grid (`GridSurface`). Writes flow and wrap within the rectangle;
-// `flush` paints the grid onto the parent surface, one row at a time, via the
-// parent's `move`/`put` (so positioning is always expressed through the `Canvas`
-// interface, never as inline escapes). It is also an `Stdio`, so bare
-// `Out.println` in a panel body flows into it.
-class FlowExtent(parent: Canvas, val rect: Rect)
-extends GridSurface(rect.width, rect.height), Extent:
-  def cursor(visible: Boolean): Unit = parent.cursor(visible)
-
-  def showCaret(column: Ordinal, row2: Ordinal): Unit =
-    parent.showCaret((rect.left + column.n0).z, (rect.top + row2.n0).z)
-
-  // Paint the whole grid onto the parent surface, one row at a time. The parent
-  // is not itself flushed here — the caller presents the root once after every
-  // panel has composited, so an inline root emits a complete frame rather than
-  // once per panel.
-  def flush(): Unit =
-    var r = 0
-
-    while r < height do
-      parent.move(rect.left.z, (rect.top + r).z)
-      parent.put(rowText(r))
-      r += 1
-
-  // `Stdio` members: routing `Out` output (and other `Stdio` writes) into this
-  // extent. `print` lays text out through the same cursor model as `put`; the
-  // underlying streams are muted because all rendering goes via `flush`.
-  val termcap: Termcap = new Termcap:
-    def ansi: Boolean = true
-    def color: ColorDepth = ColorDepth.TrueColor
-    override def width: Int = rect.width
-
-  val out = Stdio.MutePrintStream
-  val err = Stdio.MutePrintStream
-  val in = Stdio.MuteInputStream
-
-  override def print(text: Text): Unit = put(text)
+// The two rendering modes for an interactive layout. `Fullscreen` takes over the
+// terminal via the alternate screen buffer and fills its fixed height;
+// `Inline` renders a variable-height block at the cursor (sized to its content),
+// without the alternate buffer, leaving the terminal's scrollback intact.
+enum Mode:
+  case Inline, Fullscreen

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -84,10 +84,21 @@ def file(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.File, panes.to(List))
 // A split whose children stack as rows (distributing height).
 def rank(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.Rank, panes.to(List))
 
-// Drive an interactive layout across the whole terminal, looping over terminal
-// events until the user exits. Used inside `interactive`.
-def form(fullScreen: Boolean = true)(pane: Pane)(using terminal: Terminal): Unit =
-  Form(TerminalCanvas(terminal), fullScreen, pane).run(terminal.eventIterator())
+// Drive an interactive layout, looping over terminal events until the user exits.
+// Used inside `interactive`. In `Fullscreen` mode the layout takes over the
+// terminal via the alternate screen buffer (restored on exit) and fills its
+// height; in `Inline` mode it renders a variable-height block at the cursor
+// without the alternate buffer, leaving scrollback intact.
+def form(mode: Mode = Mode.Fullscreen)(pane: Pane)(using terminal: Terminal): Unit =
+  mode match
+    case Mode.Fullscreen =>
+      profanity.terminalFeatures.alternateScreen:
+        val root = TerminalCanvas(terminal)
+        root.cursor(false)
+        try Form(root, mode, pane).run(terminal.eventIterator()) finally root.cursor(true)
+
+    case Mode.Inline =>
+      Form(InlineRoot(terminal), mode, pane).run(terminal.eventIterator())
 
 // The leaf indices that must be repainted: any whose rectangle moved or resized
 // since the last layout, plus any whose content changed this frame. A leaf whose
@@ -99,11 +110,18 @@ def dirtyCells(previous: IndexedSeq[Rect], current: IndexedSeq[Rect], changed: S
 
   moved.to(Set) ++ changed
 
-// Solve `pane` against `root` and paint each leaf's content into its rectangle.
-// In full-screen mode the layout fills the surface's height; otherwise it takes
-// only the height its content requires.
-def paint(root: Canvas, fullScreen: Boolean)(pane: Pane): Unit =
-  val height = if fullScreen then root.height else pane.frame.measure(Axis.Rank).min
+// Solve `pane` against `root` once and paint each leaf's content into its
+// rectangle (no event loop). An `InlineRoot` is sized to the height its content
+// needs and presented at the cursor; any other canvas fills its own height.
+def paint(root: Canvas, pane: Pane): Unit =
+  val height = root match
+    case _: InlineRoot => pane.frame.measure(Axis.Rank).min
+    case _             => root.height
+
+  root match
+    case inline: InlineRoot => inline.reframe(root.width, height)
+    case _                  => ()
+
   val placement = pane.frame.arrange(Rect(0, 0, root.width, height))
 
   pane.leaves.zip(placement.cells).each: pair =>
@@ -118,7 +136,9 @@ def paint(root: Canvas, fullScreen: Boolean)(pane: Pane): Unit =
 
   root.flush()
 
-// Solve and paint `pane` across the whole terminal (the common entry point,
-// used inside `interactive`).
-def layout(fullScreen: Boolean = true)(pane: Pane)(using terminal: Terminal): Unit =
-  paint(TerminalCanvas(terminal), fullScreen)(pane)
+// Present `pane` as a static, variable-height block inline at the cursor, leaving
+// the cursor on a fresh line below it.
+def layout(pane: Pane)(using terminal: Terminal): Unit =
+  val root = InlineRoot(terminal)
+  paint(root, pane)
+  root.finish()

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -169,8 +169,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         val bytes = ji.ByteArrayOutputStream()
         given Stdio = Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basic)
 
-        paint(TerminalCanvas(4, 1), fullScreen = true):
-          file(panel()(Out.print(t"AA")), panel()(Out.print(t"BB")))
+        paint(TerminalCanvas(4, 1), file(panel()(Out.print(t"AA")), panel()(Out.print(t"BB"))))
 
         String(bytes.toByteArray.nn, "UTF-8").tt
       . assert(_ == t"\e[1;1HAA\e[1;3HBB")
@@ -181,8 +180,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
         // "HELLO" in a 2x1 panel wraps and scrolls until only "O" remains; the
         // sibling panel's "X" is unaffected, so neither bleeds past column 2.
-        paint(TerminalCanvas(4, 1), fullScreen = true):
-          file(panel()(Out.print(t"HELLO")), panel()(Out.print(t"X")))
+        paint(TerminalCanvas(4, 1), file(panel()(Out.print(t"HELLO")), panel()(Out.print(t"X"))))
 
         String(bytes.toByteArray.nn, "UTF-8").tt
       . assert(_ == t"\e[1;1HO \e[1;3HX ")
@@ -242,7 +240,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
            Keypress.CharKey('y'), Keypress.CharKey('o'),
            Keypress.Escape )
 
-        Form(root, fullScreen = true, rank(editor(), editor())).run(events.iterator)
+        Form(root, Mode.Fullscreen, rank(editor(), editor())).run(events.iterator)
         root.render
       . assert(_ == t"hi        \n          \nyo        \n          ")
 
@@ -253,7 +251,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         given Stdio = Stdio(null, null, null, termcapDefinitions.basic)
         val root = FlowExtent(TerminalCanvas(10, 4), Rect(0, 0, 10, 4))
         val events = List.fill(21)(Keypress.CharKey('a')) ++ List(Keypress.Escape)
-        Form(root, fullScreen = true, rank(editor(), editor())).run(events.iterator)
+        Form(root, Mode.Fullscreen, rank(editor(), editor())).run(events.iterator)
         root.render
       . assert(_ == t"aaaaaaaaaa\naaaaaaaaaa\na         \n          ")
 
@@ -274,9 +272,67 @@ object Tests extends Suite(m"Ultimatum Tests"):
             root.resize(10, 2)
             TerminalInfo.WindowSize(2, 10)
 
-        Form(root, fullScreen = true, rank(panel()(Out.print(t"A")), panel()(Out.print(t"B")))).run(resize)
+        Form(root, Mode.Fullscreen, rank(panel()(Out.print(t"A")), panel()(Out.print(t"B")))).run(resize)
         root.render
       . assert(_ == t"A         \nB         \n          \n          ")
+
+    suite(m"InlineRoot present (inline mode)"):
+      def capturing(): (ji.ByteArrayOutputStream, Stdio) =
+        val bytes = ji.ByteArrayOutputStream()
+        (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basic))
+
+      test(m"a first inline render draws each row with CR/LF and parks the caret"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 24)
+        root.reframe(3, 2)
+        root.move(Prim, Prim)
+        root.put(t"hi")
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\r\e[2Khi \r\n\e[2K   \r\e[1A\e[1G\e[?25h")
+
+      test(m"a growing block scrolls a new row in with LF"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 24)
+        root.reframe(3, 1); root.move(Prim, Prim); root.put(t"a"); root.flush()
+        bytes.reset()
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\r\e[2Kab \r\n\e[2Kcd \r\e[1A\e[1G\e[?25h")
+
+      test(m"a shrinking block clears the rows it no longer uses"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 24)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.reframe(3, 1); root.move(Prim, Prim); root.put(t"ef"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\r\e[2Kef \r\n\e[2K\e[1A\e[1G\e[?25h")
+
+      test(m"the caret is parked at its block-local position"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 24)
+        root.reframe(3, 2)
+        root.move(Prim, Prim)
+        root.put(t"ab\ncd")
+        root.showCaret(Sec, Sec)
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\r\e[2Kab \r\n\e[2Kcd \r\e[2G\e[?25h")
+
+      test(m"finish drops the cursor onto a fresh line below the block"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 24)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.finish()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[1B\r\n\e[?25h")
 
 // A test-only root `Canvas` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and


### PR DESCRIPTION
Ultimatum's interactive layouts now choose between two rendering modes. Fullscreen takes over the terminal using the alternate screen buffer and fills its height; inline renders a variable-height block at the cursor, growing and shrinking in place without disturbing scrollback and leaving the cursor below the block when it exits. The previous `fullScreen` boolean — which only changed how height was computed and never actually entered the alternate buffer or rendered inline — is replaced by a `Mode` that selects the real behaviour.

## Two rendering modes

`form` now takes a `Mode`:

```scala
import soundness.*

// Takes over the screen (alternate buffer, fixed height):
interactive:
  form(Mode.Fullscreen):
    rank(editor(), menu(List(t"alpha", t"beta"), t"alpha"))

// Renders a block right here at the prompt, sized to its content:
interactive:
  form(Mode.Inline):
    rank(editor(), editor())
```

**Inline** mode uses no alternate buffer and is sized to the height its content needs — the terminal height is irrelevant to layout. The block flows downward from the cursor and reflows in place as content grows or shrinks (an editor wrapping onto a second line pushes the rest down); on exit the cursor is left on a fresh line below it, like a submitted prompt. Scrollback above is untouched.

**Fullscreen** mode enters the alternate screen buffer (restored on exit), hides the cursor, fills the terminal height, and re-tiles on resize.

The one-shot, non-interactive `layout`/`paint` are inline by nature — they present a static block at the cursor and return:

```scala
interactive:
  layout(rank(panel()(Out.println(t"a line")), panel()(Out.println(t"another"))))
```

### Under the hood

Inline blocks are presented by a new grid-backed `InlineRoot`: panels composite into its character grid, then it blits the whole grid at the cursor using relative cursor motion plus CR/LF — a newline on the bottom line scrolls a fresh row in, so the block grows without the alternate buffer or any pre-reserved space, and freed rows are cleared when it shrinks. The grid mechanics shared with `FlowExtent` are factored into a common base.
