### PR TITLE
Make Coaxial's duplex a loan; scope-tie HTTP/2 connections

### DIFF
--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -120,11 +120,18 @@ extension [endpoint: Routable as routable](endpoint: endpoint)
 
 
 extension [endpoint: Connectable as connectable](endpoint: endpoint)
-  // Open a persistent, bidirectional connection that stays open for concurrent
-  // reads and writes (e.g. for HTTP/2), rather than a single request/response
-  // exchange. The caller is responsible for closing the returned `Duplex`.
-  def duplex(interface: Optional[MacAddress] = Unset): Duplex =
-    connectable.connect(endpoint, interface)
+  // Open a persistent, bidirectional connection for the duration of `lambda` and
+  // always close it afterwards — whether `lambda` returns or throws. This is the
+  // shape a multiplexing protocol such as HTTP/2 needs (concurrent reads and writes
+  // over one open connection), but unlike the request/response `exchange` the
+  // connection is never half-closed. A long-lived connection that must outlive any
+  // single block keeps `lambda` running (e.g. parked on its supervisor) until the
+  // enclosing scope ends, at which point the loan closes the connection.
+  def duplex[result](lambda: Duplex => result): result = duplex(lambda)(Unset)
+
+  def duplex[result](lambda: Duplex => result)(interface: Optional[MacAddress]): result =
+    val connection = connectable.connect(endpoint, interface)
+    try lambda(connection) finally connection.close()
 
 
 // Applies `SocketOption`s to freshly-constructed sockets and resolves a `MacAddress` to a network

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -234,12 +234,11 @@ object Tests extends Suite(m"Coaxial tests"):
             val count = connection.in.read(buffer)
             IArray.from(buffer.take(count.max(0)).to(List))
 
-          val duplex = socket.duplex()
-          duplex.send(Stream(ascii(t"ping")))
-          val reply = bytes(duplex.stream.head)
-          duplex.close()
-          server.stop()
-          reply
+          val reply = socket.duplex: duplex =>
+            duplex.send(Stream(ascii(t"ping")))
+            bytes(duplex.stream.head)
+
+          reply.also(server.stop())
         . assert(_ == bytes(ascii(t"ping")))
 
     suite(m"Socket options"):

--- a/lib/cordillera/src/core/cordillera.Http2.scala
+++ b/lib/cordillera/src/core/cordillera.Http2.scala
@@ -324,13 +324,32 @@ object Http2:
   // Used as the `Target` of the HTTP/2 `HttpClient` given, distinct from the
   // `DomainSocket` target telekinesis binds to its HTTP/1.1 client.
   case class Endpoint[endpoint: Connectable as connectable](endpoint: endpoint, authority: Text):
-    def connect(): Duplex = connectable.connect(endpoint, Unset)
+    // Establish a multiplexed connection whose underlying `Duplex` is closed when the
+    // enclosing `supervise` scope ends, rather than being leaked. The connection (and
+    // its reader/writer daemons) runs on a daemon that holds the `duplex` loan open —
+    // parked until the scope is torn down — so the response bodies it streams lazily
+    // stay readable for the scope's lifetime instead of being closed per request.
+    // Returns once the HTTP/2 handshake has completed.
+    def connect()(using Monitor, Probate): Http2Connection raises AsyncError =
+      val ready: Promise[Http2Connection] = Promise()
+
+      daemon:
+        try
+          endpoint.duplex: duplex =>
+            val connection = Http2Connection(duplex)
+            connection.start()
+            ready.offer(connection)
+            Promise[Unit]().await()
+
+        finally if !ready.ready then ready.cancel()
+
+      ready.await()
 
   // An `HttpClient` that speaks HTTP/2 (prior-knowledge h2c) to an `Http2.Endpoint`.
   // It captures the ambient `Monitor`/`Probate` from this given's context — the
-  // `H2Connection`'s daemons need them — so it can only be summoned inside a
-  // `supervise` scope. A fresh connection is opened per request for now; pooling
-  // is a later refinement.
+  // connection's daemons (and the scope-tied teardown) need them — so it can only be
+  // summoned inside a `supervise` scope. A fresh connection is opened per request for
+  // now; pooling is a later refinement.
   object Client:
     given http2: [endpoint] => (Monitor, Probate, Tactic[Http2Error], Tactic[AsyncError])
     =>  HttpClient onto Endpoint[endpoint] =
