### PR TITLE
Burdock: rewrite a built JAR into a download-on-demand distributable

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -456,7 +456,7 @@ object burdock extends Library:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object core
       extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.core,
-                       gastronomy.core, jacinta.core):
+                       gastronomy.core, jacinta.core, boot):
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")

--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -32,50 +32,37 @@
                                                                                                   */
 package burdock
 
+import java.net as jn
+import java.nio.file as jnf
+
 import ambience.*
 import anticipation.*
 import contingency.*
 import digression.*
 import distillate.*
-import eucalyptus.*
 import exoskeleton.*
 import fulminate.*
 import galilei.*
-import gastronomy.*, hashProviders.javaStdlibHashing, crypto.permitDeprecatedCrypto
 import gossamer.*
-import hellenism.*
-import hieroglyph.*
-import monotonous.*
-import parasite.*
+import hellenism.*, classloaders.threadContext
 import prepositional.*
 import revolution.*
 import rudiments.*
 import serpentine.*
 import spectacular.*
-import symbolism.*
-import telekinesis.*
 import turbulence.*
 import urticose.*
 import vacuous.*
 import zeppelin.*
 
-import alphabets.hex.lowerCase
 import backstops.stackTrace
-import charDecoders.utf8
 import environments.java
 import executives.direct
-import filesystemOptions.createNonexistent.disabled
 import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.readAccess.enabled
-import filesystemOptions.writeAccess.disabled
-import internetAccess.enabled
 import interpreters.posix
-import logging.silent
 import stdios.virtualMachine
 import systems.java
 import termcaps.environment
-import textSanitizers.skip
-import workingDirectories.system
 
 object Bootstrapper:
   object BurdockMain extends ManifestAttribute["Burdock-Main"]
@@ -102,103 +89,58 @@ object Bootstrapper:
         Exit.Fail(1)
 
     . recover:
-        val jarfile: Path on Local =
-          ClassRef(Class.forName("burdock.Bootstrap").nn).classpathEntry match
-            case ClasspathEntry.Jar(file) => file.decode[Path on Local]
+        val loader: ClassLoader = summon[Classloader].java
 
-            case other =>
-              abort(UserError(m"Could not determine location of bootstrap class"))
+        // Self-locate the application JAR: the classpath entry holding the
+        // `META-INF/burdock.deps` resource the build-time macro wrote. (Locating by
+        // the `burdock.Bootstrap` class would find burdock's own JAR, not the app's,
+        // once the app JAR is slim.)
+        val depsResource: jn.URL =
+          Optional(loader.getResource(Embed.ResourcePath)).lest:
+            UserError(m"this JAR was not built with Burdock (no ${Embed.ResourcePath.tt})")
 
-        Out.println(m"Bootstrapping JAR file $jarfile")
+        val connection: jn.URLConnection = depsResource.openConnection().nn
 
-        if !jarfile.exists() then abort(UserError(m"The file $jarfile does not exist"))
+        val inputJar: Path on Linux = connection match
+          case jar: jn.JarURLConnection =>
+            jnf.Paths.get(jar.getJarFileURL.nn.toURI.nn).nn.toString.nn.tt.decode[Path on Linux]
 
-        val classpath: List[Path on Local] =
-          arguments.map(_()).map(workingDirectory[Path on Local].resolve(_))
+          case _ =>
+            abort(UserError(m"Burdock can only repackage a JAR file, not a directory"))
 
-        val maven = url"https://repo1.maven.org/"
+        Out.println(m"Repackaging $inputJar")
 
-        val paths: List[Optional[(Path on Local, Relative on Local)]] =
-          classpath.map: entry =>
-            entry.ancestors.find(_.name == t"repo1.maven.org").optional.let: base =>
-              if base.parent.let(_.name) == t"https"
-              then (base, base.toward(entry))
-              else Out.println(m"Cannot resolve online location of $entry") yet Unset
+        // The bootstrap loader cannot be downloaded — it does the downloading — so
+        // its bytes are force-included from burdock's own (boot) JAR on the classpath.
+        val bootstrapClass: Data = (Classpath/"burdock"/"Bootstrap.class").read[Data]
 
-        val entries: Map[(Text, Text), Requirement] = paths.compact.flatMap: (base, relative0) =>
-          Out.println(m"Downloading $relative0 from $maven")
+        // Unpublished dependencies are reconstructed from the build-time hard-links in
+        // `~/.cache/burdock/<sha256>.jar` (see `Embed`); published ones resolve via
+        // deps.dev and are referenced by URL rather than inlined.
+        val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
+        val cacheDir: Path on Linux = t"$home/.cache/burdock".decode[Path on Linux]
 
