### PR TITLE
Validate CSS property names and values

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -509,7 +509,8 @@ object cardinality extends Library:
 
 object cataclysm extends Library:
   object core extends Component(zephyrine.core, gossamer.core, turbulence.core,
-      contingency.core, vacuous.core, fulminate.core, denominative.core):
+      contingency.core, vacuous.core, fulminate.core, denominative.core, hellenism.core,
+      jacinta.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/cataclysm/res/core/cataclysm/properties.json
+++ b/lib/cataclysm/res/core/cataclysm/properties.json
@@ -1,0 +1,12147 @@
+{
+  "--*": {
+    "syntax": "<declaration-value>",
+    "media": "all",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Custom Properties for Cascading Variables"
+    ],
+    "initial": "seeProse",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedWithVarsSubstituted",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/--*"
+  },
+  "-ms-accelerator": {
+    "syntax": "false | true",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "false",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-block-progression": {
+    "syntax": "tb | rl | bt | lr",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "tb",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-chaining": {
+    "syntax": "none | chained",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-limit": {
+    "syntax": "<'-ms-content-zoom-limit-min'> <'-ms-content-zoom-limit-max'>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": [
+      "-ms-content-zoom-limit-max",
+      "-ms-content-zoom-limit-min"
+    ],
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": [
+      "-ms-content-zoom-limit-max",
+      "-ms-content-zoom-limit-min"
+    ],
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": [
+      "-ms-content-zoom-limit-max",
+      "-ms-content-zoom-limit-min"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-limit-max": {
+    "syntax": "<percentage>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "maxZoomFactor",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "400%",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-limit-min": {
+    "syntax": "<percentage>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "minZoomFactor",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "100%",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-snap": {
+    "syntax": "<'-ms-content-zoom-snap-type'> || <'-ms-content-zoom-snap-points'>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": [
+      "-ms-content-zoom-snap-type",
+      "-ms-content-zoom-snap-points"
+    ],
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": [
+      "-ms-content-zoom-snap-type",
+      "-ms-content-zoom-snap-points"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-snap-points": {
+    "syntax": "snapInterval( <percentage>, <percentage> ) | snapList( <percentage># )",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "snapInterval(0%, 100%)",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zoom-snap-type": {
+    "syntax": "none | proximity | mandatory",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-content-zooming": {
+    "syntax": "none | zoom",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "zoomForTheTopLevelNoneForTheRest",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-filter": {
+    "syntax": "<string>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "\"\"",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-flow-from": {
+    "syntax": "[ none | <custom-ident> ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "nonReplacedElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-flow-into": {
+    "syntax": "[ none | <custom-ident> ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "iframeElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-grid-columns": {
+    "syntax": "none | <track-list> | <auto-track-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpcDifferenceLpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-grid-rows": {
+    "syntax": "none | <track-list> | <auto-track-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpcDifferenceLpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-high-contrast-adjust": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-hyphenate-limit-chars": {
+    "syntax": "auto | <integer>{1,3}",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-hyphenate-limit-lines": {
+    "syntax": "no-limit | <integer>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "no-limit",
+    "appliesto": "blockContainerElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-hyphenate-limit-zone": {
+    "syntax": "<percentage> | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "referToLineBoxWidth",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "blockContainerElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-ime-align": {
+    "syntax": "auto | after",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-overflow-style": {
+    "syntax": "auto | none | scrollbar | -ms-autohiding-scrollbar",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-chaining": {
+    "syntax": "chained | none",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "chained",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-limit": {
+    "syntax": "<'-ms-scroll-limit-x-min'> <'-ms-scroll-limit-y-min'> <'-ms-scroll-limit-x-max'> <'-ms-scroll-limit-y-max'>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": [
+      "-ms-scroll-limit-x-min",
+      "-ms-scroll-limit-y-min",
+      "-ms-scroll-limit-x-max",
+      "-ms-scroll-limit-y-max"
+    ],
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": [
+      "-ms-scroll-limit-x-min",
+      "-ms-scroll-limit-y-min",
+      "-ms-scroll-limit-x-max",
+      "-ms-scroll-limit-y-max"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-limit-x-max": {
+    "syntax": "auto | <length>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-limit-x-min": {
+    "syntax": "<length>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-limit-y-max": {
+    "syntax": "auto | <length>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-limit-y-min": {
+    "syntax": "<length>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-rails": {
+    "syntax": "none | railed",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "railed",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-snap-points-x": {
+    "syntax": "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "snapInterval(0px, 100%)",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-snap-points-y": {
+    "syntax": "snapInterval( <length-percentage>, <length-percentage> ) | snapList( <length-percentage># )",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "snapInterval(0px, 100%)",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-snap-type": {
+    "syntax": "none | proximity | mandatory",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-snap-x": {
+    "syntax": "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-x'>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-x"
+    ],
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-x"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-snap-y": {
+    "syntax": "<'-ms-scroll-snap-type'> <'-ms-scroll-snap-points-y'>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-y"
+    ],
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": [
+      "-ms-scroll-snap-type",
+      "-ms-scroll-snap-points-y"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scroll-translation": {
+    "syntax": "none | vertical-to-horizontal",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-3dlight-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "dependsOnUserAgent",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-arrow-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "ButtonText",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-base-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "dependsOnUserAgent",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-darkshadow-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "ThreeDDarkShadow",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-face-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "ThreeDFace",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-highlight-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "ThreeDHighlight",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-shadow-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "ThreeDDarkShadow",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-scrollbar-track-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "Scrollbar",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-text-autospace": {
+    "syntax": "none | ideograph-alpha | ideograph-numeric | ideograph-parenthesis | ideograph-space",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-touch-select": {
+    "syntax": "grippers | none",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "grippers",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-user-select": {
+    "syntax": "none | element | text",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "text",
+    "appliesto": "nonReplacedElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-wrap-flow": {
+    "syntax": "auto | both | start | end | maximum | clear",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "blockLevelElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-wrap-margin": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "exclusionElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-ms-wrap-through": {
+    "syntax": "wrap | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Microsoft Extensions"
+    ],
+    "initial": "wrap",
+    "appliesto": "blockLevelElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-appearance": {
+    "syntax": "none | button | button-arrow-down | button-arrow-next | button-arrow-previous | button-arrow-up | button-bevel | button-focus | caret | checkbox | checkbox-container | checkbox-label | checkmenuitem | dualbutton | groupbox | listbox | listitem | menuarrow | menubar | menucheckbox | menuimage | menuitem | menuitemtext | menulist | menulist-button | menulist-text | menulist-textfield | menupopup | menuradio | menuseparator | meterbar | meterchunk | progressbar | progressbar-vertical | progresschunk | progresschunk-vertical | radio | radio-container | radio-label | radiomenuitem | range | range-thumb | resizer | resizerpanel | scale-horizontal | scalethumbend | scalethumb-horizontal | scalethumbstart | scalethumbtick | scalethumb-vertical | scale-vertical | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | separator | sheet | spinner | spinner-downbutton | spinner-textfield | spinner-upbutton | splitter | statusbar | statusbarpanel | tab | tabpanel | tabpanels | tab-scroll-arrow-back | tab-scroll-arrow-forward | textfield | textfield-multiline | toolbar | toolbarbutton | toolbarbutton-dropdown | toolbargripper | toolbox | tooltip | treeheader | treeheadercell | treeheadersortarrow | treeitem | treeline | treetwisty | treetwistyopen | treeview | -moz-mac-unified-toolbar | -moz-win-borderless-glass | -moz-win-browsertabbar-toolbox | -moz-win-communicationstext | -moz-win-communications-toolbox | -moz-win-exclude-glass | -moz-win-glass | -moz-win-mediatext | -moz-win-media-toolbox | -moz-window-button-box | -moz-window-button-box-maximized | -moz-window-button-close | -moz-window-button-maximize | -moz-window-button-minimize | -moz-window-button-restore | -moz-window-frame-bottom | -moz-window-frame-left | -moz-window-frame-right | -moz-window-titlebar | -moz-window-titlebar-maximized",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "noneButOverriddenInUserAgentCSS",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
+  },
+  "-moz-binding": {
+    "syntax": "<url> | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsExceptGeneratedContentOrPseudoElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-border-bottom-colors": {
+    "syntax": "<color>+ | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-border-left-colors": {
+    "syntax": "<color>+ | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-border-right-colors": {
+    "syntax": "<color>+ | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-border-top-colors": {
+    "syntax": "<color>+ | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-context-properties": {
+    "syntax": "none | [ fill | fill-opacity | stroke | stroke-opacity ]#",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsThatCanReferenceImages",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-float-edge": {
+    "syntax": "border-box | content-box | margin-box | padding-box",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "content-box",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-float-edge"
+  },
+  "-moz-force-broken-image-icon": {
+    "syntax": "0 | 1",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "images",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-force-broken-image-icon"
+  },
+  "-moz-orient": {
+    "syntax": "inline | block | horizontal | vertical",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "inline",
+    "appliesto": "anyElementEffectOnProgressAndMeter",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-orient"
+  },
+  "-moz-outline-radius": {
+    "syntax": "<outline-radius>{1,4} [ / <outline-radius>{1,4} ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "-moz-outline-radius-topleft",
+      "-moz-outline-radius-topright",
+      "-moz-outline-radius-bottomright",
+      "-moz-outline-radius-bottomleft"
+    ],
+    "percentages": [
+      "-moz-outline-radius-topleft",
+      "-moz-outline-radius-topright",
+      "-moz-outline-radius-bottomright",
+      "-moz-outline-radius-bottomleft"
+    ],
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": [
+      "-moz-outline-radius-topleft",
+      "-moz-outline-radius-topright",
+      "-moz-outline-radius-bottomright",
+      "-moz-outline-radius-bottomleft"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "-moz-outline-radius-topleft",
+      "-moz-outline-radius-topright",
+      "-moz-outline-radius-bottomright",
+      "-moz-outline-radius-bottomleft"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-outline-radius-bottomleft": {
+    "syntax": "<outline-radius>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-outline-radius-bottomright": {
+    "syntax": "<outline-radius>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-outline-radius-topleft": {
+    "syntax": "<outline-radius>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-outline-radius-topright": {
+    "syntax": "<outline-radius>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-stack-sizing": {
+    "syntax": "ignore | stretch-to-fit",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "stretch-to-fit",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-text-blink": {
+    "syntax": "none | blink",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-user-focus": {
+    "syntax": "ignore | normal | select-after | select-before | select-menu | select-same | select-all | none",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-user-focus"
+  },
+  "-moz-user-input": {
+    "syntax": "auto | none | enabled | disabled",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-moz-user-input"
+  },
+  "-moz-user-modify": {
+    "syntax": "read-only | read-write | write-only",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "read-only",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/user-modify"
+  },
+  "-moz-window-dragging": {
+    "syntax": "drag | no-drag",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "drag",
+    "appliesto": "allElementsCreatingNativeWindows",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-moz-window-shadow": {
+    "syntax": "default | menu | tooltip | sheet | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "default",
+    "appliesto": "allElementsCreatingNativeWindows",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-appearance": {
+    "syntax": "none | button | button-bevel | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "noneButOverriddenInUserAgentCSS",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
+  },
+  "-webkit-border-after": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-after-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-after-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-after-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLength",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-before": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-border-before"
+  },
+  "-webkit-border-before-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-before-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-before-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLength",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-end": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-end-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-end-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-end-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLength",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-start": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-start-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-start-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-border-start-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLength",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-box-reflect": {
+    "syntax": "[ above | below | right | left ]? <length>? <image>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-box-reflect"
+  },
+  "-webkit-line-clamp": {
+    "syntax": "none | <integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions",
+      "CSS Overflow"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp"
+  },
+  "-webkit-mask": {
+    "syntax": "[ <mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || [ <visual-box> | border | padding | content | text ] || [ <visual-box> | border | padding | content ] ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": [
+      "-webkit-mask-image",
+      "-webkit-mask-repeat",
+      "-webkit-mask-attachment",
+      "-webkit-mask-position",
+      "-webkit-mask-origin",
+      "-webkit-mask-clip"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "-webkit-mask-image",
+      "-webkit-mask-repeat",
+      "-webkit-mask-attachment",
+      "-webkit-mask-position",
+      "-webkit-mask-origin",
+      "-webkit-mask-clip"
+    ],
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask"
+  },
+  "-webkit-mask-attachment": {
+    "syntax": "<attachment>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "scroll",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard"
+  },
+  "-webkit-mask-clip": {
+    "syntax": "[ <coord-box> | no-clip | border | padding | content | text ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "border",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-clip"
+  },
+  "-webkit-mask-composite": {
+    "syntax": "<composite-style>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "source-over",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite"
+  },
+  "-webkit-mask-image": {
+    "syntax": "<mask-reference>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "absoluteURIOrNone",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image"
+  },
+  "-webkit-mask-origin": {
+    "syntax": "[ <coord-box> | border | padding | content ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "padding",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-origin"
+  },
+  "-webkit-mask-position": {
+    "syntax": "<position>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "referToSizeOfElement",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "0% 0%",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOrPercentage",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-position"
+  },
+  "-webkit-mask-position-x": {
+    "syntax": "[ <length-percentage> | left | center | right ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "referToSizeOfElement",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "0%",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOrPercentage",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-position-x"
+  },
+  "-webkit-mask-position-y": {
+    "syntax": "[ <length-percentage> | top | center | bottom ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "referToSizeOfElement",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "0%",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOrPercentage",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-position-y"
+  },
+  "-webkit-mask-repeat": {
+    "syntax": "<repeat-style>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "repeat",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-repeat"
+  },
+  "-webkit-mask-repeat-x": {
+    "syntax": "repeat | no-repeat | space | round",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "repeat",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-x"
+  },
+  "-webkit-mask-repeat-y": {
+    "syntax": "repeat | no-repeat | space | round",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "repeat",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOrPercentage",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-y"
+  },
+  "-webkit-mask-size": {
+    "syntax": "<bg-size>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "relativeToBackgroundPositioningArea",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "auto auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-size"
+  },
+  "-webkit-overflow-scrolling": {
+    "syntax": "auto | touch",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollingBoxes",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "nonstandard"
+  },
+  "-webkit-tap-highlight-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "black",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-tap-highlight-color"
+  },
+  "-webkit-text-fill-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-fill-color"
+  },
+  "-webkit-text-stroke": {
+    "syntax": "<length> || <color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "-webkit-text-stroke-width",
+      "-webkit-text-stroke-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": [
+      "-webkit-text-stroke-width",
+      "-webkit-text-stroke-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "-webkit-text-stroke-width",
+      "-webkit-text-stroke-color"
+    ],
+    "order": "canonicalOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke"
+  },
+  "-webkit-text-stroke-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-color"
+  },
+  "-webkit-text-stroke-width": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "absoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-text-stroke-width"
+  },
+  "-webkit-touch-callout": {
+    "syntax": "default | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "default",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-touch-callout"
+  },
+  "-webkit-user-modify": {
+    "syntax": "read-only | read-write | read-write-plaintext-only",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "read-only",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "-webkit-user-select": {
+    "syntax": "auto | text | none | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "WebKit Extensions"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/user-select"
+  },
+  "accent-color": {
+    "syntax": "auto | <color>",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asAutoOrColor",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/accent-color"
+  },
+  "align-content": {
+    "syntax": "normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment",
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "blockContainersMultiColumnContainersFlexContainersGridContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-content"
+  },
+  "align-items": {
+    "syntax": "normal | stretch | <baseline-position> | [ <overflow-position>? <self-position> ] | anchor-center",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment",
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-items"
+  },
+  "align-self": {
+    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? <self-position> | anchor-center",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment",
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "flexItemsGridItemsAndAbsolutelyPositionedBoxes",
+    "computed": "autoOnAbsolutelyPositionedElementsValueOfAlignItemsOnParent",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/align-self"
+  },
+  "align-tracks": {
+    "syntax": "[ normal | <baseline-position> | <content-distribution> | <overflow-position>? <content-position> ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "gridContainersWithMasonryLayoutInTheirBlockAxis",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "alignment-baseline": {
+    "syntax": "baseline | alphabetic | ideographic | middle | central | mathematical | text-before-edge | text-after-edge",
+    "media": "none",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "baseline",
+    "appliesto": "inlineLevelBoxesFlexItemsGridItemsTableCellsAndSVGTextContentElements",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/alignment-baseline"
+  },
+  "all": {
+    "syntax": "initial | inherit | unset | revert | revert-layer",
+    "media": "noPracticalMedia",
+    "inherited": false,
+    "animationType": "eachOfShorthandPropertiesExceptUnicodeBiDiAndDirection",
+    "percentages": "no",
+    "groups": [
+      "CSS Cascading and Inheritance"
+    ],
+    "initial": "noPracticalInitialValue",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedAppliesToEachProperty",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/all"
+  },
+  "anchor-name": {
+    "syntax": "none | <dashed-ident>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsThatGenerateAPrincipalBox",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/anchor-name"
+  },
+  "anchor-scope": {
+    "syntax": "none | all | <dashed-ident>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
+  "animation": {
+    "syntax": "<single-animation>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "animation-name",
+      "animation-duration",
+      "animation-timing-function",
+      "animation-delay",
+      "animation-iteration-count",
+      "animation-direction",
+      "animation-fill-mode",
+      "animation-play-state",
+      "animation-timeline"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "animation-name",
+      "animation-duration",
+      "animation-timing-function",
+      "animation-delay",
+      "animation-direction",
+      "animation-iteration-count",
+      "animation-fill-mode",
+      "animation-play-state",
+      "animation-timeline"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation"
+  },
+  "animation-composition": {
+    "syntax": "<single-animation-composition>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "replace",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-composition"
+  },
+  "animation-delay": {
+    "syntax": "<time>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "0s",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-delay"
+  },
+  "animation-direction": {
+    "syntax": "<single-animation-direction>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-direction"
+  },
+  "animation-duration": {
+    "syntax": "[ auto | <time [0s,∞]> ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "0s",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-duration"
+  },
+  "animation-fill-mode": {
+    "syntax": "<single-animation-fill-mode>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-fill-mode"
+  },
+  "animation-iteration-count": {
+    "syntax": "<single-animation-iteration-count>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "1",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-iteration-count"
+  },
+  "animation-name": {
+    "syntax": "[ none | <keyframes-name> ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-name"
+  },
+  "animation-play-state": {
+    "syntax": "<single-animation-play-state>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "running",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-play-state"
+  },
+  "animation-range": {
+    "syntax": "[ <'animation-range-start'> <'animation-range-end'>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "animation-range-start",
+      "animation-range-end"
+    ],
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": [
+      "animation-range-start",
+      "animation-range-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "animation-range-start",
+      "animation-range-end"
+    ],
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range"
+  },
+  "animation-range-end": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range-end"
+  },
+  "animation-range-start": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range-start"
+  },
+  "animation-timeline": {
+    "syntax": "<single-animation-timeline>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "listEachItemIdentifierOrNoneAuto",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline"
+  },
+  "animation-timing-function": {
+    "syntax": "<easing-function>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "ease",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timing-function"
+  },
+  "animation-trigger": {
+    "syntax": "[ none | [ <dashed-ident> <animation-action>+ ]+ ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-trigger"
+  },
+  "appearance": {
+    "syntax": "none | auto | <compat-auto> | <compat-special>",
+    "media": "all",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance"
+  },
+  "aspect-ratio": {
+    "syntax": "auto || <ratio>",
+    "media": "all",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsExceptInlineBoxesAndInternalRubyOrTableBoxes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/aspect-ratio"
+  },
+  "backdrop-filter": {
+    "syntax": "none | <filter-value-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "filterList",
+    "percentages": "no",
+    "groups": [
+      "Filter Effects"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backdrop-filter"
+  },
+  "backface-visibility": {
+    "syntax": "visible | hidden",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "visible",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/backface-visibility"
+  },
+  "background": {
+    "syntax": "<bg-layer>#? , <final-bg-layer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "background-color",
+      "background-image",
+      "background-clip",
+      "background-position",
+      "background-size",
+      "background-repeat",
+      "background-attachment"
+    ],
+    "percentages": [
+      "background-position",
+      "background-size"
+    ],
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "background-image",
+      "background-position",
+      "background-size",
+      "background-repeat",
+      "background-origin",
+      "background-clip",
+      "background-attachment",
+      "background-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "background-image",
+      "background-position",
+      "background-size",
+      "background-repeat",
+      "background-origin",
+      "background-clip",
+      "background-attachment",
+      "background-color"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background"
+  },
+  "background-attachment": {
+    "syntax": "<attachment>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "scroll",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-attachment"
+  },
+  "background-blend-mode": {
+    "syntax": "<blend-mode>#",
+    "media": "none",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Compositing and Blending"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-blend-mode"
+  },
+  "background-clip": {
+    "syntax": "<bg-clip>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "border-box",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-clip"
+  },
+  "background-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "transparent",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-color"
+  },
+  "background-image": {
+    "syntax": "<bg-image>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-image"
+  },
+  "background-origin": {
+    "syntax": "<visual-box>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "padding-box",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-origin"
+  },
+  "background-position": {
+    "syntax": "<bg-position>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "referToSizeOfBackgroundPositioningAreaMinusBackgroundImageSize",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0% 0%",
+    "appliesto": "allElements",
+    "computed": [
+      "background-position-x",
+      "background-position-y"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position"
+  },
+  "background-position-x": {
+    "syntax": "[ center | [ [ left | right | x-start | x-end ]? <length-percentage>? ]! ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "referToWidthOfBackgroundPositioningAreaMinusBackgroundImageWidth",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0%",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-x"
+  },
+  "background-position-y": {
+    "syntax": "[ center | [ [ top | bottom | y-start | y-end ]? <length-percentage>? ]! ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "referToHeightOfBackgroundPositioningAreaMinusBackgroundImageHeight",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0%",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfAbsoluteLengthPercentageAndOrigin",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-position-y"
+  },
+  "background-repeat": {
+    "syntax": "<repeat-style>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "repeat",
+    "appliesto": "allElements",
+    "computed": "listEachItemHasTwoKeywordsOnePerDimension",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-repeat"
+  },
+  "background-size": {
+    "syntax": "<bg-size>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "relativeToBackgroundPositioningArea",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "auto auto",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/background-size"
+  },
+  "baseline-shift": {
+    "syntax": "<length-percentage> | sub | super | baseline",
+    "media": "none",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToTheUsedValueOfLineHeight",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "0",
+    "appliesto": "inlineLevelBoxesAndSVGTextContentElements",
+    "computed": "theSpecifiedKeywordOrAComputedLengthPercentageValue",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "baseline-source": {
+    "syntax": "auto | first | last",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "auto",
+    "appliesto": "inlineLevelBoxes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/baseline-source"
+  },
+  "block-size": {
+    "syntax": "<'width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "blockSizeOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "auto",
+    "appliesto": "sameAsWidthAndHeight",
+    "computed": "sameAsWidthAndHeight",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/block-size"
+  },
+  "border": {
+    "syntax": "<line-width> || <line-style> || <color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-width",
+      "border-style",
+      "border-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-width",
+      "border-style",
+      "border-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-width",
+      "border-style",
+      "border-color"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border"
+  },
+  "border-block": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-width",
+      "border-block-style",
+      "border-block-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-block-width",
+      "border-block-style",
+      "border-block-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-width",
+      "border-block-style",
+      "border-block-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block"
+  },
+  "border-block-color": {
+    "syntax": "<'border-top-color'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-start-color",
+      "border-block-end-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-block-start-color",
+      "border-block-end-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-start-color",
+      "border-block-end-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-color"
+  },
+  "border-block-end": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-end-width",
+      "border-block-end-style",
+      "border-block-end-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end"
+  },
+  "border-block-end-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-color"
+  },
+  "border-block-end-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-style"
+  },
+  "border-block-end-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-end-width"
+  },
+  "border-block-start": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-start-width",
+      "border-block-start-style",
+      "border-block-start-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start"
+  },
+  "border-block-start-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-color"
+  },
+  "border-block-start-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-style"
+  },
+  "border-block-start-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-start-width"
+  },
+  "border-block-style": {
+    "syntax": "<'border-top-style'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-block-start-style",
+      "border-block-end-style"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-start-style",
+      "border-block-end-style"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-style"
+  },
+  "border-block-width": {
+    "syntax": "<'border-top-width'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-block-start-width",
+      "border-block-end-width"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-block-start-width",
+      "border-block-end-width"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-block-start-width",
+      "border-block-end-width"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-block-width"
+  },
+  "border-bottom": {
+    "syntax": "<line-width> || <line-style> || <color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-bottom-width",
+      "border-bottom-style",
+      "border-bottom-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-bottom-width",
+      "border-bottom-style",
+      "border-bottom-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-bottom-width",
+      "border-bottom-style",
+      "border-bottom-color"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom"
+  },
+  "border-bottom-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-color"
+  },
+  "border-bottom-left-radius": {
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-left-radius"
+  },
+  "border-bottom-right-radius": {
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-right-radius"
+  },
+  "border-bottom-style": {
+    "syntax": "<line-style>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-style"
+  },
+  "border-bottom-width": {
+    "syntax": "<line-width>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOr0IfBorderBottomStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-bottom-width"
+  },
+  "border-collapse": {
+    "syntax": "separate | collapse",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Table"
+    ],
+    "initial": "separate",
+    "appliesto": "tableElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-collapse"
+  },
+  "border-color": {
+    "syntax": "<color>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-top-color",
+      "border-right-color",
+      "border-bottom-color",
+      "border-left-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-top-color",
+      "border-right-color",
+      "border-bottom-color",
+      "border-left-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-top-color",
+      "border-right-color",
+      "border-bottom-color",
+      "border-left-color"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-color"
+  },
+  "border-end-end-radius": {
+    "syntax": "<'border-top-left-radius'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-end-end-radius"
+  },
+  "border-end-start-radius": {
+    "syntax": "<'border-top-left-radius'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-end-start-radius"
+  },
+  "border-image": {
+    "syntax": "<'border-image-source'> || <'border-image-slice'> [ / <'border-image-width'> | / <'border-image-width'>? / <'border-image-outset'> ]? || <'border-image-repeat'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-image-source",
+      "border-image-slice",
+      "border-image-width",
+      "border-image-outset",
+      "border-image-repeat"
+    ],
+    "percentages": [
+      "border-image-slice",
+      "border-image-width"
+    ],
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-image-source",
+      "border-image-slice",
+      "border-image-width",
+      "border-image-outset",
+      "border-image-repeat"
+    ],
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
+    "computed": [
+      "border-image-source",
+      "border-image-slice",
+      "border-image-width",
+      "border-image-outset",
+      "border-image-repeat"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image"
+  },
+  "border-image-outset": {
+    "syntax": "[ <length [0,∞]> | <number [0,∞]> ]{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-outset"
+  },
+  "border-image-repeat": {
+    "syntax": "[ stretch | repeat | round | space ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "stretch",
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-repeat"
+  },
+  "border-image-slice": {
+    "syntax": "[ <number [0,∞]> | <percentage [0,∞]> ]{1,4} && fill?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSizeOfBorderImage",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "100%",
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
+    "computed": "oneToFourPercentagesOrAbsoluteLengthsPlusFill",
+    "order": "percentagesOrLengthsFollowedByFill",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-slice"
+  },
+  "border-image-source": {
+    "syntax": "none | <image>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
+    "computed": "noneOrImageWithAbsoluteURI",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-source"
+  },
+  "border-image-width": {
+    "syntax": "[ <length-percentage [0,∞]> | <number [0,∞]> | auto ]{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToWidthOrHeightOfBorderImageArea",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "1",
+    "appliesto": "allElementsExceptTableElementsWhenCollapse",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-image-width"
+  },
+  "border-inline": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-width",
+      "border-inline-style",
+      "border-inline-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-inline-width",
+      "border-inline-style",
+      "border-inline-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-width",
+      "border-inline-style",
+      "border-inline-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline"
+  },
+  "border-inline-color": {
+    "syntax": "<'border-top-color'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-start-color",
+      "border-inline-end-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-inline-start-color",
+      "border-inline-end-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-start-color",
+      "border-inline-end-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-color"
+  },
+  "border-inline-end": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-end-width",
+      "border-inline-end-style",
+      "border-inline-end-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end"
+  },
+  "border-inline-end-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-color"
+  },
+  "border-inline-end-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-style"
+  },
+  "border-inline-end-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-end-width"
+  },
+  "border-inline-start": {
+    "syntax": "<'border-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-start-width",
+      "border-inline-start-style",
+      "border-inline-start-color"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start"
+  },
+  "border-inline-start-color": {
+    "syntax": "<'border-top-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-color"
+  },
+  "border-inline-start-style": {
+    "syntax": "<'border-top-style'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-style"
+  },
+  "border-inline-start-width": {
+    "syntax": "<'border-top-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthZeroIfBorderStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-start-width"
+  },
+  "border-inline-style": {
+    "syntax": "<'border-top-style'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-inline-start-style",
+      "border-inline-end-style"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-start-style",
+      "border-inline-end-style"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-style"
+  },
+  "border-inline-width": {
+    "syntax": "<'border-top-width'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-inline-start-width",
+      "border-inline-end-width"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "border-inline-start-width",
+      "border-inline-end-width"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-inline-start-width",
+      "border-inline-end-width"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-inline-width"
+  },
+  "border-left": {
+    "syntax": "<line-width> || <line-style> || <color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-left-width",
+      "border-left-style",
+      "border-left-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-left-width",
+      "border-left-style",
+      "border-left-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-left-width",
+      "border-left-style",
+      "border-left-color"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left"
+  },
+  "border-left-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-color"
+  },
+  "border-left-style": {
+    "syntax": "<line-style>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-style"
+  },
+  "border-left-width": {
+    "syntax": "<line-width>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOr0IfBorderLeftStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-left-width"
+  },
+  "border-radius": {
+    "syntax": "<length-percentage [0,∞]>{1,4} [ / <length-percentage [0,∞]>{1,4} ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-right-radius",
+      "border-bottom-left-radius"
+    ],
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-right-radius",
+      "border-bottom-left-radius"
+    ],
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": [
+      "border-top-left-radius",
+      "border-top-right-radius",
+      "border-bottom-right-radius",
+      "border-bottom-left-radius"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-radius"
+  },
+  "border-right": {
+    "syntax": "<line-width> || <line-style> || <color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-right-width",
+      "border-right-style",
+      "border-right-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-right-width",
+      "border-right-style",
+      "border-right-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-right-width",
+      "border-right-style",
+      "border-right-color"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right"
+  },
+  "border-right-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-color"
+  },
+  "border-right-style": {
+    "syntax": "<line-style>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-style"
+  },
+  "border-right-width": {
+    "syntax": "<line-width>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOr0IfBorderRightStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-right-width"
+  },
+  "border-spacing": {
+    "syntax": "<length>{1,2}",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Table"
+    ],
+    "initial": "0",
+    "appliesto": "tableElements",
+    "computed": "twoAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-spacing"
+  },
+  "border-start-end-radius": {
+    "syntax": "<'border-top-left-radius'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-start-end-radius"
+  },
+  "border-start-start-radius": {
+    "syntax": "<'border-top-left-radius'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-start-start-radius"
+  },
+  "border-style": {
+    "syntax": "<line-style>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-top-style",
+      "border-right-style",
+      "border-bottom-style",
+      "border-left-style"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-top-style",
+      "border-right-style",
+      "border-bottom-style",
+      "border-left-style"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-style"
+  },
+  "border-top": {
+    "syntax": "<line-width> || <line-style> || <color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-top-width",
+      "border-top-style",
+      "border-top-color"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top"
+  },
+  "border-top-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-color"
+  },
+  "border-top-left-radius": {
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-left-radius"
+  },
+  "border-top-right-radius": {
+    "syntax": "<length-percentage [0,∞]>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfBorderBox",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsUAsNotRequiredWhenCollapse",
+    "computed": "twoAbsoluteLengthOrPercentages",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-right-radius"
+  },
+  "border-top-style": {
+    "syntax": "<line-style>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-style"
+  },
+  "border-top-width": {
+    "syntax": "<line-width>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOr0IfBorderTopStyleNoneOrHidden",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-top-width"
+  },
+  "border-width": {
+    "syntax": "<line-width>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "border-top-width",
+      "border-right-width",
+      "border-bottom-width",
+      "border-left-width"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/border-width"
+  },
+  "bottom": {
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToContainingBlockHeight",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/bottom"
+  },
+  "box-align": {
+    "syntax": "start | center | end | baseline | stretch",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "stretch",
+    "appliesto": "elementsWithDisplayBoxOrInlineBox",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-align"
+  },
+  "box-decoration-break": {
+    "syntax": "slice | clone",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fragmentation"
+    ],
+    "initial": "slice",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-decoration-break"
+  },
+  "box-direction": {
+    "syntax": "normal | reverse | inherit",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "normal",
+    "appliesto": "elementsWithDisplayBoxOrInlineBox",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-direction"
+  },
+  "box-flex": {
+    "syntax": "<number>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "0",
+    "appliesto": "directChildrenOfElementsWithDisplayMozBoxMozInlineBox",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-flex"
+  },
+  "box-flex-group": {
+    "syntax": "<integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "1",
+    "appliesto": "inFlowChildrenOfBoxElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-flex-group"
+  },
+  "box-lines": {
+    "syntax": "single | multiple",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "single",
+    "appliesto": "boxElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-lines"
+  },
+  "box-ordinal-group": {
+    "syntax": "<integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "1",
+    "appliesto": "childrenOfBoxElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-ordinal-group"
+  },
+  "box-orient": {
+    "syntax": "horizontal | vertical | inline-axis | block-axis | inherit",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "inline-axis",
+    "appliesto": "elementsWithDisplayBoxOrInlineBox",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-orient"
+  },
+  "box-pack": {
+    "syntax": "start | center | end | justify",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions",
+      "WebKit Extensions"
+    ],
+    "initial": "start",
+    "appliesto": "elementsWithDisplayMozBoxMozInlineBox",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-pack"
+  },
+  "box-shadow": {
+    "syntax": "none | <shadow>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "shadowList",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthsSpecifiedColorAsSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-shadow"
+  },
+  "box-sizing": {
+    "syntax": "content-box | border-box",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "content-box",
+    "appliesto": "allElementsAcceptingWidthOrHeight",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-sizing"
+  },
+  "break-after": {
+    "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fragmentation"
+    ],
+    "initial": "auto",
+    "appliesto": "blockLevelElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-after"
+  },
+  "break-before": {
+    "syntax": "auto | avoid | always | all | avoid-page | page | left | right | recto | verso | avoid-column | column | avoid-region | region",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fragmentation"
+    ],
+    "initial": "auto",
+    "appliesto": "blockLevelElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-before"
+  },
+  "break-inside": {
+    "syntax": "auto | avoid | avoid-page | avoid-column | avoid-region",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fragmentation"
+    ],
+    "initial": "auto",
+    "appliesto": "blockLevelElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/break-inside"
+  },
+  "caption-side": {
+    "syntax": "top | bottom",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Table"
+    ],
+    "initial": "top",
+    "appliesto": "tableCaptionElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caption-side"
+  },
+  "caret": {
+    "syntax": "<'caret-color'> || <'caret-animation'> || <'caret-shape'>",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": [
+      "caret-color",
+      "caret-animation",
+      "caret-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": [
+      "caret-color",
+      "caret-animation",
+      "caret-shape"
+    ],
+    "appliesto": "textOrElementsThatAcceptInput",
+    "computed": [
+      "caret-color",
+      "caret-animation",
+      "caret-shape"
+    ],
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "caret-animation": {
+    "syntax": "auto | manual",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "textOrElementsThatAcceptInput",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caret-animation"
+  },
+  "caret-color": {
+    "syntax": "auto | <color>",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "textOrElementsThatAcceptInput",
+    "computed": "asAutoOrColor",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caret-color"
+  },
+  "caret-shape": {
+    "syntax": "auto | bar | block | underscore",
+    "media": "interactive",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "textOrElementsThatAcceptInput",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "clear": {
+    "syntax": "none | left | right | both | inline-start | inline-end",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Positioned Layout"
+    ],
+    "initial": "none",
+    "appliesto": "blockLevelElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clear"
+  },
+  "clip": {
+    "syntax": "<shape> | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "rectangle",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "auto",
+    "appliesto": "absolutelyPositionedElements",
+    "computed": "autoOrRectangle",
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip"
+  },
+  "clip-path": {
+    "syntax": "<clip-source> | [ <basic-shape> || <geometry-box> ] | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "basicShapeOtherwiseNo",
+    "percentages": "referToReferenceBoxWhenSpecifiedOtherwiseBorderBox",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip-path"
+  },
+  "clip-rule": {
+    "syntax": "nonzero | evenodd",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "nonzero",
+    "appliesto": "limitedSVGElementsGraphics",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip-rule"
+  },
+  "color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "canvastext",
+    "appliesto": "allElementsAndText",
+    "computed": "computedColor",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color"
+  },
+  "color-interpolation-filters": {
+    "syntax": "auto | sRGB | linearRGB",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Filter Effects"
+    ],
+    "initial": "linearRGB",
+    "appliesto": "limitedSVGElementsFilterPrimitives",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color-interpolation-filters"
+  },
+  "color-scheme": {
+    "syntax": "normal | [ light | dark | <custom-ident> ]+ && only?",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color-scheme"
+  },
+  "column-count": {
+    "syntax": "<integer> | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "integer",
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersExceptTableWrappers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-count"
+  },
+  "column-fill": {
+    "syntax": "auto | balance",
+    "media": "visualInContinuousMediaNoEffectInOverflowColumns",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": "balance",
+    "appliesto": "multicolElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-fill"
+  },
+  "column-gap": {
+    "syntax": "normal | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Box Alignment",
+      "CSS Multi-column Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "multiColumnElementsFlexContainersGridContainers",
+    "computed": "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap"
+  },
+  "column-height": {
+    "syntax": "auto | <length [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing",
+      "CSS Multi-column Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersExceptTableWrappers",
+    "computed": "autoOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-height"
+  },
+  "column-rule": {
+    "syntax": "<'column-rule-width'> || <'column-rule-style'> || <'column-rule-color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "column-rule-width",
+      "column-rule-style",
+      "column-rule-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": [
+      "column-rule-width",
+      "column-rule-style",
+      "column-rule-color"
+    ],
+    "appliesto": "multicolElements",
+    "computed": [
+      "column-rule-width",
+      "column-rule-style",
+      "column-rule-color"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule"
+  },
+  "column-rule-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "multicolElements",
+    "computed": "computedColor",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-color"
+  },
+  "column-rule-style": {
+    "syntax": "<line-style>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": "none",
+    "appliesto": "multicolElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-style"
+  },
+  "column-rule-width": {
+    "syntax": "<line-width>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": "medium",
+    "appliesto": "multicolElements",
+    "computed": "absoluteLength0IfColumnRuleStyleNoneOrHidden",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-rule-width"
+  },
+  "column-span": {
+    "syntax": "none | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": "none",
+    "appliesto": "inFlowBlockLevelElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-span"
+  },
+  "column-width": {
+    "syntax": "auto | <length [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing",
+      "CSS Multi-column Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersExceptTableWrappers",
+    "computed": "autoOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-width"
+  },
+  "column-wrap": {
+    "syntax": "auto | nowrap | wrap",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing",
+      "CSS Multi-column Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "multicolElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-wrap"
+  },
+  "columns": {
+    "syntax": "[ <'column-width'> || <'column-count'> ] [ / <'column-height'> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "column-width",
+      "column-count",
+      "column-height"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Multi-column Layout"
+    ],
+    "initial": [
+      "column-width",
+      "column-count",
+      "column-height"
+    ],
+    "appliesto": "blockContainersExceptTableWrappers",
+    "computed": [
+      "column-width",
+      "column-count",
+      "column-height"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/columns"
+  },
+  "contain": {
+    "syntax": "none | strict | content | [ [ size || inline-size ] || layout || style || paint ]",
+    "media": "all",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Containment"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain"
+  },
+  "contain-intrinsic-block-size": {
+    "syntax": "auto? [ none | <length> ]",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "none",
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
+    "computed": "asSpecifiedWithLengthValuesComputed",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-block-size"
+  },
+  "contain-intrinsic-height": {
+    "syntax": "auto? [ none | <length> ]",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "none",
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
+    "computed": "asSpecifiedWithLengthValuesComputed",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height"
+  },
+  "contain-intrinsic-inline-size": {
+    "syntax": "auto? [ none | <length> ]",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "none",
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
+    "computed": "asSpecifiedWithLengthValuesComputed",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-inline-size"
+  },
+  "contain-intrinsic-size": {
+    "syntax": "[ auto? [ none | <length> ] ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "contain-intrinsic-width",
+      "contain-intrinsic-height"
+    ],
+    "percentages": [
+      "contain-intrinsic-width",
+      "contain-intrinsic-height"
+    ],
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": [
+      "contain-intrinsic-width",
+      "contain-intrinsic-height"
+    ],
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
+    "computed": [
+      "contain-intrinsic-width",
+      "contain-intrinsic-height"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-size"
+  },
+  "contain-intrinsic-width": {
+    "syntax": "auto? [ none | <length> ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "none",
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
+    "computed": "asSpecifiedWithLengthValuesComputed",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width"
+  },
+  "container": {
+    "syntax": "<'container-name'> [ / <'container-type'> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "container-name",
+      "container-type"
+    ],
+    "percentages": [
+      "container-name",
+      "container-type"
+    ],
+    "groups": [
+      "CSS Conditional Rules"
+    ],
+    "initial": [
+      "container-name",
+      "container-type"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "container-name",
+      "container-type"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container"
+  },
+  "container-name": {
+    "syntax": "none | <custom-ident>+",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Conditional Rules"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "noneOrOrderedListOfIdentifiers",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-name"
+  },
+  "container-type": {
+    "syntax": "normal | [ [ size | inline-size ] || scroll-state ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Conditional Rules"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/container-type"
+  },
+  "content": {
+    "syntax": "normal | none | [ <content-replacement> | <content-list> ] [ / [ <string> | <counter> | <attr()> ]+ ]?",
+    "media": "all",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Generated Content"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsTreeAbidingPseudoElementsPageMarginBoxes",
+    "computed": "normalOnElementsForPseudosNoneAbsoluteURIStringOrAsSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/content"
+  },
+  "content-visibility": {
+    "syntax": "visible | auto | hidden",
+    "media": "all",
+    "inherited": false,
+    "animationType": "discreteButVisibleForDurationWhenAnimatedHidden",
+    "percentages": "no",
+    "groups": [
+      "CSS Containment"
+    ],
+    "initial": "visible",
+    "appliesto": "elementsForWhichSizeContainmentCanApply",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/content-visibility"
+  },
+  "corner-block-end-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-end-start-shape",
+      "corner-end-end-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-end-start-shape",
+      "corner-end-end-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-end-start-shape",
+      "corner-end-end-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-block-end-shape"
+  },
+  "corner-block-start-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-block-start-shape"
+  },
+  "corner-bottom-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-bottom-shape"
+  },
+  "corner-bottom-left-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-bottom-left-shape"
+  },
+  "corner-bottom-right-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-bottom-right-shape"
+  },
+  "corner-end-end-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-end-end-shape"
+  },
+  "corner-end-start-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-end-start-shape"
+  },
+  "corner-inline-end-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-start-end-shape",
+      "corner-end-end-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-start-end-shape",
+      "corner-end-end-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-start-end-shape",
+      "corner-end-end-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-inline-end-shape"
+  },
+  "corner-inline-start-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-start-start-shape",
+      "corner-start-end-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-inline-start-shape"
+  },
+  "corner-left-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-top-left-shape",
+      "corner-bottom-left-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-top-left-shape",
+      "corner-bottom-left-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-top-left-shape",
+      "corner-bottom-left-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-left-shape"
+  },
+  "corner-right-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-top-right-shape",
+      "corner-bottom-right-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-top-right-shape",
+      "corner-bottom-right-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-top-right-shape",
+      "corner-bottom-right-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-right-shape"
+  },
+  "corner-shape": {
+    "syntax": "<corner-shape-value>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-top-left-shape",
+      "corner-top-right-shape",
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-top-left-shape",
+      "corner-top-right-shape",
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-top-left-shape",
+      "corner-top-right-shape",
+      "corner-bottom-left-shape",
+      "corner-bottom-right-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-shape"
+  },
+  "corner-start-start-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-start-start-shape"
+  },
+  "corner-start-end-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-start-end-shape"
+  },
+  "corner-top-shape": {
+    "syntax": "<corner-shape-value>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "corner-top-left-shape",
+      "corner-top-right-shape"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": [
+      "corner-top-left-shape",
+      "corner-top-right-shape"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "corner-top-left-shape",
+      "corner-top-right-shape"
+    ],
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-top-shape"
+  },
+  "corner-top-left-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-top-left-shape"
+  },
+  "corner-top-right-shape": {
+    "syntax": "<corner-shape-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "superellipseInterpolation",
+    "percentages": "no",
+    "groups": [
+      "CSS Backgrounds and Borders"
+    ],
+    "initial": "round",
+    "appliesto": "allElements",
+    "computed": "correspondingSuperellipse",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/corner-top-right-shape"
+  },
+  "counter-increment": {
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
+    "media": "all",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-increment"
+  },
+  "counter-reset": {
+    "syntax": "[ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none",
+    "media": "all",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-reset"
+  },
+  "counter-set": {
+    "syntax": "[ <counter-name> <integer>? ]+ | none",
+    "media": "all",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/counter-set"
+  },
+  "cursor": {
+    "syntax": "[ [ <url> [ <x> <y> ]? , ]* <cursor-predefined> ]",
+    "media": [
+      "visual",
+      "interactive"
+    ],
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cursor"
+  },
+  "cx": {
+    "syntax": "<length> | <percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportWidth",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "0",
+    "appliesto": "limitedSVGElementsEllipse",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cx"
+  },
+  "cy": {
+    "syntax": "<length> | <percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportHeight",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "0",
+    "appliesto": "limitedSVGElementsEllipse",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/cy"
+  },
+  "d": {
+    "syntax": "none | path(<string>)",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "basicShapeOtherwiseNo",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "none",
+    "appliesto": "limitedSVGElementsPath",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/d"
+  },
+  "direction": {
+    "syntax": "ltr | rtl",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Writing Modes"
+    ],
+    "initial": "ltr",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/direction"
+  },
+  "display": {
+    "syntax": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy>",
+    "media": "all",
+    "inherited": false,
+    "animationType": "discreteButVisibleForDurationWhenAnimatedNone",
+    "percentages": "no",
+    "groups": [
+      "CSS Display"
+    ],
+    "initial": "inline",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedExceptPositionedFloatingAndRootElementsKeywordMaybeDifferent",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/display"
+  },
+  "dominant-baseline": {
+    "syntax": "auto | text-bottom | alphabetic | ideographic | middle | central | mathematical | hanging | text-top",
+    "media": "all",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline",
+      "Scalable Vector Graphics"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersFlexContainersGridContainersInlineBoxesTableRowsSVGTextContentElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/dominant-baseline"
+  },
+  "dynamic-range-limit": {
+    "syntax": "standard | no-limit | constrained | <dynamic-range-limit-mix()>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byDynamicRangeLimitMix",
+    "percentages": "no",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "no-limit",
+    "appliesto": "allElements",
+    "computed": "computedValueForDynamicRangeLimit",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/dynamic-range-limit"
+  },
+  "empty-cells": {
+    "syntax": "show | hide",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Table"
+    ],
+    "initial": "show",
+    "appliesto": "tableCellElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/empty-cells"
+  },
+  "field-sizing": {
+    "syntax": "content | fixed",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "fixed",
+    "appliesto": "elementsWithDefaultPreferredSize",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/field-sizing"
+  },
+  "fill": {
+    "syntax": "<paint>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "black",
+    "appliesto": "limitedSVGElementsShapeText",
+    "computed": "asColorOrAbsoluteURL",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fill"
+  },
+  "fill-opacity": {
+    "syntax": "<'opacity'>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "mapToRange0To1",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "1",
+    "appliesto": "limitedSVGElementsShapeText",
+    "computed": "specifiedValueNumberClipped0To1",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fill-opacity"
+  },
+  "fill-rule": {
+    "syntax": "nonzero | evenodd",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "nonzero",
+    "appliesto": "limitedSVGElementsShapeText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/fill-rule"
+  },
+  "filter": {
+    "syntax": "none | <filter-value-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "filterList",
+    "percentages": "no",
+    "groups": [
+      "Filter Effects"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/filter"
+  },
+  "flex": {
+    "syntax": "none | [ <'flex-grow'> <'flex-shrink'>? || <'flex-basis'> ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "flex-grow",
+      "flex-shrink",
+      "flex-basis"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": [
+      "flex-grow",
+      "flex-shrink",
+      "flex-basis"
+    ],
+    "appliesto": "flexItemsAndInFlowPseudos",
+    "computed": [
+      "flex-grow",
+      "flex-shrink",
+      "flex-basis"
+    ],
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex"
+  },
+  "flex-basis": {
+    "syntax": "content | <'width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToFlexContainersInnerMainSize",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "flexItemsAndInFlowPseudos",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "lengthOrPercentageBeforeKeywordIfBothPresent",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-basis"
+  },
+  "flex-direction": {
+    "syntax": "row | row-reverse | column | column-reverse",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "row",
+    "appliesto": "flexContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-direction"
+  },
+  "flex-flow": {
+    "syntax": "<'flex-direction'> || <'flex-wrap'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "flex-direction",
+      "flex-wrap"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": [
+      "flex-direction",
+      "flex-wrap"
+    ],
+    "appliesto": "flexContainers",
+    "computed": [
+      "flex-direction",
+      "flex-wrap"
+    ],
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-flow"
+  },
+  "flex-grow": {
+    "syntax": "<number>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "number",
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "0",
+    "appliesto": "flexItemsAndInFlowPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-grow"
+  },
+  "flex-shrink": {
+    "syntax": "<number>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "number",
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "1",
+    "appliesto": "flexItemsAndInFlowPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-shrink"
+  },
+  "flex-wrap": {
+    "syntax": "nowrap | wrap | wrap-reverse",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "nowrap",
+    "appliesto": "flexContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flex-wrap"
+  },
+  "float": {
+    "syntax": "left | right | none | inline-start | inline-end",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Positioned Layout"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsNoEffectIfDisplayNone",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/float"
+  },
+  "flood-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "Filter Effects"
+    ],
+    "initial": "black",
+    "appliesto": "limitedSVGElementsFloodAndDropShadow",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flood-color"
+  },
+  "flood-opacity": {
+    "syntax": "<'opacity'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "Filter Effects"
+    ],
+    "initial": "black",
+    "appliesto": "limitedSVGElementsFloodAndDropShadow",
+    "computed": "specifiedValueClipped0To1",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/flood-opacity"
+  },
+  "font": {
+    "syntax": "[ [ <'font-style'> || <font-variant-css2> || <'font-weight'> || <font-width-css3> ]? <'font-size'> [ / <'line-height'> ]? <'font-family'># ] | <system-family-name>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "font-style",
+      "font-variant",
+      "font-weight",
+      "font-stretch",
+      "font-size",
+      "line-height",
+      "font-family"
+    ],
+    "percentages": [
+      "font-size",
+      "line-height"
+    ],
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": [
+      "font-style",
+      "font-variant",
+      "font-weight",
+      "font-stretch",
+      "font-size",
+      "line-height",
+      "font-family"
+    ],
+    "appliesto": "allElementsAndText",
+    "computed": [
+      "font-style",
+      "font-variant",
+      "font-weight",
+      "font-stretch",
+      "font-size",
+      "line-height",
+      "font-family"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font"
+  },
+  "font-family": {
+    "syntax": "[ <family-name> | <generic-family> ]#",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "dependsOnUserAgent",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-family"
+  },
+  "font-feature-settings": {
+    "syntax": "normal | <feature-tag-value>#",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-feature-settings"
+  },
+  "font-kerning": {
+    "syntax": "auto | normal | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-kerning"
+  },
+  "font-language-override": {
+    "syntax": "normal | <string>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-language-override"
+  },
+  "font-optical-sizing": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-optical-sizing"
+  },
+  "font-palette": {
+    "syntax": "normal | light | dark | <palette-identifier> | <palette-mix()>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette"
+  },
+  "font-size": {
+    "syntax": "<absolute-size> | <relative-size> | <length-percentage [0,∞]> | math",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "referToParentElementsFontSize",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "medium",
+    "appliesto": "allElementsAndText",
+    "computed": "absoluteLength",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size"
+  },
+  "font-size-adjust": {
+    "syntax": "none | [ ex-height | cap-height | ch-width | ic-width | ic-height ]? [ from-font | <number> ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "number",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust"
+  },
+  "font-smooth": {
+    "syntax": "auto | never | always | <absolute-size> | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-smooth"
+  },
+  "font-stretch": {
+    "syntax": "<font-stretch-absolute>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-stretch"
+  },
+  "font-style": {
+    "syntax": "normal | italic | oblique <angle>?",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueTypeNormalAnimatesAsObliqueZeroDeg",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-style"
+  },
+  "font-synthesis": {
+    "syntax": "none | [ weight || style || small-caps || position]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "weight style small-caps position ",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis"
+  },
+  "font-synthesis-position": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-position"
+  },
+  "font-synthesis-small-caps": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-small-caps"
+  },
+  "font-synthesis-style": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-style"
+  },
+  "font-synthesis-weight": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-synthesis-weight"
+  },
+  "font-variant": {
+    "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> || stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) || [ small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps ] || <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero || <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant"
+  },
+  "font-variant-alternates": {
+    "syntax": "normal | [ stylistic( <feature-value-name> ) || historical-forms || styleset( <feature-value-name># ) || character-variant( <feature-value-name># ) || swash( <feature-value-name> ) || ornaments( <feature-value-name> ) || annotation( <feature-value-name> ) ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates"
+  },
+  "font-variant-caps": {
+    "syntax": "normal | small-caps | all-small-caps | petite-caps | all-petite-caps | unicase | titling-caps",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-caps"
+  },
+  "font-variant-east-asian": {
+    "syntax": "normal | [ <east-asian-variant-values> || <east-asian-width-values> || ruby ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-east-asian"
+  },
+  "font-variant-emoji": {
+    "syntax": "normal | text | emoji | unicode",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-emoji"
+  },
+  "font-variant-ligatures": {
+    "syntax": "normal | none | [ <common-lig-values> || <discretionary-lig-values> || <historical-lig-values> || <contextual-alt-values> ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-ligatures"
+  },
+  "font-variant-numeric": {
+    "syntax": "normal | [ <numeric-figure-values> || <numeric-spacing-values> || <numeric-fraction-values> || ordinal || slashed-zero ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-numeric"
+  },
+  "font-variant-position": {
+    "syntax": "normal | sub | super",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-position"
+  },
+  "font-variation-settings": {
+    "syntax": "normal | [ <string> <number> ]#",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "transform",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variation-settings"
+  },
+  "font-weight": {
+    "syntax": "<font-weight-absolute> | bolder | lighter",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "keywordOrNumericalValueBolderLighterTransformedToRealValue",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-weight"
+  },
+  "font-width": {
+    "syntax": "normal | <percentage [0,∞]> | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Fonts"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsAndText",
+    "computed": "percentage",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "experimental"
+  },
+  "forced-color-adjust": {
+    "syntax": "auto | none | preserve-parent-color",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsAndText",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/forced-color-adjust"
+  },
+  "gap": {
+    "syntax": "<'row-gap'> <'column-gap'>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "row-gap",
+      "column-gap"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": [
+      "row-gap",
+      "column-gap"
+    ],
+    "appliesto": "multiColumnElementsFlexContainersGridContainers",
+    "computed": [
+      "row-gap",
+      "column-gap"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap"
+  },
+  "grid": {
+    "syntax": "<'grid-template'> | <'grid-template-rows'> / [ auto-flow && dense? ] <'grid-auto-columns'>? | [ auto-flow && dense? ] <'grid-auto-rows'>? / <'grid-template-columns'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "grid-template-rows",
+      "grid-template-columns",
+      "grid-template-areas",
+      "grid-auto-rows",
+      "grid-auto-columns",
+      "grid-auto-flow",
+      "grid-column-gap",
+      "grid-row-gap",
+      "column-gap",
+      "row-gap"
+    ],
+    "percentages": [
+      "grid-template-rows",
+      "grid-template-columns",
+      "grid-auto-rows",
+      "grid-auto-columns"
+    ],
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": [
+      "grid-template-rows",
+      "grid-template-columns",
+      "grid-template-areas",
+      "grid-auto-rows",
+      "grid-auto-columns",
+      "grid-auto-flow",
+      "grid-column-gap",
+      "grid-row-gap",
+      "column-gap",
+      "row-gap"
+    ],
+    "appliesto": "gridContainers",
+    "computed": [
+      "grid-template-rows",
+      "grid-template-columns",
+      "grid-template-areas",
+      "grid-auto-rows",
+      "grid-auto-columns",
+      "grid-auto-flow",
+      "grid-column-gap",
+      "grid-row-gap",
+      "column-gap",
+      "row-gap"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid"
+  },
+  "grid-area": {
+    "syntax": "<grid-line> [ / <grid-line> ]{0,3}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": [
+      "grid-row-start",
+      "grid-column-start",
+      "grid-row-end",
+      "grid-column-end"
+    ],
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": [
+      "grid-row-start",
+      "grid-column-start",
+      "grid-row-end",
+      "grid-column-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-area"
+  },
+  "grid-auto-columns": {
+    "syntax": "<track-size>+",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "gridContainers",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-columns"
+  },
+  "grid-auto-flow": {
+    "syntax": "[ row | column ] || dense",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "row",
+    "appliesto": "gridContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow"
+  },
+  "grid-auto-rows": {
+    "syntax": "<track-size>+",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "gridContainers",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-rows"
+  },
+  "grid-column": {
+    "syntax": "<grid-line> [ / <grid-line> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": [
+      "grid-column-start",
+      "grid-column-end"
+    ],
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": [
+      "grid-column-start",
+      "grid-column-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column"
+  },
+  "grid-column-end": {
+    "syntax": "<grid-line>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-end"
+  },
+  "grid-column-gap": {
+    "syntax": "<length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "0",
+    "appliesto": "gridContainers",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/column-gap"
+  },
+  "grid-column-start": {
+    "syntax": "<grid-line>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-column-start"
+  },
+  "grid-gap": {
+    "syntax": "<'grid-row-gap'> <'grid-column-gap'>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "grid-row-gap",
+      "grid-column-gap"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": [
+      "grid-row-gap",
+      "grid-column-gap"
+    ],
+    "appliesto": "gridContainers",
+    "computed": [
+      "grid-row-gap",
+      "grid-column-gap"
+    ],
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gap"
+  },
+  "grid-row": {
+    "syntax": "<grid-line> [ / <grid-line> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": [
+      "grid-row-start",
+      "grid-row-end"
+    ],
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": [
+      "grid-row-start",
+      "grid-row-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row"
+  },
+  "grid-row-end": {
+    "syntax": "<grid-line>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-end"
+  },
+  "grid-row-gap": {
+    "syntax": "<length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "0",
+    "appliesto": "gridContainers",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap"
+  },
+  "grid-row-start": {
+    "syntax": "<grid-line>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "gridItemsAndBoxesWithinGridContainer",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-row-start"
+  },
+  "grid-template": {
+    "syntax": "none | [ <'grid-template-rows'> / <'grid-template-columns'> ] | [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas"
+    ],
+    "percentages": [
+      "grid-template-columns",
+      "grid-template-rows"
+    ],
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": [
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas"
+    ],
+    "appliesto": "gridContainers",
+    "computed": [
+      "grid-template-columns",
+      "grid-template-rows",
+      "grid-template-areas"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template"
+  },
+  "grid-template-areas": {
+    "syntax": "none | <string>+",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-areas"
+  },
+  "grid-template-columns": {
+    "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpcDifferenceLpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-columns"
+  },
+  "grid-template-rows": {
+    "syntax": "none | <track-list> | <auto-track-list> | subgrid <line-name-list>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpcDifferenceLpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "none",
+    "appliesto": "gridContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-template-rows"
+  },
+  "hanging-punctuation": {
+    "syntax": "none | [ first || [ force-end | allow-end ] || last ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hanging-punctuation"
+  },
+  "height": {
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "regardingHeightOfGeneratedBoxContainingBlockPercentagesRelativeToContainingBlock",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsButNonReplacedAndTableColumns",
+    "computed": "percentageAutoOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/height"
+  },
+  "hyphenate-character": {
+    "syntax": "auto | <string>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphenate-character"
+  },
+  "hyphenate-limit-chars": {
+    "syntax": "[ auto | <integer> ]{1,3}",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphenate-limit-chars"
+  },
+  "hyphens": {
+    "syntax": "none | manual | auto",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "manual",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphens"
+  },
+  "image-orientation": {
+    "syntax": "from-image | <angle> | [ <angle>? flip ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "from-image",
+    "appliesto": "allElements",
+    "computed": "angleRoundedToNextQuarter",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-orientation"
+  },
+  "image-rendering": {
+    "syntax": "auto | crisp-edges | pixelated | smooth",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-rendering"
+  },
+  "image-resolution": {
+    "syntax": "[ from-image || <resolution> ] && snap?",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "1dppx",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedWithExceptionOfResolution",
+    "order": "uniqueOrder",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-resolution"
+  },
+  "ime-mode": {
+    "syntax": "auto | normal | active | inactive | disabled",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "textFields",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "initial-letter": {
+    "syntax": "normal | [ <number> <integer>? ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "normal",
+    "appliesto": "firstLetterPseudoElementsAndInlineLevelFirstChildren",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/initial-letter"
+  },
+  "initial-letter-align": {
+    "syntax": "[ auto | alphabetic | hanging | ideographic ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "auto",
+    "appliesto": "firstLetterPseudoElementsAndInlineLevelFirstChildren",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental"
+  },
+  "inline-size": {
+    "syntax": "<'width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "inlineSizeOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "auto",
+    "appliesto": "sameAsWidthAndHeight",
+    "computed": "sameAsWidthAndHeight",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inline-size"
+  },
+  "inset": {
+    "syntax": "<'top'>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalHeightOrWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": [
+      "top",
+      "bottom",
+      "left",
+      "right"
+    ],
+    "appliesto": "positionedElements",
+    "computed": [
+      "top",
+      "bottom",
+      "left",
+      "right"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset"
+  },
+  "inset-block": {
+    "syntax": "<'top'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalHeightOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": [
+      "inset-block-start",
+      "inset-block-end"
+    ],
+    "appliesto": "positionedElements",
+    "computed": [
+      "inset-block-start",
+      "inset-block-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block"
+  },
+  "inset-block-end": {
+    "syntax": "<'top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalHeightOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-end"
+  },
+  "inset-block-start": {
+    "syntax": "<'top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalHeightOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-block-start"
+  },
+  "inset-inline": {
+    "syntax": "<'top'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": [
+      "inset-inline-start",
+      "inset-inline-end"
+    ],
+    "appliesto": "positionedElements",
+    "computed": [
+      "inset-inline-start",
+      "inset-inline-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline"
+  },
+  "inset-inline-end": {
+    "syntax": "<'top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-end"
+  },
+  "inset-inline-start": {
+    "syntax": "<'top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "sameAsBoxOffsets",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inset-inline-start"
+  },
+  "interpolate-size": {
+    "syntax": "numeric-only | allow-keywords",
+    "media": "none",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Values and Units"
+    ],
+    "initial": "numeric-only",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/interpolate-size"
+  },
+  "isolation": {
+    "syntax": "auto | isolate",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Compositing and Blending"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsSVGContainerGraphicsAndGraphicsReferencingElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/isolation"
+  },
+  "interactivity": {
+    "syntax": "auto | inert",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/interactivity"
+  },
+  "interest-delay": {
+    "syntax": "<'interest-delay-start'>{1,2}",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "interest-delay-start",
+      "interest-delay-end"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": [
+      "interest-delay-start",
+      "interest-delay-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "interest-delay-start",
+      "interest-delay-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/interest-delay-end"
+  },
+  "interest-delay-end": {
+    "syntax": "normal | <time>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "normalOrComputedTime",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/interest-delay-end"
+  },
+  "interest-delay-start": {
+    "syntax": "normal | <time>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "normalOrComputedTime",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/interest-delay-start"
+  },
+  "justify-content": {
+    "syntax": "normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment",
+      "CSS Flexible Box Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "flexContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-content"
+  },
+  "justify-items": {
+    "syntax": "normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | legacy | legacy && [ left | right | center ] | anchor-center",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": "legacy",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-items"
+  },
+  "justify-self": {
+    "syntax": "auto | normal | stretch | <baseline-position> | <overflow-position>? [ <self-position> | left | right ] | anchor-center",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": "auto",
+    "appliesto": "blockLevelBoxesAndAbsolutelyPositionedBoxesAndGridItems",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/justify-self"
+  },
+  "justify-tracks": {
+    "syntax": "[ normal | <content-distribution> | <overflow-position>? [ <content-position> | left | right ] ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "normal",
+    "appliesto": "gridContainersWithMasonryLayoutInTheirInlineAxis",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "left": {
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/left"
+  },
+  "letter-spacing": {
+    "syntax": "normal | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "optimumValueOfAbsoluteLengthOrNormal",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/letter-spacing"
+  },
+  "lighting-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "Filter Effects"
+    ],
+    "initial": "white",
+    "appliesto": "limitedSVGElementsLightSource",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/lighting-color"
+  },
+  "line-break": {
+    "syntax": "auto | loose | normal | strict | anywhere",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-break"
+  },
+  "line-clamp": {
+    "syntax": "none | <integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "integer",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainersExceptMultiColumnContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-clamp"
+  },
+  "line-height": {
+    "syntax": "normal | <number> | <length> | <percentage>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "numberOrLength",
+    "percentages": "referToElementFontSize",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOrAsSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-height"
+  },
+  "line-height-step": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Rhythmic Sizing"
+    ],
+    "initial": "0",
+    "appliesto": "blockContainers",
+    "computed": "absoluteLength",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-height-step"
+  },
+  "list-style": {
+    "syntax": "<'list-style-type'> || <'list-style-position'> || <'list-style-image'>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "list-style-image",
+      "list-style-position",
+      "list-style-type"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": [
+      "list-style-type",
+      "list-style-position",
+      "list-style-image"
+    ],
+    "appliesto": "listItems",
+    "computed": [
+      "list-style-image",
+      "list-style-position",
+      "list-style-type"
+    ],
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style"
+  },
+  "list-style-image": {
+    "syntax": "<image> | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": "none",
+    "appliesto": "listItems",
+    "computed": "theKeywordListStyleImageNoneOrComputedValue",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style-image"
+  },
+  "list-style-position": {
+    "syntax": "inside | outside",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": "outside",
+    "appliesto": "listItems",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style-position"
+  },
+  "list-style-type": {
+    "syntax": "<counter-style> | <string> | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Lists and Counters"
+    ],
+    "initial": "disc",
+    "appliesto": "listItems",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/list-style-type"
+  },
+  "margin": {
+    "syntax": "<'margin-top'>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": [
+      "margin-bottom",
+      "margin-left",
+      "margin-right",
+      "margin-top"
+    ],
+    "appliesto": "allElementsExceptTableDisplayTypes",
+    "computed": [
+      "margin-bottom",
+      "margin-left",
+      "margin-right",
+      "margin-top"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin"
+  },
+  "margin-block": {
+    "syntax": "<'margin-top'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "margin-block-start",
+      "margin-block-end"
+    ],
+    "appliesto": "sameAsMargin",
+    "computed": [
+      "margin-block-start",
+      "margin-block-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block"
+  },
+  "margin-block-end": {
+    "syntax": "<'margin-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsMargin",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-end"
+  },
+  "margin-block-start": {
+    "syntax": "<'margin-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsMargin",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-start"
+  },
+  "margin-bottom": {
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-bottom"
+  },
+  "margin-inline": {
+    "syntax": "<'margin-top'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "margin-inline-start",
+      "margin-inline-end"
+    ],
+    "appliesto": "sameAsMargin",
+    "computed": [
+      "margin-inline-start",
+      "margin-inline-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline"
+  },
+  "margin-inline-end": {
+    "syntax": "<'margin-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsMargin",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-end"
+  },
+  "margin-inline-start": {
+    "syntax": "<'margin-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "dependsOnLayoutModel",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsMargin",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-inline-start"
+  },
+  "margin-left": {
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-left"
+  },
+  "margin-right": {
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-right"
+  },
+  "margin-top": {
+    "syntax": "<length-percentage> | auto | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-top"
+  },
+  "margin-trim": {
+    "syntax": "none | in-flow | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainersAndMultiColumnContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter"
+    ],
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-trim"
+  },
+  "marker": {
+    "syntax": "none | <url>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": [
+      "marker-start",
+      "marker-mid",
+      "marker-end"
+    ],
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/marker"
+  },
+  "marker-end": {
+    "syntax": "none | <url>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "none",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/marker-end"
+  },
+  "marker-mid": {
+    "syntax": "none | <url>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "none",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/marker-mid"
+  },
+  "marker-start": {
+    "syntax": "none | <url>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "none",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/marker-start"
+  },
+  "mask": {
+    "syntax": "<mask-layer>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "mask-image",
+      "mask-mode",
+      "mask-repeat",
+      "mask-position",
+      "mask-clip",
+      "mask-origin",
+      "mask-size",
+      "mask-composite"
+    ],
+    "percentages": [
+      "mask-position"
+    ],
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": [
+      "mask-image",
+      "mask-mode",
+      "mask-repeat",
+      "mask-position",
+      "mask-clip",
+      "mask-origin",
+      "mask-size",
+      "mask-composite"
+    ],
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": [
+      "mask-image",
+      "mask-mode",
+      "mask-repeat",
+      "mask-position",
+      "mask-clip",
+      "mask-origin",
+      "mask-size",
+      "mask-composite"
+    ],
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask"
+  },
+  "mask-border": {
+    "syntax": "<'mask-border-source'> || <'mask-border-slice'> [ / <'mask-border-width'>? [ / <'mask-border-outset'> ]? ]? || <'mask-border-repeat'> || <'mask-border-mode'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "mask-border-mode",
+      "mask-border-outset",
+      "mask-border-repeat",
+      "mask-border-slice",
+      "mask-border-source",
+      "mask-border-width"
+    ],
+    "percentages": [
+      "mask-border-slice",
+      "mask-border-width"
+    ],
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": [
+      "mask-border-mode",
+      "mask-border-outset",
+      "mask-border-repeat",
+      "mask-border-slice",
+      "mask-border-source",
+      "mask-border-width"
+    ],
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": [
+      "mask-border-mode",
+      "mask-border-outset",
+      "mask-border-repeat",
+      "mask-border-slice",
+      "mask-border-source",
+      "mask-border-width"
+    ],
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border"
+  },
+  "mask-border-mode": {
+    "syntax": "luminance | alpha",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "alpha",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-mode"
+  },
+  "mask-border-outset": {
+    "syntax": "[ <length> | <number> ]{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-outset"
+  },
+  "mask-border-repeat": {
+    "syntax": "[ stretch | repeat | round | space ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "stretch",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-repeat"
+  },
+  "mask-border-slice": {
+    "syntax": "<number-percentage>{1,4} fill?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "referToSizeOfMaskBorderImage",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-slice"
+  },
+  "mask-border-source": {
+    "syntax": "none | <image>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-source"
+  },
+  "mask-border-width": {
+    "syntax": "[ <length-percentage> | <number> | auto ]{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "relativeToMaskBorderImageArea",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-border-width"
+  },
+  "mask-clip": {
+    "syntax": "[ <coord-box> | no-clip ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "border-box",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-clip"
+  },
+  "mask-composite": {
+    "syntax": "<compositing-operator>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "add",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-composite"
+  },
+  "mask-image": {
+    "syntax": "<mask-reference>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecifiedURLsAbsolute",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image"
+  },
+  "mask-mode": {
+    "syntax": "<masking-mode>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "match-source",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-mode"
+  },
+  "mask-origin": {
+    "syntax": "<coord-box>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "border-box",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-origin"
+  },
+  "mask-position": {
+    "syntax": "<position>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "referToSizeOfMaskPaintingArea",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "0% 0%",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "consistsOfTwoKeywordsForOriginAndOffsets",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-position"
+  },
+  "mask-repeat": {
+    "syntax": "<repeat-style>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "repeat",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "consistsOfTwoDimensionKeywords",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-repeat"
+  },
+  "mask-size": {
+    "syntax": "<bg-size>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "repeatableList",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsSVGContainerElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-size"
+  },
+  "mask-type": {
+    "syntax": "luminance | alpha",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Masking"
+    ],
+    "initial": "luminance",
+    "appliesto": "maskElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-type"
+  },
+  "masonry-auto-flow": {
+    "syntax": "[ pack | next ] || [ definite-first | ordered ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Grid Layout"
+    ],
+    "initial": "pack",
+    "appliesto": "gridContainersWithMasonryLayout",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/grid-auto-flow"
+  },
+  "math-depth": {
+    "syntax": "auto-add | add(<integer>) | <integer>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "MathML"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-depth"
+  },
+  "math-shift": {
+    "syntax": "normal | compact",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "MathML"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-shift"
+  },
+  "math-style": {
+    "syntax": "normal | compact",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "MathML"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-style"
+  },
+  "max-block-size": {
+    "syntax": "<'max-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "blockSizeOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "sameAsWidthAndHeight",
+    "computed": "sameAsMaxWidthAndMaxHeight",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-block-size"
+  },
+  "max-height": {
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "regardingHeightOfGeneratedBoxContainingBlockPercentagesNone",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsButNonReplacedAndTableColumns",
+    "computed": "percentageAsSpecifiedAbsoluteLengthOrNone",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-height"
+  },
+  "max-inline-size": {
+    "syntax": "<'max-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "inlineSizeOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "none",
+    "appliesto": "sameAsWidthAndHeight",
+    "computed": "sameAsMaxWidthAndMaxHeight",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-inline-size"
+  },
+  "max-lines": {
+    "syntax": "none | <integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "integer",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainersExceptMultiColumnContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
+  "max-width": {
+    "syntax": "none | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "none",
+    "appliesto": "allElementsButNonReplacedAndTableRows",
+    "computed": "percentageAsSpecifiedAbsoluteLengthOrNone",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-width"
+  },
+  "min-block-size": {
+    "syntax": "<'min-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "blockSizeOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsWidthAndHeight",
+    "computed": "sameAsMinWidthAndMinHeight",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-block-size"
+  },
+  "min-height": {
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "regardingHeightOfGeneratedBoxContainingBlockPercentages0",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsButNonReplacedAndTableColumns",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-height"
+  },
+  "min-inline-size": {
+    "syntax": "<'min-width'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "inlineSizeOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "sameAsWidthAndHeight",
+    "computed": "sameAsMinWidthAndMinHeight",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-inline-size"
+  },
+  "min-width": {
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsButNonReplacedAndTableRows",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-width"
+  },
+  "mix-blend-mode": {
+    "syntax": "<blend-mode> | plus-darker | plus-lighter",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Compositing and Blending"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mix-blend-mode"
+  },
+  "object-fit": {
+    "syntax": "fill | contain | cover | none | scale-down",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "fill",
+    "appliesto": "replacedElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-fit"
+  },
+  "object-position": {
+    "syntax": "<position>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "repeatableList",
+    "percentages": "referToWidthAndHeightOfElement",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "50% 50%",
+    "appliesto": "replacedElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/object-position"
+  },
+  "object-view-box": {
+    "syntax": "none | <basic-shape-rect>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "asIfPossibleOtherwiseDiscrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Images"
+    ],
+    "initial": "none",
+    "appliesto": "replacedElements",
+    "computed": "specifiedKeywordOrComputedFunction",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
+  "offset": {
+    "syntax": "[ <'offset-position'>? [ <'offset-path'> [ <'offset-distance'> || <'offset-rotate'> ]? ]? ]! [ / <'offset-anchor'> ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "offset-position",
+      "offset-path",
+      "offset-distance",
+      "offset-anchor",
+      "offset-rotate"
+    ],
+    "percentages": [
+      "offset-position",
+      "offset-distance",
+      "offset-anchor"
+    ],
+    "groups": [
+      "Motion Path"
+    ],
+    "initial": [
+      "offset-position",
+      "offset-path",
+      "offset-distance",
+      "offset-anchor",
+      "offset-rotate"
+    ],
+    "appliesto": "transformableElements",
+    "computed": [
+      "offset-position",
+      "offset-path",
+      "offset-distance",
+      "offset-anchor",
+      "offset-rotate"
+    ],
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset"
+  },
+  "offset-anchor": {
+    "syntax": "auto | <position>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "position",
+    "percentages": "relativeToWidthAndHeight",
+    "groups": [
+      "Motion Path"
+    ],
+    "initial": "auto",
+    "appliesto": "transformableElements",
+    "computed": "forLengthAbsoluteValueOtherwisePercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-anchor"
+  },
+  "offset-distance": {
+    "syntax": "<length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToTotalPathLength",
+    "groups": [
+      "Motion Path"
+    ],
+    "initial": "0",
+    "appliesto": "transformableElements",
+    "computed": "forLengthAbsoluteValueOtherwisePercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-distance"
+  },
+  "offset-path": {
+    "syntax": "none | <offset-path> || <coord-box>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "Motion Path"
+    ],
+    "initial": "none",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-path"
+  },
+  "offset-position": {
+    "syntax": "normal | auto | <position>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "position",
+    "percentages": "referToSizeOfContainingBlock",
+    "groups": [
+      "Motion Path"
+    ],
+    "initial": "normal",
+    "appliesto": "transformableElements",
+    "computed": "forLengthAbsoluteValueOtherwisePercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-position"
+  },
+  "offset-rotate": {
+    "syntax": "[ auto | reverse ] || <angle>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "angleOrBasicShapeOrPath",
+    "percentages": "no",
+    "groups": [
+      "Motion Path"
+    ],
+    "initial": "auto",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-rotate"
+  },
+  "opacity": {
+    "syntax": "<opacity-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "mapToRange0To1",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "1",
+    "appliesto": "allElements",
+    "computed": "specifiedValueNumberClipped0To1",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/opacity"
+  },
+  "order": {
+    "syntax": "<integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "integer",
+    "percentages": "no",
+    "groups": [
+      "CSS Display"
+    ],
+    "initial": "0",
+    "appliesto": "flexItemsGridItemsAbsolutelyPositionedContainerChildren",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/order"
+  },
+  "orphans": {
+    "syntax": "<integer>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Fragmentation"
+    ],
+    "initial": "2",
+    "appliesto": "blockContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/orphans"
+  },
+  "outline": {
+    "syntax": "<'outline-width'> || <'outline-style'> || <'outline-color'>",
+    "media": [
+      "visual",
+      "interactive"
+    ],
+    "inherited": false,
+    "animationType": [
+      "outline-width",
+      "outline-style",
+      "outline-color"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": [
+      "outline-width",
+      "outline-style",
+      "outline-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "outline-width",
+      "outline-style",
+      "outline-color"
+    ],
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline"
+  },
+  "outline-color": {
+    "syntax": "auto | <color>",
+    "media": [
+      "visual",
+      "interactive"
+    ],
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "autoForTranslucentColorRGBAOtherwiseRGB",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-color"
+  },
+  "outline-offset": {
+    "syntax": "<length>",
+    "media": [
+      "visual",
+      "interactive"
+    ],
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-offset"
+  },
+  "outline-style": {
+    "syntax": "auto | <outline-line-style>",
+    "media": [
+      "visual",
+      "interactive"
+    ],
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-style"
+  },
+  "outline-width": {
+    "syntax": "<line-width>",
+    "media": [
+      "visual",
+      "interactive"
+    ],
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "medium",
+    "appliesto": "allElements",
+    "computed": "absoluteLength0ForNone",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline-width"
+  },
+  "overflow": {
+    "syntax": "[ visible | hidden | clip | scroll | auto ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "visible",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": [
+      "overflow-x",
+      "overflow-y"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow"
+  },
+  "overflow-anchor": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Anchoring"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-anchor"
+  },
+  "overflow-block": {
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-block"
+  },
+  "overflow-clip-box": {
+    "syntax": "padding-box | content-box",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Mozilla Extensions"
+    ],
+    "initial": "padding-box",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "nonstandard"
+  },
+  "overflow-clip-margin": {
+    "syntax": "<visual-box> || <length [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "0px",
+    "appliesto": "allElements",
+    "computed": "theComputedLengthAndVisualBox",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-clip-margin"
+  },
+  "overflow-inline": {
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-inline"
+  },
+  "overflow-wrap": {
+    "syntax": "normal | break-word | anywhere",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-wrap"
+  },
+  "overflow-x": {
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "visible",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-x"
+  },
+  "overflow-y": {
+    "syntax": "visible | hidden | clip | scroll | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "visible",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": "asSpecifiedButVisibleOrClipReplacedToAutoOrHiddenIfOtherValueDifferent",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-y"
+  },
+  "overlay": {
+    "syntax": "none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discreteButVisibleForDurationWhenAnimatedNone",
+    "percentages": "no",
+    "groups": [
+      "CSS Positioned Layout"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overlay"
+  },
+  "overscroll-behavior": {
+    "syntax": "[ contain | none | auto ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overscroll Behavior"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": [
+      "overscroll-behavior-x",
+      "overscroll-behavior-y"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior"
+  },
+  "overscroll-behavior-block": {
+    "syntax": "contain | none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overscroll Behavior"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-block"
+  },
+  "overscroll-behavior-inline": {
+    "syntax": "contain | none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overscroll Behavior"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-inline"
+  },
+  "overscroll-behavior-x": {
+    "syntax": "contain | none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overscroll Behavior"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-x"
+  },
+  "overscroll-behavior-y": {
+    "syntax": "contain | none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overscroll Behavior"
+    ],
+    "initial": "auto",
+    "appliesto": "nonReplacedBlockAndInlineBlockElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overscroll-behavior-y"
+  },
+  "padding": {
+    "syntax": "<'padding-top'>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": [
+      "padding-bottom",
+      "padding-left",
+      "padding-right",
+      "padding-top"
+    ],
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": [
+      "padding-bottom",
+      "padding-left",
+      "padding-right",
+      "padding-top"
+    ],
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding"
+  },
+  "padding-block": {
+    "syntax": "<'padding-top'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "padding-block-start",
+      "padding-block-end"
+    ],
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": [
+      "padding-block-start",
+      "padding-block-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block"
+  },
+  "padding-block-end": {
+    "syntax": "<'padding-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "asLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-end"
+  },
+  "padding-block-start": {
+    "syntax": "<'padding-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "asLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-block-start"
+  },
+  "padding-bottom": {
+    "syntax": "<length-percentage [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-bottom"
+  },
+  "padding-inline": {
+    "syntax": "<'padding-top'>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": [
+      "padding-inline-start",
+      "padding-inline-end"
+    ],
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": [
+      "padding-inline-start",
+      "padding-inline-end"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline"
+  },
+  "padding-inline-end": {
+    "syntax": "<'padding-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "asLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-end"
+  },
+  "padding-inline-start": {
+    "syntax": "<'padding-top'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "logicalWidthOfContainingBlock",
+    "groups": [
+      "CSS Logical Properties and Values"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "asLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-inline-start"
+  },
+  "padding-left": {
+    "syntax": "<length-percentage [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-left"
+  },
+  "padding-right": {
+    "syntax": "<length-percentage [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-right"
+  },
+  "padding-top": {
+    "syntax": "<length-percentage [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Model"
+    ],
+    "initial": "0",
+    "appliesto": "allElementsExceptInternalTableDisplayTypes",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/padding-top"
+  },
+  "page": {
+    "syntax": "auto | <custom-ident>",
+    "media": "paged",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Paged Media"
+    ],
+    "initial": "auto",
+    "appliesto": "blockElementsInNormalFlow",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page"
+  },
+  "page-break-after": {
+    "syntax": "auto | always | avoid | left | right | recto | verso",
+    "media": [
+      "visual",
+      "paged"
+    ],
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Paged Media"
+    ],
+    "initial": "auto",
+    "appliesto": "blockElementsInNormalFlow",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page-break-after"
+  },
+  "page-break-before": {
+    "syntax": "auto | always | avoid | left | right | recto | verso",
+    "media": [
+      "visual",
+      "paged"
+    ],
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Paged Media"
+    ],
+    "initial": "auto",
+    "appliesto": "blockElementsInNormalFlow",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page-break-before"
+  },
+  "page-break-inside": {
+    "syntax": "auto | avoid",
+    "media": [
+      "visual",
+      "paged"
+    ],
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Paged Media"
+    ],
+    "initial": "auto",
+    "appliesto": "blockElementsInNormalFlow",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "obsolete",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page-break-inside"
+  },
+  "paint-order": {
+    "syntax": "normal | [ fill || stroke || markers ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "normal",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/paint-order"
+  },
+  "perspective": {
+    "syntax": "none | <length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "none",
+    "appliesto": "transformableElements",
+    "computed": "absoluteLengthOrNone",
+    "order": "uniqueOrder",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/perspective"
+  },
+  "perspective-origin": {
+    "syntax": "<position>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpc",
+    "percentages": "referToSizeOfBoundingBox",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "50% 50%",
+    "appliesto": "transformableElements",
+    "computed": "forLengthAbsoluteValueOtherwisePercentage",
+    "order": "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/perspective-origin"
+  },
+  "place-content": {
+    "syntax": "<'align-content'> <'justify-content'>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": [
+      "align-content",
+      "justify-content"
+    ],
+    "appliesto": "multilineFlexContainers",
+    "computed": [
+      "align-content",
+      "justify-content"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-content"
+  },
+  "place-items": {
+    "syntax": "<'align-items'> <'justify-items'>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": [
+      "align-items",
+      "justify-items"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "align-items",
+      "justify-items"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-items"
+  },
+  "place-self": {
+    "syntax": "<'align-self'> <'justify-self'>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": [
+      "align-self",
+      "justify-self"
+    ],
+    "appliesto": "blockLevelBoxesAndAbsolutelyPositionedBoxesAndGridItems",
+    "computed": [
+      "align-self",
+      "justify-self"
+    ],
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/place-self"
+  },
+  "pointer-events": {
+    "syntax": "auto | none | visiblePainted | visibleFill | visibleStroke | visible | painted | fill | stroke | all | inherit",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/pointer-events"
+  },
+  "position": {
+    "syntax": "static | relative | absolute | sticky | fixed",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Positioned Layout"
+    ],
+    "initial": "static",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position"
+  },
+  "position-anchor": {
+    "syntax": "normal | auto | none | <anchor-name> | match-parent",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "normal",
+    "appliesto": "absolutelyPositionedElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-anchor"
+  },
+  "position-area": {
+    "syntax": "none | <position-area>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "none",
+    "appliesto": "positionedElementsWithADefaultAnchorElement",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-area"
+  },
+  "position-try": {
+    "syntax": "<'position-try-order'>? <'position-try-fallbacks'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "position-try-fallbacks",
+      "position-try-order"
+    ],
+    "percentages": [
+      "position-try-fallbacks",
+      "position-try-order"
+    ],
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": [
+      "position-try-fallbacks",
+      "position-try-order"
+    ],
+    "appliesto": "absolutelyPositionedElements",
+    "computed": [
+      "position-try-fallbacks",
+      "position-try-order"
+    ],
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-try"
+  },
+  "position-try-fallbacks": {
+    "syntax": "none | [ [<dashed-ident> || <try-tactic>] | <'position-area'> ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "none",
+    "appliesto": "absolutelyPositionedElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-try-fallbacks"
+  },
+  "position-try-order": {
+    "syntax": "normal | <try-size>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "normal",
+    "appliesto": "absolutelyPositionedElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-try-order"
+  },
+  "position-visibility": {
+    "syntax": "always | [ anchors-valid || anchors-visible || no-overflow ]",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Anchor Positioning"
+    ],
+    "initial": "anchors-visible",
+    "appliesto": "absolutelyPositionedElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/position-visibility"
+  },
+  "print-color-adjust": {
+    "syntax": "economy | exact",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Color"
+    ],
+    "initial": "economy",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/print-color-adjust"
+  },
+  "quotes": {
+    "syntax": "none | auto | [ <string> <string> ]+",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Generated Content"
+    ],
+    "initial": "dependsOnUserAgent",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/quotes"
+  },
+  "r": {
+    "syntax": "<length> | <percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportSize",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "0",
+    "appliesto": "limitedSVGElementsCircle",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/r"
+  },
+  "reading-flow": {
+    "syntax": "normal | source-order | flex-visual | flex-flow | grid-rows | grid-columns | grid-order",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Display"
+    ],
+    "initial": "normal",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/reading-flow"
+  },
+  "reading-order": {
+    "syntax": "<integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Display"
+    ],
+    "initial": "0",
+    "appliesto": "blockContainersFlexContainersGridContainers",
+    "computed": "specifiedInteger",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/reading-order"
+  },
+  "resize": {
+    "syntax": "none | both | horizontal | vertical | block | inline",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "none",
+    "appliesto": "elementsWithOverflowNotVisibleAndReplacedElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/resize"
+  },
+  "right": {
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/right"
+  },
+  "rotate": {
+    "syntax": "none | <angle> | [ x | y | z | <number>{3} ] && <angle>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "transform",
+    "percentages": "no",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "none",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rotate"
+  },
+  "row-gap": {
+    "syntax": "normal | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToDimensionOfContentArea",
+    "groups": [
+      "CSS Box Alignment"
+    ],
+    "initial": "normal",
+    "appliesto": "multiColumnElementsFlexContainersGridContainers",
+    "computed": "asSpecifiedWithLengthsAbsoluteAndNormalComputingToZeroExceptMultiColumn",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/row-gap"
+  },
+  "ruby-align": {
+    "syntax": "start | center | space-between | space-around",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Ruby"
+    ],
+    "initial": "space-around",
+    "appliesto": "rubyBasesAnnotationsBaseAnnotationContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ruby-align"
+  },
+  "ruby-merge": {
+    "syntax": "separate | collapse | auto",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Ruby"
+    ],
+    "initial": "separate",
+    "appliesto": "rubyAnnotationContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental"
+  },
+  "ruby-overhang": {
+    "syntax": "auto | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Ruby"
+    ],
+    "initial": "auto",
+    "appliesto": "rubyAnnotationContainers",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "ruby-position": {
+    "syntax": "[ alternate || [ over | under ] ] | inter-character",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Ruby"
+    ],
+    "initial": "alternate",
+    "appliesto": "rubyAnnotationContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ruby-position"
+  },
+  "rx": {
+    "syntax": "<length-percentage> | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportWidth",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "auto",
+    "appliesto": "limitedSVGElementsEllipseRect",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rx"
+  },
+  "ry": {
+    "syntax": "<length-percentage> | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportHeight",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "auto",
+    "appliesto": "limitedSVGElementsEllipseRect",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ry"
+  },
+  "scale": {
+    "syntax": "none | [ <number> | <percentage> ]{1,3}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "transform",
+    "percentages": "no",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "none",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scale"
+  },
+  "scroll-behavior": {
+    "syntax": "auto | smooth",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollingBoxes",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-behavior"
+  },
+  "scroll-initial-target": {
+    "syntax": "none | nearest",
+    "media": "noPracticalMedia",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
+  "scroll-margin": {
+    "syntax": "<length>{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": [
+      "scroll-margin-bottom",
+      "scroll-margin-left",
+      "scroll-margin-right",
+      "scroll-margin-top"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "scroll-margin-bottom",
+      "scroll-margin-left",
+      "scroll-margin-right",
+      "scroll-margin-top"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin"
+  },
+  "scroll-margin-block": {
+    "syntax": "<length>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": [
+      "scroll-margin-block-start",
+      "scroll-margin-block-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "scroll-margin-block-start",
+      "scroll-margin-block-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block"
+  },
+  "scroll-margin-block-end": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-end"
+  },
+  "scroll-margin-block-start": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-block-start"
+  },
+  "scroll-margin-bottom": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-bottom"
+  },
+  "scroll-margin-inline": {
+    "syntax": "<length>{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": [
+      "scroll-margin-inline-start",
+      "scroll-margin-inline-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "scroll-margin-inline-start",
+      "scroll-margin-inline-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline"
+  },
+  "scroll-margin-inline-end": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-end"
+  },
+  "scroll-margin-inline-start": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-inline-start"
+  },
+  "scroll-margin-left": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-left"
+  },
+  "scroll-margin-right": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-right"
+  },
+  "scroll-margin-top": {
+    "syntax": "<length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-margin-top"
+  },
+  "scroll-marker-group": {
+    "syntax": "none | before | after",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "none",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-marker-group"
+  },
+  "scroll-padding": {
+    "syntax": "[ auto | <length-percentage> ]{1,4}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": [
+      "scroll-padding-bottom",
+      "scroll-padding-left",
+      "scroll-padding-right",
+      "scroll-padding-top"
+    ],
+    "appliesto": "scrollContainers",
+    "computed": [
+      "scroll-padding-bottom",
+      "scroll-padding-left",
+      "scroll-padding-right",
+      "scroll-padding-top"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding"
+  },
+  "scroll-padding-block": {
+    "syntax": "[ auto | <length-percentage> ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": [
+      "scroll-padding-block-start",
+      "scroll-padding-block-end"
+    ],
+    "appliesto": "scrollContainers",
+    "computed": [
+      "scroll-padding-block-start",
+      "scroll-padding-block-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block"
+  },
+  "scroll-padding-block-end": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-end"
+  },
+  "scroll-padding-block-start": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-block-start"
+  },
+  "scroll-padding-bottom": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-bottom"
+  },
+  "scroll-padding-inline": {
+    "syntax": "[ auto | <length-percentage> ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": [
+      "scroll-padding-inline-start",
+      "scroll-padding-inline-end"
+    ],
+    "appliesto": "scrollContainers",
+    "computed": [
+      "scroll-padding-inline-start",
+      "scroll-padding-inline-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline"
+  },
+  "scroll-padding-inline-end": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-end"
+  },
+  "scroll-padding-inline-start": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-inline-start"
+  },
+  "scroll-padding-left": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-left"
+  },
+  "scroll-padding-right": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-right"
+  },
+  "scroll-padding-top": {
+    "syntax": "auto | <length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToTheScrollContainersScrollport",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-padding-top"
+  },
+  "scroll-snap-align": {
+    "syntax": "[ none | start | end | center ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-align"
+  },
+  "scroll-snap-coordinate": {
+    "syntax": "none | <position>#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "position",
+    "percentages": "referToBorderBox",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "scroll-snap-destination": {
+    "syntax": "<position>",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "position",
+    "percentages": "relativeToScrollContainerPaddingBoxAxis",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "0px 0px",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "scroll-snap-points-x": {
+    "syntax": "none | repeat( <length-percentage> )",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "relativeToScrollContainerPaddingBoxAxis",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "scroll-snap-points-y": {
+    "syntax": "none | repeat( <length-percentage> )",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "relativeToScrollContainerPaddingBoxAxis",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "scroll-snap-stop": {
+    "syntax": "normal | always",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-stop"
+  },
+  "scroll-snap-type": {
+    "syntax": "none | [ x | y | block | inline | both ] [ mandatory | proximity ]?",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-snap-type"
+  },
+  "scroll-snap-type-x": {
+    "syntax": "none | mandatory | proximity",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "scroll-snap-type-y": {
+    "syntax": "none | mandatory | proximity",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scroll Snap"
+    ],
+    "initial": "none",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "obsolete"
+  },
+  "scroll-target-group": {
+    "syntax": "none | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-target-group"
+  },
+  "scroll-timeline": {
+    "syntax": "[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "scroll-timeline-name",
+      "scroll-timeline-axis"
+    ],
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": [
+      "scroll-timeline-name",
+      "scroll-timeline-axis"
+    ],
+    "appliesto": "scrollContainers",
+    "computed": [
+      "scroll-timeline-name",
+      "scroll-timeline-axis"
+    ],
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline"
+  },
+  "scroll-timeline-axis": {
+    "syntax": "[ block | inline | x | y ]#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "block",
+    "appliesto": "scrollContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis"
+  },
+  "scroll-timeline-name": {
+    "syntax": "[ none | <dashed-ident> ]#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "none",
+    "appliesto": "scrollContainers",
+    "computed": "noneOrOrderedListOfIdentifiers",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name"
+  },
+  "scrollbar-color": {
+    "syntax": "auto | <color>{2}",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Scrollbars Styling"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollingBoxes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-color"
+  },
+  "scrollbar-gutter": {
+    "syntax": "auto | stable && both-edges?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollingBoxes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-gutter"
+  },
+  "scrollbar-width": {
+    "syntax": "auto | thin | none",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Scrollbars Styling"
+    ],
+    "initial": "auto",
+    "appliesto": "scrollingBoxes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scrollbar-width"
+  },
+  "shape-image-threshold": {
+    "syntax": "<opacity-value>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "number",
+    "percentages": "no",
+    "groups": [
+      "CSS Shapes"
+    ],
+    "initial": "0.0",
+    "appliesto": "floats",
+    "computed": "specifiedValueNumberClipped0To1",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-image-threshold"
+  },
+  "shape-margin": {
+    "syntax": "<length-percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Shapes"
+    ],
+    "initial": "0",
+    "appliesto": "floats",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-margin"
+  },
+  "shape-outside": {
+    "syntax": "none | [ <shape-box> || <basic-shape> ] | <image>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "basicShapeOtherwiseNo",
+    "percentages": "no",
+    "groups": [
+      "CSS Shapes"
+    ],
+    "initial": "none",
+    "appliesto": "floats",
+    "computed": "asDefinedForBasicShapeWithAbsoluteURIOtherwiseAsSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-outside"
+  },
+  "shape-rendering": {
+    "syntax": "auto | optimizeSpeed | crispEdges | geometricPrecision",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "auto",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-rendering"
+  },
+  "speak-as": {
+    "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Speech"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "specifiedValue",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
+  "stop-color": {
+    "syntax": "<'color'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "black",
+    "appliesto": "limitedSVGElementsStop",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stop-color"
+  },
+  "stop-opacity": {
+    "syntax": "<'opacity'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "black",
+    "appliesto": "limitedSVGElementsStop",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stop-opacity"
+  },
+  "stroke": {
+    "syntax": "<paint>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "stroke-dasharray",
+      "stroke-dashoffset",
+      "stroke-linecap",
+      "stroke-linejoin",
+      "stroke-miterlimit",
+      "stroke-opacity",
+      "stroke-width"
+    ],
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": [
+      "stroke-dasharray",
+      "stroke-dashoffset",
+      "stroke-linecap",
+      "stroke-linejoin",
+      "stroke-miterlimit",
+      "stroke-opacity",
+      "stroke-width"
+    ],
+    "appliesto": "asLonghands",
+    "computed": "asLonghands",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke"
+  },
+  "stroke-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "transparent",
+    "appliesto": "textAndSVGShapes",
+    "computed": "computedColor",
+    "order": "perGrammar",
+    "status": "experimental"
+  },
+  "stroke-dasharray": {
+    "syntax": "none | <dasharray>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "repeatableList",
+    "percentages": "referToSVGViewportDiagonal",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "none",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "listEachItemConsistingOfAbsoluteLengthPercentageOrKeyword",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-dasharray"
+  },
+  "stroke-dashoffset": {
+    "syntax": "<length-percentage> | <number>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportDiagonal",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "0",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "absoluteLengthOrPercentageNumbersConverted",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-dashoffset"
+  },
+  "stroke-linecap": {
+    "syntax": "butt | round | square",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "butt",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-linecap"
+  },
+  "stroke-linejoin": {
+    "syntax": "miter | miter-clip | round | bevel | arcs",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "miter",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-linejoin"
+  },
+  "stroke-miterlimit": {
+    "syntax": "<number>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "4",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-miterlimit"
+  },
+  "stroke-opacity": {
+    "syntax": "<'opacity'>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "1",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "specifiedValueClipped0To1",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-opacity"
+  },
+  "stroke-width": {
+    "syntax": "<length-percentage> | <number>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportDiagonal",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "1px",
+    "appliesto": "limitedSVGElementsShapes",
+    "computed": "absoluteLengthOrPercentageNumbersConverted",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/stroke-width"
+  },
+  "tab-size": {
+    "syntax": "<integer> | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "length",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "8",
+    "appliesto": "blockContainers",
+    "computed": "specifiedIntegerOrAbsoluteLength",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/tab-size"
+  },
+  "table-layout": {
+    "syntax": "auto | fixed",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Table"
+    ],
+    "initial": "auto",
+    "appliesto": "tableElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/table-layout"
+  },
+  "text-align": {
+    "syntax": "start | end | left | right | center | justify | match-parent",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "startOrNamelessValueIfLTRRightIfRTL",
+    "appliesto": "blockContainers",
+    "computed": "asSpecifiedExceptMatchParent",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-align"
+  },
+  "text-align-last": {
+    "syntax": "auto | start | end | left | right | center | justify",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainers",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-align-last"
+  },
+  "text-anchor": {
+    "syntax": "start | middle | end",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "start",
+    "appliesto": "limitedSVGElementsTextContent",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-anchor"
+  },
+  "text-autospace": {
+    "syntax": "normal | <autospace> | auto",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-autospace"
+  },
+  "text-box": {
+    "syntax": "normal | <'text-box-trim'> || <'text-box-edge'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "normal",
+    "appliesto": "blockContainersAndInlineBoxes",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "text-box-edge": {
+    "syntax": "auto | <text-edge>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "auto",
+    "appliesto": "blockContainersAndInlineBoxes",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "text-box-trim": {
+    "syntax": "none | trim-start | trim-end | trim-both",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "none",
+    "appliesto": "blockContainersAndInlineBoxes",
+    "computed": "theSpecifiedKeyword",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "text-combine-upright": {
+    "syntax": "none | all | [ digits <integer>? ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Writing Modes"
+    ],
+    "initial": "none",
+    "appliesto": "nonReplacedInlineElements",
+    "computed": "keywordPlusIntegerIfDigits",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-combine-upright"
+  },
+  "text-decoration": {
+    "syntax": "<'text-decoration-line'> || <'text-decoration-style'> || <'text-decoration-color'> || <'text-decoration-thickness'>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "text-decoration-color",
+      "text-decoration-style",
+      "text-decoration-line",
+      "text-decoration-thickness"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": [
+      "text-decoration-color",
+      "text-decoration-style",
+      "text-decoration-line"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "text-decoration-line",
+      "text-decoration-style",
+      "text-decoration-color",
+      "text-decoration-thickness"
+    ],
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration"
+  },
+  "text-decoration-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-color"
+  },
+  "text-decoration-inset": {
+    "syntax": "<length>{1,2} | auto",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValue",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "0",
+    "appliesto": "allElements",
+    "computed": "absoluteLengthOrKeyword",
+    "order": "perGrammar",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-inset"
+  },
+  "text-decoration-line": {
+    "syntax": "none | [ underline || overline || line-through || blink ] | spelling-error | grammar-error",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-line"
+  },
+  "text-decoration-skip": {
+    "syntax": "none | [ objects || [ spaces | [ leading-spaces || trailing-spaces ] ] || edges || box-decoration ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "objects",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip"
+  },
+  "text-decoration-skip-ink": {
+    "syntax": "auto | all | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-skip-ink"
+  },
+  "text-decoration-style": {
+    "syntax": "solid | double | dotted | dashed | wavy",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "solid",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-style"
+  },
+  "text-decoration-thickness": {
+    "syntax": "auto | from-font | <length> | <percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToElementFontSize",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness"
+  },
+  "text-emphasis": {
+    "syntax": "<'text-emphasis-style'> || <'text-emphasis-color'>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "text-emphasis-color",
+      "text-emphasis-style"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": [
+      "text-emphasis-style",
+      "text-emphasis-color"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "text-emphasis-style",
+      "text-emphasis-color"
+    ],
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis"
+  },
+  "text-emphasis-color": {
+    "syntax": "<color>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "color",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "currentcolor",
+    "appliesto": "allElements",
+    "computed": "computedColor",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-color"
+  },
+  "text-emphasis-position": {
+    "syntax": "auto | [ over | under ] && [ right | left ]?",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-position"
+  },
+  "text-emphasis-style": {
+    "syntax": "none | [ [ filled | open ] || [ dot | circle | double-circle | triangle | sesame ] ] | <string>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-emphasis-style"
+  },
+  "text-indent": {
+    "syntax": "<length-percentage> && hanging? && each-line?",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "0",
+    "appliesto": "blockContainers",
+    "computed": "percentageOrAbsoluteLengthPlusKeywords",
+    "order": "lengthOrPercentageBeforeKeywords",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-indent"
+  },
+  "text-justify": {
+    "syntax": "auto | inter-character | inter-word | none",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "inlineLevelAndTableCellElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-justify"
+  },
+  "text-orientation": {
+    "syntax": "mixed | upright | sideways",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Writing Modes"
+    ],
+    "initial": "mixed",
+    "appliesto": "allElementsExceptTableRowGroupsRowsColumnGroupsAndColumns",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-orientation"
+  },
+  "text-overflow": {
+    "syntax": "[ clip | ellipsis | <string> ]{1,2}",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Overflow"
+    ],
+    "initial": "clip",
+    "appliesto": "blockContainerElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-overflow"
+  },
+  "text-rendering": {
+    "syntax": "auto | optimizeSpeed | optimizeLegibility | geometricPrecision",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "auto",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-rendering"
+  },
+  "text-shadow": {
+    "syntax": "none | <shadow-t>#",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "shadowList",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "colorPlusThreeAbsoluteLengths",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-shadow"
+  },
+  "text-size-adjust": {
+    "syntax": "none | auto | <percentage>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSizeOfFont",
+    "groups": [
+      "CSS Mobile Text Size Adjustment"
+    ],
+    "initial": "autoForSmartphoneBrowsersSupportingInflation",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-size-adjust"
+  },
+  "text-spacing-trim": {
+    "syntax": "space-all | normal | space-first | trim-start",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "textElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-spacing-trim"
+  },
+  "text-transform": {
+    "syntax": "none | [ capitalize | uppercase | lowercase ] || full-width || full-size-kana | math-auto",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text",
+      "MathML"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-transform"
+  },
+  "text-underline-offset": {
+    "syntax": "auto | <length> | <percentage>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "referToElementFontSize",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-offset"
+  },
+  "text-underline-position": {
+    "syntax": "auto | from-font | [ under || [ left | right ] ]",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text Decoration"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-underline-position"
+  },
+  "text-wrap": {
+    "syntax": "<'text-wrap-mode'> || <'text-wrap-style'>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
+    "percentages": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "wrap",
+    "appliesto": "textAndBlockContainers",
+    "computed": [
+      "text-wrap-mode",
+      "text-wrap-style"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap"
+  },
+  "text-wrap-mode": {
+    "syntax": "wrap | nowrap",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "wrap",
+    "appliesto": "textAndBlockContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap-mode"
+  },
+  "text-wrap-style": {
+    "syntax": "auto | balance | stable | pretty",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "auto",
+    "appliesto": "textAndBlockContainers",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap-style"
+  },
+  "timeline-scope": {
+    "syntax": "none | <dashed-ident>#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "noneOrOrderedListOfIdentifiers",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/timeline-scope"
+  },
+  "timeline-trigger": {
+    "syntax": "none | [ <'timeline-trigger-name'> <'timeline-trigger-source'> <'timeline-trigger-activation-range'> [ '/' <'timeline-trigger-active-range'> ]? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-activation-range",
+      "timeline-trigger-active-range"
+    ],
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-activation-range",
+      "timeline-trigger-active-range"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "timeline-trigger-name",
+      "timeline-trigger-source",
+      "timeline-trigger-activation-range",
+      "timeline-trigger-active-range"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger"
+  },
+  "timeline-trigger-activation-range": {
+    "syntax": "[ <'timeline-trigger-activation-range-start'> <'timeline-trigger-activation-range-end'>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": [
+      "timeline-trigger-activation-range-start",
+      "timeline-trigger-activation-range-end"
+    ],
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "timeline-trigger-activation-range-start",
+      "timeline-trigger-activation-range-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "timeline-trigger-activation-range-start",
+      "timeline-trigger-activation-range-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-activation-range"
+  },
+  "timeline-trigger-activation-range-end": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-activation-range-end"
+  },
+  "timeline-trigger-activation-range-start": {
+    "syntax": "[ normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-activation-range-start"
+  },
+  "timeline-trigger-active-range": {
+    "syntax": "[ <'timeline-trigger-active-range-start'> <'timeline-trigger-active-range-end'>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": [
+      "timeline-trigger-active-range-start",
+      "timeline-trigger-active-range-end"
+    ],
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": [
+      "timeline-trigger-active-range-start",
+      "timeline-trigger-active-range-end"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "timeline-trigger-active-range-start",
+      "timeline-trigger-active-range-end"
+    ],
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-active-range"
+  },
+  "timeline-trigger-active-range-end": {
+    "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-active-range-end"
+  },
+  "timeline-trigger-active-range-start": {
+    "syntax": "[ auto | normal | <length-percentage> | <timeline-range-name> <length-percentage>? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "relativeToTimelineRangeIfSpecifiedOtherwiseEntireTimeline",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfNormalLengthPercentageOrNameLengthPercentage",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-active-range-start"
+  },
+  "timeline-trigger-name": {
+    "syntax": "none | <dashed-ident>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-name"
+  },
+  "timeline-trigger-source": {
+    "syntax": "<single-animation-timeline>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "listOfNoneAutoIdentScrollOrView",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/timeline-trigger-source"
+  },
+  "top": {
+    "syntax": "auto | <length-percentage> | <anchor()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToContainingBlockHeight",
+    "groups": [
+      "CSS Anchor Positioning",
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "lengthAbsolutePercentageAsSpecifiedOtherwiseAuto",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/top"
+  },
+  "touch-action": {
+    "syntax": "auto | none | [ [ pan-x | pan-left | pan-right ] || [ pan-y | pan-up | pan-down ] || pinch-zoom ] | manipulation",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Pointer Events"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsExceptNonReplacedInlineElementsTableRowsColumnsRowColumnGroups",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/touch-action"
+  },
+  "transform": {
+    "syntax": "none | <transform-list>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "transform",
+    "percentages": "referToSizeOfBoundingBox",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "none",
+    "appliesto": "transformableElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "uniqueOrder",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform"
+  },
+  "transform-box": {
+    "syntax": "content-box | border-box | fill-box | stroke-box | view-box",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "view-box",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-box"
+  },
+  "transform-origin": {
+    "syntax": "[ <length-percentage> | left | center | right | top | bottom ] | [ [ <length-percentage> | left | center | right ] && [ <length-percentage> | top | center | bottom ] ] <length>?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "simpleListOfLpc",
+    "percentages": "referToSizeOfBoundingBox",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "50% 50% 0",
+    "appliesto": "transformableElements",
+    "computed": "forLengthAbsoluteValueOtherwisePercentage",
+    "order": "oneOrTwoValuesLengthAbsoluteKeywordsPercentages",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-origin"
+  },
+  "transform-style": {
+    "syntax": "flat | preserve-3d",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "flat",
+    "appliesto": "transformableElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transform-style"
+  },
+  "transition": {
+    "syntax": "<single-transition>#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Transitions"
+    ],
+    "initial": [
+      "transition-delay",
+      "transition-duration",
+      "transition-property",
+      "transition-timing-function",
+      "transition-behavior"
+    ],
+    "appliesto": "allElementsAndPseudos",
+    "computed": [
+      "transition-delay",
+      "transition-duration",
+      "transition-property",
+      "transition-timing-function",
+      "transition-behavior"
+    ],
+    "order": "orderOfAppearance",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition"
+  },
+  "transition-behavior": {
+    "syntax": "<transition-behavior-value>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Transitions"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-behavior"
+  },
+  "transition-delay": {
+    "syntax": "<time>#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Transitions"
+    ],
+    "initial": "0s",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-delay"
+  },
+  "transition-duration": {
+    "syntax": "<time>#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Transitions"
+    ],
+    "initial": "0s",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-duration"
+  },
+  "transition-property": {
+    "syntax": "none | <single-transition-property>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Transitions"
+    ],
+    "initial": "all",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-property"
+  },
+  "transition-timing-function": {
+    "syntax": "<easing-function>#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Transitions"
+    ],
+    "initial": "ease",
+    "appliesto": "allElementsAndPseudos",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-timing-function"
+  },
+  "translate": {
+    "syntax": "none | <length-percentage> [ <length-percentage> <length>? ]?",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "transform",
+    "percentages": "referToSizeOfBoundingBox",
+    "groups": [
+      "CSS Transforms"
+    ],
+    "initial": "none",
+    "appliesto": "transformableElements",
+    "computed": "asSpecifiedRelativeToAbsoluteLengths",
+    "order": "perGrammar",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/translate"
+  },
+  "trigger-scope": {
+    "syntax": "none | all | <dashed-ident>#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/trigger-scope"
+  },
+  "unicode-bidi": {
+    "syntax": "normal | embed | isolate | bidi-override | isolate-override | plaintext",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Writing Modes"
+    ],
+    "initial": "normal",
+    "appliesto": "allElementsSomeValuesNoEffectOnNonInlineElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/unicode-bidi"
+  },
+  "user-select": {
+    "syntax": "auto | text | none | all",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Basic User Interface"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/user-select"
+  },
+  "vector-effect": {
+    "syntax": "none | non-scaling-stroke | non-scaling-size | non-rotation | fixed-position",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "none",
+    "appliesto": "limitedSVGElementsGraphicsAndUse",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/vector-effect"
+  },
+  "vertical-align": {
+    "syntax": "baseline | sub | super | text-top | text-bottom | middle | top | bottom | <percentage> | <length>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Inline"
+    ],
+    "initial": "baseline",
+    "appliesto": "asLonghands",
+    "computed": "asLonghands",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/vertical-align"
+  },
+  "view-timeline": {
+    "syntax": "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
+    "media": "visual",
+    "inherited": false,
+    "animationType": [
+      "view-timeline-name",
+      "view-timeline-axis"
+    ],
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": [
+      "view-timeline-name",
+      "view-timeline-axis"
+    ],
+    "appliesto": "allElements",
+    "computed": [
+      "view-timeline-name",
+      "view-timeline-axis"
+    ],
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline"
+  },
+  "view-timeline-axis": {
+    "syntax": "[ block | inline | x | y ]#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "block",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-axis"
+  },
+  "view-timeline-inset": {
+    "syntax": "[ [ auto | <length-percentage> ]{1,2} ]#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "relativeToCorrespondingDimensionOfRelevantScrollport",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "listEachItemConsistingOfPairsOfAutoOrLengthPercentage",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-inset"
+  },
+  "view-timeline-name": {
+    "syntax": "[ none | <dashed-ident> ]#",
+    "media": "interactive",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "Scroll-driven Animations"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "noneOrOrderedListOfIdentifiers",
+    "order": "perGrammar",
+    "status": "experimental",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-name"
+  },
+  "view-transition-class": {
+    "syntax": "none | <custom-ident>+",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS View Transitions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard"
+  },
+  "view-transition-name": {
+    "syntax": "none | <custom-ident> | match-element",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS View Transitions"
+    ],
+    "initial": "none",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-transition-name"
+  },
+  "visibility": {
+    "syntax": "visible | hidden | collapse",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Display",
+      "Scalable Vector Graphics"
+    ],
+    "initial": "visible",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/visibility"
+  },
+  "white-space": {
+    "syntax": "normal | pre | pre-wrap | pre-line | <'white-space-collapse'> || <'text-wrap-mode'>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space"
+  },
+  "white-space-collapse": {
+    "syntax": "collapse | preserve | preserve-breaks | preserve-spaces | break-spaces",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "collapse",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space-collapse"
+  },
+  "widows": {
+    "syntax": "<integer>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "byComputedValueType",
+    "percentages": "no",
+    "groups": [
+      "CSS Fragmentation"
+    ],
+    "initial": "2",
+    "appliesto": "blockContainerElements",
+    "computed": "asSpecified",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/widows"
+  },
+  "width": {
+    "syntax": "auto | <length-percentage [0,∞]> | min-content | max-content | fit-content | fit-content(<length-percentage [0,∞]>) | <calc-size()> | <anchor-size()>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "lpc",
+    "percentages": "referToWidthOfContainingBlock",
+    "groups": [
+      "CSS Box Sizing"
+    ],
+    "initial": "auto",
+    "appliesto": "allElementsButNonReplacedAndTableRows",
+    "computed": "percentageAutoOrAbsoluteLength",
+    "order": "lengthOrPercentageBeforeKeywordIfBothPresent",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/width"
+  },
+  "will-change": {
+    "syntax": "auto | <animateable-feature>#",
+    "media": "all",
+    "inherited": false,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Will Change"
+    ],
+    "initial": "auto",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/will-change"
+  },
+  "word-break": {
+    "syntax": "normal | break-all | keep-all | break-word | auto-phrase",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/word-break"
+  },
+  "word-spacing": {
+    "syntax": "normal | <length>",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "length",
+    "percentages": "referToWidthOfAffectedGlyph",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "allElements",
+    "computed": "absoluteLength",
+    "order": "uniqueOrder",
+    "alsoAppliesTo": [
+      "::first-letter",
+      "::first-line",
+      "::placeholder"
+    ],
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/word-spacing"
+  },
+  "word-wrap": {
+    "syntax": "normal | break-word",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "discrete",
+    "percentages": "no",
+    "groups": [
+      "CSS Text"
+    ],
+    "initial": "normal",
+    "appliesto": "nonReplacedInlineElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-wrap"
+  },
+  "writing-mode": {
+    "syntax": "horizontal-tb | vertical-rl | vertical-lr | sideways-rl | sideways-lr",
+    "media": "visual",
+    "inherited": true,
+    "animationType": "notAnimatable",
+    "percentages": "no",
+    "groups": [
+      "CSS Writing Modes"
+    ],
+    "initial": "horizontal-tb",
+    "appliesto": "allElementsExceptTableRowColumnGroupsTableRowsColumns",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/writing-mode"
+  },
+  "x": {
+    "syntax": "<length> | <percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportWidth",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "0",
+    "appliesto": "limitedSVGElementsGeometry",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/x"
+  },
+  "y": {
+    "syntax": "<length> | <percentage>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "byComputedValueType",
+    "percentages": "referToSVGViewportHeight",
+    "groups": [
+      "Scalable Vector Graphics"
+    ],
+    "initial": "0",
+    "appliesto": "limitedSVGElementsGeometry",
+    "computed": "percentageAsSpecifiedOrAbsoluteLength",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/y"
+  },
+  "z-index": {
+    "syntax": "auto | <integer>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "integer",
+    "percentages": "no",
+    "groups": [
+      "CSS Positioned Layout"
+    ],
+    "initial": "auto",
+    "appliesto": "positionedElements",
+    "computed": "asSpecified",
+    "order": "uniqueOrder",
+    "stacking": true,
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/z-index"
+  },
+  "zoom": {
+    "syntax": "normal | reset | <number [0,∞]> || <percentage [0,∞]>",
+    "media": "visual",
+    "inherited": false,
+    "animationType": "notAnimatable",
+    "percentages": "convertedToNumber",
+    "groups": [
+      "CSS Viewport"
+    ],
+    "initial": "1",
+    "appliesto": "allElements",
+    "computed": "asSpecifiedButWithPercentageConvertedToTheEquivalentNumber",
+    "order": "perGrammar",
+    "status": "standard",
+    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/zoom"
+  }
+}

