### PR TITLE
Test and benchmark the native HTTP/1.1 server backend

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1288,6 +1288,7 @@ object scintillate extends Library:
     def mvnDeps = Seq(mvn"jakarta.servlet:jakarta.servlet-api:6.0.0")
 
   object test extends Tests(server, servlet)
+  object bench extends Benchmarks(server, eucalyptus.core, quantitative.units)
 
 object sedentary extends Library:
   object core extends Component(superlunary.jvm, anthology.bundle, diuretic.core, quantitative.units):

--- a/lib/scintillate/src/bench/scintillate.Benchmarks.scala
+++ b/lib/scintillate/src/bench/scintillate.Benchmarks.scala
@@ -1,0 +1,128 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package scintillate
+
+import scala.quoted.*
+
+import ambience.*, environments.java, systems.java
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import eucalyptus.*, logging.silent
+import fulminate.*
+import gossamer.*
+import hellenism.*, classloaders.threadContext
+import hieroglyph.*, charEncoders.utf8
+import probably.*
+import proscenium.*
+import quantitative.*
+import rudiments.*
+import sedentary.*
+import symbolism.*
+import telekinesis.*
+import temporaryDirectories.system
+import turbulence.*
+import vacuous.*
+import webserverErrorPages.minimal
+
+// Benchmarks for the raw-TCP HTTP/1.1 server. The wire-codec benchmarks (parse,
+// serialize) and the full-pipeline benchmark all run entirely in memory — no
+// socket and no threads — so they measure the per-request CPU cost of the HTTP
+// machinery, isolated from OS-socket and Loom-scheduling overhead.
+object Benchmarks extends Suite(m"Scintillate socket-server benchmarks"):
+  sealed trait Information extends Dimension
+  sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
+  val Byte: MetricUnit[Bytes[1]] = MetricUnit(1.0)
+
+  given byteDesignation: Designation[Bytes[1]] = () => t"B"
+  given decimalizer:     Decimalizer            = Decimalizer(2)
+  given device:          BenchmarkDevice        = LocalhostDevice
+  given prefixes:        Prefixes               = Prefixes(List(Kilo, Mega, Giga))
+
+  // A representative GET request with a handful of headers.
+  lazy val getRequest: Data =
+    t"GET /path/to/resource HTTP/1.1\r\nHost: example.com\r\nAccept: text/html\r\nUser-Agent: bench\r\n\r\n".data
+
+  lazy val getRequestBytes: Array[Byte] = getRequest.mutable(using Unsafe)
+
+  lazy val okResponse: Http.Response = Http.Response(Http.Ok)(t"Hello, World!")
+
+  val handler: HttpConnection ?=> Http.Response = okResponse
+
+  // 1000 GET requests back-to-back, built once; each pipeline run wraps this in a
+  // fresh (O(1)) `ByteArrayInputStream`, so the measurement excludes buffer setup.
+  val pipelineCount: Int = 1000
+
+  lazy val pipelineBuffer: Array[Byte] =
+    val unit = getRequestBytes
+    val total = new Array[Byte](unit.length*pipelineCount)
+    var index = 0
+
+    while index < pipelineCount do
+      _root_.java.lang.System.arraycopy(unit, 0, total, index*unit.length, unit.length)
+      index += 1
+
+    total
+
+  // Parse the request-line and headers of a single request.
+  def parseRequest(bytes: Data): Http.Method = Http.Request.parse(Stream(bytes)).method
+
+  // Serialise a fixed response to bytes, forcing the whole stream.
+  def serializeResponse(response: Http.Response): Int =
+    Http.Response.serialize(response).read[Data].length
+
+  // Drive every pipelined request through the full connection loop into a null
+  // sink: parse, frame body, dispatch, serialize, write, keep-alive bookkeeping.
+  def drivePipeline(): Int =
+    val in = _root_.java.io.ByteArrayInputStream(pipelineBuffer)
+    val out = _root_.java.io.OutputStream.nullOutputStream.nn
+    SocketServer(0).serveConnection(handler)(in, out)
+    pipelineCount
+
+  def run(): Unit =
+    val bench = Bench()
+
+    val requestSize  = getRequest.length*Byte
+    val responseSize = serializeResponse(okResponse)*Byte
+    val pipelineSize = getRequest.length*pipelineCount*Byte
+
+    suite(m"Wire codec (no socket, no threads)"):
+      bench(m"Parse a request head")(target = 1*Second, operationSize = requestSize):
+        '{ scintillate.Benchmarks.parseRequest(scintillate.Benchmarks.getRequest) }
+
+      bench(m"Serialize a fixed response")(target = 1*Second, operationSize = responseSize):
+        '{ scintillate.Benchmarks.serializeResponse(scintillate.Benchmarks.okResponse) }
+
+    suite(m"Full pipeline (in-process, no socket)"):
+      bench(m"1000 pipelined GETs through serveConnection")
+        ( target = 1*Second, operationSize = pipelineSize ):
+        '{ scintillate.Benchmarks.drivePipeline() }

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -50,69 +50,68 @@ import zephyrine.*
 // than `com.sun.net.httpserver`. Each accepted socket is handled on its own
 // Loom virtual thread (`daemon`). The handler API is identical to `HttpServer`'s
 // — a `HttpConnection ?=> Http.Response` — so the two backends are
