### PR TITLE
Harden the native HTTP/1.1 server and add TLS

### DIFF
--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -34,10 +34,13 @@ package scintillate
 
 import java.io as ji
 import java.net as jn
+import javax.net.ssl as jns
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import gossamer.*
+import hieroglyph.charEncoders.ascii
 import parasite.*
 import rudiments.*
 import telekinesis.*
@@ -51,9 +54,19 @@ import zephyrine.*
 // Loom virtual thread (`daemon`). The handler API is identical to `HttpServer`'s
 // — a `HttpConnection ?=> Http.Response` — so the two backends are
 // interchangeable. The connection loop supports keep-alive and pipelining,
-// `Content-Length` and chunked request bodies, and `101` protocol upgrades.
-case class SocketServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
+// `Content-Length` and chunked request bodies, `100-continue`, request-size
+// limits, and `101` protocol upgrades. Supplying an `SSLContext` as `ssl` serves
+// over TLS instead of cleartext.
+case class SocketServer
+  ( port: Int, local: Boolean = true, ssl: Optional[jns.SSLContext] = Unset )
+  ( using errorPage: WebserverErrorPage )
 extends RequestServable:
+
+  // Cap on the bytes an unconsumed request body will be drained before the
+  // connection is closed rather than read in full to reach the next request.
+  private val drainLimit: Int = 65536
+
+  private val continueResponse: Data = t"HTTP/1.1 100 Continue\r\n\r\n".data
 
   private def writeAll(out: ji.OutputStream, stream: Stream[Data]): Unit raises StreamError =
     var count: Int = 0
@@ -99,6 +112,25 @@ extends RequestServable:
     head.headers.filter(_.key.lower == t"connection").exists(_.value.lower.contains(t"upgrade"))
     && head.headers.exists(_.key.lower == t"upgrade")
 
+  // A client may withhold a request body until the server agrees to receive it
+  // with an interim `100 Continue` (RFC 7231 §5.1.1).
+  private def expectsContinue(head: Http.Request.Head): Boolean =
+    head.version == 1.1 && head.headers.exists: header =>
+      header.key.lower == t"expect" && header.value.lower.contains(t"100-continue")
+
+  private def streaming(response: Http.Response): Boolean = response.body match
+    case Http.Body.Streaming(_) => true
+    case _                      => false
+
+  // Map a request-parsing failure to the status the client should see.
+  private def errorStatus(reason: HttpRequestError.Reason): Http.Status =
+    import HttpRequestError.Reason
+
+    reason match
+      case Reason.UriTooLong      => Http.UriTooLong
+      case Reason.HeadersTooLarge => Http.RequestHeaderFieldsTooLarge
+      case _                      => Http.BadRequest
+
   // Drive the HTTP/1.1 keep-alive loop over an arbitrary byte source and sink,
   // independent of any socket. `handle` calls this once per accepted connection;
   // it is also the in-process entry point for tests and benchmarks, which feed a
@@ -109,26 +141,39 @@ extends RequestServable:
     ( using HttpServerEvent is Loggable )
   :   Unit =
 
+    val closeHeader: Http.Header = Http.Header(t"connection", t"close")
+
     // Handle one request off the cursor; return whether to keep the connection
     // alive for a further request.
-    def serveRequest(cursor: Cursor[Data]): Boolean raises StreamError =
+    def serveRequest(cursor: Cursor[Data]): Boolean =
       whereas:
         case error: HttpRequestError =>
-          val response = Http.Response(Http.BadRequest)() + Http.Header(t"connection", t"close")
+          val response = Http.Response(errorStatus(error.reason))() + closeHeader
+          safely(writeAll(out, Http.Response.serialize(response)))
+          false
+
+        case StreamError(_) =>
+          // A read error or timeout while a request is in flight: best-effort 408
+          // (the socket may still be writable on a read timeout), then close.
+          val response = Http.Response(Http.RequestTimeout)() + closeHeader
           safely(writeAll(out, Http.Response.serialize(response)))
           false
 
       . recover:
           val head = Http.Request.parseHead(cursor)
           val upgrade = isUpgrade(head)