--- a/lib/cataclysm/res/core/cataclysm/syntaxes.json
+++ b/lib/cataclysm/res/core/cataclysm/syntaxes.json
@@ -1,0 +1,1136 @@
+{
+  "abs()": {
+    "syntax": "abs( <calc-sum> )"
+  },
+  "absolute-size": {
+    "syntax": "xx-small | x-small | small | medium | large | x-large | xx-large | xxx-large"
+  },
+  "acos()": {
+    "syntax": "acos( <calc-sum> )"
+  },
+  "alpha-value": {
+    "syntax": "<number> | <percentage>"
+  },
+  "an+b": {
+    "syntax": "odd | even | <integer> | <n-dimension> | '+'?† n | -n | <ndashdigit-dimension> | '+'?† <ndashdigit-ident> | <dashndashdigit-ident> | <n-dimension> <signed-integer> | '+'?† n <signed-integer> | -n <signed-integer> | <ndash-dimension> <signless-integer> | '+'?† n- <signless-integer> | -n- <signless-integer> | <n-dimension> ['+' | '-'] <signless-integer> | '+'?† n ['+' | '-'] <signless-integer> | -n ['+' | '-'] <signless-integer>"
+  },
+  "anchor()": {
+    "syntax": "anchor( <anchor-name>? && <anchor-side>, <length-percentage>? )"
+  },
+  "anchor-name": {
+    "syntax": "<dashed-ident>"
+  },
+  "anchor-side": {
+    "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
+  },
+  "anchor-size": {
+    "syntax": "width | height | block | inline | self-block | self-inline"
+  },
+  "anchor-size()": {
+    "syntax": "anchor-size( [ <anchor-name> || <anchor-size> ]? , <length-percentage>? )"
+  },
+  "angle-percentage": {
+    "syntax": "<angle> | <percentage>"
+  },
+  "angular-color-hint": {
+    "syntax": "<angle-percentage> | <zero>"
+  },
+  "angular-color-stop": {
+    "syntax": "<color> <color-stop-angle>?"
+  },
+  "angular-color-stop-list": {
+    "syntax": "<angular-color-stop> , [ <angular-color-hint>? , <angular-color-stop> ]#?"
+  },
+  "animateable-feature": {
+    "syntax": "scroll-position | contents | <custom-ident>"
+  },
+  "animation-action": {
+    "syntax": "none | play | play-once | play-forwards | play-backwards | pause | reset | replay"
+  },
+  "asin()": {
+    "syntax": "asin( <calc-sum> )"
+  },
+  "atan()": {
+    "syntax": "atan( <calc-sum> )"
+  },
+  "atan2()": {
+    "syntax": "atan2( <calc-sum>, <calc-sum> )"
+  },
+  "attachment": {
+    "syntax": "scroll | fixed | local"
+  },
+  "attr()": {
+    "syntax": "attr( <attr-name> <attr-type>? , <declaration-value>? )"
+  },
+  "attr-matcher": {
+    "syntax": "[ '~' | '|' | '^' | '$' | '*' ]? '='"
+  },
+  "attr-modifier": {
+    "syntax": "i | s"
+  },
+  "attr-type": {
+    "syntax": "type( <syntax> ) | raw-string | number | <attr-unit>"
+  },
+  "attribute-selector": {
+    "syntax": "'[' <wq-name> ']' | '[' <wq-name> <attr-matcher> [ <string-token> | <ident-token> ] <attr-modifier>? ']'"
+  },
+  "auto-repeat": {
+    "syntax": "repeat( [ auto-fill | auto-fit ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+  },
+  "auto-track-list": {
+    "syntax": "[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>? <auto-repeat>\n[ <line-names>? [ <fixed-size> | <fixed-repeat> ] ]* <line-names>?"
+  },
+  "axis": {
+    "syntax": "block | inline | x | y"
+  },
+  "baseline-position": {
+    "syntax": "[ first | last ]? baseline"
+  },
+  "basic-shape": {
+    "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()>"
+  },
+  "basic-shape-rect": {
+    "syntax": "<inset()> | <rect()> | <xywh()>"
+  },
+  "bg-clip": {
+    "syntax": "<visual-box> | border-area | text"
+  },
+  "bg-image": {
+    "syntax": "<image> | none"
+  },
+  "bg-layer": {
+    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box>"
+  },
+  "bg-position": {
+    "syntax": "[ [ left | center | right | top | bottom | <length-percentage> ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ] | [ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ] ]"
+  },
+  "bg-size": {
+    "syntax": "[ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain"
+  },
+  "blend-mode": {
+    "syntax": "normal | multiply | screen | overlay | darken | lighten | color-dodge | color-burn | hard-light | soft-light | difference | exclusion | hue | saturation | color | luminosity"
+  },
+  "blur()": {
+    "syntax": "blur( <length>? )"
+  },
+  "brightness()": {
+    "syntax": "brightness( [ <number> | <percentage> ]? )"
+  },
+  "calc()": {
+    "syntax": "calc( <calc-sum> )"
+  },
+  "calc-constant": {
+    "syntax": "e | pi | infinity | -infinity | NaN"
+  },
+  "calc-product": {
+    "syntax": "<calc-value> [ '*' <calc-value> | '/' <number> ]*"
+  },
+  "calc-size()": {
+    "syntax": "calc-size( <calc-size-basis>, <calc-sum> )"
+  },
+  "calc-size-basis": {
+    "syntax": "<intrinsic-size-keyword> | <calc-size()> | any | <calc-sum>"
+  },
+  "calc-sum": {
+    "syntax": "<calc-product> [ [ '+' | '-' ] <calc-product> ]*"
+  },
+  "calc-value": {
+    "syntax": "<number> | <dimension> | <percentage> | <calc-constant> | ( <calc-sum> )"
+  },
+  "cf-final-image": {
+    "syntax": "<image> | <color>"
+  },
+  "cf-mixing-image": {
+    "syntax": "<percentage>? && <image>"
+  },
+  "circle()": {
+    "syntax": "circle( <radial-size>? [ at <position> ]? )"
+  },
+  "clamp()": {
+    "syntax": "clamp( <calc-sum>#{3} )"
+  },
+  "class-selector": {
+    "syntax": "'.' <ident-token>"
+  },
+  "clip-source": {
+    "syntax": "<url>"
+  },
+  "color": {
+    "syntax": "<color-base> | currentColor | <system-color> | <light-dark()> | <deprecated-system-color>"
+  },
+  "color()": {
+    "syntax": "color( [ from <color> ]? <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+  },
+  "color-base": {
+    "syntax": "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
+  },
+  "color-function": {
+    "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
+  },
+  "color-interpolation-method": {
+    "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
+  },
+  "color-mix()": {
+    "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2})"
+  },
+  "color-stop": {
+    "syntax": "<color-stop-length> | <color-stop-angle>"
+  },
+  "color-stop-angle": {
+    "syntax": "[ <angle-percentage> | <zero> ]{1,2}"
+  },
+  "color-stop-length": {
+    "syntax": "<length-percentage>{1,2}"
+  },
+  "color-stop-list": {
+    "syntax": "<linear-color-stop> , [ <linear-color-hint>? , <linear-color-stop> ]#?"
+  },
+  "colorspace-params": {
+    "syntax": "[<custom-params> | <predefined-rgb-params> | <xyz-params>]"
+  },
+  "combinator": {
+    "syntax": "'>' | '+' | '~' | [ '||' ]"
+  },
+  "common-lig-values": {
+    "syntax": "[ common-ligatures | no-common-ligatures ]"
+  },
+  "compat-auto": {
+    "syntax": "searchfield | textarea | checkbox | radio | menulist | listbox | meter | progress-bar | button"
+  },
+  "compat-special": {
+    "syntax": "textfield | menulist-button"
+  },
+  "complex-selector": {
+    "syntax": "<compound-selector> [ <combinator>? <compound-selector> ]*"
+  },
+  "complex-selector-list": {
+    "syntax": "<complex-selector>#"
+  },
+  "composite-style": {
+    "syntax": "clear | copy | source-over | source-in | source-out | source-atop | destination-over | destination-in | destination-out | destination-atop | xor"
+  },
+  "compositing-operator": {
+    "syntax": "add | subtract | intersect | exclude"
+  },
+  "compound-selector": {
+    "syntax": "[ <type-selector>? <subclass-selector>* [ <pseudo-element-selector> <pseudo-class-selector>* ]* ]!"
+  },
+  "compound-selector-list": {
+    "syntax": "<compound-selector>#"
+  },
+  "conic-gradient()": {
+    "syntax": "conic-gradient( [ <conic-gradient-syntax> ] )"
+  },
+  "conic-gradient-syntax": {
+    "syntax": "[ [ [ from [ <angle> | <zero> ] ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <angular-color-stop-list>"
+  },
+  "container-condition": {
+    "syntax": "[ <container-name>? <container-query>? ]!"
+  },
+  "container-name": {
+    "syntax": "<custom-ident>"
+  },
+  "container-query": {
+    "syntax": "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]"
+  },
+  "content-distribution": {
+    "syntax": "space-between | space-around | space-evenly | stretch"
+  },
+  "content-list": {
+    "syntax": "[ <string> | <image> | <attr()> | <quote> | <counter> ]+"
+  },
+  "content-position": {
+    "syntax": "center | start | end | flex-start | flex-end"
+  },
+  "content-replacement": {
+    "syntax": "<image>"
+  },
+  "contextual-alt-values": {
+    "syntax": "[ contextual | no-contextual ]"
+  },
+  "contrast()": {
+    "syntax": "contrast( [ <number> | <percentage> ]? )"
+  },
+  "coord-box": {
+    "syntax": "<paint-box> | view-box"
+  },
+  "corner-shape-value": {
+    "syntax": "round | scoop | bevel | notch | square | squircle | <superellipse()>"
+  },
+  "cos()": {
+    "syntax": "cos( <calc-sum> )"
+  },
+  "counter": {
+    "syntax": "<counter()> | <counters()>"
+  },
+  "counter()": {
+    "syntax": "counter( <counter-name>, <counter-style>? )"
+  },
+  "counter-name": {
+    "syntax": "<custom-ident>"
+  },
+  "counter-style": {
+    "syntax": "<counter-style-name> | symbols()"
+  },
+  "counter-style-name": {
+    "syntax": "<custom-ident>"
+  },
+  "counters()": {
+    "syntax": "counters( <counter-name>, <string>, <counter-style>? )"
+  },
+  "cross-fade()": {
+    "syntax": "cross-fade( <cf-mixing-image> , <cf-final-image>? )"
+  },
+  "cubic-bezier()": {
+    "syntax": "cubic-bezier( [ <number [0,1]>, <number> ]#{2} )"
+  },
+  "cubic-bezier-easing-function": {
+    "syntax": "ease | ease-in | ease-out | ease-in-out | <cubic-bezier()>"
+  },
+  "cursor-predefined": {
+    "syntax": "auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing"
+  },
+  "custom-color-space": {
+    "syntax": "<dashed-ident>"
+  },
+  "custom-params": {
+    "syntax": "<dashed-ident> [ <number> | <percentage> | none ]+"
+  },
+  "dasharray": {
+    "syntax": "[ [ <length-percentage> | <number> ]+ ]#"
+  },
+  "dashndashdigit-ident": {
+    "syntax": "<ident-token>"
+  },
+  "deprecated-system-color": {
+    "syntax": "ActiveBorder | ActiveCaption | AppWorkspace | Background | ButtonHighlight | ButtonShadow | CaptionText | InactiveBorder | InactiveCaption | InactiveCaptionText | InfoBackground | InfoText | Menu | MenuText | Scrollbar | ThreeDDarkShadow | ThreeDFace | ThreeDHighlight | ThreeDLightShadow | ThreeDShadow | Window | WindowFrame | WindowText"
+  },
+  "discretionary-lig-values": {
+    "syntax": "[ discretionary-ligatures | no-discretionary-ligatures ]"
+  },
+  "display-box": {
+    "syntax": "contents | none"
+  },
+  "display-inside": {
+    "syntax": "flow | flow-root | table | flex | grid | ruby"
+  },
+  "display-internal": {
+    "syntax": "table-row-group | table-header-group | table-footer-group | table-row | table-cell | table-column-group | table-column | table-caption | ruby-base | ruby-text | ruby-base-container | ruby-text-container"
+  },
+  "display-legacy": {
+    "syntax": "inline-block | inline-list-item | inline-table | inline-flex | inline-grid"
+  },
+  "display-listitem": {
+    "syntax": "<display-outside>? && [ flow | flow-root ]? && list-item"
+  },
+  "display-outside": {
+    "syntax": "block | inline | run-in"
+  },
+  "drop-shadow()": {
+    "syntax": "drop-shadow( [ <color>? && <length>{2,3} ] )"
+  },
+  "dynamic-range-limit-mix()": {
+    "syntax": "dynamic-range-limit-mix( [ <'dynamic-range-limit'> && <percentage [0,100]> ]#{2,} )"
+  },
+  "easing-function": {
+    "syntax": "<linear-easing-function> | <cubic-bezier-easing-function> | <step-easing-function>"
+  },
+  "east-asian-variant-values": {
+    "syntax": "[ jis78 | jis83 | jis90 | jis04 | simplified | traditional ]"
+  },
+  "east-asian-width-values": {
+    "syntax": "[ full-width | proportional-width ]"
+  },
+  "element()": {
+    "syntax": "element( <id-selector> )"
+  },
+  "ellipse()": {
+    "syntax": "ellipse( <radial-size>? [ at <position> ]? )"
+  },
+  "env()": {
+    "syntax": "env( <custom-ident> , <declaration-value>? )"
+  },
+  "exp()": {
+    "syntax": "exp( <calc-sum> )"
+  },
+  "explicit-track-list": {
+    "syntax": "[ <line-names>? <track-size> ]+ <line-names>?"
+  },
+  "family-name": {
+    "syntax": "<string> | <custom-ident>+"
+  },
+  "feature-tag-value": {
+    "syntax": "<string> [ <integer> | on | off ]?"
+  },
+  "feature-type": {
+    "syntax": "@stylistic | @historical-forms | @styleset | @character-variant | @swash | @ornaments | @annotation"
+  },
+  "feature-value-block": {
+    "syntax": "<feature-type> '{' <feature-value-declaration-list> '}'"
+  },
+  "feature-value-block-list": {
+    "syntax": "<feature-value-block>+"
+  },
+  "feature-value-declaration": {
+    "syntax": "<custom-ident>: <integer>+;"
+  },
+  "feature-value-declaration-list": {
+    "syntax": "<feature-value-declaration>"
+  },
+  "feature-value-name": {
+    "syntax": "<custom-ident>"
+  },
+  "filter-function": {
+    "syntax": "<blur()> | <brightness()> | <contrast()> | <drop-shadow()> | <grayscale()> | <hue-rotate()> | <invert()> | <opacity()> | <saturate()> | <sepia()>"
+  },
+  "filter-value-list": {
+    "syntax": "[ <filter-function> | <url> ]+"
+  },
+  "final-bg-layer": {
+    "syntax": "<bg-image> || <bg-position> [ / <bg-size> ]? || <repeat-style> || <attachment> || <visual-box> || <visual-box> || <'background-color'>"
+  },
+  "fit-content()": {
+    "syntax": "fit-content( <length-percentage [0,∞]> )"
+  },
+  "fixed-breadth": {
+    "syntax": "<length-percentage>"
+  },
+  "fixed-repeat": {
+    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <fixed-size> ]+ <line-names>? )"
+  },
+  "fixed-size": {
+    "syntax": "<fixed-breadth> | minmax( <fixed-breadth> , <track-breadth> ) | minmax( <inflexible-breadth> , <fixed-breadth> )"
+  },
+  "font-stretch-absolute": {
+    "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded | <percentage>"
+  },
+  "font-variant-css2": {
+    "syntax": "normal | small-caps"
+  },
+  "font-weight-absolute": {
+    "syntax": "normal | bold | <number [1,1000]>"
+  },
+  "font-width-css3": {
+    "syntax": "normal | ultra-condensed | extra-condensed | condensed | semi-condensed | semi-expanded | expanded | extra-expanded | ultra-expanded"
+  },
+  "form-control-identifier": {
+    "syntax": "select"
+  },
+  "frequency-percentage": {
+    "syntax": "<frequency> | <percentage>"
+  },
+  "generic-complete": {
+    "syntax": "serif | sans-serif | system-ui | cursive | fantasy | math | monospace"
+  },
+  "general-enclosed": {
+    "syntax": "[ <function-token> <any-value> ) ] | ( <ident> <any-value> )"
+  },
+  "generic-family": {
+    "syntax": "<generic-complete> | <generic-incomplete> | emoji | fangsong"
+  },
+  "generic-incomplete": {
+    "syntax": "ui-serif | ui-sans-serif | ui-monospace | ui-rounded"
+  },
+  "geometry-box": {
+    "syntax": "<shape-box> | fill-box | stroke-box | view-box"
+  },
+  "gradient": {
+    "syntax": "<linear-gradient()> | <repeating-linear-gradient()> | <radial-gradient()> | <repeating-radial-gradient()> | <conic-gradient()> | <repeating-conic-gradient()>"
+  },
+  "grayscale()": {
+    "syntax": "grayscale( [ <number> | <percentage> ]? )"
+  },
+  "grid-line": {
+    "syntax": "auto | <custom-ident> | [ <integer> && <custom-ident>? ] | [ span && [ <integer> || <custom-ident> ] ]"
+  },
+  "historical-lig-values": {
+    "syntax": "[ historical-ligatures | no-historical-ligatures ]"
+  },
+  "hsl()": {
+    "syntax": "hsl( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsl( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+  },
+  "hsla()": {
+    "syntax": "hsla( <hue>, <percentage>, <percentage>, <alpha-value>? ) | hsla( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+  },
+  "hue": {
+    "syntax": "<number> | <angle>"
+  },
+  "hue-interpolation-method": {
+    "syntax": "[ shorter | longer | increasing | decreasing ] hue"
+  },
+  "hue-rotate()": {
+    "syntax": "hue-rotate( [ <angle> | <zero> ]? )"
+  },
+  "hwb()": {
+    "syntax": "hwb( [ <hue> | none ] [ <percentage> | <number> | none ] [ <percentage> | <number> | none ] [ / [ <alpha-value> | none ] ]? )"
+  },
+  "hypot()": {
+    "syntax": "hypot( <calc-sum># )"
+  },
+  "id-selector": {
+    "syntax": "<hash-token>"
+  },
+  "image": {
+    "syntax": "<url> | <image()> | <image-set()> | <element()> | <paint()> | <cross-fade()> | <gradient>"
+  },
+  "image()": {
+    "syntax": "image( <image-tags>? [ <image-src>? , <color>? ]! )"
+  },
+  "image-set()": {
+    "syntax": "image-set( <image-set-option># )"
+  },
+  "image-set-option": {
+    "syntax": "[ <image> | <string> ] [ <resolution> || type(<string>) ]"
+  },
+  "image-src": {
+    "syntax": "<url> | <string>"
+  },
+  "image-tags": {
+    "syntax": "ltr | rtl"
+  },
+  "inflexible-breadth": {
+    "syntax": "<length-percentage> | min-content | max-content | auto"
+  },
+  "inset()": {
+    "syntax": "inset( <length-percentage>{1,4} [ round <'border-radius'> ]? )"
+  },
+  "integer": {
+    "syntax": "<number-token>"
+  },
+  "invert()": {
+    "syntax": "invert( [ <number> | <percentage> ]? )"
+  },
+  "keyframe-block": {
+    "syntax": "<keyframe-selector># {\n  <declaration-list>\n}"
+  },
+  "keyframe-selector": {
+    "syntax": "from | to | <percentage [0,100]> | <timeline-range-name> <percentage>"
+  },
+  "keyframes-name": {
+    "syntax": "<custom-ident> | <string>"
+  },
+  "lab()": {
+    "syntax": "lab( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  "layer()": {
+    "syntax": "layer( <layer-name> )"
+  },
+  "layer-name": {
+    "syntax": "<ident> [ '.' <ident> ]*"
+  },
+  "lch()": {
+    "syntax": "lch( [<percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  "leader()": {
+    "syntax": "leader( <leader-type> )"
+  },
+  "leader-type": {
+    "syntax": "dotted | solid | space | <string>"
+  },
+  "length-percentage": {
+    "syntax": "<length> | <percentage>"
+  },
+  "light-dark()": {
+    "syntax": "light-dark( <color>, <color> )"
+  },
+  "line-name-list": {
+    "syntax": "[ <line-names> | <name-repeat> ]+"
+  },
+  "line-names": {
+    "syntax": "'[' <custom-ident>* ']'"
+  },
+  "line-style": {
+    "syntax": "none | hidden | dotted | dashed | solid | double | groove | ridge | inset | outset"
+  },
+  "line-width": {
+    "syntax": "<length> | thin | medium | thick"
+  },
+  "linear()": {
+    "syntax": "linear( [ <number> && <percentage>{0,2} ]# )"
+  },
+  "linear-color-hint": {
+    "syntax": "<length-percentage>"
+  },
+  "linear-color-stop": {
+    "syntax": "<color> <color-stop-length>?"
+  },
+  "linear-easing-function": {
+    "syntax": "linear | <linear()>"
+  },
+  "linear-gradient()": {
+    "syntax": "linear-gradient( [ <linear-gradient-syntax> ] )"
+  },
+  "linear-gradient-syntax": {
+    "syntax": "[ [ <angle> | <zero> | to <side-or-corner> ] || <color-interpolation-method> ]? , <color-stop-list>"
+  },
+  "log()": {
+    "syntax": "log( <calc-sum>, <calc-sum>? )"
+  },
+  "mask-layer": {
+    "syntax": "<mask-reference> || <position> [ / <bg-size> ]? || <repeat-style> || <geometry-box> || [ <geometry-box> | no-clip ] || <compositing-operator> || <masking-mode>"
+  },
+  "mask-position": {
+    "syntax": "[ <length-percentage> | left | center | right ] [ <length-percentage> | top | center | bottom ]?"
+  },
+  "mask-reference": {
+    "syntax": "none | <image> | <mask-source>"
+  },
+  "mask-source": {
+    "syntax": "<url>"
+  },
+  "masking-mode": {
+    "syntax": "alpha | luminance | match-source"
+  },
+  "matrix()": {
+    "syntax": "matrix( <number>#{6} )"
+  },
+  "matrix3d()": {
+    "syntax": "matrix3d( <number>#{16} )"
+  },
+  "max()": {
+    "syntax": "max( <calc-sum># )"
+  },
+  "media-and": {
+    "syntax": "<media-in-parens> [ and <media-in-parens> ]+"
+  },
+  "media-condition": {
+    "syntax": "<media-not> | <media-and> | <media-or> | <media-in-parens>"
+  },
+  "media-condition-without-or": {
+    "syntax": "<media-not> | <media-and> | <media-in-parens>"
+  },
+  "media-feature": {
+    "syntax": "( [ <mf-plain> | <mf-boolean> | <mf-range> ] )"
+  },
+  "media-in-parens": {
+    "syntax": "( <media-condition> ) | <media-feature> | <general-enclosed>"
+  },
+  "media-not": {
+    "syntax": "not <media-in-parens>"
+  },
+  "media-or": {
+    "syntax": "<media-in-parens> [ or <media-in-parens> ]+"
+  },
+  "media-query": {
+    "syntax": "<media-condition> | [ not | only ]? <media-type> [ and <media-condition-without-or> ]?"
+  },
+  "media-query-list": {
+    "syntax": "<media-query>#"
+  },
+  "media-type": {
+    "syntax": "<ident>"
+  },
+  "mf-boolean": {
+    "syntax": "<mf-name>"
+  },
+  "mf-name": {
+    "syntax": "<ident>"
+  },
+  "mf-plain": {
+    "syntax": "<mf-name> : <mf-value>"
+  },
+  "mf-range": {
+    "syntax": "<mf-name> [ '<' | '>' ]? '='? <mf-value>\n| <mf-value> [ '<' | '>' ]? '='? <mf-name>\n| <mf-value> '<' '='? <mf-name> '<' '='? <mf-value>\n| <mf-value> '>' '='? <mf-name> '>' '='? <mf-value>"
+  },
+  "mf-value": {
+    "syntax": "<number> | <dimension> | <ident> | <ratio>"
+  },
+  "min()": {
+    "syntax": "min( <calc-sum># )"
+  },
+  "minmax()": {
+    "syntax": "minmax( [ <length-percentage> | min-content | max-content | auto ] , [ <length-percentage> | <flex> | min-content | max-content | auto ] )"
+  },
+  "mod()": {
+    "syntax": "mod( <calc-sum>, <calc-sum> )"
+  },
+  "n-dimension": {
+    "syntax": "<dimension-token>"
+  },
+  "name-repeat": {
+    "syntax": "repeat( [ <integer [1,∞]> | auto-fill ], <line-names>+ )"
+  },
+  "named-color": {
+    "syntax": "aliceblue | antiquewhite | aqua | aquamarine | azure | beige | bisque | black | blanchedalmond | blue | blueviolet | brown | burlywood | cadetblue | chartreuse | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey | dodgerblue | firebrick | floralwhite | forestgreen | fuchsia | gainsboro | ghostwhite | gold | goldenrod | gray | green | greenyellow | grey | honeydew | hotpink | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow | lightgray | lightgreen | lightgrey | lightpink | lightsalmon | lightseagreen | lightskyblue | lightslategray | lightslategrey | lightsteelblue | lightyellow | lime | limegreen | linen | magenta | maroon | mediumaquamarine | mediumblue | mediumorchid | mediumpurple | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin | navajowhite | navy | oldlace | olive | olivedrab | orange | orangered | orchid | palegoldenrod | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru | pink | plum | powderblue | purple | rebeccapurple | red | rosybrown | royalblue | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna | silver | skyblue | slateblue | slategray | slategrey | snow | springgreen | steelblue | tan | teal | thistle | tomato | turquoise | violet | wheat | white | whitesmoke | yellow | yellowgreen"
+  },
+  "namespace-prefix": {
+    "syntax": "<ident>"
+  },
+  "ndash-dimension": {
+    "syntax": "<dimension-token>"
+  },
+  "ndashdigit-dimension": {
+    "syntax": "<dimension-token>"
+  },
+  "ndashdigit-ident": {
+    "syntax": "<ident-token>"
+  },
+  "ns-prefix": {
+    "syntax": "[ <ident-token> | '*' ]? '|'"
+  },
+  "number-percentage": {
+    "syntax": "<number> | <percentage>"
+  },
+  "numeric-figure-values": {
+    "syntax": "[ lining-nums | oldstyle-nums ]"
+  },
+  "numeric-fraction-values": {
+    "syntax": "[ diagonal-fractions | stacked-fractions ]"
+  },
+  "numeric-spacing-values": {
+    "syntax": "[ proportional-nums | tabular-nums ]"
+  },
+  "offset-path": {
+    "syntax": "<ray()> | <url> | <basic-shape>"
+  },
+  "oklab()": {
+    "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  "oklch()": {
+    "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
+  },
+  "opacity()": {
+    "syntax": "opacity( [ <number> | <percentage> ]? )"
+  },
+  "opacity-value": {
+    "syntax": "<number> | <percentage>"
+  },
+  "outline-line-style": {
+    "syntax": "none | dotted | dashed | solid | double | groove | ridge | inset | outset"
+  },
+  "outline-radius": {
+    "syntax": "<length> | <percentage>"
+  },
+  "overflow-position": {
+    "syntax": "unsafe | safe"
+  },
+  "page-body": {
+    "syntax": "<declaration>? [ ; <page-body> ]? | <page-margin-box> <page-body>"
+  },
+  "page-margin-box": {
+    "syntax": "<page-margin-box-type> '{' <declaration-list> '}'"
+  },
+  "page-margin-box-type": {
+    "syntax": "@top-left-corner | @top-left | @top-center | @top-right | @top-right-corner | @bottom-left-corner | @bottom-left | @bottom-center | @bottom-right | @bottom-right-corner | @left-top | @left-middle | @left-bottom | @right-top | @right-middle | @right-bottom"
+  },
+  "page-selector": {
+    "syntax": "<pseudo-page>+ | <ident> <pseudo-page>*"
+  },
+  "page-selector-list": {
+    "syntax": "[ <page-selector># ]?"
+  },
+  "page-size": {
+    "syntax": "A5 | A4 | A3 | B5 | B4 | JIS-B5 | JIS-B4 | letter | legal | ledger"
+  },
+  "paint": {
+    "syntax": "none | <color> | <url> [none | <color>]? | context-fill | context-stroke"
+  },
+  "paint()": {
+    "syntax": "paint( <ident>, <declaration-value>? )"
+  },
+  "paint-box": {
+    "syntax": "<visual-box> | fill-box | stroke-box"
+  },
+  "palette-identifier": {
+    "syntax": "<dashed-ident>"
+  },
+  "palette-mix()": {
+    "syntax": "palette-mix(<color-interpolation-method> , [ [normal | light | dark | <palette-identifier> | <palette-mix()> ] && <percentage [0,100]>? ]#{2})"
+  },
+  "path()": {
+    "syntax": "path( <'fill-rule'>? , <string> )"
+  },
+  "perspective()": {
+    "syntax": "perspective( [ <length [0,∞]> | none ] )"
+  },
+  "polar-color-space": {
+    "syntax": "hsl | hwb | lch | oklch"
+  },
+  "polygon()": {
+    "syntax": "polygon( <'fill-rule'>? , [ <length-percentage> <length-percentage> ]# )"
+  },
+  "position": {
+    "syntax": "[ [ left | center | right ] || [ top | center | bottom ] | [ left | center | right | <length-percentage> ] [ top | center | bottom | <length-percentage> ]? | [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ] ]"
+  },
+  "position-area": {
+    "syntax": "[ left | center | right | span-left | span-right | x-start | x-end | span-x-start | span-x-end | x-self-start | x-self-end | span-x-self-start | span-x-self-end | span-all ] || [ top | center | bottom | span-top | span-bottom | y-start | y-end | span-y-start | span-y-end | y-self-start | y-self-end | span-y-self-start | span-y-self-end | span-all ] | [ block-start | center | block-end | span-block-start | span-block-end | span-all ] || [ inline-start | center | inline-end | span-inline-start | span-inline-end | span-all ] | [ self-block-start | center | self-block-end | span-self-block-start | span-self-block-end | span-all ] || [ self-inline-start | center | self-inline-end | span-self-inline-start | span-self-inline-end | span-all ] | [ start | center | end | span-start | span-end | span-all ]{1,2} | [ self-start | center | self-end | span-self-start | span-self-end | span-all ]{1,2}"
+  },
+  "pow()": {
+    "syntax": "pow( <calc-sum>, <calc-sum> )"
+  },
+  "predefined-rgb": {
+    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020"
+  },
+  "predefined-rgb-params": {
+    "syntax": "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
+  },
+  "pseudo-class-selector": {
+    "syntax": "':' <ident-token> | ':' <function-token> <any-value> ')'"
+  },
+  "pseudo-element-selector": {
+    "syntax": "':' <pseudo-class-selector>"
+  },
+  "pseudo-page": {
+    "syntax": ": [ left | right | first | blank ]"
+  },
+  "query-in-parens": {
+    "syntax": "( <container-query> ) | ( <size-feature> ) | style( <style-query> ) | scroll-state( <scroll-state-query> ) | <general-enclosed>"
+  },
+  "quote": {
+    "syntax": "open-quote | close-quote | no-open-quote | no-close-quote"
+  },
+  "radial-extent": {
+    "syntax": "closest-corner | closest-side | farthest-corner | farthest-side"
+  },
+  "radial-gradient()": {
+    "syntax": "radial-gradient( [ <radial-gradient-syntax> ] )"
+  },
+  "radial-gradient-syntax": {
+    "syntax": "[ [ [ <radial-shape> || <radial-size> ]? [ at <position> ]? ] || <color-interpolation-method> ]? , <color-stop-list>"
+  },
+  "radial-shape": {
+    "syntax": "circle | ellipse"
+  },
+  "radial-size": {
+    "syntax": "<radial-extent> | <length [0,∞]> | <length-percentage [0,∞]>{2}"
+  },
+  "ratio": {
+    "syntax": "<number [0,∞]> [ / <number [0,∞]> ]?"
+  },
+  "ray()": {
+    "syntax": "ray( <angle> && <ray-size>? && contain? && [at <position>]? )"
+  },
+  "ray-size": {
+    "syntax": "closest-side | closest-corner | farthest-side | farthest-corner | sides"
+  },
+  "rect()": {
+    "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
+  },
+  "rectangular-color-space": {
+    "syntax": "srgb | srgb-linear | display-p3 | display-p3-linear | a98-rgb | prophoto-rgb | rec2020 | lab | oklab | xyz | xyz-d50 | xyz-d65"
+  },
+  "relative-selector": {
+    "syntax": "<combinator>? <complex-selector>"
+  },
+  "relative-selector-list": {
+    "syntax": "<relative-selector>#"
+  },
+  "relative-size": {
+    "syntax": "larger | smaller"
+  },
+  "rem()": {
+    "syntax": "rem( <calc-sum>, <calc-sum> )"
+  },
+  "repeat-style": {
+    "syntax": "repeat-x | repeat-y | [ repeat | space | round | no-repeat ]{1,2}"
+  },
+  "repeating-conic-gradient()": {
+    "syntax": "repeating-conic-gradient( [ <conic-gradient-syntax> ] )"
+  },
+  "repeating-linear-gradient()": {
+    "syntax": "repeating-linear-gradient( [ <linear-gradient-syntax> ] )"
+  },
+  "repeating-radial-gradient()": {
+    "syntax": "repeating-radial-gradient( [ <radial-gradient-syntax> ] )"
+  },
+  "reversed-counter-name": {
+    "syntax": "reversed( <counter-name> )"
+  },
+  "rgb()": {
+    "syntax": "rgb( <percentage>#{3} , <alpha-value>? ) | rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+  },
+  "rgba()": {
+    "syntax": "rgba( <percentage>#{3} , <alpha-value>? ) | rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )"
+  },
+  "rotate()": {
+    "syntax": "rotate( [ <angle> | <zero> ] )"
+  },
+  "rotate3d()": {
+    "syntax": "rotate3d( <number> , <number> , <number> , [ <angle> | <zero> ] )"
+  },
+  "rotateX()": {
+    "syntax": "rotateX( [ <angle> | <zero> ] )"
+  },
+  "rotateY()": {
+    "syntax": "rotateY( [ <angle> | <zero> ] )"
+  },
+  "rotateZ()": {
+    "syntax": "rotateZ( [ <angle> | <zero> ] )"
+  },
+  "round()": {
+    "syntax": "round( <rounding-strategy>?, <calc-sum>, <calc-sum> )"
+  },
+  "rounding-strategy": {
+    "syntax": "nearest | up | down | to-zero"
+  },
+  "saturate()": {
+    "syntax": "saturate( [ <number> | <percentage> ]? )"
+  },
+  "scale()": {
+    "syntax": "scale( [ <number> | <percentage> ]#{1,2} )"
+  },
+  "scale3d()": {
+    "syntax": "scale3d( [ <number> | <percentage> ]#{3} )"
+  },
+  "scaleX()": {
+    "syntax": "scaleX( [ <number> | <percentage> ] )"
+  },
+  "scaleY()": {
+    "syntax": "scaleY( [ <number> | <percentage> ] )"
+  },
+  "scaleZ()": {
+    "syntax": "scaleZ( [ <number> | <percentage> ] )"
+  },
+  "scope-end": {
+    "syntax": "<selector-list>"
+  },
+  "scope-start": {
+    "syntax": "<selector-list>"
+  },
+  "scroll()": {
+    "syntax": "scroll( [ <scroller> || <axis> ]? )"
+  },
+  "scroller": {
+    "syntax": "root | nearest | self"
+  },
+  "scroll-state-feature": {
+    "syntax": "<media-query-list>"
+  },
+  "scroll-state-in-parens": {
+    "syntax": "( <scroll-state-query> ) | ( <scroll-state-feature> ) | <general-enclosed>"
+  },
+  "scroll-state-query": {
+    "syntax": "not <scroll-state-in-parens> | <scroll-state-in-parens> [ [ and <scroll-state-in-parens> ]* | [ or <scroll-state-in-parens> ]* ] | <scroll-state-feature>"
+  },
+  "selector-list": {
+    "syntax": "<complex-selector-list>"
+  },
+  "self-position": {
+    "syntax": "center | start | end | self-start | self-end | flex-start | flex-end"
+  },
+  "sepia()": {
+    "syntax": "sepia( [ <number> | <percentage> ]? )"
+  },
+  "shadow": {
+    "syntax": "inset? && <length>{2,4} && <color>?"
+  },
+  "shadow-t": {
+    "syntax": "[ <length>{2,3} && <color>? ]"
+  },
+  "shape": {
+    "syntax": "rect(<top>, <right>, <bottom>, <left>)"
+  },
+  "shape-box": {
+    "syntax": "<visual-box> | margin-box"
+  },
+  "side-or-corner": {
+    "syntax": "[ left | right ] || [ top | bottom ]"
+  },
+  "sign()": {
+    "syntax": "sign( <calc-sum> )"
+  },
+  "signed-integer": {
+    "syntax": "<number-token>"
+  },
+  "signless-integer": {
+    "syntax": "<number-token>"
+  },
+  "sin()": {
+    "syntax": "sin( <calc-sum> )"
+  },
+  "single-animation": {
+    "syntax": "<'animation-duration'> || <easing-function> || <'animation-delay'> || <single-animation-iteration-count> || <single-animation-direction> || <single-animation-fill-mode> || <single-animation-play-state> || [ none | <keyframes-name> ] || <single-animation-timeline>"
+  },
+  "single-animation-composition": {
+    "syntax": "replace | add | accumulate"
+  },
+  "single-animation-direction": {
+    "syntax": "normal | reverse | alternate | alternate-reverse"
+  },
+  "single-animation-fill-mode": {
+    "syntax": "none | forwards | backwards | both"
+  },
+  "single-animation-iteration-count": {
+    "syntax": "infinite | <number>"
+  },
+  "single-animation-play-state": {
+    "syntax": "running | paused"
+  },
+  "single-animation-timeline": {
+    "syntax": "auto | none | <dashed-ident> | <scroll()> | <view()>"
+  },
+  "single-transition": {
+    "syntax": "[ none | <single-transition-property> ] || <time> || <easing-function> || <time> || <transition-behavior-value>"
+  },
+  "single-transition-property": {
+    "syntax": "all | <custom-ident>"
+  },
+  "size": {
+    "syntax": "closest-side | farthest-side | closest-corner | farthest-corner | <length> | <length-percentage>{2}"
+  },
+  "size-feature": {
+    "syntax": "<media-query-list>"
+  },
+  "skew()": {
+    "syntax": "skew( [ <angle> | <zero> ] , [ <angle> | <zero> ]? )"
+  },
+  "skewX()": {
+    "syntax": "skewX( [ <angle> | <zero> ] )"
+  },
+  "skewY()": {
+    "syntax": "skewY( [ <angle> | <zero> ] )"
+  },
+  "sqrt()": {
+    "syntax": "sqrt( <calc-sum> )"
+  },
+  "step-position": {
+    "syntax": "jump-start | jump-end | jump-none | jump-both | start | end"
+  },
+  "step-easing-function": {
+    "syntax": "step-start | step-end | <steps()>"
+  },
+  "steps()": {
+    "syntax": "steps( <integer>, <step-position>? )"
+  },
+  "style-feature": {
+    "syntax": "<declaration>"
+  },
+  "style-in-parens": {
+    "syntax": "( <style-query> ) | ( <style-feature> ) | <general-enclosed>"
+  },
+  "style-query": {
+    "syntax": "not <style-in-parens> | <style-in-parens> [ [ and <style-in-parens> ]* | [ or <style-in-parens> ]* ] | <style-feature>"
+  },
+  "subclass-selector": {
+    "syntax": "<id-selector> | <class-selector> | <attribute-selector> | <pseudo-class-selector>"
+  },
+  "superellipse()": {
+    "syntax": "superellipse( [ <number> | infinity | -infinity ] )"
+  },
+  "supports-condition": {
+    "syntax": "not <supports-in-parens> | <supports-in-parens> [ and <supports-in-parens> ]* | <supports-in-parens> [ or <supports-in-parens> ]*"
+  },
+  "supports-decl": {
+    "syntax": "( <declaration> )"
+  },
+  "supports-feature": {
+    "syntax": "<supports-decl> | <supports-selector-fn>"
+  },
+  "supports-in-parens": {
+    "syntax": "( <supports-condition> ) | <supports-feature> | <general-enclosed>"
+  },
+  "supports-selector-fn": {
+    "syntax": "selector( <complex-selector> )"
+  },
+  "symbol": {
+    "syntax": "<string> | <image> | <custom-ident>"
+  },
+  "symbols()": {
+    "syntax": "symbols( <symbols-type>? [ <string> | <image> ]+ )"
+  },
+  "symbols-type": {
+    "syntax": "cyclic | numeric | alphabetic | symbolic | fixed"
+  },
+  "system-color": {
+    "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
+  },
+  "system-family-name": {
+    "syntax": "caption | icon | menu | message-box | small-caption | status-bar"
+  },
+  "tan()": {
+    "syntax": "tan( <calc-sum> )"
+  },
+  "target": {
+    "syntax": "<target-counter()> | <target-counters()> | <target-text()>"
+  },
+  "target-counter()": {
+    "syntax": "target-counter( [ <string> | <url> ] , <custom-ident> , <counter-style>? )"
+  },
+  "target-counters()": {
+    "syntax": "target-counters( [ <string> | <url> ] , <custom-ident> , <string> , <counter-style>? )"
+  },
+  "target-text()": {
+    "syntax": "target-text( [ <string> | <url> ] , [ content | before | after | first-letter ]? )"
+  },
+  "text-edge": {
+    "syntax": "[ text | cap | ex | ideographic | ideographic-ink ] [ text | alphabetic | ideographic | ideographic-ink ]?"
+  },
+  "time-percentage": {
+    "syntax": "<time> | <percentage>"
+  },
+  "timeline-range-name": {
+    "syntax": "cover | contain | entry | exit | entry-crossing | exit-crossing"
+  },
+  "track-breadth": {
+    "syntax": "<length-percentage> | <flex> | min-content | max-content | auto"
+  },
+  "track-list": {
+    "syntax": "[ <line-names>? [ <track-size> | <track-repeat> ] ]+ <line-names>?"
+  },
+  "track-repeat": {
+    "syntax": "repeat( [ <integer [1,∞]> ] , [ <line-names>? <track-size> ]+ <line-names>? )"
+  },
+  "track-size": {
+    "syntax": "<track-breadth> | minmax( <inflexible-breadth> , <track-breadth> ) | fit-content( <length-percentage> )"
+  },
+  "transform-function": {
+    "syntax": "<matrix()> | <translate()> | <translateX()> | <translateY()> | <scale()> | <scaleX()> | <scaleY()> | <rotate()> | <skew()> | <skewX()> | <skewY()> | <matrix3d()> | <translate3d()> | <translateZ()> | <scale3d()> | <scaleZ()> | <rotate3d()> | <rotateX()> | <rotateY()> | <rotateZ()> | <perspective()>"
+  },
+  "transform-list": {
+    "syntax": "<transform-function>+"
+  },
+  "transition-behavior-value": {
+    "syntax": "normal | allow-discrete"
+  },
+  "translate()": {
+    "syntax": "translate( <length-percentage> , <length-percentage>? )"
+  },
+  "translate3d()": {
+    "syntax": "translate3d( <length-percentage> , <length-percentage> , <length> )"
+  },
+  "translateX()": {
+    "syntax": "translateX( <length-percentage> )"
+  },
+  "translateY()": {
+    "syntax": "translateY( <length-percentage> )"
+  },
+  "translateZ()": {
+    "syntax": "translateZ( <length> )"
+  },
+  "try-size": {
+    "syntax": "most-width | most-height | most-block-size | most-inline-size"
+  },
+  "try-tactic": {
+    "syntax": "flip-block || flip-inline || flip-start"
+  },
+  "type-or-unit": {
+    "syntax": "string | color | url | integer | number | length | angle | time | frequency | cap | ch | em | ex | ic | lh | rlh | rem | vb | vi | vw | vh | vmin | vmax | mm | Q | cm | in | pt | pc | px | deg | grad | rad | turn | ms | s | Hz | kHz | %"
+  },
+  "type-selector": {
+    "syntax": "<wq-name> | <ns-prefix>? '*'"
+  },
+  "var()": {
+    "syntax": "var( <custom-property-name> , <declaration-value>? )"
+  },
+  "view()": {
+    "syntax": "view([<axis> || <'view-timeline-inset'>]?)"
+  },
+  "viewport-length": {
+    "syntax": "auto | <length-percentage>"
+  },
+  "visual-box": {
+    "syntax": "content-box | padding-box | border-box"
+  },
+  "wq-name": {
+    "syntax": "<ns-prefix>? <ident-token>"
+  },
+  "xywh()": {
+    "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
+  },
+  "xyz": {
+    "syntax": "xyz | xyz-d50 | xyz-d65"
+  },
+  "xyz-params": {
+    "syntax": "<xyz> [ <number> | <percentage> | none ]{3}"
+  }
+}

--- a/lib/cataclysm/src/core/cataclysm.CssErrors.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssErrors.scala
@@ -32,31 +32,11 @@
                                                                                                   */
 package cataclysm
 
-import anticipation.*
-import denominative.*
 import fulminate.*
 
-object CssError:
-  object Reason:
-    given communicable: Reason is Communicable =
-      case UnterminatedComment        => m"a comment was not terminated"
-      case UnterminatedString         => m"a string literal was not terminated"
-      case UnexpectedEnd              => m"the input ended before a rule was closed"
-      case UnexpectedChar(char)       => m"the character $char was not expected here"
-      case EmptySelector              => m"a selector was expected but none was found"
-      case UnknownProperty(name)      => m"$name is not a recognized CSS property"
-      case BadValue(property, value)  => m"$value is not a valid value for the $property property"
-      case UnsupportedValue(name, _)  => m"the value of $name uses an unsupported type"
-
-  enum Reason(val number: Int) extends Clarification:
-    case UnterminatedComment         extends Reason(1)
-    case UnterminatedString          extends Reason(2)
-    case UnexpectedEnd               extends Reason(3)
-    case UnexpectedChar(char: Char)  extends Reason(4)
-    case EmptySelector               extends Reason(5)
-    case UnknownProperty(name: Text) extends Reason(6)
-    case BadValue(property: Text, value: Text) extends Reason(7)
-    case UnsupportedValue(property: Text, types: List[Text]) extends Reason(8)
-
-case class CssError(reason: CssError.Reason, line: Ordinal, column: Ordinal)(using Diagnostics)
-extends Error(251, reason.number)(m"invalid CSS at line ${line.n1} column ${column.n1}: $reason")
+// The aggregate of every `CssError` accumulated while reading a stylesheet.
+// `read[Css]` collects all errors rather than stopping at the first, raising
+// this once at the end (or returning the `Css` if there were none).
+case class CssErrors(errors: List[CssError])(using Diagnostics)
+extends Error(m"the CSS contained ${errors.length} errors"):
+  def + (error: CssError): CssErrors = CssErrors(errors :+ error)

--- a/lib/cataclysm/src/core/cataclysm.CssParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssParser.scala
@@ -159,9 +159,16 @@ private[cataclysm] object CssParser:
       else if colonAt >= 0 then
         val property = buf.substring(0, colonAt).nn.tt.trim
         val value = buf.substring(colonAt + 1).nn.tt.trim
+        checkProperty(property)
         Node.Declaration(property, value)
       else
+        checkProperty(text)
         Node.Declaration(text, t"")
+
+    // Reject any non-custom property that is not a recognized CSS property.
+    private def checkProperty(property: Text): Unit =
+      if !property.starts(t"--") && PropertyDef.of(property).absent then
+        fail(CssError.Reason.UnknownProperty(property))
 
     // Split an `@…` prelude into its identifier and the remaining prelude text.
     private def atRule(text: Text): (Text, Text) =

--- a/lib/cataclysm/src/core/cataclysm.CssParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssParser.scala
@@ -159,16 +159,32 @@ private[cataclysm] object CssParser:
       else if colonAt >= 0 then
         val property = buf.substring(0, colonAt).nn.tt.trim
         val value = buf.substring(colonAt + 1).nn.tt.trim
-        checkProperty(property)
+        validate(property, value)
         Node.Declaration(property, value)
       else
-        checkProperty(text)
+        validate(text, t"")
         Node.Declaration(text, t"")
 
-    // Reject any non-custom property that is not a recognized CSS property.
-    private def checkProperty(property: Text): Unit =
-      if !property.starts(t"--") && PropertyDef.of(property).absent then
-        fail(CssError.Reason.UnknownProperty(property))
+    // Check a declaration's property name and value, accumulating (via `raise`)
+    // any error rather than aborting, so the rest of the stylesheet is still
+    // read. Custom properties (`--…`) accept any value.
+    private def validate(property: Text, value: Text): Unit =
+      if property.starts(t"--") then ()
+      else PropertyDef.of(property) match
+        case definition: PropertyDef =>
+          SyntaxMatcher.check(definition, value) match
+            case Outcome.Valid =>
+              ()
+
+            case Outcome.Invalid =>
+              raise(CssError(CssError.Reason.BadValue(property, value), cursor.line, cursor.column))
+
+            case Outcome.Unsupported(types) =>
+              val reason = CssError.Reason.UnsupportedValue(property, types)
+              raise(CssError(reason, cursor.line, cursor.column))
+
+        case _ =>
+          raise(CssError(CssError.Reason.UnknownProperty(property), cursor.line, cursor.column))
 
     // Split an `@…` prelude into its identifier and the remaining prelude text.
     private def atRule(text: Text): (Text, Text) =

--- a/lib/cataclysm/src/core/cataclysm.Outcome.scala
+++ b/lib/cataclysm/src/core/cataclysm.Outcome.scala
@@ -1,0 +1,43 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package cataclysm
+
+import anticipation.*
+
+// The result of checking a property value against its grammar. `Unsupported`
+// carries the names of the value types the matcher does not yet implement and so
+// could not verify against.
+enum Outcome derives CanEqual:
+  case Valid
+  case Invalid
+  case Unsupported(types: List[Text])

--- a/lib/cataclysm/src/core/cataclysm.PropertyDef.scala
+++ b/lib/cataclysm/src/core/cataclysm.PropertyDef.scala
@@ -33,26 +33,43 @@
 package cataclysm
 
 import anticipation.*
-import denominative.*
-import fulminate.*
+import contingency.*
+import gossamer.*
+import hellenism.*
+import jacinta.*
+import turbulence.*
+import vacuous.*
 
-object CssError:
-  object Reason:
-    given communicable: Reason is Communicable =
-      case UnterminatedComment   => m"a comment was not terminated"
-      case UnterminatedString    => m"a string literal was not terminated"
-      case UnexpectedEnd         => m"the end of the input was reached before a rule was closed"
-      case UnexpectedChar(char)  => m"the character $char was not expected here"
-      case EmptySelector         => m"a selector was expected but none was found"
-      case UnknownProperty(name) => m"$name is not a recognized CSS property"
+import hellenism.classloaders.threadContext
 
-  enum Reason(val number: Int) extends Clarification:
-    case UnterminatedComment         extends Reason(1)
-    case UnterminatedString          extends Reason(2)
-    case UnexpectedEnd               extends Reason(3)
-    case UnexpectedChar(char: Char)  extends Reason(4)
-    case EmptySelector               extends Reason(5)
-    case UnknownProperty(name: Text) extends Reason(6)
+object PropertyDef:
+  // One entry of the bundled `properties.json`. Only `syntax` is read; jacinta
+  // ignores the dataset's other fields (initial, inherited, …).
+  private object Entry:
+    given decodable: Tactic[JsonError] => Entry is Json.Decodable = Json.DecodableDerivation.derived
 
-case class CssError(reason: CssError.Reason, line: Ordinal, column: Ordinal)(using Diagnostics)
-extends Error(251, reason.number)(m"invalid CSS at line ${line.n1} column ${column.n1}: $reason")
+  private case class Entry(syntax: Text)
+
+  // All known CSS properties, keyed by name, in a `Dictionary` for fast lookup.
+  // Read lazily from the classpath resource the first time a property is
+  // resolved; a malformed resource is a packaging error, hence `throwUnsafely`.
+  lazy val all: Dictionary[PropertyDef] =
+    import contingency.strategies.throwUnsafely
+
+    val entries = cp"/cataclysm/properties.json".read[Json].as[Map[Text, Entry]]
+
+    val pairs = entries.to(List).map: (name, entry) =>
+      (name, PropertyDef(name, entry.syntax))
+
+    Dictionary(pairs*)
+
+  // The definition of the named property, or `Unset` if it is not a recognized
+  // CSS property. Custom properties (names beginning with `--`) are the caller's
+  // responsibility — they are valid but have no definition here.
+  def of(name: Text): Optional[PropertyDef] = all(name)
+
+// The definition of a single CSS property, taken from the bundled MDN `mdn/data`
+// dataset (`css/properties.json`, CC0). For now this carries the property's name
+// and its value grammar (in CSS Value Definition Syntax) as raw `Text`; the
+// grammar is retained for a future value-validation step.
+case class PropertyDef(name: Text, syntax: Text) derives CanEqual

--- a/lib/cataclysm/src/core/cataclysm.Syntax.scala
+++ b/lib/cataclysm/src/core/cataclysm.Syntax.scala
@@ -33,50 +33,22 @@
 package cataclysm
 
 import anticipation.*
-import contingency.*
-import gossamer.*
-import hellenism.*
-import jacinta.*
-import turbulence.*
 import vacuous.*
 
-import hellenism.classloaders.threadContext
-
-object PropertyDef:
-  // One entry of the bundled `properties.json`. Only `syntax` is read; jacinta
-  // ignores the dataset's other fields (initial, inherited, …).
-  private object Entry:
-    given decodable: Tactic[JsonError] => Entry is Json.Decodable = Json.DecodableDerivation.derived
-
-  private case class Entry(syntax: Text)
-
-  // Every known CSS property. Read lazily from the classpath resource the first
-  // time a property is resolved; a malformed resource is a packaging error,
-  // hence `throwUnsafely`.
-  lazy val list: List[PropertyDef] =
-    import contingency.strategies.throwUnsafely
-
-    val entries = cp"/cataclysm/properties.json".read[Json].as[Map[Text, Entry]]
-
-    entries.to(List).map: (name, entry) =>
-      PropertyDef(name, entry.syntax)
-
-  // The same properties keyed by name in a `Dictionary` for fast lookup.
-  lazy val all: Dictionary[PropertyDef] =
-    val pairs = list.map: property =>
-      (property.name, property)
-
-    Dictionary(pairs*)
-
-  // The definition of the named property, or `Unset` if it is not a recognized
-  // CSS property. Custom properties (names beginning with `--`) are the caller's
-  // responsibility — they are valid but have no definition here.
-  def of(name: Text): Optional[PropertyDef] = all(name)
-
-// The definition of a single CSS property, taken from the bundled MDN `mdn/data`
-// dataset (`css/properties.json`, CC0). `syntax` is the raw value grammar (CSS
-// Value Definition Syntax); `grammar` is its parsed form, computed on demand.
-case class PropertyDef(name: Text, syntax: Text) derives CanEqual:
-  lazy val grammar: Syntax =
-    import contingency.strategies.throwUnsafely
-    SyntaxParser.parse(syntax)
+// The CSS Value Definition Syntax (VDS) — the grammar notation in which every
+// property's permitted values are described. A `Syntax` is the parsed form of a
+// grammar string such as `<line-width> || <line-style> || <color>`; it is what a
+// later step matches a concrete value against.
+enum Syntax derives CanEqual:
+  case Keyword(name: Text)                          // a literal identifier, e.g. `auto`
+  case Literal(token: Text)                         // a literal token, e.g. `/` `,` or quoted `'+'`
+  case Type(name: Text, bounds: Optional[Text])     // `<length>`, `<integer [1,4]>` (bounds raw)
+  case Property(name: Text)                         // `<'border-width'>` — another property
+  case Function(name: Text, body: Syntax)           // `rgb( <number>#{3} )`
+  case Sequence(terms: List[Syntax])               // juxtaposition: terms in order
+  case OneOf(options: List[Syntax])                // `|`  — exactly one
+  case AnyOf(terms: List[Syntax])                  // `||` — one or more, in any order
+  case AllOf(terms: List[Syntax])                  // `&&` — all, in any order
+  // a repeat multiplier: `?` `*` `+` `{m,n}` `#`
+  case Repeated(term: Syntax, min: Int, max: Optional[Int], separated: Boolean)
+  case Mandatory(term: Syntax)                     // `!` — the group must produce a value

--- a/lib/cataclysm/src/core/cataclysm.SyntaxMatcher.scala
+++ b/lib/cataclysm/src/core/cataclysm.SyntaxMatcher.scala
@@ -1,0 +1,389 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package cataclysm
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import hellenism.*
+import jacinta.*
+import turbulence.*
+import vacuous.*
+
+import hellenism.classloaders.threadContext
+
+// Checks a CSS property value against its `Syntax` grammar. Composite `<type>`s
+// are resolved lazily from the bundled `syntaxes.json` (which expand to keywords,
+// functions and a handful of leaf primitives); leaf primitives (`<length>`,
+// `<color>` parts, …) are matched at the token level. A value containing an
+// arbitrary-substitution function (`var()`, `env()`) is always valid (it is a
+// pending-substitution value). `calc()` and friends are accepted wherever a
+// numeric primitive is expected. Any `<type>` that is neither resolvable nor an
+// implemented primitive yields `Outcome.Unsupported`.
+object SyntaxMatcher:
+  private object Entry:
+    given decodable: Tactic[JsonError] => Entry is Json.Decodable = Json.DecodableDerivation.derived
+
+  private case class Entry(syntax: Text)
+
+  private lazy val rawComposites: Map[Text, Text] =
+    import contingency.strategies.throwUnsafely
+
+    val entries = cp"/cataclysm/syntaxes.json".read[Json].as[Map[Text, Entry]]
+    entries.view.mapValues(_.syntax).toMap
+
+  private val cache: scala.collection.mutable.HashMap[Text, Optional[Syntax]] =
+    scala.collection.mutable.HashMap()
+
+  private def composite(name: Text): Optional[Syntax] =
+    cache.getOrElseUpdate(name, rawComposites.get(name).map(parsed).getOrElse(Unset))
+
+  private def parsed(raw: Text): Optional[Syntax] = safely(SyntaxParser.parse(raw))
+
+  private val lengthUnits: Set[String] =
+    Set("px", "em", "rem", "ex", "ch", "cap", "ic", "lh", "rlh", "vw", "vh", "vi", "vb", "vmin",
+        "vmax", "svw", "svh", "lvw", "lvh", "dvw", "dvh", "cm", "mm", "q", "in", "pt", "pc")
+
+  private val angleUnits: Set[String] = Set("deg", "grad", "rad", "turn")
+  private val timeUnits: Set[String] = Set("s", "ms")
+  private val resolutionUnits: Set[String] = Set("dpi", "dpcm", "dppx", "x")
+  private val frequencyUnits: Set[String] = Set("hz", "khz")
+  private val substitutions: Set[String] = Set("var", "env")
+
+  private val mathFunctions: Set[String] =
+    Set("calc", "min", "max", "clamp", "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "pow",
+        "sqrt", "hypot", "log", "exp", "abs", "sign", "mod", "rem", "round")
+
+  private def lower(text: Text): String = text.s.toLowerCase.nn
+  private def same(a: Text, b: Text): Boolean = lower(a) == lower(b)
+
+  private def substitution(token: ValueToken): Boolean = token match
+    case ValueToken.Function(name) => substitutions(lower(name))
+    case _                         => false
+
+  def check(property: PropertyDef, value: Text)(using Tactic[CssError]): Outcome =
+    check(property.grammar, value)
+
+  def check(grammar: Syntax, value: Text)(using Tactic[CssError]): Outcome =
+    val tokens = ValueTokenizer.tokens(value).filter(_ != ValueToken.Whitespace)
+
+    if tokens.exists(substitution) then Outcome.Valid
+    else
+      val matcher = Matcher()
+
+      if matcher.consume(grammar, tokens).exists(_.isEmpty) then Outcome.Valid
+      else if matcher.unsupported.nonEmpty then Outcome.Unsupported(matcher.unsupported.to(List))
+      else Outcome.Invalid
+
+  // ── the backtracking matcher ─────────────────────────────────────────────
+
+  // `consume` returns every possible list of tokens remaining after matching
+  // `syntax` against a prefix of `tokens`. A full match exists when some
+  // remainder is empty.
+  private class Matcher:
+    val unsupported: scala.collection.mutable.LinkedHashSet[Text] =
+      scala.collection.mutable.LinkedHashSet()
+
+    private val resolving: scala.collection.mutable.HashSet[Text] =
+      scala.collection.mutable.HashSet()
+
+    def consume(syntax: Syntax, tokens: List[ValueToken]): List[List[ValueToken]] = syntax match
+      case Syntax.Keyword(name) =>
+        keyword(name, tokens)
+
+      case Syntax.Literal(token) =>
+        literal(token, tokens)
+
+      case Syntax.Type(name, _) =>
+        typeMatch(name, tokens)
+
+      case Syntax.Property(name) =>
+        propertyMatch(name, tokens)
+
+      case Syntax.Function(name, body) =>
+        functionMatch(name, body, tokens)
+
+      case Syntax.Sequence(terms) =>
+        terms.foldLeft(List(tokens)): (states, term) =>
+          states.flatMap(consume(term, _))
+
+      case Syntax.OneOf(options) =>
+        options.flatMap(consume(_, tokens))
+
+      case Syntax.AllOf(terms) =>
+        allOf(terms, tokens)
+
+      case Syntax.AnyOf(terms) =>
+        anyOf(terms, tokens)
+
+      case Syntax.Repeated(term, min, max, separated) =>
+        repeat(term, min, max, separated, tokens)
+
+      case Syntax.Mandatory(term) =>
+        consume(term, tokens)
+
+    private def pickEach(terms: List[Syntax], tokens: List[ValueToken])
+    :   List[(List[Syntax], List[ValueToken])] =
+
+      terms.indices.to(List).flatMap: index =>
+        consume(terms(index), tokens).map: rem =>
+          (terms.patch(index, Nil, 1), rem)
+
+    private def allOf(terms: List[Syntax], tokens: List[ValueToken]): List[List[ValueToken]] =
+      if terms.isEmpty then List(tokens)
+      else
+        pickEach(terms, tokens).flatMap: (rest, rem) =>
+          allOf(rest, rem)
+
+    private def anyOf(terms: List[Syntax], tokens: List[ValueToken]): List[List[ValueToken]] =
+      pickEach(terms, tokens).flatMap: (rest, rem) =>
+        rem :: anyOf(rest, rem)
+
+    private def repeat
+      ( term: Syntax, min: Int, max: Optional[Int], separated: Boolean, tokens: List[ValueToken] )
+    :   List[List[ValueToken]] =
+
+      def go(count: Int, toks: List[ValueToken]): List[List[ValueToken]] =
+        val stop = if count >= min then List(toks) else Nil
+        val more = max.lay(true)(count < _)
+
+        if !more then stop
+        else
+          val starts = if count > 0 && separated then comma(toks) else List(toks)
+          stop ::: starts.flatMap(consume(term, _)).flatMap(go(count + 1, _))
+
+      go(0, tokens)
+
+    private def comma(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Comma :: tail => List(tail)
+      case _                        => Nil
+
+    private def keyword(name: Text, tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Ident(value) :: tail if same(value, name) =>
+        List(tail)
+
+      case _ =>
+        Nil
+
+    private def literal(token: Text, tokens: List[ValueToken]): List[List[ValueToken]] =
+      if token == t"," then comma(tokens)
+      else tokens match
+        case ValueToken.Delim(char) :: tail if token == char.toString.tt =>
+          List(tail)
+
+        case _ =>
+          Nil
+
+    private def typeMatch(name: Text, tokens: List[ValueToken]): List[List[ValueToken]] =
+      composite(name) match
+        case syntax: Syntax => guarded(name, consume(syntax, tokens))
+        case _              => primitive(name, tokens)
+
+    private def propertyMatch(name: Text, tokens: List[ValueToken]): List[List[ValueToken]] =
+      PropertyDef.of(name) match
+        case property: PropertyDef =>
+          guarded(t"<$name>", consume(property.grammar, tokens))
+
+        case _ =>
+          unsupported += name
+          Nil
+
+    // Resolve a named reference, guarding against cycles in recursive grammars.
+    private inline def guarded(name: Text, inline block: => List[List[ValueToken]])
+    :   List[List[ValueToken]] =
+
+      if resolving.contains(name) then
+        unsupported += name
+        Nil
+      else
+        resolving += name
+        val result = block
+        resolving -= name
+        result
+
+    private def functionMatch(name: Text, body: Syntax, tokens: List[ValueToken])
+    :   List[List[ValueToken]] =
+
+      tokens match
+        case ValueToken.Function(fname) :: tail if same(fname, name) =>
+          val (inner, after) = split(tail)
+
+          after.lay(Nil): rest =>
+            if consume(body, inner).exists(_.isEmpty) then List(rest) else Nil
+
+        case _ =>
+          Nil
+
+    // Split `tokens` at the `)` that closes the current function, returning the
+    // tokens inside and (if balanced) those after the close.
+    private def split(tokens: List[ValueToken]): (List[ValueToken], Optional[List[ValueToken]]) =
+      def loop(depth: Int, acc: List[ValueToken], rest: List[ValueToken])
+      :   (List[ValueToken], Optional[List[ValueToken]]) =
+
+        rest match
+          case Nil =>
+            (acc.reverse, Unset)
+
+          case ValueToken.Close :: tail if depth == 0 =>
+            (acc.reverse, tail)
+
+          case (token @ ValueToken.Close) :: tail =>
+            loop(depth - 1, token :: acc, tail)
+
+          case (token @ (ValueToken.Function(_) | ValueToken.Open)) :: tail =>
+            loop(depth + 1, token :: acc, tail)
+
+          case token :: tail =>
+            loop(depth, token :: acc, tail)
+
+      loop(0, Nil, tokens)
+
+    private def afterFunction(tokens: List[ValueToken]): List[List[ValueToken]] =
+      split(tokens)._2.lay(Nil)(List(_))
+
+    // ── leaf primitives ──────────────────────────────────────────────────────
+
+    private def primitive(name: Text, tokens: List[ValueToken]): List[List[ValueToken]] =
+      lower(name) match
+        case "length" =>
+          numeric(tokens)(lengthLeaf)
+
+        case "percentage" =>
+          numeric(tokens)(percentageLeaf)
+
+        case "number" | "number-token" | "integer" =>
+          numeric(tokens)(numberLeaf)
+
+        case "angle" =>
+          numeric(tokens)(angleLeaf)
+
+        case "time" =>
+          numeric(tokens)(timeLeaf)
+
+        case "resolution" =>
+          numeric(tokens)(resolutionLeaf)
+
+        case "frequency" =>
+          numeric(tokens)(frequencyLeaf)
+
+        case "dimension" | "dimension-token" =>
+          dimensionLeaf(tokens)
+
+        case "string" | "string-token" =>
+          stringLeaf(tokens)
+
+        case "url" | "url-token" =>
+          urlLeaf(tokens)
+
+        case "hex-color" | "hash-token" =>
+          hashLeaf(tokens)
+
+        case "custom-ident" | "ident" | "ident-token" | "dashed-ident" | "custom-property-name" =>
+          identLeaf(tokens)
+
+        case _ =>
+          unsupported += name
+          Nil
+
+    // Accept a `calc()`/`min()`/… wherever a numeric primitive is expected;
+    // otherwise fall back to the leaf matcher.
+    private def numeric(tokens: List[ValueToken])(leaf: List[ValueToken] => List[List[ValueToken]])
+    :   List[List[ValueToken]] =
+
+      tokens match
+        case ValueToken.Function(name) :: tail if mathFunctions(lower(name)) =>
+          afterFunction(tail)
+
+        case _ =>
+          leaf(tokens)
+
+    private def lengthLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, unit, _) :: tail if lengthUnits(lower(unit)) => List(tail)
+      case ValueToken.Number(value, _, _) :: tail if value == 0.0               => List(tail)
+      case _                                                                    => Nil
+
+    private def percentageLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Percentage(_, _) :: tail => List(tail)
+      case _                                   => Nil
+
+    private def numberLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Number(_, _, _) :: tail => List(tail)
+      case _                                  => Nil
+
+    private def angleLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, unit, _) :: tail if angleUnits(lower(unit)) => List(tail)
+      case _                                                                   => Nil
+
+    private def timeLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, unit, _) :: tail if timeUnits(lower(unit)) => List(tail)
+      case _                                                                  => Nil
+
+    private def resolutionLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, unit, _) :: tail if resolutionUnits(lower(unit)) =>
+        List(tail)
+
+      case _ =>
+        Nil
+
+    private def frequencyLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, unit, _) :: tail if frequencyUnits(lower(unit)) =>
+        List(tail)
+
+      case _ =>
+        Nil
+
+    private def dimensionLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, _, _) :: tail => List(tail)
+      case _                                     => Nil
+
+    private def stringLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Quoted(_) :: tail => List(tail)
+      case _                            => Nil
+
+    private def identLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Ident(_) :: tail => List(tail)
+      case _                           => Nil
+
+    private def hashLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Hash(_) :: tail => List(tail)
+      case _                          => Nil
+
+    private def urlLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Url(_) :: tail =>
+        List(tail)
+
+      case ValueToken.Function(name) :: tail if same(name, t"url") =>
+        afterFunction(tail)
+
+      case _ =>
+        Nil

