### PR TITLE
Add typed asynchronous error handling to Parasite

### DIFF
--- a/doc/errors/169.md
+++ b/doc/errors/169.md
@@ -1,22 +1,22 @@
-# `SN-169` — Missing `Codicil` instance
+# `SN-169` — Missing `Probate` instance
 
 Raised at compile time by Obligatory's `rpc` macro when no
-contextual `Codicil` instance is available.
+contextual `Probate` instance is available.
 
 ## Cause
 
-The macro requires a `Codicil` to track and clean up resources
+The macro requires a `Probate` to track and clean up resources
 allocated by the RPC machinery.
 
 ## Example message
 
 ```
-[↯SN-169] a contextual `Codicil` instance is required
+[↯SN-169] a contextual `Probate` instance is required
 ```
 
 ## Resolution
 
-Bring a `Codicil` into scope at the call site (e.g. via a `Daemon`
+Bring a `Probate` into scope at the call site (e.g. via a `Daemon`
 or similar resource scope).
 
 ## See also

--- a/doc/honeycomb.md
+++ b/doc/honeycomb.md
@@ -446,7 +446,7 @@ Any `Document[Html]` may be converted to a stream with, `doc.stream[Text]` (or
 `doc.stream[Bytes]`), in a concurrent environment. This requires a few imports
 to set up:
 ```scala
-import codicils.cancel
+import probates.cancel
 import supervisors.global
 import threading.virtual
 

--- a/lib/anthology/src/java/anthology.Javac.scala
+++ b/lib/anthology/src/java/anthology.Javac.scala
@@ -64,7 +64,7 @@ case class Javac(options: List[JavacOption]):
 
   def apply(classpath: LocalClasspath)[path: Abstractable across Paths to Text]
     ( sources: Map[Text, Text], out: path )
-    ( using System, Monitor, Codicil )
+    ( using System, Monitor, Probate )
   :   CompileProcess logs CompileEvent raises CompilerError =
 
     Log.info(CompileEvent.Start)

--- a/lib/anthology/src/scala/anthology.Scalac.scala
+++ b/lib/anthology/src/scala/anthology.Scalac.scala
@@ -72,7 +72,7 @@ case class Scalac[version <: Scalac.Versions](options: List[Scalac.Option[versio
     ( classpath: LocalClasspath )
     [ path: Abstractable across Paths to Text ]
     ( sources: Map[Text, Text], out: path )
-    ( using System, Monitor, Codicil )
+    ( using System, Monitor, Probate )
   :   CompileProcess logs CompileEvent raises CompilerError =
 
     val scalacProcess: CompileProcess = CompileProcess()

--- a/lib/caduceus/src/core/caduceus.Sendable.scala
+++ b/lib/caduceus/src/core/caduceus.Sendable.scala
@@ -42,7 +42,7 @@ object Sendable:
   given text: Text is Sendable =
     text => Email(Map(), Email.Message(Email.Content(Email.Body(text))))
 
-  given htmlDoc: (Dom, Monitor, Codicil) => Document[Html] is Sendable =
+  given htmlDoc: (Dom, Monitor, Probate) => Document[Html] is Sendable =
     html =>
       Email(Map(), Email.Message(Email.Content(Email.Body.HtmlOnly(html.read[Text]))))
 

--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -51,7 +51,7 @@ object Css:
     case At(name: Text, prelude: Text, body: Optional[List[Node]])
 
 
-  given streamable: (Monitor, Codicil, CssFormatter) => Css is Streamable by Text =
+  given streamable: (Monitor, Probate, CssFormatter) => Css is Streamable by Text =
     CssSerializer.emit(_).to(Stream)
 
   given showable: CssFormatter => Css is Showable = CssSerializer.render(_)

--- a/lib/cataclysm/src/core/cataclysm.CssSerializer.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssSerializer.scala
@@ -45,7 +45,7 @@ import zephyrine.*
 // is chosen by a contextual `CssFormatter` (`cssFormatters.standard` or
 // `.compact`).
 object CssSerializer:
-  def emit(css: Css)(using CssFormatter, Monitor, Codicil): Iterator[Text] =
+  def emit(css: Css)(using CssFormatter, Monitor, Probate): Iterator[Text] =
     val emitter = Emitter[Text](4096)
 
     async:

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -42,22 +42,30 @@ import vacuous.*
 import Control.*
 
 extension [bindable: Bindable](socket: bindable)
-  def listen[input](using Monitor, Codicil)[result](lambda: bindable.Input => bindable.Output)
+  def listen[input](using Monitor, Probate)[result](lambda: bindable.Input => bindable.Output)
   :   SocketService raises BindError =
 
     val binding = bindable.bind(socket)
 
-    val bindLoop = loop:
-      val connection = bindable.connect(binding)
-      bindable.transmit(binding, connection, lambda(connection))
+    // Each accepted connection is handled on its own daemon, so connections are served
+    // concurrently and a failure in one — a handler error or a dropped client — is
+    // isolated by the trap (it ends that connection's daemon and the loop keeps
+    // accepting) rather than tearing down the whole accept loop.
+    trap:
+      case _ => Remedy.Accept
 
-    val task = async(bindLoop.run())
+    . within:
+        val bindLoop = loop:
+          val connection = bindable.connect(binding)
+          daemon(bindable.transmit(binding, connection, lambda(connection)))
 
-    new SocketService:
-      def stop(): Unit =
-        bindLoop.stop()
-        bindable.stop(binding)
-        safely(task.await())
+        val task = async(bindLoop.run())
+
+        new SocketService:
+          def stop(): Unit =
+            bindLoop.stop()
+            bindable.stop(binding)
+            safely(task.await())
 
 
 extension [endpoint: Serviceable as serviceable](endpoint: endpoint)

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -43,7 +43,7 @@ import charDecoders.utf8
 import textSanitizers.skip
 import errorDiagnostics.stackTraces
 import threading.platform
-import codicils.await
+import probates.await
 
 import Control.*
 

--- a/lib/cordillera/src/core/cordillera.H2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.H2Connection.scala
@@ -94,21 +94,13 @@ class H2Stream(val id: Int):
 // `Spool[Frame]` to the socket, serialising all writes (so no lock is needed); a
 // reader daemon parses inbound frames and dispatches them by stream id. Must be
 // created within a `supervise`-provided `Monitor`.
-class H2Connection(duplex: Duplex)(using Monitor, Codicil):
+class H2Connection(duplex: Duplex)(using Monitor, Probate):
   import H2Connection.*
 
   private val streams: scc.TrieMap[Int, H2Stream] = scc.TrieMap()
   private val nextId: juca.AtomicInteger = juca.AtomicInteger(1)
   private val outbound: Spool[Frame] = Spool()
   private val started: Promise[Unit] = Promise()
-
-  // All outbound frames go through this one spool/daemon, so writes are serialised
-  // and ordered without an explicit lock.
-  private val writer: Daemon = daemon:
-    duplex.send(Stream(connectionPreface))
-
-    outbound.stream.each: frame =>
-      duplex.send(Stream(frame.serialize))
 
   private def send(frame: Frame): Unit = outbound.put(frame)
 
@@ -164,18 +156,42 @@ class H2Connection(duplex: Duplex)(using Monitor, Codicil):
       case Frame.WindowUpdate(_, _) | Frame.Continuation(_, _, _) =>
         true
 
-  // The reader loop: decode frames and dispatch them until the socket ends, a
-  // GOAWAY arrives, or a protocol error occurs. Errors are contained here so the
-  // daemon exits cleanly rather than escaping.
-  private val reader: Daemon = daemon:
-    safely:
-      val frameReader = FrameReader(duplex.stream.iterator)
-      val decoder = Hpack()
-      var continue = true
+  // Tear the connection down after an unrecoverable reader/writer failure: unblock a
+  // pending handshake, end every open stream so awaiters of its headers/body/trailers
+  // don't hang on a connection that can no longer make progress, and stop the outbound
+  // spool so the writer exits.
+  private def tearDown(): Unit =
+    started.cancel()
+    streams.values.foreach(_.end())
+    outbound.stop()
 
-      while continue do frameReader.next() match
-        case Unset         => continue = false
-        case frame: Frame  => continue = dispatch(frame, decoder)
+  // The writer drains the outbound spool to the socket, serialising all writes (so no
+  // lock is needed); the reader decodes inbound frames and dispatches them until the
+  // socket ends, a GOAWAY arrives, or a protocol error occurs. Both run under a `trap`
+  // that tears the connection down on failure, so a write, parse or HPACK error is
+  // isolated to this connection — it neither escalates nor leaves a request awaiter
+  // hanging — rather than being swallowed or escaping the daemon.
+  private val (writer, reader): (Daemon, Daemon) =
+    trap:
+      case _ => tearDown(); Remedy.Accept
+
+    . within:
+        val writer = daemon:
+          duplex.send(Stream(connectionPreface))
+
+          outbound.stream.each: frame =>
+            duplex.send(Stream(frame.serialize))
+
+        val reader = daemon:
+          val frameReader = FrameReader(duplex.stream.iterator)
+          val decoder = Hpack()
+          var continue = true
+
+          while continue do frameReader.next() match
+            case Unset        => continue = false
+            case frame: Frame => continue = dispatch(frame, decoder)
+
+        (writer, reader)
 
   // Perform the connection handshake: emit our SETTINGS and await the peer's.
   def start(): Unit raises AsyncError =

--- a/lib/cordillera/src/core/cordillera.Http2.scala
+++ b/lib/cordillera/src/core/cordillera.Http2.scala
@@ -327,12 +327,12 @@ object Http2:
     def connect(): Duplex = connectable.connect(endpoint)
 
   // An `HttpClient` that speaks HTTP/2 (prior-knowledge h2c) to an `Http2.Endpoint`.
-  // It captures the ambient `Monitor`/`Codicil` from this given's context — the
+  // It captures the ambient `Monitor`/`Probate` from this given's context — the
   // `H2Connection`'s daemons need them — so it can only be summoned inside a
   // `supervise` scope. A fresh connection is opened per request for now; pooling
   // is a later refinement.
   object Client:
-    given http2: [endpoint] => (Monitor, Codicil, Tactic[Http2Error], Tactic[AsyncError])
+    given http2: [endpoint] => (Monitor, Probate, Tactic[Http2Error], Tactic[AsyncError])
     =>  HttpClient onto Endpoint[endpoint] =
 
       new HttpClient:

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -215,7 +215,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
 
     suite(m"End-to-end over an in-memory Duplex (the whole stack)"):
       import threading.virtual
-      import codicils.cancel
+      import probates.cancel
 
       // An in-memory `Duplex` pair: bytes written to one side surface on the other's
       // stream. Backed by `Spool`s so reads block until data arrives, like a socket.
@@ -235,7 +235,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
       // frames, and on the request HEADERS replies with response HEADERS (200 +
       // content-type), a DATA frame, and trailing HEADERS carrying a grpc-status
       // trailer. Returned as a Daemon so the caller can cancel it.
-      def runServer(serverSide: Duplex)(using Monitor, Codicil): Daemon = daemon:
+      def runServer(serverSide: Duplex)(using Monitor, Probate): Daemon = daemon:
         safely:
           serverSide.send(Stream(Frame.Settings(Nil, ack = false).serialize))
 
@@ -303,7 +303,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
 
           // Summon the HTTP/2 client given exactly as telekinesis's fetch machinery
           // would, and invoke its `request` — verifying it captures the ambient
-          // Monitor/Codicil and produces a telekinesis `Http.Response`.
+          // Monitor/Probate and produces a telekinesis `Http.Response`.
           val client = summon[HttpClient onto Http2.Endpoint[Loopback]]
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"unix")
 

--- a/lib/embarcadero/src/containerd/embarcadero.Containerd.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.Containerd.scala
@@ -76,7 +76,7 @@ object Containerd:
   // Must be called inside a `supervise` scope (the connection runs background daemons).
   def apply[endpoint]
     ( endpoint: Http2.Endpoint[endpoint], namespace: Text )
-    ( using Monitor, Codicil )
+    ( using Monitor, Probate )
   :   Containerd raises AsyncError =
 
     val metadata = Grpc.Metadata(List(t"containerd-namespace" -> namespace))

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -157,7 +157,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
 
     suite(m"containerd over a gRPC loopback"):
       import threading.virtual
-      import codicils.cancel
+      import probates.cancel
 
       def pair(): (Duplex, Duplex) =
         val clientToServer = Spool[Data]()
@@ -173,7 +173,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       // A fake containerd: completes the HTTP/2 handshake, records the namespace header
       // from the request, and replies to the `Version` call with a framed response.
       def runServer(serverSide: Duplex, namespace: Promise[Text], body: Data)
-          ( using Monitor, Codicil )
+          ( using Monitor, Probate )
       :   Daemon =
 
         daemon:

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -278,7 +278,7 @@ def cli[bus <: Matchable](using executive: Executive)
     pid.let(terminatePid.fulfill(_)).or(termination)
 
 
-  def makeClient(channel: jnc.SocketChannel)(using Monitor, Stdio, Codicil)
+  def makeClient(channel: jnc.SocketChannel)(using Monitor, Stdio, Probate)
   :   Unit logs DaemonLogEvent raises StreamError raises CharDecodeError raises NumberError =
 
     async:
@@ -476,7 +476,7 @@ def cli[bus <: Matchable](using executive: Executive)
     import environments.java
     import termcaps.environment
     import stdios.virtualMachine
-    import codicils.await
+    import probates.await
 
     Os.intercept[Shutdown]:
       safely(socketFile.wipe())

--- a/lib/eucalyptus/src/core/eucalyptus_core.scala
+++ b/lib/eucalyptus/src/core/eucalyptus_core.scala
@@ -40,7 +40,7 @@ import anticipation.*
 import contingency.*
 import fulminate.*
 import gossamer.*
-import parasite.*, codicils.cancel
+import parasite.*, probates.cancel
 import prepositional.*
 import rudiments.*
 import spectacular.*

--- a/lib/exegesis/src/core/exegesis.LspServer.scala
+++ b/lib/exegesis/src/core/exegesis.LspServer.scala
@@ -183,7 +183,7 @@ trait LspServer() extends Lsp:
   // (both request responses, funnelled in via `put`, and server-initiated notifications such as
   // `publishDiagnostics`) and frames each message back onto standard output, so writes never
   // interleave.
-  def serve()(using Stdio, Monitor, Codicil): Unit =
+  def serve()(using Stdio, Monitor, Probate): Unit =
     import charEncoders.utf8
     import strategies.throwUnsafely
 

--- a/lib/exegesis/src/demo/exegesis_run.scala
+++ b/lib/exegesis/src/demo/exegesis_run.scala
@@ -35,7 +35,7 @@ package exegesis
 import soundness.*
 
 import backstops.stackTrace
-import codicils.await
+import probates.await
 import executives.completions
 import interpreters.posix
 import strategies.throwUnsafely

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -53,7 +53,7 @@ import superlunary.*
 import symbolism.*
 import vacuous.*
 
-import codicils.cancel
+import probates.cancel
 import filesystemOptions.deleteRecursively.disabled
 import logging.silent
 import workingDirectories.java

--- a/lib/flux/src/client/flux_client.scala
+++ b/lib/flux/src/client/flux_client.scala
@@ -46,7 +46,7 @@ import soundness.*
 import backstops.silent
 import charEncoders.utf8
 import classloaders.threadContext
-import codicils.cancel
+import probates.cancel
 import executives.completions
 import harlequin.Accent
 import internetAccess.enabled
@@ -96,7 +96,7 @@ def repl(): Unit = cli:
       execute(Exit.Fail(1))
 
 // Runs a REPL server on the given TCP port and blocks until interrupted.
-private def serve(portNumber: Int)(using Stdio, Monitor, Codicil, System): Exit =
+private def serve(portNumber: Int)(using Stdio, Monitor, Probate, System): Exit =
   given Scalac[3.8] = Scalac(Nil)
   given Classloader = serverClassloader
 
@@ -125,7 +125,7 @@ private def socketFile: Text = t"$socketDirectory/${ProcessHandle.current.nn.pid
 
 // Runs a REPL server on a per-process UNIX domain socket (used when no port is
 // given) and blocks until quit, unlinking the socket file on the way out.
-private def serveSocket()(using Stdio, Monitor, Codicil, System): Exit =
+private def serveSocket()(using Stdio, Monitor, Probate, System): Exit =
   given Scalac[3.8] = Scalac(Nil)
   given Classloader = serverClassloader
 
@@ -186,7 +186,7 @@ private def unreachableSocket(path: Text)(using Stdio): Exit =
   Exit.Fail(3)
 
 // Drives an interactive session over a connection, closing it on the way out.
-private def session(duplex: Duplex)(using Stdio, Monitor, Codicil, Console, Environment): Exit =
+private def session(duplex: Duplex)(using Stdio, Monitor, Probate, Console, Environment): Exit =
   try converse(duplex) finally duplex.close()
 
 private def failedToLaunch(using Stdio): Exit =
@@ -227,7 +227,7 @@ private def launchServer()(using Stdio, System): Optional[Duplex] =
 // as a Profanity `Keypress` (or other `TerminalEvent`), so we can see exactly how
 // keys — including Shift+Enter — are decoded. With `kitty = true` the kitty
 // keyboard protocol is enabled first. Ctrl+C or Ctrl+D stops it.
-private def keyTest(kitty: Boolean)(using Stdio, Monitor, Codicil, Console, Environment): Exit =
+private def keyTest(kitty: Boolean)(using Stdio, Monitor, Probate, Console, Environment): Exit =
   whereas:
     case TerminalError() =>
       Out.println(t"flux: the terminal could not be initialised")
@@ -281,7 +281,7 @@ private def socketPaths(directory: Text): List[Text] =
 // Connects to a per-process UNIX domain socket. With no server running, launches one
 // in the background and attaches to it (so `flux` alone is a self-contained REPL,
 // reconnectable later); with exactly one, connects to it; with several, lists them.
-private def connectSocket()(using Stdio, Monitor, Codicil, Console, Environment, System): Exit =
+private def connectSocket()(using Stdio, Monitor, Probate, Console, Environment, System): Exit =
   socketPaths(socketDirectory) match
     case Nil =>
       Out.println(t"flux: starting a REPL server…")
@@ -301,7 +301,7 @@ private def connectSocket()(using Stdio, Monitor, Codicil, Console, Environment,
 
 // The read/edit/print loop. The server's reply is printed verbatim. Ctrl+C/Ctrl+D
 // dismiss the line editor (`DismissError`) and end the session.
-private def converse(duplex: Duplex)(using Stdio, Monitor, Codicil, Console, Environment): Exit =
+private def converse(duplex: Duplex)(using Stdio, Monitor, Probate, Console, Environment): Exit =
   // The kitty keyboard protocol (applied by `interactive`) makes the terminal report
   // Shift+Enter distinctly, so the editor can submit on it.
   import terminalFeatures.kittyKeyboard

--- a/lib/flux/src/core/flux.Repl.scala
+++ b/lib/flux/src/core/flux.Repl.scala
@@ -250,7 +250,7 @@ class Repl[version <: Scalac.Versions]
   // runs its body). `rendered` is evaluated after a successful run to supply the
   // `Outcome.Ran` value — `Unset` for statements, or the inspected result for an
   // expression line.
-  private def compile(code: Text)(rendered: => Optional[Text])(using Monitor, System, Codicil)
+  private def compile(code: Text)(rendered: => Optional[Text])(using Monitor, System, Probate)
   :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
 
     val name:    Text = layout.objectName(index)
@@ -319,7 +319,7 @@ class Repl[version <: Scalac.Versions]
 
     (prelude.imports.map(_.tt) ::: lines).join(t"\n")
 
-  private def evaluate(line: Text)(using Monitor, System, Codicil)
+  private def evaluate(line: Text)(using Monitor, System, Probate)
   :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
 
     val name: Text = t"res${result.toString.tt}"
@@ -346,7 +346,7 @@ class Repl[version <: Scalac.Versions]
   // original types rather than re-rendering them as source. Later lines see its
   // members via the history import. Imports create no members, so they are
   // re-injected into every line instead.
-  private def ensureSeeded()(using Monitor, System, Codicil)
+  private def ensureSeeded()(using Monitor, System, Probate)
   :   Optional[Outcome] logs CompileEvent raises CompilerError raises AsyncError =
 
     if seeded || prelude.seedTasty.isEmpty then Unset
@@ -364,7 +364,7 @@ class Repl[version <: Scalac.Versions]
       else
         Outcome.Rejected(errors.map(Notice(Importance.Error, t"<seed>", _, Unset)))
 
-  def interpret(line: Text)(using Monitor, System, Codicil)
+  def interpret(line: Text)(using Monitor, System, Probate)
   :   Outcome logs CompileEvent raises CompilerError raises AsyncError =
 
     def lineOutcome: Outcome = evaluate(line)
@@ -378,7 +378,7 @@ class Repl[version <: Scalac.Versions]
   // `Reply` values, one per line, each terminated by a blank line (compact JSON
   // has no embedded newline, so the delimiter is unambiguous). Returns a handle
   // whose `stop()` shuts the server down.
-  def serve(port: Port over Tcp)(using Monitor, System, Codicil)
+  def serve(port: Port over Tcp)(using Monitor, System, Probate)
   :   SocketService logs CompileEvent raises BindError raises StreamError =
 
     port.listen: socket =>
@@ -389,7 +389,7 @@ class Repl[version <: Scalac.Versions]
   // port is given). Coaxial's domain-socket `Connection` does not expose its
   // streams for the bidirectional, asynchronously-written protocol this server
   // needs, so the accept loop runs directly over an NIO channel.
-  def serve(socketPath: Text)(using Monitor, System, Codicil): SocketService logs CompileEvent =
+  def serve(socketPath: Text)(using Monitor, System, Probate): SocketService logs CompileEvent =
     val address: jn.UnixDomainSocketAddress = jn.UnixDomainSocketAddress.of(socketPath.s).nn
 
     val channel: jnc.ServerSocketChannel =
@@ -417,7 +417,7 @@ class Repl[version <: Scalac.Versions]
         safely(task.await())
 
   private def converse(input: ji.InputStream, output: ji.OutputStream)
-    ( using Monitor, System, Codicil )
+    ( using Monitor, System, Probate )
   :   Unit logs CompileEvent =
 
     // The TCP caller's `listen` owns the accepted socket — it writes this lambda's
@@ -471,7 +471,7 @@ class Repl[version <: Scalac.Versions]
   // for live editing); a `submit` compiles and runs; a `quit` signals the server to
   // shut down and is not answered. A malformed request becomes a `Failed` reply
   // rather than a dropped connection. `Unset` means no reply is sent.
-  private def respond(message: Text)(using Monitor, System, Codicil)
+  private def respond(message: Text)(using Monitor, System, Probate)
   :   Optional[Text] logs CompileEvent =
 
     val request: Optional[Repl.Request] =
@@ -488,7 +488,7 @@ class Repl[version <: Scalac.Versions]
 
   // Computes tab completions at `offset` in `code` and replies (with `id`). Holds
   // `mutex` like `submit`, since the shared compiler is not reentrant.
-  private def complete(id: Int, code: Text, offset: Int)(using Monitor, System, Codicil)
+  private def complete(id: Int, code: Text, offset: Int)(using Monitor, System, Probate)
   :   Text logs CompileEvent =
 
     given LocalClasspath = classpath
@@ -500,7 +500,7 @@ class Repl[version <: Scalac.Versions]
   // Typecheck-highlights, compiles, and runs `code`, replying (with `id`) with the
   // highlighting, the result value, and any diagnostics. The whole body holds
   // `mutex`, so concurrent submits serialize and never drive the compiler at once.
-  private def submit(id: Int, code: Text)(using Monitor, System, Codicil): Text logs CompileEvent =
+  private def submit(id: Int, code: Text)(using Monitor, System, Probate): Text logs CompileEvent =
     given LocalClasspath = classpath
 
     val reply: Repl.Reply = mutex:

--- a/lib/flux/src/test/flux_test.scala
+++ b/lib/flux/src/test/flux_test.scala
@@ -40,7 +40,7 @@ import _root_.java.nio.file as jnf
 import soundness.*
 
 import classloaders.threadContext
-import codicils.await
+import probates.await
 import logging.silent
 import strategies.throwUnsafely
 import systems.java
@@ -54,7 +54,7 @@ import threading.platform
 object ReplFixture:
   var greeting: String = "hello"
 
-  def session(using Scalac[3.8], Classloader, TemporaryDirectory, Monitor, System, Codicil)
+  def session(using Scalac[3.8], Classloader, TemporaryDirectory, Monitor, System, Probate)
   :   (Repl.Outcome, Repl.Outcome) =
     val repl = Repl[3.8]:
       def size: Int = greeting.length

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -227,10 +227,10 @@ object Html extends Tag.Container
   private val indentation: Text =
     "\n                                                                "
 
-  given streamable: (Monitor, Codicil) => Document[Html] is Streamable by Text =
+  given streamable: (Monitor, Probate) => Document[Html] is Streamable by Text =
     emit(_).to(Stream)
 
-  def emit(document: Document[Html], flat: Boolean = false)(using Monitor, Codicil)
+  def emit(document: Document[Html], flat: Boolean = false)(using Monitor, Probate)
   :   Iterator[Text] =
 
     val dom = document.metadata

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -48,11 +48,11 @@ import vacuous.*
 
 object GrpcChannel:
   // Open a channel to a cleartext-h2c endpoint, completing the HTTP/2 handshake. The
-  // connection's read/write daemons capture the ambient `Monitor`/`Codicil`, so this
+  // connection's read/write daemons capture the ambient `Monitor`/`Probate`, so this
   // must be called inside a `supervise` scope.
   def apply[endpoint]
     ( endpoint: Http2.Endpoint[endpoint], defaults: Grpc.Metadata = Grpc.Metadata() )
-    ( using Monitor, Codicil )
+    ( using Monitor, Probate )
   :   GrpcChannel raises AsyncError =
 
     val connection = H2Connection(endpoint.connect())

--- a/lib/obligatory/src/json/obligatory.JsonRpc.scala
+++ b/lib/obligatory/src/json/obligatory.JsonRpc.scala
@@ -83,7 +83,7 @@ object JsonRpc:
   def receive(id: Text, result: Json): Unit = promises.at(id).let(_.offer(result))
 
 
-  def request(target: HttpUrl, method: Text, payload: Json)(using Monitor, Codicil, Online)
+  def request(target: HttpUrl, method: Text, payload: Json)(using Monitor, Probate, Online)
   :   Promise[Json] =
 
     val uuid = Uuid().text
@@ -110,7 +110,7 @@ object JsonRpc:
 
 
   def notification(target: HttpUrl, method: Text, payload: Json)
-    ( using Monitor, Codicil, Online )
+    ( using Monitor, Probate, Online )
   :   Promise[Unit] =
 
     import charEncoders.utf8

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -218,8 +218,8 @@ object internal:
           val methodName = Expr(method.name.tt)
 
           Expr.summon[Monitor] match
-            case Some(monitor) => Expr.summon[Codicil] match
-              case Some(codicil) => Expr.summon[Online] match
+            case Some(monitor) => Expr.summon[Probate] match
+              case Some(probate) => Expr.summon[Online] match
                 case Some(online) =>
                   if notification then Some:
                     ' {
@@ -227,7 +227,7 @@ object internal:
 
                         safely[AsyncError]:
                           JsonRpc.notification($url, $methodName, json)
-                            ( using $monitor, $codicil, $online )
+                            ( using $monitor, $probate, $online )
 
                           . await()
 
@@ -244,7 +244,7 @@ object internal:
 
                               unsafely:
                                 JsonRpc.request($url, $methodName, json)
-                                  ( using $monitor, $codicil, $online )
+                                  ( using $monitor, $probate, $online )
 
                                 . await()
                                 . decode[result](using $decoder)
@@ -261,7 +261,7 @@ object internal:
 
                 case _ => halt(593, m"a contextual `Online` instance is required")
 
-              case _ => halt(169, m"a contextual `Codicil` instance is required")
+              case _ => halt(169, m"a contextual `Probate` instance is required")
 
             case _ => halt(323, m"a contextual `Monitor` instance is required")
 

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -147,7 +147,7 @@ object Tests extends Suite(m"Obligatory Tests"):
 
     suite(m"gRPC over HTTP/2 (loopback)"):
       import threading.virtual
-      import codicils.cancel
+      import probates.cancel
       import errorDiagnostics.stackTraces
 
       def pair(): (Duplex, Duplex) =
@@ -173,7 +173,7 @@ object Tests extends Suite(m"Obligatory Tests"):
       // A minimal in-process gRPC server: completes the HTTP/2 handshake, then on the
       // request HEADERS replies with whatever frames `responder` builds.
       def runServer(serverSide: Duplex, responder: (Hpack, Int) => List[Frame])
-          ( using Monitor, Codicil )
+          ( using Monitor, Probate )
       :   Daemon =
 
         daemon:

--- a/lib/parasite/.github/readme.md
+++ b/lib/parasite/.github/readme.md
@@ -172,11 +172,11 @@ The child task runs continuously for ten seconds. Does that mean the call to `pa
 take ten seconds too? That depends!
 
 Three options are available, as contextual values:
-- `codicils.await` will wait for all child tasks to terminate,
-- `codicils.cancel` will cancel the child asks at the first opportunity, and
-- `codicils.fail` will cause the call to `parent.await()` to throw an error
+- `probates.await` will wait for all child tasks to terminate,
+- `probates.cancel` will cancel the child asks at the first opportunity, and
+- `probates.fail` will cause the call to `parent.await()` to throw an error
   (which must be handled) if any incomplete tasks exist when the parent task returns.
-- `codicils.panic` behaves like `codicils.fail`, but throws an unchecked `Panic`
+- `probates.panic` behaves like `probates.fail`, but throws an unchecked `Panic`
   error.
 
 Each of these options may be more useful in different scenarios.

--- a/lib/parasite/doc/basics.md
+++ b/lib/parasite/doc/basics.md
@@ -139,11 +139,11 @@ The child task runs continuously for ten seconds. Does that mean the call to `pa
 take ten seconds too? That depends!
 
 Three options are available, as contextual values:
-- `codicils.await` will wait for all child tasks to terminate,
-- `codicils.cancel` will cancel the child asks at the first opportunity, and
-- `codicils.fail` will cause the call to `parent.await()` to throw an error
+- `probates.await` will wait for all child tasks to terminate,
+- `probates.cancel` will cancel the child asks at the first opportunity, and
+- `probates.fail` will cause the call to `parent.await()` to throw an error
   (which must be handled) if any incomplete tasks exist when the parent task returns.
-- `codicils.panic` behaves like `codicils.fail`, but throws an unchecked `Panic`
+- `probates.panic` behaves like `probates.fail`, but throws an unchecked `Panic`
   error.
 
 Each of these options may be more useful in different scenarios.

--- a/lib/parasite/src/core/parasite.AsyncTactic.scala
+++ b/lib/parasite/src/core/parasite.AsyncTactic.scala
@@ -30,69 +30,22 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package ultimatum
+package parasite
 
-import soundness.*
+import language.experimental.pureFunctions
 
-import backstops.silent
-import probates.cancel
-import executives.completions
-import interpreters.posix
-import strategies.throwUnsafely
-import supervisors.global
-import threading.platform
+import contingency.*
+import fulminate.*
 
-// A medium-complexity fullscreen layout demonstrating the framework: a title bar
-// and a status bar each pinned to a single row; a fixed-width sidebar menu; and a
-// main column with a section heading, a line editor, and an activity panel. TAB
-// moves focus between the menu and the editor; Escape quits.
-//
-// Run with `mill ultimatum.demo.run` from a real terminal.
-@main
-def demo(): Unit = cli:
-  execute:
-    interactive: terminal ?=>
-      form(Mode.Inline)(demoLayout)
-      Exit.Ok
+import unsafeExceptions.canThrowAny
 
-// rank(title, file(sidebar, rank(heading, compose, activity)), status), with the
-// sidebar, compose box and activity panel each wrapped in a `border` and the
-// heading underlined by a bottom-only border:
-//
-//   ┌──────────────────────── title ────────────────────────┐
-//   │ ╭ sidebar ╮ │ heading                                  │
-//   │ │  (menu) │ │ ─────────                                │
-//   │ ╰─────────╯ │ ┏━ compose ━┓                            │
-//   │             │ ┗━━━━━━━━━━━┛                            │
-//   │             │ ┌─ activity ┐                            │
-//   │             │ └───────────┘                            │
-//   └─────────────────────── status ────────────────────────┘
-private def demoLayout: Pane =
-  // A rounded border around the menu; the menu itself is 20 wide, so the bordered
-  // sidebar is 22.
-  val sidebar = border(BorderStyle.rounded):
-    menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
-        minWidth = 20, maxWidth = 20)
-
-  val activity = border():
-    panel(minHeight = 6):
-      Out.println(t"Recent activity")
-      Out.println(t"")
-      Out.println(t"  • Demo started")
-      Out.println(t"  • Four panes tiled")
-      Out.println(t"  • Tab moves focus, Esc quits")
-
-  // A bottom-only border draws a single rule under the heading, a separator with
-  // no corners or sides.
-  val heading = border(top = false, left = false, right = false):
-    panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Compose"))
-
-  val title = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  ULTIMATUM · fullscreen demo"))
-  val status = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  [Tab] focus    [Esc] quit"))
-
-  // A multiline compose box: Enter inserts a newline (it never submits, so the
-  // arrow keys can move the cursor up and down between lines).
-  val compose = border(BorderStyle.heavy):
-    editor(LineEditor(mode = LineEditor.Mode.Multiline(_ => false)))
-
-  rank(title, file(sidebar, rank(heading, compose, activity)), status)
+// The `Tactic` supplied by `async`/`task`/`daemon` to the body it evaluates. Unlike the
+// `boundary`-based tactics (`OptionalTactic`, `AttemptTactic`, …) it never breaks a stack-confined
+// `boundary.Label`, so it is safe to invoke on the forked worker thread: both `record` and `abort`
+// simply throw the pure error. The worker's `try`/`catch` then stores it as `Fulfillment.Failed`,
+// whence it is delivered — still typed — at the join (`Task#await`) or to the trap (`Probate`).
+class AsyncTactic[error <: Exception]() extends Tactic[error]:
+  def diagnostics: Diagnostics = Diagnostics.capture
+  def record(error: Diagnostics ?=> error): Unit = throw error(using diagnostics)
+  def abort(error: Diagnostics ?=> error): Nothing = throw error(using diagnostics)
+  def certify(): Unit = ()

--- a/lib/parasite/src/core/parasite.Daemon.scala
+++ b/lib/parasite/src/core/parasite.Daemon.scala
@@ -41,12 +41,12 @@ import vacuous.*
 
 object Daemon:
   def apply(evaluate: Worker => Unit)
-    ( using monitor: Monitor, codepoint: Codepoint, codicil: Codicil )
+    ( using monitor: Monitor, codepoint: Codepoint, probate: Probate )
   :   Daemon =
 
     inline def evaluate0: Worker => Unit = evaluate
 
-    new Worker(codepoint, monitor, codicil) with Daemon:
+    new Worker(codepoint, monitor, probate) with Daemon:
       type Result = Unit
       def name: Optional[Text] = Unset
       def daemon: Boolean = true

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -116,7 +116,7 @@ object PlatformSupervisor extends Supervisor():
       name.let(_.s).let(thread.setName(_))
       thread.start()
 
-abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) extends Monitor:
+abstract class Worker(frame: Codepoint, parent: Monitor, probate: Probate) extends Monitor:
   self =>
   private val state: juca.AtomicReference[Fulfillment[Result]] =
     juca.AtomicReference(Fulfillment.Initializing)
