### PR TITLE
Add a native TCP HTTP/1.1 server backend to scintillate

### DIFF
--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -98,6 +98,14 @@ extends RequestServable:
         case 1.1 => !connection.exists(_.contains(t"close"))
         case _   => connection.exists(_.contains(t"keep-alive"))
 
+    // A request asks to upgrade the protocol (e.g. to WebSocket) when it carries
+    // `Connection: Upgrade` together with an `Upgrade` header. Such a request's
+    // body is the unbounded remainder of the connection, so a frame reader can
+    // keep receiving bytes after the handshake.
+    def isUpgrade(head: Http.Request.Head): Boolean =
+      head.headers.filter(_.key.lower == t"connection").exists(_.value.lower.contains(t"upgrade"))
+      && head.headers.exists(_.key.lower == t"upgrade")
+
     // Handle a single request off the cursor and return whether the connection
     // should be kept alive for a further request.
     def serveRequest(cursor: Cursor[Data], out: ji.OutputStream): Boolean raises StreamError =
@@ -109,18 +117,28 @@ extends RequestServable:
 
       . recover:
           val head = Http.Request.parseHead(cursor)
-          val body = requestBody(cursor, head)
+          val upgrade = isUpgrade(head)
+          val body = if upgrade then cursor.remainder else requestBody(cursor, head)
           val keep = keepAlive(head)
 
           val request =
             Http.Request
               ( head.method, head.version, head.host, head.target, head.headers, () => body )
 
-          def respond(response: Http.Response): Unit raises StreamError =
-            val response2 =
-              if keep then response else response + Http.Header(t"connection", t"close")
+          var upgraded = false
 
-            writeAll(out, Http.Response.serialize(response2, head.method != Http.Head))
+          def respond(response: Http.Response): Unit raises StreamError =
+            if response.status == Http.SwitchingProtocols then
+              // Switch to the upgraded protocol: write the handshake headers, then
+              // pipe its raw stream until it ends. This blocks for the lifetime of
+              // the upgraded connection (e.g. a WebSocket session).
+              upgraded = true
+              writeAll(out, Http.Response.serialize(response))
+            else
+              val response2 =
+                if keep then response else response + Http.Header(t"connection", t"close")
+
+              writeAll(out, Http.Response.serialize(response2, head.method != Http.Head))
 
           val connection = new HttpConnection(request, false, port, respond)
           Log.fine(HttpServerEvent.Received(request))
@@ -129,10 +147,11 @@ extends RequestServable:
             try handler(using connection)
             catch case throwable: Throwable => errorPage.handle(throwable, connection)
 
-          // Drain any body the handler did not consume, so the cursor is left at
-          // the start of the next request.
-          body.each(_ => ())
-          keep
+          if upgraded then false else
+            // Drain any body the handler did not consume, so the cursor is left
+            // at the start of the next request.
+            body.each(_ => ())
+            keep
 
     def serve(socket: jn.Socket): Unit =
       try

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -32,117 +32,93 @@
                                                                                                   */
 package scintillate
 
+import java.io as ji
+import java.net as jn
+
 import anticipation.*
 import contingency.*
-import digression.*
-import gesticulate.*
-import gossamer.*
-import hellenism.*
-import hieroglyph.*
 import parasite.*
-import prepositional.*
 import rudiments.*
-import serpentine.*
-import spectacular.*
 import telekinesis.*
 import turbulence.*
 import urticose.*
 import vacuous.*
+import zephyrine.*
 
-package httpServers:
-  given stdlib: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
+// A raw-TCP HTTP/1.1 server backend, built on a `java.net.ServerSocket` rather
+// than `com.sun.net.httpserver`. Each accepted socket is handled on its own
+// Loom virtual thread (`daemon`). The handler API is identical to `HttpServer`'s
+// — a `HttpConnection ?=> Http.Response` — so the two backends are
+// interchangeable. This first cut serves a single request per connection and
+// closes it; keep-alive, request-body framing and connection upgrades build on
+// top of this skeleton.
+case class SocketServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
+extends RequestServable:
+  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
+  :   Service logs HttpServerEvent raises ServerError =
 
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
+    def startServer(): jn.ServerSocket raises ServerError =
+      try
+        val host = if local then "localhost" else "0.0.0.0"
+        jn.ServerSocket(port, 0, jn.InetAddress.getByName(host).nn)
+      catch case error: jn.BindException => abort(ServerError(port))
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      HttpServer(port.number, true).handle(lambda)
+    def writeAll(out: ji.OutputStream, stream: Stream[Data]): Unit raises StreamError =
+      var count: Int = 0
 
+      stream.each: block =>
+        try
+          out.write(block.mutable(using Unsafe))
+          count += block.length
+        catch case _: ji.IOException => abort(StreamError(count.b))
 
-  given stdlibPublic: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
+      try out.flush() catch case _: ji.IOException => abort(StreamError(count.b))
 
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
+    def serve(socket: jn.Socket): Unit =
+      try
+        val in = socket.getInputStream.nn
+        val out = socket.getOutputStream.nn
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      HttpServer(port.number, false).handle(lambda)
+        whereas:
+          case StreamError(length) =>
+            Log.warn(HttpServerEvent.BrokenStream(length))
 
+          case error: HttpRequestError =>
+            safely(writeAll(out, Http.Response.serialize(Http.Response(Http.BadRequest)())))
 
