### PR TITLE
Add an ultimatum demo application with focus indication

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1407,6 +1407,33 @@ object ultimatum extends Library:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     override def mainClass: Task.Simple[Option[String]] = Some("ultimatum.demo")
+
+    // Build the demo as a self-contained Ethereal application: stage each
+    // platform's runner alongside the assembled JAR (as `data`) and let the
+    // ziggurat installer fuse the right runner with the JAR into `bin/demo`.
+    def bin(): Command[PathRef] = Task.Command:
+      val jar = assembly().path
+      val target = moduleDir / ".." / ".." / ".." / ".." / "bin" / "demo"
+      os.makeDir.all(target / os.up)
+
+      val runnersBase = ethereal.core.rustRunners().path / "ethereal"
+      val staging = Task.dest / "staging"
+      os.makeDir.all(staging)
+
+      ethereal.core.rustTargets.foreach: (_, label, binary) =>
+        val ext = if binary.endsWith(".exe") then ".exe" else ""
+        os.copy.over(runnersBase / s"runner-$label$ext", staging / s"runner-$label$ext")
+
+      os.copy.over(jar, staging / "data")
+
+      val classpath =
+        ziggurat.core.runClasspath().map(_.path.toString).mkString(java.io.File.pathSeparator)
+
+      os.proc("java", "-cp", classpath, "ziggurat.Xeq", "installer", target.toString, staging.toString)
+        .call(stdout = os.Inherit, stderr = os.Inherit)
+
+      new java.io.File(target.toString).setExecutable(true)
+      PathRef(target)
   object test extends Tests(core)
 
 object ulysses extends Library:

--- a/build.mill
+++ b/build.mill
@@ -235,6 +235,7 @@ object groupCheck extends Module:
     "dendrology.demo",
     "ethereal.example", "exegesis.demo", "exoskeleton.args", "exoskeleton.core",
     "exoskeleton.rig", "flux.client", "flux.core", "frontier.plugin", "probably.coverage",
+    "ultimatum.demo",
     "quantitative.units",
 
     "bitumen.core", "breviloquence.core", "cordillera.core", "distillate.core",
@@ -1402,6 +1403,10 @@ object ultimatum extends Library:
   object core extends Component(profanity.core, escapade.csi):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object demo extends Component(core, ethereal.core, exoskeleton.completions):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    override def mainClass: Task.Simple[Option[String]] = Some("ultimatum.demo")
   object test extends Tests(core)
 
 object ulysses extends Library:

--- a/lib/profanity/src/core/profanity.Interaction.scala
+++ b/lib/profanity/src/core/profanity.Interaction.scala
@@ -94,8 +94,10 @@ object Interaction:
       surface.move(Prim, Prim)
       surface.clear()
       surface.put(editor.value)
-      surface.showCaret(curCol.z, curRow.z)
+      // Place the caret after flushing: in a panel, `flush` blits the grid through
+      // the parent's cursor, so the caret must be positioned last to survive it.
       surface.flush()
+      surface.showCaret(curCol.z, curRow.z)
 
     def result(editor: LineEditor): Text = editor.value
 

--- a/lib/ultimatum/src/core/ultimatum.Focus.scala
+++ b/lib/ultimatum/src/core/ultimatum.Focus.scala
@@ -33,8 +33,10 @@
 package ultimatum
 
 import anticipation.*
+import denominative.*
 import gossamer.*
 import profanity.*
+import rudiments.*
 import spectacular.*
 import vacuous.*
 
@@ -56,9 +58,13 @@ class EditorField(initial: LineEditor = LineEditor()) extends Focus:
 
   def value: Text = editor.value
 
+  // The shared `Interaction` draws the editor and positions the caret; the
+  // hardware cursor is then shown only when this field has focus, so the caret
+  // appears in the focused editor and is hidden elsewhere.
   def render(canvas: Canvas, focused: Boolean): Unit =
     given Canvas = canvas
     summon[Interaction[Text, LineEditor]].render(Unset, editor)
+    canvas.cursor(focused)
 
   def handle(event: TerminalEvent): Unit = editor = editor.apply(event)
 
@@ -73,9 +79,29 @@ class MenuField[item: Showable](initial: SelectMenu[item]) extends Focus:
 
   def value: item = menu.current
 
