### PR TITLE
Add contextual socket options and interface selection to Coaxial

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -536,7 +536,7 @@ object chiaroscuro extends Library:
   object test extends Tests(core)
 
 object coaxial extends Library:
-  object core extends Component(galilei.core, urticose.core):
+  object core extends Component(galilei.core, urticose.core, frontier.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/coaxial/src/core/coaxial.Bindable.scala
+++ b/lib/coaxial/src/core/coaxial.Bindable.scala
@@ -37,6 +37,7 @@ import java.nio.channels as jnc
 
 import anticipation.*
 import contingency.*
+import frontier.*
 import hypotenuse.*
 import prepositional.*
 import rudiments.*
@@ -45,16 +46,19 @@ import urticose.*
 import vacuous.*
 
 object Bindable:
-  given domainSocket: Tactic[StreamError] => DomainSocket is Bindable:
+  given domainSocket: (Tactic[StreamError], Every[SocketOption.Domain])
+  =>  DomainSocket is Bindable:
     type Binding = jnc.ServerSocketChannel
     type Output = Data
     type Input = Connection
 
-    def bind(domainSocket: DomainSocket): jnc.ServerSocketChannel =
+    // A Unix-domain socket has no network interface, so `interface` is not applicable here.
+    def bind(domainSocket: DomainSocket, interface: Optional[MacAddress]): jnc.ServerSocketChannel =
       val address = jn.UnixDomainSocketAddress.of(domainSocket.address.s)
 
       jnc.ServerSocketChannel.open(jn.StandardProtocolFamily.UNIX).nn.tap: channel =>
         channel.configureBlocking(true)
+        configure(channel, summon[Every[SocketOption.Domain]].values)
         channel.bind(address)
 
     def connect(channel: jnc.ServerSocketChannel): Connection =
@@ -75,12 +79,20 @@ object Bindable:
       connection.in.close()
       connection.out.close()
 
-  given tcpPort: Tactic[StreamError] => TcpPort is Bindable:
+  given tcpPort: (Tactic[StreamError], Every[SocketOption.Tcp]) => TcpPort is Bindable:
     type Binding = jn.ServerSocket
     type Output = Data
     type Input = jn.Socket
 
-    def bind(port: TcpPort): Binding = jn.ServerSocket(port.number)
+    def bind(port: TcpPort, interface: Optional[MacAddress]): Binding =
+      val address: Optional[jn.InetAddress] = interface.let(interfaceFor(_)).let(bindAddress(_))
+
+      val socket =
+        address.let(jn.ServerSocket(port.number, 50, _)).or(jn.ServerSocket(port.number))
+
+      configure(socket, summon[Every[SocketOption.Tcp]].values)
+      socket
+
     def connect(binding: Binding): jn.Socket = binding.accept().nn
 
     def transmit(socket: jn.ServerSocket, input: Input, bytes: Data): Unit =
@@ -90,12 +102,19 @@ object Bindable:
     def close(socket: jn.Socket): Unit = socket.close()
     def stop(socket: jn.ServerSocket): Unit = socket.close()
 
-  given udpPort: UdpPort is Bindable:
+  given udpPort: Every[SocketOption.Udp] => UdpPort is Bindable:
     type Binding = jn.DatagramSocket
     type Output = UdpResponse
     type Input = Packet
 
-    def bind(port: UdpPort): Binding = jn.DatagramSocket(port.number)
+    def bind(port: UdpPort, interface: Optional[MacAddress]): Binding =
+      val socket = jn.DatagramSocket(port.number)
+      configure(socket, summon[Every[SocketOption.Udp]].values)
+
+      interface.let(interfaceFor(_)).let: nic =>
+        socket.setOption(jn.StandardSocketOptions.IP_MULTICAST_IF, nic)
+
+      socket
 
     def connect(binding: Binding): Packet =
       val array = new Array[Byte](1472)
@@ -153,7 +172,7 @@ trait Bindable extends Typeclass:
   type Input
   type Output
 
-  def bind(socket: Self): Binding
+  def bind(socket: Self, interface: Optional[MacAddress]): Binding
   def connect(binding: Binding): Input
   def transmit(binding: Binding, input: Input, output: Output): Unit
   def close(connection: Input): Unit

--- a/lib/coaxial/src/core/coaxial.Connectable.scala
+++ b/lib/coaxial/src/core/coaxial.Connectable.scala
@@ -37,27 +37,40 @@ import java.nio.channels as jnc
 import java.nio.file as jnf
 
 import anticipation.*
+import frontier.*
 import prepositional.*
 import urticose.*
+import vacuous.*
 
 // Opens a persistent, bidirectional `Duplex` connection to an endpoint. The
 // counterpart to `Serviceable` for protocols that keep a connection open and read
 // and write concurrently (e.g. HTTP/2), rather than the single request/response
 // exchange `Serviceable` models. Channels are opened in blocking mode so a read
-// loop parks in `read` instead of busy-polling.
+// loop parks in `read` instead of busy-polling. The channel is opened unconnected
+// so socket options (and, for TCP, a local interface bind) take effect before connect.
 object Connectable:
-  given domainSocket: DomainSocket is Connectable = domainSocket =>
-    val path = jnf.Path.of(domainSocket.address.s)
-    val address = jn.UnixDomainSocketAddress.of(path)
-    val channel = jnc.SocketChannel.open(address).nn
-    channel.configureBlocking(true)
-    Duplex.channel(channel)
+  given domainSocket: Every[SocketOption.Domain] => DomainSocket is Connectable:
+    // A Unix-domain socket has no network interface, so `interface` is not applicable here.
+    def connect(domainSocket: DomainSocket, interface: Optional[MacAddress]): Duplex =
+      val address = jn.UnixDomainSocketAddress.of(jnf.Path.of(domainSocket.address.s))
+      val channel = jnc.SocketChannel.open(jn.StandardProtocolFamily.UNIX).nn
+      channel.configureBlocking(true)
+      configure(channel, summon[Every[SocketOption.Domain]].values)
+      channel.connect(address)
+      Duplex.channel(channel)
 
-  given tcpEndpoint: Online => Endpoint[TcpPort] is Connectable = endpoint =>
-    val address = jn.InetSocketAddress(endpoint.remote.s, endpoint.port.number)
-    val channel = jnc.SocketChannel.open(address).nn
-    channel.configureBlocking(true)
-    Duplex.channel(channel)
+  given tcpEndpoint: (Online, Every[SocketOption.Tcp]) => Endpoint[TcpPort] is Connectable:
+    def connect(endpoint: Endpoint[TcpPort], interface: Optional[MacAddress]): Duplex =
+      val address = jn.InetSocketAddress(endpoint.remote.s, endpoint.port.number)
+      val channel = jnc.SocketChannel.open().nn
+      channel.configureBlocking(true)
+      configure(channel, summon[Every[SocketOption.Tcp]].values)
+
+      interface.let(interfaceFor(_)).let(bindAddress(_)).let: local =>
+        channel.bind(jn.InetSocketAddress(local, 0))
+
+      channel.connect(address)
+      Duplex.channel(channel)
 
 trait Connectable extends Typeclass:
-  def connect(endpoint: Self): Duplex
+  def connect(endpoint: Self, interface: Optional[MacAddress]): Duplex

--- a/lib/coaxial/src/core/coaxial.Routable.scala
+++ b/lib/coaxial/src/core/coaxial.Routable.scala
@@ -35,18 +35,25 @@ package coaxial
 import java.net as jn
 
 import anticipation.*
+import frontier.*
 import prepositional.*
 import rudiments.*
 import urticose.*
 import vacuous.*
 
 object Routable:
-  given udpEndpoint: Endpoint[UdpPort] is Routable:
+  given udpEndpoint: Every[SocketOption.Udp] => Endpoint[UdpPort] is Routable:
     case class Connection(address: jn.InetAddress, port: Int, socket: jn.DatagramSocket)
 
-    def connect(endpoint: Endpoint[UdpPort]): Connection =
+    def connect(endpoint: Endpoint[UdpPort], interface: Optional[MacAddress]): Connection =
       val address = jn.InetAddress.getByName(endpoint.remote.s).nn
-      Connection(address, endpoint.port.number, jn.DatagramSocket())
+      val socket = jn.DatagramSocket()
+      configure(socket, summon[Every[SocketOption.Udp]].values)
+
+      interface.let(interfaceFor(_)).let: nic =>
+        socket.setOption(jn.StandardSocketOptions.IP_MULTICAST_IF, nic)
+
+      Connection(address, endpoint.port.number, socket)
 
     def transmit(connection: Connection, input: Stream[Data]): Unit =
       input.each: bytes =>
@@ -56,11 +63,17 @@ object Routable:
 
         connection.socket.send(packet)
 
-  given udpPort: UdpPort is Routable:
+  given udpPort: Every[SocketOption.Udp] => UdpPort is Routable:
     case class Connection(port: Int, socket: jn.DatagramSocket)
 
-    def connect(port: UdpPort): Connection =
-      Connection(port.number, jn.DatagramSocket())
+    def connect(port: UdpPort, interface: Optional[MacAddress]): Connection =
+      val socket = jn.DatagramSocket()
+      configure(socket, summon[Every[SocketOption.Udp]].values)
+
+      interface.let(interfaceFor(_)).let: nic =>
+        socket.setOption(jn.StandardSocketOptions.IP_MULTICAST_IF, nic)
+
+      Connection(port.number, socket)
 
     def transmit(connection: Connection, input: Stream[Data]): Unit =
       input.each: bytes =>
@@ -76,5 +89,5 @@ object Routable:
 trait Routable extends Typeclass:
   type Connection
 
-  def connect(endpoint: Self): Connection
+  def connect(endpoint: Self, interface: Optional[MacAddress]): Connection
   def transmit(connection: Connection, input: Stream[Data]): Unit

--- a/lib/coaxial/src/core/coaxial.Serviceable.scala
+++ b/lib/coaxial/src/core/coaxial.Serviceable.scala
@@ -39,21 +39,25 @@ import java.nio.file as jnf
 
 import anticipation.*
 import contingency.*
+import frontier.*
 import rudiments.*
 import turbulence.*
 import urticose.*
 import vacuous.*
 
 object Serviceable:
-  given domainSocket: Tactic[StreamError] => DomainSocket is Serviceable:
+  given domainSocket: (Tactic[StreamError], Every[SocketOption.Domain])
+  =>  DomainSocket is Serviceable:
     type Output = Data
 
     case class Connection(channel: jnc.SocketChannel)
 
-    def connect(domainSocket: DomainSocket): Connection =
-      val path = jnf.Path.of(domainSocket.address.s)
-      val address = jn.UnixDomainSocketAddress.of(path)
-      val channel = jnc.SocketChannel.open(address).nn
+    // A Unix-domain socket has no network interface, so `interface` is not applicable here.
+    def connect(domainSocket: DomainSocket, interface: Optional[MacAddress]): Connection =
+      val address = jn.UnixDomainSocketAddress.of(jnf.Path.of(domainSocket.address.s))
+      val channel = jnc.SocketChannel.open(jn.StandardProtocolFamily.UNIX).nn
+      configure(channel, summon[Every[SocketOption.Domain]].values)
+      channel.connect(address)
       channel.configureBlocking(false)
 
       Connection(channel)
@@ -84,12 +88,20 @@ object Serviceable:
 
     def close(connection: Connection): Unit = connection.channel.close()
 
-  given tcpEndpoint: (Online, Tactic[StreamError]) => Endpoint[TcpPort] is Serviceable:
+  given tcpEndpoint: (Online, Tactic[StreamError], Every[SocketOption.Tcp])
+  =>  Endpoint[TcpPort] is Serviceable:
     type Output = Data
     type Connection = jn.Socket
 
-    def connect(endpoint: Endpoint[TcpPort]): jn.Socket =
-      jn.Socket(jn.InetAddress.getByName(endpoint.remote.s), endpoint.port.number)
+    def connect(endpoint: Endpoint[TcpPort], interface: Optional[MacAddress]): jn.Socket =
+      val socket =
+        interface.let(interfaceFor(_)).let(bindAddress(_)).let: local =>
+          jn.Socket(jn.InetAddress.getByName(endpoint.remote.s), endpoint.port.number, local, 0)
+
+        . or(jn.Socket(jn.InetAddress.getByName(endpoint.remote.s), endpoint.port.number))
+
+      configure(socket, summon[Every[SocketOption.Tcp]].values)
+      socket
 
     def transmit(socket: jn.Socket, input: Stream[Data]): Unit =
       val out = socket.getOutputStream.nn
@@ -101,11 +113,20 @@ object Serviceable:
     def close(socket: jn.Socket): Unit = socket.close()
     def receive(socket: jn.Socket): Stream[Data] = socket.getInputStream.nn.stream[Data]
 
-  given tcpPort: Tactic[StreamError] => TcpPort is Serviceable:
+  given tcpPort: (Tactic[StreamError], Every[SocketOption.Tcp]) => TcpPort is Serviceable:
     type Output = Data
     type Connection = jn.Socket
 
-    def connect(port: TcpPort): jn.Socket = jn.Socket(jn.InetAddress.getLocalHost.nn, port.number)
+    def connect(port: TcpPort, interface: Optional[MacAddress]): jn.Socket =
+      val socket =
+        interface.let(interfaceFor(_)).let(bindAddress(_)).let: local =>
+          jn.Socket(jn.InetAddress.getLocalHost.nn, port.number, local, 0)
+
+        . or(jn.Socket(jn.InetAddress.getLocalHost.nn, port.number))
+
+      configure(socket, summon[Every[SocketOption.Tcp]].values)
+      socket
+
     def close(socket: jn.Socket): Unit = socket.close()
     def receive(socket: jn.Socket): Stream[Data] = socket.getInputStream.nn.stream[Data]
 

--- a/lib/coaxial/src/core/coaxial.SocketOption.scala
+++ b/lib/coaxial/src/core/coaxial.SocketOption.scala
@@ -30,11 +30,52 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package coaxial
 
-export
-  coaxial
-  . { Bindable, BindError, Connectable, Connection, Control, DomainSocket,
-      DomainSocketEndpoint, duplex, Duplex, exchange, Ingressive, listen, Packet, Routable,
-      Serviceable, SocketOption, socketOptions, SocketService, Transmissible, transmit,
-      UdpResponse }
+import vacuous.*
+
+// A socket option, applied to a freshly-constructed socket before it is bound or connected. Each
+// option is typed by the connection types it is valid for: the nested marker traits `Tcp`, `Udp`
+// and `Domain` (Unix-domain) each extend `SocketOption`, and every concrete option extends every
+// connection trait it applies to. A bind/connect site for a particular connection then collects
+// `Every[SocketOption.Tcp]` (or `.Udp`/`.Domain`), so only options valid for that connection are
+// ever gathered. Flag options that simply enable a feature are parameterless markers — their
+// presence is a deviation from the default-off baseline; only options carrying a real value (a
+// buffer size, a duration, a linger interval, a traffic class) take a parameter.
+object SocketOption:
+  sealed trait Tcp    extends SocketOption
+  sealed trait Udp    extends SocketOption
+  sealed trait Domain extends SocketOption
+
+  case object ReuseAddress                  extends Tcp, Udp, Domain  // SO_REUSEADDR
+  case object ReusePort                      extends Tcp, Udp         // SO_REUSEPORT (OS-dependent)
+  case class  ReceiveBuffer(bytes: Int)      extends Tcp, Udp, Domain // SO_RCVBUF
+  case class  SendBuffer(bytes: Int)         extends Tcp, Udp, Domain // SO_SNDBUF
+  case class  Timeout(milliseconds: Int)     extends Tcp, Udp, Domain // SO_TIMEOUT (blocking)
+
+  case object NoDelay                        extends Tcp              // TCP_NODELAY
+  case object KeepAlive                      extends Tcp              // SO_KEEPALIVE
+  case class  Linger(seconds: Optional[Int]) extends Tcp, Domain      // SO_LINGER
+  case class  TrafficClass(value: Int)       extends Tcp, Udp         // IP_TOS
+
+  case object Broadcast                      extends Udp              // SO_BROADCAST
+
+sealed trait SocketOption
+
+// Importable socket-option contributions. Each flag is a named `given` declared at its concrete
+// option type (not `SocketOption`), so the per-connection `Every[SocketOption.Tcp]` / `.Udp` /
+// `.Domain` searches collect it. Bring one into scope with, e.g., `import socketOptions.noDelay`.
+// Options that carry a value are factory methods whose result type is the concrete option, so a
+// `given SocketOption.ReceiveBuffer = socketOptions.receiveBuffer(65536)` is likewise collected.
+object socketOptions:
+  given reuseAddress: SocketOption.ReuseAddress.type = SocketOption.ReuseAddress
+  given reusePort:    SocketOption.ReusePort.type    = SocketOption.ReusePort
+  given noDelay:      SocketOption.NoDelay.type      = SocketOption.NoDelay
+  given keepAlive:    SocketOption.KeepAlive.type    = SocketOption.KeepAlive
+  given broadcast:    SocketOption.Broadcast.type    = SocketOption.Broadcast
+
+  def receiveBuffer(bytes: Int): SocketOption.ReceiveBuffer = SocketOption.ReceiveBuffer(bytes)
+  def sendBuffer(bytes: Int): SocketOption.SendBuffer = SocketOption.SendBuffer(bytes)
+  def linger(seconds: Optional[Int] = Unset): SocketOption.Linger = SocketOption.Linger(seconds)
+  def trafficClass(value: Int): SocketOption.TrafficClass = SocketOption.TrafficClass(value)
+  def timeout(milliseconds: Int): SocketOption.Timeout = SocketOption.Timeout(milliseconds)

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -32,20 +32,34 @@
                                                                                                   */
 package coaxial
 
+import java.net as jn
+import java.nio.channels as jnc
+import java.util as ju
+
 import anticipation.*
 import contingency.*
 import parasite.*
 import rudiments.*
 import turbulence.*
+import urticose.MacAddress
 import vacuous.*
 
 import Control.*
 
 extension [bindable: Bindable](socket: bindable)
+  // A default argument cannot be combined with the path-dependent `bindable.Input`/`.Output`
+  // types here (default-getter synthesis fails), so the interface-less form is a separate
+  // overload that delegates with `Unset`.
   def listen[input](using Monitor, Probate)[result](lambda: bindable.Input => bindable.Output)
   :   SocketService raises BindError =
 
-    val binding = bindable.bind(socket)
+    socket.listen(lambda)(Unset)
+
+  def listen[input](using Monitor, Probate)[result](lambda: bindable.Input => bindable.Output)
+    ( interface: Optional[MacAddress] )
+  :   SocketService raises BindError =
+
+    val binding = bindable.bind(socket, interface)
 
     // Each accepted connection is handled on its own daemon, so connections are served
     // concurrently and a failure in one — a handler error or a dropped client — is
@@ -70,7 +84,7 @@ extension [bindable: Bindable](socket: bindable)
 
 extension [endpoint: Serviceable as serviceable](endpoint: endpoint)
   def transmit[message: Transmissible](input: message): Stream[Data] =
-    val connection = serviceable.connect(endpoint)
+    val connection = serviceable.connect(endpoint, Unset)
 
     serviceable.transmit(connection, message.serialize(input))
     serviceable.receive(connection)
@@ -80,7 +94,7 @@ extension [endpoint: Serviceable as serviceable](endpoint: endpoint)
     ( handle: (state: state) ?=> message => Control[state] )
   :   state =
 
-    val connection = serviceable.connect(endpoint)
+    val connection = serviceable.connect(endpoint, Unset)
 
     def recur(input: Stream[Data], state: state): state = input.flow(state):
       handle(using state)(message.deserialize(next)) match
@@ -102,11 +116,106 @@ extension [endpoint: Routable as routable](endpoint: endpoint)
   def transmit[transmissible: Transmissible](message: transmissible)(using Monitor)
   :   Unit raises StreamError =
 
-    routable.transmit(routable.connect(endpoint), transmissible.serialize(message))
+    routable.transmit(routable.connect(endpoint, Unset), transmissible.serialize(message))
 
 
 extension [endpoint: Connectable as connectable](endpoint: endpoint)
   // Open a persistent, bidirectional connection that stays open for concurrent
   // reads and writes (e.g. for HTTP/2), rather than a single request/response
   // exchange. The caller is responsible for closing the returned `Duplex`.
-  def duplex(): Duplex = connectable.connect(endpoint)
+  def duplex(interface: Optional[MacAddress] = Unset): Duplex =
+    connectable.connect(endpoint, interface)
+
+
+// Applies `SocketOption`s to freshly-constructed sockets and resolves a `MacAddress` to a network
+// interface. The Java socket kinds share no common Scala interface for `setOption`/`setSoTimeout`,
+// so each is adapted to a small `Configurable` and the option-mapping is written once. Options a
+// particular socket does not support are silently skipped (guarded by `supportedOptions`), which
+// is the runtime backstop for socket-kind nuances within a transport (e.g. a server socket has no
+// `TCP_NODELAY`).
+private[coaxial] trait Configurable:
+  def supported: ju.Set[jn.SocketOption[?]]
+  def soTimeout(milliseconds: Int): Unit
+  def option[value](socketOption: jn.SocketOption[value], value: value): Unit
+
+  def set[value](socketOption: jn.SocketOption[value], value: value): Unit =
+    if supported.contains(socketOption) then option(socketOption, value)
+
+private[coaxial] def applyOptions(options: List[SocketOption])(target: Configurable): Unit =
+  import jn.StandardSocketOptions.*
+  val yes: java.lang.Boolean = Boolean.box(true)
+
+  options.each:
+    case SocketOption.ReuseAddress          => target.set(SO_REUSEADDR.nn, yes)
+    case SocketOption.ReusePort             => target.set(SO_REUSEPORT.nn, yes)
+    case SocketOption.NoDelay               => target.set(TCP_NODELAY.nn, yes)
+    case SocketOption.KeepAlive             => target.set(SO_KEEPALIVE.nn, yes)
+    case SocketOption.Broadcast             => target.set(SO_BROADCAST.nn, yes)
+    case SocketOption.ReceiveBuffer(n)      => target.set(SO_RCVBUF.nn, Int.box(n))
+    case SocketOption.SendBuffer(n)         => target.set(SO_SNDBUF.nn, Int.box(n))
+    case SocketOption.TrafficClass(n)       => target.set(IP_TOS.nn, Int.box(n))
+    case SocketOption.Linger(seconds)       => target.set(SO_LINGER.nn, Int.box(seconds.or(-1)))
+    case SocketOption.Timeout(milliseconds) => target.soTimeout(milliseconds)
+
+private[coaxial] def configure(channel: jnc.NetworkChannel, options: List[SocketOption]): Unit =
+  applyOptions(options):
+    new Configurable:
+      def supported: ju.Set[jn.SocketOption[?]] = channel.supportedOptions.nn
+      def soTimeout(milliseconds: Int): Unit = ()  // not meaningful for a (selectable) channel
+
+      def option[value](socketOption: jn.SocketOption[value], value: value): Unit =
+        channel.setOption(socketOption, value)
+
+private[coaxial] def configure(socket: jn.Socket, options: List[SocketOption]): Unit =
+  applyOptions(options):
+    new Configurable:
+      def supported: ju.Set[jn.SocketOption[?]] = socket.supportedOptions.nn
+      def soTimeout(milliseconds: Int): Unit = socket.setSoTimeout(milliseconds)
+
+      def option[value](socketOption: jn.SocketOption[value], value: value): Unit =
+        socket.setOption(socketOption, value)
+
+private[coaxial] def configure(socket: jn.ServerSocket, options: List[SocketOption]): Unit =
+  applyOptions(options):
+    new Configurable:
+      def supported: ju.Set[jn.SocketOption[?]] = socket.supportedOptions.nn
+      def soTimeout(milliseconds: Int): Unit = socket.setSoTimeout(milliseconds)
+
+      def option[value](socketOption: jn.SocketOption[value], value: value): Unit =
+        socket.setOption(socketOption, value)
+
+private[coaxial] def configure(socket: jn.DatagramSocket, options: List[SocketOption]): Unit =
+  applyOptions(options):
+    new Configurable:
+      def supported: ju.Set[jn.SocketOption[?]] = socket.supportedOptions.nn
+      def soTimeout(milliseconds: Int): Unit = socket.setSoTimeout(milliseconds)
+
+      def option[value](socketOption: jn.SocketOption[value], value: value): Unit =
+        socket.setOption(socketOption, value)
+
+// Resolves a `MacAddress` to the local network interface whose hardware address matches, if any.
+private[coaxial] def interfaceFor(mac: MacAddress): Optional[jn.NetworkInterface] =
+  val target: Array[Byte] =
+    Array(mac.byte0, mac.byte1, mac.byte2, mac.byte3, mac.byte4, mac.byte5).map(_.toByte)
+
+  def recur(interfaces: ju.Enumeration[jn.NetworkInterface]): Optional[jn.NetworkInterface] =
+    if !interfaces.hasMoreElements then Unset else
+      val nic = interfaces.nextElement.nn
+      val hardware = nic.getHardwareAddress
+
+      if hardware != null && ju.Arrays.equals(hardware, target) then nic else recur(interfaces)
+
+  recur(jn.NetworkInterface.getNetworkInterfaces.nn)
+
+// Picks a bind address from a resolved interface, preferring an IPv4 address.
+private[coaxial] def bindAddress(nic: jn.NetworkInterface): Optional[jn.InetAddress] =
+  def recur(addresses: ju.Enumeration[jn.InetAddress], fallback: Optional[jn.InetAddress])
+  :   Optional[jn.InetAddress] =
+
+    if !addresses.hasMoreElements then fallback else
+      val address = addresses.nextElement.nn
+
+      if address.isInstanceOf[jn.Inet4Address] then address
+      else recur(addresses, fallback.or(address))
+
+  recur(nic.getInetAddresses.nn, Unset)

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -190,7 +190,7 @@ object Tests extends Suite(m"Coaxial tests"):
           // makes any type conform to `Unit`, the `Routable` overload is not
           // reachable by ascription, so its given is exercised directly here.
           val routable = summon[UdpPort is Routable]
-          routable.transmit(routable.connect(port), Stream(ascii(t"ping")))
+          routable.transmit(routable.connect(port, Unset), Stream(ascii(t"ping")))
           received.await().also(server.stop())
         . assert(_ == t"ping")
 
@@ -241,3 +241,47 @@ object Tests extends Suite(m"Coaxial tests"):
           server.stop()
           reply
         . assert(_ == bytes(ascii(t"ping")))
+
+    suite(m"Socket options"):
+      test(m"reuseAddress sets SO_REUSEADDR on a bound TCP server socket"):
+        import socketOptions.reuseAddress
+        val server = summon[TcpPort is Bindable].bind(Port[Tcp](), Unset)
+        server.getOption(java.net.StandardSocketOptions.SO_REUSEADDR).nn.booleanValue
+          .also(server.close())
+      . assert(_ == true)
+
+      test(m"broadcast sets SO_BROADCAST on a bound UDP socket"):
+        import socketOptions.broadcast
+        val socket = summon[UdpPort is Bindable].bind(Port[Udp](), Unset)
+        socket.getOption(java.net.StandardSocketOptions.SO_BROADCAST).nn.booleanValue
+          .also(socket.close())
+      . assert(_ == true)
+
+      test(m"a UDP-only option is collected only for UDP connections"):
+        import socketOptions.broadcast
+        (summon[Every[SocketOption.Tcp]].values, summon[Every[SocketOption.Udp]].values)
+      . assert(_ == (Nil, List(SocketOption.Broadcast)))
+
+      test(m"a shared option is collected for every connection type"):
+        import socketOptions.reuseAddress
+        ( summon[Every[SocketOption.Tcp]].values,
+          summon[Every[SocketOption.Udp]].values,
+          summon[Every[SocketOption.Domain]].values )
+      . assert(_ == (List(SocketOption.ReuseAddress),
+                     List(SocketOption.ReuseAddress),
+                     List(SocketOption.ReuseAddress)))
+
+      test(m"interfaceFor resolves a local interface by its hardware address"):
+        var nic: java.net.NetworkInterface | Null = null
+        val interfaces = java.net.NetworkInterface.getNetworkInterfaces.nn
+
+        while nic == null && interfaces.hasMoreElements do
+          val candidate = interfaces.nextElement.nn
+          if candidate.getHardwareAddress != null then nic = candidate
+
+        // Skip on hosts where no interface exposes a hardware address.
+        if nic == null then true else
+          var value = 0L
+          nic.getHardwareAddress.nn.each: byte => value = (value << 8) | (byte & 0xFF)
+          interfaceFor(urticose.MacAddress(value)).let(_ => true).or(false)
+      . assert(_ == true)

--- a/lib/cordillera/src/core/cordillera.Http2.scala
+++ b/lib/cordillera/src/core/cordillera.Http2.scala
@@ -324,7 +324,7 @@ object Http2:
   // Used as the `Target` of the HTTP/2 `HttpClient` given, distinct from the
   // `DomainSocket` target telekinesis binds to its HTTP/1.1 client.
   case class Endpoint[endpoint: Connectable as connectable](endpoint: endpoint, authority: Text):
-    def connect(): Duplex = connectable.connect(endpoint)
+    def connect(): Duplex = connectable.connect(endpoint, Unset)
 
   // An `HttpClient` that speaks HTTP/2 (prior-knowledge h2c) to an `Http2.Endpoint`.
   // It captures the ambient `Monitor`/`Probate` from this given's context — the

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -299,7 +299,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
           // lets the real `HttpClient` given (which calls `target.connect()`) run
           // against the loopback without a socket.
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           // Summon the HTTP/2 client given exactly as telekinesis's fetch machinery
           // would, and invoke its `request` — verifying it captures the ambient

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -221,7 +221,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           val containerd = Containerd(endpoint, t"example")
@@ -241,7 +241,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           val containerd = Containerd(endpoint, t"example")
@@ -260,7 +260,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           val container = Containerd(endpoint, t"example").container(t"gamma")
@@ -279,7 +279,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           Containerd(endpoint, t"example").namespaces().map(ns => (ns.name, ns.labels))
@@ -300,7 +300,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
 
@@ -322,7 +322,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           val created = Containerd(endpoint, t"example").createContainer(container)
@@ -337,7 +337,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           val rootfs = List(Mount(t"overlay", t"overlay", t"/", List(t"lowerdir=/a")))
@@ -356,7 +356,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
           runServer(serverSide, namespace, body)
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"localhost")
           Containerd(endpoint, t"example").tasks().map(task => (task.containerId, task.pid, task.state))

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -217,7 +217,7 @@ object Tests extends Suite(m"Obligatory Tests"):
                 trailers(hpack, id, List(HpackEntry(t"grpc-status", t"0")), true) ))
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val channel = GrpcChannel(Http2.Endpoint(Loopback(clientSide), t"localhost"))
           channel.unary[Ping, Pong](method, Ping(t"ping")).message
