### PR TITLE
Adopt the validated DOM-id type in list attributes and css"" selectors

### DIFF
--- a/lib/cataclysm/src/core/cataclysm.CssInterpolator.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssInterpolator.scala
@@ -37,17 +37,23 @@ import scala.quoted.*
 import anticipation.*
 import contingency.*
 import fulminate.*
+import gossamer.*
+import nomenclature.*
 import spectacular.*
 import vacuous.*
 
 // The macro behind the `css"…"` interpolator. The literal parts are joined with a
 // sentinel char at each `$substitution`, parsed at compile time, and the parsed
 // `Css` is rebuilt as an `Expr` — a declaration value that is a lone sentinel
-// becomes the (type-checked) substitution, everything else is literal. A
-// substitution is therefore only allowed as a whole property value; anywhere else
-// (a selector, a property name, an at-rule prelude, or mixed with literal text) is
-// a compile error. Each substitution's type must have a `CssConvertible` whose VDS
-// type is valid for that property, so `css"a { color: $length }"` does not compile.
+// becomes the (type-checked) substitution, everything else is literal. Each such
+// substitution's type must have a `CssConvertible` whose VDS type is valid for that
+// property, so `css"a { color: $length }"` does not compile.
+//
+// A substitution within a selector is also permitted, but only of a `Name[CssClass]`
+// or a `Name[DomId]`, which render as the simple selectors `.class` and `#id`
+// respectively; so `css"$button { … }"` is a rule for the class `button`. Anywhere
+// else (a property name, an at-rule prelude, or mixed with literal property text) is
+// a compile error.
 //
 // NB: `Optional`'s `let`/`lay`/… are inline and crash `pickleQuotes` when used
 // around the quotes below, so this file branches on `Optional` with plain `match`.
@@ -108,14 +114,44 @@ object CssInterpolator:
         case _ =>
           halt(m"cataclysm: the substitution could not be read")
 
+    // The selector fragment for the next substitution, which must be a name: a
+    // `Name[CssClass]` renders as `.class` and a `Name[DomId]` as `#id`.
+    def selectorFragment(): Expr[Text] =
+      val expr = insertions(holeIndex)
+      holeIndex += 1
+      val pos = expr.asTerm.underlyingArgument.pos
+
+      expr match
+        case '{$value: tpe} =>
+          if TypeRepr.of[tpe] <:< TypeRepr.of[Name[CssClass]]
+          then '{(${Expr(".")} + ${value.asExprOf[Text]}.s).tt}
+          else if TypeRepr.of[tpe] <:< TypeRepr.of[Name[DomId]]
+          then '{(${Expr("#")} + ${value.asExprOf[Text]}.s).tt}
+          else halt(m"cataclysm: only a CSS class or DOM id may be substituted in a selector", pos)
+
+        case _ =>
+          halt(m"cataclysm: the substitution could not be read")
+
+    // Rebuild a selector containing substitutions: split its rendered text at each
+    // sentinel and interleave the (name-typed) holes between the literal segments.
+    def assembleSelector(text: Text): Expr[SelectorList] =
+      val segments = text.cut(placeholder)
+      var acc: Expr[String] = Expr(segments.head.s)
+
+      for segment <- segments.tail do
+        acc = '{$acc + ${selectorFragment()}.s + ${Expr(segment.s)}}
+
+      '{SelectorList.read($acc.tt)}
+
     def listExpr(nodes: List[Css.Node]): Expr[List[Css.Node]] = Expr.ofList(nodes.map(nodeExpr))
 
     def nodeExpr(node: Css.Node): Expr[Css.Node] = node match
       case Css.Node.Rule(selector, body) =>
-        if has(selector.show) then
-          halt(m"cataclysm: a substitution may only be a property value, not a selector")
+        val selectorExpr =
+          if has(selector.show) then assembleSelector(selector.show)
+          else '{SelectorList.read(${lift(selector.show)})}
 
-        '{Css.Node.Rule(SelectorList.read(${lift(selector.show)}), ${listExpr(body)})}
+        '{Css.Node.Rule($selectorExpr, ${listExpr(body)})}
 
       case Css.Node.Declaration(property, value) =>
         if has(property) then
@@ -141,6 +177,6 @@ object CssInterpolator:
     val result = '{Css(${listExpr(css.rules)})}
 
     if holeIndex != insertions.length
-    then halt(m"cataclysm: a substitution is only allowed as a property value")
+    then halt(m"cataclysm: a substitution is only allowed as a property value or in a selector")
 
     result

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -688,11 +688,30 @@ object Tests extends Suite(m"Cataclysm Tests"):
         css"@media screen { a { width: $width } }"
       . assert(_ == t"@media screen { a { width: 4px } }".read[Css])
 