@@ -163,16 +163,16 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
     if Thread.interrupted() || state.get() == Cancelled then throw new InterruptedException()
 
 
-  def map[result2](lambda: Result => result2)(using Monitor, Codicil)
-  :   Task[result2] raises AsyncError =
+  def map[result2](lambda: Result => result2)(using Monitor, Probate)
+  :   Task[result2] incurs AsyncError =
 
-    async(lambda(await()))
+    async(lambda(join()))
 
 
-  def bind[result2](lambda: Result => Task[result2])(using Monitor, Codicil)
-  :   Task[result2] raises AsyncError =
+  def bind[result2](lambda: Result => Task[result2])(using Monitor, Probate)
+  :   Task[result2] incurs AsyncError =
 
-    async(lambda(await()).await())
+    async(lambda(join()).join())
 
 
   def cancel(): Unit =
@@ -202,7 +202,11 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
       case other                => panic(m"impossible state")
 
 
-  def await[abstractable: Abstractable across Durations to Long](duration: abstractable)
+  // The raw, untyped join: the original exception of a `Failed` worker is rethrown verbatim (under
+  // `canThrowAny`), so the static error is only `AsyncError`. Used internally (`map`/`bind`/
+  // `sequence`/`race`) where the body's error type is not tracked. Public callers go via the typed
+  // `Task#await`, which routes through `deliver` instead.
+  def join[abstractable: Abstractable across Durations to Long](duration: abstractable)
   :   Result raises AsyncError =
 
     promise.attend(duration)
