### PR TITLE
ultimatum: pane borders and robust inline-mode resizing

### DIFF
--- a/lib/ultimatum/src/core/ultimatum.BorderStyle.scala
+++ b/lib/ultimatum/src/core/ultimatum.BorderStyle.scala
@@ -30,8 +30,34 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ultimatum
 
-export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, Axis, Sizing, Limits, Frame, Placement,
-    Pane, Panes, Mode, BorderStyle, panel, file, rank, border, layout, paint, Focus, EditorField,
-    MenuField, Form, dirtyCells, editor, menu, form}
+import anticipation.*
+import gossamer.*
+
+object BorderStyle:
+  // Light single lines with square corners (the default).
+  val light: BorderStyle = BorderStyle(t"─", t"│", t"┌", t"┐", t"└", t"┘")
+
+  // Light single lines with rounded corners.
+  val rounded: BorderStyle = BorderStyle(t"─", t"│", t"╭", t"╮", t"╰", t"╯")
+
+  // Heavy single lines with square corners.
+  val heavy: BorderStyle = BorderStyle(t"━", t"┃", t"┏", t"┓", t"┗", t"┛")
+
+  // Double lines.
+  val double: BorderStyle = BorderStyle(t"═", t"║", t"╔", t"╗", t"╚", t"╝")
+
+  // ASCII-only, for terminals without box-drawing glyphs.
+  val ascii: BorderStyle = BorderStyle(t"-", t"|", t"+", t"+", t"+", t"+")
+
+// The glyphs a `border` draws with: a horizontal rule, a vertical rule, and the
+// four corners. An edge fills its rectangle by repeating its rule, so a single
+// style serves any size; corners are drawn only where two requested sides meet.
+case class BorderStyle
+  ( horizontal:  Text,
+    vertical:    Text,
+    topLeft:     Text,
+    topRight:    Text,
+    bottomLeft:  Text,
+    bottomRight: Text )

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -44,12 +44,24 @@ import vacuous.*
 // exits, and other events fold into the focused widget. Fullscreen repaints only
 // the changed cells; inline re-sizes the grid to the measured block height each
 // frame and re-presents the whole block at the cursor.
-class Form(root: Canvas, mode: Mode, pane: Pane, wake: () => Unit = () => ()):
+class Form
+  ( root:         Canvas,
+    mode:         Mode,
+    pane:         Pane,
+    wake:         () => Unit   = () => (),
+    throttle:     Long         = 0,
+    debounce:     Long         = 0,
+    scheduleWake: Long => Unit = _ => () ):
   private var leaves: IndexedSeq[Pane] = IndexedSeq()
   private var focuses: IndexedSeq[Focus] = IndexedSeq()
   private var focusLeaf: IndexedSeq[Int] = IndexedSeq()
   private var focused: Optional[Focus] = Unset
   private var rects: IndexedSeq[Rect] = IndexedSeq()
+  private var lastRedraw: Long = 0
+  private var lastWinch: Long = 0
+  private var deferred: Optional[Set[Int]] = Unset
+  private var wakePending: Boolean = false
+  private var resizePending: Boolean = false
 
   // Bind every container to the wake function so a mutation requests a repaint.
   private def bind(node: Pane): Unit = node match
@@ -161,8 +173,52 @@ class Form(root: Canvas, mode: Mode, pane: Pane, wake: () => Unit = () => ()):
     if focuses.nonEmpty then paint(focusLeaf(focusIndex))
     root.flush()
 
+  // Repaint immediately, folding in any coalesced or pending-resize work. Used for
+  // typing, focus changes and application redraws, which must stay responsive.
+  private def requestRefresh(changed: Set[Int]): Unit =
+    deferred = deferred.lay(changed)(_ ++ changed)
+    flushDeferred()
+
+  // Milliseconds until a coalesced resize may repaint: `debounce` ms after the last
+  // WINCH (so a drag must pause first) but never sooner than `throttle` ms after the
+  // last repaint. Zero means it may repaint now.
+  private def resizeDelay: Long =
+    ((lastWinch + debounce).max(lastRedraw + throttle) - System.currentTimeMillis).max(0)
+
+  // A resize coalesces until the drag pauses: each WINCH pushes the deadline back by
+  // `debounce` ms, and the single pending wake reschedules itself (in the `Redraw`
+  // handler) until the deadline is reached, so the block is repainted only after the
+  // drag is quiet — no mid-drag redraws to ghost or flicker. The (blocking) cursor
+  // query is deferred to that repaint, so a whole drag costs one query. Typing is
+  // unaffected and stays immediate.
+  private def requestResizeRefresh(): Unit =
+    deferred = deferred.or(Set())
+    lastWinch = System.currentTimeMillis
+
+    if resizeDelay <= 0 then flushDeferred()
+    else if !wakePending then
+      wakePending = true
+      scheduleWake(resizeDelay)
+
+  private def flushDeferred(): Unit = deferred.let: changed =>
+    deferred = Unset
+    wakePending = false
+    lastRedraw = System.currentTimeMillis
+
+    // A resize may have moved the old block; invalidate it (a width-only resize
+    // counts too) so the next present clears it. Done here, once, however many
+    // resizes were coalesced.
+    if resizePending then
+      resizePending = false
+
+      root match
+        case inline: InlineRoot => inline.invalidate()
+        case _                  => ()
+
+    refresh(changed)
+
   def run(events: Iterator[TerminalEvent]): Unit =
