### PR TITLE
Expand cataclysm value-type coverage with global keywords and more units

### DIFF
--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -104,8 +104,32 @@ object Css:
       Value(convertible.value(instance)).asInstanceOf[Value of convertible.Topic]
 
   // Render a number for CSS, dropping a redundant `.0` (so `12px`, not `12.0px`).
+  // Values are rounded to six decimal places first, so unit conversions (e.g. a
+  // length in metres scaled to `mm`) don't leak binary floating-point noise like
+  // `30.000000000000004`.
   private[cataclysm] def number(value: Double): Text =
-    if value.isFinite && value == value.floor then value.toLong.show else value.toString.tt
+    if !value.isFinite then value.toString.tt
+    else
+      val rounded = Math.rint(value*1000000.0)/1000000.0
+      if rounded == rounded.floor then rounded.toLong.show else rounded.toString.tt
+
+  // The CSS-wide keywords (valid for every property) and the colour keywords, as
+  // typed values for `Css.Style(…)` and `css"…"`, e.g. `Css.Style(color = Css.inherit)`
+  // or `css"a { color: ${Css.transparent} }"`. The lowercase accessors avoid the
+  // clash a bare `Unset` would have with `vacuous.Unset`.
+  enum Keyword derives CanEqual:
+    case Inherit, Initial, Unset, Revert, RevertLayer
+
+  enum ColorKeyword derives CanEqual:
+    case Transparent, CurrentColor
+
+  val inherit: Keyword = Keyword.Inherit
+  val initial: Keyword = Keyword.Initial
+  val unset: Keyword = Keyword.Unset
+  val revert: Keyword = Keyword.Revert
+  val revertLayer: Keyword = Keyword.RevertLayer
+  val transparent: ColorKeyword = ColorKeyword.Transparent
+  val currentColor: ColorKeyword = ColorKeyword.CurrentColor
 
   into trait Value extends Topical:
     def text: Text

--- a/lib/cataclysm/src/core/cataclysm.CssConvertible.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssConvertible.scala
@@ -62,11 +62,11 @@ object CssConvertible:
   given vmaxes: (Quantity[ViewportMaxes[1]] is CssConvertible of "length") =
     q => t"${number(q.value)}vmax"
 