--- a/lib/cataclysm/src/core/cataclysm.SyntaxParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.SyntaxParser.scala
@@ -1,0 +1,325 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package cataclysm
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import vacuous.*
+import zephyrine.*
+
+// Parses a CSS Value Definition Syntax (VDS) string — a property's value grammar
+// from the MDN dataset — into a `Syntax` tree. Combinator precedence, from
+// loosest to tightest, is: `|`, `||`, `&&`, juxtaposition, then the multipliers
+// (`?`, `*`, `+`, `{m,n}`, `#`, `!`) which bind to the preceding term.
+private[cataclysm] object SyntaxParser:
+  def parse(text: Text)(using Tactic[CssError]): Syntax =
+    import zephyrine.lineation.linefeedChars
+
+    Parser(Cursor[Text](text)).document()
+
+  private class Parser(cursor: Cursor[Text])(using Tactic[CssError]):
+    def document(): Syntax =
+      ws()
+      val result = oneOf()
+      ws()
+      if !cursor.peek.isEnd then unexpected()
+      result
+
+    // ── primitives ──────────────────────────────────────────────────────────
+
+    private def fail(reason: CssError.Reason): Nothing =
+      abort(CssError(reason, cursor.line, cursor.column))
+
+    private def unexpected(): Nothing =
+      val datum = cursor.peek
+
+      if datum.isEnd then fail(CssError.Reason.UnexpectedEnd)
+      else fail(CssError.Reason.UnexpectedChar(datum.asInt.toChar))
+
+    private def whitespaceChar(datum: Datum): Boolean =
+      datum == ' ' || datum == '\t' || datum == '\n' || datum == '\r'
+
+    private def ws(): Unit = while whitespaceChar(cursor.peek) do cursor.advance()
+
+    private def eat(char: Char): Unit =
+      if cursor.peek == char then cursor.advance() else unexpected()
+
+    private def nameChar(char: Char): Boolean = char.isLetter || char.isDigit || char == '-'
+
+    private def digit(datum: Datum): Boolean = !datum.isEnd && datum.asInt.toChar.isDigit
+
+    // ── combinators, loosest to tightest ────────────────────────────────────
+
+    private def oneOf(): Syntax =
+      val acc = scala.collection.mutable.ListBuffer[Syntax](anyOf())
+      ws()
+
+      while cursor.peek == '|' do
+        cursor.advance()
+        ws()
+        acc.append(anyOf())
+        ws()
+
+      if acc.size == 1 then acc.head else Syntax.OneOf(acc.toList)
+
+    private def anyOf(): Syntax =
+      val acc = scala.collection.mutable.ListBuffer[Syntax](allOf())
+      ws()
+
+      while pipePipe() do
+        cursor.advance()
+        eat('|')
+        ws()
+        acc.append(allOf())
+        ws()
+
+      if acc.size == 1 then acc.head else Syntax.AnyOf(acc.toList)
+
+    private def allOf(): Syntax =
+      val acc = scala.collection.mutable.ListBuffer[Syntax](sequence())
+      ws()
+
+      while cursor.peek == '&' do
+        cursor.advance()
+        eat('&')
+        ws()
+        acc.append(sequence())
+        ws()
+
+      if acc.size == 1 then acc.head else Syntax.AllOf(acc.toList)
+
+    private def sequence(): Syntax =
+      val acc = scala.collection.mutable.ListBuffer[Syntax]()
+      ws()
+
+      while termStart() do
+        acc.append(term())
+        ws()
+
+      if acc.isEmpty then unexpected()
+      if acc.size == 1 then acc.head else Syntax.Sequence(acc.toList)
+
+    // A `|` that is not the start of a `||`.
+    private def pipePipe(): Boolean =
+      cursor.peek == '|' && cursor.lookahead { cursor.next(); cursor.peek == '|' }
+
+    private def termStart(): Boolean =
+      val datum = cursor.peek
+      !(datum.isEnd || datum == '|' || datum == '&' || datum == ']' || datum == ')')
+
+    // ── a term: a primary followed by zero or more multipliers ───────────────
+
+    private def term(): Syntax =
+      var result = primary()
+      var continue = true
+
+      while continue do
+        val datum = cursor.peek
+
+        if datum == '?' then result = once(result)
+        else if datum == '*' then result = star(result)
+        else if datum == '+' then result = plus(result)
+        else if datum == '!' then result = mandatory(result)
+        else if datum == '#' then result = hash(result)
+        else if datum == '{' then result = braces(result)
+        else continue = false
+
+      result
+
+    private def once(term: Syntax): Syntax =
+      cursor.advance()
+      Syntax.Repeated(term, 0, 1, false)
+
+    private def star(term: Syntax): Syntax =
+      cursor.advance()
+      Syntax.Repeated(term, 0, Unset, false)
+
+    private def plus(term: Syntax): Syntax =
+      cursor.advance()
+      Syntax.Repeated(term, 1, Unset, false)
+
+    private def mandatory(term: Syntax): Syntax =
+      cursor.advance()
+      Syntax.Mandatory(term)
+
+    private def hash(term: Syntax): Syntax =
+      cursor.advance()
+
+      if cursor.peek == '{' then
+        val (min, max) = range()
+        Syntax.Repeated(term, min, max, true)
+      else
+        Syntax.Repeated(term, 1, Unset, true)
+
+    private def braces(term: Syntax): Syntax =
+      val (min, max) = range()
+      Syntax.Repeated(term, min, max, false)
+
+    private def range(): (Int, Optional[Int]) =
+      eat('{')
+      val min = number()
+
+      val max =
+        if cursor.peek == ',' then
+          cursor.advance()
+          if digit(cursor.peek) then number() else Unset
+        else
+          min
+
+      eat('}')
+      (min, max)
+
+    private def number(): Int =
+      val buf = java.lang.StringBuilder()
+
+      while digit(cursor.peek) do
+        buf.append(cursor.peek.asInt.toChar)
+        cursor.advance()
+
+      if buf.length == 0 then unexpected()
+      buf.toString.nn.toInt
+
+    // ── primaries ────────────────────────────────────────────────────────────
+
+    private def primary(): Syntax =
+      val datum = cursor.peek
+
+      if datum == '<' then angle()
+      else if datum == '[' then group()
+      else if datum == '\'' then quoted()
+      else if datum == '/' then literal('/')
+      else if datum == ',' then literal(',')
+      else identOrFunction()
+
+    private def literal(char: Char): Syntax =
+      cursor.advance()
+      Syntax.Literal(char.toString.nn.tt)
+
+    private def group(): Syntax =
+      cursor.advance()
+      ws()
+      val inner = oneOf()
+      ws()
+      eat(']')
+      inner
+
+    private def quoted(): Syntax =
+      cursor.advance()
+      val buf = java.lang.StringBuilder()
+
+      while !cursor.peek.isEnd && cursor.peek != '\'' do
+        buf.append(cursor.peek.asInt.toChar)
+        cursor.advance()
+
+      eat('\'')
+      Syntax.Literal(buf.toString.nn.tt)
+
+    private def identOrFunction(): Syntax =
+      val name = readName()
+
+      if cursor.peek == '(' then
+        cursor.advance()
+        ws()
+        val body = oneOf()
+        ws()
+        eat(')')
+        Syntax.Function(name, body)
+      else
+        Syntax.Keyword(name)
+
+    private def readName(): Text =
+      val buf = java.lang.StringBuilder()
+
+      while !cursor.peek.isEnd && nameChar(cursor.peek.asInt.toChar) do
+        buf.append(cursor.peek.asInt.toChar)
+        cursor.advance()
+
+      if buf.length == 0 then unexpected()
+      buf.toString.nn.tt
+
+    // ── `<type>`, `<type [bounds]>` and `<'property'>` ────────────────────────
+
+    private def angle(): Syntax =
+      cursor.advance()
+      ws()
+      if cursor.peek == '\'' then propertyRef() else typeRef()
+
+    private def propertyRef(): Syntax =
+      cursor.advance()
+      val name = readUntil('\'')
+      eat('\'')
+      ws()
+      eat('>')
+      Syntax.Property(name)
+
+    private def typeRef(): Syntax =
+      val name = typeName()
+      ws()
+      val bounds = if cursor.peek == '[' then bracketBounds() else Unset
+      ws()
+      eat('>')
+      Syntax.Type(name, bounds)
+
+    private def typeBoundary(datum: Datum): Boolean =
+      datum.isEnd || whitespaceChar(datum) || datum == '[' || datum == '>'
+
+    private def typeName(): Text =
+      val buf = java.lang.StringBuilder()
+      var continue = true
+
+      while continue do
+        val datum = cursor.peek
+
+        if typeBoundary(datum) then continue = false
+        else
+          buf.append(datum.asInt.toChar)
+          cursor.advance()
+
+      if buf.length == 0 then unexpected()
+      buf.toString.nn.tt
+
+    private def bracketBounds(): Text =
+      cursor.advance()
+      val text = readUntil(']')
+      eat(']')
+      text.trim
+
+    private def readUntil(stop: Char): Text =
+      val buf = java.lang.StringBuilder()
+
+      while !cursor.peek.isEnd && cursor.peek != stop do
+        buf.append(cursor.peek.asInt.toChar)
+        cursor.advance()
+
+      buf.toString.nn.tt

