### PR TITLE
Reconcile DOM-id and CSS-class names via Nomenclature

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -226,7 +226,7 @@ object groupCheck extends Module:
   // into any group bundle; review whether each belongs in a bundle or stays here.
   def excluded: Set[String] = Set(
     "adversaria.examples", "anthology.bundle", "anthology.scala",
-    "anticipation.codec", "anticipation.color", "anticipation.css",
+    "anticipation.codec", "anticipation.color",
     "anticipation.generic", "anticipation.gfx", "anticipation.html",
     "anticipation.http", "anticipation.log", "anticipation.opaque",
     "anticipation.path", "anticipation.print", "anticipation.text",
@@ -373,9 +373,6 @@ object anticipation extends Library:
   object gfx extends Component(prepositional.core, color):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object css extends Component(text, generic):
-    override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object url extends Component(text, generic):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -512,7 +509,7 @@ object cataclysm extends Library:
   object core extends Component(zephyrine.core, gossamer.core, turbulence.core,
       contingency.core, vacuous.core, fulminate.core, denominative.core, hellenism.core,
       jacinta.core, quantitative.units, iridescence.core, gesticulate.core, rudiments.core,
-      contextual.core):
+      contextual.core, nomenclature.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object html extends Component(core, honeycomb.core, gigantism.core):
@@ -886,7 +883,7 @@ object frontier extends Library:
   object test extends Tests(core, scintillate.servlet, jacinta.schema)
 
 object fulminate extends Library:
-  object core extends Component(anticipation.css, anticipation.http, anticipation.print, anticipation.log, proscenium.core, gigantism.core):
+  object core extends Component(anticipation.http, anticipation.print, anticipation.log, proscenium.core, gigantism.core):
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -974,7 +971,8 @@ object hellenism extends Library:
   object test extends Tests(core, turbulence.core)
 
 object honeycomb extends Library:
-  object core extends Component(panopticon.core, gesticulate.core, xylophone.core, urticose.url):
+  object core extends Component(panopticon.core, gesticulate.core, xylophone.core, urticose.url,
+      nomenclature.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/cataclysm/src/core/cataclysm.CssError.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssError.scala
@@ -47,6 +47,7 @@ object CssError:
       case UnknownProperty(name)      => m"$name is not a recognized CSS property"
       case BadValue(property, value)  => m"$value is not a valid value for the $property property"
       case UnsupportedValue(name, _)  => m"the value of $name uses an unsupported type"
+      case InvalidName(name)          => m"$name is not a valid CSS identifier"
 
   enum Reason(val number: Int) extends Clarification:
     case UnterminatedComment         extends Reason(1)
@@ -57,6 +58,7 @@ object CssError:
     case UnknownProperty(name: Text) extends Reason(6)
     case BadValue(property: Text, value: Text) extends Reason(7)
     case UnsupportedValue(property: Text, types: List[Text]) extends Reason(8)
+    case InvalidName(name: Text) extends Reason(9)
 
 case class CssError(reason: CssError.Reason, line: Ordinal, column: Ordinal)(using Diagnostics)
 extends Error(251, reason.number)(m"invalid CSS at line ${line.n1} column ${column.n1}: $reason")

--- a/lib/cataclysm/src/core/cataclysm.Selector.scala
+++ b/lib/cataclysm/src/core/cataclysm.Selector.scala
@@ -35,6 +35,7 @@ package cataclysm
 import anticipation.*
 import contingency.*
 import gossamer.*
+import nomenclature.*
 import spectacular.*
 import vacuous.*
 
@@ -164,8 +165,8 @@ object Simple:
 enum Simple derives CanEqual:
   case Universal(namespace: Optional[Namespace])                                  // *
   case Type(namespace: Optional[Namespace], name: Text)                           // div
-  case Id(name: Text)                                                             // #id
-  case Class(name: Text)                                                          // .cls
+  case Id(name: Name[DomId])                                                      // #id
+  case Class(name: Name[CssClass])                                                // .cls
   case Nesting                                                                    // &
   case Attribute(namespace: Optional[Namespace], name: Text, test: Optional[AttributeTest])
   case PseudoClass(name: Text, argument: Optional[PseudoArgument])                // :hover

--- a/lib/cataclysm/src/core/cataclysm.SelectorParser.scala
+++ b/lib/cataclysm/src/core/cataclysm.SelectorParser.scala
@@ -35,6 +35,7 @@ package cataclysm
 import anticipation.*
 import contingency.*
 import gossamer.*
+import nomenclature.*
 import vacuous.*
 import zephyrine.*
 
@@ -243,11 +244,26 @@ private[cataclysm] object SelectorParser:
 
     private def id(): Simple =
       cursor.advance()
-      Simple.Id(readIdent())
+      val text = readIdent()
+
+      Simple.Id:
+        safely(Name[DomId](text)).or:
+          invalid(text)
+          text.asInstanceOf[Name[DomId]]
 
     private def cls(): Simple =
       cursor.advance()
-      Simple.Class(readIdent())
+      val text = readIdent()
+
+      Simple.Class:
+        safely(Name[CssClass](text)).or:
+          invalid(text)
+          text.asInstanceOf[Name[CssClass]]
+
+    // The parser is lenient: an invalid identifier (e.g. a class starting with a
+    // digit) raises a `CssError` but parsing continues with the name verbatim.
+    private def invalid(text: Text): Unit =
+      raise(CssError(CssError.Reason.InvalidName(text), cursor.line, cursor.column))
 
     private def attribute(): Simple =
       eat('[')

--- a/lib/cataclysm/src/core/cataclysm_core.scala
+++ b/lib/cataclysm/src/core/cataclysm_core.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import contextual.*
 import contingency.*
 import fulminate.*
+import nomenclature.*
 import prepositional.*
 import turbulence.*
 import vacuous.*
@@ -59,8 +60,10 @@ given cssAggregable: (Tactic[CssErrors], Diagnostics) => Css is Aggregable by Te
 // The class and id names referenced anywhere in a stylesheet, including inside
 // nested rules and the selector-list arguments of `:is()`/`:not()`/`:nth-…(of)`.
 extension (css: Css)
-  def classes: Set[Text] = simples(css.rules).collect { case Simple.Class(name) => name }.to(Set)
-  def ids: Set[Text] = simples(css.rules).collect { case Simple.Id(name) => name }.to(Set)
+  def classes: Set[Name[CssClass]] =
+    simples(css.rules).collect { case Simple.Class(name) => name }.to(Set)
+
+  def ids: Set[Name[DomId]] = simples(css.rules).collect { case Simple.Id(name) => name }.to(Set)
 
 private def simples(nodes: List[Css.Node]): List[Simple] =
   nodes.flatMap:

--- a/lib/cataclysm/src/html/cataclysm.HtmlMacros.scala
+++ b/lib/cataclysm/src/html/cataclysm.HtmlMacros.scala
@@ -93,7 +93,8 @@ private[cataclysm] object HtmlMacros:
     val css = safely(CssParser.parse(Iterator(content))).or:
       halt(m"cataclysm: could not parse the stylesheet at $path")
 
-    (css.classes, css.ids)
+    // Upcast the typed names to `Text` for comparison against the requested name.
+    (css.classes.map(name => name: Text), css.ids.map(name => name: Text))
 
   // Decide whether `name` is a class or an id in the in-scope stylesheet, or halt.
   def attributeFor[name <: Label: Type]: Macro[Text] =

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -55,8 +55,8 @@ object Tests extends Suite(m"Cataclysm Tests"):
   def rel(lead: Combinator, head: Compound): Selector = Selector(lead, head, Nil)
   def cpd(parts: Simple*): Compound = Compound(parts.toList)
   def typ(name: Text): Simple = Simple.Type(Unset, name)
-  def cls(name: Text): Simple = Simple.Class(name)
-  def hid(name: Text): Simple = Simple.Id(name)
+  def cls(name: Text): Simple = Simple.Class(Name[CssClass](name))
+  def hid(name: Text): Simple = Simple.Id(Name[DomId](name))
   def uni: Simple = Simple.Universal(Unset)
   def pc(name: Text): Simple = Simple.PseudoClass(name, Unset)
 
@@ -527,11 +527,11 @@ object Tests extends Suite(m"Cataclysm Tests"):
       val css = t".a #b { color: red } @media screen { .c:not(.d) e#f { color: blue } }".read[Css]
 
       test(m"class names are collected, including nested and inside :not()"):
-        css.classes
+        css.classes.map(name => name: Text)
       . assert(_ == Set(t"a", t"c", t"d"))
 
       test(m"id names are collected, including nested"):
-        css.ids
+        css.ids.map(name => name: Text)
       . assert(_ == Set(t"b", t"f"))
 
     suite(m"CSS-checked attributions"):

--- a/lib/harlequin/src/md/harlequin.CommonFormattable.scala
+++ b/lib/harlequin/src/md/harlequin.CommonFormattable.scala
@@ -33,9 +33,11 @@
 package harlequin
 
 import anticipation.*
+import contingency.*
 import gossamer.*
 import harlequin.*
 import honeycomb.*
+import nomenclature.*
 import prepositional.*
 import punctuation.*
 import spectacular.*
@@ -46,7 +48,8 @@ import doms.html.whatwg, whatwg.*
 trait CommonFormattable extends Formattable:
   given lineClass: (Attribution of "line" | "amok") = Attribution.classes()
 
-  def classes(accent: Accent): Stylesheet = Stylesheet(Set(accent.show.lower))
+  def classes(accent: Accent): ClassList =
+    ClassList(Set(unsafely(Name[CssClass](accent.show.lower))))
 
   def element(accent: Accent, text: Text): Element of "code" =
     whatwg.Code(`class` = classes(accent))(text)

--- a/lib/honeycomb/src/core/honeycomb.Attributive.scala
+++ b/lib/honeycomb/src/core/honeycomb.Attributive.scala
@@ -34,6 +34,7 @@ package honeycomb
 
 import anticipation.*
 import gossamer.*
+import nomenclature.*
 import prepositional.*
 import spectacular.*
 import urticose.*
@@ -55,8 +56,9 @@ object Attributive:
   given int: Int is Attributive to Whatwg.Integral = _ -> _.show
   given posInt: Int is Attributive to Whatwg.PositiveInt = _ -> _.show
   given double: Double is Attributive to Whatwg.Decimal = _ -> _.toString.tt
-  given domId: DomId is Attributive to Whatwg.Id = _ -> _.toString.tt
-  given stylesheet: Stylesheet is Attributive to Whatwg.CssClassList = _ -> _.classes.join(t" ")
+  given domId: (Name[DomId] is Attributive to Whatwg.Id) = _ -> _
+  given cssClass: (Name[CssClass] is Attributive to Whatwg.CssClassList) = _ -> _
+  given classList: ClassList is Attributive to Whatwg.CssClassList = _ -> _.classes.join(t" ")
 
   given url: [url: Abstractable across Urls to Text] => url is Attributive to Whatwg.Url =
     (key, value) => (key, value.generic)
@@ -64,7 +66,7 @@ object Attributive:
   given url: HttpUrl is Attributive to Whatwg.Url = (key, value) => (key, value.show)
   given style: Text is Attributive to Whatwg.Css = (key, value) => (key, value)
 
-  given cssClassList: List[Text] is Attributive to Whatwg.CssClassList =
+  given cssClassList: List[Name[CssClass]] is Attributive to Whatwg.CssClassList =
     (key, value) => (key, value.join(t" "))
 
 trait Attributive extends Typeclass, Resultant:

--- a/lib/honeycomb/src/core/honeycomb.ClassList.scala
+++ b/lib/honeycomb/src/core/honeycomb.ClassList.scala
@@ -30,12 +30,31 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package anticipation
+package honeycomb
 
+import anticipation.*
+import beneficence.*
+import contingency.*
+import gossamer.*
+import nomenclature.*
 import prepositional.*
+import symbolism.*
+import typonym.*
 
-trait GenericCssSelection extends Typeclass:
-  def selection(value: Self): Text
+object ClassList:
+  def apply[name <: Label: Reifiable to List[String]](): ClassList of name =
+    val classes = name.reify.map { label => unsafely(Name[CssClass](label.tt)) }.to(Set)
+    new ClassList(classes) { type Topic = name }
 
-  def contramap[self2](lambda: self2 => Self): self2 is GenericCssSelection =
-    value => selection(lambda(value))
+  given addable: ClassList is Addable by ClassList to ClassList =
+    (classes, additions) => ClassList(classes.classes ++ additions.classes)
+
+  given subtractable: ClassList is Subtractable by ClassList to ClassList =
+    (classes, subtractions) => ClassList(classes.classes -- subtractions.classes)
+
+  given empty: ClassList(Set()):
+    type Topic = "apply"
+
+// A set of CSS class names, e.g. for an element's `class` attribute. Build one
+// from class-name literals with `ClassList["one" | "two"]()`.
+case class ClassList(classes: Set[Name[CssClass]]) extends Topical, Findable

--- a/lib/honeycomb/src/core/soundness_honeycomb_core.scala
+++ b/lib/honeycomb/src/core/soundness_honeycomb_core.scala
@@ -35,8 +35,8 @@ package soundness
 export
   honeycomb
   . { Attribute, Attribution, Attributive, Autocomplete, Capture, Comment, Crossorigin, Doctype,
-      Dom, DomId, Element, Fragment, h, HDir, Honeycomb, Html, html, Html4Transitional, HttpEquiv,
-      Kind, Method, Node, Preload, Rel, Renderable, Rev, Sandbox, Shape, Stylesheet, Tag, Target,
+      Dom, Element, Fragment, h, HDir, Honeycomb, Html, html, Html4Transitional, HttpEquiv,
+      Kind, Method, Node, Preload, Rel, Renderable, Rev, Sandbox, Shape, ClassList, Tag, Target,
       TextNode, Unattributive, Whatwg, Wrap }
 
 package doms.html:

--- a/lib/legerdemain/src/core/legerdemain.Combobox.scala
+++ b/lib/legerdemain/src/core/legerdemain.Combobox.scala
@@ -33,8 +33,10 @@
 package legerdemain
 
 import anticipation.*
+import contingency.*
 import fulminate.*
 import honeycomb.*
+import nomenclature.*
 import prepositional.*
 import vacuous.*
 
@@ -46,8 +48,10 @@ object Combobox:
     val items = combobox.options.map: option =>
       whatwg.Option(value = option)
 
+    val id = unsafely(Name[DomId](combobox.name))
+
     Fragment
-      ( Input(name = combobox.name, list = DomId(combobox.name), value = combobox.value),
-        Datalist(id = DomId(combobox.name))(items*) )
+      ( Input(name = combobox.name, list = id, value = combobox.value),
+        Datalist(id = id)(items*) )
 
 case class Combobox(name: Text, options: List[Text], value: Text) extends Widget

--- a/lib/nomenclature/src/core/nomenclature.CssClass.scala
+++ b/lib/nomenclature/src/core/nomenclature.CssClass.scala
@@ -28,30 +28,16 @@
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
 ┃                                                                                                  ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package honeycomb
+package nomenclature
 
-import anticipation.*
-import beneficence.*
-import gossamer.*
 import prepositional.*
-import symbolism.*
-import typonym.*
+import rudiments.*
 
-object Stylesheet:
-  given generic: Stylesheet is GenericCssSelection = _.classes.join(t".", t".", t"")
+// The naming plane for a CSS class: `Name[CssClass]`. Names are constrained to
+// valid CSS identifiers (see `CssIdentifier`).
+object CssClass:
+  inline given nominative: CssClass is Nominative under CssIdentifier["a valid CSS identifier"] = !!
 
-  def apply[name <: Label: Reifiable to List[String]](): Stylesheet of name =
-    new Stylesheet(name.reify.map(_.tt).to(Set)) { type Topic = name }
-
-  given addable: Stylesheet is Addable by Stylesheet to Stylesheet =
-    (classes, additions) => Stylesheet(classes.classes ++ additions.classes)
-
-  given subtractable: Stylesheet is Subtractable by Stylesheet to Stylesheet =
-    (classes, subtractions) => Stylesheet(classes.classes -- subtractions.classes)
-
-  given empty: Stylesheet(Set()):
-    type Topic = "apply"
-
-case class Stylesheet(classes: Set[Text]) extends Topical, Findable
+sealed trait CssClass

--- a/lib/nomenclature/src/core/nomenclature.CssIdentifier.scala
+++ b/lib/nomenclature/src/core/nomenclature.CssIdentifier.scala
@@ -28,15 +28,18 @@
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
 ┃                                                                                                  ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package honeycomb
+package nomenclature
 
 import anticipation.*
-import gossamer.*
-import spectacular.*
+import fulminate.*
 
-object DomId:
-  given generic: DomId is GenericCssSelection = id => t"#${id.name}"
+// Requires that a name is a valid CSS `<ident-token>` (CSS Syntax Module Level 3),
+// the grammar shared by class selectors (`.name`) and the identifiers used by id
+// selectors. The `description` type parameter is the human-readable phrasing used
+// in error messages; the check itself is the exact (non-escaped) grammar.
+object CssIdentifier
+extends Rule({ description => m"must be $description" }, { (name, _) => identifierRules.css(name) })
 
-case class DomId(name: Text)
+sealed trait CssIdentifier[description <: Label] extends Check[description]

--- a/lib/nomenclature/src/core/nomenclature.DomId.scala
+++ b/lib/nomenclature/src/core/nomenclature.DomId.scala
@@ -28,8 +28,16 @@
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
 ┃                                                                                                  ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package nomenclature
 
-export anticipation.GenericCssSelection
+import prepositional.*
+import rudiments.*
+
+// The naming plane for a DOM element id: `Name[DomId]`. Names are constrained to
+// valid HTML ids (see `DomIdentifier`).
+object DomId:
+  inline given nominative: DomId is Nominative under DomIdentifier["a valid DOM id"] = !!
+
+sealed trait DomId

--- a/lib/nomenclature/src/core/nomenclature.DomIdentifier.scala
+++ b/lib/nomenclature/src/core/nomenclature.DomIdentifier.scala
@@ -28,33 +28,17 @@
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
 ┃                                                                                                  ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package tarantula
+package nomenclature
 
 import anticipation.*
-import oldcataclysm.*
-import gossamer.*
-import honeycomb.*
-import nomenclature.*
-import prepositional.*
-import spectacular.*
+import fulminate.*
 
-object Focusable:
-  def apply[element](strategy0: Text, focus0: element => Text): element is Focusable =
-    new Focusable:
-      type Self = element
-      def strategy: Text = strategy0
-      def focus(value: Self): Text = focus0(value)
+// Requires that a name is a valid HTML element id: at least one character and no
+// ASCII whitespace (per the HTML Living Standard). The `description` type
+// parameter is the human-readable phrasing used in error messages.
+object DomIdentifier
+extends Rule({ description => m"must be $description" }, { (name, _) => identifierRules.dom(name) })
 
-  given text: Text is Focusable = Focusable(t"link text", identity(_))
-  given selector: Selector is Focusable = Focusable(t"css selector", _.normalize.value)
-  given tag: Tag is Focusable = Focusable(t"tag name", _.label)
-  given domId: Name[DomId] is Focusable = Focusable(t"css selector", v => t"#$v")
-
-  given cssClass: ClassList is Focusable =
-    Focusable(t"css selector", _.classes.join(t".", t".", t""))
-
-trait Focusable extends Typeclass:
-  def strategy: Text
-  def focus(value: Self): Text
+sealed trait DomIdentifier[description <: Label] extends Check[description]

--- a/lib/nomenclature/src/core/nomenclature_core.scala
+++ b/lib/nomenclature/src/core/nomenclature_core.scala
@@ -32,12 +32,68 @@
                                                                                                   */
 package nomenclature
 
+import anticipation.*
 
 export nomenclature.internal.Name
 export nomenclature.Moniker.Moniker
 
 extension (inline context: StringContext)
   transparent inline def n: Any = ${protointernal.extractor('context)}
+
+// Predicates backing the `DomIdentifier` and `CssIdentifier` constraints. They
+// live here (not in the constraint objects) because a `Rule` super-constructor
+// argument cannot reference the object's own members. Index loops keep within
+// `java.lang`/`scala`/`proscenium` (no `Predef` string-collection extensions).
+private[nomenclature] object identifierRules:
+  // HTML element id: at least one character and no ASCII whitespace.
+  def dom(name: Text): Boolean =
+    val text = name.s
+    val length = text.length
+
+    if length == 0 then false else
+      var index = 0
+      var valid = true
+
+      while valid && index < length do
+        val char = text.charAt(index)
+
+        if char == '\t' || char == '\n' || char == '\r' || char == ' ' || char.toInt == 12
+        then valid = false
+
+        index += 1
+
+      valid
+
+  // CSS `<ident-token>` (CSS Syntax Module Level 3), non-escaped subset: an
+  // optional leading `-` (or `--`), an ident-start code point, then ident code
+  // points. Escapes and a lone `-` are not accepted.
+  def css(name: Text): Boolean =
+    val text = name.s
+    val length = text.length
+
+    def identStart(char: Char): Boolean =
+      char == '_' || char.toInt >= 0x80 || (char >= 'a' && char <= 'z')
+      || (char >= 'A' && char <= 'Z')
+
+    def identChar(char: Char): Boolean =
+      identStart(char) || char == '-' || (char >= '0' && char <= '9')
+
+    val start =
+      if length == 0 then -1
+      else if text.charAt(0) != '-' then (if identStart(text.charAt(0)) then 0 else -1)
+      else if length >= 2 && text.charAt(1) == '-' then 2
+      else if length >= 2 && identStart(text.charAt(1)) then 1
+      else -1
+
+    if start < 0 then false else
+      var index = start
+      var valid = true
+
+      while valid && index < length do
+        if !identChar(text.charAt(index)) then valid = false
+        index += 1
+
+      valid
 
 transparent inline def disintersect[intersection] =
   ${protointernal.disintersection[intersection]}

--- a/lib/nomenclature/src/core/soundness_nomenclature_core.scala
+++ b/lib/nomenclature/src/core/soundness_nomenclature_core.scala
@@ -34,6 +34,7 @@ package soundness
 
 export
   nomenclature
-  . { Check, disintersect, Moniker, MonikerError, MustContain, MustEnd, MustMatch, MustNotContain,
-      MustNotEnd, MustNotEqual, MustNotMatch, MustNotStart, MustStart, n, Name, NameError,
-      NameExtractor, Nominative, Required, Rule, staticCompanion, Vocabulary }
+  . { Check, CssClass, CssIdentifier, disintersect, DomId, DomIdentifier, Moniker, MonikerError,
+      MustContain, MustEnd, MustMatch, MustNotContain, MustNotEnd, MustNotEqual, MustNotMatch,
+      MustNotStart, MustStart, n, Name, NameError, NameExtractor, Nominative, Required, Rule,
+      staticCompanion, Vocabulary }

--- a/lib/nomenclature/src/test/nomenclature_test.scala
+++ b/lib/nomenclature/src/test/nomenclature_test.scala
@@ -85,6 +85,26 @@ object Tests extends Suite(m"Nomenclature tests"):
       capture[NameError](Name[Required](t"")).message.show
     . assert(_ == t"""the name “” is not valid because it must not be empty""")
 
+    test(m"A valid CSS class name is accepted"):
+      Name[CssClass](t"main-nav")
+    . assert(_ == t"main-nav")
+
+    test(m"A CSS class name may not start with a digit"):
+      capture[NameError](Name[CssClass](t"1col")).message.show
+    . assert(_ == t"the name 1col is not valid because it must be a valid CSS identifier")
+
+    test(m"A CSS class name is constructed at compiletime"):
+      n"button": Name[CssClass]
+    . assert(_ == t"button")
+
+    test(m"A valid DOM id is accepted"):
+      Name[DomId](t"main-content")
+    . assert(_ == t"main-content")
+
+    test(m"A DOM id may not contain whitespace"):
+      capture[NameError](Name[DomId](t"a b")).message.show
+    . assert(_ == t"the name a b is not valid because it must be a valid DOM id")
+
     val adjectives = cp"/nomenclature/adjectives.txt"
     val animals = cp"/nomenclature/animals.txt"
 

--- a/lib/oldcataclysm/src/core/oldcataclysm.Selectable.scala
+++ b/lib/oldcataclysm/src/core/oldcataclysm.Selectable.scala
@@ -32,17 +32,10 @@
                                                                                                   */
 package oldcataclysm
 
-import anticipation.*
 import prepositional.*
 
 object Selectable:
   given ident: Selector is Selectable = identity(_)
-
-  given generic: [selectable: GenericCssSelection] => selectable is Selectable =
-    selectable.selection(_).s match
-      case s".$cls" => Selector.Class(cls.tt)
-      case s"#$id"  => Selector.Id(id.tt)
-      case element  => Selector.Element(element.tt)
 
 trait Selectable extends Typeclass:
   def selector(value: Self): Selector


### PR DESCRIPTION
DOM ids and CSS class names were represented by three duplicated, unvalidated types (`honeycomb.DomId`, `honeycomb.Stylesheet`, and cataclysm's `Simple.Id`/`Simple.Class`). They are now a single pair of validated `nomenclature.Name` planes shared by both libraries.

```scala
Name[DomId]      // a DOM element id      (n"main-content" / Name[DomId](text))
Name[CssClass]   // a CSS class name      (n"button"       / Name[CssClass](text))
```

Each plane carries an exact-spec constraint — `DomIdentifier` (HTML id: non-empty, no ASCII whitespace) and `CssIdentifier` (the CSS `<ident-token>` grammar) — checked at compile time for literals (`n"…": Name[CssClass]`) or at runtime otherwise.

- **honeycomb**: `DomId` now comes from nomenclature; the misleadingly-named `Stylesheet` (really a set of classes) is renamed **`ClassList`** holding `Set[Name[CssClass]]`; the `id`/`class` attribute instances are keyed on the name types.
- **cataclysm**: `Simple.Id`/`Simple.Class` carry the typed names, the selector parser validates identifiers (raising a new `CssError.InvalidName` but continuing), and `Css#ids`/`Css#classes` return the typed name sets.
- Removes the now-unused `GenericCssSelection` typeclass and its `anticipation.css` module (only the honeycomb selections and `oldcataclysm.Selectable` used it), dropping `fulminate`'s spurious dependency on it.

Note: `DomId` and `CssClass` deliberately follow different specs (HTML id vs CSS identifier); and `Stylesheet`→`ClassList` is a rename of the class-set type only — the unrelated `Link.Stylesheet` / `rel="stylesheet"` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
