### PR TITLE
Render the flux REPL inline on a styled-grapheme rendering foundation

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1403,7 +1403,7 @@ object typonym extends Library:
   object test extends Tests(core)
 
 object ultimatum extends Library:
-  object core extends Component(profanity.core, escapade.csi):
+  object core extends Component(profanity.core, escapade.core, yossarian.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object demo extends Component(core, ethereal.core, exoskeleton.completions):

--- a/build.mill
+++ b/build.mill
@@ -839,7 +839,7 @@ object flux extends Library:
 
   object client extends Component(core, ethereal.core, exoskeleton.completions, profanity.core,
                                   coaxial.core, urticose.core, jacinta.core, escapade.core,
-                                  iridescence.core, harlequin.ansi, escritoire.core):
+                                  iridescence.core, harlequin.ansi, escritoire.core, ultimatum.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     override def mainClass: Task.Simple[Option[String]] = Some("flux.repl")

--- a/lib/escapade/src/core/escapade.Imprintable.scala
+++ b/lib/escapade/src/core/escapade.Imprintable.scala
@@ -30,13 +30,56 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package escapade
 
-export
-  escapade
-  . { Ansi, Ansi2, Bg, Bold, CharSpan, Colorable, Conceal, csi, e, Escape, escapes, Fg, Imprintable,
-      Italic, Reverse, Ribbon, Strike, Stylize, Teletype, teletype, Teletypeable, TeletypeBuilder,
-      TextStyle, Underline }
+import anticipation.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
 
-package displayableTypes:
-  export escapade.displayableTypes.message
+object Imprintable:
+  // Emit each grapheme of `text` paired with one uniform `style`.
+  private def graphemeCells(text: Text, style: StyleWord)(lambda: (Grapheme, StyleWord) => Unit)
+  :   Unit =
+
+    Writing(text).graphemes.each: grapheme =>
+      lambda(grapheme, style)
+
+  given text: Text is Imprintable:
+    def cells(self: Text)(lambda: (Grapheme, StyleWord) => Unit): Unit =
+      graphemeCells(self, StyleWord.Default)(lambda)
+
+  given writing: Writing is Imprintable:
+    def cells(self: Writing)(lambda: (Grapheme, StyleWord) => Unit): Unit =
+      self.graphemes.each: grapheme =>
+        lambda(grapheme, StyleWord.Default)
+
+  given ascii: Ascii is Imprintable:
+    def cells(self: Ascii)(lambda: (Grapheme, StyleWord) => Unit): Unit =
+      graphemeCells(summon[Ascii is Textual].text(self), StyleWord.Default)(lambda)
+
+  // Each grapheme takes the style of its first character (escapade stores styles per
+  // character; a grapheme is styled as a unit), so colour survives decomposition.
+  given teletype: Teletype is Imprintable:
+    def cells(self: Teletype)(lambda: (Grapheme, StyleWord) => Unit): Unit =
+      val writing    = Writing(self.plain)
+      val boundaries = writing.boundaries
+      val count      = boundaries.length - 1
+      var index      = 0
+
+      while index < count do
+        val start: Int  = boundaries(index)
+        val piece: Text = self.plain.s.substring(start, boundaries(index + 1)).nn.tt
+        lambda(Grapheme(piece.s), StyleWord(self.styleAt(start)))
+        index += 1
+
+// Content that can be imprinted onto a terminal cell grid: it decomposes into a
+// sequence of grapheme cells, each paired with the `StyleWord` that styles it (the
+// default style for unstyled content). Working in graphemes — not chars — makes each
+// cell's terminal display width unambiguous (a wide CJK glyph or a ZWJ emoji is one
+// cell, a combining mark contributes none), so a surface advances its cursor by
+// `Grapheme` width rather than character count. The instances cover the text types
+// seamlessly: `Text`, `Ascii` and `Writing` carry the default style; `Teletype`
+// carries its own per-character styling.
+trait Imprintable extends Typeclass:
+  def cells(self: Self)(lambda: (Grapheme, StyleWord) => Unit): Unit

--- a/lib/escapade/src/core/escapade.StyleWord.scala
+++ b/lib/escapade/src/core/escapade.StyleWord.scala
@@ -34,6 +34,8 @@ package escapade
 
 import language.experimental.pureFunctions
 
+import scala.reflect.*
+
 import anticipation.*
 import gossamer.*
 
@@ -62,6 +64,11 @@ object StyleWord:
     | Reverse | Conceal | Strike | Overline | HyperlinkChange
 
   val Default: StyleWord = 0L
+
+  // A `StyleWord` is a `Long`, so an `Array[StyleWord]` is an unboxed `long[]`; the
+  // opaque type hides that from callers, so expose the `ClassTag` (cells stored in a
+  // grid need it to allocate without boxing).
+  given classTag: ClassTag[StyleWord] = summon[ClassTag[Long]].asInstanceOf[ClassTag[StyleWord]]
 
   inline def apply(raw: Long): StyleWord = raw
 

--- a/lib/escapade/src/test/escapade_test.scala
+++ b/lib/escapade/src/test/escapade_test.scala
@@ -985,3 +985,31 @@ object Tests extends Suite(m"Escapade tests"):
       test(m"trailing style is reset after styled prefix"):
         e"$Bold(abc)def".trailingStyle
       . assert(_ == 0L)
+
+    // ─── Imprintable: grapheme-cell decomposition ──────────────────────────
+
+    suite(m"Imprintable"):
+      def cellList[content](value: content)(using imprintable: content is Imprintable)
+      :   List[(Grapheme, StyleWord)] =
+        var cells: List[(Grapheme, StyleWord)] = Nil
+
+        imprintable.cells(value): (grapheme, style) =>
+          cells = (grapheme, style) :: cells
+
+        cells.reverse
+
+      test(m"plain Text decomposes into one cell per grapheme"):
+        cellList(t"abc").map(_._1.text)
+      . assert(_ == List(t"a", t"b", t"c"))
+
+      test(m"plain Text cells carry the default style"):
+        cellList(t"abc").map(_._2 == StyleWord.Default)
+      . assert(_ == List(true, true, true))
+
+      test(m"an accented character is a single grapheme cell"):
+        cellList(t"é").length
+      . assert(_ == 1)
+
+      test(m"a styled Teletype carries its style per cell"):
+        cellList(e"a$Bold(b)c").map(_._2.isBold)
+      . assert(_ == List(false, true, false))

--- a/lib/flux/src/client/flux_client.scala
+++ b/lib/flux/src/client/flux_client.scala
@@ -340,61 +340,199 @@ private def converse(duplex: Duplex)(using Stdio, Monitor, Probate, Console, Env
       Exit.Fail(4)
 
   . recover:
-      interactive:
-        given Interaction[Text, LineEditor] =
-          liveHighlighting(duplex, state, pending, nextId, completions)
-
-        var running = true
-
-        while running do
-          Out.print(t"> ")
-
-          // Multi-line editing: Enter submits when brackets are balanced, and
-          // otherwise inserts a newline to continue the input; Shift+Enter always
-          // submits.
-          val editor = LineEditor(mode = LineEditor.Mode.Multiline(balanced))
-
-          whereas:
-            case DismissError() => running = false
-
-          . recover:
-              editor.ask: line =>
-                // A line beginning with `/` is a client command, handled locally
-                // rather than submitted: `/disconnect` ends the session (like
-                // Ctrl+D); `/quit` also tells the server to shut down.
-                if line == t"/disconnect" then running = false
-                else if line == t"/quit" then
-                  duplex.send(Stream((encode(Repl.Request.Quit(0)) + t"\n\n").data))
-                  running = false
-                else if line.starts(t"/") then
-                  Out.println(t"flux: unknown command: $line")
-                else
-                  // The editor already showed the (live-highlighted) line; submit
-                  // it and print the awaited result value and any diagnostics.
-                  duplex.send(Stream((encode(Repl.Request.Submit(0, line)) + t"\n\n").data))
-
-                  submits.take().nn match
-                    case Repl.Reply.Ran(_, value, output, tpe, diagnostics, _) =>
-                      if output != t"" then Out.print(output)
-
-                      value.let: rendered =>
-                        tpe.lay(Out.println(rendered)): typeName =>
-                          Out.println(t"$rendered : $typeName")
-
-                      if diagnostics != t"" then Out.println(diagnostics)
-
-                    case Repl.Reply.Threw(_, output, diagnostics, _) =>
-                      if output != t"" then Out.print(output)
-                      Out.println(diagnostics)
-
-                    case Repl.Reply.Rejected(_, diagnostics, _) => Out.println(diagnostics)
-                    case Repl.Reply.Crashed(_, diagnostics, _)  => Out.println(diagnostics)
-                    case Repl.Reply.Failed(_, message)          => Out.println(message)
-                    case Repl.Reply.Tokenized(_, _)             => ()
-                    case Repl.Reply.Completed(_, _)             => ()
-
+      interactive: terminal ?=>
+        runRepl(duplex, state, pending, nextId, submits, completions)
         live = false
         Exit.Ok
+
+// One REPL input line is an inline block at the bottom of the console — a bordered,
+// live-highlighted editor with, when completions are active, a pane above it listing
+// them. On submit the block is frozen in place (`finish`), the result is printed below
+// it, and the next line opens a fresh block beneath, so output scrolls up into the
+// console's own scrollback above the editor. Rendering goes through ultimatum's
+// `paint`/`InlineRoot`, so the editor's syntax colours and wide-character widths are
+// exactly those of the cell grid.
+private def runRepl
+  ( duplex:      Duplex,
+    state:       LiveState,
+    pending:     TrieMap[Int, Int],
+    nextId:      juc.atomic.AtomicInteger,
+    submits:     juc.LinkedBlockingQueue[Repl.Reply],
+    completions: juc.LinkedBlockingQueue[List[Repl.CompletionItem]] )
+  ( using terminal: Terminal, monitor: Monitor )
+:   Unit =
+
+  given Stdio = terminal.stdio
+  val events = terminal.eventIterator()
+  var running = true
+
+  while running && events.hasNext do
+    val root = InlineRoot(terminal)
+    var editor: LineEditor = LineEditor(mode = LineEditor.Mode.Multiline(balanced))
+    var candidates: List[Repl.CompletionItem] = Nil
+    var tokens: List[Repl.Token] = Nil
+    var lastValue: Text = t""
+    var lastVersion: Int = -1
+
+    // Record the live-highlight edit and fire an async server `tokenize` to refine it.
+    def refresh(): Unit =
+      val (version, refreshed) = state.record(lastValue, editor.value)
+      tokens = refreshed
+      lastValue = editor.value
+
+      if editor.value.length > 0 && version != lastVersion then
+        lastVersion = version
+        val id = nextId.getAndIncrement
+        pending(id) = version
+        duplex.send(Stream((encode(Repl.Request.Tokenize(id, editor.value)) + t"\n\n").data))
+
+    def frame(): Unit =
+      val innerWidth = (terminal.knownColumns - 2).max(1)
+      val rows = LineEditor.cursorPosition(editor.value, editor.value.length, innerWidth)._1 + 1
+      paint(root, replPane(editor, tokens, candidates, rows))
+      root.flush()
+
+    refresh()
+    frame()
+    var editing = true
+    var submitted: Optional[Text] = Unset
+
+    while editing && events.hasNext do
+      events.next() match
+        case Keypress.Ctrl('C' | 'D') => running = false; editing = false
+        case Keypress.Escape          => running = false; editing = false
+
+        case _: TerminalInfo.WindowSize =>
+          root.invalidate()
+          frame()
+
+        case Keypress.Tab =>
+          val (advanced, shown) = completeAt(editor, duplex, completions)
+          editor = advanced
+          candidates = shown
+          refresh()
+          frame()
+
+        case event if editor.submitsOn(event) =>
+          submitted = editor.value
+          editing = false
+
+        case keypress: Keypress =>
+          editor = editor(keypress)
+          candidates = Nil
+          refresh()
+          frame()
+
+        case _ =>
+          ()
+
+    // Freeze the block onto the screen (cursor drops below it) and print the result
+    // there, so it scrolls above the next line's fresh block.
+    root.finish()
+
+    submitted.let: line =>
+      if line == t"/disconnect" then
+        running = false
+      else if line == t"/quit" then
+        duplex.send(Stream((encode(Repl.Request.Quit(0)) + t"\n\n").data))
+        running = false
+      else if line.starts(t"/") then
+        Out.println(t"flux: unknown command: $line")
+      else
+        duplex.send(Stream((encode(Repl.Request.Submit(0, line)) + t"\n\n").data))
+
+        submits.take().nn match
+          case Repl.Reply.Ran(_, value, output, tpe, diagnostics, _) =>
+            if output != t"" then Out.print(output)
+
+            value.let: rendered =>
+              tpe.lay(Out.println(rendered)): typeName =>
+                Out.println(t"$rendered : $typeName")
+
+            if diagnostics != t"" then Out.println(diagnostics)
+
+          case Repl.Reply.Threw(_, output, diagnostics, _) =>
+            if output != t"" then Out.print(output)
+            Out.println(diagnostics)
+
+          case Repl.Reply.Rejected(_, diagnostics, _) => Out.println(diagnostics)
+          case Repl.Reply.Crashed(_, diagnostics, _)  => Out.println(diagnostics)
+          case Repl.Reply.Failed(_, message)          => Out.println(message)
+          case Repl.Reply.Tokenized(_, _)             => ()
+          case Repl.Reply.Completed(_, _)             => ()
+
+// The inline block: a bordered editor box showing the live-highlighted line with its
+// caret, and — when completions are active — a pane above it listing them, which
+// auto-sizes to the candidate count (capped) and vanishes when there are none.
+private def replPane
+  ( editor:     LineEditor,
+    tokens:     List[Repl.Token],
+    candidates: List[Repl.CompletionItem],
+    rows:       Int )
+:   Pane =
+
+  val box = border(BorderStyle.rounded):
+    panel(minHeight = rows, maxHeight = rows):
+      val extent = summon[Extent]
+      val cols = extent.width.max(1)
+      extent.put(colourful(tokens))
+      val (curRow, curCol) = LineEditor.cursorPosition(editor.value, editor.position, cols)
+      extent.showCaret(curCol.z, curRow.z)
+
+  if candidates.isEmpty then box
+  else
+    val shown = candidates.length.min(10)
+
+    val list = panel(minHeight = shown, maxHeight = shown):
+      candidates.take(shown).each: item =>
+        Out.println(t"${item.name}  ${item.signature}")
+
+    rank(list, box)
+
+// On Tab, complete: a `/`-command line completes locally against `slashCommands`;
+// otherwise the server is asked and we block for the reply. A unique candidate is
+// inserted; with several, the longest common prefix is inserted and the candidates are
+// returned for display.
+private def completeAt
+  ( editor:      LineEditor,
+    duplex:      Duplex,
+    completions: juc.LinkedBlockingQueue[List[Repl.CompletionItem]] )
+:   (LineEditor, List[Repl.CompletionItem]) =
+
+  if editor.value.starts(t"/") then
+    slashCommands.filter { (name, _) => name.starts(editor.value) } match
+      case (name, _) :: Nil =>
+        (LineEditor(name, name.length, editor.mode), Nil)
+
+      case matches =>
+        val items =
+          matches.map: (name, help) =>
+            Repl.CompletionItem(name, t"command", help)
+
+        val prefix = longestCommonPrefix(matches.map(_._1))
+
+        val advanced =
+          if prefix.length > editor.value.length then LineEditor(prefix, prefix.length, editor.mode)
+          else editor
+
+        (advanced, items)
+  else
+    val request = encode(Repl.Request.Complete(0, editor.value, editor.position))
+    duplex.send(Stream((request + t"\n\n").data))
+
+    val candidates: List[Repl.CompletionItem] = completions.take().nn
+
+    candidates match
+      case single :: Nil =>
+        (insertCompletion(editor, single.name), Nil)
+
+      case _ =>
+        val prefix = longestCommonPrefix(candidates.map(_.name))
+
+        val advanced =
+          if prefix.length > partialLength(editor) then insertCompletion(editor, prefix) else editor
+
+        (advanced, candidates)
 
 // The editor's syntax-highlighting colours, *specified* here as an iridescence
 // `Palette` rather than hardcoded per accent. Harlequin's `syntaxHighlighting`
@@ -603,30 +741,6 @@ private val slashCommands: List[(Text, Text)] =
     ( t"/disconnect" -> t"leave the session, keeping the server running",
       t"/quit"       -> t"stop the server and quit" )
 
-// Prints tab completions below the editor as a minimal Escritoire table of name and
-// signature, with no heading row (the header section is dropped from the grid). The
-// caller redraws the prompt afterwards so it reappears beneath the table.
-private def showCompletions(completions: List[Repl.CompletionItem])(using Stdio): Unit =
-  import tableStyles.minimal
-  import columnAttenuation.ignore
-  import textMetrics.uniform
-
-  Out.print(t"\r\n")
-
-  if completions.isEmpty then Out.print(t"(no completions)\r\n")
-  else
-    val table =
-      Scaffold[Repl.CompletionItem]
-        ( Column(t"Name")(_.name),
-          Column(t"Signature")(_.signature) )
-
-    // `tabulate(…).grid(…)` yields a header section then a body section; dropping the
-    // header (`sections.tail`) renders the rows alone, with no titles or rule.
-    val grid = table.tabulate(completions.take(20)).grid(80)
-
-    Grid(grid.sections.tail, grid.style).render.each: line =>
-      Out.print(t"$line\r\n")
-
 // Replaces the partial identifier ending at the cursor with the completion `name`,
 // returning the editor with the cursor just after the inserted text.
 private def insertCompletion(editor: LineEditor, name: Text): LineEditor =
@@ -676,119 +790,6 @@ private def balanced(text: Text): Boolean =
 
   string.length > 0 && depth <= 0
 
-// A line-editor interaction that highlights the buffer live: each keystroke is
-// applied to the live highlight via the heuristic and drawn immediately (never
-// waiting on the server), then an async `tokenize` is fired to refine it. Mirrors
-// Profanity's default cursor handling — colour codes are zero-width.
-private def liveHighlighting
-  ( duplex:      Duplex,
-    state:       LiveState,
-    pending:     TrieMap[Int, Int],
-    nextId:      juc.atomic.AtomicInteger,
-    completions: juc.LinkedBlockingQueue[List[Repl.CompletionItem]] )
-  ( using terminal: Terminal )
-:   Interaction[Text, LineEditor] =
-
-  new Interaction[Text, LineEditor]:
-    given Stdio = terminal.stdio
-    var lastVersion: Int     = -1
-    var redrawFresh: Boolean = false        // draw the next frame fresh, below a table
-    override def after(): Unit = Out.println()
-
-    def result(editor: LineEditor): Text = editor.value
-
-    // The editor's mode (set when it is created) decides whether Enter submits or
-    // inserts a newline.
-    override def submits(event: TerminalEvent, editor: LineEditor): Boolean =
-      editor.submitsOn(event)
-
-    // On Tab, complete. A line beginning with `/` completes the client `/`-commands
-    // locally; otherwise the server is asked for completions at the cursor and we
-    // block for the reply (delivered by the background reader). Either way a unique
-    // candidate is inserted; with several, the candidates are shown as a table and the
-    // editor is advanced by the longest prefix common to all their names — so a set of
-    // overloads, which share a name, completes that whole name.
-    override def react(editor: LineEditor, event: TerminalEvent): LineEditor = event match
-      case Keypress.Tab if editor.value.starts(t"/") =>
-        completeCommand(editor)
-
-      case Keypress.Tab =>
-        val request = encode(Repl.Request.Complete(0, editor.value, editor.position))
-        duplex.send(Stream((request + t"\n\n").data))
-        val candidates: List[Repl.CompletionItem] = completions.take().nn
-
-        candidates match
-          case single :: Nil =>
-            insertCompletion(editor, single.name)
-
-          case _ =>
-            showCompletions(candidates)
-            redrawFresh = true
-            val prefix = longestCommonPrefix(candidates.map(_.name))
-
-            if prefix.length > partialLength(editor) then insertCompletion(editor, prefix)
-            else editor
-
-      case _ =>
-        editor
-
-    // Completes the `/`-commands against the whole line: a unique match fills in the
-    // command; otherwise the matches are listed and the longest common prefix added.
-    def completeCommand(editor: LineEditor): LineEditor =
-      val typed: Text = editor.value
-
-      slashCommands.filter { (name, _) => name.starts(typed) } match
-        case (name, _) :: Nil =>
-          LineEditor(name, name.length, editor.mode)
-
-        case matches =>
-          val items =
-            matches.map: (name, help) =>
-              Repl.CompletionItem(name, t"command", help)
-
-          showCompletions(items)
-          redrawFresh = true
-          val prefix = longestCommonPrefix(matches.map(_._1))
-
-          if prefix.length > typed.length then LineEditor(prefix, prefix.length, editor.mode)
-          else editor
-
-    def render(old: Optional[LineEditor], editor: LineEditor): Unit =
-      val cols              = terminal.knownColumns.max(1)
-      val len               = editor.value.length
-      val (curRow, curCol)  = LineEditor.cursorPosition(editor.value, editor.position, cols)
-      val (endRow, _)       = LineEditor.cursorPosition(editor.value, len, cols)
-      val (version, tokens) = state.record(old.lay(t"")(_.value), editor.value)
-      val coloured          = colourful(tokens).render(terminal.stdio.termcap)
-
-      // After a table the cursor sits below it, so ignore the previous frame's
-      // position and draw fresh where the cursor now is.
-      val anchor            = if redrawFresh then Unset else old
-      redrawFresh           = false
-
-      Out.print:
-        Text.build:
-          anchor.let: o =>
-            val (oldRow, _) = LineEditor.cursorPosition(o.value, o.position, cols)
-            if oldRow > 0 then append(t"\e[${oldRow}F") else append(t"\r")
-
-          append(t"\e[J")
-          // In raw mode a bare newline only moves down, so emit CR+LF for each.
-          append(coloured.sub(t"\n", t"\r\n"))
-
-          if len > 0 then
-            if endRow > 0 then append(t"\e[${endRow}F") else append(t"\r")
-
-          if curRow > 0 then append(t"\e[${curRow}B")
-          if curCol > 0 then append(t"\e[${curCol + 1}G")
-
-      // Fire an async `tokenize` (correlated by id → version); the background
-      // reader reconciles the reply, refining the next render.
-      if len > 0 && version != lastVersion then
-        lastVersion = version
-        val id = nextId.getAndIncrement
-        pending(id) = version
-        duplex.send(Stream((encode(Repl.Request.Tokenize(id, editor.value)) + t"\n\n").data))
 
 // Serializes a `Request` as compact JSON for the wire. `Json` is `Dynamic`, so
 // `.show` is intercepted; summon the `Encodable in Text` instance explicitly.

--- a/lib/flux/src/client/flux_client.scala
+++ b/lib/flux/src/client/flux_client.scala
@@ -130,6 +130,14 @@ private def serveSocket()(using Stdio, Monitor, Probate, System): Exit =
 
   val socketPath: Text = socketFile
 
+  // Delete the socket on any exit (a clean stop, a crash, or a kill signal), so it
+  // never lingers as a stale file a later client has to clean up.
+  val removeSocket: Runnable = () =>
+    safely(jnf.Files.deleteIfExists(jnf.Path.of(socketPath.s)))
+    ()
+
+  jl.Runtime.getRuntime.nn.addShutdownHook(jl.Thread(removeSocket))
+
   try
     jnf.Files.createDirectories(jnf.Path.of(socketDirectory.s)).nn
     jnf.Files.deleteIfExists(jnf.Path.of(socketPath.s))
@@ -278,7 +286,17 @@ private def socketPaths(directory: Text): List[Text] =
 // in the background and attaches to it (so `flux` alone is a self-contained REPL,
 // reconnectable later); with exactly one, connects to it; with several, lists them.
 private def connectSocket()(using Stdio, Monitor, Probate, Console, Environment, System): Exit =
-  socketPaths(socketDirectory) match
+  // Probe every socket file: a connectable one is live; one that refuses (a crashed or
+  // killed server that never cleaned up) is a stale leftover, so delete it. Then attach
+  // to the lone live server, list several, or — when none survive — start a fresh one.
+  val live: scm.ArrayBuffer[Text] = scm.ArrayBuffer()
+
+  socketPaths(socketDirectory).each: path =>
+    if connectDomain(DomainSocket(path)) { _ => () }.absent
+    then safely(jnf.Files.deleteIfExists(jnf.Path.of(path.s)))
+    else live += path
+
+  live.to(List) match
     case Nil =>
       Out.println(t"flux: starting a REPL server…")
       launchServer()(converse(_)).or(failedToLaunch)
@@ -302,37 +320,11 @@ private def converse(duplex: Duplex)(using Stdio, Monitor, Probate, Console, Env
   // Shift+Enter distinctly, so the editor can submit on it.
   import terminalFeatures.kittyKeyboard
 
-  // `duplex.stream` blocks on its first socket read, so force the iterator lazily
-  // — only after a line has been sent — otherwise it would deadlock here before
-  // the editor starts (the server sends nothing until it receives a message).
-  lazy val chunks: Iterator[Data] = duplex.stream.iterator
-
-  val state                 = LiveState()
-  val pending               = TrieMap[Int, Int]()                  // tokenize id → version
-  val submits               = juc.LinkedBlockingQueue[Repl.Reply]()
-  val completions           = juc.LinkedBlockingQueue[List[Repl.CompletionItem]]()
-  val nextId                = juc.atomic.AtomicInteger(1)           // 0 is reserved for submit
-  @volatile var live        = true
-
-  // Background reader: replies may arrive in any order, so route each by kind —
-  // `tokenize` replies refine the live highlight (re-associated by id → version),
-  // everything else is a `submit` result the editor awaits.
-  async:
-    while live do
-      val raw = reply(chunks).trim
-
-      if raw.length == 0 then live = false
-      else safely[Exception](Json.parseTracked(raw).as[Repl.Reply]).let:
-        case Repl.Reply.Tokenized(id, highlight) =>
-          pending.remove(id).foreach(state.reconcile(_, highlight))
-
-        // Hand completions to the editor thread (which blocks on Tab) rather than
-        // printing them here, so it can redraw the prompt below them.
-        case Repl.Reply.Completed(_, items) =>
-          completions.put(items)
-
-        case reply =>
-          submits.put(reply)
+  val state       = LiveState()
+  val pending     = TrieMap[Int, Int]()                  // tokenize id → version
+  val submits     = juc.LinkedBlockingQueue[Repl.Reply]()
+  val completions = juc.LinkedBlockingQueue[List[Repl.CompletionItem]]()
+  val nextId      = juc.atomic.AtomicInteger(1)          // 0 is reserved for submit
 
   whereas:
     case TerminalError() =>
@@ -342,7 +334,6 @@ private def converse(duplex: Duplex)(using Stdio, Monitor, Probate, Console, Env
   . recover:
       interactive: terminal ?=>
         runRepl(duplex, state, pending, nextId, submits, completions)
-        live = false
         Exit.Ok
 
 // One REPL input line is an inline block at the bottom of the console — a bordered,
@@ -363,6 +354,33 @@ private def runRepl
 :   Unit =
 
   given Stdio = terminal.stdio
+
+  // `duplex.stream` blocks on its first socket read, so force the iterator lazily —
+  // only once a request has been sent — otherwise it would deadlock before the editor
+  // even starts (the server sends nothing until it receives a message).
+  lazy val chunks: Iterator[Data] = duplex.stream.iterator
+  @volatile var live = true
+
+  // Background reader: route replies by kind. A `tokenize` reply refines the live
+  // highlight and posts a `Redraw`, so the refined colour appears as soon as the server
+  // answers — not one keypress later. Other replies are a `submit` result the loop
+  // awaits, or the `completions` the Tab handler blocks on.
+  async:
+    while live do
+      val raw = reply(chunks).trim
+
+      if raw.length == 0 then live = false
+      else safely[Exception](Json.parseTracked(raw).as[Repl.Reply]).let:
+        case Repl.Reply.Tokenized(id, highlight) =>
+          pending.remove(id).foreach(state.reconcile(_, highlight))
+          terminal.events.put(TerminalInfo.Redraw)
+
+        case Repl.Reply.Completed(_, items) =>
+          completions.put(items)
+
+        case reply =>
+          submits.put(reply)
+
   val events = terminal.eventIterator()
   var running = true
 
@@ -410,6 +428,12 @@ private def runRepl
 
           case _: TerminalInfo.WindowSize =>
             root.invalidate()
+            frame()
+
+          // A tokenize reply arrived (posted by the reader): re-derive the highlight
+          // from the reconciled checkpoint and repaint, with no edit and no new request.
+          case TerminalInfo.Redraw =>
+            tokens = state.record(editor.value, editor.value)._2
             frame()
 
           case Keypress.Tab =>
@@ -466,6 +490,9 @@ private def runRepl
           case Repl.Reply.Failed(_, message)          => Out.println(message)
           case Repl.Reply.Tokenized(_, _)             => ()
           case Repl.Reply.Completed(_, _)             => ()
+
+  // The loop has exited (Ctrl+D/C, Escape, /quit, or a closed stream): stop the reader.
+  live = false
 
 // The inline block: a bordered editor box showing the live-highlighted line with its
 // caret, and — when completions are active — a pane above it listing them, which

--- a/lib/flux/src/client/flux_client.scala
+++ b/lib/flux/src/client/flux_client.scala
@@ -46,13 +46,13 @@ import soundness.*
 import backstops.silent
 import charEncoders.utf8
 import classloaders.threadContext
-import probates.cancel
 import executives.completions
 import harlequin.Accent
 import internetAccess.enabled
 import interpreters.posix
 import jsonDiscriminables.discriminatedUnionByKind
 import logging.silent
+import probates.cancel
 import supervisors.global
 import systems.java
 import temporaryDirectories.system
@@ -366,7 +366,7 @@ private def runRepl
   val events = terminal.eventIterator()
   var running = true
 
-  while running && events.hasNext do
+  while running do
     val root = InlineRoot(terminal)
     var editor: LineEditor = LineEditor(mode = LineEditor.Mode.Multiline(balanced))
     var candidates: List[Repl.CompletionItem] = Nil
@@ -397,34 +397,40 @@ private def runRepl
     var editing = true
     var submitted: Optional[Text] = Unset
 
-    while editing && events.hasNext do
-      events.next() match
-        case Keypress.Ctrl('C' | 'D') => running = false; editing = false
-        case Keypress.Escape          => running = false; editing = false
+    // The block is already drawn; now wait for events. `hasNext` blocks until a
+    // keypress (or returns false when the input stream closes, ending the session).
+    while editing do
+      if !events.hasNext then
+        editing = false
+        running = false
+      else
+        events.next() match
+          case Keypress.Ctrl('C' | 'D') => running = false; editing = false
+          case Keypress.Escape          => running = false; editing = false
 
-        case _: TerminalInfo.WindowSize =>
-          root.invalidate()
-          frame()
+          case _: TerminalInfo.WindowSize =>
+            root.invalidate()
+            frame()
 
-        case Keypress.Tab =>
-          val (advanced, shown) = completeAt(editor, duplex, completions)
-          editor = advanced
-          candidates = shown
-          refresh()
-          frame()
+          case Keypress.Tab =>
+            val (advanced, shown) = completeAt(editor, duplex, completions)
+            editor = advanced
+            candidates = shown
+            refresh()
+            frame()
 
-        case event if editor.submitsOn(event) =>
-          submitted = editor.value
-          editing = false
+          case event if editor.submitsOn(event) =>
+            submitted = editor.value
+            editing = false
 
-        case keypress: Keypress =>
-          editor = editor(keypress)
-          candidates = Nil
-          refresh()
-          frame()
+          case keypress: Keypress =>
+            editor = editor(keypress)
+            candidates = Nil
+            refresh()
+            frame()
 
-        case _ =>
-          ()
+          case _ =>
+            ()
 
     // Freeze the block onto the screen (cursor drops below it) and print the result
     // there, so it scrolls above the next line's fresh block.

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -169,9 +169,33 @@ object SourceCode:
             case -1    => xs :: acc
             case index => lines(xs.drop(index + 1), xs.take(index) :: acc)
 
+    def quoted(text: Text): Boolean =
+      text.length > 0
+      && { val first = text.s.charAt(0); first == '"' || first == '\'' || first == '`' }
+
+    // Recovering from an unterminated quoted literal at the end of the input, the
+    // Scala scanner spills the literal's final character into a separate token — so
+    // `"ab` lexes as an error token `"a` followed by an identifier `b`. Fold each
+    // such trailing run back into the error token, so an in-progress string (or char
+    // or backquoted identifier) highlights as one consistent unit rather than having
+    // its last character mis-coloured.
+    def coalesce(sequence: List[Token]): List[Token] = sequence match
+      case Nil => Nil
+
+      case head :: tail if head.accent == Accent.Error && quoted(head.text) =>
+        val (spill, rest) = tail.span(_.accent != Accent.Unparsed)
+
+        if spill.isEmpty then head :: coalesce(tail)
+        else head.copy(text = t"${head.text}${spill.map(_.text).join}") :: coalesce(rest)
+
+      case head :: tail =>
+        head :: coalesce(tail)
+
+    val tokens: List[Token] = coalesce(soften(stream()).to(List))
+
     // Give each token a `Line`-mode `Span` with its 0-based line and column,
     // accumulating token widths along each assembled line.
-    val positioned = lines(soften(stream()).to(List)).reverse.zipWithIndex.map: (tokens, index) =>
+    val positioned = lines(tokens).reverse.zipWithIndex.map: (tokens, index) =>
       tokens.zip(tokens.scanLeft(0)(_ + _.length)).map: (token, column) =>
         token.copy(span = Span.line(index.z, column.z, token.length))
 

--- a/lib/profanity/src/core/profanity.LineEditor.scala
+++ b/lib/profanity/src/core/profanity.LineEditor.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import fulminate.*
 import gossamer.{where as _, *}
+import hieroglyph.*, textMetrics.wideCharacterWidth
 import rudiments.*
 import spectacular.*
 import vacuous.*
@@ -50,25 +51,46 @@ object LineEditor:
     case SingleLine
     case Multiline(submit: Text => Boolean)
 
-  // (row, column) of `position` in `text` laid out `cols` wide, counting embedded
-  // newlines and wrapping long lines; reduces to `position/cols`, `position%cols`
-  // when there are no newlines.
+  // (row, column) of character offset `position` in `text` laid out `cols` wide,
+  // exactly as a cell grid does: it walks grapheme clusters (so a wide CJK glyph or an
+  // emoji is one cell of display-width 2, a combining mark 0), advancing by display
+  // width and wrapping a grapheme that would exceed `cols`, with an embedded newline
+  // moving to the start of the next row. Reduces to `position/cols`, `position%cols`
+  // for plain single-width text with no newlines.
   def cursorPosition(text: Text, position: Int, cols: Int): (Int, Int) =
-    val string:    String = text.s
-    val limit:     Int    = position.min(string.length)
-    var rows:      Int    = 0
-    var lineStart: Int    = 0
-    var index:     Int    = 0
+    val metric:     Grapheme is Measurable = summon[Grapheme is Measurable]
+    val string:     String                 = text.s
+    val limit:      Int                    = position.min(string.length)
+    val boundaries: IArray[Int]            = Writing(text).boundaries
+    var row:        Int                    = 0
+    var column:     Int                    = 0
+    var index:      Int                    = 0
 
-    while index < limit do
-      if string.charAt(index) == '\n' then
-        rows += (index - lineStart)/cols + 1
-        lineStart = index + 1
+    while index < boundaries.length - 1 && boundaries(index) < limit do
+      val start = boundaries(index)
+      val end   = boundaries(index + 1)
+
+      if end - start == 1 && string.charAt(start) == '\n' then
+        row += 1
+        column = 0
+      else
+        val cellWidth = metric.width(Grapheme(string.substring(start, end).nn))
+
+        if cols > 0 && column + cellWidth > cols then
+          row += 1
+          column = 0
+
+        column += cellWidth
 
       index += 1
 
-    val column = limit - lineStart
-    (rows + column/cols, column%cols)
+    // An exact-fill row leaves the caret at column `cols`; wrap it to the next row's
+    // start, matching the grid (where the next cell would wrap).
+    if cols > 0 && column >= cols then
+      row += column/cols
+      column = column%cols
+
+    (row, column)
 
 case class LineEditor
   ( value:     Text            = t"",

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -314,6 +314,14 @@ object Tests extends Suite(m"Profanity Tests"):
         edited(Keypress.CharKey('h'), Keypress.CharKey('i'), Keypress.Enter)
       . assert(_ == t"hi")
 
+      test(m"cursorPosition counts a wide grapheme as two columns"):
+        LineEditor.cursorPosition(t"中b", 2, 10)
+      . assert(_ == (0, 3))
+
+      test(m"cursorPosition wraps a wide grapheme that would straddle the edge"):
+        LineEditor.cursorPosition(t"ab中", 3, 3)
+      . assert(_ == (1, 2))
+
       test(m"Backspace removes the previous character"):
         edited
           ( Keypress.CharKey('h'), Keypress.CharKey('i'), Keypress.CharKey('x'),

--- a/lib/ultimatum/src/core/ultimatum.FlowExtent.scala
+++ b/lib/ultimatum/src/core/ultimatum.FlowExtent.scala
@@ -59,7 +59,7 @@ extends GridSurface(rect.width, rect.height), Extent:
 
     while r < height do
       parent.move(rect.left.z, (rect.top + r).z)
-      parent.put(rowText(r))
+      parent.put(rowContent(r, gridWidth))
       r += 1
 
   // `Stdio` members: routing `Out` output (and other `Stdio` writes) into this

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -135,6 +135,25 @@ extends Canvas:
 
     builder.text
 
+  // A styled `Teletype` of row `r`, up to `columns` cells (wide-trailing sentinels
+  // skipped), so the row's colour can be composited onto a parent surface or rendered
+  // to SGR by the inline presenter.
+  protected def rowContent(r: Int, columns: Int): Teletype =
+    var content = Teletype.empty
+    val limit = columns.min(gridWidth)
+    var c = 0
+
+    while c < limit do
+      val grapheme = screen.grapheme(c.z, r.z).text
+      if !grapheme.nil then content = content.append(styledCell(grapheme, screen.style(c.z, r.z)))
+      c += 1
+
+    content
+
+  // A `Teletype` of `text` in one uniform style (sparse single-run form).
+  private def styledCell(text: Text, style: StyleWord): Teletype =
+    Teletype(text, IArray(style.raw, 0L), boundaries = IArray(0))
+
   // A plain-text snapshot of the grid (rows joined by newlines), for testing and for
   // content-change detection.
   def render: Text = screen.render

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -35,20 +35,28 @@ package ultimatum
 import anticipation.*
 import denominative.*
 import escapade.*
+import gossamer.*
+import hieroglyph.*, textMetrics.wideCharacterWidth
 import profanity.*
+import yossarian.*
 
-// The shared character-grid mechanics behind `FlowExtent` (a clipped sub-rectangle
-// that composites onto a parent) and `InlineRoot` (the inline-mode root that
-// presents its grid at the cursor). Writes flow within the grid: text wraps at
-// the grid width and, once the last row fills, the grid scrolls up — like a
-// miniature terminal. Subclasses supply `cursor`, `showCaret` and `flush`.
+// The shared styled-grapheme grid behind `FlowExtent` (a clipped sub-rectangle that
+// composites onto a parent) and `InlineRoot` (the inline-mode root that presents its
+// grid at the cursor). Cells are stored in a `yossarian.Screen[StyleWord]`, so each
+// holds one grapheme cluster with its own style: writes flow within the grid, wrap at
+// the grid width (counting display columns, so a wide CJK glyph takes two cells), and
+// scroll up once the last row fills — like a miniature terminal. Any `Imprintable`
+// content (`Text`/`Ascii`/`Writing`/`Teletype`) can be written, so colour survives.
+// Subclasses supply `cursor`, `showCaret` and `flush`.
 private[ultimatum] abstract class GridSurface(initialWidth: Int, initialHeight: Int)
 extends Canvas:
-  protected var gridWidth: Int = initialWidth
-  protected var gridHeight: Int = initialHeight
-  protected var cells: Array[Char] = Array.fill(gridWidth*gridHeight)(' ')
+  protected var gridWidth: Int = initialWidth.max(1)
+  protected var gridHeight: Int = initialHeight.max(1)
+  protected var screen: Screen[StyleWord] = Screen(gridWidth, gridHeight, StyleWord.Default)
   protected var col: Int = 0
   protected var row: Int = 0
+
+  private val metric: Grapheme is Measurable = summon[Grapheme is Measurable]
 
   def width: Int = gridWidth
   def height: Int = gridHeight
@@ -56,54 +64,54 @@ extends Canvas:
   // Reallocate the grid to a new size, blanking it and homing the cursor. Used by
   // `InlineRoot` to resize to the measured block height each frame.
   protected def reshape(width2: Int, height2: Int): Unit =
-    gridWidth = width2
-    gridHeight = height2
-    cells = Array.fill(gridWidth*gridHeight)(' ')
+    gridWidth = width2.max(1)
+    gridHeight = height2.max(1)
+    screen = Screen(gridWidth, gridHeight, StyleWord.Default)
     col = 0
     row = 0
 
-  protected def scrollUp(): Unit =
-    System.arraycopy(cells, gridWidth, cells, 0, gridWidth*(gridHeight - 1))
-    var i = gridWidth*(gridHeight - 1)
-
-    while i < gridWidth*gridHeight do
-      cells(i) = ' '
-      i += 1
+  protected def scrollUp(): Unit = screen.scroll(1)
 
   protected def newline(): Unit =
     col = 0
     if row < gridHeight - 1 then row += 1 else scrollUp()
 
-  protected def putChar(char: Char): Unit =
-    if char == '\n' then newline()
+  // Write one styled grapheme cell, advancing the cursor by the grapheme's display
+  // width. A zero-width grapheme is dropped (clustering already folded it into its
+  // base); a width-2 grapheme writes an empty trailing sentinel into the next cell and
+  // wraps to a new row if it would straddle the right edge.
+  protected def putCell(grapheme: Grapheme, style: StyleWord): Unit =
+    if grapheme.text == t"\n" then newline()
     else
-      if col >= gridWidth then newline()
-      cells(row*gridWidth + col) = char
-      col += 1
+      val cellWidth = metric.width(grapheme)
 
-  protected def rowText(r: Int): Text = String(cells, r*gridWidth, gridWidth).tt
+      if cellWidth > 0 then
+        // Wrap before writing (never eagerly after), so the final cell of a full row
+        // doesn't scroll a row off the top until the next cell actually arrives.
+        if col + cellWidth > gridWidth then newline()
+
+        if row < gridHeight && col < gridWidth then
+          screen.set(col.z, row.z, grapheme, style, t"")
+
+          if cellWidth >= 2 && col + 1 < gridWidth then
+            screen.set((col + 1).z, row.z, Grapheme(""), style, t"")
+
+        col += cellWidth
+
+  // Imprint any styled content cell-by-cell (the seamless entry for all text types).
+  protected def imprint[content: Imprintable](content: content): Unit =
+    summon[content is Imprintable].cells(content): (grapheme, style) =>
+      putCell(grapheme, style)
 
   def move(column: Ordinal, row2: Ordinal): Unit =
     col = column.n0.min(gridWidth - 1).max(0)
     row = row2.n0.min(gridHeight - 1).max(0)
 
-  def put(text: Text): Unit =
-    val string = text.s
-    var i = 0
-
-    while i < string.length do
-      putChar(string.charAt(i))
-      i += 1
-
-  def put(text: Teletype): Unit = put(text.plain)
+  def put(text: Text): Unit = imprint(text)
+  def put(text: Teletype): Unit = imprint(text)
 
   def clear(): Unit =
-    var i = 0
-
-    while i < cells.length do
-      cells(i) = ' '
-      i += 1
-
+    screen = Screen(gridWidth, gridHeight, StyleWord.Default)
     col = 0
     row = 0
 
@@ -111,18 +119,22 @@ extends Canvas:
     var c = col
 
     while c < gridWidth do
-      cells(row*gridWidth + c) = ' '
+      screen.set(c.z, row.z, Grapheme(" "), StyleWord.Default, t"")
       c += 1
 
-  // A plain-text snapshot of the grid (rows joined by newlines), for testing and
-  // for content-change detection.
-  def render: Text =
+  // The plain text of row `r` (graphemes concatenated, wide-trailing sentinels
+  // skipped). Styling is read directly off `screen` by the flush path.
+  protected def rowText(r: Int): Text =
     val builder = StringBuilder()
-    var r = 0
+    var c = 0
 
-    while r < gridHeight do
-      builder.append(String(cells, r*gridWidth, gridWidth))
-      if r < gridHeight - 1 then builder.append('\n')
-      r += 1
+    while c < gridWidth do
+      val grapheme = screen.grapheme(c.z, r.z).text
+      if !grapheme.nil then builder.append(grapheme)
+      c += 1
 
-    builder.toString.tt
+    builder.text
+
+  // A plain-text snapshot of the grid (rows joined by newlines), for testing and for
+  // content-change detection.
+  def render: Text = screen.render

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -144,11 +144,19 @@ extends GridSurface(widthFn(), 0):
     // so it can never wrap (a wrapped row would scroll the screen and break addressing).
     emit(csi.cup(top, 1))
 
+    // Each row is rendered to SGR from its styled cells, then reset (`sgr(0)`) so the
+    // next absolutely-addressed, `el(2)`-cleared row starts from a clean style and no
+    // colour bleeds across the frame.
+    val termcap = summon[Stdio].termcap
     var r = 0
 
     while r < h do
       emit(csi.el(2))
-      emit(rowText(r).keep(columns))
+      val rendered = rowContent(r, columns).render(termcap)
+      emit(rendered)
+      // Reset only after a row that actually emitted SGR, so a plain row is byte-for-
+      // byte as before and no colour bleeds into the next `el(2)`-cleared row.
+      if rendered.contains(t"\e") then emit(csi.sgr(0))
       emit(t"\r")
       if r < h - 1 then emit(t"\n")
       r += 1

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -79,6 +79,18 @@ object Tests extends Suite(m"Ultimatum Tests"):
         flow.render
       . assert(_ == t"abc\ndef")
 
+      test(m"a wide (CJK) grapheme occupies two cells"):
+        val flow = extent(4, 1)
+        flow.put(t"a中b")
+        flow.render
+      . assert(_ == t"a中b")
+
+      test(m"a wide grapheme wraps when it would straddle the right edge"):
+        val flow = extent(3, 2)
+        flow.put(t"ab中")
+        flow.render
+      . assert(_ == t"ab \n中 ")
+
       test(m"a newline moves to the start of the next row"):
         val flow = extent(5, 3)
         flow.put(t"ab\ncd")

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -310,6 +310,17 @@ object Tests extends Suite(m"Ultimatum Tests"):
         val bytes = ji.ByteArrayOutputStream()
         (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basic))
 
+      test(m"a styled cell emits its colour as SGR"):
+        val bytes = ji.ByteArrayOutputStream()
+        given Stdio = Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.xtermTrueColor)
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 1)
+        root.move(Prim, Prim)
+        root.put(e"$Bold(hi)")
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_.contains(t"[1m"))
+
       // The block (2 rows) is docked to the bottom of the 4-row terminal: it scrolls
       // 2 rows in (`\n\n`) to reserve space, then draws each row at an absolute screen
       // position (rows 3 and 4) and parks the caret absolutely.

--- a/lib/yossarian/src/core/yossarian.Pty.scala
+++ b/lib/yossarian/src/core/yossarian.Pty.scala
@@ -60,7 +60,7 @@ object Pty:
     case _ =>
       Stream()
 
-case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
+case class Pty(buffer: Screen[Style], state: PtyState, output: Spool[Text]):
   def stream: Stream[Text] = output.stream
 
   def title: Text = state.title
@@ -69,7 +69,7 @@ case class Pty(buffer: Screen, state: PtyState, output: Spool[Text]):
 
   def consume(input: Text): Pty raises PtyEscapeError =
     val escBuffer = StringBuilder()
-    val buffer2: Screen = buffer.copy()
+    val buffer2: Screen[Style] = buffer.copy()
 
     // Pre-compute UAX #29 grapheme boundaries for the whole input. Normal-
     // state printable handling walks this array to find the smallest

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package yossarian
 
+import scala.reflect.*
+
 import anticipation.*
 import denominative.*
 import gossamer.*
@@ -43,27 +45,35 @@ object internal:
   opaque type Style = Long
 
   object Screen:
-    def apply(width: Int, height: Int): Screen =
+    def apply[styling: ClassTag](width: Int, height: Int, blank: styling): Screen[styling] =
       val graphemes = Array.fill[Grapheme](width*height)(Grapheme(" "))
-      val styles = Array.fill[Style](width*height)(Style())
+      val styles = Array.fill[styling](width*height)(blank)
       val links = Array.fill[Text](width*height)(t"")
-      new Screen(width, styles, graphemes, links)
+      new Screen(width, blank, styles, graphemes, links)
+
+    // The terminal-emulator buffer: cells are `yossarian.Style` blanked to the
+    // default style.
+    def apply(width: Int, height: Int): Screen[Style] = apply(width, height, Style())
 
   // A cell-aligned screen buffer. Each cell holds one grapheme cluster (per
   // UAX #29) — an ASCII character, an East-Asian-Wide CJK glyph, an emoji, or
   // a base + combining marks. Wide graphemes occupy two adjacent cells: the
   // leading cell holds the grapheme; the trailing cell holds an empty
-  // Grapheme("") sentinel, distinguishable via isWideTrailing.
-  class Screen
+  // Grapheme("") sentinel, distinguishable via isWideTrailing. The per-cell style
+  // type is generic, so the same buffer backs both yossarian's terminal emulator
+  // (`Screen[Style]`) and a TUI surface (`Screen[escapade.StyleWord]`); `blank` is
+  // the style a vacated cell takes.
+  class Screen[styling]
     ( val width:      Int,
-      styleBuffer:    Array[Style],
+      blank:          styling,
+      styleBuffer:    Array[styling],
       graphemeBuffer: Array[Grapheme],
       linkBuffer:     Array[Text] ):
 
     def capacity: Int = graphemeBuffer.length
     def height: Int = capacity/width
     def offset(x: Ordinal, y: Ordinal): Int = y.n0*width + x.n0
-    def style(x: Ordinal, y: Ordinal): Style = styleBuffer(offset(x, y))
+    def style(x: Ordinal, y: Ordinal): styling = styleBuffer(offset(x, y))
     def link(x: Ordinal, y: Ordinal): Text = linkBuffer(offset(x, y))
 
     // The grapheme stored at this cell. An empty Grapheme("") value marks the
@@ -81,8 +91,8 @@ object internal:
     def isWideTrailing(x: Ordinal, y: Ordinal): Boolean =
       graphemeBuffer(offset(x, y)).text.nil
 
-    def line: Screen =
-      new Screen(graphemeBuffer.length, styleBuffer, graphemeBuffer, linkBuffer)
+    def line: Screen[styling] =
+      new Screen(graphemeBuffer.length, blank, styleBuffer, graphemeBuffer, linkBuffer)
 
     def render: Text =
       val sb = StringBuilder()
@@ -101,15 +111,15 @@ object internal:
 
       sb.text
 
-    def find(text: Text): Optional[Screen] = line.render.seek(text).let: ordinal =>
+    def find(text: Text): Optional[Screen[styling]] = line.render.seek(text).let: ordinal =>
       val index = ordinal.n0
 
       new Screen
-        ( text.length, styleBuffer.slice(index, index + text.length),
+        ( text.length, blank, styleBuffer.slice(index, index + text.length),
           graphemeBuffer.slice(index, index + text.length),
           linkBuffer.slice(index, index + text.length) )
 
-    def styles: IArray[Style] = styleBuffer.clone().immutable(using Unsafe)
+    def styles: IArray[styling] = styleBuffer.clone().immutable(using Unsafe)
 
     def scroll(n: Int): Unit = scroll(n, 0, height - 1)
 
@@ -130,28 +140,22 @@ object internal:
       val fillStart = if n < 0 then regionStart else regionStart + length
 
       for i <- 0 until offset do
-        styleBuffer(fillStart + i) = Style()
+        styleBuffer(fillStart + i) = blank
         graphemeBuffer(fillStart + i) = Grapheme(" ")
         linkBuffer(fillStart + i) = t""
 
-    def set(x: Ordinal, y: Ordinal, grapheme: Grapheme, style: Style, link: Text): Unit =
+    def set(x: Ordinal, y: Ordinal, grapheme: Grapheme, style: styling, link: Text): Unit =
       styleBuffer(offset(x, y)) = style
       graphemeBuffer(offset(x, y)) = grapheme
       linkBuffer(offset(x, y)) = link
 
-    def set(cursor: Ordinal, grapheme: Grapheme, style: Style, link: Text): Unit =
+    def set(cursor: Ordinal, grapheme: Grapheme, style: styling, link: Text): Unit =
       styleBuffer(cursor.n0) = style
       graphemeBuffer(cursor.n0) = grapheme
       linkBuffer(cursor.n0) = link
 
-    def copy(): Screen =
-      val styles = new Array[Style](capacity)
-      System.arraycopy(styleBuffer, 0, styles, 0, styles.length)
-      val graphemes = new Array[Grapheme](capacity)
-      System.arraycopy(graphemeBuffer, 0, graphemes, 0, graphemes.length)
-      val links = new Array[Text](capacity)
-      System.arraycopy(linkBuffer, 0, links, 0, links.length)
-      new Screen(width, styles, graphemes, links)
+    def copy(): Screen[styling] =
+      new Screen(width, blank, styleBuffer.clone(), graphemeBuffer.clone(), linkBuffer.clone())
 
 
   extension (style: Style)


### PR DESCRIPTION
The `flux` REPL now renders inline in the terminal — a bordered input field with live syntax highlighting, an auto-sizing tab-completion pane above it, and results scrolling naturally above the input block — built on a new styled-grapheme rendering layer shared across escapade, yossarian, ultimatum and profanity that emits colour on flush and measures content by terminal display-width, so wide CJK characters and emoji stay aligned. A new `Imprintable` typeclass lets `Text`, `Ascii`, `Writing` and `Teletype` all be rendered into a cell grid seamlessly, and harlequin now highlights an in-progress (unterminated) string literal as one consistent unit instead of mis-colouring its last character.

### Styled-grapheme terminal rendering

A new `Imprintable` typeclass (in escapade) decomposes any content — `Text`, `Ascii`, `Writing`, or styled `Teletype` — into `(Grapheme, StyleWord)` cells, so terminal surfaces can accept all of them uniformly and store content by grapheme rather than by UTF-16 char:

```scala
grid.put(t"a中b")            // plain text
grid.put(e"$Bold(hi)")       // styled Teletype — colour survives to flush
```

yossarian's `Screen` is now generic over its cell-style type (`Screen[styling]`), so ultimatum backs its inline grid with `Screen[StyleWord]` (colour) while the terminal emulator keeps `Screen[Style]` — no new dependency between them. ultimatum's inline grid now emits SGR colour on flush and advances the cursor by display-width (wide glyphs occupy two cells, combining marks zero), and profanity's `LineEditor.cursorPosition` is grapheme-width aware so the caret lands correctly on lines containing wide characters.

### Inline `flux` REPL

`flux` renders its REPL inline: a rounded-border input field, a completion pane that grows and shrinks with the candidate list (and vanishes when empty), and output that scrolls above the docked input block. Syntax highlighting updates live as you type. A `flux` server now removes its socket file on exit, and a client deletes stale socket files (from a crashed server) before launching a fresh one.

### harlequin: in-progress string literals

An unterminated quoted literal — e.g. a string you're still typing — now highlights as one consistent unit. Previously the Scala scanner's recovery spilled the literal's final character into a separate identifier token, so `"abc` showed `"ab` in the error colour and a stray `c` in the identifier colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)