--- a/lib/cataclysm/src/core/cataclysm.ValueToken.scala
+++ b/lib/cataclysm/src/core/cataclysm.ValueToken.scala
@@ -1,0 +1,53 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package cataclysm
+
+import anticipation.*
+
+// A CSS value token, the unit a property value is broken into before being
+// matched against a `Syntax` grammar. Follows the CSS Syntax Module Level 3
+// tokenizer, restricted to the tokens that appear in property values.
+enum ValueToken derives CanEqual:
+  case Whitespace
+  case Ident(value: Text)                               // auto, solid, --my-var
+  case Function(name: Text)                             // an ident directly followed by `(`
+  case Hash(value: Text)                                // `#ff0000` → value `ff0000`
+  case Quoted(value: Text)                              // a string's contents (without quotes)
+  case Url(value: Text)                                 // an unquoted `url(…)`
+  case Number(value: Double, integer: Boolean, raw: Text)
+  case Percentage(value: Double, raw: Text)
+  case Dimension(value: Double, unit: Text, raw: Text)  // `10px` → 10, `px`
+  case Comma
+  case Open                                             // (
+  case Close                                            // )
+  case Delim(char: Char)                                // any other single char, e.g. `/` `+`

--- a/lib/cataclysm/src/core/cataclysm.ValueTokenizer.scala
+++ b/lib/cataclysm/src/core/cataclysm.ValueTokenizer.scala
@@ -1,0 +1,239 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package cataclysm
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import zephyrine.*
+
+// Breaks a CSS property value into `ValueToken`s, following the CSS Syntax
+// Module Level 3 tokenizer for the subset that appears in values. The output
+// feeds the value matcher; it is deliberately lenient, raising a `CssError`
+// only for an unterminated string.
+private[cataclysm] object ValueTokenizer:
+  def tokens(text: Text)(using Tactic[CssError]): List[ValueToken] =
+    import zephyrine.lineation.linefeedChars
+
+    Tokenizer(Cursor[Text](text)).all()
+
+  private class Tokenizer(cursor: Cursor[Text])(using Tactic[CssError]):
+    def all(): List[ValueToken] =
+      val acc = scala.collection.mutable.ListBuffer[ValueToken]()
+      while !cursor.peek.isEnd do acc.append(next())
+      acc.toList
+
+    // ── primitives ──────────────────────────────────────────────────────────
+
+    private def fail(reason: CssError.Reason): Nothing =
+      abort(CssError(reason, cursor.line, cursor.column))
+
+    private def whitespaceChar(char: Char): Boolean =
+      char == ' ' || char == '\t' || char == '\n' || char == '\r'
+
+    private def identStart(char: Char): Boolean = char.isLetter || char == '_' || char.toInt >= 0x80
+    private def identChar(char: Char): Boolean = identStart(char) || char.isDigit || char == '-'
+    private def digit(datum: Datum): Boolean = !datum.isEnd && datum.asInt.toChar.isDigit
+    private def peekChar: Char = cursor.peek.asInt.toChar
+    private def peek2: Datum = cursor.lookahead { cursor.next(); cursor.peek }
+    private def peek3: Datum = cursor.lookahead { cursor.next(); cursor.next(); cursor.peek }
+
+    // ── dispatch ──────────────────────────────────────────────────────────────
+
+    private def next(): ValueToken =
+      val char = peekChar
+
+      if whitespaceChar(char) then whitespace()
+      else if char == '"' || char == '\'' then string(char)
+      else if char == '#' then hash()
+      else if char == ',' then single(ValueToken.Comma)
+      else if char == '(' then single(ValueToken.Open)
+      else if char == ')' then single(ValueToken.Close)
+      else if numberStart(char) then number()
+      else if identStart(char) then identOrFunction()
+      else if char == '-' && identAhead() then identOrFunction()
+      else delim(char)
+
+    private def numberStart(char: Char): Boolean =
+      if char.isDigit then true
+      else if char == '.' then digit(peek2)
+      else if char == '+' || char == '-' then digit(peek2) || (peek2 == '.' && digit(peek3))
+      else false
+
+    private def identAhead(): Boolean =
+      val datum = peek2
+      !datum.isEnd && (identStart(datum.asInt.toChar) || datum == '-')
+
+    private def single(token: ValueToken): ValueToken =
+      cursor.advance()
+      token
+
+    private def delim(char: Char): ValueToken =
+      cursor.advance()
+      ValueToken.Delim(char)
+
+    // ── whitespace, strings and hashes ────────────────────────────────────────
+
+    private def whitespace(): ValueToken =
+      while !cursor.peek.isEnd && whitespaceChar(peekChar) do cursor.advance()
+      ValueToken.Whitespace
+
+    private def string(quote: Char): ValueToken =
+      cursor.advance()
+      val buf = java.lang.StringBuilder()
+      var continue = true
+
+      while continue do
+        val datum = cursor.peek
+
+        if datum.isEnd then
+          fail(CssError.Reason.UnterminatedString)
+        else
+          val char = datum.asInt.toChar
+
+          if char == '\\' then
+            cursor.advance()
+            val escaped = cursor.peek
+
+            if escaped.isEnd then fail(CssError.Reason.UnterminatedString)
+            else
+              buf.append(escaped.asInt.toChar)
+              cursor.advance()
+          else if char == quote then
+            cursor.advance()
+            continue = false
+          else
+            buf.append(char)
+            cursor.advance()
+
+      ValueToken.Quoted(buf.toString.nn.tt)
+
+    private def hash(): ValueToken =
+      cursor.advance()
+      val buf = java.lang.StringBuilder()
+
+      while !cursor.peek.isEnd && identChar(peekChar) do
+        buf.append(peekChar)
+        cursor.advance()
+
+      ValueToken.Hash(buf.toString.nn.tt)
+
+    // ── numbers, percentages and dimensions ───────────────────────────────────
+
+    private def number(): ValueToken =
+      val buf = java.lang.StringBuilder()
+
+      if cursor.peek == '+' || cursor.peek == '-' then
+        buf.append(peekChar)
+        cursor.advance()
+
+      while digit(cursor.peek) do
+        buf.append(peekChar)
+        cursor.advance()
+
+      if cursor.peek == '.' && digit(peek2) then
+        buf.append('.')
+        cursor.advance()
+
+        while digit(cursor.peek) do
+          buf.append(peekChar)
+          cursor.advance()
+
+      if (cursor.peek == 'e' || cursor.peek == 'E') && exponentAhead() then
+        buf.append(peekChar)
+        cursor.advance()
+
+        if cursor.peek == '+' || cursor.peek == '-' then
+          buf.append(peekChar)
+          cursor.advance()
+
+        while digit(cursor.peek) do
+          buf.append(peekChar)
+          cursor.advance()
+
+      classify(buf.toString.nn)
+
+    private def exponentAhead(): Boolean =
+      digit(peek2) || ((peek2 == '+' || peek2 == '-') && digit(peek3))
+
+    private def classify(raw: String): ValueToken =
+      if cursor.peek == '%' then
+        cursor.advance()
+        ValueToken.Percentage(raw.toDouble, (raw+"%").tt)
+      else if !cursor.peek.isEnd && identStart(peekChar) then
+        val unit = readName()
+        ValueToken.Dimension(raw.toDouble, unit, (raw+unit.s).tt)
+      else
+        val integer = !raw.contains(".") && !raw.contains("e") && !raw.contains("E")
+        ValueToken.Number(raw.toDouble, integer, raw.tt)
+
+    // ── identifiers, functions and urls ───────────────────────────────────────
+
+    private def readName(): Text =
+      val buf = java.lang.StringBuilder()
+
+      while !cursor.peek.isEnd && identChar(peekChar) do
+        buf.append(peekChar)
+        cursor.advance()
+
+      buf.toString.nn.tt
+
+    private def identOrFunction(): ValueToken =
+      val name = readName()
+
+      if cursor.peek == '(' then
+        if name.s.toLowerCase.nn == "url" then url()
+        else
+          cursor.advance()
+          ValueToken.Function(name)
+      else
+        ValueToken.Ident(name)
+
+    private def url(): ValueToken =
+      cursor.advance()
+      skipSpaces()
+
+      if cursor.peek == '"' || cursor.peek == '\'' then ValueToken.Function(t"url")
+      else
+        val buf = java.lang.StringBuilder()
+
+        while !cursor.peek.isEnd && cursor.peek != ')' && !whitespaceChar(peekChar) do
+          buf.append(peekChar)
+          cursor.advance()
+
+        skipSpaces()
+        if cursor.peek == ')' then cursor.advance()
+        ValueToken.Url(buf.toString.nn.tt)
+
+    private def skipSpaces(): Unit =
+      while !cursor.peek.isEnd && whitespaceChar(peekChar) do cursor.advance()