+
+          // Tell a waiting client it may send the body before we read it.
+          if expectsContinue(head) then writeAll(out, Stream(continueResponse))
+
           val body = if upgrade then cursor.remainder else requestBody(cursor, head)
-          val keep = keepAlive(head)
 
           val request =
             Http.Request
               ( head.method, head.version, head.host, head.target, head.headers, () => body )
 
           var upgraded = false
+          var keep = keepAlive(head)
 
           def respond(response: Http.Response): Unit raises StreamError =
             if response.status == Http.SwitchingProtocols then
@@ -138,23 +183,33 @@ extends RequestServable:
               upgraded = true
               writeAll(out, Http.Response.serialize(response))
             else
-              val response2 =
-                if keep then response else response + Http.Header(t"connection", t"close")
+              // A streaming body to a pre-1.1 client can't be chunked, so it must
+              // be delimited by closing the connection.
+              if head.version != 1.1 && streaming(response) then keep = false
+              val response2 = if keep then response else response + closeHeader
+              val bytes = Http.Response.serialize(response2, head.method != Http.Head, head.version)
+              writeAll(out, bytes)
 
-              writeAll(out, Http.Response.serialize(response2, head.method != Http.Head))
-
-          val connection = new HttpConnection(request, false, port, respond)
+          val connection = new HttpConnection(request, ssl.present, port, respond)
           Log.fine(HttpServerEvent.Received(request))
 
           connection.respond:
             try handler(using connection)
             catch case throwable: Throwable => errorPage.handle(throwable, connection)
 
-          if upgraded then false else
-            // Drain any body the handler did not consume, so the cursor is left
-            // at the start of the next request.
-            body.each(_ => ())
-            keep
+          if upgraded || !keep then false else
+            // Drain any body the handler did not consume so the cursor reaches the
+            // next request — but bound it: past `drainLimit` unread bytes, close
+            // rather than read a large ignored upload. Walking already-consumed
+            // (memoised) blocks doesn't move the cursor, so the position delta
+            // measures only what the drain itself reads.
+            val drainStart = cursor.position.n0
+
+            def drained(stream: Stream[Data]): Boolean = stream match
+              case _ #:: tail => cursor.position.n0 - drainStart <= drainLimit && drained(tail)
+              case _          => true
+
+            drained(body)
 
     try
       whereas:
@@ -176,8 +231,10 @@ extends RequestServable:
 
     def startServer(): jn.ServerSocket raises ServerError =
       try
-        val host = if local then "localhost" else "0.0.0.0"
-        jn.ServerSocket(port, 0, jn.InetAddress.getByName(host).nn)
+        val address = jn.InetAddress.getByName(if local then "localhost" else "0.0.0.0").nn
+
+        ssl.lay(jn.ServerSocket(port, 0, address)): context =>
+          context.getServerSocketFactory.nn.createServerSocket(port, 0, address).nn
       catch case error: jn.BindException => abort(ServerError(port))
 
     val serverSocket = startServer()

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -202,6 +202,57 @@ object Tests extends Suite(m"Scintillate tests"):
 
         . assert(_ == clients*perClient)
 