-  given native: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
+        . recover:
+            val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
+            val head = Http.Request.parseHead(cursor)
 
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
+            val request =
+              Http.Request
+                ( head.method, head.version, head.host, head.target, head.headers,
+                  () => cursor.remainder )
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      SocketServer(port.number, true).handle(lambda)
+            def respond(response: Http.Response): Unit raises StreamError =
+              val includeBody = head.method != Http.Head
+              writeAll(out, Http.Response.serialize(response, includeBody))
 
+            val connection = new HttpConnection(request, false, port, respond)
+            Log.fine(HttpServerEvent.Received(request))
 
-  given nativePublic: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
+            connection.respond:
+              try handler(using connection)
+              catch case throwable: Throwable => errorPage.handle(throwable, connection)
 
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
+      catch case NonFatal(exception) => exception.printStackTrace()
+      finally safely(socket.close())
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      SocketServer(port.number, false).handle(lambda)
+    val serverSocket = startServer()
 
-def cookie(using request: Http.Request)(key: Text): Optional[Text] = request.textCookies.at(key)
+    val acceptLoop = loop:
+      safely(serverSocket.accept().nn).let: socket =>
+        daemon(serve(socket))
 
-def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.Response)
-  ( using connection: HttpConnection )
-:   Http.Response raises AuthError =
+    val acceptTask = daemon(acceptLoop.run())
+    val cancel: Promise[Unit] = Promise[Unit]()
+    val stopTask = async(cancel.attend() yet { acceptLoop.stop(); safely(serverSocket.close()) })
 
-  connection.headers.authorization match
-    case List(Auth.Basic(username, password)) =>
-      if validate(username, password) then response else Http.Response(Http.Forbidden)()
+    Service: () =>
+      safely(cancel.fulfill(()))
 
-    case _ =>
-      val auth = t"""Basic realm="$realm", charset="UTF-8""""
-
-      Http.Response(Http.Unauthorized, wwwAuthenticate = auth)()
-
-
-inline def request: Http.Request = infer[Http.Request]
-
-extension (request: Http.Request)
-  def as[body: Acceptable]: body = body.accept(request)
-
-package webserverErrorPages:
-  given minimal: WebserverErrorPage = (request, throwable) =>
-    import hieroglyph.charEncoders.utf8
-    Http.Response(Unfulfilled(t"An error occurred which prevented the request from completing."))
-
-  private def prefix(using Classloader): Data = cp"/scintillate/error.pre.html".read[Data]
-  private def postfix(using Classloader): Data = cp"/scintillate/error.post.html".read[Data]
-
-  given standard: Classloader => WebserverErrorPage = (throwable, request) =>
-    Http.Response(Unfulfilled(Stream(prefix, postfix).ascribe(media"text/html")))
-
-  given stackTraces: Classloader => WebserverErrorPage = (throwable, request) =>
-    import charEncoders.utf8
-
-    val stack = t"<pre>${throwable.stackTrace}</pre>".read[Data]
-    Http.Response(Unfulfilled(Stream(prefix, stack, postfix).ascribe(media"text/html")))

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -77,17 +77,21 @@ extends RequestServable:
 
       try out.flush() catch case _: ji.IOException => abort(StreamError(count.b))
 
-    // Frame the request body off the shared connection cursor: `Content-Length`
-    // bytes, or empty when no length is given. (Chunked request bodies are not
-    // yet decoded.) The framed stream stops exactly at the body's end so the
-    // cursor is left at the next pipelined request.
+    // Frame the request body off the shared connection cursor: chunked decoding
+    // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or
+    // empty when neither is given. The framed stream stops exactly at the body's
+    // end so the cursor is left at the next pipelined request.
     def requestBody(cursor: Cursor[Data], head: Http.Request.Head): Stream[Data] =
-      val length: Optional[Int] =
-        head.headers.filter(_.key.lower == t"content-length").prim.let(_.value)
-        . lay(Unset: Optional[Int]): text =>
-            safely(Integer.parseInt(text.s.trim.nn))
+      val chunked: Boolean = head.headers.exists: header =>
+        header.key.lower == t"transfer-encoding" && header.value.lower.contains(t"chunked")
 
-      length.lay(Stream())(Http.Request.fixedBody(cursor, _))
+      if chunked then Http.Request.chunkedBody(cursor) else
+        val length: Optional[Int] =
+          head.headers.filter(_.key.lower == t"content-length").prim.let(_.value)
+          . lay(Unset: Optional[Int]): text =>
+              safely(Integer.parseInt(text.s.trim.nn))
+
+        length.lay(Stream())(Http.Request.fixedBody(cursor, _))
 
     // RFC 7230 §6.3: HTTP/1.1 keeps connections alive unless `Connection: close`;
     // HTTP/1.0 closes unless `Connection: keep-alive`.

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -37,6 +37,7 @@ import java.net as jn
 
 import anticipation.*
 import contingency.*
+import gossamer.*
 import parasite.*
 import rudiments.*
 import telekinesis.*
@@ -57,6 +58,8 @@ extends RequestServable:
   def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
   :   Service logs HttpServerEvent raises ServerError =
 
+    val idleTimeout: Int = 30000
+
     def startServer(): jn.ServerSocket raises ServerError =
       try
         val host = if local then "localhost" else "0.0.0.0"
@@ -74,8 +77,66 @@ extends RequestServable:
 
       try out.flush() catch case _: ji.IOException => abort(StreamError(count.b))
 