--- a/lib/cataclysm/src/core/cataclysm_core.scala
+++ b/lib/cataclysm/src/core/cataclysm_core.scala
@@ -34,8 +34,17 @@ package cataclysm
 
 import anticipation.*
 import contingency.*
+import fulminate.*
 import prepositional.*
 import turbulence.*
 
-given cssAggregable: Tactic[CssError] => Css is Aggregable by Text =
-  source => CssParser.parse(source.iterator)
+// Reading a stylesheet accumulates every `CssError` (unknown property, invalid
+// or unsupported value, …) instead of stopping at the first: the parse runs
+// inside a `track`, and any errors are folded into a single `CssErrors` raised
+// at the end. A fully-valid stylesheet yields the `Css` with nothing raised.
+given cssAggregable: (Tactic[CssErrors], Diagnostics) => Css is Aggregable by Text = source =>
+  track[Text](CssErrors(Nil)):
+    case error: CssError => accrual + error
+
+  . within:
+      CssParser.parse(source.iterator)

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package soundness
 
-export cataclysm.{Css, CssError, cssAggregable, SelectorList, Selector, Compound, Simple,
-    Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument}
+export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
+    Simple, Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument}

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -77,6 +77,12 @@ object Tests extends Suite(m"Cataclysm Tests"):
   def num(n: Int): ValueToken = ValueToken.Number(n, true, n.toString.tt)
   def dim(n: Int, unit: Text): ValueToken = ValueToken.Dimension(n, unit, (n.toString+unit.s).tt)
 