-  given centimetres: (Quantity[Centimetres[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}cm"
-
-  given millimetres: (Quantity[Millimetres[1]] is CssConvertible of "length") =
-    q => t"${number(q.value)}mm"
+  // Any physical length (Quantitative's `Distance` dimension) renders in `mm`; CSS
+  // reads `cm`/`mm`/etc. consistently, so the rendered unit need not match how the
+  // value was written. `q.value` is in metres, hence the factor of 1000.
+  given metres: (Quantity[Metres[1]] is CssConvertible of "length") =
+    q => t"${number(q.value*1000)}mm"
 
   given inches: (Quantity[Inches[1]] is CssConvertible of "length") = q => t"${number(q.value)}in"
   given points: (Quantity[Points[1]] is CssConvertible of "length") = q => t"${number(q.value)}pt"
@@ -81,8 +81,32 @@ object CssConvertible:
   given chroma: (Chroma is CssConvertible of "color") =
     color => hex(color.red, color.green, color.blue)
 
+  // Likewise any time (Quantitative's `Seconds`) renders in `ms`; `q.value` is in
+  // seconds, hence the factor of 1000.
+  given seconds: (Quantity[Seconds[1]] is CssConvertible of "time") =
+    q => t"${number(q.value*1000)}ms"
+
+  given degrees: (Quantity[Degrees[1]] is CssConvertible of "angle") = q => t"${number(q.value)}deg"
+  given radians: (Quantity[Radians[1]] is CssConvertible of "angle") = q => t"${number(q.value)}rad"
+
+  given turns: (Quantity[Turns[1]] is CssConvertible of "angle") =
+    q => t"${number(q.value)}turn"
+
+  given flexes: (Quantity[Flexes[1]] is CssConvertible of "flex") = q => t"${number(q.value)}fr"
+
   given integer: (Int is CssConvertible of "integer") = _.show
   given decimal: (Double is CssConvertible of "number") = Css.number(_)
+
+  given keyword: (Css.Keyword is CssConvertible of "*") = _ match
+    case Css.Keyword.Inherit     => t"inherit"
+    case Css.Keyword.Initial     => t"initial"
+    case Css.Keyword.Unset       => t"unset"
+    case Css.Keyword.Revert      => t"revert"
+    case Css.Keyword.RevertLayer => t"revert-layer"
+
+  given colorKeyword: (Css.ColorKeyword is CssConvertible of "color") = _ match
+    case Css.ColorKeyword.Transparent  => t"transparent"
+    case Css.ColorKeyword.CurrentColor => t"currentcolor"
 
   private def number(value: Double): Text = Css.number(value)
 

--- a/lib/cataclysm/src/core/cataclysm.CssMacros.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssMacros.scala
@@ -67,13 +67,18 @@ private[cataclysm] object CssMacros:
     case t"percentage" => t"1%"
     case t"number"     => t"1.5"
     case t"integer"    => t"1"
+    case t"time"       => t"1s"
+    case t"angle"      => t"1deg"
+    case t"flex"       => t"1fr"
     case _             => Unset
 
   // `Unset` if a value of VDS type `topic` is acceptable for `property`; otherwise
   // a `Message` describing why not (unknown property, or wrong value type).
   def propertyIssue(property: Text, topic: Text): Optional[Message] =
     PropertyDef.of(property).lay(m"cataclysm: $property is not a known CSS property"): definition =>
-      sample(topic).lay(Unset):
+      // A wildcard topic (the CSS-wide keywords) is valid for any known property.
+      if topic == t"*" then Unset
+      else sample(topic).lay(Unset):
         sampleText =>
           val outcome = safely(SyntaxMatcher.check(definition, sampleText))
 

--- a/lib/cataclysm/src/core/cataclysm.SyntaxMatcher.scala
+++ b/lib/cataclysm/src/core/cataclysm.SyntaxMatcher.scala
@@ -78,7 +78,13 @@ object SyntaxMatcher:
   private val timeUnits: Set[String] = Set("s", "ms")
   private val resolutionUnits: Set[String] = Set("dpi", "dpcm", "dppx", "x")
   private val frequencyUnits: Set[String] = Set("hz", "khz")
+  private val flexUnits: Set[String] = Set("fr")
   private val substitutions: Set[String] = Set("var", "env")
+
+  // The CSS-wide keywords are valid as the sole value of every property, but appear
+  // in no property's grammar, so they are accepted before grammar matching.
+  private val globalKeywords: Set[String] = Set("inherit", "initial", "unset", "revert",
+      "revert-layer")
 
   private val mathFunctions: Set[String] =
     Set("calc", "min", "max", "clamp", "sin", "cos", "tan", "asin", "acos", "atan", "atan2", "pow",
@@ -91,6 +97,10 @@ object SyntaxMatcher:
     case ValueToken.Function(name) => substitutions(lower(name))
     case _                         => false
 
+  private def globalKeyword(tokens: List[ValueToken]): Boolean = tokens match
+    case List(ValueToken.Ident(value)) => globalKeywords(lower(value))
+    case _                             => false
+
   def check(property: PropertyDef, value: Text)(using Tactic[CssError]): Outcome =
     check(property.grammar, value)
 
@@ -98,6 +108,7 @@ object SyntaxMatcher:
     val tokens = ValueTokenizer.tokens(value).filter(_ != ValueToken.Whitespace)
 
     if tokens.exists(substitution) then Outcome.Valid
+    else if globalKeyword(tokens) then Outcome.Valid
     else
       val matcher = Matcher()
 
@@ -296,6 +307,15 @@ object SyntaxMatcher:
         case "frequency" =>
           numeric(tokens)(frequencyLeaf)
 
+        case "flex" =>
+          flexLeaf(tokens)
+
+        case "ratio" =>
+          ratioLeaf(tokens)
+
+        case "declaration-value" | "any-value" =>
+          List(Nil)
+
         case "dimension" | "dimension-token" =>
           dimensionLeaf(tokens)
 
@@ -361,6 +381,17 @@ object SyntaxMatcher:
 
       case _ =>
         Nil
+
+    private def flexLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
+      case ValueToken.Dimension(_, unit, _) :: tail if flexUnits(lower(unit)) => List(tail)
+      case _                                                                  => Nil
+
+    // `<ratio> = <number> [ / <number> ]?`
+    private def ratioLeaf(tokens: List[ValueToken]): List[List[ValueToken]] =
+      numberLeaf(tokens).flatMap: rest =>
+        rest match
+          case ValueToken.Delim('/') :: tail => numberLeaf(tail)
+          case _                             => List(rest)
 
     private def dimensionLeaf(tokens: List[ValueToken]): List[List[ValueToken]] = tokens match
       case ValueToken.Dimension(_, _, _) :: tail => List(tail)

--- a/lib/cataclysm/src/core/cataclysm_units.scala
+++ b/lib/cataclysm/src/core/cataclysm_units.scala
@@ -33,13 +33,12 @@
 package cataclysm
 
 import quantitative.*
-import rudiments.*
 
 // CSS's relative and viewport units are modelled as fresh Quantitative dimensions
 // with no `Ratio` to anything else, so they are deliberately inconvertible:
-// `2.0*Em + 1.0*Vh` and `(1.0*Px).in[Centimetres]` are compile errors. The
-// absolute units (cm, mm, in, pt, pc) live in Quantitative's existing `Distance`
-// dimension and interconvert with one another as usual.
+// `2.0*Em + 1.0*Vh` and `(1.0*Px).in[Metres]` are compile errors. The physical
+// units (cm, mm, in, pt, pc) reuse Quantitative's `Distance` dimension and
+// interconvert with one another as usual.
 sealed trait CssPixel extends Dimension
 sealed trait CssFontSize extends Dimension
 sealed trait CssRootFontSize extends Dimension
@@ -62,21 +61,23 @@ trait ViewportMins[Power <: Nat] extends Units[Power, CssViewportMin]
 trait ViewportMaxes[Power <: Nat] extends Units[Power, CssViewportMax]
 trait Percents[Power <: Nat] extends Units[Power, CssRatio]
 
-// CSS-named absolute units in Quantitative's `Distance` dimension, alongside the
-// existing `Inches`, `Points` and `Picas`.
-object Centimetres:
-  inline given ratio: Ratio[Centimetres[-1] & Metres[1], 0.01] = !!
+// Angles and grid flex are fresh, deliberately-inconvertible dimensions (like the
+// relative lengths above): `1.0*Deg + 1.0*Rad` and `2.0*Fr + 1.0*Px` are errors.
+sealed trait CssDegree extends Dimension
+sealed trait CssRadian extends Dimension
+sealed trait CssTurn extends Dimension
+sealed trait CssFlex extends Dimension
 
-trait Centimetres[Power <: Nat] extends Units[Power, Distance]
+trait Degrees[Power <: Nat] extends Units[Power, CssDegree]
+trait Radians[Power <: Nat] extends Units[Power, CssRadian]
+trait Turns[Power <: Nat] extends Units[Power, CssTurn]
+trait Flexes[Power <: Nat] extends Units[Power, CssFlex]
 
-object Millimetres:
-  inline given ratio: Ratio[Millimetres[-1] & Metres[1], 0.001] = !!
-
-trait Millimetres[Power <: Nat] extends Units[Power, Distance]
-
-// One unit of each CSS dimension, to be multiplied by a number, e.g. `4.0*Px` or
-// `50.0*Pct`. Absolute lengths reuse Quantitative's `Inch`, with `Cm`/`Mm`/`Pt`/
-// `Pc` added here.
+// One unit of each CSS dimension, to be multiplied by a number, e.g. `4.0*Px`,
+// `50.0*Pct` or `200.0*Ms`. Physical lengths and times reuse Quantitative's own
+// `Metres` and `Seconds`, rendered respectively as `mm` and `ms` (see
+// `CssConvertible`), so `Cm`/`Mm`/`S`/`Ms` are convenient magnitudes, not new
+// types — `Inch`, `Centi(Metre)`, `Milli(Second)` etc. work just as well.
 val Px: Quantity[Pixels[1]] = Quantity(1.0)
 val Em: Quantity[Ems[1]] = Quantity(1.0)
 val Rem: Quantity[Rems[1]] = Quantity(1.0)
@@ -86,8 +87,14 @@ val Vw: Quantity[ViewportWidths[1]] = Quantity(1.0)
 val Vh: Quantity[ViewportHeights[1]] = Quantity(1.0)
 val Vmin: Quantity[ViewportMins[1]] = Quantity(1.0)
 val Vmax: Quantity[ViewportMaxes[1]] = Quantity(1.0)
-val Cm: Quantity[Centimetres[1]] = Quantity(1.0)
-val Mm: Quantity[Millimetres[1]] = Quantity(1.0)
+val Cm: Quantity[Metres[1]] = Quantity(0.01)
+val Mm: Quantity[Metres[1]] = Quantity(0.001)
 val Pt: Quantity[Points[1]] = Quantity(1.0)
 val Pc: Quantity[Picas[1]] = Quantity(1.0)
 val Pct: Quantity[Percents[1]] = Quantity(1.0)
+val S: Quantity[Seconds[1]] = Quantity(1.0)
+val Ms: Quantity[Seconds[1]] = Quantity(0.001)
+val Deg: Quantity[Degrees[1]] = Quantity(1.0)
+val Rad: Quantity[Radians[1]] = Quantity(1.0)
+val Turn: Quantity[Turns[1]] = Quantity(1.0)
+val Fr: Quantity[Flexes[1]] = Quantity(1.0)

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -35,8 +35,8 @@ package soundness
 export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
     Simple, Combinator, AttributeMatcher, AttributeTest, Namespace, PseudoArgument, CssFormatter,
     CssSerializer, CssConvertible, Pixels, Ems, Rems, Exs, Chs, ViewportWidths,
-    ViewportHeights, ViewportMins, ViewportMaxes, Centimetres, Millimetres, Percents, Px, Em, Rem,
-    Ex, Ch, Vw, Vh, Vmin, Vmax, Cm, Mm, Pt, Pc, Pct, css}
+    ViewportHeights, ViewportMins, ViewportMaxes, Percents, Degrees, Radians, Turns, Flexes, Px, Em,
+    Rem, Ex, Ch, Vw, Vh, Vmin, Vmax, Cm, Mm, Pt, Pc, Pct, S, Ms, Deg, Rad, Turn, Fr, css}
 
 package cssFormatters:
   export cataclysm.cssFormatters.{standard, compact}

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -523,6 +523,26 @@ object Tests extends Suite(m"Cataclysm Tests"):
         vmatch(Syntax.Repeated(ty(t"length"), 1, Unset, true), t"1px, 2px, 3px")
       . assert(_ == Outcome.Valid)
 
+      test(m"the global keyword inherit is valid for any property"):
+        vm(t"color", t"inherit")
+      . assert(_ == Outcome.Valid)
+
+      test(m"the global keyword unset is valid for any property"):
+        vm(t"width", t"unset")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a flex value is valid"):
+        vmatch(ty(t"flex"), t"1fr")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a ratio value is valid"):
+        vmatch(ty(t"ratio"), t"16/9")
+      . assert(_ == Outcome.Valid)
+
+      test(m"a single-number ratio is valid"):
+        vmatch(ty(t"ratio"), t"1")
+      . assert(_ == Outcome.Valid)
+
     suite(m"Selector names"):
       val css = t".a #b { color: red } @media screen { .c:not(.d) e#f { color: blue } }".read[Css]
 
@@ -606,6 +626,9 @@ object Tests extends Suite(m"Cataclysm Tests"):
       def lengthText(value: Css.Value of "length"): Text = value.text
       def colorText(value: Css.Value of "color"): Text = value.text
       def percentageText(value: Css.Value of "percentage"): Text = value.text
+      def timeText(value: Css.Value of "time"): Text = value.text
+      def angleText(value: Css.Value of "angle"): Text = value.text
+      def flexText(value: Css.Value of "flex"): Text = value.text
 
       test(m"pixels render with a px suffix"):
         lengthText(2.0*Px)
@@ -619,9 +642,13 @@ object Tests extends Suite(m"Cataclysm Tests"):
         lengthText(100.0*Vh)
       . assert(_ == t"100vh")
 
-      test(m"a centimetre value renders as cm"):
+      test(m"a centimetre value renders in millimetres"):
         lengthText(3.0*Cm)
-      . assert(_ == t"3cm")
+      . assert(_ == t"30mm")
+
+      test(m"a metres-based length always renders in mm"):
+        lengthText(2.0*Mm)
+      . assert(_ == t"2mm")
 
       test(m"an Srgb colour renders as a hex triplet"):
         colorText(iridescence.Srgb(1.0, 0.0, 0.0))
@@ -630,6 +657,22 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"a percentage renders with a percent sign"):
         percentageText(50.0*Pct)
       . assert(_ == t"50%")
