### PR TITLE
Remote runners for the packager, plus Burdock SHA-256 and a deps.dev resolver

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -454,7 +454,9 @@ object burdock extends Library:
   object boot extends Component:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object core extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.core, gastronomy.core):
+  object core
+      extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.core,
+                       gastronomy.core, jacinta.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -1562,7 +1562,9 @@ object ziggurat extends Library:
   object core extends Component(hellenism.core, monotonous.core, turbulence.core, gastronomy.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object packager extends Component(core, guillotine.core, galilei.core, eucalyptus.core):
+  object packager
+      extends Component(core, guillotine.core, galilei.core, eucalyptus.core, ethereal.core,
+                       telekinesis.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, packager)

--- a/lib/burdock/src/boot/burdock/Bootstrap.java
+++ b/lib/burdock/src/boot/burdock/Bootstrap.java
@@ -56,8 +56,8 @@ public class Bootstrap {
       String requirements = attributes.getValue("Burdock-Require");
       if (requirements != null) {
         for (String item : requirements.split(" ")) {
-          String requiredHash = item.substring(0, 40);
-          URL url = new URI(item.substring(41)).toURL();
+          String requiredHash = item.substring(0, 64);
+          URL url = new URI(item.substring(65)).toURL();
           info("Application requires "+url+".", 3);
           File dir = new File(cache, "burdock");
           dir.mkdirs();
@@ -66,7 +66,7 @@ public class Bootstrap {
 
           if (!file.exists()) {
             info("File does not exist locally.", 3);
-            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
             String calculatedHash = null;
 
             info("Downloading "+url, 2);
@@ -99,7 +99,7 @@ public class Bootstrap {
               quit("SHA-256 checksum of dependency "+url+" does not match expected value ("+
                   requiredHash+").", 1);
             }
-          } else if (verbosity >= 1) {
+          } else {
             info("JAR file exists locally at "+file+".", 3);
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             try (FileInputStream fis = new FileInputStream(file)) {

--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -133,22 +133,27 @@ object Bootstrapper:
 
           val url = (maven + relative).encode.decode[HttpUrl]
           val url2 = (maven + relative0).encode.decode[HttpUrl]
-          val digest = url.fetch().read[Text]
+          val remoteSha1 = url.fetch().read[Text]
           val data: Data = (base + relative0).open(_.read[Data])
-          val localDigest: Text = data.digest[Sha1].serialize[Hex]
+          val localSha1: Text = data.digest[Sha1].serialize[Hex]
 
-          if digest != localDigest then
+          if remoteSha1 != localSha1 then
             Out.println:
               m"SHA-1 checksum of local file ${base + relative0} did not match remote $url"
 
             Nil
 
           else
+            // The embedded integrity digest and the per-class match key are both
+            // SHA-256 (see `Bootstrap.java`); the remote SHA-1 above is only the
+            // build-time check that the local file is the published artifact.
+            val sha256: Text = data.digest[Sha2[256]].serialize[Hex]
+
             Zipfile.read(data).entries.filter: entry =>
               val name: Text = entry.ref.encode
               !entry.directory && name != t"META-INF/MANIFEST.MF"
             . map: entry =>
-              (entry.ref.show, entry.checksum[Sha1].serialize[Hex]) -> Requirement(url2, digest)
+              (entry.ref.show, entry.checksum[Sha2[256]].serialize[Hex]) -> Requirement(url2, sha256)
 
         . to(Map)
 
@@ -160,7 +165,7 @@ object Bootstrapper:
             then manifest.fulfill(entry.read[Data].read[Manifest]) yet Unset
             else if entry.ref.show == t"burdock/Bootstrap.class"
             then Entry(entry.ref.show, entry.read[Data])
-            else entries.at((entry.ref.show, entry.checksum[Sha1].serialize[Hex])).or:
+            else entries.at((entry.ref.show, entry.checksum[Sha2[256]].serialize[Hex])).or:
               Entry(entry.ref.show, entry.read[Data])
 
           . to(List).compact

--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -152,8 +152,10 @@ object Bootstrapper:
             Zipfile.read(data).entries.filter: entry =>
               val name: Text = entry.ref.encode
               !entry.directory && name != t"META-INF/MANIFEST.MF"
+
             . map: entry =>
-              (entry.ref.show, entry.checksum[Sha2[256]].serialize[Hex]) -> Requirement(url2, sha256)
+                val checksum: Text = entry.checksum[Sha2[256]].serialize[Hex]
+                (entry.ref.show, checksum) -> Requirement(url2, sha256)
 
         . to(Map)
 

--- a/lib/burdock/src/core/burdock.DepsDev.scala
+++ b/lib/burdock/src/core/burdock.DepsDev.scala
@@ -1,0 +1,79 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package burdock
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import eucalyptus.*
+import fulminate.*
+import gossamer.*
+import jacinta.*
+import monotonous.*, alphabets.base64.standard, alphabets.hex.lowerCase
+import prepositional.*
+import telekinesis.*
+import urticose.*
+import vacuous.*
+
+import internetAccess.enabled
+
+// Resolves a dependency's content hash to its public download URL using Google's
+// deps.dev ("Open Source Insights") Query API. Returns `Unset` for anything
+// deps.dev does not know as a Maven artifact — the caller then inlines the
+// dependency's classes from the local Burdock cache instead.
+object DepsDev:
+  case class VersionKey(system: Text, name: Text, version: Text)
+  case class Version(versionKey: VersionKey)
+  case class Result(version: Version)
+  case class QueryResult(results: List[Result])
+
+  case class Unresolved()(using Diagnostics) extends Error(m"not a known Maven artifact")
+
+  def mavenUrl(sha256Hex: Text): Optional[HttpUrl] = safely:
+    // deps.dev expects the hash base64-encoded (not hex).
+    val base64: Text = sha256Hex.deserialize[Hex].serialize[Base64]
+    val query: HttpUrl = url"https://api.deps.dev/v3/query?hash.type=SHA256&hash.value=$base64"
+    val result: QueryResult = mute[HttpEvent](query.fetch().receive[Json]).as[QueryResult]
+
+    val key: VersionKey =
+      result.results.map(_.version.versionKey).find(_.system == t"MAVEN")
+      . getOrElse(abort(Unresolved()))
+
+    // `name` is `group:artifact`; the Maven Central path uses `/` for the group.
+    val parts: List[Text] = key.name.cut(t":")
+    val group: Text = parts.head.cut(t".").join(t"/")
+    val artifact: Text = parts.last
+    val version: Text = key.version
+    val jar: Text = t"$artifact-$version.jar"
+
+    t"https://repo1.maven.org/maven2/$group/$artifact/$version/$jar".decode[HttpUrl]

--- a/lib/ethereal/src/core/ethereal.Assembler.scala
+++ b/lib/ethereal/src/core/ethereal.Assembler.scala
@@ -1,0 +1,138 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ethereal
+
+import java.lang as jl
+import java.nio as jnio
+
+import ambience.*
+import anticipation.*
+import contingency.*
+import eucalyptus.*
+import fulminate.*
+import galilei.*
+import gossamer.*
+import guillotine.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import spectacular.*
+import turbulence.*
+import vacuous.*
+
+import filesystemOptions.createNonexistent.enabled
+import filesystemOptions.createNonexistentParents.enabled
+import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.readAccess.enabled
+import filesystemOptions.writeAccess.enabled
+
+case class AssemblyError(detail: Message)(using Diagnostics) extends Error(detail)
+
+// Produces a self-contained per-platform executable by patching a bare ethereal
+// runner binary's ETHRCFG block (build id, Java version policy, ML-DSA-44 public
+// key) and appending the application JAR at EOF. Shared by the
+// `-Dbuild.executable` CLI build path and the ziggurat packager, which supplies
+// a runner downloaded from a URL rather than read from the classpath.
+object Assembler:
+  // v2 ETHRCFG layout — keep in sync with lib/ethereal/src/runner/src/config.rs.
+  val MagicMarker: Array[Byte] =
+    Array[Byte]('E'.toByte, 'T'.toByte, 'H'.toByte, 'R'.toByte,
+                'C'.toByte, 'F'.toByte, 'G'.toByte, 2.toByte)
+
+  val PublicKeyLength: Int = 1312   // ML-DSA-44 public key size
+
+  def assemble
+     (runner:        Data,           // bare runner binary
+      jarFile:       Path on Linux,  // application JAR appended at EOF
+      output:        Path on Linux,
+      platformLabel: Text,
+      buildId:       Long,
+      javaMinimum:   Int,
+      javaPreferred: Int,
+      jdk:           Boolean,
+      publicKey:     Data)           // 1312 raw bytes (all-zero disables upgrades)
+     (using WorkingDirectory)
+  :   Unit raises AssemblyError raises IoError raises StreamError =
+
+    val isWindows: Boolean = platformLabel.starts(t"windows")
+    val bytes: Array[Byte] = IArray.genericWrapArray(runner).toArray
+
+    val magicOffset: Int =
+      var found: Int = -1
+      var i = 0
+
+      while found < 0 && i <= bytes.length - MagicMarker.length do
+        var matches = true
+        var j = 0
+
+        while matches && j < MagicMarker.length do
+          if bytes(i + j) != MagicMarker(j) then matches = false
+          j += 1
+
+        if matches then found = i
+        i += 1
+
+      if found < 0
+      then abort(AssemblyError(m"The runner binary does not contain the ETHRCFG marker"))
+
+      found
+
+    val configOffset: Int = magicOffset + MagicMarker.length
+    val keyBytes: Array[Byte] = IArray.genericWrapArray(publicKey).toArray
+
+    // Write the 24-byte metadata region.
+    val metaBuf = jnio.ByteBuffer.wrap(bytes, configOffset, 24).nn
+    metaBuf.order(jnio.ByteOrder.LITTLE_ENDIAN).nn
+    metaBuf.putLong(buildId)
+    metaBuf.putShort(javaMinimum.toShort)
+    metaBuf.putShort(javaPreferred.toShort)
+    metaBuf.put((if jdk then 1 else 0).toByte)
+    while metaBuf.hasRemaining do metaBuf.put(0.toByte)
+
+    // Write the 1312-byte public-key region at offset 32 within the ETHRCFG
+    // block (8 magic + 24 metadata). The signature slot at offset 1344 stays
+    // zero — populated later by the signer when shipped as an upgrade.
+    jl.System.arraycopy(keyBytes, 0, bytes, configOffset + 24, PublicKeyLength)
+
+    output.open: file =>
+      Stream(IArray.from(bytes.iterator): IArray[Byte]).writeTo(file)
+
+    if platformLabel.starts(t"macos") then
+      if !isWindows then output.executable() = true
+      safely(mute[ExecEvent](sh"codesign --sign - --force $output".exec[Exit]()))
+
+    jarFile.open: jarFile =>
+      Eof(output).open(jarFile.stream[Data].writeTo(_))
+
+    if !isWindows then output.executable() = true

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -154,36 +154,7 @@ def cli[bus <: Matchable](using executive: Executive)
               if isWindows then t"runner-$platformLabel.exe" else t"runner-$platformLabel"
 
             val runnerResource: Path on Classpath = Classpath/"ethereal"/runnerName
-            val runnerBytes: IArray[Byte] = runnerResource.read[Data]
-
-            val magic: Array[Byte] = Array[Byte](
-              'E'.toByte, 'T'.toByte, 'H'.toByte, 'R'.toByte,
-              'C'.toByte, 'F'.toByte, 'G'.toByte, 2.toByte)
-
-            // v2 ETHRCFG layout — keep in sync with lib/ethereal/src/runner/src/config.rs.
-            val pubkeyLen: Int = 1312                       // ML-DSA-44 public key size
-            val pubkeyOffsetInBlock: Int = 32 - magic.length  // after the 24-byte meta region
-
-            val magicOffset: Int =
-              var found: Int = -1
-              var i = 0
-
-              while found < 0 && i <= runnerBytes.length - magic.length do
-                var matches = true
-                var j = 0
-
-                while matches && j < magic.length do
-                  if runnerBytes(i + j) != magic(j) then matches = false
-                  j += 1
-
-                if matches then found = i
-                i += 1
-
-              if found < 0 then
-                Out.println(e"Runner binary does not contain the ETHRCFG\\x02 magic marker")
-                Exit.Fail(1).terminate()
-
-              found
+            val runnerBytes: Data = runnerResource.read[Data]
 
             // ML-DSA-44 public key used by the runner to verify upgrades.
             // When `ethereal.publicKey` is unset the slot stays zero and the
@@ -192,52 +163,33 @@ def cli[bus <: Matchable](using executive: Executive)
             // than the .pending path. Releases that need signed upgrades
             // pass `-Dethereal.publicKey=<path>` pointing at a 1312-byte raw
             // ML-DSA-44 public key file.
-            val publicKeyBytes: Array[Byte] =
+            val publicKey: Data =
               safely(System.properties.ethereal.publicKey[Text]()).absolve match
                 case Unset =>
-                  new Array[Byte](pubkeyLen)   // all zeros — upgrades blocked
+                  IArray.fill(Assembler.PublicKeyLength)(0.toByte)   // upgrades blocked
 
                 case keyPath: Text =>
                   val resolved: Path on Linux = safely(keyPath.decode[Path on Linux]).or:
                     val work: Path on Linux = workingDirectory
                     work + keyPath.decode[Relative on Linux]
-                  val raw = resolved.open(_.stream[Data].read[Data]).to(Array)
-                  if raw.length != pubkeyLen then
+
+                  val raw: Data = resolved.open(_.stream[Data].read[Data])
+
+                  if raw.length != Assembler.PublicKeyLength then
                     Out.println(e"Public key at $keyPath is the wrong size (expected 1312 bytes)")
                     Exit.Fail(1).terminate()
+
                   raw
 
-            val configOffset: Int = magicOffset + magic.length
-            val patched: Array[Byte] = IArray.genericWrapArray(runnerBytes).toArray
+            whereas:
+              case AssemblyError(_) =>
+                Out.println(e"Runner binary does not contain the ETHRCFG\\x02 magic marker")
+                Exit.Fail(1).terminate()
 
-            // Write the 24-byte metadata region.
-            val metaBuf = jnio.ByteBuffer.wrap(patched, configOffset, 24).nn
-            metaBuf.order(jnio.ByteOrder.LITTLE_ENDIAN).nn
-            metaBuf.putLong(buildId)
-            metaBuf.putShort(javaMinimum.toShort)
-            metaBuf.putShort(javaPreferred.toShort)
-            metaBuf.put((if jdk then 1 else 0).toByte)
-            while metaBuf.hasRemaining do metaBuf.put(0.toByte)
-
-            // Write the 1312-byte public-key region at offset 32 within the
-            // ETHRCFG block (8 magic + 24 metadata).
-            jl.System.arraycopy(publicKeyBytes, 0,
-                                patched, configOffset + 24,
-                                pubkeyLen)
-            // Signature slot at offset 1344 stays zero — populated later by
-            // the signer when this binary is itself shipped as an upgrade.
-
-            path.open: file =>
-              Stream(IArray.from(patched.iterator): IArray[Byte]).writeTo(file)
-
-            if platformLabel.starts(t"macos") then
-              if !isWindows then path.executable() = true
-              safely(mute[ExecEvent](sh"codesign --sign - --force $path".exec[Exit]()))
-
-            jarFile.open: jarFile =>
-              Eof(path).open(jarFile.stream[Data].writeTo(_))
-
-            if !isWindows then path.executable() = true
+            . mitigate:
+                Assembler.assemble
+                 (runnerBytes, jarFile, path, platformLabel, buildId, javaMinimum,
+                  javaPreferred, jdk, publicKey)
 
             Out.println(t"Built executable file $destination")
 

--- a/lib/ziggurat/src/packager/ziggurat.Packager.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packager.scala
@@ -36,6 +36,7 @@ import ambience.*
 import anticipation.*
 import contingency.*
 import distillate.*
+import ethereal.*
 import eucalyptus.*
 import fulminate.*
 import galilei.*
@@ -47,10 +48,13 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 import spectacular.*
+import telekinesis.*
 import turbulence.*
+import urticose.*
 import vacuous.*
 
 import errorDiagnostics.empty
+import internetAccess.enabled
 import filesystemOptions.createNonexistent.enabled
 import filesystemOptions.createNonexistentParents.enabled
 import filesystemOptions.deleteRecursively.enabled
@@ -59,10 +63,11 @@ import filesystemOptions.overwritePreexisting.enabled
 import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.enabled
 
-// Turns a `Packaging` configuration into a distributable. Stage A handles the
-// `Dependencies.FatJar` + `RunnerSource.LocalResource` combination across all
-// three deliveries; other cases abort with a clear `PackageError` until later
-// stages implement them.
+// Turns a `Packaging` configuration into a distributable, across all three
+// deliveries. With `RunnerSource.LocalResource` the application self-assembles
+// each per-platform binary in a subprocess; with `RunnerSource.Remote` the
+// runners are downloaded, verified, and assembled in-process via
+// `ethereal.Assembler`. Burdock remote dependencies remain unimplemented.
 object Packager:
   def pack(config: Packaging)
      (using working: WorkingDirectory, environment: Environment)
@@ -74,13 +79,6 @@ object Packager:
 
       case Packaging.Dependencies.BurdockRemote(_) =>
         abort(PackageError(m"Burdock remote dependencies are not yet supported (Stage C)"))
-
-    config.runnerSource.absolve match
-      case Packaging.RunnerSource.LocalResource =>
-        ()
-
-      case Packaging.RunnerSource.Remote(_) =>
-        abort(PackageError(m"Downloading runners is not yet supported (Stage B)"))
 
     config.delivery match
       case Packaging.Delivery.Native if config.targets.length != 1 =>
@@ -98,7 +96,7 @@ object Packager:
     . mitigate:
         config.delivery match
           case Packaging.Delivery.Native =>
-            assemble(config, appJar, config.targets.head, config.output)
+            buildBinary(config, appJar, config.targets.head, config.output)
             config.output
 
           case Packaging.Delivery.EmbedAll =>
@@ -106,7 +104,7 @@ object Packager:
 
             val payloads: List[Payload] = config.targets.map: label =>
               val staged: Path on Linux = t"$dir/.xeq-$label".decode[Path on Linux]
-              assemble(config, appJar, label, staged)
+              buildBinary(config, appJar, label, staged)
               val bytes: Data = staged.open(_.read[Data])
               staged.delete()
               Payload(label, bytes, gzip = !label.starts(t"windows"))
@@ -121,7 +119,7 @@ object Packager:
             val entries: List[(Text, Text, Text)] = config.targets.map: label =>
               val asset: Text = t"xeq-$label-$version"
               val staged: Path on Linux = t"$dir/$asset".decode[Path on Linux]
-              assemble(config, appJar, label, staged)
+              buildBinary(config, appJar, label, staged)
               val hash: Text = staged.open(_.read[Data]).digest[Sha2[256]].serialize[Hex]
               (label, t"$base$asset", hash)
 
@@ -129,11 +127,27 @@ object Packager:
             config.output
 
 
+  // Produces one self-contained per-platform binary, dispatching on the runner
+  // source: the app self-assembles in a subprocess (LocalResource), or the
+  // runner is downloaded and assembled in-process (Remote).
+  private def buildBinary(config: Packaging, appJar: Path on Linux, label: Text, output: Path on Linux)
+     (using working: WorkingDirectory)
+  :   Unit raises ExecError raises PackageError =
+
+    config.runnerSource match
+      case Packaging.RunnerSource.LocalResource =>
+        assembleViaSubprocess(config, appJar, label, output)
+
+      case Packaging.RunnerSource.Remote(baseUrl, hashes) =>
+        assembleRemote(config, appJar, label, output, baseUrl, hashes)
+
+
   // Drives the application's own self-assembly (ethereal's `cli` build path) in a
   // subprocess: `java -Dbuild.executable=… -Dbuild.target=… … -jar <appJar>`
   // produces one self-contained per-platform binary and exits. `ethereal.name`
   // must be left unset or the build path is not taken.
-  private def assemble(config: Packaging, appJar: Path on Linux, label: Text, output: Path on Linux)
+  private def assembleViaSubprocess
+     (config: Packaging, appJar: Path on Linux, label: Text, output: Path on Linux)
      (using working: WorkingDirectory)
   :   Unit raises ExecError raises PackageError =
 
@@ -159,6 +173,61 @@ object Packager:
 
     if mute[ExecEvent](Command(arguments*).exec[Exit]()) != Exit.Ok
     then abort(PackageError(m"Assembling the executable for $label failed"))
+
+
+  // Downloads `<baseUrl>/runner-<label>[.exe]`, verifies its SHA-256 against
+  // `hashes(label)`, then patches the ETHRCFG block and appends the app JAR
+  // in-process via `ethereal.Assembler`. All lower-level failures are surfaced
+  // as `PackageError`.
+  private def assembleRemote
+     (config:  Packaging,
+      appJar:  Path on Linux,
+      label:   Text,
+      output:  Path on Linux,
+      baseUrl: Text,
+      hashes:  Map[Text, Text])
+     (using working: WorkingDirectory)
+  :   Unit raises PackageError =
+
+    whereas:
+      case HttpError(_, _)       => PackageError(m"Failed to download the runner for $label")
+      case ConnectError(_)       => PackageError(m"Could not connect to download the runner for $label")
+      case AssemblyError(detail) => PackageError(detail)
+      case IoError(_, _, _, _)   => PackageError(m"A filesystem error occurred assembling $label")
+      case StreamError(_)        => PackageError(m"A stream error occurred assembling $label")
+      case UrlError(_, _, _)     => PackageError(m"The runner URL for $label is invalid")
+
+    . mitigate:
+        val expected: Text = hashes.at(label).lest(PackageError(m"No runner hash given for $label"))
+
+        val runnerName: Text =
+          if label.starts(t"windows") then t"runner-$label.exe" else t"runner-$label"
+
+        val base: Text = if baseUrl.ends(t"/") then baseUrl else t"$baseUrl/"
+
+        val runner: Data =
+          mute[HttpEvent](t"$base$runnerName".decode[HttpUrl].fetch().read[Data])
+        val actual: Text = runner.digest[Sha2[256]].serialize[Hex]
+
+        if actual != expected then
+          abort(PackageError(m"Downloaded runner for $label has SHA-256 $actual, expected $expected"))
+
+        val zeros: Data = IArray.fill(Assembler.PublicKeyLength)(0.toByte)
+
+        val publicKey: Data = config.signing.lay(zeros): signing =>
+          signing.publicKey.lay(zeros): key =>
+            val raw: Data = key.open(_.stream[Data].read[Data])
+
+            if raw.length != Assembler.PublicKeyLength
+            then abort(PackageError(m"The public key for $label is the wrong size"))
+
+            raw
+
+        val jdk: Boolean = config.java.bundle == Packaging.Bundle.Jdk
+
+        Assembler.assemble
+         (runner, appJar, output, label, config.buildId, config.java.minimum,
+          config.java.preferred, jdk, publicKey)
 
 
   private def write(output: Path on Linux, data: Data)

--- a/lib/ziggurat/src/packager/ziggurat.Packaging.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packaging.scala
@@ -52,8 +52,11 @@ object Packaging:
 
   // Where each platform's bare runner binary comes from.
   enum RunnerSource:
-    case LocalResource          // `Classpath/"ethereal"/runner-<label>` in the app jar
-    case Remote(baseUrl: Text)  // downloaded from `<baseUrl>/runner-<label>` (Stage B)
+    case LocalResource  // the app self-assembles using `Classpath/"ethereal"/runner-<label>`
+
+    // Each runner is downloaded from `<baseUrl>/runner-<label>[.exe]` and verified
+    // against `hashes(label)` (lowercase SHA-256 hex), then assembled in-process.
+    case Remote(baseUrl: Text, hashes: Map[Text, Text])
 
   // The bundled Java runtime *preference* recorded in the ETHRCFG block. Records
   // a preference only — the runner downloads a JRE/JDK at runtime; nothing is

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -188,10 +188,11 @@ object Tests extends Suite(m"Ziggurat tests"):
         capture[PackageError](Packager.pack(config(Packaging.Delivery.EmbedAll, dependencies)))
       .assert(_ => true)
 
-      test(m"remote runner source is rejected"):
-        val remote = Packaging.RunnerSource.Remote(t"https://example.com/")
+      test(m"remote runner with no hash for the target is rejected"):
+        // Fails on the missing-hash check before any download is attempted.
+        val remote = Packaging.RunnerSource.Remote(t"https://example.invalid/", Map())
         capture[PackageError]:
-          Packager.pack(config(Packaging.Delivery.EmbedAll, fatJar, remote))
+          Packager.pack(config(Packaging.Delivery.Native, fatJar, remote))
       .assert(_ => true)
 
       test(m"native delivery with multiple targets is rejected"):


### PR DESCRIPTION
This continues the configurable-packaging work. Ethereal's executable-assembly logic (the ETHRCFG patch plus the JAR append) is extracted from the `cli` build path into a reusable `Assembler`, which lets the ziggurat packager download a platform's runner from a URL, verify its SHA-256, and assemble the executable in-process — the `RunnerSource.Remote` case — rather than relying on a locally cross-compiled runner. Separately, Burdock (the dependency-bootstrapping mechanism) gains two foundations for the upcoming download-on-demand redesign: its integrity hashing is corrected and standardised on SHA-256 end-to-end, and a deps.dev resolver turns a dependency's content hash into its public download URL.

## Remote runners

`ziggurat.Packaging` gains `RunnerSource.Remote(baseUrl, hashes)`: the packager downloads each platform's `runner-<label>` from `baseUrl`, verifies it against the supplied SHA-256 table, and assembles the executable in-process. `LocalResource` (the application self-assembling in a subprocess) is unchanged.

## Reusable executable assembly

The per-platform assembly is now `ethereal.Assembler.assemble`, callable directly (it raises `AssemblyError` instead of terminating the JVM). The `-Dbuild.executable` CLI path becomes a thin shim over it; produced binaries are byte-identical (the ethereal suite passes unchanged).

## Burdock integrity fixes

Burdock embedded SHA-1 digests while verifying *cached* files with SHA-256, so every cache hit mismatched — and the cached-file check was wrongly gated on verbosity, skipping verification in silent mode. It now uses **SHA-256 end-to-end** and always verifies cached files. A new `burdock.DepsDev.mavenUrl` resolves a dependency's SHA-256 to its Maven Central URL via the deps.dev Query API, returning `Unset` for anything unindexed — groundwork for the download-on-demand redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)