+  // ── value-matcher helpers ────────────────────────────────────────────────
+  def vm(property: Text, value: Text): Outcome =
+    SyntaxMatcher.check(PropertyDef.of(property).vouch, value)
+
+  def vmatch(grammar: Syntax, value: Text): Outcome = SyntaxMatcher.check(grammar, value)
+
   def run(): Unit =
     suite(m"CSS parsing"):
       test(m"a single flat rule with one declaration"):
@@ -457,6 +463,53 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"calc with spaced operators"):
         vt(t"calc(1px + 2px)")
       . assert(_ == calcTokens)
+
+    suite(m"Value matching"):
+      val numbers = Syntax.OneOf(List(kw(t"auto"), ty(t"length")))
+
+      test(m"a keyword value is valid"):
+        vm(t"color", t"red")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a length value is valid"):
+        vm(t"width", t"10px")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a unitless zero is a valid length"):
+        vm(t"margin", t"0")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a var() value is always valid"):
+        vm(t"width", t"var(--w)")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a calc() value is accepted where a length is expected"):
+        vm(t"width", t"calc(100% - 10px)")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a matching keyword in a hand-built grammar"):
+        vmatch(numbers, t"auto")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a non-matching value is invalid"):
+        vmatch(numbers, t"red")
+      . assert(_ == Outcome.Invalid)
+
+      test(m"an unimplemented type is unsupported"):
+        vmatch(Syntax.Type(t"frobnicate", Unset), t"anything")
+      . assert(_ == Outcome.Unsupported(List(t"frobnicate")))
+
+      test(m"a sequence of lengths"):
+        vmatch(Syntax.Sequence(List(ty(t"length"), ty(t"length"))), t"1px 2px")
+      . assert(_ == Outcome.Valid)
+
+      test(m"any-order matching with the double-ampersand"):
+        vmatch(Syntax.AnyOf(List(kw(t"a"), kw(t"b"))), t"b a")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a comma-separated repeat"):
+        vmatch(Syntax.Repeated(ty(t"length"), 1, Unset, true), t"1px, 2px, 3px")
+      . assert(_ == Outcome.Valid)
 
     suite(m"CSS errors"):
       test(m"an unterminated comment is reported"):

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -71,6 +71,12 @@ object Tests extends Suite(m"Cataclysm Tests"):
   def kw(name: Text): Syntax = Syntax.Keyword(name)
   def ty(name: Text): Syntax = Syntax.Type(name, Unset)
 