+  // Renders the options with a focus-aware marker on the current selection: a
+  // pointer (`>`) when this field has focus, a dot (`·`) when it does not, so the
+  // selection is always visible but the focused menu is distinguished. The
+  // hardware cursor is kept hidden — a menu has no text caret.
   def render(canvas: Canvas, focused: Boolean): Unit =
     given Canvas = canvas
-    summon[Interaction[item, SelectMenu[item]]].render(Unset, menu)
+    val cols = canvas.width.max(1)
+    canvas.move(Prim, Prim)
+    canvas.clear()
+    var row = 0
+
+    menu.options.each: option =>
+      canvas.move(Prim, row.z)
+
+      val marker =
+        if option != menu.current then t"   " else if focused then t" > " else t" · "
+
+      val line = t"$marker${option.show}"
+      canvas.put(line)
+      row += (line.length - 1)/cols + 1
+
+    canvas.flush()
+    canvas.cursor(false)
 
   def handle(event: TerminalEvent): Unit = menu = menu.apply(event)
 

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -168,8 +168,11 @@ class Form(root: Canvas, mode: Mode, pane: Pane, wake: () => Unit = () => ()):
     while running && events.hasNext do events.next() match
       case Keypress.Tab =>
         if focuses.nonEmpty then
+          // Repaint the panel losing focus too, so its focus indicator updates;
+          // the panel gaining focus is repainted by `refresh` (focused last).
+          val vacated = focusLeaf(focusIndex)
           focused = focuses((focusIndex + 1)%focuses.length)
-          refresh(Set())
+          refresh(Set(vacated))
 
       case Keypress.Escape | Keypress.Ctrl('C' | 'D') =>
         running = false

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -64,6 +64,7 @@ extends GridSurface(widthFn(), 0):
   private var cursorRow: Int = 0
   private var caretColumn: Int = 0
   private var caretRow: Int = 0
+  private var caretVisible: Boolean = true
 
   override def width: Int = widthFn()
 
@@ -71,7 +72,10 @@ extends GridSurface(widthFn(), 0):
   // height; called by the driver before compositing each frame.
   def reframe(width: Int, height: Int): Unit = reshape(width, height.min(heightFn()))
 
-  def cursor(visible: Boolean): Unit = Out.print(csi.dectcem(visible))
+  // Cursor visibility is deferred like the caret: recorded now, applied by `flush`
+  // (which hides the cursor while it redraws), so a focused editor shows it and a
+  // focused menu keeps it hidden.
+  def cursor(visible: Boolean): Unit = caretVisible = visible
 
   // Inline carets are deferred: record the block-local target and let `flush`
   // position it relative to the block, since mid-composite the cursor is wherever
@@ -110,7 +114,7 @@ extends GridSurface(widthFn(), 0):
 
     presentedRows = height
     cursorRow = caretRow
-    Out.print(csi.dectcem(true))
+    Out.print(csi.dectcem(caretVisible))
 
   // On exit, drop the cursor onto a fresh line below the block and re-show it, so
   // subsequent output continues after the rendered block (like a submitted prompt).

--- a/lib/ultimatum/src/demo/ultimatum_demo.scala
+++ b/lib/ultimatum/src/demo/ultimatum_demo.scala
@@ -1,0 +1,80 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ultimatum
+
+import soundness.*
+
+import backstops.silent
+import codicils.cancel
+import executives.completions
+import interpreters.posix
+import strategies.throwUnsafely
+import supervisors.global
+import threading.platform
+
+// A medium-complexity fullscreen layout demonstrating the framework: a title bar
+// and a status bar each pinned to a single row; a fixed-width sidebar menu; and a
+// main column with a section heading, a line editor, and an activity panel. TAB
+// moves focus between the menu and the editor; Escape quits.
+//
+// Run with `mill ultimatum.demo.run` from a real terminal.
+@main
+def demo(): Unit = cli:
+  execute:
+    interactive: terminal ?=>
+      form(Mode.Fullscreen)(demoLayout)
+      Exit.Ok
+
+// rank(title, file(sidebar, rank(heading, editor, activity)), status):
+//
+//   ┌──────────────────────── title ────────────────────────┐
+//   │ sidebar (menu) │ heading                               │
+//   │                │ editor                                │
+//   │                │ activity                              │
+//   └─────────────────────── status ────────────────────────┘
+private def demoLayout: Pane =
+  val sidebar = menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
+      minWidth = 22, maxWidth = 22)
+
+  val activity = panel(minHeight = 6):
+    Out.println(t"Recent activity")
+    Out.println(t"")
+    Out.println(t"  • Demo started")
+    Out.println(t"  • Four panes tiled")
+    Out.println(t"  • Tab moves focus, Esc quits")
+
+  val heading = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Compose"))
+  val title = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  ULTIMATUM · fullscreen demo"))
+  val status = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  [Tab] focus    [Esc] quit"))
+
+  rank(title, file(sidebar, rank(heading, editor(), activity)), status)

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -432,6 +432,16 @@ object Tests extends Suite(m"Ultimatum Tests"):
           EditorField(LineEditor(t"hi")).render(TerminalCanvas(20, 1), false)
       . assert(_.s.contains("[?25l"))
 
