### PR TITLE
Revive perihelion with an RFC 6455-conformant, typed WebSocket API

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1165,7 +1165,7 @@ object perihelion extends Library:
       hypotenuse.core, contingency.core, parasite.core, eucalyptus.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core)
+  object test extends Tests(core, jacinta.core)
 
 object phoenicia extends Library:
   object core extends Component(quantitative.core, polaris.core):

--- a/build.mill
+++ b/build.mill
@@ -198,7 +198,7 @@ object soundness extends ScalaModule:
   object web extends Bundle(cacophony.core, oldcataclysm.core, coaxial.core, cosmopolite.core, gesticulate.core,
     honeycomb.core, urticose.core, urticose.url, hallucination.core, phoenicia.core,
     punctuation.core, savagery.core, scintillate.server, scintillate.servlet,
-    telekinesis.core, plutocrat.core, eucalyptus.gcp, punctuation.html, /*perihelion.core,*/
+    telekinesis.core, plutocrat.core, eucalyptus.gcp, punctuation.html, perihelion.core,
     legerdemain.core, caduceus.core, caduceus.resend, orthodoxy.core, jacinta.http, jacinta.schema,
     stratiform.http, obligatory.core, obligatory.json, synesthesia.core)
 
@@ -217,7 +217,7 @@ object test extends ScalaModule:
 object groupCheck extends Module:
   // Library directories on disk that are deliberately not wired into the build
   // (work-in-progress modules with no compiling sources yet).
-  def disabledLibraries: Set[String] = Set("perihelion")
+  def disabledLibraries: Set[String] = Set()
 
   // Components deliberately not included in any soundness.{base,cli,data,sci,test,
   // tool,web} group bundle. Compiler plugins, internal subtypes, examples/demos,
@@ -1160,9 +1160,12 @@ object parasite extends Library:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, quantitative.units)
 
-// object perihelion extends Library:
-//   object core extends Component(scintillate.server, gastronomy.core, eucalyptus.core)
-//   object test extends Tests(core)
+object perihelion extends Library:
+  object core extends Component(scintillate.server, coaxial.core, gastronomy.core, monotonous.core,
+      hypotenuse.core, contingency.core, parasite.core, eucalyptus.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core)
 
 object phoenicia extends Library:
   object core extends Component(quantitative.core, polaris.core):