+      suite(m"TLS"):
+        test(m"The server serves a request over TLS"):
+          // A throwaway self-signed certificate, generated with the JDK's keytool.
+          val dir = java.nio.file.Files.createTempDirectory("scintillate-tls").nn
+          val path = dir.resolve("test.p12").nn.toString.nn
+
+          val keytool = java.lang.ProcessBuilder("keytool", "-genkeypair", "-alias", "test",
+              "-keyalg", "RSA", "-keysize", "2048", "-validity", "1", "-storetype", "PKCS12",
+              "-keystore", path, "-storepass", "changeit", "-dname", "CN=localhost")
+
+          keytool.redirectErrorStream(true)
+          keytool.redirectOutput(java.lang.ProcessBuilder.Redirect.DISCARD)
+          keytool.start().nn.waitFor()
+
+          val password = "changeit".toCharArray.nn
+          val keystore = java.security.KeyStore.getInstance("PKCS12").nn
+          keystore.load(java.io.FileInputStream(path), password)
+          val keyManagers = javax.net.ssl.KeyManagerFactory.getInstance("SunX509").nn
+          keyManagers.init(keystore, password)
+          val serverContext = javax.net.ssl.SSLContext.getInstance("TLS").nn
+          serverContext.init(keyManagers.getKeyManagers, null, null)
+
+          val port = freePort()
+
+          val server =
+            SocketServer(port, ssl = serverContext).handle(Http.Response(Http.Ok)(t"secure"))
+
+          // A client that trusts any certificate, so the self-signed one is accepted.
+          val trustManager = new javax.net.ssl.X509TrustManager:
+            type Certs = Array[java.security.cert.X509Certificate | Null] | Null
+
+            def getAcceptedIssuers: Certs =
+              scala.Array.empty[java.security.cert.X509Certificate | Null]
+
+            def checkClientTrusted(chain: Certs, kind: String | Null): Unit = ()
+            def checkServerTrusted(chain: Certs, kind: String | Null): Unit = ()
+
+          val clientContext = javax.net.ssl.SSLContext.getInstance("TLS").nn
+          clientContext.init(null, scala.Array(trustManager), java.security.SecureRandom())
+          val socket = clientContext.getSocketFactory.nn.createSocket("localhost", port).nn
+          val out = socket.getOutputStream.nn
+          val request = t"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+          out.write(request.s.getBytes("US-ASCII").nn)
+          out.flush()
+          val response = String(socket.getInputStream.nn.readAllBytes().nn, "US-ASCII").tt
+          socket.close()
+          server.cancel()
+          response
+
+        . assert(_.contains(t"secure"))
+
     // Drive the connection loop entirely in memory — no socket, no threads — by
     // feeding request bytes through `serveConnection` and capturing the response.
     def inProcess(handler: HttpConnection ?=> Http.Response, request: Text): Text =
@@ -260,3 +311,39 @@ object Tests extends Suite(m"Scintillate tests"):
         true
 
       . assert(_ == true)
+
+      test(m"Expect: 100-continue gets an interim 100 response"):
+        val request =
+          t"POST / HTTP/1.1\r\nHost: x\r\nExpect: 100-continue\r\nContent-Length: 5\r\n\r\nhello"
+
+        inProcess(Http.Response(Http.Ok)(t"done"), request)
+
+      . assert(r => r.contains(t"100 Continue") && r.contains(t"done"))
+
+      test(m"An over-long request line is rejected with 414"):
+        inProcess(Http.Response(Http.Ok)(t"ok"), t"GET /${t"a"*9000} HTTP/1.1\r\nHost: x\r\n\r\n")
+
+      . assert(_.contains(t"414"))
+
+      test(m"Over-large headers are rejected with 431"):
+        inProcess(Http.Response(Http.Ok)(t"ok"), t"GET / HTTP/1.1\r\nHost: x\r\nX-Big: ${t"a"*70000}\r\n\r\n")
+
+      . assert(_.contains(t"431"))
+
+      test(m"A streaming response to HTTP/1.0 is close-delimited, not chunked"):
+        val body = Http.Body.Streaming(Stream(t"Hello".data, t"World".data))
+        inProcess(Http.Response(Http.Ok)(body), t"GET / HTTP/1.0\r\nHost: x\r\n\r\n")
+
+      . assert: response =>
+          !response.contains(t"transfer-encoding: chunked")
+          && response.contains(t"connection: close")
+          && response.contains(t"HelloWorld")
+
+      test(m"A large unconsumed body closes the connection instead of draining"):
+        val request =
+          t"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 70000\r\n\r\n${t"a"*70000}"
+          + t"GET /second HTTP/1.1\r\nHost: x\r\n\r\n"
+
+        inProcess(Http.Response(Http.Ok)(t"ok"), request).cut(t"HTTP/1.1 200 OK").length - 1
+
+      . assert(_ == 1)

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -37,6 +37,7 @@ import language.dynamics
 import anticipation.*
 import coaxial.*
 import contingency.*