-// interchangeable. This first cut serves a single request per connection and
-// closes it; keep-alive, request-body framing and connection upgrades build on
-// top of this skeleton.
+// interchangeable. The connection loop supports keep-alive and pipelining,
+// `Content-Length` and chunked request bodies, and `101` protocol upgrades.
 case class SocketServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
 extends RequestServable:
-  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
-  :   Service logs HttpServerEvent raises ServerError =
 
-    val idleTimeout: Int = 30000
+  private def writeAll(out: ji.OutputStream, stream: Stream[Data]): Unit raises StreamError =
+    var count: Int = 0
 
-    def startServer(): jn.ServerSocket raises ServerError =
+    stream.each: block =>
       try
-        val host = if local then "localhost" else "0.0.0.0"
-        jn.ServerSocket(port, 0, jn.InetAddress.getByName(host).nn)
-      catch case error: jn.BindException => abort(ServerError(port))
+        out.write(block.mutable(using Unsafe))
+        count += block.length
+      catch case _: ji.IOException => abort(StreamError(count.b))
 
-    def writeAll(out: ji.OutputStream, stream: Stream[Data]): Unit raises StreamError =
-      var count: Int = 0
+    try out.flush() catch case _: ji.IOException => abort(StreamError(count.b))
 
-      stream.each: block =>
-        try
-          out.write(block.mutable(using Unsafe))
-          count += block.length
-        catch case _: ji.IOException => abort(StreamError(count.b))
+  // Frame the request body off the shared connection cursor: chunked decoding
+  // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or empty
+  // when neither is given. The framed stream stops exactly at the body's end so
+  // the cursor is left at the next pipelined request.
+  private def requestBody(cursor: Cursor[Data], head: Http.Request.Head): Stream[Data] =
+    val chunked: Boolean = head.headers.exists: header =>
+      header.key.lower == t"transfer-encoding" && header.value.lower.contains(t"chunked")
 
-      try out.flush() catch case _: ji.IOException => abort(StreamError(count.b))
+    if chunked then Http.Request.chunkedBody(cursor) else
+      val length: Optional[Int] =
+        head.headers.filter(_.key.lower == t"content-length").prim.let(_.value)
+        . lay(Unset: Optional[Int]): text =>
+            safely(Integer.parseInt(text.s.trim.nn))
 
-    // Frame the request body off the shared connection cursor: chunked decoding
-    // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or
-    // empty when neither is given. The framed stream stops exactly at the body's
-    // end so the cursor is left at the next pipelined request.
-    def requestBody(cursor: Cursor[Data], head: Http.Request.Head): Stream[Data] =
-      val chunked: Boolean = head.headers.exists: header =>
-        header.key.lower == t"transfer-encoding" && header.value.lower.contains(t"chunked")
+      length.lay(Stream())(Http.Request.fixedBody(cursor, _))
 
-      if chunked then Http.Request.chunkedBody(cursor) else
-        val length: Optional[Int] =
-          head.headers.filter(_.key.lower == t"content-length").prim.let(_.value)
-          . lay(Unset: Optional[Int]): text =>
-              safely(Integer.parseInt(text.s.trim.nn))
+  // RFC 7230 §6.3: HTTP/1.1 keeps connections alive unless `Connection: close`;
+  // HTTP/1.0 closes unless `Connection: keep-alive`.
+  private def keepAlive(head: Http.Request.Head): Boolean =
+    val connection = head.headers.filter(_.key.lower == t"connection").map(_.value.lower)
 