-          val name: Text = relative0.name.or(panic(m"path was unexpectedly the root"))
-          val relative = relative0.parent / (name+t".sha1")
+        def cached(hash: Text): Optional[List[Entry]] =
+          val cacheJar: Path on Linux = cacheDir/t"$hash.jar"
 
-          val url = (maven + relative).encode.decode[HttpUrl]
-          val url2 = (maven + relative0).encode.decode[HttpUrl]
-          val remoteSha1 = url.fetch().read[Text]
-          val data: Data = (base + relative0).open(_.read[Data])
-          val localSha1: Text = data.digest[Sha1].serialize[Hex]
-
-          if remoteSha1 != localSha1 then
-            Out.println:
-              m"SHA-1 checksum of local file ${base + relative0} did not match remote $url"
-
-            Nil
-
-          else
-            // The embedded integrity digest and the per-class match key are both
-            // SHA-256 (see `Bootstrap.java`); the remote SHA-1 above is only the
-            // build-time check that the local file is the published artifact.
-            val sha256: Text = data.digest[Sha2[256]].serialize[Hex]
-
-            Zipfile.read(data).entries.filter: entry =>
-              val name: Text = entry.ref.encode
-              !entry.directory && name != t"META-INF/MANIFEST.MF"
+          if !cacheJar.exists() then Unset else
+            Zipfile.read(cacheJar).entries.filter: entry =>
+              !entry.directory && entry.ref.show != t"META-INF/MANIFEST.MF"
 
             . map: entry =>
-                val checksum: Text = entry.checksum[Sha2[256]].serialize[Hex]
-                (entry.ref.show, checksum) -> Requirement(url2, sha256)
+                Entry(entry.ref.show, entry.read[Data])
 
-        . to(Map)
+            . to(List)
 
-        val manifest: Promise[Manifest] = Promise()
-
-        val todo: List[Requirement | Entry] =
-          Zipfile.read(jarfile).entries.map: entry =>
-            if entry.ref.show == t"META-INF/MANIFEST.MF"
-            then manifest.fulfill(entry.read[Data].read[Manifest]) yet Unset
-            else if entry.ref.show == t"burdock/Bootstrap.class"
-            then Entry(entry.ref.show, entry.read[Data])
-            else entries.at((entry.ref.show, entry.checksum[Sha2[256]].serialize[Hex])).or:
-              Entry(entry.ref.show, entry.read[Data])
-
-          . to(List).compact
-
-        val manifest2 = manifest().lest:
-          UserError(m"There is no META-INF/MANIFEST.MF entry in the JAR file")
-
-        val manifest3 =
-          import manifestAttributes.*
-          val require = BurdockRequire(todo.sift[Requirement].to(Set).to(List))
-
-          val burdockMain = manifest2(MainClass).let(BurdockMain(_)).lest:
-            UserError(m"Manifest file did not contain a Main-Class entry")
-
-          val verbosity = BurdockVerbosity(t"silent")
-
-          manifest2 - MainClass + require + burdockMain + verbosity
-          + MainClass(fqcn"burdock.Bootstrap")
-
-        val tmpFile = jarfile.parent.vouch / t"${jarfile.name}.tmp"
-
-        Zipfile.write(tmpFile):
-          Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifest3.serialize)
-          #:: todo.sift[Entry].to(Stream).map: entry =>
-            Zip.Entry(entry.name.decode[Path on Zip], () => Stream(entry.data))
+        val tmpFile: Path on Linux = inputJar.parent.vouch/t"${inputJar.name}.tmp"
+        Repackage.repackage(inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass)
 
         import filesystemOptions.overwritePreexisting.enabled
         import filesystemOptions.deleteRecursively.disabled
         import filesystemOptions.moveAtomically.enabled
         import filesystemOptions.createNonexistentParents.disabled
 
-        tmpFile.moveTo(jarfile)
+        tmpFile.moveTo(inputJar)
+        Out.println(m"Repackaged $inputJar")
 
         Exit.Ok

--- a/lib/burdock/src/core/burdock.Embed.scala
+++ b/lib/burdock/src/core/burdock.Embed.scala
@@ -39,7 +39,6 @@ import java.util as ju
 import scala.quoted.*
 
 import anticipation.*