+  // ── value-tokenizer helpers ──────────────────────────────────────────────
+  def vt(text: Text): List[ValueToken] = ValueTokenizer.tokens(text)
+  val ws: ValueToken = ValueToken.Whitespace
+  def num(n: Int): ValueToken = ValueToken.Number(n, true, n.toString.tt)
+  def dim(n: Int, unit: Text): ValueToken = ValueToken.Dimension(n, unit, (n.toString+unit.s).tt)
+
   def run(): Unit =
     suite(m"CSS parsing"):
       test(m"a single flat rule with one declaration"):
@@ -381,6 +387,76 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"every property's value grammar parses"):
         PropertyDef.list.map(_.grammar).length
       . assert(_ == 663)
+
+    suite(m"Value tokenizer"):
+      val rgbMid = List(num(1), ValueToken.Comma, ws, num(2), ValueToken.Comma, ws, num(3))
+      val rgbTokens = ValueToken.Function(t"rgb") :: rgbMid ::: List(ValueToken.Close)
+      val calcMid = List(dim(1, t"px"), ws, ValueToken.Delim('+'), ws, dim(2, t"px"))
+      val calcTokens = ValueToken.Function(t"calc") :: calcMid ::: List(ValueToken.Close)
+
+      test(m"an identifier"):
+        vt(t"auto")
+      . assert(_ == List(ValueToken.Ident(t"auto")))
+
+      test(m"a dimension"):
+        vt(t"10px")
+      . assert(_ == List(dim(10, t"px")))
+
+      test(m"a percentage"):
+        vt(t"50%")
+      . assert(_ == List(ValueToken.Percentage(50, t"50%")))
+
+      test(m"a signed integer"):
+        vt(t"-3")
+      . assert(_ == List(ValueToken.Number(-3, true, t"-3")))
+
+      test(m"a fractional number"):
+        vt(t"1.5")
+      . assert(_ == List(ValueToken.Number(1.5, false, t"1.5")))
+
+      test(m"a hash"):
+        vt(t"#ff0000")
+      . assert(_ == List(ValueToken.Hash(t"ff0000")))
+
+      test(m"a quoted string"):
+        vt(t""""hello"""")
+      . assert(_ == List(ValueToken.Quoted(t"hello")))
+
+      test(m"a space-separated sequence"):
+        vt(t"1px solid red")
+      . assert(_ == List(dim(1, t"px"), ws, ValueToken.Ident(t"solid"), ws, ValueToken.Ident(t"red")))
+
+      test(m"functional notation"):
+        vt(t"rgb(1, 2, 3)")
+      . assert(_ == rgbTokens)
+
+      test(m"em is a unit, not an exponent"):
+        vt(t"1em")
+      . assert(_ == List(dim(1, t"em")))
+
+      test(m"scientific notation is one number"):
+        vt(t"1e3")
+      . assert(_ == List(ValueToken.Number(1000, false, t"1e3")))
+
+      test(m"a slash is a delimiter"):
+        vt(t"12px/1.5")
+      . assert(_ == List(dim(12, t"px"), ValueToken.Delim('/'), ValueToken.Number(1.5, false, t"1.5")))
+
+      test(m"an unquoted url"):
+        vt(t"url(http://e.com/i.png)")
+      . assert(_ == List(ValueToken.Url(t"http://e.com/i.png")))
+
+      test(m"a quoted url is a function"):
+        vt(t"""url("x.png")""")
+      . assert(_ == List(ValueToken.Function(t"url"), ValueToken.Quoted(t"x.png"), ValueToken.Close))
+
+      test(m"a custom-property reference inside var()"):
+        vt(t"var(--my-color)")
+      . assert(_ == List(ValueToken.Function(t"var"), ValueToken.Ident(t"--my-color"), ValueToken.Close))
+
+      test(m"calc with spaced operators"):
+        vt(t"calc(1px + 2px)")
+      . assert(_ == calcTokens)
 
     suite(m"CSS errors"):
       test(m"an unterminated comment is reported"):

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -37,6 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 
+import cataclysm.Syntax
 import Css.Node.*
 
 object Tests extends Suite(m"Cataclysm Tests"):
@@ -64,6 +65,11 @@ object Tests extends Suite(m"Cataclysm Tests"):
   val next: Combinator = Combinator.NextSibling
   val subseq: Combinator = Combinator.SubsequentSibling
   val col: Combinator = Combinator.Column
+
+  // ── value-definition-syntax helpers ──────────────────────────────────────
+  def vp(text: Text): Syntax = SyntaxParser.parse(text)
+  def kw(name: Text): Syntax = Syntax.Keyword(name)
+  def ty(name: Text): Syntax = Syntax.Type(name, Unset)
 
   def run(): Unit =
     suite(m"CSS parsing"):
@@ -298,6 +304,83 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"an unknown property has no definition"):
         PropertyDef.of(t"colour").absent
       . assert(_ == true)
