### PR TITLE
Append and insert panes into a running ultimatum layout

### DIFF
--- a/lib/profanity/src/core/profanity.TerminalEvent.scala
+++ b/lib/profanity/src/core/profanity.TerminalEvent.scala
@@ -47,6 +47,11 @@ enum TerminalInfo extends TerminalEvent:
   case GainFocus
   case Paste(text: Text)
 
+  // A synthetic event an application can put onto the terminal's event spool to
+  // wake the event loop and request a repaint — e.g. after a background task has
+  // changed the layout.
+  case Redraw
+
 object Signal:
   given decoder: Signal is Decodable in Text = text => Signal.valueOf(text.lower.capitalize.s)
   given encodable: Signal is Encodable in Text = _.shortName

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -34,25 +34,50 @@ package ultimatum
 
 import profanity.*
 import rudiments.*
+import vacuous.*
 
-// Drives an interactive layout: solves it, paints each panel, then loops over
-// terminal events — TAB cycles focus between widgets, Escape/Ctrl-C exits, and
-// every other event is folded into the focused widget. After each edit (or a
-// terminal resize) the layout is re-solved using each widget's live intrinsic
-// size and the root is presented. In `Fullscreen` mode only the panels whose
-// rectangle or content changed are repainted (the root composites straight to the
-// screen); in `Inline` mode the grid is re-sized to the measured block height each
-// frame and the whole block is re-presented at the cursor.
-class Form(root: Canvas, mode: Mode, pane: Pane):
-  private val leaves: IndexedSeq[Pane] = pane.leaves.to(IndexedSeq)
-  private val focuses: IndexedSeq[Focus] = leaves.collect { case Pane.Widget(_, focus) => focus }
-
-  // The leaf index hosting each focusable, in focus order.
-  private val focusLeaf: IndexedSeq[Int] = leaves.indices.collect:
-    case i if leaves(i).isInstanceOf[Pane.Widget] => i
-
+// Drives an interactive layout. The pane tree is re-derived from its live
+// containers on every frame, so panes appended or inserted while the form runs
+// are picked up and the layout re-tiles; a container mutation also wakes the
+// loop (via `wake`) so background changes appear immediately. TAB cycles focus
+// between widgets (tracked by identity, so it survives insertions), Escape/Ctrl-C
+// exits, and other events fold into the focused widget. Fullscreen repaints only
+// the changed cells; inline re-sizes the grid to the measured block height each
+// frame and re-presents the whole block at the cursor.
+class Form(root: Canvas, mode: Mode, pane: Pane, wake: () => Unit = () => ()):
+  private var leaves: IndexedSeq[Pane] = IndexedSeq()
+  private var focuses: IndexedSeq[Focus] = IndexedSeq()
+  private var focusLeaf: IndexedSeq[Int] = IndexedSeq()
+  private var focused: Optional[Focus] = Unset
   private var rects: IndexedSeq[Rect] = IndexedSeq()
-  private var focus: Int = 0
+
+  // Bind every container to the wake function so a mutation requests a repaint.
+  private def bind(node: Pane): Unit = node match
+    case Pane.Branch(_, _, panes) =>
+      panes.onChange = wake
+      panes.contents.each(bind(_))
+
+    case _ =>
+      ()
+
+  // Snapshot the live tree's leaves and focusables; keep focus on the same widget
+  // if it still exists, else fall back to the first.
+  private def rederive(): Unit =
+    bind(pane)
+    leaves = pane.leaves.to(IndexedSeq)
+    focuses = leaves.collect { case Pane.Widget(_, focus) => focus }
+
+    focusLeaf = leaves.indices.collect:
+      case i if leaves(i).isInstanceOf[Pane.Widget] => i
+
+    val stays = focused.lay(false): widget =>
+      focuses.indexWhere(_ eq widget) >= 0
+
+    if !stays then focused = if focuses.isEmpty then Unset else focuses(0)
+
+  private def focusIndex: Int = focused.lay(0): widget =>
+    val index = focuses.indexWhere(_ eq widget)
+    if index < 0 then 0 else index
 
   // Project the panes to a frame, overriding each widget's minimum with the live
   // size its content needs at the width it last occupied (the root width on the
@@ -62,8 +87,8 @@ class Form(root: Canvas, mode: Mode, pane: Pane):
     var index = -1
 
     def project(node: Pane): Frame = node match
-      case Pane.Branch(sizing, axis, children) =>
-        Frame.Split(sizing, axis, children.map(project))
+      case Pane.Branch(sizing, axis, panes) =>
+        Frame.Split(sizing, axis, panes.contents.map(project).to(List))
 
       case Pane.Leaf(sizing, _) =>
         index += 1
@@ -80,8 +105,6 @@ class Form(root: Canvas, mode: Mode, pane: Pane):
 
     project(pane)
 