@@ -211,10 +215,48 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
     result()
 
 
-  def await(): Result raises AsyncError =
+  def join(): Result raises AsyncError =
     promise.attend()
     thread.join()
     result()
+
+
+  // The typed join. A `Failed` worker carries a pure exception; rather than rethrowing it raw
+  // (which would bypass a non-throwing `Tactic`), we `abort` it through the caller's in-scope
+  // `Tactic[error | AsyncError]`. `error` is reconstructed by an unchecked cast that is sound for
+  // any failure raised through the body's `AsyncTactic` (the only typed-error path); a genuinely
+  // unchecked throwable from the body flows through as the raw `join` would have rethrown it.
+  def deliver[error <: Exception]()(using Tactic[error | AsyncError]): Result =
+    promise.attend()
+    thread.join()
+    fulfilment()
+
+
+  def deliver[error <: Exception, abstractable: Abstractable across Durations to Long]
+    ( duration: abstractable )
+    ( using Tactic[error | AsyncError] )
+  :   Result =
+
+    promise.attend(duration)
+    if !promise.ready then abort(AsyncError(Reason.Timeout))
+    thread.join()
+    fulfilment()
+
+
+  private def fulfilment[error <: Exception]()(using Tactic[error | AsyncError]): Result =
+    state.updateAndGet:
+      case Completed(duration, result) => Delivered(duration, result)
+      case Delivered(duration, result) => Delivered(duration, result)
+      case other                       => other
+
+    . match
+      case Completed(_, result)        => result
+      case Delivered(_, result)        => result
+      case Failed(failure: AsyncError) => abort(failure)
+      case Failed(failure: Exception)  => abort(failure.asInstanceOf[error])
+      case Failed(failure)             => throw failure
+      case Cancelled                   => abort(AsyncError(Reason.Cancelled))
+      case _                           => abort(AsyncError(Reason.Incomplete))
 
   private lazy val thread: Thread = parent.supervisor.fork(stack):
     val started: Boolean = state.updateAndGet:
@@ -246,7 +288,26 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
         state.set(Failed(error))
 
     finally
-      try codicil.cleanup(this) catch case error: Throwable => state.set(Failed(error))
+      try probate.cleanup(this) catch case error: Throwable => state.set(Failed(error))
+
+      // A fire-and-forget worker has no join at which to deliver a failure, so route it to the trap
+      // installed nearby. This runs before the promise is settled below, so anything attending the
+      // worker observes completion only once the trap has run. An error no trap accepts becomes an
+      // `escalation`: rethrown after settling, reaching this thread's uncaught-exception handler
+      // (`Fault`, or the JVM default), so that it is never silently dropped.
+      def remedy(error: Error): Optional[Throwable] = probate.trap(this, error) match
+        case Remedy.Accept          => Unset
+        case Remedy.Reject          => error
+        case Remedy.Escalate(other) => other
+
+      val escalation: Optional[Throwable] = if !daemon then Unset else state.get().nn match
+        case Failed(error: Error) => remedy(error)
+        case Failed(error)        => error
+        case Initializing         => Unset
+        case Cancelled            => Unset
+        case Active(_)            => Unset
+        case Completed(_, _)      => Unset
+        case Delivered(_, _)      => Unset
 
       state.updateAndGet: state =>
         parent.remove(this)
@@ -259,5 +320,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor, codicil: Codicil) exten
           case state@Delivered(duration, value) => state
           case state@Failed(_)                  => state.also(promise.cancel())
           case Cancelled                        => Cancelled
+
+      escalation.let(throw _)
 
   thread

--- a/lib/parasite/src/core/parasite.Probate.scala
+++ b/lib/parasite/src/core/parasite.Probate.scala
@@ -30,69 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package ultimatum
+package parasite
 
-import soundness.*
+import language.experimental.into
+import language.experimental.pureFunctions
 
-import backstops.silent
-import probates.cancel
-import executives.completions
-import interpreters.posix
-import strategies.throwUnsafely
-import supervisors.global
-import threading.platform
+import fulminate.*
 
-// A medium-complexity fullscreen layout demonstrating the framework: a title bar
-// and a status bar each pinned to a single row; a fixed-width sidebar menu; and a
-// main column with a section heading, a line editor, and an activity panel. TAB
-// moves focus between the menu and the editor; Escape quits.
-//
-// Run with `mill ultimatum.demo.run` from a real terminal.
-@main
-def demo(): Unit = cli:
-  execute:
-    interactive: terminal ?=>
-      form(Mode.Inline)(demoLayout)
-      Exit.Ok
+trait Probate:
+  // The fate of an unfinished child when its parent completes (await it, cancel it, …).
+  def cleanup(worker: Worker): Unit
 
-// rank(title, file(sidebar, rank(heading, compose, activity)), status), with the
-// sidebar, compose box and activity panel each wrapped in a `border` and the
-// heading underlined by a bottom-only border:
-//
-//   ┌──────────────────────── title ────────────────────────┐
-//   │ ╭ sidebar ╮ │ heading                                  │
-//   │ │  (menu) │ │ ─────────                                │
-//   │ ╰─────────╯ │ ┏━ compose ━┓                            │
-//   │             │ ┗━━━━━━━━━━━┛                            │
-//   │             │ ┌─ activity ┐                            │
-//   │             │ └───────────┘                            │
-//   └─────────────────────── status ────────────────────────┘
-private def demoLayout: Pane =
-  // A rounded border around the menu; the menu itself is 20 wide, so the bordered
-  // sidebar is 22.
-  val sidebar = border(BorderStyle.rounded):
-    menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
-        minWidth = 20, maxWidth = 20)
-
-  val activity = border():
-    panel(minHeight = 6):
-      Out.println(t"Recent activity")
-      Out.println(t"")
-      Out.println(t"  • Demo started")
-      Out.println(t"  • Four panes tiled")
-      Out.println(t"  • Tab moves focus, Esc quits")
-
-  // A bottom-only border draws a single rule under the heading, a separator with
-  // no corners or sides.
-  val heading = border(top = false, left = false, right = false):
-    panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Compose"))
-
-  val title = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  ULTIMATUM · fullscreen demo"))
-  val status = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  [Tab] focus    [Esc] quit"))
-
-  // A multiline compose box: Enter inserts a newline (it never submits, so the
-  // arrow keys can move the cursor up and down between lines).
-  val compose = border(BorderStyle.heavy):
-    editor(LineEditor(mode = LineEditor.Mode.Multiline(_ => false)))
-
-  rank(title, file(sidebar, rank(heading, compose, activity)), status)
+  // The fate of an error that escaped a fire-and-forget worker. A plain probate is the end of the
+  // trap chain, so its default escalates: absent an installed `trap`, an escaped error is rethrown
+  // (never silently dropped). `trap { … }.within { … }` (see `Trap`) overrides this to intercept
+  // errors near where work is spawned, and chains back to here for anything it rejects.
+  def trap(worker: Worker, error: Error): Remedy = Remedy.Escalate(error)