+    // Frame the request body off the shared connection cursor: `Content-Length`
+    // bytes, or empty when no length is given. (Chunked request bodies are not
+    // yet decoded.) The framed stream stops exactly at the body's end so the
+    // cursor is left at the next pipelined request.
+    def requestBody(cursor: Cursor[Data], head: Http.Request.Head): Stream[Data] =
+      val length: Optional[Int] =
+        head.headers.filter(_.key.lower == t"content-length").prim.let(_.value)
+        . lay(Unset: Optional[Int]): text =>
+            safely(Integer.parseInt(text.s.trim.nn))
+
+      length.lay(Stream())(Http.Request.fixedBody(cursor, _))
+
+    // RFC 7230 §6.3: HTTP/1.1 keeps connections alive unless `Connection: close`;
+    // HTTP/1.0 closes unless `Connection: keep-alive`.
+    def keepAlive(head: Http.Request.Head): Boolean =
+      val connection = head.headers.filter(_.key.lower == t"connection").map(_.value.lower)
+
+      head.version match
+        case 1.1 => !connection.exists(_.contains(t"close"))
+        case _   => connection.exists(_.contains(t"keep-alive"))
+
+    // Handle a single request off the cursor and return whether the connection
+    // should be kept alive for a further request.
+    def serveRequest(cursor: Cursor[Data], out: ji.OutputStream): Boolean raises StreamError =
+      whereas:
+        case error: HttpRequestError =>
+          val response = Http.Response(Http.BadRequest)() + Http.Header(t"connection", t"close")
+          safely(writeAll(out, Http.Response.serialize(response)))
+          false
+
+      . recover:
+          val head = Http.Request.parseHead(cursor)
+          val body = requestBody(cursor, head)
+          val keep = keepAlive(head)
+
+          val request =
+            Http.Request
+              ( head.method, head.version, head.host, head.target, head.headers, () => body )
+
+          def respond(response: Http.Response): Unit raises StreamError =
+            val response2 =
+              if keep then response else response + Http.Header(t"connection", t"close")
+
+            writeAll(out, Http.Response.serialize(response2, head.method != Http.Head))
+
+          val connection = new HttpConnection(request, false, port, respond)
+          Log.fine(HttpServerEvent.Received(request))
+
+          connection.respond:
+            try handler(using connection)
+            catch case throwable: Throwable => errorPage.handle(throwable, connection)
+
+          // Drain any body the handler did not consume, so the cursor is left at
+          // the start of the next request.
+          body.each(_ => ())
+          keep
+
     def serve(socket: jn.Socket): Unit =
       try
+        socket.setSoTimeout(idleTimeout)
         val in = socket.getInputStream.nn
         val out = socket.getOutputStream.nn
 
@@ -83,28 +144,11 @@ extends RequestServable:
           case StreamError(length) =>
             Log.warn(HttpServerEvent.BrokenStream(length))
 
-          case error: HttpRequestError =>
-            safely(writeAll(out, Http.Response.serialize(Http.Response(Http.BadRequest)())))
-
         . recover:
             val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
-            val head = Http.Request.parseHead(cursor)
 
-            val request =
-              Http.Request
-                ( head.method, head.version, head.host, head.target, head.headers,
-                  () => cursor.remainder )
-
-            def respond(response: Http.Response): Unit raises StreamError =
-              val includeBody = head.method != Http.Head
-              writeAll(out, Http.Response.serialize(response, includeBody))
-
-            val connection = new HttpConnection(request, false, port, respond)
-            Log.fine(HttpServerEvent.Received(request))
-
-            connection.respond:
-              try handler(using connection)
-              catch case throwable: Throwable => errorPage.handle(throwable, connection)
+            var continue = true
+            while continue && !cursor.finished do continue = serveRequest(cursor, out)
 
       catch case NonFatal(exception) => exception.printStackTrace()
       finally safely(socket.close())

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -132,3 +132,21 @@ object Tests extends Suite(m"Scintillate tests"):
           response
 
         . assert(_.contains(t"connection: close"))
+
+        test(m"A 101 response upgrades to a raw bidirectional stream"):
+          val port = freePort()
+
+          // Echo upgrade: the response body is the post-handshake request stream,
+          // piped straight back out with no HTTP framing.
+          val server = SocketServer(port).handle:
+            Http.Response(Http.SwitchingProtocols)(Http.Body.Streaming(request.body()))
+
+          val response =
+            rawRequest
+              ( port,
+                t"GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: echo\r\n\r\nPING" )
+
+          server.cancel()
+          response
+
+        . assert(r => r.contains(t"101 Switching Protocols") && r.ends(t"PING"))

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -54,6 +54,9 @@ object Tests extends Suite(m"Scintillate tests"):
       val out = socket.getOutputStream.nn
       out.write(request.s.getBytes("US-ASCII").nn)
       out.flush()
+      // Half-close so a kept-alive server sees EOF once it has read our request(s)
+      // and stops waiting for more; we can still read the response.
+      socket.shutdownOutput()
       val response = String(socket.getInputStream.nn.readAllBytes().nn, "US-ASCII")
       socket.close()
       response.tt
@@ -89,3 +92,43 @@ object Tests extends Suite(m"Scintillate tests"):
           response
 
         . assert(_.contains(t"GET /foo/bar"))
