### PR TITLE
Burdock: compile-time dependency hashing, cache hard-linking, and repackager partition

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -457,6 +457,7 @@ object burdock extends Library:
   object core
       extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.core,
                        gastronomy.core, jacinta.core):
+    def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/burdock/src/core/burdock.Embed.scala
+++ b/lib/burdock/src/core/burdock.Embed.scala
@@ -48,17 +48,32 @@ import gossamer.*
 // literals. The published-vs-unpublished decision is deferred to repackage (where
 // deps.dev is queried); the cache covers anything deps.dev cannot resolve.
 object Embed:
+  // Resource path (within the compiled JAR) holding the newline-separated
+  // dependency SHA-256 hashes; read by the repackager and, in turn, the runtime
+  // bootstrap. Keep in sync with the repackager.
+  final val ResourcePath: String = "META-INF/burdock.deps"
+
   inline def dependencyHashes: List[Text] = ${Embed.dependencyHashesMacro}
 
   def dependencyHashesMacro(using Quotes): Expr[List[Text]] =
-    val classpath: String = quotes.absolve match
+    val (classpath, outputDir) = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         import dotty.tools.dotc.config.Settings.Setting.value
-        value(quotes.ctx.settings.classpath)(using quotes.ctx)
+        val ctx = quotes.ctx
+        (value(ctx.settings.classpath)(using ctx), value(ctx.settings.outputDir)(using ctx).jpath.nn)
 
     val hashes: List[String] = hashAndCache(classpath)
+    writeResource(outputDir, hashes)
 
     '{ ${Expr(hashes)}.map(_.tt) }
+
+  // Writes the hash list into the compile output as `META-INF/burdock.deps`, so
+  // it is packaged into the JAR as an ordinary resource.
+  private def writeResource(outputDir: jnf.Path, hashes: List[String]): Unit =
+    val metaInf: jnf.Path = outputDir.resolve("META-INF").nn
+    jnf.Files.createDirectories(metaInf)
+    val content: String = hashes.mkString("\n")
+    jnf.Files.write(metaInf.resolve("burdock.deps").nn, content.getBytes("UTF-8").nn)
 
   // Runs at compile time, in the compiler JVM: pure java.* so it needs nothing
   // from the soundness runtime. Hard-links fall back to a copy across filesystems.

--- a/lib/burdock/src/core/burdock.Embed.scala
+++ b/lib/burdock/src/core/burdock.Embed.scala
@@ -32,24 +32,60 @@
                                                                                                   */
 package burdock
 
-import soundness.*
+import java.nio.file as jnf
+import java.security as js
+import java.util as ju
 
-object Tests extends Suite(m"Burdock Tests"):
-  def run(): Unit =
-    suite(m"Dependency-hashing macro"):
-      val hashes: List[Text] = Embed.dependencyHashes
-      val home: Text = java.lang.System.getProperty("user.home").nn.tt
+import scala.quoted.*
 
-      test(m"captures a non-empty set of dependency hashes"):
-        hashes.length
-      .assert(_ > 0)
+import anticipation.*
+import gossamer.*
 
-      test(m"every hash is 64-character SHA-256 hex"):
-        hashes.all { hash => hash.length == 64 && hash.lower == hash }
-      .assert(_ == true)
+// The compile-time half of the Burdock redesign. `dependencyHashes` captures the
+// build's classpath, computes each dependency JAR's SHA-256, hard-links it into
+// the Burdock cache (`~/.cache/burdock/<sha256>.jar`) so its bytes stay
+// retrievable by hash locally, and embeds the SHA-256 list as compiled-in
+// literals. The published-vs-unpublished decision is deferred to repackage (where
+// deps.dev is queried); the cache covers anything deps.dev cannot resolve.
+object Embed:
+  inline def dependencyHashes: List[Text] = ${Embed.dependencyHashesMacro}
 