-    refresh(Set())
+    requestRefresh(Set())
     var running = true
 
     while running && events.hasNext do events.next() match
@@ -172,20 +228,27 @@ class Form(root: Canvas, mode: Mode, pane: Pane, wake: () => Unit = () => ()):
           // the panel gaining focus is repainted by `refresh` (focused last).
           val vacated = focusLeaf(focusIndex)
           focused = focuses((focusIndex + 1)%focuses.length)
-          refresh(Set(vacated))
+          requestRefresh(Set(vacated))
 
       case Keypress.Escape | Keypress.Ctrl('C' | 'D') =>
         running = false
 
       // A resize re-tiles to the new size; reset the rects so the whole layout is
-      // repainted against the live dimensions.
+      // repainted against the live dimensions, and mark the resize so the next
+      // repaint clears the moved block (with a cursor query). The repaint is debounced
+      // until the drag pauses; typing is unaffected.
       case _: TerminalInfo.WindowSize =>
         rects = IndexedSeq()
-        refresh(Set())
+        resizePending = true
+        requestResizeRefresh()
 
-      // An application redraw request (e.g. after a background layout change).
+      // An application redraw request (e.g. after a background layout change), or the
+      // scheduled wake for a debounced resize: repaint if the drag has gone quiet,
+      // else reschedule the wake for the rest of the debounce window.
       case TerminalInfo.Redraw =>
-        refresh(Set())
+        if !resizePending then requestRefresh(Set())
+        else if resizeDelay <= 0 then flushDeferred()
+        else scheduleWake(resizeDelay)
 
       // Other signals are never widget input.
       case _: Signal =>
@@ -194,7 +257,7 @@ class Form(root: Canvas, mode: Mode, pane: Pane, wake: () => Unit = () => ()):
       case event =>
         if focuses.nonEmpty then
           focuses(focusIndex).handle(event)
-          refresh(Set(focusLeaf(focusIndex)))
+          requestRefresh(Set(focusLeaf(focusIndex)))
 
     root match
       case inline: InlineRoot => inline.finish()

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -50,24 +50,25 @@ object InlineRoot:
     new InlineRoot(() => width, () => height)
 
 // The root `Canvas` for INLINE mode: panels composite into its character grid
-// (inherited from `GridSurface`), and `flush` presents the grid in the BOTTOM
-// `height` rows of the terminal, addressed by ABSOLUTE screen row (`cup`). Pinning
-// the block to the bottom and drawing each row at an absolute position means a redraw
-// always lands in the same place and never drifts — the property a relative,
-// cursor-tracking present loses the moment a resize reflows the lines already on
-// screen. The block grows by scrolling content up into scrollback to free rows at
-// the bottom, and shrinks by clearing the rows it vacates above. A resize clears the
-// block's rows (sized for the terminal re-wrapping our wider lines) before redrawing,
-// keeping the content above. `widthFn`/`heightFn` supply the live terminal columns
-// and rows, re-read every frame, so the dock follows a resize; an oversize block is
-// clamped to the terminal height. (Because it is bottom-docked, a resize that makes
-// the terminal taller leaves a gap above the block — the cost of robust inline
-// positioning when the terminal can't report the cursor position.)
+// (inherited from `GridSurface`), and `flush` presents the grid with ABSOLUTE row
+// addressing (`cup`) so a redraw always lands in the same place and never drifts —
+// the property a relative, cursor-tracking present loses the moment a resize reflows
+// the lines already on screen. There are two anchorings: on launch the block is
+// BOTTOM-docked, so it appears inline immediately beneath the shell command (growing
+// by scrolling content into scrollback, shrinking by clearing the rows it vacates
+// above). On the first resize it switches to TOP-anchored — pinned to rows 1..height
+// — because a bottom-docked block leaves a gap (and strands a ghost) when the
+// terminal grows taller, whereas a top-anchored one is simply overdrawn in place. A
+// top-anchored resize clears the whole screen first (the block relocates here and the
+// terminal may have moved the old one); otherwise each row is cleared in place.
+// `widthFn`/`heightFn` supply the live terminal columns and rows, re-read every
+// frame; an oversize block is clamped to the terminal height.
 class InlineRoot(widthFn: () => Int, heightFn: () => Int)(using Stdio)
 extends GridSurface(widthFn(), 0):
   private var presentedRows: Int = 0
   private var presentedColumns: Int = 0
   private var invalidated: Boolean = false
+  private var topAnchored: Boolean = false
   private var caretColumn: Int = 0
   private var caretRow: Int = 0
   private var caretVisible: Boolean = true
@@ -82,10 +83,12 @@ extends GridSurface(widthFn(), 0):
   // so a focused editor shows it and a focused menu keeps it hidden.
   def cursor(visible: Boolean): Unit = caretVisible = visible
 
-  // Mark the next present as a resize repaint: it clears the old block's rows before
-  // redrawing, since a resize can move it. The driver calls this on every
-  // `WindowSize` event (a width-only resize counts too).
-  def invalidate(): Unit = invalidated = true
+  // Mark the next present as a resize repaint, and switch to top-anchoring (the first
+  // resize trips this). The driver calls it on every `WindowSize` event (a width-only
+  // resize counts too).
+  def invalidate(): Unit =
+    invalidated = true
+    topAnchored = true
 
   // Record the caret's block-local target; `flush` positions the hardware cursor at
   // the corresponding absolute screen cell.