-  // Re-solve the layout; in inline mode also reframe the root grid to the measured
-  // block height (clamped to the terminal). Returns the new panel rectangles.
   private def solve(): IndexedSeq[Rect] =
     val frame = liveFrame
 
@@ -104,16 +127,25 @@ class Form(root: Canvas, mode: Mode, pane: Pane):
         extent.flush()
 
       case Pane.Widget(_, widget) =>
-        widget.render(extent, focusLeaf.indexOf(index) == focus)
+        widget.render(extent, focusLeaf.indexOf(index) == focusIndex)
 
       case _ =>
         ()
 
-  // Re-solve and repaint, then present the root. Inline always repaints every
-  // panel (its grid was just reframed and blanked); fullscreen repaints only the
-  // cells whose rectangle or content changed. The focused widget is painted last
-  // so the caret rests in it.
+  // Re-derive, re-solve and repaint, then present. A change in the number of
+  // leaves (a pane was added or removed) forces a full repaint, clearing the
+  // screen in fullscreen so a removed panel leaves no residue; otherwise
+  // fullscreen repaints only the dirty cells and inline re-presents the block.
   private def refresh(changed: Set[Int]): Unit =
+    rederive()
+
+    if leaves.length != rects.length then
+      mode match
+        case Mode.Fullscreen => root.clear()
+        case Mode.Inline     => ()
+
+      rects = IndexedSeq()
+
     val updated = solve()
 
     mode match
@@ -126,7 +158,7 @@ class Form(root: Canvas, mode: Mode, pane: Pane):
         rects = updated
         dirty.each(paint(_))
 
-    if focuses.nonEmpty then paint(focusLeaf(focus))
+    if focuses.nonEmpty then paint(focusLeaf(focusIndex))
     root.flush()
 
   def run(events: Iterator[TerminalEvent]): Unit =
@@ -136,31 +168,30 @@ class Form(root: Canvas, mode: Mode, pane: Pane):
     while running && events.hasNext do events.next() match
       case Keypress.Tab =>
         if focuses.nonEmpty then
-          focus = (focus + 1)%focuses.length
+          focused = focuses((focusIndex + 1)%focuses.length)
           refresh(Set())
 
       case Keypress.Escape | Keypress.Ctrl('C' | 'D') =>
         running = false
 
-      // The terminal reports its new size after a resize. Fullscreen clears the
-      // whole screen and forces a full re-tile; inline must NOT clear the screen
-      // (that would wipe scrollback) — its reframe + present reconcile the change.
+      // A resize re-tiles to the new size; reset the rects so the whole layout is
+      // repainted against the live dimensions.
       case _: TerminalInfo.WindowSize =>
-        mode match
-          case Mode.Fullscreen => root.clear()
-          case Mode.Inline     => ()
-
         rects = IndexedSeq()
         refresh(Set())
 
-      // Signals are never widget input; the WindowSize event above does the work.
+      // An application redraw request (e.g. after a background layout change).
+      case TerminalInfo.Redraw =>
+        refresh(Set())
+
+      // Other signals are never widget input.
       case _: Signal =>
         ()
 
       case event =>
         if focuses.nonEmpty then
-          focuses(focus).handle(event)
-          refresh(Set(focusLeaf(focus)))
+          focuses(focusIndex).handle(event)
+          refresh(Set(focusLeaf(focusIndex)))
 
     root match
       case inline: InlineRoot => inline.finish()

--- a/lib/ultimatum/src/core/ultimatum.Pane.scala
+++ b/lib/ultimatum/src/core/ultimatum.Pane.scala
@@ -43,24 +43,27 @@ enum Pane:
 
   case Leaf(sizing: Sizing, content: Extent => Unit)
   case Widget(sizing: Sizing, focus: Focus)
-  case Branch(sizing: Sizing, axis: Axis, children: List[Pane])
+  case Branch(sizing: Sizing, axis: Axis, panes: Panes)
 
   // The pure layout structure, with content discarded, for the solver. A widget
   // contributes only its declared `Sizing` here; the interactive driver injects
   // each widget's live intrinsic size (measured at its actual width) when it
-  // re-solves, so growing content can push the rest of the layout around.
+  // re-solves, so growing content can push the rest of the layout around. A
+  // branch reads its container's current contents, so a mutated layout re-solves.
   def frame: Frame = this match
-    case Leaf(sizing, _)            => Frame.Cell(sizing)
-    case Widget(sizing, _)          => Frame.Cell(sizing)
-    case Branch(sizing, axis, kids) => Frame.Split(sizing, axis, kids.map(_.frame))
+    case Leaf(sizing, _)   => Frame.Cell(sizing)
+    case Widget(sizing, _) => Frame.Cell(sizing)
+
+    case Branch(sizing, axis, panes) =>
+      Frame.Split(sizing, axis, panes.contents.map(_.frame).to(List))
 
   // The leaves in frame order (left to right for files, top to bottom for ranks).
   def leaves: List[Pane] = this match