-import gossamer.*
 
 // The compile-time half of the Burdock redesign. `dependencyHashes` captures the
 // build's classpath, computes each dependency JAR's SHA-256, hard-links it into
@@ -60,12 +59,14 @@ object Embed:
       case quotes: runtime.impl.QuotesImpl =>
         import dotty.tools.dotc.config.Settings.Setting.value
         val ctx = quotes.ctx
-        (value(ctx.settings.classpath)(using ctx), value(ctx.settings.outputDir)(using ctx).jpath.nn)
+        val classpath0: String = value(ctx.settings.classpath)(using ctx)
+        val outputDir0: jnf.Path = value(ctx.settings.outputDir)(using ctx).jpath.nn
+        (classpath0, outputDir0)
 
     val hashes: List[String] = hashAndCache(classpath)
     writeResource(outputDir, hashes)
 
-    '{ ${Expr(hashes)}.map(_.tt) }
+    '{${Expr(hashes)}.map(_.tt)}
 
   // Writes the hash list into the compile output as `META-INF/burdock.deps`, so
   // it is packaged into the JAR as an ordinary resource.

--- a/lib/burdock/src/core/burdock.Repackage.scala
+++ b/lib/burdock/src/core/burdock.Repackage.scala
@@ -34,16 +34,25 @@ package burdock
 
 import anticipation.*
 import contingency.*
+import digression.*
+import distillate.*
 import fulminate.*
+import galilei.*
 import gossamer.*
 import prepositional.*
+import revolution.*
 import rudiments.*
+import serpentine.*
+import spectacular.*
+import symbolism.*
+import turbulence.*
 import urticose.*
 import vacuous.*
+import zeppelin.*
 
+import Bootstrapper.given
+import Bootstrapper.{BurdockMain, BurdockRequire, BurdockVerbosity, Entry, Requirement}
 import errorDiagnostics.empty
-
-import Bootstrapper.{Requirement, Entry}
 
 // The repackager. Reads the dependency hashes embedded by the compile-time macro
 // and partitions them: a hash that resolves to a public URL is externalized (a
@@ -52,15 +61,17 @@ import Bootstrapper.{Requirement, Entry}
 // every dependency is either externalized or inlined — a hash that is neither is
 // an error.
 object Repackage:
-  case class RepackageError(hash: Text)(using Diagnostics)
-  extends Error(m"the dependency with hash $hash is neither publicly downloadable nor cached")
+  case class RepackageError(detail: Message)(using Diagnostics) extends Error(detail)
+
+  // Resolves a dependency hash to its public URL (deps.dev), or `Unset`.
+  type Resolver = Text => Optional[HttpUrl]
+
+  // Looks up a dependency hash's class entries in the local cache, or `Unset`.
+  type CacheReader = Text => Optional[List[Entry]]
 
   // Pure partition; `resolve` (deps.dev) and `cached` (cache lookup) are injected
   // so the logic is testable without the network or the filesystem.
-  def partition
-     (hashes:  List[Text],
-      resolve: Text => Optional[HttpUrl],
-      cached:  Text => Optional[List[Entry]])
+  def partition(hashes: List[Text], resolve: Resolver, cached: CacheReader)
   :   (List[Requirement], List[Entry]) raises RepackageError =
 
     val requirements = List.newBuilder[Requirement]
@@ -68,7 +79,70 @@ object Repackage:
 
     hashes.each: hash =>
       resolve(hash) match
-        case url: HttpUrl => requirements += Requirement(url, hash)
-        case Unset        => cached(hash).lay(abort(RepackageError(hash)))(inlined ++= _)
+        case url: HttpUrl =>
+          requirements += Requirement(url, hash)
+
+        case Unset =>
+          val error = RepackageError(m"dependency $hash is neither published nor cached")
+          cached(hash).lay(abort(error))(inlined ++= _)
 
     (requirements.result(), inlined.result())