@@ -108,28 +111,38 @@ extends GridSurface(widthFn(), 0):
 
     emit(csi.dectcem(false))
 
-    if resized then
-      // The terminal was resized. The block was docked to the bottom, so clear only
-      // its rows there (not the whole screen), preserving the content above. When the
-      // width shrank, the terminal re-wrapped our previous, wider lines, so the old
-      // block spans more physical rows; size the cleared region for that re-wrap.
-      val narrowed = presentedColumns > columns && columns > 0
-      val wrap = if narrowed then (presentedColumns + columns - 1)/columns else 1
-      val cleared = (presentedRows*wrap).max(h)
-      emit(csi.cup((rows - cleared + 1).max(1), 1))
-      emit(csi.ed(0))
-    else if h > presentedRows then
-      // Grow in place: scroll the screen up so the extra rows are free at the bottom,
-      // pushing the content above into scrollback rather than overwriting it. `cud` to
-      // the bottom first, since only a `\n` on the bottom line scrolls.
-      emit(csi.cud(9999))
-      emit(t"\r")
-      emit(t"\n"*(h - presentedRows))
+    // The block's absolute top row, and the resize/grow clearing for each anchoring.
+    val top =
+      if topAnchored then
+        // Pinned to the top. A resize relocates the block here (on the first one) and
+        // may have moved the old block, so clear the whole screen before redrawing.
+        if resized then
+          emit(csi.cup(1, 1))
+          emit(csi.ed(0))
 
-    // Draw the block into the bottom `h` rows from an ABSOLUTE top, clipping each row
-    // to the live width so it can never wrap (a wrapped row would scroll the screen
-    // and break the addressing).
-    emit(csi.cup((rows - h + 1).max(1), 1))
+        1
+      else
+        if resized then
+          // Clear the block's rows at the bottom dock, sized for the terminal
+          // re-wrapping our previous, wider lines.
+          val narrowed = presentedColumns > columns && columns > 0
+          val wrap = if narrowed then (presentedColumns + columns - 1)/columns else 1
+          val cleared = (presentedRows*wrap).max(h)
+          emit(csi.cup((rows - cleared + 1).max(1), 1))
+          emit(csi.ed(0))
+        else if h > presentedRows then
+          // Grow in place: scroll the screen up so the extra rows are free at the
+          // bottom, pushing the content above into scrollback. `cud` to the bottom
+          // first, since only a `\n` on the bottom line scrolls.
+          emit(csi.cud(9999))
+          emit(t"\r")
+          emit(t"\n"*(h - presentedRows))
+
+        (rows - h + 1).max(1)
+
+    // Draw the block from its absolute `top` down, clipping each row to the live width
+    // so it can never wrap (a wrapped row would scroll the screen and break addressing).
+    emit(csi.cup(top, 1))
 
     var r = 0
 
@@ -140,15 +153,23 @@ extends GridSurface(widthFn(), 0):
       if r < h - 1 then emit(t"\n")
       r += 1
 
-    // Shrink in place: clear the rows a taller previous block used above the new top
-    // (a resize already cleared the block's rows).
-    if !resized then
-      var j = 0
+    // Shrink: clear the rows a taller previous block vacated — below the block when
+    // top-anchored, above it when bottom-docked (a resize already cleared them).
+    if !resized && presentedRows > h then
+      if topAnchored then
+        var k = h
 
-      while j < presentedRows - h do
-        emit(csi.cup((rows - presentedRows + 1 + j).max(1), 1))
-        emit(csi.el(2))
-        j += 1
+        while k < presentedRows do
+          emit(t"\n")
+          emit(csi.el(2))
+          k += 1
+      else
+        var j = 0
+
+        while j < presentedRows - h do
+          emit(csi.cup((rows - presentedRows + 1 + j).max(1), 1))
+          emit(csi.el(2))
+          j += 1
 
     presentedRows = h
     presentedColumns = columns
@@ -156,8 +177,7 @@ extends GridSurface(widthFn(), 0):
     // The caret is the hardware cursor, placed at an absolute cell and shown only when
     // visible; otherwise the cursor is left hidden.
     if caretVisible then
-      val caretAbsRow = (rows - h + 1 + caretRow.min(h - 1)).max(1)
-      emit(csi.cup(caretAbsRow, caretColumn.min(columns - 1).max(0) + 1))
+      emit(csi.cup((top + caretRow.min(h - 1)).max(1), caretColumn.min(columns - 1).max(0) + 1))
       emit(csi.dectcem(true))
 
     Out.print(frame.toString.tt)
@@ -165,6 +185,7 @@ extends GridSurface(widthFn(), 0):
   // On exit, drop the cursor onto a fresh line below the block and re-show it, so
   // subsequent output continues after the rendered block (like a submitted prompt).
   def finish(): Unit =
-    Out.print(csi.cup(heightFn(), 1))
+    val below = if topAnchored then (presentedRows + 1).min(heightFn()) else heightFn()
+    Out.print(csi.cup(below.max(1), 1))
     Out.print(t"\r\n")
     Out.print(csi.dectcem(true))

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -37,6 +37,7 @@ import denominative.*
 import escapade.*
 import gossamer.*
 import profanity.*