+      // Tabbing focus away from the menu must repaint it, so its marker updates
+      // from `>` to `·` (a regression: only the panel gaining focus was redrawn).
+      test(m"a panel that loses focus is repainted so its marker updates"):
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basic)
+        val root = FlowExtent(TerminalCanvas(12, 3), Rect(0, 0, 12, 3))
+        val pane = rank(menu(List(t"alpha", t"beta"), t"alpha"), editor())
+        Form(root, Mode.Fullscreen, pane).run(List(Keypress.Tab, Keypress.Escape).iterator)
+        root.render
+      . assert(_ == t" · alpha    \n   beta     \n            ")
+
 // A test-only root `Canvas` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and
 // the composed screen read back.

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -399,6 +399,39 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.render
       . assert(_ == t"A         \nB         ")
 
+    suite(m"Focus indication"):
+      def grid(): FlowExtent =
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basic)
+        FlowExtent(TerminalCanvas(12, 2), Rect(0, 0, 12, 2))
+
+      def captured(block: Stdio ?=> Unit): Text =
+        val bytes = ji.ByteArrayOutputStream()
+        given Stdio = Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basic)
+        block
+        String(bytes.toByteArray.nn, "UTF-8").tt
+
+      test(m"a focused menu marks its selection with a pointer"):
+        val extent = grid()
+        MenuField(SelectMenu(List(t"alpha", t"beta"), t"alpha")).render(extent, true)
+        extent.render
+      . assert(_ == t" > alpha    \n   beta     ")
+
+      test(m"an unfocused menu marks its selection with a dot"):
+        val extent = grid()
+        MenuField(SelectMenu(List(t"alpha", t"beta"), t"alpha")).render(extent, false)
+        extent.render
+      . assert(_ == t" · alpha    \n   beta     ")
+
+      test(m"a focused editor shows the hardware cursor"):
+        captured: stdio ?=>
+          EditorField(LineEditor(t"hi")).render(TerminalCanvas(20, 1), true)
+      . assert(_.s.contains("[?25h"))
+
+      test(m"an unfocused editor hides the hardware cursor"):
+        captured: stdio ?=>
+          EditorField(LineEditor(t"hi")).render(TerminalCanvas(20, 1), false)
+      . assert(_.s.contains("[?25l"))
+
 // A test-only root `Canvas` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and
 // the composed screen read back.


### PR DESCRIPTION
Adds `ultimatum.demo`, a medium-complexity fullscreen sample application that exercises the framework's layout solver, focus cycling and widgets, packaged as an Ethereal application; and gives the editor and menu widgets a visible indication of which one holds focus.

## A runnable demo

`ultimatum.demo` is a new submodule with a fullscreen layout — a title bar, a sidebar menu, a heading, a line editor and an activity panel, with a status line — driven by `form(Mode.Fullscreen)`. It builds as an Ethereal application:

```
mill ultimatum.demo.bin
./bin/demo
```

Tab cycles focus between the menu and the editor; Escape exits.

## Visible focus

Widgets now show whether they hold focus. The line editor shows the hardware cursor only when focused and hides it otherwise. The selection menu marks its current option with a pointer (`>`) when focused and a dot (`·`) when not, so the selection stays visible but the focused widget is distinguished.

A redraw bug is also fixed: on Tab, the panel *losing* focus is now repainted so its marker updates immediately, rather than keeping a stale focused marker until the next unrelated redraw.