+      val button = Name[CssClass](t"button")
+      val main = Name[DomId](t"main")
+
+      test(m"a CSS class substitution in selector position"):
+        css"$button { color: red }"
+      . assert(_ == t".button { color: red }".read[Css])
+
+      test(m"a DOM id substitution in selector position"):
+        css"$main { color: red }"
+      . assert(_ == t"#main { color: red }".read[Css])
+
+      test(m"a class substitution compounded with an element"):
+        css"div$button { color: red }"
+      . assert(_ == t"div.button { color: red }".read[Css])
+
+      test(m"a selector hole and a value hole in document order"):
+        css"$button { color: $red }"
+      . assert(_ == t".button { color: #ff0000 }".read[Css])
+
       test(m"a wrong-typed substitution fails to compile"):
         demilitarize(css"a { color: $width }").exists(_.message.contains("not valid for"))
       . assert(_ == true)
 
-      test(m"a substitution in selector position fails to compile"):
+      test(m"a non-name substitution in selector position fails to compile"):
         demilitarize(css"$width { color: red }").nonEmpty
       . assert(_ == true)
 

--- a/lib/honeycomb/src/core/honeycomb.Attributive.scala
+++ b/lib/honeycomb/src/core/honeycomb.Attributive.scala
@@ -69,5 +69,8 @@ object Attributive:
   given cssClassList: List[Name[CssClass]] is Attributive to Whatwg.CssClassList =
     (key, value) => (key, value.join(t" "))
 
+  given domIds: List[Name[DomId]] is Attributive to Whatwg.Ids =
+    (key, value) => (key, value.join(t" "))
+
 trait Attributive extends Typeclass, Resultant:
   def attribute(key: Text, value: Self): Optional[(Text, Optional[Text])]

--- a/lib/honeycomb/src/core/honeycomb.Whatwg.scala
+++ b/lib/honeycomb/src/core/honeycomb.Whatwg.scala
@@ -220,7 +220,7 @@ object Whatwg:
     attribute()
 
   given `for`: ("for" is Attribute on "label" of Id) = attribute()
-  given for2: ("for" is Attribute on "output" of Tokens) = attribute()
+  given for2: ("for" is Attribute on "output" of Ids) = attribute()
   given form: ("form" is Attribute on FormTags of Id) = attribute()
   given formaction: ("formaction" is Attribute on "input" | "button" of Url) = attribute()
   given formenctype: ("formenctype" is Attribute on "input" | "button" of Enctype) = attribute()
@@ -230,7 +230,7 @@ object Whatwg:
     attribute()
 
   given formtarget: ("formtarget" is Attribute on "input" | "button" of Target) = attribute()
-  given headers: ("headers" is Attribute on "td" | "th" of Tokens) = attribute()
+  given headers: ("headers" is Attribute on "td" | "th" of Ids) = attribute()
   given headingoffset: ("headingoffset" is Attribute of Upto8) = globalAttribute()
   given headingreset: ("headingoffset" is Attribute of Presence) = globalAttribute()
   given height: ("height" is Attribute on HeightTags of PositiveInt) = attribute()


### PR DESCRIPTION
Following the reconciliation of DOM-id and CSS-class names onto nomenclature's
validated Name types, this extends their use to two places that still took raw
text: the id-reference *list* attributes in honeycomb, and selector positions in
the css"…" interpolator. The id-reference list attributes (`headers`, and the
`output` element's `for`) now accept a list of `Name[DomId]`, and a css"…"
substitution may now appear in a selector when it is a `Name[CssClass]` or a
`Name[DomId]`.

## CSS class and id substitutions in selectors

A `css"…"` substitution in selector position is now permitted, provided it is a
`Name[CssClass]` (rendered as a class selector) or a `Name[DomId]` (rendered as
an id selector):

```scala
val button = n"button": Name[CssClass]
val main = n"main": Name[DomId]

css"$button { color: red }"        // .button { color: red }
css"$main { color: red }"          // #main { color: red }
css"div$button { color: $red }"    // div.button { color: … }
```

Any other type in selector position remains a compile error.

## Typed id-reference list attributes

The `headers` attribute (on `td`/`th`) and the `output` element's `for`
attribute are lists of DOM ids, so they now use the `Ids` marker (alongside
`itemref`) and accept a `List[Name[DomId]]`, matching the single-id attributes
already migrated. The general `Tokens` marker is unchanged, as it also covers
keyword lists such as `rel` and `blocking`.