+import symbolism.*
 import turbulence.*
 
 object InlineRoot:
@@ -49,19 +50,24 @@ object InlineRoot:
     new InlineRoot(() => width, () => height)
 
 // The root `Canvas` for INLINE mode: panels composite into its character grid
-// (inherited from `GridSurface`), and `flush` presents the whole grid at the
-// terminal's current cursor using relative motion plus CR/LF. Because a `\n` on
-// the bottom line scrolls a fresh row in (whereas a relative `cud` clamps), the
-// block grows downward without needing the alternate screen buffer or any
-// pre-reserved space; on shrink the freed rows are cleared. The cursor is tracked
-// relative to its own resting row within the block, never an absolute screen row,
-// so the present stays correct after the terminal scrolls. `widthFn`/`heightFn`
-// supply the live terminal columns and the height clamp (an oversize block
-// degrades to a bottom-anchored window).
+// (inherited from `GridSurface`), and `flush` presents the grid in the BOTTOM
+// `height` rows of the terminal, addressed by ABSOLUTE screen row (`cup`). Pinning
+// the block to the bottom and drawing each row at an absolute position means a redraw
+// always lands in the same place and never drifts — the property a relative,
+// cursor-tracking present loses the moment a resize reflows the lines already on
+// screen. The block grows by scrolling content up into scrollback to free rows at
+// the bottom, and shrinks by clearing the rows it vacates above. A resize clears the
+// block's rows (sized for the terminal re-wrapping our wider lines) before redrawing,
+// keeping the content above. `widthFn`/`heightFn` supply the live terminal columns
+// and rows, re-read every frame, so the dock follows a resize; an oversize block is
+// clamped to the terminal height. (Because it is bottom-docked, a resize that makes
+// the terminal taller leaves a gap above the block — the cost of robust inline
+// positioning when the terminal can't report the cursor position.)
 class InlineRoot(widthFn: () => Int, heightFn: () => Int)(using Stdio)
 extends GridSurface(widthFn(), 0):
   private var presentedRows: Int = 0
-  private var cursorRow: Int = 0
+  private var presentedColumns: Int = 0
+  private var invalidated: Boolean = false
   private var caretColumn: Int = 0
   private var caretRow: Int = 0
   private var caretVisible: Boolean = true
@@ -72,54 +78,93 @@ extends GridSurface(widthFn(), 0):
   // height; called by the driver before compositing each frame.
   def reframe(width: Int, height: Int): Unit = reshape(width, height.min(heightFn()))
 
-  // Cursor visibility is deferred like the caret: recorded now, applied by `flush`
-  // (which hides the cursor while it redraws), so a focused editor shows it and a
-  // focused menu keeps it hidden.
+  // Cursor visibility is deferred like the caret: recorded now, applied by `flush`,
+  // so a focused editor shows it and a focused menu keeps it hidden.
   def cursor(visible: Boolean): Unit = caretVisible = visible
 
-  // Inline carets are deferred: record the block-local target and let `flush`
-  // position it relative to the block, since mid-composite the cursor is wherever
-  // the last panel left it.
+  // Mark the next present as a resize repaint: it clears the old block's rows before
+  // redrawing, since a resize can move it. The driver calls this on every
+  // `WindowSize` event (a width-only resize counts too).
+  def invalidate(): Unit = invalidated = true
+
+  // Record the caret's block-local target; `flush` positions the hardware cursor at
+  // the corresponding absolute screen cell.
   override def showCaret(column: Ordinal, row2: Ordinal): Unit =
     caretColumn = column.n0
     caretRow = row2.n0
 
   def flush(): Unit =
-    Out.print(csi.dectcem(false))
-    if cursorRow > 0 then Out.print(csi.cuu(cursorRow))
-    Out.print(t"\r")
+    val rows    = heightFn()
+    val columns = gridWidth.min(widthFn())
+    val h       = height
+    val resized = invalidated
+    invalidated = false
+
+    // The whole frame is built up and emitted as ONE write, so the SIGWINCH handler's
+    // size-probe sequence (which jumps the cursor to the corner and back) cannot
+    // interleave between our escapes and corrupt the redraw.
+    val frame = StringBuilder()
+    def emit(text: Text): Unit = frame.append(text.s)
+
+    emit(csi.dectcem(false))
+
+    if resized then
+      // The terminal was resized. The block was docked to the bottom, so clear only
+      // its rows there (not the whole screen), preserving the content above. When the
+      // width shrank, the terminal re-wrapped our previous, wider lines, so the old
+      // block spans more physical rows; size the cleared region for that re-wrap.
+      val narrowed = presentedColumns > columns && columns > 0
+      val wrap = if narrowed then (presentedColumns + columns - 1)/columns else 1
+      val cleared = (presentedRows*wrap).max(h)
+      emit(csi.cup((rows - cleared + 1).max(1), 1))
+      emit(csi.ed(0))
+    else if h > presentedRows then
+      // Grow in place: scroll the screen up so the extra rows are free at the bottom,
+      // pushing the content above into scrollback rather than overwriting it. `cud` to
+      // the bottom first, since only a `\n` on the bottom line scrolls.
+      emit(csi.cud(9999))
+      emit(t"\r")
+      emit(t"\n"*(h - presentedRows))
+
+    // Draw the block into the bottom `h` rows from an ABSOLUTE top, clipping each row
+    // to the live width so it can never wrap (a wrapped row would scroll the screen
+    // and break the addressing).
+    emit(csi.cup((rows - h + 1).max(1), 1))
 
     var r = 0
 