+
+        test(m"A POST body is available to the handler"):
+          val port = freePort()
+
+          val server = SocketServer(port).handle:
+            Http.Response(Http.Ok)(request.body().read[Data].utf8)
+
+          val response =
+            rawRequest(port, t"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello")
+
+          server.cancel()
+          response
+
+        . assert(_.contains(t"hello"))
+
+        test(m"Two pipelined requests get two responses on one connection"):
+          val port = freePort()
+          val server = SocketServer(port).handle(Http.Response(Http.Ok)(t"ok"))
+
+          val response =
+            rawRequest
+              ( port,
+                t"GET /a HTTP/1.1\r\nHost: x\r\n\r\nGET /b HTTP/1.1\r\nHost: x\r\n\r\n" )
+
+          server.cancel()
+          response.cut(t"HTTP/1.1 200 OK").length
+
+        . assert(_ == 3)
+
+        test(m"Connection: close stops after one response"):
+          val port = freePort()
+          val server = SocketServer(port).handle(Http.Response(Http.Ok)(t"bye"))
+
+          val response =
+            rawRequest(port, t"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+
+          server.cancel()
+          response
+
+        . assert(_.contains(t"connection: close"))

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -107,6 +107,23 @@ object Tests extends Suite(m"Scintillate tests"):
 
         . assert(_.contains(t"hello"))
 
+        test(m"A chunked request body is decoded for the handler"):
+          val port = freePort()
+
+          val server = SocketServer(port).handle:
+            Http.Response(Http.Ok)(request.body().read[Data].utf8)
+
+          val response =
+            rawRequest
+              ( port,
+                t"POST / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n"
+                + t"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n" )
+
+          server.cancel()
+          response
+
+        . assert(_.contains(t"hello world"))
+
         test(m"Two pipelined requests get two responses on one connection"):
           val port = freePort()
           val server = SocketServer(port).handle(Http.Response(Http.Ok)(t"ok"))

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -34,5 +34,58 @@ package scintillate
 
 import soundness.*
 
+import logging.silent
+import strategies.throwUnsafely
+import charEncoders.utf8
+import webserverErrorPages.minimal
+import threading.virtual
+import codicils.await
+
 object Tests extends Suite(m"Scintillate tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    def freePort(): Int =
+      val socket = java.net.ServerSocket(0)
+      val port = socket.getLocalPort
+      socket.close()
+      port
+
+    def rawRequest(port: Int, request: Text): Text =
+      val socket = java.net.Socket("localhost", port)
+      val out = socket.getOutputStream.nn
+      out.write(request.s.getBytes("US-ASCII").nn)
+      out.flush()
+      val response = String(socket.getInputStream.nn.readAllBytes().nn, "US-ASCII")
+      socket.close()
+      response.tt
+
+    supervise:
+      suite(m"Native socket server"):
+        test(m"GET returns the handler's response body"):
+          val port = freePort()
+          val server = SocketServer(port).handle(Http.Response(Http.Ok)(t"hello from native"))
+          val response = rawRequest(port, t"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+          server.cancel()
+          response
+
+        . assert(_.contains(t"hello from native"))
+
+        test(m"Status line carries the handler's status"):
+          val port = freePort()
+          val server = SocketServer(port).handle(Http.Response(Http.NotFound)(t"nope"))
+          val response = rawRequest(port, t"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+          server.cancel()
+          response.cut(t"\r\n").head
+
+        . assert(_ == t"HTTP/1.1 404 Not Found")
+
+        test(m"Request method and target reach the handler"):
+          val port = freePort()
+
+          val server = SocketServer(port).handle:
+            Http.Response(Http.Ok)(t"${request.method.show} ${request.target}")
+
+          val response = rawRequest(port, t"GET /foo/bar HTTP/1.1\r\nHost: localhost\r\n\r\n")
+          server.cancel()
+          response
+
+        . assert(_.contains(t"GET /foo/bar"))

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -250,6 +250,72 @@ object Http:
 
       text.data #:: request.body()
 
+    case class Head
+      ( method: Method, version: Version, host: Host, target: Text, headers: List[Header] )
+
+    // Parse a request-line (`METHOD SP target SP HTTP-version CRLF`) and the
+    // header block off `cursor`, leaving it positioned at the first byte of
+    // the message body. The symmetric twin of `Http.Response.parse`'s
+    // status-line + header parsing; factored out so a server driving a single
+    // cursor across a keep-alive connection can frame the body itself. Scans
+    // with `peek`/`next` rather than `seek` so it works on a bare `Cursor[Data]`
+    // parameter (which loses the `tracked` `Operand = Byte` refinement that
+    // `seek`'s signature relies on).
+    def parseHead(cursor: Cursor[Data]): Head raises HttpRequestError =
+      inline def expected(char: Char): Diagnostics ?=> HttpRequestError =
+        HttpRequestError(HttpRequestError.Reason.Expectation(char, cursor.peek.asInt.toChar))
+
+      def upTo(stop: Char): Text = cursor.hold:
+        val start = cursor.mark
+        while !cursor.finished && !(cursor.peek == stop) do cursor.next()
+        Ascii(cursor.grab(start, cursor.mark)).show
+
+      val method: Http.Method = upTo(' ').decode[Http.Method]
+      cursor.next()
+
+      val target: Text = upTo(' ')
+      cursor.next()
+
+      val version: Http.Version = Http.Version.parse(upTo('\r'))
+      cursor.next()
+      cursor.expect('\n')(expected('\n'))
+
+      def readHeaders(headers: List[Http.Header]): List[Http.Header] =
+        if cursor.peek == '\r' then
+          cursor.next()
+          cursor.expect('\n')(expected('\n'))
+          headers
+
+        else
+          val key: Text = upTo(':')
+          cursor.next()
+
+          while cursor.peek == ' ' || cursor.peek == '\t' do cursor.next()
+
+          val value: Text = upTo('\r')
+          cursor.next()
+          cursor.expect('\n')(expected('\n'))
+          readHeaders(Http.Header(key, value) :: headers)
+
+      val headers = readHeaders(Nil).reverse
+
+      val hostText: Optional[Text] = headers.filter(_.key.lower == t"host").prim.let(_.value)
+
+      val host: Host = hostText.lay(abort(HttpRequestError(HttpRequestError.Reason.Host(t"")))):
+        text =>
+          safely(text.decode[Host]).or:
+            safely(text.cut(t":").prim.or(text).decode[Host]).or:
+              abort(HttpRequestError(HttpRequestError.Reason.Host(text)))
+
+      Head(method, version, host, target, headers)
+
+    def parse(stream: Stream[Data]): Request raises HttpRequestError =
+      val cursor = Cursor[Data](stream.filter(_.nonEmpty).iterator)
+      val head = parseHead(cursor)
+
+      Request
+        ( head.method, head.version, head.host, head.target, head.headers, () => cursor.remainder )
+
   enum Body:
     case Streaming(data: Stream[Data])
     case Fixed(data: Data)

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -282,8 +282,15 @@ object Http:
 
       def readHeaders(headers: List[Http.Header]): List[Http.Header] =
         if cursor.peek == '\r' then
-          cursor.next()
-          cursor.expect('\n')(expected('\n'))
+          // Consume the final CRLF with `advance` rather than `next`/`expect`:
+          // `next` calls `more`, which forces a blocking refill of the underlying
+          // stream. That is fatal when a request has no body (e.g. a `GET`) and
+          // the client is already waiting for our response — there are no more
+          // bytes to read. `advance` steps past the terminator without reading
+          // ahead, leaving the cursor at the first byte of the body (if any).
+          cursor.advance()
+          if !(cursor.peek == '\n') then raise(expected('\n'))
+          cursor.advance()
           headers
 
         else

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -471,23 +471,35 @@ object Http:
     def serialize(response: Response, includeBody: Boolean = true): Stream[Data] =
       import charEncoders.ascii
 
+      // After `101 Switching Protocols` the bytes are no longer HTTP: the body is
+      // the upgraded protocol's raw stream (e.g. WebSocket frames), so suppress
+      // Content-Length / chunked framing and the headers that announce them.
+      val upgrade: Boolean = response.status == Http.SwitchingProtocols
+
       val explicitChunked: Boolean = response.textHeaders.exists: header =>
         header.key.lower == t"transfer-encoding" && header.value.lower == t"chunked"
 
       val hasContentLength: Boolean = response.textHeaders.exists(_.key.lower == t"content-length")
 
-      val (extraHeaders, chunked): (List[Header], Boolean) = response.body match
-        case Body.Empty =>
-          (if hasContentLength then Nil else List(Header(t"content-length", t"0")), false)
+      val (extraHeaders, chunked): (List[Header], Boolean) =
+        if upgrade then (Nil, false) else response.body match
+          case Body.Empty =>
+            (if hasContentLength then Nil else List(Header(t"content-length", t"0")), false)
 
-        case Body.Fixed(data) =>
-          val length = data.length.toString.tt
-          (if hasContentLength then Nil else List(Header(t"content-length", length)), false)
+          case Body.Fixed(data) =>
+            val length = data.length.toString.tt
+            (if hasContentLength then Nil else List(Header(t"content-length", length)), false)
 
-        case Body.Streaming(_) =>
-          if explicitChunked then (Nil, true)
-          else if hasContentLength then (Nil, false)
-          else (List(Header(t"transfer-encoding", t"chunked")), true)
+          case Body.Streaming(_) =>
+            if explicitChunked then (Nil, true)
+            else if hasContentLength then (Nil, false)
+            else (List(Header(t"transfer-encoding", t"chunked")), true)
+
+      val headers: List[Header] =
+        if !upgrade then response.textHeaders ++ extraHeaders else
+          response.textHeaders.filter: header =>
+            val key = header.key.lower
+            key != t"transfer-encoding" && key != t"content-length"
 
       val head: Text = Text.build:
         append(t"HTTP/1.1 ")
@@ -496,7 +508,7 @@ object Http:
         append(response.status.description)
         append(t"\r\n")
 
-        (response.textHeaders ++ extraHeaders).each: header =>
+        headers.each: header =>
           append(header.key)
           append(t": ")
           append(header.value)
@@ -514,7 +526,8 @@ object Http:
           Stream(t"0\r\n\r\n".data)
 
       def bodyBytes: Stream[Data] =
-        if !includeBody then Stream() else response.body match
+        if !includeBody then Stream() else if upgrade then response.body.stream
+        else response.body match
           case Body.Empty             => Stream()
           case Body.Fixed(data)       => Stream(data)
           case Body.Streaming(stream) => if chunked then chunkedFraming(stream) else stream

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -323,6 +323,30 @@ object Http:
       Request
         ( head.method, head.version, head.host, head.target, head.headers, () => cursor.remainder )
 
+    // Stream exactly `length` bytes of body off `cursor`, in buffer-sized
+    // pieces, leaving it at the first byte after the body (the start of the next
+    // pipelined request on a kept-alive connection). Uses `advance` rather than
+    // `next`, so — like `parseHead` — it never reads past the body and so never
+    // blocks waiting for bytes that will not arrive until the client has our
+    // response.
+    def fixedBody(cursor: Cursor[Data], length: Int): Stream[Data] =
+      def recur(remaining: Int): Stream[Data] =
+        if remaining <= 0 || cursor.finished then Stream() else
+          val take = remaining.min(cursor.available)
+
+          val chunk = cursor.hold:
+            val start = cursor.mark
+            var index = 0
+            while index < take do
+              cursor.advance()
+              index += 1
+
+            cursor.grab(start, cursor.mark)
+
+          chunk #:: recur(remaining - take)
+
+      Stream.defer(recur(length))
+
   enum Body:
     case Streaming(data: Stream[Data])
     case Fixed(data: Data)

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -431,6 +431,65 @@ object Http:
     private[Http] def response(status: Status, headers: List[Header], body: Body): Response =
       new Response(1.1, status, headers, body)
 
+    // Serialise a response to HTTP/1.1 wire bytes: status line, headers (with an
+    // automatic `Content-Length` for fixed/empty bodies, or `Transfer-Encoding:
+    // chunked` framing for streaming bodies), the blank line, then the framed
+    // body. `includeBody` is `false` for responses to `HEAD` requests and for
+    // `101` upgrades (where the caller pipes the post-handshake stream raw). The
+    // inverse of `parse`.
+    def serialize(response: Response, includeBody: Boolean = true): Stream[Data] =
+      import charEncoders.ascii
+
+      val explicitChunked: Boolean = response.textHeaders.exists: header =>
+        header.key.lower == t"transfer-encoding" && header.value.lower == t"chunked"
+
+      val hasContentLength: Boolean = response.textHeaders.exists(_.key.lower == t"content-length")
+
+      val (extraHeaders, chunked): (List[Header], Boolean) = response.body match
+        case Body.Empty =>
+          (if hasContentLength then Nil else List(Header(t"content-length", t"0")), false)
+
+        case Body.Fixed(data) =>
+          val length = data.length.toString.tt
+          (if hasContentLength then Nil else List(Header(t"content-length", length)), false)
+
+        case Body.Streaming(_) =>
+          if explicitChunked then (Nil, true)
+          else if hasContentLength then (Nil, false)
+          else (List(Header(t"transfer-encoding", t"chunked")), true)
+
+      val head: Text = Text.build:
+        append(t"HTTP/1.1 ")
+        append(response.status.code.toString.tt)
+        append(t" ")
+        append(response.status.description)
+        append(t"\r\n")
+
+        (response.textHeaders ++ extraHeaders).each: header =>
+          append(header.key)
+          append(t": ")
+          append(header.value)
+          append(t"\r\n")
+
+        append(t"\r\n")
+
+      def chunkedFraming(stream: Stream[Data]): Stream[Data] = stream match
+        case block #:: tail =>
+          if block.length == 0 then chunkedFraming(tail) else
+            val size: Text = Integer.toHexString(block.length).nn.tt
+            t"$size\r\n".data #:: block #:: t"\r\n".data #:: chunkedFraming(tail)
+
+        case _ =>
+          Stream(t"0\r\n\r\n".data)
+
+      def bodyBytes: Stream[Data] =
+        if !includeBody then Stream() else response.body match
+          case Body.Empty             => Stream()
+          case Body.Fixed(data)       => Stream(data)
+          case Body.Streaming(stream) => if chunked then chunkedFraming(stream) else stream
+
+      head.data #:: bodyBytes
+
     def parse(stream: Stream[Data]): Response raises HttpResponseError =
       val cursor = Cursor[Data](stream.filter(_.nonEmpty).iterator)
 

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -337,6 +337,7 @@ object Http:
           val chunk = cursor.hold:
             val start = cursor.mark
             var index = 0
+
             while index < take do
               cursor.advance()
               index += 1
@@ -346,6 +347,67 @@ object Http:
           chunk #:: recur(remaining - take)
 
       Stream.defer(recur(length))
+
+    // Decode a `Transfer-Encoding: chunked` request body off `cursor`, yielding
+    // each chunk's data and leaving the cursor after the terminating `0`-chunk
+    // and trailers — i.e. at the next request. Lenient: a malformed length or a
+    // truncated stream simply ends the body. Consumes CRLFs with `advance` (not
+    // `next`), so it never reads past the body's final `\r\n` (see `parseHead`).
+    def chunkedBody(cursor: Cursor[Data]): Stream[Data] =
+      def hex(digit: Int): Int =
+        if digit >= '0' && digit <= '9' then digit - '0'
+        else if digit >= 'a' && digit <= 'f' then digit - 'a' + 10
+        else if digit >= 'A' && digit <= 'F' then digit - 'A' + 10
+        else -1
+
+      def consumeCrlf(): Unit =
+        if cursor.peek == '\r' then cursor.advance()
+        if cursor.peek == '\n' then cursor.advance()
+
+      def skipToCrlf(): Unit = while !(cursor.peek == '\r') && !cursor.finished do cursor.advance()
+
+      def readSize(): Int =
+        var size = 0
+        var continue = true
+
+        while continue do
+          val value = hex(cursor.peek.asInt)
+
+          if value < 0 then continue = false else
+            size = size*16 + value
+            cursor.advance()
+
+        skipToCrlf() // discard any chunk extension
+        consumeCrlf()
+        size
+
+      def recur(): Stream[Data] = Stream.defer:
+        if cursor.finished then Stream() else
+          val size = readSize()
+
+          if size <= 0 then
+            while !(cursor.peek == '\r') && !cursor.finished do // trailer header lines
+              skipToCrlf()
+              consumeCrlf()
+
+            consumeCrlf() // final blank line
+            Stream()
+
+          else
+            val data = cursor.hold:
+              val start = cursor.mark
+              var index = 0
+
+              while index < size && !cursor.finished do
+                cursor.advance()
+                index += 1
+
+              cursor.grab(start, cursor.mark)
+
+            consumeCrlf()
+            data #:: recur()
+
+      recur()
 
   enum Body:
     case Streaming(data: Stream[Data])

--- a/lib/telekinesis/src/core/telekinesis.HttpRequestError.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpRequestError.scala
@@ -1,0 +1,50 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package telekinesis
+
+import anticipation.*
+import fulminate.*
+
+object HttpRequestError:
+  enum Reason(val number: Int) extends Clarification:
+    case Expectation(expected: Char, found: Char) extends Reason(1)
+    case Version(value: Text)                     extends Reason(2)
+    case Host(value: Text)                        extends Reason(3)
+
+  given communicable: Reason is Communicable =
+    case Reason.Expectation(expected, found) => m"$found was found when $expected was expected"
+    case Reason.Version(value)               => m"the HTTP version $value was invalid"
+    case Reason.Host(value)                  => m"the host $value was missing or invalid"
+
+case class HttpRequestError(reason: HttpRequestError.Reason)(using Diagnostics)
+extends Error(367, reason.number)(m"could not parse HTTP request because $reason")

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -383,6 +383,21 @@ object Tests extends Suite(m"Telekinesis tests"):
 
         . assert(_ == t" world")
 
+        test(m"chunkedBody decodes chunks at block size $blockSize"):
+          val fixture = t"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
+          val cursor = Cursor[Data](chunks(fixture, blockSize).iterator)
+          Http.Request.chunkedBody(cursor).read[Data].utf8
+
+        . assert(_ == t"hello world")
+
+        test(m"chunkedBody leaves the cursor after the body at block size $blockSize"):
+          val fixture = t"3\r\nabc\r\n0\r\n\r\nNEXT"
+          val cursor = Cursor[Data](chunks(fixture, blockSize).iterator)
+          Http.Request.chunkedBody(cursor).each(_ => ())
+          cursor.remainder.read[Data].utf8
+
+        . assert(_ == t"NEXT")
+
     suite(m"Response serialization"):
       def chunks(text: Text, size: Int): Stream[Data] =
         val data: Data = text.data

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -369,6 +369,68 @@ object Tests extends Suite(m"Telekinesis tests"):
         case HttpRequestError.Reason.Host(_) => true
         case _                               => false
 
+    suite(m"Response serialization"):
+      def chunks(text: Text, size: Int): Stream[Data] =
+        val data: Data = text.data
+        def go(offset: Int): Stream[Data] =
+          if offset >= data.length then Stream() else
+            val end = math.min(offset + size, data.length)
+            data.slice(offset, end) #:: go(end)
+        go(0)
+
+      def bodyText(response: Http.Response): Text = response.body.stream.read[Data].utf8
+
+      def wire(response: Http.Response, includeBody: Boolean = true): Text =
+        Http.Response.serialize(response, includeBody).read[Data].utf8
+
+      val blockSizes = List(1, 2, 3, 7, 13, 4096)
+
+      test(m"Status line carries code and reason phrase"):
+        wire(Http.Response(Http.NotFound)()).cut(t"\r\n").head
+
+      . assert(_ == t"HTTP/1.1 404 Not Found")
+
+      for blockSize <- blockSizes do
+        test(m"Round-trip a fixed body at block size $blockSize"):
+          val response = Http.Response(Http.Ok)(t"hello world")
+          val parsed = Http.Response.parse(chunks(wire(response), blockSize))
+          (parsed.status, bodyText(parsed))
+
+        . assert(_ == (Http.Ok, t"hello world"))
+
+      test(m"Fixed body sets a correct Content-Length"):
+        wire(Http.Response(Http.Ok)(t"hello")).contains(t"content-length: 5")
+
+      . assert(_ == true)
+
+      test(m"Empty body sets Content-Length 0"):
+        wire(Http.Response(Http.NoContent)()).contains(t"content-length: 0")
+
+      . assert(_ == true)
+
+      test(m"Streaming body is framed with chunked transfer-encoding"):
+        val body = Http.Body.Streaming(Stream(t"Hello".data, t"World".data))
+        wire(Http.Response(Http.Ok)(body))
+
+      . assert: text =>
+          text.contains(t"transfer-encoding: chunked")
+          && text.contains(t"5\r\nHello\r\n")
+          && text.contains(t"5\r\nWorld\r\n")
+          && text.ends(t"0\r\n\r\n")
+
+      test(m"Streaming body skips zero-length blocks"):
+        val body = Http.Body.Streaming(Stream(t"ab".data, t"".data, t"cd".data))
+        wire(Http.Response(Http.Ok)(body))
+
+      . assert(_.contains(t"2\r\nab\r\n2\r\ncd\r\n"))
+
+      test(m"HEAD response omits the body but keeps headers"):
+        val response = Http.Response(Http.Ok)(t"hello")
+        val text = wire(response, includeBody = false)
+        text.ends(t"\r\n\r\n") && !text.contains(t"hello") && text.contains(t"content-length: 5")
+
+      . assert(_ == true)
+
     suite(m"Redirect handling"):
       test(m"Follow a relative redirect chain by default"):
         url"https://httpbin.org/redirect/3".fetch().status

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -292,6 +292,83 @@ object Tests extends Suite(m"Telekinesis tests"):
 
       . assert()
 
+    suite(m"Request parsing"):
+      def chunks(text: Text, size: Int): Stream[Data] =
+        val data: Data = text.data
+        def go(offset: Int): Stream[Data] =
+          if offset >= data.length then Stream() else
+            val end = math.min(offset + size, data.length)
+            data.slice(offset, end) #:: go(end)
+        go(0)
+
+      def bodyText(request: Http.Request): Text = request.body().read[Data].utf8
+
+      val blockSizes = List(1, 2, 3, 7, 13, 4096)
+      val fixture = t"GET /path?q=1 HTTP/1.1\r\nHost: example.com\r\nX-Foo: bar\r\n\r\nbody"
+
+      for blockSize <- blockSizes do
+        test(m"Parse method at block size $blockSize"):
+          Http.Request.parse(chunks(fixture, blockSize)).method
+
+        . assert(_ == Http.Get)
+
+        test(m"Parse target at block size $blockSize"):
+          Http.Request.parse(chunks(fixture, blockSize)).target
+
+        . assert(_ == t"/path?q=1")
+
+        test(m"Parse version at block size $blockSize"):
+          Http.Request.parse(chunks(fixture, blockSize)).version
+
+        . assert(_ == 1.1)
+
+        test(m"Parse host at block size $blockSize"):
+          Http.Request.parse(chunks(fixture, blockSize)).host.show
+
+        . assert(_ == t"example.com")
+
+        test(m"Parse headers at block size $blockSize"):
+          Http.Request.parse(chunks(fixture, blockSize)).textHeaders
+
+        . assert(_ == List(Http.Header(t"Host", t"example.com"), Http.Header(t"X-Foo", t"bar")))
+
+        test(m"Parse body at block size $blockSize"):
+          bodyText(Http.Request.parse(chunks(fixture, blockSize)))
+
+        . assert(_ == t"body")
+
+      val methods: List[Http.Method] =
+        List(Http.Get, Http.Head, Http.Post, Http.Put, Http.Delete, Http.Patch, Http.Options,
+            Http.Trace, Http.Connect)
+
+      for method <- methods do
+        test(m"Parse method ${method.show}"):
+          val fixture = t"${method.show} / HTTP/1.1\r\nHost: example.com\r\n\r\n"
+          Http.Request.parse(chunks(fixture, 4096)).method
+
+        . assert(_ == method)
+
+      test(m"Parse HTTP/1.0 version"):
+        val fixture = t"GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
+        Http.Request.parse(chunks(fixture, 4096)).version
+
+      . assert(_ == 1.0)
+
+      test(m"Host header with port has the port stripped"):
+        val fixture = t"GET / HTTP/1.1\r\nHost: example.com:8080\r\n\r\n"
+        Http.Request.parse(chunks(fixture, 4096)).host.show
+
+      . assert(_ == t"example.com")
+
+      test(m"Missing Host header raises Host reason"):
+        capture[HttpRequestError]:
+          Http.Request.parse(chunks(t"GET / HTTP/1.1\r\n\r\n", 4096))
+        . reason
+
+      . assert:
+        case HttpRequestError.Reason.Host(_) => true
+        case _                               => false
+
     suite(m"Redirect handling"):
       test(m"Follow a relative redirect chain by default"):
         url"https://httpbin.org/redirect/3".fetch().status

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -369,6 +369,20 @@ object Tests extends Suite(m"Telekinesis tests"):
         case HttpRequestError.Reason.Host(_) => true
         case _                               => false
 
+      for blockSize <- blockSizes do
+        test(m"fixedBody reads exactly N bytes at block size $blockSize"):
+          val cursor = Cursor[Data](chunks(t"hello world", blockSize).iterator)
+          Http.Request.fixedBody(cursor, 5).read[Data].utf8
+
+        . assert(_ == t"hello")
+
+        test(m"fixedBody leaves the cursor after the body at block size $blockSize"):
+          val cursor = Cursor[Data](chunks(t"hello world", blockSize).iterator)
+          Http.Request.fixedBody(cursor, 5).each(_ => ())
+          cursor.remainder.read[Data].utf8
+
+        . assert(_ == t" world")
+
     suite(m"Response serialization"):
       def chunks(text: Text, size: Int): Stream[Data] =
         val data: Data = text.data


### PR DESCRIPTION
Scintillate gains a second HTTP server backend, `SocketServer`, built directly on a raw TCP socket rather than the JDK's `com.sun.net.httpserver`. It speaks production HTTP/1.1 — keep-alive and request pipelining, Content-Length and chunked request bodies, and HEAD handling — on one Loom virtual thread per connection, and, unlike the stdlib server, it can hand a connection over to another protocol via a `101 Switching Protocols` response, which is the seam WebSocket upgrades need. The existing handler API is unchanged, so the same `HttpConnection ?=> Http.Response` handlers run on either backend; the new one is selected purely by import.

## Native TCP HTTP/1.1 server backend

`scintillate` now provides `SocketServer`, an HTTP/1.1 server built on a raw `java.net.ServerSocket` instead of the JDK's bundled HTTP server. Select it by importing the `native` (localhost) or `nativePublic` (all interfaces) backend instead of `stdlib`:

```scala
import scintillate.*, httpServers.native
// Handlers are written exactly as before; the import chooses the backend.
```

The backend supports:

- **Keep-alive and pipelining** — connections are reused across requests (HTTP/1.1 default; `Connection: close`/`keep-alive` honoured), bounded by an idle timeout.
- **Request bodies** framed by `Content-Length` or `Transfer-Encoding: chunked`.
- **Connection upgrades** — a handler returning `101 Switching Protocols` hands the raw connection to another protocol (e.g. WebSockets), with the post-handshake bytes available as the request body.

The HTTP/1.1 wire format lives in `telekinesis`: `Http.Request.parse`/`parseHead` and `Http.Response.serialize` are the symmetric counterparts of the existing response parser. HTTP/2 is not yet supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