@@ -232,7 +232,7 @@ object Tests extends Suite(m"Obligatory Tests"):
                 HpackEntry(t"grpc-status", t"5"), HpackEntry(t"grpc-message", t"absent")), true)))
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val channel = GrpcChannel(Http2.Endpoint(Loopback(clientSide), t"localhost"))
           capture[GrpcError](channel.unary[Ping, Pong](method, Ping(t"ping"))).status
@@ -254,7 +254,7 @@ object Tests extends Suite(m"Obligatory Tests"):
                 trailers(hpack, id, List(HpackEntry(t"grpc-status", t"0")), true) ))
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val channel = GrpcChannel(Http2.Endpoint(Loopback(clientSide), t"localhost"))
           channel.serverStreaming[Ping, Pong](method, Ping(t"ping")).map(_.message).to(List)
@@ -271,7 +271,7 @@ object Tests extends Suite(m"Obligatory Tests"):
                 trailers(hpack, id, List(HpackEntry(t"grpc-status", t"0")), true) ))
 
           case class Loopback(duplex: Duplex)
-          given (Loopback is Connectable) = _.duplex
+          given (Loopback is Connectable) = (loopback, _) => loopback.duplex
 
           val channel = GrpcChannel(Http2.Endpoint(Loopback(clientSide), t"localhost"))
           val echo = Grpc.remote[Echo](channel, t"echo.Echo")