-        length.lay(Stream())(Http.Request.fixedBody(cursor, _))
+    head.version match
+      case 1.1 => !connection.exists(_.contains(t"close"))
+      case _   => connection.exists(_.contains(t"keep-alive"))
 
-    // RFC 7230 §6.3: HTTP/1.1 keeps connections alive unless `Connection: close`;
-    // HTTP/1.0 closes unless `Connection: keep-alive`.
-    def keepAlive(head: Http.Request.Head): Boolean =
-      val connection = head.headers.filter(_.key.lower == t"connection").map(_.value.lower)
+  // A request asks to upgrade the protocol (e.g. to WebSocket) when it carries
+  // `Connection: Upgrade` together with an `Upgrade` header. Such a request's
+  // body is the unbounded remainder of the connection, so a frame reader can
+  // keep receiving bytes after the handshake.
+  private def isUpgrade(head: Http.Request.Head): Boolean =
+    head.headers.filter(_.key.lower == t"connection").exists(_.value.lower.contains(t"upgrade"))
+    && head.headers.exists(_.key.lower == t"upgrade")
 
-      head.version match
-        case 1.1 => !connection.exists(_.contains(t"close"))
-        case _   => connection.exists(_.contains(t"keep-alive"))
+  // Drive the HTTP/1.1 keep-alive loop over an arbitrary byte source and sink,
+  // independent of any socket. `handle` calls this once per accepted connection;
+  // it is also the in-process entry point for tests and benchmarks, which feed a
+  // `ByteArrayInputStream` of requests and capture the responses with no network
+  // involvement. The caller owns the streams (closing, read timeouts).
+  def serveConnection(handler: HttpConnection ?=> Http.Response)
+    ( in: ji.InputStream, out: ji.OutputStream )
+    ( using HttpServerEvent is Loggable )
+  :   Unit =
 
-    // A request asks to upgrade the protocol (e.g. to WebSocket) when it carries
-    // `Connection: Upgrade` together with an `Upgrade` header. Such a request's
-    // body is the unbounded remainder of the connection, so a frame reader can
-    // keep receiving bytes after the handshake.
-    def isUpgrade(head: Http.Request.Head): Boolean =
-      head.headers.filter(_.key.lower == t"connection").exists(_.value.lower.contains(t"upgrade"))
-      && head.headers.exists(_.key.lower == t"upgrade")
-
-    // Handle a single request off the cursor and return whether the connection
-    // should be kept alive for a further request.
-    def serveRequest(cursor: Cursor[Data], out: ji.OutputStream): Boolean raises StreamError =
+    // Handle one request off the cursor; return whether to keep the connection
+    // alive for a further request.
+    def serveRequest(cursor: Cursor[Data]): Boolean raises StreamError =
       whereas:
         case error: HttpRequestError =>
           val response = Http.Response(Http.BadRequest)() + Http.Header(t"connection", t"close")
@@ -157,30 +156,39 @@ extends RequestServable:
             body.each(_ => ())
             keep
 
-    def serve(socket: jn.Socket): Unit =
+    try
+      whereas:
+        case StreamError(length) =>
+          Log.warn(HttpServerEvent.BrokenStream(length))
+
+      . recover:
+          val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
+
+          var continue = true
+          while continue && !cursor.finished do continue = serveRequest(cursor)
+
+    catch case NonFatal(exception) => exception.printStackTrace()
+
+  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
+  :   Service logs HttpServerEvent raises ServerError =
+
+    val idleTimeout: Int = 30000
+
+    def startServer(): jn.ServerSocket raises ServerError =
       try
-        socket.setSoTimeout(idleTimeout)
-        val in = socket.getInputStream.nn
-        val out = socket.getOutputStream.nn
-
-        whereas:
-          case StreamError(length) =>
-            Log.warn(HttpServerEvent.BrokenStream(length))
-
-        . recover:
-            val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
-
-            var continue = true
-            while continue && !cursor.finished do continue = serveRequest(cursor, out)
-
-      catch case NonFatal(exception) => exception.printStackTrace()
-      finally safely(socket.close())
+        val host = if local then "localhost" else "0.0.0.0"
+        jn.ServerSocket(port, 0, jn.InetAddress.getByName(host).nn)
+      catch case error: jn.BindException => abort(ServerError(port))
 
     val serverSocket = startServer()
 
     val acceptLoop = loop:
       safely(serverSocket.accept().nn).let: socket =>
