### PR TITLE
Harden surveillance filewatching and add a pluggable polling backend

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1362,7 +1362,7 @@ object surveillance extends Library:
   object core extends Component(eucalyptus.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core, galilei.core, imperial.core, diuretic.core)
+  object test extends Tests(core, galilei.core, imperial.core, diuretic.core, quantitative.units)
 
 object symbolism extends Library:
   object core extends Component(prepositional.core):

--- a/build.mill
+++ b/build.mill
@@ -1362,7 +1362,7 @@ object surveillance extends Library:
   object core extends Component(eucalyptus.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core)
+  object test extends Tests(core, galilei.core, imperial.core, diuretic.core)
 
 object symbolism extends Library:
   object core extends Component(prepositional.core):

--- a/lib/surveillance/.github/readme.md
+++ b/lib/surveillance/.github/readme.md
@@ -6,7 +6,7 @@
 
 __Representation-agnostic filewatching with streams in Scala__
 
-__Surveillance__ watches directories for changes, and provides a `LazyList` of streaming `WatchEvent`s. While it
+__Surveillance__ watches directories for changes, and provides a `Stream` of streaming `WatchEvent`s. While it
 works well with [Galilei](https://github.com/propensive/galilei/), it can work with any representation of
 paths.
 
@@ -43,13 +43,20 @@ import serpentine.*
 import surveillance.*
 
 val dir = (Unix / p"home" / p"work" / p"updates").directory()
-val watcher = dir.watch()
+
+dir.watch: watcher =>
+  watcher.stream.each:
+    case WatchEvent.NewFile(dir, file) => // ...
+    case other                         => // ...
 ```
 
-Constructing a new `Watcher` on a directory will register that directory with the filesystem's filewatching service
-and start a new thread to respond to updates.
+The `watch` extension method takes a lambda whose single parameter is a `Watch`. It registers the directory (or
+directories) with the filesystem's filewatching service — starting a shared background thread on first use — invokes
+the lambda, and unregisters the watch (terminating its stream) when the lambda returns. Registration failures, such
+as a nonexistent path or the operating system's watch limit being exceeded, are raised as a `WatchError`.
 
-The most important method of a `Watcher` is its `stream` method, which will return a `LazyList[WatchEvent]`
+The most important method of a `Watch` is its `stream` method, which returns a `Stream[WatchEvent]` that yields
+events as they occur and ends when the watch is unregistered.
 
 
 

--- a/lib/surveillance/.github/readme.md
+++ b/lib/surveillance/.github/readme.md
@@ -58,6 +58,28 @@ as a nonexistent path or the operating system's watch limit being exceeded, are 
 The most important method of a `Watch` is its `stream` method, which returns a `Stream[WatchEvent]` that yields
 events as they occur and ends when the watch is unregistered.
 
+### Backends
+
+The mechanism that detects changes is chosen by a contextual `Watcher` instance. Without any import the default
+`Watcher` is used, which delegates to the operating system's native filewatching service (a shared
+`java.nio.file.WatchService` and a single background thread).
+
+Some filesystems and platforms offer no usable native filewatching. For those cases, Surveillance provides a
+polling backend that periodically snapshots each watched directory and compares successive snapshots. Select it by
+putting a polling `Watcher` in scope, specifying how often to poll:
+```scala
+import quantitative.*
+
+given Watcher = watchers.polling(0.5*Second)
+
+dir.watch: watcher =>
+  watcher.stream.each:
+    case WatchEvent.NewFile(dir, file) => // ...
+    case other                         => // ...
+```
+The polling backend needs no operating-system support, at the cost of latency bounded by the polling interval and
+an inability to detect changes that leave a file's size and modification time unchanged.
+
 
 
 

--- a/lib/surveillance/src/core/surveillance.NativeWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.NativeWatcher.scala
@@ -1,0 +1,161 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package surveillance
+
+import java.io as ji
+import java.nio.file as jnf, jnf.StandardWatchEventKinds.*
+
+import scala.collection.mutable as scm
+
+import anticipation.*
+import contingency.*
+import denominative.*
+import parasite.*, threading.platform
+import rudiments.*
+import spectacular.*
+import turbulence.*
+import vacuous.*
+
+// The native backend wraps the operating system's filewatching service (`java.nio.file
+// .WatchService`). A single service and a single polling thread are shared across every
+// registration; keys are reference-counted so the service is closed only once nothing is being
+// watched.
+object NativeWatcher extends Watcher:
+  private case class WatchService(watchService: jnf.WatchService, pollLoop: Loop):
+    import codicils.await
+
+    def stop(): Unit =
+      pollLoop.stop()
+      try watchService.close() catch case _: ji.IOException => ()
+
+    val async: Optional[Task[Unit]] = safely(supervise(task("surveillance".tt)(pollLoop.run())))
+
+  private val serviceMutex: Mutex = Mutex()
+  private val watchesMutex: Mutex = Mutex()
+  @volatile private var serviceValue: Optional[WatchService] = Unset
+
+  private def service: WatchService = serviceValue.or:
+    serviceMutex:
+      serviceValue.or:
+        jnf.FileSystems.getDefault.nn.newWatchService().nn.pipe: watchService =>
+          WatchService(watchService, pollLoop(watchService)).tap: service =>
+            serviceValue = service
+
+  private val watches: scm.HashMap[jnf.WatchKey, Set[PathWatch]] = scm.HashMap()
+
+  private def pollLoop(service: jnf.WatchService): Loop = loop:
+    try
+      service.take().nn match
+        case key: jnf.WatchKey =>
+          val pathWatches = watchesMutex(watches.at(key).or(Set()))
+
+          key.pollEvents().nn.iterator.nn.asScala.each: event =>
+            pathWatches.each(_.put(event))
+
+          // `reset` returns `false` once the key is no longer valid (e.g. the watched
+          // directory was deleted); drop it so the map doesn't retain dead keys.
+          if !key.reset() then watchesMutex(watches.remove(key))
+
+    catch case _: jnf.ClosedWatchServiceException => ()
+
+  private def registerKey(directory: jnf.Path): jnf.WatchKey raises WatchError =
+    try directory.register(service.watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE).nn
+    catch
+      case _: jnf.NoSuchFileException   => abort(WatchError(WatchError.Reason.Nonexistent))
+      case _: jnf.NotDirectoryException => abort(WatchError(WatchError.Reason.NotDirectory))
+      case _: jnf.AccessDeniedException => abort(WatchError(WatchError.Reason.PermissionDenied))
+      case _: SecurityException         => abort(WatchError(WatchError.Reason.PermissionDenied))
+
+      // `register` on an existing, accessible directory has essentially one remaining
+      // failure mode: the operating system's watch limit (e.g. inotify `max_user_watches`).
+      case _: ji.IOException            => abort(WatchError(WatchError.Reason.LimitExceeded))
+
+  def watch(directories: Map[jnf.Path, Text => Boolean], spool: Spool[WatchEvent])
+  :   Watcher.Registration raises WatchError =
+
+    val pathWatches: Set[PathWatch] = watchesMutex:
+      directories.map:
+        case (directory, filter) =>
+          val key = registerKey(directory)
+
+          new PathWatch(key, directory, spool, filter).tap: pathWatch =>
+            watches(key) = watches.at(key).or(Set()) + pathWatch
+
+      . to(Set)
+
+    Registration(pathWatches)
+
+  private class PathWatch
+    ( private[NativeWatcher] val key:    jnf.WatchKey,
+      private[NativeWatcher] val base:   jnf.Path,
+                             val spool:  Spool[WatchEvent],
+                             val filter: Text => Boolean ):
+
+    def put(event: jnf.WatchEvent[?]): Unit =
+      event.context.nn.absolve match
+        case path: jnf.Path =>
+          val name = path.toString.tt
+
+          if filter(name) then
+            try
+              event.kind match
+                case ENTRY_CREATE =>
+                  if base.resolve(path).nn.toFile.nn.isDirectory
+                  then spool.put(WatchEvent.NewDirectory(base.toString.show, name))
+                  else spool.put(WatchEvent.NewFile(base.toString.show, name))
+
+                case ENTRY_MODIFY =>
+                  spool.put(WatchEvent.Modify(base.toString.show, name))
+
+                case ENTRY_DELETE =>
+                  spool.put(WatchEvent.Delete(base.toString.show, name))
+
+                case _ =>
+                  ()
+
+            catch case error: Exception => ()
+
+  private class Registration(pathWatches: Set[PathWatch]) extends Watcher.Registration:
+    def cancel(): Unit =
+      watchesMutex:
+        pathWatches.each: pathWatch =>
+          watches(pathWatch.key) = watches.at(pathWatch.key).or(Set()) - pathWatch
+
+          if watches.at(pathWatch.key).or(Set()).nil then
+            pathWatch.key.cancel()
+            watches.remove(pathWatch.key)
+
+        if watches.nil then serviceMutex:
+          serviceValue.let: service =>
+            service.stop()
+            serviceValue = Unset

--- a/lib/surveillance/src/core/surveillance.PollingWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.PollingWatcher.scala
@@ -30,9 +30,98 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package surveillance
 
-export surveillance.{Watch, watch, Watcher, WatchError, WatchEvent}
+import java.nio.file as jnf
 
-package watchers:
-  export surveillance.watchers.{native, polling}
+import scala.collection.mutable as scm
+
+import anticipation.*
+import contingency.*
+import denominative.*
+import parasite.*, threading.platform
+import prepositional.*
+import rudiments.*
+import spectacular.*
+import turbulence.*
+import vacuous.*
+
+// The polling backend detects changes by snapshotting each watched directory's entries (their
+// kind, modification time and size) on a fixed interval and diffing successive snapshots. It needs
+// no operating-system filewatching support, at the cost of latency bounded by the interval and the
+// inability to observe changes that leave size and modification time unchanged. A single background
+// task per registration does the scanning; cancelling the registration interrupts it.
+class PollingWatcher[duration: Abstractable across Durations to Long](interval: duration)
+extends Watcher:
+
+  import codicils.await
+
+  private case class Entry(directory: Boolean, modified: Long, size: Long)
+
+  private def scan(directory: jnf.Path, filter: Text => Boolean): Map[Text, Entry] =
+    Optional(directory.toFile.nn.listFiles()).let: files =>
+      scala.collection.immutable.ArraySeq.unsafeWrapArray(files).flatMap: file =>
+        val entry = file.nn
+        val name = entry.getName.nn.tt
+
+        if filter(name)
+        then List(name -> Entry(entry.isDirectory, entry.lastModified, entry.length))
+        else Nil
+
+      . to(Map)
+
+    . or(Map())
+
+  private def diff
+    ( directory: jnf.Path,
+      previous:  Map[Text, Entry],
+      current:   Map[Text, Entry],
+      spool:     Spool[WatchEvent] )
+  :   Unit =
+
+    val base = directory.toString.show
+
+    current.each: (name, entry) =>
+      previous.at(name) match
+        case last: Entry =>
+          if !entry.directory && last != entry then spool.put(WatchEvent.Modify(base, name))
+
+        case Unset =>
+          if entry.directory then spool.put(WatchEvent.NewDirectory(base, name))
+          else spool.put(WatchEvent.NewFile(base, name))
+
+    previous.each: (name, _) =>
+      if !current.contains(name) then spool.put(WatchEvent.Delete(base, name))
+
+  def watch(directories: Map[jnf.Path, Text => Boolean], spool: Spool[WatchEvent])
+  :   Watcher.Registration raises WatchError =
+
+    directories.each: (directory, _) =>
+      val file = directory.toFile.nn
+
+      if !file.exists then abort(WatchError(WatchError.Reason.Nonexistent))
+      else if !file.isDirectory then abort(WatchError(WatchError.Reason.NotDirectory))
+
+    val snapshots: scm.HashMap[jnf.Path, Map[Text, Entry]] = scm.HashMap()
+
+    directories.each: (directory, filter) =>
+      snapshots(directory) = scan(directory, filter)
+
+    val async: Optional[Task[Unit]] = safely:
+      supervise:
+        task("surveillance-poll".tt):
+          try
+            while true do
+              snooze(interval)
+
+              directories.each: (directory, filter) =>
+                val current = scan(directory, filter)
+                diff(directory, snapshots.at(directory).or(Map()), current, spool)
+                snapshots(directory) = current
+
+          catch case _: InterruptedException => ()
+
+    Registration(async)
+
+  private class Registration(async: Optional[Task[Unit]]) extends Watcher.Registration:
+    def cancel(): Unit = async.let(_.cancel())

--- a/lib/surveillance/src/core/surveillance.Watch.scala
+++ b/lib/surveillance/src/core/surveillance.Watch.scala
@@ -32,157 +32,43 @@
                                                                                                   */
 package surveillance
 
-import java.io as ji
-import java.nio.file as jnf, jnf.StandardWatchEventKinds.*
-
-import scala.collection.mutable as scm
+import java.nio.file as jnf
 
 import anticipation.*
 import contingency.*
-import denominative.*
-import parasite.*, threading.platform
 import prepositional.*
-import rudiments.*
-import spectacular.*
 import turbulence.*
 import vacuous.*
 
 object Watch:
-  private case class WatchService(watchService: jnf.WatchService, pollLoop: Loop):
-    import codicils.await
-
-    def stop(): Unit =
-      pollLoop.stop()
-      try watchService.close() catch case _: ji.IOException => ()
-
-    val async: Optional[Task[Unit]] = safely(supervise(task("surveillance".tt)(pollLoop.run())))
-
-  private val serviceMutex: Mutex = Mutex()
-  private val watchesMutex: Mutex = Mutex()
-  @volatile private var serviceValue: Optional[WatchService] = Unset
-
-  private def service: WatchService = serviceValue.or:
-    serviceMutex:
-      serviceValue.or:
-        jnf.FileSystems.getDefault.nn.newWatchService().nn.pipe: watchService =>
-          WatchService(watchService, pollLoop(watchService)).tap: service =>
-            serviceValue = service
-
-  private val watches: scm.HashMap[jnf.WatchKey, Set[Watch#PathWatch]] = scm.HashMap()
-
-  private def register(paths: Map[jnf.Path, Text => Boolean]): Watch raises WatchError =
-    new Watch().tap(_.watch(paths))
-
-  private def pollLoop(service: jnf.WatchService): Loop = loop:
-    try
-      service.take().nn match
-        case key: jnf.WatchKey =>
-          val pathWatches = watchesMutex(watches.at(key).or(Set()))
-
-          key.pollEvents().nn.iterator.nn.asScala.each: event =>
-            pathWatches.each(_.put(event))
-
-          // `reset` returns `false` once the key is no longer valid (e.g. the watched
-          // directory was deleted); drop it so the map doesn't retain dead keys.
-          if !key.reset() then watchesMutex(watches.remove(key))
-
-    catch case _: jnf.ClosedWatchServiceException => ()
-
-  def apply[path: Abstractable across Paths to Text](paths: Iterable[path])
+  def apply[path: Abstractable across Paths to Text](paths: Iterable[path])(using watcher: Watcher)
   :   Watch raises WatchError =
 
-    Watch.register:
-      val pathGroups: Map[jnf.Path, Iterable[Text => Boolean]] =
-        paths.map(_.generic.s).map(jnf.Paths.get(_).nn).map: javaPath =>
-          if javaPath.toFile.nn.isDirectory then (javaPath, (_: Text) => true)
-          else
-            val parent = Optional(javaPath.getParent).or(jnf.Paths.get("").nn)
-            (parent, (_: Text) == javaPath.getFileName.nn.toString.tt)
+    val pathGroups: Map[jnf.Path, Iterable[Text => Boolean]] =
+      paths.map(_.generic.s).map(jnf.Paths.get(_).nn).map: javaPath =>
+        if javaPath.toFile.nn.isDirectory then (javaPath, (_: Text) => true)
+        else
+          val parent = Optional(javaPath.getParent).or(jnf.Paths.get("").nn)
+          (parent, (_: Text) == javaPath.getFileName.nn.toString.tt)
 
-        . groupBy(_(0)).view.mapValues(_.map(_(1))).to(Map)
+      . groupBy(_(0)).view.mapValues(_.map(_(1))).to(Map)
 
+    val directories: Map[jnf.Path, Text => Boolean] =
       pathGroups.view.mapValues: predicates =>
         (value: Text) => predicates.exists(_(value))
 
       . to(Map)
 
-class Watch():
-  private val mutex: Mutex = Mutex()
-  private val spool: Spool[WatchEvent] = Spool()
-  private val watches: scm.HashSet[PathWatch] = scm.HashSet[PathWatch]()
+    val spool: Spool[WatchEvent] = Spool()
 
+    new Watch(spool, watcher.watch(directories, spool))
 
-  private class PathWatch
-    ( private[Watch]  val key:    jnf.WatchKey,
-      private[Watch]  val base:   jnf.Path,
-                      val spool:  Spool[WatchEvent],
-                      val filter: Text => Boolean ):
-
-    def put(event: jnf.WatchEvent[?]): Unit =
-      event.context.nn.absolve match
-        case path: jnf.Path =>
-          val name = path.toString.tt
-
-          if filter(name) then
-            try
-              event.kind match
-                case ENTRY_CREATE =>
-                  if base.resolve(path).nn.toFile.nn.isDirectory
-                  then spool.put(WatchEvent.NewDirectory(base.toString.show, name))
-                  else spool.put(WatchEvent.NewFile(base.toString.show, name))
-
-                case ENTRY_MODIFY =>
-                  spool.put(WatchEvent.Modify(base.toString.show, name))
-
-                case ENTRY_DELETE =>
-                  spool.put(WatchEvent.Delete(base.toString.show, name))
-
-                case _ =>
-                  ()
-
-            catch case error: Exception => ()
-
-
+// A `Watch` is the user-facing handle returned by registering one or more paths. Its `stream`
+// yields events as they occur, and `unregister` cancels the backend registration and terminates
+// the stream. The actual change-detection is delegated to a `Watcher` backend.
+class Watch(spool: Spool[WatchEvent], registration: Watcher.Registration):
   def stream: Stream[WatchEvent] = spool.stream
 
-  private def registerKey(path: jnf.Path): jnf.WatchKey raises WatchError =
-    try path.register(Watch.service.watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE).nn
-    catch
-      case _: jnf.NoSuchFileException   => abort(WatchError(WatchError.Reason.Nonexistent))
-      case _: jnf.NotDirectoryException => abort(WatchError(WatchError.Reason.NotDirectory))
-      case _: jnf.AccessDeniedException => abort(WatchError(WatchError.Reason.PermissionDenied))
-      case _: SecurityException         => abort(WatchError(WatchError.Reason.PermissionDenied))
-
-      // `register` on an existing, accessible directory has essentially one remaining
-      // failure mode: the operating system's watch limit (e.g. inotify `max_user_watches`).
-      case _: ji.IOException            => abort(WatchError(WatchError.Reason.LimitExceeded))
-
-  def watch(paths: Map[jnf.Path, Text => Boolean]): Unit raises WatchError =
-    val watches2 = Watch.watchesMutex:
-      paths.map:
-        case (path, filter) =>
-          val key = registerKey(path)
-
-          new PathWatch(key, path, spool, filter).tap: watch =>
-            Watch.watches(key) = Watch.watches.at(key).or(Set()) + watch
-
-    mutex(watches ++= watches2)
-
   def unregister(): Unit =
-    val localWatches = mutex(watches.to(Set))
-
-    Watch.watchesMutex:
-      localWatches.each: watch =>
-        Watch.watches(watch.key) = Watch.watches.at(watch.key).or(Set()) - watch
-
-        if Watch.watches.at(watch.key).or(Set()).nil then
-          watch.key.cancel()
-          Watch.watches.remove(watch.key)
-
-      if Watch.watches.nil then Watch.serviceMutex:
-        Watch.serviceValue.let: service =>
-          service.stop()
-          Watch.serviceValue = Unset
-
-    mutex(watches.clear())
+    registration.cancel()
     spool.stop()

--- a/lib/surveillance/src/core/surveillance.Watch.scala
+++ b/lib/surveillance/src/core/surveillance.Watch.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package surveillance
 
+import java.io as ji
 import java.nio.file as jnf, jnf.StandardWatchEventKinds.*
 
 import scala.collection.mutable as scm
@@ -50,39 +51,53 @@ object Watch:
   private case class WatchService(watchService: jnf.WatchService, pollLoop: Loop):
     import codicils.await
 
-    def stop(): Unit = pollLoop.stop()
+    def stop(): Unit =
+      pollLoop.stop()
+      try watchService.close() catch case _: ji.IOException => ()
 
     val async: Optional[Task[Unit]] = safely(supervise(task("surveillance".tt)(pollLoop.run())))
 
   private val serviceMutex: Mutex = Mutex()
   private val watchesMutex: Mutex = Mutex()
-  private var serviceValue: Optional[WatchService] = Unset
+  @volatile private var serviceValue: Optional[WatchService] = Unset
 
   private def service: WatchService = serviceValue.or:
     serviceMutex:
-      jnf.FileSystems.getDefault.nn.newWatchService().nn.pipe: watchService =>
-        WatchService(watchService, pollLoop(watchService)).tap: service =>
-          serviceValue = service
+      serviceValue.or:
+        jnf.FileSystems.getDefault.nn.newWatchService().nn.pipe: watchService =>
+          WatchService(watchService, pollLoop(watchService)).tap: service =>
+            serviceValue = service
 
   private val watches: scm.HashMap[jnf.WatchKey, Set[Watch#PathWatch]] = scm.HashMap()
 
-  private def register(paths: Map[jnf.Path, Text => Boolean]): Watch =
+  private def register(paths: Map[jnf.Path, Text => Boolean]): Watch raises WatchError =
     new Watch().tap(_.watch(paths))
 
   private def pollLoop(service: jnf.WatchService): Loop = loop:
-    service.take().nn match
-      case key: jnf.WatchKey =>
-        key.pollEvents().nn.iterator.nn.asScala.each: event =>
-          watchesMutex(watches(key)).each(_.put(event))
+    try
+      service.take().nn match
+        case key: jnf.WatchKey =>
+          val pathWatches = watchesMutex(watches.at(key).or(Set()))
 
-        key.reset()
+          key.pollEvents().nn.iterator.nn.asScala.each: event =>
+            pathWatches.each(_.put(event))
 
-  def apply[path: Abstractable across Paths to Text](paths: Iterable[path]): Watch =
+          // `reset` returns `false` once the key is no longer valid (e.g. the watched
+          // directory was deleted); drop it so the map doesn't retain dead keys.
+          if !key.reset() then watchesMutex(watches.remove(key))
+
+    catch case _: jnf.ClosedWatchServiceException => ()
+
+  def apply[path: Abstractable across Paths to Text](paths: Iterable[path])
+  :   Watch raises WatchError =
+
     Watch.register:
       val pathGroups: Map[jnf.Path, Iterable[Text => Boolean]] =
         paths.map(_.generic.s).map(jnf.Paths.get(_).nn).map: javaPath =>
           if javaPath.toFile.nn.isDirectory then (javaPath, (_: Text) => true)
-          else (javaPath.getParent.nn, (_: Text) == javaPath.getFileName.nn.toString.tt)
+          else
+            val parent = Optional(javaPath.getParent).or(jnf.Paths.get("").nn)
+            (parent, (_: Text) == javaPath.getFileName.nn.toString.tt)
 
         . groupBy(_(0)).view.mapValues(_.map(_(1))).to(Map)
 
@@ -130,28 +145,44 @@ class Watch():
 
   def stream: Stream[WatchEvent] = spool.stream
 
-  def watch(paths: Map[jnf.Path, Text => Boolean]): Unit =
-    val watches2 = paths.map:
-      case (path, filter) =>
-        val key =
-          path.register(Watch.service.watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE).nn
+  private def registerKey(path: jnf.Path): jnf.WatchKey raises WatchError =
+    try path.register(Watch.service.watchService, ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE).nn
+    catch
+      case _: jnf.NoSuchFileException   => abort(WatchError(WatchError.Reason.Nonexistent))
+      case _: jnf.NotDirectoryException => abort(WatchError(WatchError.Reason.NotDirectory))
+      case _: jnf.AccessDeniedException => abort(WatchError(WatchError.Reason.PermissionDenied))
+      case _: SecurityException         => abort(WatchError(WatchError.Reason.PermissionDenied))
 
-        new PathWatch(key, path, spool, filter).tap: watch =>
-          Watch.watchesMutex:
+      // `register` on an existing, accessible directory has essentially one remaining
+      // failure mode: the operating system's watch limit (e.g. inotify `max_user_watches`).
+      case _: ji.IOException            => abort(WatchError(WatchError.Reason.LimitExceeded))
+
+  def watch(paths: Map[jnf.Path, Text => Boolean]): Unit raises WatchError =
+    val watches2 = Watch.watchesMutex:
+      paths.map:
+        case (path, filter) =>
+          val key = registerKey(path)
+
+          new PathWatch(key, path, spool, filter).tap: watch =>
             Watch.watches(key) = Watch.watches.at(key).or(Set()) + watch
 
     mutex(watches ++= watches2)
 
   def unregister(): Unit =
+    val localWatches = mutex(watches.to(Set))
+
     Watch.watchesMutex:
-      watches.each: watch =>
+      localWatches.each: watch =>
         Watch.watches(watch.key) = Watch.watches.at(watch.key).or(Set()) - watch
 
-        if Watch.watches(watch.key).nil then
+        if Watch.watches.at(watch.key).or(Set()).nil then
           watch.key.cancel()
           Watch.watches.remove(watch.key)
 
-        if Watch.watches.nil then mutex:
-          Watch.serviceValue.let: service =>
-            service.stop()
-            Watch.serviceValue = Unset
+      if Watch.watches.nil then Watch.serviceMutex:
+        Watch.serviceValue.let: service =>
+          service.stop()
+          Watch.serviceValue = Unset
+
+    mutex(watches.clear())
+    spool.stop()

--- a/lib/surveillance/src/core/surveillance.Watcher.scala
+++ b/lib/surveillance/src/core/surveillance.Watcher.scala
@@ -30,9 +30,27 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package surveillance
 
-export surveillance.{Watch, watch, Watcher, WatchError, WatchEvent}
+import java.nio.file as jnf
 
-package watchers:
-  export surveillance.watchers.{native, polling}
+import anticipation.*
+import contingency.*
+import turbulence.*
+
+// A `Watcher` is the backend that detects filesystem changes. The default (selected without any
+// import) is `NativeWatcher`, which delegates to the operating system's filewatching service. The
+// `watchers.polling` backend instead snapshots directories on a fixed interval, for filesystems or
+// platforms where native filewatching is unavailable or unreliable.
+
+object Watcher:
+  given default: Watcher = NativeWatcher
+
+  // A handle to a single backend registration; cancelling it stops delivery of further events for
+  // the directories registered in the corresponding `watch` call.
+  trait Registration:
+    def cancel(): Unit
+
+trait Watcher:
+  def watch(directories: Map[jnf.Path, Text => Boolean], spool: Spool[WatchEvent])
+  :   Watcher.Registration raises WatchError

--- a/lib/surveillance/src/core/surveillance_core.scala
+++ b/lib/surveillance/src/core/surveillance_core.scala
@@ -38,18 +38,24 @@ import prepositional.*
 import rudiments.*
 
 extension [path: Abstractable across Paths to Text](path: path)
-  def watch[result](lambda: Watch => result): result raises WatchError =
+  def watch[result](lambda: Watch => result)(using Watcher): result raises WatchError =
     val watchSet = Watch(List(path))
 
     lambda(watchSet).also:
       watchSet.unregister()
 
 extension [path: Abstractable across Paths to Text](paths: Iterable[path])
-  def watch[result](lambda: Watch => result): result raises WatchError =
+  def watch[result](lambda: Watch => result)(using Watcher): result raises WatchError =
     val watchSet = Watch(paths)
 
     lambda(watchSet).also:
       watchSet.unregister()
 
 export WatchEvent.{NewFile, NewDirectory, Modify, Delete}
+
+package watchers:
+  given native: Watcher = NativeWatcher
+
+  def polling[duration: Abstractable across Durations to Long](interval: duration): Watcher =
+    PollingWatcher(interval)
 

--- a/lib/surveillance/src/test/surveillance_test.scala
+++ b/lib/surveillance/src/test/surveillance_test.scala
@@ -64,3 +64,18 @@ object Tests extends Suite(m"Surveillance tests"):
       directory.watch(watcher => watcher).stream.to(List)
 
     . assert(_ == Nil)
+
+    test(m"The polling watcher reports a newly-created file"):
+      given Watcher = watchers.polling(0.05*Second)
+      val directory = temporaryDirectory[Path on Local]/Uuid().show
+      directory.create[Directory]()
+      val leaf: Text = Uuid().show
+
+      directory.watch: watcher =>
+        (directory/leaf).create[File]()
+
+        watcher.stream.head match
+          case NewFile(_, file) => file == leaf
+          case _                => false
+
+    . assert(_ == true)

--- a/lib/surveillance/src/test/surveillance_test.scala
+++ b/lib/surveillance/src/test/surveillance_test.scala
@@ -34,5 +34,33 @@ package surveillance
 
 import soundness.*
 
+import errorDiagnostics.empty
+import filesystemOptions.createNonexistentParents.enabled
+import filesystemOptions.overwritePreexisting.disabled
+import strategies.throwUnsafely
+import systems.java
+import temporaryDirectories.system
+
 object Tests extends Suite(m"Surveillance tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    test(m"Watching a path beneath a nonexistent directory raises a WatchError"):
+      val target = t"/surveillance-nonexistent-parent-9d3f17/child".decode[Path on Local]
+      capture[WatchError](target.watch(watcher => watcher)).reason
+
+    . assert(_ == WatchError.Reason.Nonexistent)
+
+    test(m"Watching a path whose parent is a regular file raises a WatchError"):
+      val file = temporaryDirectory[Path on Local]/Uuid().show
+      file.create[File]()
+      capture[WatchError]((file/Uuid().show).watch(watcher => watcher)).reason
+
+    . assert(_ == WatchError.Reason.NotDirectory)
+
+    test(m"A scoped watch on an untouched directory yields a terminating, empty stream"):
+      val directory = temporaryDirectory[Path on Local]/Uuid().show
+      directory.create[Directory]()
+
+      // Before `unregister` stopped the spool this `to(List)` would block forever.
+      directory.watch(watcher => watcher).stream.to(List)
+
+    . assert(_ == Nil)


### PR DESCRIPTION
Surveillance's filesystem watching has been reworked for correctness and flexibility: several race conditions and resource leaks in the native filewatcher have been fixed, the typed errors its API always promised are now actually raised, and change-detection has been made pluggable so that a polling backend can be used on filesystems and platforms where the operating system's native filewatching is unavailable or unreliable.

Filewatching reliability has been improved. The shared `WatchService` is now created under a correct double-checked lock (previously concurrent watchers could spawn duplicate native services and background threads), the polling thread can no longer be silently killed by an event arriving for a just-registered or just-removed path, and unregistering a watch now actually closes the native service and terminates the event stream rather than leaking a thread and blocking consumers forever.

Registration failures are now reported as the `WatchError` the API already declared, instead of escaping as raw `java.nio` exceptions:

```scala
// raises WatchError(Nonexistent) / WatchError(NotDirectory) / etc.
path.watch: watcher =>
  watcher.stream.each:
    case WatchEvent.NewFile(dir, file) => // ...
    case other                         => // ...
```

The mechanism that detects changes is now chosen by a contextual `Watcher`. Without any import the default native backend (the OS `WatchService`) is used, exactly as before. For environments without usable native filewatching, a polling backend snapshots each watched directory on a fixed interval and diffs successive snapshots:

```scala
import quantitative.*

given Watcher = watchers.polling(0.5*Second)

dir.watch: watcher =>
  watcher.stream.each:
    case WatchEvent.NewFile(dir, file) => // ...
    case other                         => // ...
```

The polling backend needs no operating-system support, at the cost of latency bounded by the polling interval and an inability to detect changes that leave a file's size and modification time unchanged.