-    case Branch(_, _, children) => children.flatMap(_.leaves)
-    case leaf                   => List(leaf)
+    case Branch(_, _, panes) => panes.contents.to(List).flatMap(_.leaves)
+    case leaf                => List(leaf)
 
   // A copy of this pane re-weighted for use as a child of a split.
   def weight(fraction: Double): Pane = this match
-    case Leaf(sizing, content)      => Leaf(sizing.copy(fraction = fraction), content)
-    case Widget(sizing, focus)      => Widget(sizing.copy(fraction = fraction), focus)
-    case Branch(sizing, axis, kids) => Branch(sizing.copy(fraction = fraction), axis, kids)
+    case Leaf(sizing, content)       => Leaf(sizing.copy(fraction = fraction), content)
+    case Widget(sizing, focus)       => Widget(sizing.copy(fraction = fraction), focus)
+    case Branch(sizing, axis, panes) => Branch(sizing.copy(fraction = fraction), axis, panes)

--- a/lib/ultimatum/src/core/ultimatum.Panes.scala
+++ b/lib/ultimatum/src/core/ultimatum.Panes.scala
@@ -30,9 +30,46 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ultimatum
 
-export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, Axis, Sizing, Limits, Frame, Placement,
-    Pane, Panes, Mode, panel, file, rank, layout, paint, Focus, EditorField, MenuField, Form,
-    dirtyCells,
-    editor, menu, form}
+// A mutable, ordered container of child panes, backed by a `Series` for random
+// access. Holding a reference to it lets the layout change while a `form` is
+// running: appending a pane, or inserting one before or after an existing pane,
+// re-tiles the running form. Mutations are picked up the next time the form
+// re-derives its tree; when the container is bound into a running form, a
+// mutation also wakes the event loop so the change is shown immediately (even
+// from a background task).
+class Panes(initial: Pane*):
+  private var series: Series[Pane] = initial.to(Series)
+
+  // Installed by the running form so a mutation requests a repaint; a no-op until
+  // the container is bound.
+  private[ultimatum] var onChange: () => Unit = () => ()
+
+  def contents: Series[Pane] = series
+  def size: Int = series.length
+  def apply(index: Int): Pane = series(index)
+
+  private def revise(updated: Series[Pane]): Unit =
+    series = updated
+    onChange()
+
+  def append(pane: Pane): Unit = revise(series :+ pane)
+  def prepend(pane: Pane): Unit = revise(pane +: series)
+
+  // Insert at a position, clamped to the container's bounds.
+  def insert(index: Int, pane: Pane): Unit =
+    revise(series.patch(index.min(series.length).max(0), Series(pane), 0))
+
+  // Insert immediately before `reference` (by identity); appends if it is absent.
+  def insertBefore(reference: Pane, pane: Pane): Unit =
+    val index = series.indexWhere(_ eq reference)
+    if index < 0 then append(pane) else insert(index, pane)
+
+  // Insert immediately after `reference` (by identity); appends if it is absent.
+  def insertAfter(reference: Pane, pane: Pane): Unit =
+    val index = series.indexWhere(_ eq reference)
+    if index < 0 then append(pane) else insert(index + 1, pane)
+
+  // Remove `reference` (by identity), if present.
+  def remove(reference: Pane): Unit = revise(series.filter(_ ne reference))

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -79,10 +79,16 @@ def menu[item: Showable]
   Pane.Widget(sizing, MenuField(SelectMenu(options, current)))
 
 // A split whose children sit side by side as columns (distributing width).
-def file(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.File, panes.to(List))
+def file(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.File, Panes(panes*))
+
+// A column split over a live container, whose children can change while running.
+def file(panes: Panes): Pane = Pane.Branch(Sizing(), Axis.File, panes)
 
 // A split whose children stack as rows (distributing height).
-def rank(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.Rank, panes.to(List))
+def rank(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.Rank, Panes(panes*))
+
+// A row split over a live container, whose children can change while running.
+def rank(panes: Panes): Pane = Pane.Branch(Sizing(), Axis.Rank, panes)
 
 // Drive an interactive layout, looping over terminal events until the user exits.
 // Used inside `interactive`. In `Fullscreen` mode the layout takes over the
@@ -90,15 +96,20 @@ def rank(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.Rank, panes.to(List))
 // height; in `Inline` mode it renders a variable-height block at the cursor
 // without the alternate buffer, leaving scrollback intact.
 def form(mode: Mode = Mode.Fullscreen)(pane: Pane)(using terminal: Terminal): Unit =