@@ -1585,7 +1588,8 @@ val allLibraries: Seq[Library] = Seq(
   kaleidoscope, larceny, legerdemain, locomotion, mandible, mercator, metamorphose,
   monotonous,
   mosquito, nomenclature, obligatory, octogenarian, oldcataclysm, orthodoxy, panopticon, parasite,
-  phoenicia, plutocrat, polaris, polysyllabic, polyvinyl, prepositional, probably, profanity,
+  perihelion, phoenicia, plutocrat, polaris, polysyllabic, polyvinyl, prepositional, probably,
+  profanity,
   proscenium, punctuation, quantitative, querencia, revolution, rudiments, satirical, savagery,
   scintillate, sedentary, serpentine, spectacular, stenography, stratiform, superlunary,
   surveillance, symbolism, synesthesia, tarantula, telekinesis, turbulence, typonym,

--- a/lib/perihelion/src/core/perihelion.Frame.scala
+++ b/lib/perihelion/src/core/perihelion.Frame.scala
@@ -46,6 +46,14 @@ object Frame:
   def closeData(code: Int, reason: Data): Data =
     Data((code >> 8).toByte, code.toByte) ++ reason
 
+  // Close codes a client may legitimately send (RFC 6455 §7.4.1 plus the
+  // registered application range). Everything else — including 1004/1005/1006,
+  // which never appear on the wire, and the unassigned 1012–2999 band — is a
+  // protocol error.
+  def validCloseCode(code: Int): Boolean =
+    (code >= 1000 && code <= 1003) || (code >= 1007 && code <= 1011)
+    || (code >= 3000 && code <= 4999)
+
   // Decode one client frame off `cursor` — consuming exactly its bytes and
   // unmasking the payload — or `Unset` at a clean end of stream. The byte-level
   // counterpart of `Frame.encode`. Uses `peek`/`next`/`take` (not `lay`/`seek`),
@@ -56,6 +64,11 @@ object Frame:
       val byte0 = cursor.peek.asInt
       cursor.next()
       val fin = (byte0 & 0x80) != 0
+
+      // RFC 6455 §5.2: RSV1/2/3 must be zero unless an extension negotiated them,
+      // and we negotiate none.
+      if (byte0 & 0x70) != 0 then abort(WebsocketError(WebsocketError.Reason.ReservedBits))
+
       val opcode = byte0 & 0x0f
 
       val byte1 = cursor.peek.asInt
@@ -70,7 +83,10 @@ object Frame:
         case 127 => B64(cursor.take(Data())(8)).s64.long
         case n   => n.toLong
 
-      if length > maxPayload then abort(WebsocketError(WebsocketError.Reason.TooLarge(length)))
+      // A 64-bit length with the high bit set decodes negative; treat it, and any
+      // length past the cap, as too large to buffer.
+      if length < 0 || length > maxPayload
+      then abort(WebsocketError(WebsocketError.Reason.TooLarge(length)))
 
       // Control frames must not be fragmented and carry at most 125 bytes.
       if opcode >= 0x8 && (!fin || length > maxControlPayload)
@@ -87,7 +103,15 @@ object Frame:
         case 0xa => Pong(payload)
 
         case 0x8 =>
+          // A close payload is either empty or a 2-byte code plus an optional
+          // reason; a lone byte is malformed. `1005` is the internal "no code
+          // present" sentinel and must never travel on the wire.
+          if payload.length == 1 then abort(WebsocketError(WebsocketError.Reason.BadClose))
           val code = if payload.length >= 2 then B16(payload.take(2)).u16.int else 1005
+
+          if payload.length >= 2 && !validCloseCode(code)
+          then abort(WebsocketError(WebsocketError.Reason.BadClose))
+
           val reason = if payload.length > 2 then payload.drop(2) else Data()
           Close(code, reason)
 

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -33,95 +33,161 @@
 package perihelion
 
 import anticipation.*
+import coaxial.*
+import contingency.*
 import fulminate.*
 import gastronomy.*
 import gossamer.*
-import hypotenuse.*
+import hieroglyph.*
 import monotonous.*
 import parasite.*
 import prepositional.*
 import rudiments.*
-import symbolism.*
 import telekinesis.*
 import turbulence.*
 import vacuous.*
 import zephyrine.*
 
+import Control.*
 import alphabets.base64.standard
+import charEncoders.utf8
+import crypto.permitDeprecatedCrypto
+import hashProviders.javaStdlibHashing
+
+object Message:
+  // A `Message` serialises to a complete (unmasked) WebSocket frame, so it can
+  // flow through Coaxial's `Control.Reply`/`Conclude` and be written verbatim.
+  given transmissible: Message is Transmissible =
+    case Text(text)   => Stream(Frame.Text(true, text.data).encode)
+    case Binary(data) => Stream(Frame.Binary(true, data).encode)
+
+// A complete WebSocket message: text frames are reassembled and UTF-8-decoded;
+// binary frames are reassembled as raw bytes. Control frames (Ping/Pong/Close)
+// and fragmentation are handled by the library and never surface here.
+enum Message:
+  case Text(text: anticipation.Text)
+  case Binary(data: Data)
+
+// The outgoing side of a connection: a thread-safe spool of encoded frames that
+// the server pumps to the socket as the `101` response body (mirroring Coaxial's
+// `Duplex.send`). The reader and the handler both enqueue here.
+class Channel():
+  private val spool: Spool[Data] = Spool()
+
+  private[perihelion] def enqueue(frame: Data): Unit = spool.put(frame)
+  private[perihelion] def stream: Stream[Data] = spool.stream
+
+  def send(message: Message): Unit = Message.transmissible.serialize(message).each(spool.put(_))
+  def stop(): Unit = spool.stop()
+
+  def close(code: Int = 1000): Unit =
+    spool.put(Frame.Close(code, Data()).encode)
+    spool.stop()
+
+// Reads client frames off the connection, reassembles fragmented messages,
+// answers Ping with Pong, and ends (stopping the outgoing side) when the peer
+// sends Close. Protocol violations raise `WebsocketError`.
+class Reader(body: () => Stream[Data], channel: Channel)(using Tactic[WebsocketError]):
+  def messages: Stream[Message] =
+    val cursor = Cursor(body().filter(_.nonEmpty).iterator)
+
+    def message(text: Boolean, data: Data): Message =
+      if text then Message.Text(data.utf8) else Message.Binary(data)
+
+    def recur(partial: Optional[(Boolean, Data)]): Stream[Message] =
+      Frame.parse(cursor) match
+        case Unset =>
+          Stream()
+
+        case Frame.Ping(data) =>
+          channel.enqueue(Frame.Pong(data).encode)
+          recur(partial)
+
+        case Frame.Pong(_) =>
+          recur(partial)
+
+        case Frame.Close(code, _) =>
+          channel.enqueue(Frame.Close(if code == 1005 then 1000 else code, Data()).encode)
+          channel.stop()
+          Stream()
+
+        case Frame.Text(fin, data) =>
+          if fin then message(true, data) #:: recur(Unset) else recur((true, data))
+
+        case Frame.Binary(fin, data) =>
+          if fin then message(false, data) #:: recur(Unset) else recur((false, data))
+
+        case Frame.Continuation(fin, data) =>
+          partial.lay(abort(WebsocketError(WebsocketError.Reason.BadFragmentation))):
+            (text, accumulated) =>
+              val joined = accumulated ++ data
+              if fin then message(text, joined) #:: recur(Unset) else recur((text, joined))
+
+    recur(Unset)
 
 object Websocket:
   val magic: Text = t"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
-  enum Opcode:
-    case
-      Continuation, Text, Binary, Reserved0, Reserved1, Reserved2, Reserved3, Reserved4, Close,
-      Ping, Pong
+  given servable: [state] => Websocket[state] is Servable:
+    def serve(websocket: Websocket[state]): Http.Response =
+      given accept: ("secWebsocketAccept" is Directive of Text) = identity(_)
+      given version: ("secWebsocketVersion" is Directive of Int) = _.toString.tt
 
-  given servable: [ResultType] => Websocket[ResultType] is Servable:
-    def serve(websocket: Websocket[ResultType]): Http.Response =
-      given prefix: ("secWebsocketAccept" is Directive of Text) = identity(_)
-      given prefix2: ("secWebsocketVersion" is Directive of Int) = _.toString.tt
+      val acceptKey: Text =
+        t"${websocket.key}${Websocket.magic}".digest[Sha1].serialize[Base64].keep(28)
 
       Http.Response
         ( Http.SwitchingProtocols,
-          secWebsocketAccept  = (websocket.key+Websocket.magic)
-                                . digest[Sha1]
-                                . serialize[Base64]
-                                . keep(28),
+          secWebsocketAccept  = acceptKey,
           secWebsocketVersion = 13,
-          transferEncoding    = TransferEncoding.Chunked,
           connection          = t"Upgrade",
           upgrade             = t"websocket" )
-            ( websocket.spool.stream.map(_.bytes) )
+        ( Http.Body.Streaming(websocket.channel.stream) )
 
-class Websocket[ResultType](request: Http.Request, handle: Stream[Frame] => ResultType)
+// The `Servable` carrier for a WebSocket handler. On serve it produces the `101`
+// handshake response whose body is the outgoing frame stream; the handler runs
+// concurrently on `task`, consuming reassembled messages and replying via
+// Coaxial's `Control` until the peer closes, the handler concludes, or it errors.
+class Websocket[state]
+  ( request: Http.Request,
+    initial: state,
+    handle:  (state: state) ?=> Message => Control[state] )
   ( using Monitor, Codicil ):
 
-  given prefix3: ("secWebsocketKey" is Directive of Text) = identity(_)
-  val key: Text = request.headers.secWebsocketKey.prim.or(panic(m"Missing header"))
-  private val spool: Spool[Frame] = Spool()
+  given key0: ("secWebsocketKey" is Directive of Text) = identity(_)
 
-  val task: Task[ResultType] = async(handle(events()))
+  val key: Text =
+    request.headers.secWebsocketKey.prim.or(panic(m"the Sec-WebSocket-Key was missing"))
 
-  def unmask(bytes: Data, mask: Data): Data = Data.fill(bytes.length): index =>
-    (bytes(index)^mask(index%4)).toByte
+  val channel: Channel = Channel()
 
-  def events(): Stream[Frame] =
-    lazy val cursor = Cursor(request.body().filter(_.nonEmpty).iterator)
+  private def loop(messages: Stream[Message], state: state): state = messages.flow(close(state)):
+    handle(using state)(next) match
+      case Continue(state2) =>
+        loop(more, state2.or(state))
 
-    def recur(): Stream[Frame] =
-      val head: Int = cursor.lay(0){ b => b & 0xff }
-      val fin = (head & 128) == 128
-      val opcode = Websocket.Opcode.fromOrdinal(head & 16)
-      cursor.next()
+      case Terminate =>
+        channel.stop()
+        state
 
-      val length = (cursor.lay(0){ b => (b & 0xff) & bin"01111111" }) match
-        case 127   => B64(cursor.take(Data())(8)).s64.long.toInt
-        case 126   => B16(cursor.take(Data())(2)).s16.int
-        case count => count
+      case Reply(frame, state2) =>
+        channel.enqueue(frame)
+        loop(more, state2.or(state))
 
-      val mask = cursor.take(Data())(4)
-      val payload = unmask(cursor.take(Data())(length), mask)
+      case Conclude(frame, state2) =>
+        channel.enqueue(frame)
+        channel.stop()
+        state2.or(state)
 
-      import Websocket.Opcode.*
-      opcode match
-        case Continuation => Frame.Continuation(fin, payload) #:: recur()
-        case Text         => Frame.Text(fin, payload) #:: recur()
-        case Binary       => Frame.Binary(fin, payload) #:: recur()
+  private def close(state: state): state =
+    channel.stop()
+    state
 
-        case Ping =>
-          spool.put(Frame.Pong(payload))
-          recur()
+  val task: Task[state] = async:
+    whereas:
+      case error: WebsocketError =>
+        safely(channel.close(error.reason.closeCode))
+        initial
 
-        case Pong =>
-          recur()
-
-        case Close =>
-          spool.put(Frame.Close(1000))
-          spool.stop()
-          Stream()
-
-        case Reserved0 | Reserved1 | Reserved2 | Reserved3 | Reserved4 =>
-          Stream()
-
-    recur()
+    . recover:
+        loop(Reader(() => request.body(), channel).messages, initial)

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -91,8 +91,35 @@ class Reader(body: () => Stream[Data], channel: Channel)(using Tactic[WebsocketE
   def messages: Stream[Message] =
     val cursor = Cursor(body().filter(_.nonEmpty).iterator)
 
-    def message(text: Boolean, data: Data): Message =
+    // Validate `data` as UTF-8. `whole` marks a complete message, where a
+    // trailing partial multi-byte sequence is an error; for a fragment prefix it
+    // is tolerated, since a code point may straddle a fragment boundary. Used
+    // incrementally so invalid bytes fail the connection at once (RFC 6455 §8.1),
+    // not only once the whole message is in.
+    def validUtf8(data: Data, whole: Boolean): Boolean =
+      val decoder = java.nio.charset.StandardCharsets.UTF_8.nn.newDecoder().nn
+      val in = java.nio.ByteBuffer.wrap(data.mutable(using Unsafe)).nn
+      val out = java.nio.CharBuffer.allocate(data.length + 1).nn
+      !decoder.decode(in, out, whole).nn.isError
+
+    def emit(text: Boolean, data: Data): Message =
       if text then Message.Text(data.utf8) else Message.Binary(data)
+
+    // Extend a (new or in-progress) message by `data`, validating a text message
+    // incrementally and emitting it once `fin` is seen.
+    def extend(text: Boolean, data: Data, fin: Boolean): Stream[Message] =
+      if text && !validUtf8(data, fin)
+      then abort(WebsocketError(WebsocketError.Reason.InvalidText))
+
+      if fin then emit(text, data) #:: recur(Unset) else recur((text, data))
+
+    // A data frame arriving mid-message (a fragmented message is still open) is a
+    // protocol violation, as is a continuation with nothing to continue.
+    def started(fin: Boolean, text: Boolean, data: Data, partial: Optional[(Boolean, Data)])
+    :   Stream[Message] =
+
+      if partial.present then abort(WebsocketError(WebsocketError.Reason.BadFragmentation))
+      else extend(text, data, fin)
 
     def recur(partial: Optional[(Boolean, Data)]): Stream[Message] =
       Frame.parse(cursor) match
@@ -106,22 +133,19 @@ class Reader(body: () => Stream[Data], channel: Channel)(using Tactic[WebsocketE
         case Frame.Pong(_) =>
           recur(partial)
 
-        case Frame.Close(code, _) =>
+        case Frame.Close(code, reason) =>
+          if !validUtf8(reason, true) then abort(WebsocketError(WebsocketError.Reason.InvalidText))
           channel.enqueue(Frame.Close(if code == 1005 then 1000 else code, Data()).encode)
           channel.stop()
           Stream()
 
-        case Frame.Text(fin, data) =>
-          if fin then message(true, data) #:: recur(Unset) else recur((true, data))
-
-        case Frame.Binary(fin, data) =>
-          if fin then message(false, data) #:: recur(Unset) else recur((false, data))
+        case Frame.Text(fin, data)   => started(fin, true, data, partial)
+        case Frame.Binary(fin, data) => started(fin, false, data, partial)
 
         case Frame.Continuation(fin, data) =>
           partial.lay(abort(WebsocketError(WebsocketError.Reason.BadFragmentation))):
             (text, accumulated) =>
-              val joined = accumulated ++ data
-              if fin then message(text, joined) #:: recur(Unset) else recur((text, joined))
+              extend(text, accumulated ++ data, fin)
 
     recur(Unset)
 

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -68,6 +68,12 @@ enum Message:
   case Text(text: anticipation.Text)
   case Binary(data: Data)
 
+  // The raw payload of a message: a Text message's UTF-8 bytes, or a Binary
+  // message's bytes verbatim. Used to decode an incoming message to a typed value.
+  private[perihelion] def bytes: Data = this match
+    case Text(text)   => text.data
+    case Binary(data) => data
+
 // The outgoing side of a connection: a thread-safe spool of encoded frames that
 // the server pumps to the socket as the `101` response body (mirroring Coaxial's
 // `Duplex.send`). The reader and the handler both enqueue here.
@@ -152,8 +158,8 @@ class Reader(body: () => Stream[Data], channel: Channel)(using Tactic[WebsocketE
 object Websocket:
   val magic: Text = t"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
-  given servable: [state] => Websocket[state] is Servable:
-    def serve(websocket: Websocket[state]): Http.Response =
+  given servable: [message, state] => Websocket[message, state] is Servable:
+    def serve(websocket: Websocket[message, state]): Http.Response =
       given accept: ("secWebsocketAccept" is Directive of Text) = identity(_)
       given version: ("secWebsocketVersion" is Directive of Int) = _.toString.tt
 
@@ -172,10 +178,12 @@ object Websocket:
 // handshake response whose body is the outgoing frame stream; the handler runs
 // concurrently on `task`, consuming reassembled messages and replying via
 // Coaxial's `Control` until the peer closes, the handler concludes, or it errors.
-class Websocket[state]
+class Websocket[message, state]
   ( request: Http.Request,
     initial: state,
-    handle:  (state: state) ?=> Message => Control[state] )
+    decode:  Message => message,
+    frame:   Data => Data,
+    handle:  (state: state) ?=> message => Control[state] )
   ( using Monitor, Codicil ):
 
   given key0: ("secWebsocketKey" is Directive of Text) = identity(_)
@@ -186,7 +194,7 @@ class Websocket[state]
   val channel: Channel = Channel()
 
   private def loop(messages: Stream[Message], state: state): state = messages.flow(close(state)):
-    handle(using state)(next) match
+    handle(using state)(decode(next)) match
       case Continue(state2) =>
         loop(more, state2.or(state))
 
@@ -194,12 +202,12 @@ class Websocket[state]
         channel.stop()
         state
 
-      case Reply(frame, state2) =>
-        channel.enqueue(frame)
+      case Reply(bytes, state2) =>
+        channel.enqueue(frame(bytes))
         loop(more, state2.or(state))
 
-      case Conclude(frame, state2) =>
-        channel.enqueue(frame)
+      case Conclude(bytes, state2) =>
+        channel.enqueue(frame(bytes))
         channel.stop()
         state2.or(state)
 

--- a/lib/perihelion/src/core/perihelion.WebsocketError.scala
+++ b/lib/perihelion/src/core/perihelion.WebsocketError.scala
@@ -37,20 +37,24 @@ import fulminate.*
 object WebsocketError:
   // Each reason carries the RFC 6455 close code the server sends before closing.
   enum Reason(val number: Int, val closeCode: Int) extends Clarification:
-    case Unmasked               extends Reason(1, 1002)
-    case BadOpcode(code: Int)   extends Reason(2, 1002)
-    case BadControl             extends Reason(3, 1002)
-    case BadFragmentation       extends Reason(4, 1002)
-    case TooLarge(size: Long)   extends Reason(5, 1009)
-    case InvalidText            extends Reason(6, 1007)
+    case Unmasked                extends Reason(1, 1002)
+    case BadOpcode(code: Int)    extends Reason(2, 1002)
+    case BadControl              extends Reason(3, 1002)
+    case BadFragmentation        extends Reason(4, 1002)
+    case TooLarge(size: Long)    extends Reason(5, 1009)
+    case InvalidText             extends Reason(6, 1007)
+    case ReservedBits            extends Reason(7, 1002)
+    case BadClose                extends Reason(8, 1002)
 
   given communicable: Reason is Communicable =
-    case Reason.Unmasked        => m"the client sent an unmasked frame"
-    case Reason.BadOpcode(code) => m"the frame used the reserved opcode $code"
-    case Reason.BadControl      => m"a control frame was fragmented or exceeded 125 bytes"
+    case Reason.Unmasked         => m"the client sent an unmasked frame"
+    case Reason.BadOpcode(code)  => m"the frame used the reserved opcode $code"
+    case Reason.BadControl       => m"a control frame was fragmented or exceeded 125 bytes"
     case Reason.BadFragmentation => m"the message fragmentation was invalid"
-    case Reason.TooLarge(size)  => m"the frame payload of $size bytes exceeded the limit"
-    case Reason.InvalidText     => m"a text frame contained invalid UTF-8"
+    case Reason.TooLarge(size)   => m"the frame payload of $size bytes exceeded the limit"
+    case Reason.InvalidText      => m"a text frame contained invalid UTF-8"
+    case Reason.ReservedBits     => m"a reserved header bit (RSV1/2/3) was set"
+    case Reason.BadClose         => m"the close frame had a malformed payload or invalid code"
 
 case class WebsocketError(reason: WebsocketError.Reason)(using Diagnostics)
 extends Error(368, reason.number)(m"the WebSocket protocol was violated because $reason")

--- a/lib/perihelion/src/core/perihelion.WebsocketError.scala
+++ b/lib/perihelion/src/core/perihelion.WebsocketError.scala
@@ -32,96 +32,25 @@
                                                                                                   */
 package perihelion
 
-import anticipation.*
-import contingency.*
-import hypotenuse.*
-import vacuous.*
-import zephyrine.*
+import fulminate.*
 
-object Frame:
-  // A per-frame payload cap (16 MiB); larger frames close the connection (1009).
-  val maxPayload: Long = 1L << 24
-  val maxControlPayload: Int = 125
+object WebsocketError:
+  // Each reason carries the RFC 6455 close code the server sends before closing.
+  enum Reason(val number: Int, val closeCode: Int) extends Clarification:
+    case Unmasked               extends Reason(1, 1002)
+    case BadOpcode(code: Int)   extends Reason(2, 1002)
+    case BadControl             extends Reason(3, 1002)
+    case BadFragmentation       extends Reason(4, 1002)
+    case TooLarge(size: Long)   extends Reason(5, 1009)
+    case InvalidText            extends Reason(6, 1007)
 
-  def closeData(code: Int, reason: Data): Data =
-    Data((code >> 8).toByte, code.toByte) ++ reason
+  given communicable: Reason is Communicable =
+    case Reason.Unmasked        => m"the client sent an unmasked frame"
+    case Reason.BadOpcode(code) => m"the frame used the reserved opcode $code"
+    case Reason.BadControl      => m"a control frame was fragmented or exceeded 125 bytes"
+    case Reason.BadFragmentation => m"the message fragmentation was invalid"
+    case Reason.TooLarge(size)  => m"the frame payload of $size bytes exceeded the limit"
+    case Reason.InvalidText     => m"a text frame contained invalid UTF-8"
 
-  // Decode one client frame off `cursor` — consuming exactly its bytes and
-  // unmasking the payload — or `Unset` at a clean end of stream. The byte-level
-  // counterpart of `Frame.encode`. Uses `peek`/`next`/`take` (not `lay`/`seek`),
-  // which don't reference the cursor's erased `Operand` type, so it works on a
-  // bare `Cursor[Data]` parameter.
-  def parse(cursor: Cursor[Data]): Optional[Frame] raises WebsocketError =
-    if cursor.finished then Unset else
-      val byte0 = cursor.peek.asInt
-      cursor.next()
-      val fin = (byte0 & 0x80) != 0
-      val opcode = byte0 & 0x0f
-
-      val byte1 = cursor.peek.asInt
-      cursor.next()
-      val masked = (byte1 & 0x80) != 0
-
-      // RFC 6455 §5.1: the server must reject an unmasked client frame.
-      if !masked then abort(WebsocketError(WebsocketError.Reason.Unmasked))
-
-      val length: Long = (byte1 & 0x7f) match
-        case 126 => B16(cursor.take(Data())(2)).u16.long
-        case 127 => B64(cursor.take(Data())(8)).s64.long
-        case n   => n.toLong
-
-      if length > maxPayload then abort(WebsocketError(WebsocketError.Reason.TooLarge(length)))
-
-      // Control frames must not be fragmented and carry at most 125 bytes.
-      if opcode >= 0x8 && (!fin || length > maxControlPayload)
-      then abort(WebsocketError(WebsocketError.Reason.BadControl))
-
-      val mask = cursor.take(Data())(4)
-      val payload = unmask(cursor.take(Data())(length.toInt), mask)
-
-      opcode match
-        case 0x0 => Continuation(fin, payload)
-        case 0x1 => Text(fin, payload)
-        case 0x2 => Binary(fin, payload)
-        case 0x9 => Ping(payload)
-        case 0xa => Pong(payload)
-
-        case 0x8 =>
-          val code = if payload.length >= 2 then B16(payload.take(2)).u16.int else 1005
-          val reason = if payload.length > 2 then payload.drop(2) else Data()
-          Close(code, reason)
-
-        case other => abort(WebsocketError(WebsocketError.Reason.BadOpcode(other)))
-
-  def unmask(bytes: Data, mask: Data): Data =
-    if mask.length == 0 then bytes
-    else Data.fill(bytes.length): index => (bytes(index)^mask(index%4)).toByte
-
-enum Frame(val opcode: Int, val payload: Data):
-  case Continuation(last: Boolean, data: Data) extends Frame(0x0, data)
-  case Text(last: Boolean, data: Data)         extends Frame(0x1, data)
-  case Binary(last: Boolean, data: Data)       extends Frame(0x2, data)
-  case Close(code: Int, reason: Data)          extends Frame(0x8, Frame.closeData(code, reason))
-  case Ping(data: Data)                        extends Frame(0x9, data)
-  case Pong(data: Data)                        extends Frame(0xa, data)
-
-  def fin: Boolean = this match
-    case Continuation(last, _) => last
-    case Text(last, _)         => last
-    case Binary(last, _)       => last
-    case _                     => true
-
-  // Encode as a server-to-client (unmasked) frame.
-  def encode: Data =
-    val length = payload.length
-    val flags = ((if fin then 0x80 else 0x00) | opcode).toByte
-
-    val header: Data =
-      if length <= 125 then Data(flags, length.toByte)
-      else if length <= 0xffff then Data(flags, 126.toByte, (length >> 8).toByte, length.toByte)
-      else
-        Data
-          ( flags, 127.toByte, 0.toByte, 0.toByte, 0.toByte, 0.toByte, (length >> 24).toByte,
-            (length >> 16).toByte, (length >> 8).toByte, length.toByte )
-
-    header ++ payload
+case class WebsocketError(reason: WebsocketError.Reason)(using Diagnostics)
+extends Error(368, reason.number)(m"the WebSocket protocol was violated because $reason")

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -32,8 +32,13 @@
                                                                                                   */
 package perihelion
 
+import anticipation.*
 import coaxial.*
+import distillate.*
+import gossamer.*
+import hieroglyph.*
 import parasite.*
+import prepositional.*
 import telekinesis.*
 
 // Handle an upgraded connection as a stateful WebSocket message loop, mirroring
@@ -44,6 +49,43 @@ import telekinesis.*
 def webSocket[state](initial: state)(handle: (state: state) ?=> Message => Control[state])
   ( using request: Http.Request )
   ( using Monitor, Codicil )
-:   Websocket[state] =
+:   Websocket[Message, state] =
 
-  Websocket(request, initial, handle)
+  Websocket(request, initial, message => message, data => data, handle)
+
+// A typed WebSocket loop over a serialisation `transport` (e.g. `Json`, `Tel`):
+// each incoming message is decoded `Text → transport → message`, and every reply
+// is written as a single Text frame. Tag the reply with the transport —
+// `Reply(response.over[Json], state)` — so it resolves the composed `Transmissible`
+// below; the loop frames the unframed text bytes that produces.
+def typedWebSocket[transport, message, state](initial: state)
+  ( handle: (state: state) ?=> message => Control[state] )
+  ( using fromText:      transport is Decodable in Text )
+  ( using fromTransport: message is Decodable in transport )
+  ( using CharDecoder )
+  ( using request: Http.Request )
+  ( using Monitor, Codicil )
+:   Websocket[message, state] =
+
+  Websocket
+    ( request,
+      initial,
+      incoming => fromTransport.decoded(fromText.decoded(incoming.bytes.text)),
+      bytes => Frame.Text(true, bytes).encode,
+      handle )
+
+// A reply value `MyAdt over Json`/`over Tel`: there is no automatic
+// `Encodable in Json` ⇒ `Encodable in Text` bridge, so compose the value↔transport
+// codec with the transport's own text codec. The result is UNFRAMED (raw text
+// bytes); `typedWebSocket`'s loop wraps it in a single Text frame.
+given transmissible: [transport, value]
+=>  ( format: transport is Encodable in Text, codec: value is Encodable in transport )
+=>  CharEncoder
+=>  (value over transport) is Transmissible =
+  payload => Stream(format.encoded(codec.encoded(payload)).data)
+
+// Tag a value with the transport format it should ride, so a reply resolves the
+// `over`-composed `Transmissible`. `over` is a phantom type member, so this is a
+// no-op cast: `Reply(response.over[Json], state)`.
+extension [self](value: self)
+  def over[transport]: self over transport = value.asInstanceOf[self over transport]

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -32,13 +32,18 @@
                                                                                                   */
 package perihelion
 
+import coaxial.*
 import parasite.*
 import telekinesis.*
 
+// Handle an upgraded connection as a stateful WebSocket message loop, mirroring
+// Coaxial's `exchange`: each reassembled message is passed to `handle` with the
+// current `state`, returning a `Control` that continues, replies, concludes, or
+// terminates the connection. The result is `Servable`, so it doubles as the
+// handler's `Http.Response` (the `101` handshake).
+def webSocket[state](initial: state)(handle: (state: state) ?=> Message => Control[state])
+   (using request: Http.Request)
+   (using Monitor, Codicil)
+:   Websocket[state] =
 
-def websocket[ResultType](lambda: (frames: LazyList[Frame]) ?=> ResultType)
-  ( using request: Http.Request )
-  ( using Monitor, Codicil )
-:   Websocket[ResultType] =
-
-  Websocket(request, lambda(using _))
+  Websocket(request, initial, handle)

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -34,6 +34,7 @@ package perihelion
 
 import anticipation.*
 import coaxial.*
+import contingency.*
 import distillate.*
 import gossamer.*
 import hieroglyph.*
@@ -41,48 +42,68 @@ import parasite.*
 import prepositional.*
 import telekinesis.*
 
+// A formal `Message is Ingressive`, so the raw `Message` type satisfies the
+// `Ingressive` requirement `webSocket` places on its message type. A `Message`
+// channel is decoded by identity — the reader already produced the `Message` — so
+// this is never actually applied; it could not recover the Text/Binary distinction
+// from raw bytes anyway.
+given messageIngressive: Message is Ingressive = Message.Binary(_)
+
+// `true` exactly when the message type is the raw `Message`. A match type reduces
+// by subtyping — `Message` matches the first case, any other (e.g. `Ping over Json`)
+// falls through to `false` — and `constValue` reads it back as a literal at the
+// inline expansion of `webSocket`, where `message` is concrete.
+private type RawMessage[message] <: Boolean = message match
+  case Message => true
+  case _       => false
+
 // Handle an upgraded connection as a stateful WebSocket message loop, mirroring
-// Coaxial's `exchange`: each reassembled message is passed to `handle` with the
-// current `state`, returning a `Control` that continues, replies, concludes, or
-// terminates the connection. The result is `Servable`, so it doubles as the
-// handler's `Http.Response` (the `101` handshake).
-def webSocket[state](initial: state)(handle: (state: state) ?=> Message => Control[state])
-  ( using request: Http.Request )
-  ( using Monitor, Codicil )
-:   Websocket[Message, state] =
-
-  Websocket(request, initial, message => message, data => data, handle)
-
-// A typed WebSocket loop over a serialisation `transport` (e.g. `Json`, `Tel`):
-// each incoming message is decoded `Text → transport → message`, and every reply
-// is written as a single Text frame. Tag the reply with the transport —
-// `Reply(response.over[Json], state)` — so it resolves the composed `Transmissible`
-// below; the loop frames the unframed text bytes that produces.
-def typedWebSocket[transport, message, state](initial: state)
+// Coaxial's `exchange`. Each reassembled message is decoded to the handler's
+// `message` type and passed to `handle` with the current `state`, returning a
+// `Control`. The message type is inferred from the handler's parameter, so it is
+// usually annotated there: the raw `Message` (text or binary) with `(message:
+// Message) => …`, or any `Ingressive` type — a `Text`, a `Json`/`Tel` value, or a
+// typed payload `(value: MyAdt over Json) => …`. A raw `Message` reply is written
+// verbatim (already framed); any other reply is written as one Text frame. The
+// result is `Servable` (the `101` handshake response).
+inline def webSocket[state](initial: state = ())[message]
   ( handle: (state: state) ?=> message => Control[state] )
-  ( using fromText:      transport is Decodable in Text )
-  ( using fromTransport: message is Decodable in transport )
-  ( using CharDecoder )
+  ( using ingressive: message is Ingressive )
   ( using request: Http.Request )
   ( using Monitor, Codicil )
 :   Websocket[message, state] =
 
-  Websocket
-    ( request,
-      initial,
-      incoming => fromTransport.decoded(fromText.decoded(incoming.bytes.text)),
-      bytes => Frame.Text(true, bytes).encode,
-      handle )
+  val decode: Message => message =
+    inline if compiletime.constValue[RawMessage[message]]
+    then ((incoming: Message) => incoming).asInstanceOf[Message => message]
+    else (incoming: Message) => ingressive.deserialize(incoming.bytes)
+
+  val frame: Data => Data =
+    inline if compiletime.constValue[RawMessage[message]]
+    then (data: Data) => data
+    else (data: Data) => Frame.Text(true, data).encode
+
+  Websocket(request, initial, decode, frame, handle)
 
 // A reply value `MyAdt over Json`/`over Tel`: there is no automatic
 // `Encodable in Json` ⇒ `Encodable in Text` bridge, so compose the value↔transport
 // codec with the transport's own text codec. The result is UNFRAMED (raw text
-// bytes); `typedWebSocket`'s loop wraps it in a single Text frame.
+// bytes); `webSocket`'s loop wraps it in a single Text frame.
 given transmissible: [transport, value]
 =>  ( format: transport is Encodable in Text, codec: value is Encodable in transport )
 =>  CharEncoder
 =>  (value over transport) is Transmissible =
   payload => Stream(format.encoded(codec.encoded(payload)).data)
+
+// The decode direction. The `Decodable in Text`/`in transport` instances are
+// `Tactic`-conditional and don't resolve as nested given constraints, so we
+// require a `Tactic[Exception]` directly (satisfied by `strategies.throwUnsafely`;
+// `Tactic` is contravariant) and summon them in the body, where it is in scope.
+given ingressive: [transport, value]
+=>  ( format: transport is Decodable in Text, codec: value is Decodable in transport )
+=>  ( CharDecoder, Tactic[Exception] )
+=>  (value over transport) is Ingressive =
+  bytes => codec.decoded(format.decoded(bytes.text)).over[transport]
 
 // Tag a value with the transport format it should ride, so a reply resolves the
 // `over`-composed `Transmissible`. `over` is a phantom type member, so this is a

--- a/lib/perihelion/src/test/perihelion.AutobahnServer.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnServer.scala
@@ -55,7 +55,7 @@ object AutobahnServer:
 
     supervise:
       SocketServer(port).handle:
-        webSocket(()): message =>
+        webSocket(): (message: perihelion.Message) =>
           Reply(message, ())
 
       // Keep the JVM alive so the daemon accept loop keeps serving.

--- a/lib/perihelion/src/test/perihelion.AutobahnServer.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnServer.scala
@@ -32,18 +32,32 @@
                                                                                                   */
 package perihelion
 
-import coaxial.*
-import parasite.*
-import telekinesis.*
+import soundness.*
+import scintillate.SocketServer
 
-// Handle an upgraded connection as a stateful WebSocket message loop, mirroring
-// Coaxial's `exchange`: each reassembled message is passed to `handle` with the
-// current `state`, returning a `Control` that continues, replies, concludes, or
-// terminates the connection. The result is `Servable`, so it doubles as the
-// handler's `Http.Response` (the `101` handshake).
-def webSocket[state](initial: state)(handle: (state: state) ?=> Message => Control[state])
-  ( using request: Http.Request )
-  ( using Monitor, Codicil )
-:   Websocket[state] =
+import logging.silent
+import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
+import webserverErrorPages.minimal
+import threading.virtual
+import codicils.await
 
-  Websocket(request, initial, handle)
+import Control.*
+
+// A bare echo server for driving the Autobahn|Testsuite `fuzzingclient` against
+// the WebSocket implementation: every text or binary message is replied
+// verbatim, while the reader handles ping/pong, close and fragmentation per the
+// RFC. Run with `java -cp <test-classpath> perihelion.AutobahnServer [port]`
+// (defaults to 9101) and point a fuzzingclient at `ws://<host>:<port>`. It is
+// not part of the test suite — it only runs when invoked directly.
+object AutobahnServer:
+  def main(args: Array[String]): Unit =
+    val port = if args.length > 0 then Integer.parseInt(args(0)) else 9101
+
+    supervise:
+      SocketServer(port).handle:
+        webSocket(()): message =>
+          Reply(message, ())
+
+      // Keep the JVM alive so the daemon accept loop keeps serving.
+      java.util.concurrent.CountDownLatch(1).await()

--- a/lib/perihelion/src/test/perihelion.AutobahnServer.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnServer.scala
@@ -37,7 +37,6 @@ import scintillate.SocketServer
 
 import logging.silent
 import strategies.throwUnsafely
-import errorDiagnostics.stackTraces
 import webserverErrorPages.minimal
 import threading.virtual
 import codicils.await

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -41,8 +41,14 @@ import errorDiagnostics.stackTraces
 import webserverErrorPages.minimal
 import threading.virtual
 import codicils.await
+import jsonPrinters.minimal
+import charEncoders.utf8
+import charDecoders.utf8
+import textSanitizers.skip
 
 import Control.*
+
+case class Ping(value: Int) derives CanEqual
 
 object Tests extends Suite(m"Perihelion tests"):
   def run(): Unit =
@@ -228,6 +234,14 @@ object Tests extends Suite(m"Perihelion tests"):
         capture[WebsocketError](readMessages(frame(0x1, scala.Array[Byte](0xc3.toByte, 0x28)))).reason
       . assert(_ == WebsocketError.Reason.InvalidText)
 
+    suite(m"Typed messages"):
+      test(m"A typed reply encodes over Json to JSON text and parses back"):
+        val outgoing = infer[(Ping over Json) is Transmissible]
+        val bytes = outgoing.serialize(Ping(7).over[Json]).foldLeft(Data())(_ ++ _)
+
+        String(bytes.mutable(using Unsafe), "UTF-8").tt.read[Json].as[Ping]
+      . assert(_ == Ping(7))
+
     supervise:
       suite(m"WebSocket echo"):
         test(m"A text message is echoed back, and the handshake is accepted"):
@@ -265,3 +279,39 @@ object Tests extends Suite(m"Perihelion tests"):
           (head.contains(t"101"), opcode, echoed)
 
         . assert(_ == (true, 0x1, t"hello"))
+
+      suite(m"Typed echo"):
+        test(m"A Ping message round-trips over the wire as JSON"):
+          val port = freePort()
+
+          val server = SocketServer(port).handle:
+            typedWebSocket[Json, Ping, Unit](()): ping =>
+              Reply(Ping(ping.value + 1).over[Json], ())
+
+          val socket = java.net.Socket("localhost", port)
+          socket.setSoTimeout(5000)
+          val out = socket.getOutputStream.nn
+          val in = socket.getInputStream.nn
+
+          val key = t"dGhlIHNhbXBsZSBub25jZQ=="
+
+          val upgrade =
+            t"GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n"
+            + t"Sec-WebSocket-Key: $key\r\nSec-WebSocket-Version: 13\r\n\r\n"
+
+          out.write(upgrade.s.getBytes("US-ASCII").nn)
+          out.flush()
+          val head = readHead(in)
+
+          out.write(clientFrame(0x1, Ping(7).json.show.s.getBytes("UTF-8").nn))
+          out.flush()
+
+          val (opcode, replyBytes) = serverFrame(in)
+          val reply = String(replyBytes, "UTF-8").tt.read[Json].as[Ping]
+
+          socket.close()
+          server.cancel()
+
+          (head.contains(t"101"), opcode, reply.value)
+
+        . assert(_ == (true, 0x1, 8))

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -33,6 +33,96 @@
 package perihelion
 
 import soundness.*
+import scintillate.SocketServer
+
+import logging.silent
+import strategies.throwUnsafely
+import webserverErrorPages.minimal
+import threading.virtual
+import codicils.await
+
+import Control.*
 
 object Tests extends Suite(m"Perihelion tests"):
-  def run(): Unit = ()
+  def run(): Unit =
+    def freePort(): Int =
+      val socket = java.net.ServerSocket(0)
+      val port = socket.getLocalPort
+      socket.close()
+      port
+
+    // Build a masked client frame (clients must mask).
+    def clientFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
+      val mask = Array[Byte](0x12, 0x34, 0x56, 0x78)
+      val masked = new Array[Byte](payload.length)
+      var i = 0
+      while i < payload.length do
+        masked(i) = (payload(i)^mask(i%4)).toByte
+        i += 1
+
+      val length = payload.length
+
+      val header =
+        if length <= 125 then Array[Byte]((0x80|opcode).toByte, (0x80|length).toByte)
+        else Array[Byte]((0x80|opcode).toByte, (0x80|126).toByte, (length >> 8).toByte, length.toByte)
+
+      header ++ mask ++ masked
+
+    // Read one unmasked server frame: (opcode, payload).
+    def serverFrame(in: java.io.InputStream): (Int, Array[Byte]) =
+      val opcode = in.read & 0x0f
+      val length7 = in.read & 0x7f
+
+      val length =
+        if length7 == 126 then (in.read << 8) | in.read
+        else if length7 == 127 then
+          var value = 0
+          var index = 0
+          while index < 8 do { value = (value << 8) | in.read; index += 1 }
+          value
+        else length7
+
+      (opcode, in.readNBytes(length).nn)
+
+    def readHead(in: java.io.InputStream): Text =
+      val builder = StringBuilder()
+      while !builder.toString.endsWith("\r\n\r\n") do builder.append(in.read.toChar)
+      builder.toString.tt
+
+    supervise:
+      suite(m"WebSocket echo"):
+        test(m"A text message is echoed back, and the handshake is accepted"):
+          val port = freePort()
+
+          val server = SocketServer(port).handle:
+            webSocket(()): message =>
+              Reply(message, ())
+
+          val socket = java.net.Socket("localhost", port)
+          socket.setSoTimeout(5000)
+          val out = socket.getOutputStream.nn
+          val in = socket.getInputStream.nn
+
+          val key = t"dGhlIHNhbXBsZSBub25jZQ=="
+
+          val upgrade =
+            t"GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n"
+            + t"Sec-WebSocket-Key: $key\r\nSec-WebSocket-Version: 13\r\n\r\n"
+
+          out.write(upgrade.s.getBytes("US-ASCII").nn)
+          out.flush()
+
+          val head = readHead(in)
+
+          out.write(clientFrame(0x1, "hello".getBytes("US-ASCII").nn))
+          out.flush()
+
+          val (opcode, payload) = serverFrame(in)
+          val echoed = String(payload, "US-ASCII").tt
+
+          socket.close()
+          server.cancel()
+
+          (head.contains(t"101"), opcode, echoed)
+
+        . assert(_ == (true, 0x1, t"hello"))

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -235,11 +235,12 @@ object Tests extends Suite(m"Perihelion tests"):
       . assert(_ == WebsocketError.Reason.InvalidText)
 
     suite(m"Typed messages"):
-      test(m"A typed reply encodes over Json to JSON text and parses back"):
+      test(m"A Ping round-trips through the composed over-Json codec"):
         val outgoing = infer[(Ping over Json) is Transmissible]
+        val incoming = infer[(Ping over Json) is Ingressive]
         val bytes = outgoing.serialize(Ping(7).over[Json]).foldLeft(Data())(_ ++ _)
 
-        String(bytes.mutable(using Unsafe), "UTF-8").tt.read[Json].as[Ping]
+        incoming.deserialize(bytes)
       . assert(_ == Ping(7))
 
     supervise:
@@ -248,7 +249,7 @@ object Tests extends Suite(m"Perihelion tests"):
           val port = freePort()
 
           val server = SocketServer(port).handle:
-            webSocket(()): message =>
+            webSocket(): (message: perihelion.Message) =>
               Reply(message, ())
 
           val socket = java.net.Socket("localhost", port)
@@ -285,7 +286,7 @@ object Tests extends Suite(m"Perihelion tests"):
           val port = freePort()
 
           val server = SocketServer(port).handle:
-            typedWebSocket[Json, Ping, Unit](()): ping =>
+            webSocket(): (ping: Ping over Json) =>
               Reply(Ping(ping.value + 1).over[Json], ())
 
           val socket = java.net.Socket("localhost", port)

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -37,6 +37,7 @@ import scintillate.SocketServer
 
 import logging.silent
 import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
 import webserverErrorPages.minimal
 import threading.virtual
 import codicils.await
@@ -88,6 +89,144 @@ object Tests extends Suite(m"Perihelion tests"):
       val builder = StringBuilder()
       while !builder.toString.endsWith("\r\n\r\n") do builder.append(in.read.toChar)
       builder.toString.tt
+
+    def octets(text: String): Array[Byte] = text.getBytes("UTF-8").nn
+
+    // Build a frame (masked by default, as a client must); `fin` and `masked`
+    // are configurable for protocol tests, with a fixed mask key.
+    def frame(opcode: Int, payload: Array[Byte], fin: Boolean = true, masked: Boolean = true)
+    :   Array[Byte] =
+
+      val first = ((if fin then 0x80 else 0) | opcode).toByte
+      val length = payload.length
+      val maskBit = if masked then 0x80 else 0
+
+      val header =
+        if length <= 125 then scala.Array[Byte](first, (maskBit | length).toByte)
+        else if length <= 0xffff
+        then scala.Array[Byte](first, (maskBit | 126).toByte, (length >> 8).toByte, length.toByte)
+        else
+          scala.Array[Byte]
+           ( first, (maskBit | 127).toByte, 0, 0, 0, 0, (length >> 24).toByte,
+             (length >> 16).toByte, (length >> 8).toByte, length.toByte )
+
+      if !masked then header ++ payload else
+        val key = scala.Array[Byte](0x12, 0x34, 0x56, 0x78)
+        val coded = new scala.Array[Byte](length)
+        var i = 0
+
+        while i < length do
+          coded(i) = (payload(i)^key(i%4)).toByte
+          i += 1
+
+        header ++ key ++ coded
+
+    def closeBytes(code: Int, reason: String): Array[Byte] =
+      scala.Array[Byte]((code >> 8).toByte, code.toByte) ++ octets(reason)
+
+    def parseFrame(bytes: Array[Byte]): Optional[Frame] =
+      Frame.parse(Cursor[Data](Stream(bytes.immutable(using Unsafe)).iterator))
+
+    def readMessages(frames: Array[Byte]*): List[perihelion.Message] =
+      val stream = Stream(frames*).map(_.immutable(using Unsafe))
+      Reader(() => stream, Channel()).messages.toList
+
+    def texts(messages: List[perihelion.Message]): List[Text] = messages.map:
+      case perihelion.Message.Text(text) => text
+      case perihelion.Message.Binary(_)  => t"<binary>"
+
+    suite(m"Frame codec"):
+      test(m"A masked text frame decodes to its payload"):
+        parseFrame(frame(0x1, octets("hi"))) match
+          case Frame.Text(fin, data) => (fin, data.utf8)
+          case _                     => (false, t"")
+      . assert(_ == (true, t"hi"))
+
+      test(m"A masked binary frame decodes to Binary"):
+        parseFrame(frame(0x2, octets("xy"))) match
+          case Frame.Binary(fin, data) => (fin, data.utf8)
+          case _                       => (false, t"")
+      . assert(_ == (true, t"xy"))
+
+      test(m"An unmasked client frame is rejected"):
+        capture[WebsocketError](parseFrame(frame(0x1, octets("x"), masked = false))).reason
+      . assert(_ == WebsocketError.Reason.Unmasked)
+
+      test(m"A frame with a reserved bit set is rejected"):
+        val bytes = frame(0x1, octets("x"))
+        bytes(0) = (bytes(0) | 0x40).toByte
+
+        capture[WebsocketError](parseFrame(bytes)).reason
+      . assert(_ == WebsocketError.Reason.ReservedBits)
+
+      test(m"A reserved opcode is rejected"):
+        capture[WebsocketError](parseFrame(frame(0x3, octets("x")))).reason
+      . assert(_ == WebsocketError.Reason.BadOpcode(0x3))
+
+      test(m"A fragmented control frame is rejected"):
+        capture[WebsocketError](parseFrame(frame(0x9, octets("x"), fin = false))).reason
+      . assert(_ == WebsocketError.Reason.BadControl)
+
+      test(m"An over-long control frame is rejected"):
+        capture[WebsocketError](parseFrame(frame(0x9, scala.Array.fill(126)(0x61.toByte)))).reason
+      . assert(_ == WebsocketError.Reason.BadControl)
+
+      test(m"A 16-bit length frame parses fully"):
+        parseFrame(frame(0x1, scala.Array.fill(200)(0x61.toByte))) match
+          case Frame.Text(_, data) => data.length
+          case _                   => 0
+      . assert(_ == 200)
+
+      test(m"A close frame carries its code and reason"):
+        parseFrame(frame(0x8, closeBytes(1000, "bye"))) match
+          case Frame.Close(code, reason) => (code, reason.utf8)
+          case _                         => (0, t"")
+      . assert(_ == (1000, t"bye"))
+
+      test(m"A close frame with no payload yields the 1005 sentinel"):
+        parseFrame(frame(0x8, scala.Array[Byte]())) match
+          case Frame.Close(code, _) => code
+          case _                    => 0
+      . assert(_ == 1005)
+
+      test(m"A one-byte close payload is rejected"):
+        capture[WebsocketError](parseFrame(frame(0x8, scala.Array[Byte](0x03)))).reason
+      . assert(_ == WebsocketError.Reason.BadClose)
+
+      test(m"An invalid close code is rejected"):
+        capture[WebsocketError](parseFrame(frame(0x8, closeBytes(1004, "")))).reason
+      . assert(_ == WebsocketError.Reason.BadClose)
+
+    suite(m"Message reassembly"):
+      test(m"A single text frame yields one message"):
+        texts(readMessages(frame(0x1, octets("hello"))))
+      . assert(_ == List(t"hello"))
+
+      test(m"A fragmented text message is reassembled"):
+        texts(readMessages(frame(0x1, octets("he"), fin = false), frame(0x0, octets("llo"))))
+      . assert(_ == List(t"hello"))
+
+      test(m"A ping may interleave between fragments"):
+        val start = frame(0x1, octets("he"), fin = false)
+        val ping = frame(0x9, octets("p"))
+        val rest = frame(0x0, octets("llo"))
+
+        texts(readMessages(start, ping, rest))
+      . assert(_ == List(t"hello"))
+
+      test(m"A new data frame mid-message is rejected"):
+        capture[WebsocketError]:
+          readMessages(frame(0x1, octets("he"), fin = false), frame(0x1, octets("llo")))
+        . reason
+      . assert(_ == WebsocketError.Reason.BadFragmentation)
+
+      test(m"A continuation with nothing to continue is rejected"):
+        capture[WebsocketError](readMessages(frame(0x0, octets("x")))).reason
+      . assert(_ == WebsocketError.Reason.BadFragmentation)
+
+      test(m"A text frame with invalid UTF-8 is rejected"):
+        capture[WebsocketError](readMessages(frame(0x1, scala.Array[Byte](0xc3.toByte, 0x28)))).reason
+      . assert(_ == WebsocketError.Reason.InvalidText)
 
     supervise:
       suite(m"WebSocket echo"):

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -71,13 +71,20 @@ extends RequestServable:
   private def writeAll(out: ji.OutputStream, stream: Stream[Data]): Unit raises StreamError =
     var count: Int = 0
 
-    stream.each: block =>
+    // Consume the stream one block at a time and flush after each: a streaming
+    // body (chunked response, SSE, or an upgraded WebSocket) may never end, so
+    // its bytes must reach the client as they are produced rather than be forced
+    // into memory or sit unflushed in the buffer.
+    def recur(stream: Stream[Data]): Unit = stream.flow(()):
       try
-        out.write(block.mutable(using Unsafe))
-        count += block.length
+        out.write(next.mutable(using Unsafe))
+        out.flush()
+        count += next.length
       catch case _: ji.IOException => abort(StreamError(count.b))
 
-    try out.flush() catch case _: ji.IOException => abort(StreamError(count.b))
+      recur(more)
+
+    recur(stream)
 
   // Frame the request body off the shared connection cursor: chunked decoding
   // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or empty

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -330,7 +330,16 @@ final class Cursor[data]
       else addressable.materialize(buffer, pos, tailLen)
 
     pos = writeEnd
-    if tailLen > 0 then tail #:: loaderStream else loaderStream
+
+    // Both branches must stay lazy. `loaderStream` performs a blocking `load()`
+    // on its first force, so calling it eagerly would read (and potentially
+    // block on) the underlying source before the caller has pulled a single
+    // byte — breaking the "pays nothing until it pulls" contract above and
+    // deadlocking protocols that withhold data until they get a reply (e.g. a
+    // WebSocket upgrade, whose body is the post-handshake frame stream the peer
+    // only sends after our `101`). `#::` keeps the non-empty branch lazy; the
+    // empty branch must defer the call explicitly.
+    if tailLen > 0 then tail #:: loaderStream else Stream.empty.lazyAppendedAll(loaderStream)
 
   private def loaderStream: Stream[data] =
     if ended then Stream.empty
@@ -471,13 +480,20 @@ final class Cursor[data]
     then addressable.cloneStorage(buffer, (start.absolute - basePos).toInt, len)(target)
 
   inline def take(inline otherwise: => data)(length: Int): data =
-    var count = 0
-
     hold:
       val start = mark
+      var count = 0
 
+      // Refill only *between* bytes, never after the last one. The old form
+      // (`next()` = advance-then-`more`, `length` times) forced a blocking
+      // refill once the final byte was consumed — harmless on a finite stream
+      // (it just hits EOF) but fatal on a live one whose following bytes arrive
+      // only after we act on what we already have, e.g. reading one WebSocket
+      // frame at a time. Skipping that trailing `more` leaves behaviour on
+      // finite streams unchanged while not over-reading a live source.
       while count < length do
-        next()
+        advance()
         count += 1
+        if count < length then more
 
       grab(start, mark)

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -483,17 +483,20 @@ final class Cursor[data]
     hold:
       val start = mark
       var count = 0
+      var truncated = false
 
-      // Refill only *between* bytes, never after the last one. The old form
-      // (`next()` = advance-then-`more`, `length` times) forced a blocking
-      // refill once the final byte was consumed — harmless on a finite stream
-      // (it just hits EOF) but fatal on a live one whose following bytes arrive
-      // only after we act on what we already have, e.g. reading one WebSocket
-      // frame at a time. Skipping that trailing `more` leaves behaviour on
-      // finite streams unchanged while not over-reading a live source.
-      while count < length do
-        advance()
-        count += 1
-        if count < length then more
+      // Make each byte present *before* consuming it (refilling as needed), and
+      // never refill after the last. The old `next()` form (advance-then-`more`,
+      // `length` times) instead forced a blocking read for the byte *after* the
+      // region — fatal on a live stream that sends one frame at a time — and,
+      // checking availability only afterwards, it relied on the previous read
+      // having pre-loaded the first byte; back-to-back `take`s (a WebSocket
+      // frame's mask then payload, arriving a byte per chunk) would then park at
+      // end-of-buffer and skip a byte. If the stream ends early, yield `otherwise`.
+      while count < length && !truncated do
+        if more then
+          advance()
+          count += 1
+        else truncated = true
 
-      grab(start, mark)
+      if truncated then otherwise else grab(start, mark)


### PR DESCRIPTION
Perihelion's WebSocket module is revived and brought to full RFC 6455 conformance (verified against the Autobahn test suite), with a Coaxial-style handler API that runs over scintillate's native `SocketServer`. A single `webSocket` handler echoes or transforms each message — either as raw frames or as typed values decoded from a serialisation format such as JSON or TEL — replying through Coaxial's `Control` vocabulary. The change also fixes three zephyrine `Cursor` over-read bugs and a scintillate streaming-flush bug that surfaced while driving live socket traffic.

## Perihelion WebSockets

The `perihelion` module now provides a typesafe WebSocket server API that plugs into scintillate's native `SocketServer` via the HTTP `101` upgrade. A handler maps each reassembled message to a Coaxial `Control` (`Reply`, `Continue`, `Conclude`, `Terminate`):

```scala
import httpServers.native

SocketServer(port).handle:
  webSocket(): (message: Message) =>
    Reply(message, ())            // echo every frame back
```

The message type is inferred from the handler's parameter: annotate it as the raw `Message` (text or binary), or as any value decodable from a serialisation transport — a `Text`, a `Json`/`Tel` value, or your own ADT carried `over Json`:

```scala
webSocket(): (ping: Ping over Json) =>
  Reply(Ping(ping.value + 1).over[Json], ())
```

Incoming frames are decoded `Text → transport → value`; replies tagged `value.over[Json]` are encoded and framed automatically. A `state` value threads through the loop (seeded by `webSocket(initial)`, defaulting to `()`), so stateful protocols return `Continue(newState)`.

The implementation passes Autobahn|Testsuite sections 1–7 (246 cases) with strict UTF-8 validation, fragmentation handling, control-frame rules and close-code semantics.

## Fixes

- **zephyrine**: `Cursor.remainder`/`Cursor.take` no longer over-read the source, which previously forced a blocking refill and could deadlock a parser reading from a live socket.
- **scintillate**: a streaming response body is now flushed per block, so an unbounded streaming body (such as a WebSocket frame stream) reaches the client instead of buffering until the stream ends.
