### PR TITLE
Stop a terminating Ethereal daemon from deleting its successor's socket

### DIFF
--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -266,10 +266,26 @@ def cli[bus <: Matchable](using executive: Executive)
 
   def client(pid: Pid): Client of bus = clients.getOrElseUpdate(pid, Client[bus](pid))
 
+  def ownsState: Boolean =
+    val recorded: Optional[Text] =
+      if pidFile.exists() then safely(pidFile.open(_.stream[Data].read[Text]).trim)
+      else Unset
+
+    recorded.let(_ == Process().pid.value.show).or(false)
+
+  // Only clear the state files if this daemon still owns them. A successor
+  // daemon (e.g. after an upgrade) rebinds the socket at the same path and
+  // overwrites `pidFile` with its own pid before binding, so a dying daemon
+  // that no longer matches the recorded pid must not wipe the live successor's
+  // socket out from under it.
+  def wipeState(): Unit =
+    if ownsState then
+      safely(socketFile.wipe())
+      safely(buildFile.wipe())
+      safely(pidFile.wipe())
+
   lazy val termination: Unit =
-    safely(socketFile.wipe())
-    safely(buildFile.wipe())
-    safely(pidFile.wipe())
+    wipeState()
     jl.System.exit(0)
 
   def shutdown(pid: Optional[Pid])(using Stdio): Unit logs DaemonLogEvent =
@@ -477,9 +493,7 @@ def cli[bus <: Matchable](using executive: Executive)
     import probates.await
 
     Os.intercept[Shutdown]:
-      safely(socketFile.wipe())
-      safely(buildFile.wipe())
-      safely(pidFile.wipe())
+      wipeState()
 
     supervise:
       import logFormats.standard

--- a/lib/ethereal/src/test/ethereal_test.scala
+++ b/lib/ethereal/src/test/ethereal_test.scala
@@ -60,6 +60,7 @@ object Tests extends Suite(m"Ethereal Tests"):
     // daemon handshake and makes these tests flaky under load.
     val name:        Text = t"e${Uuid().text.cut(t"-").head}"
     val upgradeName: Text = t"u${Uuid().text.cut(t"-").head}"
+    val selfuName:   Text = t"s${Uuid().text.cut(t"-").head}"
 
     safely(sh"pkill $name".exec[Exit]())
     snooze(0.1*Second)
@@ -572,13 +573,13 @@ object Tests extends Suite(m"Ethereal Tests"):
     sh"rm -rf $upgradeStateDir".exec[Unit]()
 
     val selfuStateDir: Path on Local =
-      Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / t"selfu"
-    val selfuDataDir: Path on Local = Xdg.dataHome[Path on Local] / t"selfu"
+      Xdg.runtimeDir[Path on Local].or(Xdg.stateHome[Path on Local]) / selfuName
+    val selfuDataDir: Path on Local = Xdg.dataHome[Path on Local] / selfuName
     sh"rm -rf $selfuStateDir $selfuDataDir".exec[Unit]()
-    safely(sh"pkill selfu".exec[Exit]())
+    safely(sh"pkill $selfuName".exec[Exit]())
     snooze(0.1*Second)
 
-    val selfuV1 = Enclave("selfu", buildId = 1).dispatch:
+    val selfuV1 = Enclave(selfuName, buildId = 1).dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -594,7 +595,7 @@ object Tests extends Suite(m"Ethereal Tests"):
           t"finished"
         }
 
-    val selfuV2 = Enclave("selfu", buildId = 2).dispatch:
+    val selfuV2 = Enclave(selfuName, buildId = 2).dispatch:
       ' {
           import executives.completions
           import interpreters.posix
@@ -631,7 +632,7 @@ object Tests extends Suite(m"Ethereal Tests"):
 
       .assert(_ == Exit.Ok)
 
-    safely(sh"pkill selfu".exec[Exit]())
+    safely(sh"pkill $selfuName".exec[Exit]())
     sh"rm -rf $selfuStateDir $selfuDataDir".exec[Unit]()
 
     val brokenStateDir: Path on Local =


### PR DESCRIPTION
Ethereal daemons store their Unix-domain socket and readiness files at a fixed per-application path, and a daemon used to clear those files unconditionally when it terminated. If the daemon was being replaced — during an upgrade, a self-update, or any quick restart — a slow-to-exit predecessor could delete the socket its successor had just bound, leaving the launcher unable to connect and exiting with a startup failure and empty output under load. A terminating daemon now wipes its socket, build, and pid files only when they still belong to it, so it can no longer pull the rug out from under its replacement.

### Daemon replacement is no longer racy under load

No API changes. Previously, replacing a running Ethereal daemon (an upgrade, a self-update, or a fast restart) could intermittently fail — the launcher would print nothing and exit with a startup failure — because the outgoing daemon could delete the incoming daemon's freshly-bound socket while shutting down. The daemon now treats its `pid` file as an ownership token and only removes its `socket`/`build`/`pid` files if that file still records its own pid; a daemon that has already been superseded leaves the successor's files in place. Any socket a terminating daemon leaves behind is reclaimed by the launcher's existing liveness probe, so no stale endpoints accumulate.

This also removes a long-standing source of flakiness in the daemon upgrade and self-update test suites under CPU contention.

Closes #1317.