+
+    suite(m"Value Definition Syntax"):
+      test(m"a primitive type"):
+        vp(t"<color>")
+      . assert(_ == ty(t"color"))
+
+      test(m"a keyword"):
+        vp(t"auto")
+      . assert(_ == kw(t"auto"))
+
+      test(m"alternatives with the bar combinator"):
+        vp(t"<length> | auto")
+      . assert(_ == Syntax.OneOf(List(ty(t"length"), kw(t"auto"))))
+
+      test(m"the any-order double-bar combinator"):
+        vp(t"<line-width> || <line-style> || <color>")
+      . assert(_ == Syntax.AnyOf(List(ty(t"line-width"), ty(t"line-style"), ty(t"color"))))
+
+      test(m"the all-of double-ampersand combinator"):
+        vp(t"<a> && <b>")
+      . assert(_ == Syntax.AllOf(List(ty(t"a"), ty(t"b"))))
+
+      test(m"juxtaposition is a sequence"):
+        vp(t"<a> <b>")
+      . assert(_ == Syntax.Sequence(List(ty(t"a"), ty(t"b"))))
+
+      test(m"the optional multiplier"):
+        vp(t"<a>?")
+      . assert(_ == Syntax.Repeated(ty(t"a"), 0, 1, false))
+
+      test(m"the star multiplier"):
+        vp(t"<a>*")
+      . assert(_ == Syntax.Repeated(ty(t"a"), 0, Unset, false))
+
+      test(m"the plus multiplier"):
+        vp(t"<a>+")
+      . assert(_ == Syntax.Repeated(ty(t"a"), 1, Unset, false))
+
+      test(m"a range multiplier"):
+        vp(t"<a>{1,4}")
+      . assert(_ == Syntax.Repeated(ty(t"a"), 1, 4, false))
+
+      test(m"the comma-separated-list multiplier"):
+        vp(t"<a>#")
+      . assert(_ == Syntax.Repeated(ty(t"a"), 1, Unset, true))
+
+      test(m"a bounded comma-separated list"):
+        vp(t"<a>#{1,4}")
+      . assert(_ == Syntax.Repeated(ty(t"a"), 1, 4, true))
+
+      test(m"a bracketed group with a multiplier"):
+        vp(t"[ <a> | <b> ]?")
+      . assert(_ == Syntax.Repeated(Syntax.OneOf(List(ty(t"a"), ty(t"b"))), 0, 1, false))
+
+      test(m"functional notation"):
+        vp(t"rgb( <number>#{3} )")
+      . assert(_ == Syntax.Function(t"rgb", Syntax.Repeated(ty(t"number"), 3, 3, true)))
+
+      test(m"a property reference"):
+        vp(t"<'border-width'>")
+      . assert(_ == Syntax.Property(t"border-width"))
+
+      test(m"a bounded type keeps its range as raw text"):
+        vp(t"<integer [1,4]>")
+      . assert(_ == Syntax.Type(t"integer", t"1,4"))
+
+      test(m"a literal slash in a sequence"):
+        vp(t"<a> / <b>")
+      . assert(_ == Syntax.Sequence(List(ty(t"a"), Syntax.Literal(t"/"), ty(t"b"))))
+
+      test(m"the bar combinator is looser than juxtaposition"):
+        vp(t"<a> <b> | <c>")
+      . assert(_ == Syntax.OneOf(List(Syntax.Sequence(List(ty(t"a"), ty(t"b"))), ty(t"c"))))
+
+      test(m"every property's value grammar parses"):
+        PropertyDef.list.map(_.grammar).length
+      . assert(_ == 663)
 
     suite(m"CSS errors"):
       test(m"an unterminated comment is reported"):

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -116,8 +116,8 @@ object Tests extends Suite(m"Cataclysm Tests"):
       . assert(_ == List(rule(t"a", decl(t"color", t"red"))))
 
       test(m"a colon inside parentheses does not split a declaration"):
-        t"a { background: url(http://e.com/i.png) }".read[Css].rules
-      . assert(_ == List(rule(t"a", decl(t"background", t"url(http://e.com/i.png)"))))
+        t"a { background-image: url(http://e.com/i.png) }".read[Css].rules
+      . assert(_ == List(rule(t"a", decl(t"background-image", t"url(http://e.com/i.png)"))))
 
       test(m"a semicolon inside a string does not terminate the value"):
         t"""a { content: "a;b" }""".read[Css].rules
@@ -302,8 +302,20 @@ object Tests extends Suite(m"Cataclysm Tests"):
       . assert(_ == List(rule(t"a", decl(t"color", t"red"))))
 
       test(m"an unknown property is rejected"):
-        capture[CssError](t"a { colour: red }".read[Css]).reason
+        capture[CssErrors](t"a { colour: red }".read[Css]).errors.head.reason
       . assert(_ == CssError.Reason.UnknownProperty(t"colour"))
+
+      test(m"errors from several declarations accumulate"):
+        capture[CssErrors](t"a { colour: red; bogus: 1px }".read[Css]).errors.length
+      . assert(_ == 2)
+
+      test(m"an invalid value is reported"):
+        capture[CssErrors](t"a { width: notalength }".read[Css]).errors.length
+      . assert(_ == 1)
+
+      test(m"a var() value passes validation"):
+        t"a { width: var(--w) }".read[Css].rules.length
+      . assert(_ == 1)
 
       test(m"a custom property is accepted"):
         t"a { --my-color: red }".read[Css].rules
@@ -513,13 +525,13 @@ object Tests extends Suite(m"Cataclysm Tests"):
 
     suite(m"CSS errors"):
       test(m"an unterminated comment is reported"):
-        capture[CssError](t"a { /* unterminated }".read[Css]).reason
+        capture[CssErrors](t"a { /* unterminated }".read[Css]).errors.head.reason
       . assert(_ == CssError.Reason.UnterminatedComment)
 
       test(m"an unterminated string is reported"):
-        capture[CssError](t"""a { content: "x }""".read[Css]).reason
+        capture[CssErrors](t"""a { content: "x }""".read[Css]).errors.head.reason
       . assert(_ == CssError.Reason.UnterminatedString)
 
       test(m"a missing closing brace is reported"):
-        capture[CssError](t"a { color: red;".read[Css]).reason
+        capture[CssErrors](t"a { color: red;".read[Css]).errors.head.reason
       . assert(_ == CssError.Reason.UnexpectedEnd)

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -278,6 +278,27 @@ object Tests extends Suite(m"Cataclysm Tests"):
         capture[CssError](parse(t"a!")).reason
       . assert(_ == CssError.Reason.UnexpectedChar('!'))
 
+    suite(m"Property validation"):
+      test(m"a known property is accepted"):
+        t"a { color: red }".read[Css].rules
+      . assert(_ == List(rule(t"a", decl(t"color", t"red"))))
+
+      test(m"an unknown property is rejected"):
+        capture[CssError](t"a { colour: red }".read[Css]).reason
+      . assert(_ == CssError.Reason.UnknownProperty(t"colour"))
+
+      test(m"a custom property is accepted"):
+        t"a { --my-color: red }".read[Css].rules
+      . assert(_ == List(rule(t"a", decl(t"--my-color", t"red"))))
+
+      test(m"a known property's value grammar is loaded"):
+        PropertyDef.of(t"color").vouch.syntax
+      . assert(_ == t"<color>")
+
+      test(m"an unknown property has no definition"):
+        PropertyDef.of(t"colour").absent
+      . assert(_ == true)
+
     suite(m"CSS errors"):
       test(m"an unterminated comment is reported"):
         capture[CssError](t"a { /* unterminated }".read[Css]).reason


### PR DESCRIPTION
Cataclysm now validates the declarations it parses. Property names are checked against the bundled MDN dataset, and each value is checked against that property's grammar; problems are accumulated rather than stopping at the first, so reading a stylesheet reports every error at once. A fully-valid stylesheet still yields a `Css`.

## Validation when reading CSS

`source.read[Css]` now checks every declaration:

- the **property name** must be a known CSS property (from the bundled, CC0 `mdn/data`), or a custom property (`--…`);
- the **value** must match that property's grammar.

Errors are **accumulated**: reading continues past a bad declaration and all problems are raised together as a single `CssErrors` (a list of `CssError`s) — so `read[Css]` now reports `Tactic[CssErrors]`. A stylesheet with no problems returns its `Css` as before.

```scala
import cataclysm.*, strategies.throwUnsafely
t"a { color: red; colour: blue; width: 3 }".read[Css]   // raises CssErrors with two errors
```

## How values are checked

Each property's value grammar (CSS Value Definition Syntax) is parsed into a `Syntax` tree; values are tokenized and matched against it, resolving `<type>` references on demand. `var()`/`env()` values are always accepted (pending-substitution), and `calc()`/`min()`/`max()`/`clamp()` are accepted where a numeric value is expected. A value type that isn't yet implemented is reported as unsupported rather than silently accepted.

## Notes

- Validation is strict; a lenient mode can be added later.
- The previous typed CSS DSL remains available under the `oldcataclysm` package.