-    while r < height do
-      Out.print(csi.el(2))
-      Out.print(rowText(r))
-      Out.print(t"\r")
-      if r < height - 1 then Out.print(t"\n")
+    while r < h do
+      emit(csi.el(2))
+      emit(rowText(r).keep(columns))
+      emit(t"\r")
+      if r < h - 1 then emit(t"\n")
       r += 1
 
-    if presentedRows > height then
-      var k = height
+    // Shrink in place: clear the rows a taller previous block used above the new top
+    // (a resize already cleared the block's rows).
+    if !resized then
+      var j = 0
 
-      while k < presentedRows do
-        Out.print(t"\n")
-        Out.print(csi.el(2))
-        k += 1
+      while j < presentedRows - h do
+        emit(csi.cup((rows - presentedRows + 1 + j).max(1), 1))
+        emit(csi.el(2))
+        j += 1
 
-      Out.print(csi.cuu(presentedRows - height))
+    presentedRows = h
+    presentedColumns = columns
 
-    val up = (height - 1) - caretRow
-    if up > 0 then Out.print(csi.cuu(up))
-    Out.print(csi.cha(caretColumn + 1))
+    // The caret is the hardware cursor, placed at an absolute cell and shown only when
+    // visible; otherwise the cursor is left hidden.
+    if caretVisible then
+      val caretAbsRow = (rows - h + 1 + caretRow.min(h - 1)).max(1)
+      emit(csi.cup(caretAbsRow, caretColumn.min(columns - 1).max(0) + 1))
+      emit(csi.dectcem(true))
 
-    presentedRows = height
-    cursorRow = caretRow
-    Out.print(csi.dectcem(caretVisible))
+    Out.print(frame.toString.tt)
 
   // On exit, drop the cursor onto a fresh line below the block and re-show it, so
   // subsequent output continues after the rendered block (like a submitted prompt).
   def finish(): Unit =
-    val down = (height - 1) - cursorRow
-    if down > 0 then Out.print(csi.cud(down))
+    Out.print(csi.cup(heightFn(), 1))
     Out.print(t"\r\n")
     Out.print(csi.dectcem(true))

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -32,9 +32,12 @@
                                                                                                   */
 package ultimatum
 
+import anticipation.*
+import denominative.*
 import profanity.*
 import rudiments.*
 import spectacular.*
+import symbolism.*
 import vacuous.*
 
 // Construct a leaf panel: a fractional weight and optional per-axis bounds,
@@ -89,6 +92,57 @@ def rank(panes: Pane*): Pane = Pane.Branch(Sizing(), Axis.Rank, Panes(panes*))
 
 // A row split over a live container, whose children can change while running.
 def rank(panes: Panes): Pane = Pane.Branch(Sizing(), Axis.Rank, panes)
+
+// Wrap `child` in a box-drawing border. Each requested side becomes a thin leaf
+// panel whose content is regenerated from its solved size, so an edge always
+// spans the bordered region exactly and re-rules itself when the layout resizes.
+// A corner is drawn only where two requested sides meet, so a partial border
+// (e.g. only `top`) is a single rule with no corners. The border reserves one
+// extra row or column on each requested side, propagated by the solver (each
+// edge's fixed bound flows up as the cross-axis limit of its band).
+def border
+  ( style:  BorderStyle = BorderStyle.light,
+    top:    Boolean     = true,
+    right:  Boolean     = true,
+    bottom: Boolean     = true,
+    left:   Boolean     = true )
+  ( child: Pane )
+:   Pane =
+
+  // A horizontal rule filling its width: a single fixed-height row.
+  def horizontalRule: Pane = panel(minHeight = 1, maxHeight = 1):
+    val extent = summon[Extent]
+    extent.move(Prim, Prim)
+    extent.put(style.horizontal*extent.width)
+
+  // A vertical rule filling its height: a single fixed-width column.
+  def verticalRule: Pane = panel(minWidth = 1, maxWidth = 1):
+    val extent = summon[Extent]
+    var row = 0
+
+    while row < extent.height do
+      extent.move(Prim, row.z)
+      extent.put(style.vertical)
+      row += 1
+
+  // A single cell holding one corner glyph.
+  def corner(glyph: Text): Pane =
+    panel(minWidth = 1, maxWidth = 1, minHeight = 1, maxHeight = 1)(summon[Extent].put(glyph))
+
+  // The middle band: the child flanked by whichever vertical edges are requested.
+  val middle =
+    val edge = if left then List(verticalRule) else Nil
+    file((edge ++ List(child) ++ (if right then List(verticalRule) else Nil))*)
+
+  // A horizontal band (the top or bottom): a rule flanked by whichever corners
+  // are requested (a corner appears only where a vertical edge also meets it).
+  def band(leftCorner: Text, rightCorner: Text): Pane =
+    val start = if left then List(corner(leftCorner)) else Nil
+    file((start ++ List(horizontalRule) ++ (if right then List(corner(rightCorner)) else Nil))*)
+
+  val head = if top then List(band(style.topLeft, style.topRight)) else Nil
+  val foot = if bottom then List(band(style.bottomLeft, style.bottomRight)) else Nil
+  rank((head ++ List(middle) ++ foot)*)
 
 // Drive an interactive layout, looping over terminal events until the user exits.
 // Used inside `interactive`. In `Fullscreen` mode the layout takes over the

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -34,7 +34,9 @@ package ultimatum
 
 import anticipation.*
 import denominative.*