+
+
+  // Rewrites `inputJar` into `outputJar`: keeps the application's own classes,
+  // externalizes published dependencies as `Burdock-Require` references, inlines
+  // the rest from the cache, and sets `Main-Class` to the runtime bootstrap.
+  // `resolve`/`cached` are injected; `bootstrapClass` is the `burdock.Bootstrap`
+  // class bytes (force-included since it can't itself be downloaded).
+  def repackage
+    ( inputJar: Path on Linux, outputJar: Path on Linux, resolve: Resolver, cached: CacheReader,
+      bootstrapClass: Data )
+  :   Unit raises RepackageError =
+
+    whereas:
+      case IoError(_, _, _, _)  => RepackageError(m"a filesystem error occurred while repackaging")
+      case StreamError(_)       => RepackageError(m"a stream error occurred while repackaging")
+      case ZipError(_)          => RepackageError(m"the JAR could not be read or written")
+      case PathError(_, _)      => RepackageError(m"a path could not be resolved while repackaging")
+      case NumberError(_, _, _) => RepackageError(m"the manifest contained malformed data")
+      case FqcnError(_, _)      => RepackageError(m"the Main-Class is not a valid class name")
+
+    . mitigate:
+        val resource: Text = Embed.ResourcePath.tt
+        var manifestData: Optional[Data] = Unset
+        var depsData: Optional[Data] = Unset
+        val ownBuilder = List.newBuilder[Entry]
+
+        Zipfile.read(inputJar).entries.each: entry =>
+          val name: Text = entry.ref.show
+
+          if name == t"META-INF/MANIFEST.MF" then manifestData = entry.read[Data]
+          else if name == resource then depsData = entry.read[Data]
+          else ownBuilder += Entry(name, entry.read[Data])
+
+        val manifest: Manifest =
+          manifestData.lest(RepackageError(m"the JAR has no manifest")).read[Manifest]
+
+        val hashes: List[Text] =
+          depsData.lest(RepackageError(m"the JAR has no $resource resource")).utf8
+          . cut(t"\n").filter(_ != t"")
+
+        val ownEntries: List[Entry] = ownBuilder.result()
+        val (requirements, inlined) = partition(hashes, resolve, cached)
+
+        import manifestAttributes.*
+
+        val originalMain =
+          manifest(MainClass).lest(RepackageError(m"the JAR manifest has no Main-Class"))
+
+        val manifest2: Manifest =
+          manifest - MainClass + BurdockRequire(requirements) + BurdockMain(originalMain)
+          + BurdockVerbosity(t"silent") + MainClass(fqcn"burdock.Bootstrap")
+
+        val bootstrap: Entry = Entry(t"burdock/Bootstrap.class", bootstrapClass)
+        val entries: List[Entry] = bootstrap :: ownEntries ++ inlined
+
+        Zipfile.write(outputJar):
+          Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifest2.serialize)
+          #:: entries.to(Stream).map: entry =>
+            Zip.Entry(entry.name.decode[Path on Zip], () => Stream(entry.data))

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -37,12 +37,22 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 import charEncoders.utf8
+import environments.java
+import systems.java
+import temporaryDirectories.system
+import workingDirectories.default
+import filesystemOptions.createNonexistent.enabled
+import filesystemOptions.createNonexistentParents.enabled
+import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.overwritePreexisting.enabled
+import filesystemOptions.readAccess.enabled
+import filesystemOptions.writeAccess.enabled
 
 object Tests extends Suite(m"Burdock Tests"):
   def run(): Unit =
     suite(m"Dependency-hashing macro"):
       val hashes: List[Text] = Embed.dependencyHashes
-      val home: Text = java.lang.System.getProperty("user.home").nn.tt
+      val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
 
       test(m"captures a non-empty set of dependency hashes"):
         hashes.length
@@ -55,12 +65,12 @@ object Tests extends Suite(m"Burdock Tests"):
       test(m"every hash is hard-linked into the Burdock cache"):
         hashes.all: hash =>
           val jar: Text = t"$home/.cache/burdock/$hash.jar"
-          java.nio.file.Files.exists(java.nio.file.Paths.get(jar.s).nn)
+          _root_.java.nio.file.Files.exists(_root_.java.nio.file.Paths.get(jar.s).nn)
       .assert(_ == true)
 
       test(m"the hash list is written as a packaged resource"):
         val stream = getClass.nn.getResourceAsStream("/META-INF/burdock.deps").nn
-        val content: Text = java.lang.String(stream.readAllBytes().nn, "UTF-8").tt
+        val content: Text = _root_.java.lang.String(stream.readAllBytes().nn, "UTF-8").tt
         content.cut(t"\n").to(Set)
       .assert(_ == hashes.to(Set))
 
@@ -84,3 +94,53 @@ object Tests extends Suite(m"Burdock Tests"):
       test(m"a hash that is neither published nor cached is rejected"):
         capture[Repackage.RepackageError](Repackage.partition(List(t"ccc"), resolve, cached))
       .assert(_ => true)