@@ -341,6 +360,4 @@ object Http2:
         def request(request: Http.Request, target: Endpoint[endpoint])
         :   Http.Response logs HttpEvent =
 
-          val connection = H2Connection(target.connect())
-          connection.start()
-          connection.fetch(request, t"http", target.authority)(1)
+          target.connect().fetch(request, t"http", target.authority)(1)

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -50,7 +50,7 @@ import vacuous.*
 
 import Http2.*
 
-object H2Connection:
+object Http2Connection:
   // The client connection preface (RFC 7540 §3.5): a fixed octet sequence that
   // precedes the first SETTINGS frame in prior-knowledge h2c.
   private[cordillera] val connectionPreface: Bytes = t"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".data
@@ -66,7 +66,7 @@ object H2Connection:
 // (fed by DATA frames), and a promise for trailers (resolved on a second, end-stream
 // HEADERS frame — gRPC's status). The reader daemon populates these; the caller
 // awaits `headers` and consumes `body.stream`.
-class H2Stream(val id: Int):
+class Http2Stream(val id: Int):
   val headers: Promise[List[HpackEntry]] = Promise()
   val trailers: Promise[List[HpackEntry]] = Promise()
   val body: Spool[Bytes] = Spool()
@@ -94,10 +94,10 @@ class H2Stream(val id: Int):
 // `Spool[Frame]` to the socket, serialising all writes (so no lock is needed); a
 // reader daemon parses inbound frames and dispatches them by stream id. Must be
 // created within a `supervise`-provided `Monitor`.
-class H2Connection(duplex: Duplex)(using Monitor, Probate):
-  import H2Connection.*
+class Http2Connection(duplex: Duplex)(using Monitor, Probate):
+  import Http2Connection.*
 
-  private val streams: scc.TrieMap[Int, H2Stream] = scc.TrieMap()
+  private val streams: scc.TrieMap[Int, Http2Stream] = scc.TrieMap()
   private val nextId: juca.AtomicInteger = juca.AtomicInteger(1)
   private val outbound: Spool[Frame] = Spool()
   private val started: Promise[Unit] = Promise()
@@ -200,9 +200,9 @@ class H2Connection(duplex: Duplex)(using Monitor, Probate):
 
   // Open a new client stream, send its header block (and optional body), and return
   // the stream handle whose promises/spool the reader will populate.
-  def request(headerBlock: List[HpackEntry], body: Optional[Bytes]): H2Stream =
+  def request(headerBlock: List[HpackEntry], body: Optional[Bytes]): Http2Stream =
     val id = nextId.getAndAdd(2)
-    val stream = H2Stream(id)
+    val stream = Http2Stream(id)
     streams(id) = stream
     val encoder = Hpack()
     val noBody = body.absent
@@ -220,7 +220,7 @@ class H2Connection(duplex: Duplex)(using Monitor, Probate):
   // pseudo-headers the request type doesn't carry. Trailers (e.g. gRPC status) are
   // available afterwards via `stream.trailers`.
   def fetch(request: Http.Request, scheme: Text, authority: Text)
-  :   (H2Stream, Http.Response) raises Http2Error raises AsyncError =
+  :   (Http2Stream, Http.Response) raises Http2Error raises AsyncError =
 
     val headerBlock = PseudoHeaders.request(request, scheme, authority)
     val chunks = request.body().to(List)

--- a/lib/cordillera/src/core/soundness_cordillera_core.scala
+++ b/lib/cordillera/src/core/soundness_cordillera_core.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package soundness
 