+import parasite.*
 import profanity.*
+import quantitative.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
@@ -149,7 +151,10 @@ def border
 // terminal via the alternate screen buffer (restored on exit) and fills its
 // height; in `Inline` mode it renders a variable-height block at the cursor
 // without the alternate buffer, leaving scrollback intact.
-def form(mode: Mode = Mode.Fullscreen)(pane: Pane)(using terminal: Terminal): Unit =
+def form(mode: Mode = Mode.Fullscreen)(pane: Pane)
+  ( using terminal: Terminal, monitor: Monitor, codicil: Codicil )
+:   Unit =
+
   // A container mutation wakes the loop by putting a redraw event on the spool.
   val wake = () => terminal.events.put(TerminalInfo.Redraw)
 
@@ -163,7 +168,19 @@ def form(mode: Mode = Mode.Fullscreen)(pane: Pane)(using terminal: Terminal): Un
         finally root.cursor(true)
 
     case Mode.Inline =>
-      Form(InlineRoot(terminal), mode, pane, wake).run(terminal.eventIterator())
+      // A deferred resize repaint is woken by posting a `Redraw` after the remaining
+      // window (plus a small margin so it lands past it).
+      val scheduleWake = (delay: Long) =>
+        async:
+          snooze((delay + 16).toDouble*Milli(Second))
+          terminal.events.put(TerminalInfo.Redraw)
+
+        ()
+
+      // Resize repaints are throttled to ~10/second and debounced by 50 ms of quiet,
+      // so a drag must pause before the block is redrawn; typing stays immediate.
+      Form(InlineRoot(terminal), mode, pane, wake, 100, 50, scheduleWake)
+      . run(terminal.eventIterator())
 
 // The leaf indices that must be repainted: any whose rectangle moved or resized
 // since the last layout, plus any whose content changed this frame. A leaf whose

--- a/lib/ultimatum/src/demo/ultimatum_demo.scala
+++ b/lib/ultimatum/src/demo/ultimatum_demo.scala
@@ -52,7 +52,7 @@ import threading.platform
 def demo(): Unit = cli:
   execute:
     interactive: terminal ?=>
-      form(Mode.Fullscreen)(demoLayout)
+      form(Mode.Inline)(demoLayout)
       Exit.Ok
 
 // rank(title, file(sidebar, rank(heading, editor, activity)), status):
@@ -77,4 +77,8 @@ private def demoLayout: Pane =
   val title = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  ULTIMATUM · fullscreen demo"))
   val status = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  [Tab] focus    [Esc] quit"))
 
-  rank(title, file(sidebar, rank(heading, editor(), activity)), status)
+  // A multiline compose box: Enter inserts a newline (it never submits, so the
+  // arrow keys can move the cursor up and down between lines).
+  val compose = editor(LineEditor(mode = LineEditor.Mode.Multiline(_ => false)))
+
+  rank(title, file(sidebar, rank(heading, compose, activity)), status)

--- a/lib/ultimatum/src/demo/ultimatum_demo.scala
+++ b/lib/ultimatum/src/demo/ultimatum_demo.scala
@@ -55,30 +55,44 @@ def demo(): Unit = cli:
       form(Mode.Inline)(demoLayout)
       Exit.Ok
 
-// rank(title, file(sidebar, rank(heading, editor, activity)), status):
+// rank(title, file(sidebar, rank(heading, compose, activity)), status), with the
+// sidebar, compose box and activity panel each wrapped in a `border` and the
+// heading underlined by a bottom-only border:
 //
 //   ┌──────────────────────── title ────────────────────────┐
-//   │ sidebar (menu) │ heading                               │
-//   │                │ editor                                │
-//   │                │ activity                              │
+//   │ ╭ sidebar ╮ │ heading                                  │
+//   │ │  (menu) │ │ ─────────                                │
+//   │ ╰─────────╯ │ ┏━ compose ━┓                            │
+//   │             │ ┗━━━━━━━━━━━┛                            │
+//   │             │ ┌─ activity ┐                            │
+//   │             │ └───────────┘                            │
 //   └─────────────────────── status ────────────────────────┘
 private def demoLayout: Pane =
-  val sidebar = menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
-      minWidth = 22, maxWidth = 22)
+  // A rounded border around the menu; the menu itself is 20 wide, so the bordered
+  // sidebar is 22.
+  val sidebar = border(BorderStyle.rounded):
+    menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
+        minWidth = 20, maxWidth = 20)
 