--- a/lib/parasite/src/core/parasite.Remedy.scala
+++ b/lib/parasite/src/core/parasite.Remedy.scala
@@ -32,8 +32,15 @@
                                                                                                   */
 package parasite
 
-import language.experimental.into
 import language.experimental.pureFunctions
 
-trait Codicil:
-  def cleanup(worker: Worker): Unit
+import fulminate.*
+
+// The disposition a trap chooses for an error that escaped a fire-and-forget worker (a `daemon`, or
+// a task abandoned by its `Probate`). `Accept` consumes it (handled as a side effect, e.g. logged)
+// and stops propagation; `Reject` passes the original error to the enclosing trap; `Escalate`
+// rejects but substitutes a different (pure, thread-safe) error to propagate in its place.
+enum Remedy:
+  case Accept
+  case Reject
+  case Escalate(error: Error)

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -43,21 +43,29 @@ import prepositional.*
 import vacuous.*
 
 object Task:
-  def apply[result](evaluate: Worker => result, name: Optional[Text])
-    ( using monitor: Monitor, codepoint: Codepoint, codicil: Codicil )
-  :   Task[result] =
+  def apply[result, error <: Exception](evaluate: Worker => result, name: Optional[Text])
+    ( using monitor: Monitor, codepoint: Codepoint, probate: Probate )
+  :   Task[result] { type Error = error } =
 
     inline def evaluate0: Worker => result = evaluate
     inline def name0: Optional[Text] = name
 
-    new Worker(codepoint, monitor, codicil) with Task[result]:
+    new Worker(codepoint, monitor, probate) with Task[result]:
       type Result = result
+      type Error = error
       def name: Optional[Text] = name0
       def daemon: Boolean = false
       def evaluate(worker: Worker): Result = evaluate0(worker)
 
+      def await(): result raises (error | AsyncError) = deliver[error]()
 
-  given monad: (Monitor, Codicil, Tactic[AsyncError]) => Monad[Task]:
+      def await[duration: Abstractable across Durations to Long](duration: duration)
+      :   result raises (error | AsyncError) =
+
+        deliver[error, duration](duration)
+
+
+  given monad: (Monitor, Probate, Tactic[AsyncError]) => Monad[Task]:
     def bind[value, value2](value: Task[value])(lambda: value => Task[value2]): Task[value2] =
       value.bind(lambda)
 
@@ -67,27 +75,40 @@ object Task:
       value.map(lambda)
 
   extension [result](tasks: Seq[Task[result]])
-    def sequence(using Monitor, Codicil): Task[Seq[result]] raises AsyncError =
-      async(tasks.map(_.await()))
+    def sequence(using Monitor, Probate): Task[Seq[result]] incurs AsyncError =
+      async(tasks.map(_.join()))
 
   extension [result](tasks: Iterable[Task[result]])
-    def race()(using Monitor, Codicil): result raises AsyncError =
+    def race()(using Monitor, Probate): result raises AsyncError =
       val promise: Promise[result] = Promise()
       tasks.foreach(_.map(promise.offer(_)))
 
       try promise.await() finally tasks.foreach(_.cancel())
 
+// A task carries the error type its body may raise as the `Error` member, refined by the `incurs`
+// alias (`Task[result] incurs error` = `Task[result] { type Error <: error }`). It is preserved to
+// `await`, where it is delivered through the caller's in-scope `Tactic`. `AsyncError` (cancellation
+// or timeout) is always a possible outcome, so it is added at the `await` site, not the member.
 trait Task[+result]:
+  type Error <: Exception
+
   def ready: Boolean
-  def await(): result raises AsyncError
   def attend(): Unit
   def cancel(): Unit
 
+  def await(): result raises (Error | AsyncError)
+
   def await[duration: Abstractable across Durations to Long](duration: duration)
+  :   result raises (Error | AsyncError)
+
+  // The raw join, for parasite-internal combinators that do not track the error type.
+  protected[parasite] def join(): result raises AsyncError
+
+  protected[parasite] def join[duration: Abstractable across Durations to Long](duration: duration)
   :   result raises AsyncError
 
-  def bind[result2](lambda: result => Task[result2])(using Monitor, Codicil)
-  :   Task[result2] raises AsyncError
+  def bind[result2](lambda: result => Task[result2])(using Monitor, Probate)
+  :   Task[result2] incurs AsyncError
 
-  def map[result2](lambda: result => result2)(using Monitor, Codicil)
-  :   Task[result2] raises AsyncError
+  def map[result2](lambda: result => result2)(using Monitor, Probate)
+  :   Task[result2] incurs AsyncError

--- a/lib/parasite/src/core/parasite.Timeout.scala
+++ b/lib/parasite/src/core/parasite.Timeout.scala
@@ -45,7 +45,7 @@ import abstractables.instantIsAbstractable
 
 object Timeout:
   def apply[duration: Abstractable across Durations to Long](timeout0: duration)(action: => Unit)
-    ( using Monitor, Codicil )
+    ( using Monitor, Probate )
   :   Timeout =
 
     val timeout = timeout0.generic/1_000_000L

--- a/lib/parasite/src/core/parasite.Trap.scala
+++ b/lib/parasite/src/core/parasite.Trap.scala
@@ -30,69 +30,26 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package ultimatum
+package parasite
 
-import soundness.*
+import language.experimental.pureFunctions
 
-import backstops.silent
-import probates.cancel
-import executives.completions
-import interpreters.posix
-import strategies.throwUnsafely
-import supervisors.global
-import threading.platform
+import fulminate.*
 
-// A medium-complexity fullscreen layout demonstrating the framework: a title bar
-// and a status bar each pinned to a single row; a fixed-width sidebar menu; and a
-// main column with a section heading, a line editor, and an activity panel. TAB
-// moves focus between the menu and the editor; Escape quits.
-//
-// Run with `mill ultimatum.demo.run` from a real terminal.
-@main
-def demo(): Unit = cli:
-  execute:
-    interactive: terminal ?=>
-      form(Mode.Inline)(demoLayout)
-      Exit.Ok
+// A `Probate` that handles errors escaping fire-and-forget workers spawned within its region. Its
+// child-fate policy (`cleanup`) is delegated unchanged to the enclosing probate; only the failure
+// branch (`trap`) is overridden. A handled error whose remedy is `Reject` — like one the handler
+// does not match — bubbles to the enclosing trap, so traps compose as they nest lexically.
+class Trap(handler: PartialFunction[Error, Remedy], outer: Probate) extends Probate:
+  def cleanup(worker: Worker): Unit = outer.cleanup(worker)
 
-// rank(title, file(sidebar, rank(heading, compose, activity)), status), with the
-// sidebar, compose box and activity panel each wrapped in a `border` and the
-// heading underlined by a bottom-only border:
-//
-//   ┌──────────────────────── title ────────────────────────┐
-//   │ ╭ sidebar ╮ │ heading                                  │
-//   │ │  (menu) │ │ ─────────                                │
-//   │ ╰─────────╯ │ ┏━ compose ━┓                            │
-//   │             │ ┗━━━━━━━━━━━┛                            │
-//   │             │ ┌─ activity ┐                            │
-//   │             │ └───────────┘                            │
-//   └─────────────────────── status ────────────────────────┘
-private def demoLayout: Pane =
-  // A rounded border around the menu; the menu itself is 20 wide, so the bordered
-  // sidebar is 22.
-  val sidebar = border(BorderStyle.rounded):
-    menu(List(t"Overview", t"Compose", t"Activity", t"Settings"), t"Overview",
-        minWidth = 20, maxWidth = 20)
+  override def trap(worker: Worker, error: Error): Remedy =
+    if handler.isDefinedAt(error) then handler(error) match
+      case Remedy.Accept          => Remedy.Accept
+      case Remedy.Reject          => outer.trap(worker, error)
+      case Remedy.Escalate(other) => outer.trap(worker, other)
+    else outer.trap(worker, error)
 
-  val activity = border():
-    panel(minHeight = 6):
-      Out.println(t"Recent activity")
-      Out.println(t"")
-      Out.println(t"  • Demo started")
-      Out.println(t"  • Four panes tiled")
-      Out.println(t"  • Tab moves focus, Esc quits")
-
-  // A bottom-only border draws a single rule under the heading, a separator with
-  // no corners or sides.
-  val heading = border(top = false, left = false, right = false):
-    panel(minHeight = 1, maxHeight = 1)(Out.print(t"  Compose"))
-
-  val title = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  ULTIMATUM · fullscreen demo"))
-  val status = panel(minHeight = 1, maxHeight = 1)(Out.print(t"  [Tab] focus    [Esc] quit"))
-
-  // A multiline compose box: Enter inserts a newline (it never submits, so the
-  // arrow keys can move the cursor up and down between lines).
-  val compose = border(BorderStyle.heavy):
-    editor(LineEditor(mode = LineEditor.Mode.Multiline(_ => false)))
-
-  rank(title, file(sidebar, rank(heading, compose, activity)), status)
+  // Installs this trap as the `Probate` in scope for `body`; daemons and abandoned tasks spawned
+  // within it route their escaped errors here.
+  def within[result](body: Probate ?=> result): result = body(using this)

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -54,14 +54,14 @@ package threading:
   given virtual: Threading = () => VirtualSupervisor
   given adaptive: Threading = () => AdaptiveSupervisor
 
-package codicils:
-  given await: Codicil = _.delegate(_.attend())
-  given cancel: Codicil = _.delegate(_.cancel())
+package probates:
+  given await: Probate = _.delegate(_.attend())
+  given cancel: Probate = _.delegate(_.cancel())
 
-  given panic: Codicil = _.delegate: child =>
+  given panic: Probate = _.delegate: child =>
     if !child.ready then fulminate.panic(m"asynchronous child task did not complete")
 
-  given fail: Tactic[AsyncError] => Codicil = _.delegate: child =>
+  given fail: Tactic[AsyncError] => Probate = _.delegate: child =>
     if !child.ready then raise(AsyncError(AsyncError.Reason.Incomplete))
 
 package supervisors:
@@ -77,20 +77,53 @@ package retryTenacities:
 
 transparent inline def monitor: Monitor = infer[Monitor]
 
-def daemon(using Codepoint)(evaluate: Worker ?=> Unit)(using Monitor, Codicil): Daemon =
-  Daemon(evaluate(using _))
+// Like `async`, but fire-and-forget: a daemon is never joined, so a raised error cannot surface at
+// a join. The body runs with an `AsyncTactic[error]`; a raised error fails the worker and is routed
+// to the nearest `trap` (and escalated if unhandled) rather than tracked in the return type.
+def daemon[error <: Exception](using Codepoint)
+  ( evaluate: (Worker, Tactic[error]) ?=> Unit )
+  ( using Monitor, Probate )
+:   Daemon =
 