### PR DESCRIPTION
Coaxial sockets can now be configured with socket options — reuse-address, no-delay, keep-alive, send/receive buffer sizes, linger, traffic class, broadcast, reuse-port and timeouts — and bound to a specific local network interface by MAC address, without dropping down to `java.net`. Options are supplied as ordinary contextual givens gathered at each bind/connect site (via Frontier's `Every`), and are typed by the connection types they apply to, so only options valid for a given connection (TCP, UDP or Unix-domain) are ever applied.

## Coaxial

Enable socket options by bringing them into scope as givens. Flags are importable markers whose presence enables the option; sized options have factory methods:

```scala
import socketOptions.{reuseAddress, noDelay}
given SocketOption.ReceiveBuffer = socketOptions.receiveBuffer(64*1024)

tcp"8080".listen: connection =>
  // SO_REUSEADDR, TCP_NODELAY and SO_RCVBUF are applied to the server socket
  handle(connection)
```

Each option extends the connection-type marker traits it is valid for (`SocketOption.Tcp`/`.Udp`/`.Domain`), and each connection collects only its own (`Every[SocketOption.Tcp]`, etc.), so a UDP-only option such as `broadcast` is never applied to a TCP socket. Options a particular socket kind doesn't support are skipped.

`listen` and `duplex` also take an optional explicit network-interface selector, given as a `MacAddress` (from urticose):

```scala
tcp"8080".listen(handler)(interface = mac"01-23-45-ab-cd-ef")
(host"example.com" on tcp"443").duplex(interface = mac"01-23-45-ab-cd-ef")
```