-  val activity = panel(minHeight = 6):
-    Out.println(t"Recent activity")
-    Out.println(t"")
-    Out.println(t"  • Demo started")
-    Out.println(t"  • Four panes tiled")
-    Out.println(t"  • Tab moves focus, Esc quits")
+  val activity = border():
+    panel(minHeight = 6):
+      Out.println(t"Recent activity")
+      Out.println(t"")
+      Out.println(t"  • Demo started")
+      Out.println(t"  • Four panes tiled")
+      Out.println(t"  • Tab moves focus, Esc quits")
 
-  val heading = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Compose"))
+  // A bottom-only border draws a single rule under the heading, a separator with
+  // no corners or sides.
+  val heading = border(top = false, left = false, right = false):
+    panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Compose"))
+
   val title = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  ULTIMATUM · fullscreen demo"))
   val status = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  [Tab] focus    [Esc] quit"))
 
   // A multiline compose box: Enter inserts a newline (it never submits, so the
   // arrow keys can move the cursor up and down between lines).
-  val compose = editor(LineEditor(mode = LineEditor.Mode.Multiline(_ => false)))
+  val compose = border(BorderStyle.heavy):
+    editor(LineEditor(mode = LineEditor.Mode.Multiline(_ => false)))
 
   rank(title, file(sidebar, rank(heading, compose, activity)), status)

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -356,9 +356,10 @@ object Tests extends Suite(m"Ultimatum Tests"):
         String(bytes.toByteArray.nn, "UTF-8").tt
       . assert(_ == t"\e[4;1H\r\n\e[?25h")
 
-      // After `invalidate` (a resize), the present clears the block's rows at the
-      // bottom (`\e[3;1H\e[0J`) before repainting there, preserving the content above.
-      test(m"an invalidated present clears the block's rows then repaints"):
+      // The first resize switches to top-anchoring: the present clears the whole
+      // screen (`\e[1;1H\e[0J`) and repaints the block pinned to rows 1..h, so a taller
+      // terminal can't strand a ghost above it.
+      test(m"the first resize top-anchors the block, clearing the screen"):
         val (bytes, stdio) = capturing()
         given Stdio = stdio
         val root = InlineRoot(3, 4)