+import denominative.*
 import distillate.*
 import fulminate.*
 import gesticulate.*
@@ -261,26 +262,44 @@ object Http:
     // with `peek`/`next` rather than `seek` so it works on a bare `Cursor[Data]`
     // parameter (which loses the `tracked` `Operand = Byte` refinement that
     // `seek`'s signature relies on).
-    def parseHead(cursor: Cursor[Data]): Head raises HttpRequestError =
-      inline def expected(char: Char): Diagnostics ?=> HttpRequestError =
-        HttpRequestError(HttpRequestError.Reason.Expectation(char, cursor.peek.asInt.toChar))
+    // `maxRequestLine` and `maxHeaders` bound how many bytes the request line and
+    // the header block may occupy, yielding `414`/`431` (rather than reading an
+    // unbounded amount) — the scan aborts mid-token once the cap is crossed.
+    def parseHead
+      ( cursor: Cursor[Data], maxRequestLine: Int = 8192, maxHeaders: Int = 65536 )
+    :   Head raises HttpRequestError =
 
-      def upTo(stop: Char): Text = cursor.hold:
+      import HttpRequestError.Reason
+
+      inline def expected(char: Char): Diagnostics ?=> HttpRequestError =
+        HttpRequestError(Reason.Expectation(char, cursor.peek.asInt.toChar))
+
+      def upTo(stop: Char, limit: Int, reason: Reason): Text = cursor.hold:
         val start = cursor.mark
-        while !cursor.finished && !(cursor.peek == stop) do cursor.next()
+
+        while !cursor.finished && !(cursor.peek == stop) do
+          if cursor.position.n0 > limit then abort(HttpRequestError(reason))
+          cursor.next()
+
         Ascii(cursor.grab(start, cursor.mark)).show
 
-      val method: Http.Method = upTo(' ').decode[Http.Method]
+      val lineLimit = cursor.position.n0 + maxRequestLine
+
+      val method: Http.Method = upTo(' ', lineLimit, Reason.UriTooLong).decode[Http.Method]
       cursor.next()
 
-      val target: Text = upTo(' ')
+      val target: Text = upTo(' ', lineLimit, Reason.UriTooLong)
       cursor.next()
 
-      val version: Http.Version = Http.Version.parse(upTo('\r'))
+      val version: Http.Version = Http.Version.parse(upTo('\r', lineLimit, Reason.UriTooLong))
       cursor.next()
       cursor.expect('\n')(expected('\n'))
 
+      val headerLimit = cursor.position.n0 + maxHeaders
+
       def readHeaders(headers: List[Http.Header]): List[Http.Header] =
+        if cursor.position.n0 > headerLimit then abort(HttpRequestError(Reason.HeadersTooLarge))
+
         if cursor.peek == '\r' then
           // Consume the final CRLF with `advance` rather than `next`/`expect`:
           // `next` calls `more`, which forces a blocking refill of the underlying
@@ -294,12 +313,12 @@ object Http:
           headers
 
         else
-          val key: Text = upTo(':')
+          val key: Text = upTo(':', headerLimit, Reason.HeadersTooLarge)
           cursor.next()
 
           while cursor.peek == ' ' || cursor.peek == '\t' do cursor.next()
 
-          val value: Text = upTo('\r')
+          val value: Text = upTo('\r', headerLimit, Reason.HeadersTooLarge)
           cursor.next()
           cursor.expect('\n')(expected('\n'))
           readHeaders(Http.Header(key, value) :: headers)
@@ -530,13 +549,20 @@ object Http:
     // body. `includeBody` is `false` for responses to `HEAD` requests and for
     // `101` upgrades (where the caller pipes the post-handshake stream raw). The
     // inverse of `parse`.