+  // A container mutation wakes the loop by putting a redraw event on the spool.
+  val wake = () => terminal.events.put(TerminalInfo.Redraw)
+
   mode match
     case Mode.Fullscreen =>
       profanity.terminalFeatures.alternateScreen:
         val root = TerminalCanvas(terminal)
         root.cursor(false)
-        try Form(root, mode, pane).run(terminal.eventIterator()) finally root.cursor(true)
+
+        try Form(root, mode, pane, wake).run(terminal.eventIterator())
+        finally root.cursor(true)
 
     case Mode.Inline =>
-      Form(InlineRoot(terminal), mode, pane).run(terminal.eventIterator())
+      Form(InlineRoot(terminal), mode, pane, wake).run(terminal.eventIterator())
 
 // The leaf indices that must be repainted: any whose rectangle moved or resized
 // since the last layout, plus any whose content changed this frame. A leaf whose

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -334,6 +334,71 @@ object Tests extends Suite(m"Ultimatum Tests"):
         String(bytes.toByteArray.nn, "UTF-8").tt
       . assert(_ == t"\e[1B\r\n\e[?25h")
 
+    suite(m"Dynamic panes"):
+      def cell(): Pane = panel()(())
+
+      test(m"append adds a pane at the end"):
+        val a = cell()
+        val b = cell()
+        val panes = Panes(a)
+        panes.append(b)
+        panes.contents.to(List) == List(a, b)
+      . assert(_ == true)
+
+      test(m"prepend adds a pane at the start"):
+        val a = cell()
+        val b = cell()
+        val panes = Panes(a)
+        panes.prepend(b)
+        panes.contents.to(List) == List(b, a)
+      . assert(_ == true)
+
+      test(m"insertBefore places a pane immediately before the reference"):
+        val a = cell()
+        val b = cell()
+        val c = cell()
+        val panes = Panes(a, b)
+        panes.insertBefore(b, c)
+        panes.contents.to(List) == List(a, c, b)
+      . assert(_ == true)
+
+      test(m"insertAfter places a pane immediately after the reference"):
+        val a = cell()
+        val b = cell()
+        val c = cell()
+        val panes = Panes(a, b)
+        panes.insertAfter(a, c)
+        panes.contents.to(List) == List(a, c, b)
+      . assert(_ == true)
+
+      test(m"remove deletes a pane by identity"):
+        val a = cell()
+        val b = cell()
+        val panes = Panes(a, b)
+        panes.remove(a)
+        panes.contents.to(List) == List(b)
+      . assert(_ == true)
+
+      // Drive a running form, append a pane mid-loop (the synthetic iterator
+      // yields a Redraw to wake it), and confirm the layout re-tiles to include it.
+      test(m"a form picks up a pane appended while it runs"):
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basic)
+        val root = FlowExtent(TerminalCanvas(10, 2), Rect(0, 0, 10, 2))
+        val panes = Panes(panel()(Out.print(t"A")))
+
+        val events = new Iterator[TerminalEvent]:
+          private var pending = true
+          def hasNext = pending
+
+          def next() =
+            pending = false
+            panes.append(panel()(Out.print(t"B")))
+            TerminalInfo.Redraw
+
+        Form(root, Mode.Fullscreen, rank(panes)).run(events)
+        root.render
+      . assert(_ == t"A         \nB         ")
+
 // A test-only root `Canvas` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and
 // the composed screen read back.


### PR DESCRIPTION
Ultimatum layouts can now change while they are running. A container's children are held in a mutable, randomly-accessible `Panes` container instead of a fixed list, so you can append a pane — or insert one before or after an existing pane — and the running form re-tiles to show it, including from a background task, which wakes the event loop immediately.

## Dynamic panes

Keep a reference to a `Panes` container, pass it to `file`/`rank`, and mutate it while the form runs:

```scala
import soundness.*

val messages = Panes(editor())

interactive:
  form(Mode.Inline)(rank(messages))
```

```scala
// from an event handler or a background task, at any time:
messages.append(panel()(Out.println(t"a new line")))

val first = panel()(Out.println(t"top"))
messages.prepend(first)
messages.insertAfter(first, panel()(Out.println(t"second")))
messages.remove(first)
```

`Panes` is backed by a `Series`, so it has random access (`panes(i)`, `panes.size`, `panes.contents`); `insertBefore`/`insertAfter`/`remove` locate the reference pane by identity. The form re-derives its layout from the live container on every frame, re-tiling as panes come and go, and focus stays on the same widget even when panes are inserted ahead of it.

A mutation made from a background task is shown immediately rather than on the next keypress: a bound container wakes the event loop by putting a new `TerminalInfo.Redraw` event onto the terminal's event spool.