-      test(m"every hash is hard-linked into the Burdock cache"):
-        hashes.all: hash =>
-          val jar: Text = t"$home/.cache/burdock/$hash.jar"
-          java.nio.file.Files.exists(java.nio.file.Paths.get(jar.s).nn)
-      .assert(_ == true)
+  def dependencyHashesMacro(using Quotes): Expr[List[Text]] =
+    val classpath: String = quotes.absolve match
+      case quotes: runtime.impl.QuotesImpl =>
+        import dotty.tools.dotc.config.Settings.Setting.value
+        value(quotes.ctx.settings.classpath)(using quotes.ctx)
+
+    val hashes: List[String] = hashAndCache(classpath)
+
+    '{ ${Expr(hashes)}.map(_.tt) }
+
+  // Runs at compile time, in the compiler JVM: pure java.* so it needs nothing
+  // from the soundness runtime. Hard-links fall back to a copy across filesystems.
+  private def hashAndCache(classpath: String): List[String] =
+    val home: String = System.getProperty("user.home").nn
+    val cacheDir: jnf.Path = jnf.Paths.get(home, ".cache", "burdock").nn
+    jnf.Files.createDirectories(cacheDir)
+
+    val entries: Array[String | Null] = classpath.split(java.io.File.pathSeparator).nn
+    val hashes = List.newBuilder[String]
+    var i = 0
+
+    while i < entries.length do
+      val entry: String = entries(i).nn
+      i += 1
+      val path: jnf.Path = jnf.Paths.get(entry).nn
+
+      if entry.endsWith(".jar") && jnf.Files.isRegularFile(path) then
+        val bytes: Array[Byte] = jnf.Files.readAllBytes(path).nn
+        val digest: Array[Byte] = js.MessageDigest.getInstance("SHA-256").nn.digest(bytes).nn
+        val hex: String = ju.HexFormat.of().nn.formatHex(digest).nn
+        val target: jnf.Path = cacheDir.resolve(hex+".jar").nn
+
+        if !jnf.Files.exists(target) then
+          try jnf.Files.createLink(target, path)
+          catch case _: Throwable => jnf.Files.copy(path, target)
+
+        hashes += hex
+
+    hashes.result()

--- a/lib/burdock/src/core/burdock.Repackage.scala
+++ b/lib/burdock/src/core/burdock.Repackage.scala
@@ -1,5 +1,5 @@
                                                                                                   /*
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃                                                                                                  ┃
 ┃                                                   ╭───╮                                          ┃
 ┃                                                   │   │                                          ┃
@@ -32,55 +32,43 @@
                                                                                                   */
 package burdock
 
-import soundness.*
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import urticose.*
+import vacuous.*
 
-import strategies.throwUnsafely
-import errorDiagnostics.stackTraces
-import charEncoders.utf8
+import errorDiagnostics.empty
 
-object Tests extends Suite(m"Burdock Tests"):
-  def run(): Unit =
-    suite(m"Dependency-hashing macro"):
-      val hashes: List[Text] = Embed.dependencyHashes
-      val home: Text = java.lang.System.getProperty("user.home").nn.tt
+import Bootstrapper.{Requirement, Entry}
 
-      test(m"captures a non-empty set of dependency hashes"):
-        hashes.length
-      .assert(_ > 0)
+// The repackager. Reads the dependency hashes embedded by the compile-time macro
+// and partitions them: a hash that resolves to a public URL is externalized (a
+// `Burdock-Require` reference, fetched at runtime); anything else is inlined by
+// copying the cached JAR's classes into the artifact. The completeness invariant:
+// every dependency is either externalized or inlined — a hash that is neither is
+// an error.
+object Repackage:
+  case class RepackageError(hash: Text)(using Diagnostics)
+  extends Error(m"the dependency with hash $hash is neither publicly downloadable nor cached")
 
-      test(m"every hash is 64-character SHA-256 hex"):
-        hashes.all { hash => hash.length == 64 && hash.lower == hash }
-      .assert(_ == true)
+  // Pure partition; `resolve` (deps.dev) and `cached` (cache lookup) are injected
+  // so the logic is testable without the network or the filesystem.
+  def partition
+     (hashes:  List[Text],
+      resolve: Text => Optional[HttpUrl],
+      cached:  Text => Optional[List[Entry]])
+  :   (List[Requirement], List[Entry]) raises RepackageError =
 
-      test(m"every hash is hard-linked into the Burdock cache"):
-        hashes.all: hash =>
-          val jar: Text = t"$home/.cache/burdock/$hash.jar"
-          java.nio.file.Files.exists(java.nio.file.Paths.get(jar.s).nn)
-      .assert(_ == true)
+    val requirements = List.newBuilder[Requirement]
+    val inlined = List.newBuilder[Entry]
 