@@ -367,7 +368,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.invalidate()
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[3;1H\e[0J\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[1;1H\e[0J\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
 
     suite(m"Dynamic panes"):
       def cell(): Pane = panel()(())

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -459,6 +459,39 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.render
       . assert(_ == t" · alpha    \n   beta     \n            ")
 
+    suite(m"Borders"):
+      def render(width: Int, height: Int)(pane: Pane): Text =
+        given Stdio = Stdio(null, null, null, termcapDefinitions.basic)
+        val root = FlowExtent(TerminalCanvas(width, height), Rect(0, 0, width, height))
+        paint(root, pane)
+        root.render
+
+      test(m"a full border frames the content with corners and rules"):
+        render(4, 3)(border()(panel()(Out.print(t"hi"))))
+      . assert(_ == t"┌──┐\n│hi│\n└──┘")
+
+      test(m"the border style selects the glyphs (rounded corners)"):
+        render(3, 3)(border(BorderStyle.rounded)(panel()(Out.print(t"x"))))
+      . assert(_ == t"╭─╮\n│x│\n╰─╯")
+
+      test(m"a rule re-fills to the content's width"):
+        render(6, 3)(border()(panel()(Out.print(t"wide"))))
+      . assert(_ == t"┌────┐\n│wide│\n└────┘")
+
+      test(m"a top-only border is a single rule with no corners"):
+        render(2, 2)(border(top = true, right = false, bottom = false, left = false)
+            (panel()(Out.print(t"ab"))))
+      . assert(_ == t"──\nab")
+
+      test(m"left-and-right-only borders omit every corner"):
+        render(4, 1)(border(top = false, bottom = false)(panel()(Out.print(t"ab"))))
+      . assert(_ == t"│ab│")
+
+      test(m"a full border adds one cell on every side to the minimum size"):
+        val bordered = border()(panel(minWidth = 3, minHeight = 2)(())).frame
+        (bordered.measure(Axis.File).min, bordered.measure(Axis.Rank).min)
+      . assert(_ == (5, 4))
+
 // A test-only root `Canvas` that paints into a fixed in-memory grid but reports a
 // settable size, so a layout can be re-tiled to a smaller `width`/`height` and
 // the composed screen read back.

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -298,58 +298,76 @@ object Tests extends Suite(m"Ultimatum Tests"):
         val bytes = ji.ByteArrayOutputStream()
         (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basic))
 
-      test(m"a first inline render draws each row with CR/LF and parks the caret"):
+      // The block (2 rows) is docked to the bottom of the 4-row terminal: it scrolls
+      // 2 rows in (`\n\n`) to reserve space, then draws each row at an absolute screen
+      // position (rows 3 and 4) and parks the caret absolutely.
+      test(m"a first inline render docks the block to the bottom rows"):
         val (bytes, stdio) = capturing()
         given Stdio = stdio
-        val root = InlineRoot(3, 24)
+        val root = InlineRoot(3, 4)
         root.reframe(3, 2)
         root.move(Prim, Prim)
         root.put(t"hi")
         root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\r\e[2Khi \r\n\e[2K   \r\e[1A\e[1G\e[?25h")
+      . assert(_ == t"\e[?25l\e[9999B\r\n\n\e[3;1H\e[2Khi \r\n\e[2K   \r\e[3;1H\e[?25h")
 
-      test(m"a growing block scrolls a new row in with LF"):
+      test(m"a growing block scrolls one more row into the dock"):
         val (bytes, stdio) = capturing()
         given Stdio = stdio
-        val root = InlineRoot(3, 24)
+        val root = InlineRoot(3, 4)
         root.reframe(3, 1); root.move(Prim, Prim); root.put(t"a"); root.flush()
         bytes.reset()
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\r\e[2Kab \r\n\e[2Kcd \r\e[1A\e[1G\e[?25h")
+      . assert(_ == t"\e[?25l\e[9999B\r\n\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
 
-      test(m"a shrinking block clears the rows it no longer uses"):
+      // The block bottom-docks: shrinking moves it down (row 4) and clears the row it
+      // vacated above (row 3).
+      test(m"a shrinking block clears the row it vacated above"):
         val (bytes, stdio) = capturing()
         given Stdio = stdio
-        val root = InlineRoot(3, 24)
+        val root = InlineRoot(3, 4)
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         bytes.reset()
         root.reframe(3, 1); root.move(Prim, Prim); root.put(t"ef"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\r\e[2Kef \r\n\e[2K\e[1A\e[1G\e[?25h")
+      . assert(_ == t"\e[?25l\e[4;1H\e[2Kef \r\e[3;1H\e[2K\e[4;1H\e[?25h")
 
-      test(m"the caret is parked at its block-local position"):
+      test(m"the caret is placed at its absolute screen cell"):
         val (bytes, stdio) = capturing()
         given Stdio = stdio
-        val root = InlineRoot(3, 24)
+        val root = InlineRoot(3, 4)
         root.reframe(3, 2)
         root.move(Prim, Prim)
         root.put(t"ab\ncd")
         root.showCaret(Sec, Sec)
         root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\r\e[2Kab \r\n\e[2Kcd \r\e[2G\e[?25h")
+      . assert(_ == t"\e[?25l\e[9999B\r\n\n\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[4;2H\e[?25h")
 
       test(m"finish drops the cursor onto a fresh line below the block"):
         val (bytes, stdio) = capturing()
         given Stdio = stdio
-        val root = InlineRoot(3, 24)
+        val root = InlineRoot(3, 4)
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         bytes.reset()
         root.finish()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[1B\r\n\e[?25h")
+      . assert(_ == t"\e[4;1H\r\n\e[?25h")
+
+      // After `invalidate` (a resize), the present clears the block's rows at the
+      // bottom (`\e[3;1H\e[0J`) before repainting there, preserving the content above.
+      test(m"an invalidated present clears the block's rows then repaints"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.invalidate()
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[3;1H\e[0J\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
 
     suite(m"Dynamic panes"):
       def cell(): Pane = panel()(())

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -198,6 +198,23 @@ object Tests extends Suite(m"Ultimatum Tests"):
         field.value
       . assert(_ == t"hi")
 
+      // The demo's compose box is multiline; the Up/Down arrows must move the
+      // cursor between lines (in single-line mode they are inert).
+      test(m"a multiline editor field moves its cursor up a line on Up"):
+        val field = EditorField(LineEditor(t"ab\ncd", mode = LineEditor.Mode.Multiline(_ => false)))
+        field.handle(Keypress.Up)
+        field.handle(Keypress.CharKey('X'))
+        field.value
+      . assert(_ == t"abX\ncd")
+
+      test(m"a multiline editor field moves its cursor down a line on Down"):
+        val field = EditorField(LineEditor(t"ab\ncd", 0,
+            mode = LineEditor.Mode.Multiline(_ => false)))
+        field.handle(Keypress.Down)
+        field.handle(Keypress.CharKey('X'))
+        field.value
+      . assert(_ == t"ab\nXcd")
+
       test(m"an editor field's intrinsic height grows when its text wraps"):
         EditorField(LineEditor(t"aaaaa")).measure(3)
       . assert(_ == (0, 2))


### PR DESCRIPTION
Adds box-drawing borders around panes to the ultimatum TUI framework, reworks inline-mode rendering so a terminal resize is handled cleanly (no ghosting, no drift), and updates the demo to use borders and a multiline compose editor.

## Borders

`border(...)` wraps a pane in box-drawing rules:

```scala
border(BorderStyle.rounded)(menu(items, current))
border(top = false, left = false, right = false)(heading)   // a bottom rule only
```

Sides are individually selectable, and corners are drawn only where two sides meet, so a partial border (e.g. a bottom-only rule) renders without them. `BorderStyle` provides `light`, `rounded`, `heavy`, `double` and `ascii` presets, and each edge regenerates from its solved size so the rules always span the bordered region exactly — including after a resize.

## Inline-mode resizing

An inline layout (`form(Mode.Inline)(…)`) renders a variable-height block at the cursor, in the main screen buffer, where a resize reflows already-drawn lines. Rendering now uses absolute, single-write frames so a redraw never drifts and the SIGWINCH size-probe can't corrupt it. The block launches inline beneath the launching command, and on the first resize switches to a top-anchored layout that stays ghost-free and gap-free as the terminal grows or shrinks. Resize redraws are debounced (50 ms of quiet) and throttled (~10/s) so a drag repaints only once it settles, while typing stays immediate.

## Demo

The demo's compose box is now a multiline editor (the arrow keys move between lines), and its panels use borders.