-def async[result](using Codepoint)(evaluate: Worker ?=> result)(using Monitor, Codicil)
-:   Task[result] =
+  val tactic = AsyncTactic[error]()
 
-  Task(evaluate(using _), name = Unset)
+  Daemon: worker =>
+    evaluate(using worker, tactic)
 
 
-def task[result](using Codepoint)(name: Text)(evaluate: Worker ?=> result)
-  ( using Monitor, Codicil )
-:   Task[result] =
+// Establishes a trap over a region of asynchronous work: `trap { case … => … }.within { … }`. The
+// handler maps an escaped error to a `Remedy`; the enclosing `Probate` (the default for unmatched
+// or rejected errors) is captured so traps chain outwards to the supervision root.
+def trap(handler: PartialFunction[Error, Remedy])(using outer: Probate): Trap = Trap(handler, outer)
 
-  Task(evaluate(using _), name = name)
+
+// `Task[result] incurs error` = `Task[result] { type Error <: error }`. The bound (not an equality)
+// keeps the error covariant: a task that can fail only with `AsyncError` is usable where one that
+// `incurs FooError` is expected, and `await`'s `raises (Error | AsyncError)` is dischargeable by a
+// `Tactic` for the bound. `task <: Task[?]` keeps the refinement applicable only to actual tasks.
+infix type incurs[task <: Task[?], error <: Exception] = task { type Error <: error }
+
+
+// `error` is the union of error types the body may `raise`, inferred exactly as for synchronous
+// `raises`, and carried in the task's `Error` member so it can be delivered, still typed, at the
+// join. The body is evaluated with an `AsyncTactic[error]` that records a raised error as the
+// worker's `Failed` outcome instead of trying to break a stack-confined `boundary` across threads.
+def async[result, error <: Exception](using Codepoint)
+  ( evaluate: (Worker, Tactic[error]) ?=> result )
+  ( using Monitor, Probate )
+:   Task[result] incurs (error | AsyncError) =
+
+  val tactic = AsyncTactic[error]()
+  Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = Unset)
+
+
+def task[result, error <: Exception](using Codepoint)(name: Text)
+  ( evaluate: (Worker, Tactic[error]) ?=> result )
+  ( using Monitor, Probate )
+:   Task[result] incurs (error | AsyncError) =
+
+  val tactic = AsyncTactic[error]()
+  Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = name)
 
 
 def relent[result]()(using Worker): Unit = monitor.relent()
@@ -117,7 +150,7 @@ def hibernate[instant: Abstractable across Instants to Long](instant: instant)(u
 
 
 extension [result](stream: Stream[result])
-  def concurrent(using Monitor, Codicil): Stream[result] raises AsyncError =
+  def concurrent(using Monitor, Probate): Stream[result] raises AsyncError =
     if async(stream.nil).await() then Stream() else stream.head #:: stream.tail.concurrent
 
 

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export
   parasite
-  . { AdaptiveSupervisor, async, AsyncError, cancel, Chain, Codicil, Daemon, daemon, delay,
+  . { AdaptiveSupervisor, async, AsyncError, cancel, Chain, Probate, Daemon, daemon, delay,
       Destruction, Fault, Fulfillment, GarbageCollection, Heap, hibernate, Hook, intercept,
       Interceptable, Monitor, monitor, Observation, Os, Perseverance, PlatformSupervisor, Promise,
       relent, retry, RetryError, Shutdown, sleep, snooze, supervise, Supervisor, Task, task,
@@ -43,8 +43,8 @@ export
 package threading:
   export parasite.threading.{adaptive, platform, virtual}
 
-package codicils:
-  export parasite.codicils.{await, cancel, fail, panic}
+package probates:
+  export parasite.probates.{await, cancel, fail, panic}
 
 package supervisors:
   export parasite.supervisors.global

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -42,7 +42,10 @@ import strategies.throwUnsafely
 import errorDiagnostics.empty
 
 import threading.virtual
-import codicils.cancel
+import probates.cancel
+
+case class FooError(value: Int)(using Diagnostics) extends Error(m"foo failed with $value")
+case class BarError(label: Text)(using Diagnostics) extends Error(m"bar failed: $label")
 
 object Tests extends Suite(m"Parasite tests"):
 
@@ -350,7 +353,7 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == 11)
 
         test(m"Failure in task propagates"):
-          val task = async[Int]:
+          val task = async[Int, Nothing]:
             throw new RuntimeException("boom")
           val result = try task.await() catch case _: RuntimeException => -1
           result
@@ -414,9 +417,9 @@ object Tests extends Suite(m"Parasite tests"):
           safely(task.await())
         . assert(_ == Unset)
 
-      suite(m"Codicils"):
-        test(m"With await codicil parent waits for incomplete child"):
-          import codicils.await
+      suite(m"Probates"):
+        test(m"With await probate parent waits for incomplete child"):
+          import probates.await
           val parentReady = Promise[Unit]()
           val childDone = juca.AtomicBoolean(false)
           val task = async:
@@ -429,8 +432,8 @@ object Tests extends Suite(m"Parasite tests"):
           childDone.get()
         . assert(_ == true)
 
-        test(m"With cancel codicil parent cancels incomplete child"):
-          import codicils.cancel
+        test(m"With cancel probate parent cancels incomplete child"):
+          import probates.cancel
           val parentReady = Promise[Unit]()
           val childGate = Promise[Unit]()
           val childCompleted = juca.AtomicBoolean(false)
@@ -444,8 +447,8 @@ object Tests extends Suite(m"Parasite tests"):
           childCompleted.get()
         . assert(_ == false)
 
-        test(m"With fail codicil incomplete child raises"):
-          import codicils.fail
+        test(m"With fail probate incomplete child raises"):
+          import probates.fail
           val task = async:
             val child = async:
               snooze(10.0*Second)
@@ -453,8 +456,8 @@ object Tests extends Suite(m"Parasite tests"):
           capture(task.await())
         . assert(_ == AsyncError(AsyncError.Reason.Incomplete))
 
-        test(m"Codicils only affect non-daemon children for daemons"):
-          import codicils.cancel
+        test(m"Probates only affect non-daemon children for daemons"):
+          import probates.cancel
           val daemonRunning = Promise[Unit]()
           val daemonCompleted = juca.AtomicBoolean(false)
           val task = async:
@@ -719,8 +722,8 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ <= 20)
 
       suite(m"Race conditions in delegate"):
-        test(m"Codicil await with multiple children"):
-          import codicils.await
+        test(m"Probate await with multiple children"):
+          import probates.await
           val numChildren = 30
           val completed = juca.AtomicInteger(0)
           val task = async:
@@ -733,8 +736,8 @@ object Tests extends Suite(m"Parasite tests"):
           completed.get()
         . assert(_ == 30)
 
-        test(m"Codicil cancel cancels all incomplete children"):
-          import codicils.cancel
+        test(m"Probate cancel cancels all incomplete children"):
+          import probates.cancel
           val numChildren = 30
           val gate = Promise[Unit]()
           val completed = juca.AtomicInteger(0)
@@ -864,8 +867,8 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == AsyncError(AsyncError.Reason.Cancelled))
 
       suite(m"Children of children"):
-        test(m"Nested tasks with await codicil all complete"):
-          import codicils.await
+        test(m"Nested tasks with await probate all complete"):
+          import probates.await
           val counter = juca.AtomicInteger(0)
           val task = async:
             val a = async:
@@ -883,7 +886,7 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == 3)
 
         test(m"Cancelling outer cancels nested children"):
-          import codicils.cancel
+          import probates.cancel
           val gate = Promise[Unit]()
           val started = juc.CountDownLatch(3)
           val completed = juca.AtomicInteger(0)
@@ -1014,7 +1017,7 @@ object Tests extends Suite(m"Parasite tests"):
 
         test(m"Spawning tasks under load - no lost promises"):
           val n = 200
-          import codicils.await
+          import probates.await
           val sums = juca.AtomicInteger(0)
           val outer = async:
             (1 to n).foreach: i =>
@@ -1035,7 +1038,7 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == 42)
 
         test(m"Multiple daemons all started and cancelled"):
-          import codicils.cancel
+          import probates.cancel
           val started = juc.CountDownLatch(10)
           val gate = Promise[Unit]()
           val finished = juca.AtomicInteger(0)
@@ -1214,8 +1217,8 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == 1)
 
       suite(m"Bidirectional cancellation"):
-        test(m"Cancel propagates from parent to child via codicil"):
-          import codicils.cancel
+        test(m"Cancel propagates from parent to child via probate"):
+          import probates.cancel
           val childGate = Promise[Unit]()
           val childResult = juca.AtomicInteger(0)
           val task = async:
@@ -1223,13 +1226,13 @@ object Tests extends Suite(m"Parasite tests"):
               childGate.await()
               childResult.set(42)
             ()  // parent's body completes immediately
-          // child is incomplete; codicil.cancel cancels it
+          // child is incomplete; probate.cancel cancels it
           task.await()
           childResult.get()
         . assert(_ == 0)
 
-        test(m"Multiple sibling tasks all cancelled by codicil"):
-          import codicils.cancel
+        test(m"Multiple sibling tasks all cancelled by probate"):
+          import probates.cancel
           val gate = Promise[Unit]()
           val started = juc.CountDownLatch(5)
           val completed = juca.AtomicInteger(0)
@@ -1308,9 +1311,9 @@ object Tests extends Suite(m"Parasite tests"):
           allMonotonic
         . assert(_ == true)
 
-      suite(m"Panic codicil"):
-        test(m"Panic codicil with all children complete passes"):
-          import codicils.panic
+      suite(m"Panic probate"):
+        test(m"Panic probate with all children complete passes"):
+          import probates.panic
           val task = async:
             async(()).await()
           task.await()
@@ -1348,13 +1351,13 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == 10)
 
         test(m"Heavy parent-child cancellation cascade"):
-          import codicils.cancel
+          import probates.cancel
           val depth = 20
           val gate = Promise[Unit]()
           val completed = juca.AtomicInteger(0)
           val started = juc.CountDownLatch(1)
 
-          def make(d: Int)(using Monitor, Codicil): Task[Unit] = async:
+          def make(d: Int)(using Monitor, Probate): Task[Unit] = async:
             if d == 0 then
               started.countDown()
               gate.await()
@@ -1397,7 +1400,7 @@ object Tests extends Suite(m"Parasite tests"):
             2
           bad.cancel()
           val seq = Seq(good, bad).sequence
-          val result = capture(seq.await())
+          val result = capture[AsyncError](seq.await())
           result.reason
         . assert(_ == AsyncError.Reason.Cancelled)
 
@@ -1421,3 +1424,104 @@ object Tests extends Suite(m"Parasite tests"):
           (attempts.get(), elapsed >= 60L)
         . assert: (n, ok) =>
             n == 4 && ok