-    def serialize(response: Response, includeBody: Boolean = true): Stream[Data] =
+    def serialize(response: Response, includeBody: Boolean = true, version: Version = 1.1)
+    :   Stream[Data] =
+
       import charEncoders.ascii
 
       // After `101 Switching Protocols` the bytes are no longer HTTP: the body is
       // the upgraded protocol's raw stream (e.g. WebSocket frames), so suppress
       // Content-Length / chunked framing and the headers that announce them.
       val upgrade: Boolean = response.status == Http.SwitchingProtocols
+
+      // Chunked transfer-encoding is an HTTP/1.1 feature; a streaming body to an
+      // HTTP/1.0 client must instead be delimited by closing the connection (the
+      // server adds `Connection: close`), so its body is written raw.
+      val chunkable: Boolean = version != 1.0 && version != 0.9
 
       val explicitChunked: Boolean = response.textHeaders.exists: header =>
         header.key.lower == t"transfer-encoding" && header.value.lower == t"chunked"
@@ -553,9 +579,10 @@ object Http:
             (if hasContentLength then Nil else List(Header(t"content-length", length)), false)
 
           case Body.Streaming(_) =>
-            if explicitChunked then (Nil, true)
+            if explicitChunked && chunkable then (Nil, true)
             else if hasContentLength then (Nil, false)
-            else (List(Header(t"transfer-encoding", t"chunked")), true)
+            else if chunkable then (List(Header(t"transfer-encoding", t"chunked")), true)
+            else (Nil, false)
 
       val headers: List[Header] =
         if !upgrade then response.textHeaders ++ extraHeaders else

--- a/lib/telekinesis/src/core/telekinesis.HttpRequestError.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpRequestError.scala
@@ -40,11 +40,15 @@ object HttpRequestError:
     case Expectation(expected: Char, found: Char) extends Reason(1)
     case Version(value: Text)                     extends Reason(2)
     case Host(value: Text)                        extends Reason(3)
+    case UriTooLong                               extends Reason(4)
+    case HeadersTooLarge                          extends Reason(5)
 
   given communicable: Reason is Communicable =
     case Reason.Expectation(expected, found) => m"$found was found when $expected was expected"
     case Reason.Version(value)               => m"the HTTP version $value was invalid"
     case Reason.Host(value)                  => m"the host $value was missing or invalid"
+    case Reason.UriTooLong                   => m"the request line exceeded the maximum length"
+    case Reason.HeadersTooLarge              => m"the request headers exceeded the maximum size"
 
 case class HttpRequestError(reason: HttpRequestError.Reason)(using Diagnostics)
 extends Error(367, reason.number)(m"could not parse HTTP request because $reason")


### PR DESCRIPTION
The raw-TCP HTTP/1.1 server backend gains the production-hardening items left over from the initial implementation, plus TLS. None of it changes the handler API.

## Server hardening and TLS

`SocketServer` now handles:

- **`Expect: 100-continue`** — a request that asks to continue gets an interim `100 Continue` before its body is read.
- **Request-size limits** — over-long request lines and header blocks are rejected with `414`/`431` (telekinesis's `Http.Request.parseHead` gained `maxRequestLine`/`maxHeaders` caps that abort the scan mid-token).
- **`408 Request Timeout`** — a read error or timeout while a request is in flight gets a best-effort timeout response before the connection closes.
- **HTTP/1.0 streaming** — a streaming body to a 1.0 client (which can't do chunked) is written raw and delimited by `Connection: close`.
- **Bounded body draining** — an unconsumed request body over 64 KiB closes the connection instead of being read in full.
- **TLS** — supplying an `SSLContext` as `ssl` serves over TLS:

```scala
SocketServer(443, ssl = sslContext).handle(myHandler)
```

The connection's `tls` flag is set accordingly, and `serveConnection` is unchanged since it already works over arbitrary streams.

Each item is covered by an in-process test, plus a real-socket TLS handshake test using a self-signed certificate generated with `keytool`. HTTP/2 and WebSocket end-to-end remain for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