+
+      test(m"a millisecond value renders with an ms suffix"):
+        timeText(200.0*Ms)
+      . assert(_ == t"200ms")
+
+      test(m"a second value renders in milliseconds"):
+        timeText(1.5*S)
+      . assert(_ == t"1500ms")
+
+      test(m"a degree value renders with a deg suffix"):
+        angleText(90.0*Deg)
+      . assert(_ == t"90deg")
+
+      test(m"a flex value renders with an fr suffix"):
+        flexText(2.0*Fr)
+      . assert(_ == t"2fr")
 
       test(m"adding two different relative units fails to compile"):
         demilitarize(2.0*Em + 1.0*Vh).nonEmpty
@@ -658,6 +701,22 @@ object Tests extends Suite(m"Cataclysm Tests"):
 
       test(m"an unknown property fails to compile"):
         demilitarize(Css.Style(notARealProperty = 4.0*Px)).exists(_.message.contains("known CSS"))
+      . assert(_ == true)
+
+      test(m"a global keyword is valid for any property"):
+        Css.Style(color = Css.inherit, width = Css.unset).text
+      . assert(_ == t"color: inherit; width: unset")
+
+      test(m"a transparent colour keyword renders"):
+        Css.Style(color = Css.transparent).text
+      . assert(_ == t"color: transparent")
+
+      test(m"a millisecond duration renders in a style"):
+        Css.Style(transitionDuration = 200.0*Ms).text
+      . assert(_ == t"transition-duration: 200ms")
+
+      test(m"an angle value for a colour property fails to compile"):
+        demilitarize(Css.Style(color = 5.0*Deg)).exists(_.message.contains("not valid for"))
       . assert(_ == true)
 
       test(m"a Css.Style is usable as a Honeycomb style attribute"):