+
+      suite(m"Typed asynchronous errors"):
+        test(m"Awaiting a failed task delivers its body's typed error"):
+          capture[FooError](async(abort(FooError(7))).await()).value
+        . assert(_ == 7)
+
+        test(m"Awaiting a successful task delivers its value"):
+          async(2 + 3).await()
+        . assert(_ == 5)
+
+        test(m"A raised (non-aborting) error still fails the task"):
+          capture[FooError]:
+            async:
+              raise(FooError(4))
+              99
+            . await()
+          . value
+        . assert(_ == 4)
+
+        test(m"An error handled inside the task does not surface at await"):
+          async:
+            safely(abort(FooError(1))).or(99)
+          . await()
+        . assert(_ == 99)
+
+        test(m"Cancellation surfaces as AsyncError, not the body's error type"):
+          val task = async:
+            snooze(1.0*Second)
+            abort(FooError(1))
+          task.cancel()
+          capture[AsyncError](task.await()).reason
+        . assert(_ == AsyncError.Reason.Cancelled)
+
+        test(m"A task that raises one of two error types delivers the one that occurred"):
+          def make(flag: Boolean) = async:
+            if flag then abort(FooError(1)) else abort(BarError(t"b"))
+          capture[FooError](make(true).await()).value
+        . assert(_ == 1)
+
+      suite(m"Asynchronous error traps"):
+        test(m"A trap accepts a daemon's escaped error"):
+          val caught = juca.AtomicInteger(0)
+
+          trap:
+            case FooError(n) => caught.set(n); Remedy.Accept
+          . within:
+              daemon(abort(FooError(5))).attend()
+
+          caught.get()
+        . assert(_ == 5)
+
+        test(m"A successful daemon never invokes the trap"):
+          val trapped = juca.AtomicBoolean(false)
+          val ran = juca.AtomicBoolean(false)
+
+          trap:
+            case FooError(_) => trapped.set(true); Remedy.Accept
+          . within:
+              daemon(ran.set(true)).attend()
+
+          (ran.get(), trapped.get())
+        . assert(_ == (true, false))
+
+        test(m"An error unmatched by an inner trap bubbles to the outer trap"):
+          val caught = juca.AtomicReference[Text](t"none")
+
+          trap:
+            case BarError(s) => caught.set(s); Remedy.Accept
+          . within:
+              trap:
+                case FooError(_) => caught.set(t"foo"); Remedy.Accept
+              . within:
+                  daemon(abort(BarError(t"outer"))).attend()
+
+          caught.get()
+        . assert(_ == t"outer")
+
+        test(m"Escalate substitutes a different error for the enclosing trap"):
+          val caught = juca.AtomicReference[Text](t"none")
+
+          trap:
+            case BarError(s) => caught.set(s); Remedy.Accept
+          . within:
+              trap:
+                case FooError(_) => Remedy.Escalate(BarError(t"swapped"))
+              . within:
+                  daemon(abort(FooError(9))).attend()
+
+          caught.get()
+        . assert(_ == t"swapped")
+
+        test(m"An unhandled daemon error escalates rather than vanishing silently"):
+          val signal = Promise[Int]()
+          val hook = Os.intercept[Fault]:
+            signal.offer(1)
+
+          daemon(abort(FooError(42)))
+          val delivered = safely(signal.await(2.0*Second)).or(0)
+          hook.cancel()
+          delivered
+        . assert(_ == 1)

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -184,7 +184,7 @@ class Websocket[message, state]
     decode:  Message => message,
     frame:   Data => Data,
     handle:  (state: state) ?=> message => Control[state] )
-  ( using Monitor, Codicil ):
+  ( using Monitor, Probate ):
 
   given key0: ("secWebsocketKey" is Directive of Text) = identity(_)
 

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -70,7 +70,7 @@ inline def webSocket[state](initial: state = ())[message]
   ( handle: (state: state) ?=> message => Control[state] )
   ( using ingressive: message is Ingressive )
   ( using request: Http.Request )
-  ( using Monitor, Codicil )
+  ( using Monitor, Probate )
 :   Websocket[message, state] =
 
   val decode: Message => message =

--- a/lib/perihelion/src/test/perihelion.AutobahnServer.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnServer.scala
@@ -39,7 +39,7 @@ import logging.silent
 import strategies.throwUnsafely
 import webserverErrorPages.minimal
 import threading.virtual
-import codicils.await
+import probates.await
 
 import Control.*
 

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -40,7 +40,7 @@ import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 import webserverErrorPages.minimal
 import threading.virtual
-import codicils.await
+import probates.await
 import jsonPrinters.minimal
 import charEncoders.utf8
 import charDecoders.utf8

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -122,7 +122,7 @@ object Keyboard:
     case '6'       => Keypress.PageDown
     case _         => Keypress.Escape
 
-  class Standard()(using Monitor, Codicil) extends Keyboard:
+  class Standard()(using Monitor, Probate) extends Keyboard:
     type Keypress = profanity.Keypress | TerminalInfo
 
     def process(stream: Stream[Char]): Stream[Keypress] = stream match

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -50,7 +50,7 @@ object Terminal:
   def reportSize: Text = t"\e7\e[4095C\e[4095B\e[6n\e8"
 
 case class Terminal()
-  ( using console: Console, monitor: Monitor, codicil: Codicil, environment: Environment )
+  ( using console: Console, monitor: Monitor, probate: Probate, environment: Environment )
 extends Interactivity[TerminalEvent]:
 
   export console.stdio.{in, out, err}
@@ -101,16 +101,24 @@ extends Interactivity[TerminalEvent]:
   private def dark(red: Int, green: Int, blue: Int): Boolean =
     (0.299*red + 0.587*green + 0.114*blue) < 32768
 
-  val pumpInput: Task[Unit] = task(t"stdin"):
-    keyboard.process(In.stream[Char]).each:
-      case resize@TerminalInfo.WindowSize(rows2, columns2) =>
-        rows = rows2
-        columns = columns2
-        events.put(resize)
+  // The keyboard pump runs as a daemon under a trap: if reading or decoding stdin fails,
+  // the event spool is stopped so the session consuming `events.stream` sees the input end
+  // and can exit cleanly, rather than blocking forever on a pump that has silently died.
+  val pumpInput: Daemon =
+    trap:
+      case _ => events.stop(); Remedy.Accept
 
-      case bgColor@TerminalInfo.BgColor(red, green, blue) =>
-        mode = if dark(red, green, blue) then Brightness.Dark else Brightness.Light
-        events.put(bgColor)
+    . within:
+        daemon:
+          keyboard.process(In.stream[Char]).each:
+            case resize@TerminalInfo.WindowSize(rows2, columns2) =>
+              rows = rows2
+              columns = columns2
+              events.put(resize)
 
-      case other =>
-        events.put(other)
+            case bgColor@TerminalInfo.BgColor(red, green, blue) =>
+              mode = if dark(red, green, blue) then Brightness.Dark else Brightness.Light
+              events.put(bgColor)
+
+            case other =>
+              events.put(other)

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -46,7 +46,7 @@ given stdio: (terminal: Terminal) => Stdio = terminal.stdio
 def interactive[result](block: (terminal: Terminal) ?=> result)
   ( using console:     Console,
           monitor:     Monitor,
-          codicil:     Codicil,
+          probate:     Probate,
           environment: Environment )
   ( using features: Every[TerminalFeature] )
 :   result raises TerminalError =
@@ -68,7 +68,7 @@ def interactive[result](block: (terminal: Terminal) ?=> result)
     finally
       terminal.stdio.in.close()
       terminal.events.stop()
-      safely(terminal.pumpInput.await())
+      terminal.pumpInput.attend()
 
   // Apply every in-scope `TerminalFeature` around the session, nested so that each
   // turns off (in its own try/finally) in the reverse of the order it turned on.
@@ -90,7 +90,7 @@ package keyboards:
 
     def process(stream: Stream[Char]): Stream[Int] = stream.map(_.toInt)
 
-  given standard: (monitor: Monitor, codicil: Codicil) => Keyboard.Standard = Keyboard.Standard()
+  given standard: (monitor: Monitor, probate: Probate) => Keyboard.Standard = Keyboard.Standard()
 
 // The standard terminal features, each a turn-on/turn-off escape-sequence pair.
 // Import the ones a session should enable (or `terminalFeatures.*` for all);

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -47,7 +47,7 @@ import threading.platform
 
 import strategies.throwUnsafely
 import backstops.silent
-import codicils.cancel
+import probates.cancel
 
 import Shell.*
 
@@ -57,7 +57,7 @@ object Tests extends Suite(m"Profanity Tests"):
       ' {
           import executives.completions
           import interpreters.posix
-          import codicils.cancel
+          import probates.cancel
 
           cli:
             arguments match

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -47,7 +47,7 @@ import urticose.*
 
 case class HttpServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
 extends RequestServable:
-  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
+  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
   :   Service logs HttpServerEvent raises ServerError =
 
     def handle(exchange: csnh.HttpExchange | Null): Unit =
@@ -57,7 +57,7 @@ extends RequestServable:
             Log.warn(HttpServerEvent.BrokenStream(length))
 
           case error @ HostnameError(_, _) =>
-            error.printStackTrace()
+            Log.warn(HttpServerEvent.ConnectionFailed(error))
 
             try
               exchange.nn.sendResponseHeaders(400, -1)
@@ -72,7 +72,8 @@ extends RequestServable:
                 errorPage.handle(throwable, connection)
 
 
-      catch case NonFatal(exception) => exception.printStackTrace()
+      catch case NonFatal(exception) =>
+        Log.warn(HttpServerEvent.ConnectionFailed(fulminate.Error(exception)))
 
     def startServer(): com.sun.net.httpserver.HttpServer raises ServerError =
       try

--- a/lib/scintillate/src/server/scintillate.HttpServerEvent.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServerEvent.scala
@@ -41,8 +41,10 @@ object HttpServerEvent:
     case Received(request)            => m"Received request $request"
     case Processed(request, duration) => m"Processed request $request in ${duration}ms"
     case BrokenStream(length)         => m"Sending response was aborted after $length"
+    case ConnectionFailed(error)      => m"The connection handler failed: ${error.message}"
 
 enum HttpServerEvent:
   case Received(request: Http.Request)
   case Processed(request: Http.Request, duration: Long)
   case BrokenStream(length: Bytes)
+  case ConnectionFailed(error: Error)

--- a/lib/scintillate/src/server/scintillate.RequestServable.scala
+++ b/lib/scintillate/src/server/scintillate.RequestServable.scala
@@ -39,5 +39,5 @@ import telekinesis.*
 import urticose.*
 
 trait RequestServable:
-  def handle(handle: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
+  def handle(handle: HttpConnection ?=> Http.Response)(using Monitor, Probate)
   :   Service logs HttpServerEvent raises ServerError

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -218,20 +218,20 @@ extends RequestServable:
 
             drained(body)
 
-    try
-      whereas:
-        case StreamError(length) =>
-          Log.warn(HttpServerEvent.BrokenStream(length))
+    // A stream error tearing down the connection is logged and ends it; any other
+    // unexpected failure is left to propagate out of the per-connection daemon, where
+    // the `trap` installed in `handle` logs it and isolates it to this connection.
+    whereas:
+      case StreamError(length) =>
+        Log.warn(HttpServerEvent.BrokenStream(length))
 
-      . recover:
-          val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
+    . recover:
+        val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
 
-          var continue = true
-          while continue && !cursor.finished do continue = serveRequest(cursor)
+        var continue = true
+        while continue && !cursor.finished do continue = serveRequest(cursor)
 
-    catch case NonFatal(exception) => exception.printStackTrace()
-
-  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Codicil)
+  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
   :   Service logs HttpServerEvent raises ServerError =
 
     val idleTimeout: Int = 30000