+
+    suite(m"Repackager (end-to-end)"):
+      val tmp: Path on Linux = temporaryDirectory[Path on Linux]
+      val inputJar: Path on Linux = tmp/t"burdock-in-${Uuid().show}.jar"
+      val outputJar: Path on Linux = tmp/t"burdock-out-${Uuid().show}.jar"
+
+      val manifestText: Text = t"Manifest-Version: 1.0\nMain-Class: com.example.Main\n\n"
+
+      Zipfile.write(inputJar):
+        Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifestText.data)
+        #:: Zip.Entry(t"META-INF/burdock.deps".decode[Path on Zip], t"aaa\nbbb".data)
+        #:: Zip.Entry(t"com/example/Main.class".decode[Path on Zip], t"main".data)
+        #:: LazyList()
+
+      val resolve: Repackage.Resolver =
+        h => if h == t"aaa" then url"https://repo1.maven.org/maven2/g/a/1/a-1.jar" else Unset
+
+      val cached: Repackage.CacheReader =
+        h => if h == t"bbb" then List(Bootstrapper.Entry(t"dep/Lib.class", t"lib".data)) else Unset
+
+      Repackage.repackage(inputJar, outputJar, resolve, cached, t"bootstrap-bytes".data)
+
+      val names: List[Text] = Zipfile.read(outputJar).entries.map(_.ref.show).to(List)
+
+      val manifest: Text =
+        Zipfile.read(outputJar).entries.find(_.ref.show == t"META-INF/MANIFEST.MF").get.read[Data].utf8
+
+      test(m"keeps the application's own class"):
+        names.contains(t"com/example/Main.class")
+      .assert(_ == true)
+
+      test(m"inlines the unpublished cached dependency"):
+        names.contains(t"dep/Lib.class")
+      .assert(_ == true)
+
+      test(m"force-includes the bootstrap class"):
+        names.contains(t"burdock/Bootstrap.class")
+      .assert(_ == true)
+
+      test(m"sets Main-Class to the burdock bootstrap"):
+        manifest.contains(t"burdock.Bootstrap")
+      .assert(_ == true)
+
+      test(m"preserves the original entry point as Burdock-Main"):
+        manifest.contains(t"com.example.Main")
+      .assert(_ == true)
+
+      test(m"records the published dependency as a requirement"):
+        manifest.contains(t"aaa")
+      .assert(_ == true)

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -37,16 +37,8 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTraces
 import charEncoders.utf8
-import environments.java
 import systems.java
 import temporaryDirectories.system
-import workingDirectories.default
-import filesystemOptions.createNonexistent.enabled
-import filesystemOptions.createNonexistentParents.enabled
-import filesystemOptions.dereferenceSymlinks.enabled
-import filesystemOptions.overwritePreexisting.enabled
-import filesystemOptions.readAccess.enabled
-import filesystemOptions.writeAccess.enabled
 
 object Tests extends Suite(m"Burdock Tests"):
   def run(): Unit =


### PR DESCRIPTION
Burdock can now turn an ordinary built JAR into a self-bootstrapping, download-on-demand distributable. Run Burdock's repackager against an application JAR and it locates the JAR on the classpath, externalizes every dependency that deps.dev resolves to a public download URL, inlines any unpublished dependency from the local Burdock cache, and rewrites the JAR's manifest so it fetches its dependencies at runtime — guaranteeing that every class is either physically present in the JAR or referenced from a public download.

## Burdock download-on-demand repackaging

Building on the compile-time dependency-hashing macro (which records each classpath JAR's SHA-256 in `META-INF/burdock.deps` and hard-links it into `~/.cache/burdock`), Burdock now ships the repackager that consumes those hashes.

`Repackage.repackage` rewrites a JAR by:
- keeping the application's own classes inline;
- **externalizing** each dependency that `deps.dev` resolves to a public Maven URL, recorded as a `Burdock-Require` manifest entry and fetched at runtime;
- **inlining** any dependency that isn't publicly downloadable, reconstructed from its cached JAR — so private/SNAPSHOT/local builds stay self-contained;
- force-including `burdock.Bootstrap` (it can't be downloaded — it *does* the downloading) and setting `Main-Class` to it, preserving the original entry point as `Burdock-Main`.

The repackager is **complete by construction**: a dependency hash that resolves to neither a public URL nor the local cache is an error, so the rewritten artifact never dangles.

The `burdock.Bootstrapper` entry point self-locates the application JAR via its `META-INF/burdock.deps` resource (rather than by class, which would find Burdock's own JAR once the app JAR is slim), wires the live `deps.dev` resolver and the `~/.cache/burdock` reader, and overwrites the JAR in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)