-export cordillera.{Http2, Hpack, HpackEntry, HpackTable, Huffman, H2Connection, H2Stream,
+export cordillera.{Http2, Hpack, HpackEntry, HpackTable, Huffman, Http2Connection, Http2Stream,
     Http2Error, FrameReader, PseudoHeaders}

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -273,7 +273,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
         supervise:
           val (clientSide, serverSide) = pair()
           val server = runServer(serverSide)
-          val connection = H2Connection(clientSide)
+          val connection = Http2Connection(clientSide)
           connection.start()
 
           val request = Http.Request(Http.Post, 2.0, unsafely(t"unix".decode[Host]),

--- a/lib/flux/src/client/flux_client.scala
+++ b/lib/flux/src/client/flux_client.scala
@@ -79,8 +79,7 @@ def repl(): Unit = cli:
     case Argument(As[Int](portNumber)) :: Nil =>
       execute:
         safely(Port[Tcp](portNumber)).lay(invalidPort(portNumber)): port =>
-          connect(port).lay(unreachable(portNumber)): duplex =>
-            try converse(duplex) finally duplex.close()
+          connect(port)(converse(_)).or(unreachable(portNumber))
 
     case Nil =>
       execute(connectSocket())
@@ -173,21 +172,18 @@ private def unreachable(portNumber: Int)(using Stdio): Exit =
   Out.println(t"flux: could not connect to localhost:$portNumber")
   Exit.Fail(3)
 
-// Opens a TCP connection to the server, or `Unset` if it is refused.
-private def connect(port: Port over Tcp): Optional[Duplex] =
-  try (ip"127.0.0.1" via port).duplex() catch case _: Exception => Unset
+// Runs `body` over a fresh TCP connection — always closing it afterwards — or returns
+// `Unset` if the connection is refused.
+private def connect[result](port: Port over Tcp)(body: Duplex => result): Optional[result] =
+  try (ip"127.0.0.1" via port).duplex(body) catch case _: ji.IOException => Unset
 
-// Opens a UNIX domain socket connection, or `Unset` if it is refused.
-private def connectDomain(socket: DomainSocket): Optional[Duplex] =
-  try socket.duplex() catch case _: Exception => Unset
+// As `connect`, but over a UNIX domain socket.
+private def connectDomain[result](socket: DomainSocket)(body: Duplex => result): Optional[result] =
+  try socket.duplex(body) catch case _: ji.IOException => Unset
 
 private def unreachableSocket(path: Text)(using Stdio): Exit =
   Out.println(t"flux: could not connect to $path")
   Exit.Fail(3)
-
-// Drives an interactive session over a connection, closing it on the way out.
-private def session(duplex: Duplex)(using Stdio, Monitor, Probate, Console, Environment): Exit =
-  try converse(duplex) finally duplex.close()
 
 private def failedToLaunch(using Stdio): Exit =
   Out.println(t"flux: could not start a REPL server")
@@ -198,7 +194,7 @@ private def failedToLaunch(using Stdio): Exit =
 // the server is a separate process it outlives this client, so the same session can
 // be reconnected to later by running `flux` again. Returns the live connection,
 // or `Unset` if no server became reachable in time.
-private def launchServer()(using Stdio, System): Optional[Duplex] =
+private def launchServer[result]()(using Stdio, System)(body: Duplex => result): Optional[result] =
   safely(System.properties.ethereal.script[Text]()).lay(Unset): executable =>
     val before: List[Text] = socketPaths(socketDirectory)
 
@@ -208,20 +204,20 @@ private def launchServer()(using Stdio, System): Optional[Duplex] =
     builder.redirectInput(ji.File("/dev/null"))
     safely(builder.start())
 
-    var duplex: Optional[Duplex] = Unset
+    var result: Optional[result] = Unset
     var waited: Int              = 0
 
-    // Poll for a new, connectable socket (the socket file appears once it binds).
-    while duplex.absent && waited < 10000 do
+    // Poll for a new, connectable socket (the socket file appears once it binds), then
+    // run `body` over the first one that connects.
+    while result.absent && waited < 10000 do
       jl.Thread.sleep(100)
       waited += 100
 
       socketPaths(socketDirectory).each: candidate =>
-        if duplex.absent && !before.contains(candidate) then
-          connectDomain(DomainSocket(candidate)).let: connection =>
-            duplex = connection
+        if result.absent && !before.contains(candidate) then
+          result = connectDomain(DomainSocket(candidate))(body)
 
-    duplex
+    result
 
 // TEMPORARY keyboard diagnostic. Instead of the editor, print each terminal event
 // as a Profanity `Keypress` (or other `TerminalEvent`), so we can see exactly how
@@ -285,10 +281,10 @@ private def connectSocket()(using Stdio, Monitor, Probate, Console, Environment,
   socketPaths(socketDirectory) match
     case Nil =>
       Out.println(t"flux: starting a REPL server…")
-      launchServer().lay(failedToLaunch)(session(_))
+      launchServer()(converse(_)).or(failedToLaunch)
 
     case path :: Nil =>
-      connectDomain(DomainSocket(path)).lay(unreachableSocket(path))(session(_))
+      connectDomain(DomainSocket(path))(converse(_)).or(unreachableSocket(path))
 
     case paths =>
       Out.println(t"flux: several REPL servers are running:")

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -55,9 +55,7 @@ object GrpcChannel:
     ( using Monitor, Probate )
   :   GrpcChannel raises AsyncError =
 
-    val connection = H2Connection(endpoint.connect())
-    connection.start()
-    new GrpcChannel(connection, endpoint.authority, defaults)
+    new GrpcChannel(endpoint.connect(), endpoint.authority, defaults)
 
 // A gRPC channel over a single, persistent HTTP/2 connection (`cordillera`). Each
 // call opens one multiplexed stream: the request is one length-prefixed protobuf
@@ -66,7 +64,7 @@ object GrpcChannel:
 // is always a single message, so client-streaming and bidirectional streaming wait
 // on a `cordillera` enhancement.
 class GrpcChannel
-  ( connection: H2Connection, authority: Text, defaults: Grpc.Metadata = Grpc.Metadata() ):
+  ( connection: Http2Connection, authority: Text, defaults: Grpc.Metadata = Grpc.Metadata() ):
   // The `:authority` pseudo-header is supplied to `fetch` separately; the request's
   // `Host` is unused by the HTTP/2 transport, so the hostname is parsed leniently.
   private val host: Host = unsafely(authority.cut(t":").prim.or(authority).decode[Host])
@@ -98,7 +96,7 @@ class GrpcChannel
   // Read the canonical status from the `grpc-status`/`grpc-message` fields, looking
   // in the trailers first and then the initial headers (a Trailers-Only response
   // carries the status in the headers). Raise unless the status is `Ok`.
-  private def expectStatus(stream: H2Stream): Unit raises GrpcError raises AsyncError =
+  private def expectStatus(stream: Http2Stream): Unit raises GrpcError raises AsyncError =
     val fields = stream.trailers.await() ++ stream.headers.await()
     val codeText = fields.find(_.name == t"grpc-status").optional.let(_.value)
     val message = fields.find(_.name == t"grpc-message").optional.let(_.value).or(t"")


### PR DESCRIPTION
Coaxial's `duplex` no longer hands back an unmanaged `Duplex` for the caller to remember to close (and leak on an exception path). It is now a loan — `endpoint.duplex { d => … }` — that always closes the connection when the lambda returns or throws, matching how `exchange` already manages its connection.

## Coaxial

```scala
val reply = (host"example.com" on tcp"1920").duplex: duplex =>
  duplex.send(Stream(request))
  duplex.stream.head
// the connection is closed here, however the block exits
```

A connection that must outlive a single block keeps the lambda running (e.g. parked on its supervisor) until the enclosing scope ends, at which point the loan closes it.

## cordillera / obligatory

`Http2.Endpoint.connect()` establishes the HTTP/2 connection inside the loan on a supervised daemon that parks until the enclosing `supervise` scope ends, handing the started connection back to callers via a `Promise`. The underlying duplex is now closed when the scope is torn down rather than leaked, and response bodies still stream lazily for the scope's lifetime. (This also lays the groundwork for connection pooling: the establish-and-hand-off primitive a pool shares per endpoint.) `H2Connection`/`H2Stream` are renamed to `Http2Connection`/`Http2Stream`.

## flux

The REPL client's connection helpers are continuation-passing, running the interactive session inside the loan.