-      test(m"the hash list is written as a packaged resource"):
-        val stream = getClass.nn.getResourceAsStream("/META-INF/burdock.deps").nn
-        val content: Text = java.lang.String(stream.readAllBytes().nn, "UTF-8").tt
-        content.cut(t"\n").to(Set)
-      .assert(_ == hashes.to(Set))
+    hashes.each: hash =>
+      resolve(hash) match
+        case url: HttpUrl => requirements += Requirement(url, hash)
+        case Unset        => cached(hash).lay(abort(RepackageError(hash)))(inlined ++= _)
 
-    suite(m"Repackager partition"):
-      val published = url"https://repo1.maven.org/maven2/g/a/1/a-1.jar"
-      val resolve: Text => Optional[HttpUrl] = h => if h == t"aaa" then published else Unset
-      val classEntry = Bootstrapper.Entry(t"pkg/X.class", t"bytes".data)
-      val cached: Text => Optional[List[Bootstrapper.Entry]] =
-        h => if h == t"bbb" then List(classEntry) else Unset
-
-      test(m"a published hash becomes a remote requirement"):
-        val (requirements, inlined) = Repackage.partition(List(t"aaa"), resolve, cached)
-        (requirements.length, inlined.length)
-      .assert(_ == (1, 0))
-
-      test(m"an unpublished but cached hash is inlined"):
-        val (requirements, inlined) = Repackage.partition(List(t"bbb"), resolve, cached)
-        (requirements.length, inlined.length)
-      .assert(_ == (0, 1))
-
-      test(m"a hash that is neither published nor cached is rejected"):
-        capture[Repackage.RepackageError](Repackage.partition(List(t"ccc"), resolve, cached))
-      .assert(_ => true)
+    (requirements.result(), inlined.result())

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -53,3 +53,9 @@ object Tests extends Suite(m"Burdock Tests"):
           val jar: Text = t"$home/.cache/burdock/$hash.jar"
           java.nio.file.Files.exists(java.nio.file.Paths.get(jar.s).nn)
       .assert(_ == true)
+
+      test(m"the hash list is written as a packaged resource"):
+        val stream = getClass.nn.getResourceAsStream("/META-INF/burdock.deps").nn
+        val content: Text = java.lang.String(stream.readAllBytes().nn, "UTF-8").tt
+        content.cut(t"\n").to(Set)
+      .assert(_ == hashes.to(Set))


### PR DESCRIPTION
Foundations for Burdock's download-on-demand redesign. A compile-time macro captures the build's classpath, computes each dependency's SHA-256, hard-links it into a per-user cache so its bytes stay retrievable by hash locally, and embeds the hash list into the JAR as a `META-INF/burdock.deps` resource. The repackager's partition logic then resolves each hash to a public URL (deps.dev → externalize) or the local cache (inline), enforcing the completeness invariant that anything neither published nor cached is rejected. The repackager's JAR-rewriting entry point follows as a separate, fixture-tested change.

## Compile-time dependency capture

`burdock.Embed.dependencyHashes` reads the build's classpath at compile time (via a `QuotesImpl` cast), SHA-256s each dependency JAR, hard-links each into `~/.cache/burdock/<sha256>.jar`, and writes the hash list to `META-INF/burdock.deps` in the artifact — a java-readable, reflection-free handoff to the repackager. Adds `scala3-compiler` as a compile-only dependency (to reach `dotty.tools.dotc`).

## Repackager partition

`burdock.Repackage.partition` splits the embedded hashes: a hash that resolves to a public URL becomes a remote `Burdock-Require` reference; an unpublished-but-cached hash is inlined from the cache; a hash that is neither is rejected. The resolver and cache lookup are injected, so the logic is unit-tested without network or filesystem.

The published-vs-unpublished decision is deferred entirely to this step (the cache is the fallback source), which sidesteps deps.dev indexing latency. The JAR-rewriting entry point that consumes this — self-locating the artifact, forcing `Bootstrap.class` inclusion, and writing the slimmed JAR — lands separately with a host-native end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)