@@ -706,6 +765,10 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"a selector hole and a value hole in document order"):
         css"$button { color: $red }"
       . assert(_ == t".button { color: #ff0000 }".read[Css])
+
+      test(m"a global keyword substitution in value position"):
+        css"a { color: ${Css.inherit} }"
+      . assert(_ == t"a { color: inherit }".read[Css])
 
       test(m"a wrong-typed substitution fails to compile"):
         demilitarize(css"a { color: $width }").exists(_.message.contains("not valid for"))


### PR DESCRIPTION
This extends the new cataclysm CSS library's value validation and typed-value
authoring. The matcher now accepts the CSS-wide keywords for any property and a
few more value types, and there are typed Scala values for global keywords,
colour keywords, and angle/flex units. Physical lengths and times reuse
Quantitative's existing dimensions rather than introducing new CSS-specific unit
types.

## CSS-wide keywords

`inherit`, `initial`, `unset`, `revert` and `revert-layer` are valid as the sole
value of every property. The matcher now accepts them (previously `color: inherit`
was reported invalid), and they are available as typed values:

```scala
Css.Style(color = Css.inherit, display = Css.unset)
css"a { color: ${Css.inherit} }"
```

(The accessors are lowercase — `Css.inherit` etc. — to avoid clashing with
`vacuous.Unset`.)

## More value types

The value matcher now understands `<flex>` (the `fr` unit), `<ratio>` (e.g.
`16/9`), and `<declaration-value>`/`<any-value>`, so more real-world values
validate instead of reporting as unsupported.

## Time, angle and flex values

Physical lengths and times reuse Quantitative's own `Metres` and `Seconds`
dimensions, rendered as `mm` and `ms` respectively — CSS reads `cm`/`mm` and
`s`/`ms` consistently, so the unit a value was written in need not be preserved:

```scala
Css.Style(transitionDuration = 200.0*Ms)   // → transition-duration: 200ms
Css.Style(width = 3.0*Cm)                   // → width: 30mm
Css.Style(color = Css.transparent)
```

`Cm`/`Mm`/`S`/`Ms` are convenient magnitudes over `Metres`/`Seconds`, not new
types. Angle (`Deg`, `Rad`, `Turn`) and flex (`Fr`) are CSS-specific dimensions
with no Quantitative equivalent. Each value is still type-checked against the
property's grammar, so e.g. an angle for `color` fails to compile.