-        daemon(serve(socket))
+        daemon:
+          try
+            socket.setSoTimeout(idleTimeout)
+            serveConnection(handler)(socket.getInputStream.nn, socket.getOutputStream.nn)
+          finally safely(socket.close())
 
     val acceptTask = daemon(acceptLoop.run())
     val cancel: Promise[Unit] = Promise[Unit]()

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -167,3 +167,62 @@ object Tests extends Suite(m"Scintillate tests"):
           response
 
         . assert(r => r.contains(t"101 Switching Protocols") && r.ends(t"PING"))
+
+    // Drive the connection loop entirely in memory — no socket, no threads — by
+    // feeding request bytes through `serveConnection` and capturing the response.
+    def inProcess(handler: HttpConnection ?=> Http.Response, request: Text): Text =
+      val in = java.io.ByteArrayInputStream(request.s.getBytes("US-ASCII").nn)
+      val out = java.io.ByteArrayOutputStream()
+      SocketServer(0).serveConnection(handler)(in, out)
+      String(out.toByteArray.nn, "US-ASCII").tt
+
+    suite(m"In-process connection loop"):
+      test(m"A request is served entirely in-process with no socket"):
+        inProcess(Http.Response(Http.Ok)(t"in-process"), t"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+
+      . assert(_.contains(t"in-process"))
+
+      test(m"1000 pipelined requests produce 1000 responses"):
+        val many = t"GET / HTTP/1.1\r\nHost: x\r\n\r\n"*1000
+        inProcess(Http.Response(Http.Ok)(t"ok"), many).cut(t"HTTP/1.1 200 OK").length
+
+      . assert(_ == 1001)
+
+      test(m"Every truncation of a valid request is handled without hanging"):
+        val bytes = t"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello".s.getBytes("US-ASCII").nn
+        var n = 0
+
+        while n <= bytes.length do
+          val in = java.io.ByteArrayInputStream(bytes, 0, n)
+          SocketServer(0).serveConnection(Http.Response(Http.Ok)(t"ok"))(in, java.io.ByteArrayOutputStream())
+          n += 1
+
+        true
+
+      . assert(_ == true)
+
+      test(m"Random byte streams never crash or hang the loop"):
+        var seed: Long = 0x2545f4914f6cdd1dL
+
+        def next(): Int =
+          seed = seed*6364136223846793005L + 1442695040888963407L
+          ((seed >>> 56) & 0xff).toInt
+
+        var iteration = 0
+
+        while iteration < 1000 do
+          val length = next()%80
+          val bytes = new Array[Byte](length)
+          var i = 0
+
+          while i < length do
+            bytes(i) = next().toByte
+            i += 1
+
+          val in = java.io.ByteArrayInputStream(bytes)
+          SocketServer(0).serveConnection(Http.Response(Http.Ok)(t"ok"))(in, java.io.ByteArrayOutputStream())
+          iteration += 1
+
+        true
+
+      . assert(_ == true)


### PR DESCRIPTION
The raw-TCP HTTP/1.1 server backend gains a no-network testing and benchmarking story. `SocketServer`'s per-connection keep-alive loop is split out as a public `serveConnection(handler)(in, out)` over arbitrary streams, so the entire request pipeline — parse, body framing, dispatch, serialize, drain, keep-alive — can run in memory with no socket and no threads. That seam powers deterministic fuzz tests (every truncation of a valid request, and a thousand random byte streams, all asserting the loop terminates rather than hangs) and a benchmark suite that measures the HTTP machinery's per-request cost in isolation from socket and scheduler overhead.

## In-process testing and benchmarks for `SocketServer`

`SocketServer.serveConnection(handler)(in, out)` is now public: it drives the HTTP/1.1 keep-alive loop over any `java.io.InputStream`/`OutputStream`, independent of a socket. `handle` uses it per accepted connection, and it doubles as the entry point for in-memory tests and benchmarks.

A new `scintillate.bench` component measures the wire codec and the full pipeline with no network involved. Indicative local figures:

| Benchmark | Throughput |
|---|---|
| Parse a request head | ~1.4M req/s |
| Serialize a fixed response | ~4.4M resp/s |
| 1000 pipelined GETs end-to-end through `serveConnection` | ~547k req/s |

The test suite adds an in-process group: a thousand pipelined requests on one connection, every truncation of a valid request, and a thousand random byte streams — each asserting the connection loop terminates without crashing or hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