@@ -246,18 +246,29 @@ extends RequestServable:
 
     val serverSocket = startServer()
 
-    val acceptLoop = loop:
-      safely(serverSocket.accept().nn).let: socket =>
-        daemon:
-          try
-            socket.setSoTimeout(idleTimeout)
-            serveConnection(handler)(socket.getInputStream.nn, socket.getOutputStream.nn)
-          finally safely(socket.close())
+    // A failure in a per-connection daemon (anything not already turned into an HTTP
+    // response) is logged and accepted, isolating it to that connection: the server
+    // keeps accepting, and the error neither escalates nor is dumped to stderr.
+    trap:
+      case error => Log.warn(HttpServerEvent.ConnectionFailed(error)); Remedy.Accept
 
-    val acceptTask = daemon(acceptLoop.run())
-    val cancel: Promise[Unit] = Promise[Unit]()
-    val stopTask = async(cancel.attend() yet { acceptLoop.stop(); safely(serverSocket.close()) })
+    . within:
+        val acceptLoop = loop:
+          safely(serverSocket.accept().nn).let: socket =>
+            daemon:
+              try
+                socket.setSoTimeout(idleTimeout)
+                serveConnection(handler)(socket.getInputStream.nn, socket.getOutputStream.nn)
+              finally safely(socket.close())
 
-    Service: () =>
-      safely(cancel.fulfill(()))
+        val acceptTask = daemon(acceptLoop.run())
+        val cancel: Promise[Unit] = Promise[Unit]()
+
+        val stopTask = async:
+          cancel.attend()
+          acceptLoop.stop()
+          safely(serverSocket.close())
+
+        Service: () =>
+          safely(cancel.fulfill(()))
 

--- a/lib/scintillate/src/server/scintillate_core.scala
+++ b/lib/scintillate/src/server/scintillate_core.scala
@@ -51,7 +51,7 @@ import vacuous.*
 
 package httpServers:
   given stdlib: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
+  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
   =>  WebserverErrorPage
   =>  Http is Protocolic:
 
@@ -66,7 +66,7 @@ package httpServers:
 
 
   given stdlibPublic: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
+  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
   =>  WebserverErrorPage
   =>  Http is Protocolic:
 
@@ -81,7 +81,7 @@ package httpServers:
 
 
   given native: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
+  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
   =>  WebserverErrorPage
   =>  Http is Protocolic:
 
@@ -96,7 +96,7 @@ package httpServers:
 
 
   given nativePublic: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Codicil, HttpServerEvent is Loggable )
+  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
   =>  WebserverErrorPage
   =>  Http is Protocolic:
 

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -39,7 +39,7 @@ import strategies.throwUnsafely
 import charEncoders.utf8
 import webserverErrorPages.minimal
 import threading.virtual
-import codicils.await
+import probates.await
 
 object Tests extends Suite(m"Scintillate tests"):
   def run(): Unit =

--- a/lib/surveillance/src/core/surveillance.NativeWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.NativeWatcher.scala
@@ -52,7 +52,7 @@ import vacuous.*
 // watched.
 object NativeWatcher extends Watcher:
   private case class WatchService(watchService: jnf.WatchService, pollLoop: Loop):
-    import codicils.await
+    import probates.await
 
     def stop(): Unit =
       pollLoop.stop()

--- a/lib/surveillance/src/core/surveillance.PollingWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.PollingWatcher.scala
@@ -54,7 +54,7 @@ import vacuous.*
 class PollingWatcher[duration: Abstractable across Durations to Long](interval: duration)
 extends Watcher:
 
-  import codicils.await
+  import probates.await
 
   private case class Entry(directory: Boolean, modified: Long, size: Long)
 

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -62,7 +62,7 @@ object Mcp:
   def send[interface <: McpServer](id: Text, server: interface, mcpInterface: Interface)
     ( dispatch: Json => Optional[Json] )
     ( using request: Http.Request )
-    ( using Monitor, Codicil, Online )
+    ( using Monitor, Probate, Online )
   :   Http.Response =
 
     import jsonPrinters.minimal

--- a/lib/synesthesia/src/core/synesthesia.McpServer.scala
+++ b/lib/synesthesia/src/core/synesthesia.McpServer.scala
@@ -67,7 +67,7 @@ trait McpServer():
   private given mcpSessionId: ("mcpSessionId" is Directive of Text) = identity(_)
 
 
-  def serve(using this.type is McpSpecification, Monitor, Codicil, Online, Http.Request)
+  def serve(using this.type is McpSpecification, Monitor, Probate, Online, Http.Request)
   :   Http.Response =
 
     whereas:

--- a/lib/synesthesia/src/test/synesthesia_test.scala
+++ b/lib/synesthesia/src/test/synesthesia_test.scala
@@ -45,7 +45,7 @@ object Tests extends Suite(m"Synesthesia Tests"):
     // test(m"Remote server"):
     //   import internetAccess.enabled
     //   import supervisors.global
-    //   import codicils.cancel
+    //   import probates.cancel
     //   import httpServers.stdlib
     //   import logging.silent
     //   import webserverErrorPages.stackTraces

--- a/lib/turbulence/src/core/turbulence.Multiplexer.scala
+++ b/lib/turbulence/src/core/turbulence.Multiplexer.scala
@@ -41,12 +41,12 @@ import denominative.*
 import parasite.*
 import rudiments.*
 
-import codicils.await
+import probates.await
 
 case class Multiplexer[key, element]()(using Monitor):
   private case class Removal(key: key)
 
-  private val active: TrieMap[key, Task[Unit]] = TrieMap()
+  private val active: TrieMap[key, Daemon] = TrieMap()
   private val queue: juc.LinkedBlockingQueue[element | Removal] = juc.LinkedBlockingQueue()
 
   def close(): Unit = active.keys.each(remove(_))
@@ -58,7 +58,17 @@ case class Multiplexer[key, element]()(using Monitor):
       queue.put(stream.head)
       pump(key, stream.tail)
 
-  def add(key: key, stream: Stream[element]): Unit = active(key) = async(pump(key, stream))
+  // Each source is drained by its own daemon. If one fails (the source stream throws),
+  // a trap removes its key — so the consumer sees that source end rather than blocking
+  // forever on a `Removal` the failed pump never enqueued — and isolates the failure to
+  // that source rather than letting it escape.
+  def add(key: key, stream: Stream[element]): Unit =
+    active(key) =
+      trap:
+        case _ => remove(key); Remedy.Accept
+
+      . within(daemon(pump(key, stream)))
+
   private def remove(key: key): Unit = if !active.nil then queue.put(Removal(key))
 
   def stream: Stream[element] = queue.take().nn.absolve match

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -50,7 +50,7 @@ import symbolism.*
 import vacuous.*
 
 import abstractables.instantIsAbstractable
-import codicils.await
+import probates.await
 
 inline def more[value](using value: value aka "more"): value = value()
 

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -152,7 +152,7 @@ def border
 // height; in `Inline` mode it renders a variable-height block at the cursor
 // without the alternate buffer, leaving scrollback intact.
 def form(mode: Mode = Mode.Fullscreen)(pane: Pane)
-  ( using terminal: Terminal, monitor: Monitor, codicil: Codicil )
+  ( using terminal: Terminal, monitor: Monitor, probate: Probate )
 :   Unit =
 
   // A container mutation wakes the loop by putting a redraw event on the spool.

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -513,7 +513,7 @@ object Xml extends Tag.Container
       case node: Node =>
         Document(node, Xml.header)
 
-  given streamable: (Monitor, Codicil) => Document[Xml] is Streamable by Text =
+  given streamable: (Monitor, Probate) => Document[Xml] is Streamable by Text =
     emit(_).to(Stream)
 
   // Tracking-mode parse entry points. Build the parser with a line-feed
@@ -534,7 +534,7 @@ object Xml extends Tag.Container
     val index = parser.rootIndex
     Tracked(xml, PositionIndex(if index == null then IArray.empty[Int] else index))
 
-  def emit(document: Document[Xml], flat: Boolean = false)(using Monitor, Codicil): Iterator[Text] =
+  def emit(document: Document[Xml], flat: Boolean = false)(using Monitor, Probate): Iterator[Text] =
 
     val emitter = Emitter[Text](4096)
 

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 import threading.virtual
-import codicils.cancel
+import probates.cancel
 
 case class Worker(name: Text, age: Int)
 case class Firm(name: Text, ceo: Worker)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 import randomization.unseeded
 
 import supervisors.global
-import codicils.panic
+import probates.panic
 
 object Tests extends Suite(m"Zephyrine tests"):
   val bytes = Data.fill(1000)(_.toByte)


### PR DESCRIPTION
Parasite's asynchronous blocks now keep the static error-handling guarantees of synchronous code: a task carries the error type its body may raise and delivers it, still typed, when you await it, while fire-and-forget work routes an escaped error to a trap installed near where it was spawned — escalating it if nothing handles it, rather than letting it vanish. Five modules (Scintillate, Cordillera, Turbulence, Profanity and Coaxial) adopt the mechanism so their servers, connections and streams survive or surface per-unit failures that were previously dropped to stderr or left to hang.

## Typed task errors with `incurs`

A `Task` now carries the error type its body may raise, written with the new `incurs` infix — the asynchronous counterpart to `raises`:

```scala
def loadUser(): User raises (HttpError | AsyncError) =
  async(fetchUser()).await()   // await delivers the body's typed error
```

## Traps for fire-and-forget work

A `daemon`, or any task nobody awaits, has no join at which to deliver an error. A `trap { … }.within { … }` block installs a handler near where such work is spawned:

```scala
trap:
  case error => Log.warn(error); Remedy.Accept
.within:
  daemon(serve(connection))
```

A handler returns `Remedy.Accept` (handled — stop), `Remedy.Reject` (bubble to an enclosing trap) or `Remedy.Escalate(other)` (substitute a different error). An error no trap accepts is escalated to the thread's uncaught-exception handler rather than silently dropped. The context value governing a worker's children is renamed from `Codicil` to **`Probate`** (it now also traps escaped errors); the `codicils.*` givens become `probates.*`.

## Servers and streams no longer lose async failures

- Scintillate's native `SocketServer` isolates a failing connection (logged as `HttpServerEvent.ConnectionFailed`) instead of swallowing it to stderr.
- Cordillera's HTTP/2 connection tears down cleanly on a reader/writer failure instead of hanging request awaiters.
- Turbulence's `Multiplexer` ends a source whose pump fails instead of blocking the consumer forever.
- Profanity's terminal input pump stops the event stream on failure instead of going deaf.
- Coaxial's `listen` serves each connection on its own fibre and isolates a failing one instead of tearing down the whole server.
