### PR TITLE
Drive Ethereal's daemon socket through Coaxial

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -668,7 +668,7 @@ object polysyllabic extends Library:
   object bench extends Benchmarks(core, escritoire.core, hellenism.core, quantitative.units)
 
 object ethereal extends Library:
-  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, quantitative.units):
+  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.core, quantitative.units):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     val rustTargets: Seq[(String, String, String)] = Seq(

--- a/lib/coaxial/src/core/coaxial.Connection.scala
+++ b/lib/coaxial/src/core/coaxial.Connection.scala
@@ -41,3 +41,9 @@ import turbulence.*
 case class Connection
   ( private[coaxial] val in: ji.InputStream, private[coaxial] val out: ji.OutputStream ):
   def stream(): Stream[Data] raises StreamError = in.stream[Data]
+  def reader: ji.InputStream = in
+  def writer: ji.OutputStream = out
+
+  def close(): Unit =
+    safely(in.close())
+    safely(out.close())

--- a/lib/ethereal/src/core/ethereal.Client.scala
+++ b/lib/ethereal/src/core/ethereal.Client.scala
@@ -35,8 +35,8 @@ package ethereal
 import language.experimental.pureFunctions
 
 import java.io as ji
-import java.nio.channels as jnc
 
+import coaxial.*
 import contingency.*
 import exoskeleton.*
 import guillotine.*
@@ -64,6 +64,6 @@ case class Client(pid: Pid) extends Topical:
 
   def receive(message: Topic): Unit = bus.put(message)
 
-  val socket: Promise[jnc.SocketChannel] = Promise()
+  val socket: Promise[Connection] = Promise()
 
   def close(): Unit = safely(socket.await(1.0*Second).close())

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -36,15 +36,14 @@ import language.experimental.pureFunctions
 
 import java.io as ji
 import java.lang as jl
-import java.net as jn
 import java.nio as jnio
-import java.nio.channels as jnc
 import java.util.concurrent.atomic as juca
 
 import scala.collection.concurrent as scc
 
 import ambience.*, systems.java
 import anticipation.*
+import coaxial.*
 import contingency.*
 import digression.*
 import distillate.*
@@ -278,199 +277,198 @@ def cli[bus <: Matchable](using executive: Executive)
     pid.let(terminatePid.fulfill(_)).or(termination)
 
 
-  def makeClient(channel: jnc.SocketChannel)(using Monitor, Stdio, Probate)
+  def makeClient(connection: Connection)(using Monitor, Stdio, Probate)
   :   Unit logs DaemonLogEvent raises StreamError raises CharDecodeError raises NumberError =
 
-    async:
-      val rawIn: ji.InputStream = jnc.Channels.newInputStream(channel).nn
-      val rawOut: ji.OutputStream = jnc.Channels.newOutputStream(channel).nn
-      val in: ji.BufferedInputStream = ji.BufferedInputStream(rawIn, 16384)
+    val rawIn: ji.InputStream = connection.reader
+    val rawOut: ji.OutputStream = connection.writer
+    val in: ji.BufferedInputStream = ji.BufferedInputStream(rawIn, 16384)
 
-      def line(): Text =
-        val sb = jl.StringBuilder()
-        var b = in.read()
+    def line(): Text =
+      val sb = jl.StringBuilder()
+      var b = in.read()
 
-        while b != '\n' && b != -1 do
-          sb.append(b.toChar)
-          b = in.read()
+      while b != '\n' && b != -1 do
+        sb.append(b.toChar)
+        b = in.read()
 
-        sb.toString.tt
+      sb.toString.tt
 
-      def chunk(): Text =
-        var buffer: Text = line()
-        var current: Text = t""
+    def chunk(): Text =
+      var buffer: Text = line()
+      var current: Text = t""
 
-        while
-          current = line()
-          current != t"##"
-        do buffer += t"\n$current"
+      while
+        current = line()
+        current != t"##"
+      do buffer += t"\n$current"
 
-        buffer
+      buffer
 
-      val message: Optional[DaemonEvent] = line() match
-        case t"e" =>
-          val pid: Pid = line().decode[Pid]
-          DaemonEvent.Stderr(pid)
+    val message: Optional[DaemonEvent] = line() match
+      case t"e" =>
+        val pid: Pid = line().decode[Pid]
+        DaemonEvent.Stderr(pid)
 
-        case t"s" =>
-          val pid: Pid = line().decode[Pid]
-          val name: Text = line()
+      case t"s" =>
+        val pid: Pid = line().decode[Pid]
+        val name: Text = line()
 
-          val signal: UnixSignal | WindowsSignal =
-            safely(name.decode[UnixSignal]).or(name.decode[WindowsSignal])
+        val signal: UnixSignal | WindowsSignal =
+          safely(name.decode[UnixSignal]).or(name.decode[WindowsSignal])
 
-          DaemonEvent.Trap(pid, signal)
+        DaemonEvent.Trap(pid, signal)
 
-        case t"x" =>
-          DaemonEvent.Exit(line().decode[Pid])
+      case t"x" =>
+        DaemonEvent.Exit(line().decode[Pid])
 
-        case t"i" =>
-          val stdin: Stdin = if line() == t"p" then Stdin.Pipe else Stdin.Terminal
-          val pid: Pid = Pid(line().decode[Int])
-          val userId: Int = line().decode[Int]
-          val username: Text = line()
-          val login = Login(username, userId)
-          val script: Text = line()
-          val pwd: Text = line()
-          val count: Int = line().decode[Int]
-          val textArguments: List[Text] = chunk().cut(t"\u0000").take(count).to(List)
-          val environment: List[Text] = chunk().cut(t"\u0000").init.to(List)
+      case t"i" =>
+        val stdin: Stdin = if line() == t"p" then Stdin.Pipe else Stdin.Terminal
+        val pid: Pid = Pid(line().decode[Int])
+        val userId: Int = line().decode[Int]
+        val username: Text = line()
+        val login = Login(username, userId)
+        val script: Text = line()
+        val pwd: Text = line()
+        val count: Int = line().decode[Int]
+        val textArguments: List[Text] = chunk().cut(t"\u0000").take(count).to(List)
+        val environment: List[Text] = chunk().cut(t"\u0000").init.to(List)
 
-          DaemonEvent.Init(pid, login, pwd, script, stdin, textArguments, environment)
+        DaemonEvent.Init(pid, login, pwd, script, stdin, textArguments, environment)
 
-        case _ =>
-          Unset
+      case _ =>
+        Unset
 
-      message match
-        case Unset =>
-          Log.warn(DaemonLogEvent.UnrecognizedMessage)
-          channel.close()
+    message match
+      case Unset =>
+        Log.warn(DaemonLogEvent.UnrecognizedMessage)
+        connection.close()
 
-        case DaemonEvent.Trap(pid, signal) =>
-          Log.info(DaemonLogEvent.ReceivedSignal(signal))
+      case DaemonEvent.Trap(pid, signal) =>
+        Log.info(DaemonLogEvent.ReceivedSignal(signal))
 
-          val response: SignalResponse =
-            safely:
-              val invocation = client(pid).invocation.await(250.0*Milli(Second))
-              invocation.dispatchSignal(signal)
+        val response: SignalResponse =
+          safely:
+            val invocation = client(pid).invocation.await(250.0*Milli(Second))
+            invocation.dispatchSignal(signal)
 
-            . or(SignalResponse.Reject)
+          . or(SignalResponse.Reject)
 
-          val ackByte: Byte = if response == SignalResponse.Accept then 'a' else 'r'
-          safely(rawOut.write(Array[Byte](ackByte, '\n'.toByte)))
-          safely(rawOut.flush())
-          channel.close()
+        val ackByte: Byte = if response == SignalResponse.Accept then 'a' else 'r'
+        safely(rawOut.write(Array[Byte](ackByte, '\n'.toByte)))
+        safely(rawOut.flush())
+        connection.close()
 
-        case DaemonEvent.Exit(pid) =>
-          Log.fine(DaemonLogEvent.ExitStatusRequest(pid))
-          val exitStatus: Exit = client(pid).exitPromise.await()
+      case DaemonEvent.Exit(pid) =>
+        Log.fine(DaemonLogEvent.ExitStatusRequest(pid))
+        val exitStatus: Exit = client(pid).exitPromise.await()
 
-          rawOut.write(exitStatus().show.data.mutable(using Unsafe))
-          channel.close()
-          clients.remove(pid)
-          if terminatePid() == pid then termination
+        rawOut.write(exitStatus().show.data.mutable(using Unsafe))
+        connection.close()
+        clients.remove(pid)
+        if terminatePid() == pid then termination
 
-        case DaemonEvent.Stderr(pid) =>
-          Log.fine(DaemonLogEvent.StderrRequest(pid))
-          val stderrClient = client(pid)
-          stderrClient.stderr.offer(rawOut)
-          safely(stderrClient.exitPromise.await())
-          safely(channel.close())
+      case DaemonEvent.Stderr(pid) =>
+        Log.fine(DaemonLogEvent.StderrRequest(pid))
+        val stderrClient = client(pid)
+        stderrClient.stderr.offer(rawOut)
+        safely(stderrClient.exitPromise.await())
+        safely(connection.close())
 
-        case DaemonEvent.Init(pid, login, directory, script, shellInput, textArguments, env) =>
-          Log.fine(DaemonLogEvent.Init(pid))
-          val connection = client(pid)
-          connection.socket.fulfill(channel)
+      case DaemonEvent.Init(pid, login, directory, script, shellInput, textArguments, env) =>
+        Log.fine(DaemonLogEvent.Init(pid))
+        val clientState = client(pid)
+        clientState.socket.fulfill(connection)
 
-          val lazyStderr: ji.OutputStream = new ji.OutputStream():
-            private val stderrOut: juca.AtomicReference[ji.OutputStream | Null] =
-              juca.AtomicReference(null)
+        val lazyStderr: ji.OutputStream = new ji.OutputStream():
+          private val stderrOut: juca.AtomicReference[ji.OutputStream | Null] =
+            juca.AtomicReference(null)
 
-            private def connected(): ji.OutputStream =
-              val s = stderrOut.get()
+          private def connected(): ji.OutputStream =
+            val s = stderrOut.get()
 
-              if s != null then s
-              else
-                val newS = connection.stderr.await()
-                stderrOut.set(newS)
-                newS
-
-            def write(i: Int): Unit = connected().write(i)
-            override def write(bytes: Array[Byte] | Null): Unit = connected().write(bytes)
-
-            override def write(bytes: Array[Byte] | Null, offset: Int, length: Int): Unit =
-              connected().write(bytes, offset, length)
-
-            override def close(): Unit =
-              val s = stderrOut.get()
-              if s != null then safely(s.close())
-
-          given environment: Environment = LazyEnvironment(env)
-
-          val termcap: Termcap = new Termcap:
-            def ansi: Boolean = true
-
-            lazy val color: ColorDepth =
-              import workingDirectories.system
-
-              if safely(Environment.colorterm[Text]) == t"truecolor" then ColorDepth.TrueColor
-              else
-                ColorDepth
-                  ( safely(mute[ExecEvent](sh"tput colors".exec[Text]().decode[Int])).or(-1) )
-
-          val stdio: Stdio =
-            Stdio
-              ( ji.PrintStream(rawOut, true),
-                ji.PrintStream(lazyStderr, true),
-                in,
-                termcap )
-
-          def deliver(sourcePid: Pid, message: bus): Unit =
-            clients.each: (pid, client) =>
-              if sourcePid != pid then client.receive(message)
-
-          val service: DaemonService[bus] =
-            DaemonService[bus]
-              ( pid,
-                () => shutdown(pid),
-                shellInput,
-                script.decode[Path on Local],
-                deliver(pid, _),
-                connection.bus.stream,
-                name,
-                startTime )
-
-          Log.fine(DaemonLogEvent.NewCli)
-
-          try
-            val cli: executive.Interface =
-              executive.invocation
-                ( textArguments,
-                  environment,
-                  () => directory,
-                  stdio,
-                  service,
-                  login )
-
-            connection.invocation.offer(cli)
-
-            if cli.proceed then
-              val result = block(using service, cli, environment)
-              val exitStatus: Exit = executive.process(cli)(result)
-
-              connection.exitPromise.fulfill(exitStatus)
+            if s != null then s
             else
-              connection.exitPromise.fulfill(Exit.Ok)
+              val newS = clientState.stderr.await()
+              stderrOut.set(newS)
+              newS
 
-          catch
-            case exception: Exception =>
-              Log.warn(DaemonLogEvent.Failure)
-              connection.exitPromise.fulfill(handler.handle(exception)(using stdio))
+          def write(i: Int): Unit = connected().write(i)
+          override def write(bytes: Array[Byte] | Null): Unit = connected().write(bytes)
 
-          finally
-            lazyStderr.close()
-            channel.close()
-            Log.info(DaemonLogEvent.CloseConnection(pid))
+          override def write(bytes: Array[Byte] | Null, offset: Int, length: Int): Unit =
+            connected().write(bytes, offset, length)
+
+          override def close(): Unit =
+            val s = stderrOut.get()
+            if s != null then safely(s.close())
+
+        given environment: Environment = LazyEnvironment(env)
+
+        val termcap: Termcap = new Termcap:
+          def ansi: Boolean = true
+
+          lazy val color: ColorDepth =
+            import workingDirectories.system
+
+            if safely(Environment.colorterm[Text]) == t"truecolor" then ColorDepth.TrueColor
+            else
+              ColorDepth
+                ( safely(mute[ExecEvent](sh"tput colors".exec[Text]().decode[Int])).or(-1) )
+
+        val stdio: Stdio =
+          Stdio
+            ( ji.PrintStream(rawOut, true),
+              ji.PrintStream(lazyStderr, true),
+              in,
+              termcap )
+
+        def deliver(sourcePid: Pid, message: bus): Unit =
+          clients.each: (pid, client) =>
+            if sourcePid != pid then client.receive(message)
+
+        val service: DaemonService[bus] =
+          DaemonService[bus]
+            ( pid,
+              () => shutdown(pid),
+              shellInput,
+              script.decode[Path on Local],
+              deliver(pid, _),
+              clientState.bus.stream,
+              name,
+              startTime )
+
+        Log.fine(DaemonLogEvent.NewCli)
+
+        try
+          val cli: executive.Interface =
+            executive.invocation
+              ( textArguments,
+                environment,
+                () => directory,
+                stdio,
+                service,
+                login )
+
+          clientState.invocation.offer(cli)
+
+          if cli.proceed then
+            val result = block(using service, cli, environment)
+            val exitStatus: Exit = executive.process(cli)(result)
+
+            clientState.exitPromise.fulfill(exitStatus)
+          else
+            clientState.exitPromise.fulfill(Exit.Ok)
+
+        catch
+          case exception: Exception =>
+            Log.warn(DaemonLogEvent.Failure)
+            clientState.exitPromise.fulfill(handler.handle(exception)(using stdio))
+
+        finally
+          lazyStderr.close()
+          connection.close()
+          Log.info(DaemonLogEvent.CloseConnection(pid))
 
   application(using executives.direct(using backstops.silent))(Nil):
     import environments.java
@@ -489,11 +487,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
       safely(socketFile.wipe())
 
-      val channel: jnc.ServerSocketChannel =
-        jnc.ServerSocketChannel.open(jn.StandardProtocolFamily.UNIX).nn
-
-      channel.configureBlocking(true)
-      channel.bind(jn.UnixDomainSocketAddress.of(socketFile.encode.s))
+      val domainSocket: DomainSocket = DomainSocket(socketFile.encode)
 
       val buildId = safely(System.properties.build.id[Int]()).or:
         safely((Classpath/"build.id").read[Text].trim.decode[Int]).or(0)
@@ -517,12 +511,17 @@ def cli[bus <: Matchable](using executive: Executive)
         Log.warn(DaemonLogEvent.IdleTimeout)
         termination
 
-      loop:
-        val socket = channel.accept().nn
-        inactivityTimer.nudge()
-        safely(makeClient(socket))
+      safely:
+        domainSocket.listen: connection =>
+          inactivityTimer.nudge()
+          safely(makeClient(connection))
+          Data()
 
-      . run()
+      // The accept loop runs on its own daemon inside `listen`, so park the
+      // supervisor here to keep the daemon process alive until `termination`
+      // (an idle timeout, a watched-file change, or an explicit shutdown)
+      // calls `System.exit`.
+      Promise[Unit]().await()
 
     Exit.Ok
 

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -489,6 +489,21 @@ def cli[bus <: Matchable](using executive: Executive)
 
       val domainSocket: DomainSocket = DomainSocket(socketFile.encode)
 
+      val inactivityTimer: Timeout = Timeout(idleTimeout):
+        Log.warn(DaemonLogEvent.IdleTimeout)
+        termination
+
+      // Bind and start accepting *before* the build- and pid-files are written:
+      // a launcher waits for those readiness files to appear and then connects,
+      // so the socket must already be listening by the time they exist. (`listen`
+      // binds synchronously and serves on its own daemon, so the bound socket
+      // queues connections immediately even before the files are created.)
+      safely:
+        domainSocket.listen: connection =>
+          inactivityTimer.nudge()
+          safely(makeClient(connection))
+          Data()
+
       val buildId = safely(System.properties.build.id[Int]()).or:
         safely((Classpath/"build.id").read[Text].trim.decode[Int]).or(0)
 
@@ -506,16 +521,6 @@ def cli[bus <: Matchable](using executive: Executive)
 
               case other =>
                 ()
-
-      val inactivityTimer: Timeout = Timeout(idleTimeout):
-        Log.warn(DaemonLogEvent.IdleTimeout)
-        termination
-
-      safely:
-        domainSocket.listen: connection =>
-          inactivityTimer.nudge()
-          safely(makeClient(connection))
-          Data()
 
       // The accept loop runs on its own daemon inside `listen`, so park the
       // supervisor here to keep the daemon process alive until `termination`


### PR DESCRIPTION
Ethereal's daemon previously spoke to its Unix domain socket using raw Java NIO, bypassing Coaxial even though Coaxial already models exactly that socket. The daemon now binds and accepts connections through Coaxial's `DomainSocket.listen`, which serves each client on its own daemon, and Coaxial's `Connection` type gains the public stream accessors a long-lived bidirectional server needs. The wire protocol and the launcher are unchanged, so this is purely an internal consolidation onto the project's own networking abstraction.

## Coaxial

`Connection` now exposes its underlying byte streams and a `close` method, so a server handler can do long-lived, bidirectional streaming over an accepted connection rather than the single request/response that `listen`'s return value models:

```scala
domainSocket.listen: connection =>
  val in  = connection.reader   // java.io.InputStream
  val out = connection.writer   // java.io.OutputStream
  // …stream over the connection for as long as you need…
  connection.close()
  Data()
```

## Ethereal

No user-visible API change — the daemon's socket handling is now built on Coaxial's `DomainSocket` instead of `java.nio.channels`, with each connection served on its own daemon.
