### PR TITLE
Add a CSS serializer, typed values, and output integrations to cataclysm

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -511,7 +511,7 @@ object cardinality extends Library:
 object cataclysm extends Library:
   object core extends Component(zephyrine.core, gossamer.core, turbulence.core,
       contingency.core, vacuous.core, fulminate.core, denominative.core, hellenism.core,
-      jacinta.core):
+      jacinta.core, quantitative.units, iridescence.core, gesticulate.core, rudiments.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object html extends Component(core, honeycomb.core, gigantism.core):

--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -32,7 +32,11 @@
                                                                                                   */
 package cataclysm
 
+import language.dynamics
+
 import anticipation.*
+import gesticulate.*
+import gossamer.*
 import parasite.*
 import prepositional.*
 import spectacular.*
@@ -50,6 +54,27 @@ object Css:
 
   given showable: CssFormatter => Css is Showable = CssSerializer.render(_)
 
+  // Serve a stylesheet as an HTTP `text/css` response body (paired with the
+  // `Streamable` instance above).
+  given media: Css is Media = _ => media"text/css"(charset = "UTF-8")
+
+  // A set of declarations for an inline `style="…"` attribute, built with a typed
+  // dynamic constructor: `Css.Style(borderWidth = 4.0*Px, color = rgb)`. Property
+  // names are camelCase (converted to kebab-case) and each value is checked
+  // against the property's grammar at compile time (see `StyleMacros`).
+  object Style extends Dynamic:
+    // The private primary constructor suppresses the synthetic constructor proxy,
+    // so `Css.Style(borderWidth = …)` routes to `applyDynamicNamed` rather than
+    // failing against a positional `apply`. `of` is the factory the macro emits.
+    def of(properties: List[(Text, Text)]): Style = new Style(properties)
+    def applyDynamic(method: "apply")(): Style = of(Nil)
+
+    inline def applyDynamicNamed(method: "apply")(inline properties: (Label, Any)*): Style =
+      ${StyleMacros.style('properties)}
+
+  class Style private (val properties: List[(Text, Text)]):
+    def text: Text = properties.map { (name, value) => t"$name: $value" }.join(t"; ")
+
   // A typed CSS value tagged with its value-definition-syntax type (e.g.
   // `Css.Value of "length"`). Native types convert in via `CssConvertible`; the
   // type is `into`, so a colour or quantity is accepted wherever a value of the
@@ -64,6 +89,10 @@ object Css:
     given converter: [value] => (convertible: value is CssConvertible)
     =>  Conversion[value, Value of convertible.Topic] = instance =>
       Value(convertible.value(instance)).asInstanceOf[Value of convertible.Topic]
+
+  // Render a number for CSS, dropping a redundant `.0` (so `12px`, not `12.0px`).
+  private[cataclysm] def number(value: Double): Text =
+    if value.isFinite && value == value.floor then value.toLong.show else value.toString.tt
 
   into trait Value extends Topical:
     def text: Text

--- a/lib/cataclysm/src/core/cataclysm.CssConvertible.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssConvertible.scala
@@ -33,39 +33,61 @@
 package cataclysm
 
 import anticipation.*
-import parasite.*
+import gossamer.*
+import iridescence.*
 import prepositional.*
+import quantitative.*
 import spectacular.*
-import turbulence.*
-import vacuous.*
 
-object Css:
-  enum Node derives CanEqual:
-    case Rule(selector: SelectorList, body: List[Node])
-    case Declaration(property: Text, value: Text)
-    case At(name: Text, prelude: Text, body: Optional[List[Node]])
+// Records that a native Scala type renders to a CSS value of the value-definition
+// type `Topic` (e.g. `"length"`, `"color"`). A single generic `Conversion` (in
+// `Css.Value`) lifts any such type into a `Css.Value of Topic`, so a new
+// convertible type costs one instance here, not one given per CSS property.
+object CssConvertible:
+  given pixels: (Quantity[Pixels[1]] is CssConvertible of "length") = q => t"${number(q.value)}px"
+  given ems: (Quantity[Ems[1]] is CssConvertible of "length") = q => t"${number(q.value)}em"
+  given rems: (Quantity[Rems[1]] is CssConvertible of "length") = q => t"${number(q.value)}rem"
+  given exs: (Quantity[Exs[1]] is CssConvertible of "length") = q => t"${number(q.value)}ex"
+  given chs: (Quantity[Chs[1]] is CssConvertible of "length") = q => t"${number(q.value)}ch"
 
-  given streamable: (Monitor, Codicil, CssFormatter) => Css is Streamable by Text =
-    CssSerializer.emit(_).to(Stream)
+  given vws: (Quantity[ViewportWidths[1]] is CssConvertible of "length") =
+    q => t"${number(q.value)}vw"
 
-  given showable: CssFormatter => Css is Showable = CssSerializer.render(_)
+  given vhs: (Quantity[ViewportHeights[1]] is CssConvertible of "length") =
+    q => t"${number(q.value)}vh"
 
-  // A typed CSS value tagged with its value-definition-syntax type (e.g.
-  // `Css.Value of "length"`). Native types convert in via `CssConvertible`; the
-  // type is `into`, so a colour or quantity is accepted wherever a value of the
-  // matching VDS type is expected.
-  object Value:
-    def apply(text: Text): Value =
-      val text0 = text
+  given vmins: (Quantity[ViewportMins[1]] is CssConvertible of "length") =
+    q => t"${number(q.value)}vmin"
 
-      new Value:
-        def text: Text = text0
+  given vmaxes: (Quantity[ViewportMaxes[1]] is CssConvertible of "length") =
+    q => t"${number(q.value)}vmax"
 
-    given converter: [value] => (convertible: value is CssConvertible)
-    =>  Conversion[value, Value of convertible.Topic] = instance =>
-      Value(convertible.value(instance)).asInstanceOf[Value of convertible.Topic]
+  given centimetres: (Quantity[Centimetres[1]] is CssConvertible of "length") =
+    q => t"${number(q.value)}cm"
 
-  into trait Value extends Topical:
-    def text: Text
+  given millimetres: (Quantity[Millimetres[1]] is CssConvertible of "length") =
+    q => t"${number(q.value)}mm"
 
-case class Css(rules: List[Css.Node]) derives CanEqual
+  given inches: (Quantity[Inches[1]] is CssConvertible of "length") = q => t"${number(q.value)}in"
+  given points: (Quantity[Points[1]] is CssConvertible of "length") = q => t"${number(q.value)}pt"
+  given picas: (Quantity[Picas[1]] is CssConvertible of "length") = q => t"${number(q.value)}pc"
+
+  given srgb: (Srgb is CssConvertible of "color") = hex(_)
+  given integer: (Int is CssConvertible of "integer") = _.show
+  given decimal: (Double is CssConvertible of "number") = number(_)
+
+  given percentage: (Percentage is CssConvertible of "percentage") =
+    percentage => t"${number(percentage.value)}%"
+
+  // Drop a redundant `.0` so a whole number renders as `12px`, not `12.0px`.
+  private def number(value: Double): Text =
+    if value.isFinite && value == value.floor then value.toLong.show else value.toString.tt
+
+  private def hex(color: Srgb): Text =
+    def channel(component: Double): Text =
+      String.format("%02x", (component*255).toInt.max(0).min(255)).nn.tt
+
+    t"#${channel(color.red)}${channel(color.green)}${channel(color.blue)}"
+
+trait CssConvertible extends Typeclass, Topical:
+  def value(self: Self): Text

--- a/lib/cataclysm/src/core/cataclysm.CssFormatter.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssFormatter.scala
@@ -32,22 +32,14 @@
                                                                                                   */
 package cataclysm
 
-import anticipation.*
-import parasite.*
-import prepositional.*
-import spectacular.*
-import turbulence.*
-import vacuous.*
+// Controls how a `Css` tree is serialized. `newlines` puts each rule and
+// declaration on its own indented line; `spaces` adds the cosmetic spaces (after
+// `:` and before `{`) that aid legibility. The two bundled formatters are
+// `cssFormatters.standard` (both on) and `cssFormatters.compact` (both off).
+object CssFormatter:
+  def apply(newlines: Boolean, spaces: Boolean): CssFormatter = Basic(newlines, spaces)
+  private case class Basic(newlines: Boolean, spaces: Boolean) extends CssFormatter
 
-object Css:
-  enum Node derives CanEqual:
-    case Rule(selector: SelectorList, body: List[Node])
-    case Declaration(property: Text, value: Text)
-    case At(name: Text, prelude: Text, body: Optional[List[Node]])
-
-  given streamable: (Monitor, Codicil, CssFormatter) => Css is Streamable by Text =
-    CssSerializer.emit(_).to(Stream)
-
-  given showable: CssFormatter => Css is Showable = CssSerializer.render(_)
-
-case class Css(rules: List[Css.Node]) derives CanEqual
+trait CssFormatter:
+  def newlines: Boolean
+  def spaces: Boolean

--- a/lib/cataclysm/src/core/cataclysm.CssSerializer.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssSerializer.scala
@@ -33,21 +33,66 @@
 package cataclysm
 
 import anticipation.*
+import gossamer.*
 import parasite.*
-import prepositional.*
 import spectacular.*
-import turbulence.*
 import vacuous.*
+import zephyrine.*
 
-object Css:
-  enum Node derives CanEqual:
-    case Rule(selector: SelectorList, body: List[Node])
-    case Declaration(property: Text, value: Text)
-    case At(name: Text, prelude: Text, body: Optional[List[Node]])
+// Serializes a `Css` tree back to CSS text. Output is produced lazily through a
+// `zephyrine.Emitter` (the same streaming mechanism Honeycomb uses for HTML), so
+// a large stylesheet never needs to be held in memory at once. The output style
+// is chosen by a contextual `CssFormatter` (`cssFormatters.standard` or
+// `.compact`).
+object CssSerializer:
+  def emit(css: Css)(using CssFormatter, Monitor, Codicil): Iterator[Text] =
+    val emitter = Emitter[Text](4096)
 
-  given streamable: (Monitor, Codicil, CssFormatter) => Css is Streamable by Text =
-    CssSerializer.emit(_).to(Stream)
+    async:
+      write(css)(emitter.put(_))
+      emitter.finish()
 
-  given showable: CssFormatter => Css is Showable = CssSerializer.render(_)
+    emitter.iterator
 
-case class Css(rules: List[Css.Node]) derives CanEqual
+  def render(css: Css)(using CssFormatter): Text = Text.build(write(css) { text => append(text) })
+
+  private def write(css: Css)(put: Text => Unit)(using formatter: CssFormatter): Unit =
+    def newline(indent: Int): Unit = if formatter.newlines then put(indentText(indent))
+
+    def block(body: List[Css.Node], indent: Int): Unit =
+      put(if formatter.spaces then t" {" else t"{")
+
+      body.foreach: child =>
+        newline(indent + 1)
+        emitNode(child, indent + 1)
+
+      newline(indent)
+      put(t"}")
+
+    def emitNode(node: Css.Node, indent: Int): Unit = node match
+      case Css.Node.Rule(selector, body) =>
+        put(selector.show)
+        block(body, indent)
+
+      case Css.Node.Declaration(property, value) =>
+        put(property)
+        put(if formatter.spaces then t": " else t":")
+        put(value)
+        put(t";")
+
+      case Css.Node.At(name, prelude, body) =>
+        put(t"@$name")
+        if prelude != t"" then put(t" $prelude")
+
+        body.lay(put(t";")): nodes =>
+          block(nodes, indent)
+
+    var first = true
+
+    css.rules.foreach: child =>
+      if first then first = false else newline(0)
+      emitNode(child, 0)
+
+    if formatter.newlines then put(t"\n")
+
+  private def indentText(indent: Int): Text = ("\n" + " "*(2*indent)).tt

--- a/lib/cataclysm/src/core/cataclysm.Selector.scala
+++ b/lib/cataclysm/src/core/cataclysm.Selector.scala
@@ -33,6 +33,8 @@
 package cataclysm
 
 import anticipation.*
+import gossamer.*
+import spectacular.*
 import vacuous.*
 
 // The structural model of a CSS selector, following Selectors Level 4. The
@@ -40,12 +42,31 @@ import vacuous.*
 // `Selector` (a complex selector — compounds joined by combinators), and a
 // `Compound` (simple selectors with no whitespace between them, the tightest).
 
+object SelectorList:
+  given showable: SelectorList is Showable = _.selectors.map(_.show).join(t", ")
+
 case class SelectorList(selectors: List[Selector]) derives CanEqual
+
+object Selector:
+  given showable: Selector is Showable = selector =>
+    val lead = selector.lead.lay(t""):
+      case Combinator.Descendant => t""
+      case other                 => t"${other.show} "
+
+    val rest = selector.rest.map: (combinator, compound) =>
+      combinator match
+        case Combinator.Descendant => t" ${compound.show}"
+        case other                 => t" ${other.show} ${compound.show}"
+
+    t"$lead${selector.head.show}${rest.join}"
 
 // A complex selector: a head compound followed by combinator/compound steps.
 // `lead` is set only for a relative selector (e.g. the `>` in `:has(> img)`).
 case class Selector(lead: Optional[Combinator], head: Compound, rest: List[(Combinator, Compound)])
 derives CanEqual
+
+object Compound:
+  given showable: Compound is Showable = _.parts.map(_.show).join
 
 // A compound selector: a run of simple selectors bound together with no
 // combinator (hence no whitespace) between them.
@@ -54,6 +75,14 @@ case class Compound(parts: List[Simple]) derives CanEqual
 // The right-hand side of an attribute selector, e.g. the `^= "x" i` part.
 case class AttributeTest(matcher: AttributeMatcher, value: Text, modifier: Optional[Char])
 derives CanEqual
+
+object Combinator:
+  given showable: Combinator is Showable =
+    case Descendant        => t" "
+    case Child             => t">"
+    case NextSibling       => t"+"
+    case SubsequentSibling => t"~"
+    case Column            => t"||"
 
 enum Combinator derives CanEqual:
   case Descendant         //
@@ -74,6 +103,58 @@ enum Namespace derives CanEqual:
   case Any                    // *|
   case Default                // |
   case Named(prefix: Text)    // ns|
+
+object Simple:
+  given showable: Simple is Showable =
+    case Universal(namespace)          => t"${prefix(namespace)}*"
+    case Type(namespace, name)         => t"${prefix(namespace)}$name"
+    case Id(name)                      => t"#$name"
+    case Class(name)                   => t".$name"
+    case Nesting                       => t"&"
+    case Attribute(namespace, name, t) => t"[${prefix(namespace)}$name${attributeTest(t)}]"
+    case PseudoClass(name, argument)   => t":$name${pseudoArgument(argument)}"
+    case PseudoElement(name, argument) => t"::$name${pseudoArgument(argument)}"
+
+  // Render the optional namespace prefix of a type, universal or attribute selector.
+  private def prefix(namespace: Optional[Namespace]): Text = namespace.lay(t""):
+    case Namespace.Any         => t"*|"
+    case Namespace.Default     => t"|"
+    case Namespace.Named(name) => t"$name|"
+
+  private def attributeTest(test: Optional[AttributeTest]): Text = test.lay(t""): test =>
+    val modifier = test.modifier.lay(t""): char => t" ${char.show}"
+    t"${matcherSymbol(test.matcher)}${test.value}$modifier"
+
+  private def matcherSymbol(matcher: AttributeMatcher): Text = matcher match
+    case AttributeMatcher.Exact     => t"="
+    case AttributeMatcher.Includes  => t"~="
+    case AttributeMatcher.DashMatch => t"|="
+    case AttributeMatcher.Prefix    => t"^="
+    case AttributeMatcher.Suffix    => t"$$="
+    case AttributeMatcher.Substring => t"*="
+
+  private def pseudoArgument(argument: Optional[PseudoArgument]): Text = argument.lay(t""):
+    case PseudoArgument.Selectors(list) => t"(${list.show})"
+    case PseudoArgument.Nth(a, b, of)   => t"(${nth(a, b)}${ofClause(of)})"
+    case PseudoArgument.Raw(text)       => t"($text)"
+
+  private def ofClause(of: Optional[SelectorList]): Text = of.lay(t""): list =>
+    t" of ${list.show}"
+
+  // Render an `An+B` micro-syntax, canonicalising `1n`→`n`, `-1n`→`-n` and `a==0`→`b`.
+  private def nth(a: Int, b: Int): Text =
+    if a == 0 then b.show else
+      val coefficient = a match
+        case 1  => t"n"
+        case -1 => t"-n"
+        case _  => t"${a}n"
+
+      val offset =
+        if b == 0 then t""
+        else if b > 0 then t"+$b"
+        else t"-${-b}"
+
+      t"$coefficient$offset"
 
 enum Simple derives CanEqual:
   case Universal(namespace: Optional[Namespace])                                  // *

--- a/lib/cataclysm/src/core/cataclysm.StyleMacros.scala
+++ b/lib/cataclysm/src/core/cataclysm.StyleMacros.scala
@@ -32,60 +32,71 @@
                                                                                                   */
 package cataclysm
 
+import scala.quoted.*
+
 import anticipation.*
+import contingency.*
+import fulminate.*
 import gossamer.*
-import iridescence.*
-import prepositional.*
-import quantitative.*
-import spectacular.*
+import vacuous.*
 
-// Records that a native Scala type renders to a CSS value of the value-definition
-// type `Topic` (e.g. `"length"`, `"color"`). A single generic `Conversion` (in
-// `Css.Value`) lifts any such type into a `Css.Value of Topic`, so a new
-// convertible type costs one instance here, not one given per CSS property.
-object CssConvertible:
-  given pixels: (Quantity[Pixels[1]] is CssConvertible of "length") = q => t"${number(q.value)}px"
-  given ems: (Quantity[Ems[1]] is CssConvertible of "length") = q => t"${number(q.value)}em"
-  given rems: (Quantity[Rems[1]] is CssConvertible of "length") = q => t"${number(q.value)}rem"
-  given exs: (Quantity[Exs[1]] is CssConvertible of "length") = q => t"${number(q.value)}ex"
-  given chs: (Quantity[Chs[1]] is CssConvertible of "length") = q => t"${number(q.value)}ch"
+// Compile-time machinery behind the `Css.Style(borderWidth = …, color = …)`
+// dynamic constructor. Each named parameter's camelCase label becomes a
+// kebab-case property name; the value's type must have a `CssConvertible`
+// instance (which both renders it and tags it with a value-definition-syntax
+// type); and that type is checked against the property's grammar, so e.g.
+// `Css.Style(color = 4.0*Px)` and `Css.Style(notAProperty = …)` fail to compile.
+object StyleMacros:
+  def style(properties: Expr[Seq[(Label, Any)]])(using Quotes): Expr[Css.Style] =
+    import quotes.reflect.*
 
-  given vws: (Quantity[ViewportWidths[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}vw"
+    def refinements(repr: TypeRepr): Map[Text, TypeRepr] = repr.dealias match
+      case Refinement(parent, name, TypeBounds(_, hi)) => refinements(parent).updated(name.tt, hi)
+      case Refinement(parent, name, info)              => refinements(parent).updated(name.tt, info)
+      case AndType(left, right)                        => refinements(left) ++ refinements(right)
+      case _                                           => Map()
 
-  given vhs: (Quantity[ViewportHeights[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}vh"
+    // The value-definition-syntax type the convertible tags its values with.
+    def topicOf(convertible: Expr[Any]): Text =
+      val members = refinements(convertible.asTerm.tpe) ++ refinements(convertible.asTerm.tpe.widen)
 
-  given vmins: (Quantity[ViewportMins[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}vmin"
+      members.get(t"Topic") match
+        case Some(ConstantType(StringConstant(name))) => name.tt
+        case _                                        => t""
 
-  given vmaxes: (Quantity[ViewportMaxes[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}vmax"
+    // A canonical instance of a value type, used to probe the property's grammar.
+    def sample(topic: Text): Optional[Text] = topic match
+      case t"length"     => t"1px"
+      case t"color"      => t"#000000"
+      case t"percentage" => t"1%"
+      case t"number"     => t"1.5"
+      case t"integer"    => t"1"
+      case _             => Unset
 
-  given centimetres: (Quantity[Centimetres[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}cm"
+    def check(property: Text, topic: Text): Unit =
+      val propertyDef = PropertyDef.of(property).or:
+        halt(m"cataclysm: $property is not a known CSS property")
 
-  given millimetres: (Quantity[Millimetres[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}mm"
+      sample(topic).lay(()): sampleText =>
+        val outcome = safely(SyntaxMatcher.check(propertyDef, sampleText))
 
-  given inches: (Quantity[Inches[1]] is CssConvertible of "length") = q => t"${number(q.value)}in"
-  given points: (Quantity[Points[1]] is CssConvertible of "length") = q => t"${number(q.value)}pt"
-  given picas: (Quantity[Picas[1]] is CssConvertible of "length") = q => t"${number(q.value)}pc"
+        if outcome.or(Outcome.Unsupported(Nil)) == Outcome.Invalid
+        then halt(m"cataclysm: a $topic value is not valid for the $property property")
 
-  given percents: (Quantity[Percents[1]] is CssConvertible of "percentage") =
-    q => t"${number(q.value)}%"
+    def recur(exprs: Seq[Expr[(Label, Any)]]): List[Expr[(Text, Text)]] = exprs match
+      case '{type key <: Label; ($key: key, $value: value)} +: tail =>
+        val convertible = Expr.summon[value is CssConvertible].getOrElse:
+          halt(m"cataclysm: no CSS value is available for this property's value")
 
-  given srgb: (Srgb is CssConvertible of "color") = hex(_)
-  given integer: (Int is CssConvertible of "integer") = _.show
-  given decimal: (Double is CssConvertible of "number") = Css.number(_)
+        val name = key.value.getOrElse(halt(m"cataclysm: the property name must be a literal"))
+        val property = name.tt.uncamel.kebab
+        check(property, topicOf(convertible))
 
-  private def number(value: Double): Text = Css.number(value)
+        '{(${Expr(property)}, $convertible.value($value))} :: recur(tail)
 
-  private def hex(color: Srgb): Text =
-    def channel(component: Double): Text =
-      String.format("%02x", (component*255).toInt.max(0).min(255)).nn.tt
+      case _ =>
+        Nil
 
-    t"#${channel(color.red)}${channel(color.green)}${channel(color.blue)}"
-
-trait CssConvertible extends Typeclass, Topical:
-  def value(self: Self): Text
+    properties match
+      case Varargs(exprs) => '{Css.Style.of(${Expr.ofList(recur(exprs))})}
+      case _              => '{Css.Style.of(Nil)}

--- a/lib/cataclysm/src/core/cataclysm_core.scala
+++ b/lib/cataclysm/src/core/cataclysm_core.scala
@@ -77,3 +77,7 @@ private def argumentSimples(argument: Optional[PseudoArgument]): List[Simple] =
     case PseudoArgument.Selectors(list) => listSimples(list)
     case PseudoArgument.Nth(_, _, of)   => of.lay(Nil)(listSimples)
     case PseudoArgument.Raw(_)          => Nil
+
+package cssFormatters:
+  given standard: CssFormatter = CssFormatter(newlines = true, spaces = true)
+  given compact: CssFormatter = CssFormatter(newlines = false, spaces = false)

--- a/lib/cataclysm/src/core/cataclysm_units.scala
+++ b/lib/cataclysm/src/core/cataclysm_units.scala
@@ -32,40 +32,66 @@
                                                                                                   */
 package cataclysm
 
-import anticipation.*
-import parasite.*
-import prepositional.*
-import spectacular.*
-import turbulence.*
-import vacuous.*
+import quantitative.*
+import rudiments.*
 
-object Css:
-  enum Node derives CanEqual:
-    case Rule(selector: SelectorList, body: List[Node])
-    case Declaration(property: Text, value: Text)
-    case At(name: Text, prelude: Text, body: Optional[List[Node]])
+// CSS's relative and viewport length units are modelled as fresh Quantitative
+// dimensions with no `Ratio` to anything else, so they are deliberately
+// inconvertible: `2.0.em + 1.0.vh` and `1.0.px.in[Centimetres]` are both compile
+// errors. The absolute units (cm, mm, in, pt, pc) live in Quantitative's existing
+// `Distance` dimension and interconvert with one another as usual.
+sealed trait CssPixel extends Dimension
+sealed trait CssFontSize extends Dimension
+sealed trait CssRootFontSize extends Dimension
+sealed trait CssXHeight extends Dimension
+sealed trait CssCharacterWidth extends Dimension
+sealed trait CssViewportWidth extends Dimension
+sealed trait CssViewportHeight extends Dimension
+sealed trait CssViewportMin extends Dimension
+sealed trait CssViewportMax extends Dimension
 
-  given streamable: (Monitor, Codicil, CssFormatter) => Css is Streamable by Text =
-    CssSerializer.emit(_).to(Stream)
+trait Pixels[Power <: Nat] extends Units[Power, CssPixel]
+trait Ems[Power <: Nat] extends Units[Power, CssFontSize]
+trait Rems[Power <: Nat] extends Units[Power, CssRootFontSize]
+trait Exs[Power <: Nat] extends Units[Power, CssXHeight]
+trait Chs[Power <: Nat] extends Units[Power, CssCharacterWidth]
+trait ViewportWidths[Power <: Nat] extends Units[Power, CssViewportWidth]
+trait ViewportHeights[Power <: Nat] extends Units[Power, CssViewportHeight]
+trait ViewportMins[Power <: Nat] extends Units[Power, CssViewportMin]
+trait ViewportMaxes[Power <: Nat] extends Units[Power, CssViewportMax]
 
-  given showable: CssFormatter => Css is Showable = CssSerializer.render(_)
+// CSS-named absolute units in Quantitative's `Distance` dimension, alongside the
+// existing `Inches`, `Points` and `Picas`.
+object Centimetres:
+  inline given ratio: Ratio[Centimetres[-1] & Metres[1], 0.01] = !!
 
-  // A typed CSS value tagged with its value-definition-syntax type (e.g.
-  // `Css.Value of "length"`). Native types convert in via `CssConvertible`; the
-  // type is `into`, so a colour or quantity is accepted wherever a value of the
-  // matching VDS type is expected.
-  object Value:
-    def apply(text: Text): Value =
-      val text0 = text
+trait Centimetres[Power <: Nat] extends Units[Power, Distance]
 
-      new Value:
-        def text: Text = text0
+object Millimetres:
+  inline given ratio: Ratio[Millimetres[-1] & Metres[1], 0.001] = !!
 
-    given converter: [value] => (convertible: value is CssConvertible)
-    =>  Conversion[value, Value of convertible.Topic] = instance =>
-      Value(convertible.value(instance)).asInstanceOf[Value of convertible.Topic]
+trait Millimetres[Power <: Nat] extends Units[Power, Distance]
 
-  into trait Value extends Topical:
-    def text: Text
+// A CSS percentage, e.g. `50.0.pct`.
+opaque type Percentage = Double
 
-case class Css(rules: List[Css.Node]) derives CanEqual
+object Percentage:
+  def apply(value: Double): Percentage = value
+  extension (percentage: Percentage) def value: Double = percentage
+
+extension (value: Double)
+  def px: Quantity[Pixels[1]] = Quantity(value)
+  def em: Quantity[Ems[1]] = Quantity(value)
+  def rem: Quantity[Rems[1]] = Quantity(value)
+  def ex: Quantity[Exs[1]] = Quantity(value)
+  def ch: Quantity[Chs[1]] = Quantity(value)
+  def vw: Quantity[ViewportWidths[1]] = Quantity(value)
+  def vh: Quantity[ViewportHeights[1]] = Quantity(value)
+  def vmin: Quantity[ViewportMins[1]] = Quantity(value)
+  def vmax: Quantity[ViewportMaxes[1]] = Quantity(value)
+  def cm: Quantity[Centimetres[1]] = Quantity(value)
+  def mm: Quantity[Millimetres[1]] = Quantity(value)
+  def inch: Quantity[Inches[1]] = Quantity(value)
+  def pt: Quantity[Points[1]] = Quantity(value)
+  def pc: Quantity[Picas[1]] = Quantity(value)
+  def pct: Percentage = Percentage(value)

--- a/lib/cataclysm/src/core/cataclysm_units.scala
+++ b/lib/cataclysm/src/core/cataclysm_units.scala
@@ -35,11 +35,11 @@ package cataclysm
 import quantitative.*
 import rudiments.*
 
-// CSS's relative and viewport length units are modelled as fresh Quantitative
-// dimensions with no `Ratio` to anything else, so they are deliberately
-// inconvertible: `2.0.em + 1.0.vh` and `1.0.px.in[Centimetres]` are both compile
-// errors. The absolute units (cm, mm, in, pt, pc) live in Quantitative's existing
-// `Distance` dimension and interconvert with one another as usual.
+// CSS's relative and viewport units are modelled as fresh Quantitative dimensions
+// with no `Ratio` to anything else, so they are deliberately inconvertible:
+// `2.0*Em + 1.0*Vh` and `(1.0*Px).in[Centimetres]` are compile errors. The
+// absolute units (cm, mm, in, pt, pc) live in Quantitative's existing `Distance`
+// dimension and interconvert with one another as usual.
 sealed trait CssPixel extends Dimension
 sealed trait CssFontSize extends Dimension
 sealed trait CssRootFontSize extends Dimension
@@ -49,6 +49,7 @@ sealed trait CssViewportWidth extends Dimension
 sealed trait CssViewportHeight extends Dimension
 sealed trait CssViewportMin extends Dimension
 sealed trait CssViewportMax extends Dimension
+sealed trait CssRatio extends Dimension
 
 trait Pixels[Power <: Nat] extends Units[Power, CssPixel]
 trait Ems[Power <: Nat] extends Units[Power, CssFontSize]
@@ -59,6 +60,7 @@ trait ViewportWidths[Power <: Nat] extends Units[Power, CssViewportWidth]
 trait ViewportHeights[Power <: Nat] extends Units[Power, CssViewportHeight]
 trait ViewportMins[Power <: Nat] extends Units[Power, CssViewportMin]
 trait ViewportMaxes[Power <: Nat] extends Units[Power, CssViewportMax]
+trait Percents[Power <: Nat] extends Units[Power, CssRatio]
 
 // CSS-named absolute units in Quantitative's `Distance` dimension, alongside the
 // existing `Inches`, `Points` and `Picas`.
@@ -72,26 +74,20 @@ object Millimetres:
 
 trait Millimetres[Power <: Nat] extends Units[Power, Distance]
 
-// A CSS percentage, e.g. `50.0.pct`.
-opaque type Percentage = Double
-
-object Percentage:
-  def apply(value: Double): Percentage = value
-  extension (percentage: Percentage) def value: Double = percentage
-
-extension (value: Double)
-  def px: Quantity[Pixels[1]] = Quantity(value)
-  def em: Quantity[Ems[1]] = Quantity(value)
-  def rem: Quantity[Rems[1]] = Quantity(value)
-  def ex: Quantity[Exs[1]] = Quantity(value)
-  def ch: Quantity[Chs[1]] = Quantity(value)
-  def vw: Quantity[ViewportWidths[1]] = Quantity(value)
-  def vh: Quantity[ViewportHeights[1]] = Quantity(value)
-  def vmin: Quantity[ViewportMins[1]] = Quantity(value)
-  def vmax: Quantity[ViewportMaxes[1]] = Quantity(value)
-  def cm: Quantity[Centimetres[1]] = Quantity(value)
-  def mm: Quantity[Millimetres[1]] = Quantity(value)
-  def inch: Quantity[Inches[1]] = Quantity(value)
-  def pt: Quantity[Points[1]] = Quantity(value)
-  def pc: Quantity[Picas[1]] = Quantity(value)
-  def pct: Percentage = Percentage(value)
+// One unit of each CSS dimension, to be multiplied by a number, e.g. `4.0*Px` or
+// `50.0*Pct`. Absolute lengths reuse Quantitative's `Inch`, with `Cm`/`Mm`/`Pt`/
+// `Pc` added here.
+val Px: Quantity[Pixels[1]] = Quantity(1.0)
+val Em: Quantity[Ems[1]] = Quantity(1.0)
+val Rem: Quantity[Rems[1]] = Quantity(1.0)
+val Ex: Quantity[Exs[1]] = Quantity(1.0)
+val Ch: Quantity[Chs[1]] = Quantity(1.0)
+val Vw: Quantity[ViewportWidths[1]] = Quantity(1.0)
+val Vh: Quantity[ViewportHeights[1]] = Quantity(1.0)
+val Vmin: Quantity[ViewportMins[1]] = Quantity(1.0)
+val Vmax: Quantity[ViewportMaxes[1]] = Quantity(1.0)
+val Cm: Quantity[Centimetres[1]] = Quantity(1.0)
+val Mm: Quantity[Millimetres[1]] = Quantity(1.0)
+val Pt: Quantity[Points[1]] = Quantity(1.0)
+val Pc: Quantity[Picas[1]] = Quantity(1.0)
+val Pct: Quantity[Percents[1]] = Quantity(1.0)

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -34,7 +34,9 @@ package soundness
 
 export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
     Simple, Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument, CssFormatter,
-    CssSerializer}
+    CssSerializer, CssConvertible, Percentage, Pixels, Ems, Rems, Exs, Chs, ViewportWidths,
+    ViewportHeights, ViewportMins, ViewportMaxes, Centimetres, Millimetres, px, em, rem, ex, ch, vw,
+    vh, vmin, vmax, cm, mm, inch, pt, pc, pct}
 
 package cssFormatters:
   export cataclysm.cssFormatters.{standard, compact}

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -33,4 +33,8 @@
 package soundness
 
 export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
-    Simple, Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument}
+    Simple, Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument, CssFormatter,
+    CssSerializer}
+
+package cssFormatters:
+  export cataclysm.cssFormatters.{standard, compact}

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -34,9 +34,9 @@ package soundness
 
 export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
     Simple, Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument, CssFormatter,
-    CssSerializer, CssConvertible, Percentage, Pixels, Ems, Rems, Exs, Chs, ViewportWidths,
-    ViewportHeights, ViewportMins, ViewportMaxes, Centimetres, Millimetres, px, em, rem, ex, ch, vw,
-    vh, vmin, vmax, cm, mm, inch, pt, pc, pct}
+    CssSerializer, CssConvertible, Pixels, Ems, Rems, Exs, Chs, ViewportWidths,
+    ViewportHeights, ViewportMins, ViewportMaxes, Centimetres, Millimetres, Percents, Px, Em, Rem,
+    Ex, Ch, Vw, Vh, Vmin, Vmax, Cm, Mm, Pt, Pc, Pct}
 
 package cssFormatters:
   export cataclysm.cssFormatters.{standard, compact}

--- a/lib/cataclysm/src/html/cataclysm_html.scala
+++ b/lib/cataclysm/src/html/cataclysm_html.scala
@@ -43,6 +43,10 @@ import prepositional.*
 // both).
 transparent inline def attributeFor[name <: Label]: Text = ${HtmlMacros.attributeFor[name]}
 
+// Lets a `Css.Style` be used as an inline `style="…"` attribute value in
+// Honeycomb, e.g. `Div(style = Css.Style(color = rgb, width = 4.0*Px))`.
+given inlineStyle: (Css.Style is Attributive to Whatwg.Css) = _ -> _.text
+
 // Import this to make `Tag.foo(…)` check `foo` against the in-scope `Styles`
 // stylesheet, attaching `class="foo"` or `id="foo"` accordingly.
 package cssBindings:

--- a/lib/cataclysm/src/html/soundness_cataclysm_html.scala
+++ b/lib/cataclysm/src/html/soundness_cataclysm_html.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export cataclysm.Styles
+export cataclysm.{Styles, inlineStyle}
 
 package cssBindings:
   export cataclysm.cssBindings.checked

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -601,3 +601,40 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"a nested at-rule round-trips through serialization"):
         roundTrip(nestedAt)
       . assert(_ == nestedAt)
+
+    suite(m"Typed CSS values"):
+      def lengthText(value: Css.Value of "length"): Text = value.text
+      def colorText(value: Css.Value of "color"): Text = value.text
+      def percentageText(value: Css.Value of "percentage"): Text = value.text
+
+      test(m"pixels render with a px suffix"):
+        lengthText(2.0.px)
+      . assert(_ == t"2px")
+
+      test(m"a fractional em keeps its decimal"):
+        lengthText(1.5.em)
+      . assert(_ == t"1.5em")
+
+      test(m"a viewport-height value renders as vh"):
+        lengthText(100.0.vh)
+      . assert(_ == t"100vh")
+
+      test(m"a centimetre value renders as cm"):
+        lengthText(3.0.cm)
+      . assert(_ == t"3cm")
+
+      test(m"an Srgb colour renders as a hex triplet"):
+        colorText(iridescence.Srgb(1.0, 0.0, 0.0))
+      . assert(_ == t"#ff0000")
+
+      test(m"a percentage renders with a percent sign"):
+        percentageText(50.0.pct)
+      . assert(_ == t"50%")
+
+      test(m"adding two different relative units fails to compile"):
+        demilitarize(2.0.em + 1.0.vh).nonEmpty
+      . assert(_ == true)
+
+      test(m"adding a relative and an absolute length fails to compile"):
+        demilitarize(2.0.px + 3.0.cm).nonEmpty
+      . assert(_ == true)

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -608,19 +608,19 @@ object Tests extends Suite(m"Cataclysm Tests"):
       def percentageText(value: Css.Value of "percentage"): Text = value.text
 
       test(m"pixels render with a px suffix"):
-        lengthText(2.0.px)
+        lengthText(2.0*Px)
       . assert(_ == t"2px")
 
       test(m"a fractional em keeps its decimal"):
-        lengthText(1.5.em)
+        lengthText(1.5*Em)
       . assert(_ == t"1.5em")
 
       test(m"a viewport-height value renders as vh"):
-        lengthText(100.0.vh)
+        lengthText(100.0*Vh)
       . assert(_ == t"100vh")
 
       test(m"a centimetre value renders as cm"):
-        lengthText(3.0.cm)
+        lengthText(3.0*Cm)
       . assert(_ == t"3cm")
 
       test(m"an Srgb colour renders as a hex triplet"):
@@ -628,13 +628,38 @@ object Tests extends Suite(m"Cataclysm Tests"):
       . assert(_ == t"#ff0000")
 
       test(m"a percentage renders with a percent sign"):
-        percentageText(50.0.pct)
+        percentageText(50.0*Pct)
       . assert(_ == t"50%")
 
       test(m"adding two different relative units fails to compile"):
-        demilitarize(2.0.em + 1.0.vh).nonEmpty
+        demilitarize(2.0*Em + 1.0*Vh).nonEmpty
       . assert(_ == true)
 
       test(m"adding a relative and an absolute length fails to compile"):
-        demilitarize(2.0.px + 3.0.cm).nonEmpty
+        demilitarize(2.0*Px + 3.0*Cm).nonEmpty
       . assert(_ == true)
+
+    suite(m"CSS output integrations"):
+      test(m"a stylesheet is served with the text/css media type"):
+        t"a { color: red }".read[Css].mediaType.show
+      . assert(_.starts(t"text/css"))
+
+      test(m"an inline style renders its declarations"):
+        Css.Style(color = iridescence.Srgb(1.0, 0.0, 0.0), width = 4.0*Px).text
+      . assert(_ == t"color: #ff0000; width: 4px")
+
+      test(m"a camelCase property name becomes kebab-case"):
+        Css.Style(borderWidth = 2.0*Px).text
+      . assert(_ == t"border-width: 2px")
+
+      test(m"a value of the wrong type fails to compile"):
+        demilitarize(Css.Style(color = 4.0*Px)).exists(_.message.contains("not valid for"))
+      . assert(_ == true)
+
+      test(m"an unknown property fails to compile"):
+        demilitarize(Css.Style(notARealProperty = 4.0*Px)).exists(_.message.contains("known CSS"))
+      . assert(_ == true)
+
+      test(m"a Css.Style is usable as a Honeycomb style attribute"):
+        summon[Css.Style is Attributive to Whatwg.Css]
+      . assert(_ != Unset)

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -574,3 +574,30 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"a missing closing brace is reported"):
         capture[CssErrors](t"a { color: red;".read[Css]).errors.head.reason
       . assert(_ == CssError.Reason.UnexpectedEnd)
+
+    suite(m"CSS serialization"):
+      val complex = t"""ul > li.item:nth-child(2n+1) a[href^="http"] { color: red }""".read[Css]
+
+      val nestedAtText =
+        t"@media screen and (min-width: 700px) { a { color: red; & b { color: blue } } }"
+
+      val nestedAt = nestedAtText.read[Css]
+
+      def roundTrip(css: Css): Css =
+        CssSerializer.render(css)(using cssFormatters.compact).read[Css]
+
+      test(m"compact serialization has no spaces or newlines"):
+        CssSerializer.render(t"a { color: red }".read[Css])(using cssFormatters.compact)
+      . assert(_ == t"a{color:red;}")
+
+      test(m"standard serialization indents declarations"):
+        CssSerializer.render(t"a { color: red }".read[Css])(using cssFormatters.standard)
+      . assert(_ == t"a {\n  color: red;\n}\n")
+
+      test(m"a complex selector round-trips through serialization"):
+        roundTrip(complex)
+      . assert(_ == complex)
+
+      test(m"a nested at-rule round-trips through serialization"):
+        roundTrip(nestedAt)
+      . assert(_ == nestedAt)


### PR DESCRIPTION
Cataclysm gains an output side to complement its parser: a streaming serializer that renders the `Css` AST back to text, a typed CSS-value system with native-type converters, and integrations to serve CSS over HTTP and as an inline HTML style attribute.

The serializer streams through a `zephyrine.Emitter` (the same mechanism Honeycomb uses for HTML), with the output style chosen by a contextual `CssFormatter`:

```scala
import cssFormatters.standard   // or cssFormatters.compact
stylesheet.show                 // or CssSerializer.emit(stylesheet) for a stream
```

Typed values are written `Css.Value of "xyz"` (the value-definition-syntax type), modelled on Xenophile's `Foreign of "X"`. It is an `into` type, so a native colour (iridescence) or quantity converts in automatically. CSS units are value singletons multiplied by a number — `4.0*Px`, `1.5*Em`, `50.0*Pct` — with the relative/viewport units (`Px`, `Em`, `Vh`, …) given their own Quantitative dimensions so they are deliberately inconvertible (`2.0*Em + 1.0*Vh` is a compile error), while absolute lengths (`Cm`, `Mm`, `Inch`, `Pt`, `Pc`) share the `Distance` dimension.

Declarations are built with a checked `Dynamic` constructor that converts camelCase names to kebab-case and verifies each value's type against the property's grammar at compile time:

```scala
Css.Style(borderWidth = 4.0*Px, color = rgb)   // ⇒ border-width: 4px; color: #…
Css.Style(color = 4.0*Px)                       // compile error: a length is not valid for color
Css.Style(notAProperty = 4.0*Px)               // compile error: not a known CSS property
```

A `Css` is served as an HTTP `text/css` response body (`Media` + `Streamable`), and a `Css.Style` is usable as a Honeycomb inline `style="…"` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
