### PR TITLE
Derive TEL select schemas so sum types round-trip through BinTEL

### DIFF
--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -106,6 +106,14 @@ extension (element: Tel.Element)
   // BLAKE3 digest of this element's BinTEL body (§3 value hash).
   def valueHash(schema: Tels): Digest in Blake3 = element.bintel(schema).digest[Blake3]
 
+extension [value: Tel.Encodable](value: value)
+  // Encode any value to BinTEL body bytes, deriving the schema from its type:
+  // `value.bintel` is `value.encode.bintel(Tels.tels[value](…))`. The schema name is
+  // internal (a BinTEL body never embeds it), so a decoder that derives the schema from
+  // the same type agrees on the layout regardless of the chosen name.
+  def bintel(using value is TelSchematic over Tels.Type): Data raises TelError =
+    value.encode.bintel(Tels.tels[value](Text("root")))
+
 object Bintel:
 
   // §6 magic number: the 4 bytes that prefix every BinTEL document.

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -170,15 +170,24 @@ trait Tel2:
                   else ctx.decoded(match0.vouch)
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
-      // A sum's precise per-variant schema is available from the standalone
-      // `Schematic` / `Tels.tels`; the codec-carried shape stays permissive (`Any`)
-      // because walking the variants (`delegate`) is `fallible` and would leak a
-      // `Tactic[VariantError]` requirement onto every codec.
+      // A sum is a single compound whose keyword is the variant's (kebab-cased) name;
+      // dispatch on that keyword and decode the same compound as the chosen variant.
+      // This is the discriminated form `Tel.Type.assign` and BinTEL also key on. The
+      // codec-carried shape stays permissive (`Any`) — walking the variants
+      // (`delegate`) is `fallible` and would leak a `Tactic[VariantError]` requirement
+      // onto every codec; the precise select schema comes from the standalone
+      // `Schematic` / `Tels.tels`.
       Tel.Decodable(Shape.Any):
         telVal =>
           provide[Tactic[TelError]]:
             provide[Tactic[VariantError]]:
-              val variantKeyword = telVal.primaryAtom
+              // The compound's keyword is the variant's kebab-cased name; map it back
+              // to the variant label `delegate` dispatches on.
+              val labels: Map[Text, Text] =
+                variantLabels[derivation].map { label => Tel.camelToKebab(label.s) -> label }.to(Map)
+
+              val variantKeyword: Text = labels.getOrElse(telVal.keyword, telVal.keyword)
+
               delegate(variantKeyword): [variant <: derivation] =>
                 ctx => ctx.decoded(telVal)
 
@@ -216,10 +225,20 @@ trait Tel2:
           Tel.compound(t"", IArray.empty, IArray.from(compounds))
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Encodable =
+      // A sum encodes as a single compound whose keyword is the variant's (kebab-cased)
+      // name, with the variant's fields as its children — the discriminated form the
+      // decoder, `Tel.Type.assign` and BinTEL all key on. The codec-carried shape stays
+      // permissive (`Any`); the precise select schema comes from the standalone
+      // `Schematic` / `Tels.tels`.
       Tel.Encodable(Shape.Any):
         value =>
           variant(value): [variant <: derivation] =>
-            v => contextual.encode(v)
+            v =>
+              val keyword: Text = Tel.camelToKebab(label.s)
+
+              contextual.encode(v).subtree match
+                case compound: Tel.Compound => Tel.make(compound.copy(keyword = keyword))
+                case other                  => Tel.make(other)
 
   // Primitive instances: Text/Int/Long/Double/Boolean as Compound + inline
   // atom. These mirror jacinta.Json's primitive decoders but go through

--- a/lib/stratiform/src/core/stratiform.TelEncoding.scala
+++ b/lib/stratiform/src/core/stratiform.TelEncoding.scala
@@ -170,10 +170,10 @@ trait Tel2:
                   else ctx.decoded(match0.vouch)
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
-      // A sum is a single compound whose keyword is the variant's (kebab-cased) name;
-      // dispatch on that keyword and decode the same compound as the chosen variant.
-      // This is the discriminated form `Tel.Type.assign` and BinTEL also key on. The
-      // codec-carried shape stays permissive (`Any`) — walking the variants
+      // A sum is a document whose single child compound is the chosen variant, keyed by
+      // the variant's (kebab-cased) name. Dispatch on that child's keyword and decode it
+      // as the variant. This is the select-member form `Tel.Type.assign` and BinTEL key
+      // on. The codec-carried shape stays permissive (`Any`) — walking the variants
       // (`delegate`) is `fallible` and would leak a `Tactic[VariantError]` requirement
       // onto every codec; the precise select schema comes from the standalone
       // `Schematic` / `Tels.tels`.
@@ -181,15 +181,15 @@ trait Tel2:
         telVal =>
           provide[Tactic[TelError]]:
             provide[Tactic[VariantError]]:
-              // The compound's keyword is the variant's kebab-cased name; map it back
-              // to the variant label `delegate` dispatches on.
+              // Map the variant's kebab keyword back to the label `delegate` dispatches on.
               val labels: Map[Text, Text] =
                 variantLabels[derivation].map { label => Tel.camelToKebab(label.s) -> label }.to(Map)
 
-              val variantKeyword: Text = labels.getOrElse(telVal.keyword, telVal.keyword)
+              val variant: Tel = Tel.make(telVal.childCompounds.head)
+              val variantKeyword: Text = labels.getOrElse(variant.keyword, variant.keyword)
 
               delegate(variantKeyword): [variant <: derivation] =>
-                ctx => ctx.decoded(telVal)
+                ctx => ctx.decoded(variant)
 
   object EncodableDerivation extends Derivable[Tel.Encodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
@@ -225,10 +225,12 @@ trait Tel2:
           Tel.compound(t"", IArray.empty, IArray.from(compounds))
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Encodable =
-      // A sum encodes as a single compound whose keyword is the variant's (kebab-cased)
-      // name, with the variant's fields as its children — the discriminated form the
-      // decoder, `Tel.Type.assign` and BinTEL all key on. The codec-carried shape stays
-      // permissive (`Any`); the precise select schema comes from the standalone
+      // A sum encodes as a document whose single child compound is the chosen variant,
+      // keyed by the variant's (kebab-cased) name with the variant's fields as its own
+      // children. This is the select-member form `Tel.Type.assign` and BinTEL key on (the
+      // variant is a member of the document, matched by the schema's `SelectRef`), and it
+      // round-trips identically to the same document parsed from text. The codec-carried
+      // shape stays permissive (`Any`); the precise select schema comes from the standalone
       // `Schematic` / `Tels.tels`.
       Tel.Encodable(Shape.Any):
         value =>
@@ -237,8 +239,11 @@ trait Tel2:
               val keyword: Text = Tel.camelToKebab(label.s)
 
               contextual.encode(v).subtree match
-                case compound: Tel.Compound => Tel.make(compound.copy(keyword = keyword))
-                case other                  => Tel.make(other)
+                case compound: Tel.Compound =>
+                  Tel.compound(t"", IArray.empty, IArray(compound.copy(keyword = keyword)))
+
+                case other =>
+                  Tel.make(other)
 
   // Primitive instances: Text/Int/Long/Double/Boolean as Compound + inline
   // atom. These mirror jacinta.Json's primitive decoders but go through

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package stratiform
 
+import scala.compiletime.*
+
 import adversaria.*
 import anticipation.*
 import distillate.*
@@ -78,6 +80,12 @@ object telSchematics:
 trait TelSchematic extends Schematic:
   def polarity: Tels.Polarity = Tels.Polarity.Tight
   def repeatable: Tels.Polarity = Tels.Polarity.Implicit
+
+  // Named `select` definitions a sum type contributes to the schema's namespace
+  // (a select is referenced by name, never inlined). Empty for scalars and
+  // products; a sum returns its own `SelectDefinition` here while `schema()`
+  // returns a `Reference` to it.
+  def selectDefinitions: List[Tels.SelectDefinition] = Nil
 
 // Schema derivation for TEL: scalars map to `Tels.Scalar`, products to a
 // `Tels.Struct` of `Field`s, collections to a `Struct` with a repeatable `item`
@@ -144,10 +152,20 @@ trait Tels2:
     TelsDerivation.derived
 
   // Assembles a self-contained `Tels` document whose root struct is the schema of
-  // `value`.
-  def tels[value: Schematic over Tels.Type](name: Text): Tels = value.schema().absolve match
-    case struct: Tels.Struct =>
-      Tels(name, struct, IArray.empty, Unset, IArray.empty, IArray.empty, IArray.empty)
+  // `value`, registering any `select` definitions the type contributes. A top-level
+  // sum's schema is a `Reference`, so its document root is a struct with a single
+  // select member referencing the registered `SelectDefinition`.
+  def tels[value](name: Text)(using schematic: value is TelSchematic over Tels.Type): Tels =
+    val selects: IArray[Tels.SelectDefinition] = IArray.from(schematic.selectDefinitions)
+
+    schematic.schema().absolve match
+      case struct: Tels.Struct =>
+        Tels(name, struct, IArray.empty, Unset, IArray.empty, IArray.empty, selects)
+
+      case Tels.Reference(reference) =>
+        val member = Tels.SelectRef(Polarity.Implicit, Polarity.Implicit, reference)
+        val root   = Tels.Struct(IArray(member), IArray.empty)
+        Tels(name, root, IArray.empty, Unset, IArray.empty, IArray.empty, selects)
 
 object Tels2:
   // Reifies a codec's format-neutral `Shape` (carried by `Tel.Encodable` /
@@ -210,7 +228,43 @@ object TelsDerivation extends Derivable[TelSchematic over Tels.Type]:
 
       Tels.Struct(IArray.from(members), IArray.empty)
 
-  // TEL sums (selects) are not yet derived structurally; a permissive empty
-  // struct lets a containing type still derive a schema.
-  inline def disjunction[derivation: SumReflection]: derivation is TelSchematic over Tels.Type =
-    () => Tels.Struct(IArray.empty, IArray.empty)
+  // The variants of a sum, as schema `Variant`s: each variant's keyword is its
+  // kebab-cased name (the discriminator the codec writes) and its type is the
+  // variant product's own derived struct. A value-less fold over the mirror's
+  // element types, so the whole select is available without an instance.
+  private transparent inline def variants[variants <: Tuple, labels <: Tuple]
+  :   List[Tels.Variant] =
+
+    inline erasedValue[variants] match
+      case _: (variant *: moreVariants) =>
+        inline erasedValue[labels] match
+          case _: (label *: moreLabels) =>
+            val keyword: Text = Tel.camelToKebab(constValue[label & String])
+            val variantType: Tels.Type = infer[variant is TelSchematic over Tels.Type].schema()
+            Tels.Variant(keyword, variantType) :: variants[moreVariants, moreLabels]
+
+      case _ =>
+        Nil
+
+  // The schematic for a sum: `schema()` indirects to the named select; the select
+  // itself is surfaced through `selectDefinitions` for registration. A plain `def`
+  // (not the inline body) so the anonymous class is compiled once, not per call site.
+  private def selectSchematic(select: Tels.SelectDefinition): TelSchematic over Tels.Type =
+    new TelSchematic:
+      type Transport = Tels.Type
+      def schema(): Tels.Type = Tels.Reference(select.name)
+      override def selectDefinitions: List[Tels.SelectDefinition] = List(select)
+
+  // A sum derives to a named `SelectDefinition` (its variants) registered in the
+  // namespace, with `schema()` returning a `Reference` to it — the indirected form
+  // `Tel.Type.assign` and BinTEL resolve. Mirrors the codec's discriminator.
+  inline def disjunction[derivation](using reflection: SumReflection[derivation])
+  :   derivation is TelSchematic over Tels.Type =
+
+    val name: Text = constValue[reflection.MirroredLabel].tt
+
+    val selectVariants: List[Tels.Variant] =
+      variants[reflection.MirroredElemTypes, reflection.MirroredElemLabels]
+
+    val select = Tels.SelectDefinition(name, IArray.from(selectVariants), IArray.empty)
+    selectSchematic(select).asInstanceOf[derivation is TelSchematic over Tels.Type]

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -232,9 +232,9 @@ object Tests extends Suite(m"Stratiform Tests"):
         Tests.Team(t"Reds", Nil).encode.childCompounds.filter(_.keyword == t"members").length
       . assert(_ == 0)
 
-      test(m"a sum encodes with the variant name as the compound keyword"):
+      test(m"a sum encodes its variant as a child keyed by the variant name"):
         val shape: Tests.Shape2 = Tests.Shape2.Circle(7)
-        shape.encode.keyword
+        shape.encode.childCompounds.head.keyword
       . assert(_ == t"circle")
 
       test(m"a single-field sum variant round-trips"):
@@ -251,6 +251,25 @@ object Tests extends Suite(m"Stratiform Tests"):
         val shape: Tests.Shape2 = Tests.Shape2.Dot
         shape.encode.as[Tests.Shape2]
       . assert(_ == Tests.Shape2.Dot)
+
+    suite(m"sum-type schema derivation"):
+      test(m"a sum derives a select with one variant per case"):
+        Tels.tels[Tests.Shape2](t"shape").selects.flatMap(_.variants).map(_.keyword).to(List)
+      . assert(_ == List(t"circle", t"rectangle", t"dot"))
+
+      test(m"each variant's fields are derived into its struct"):
+        val select = Tels.tels[Tests.Shape2](t"shape").selects.head
+        select.variants.find(_.keyword == t"rectangle").get.variantType match
+          case struct: Tels.Struct => struct.members.length
+          case _                   => -1
+      . assert(_ == 2)
+
+      test(m"the document root references the select"):
+        Tels.tels[Tests.Shape2](t"shape").document.members.map:
+          case ref: Tels.SelectRef => ref.reference
+          case _                   => t""
+        . to(List)
+      . assert(_ == List(t"Shape2"))
 
     suite(m"`over Tel` decoder shorthand"):
       test(m"`read[T over Tel]` resolves a value directly from text"):
@@ -1394,6 +1413,18 @@ object Tests extends Suite(m"Stratiform Tests"):
               case Tel.Element.Value(_, _, t) => t
           case _ => Nil
       . assert(_ == List(t"Alice"))
+
+      test(m"a derived sum schema round-trips a variant's fields through BinTEL"):
+        val schema = Tels.tels[Tests.Shape2](t"shape")
+        val shape: Tests.Shape2 = Tests.Shape2.Rectangle(3, 4)
+        val bytes = shape.encode.bintel(schema)
+
+        def values(element: Tel.Element): List[Text] = element match
+          case Tel.Element.Node(_, _, children) => children.to(List).flatMap(values)
+          case Tel.Element.Value(_, _, text)    => List(text)
+
+        values(Bintel.decode(bytes, schema))
+      . assert(_ == List(t"3", t"4"))
 
       test(m"empty scalar value round-trips"):
         val scalar = Tels.Scalar(IArray.empty)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1414,16 +1414,15 @@ object Tests extends Suite(m"Stratiform Tests"):
           case _ => Nil
       . assert(_ == List(t"Alice"))
 
-      test(m"a derived sum schema round-trips a variant's fields through BinTEL"):
-        val schema = Tels.tels[Tests.Shape2](t"shape")
+      test(m"a value derives its own schema and round-trips through BinTEL"):
         val shape: Tests.Shape2 = Tests.Shape2.Rectangle(3, 4)
-        val bytes = shape.encode.bintel(schema)
+        val schema = Tels.tels[Tests.Shape2](t"shape")
 
         def values(element: Tel.Element): List[Text] = element match
           case Tel.Element.Node(_, _, children) => children.to(List).flatMap(values)
           case Tel.Element.Value(_, _, text)    => List(text)
 
-        values(Bintel.decode(bytes, schema))
+        values(Bintel.decode(shape.bintel, schema))
       . assert(_ == List(t"3", t"4"))
 
       test(m"empty scalar value round-trips"):

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -67,6 +67,11 @@ object Tests extends Suite(m"Stratiform Tests"):
   case class PersonAge(name: Text, age: Int) derives CanEqual
   case class Team(name: Text, members: List[Person]) derives CanEqual
 
+  enum Shape2 derives CanEqual:
+    case Circle(radius: Int)
+    case Rectangle(width: Int, height: Int)
+    case Dot
+
 
   def run(): Unit =
     suite(m"Positive corpus"):
@@ -226,6 +231,26 @@ object Tests extends Suite(m"Stratiform Tests"):
       test(m"an empty List field encodes as no compounds"):
         Tests.Team(t"Reds", Nil).encode.childCompounds.filter(_.keyword == t"members").length
       . assert(_ == 0)
+
+      test(m"a sum encodes with the variant name as the compound keyword"):
+        val shape: Tests.Shape2 = Tests.Shape2.Circle(7)
+        shape.encode.keyword
+      . assert(_ == t"circle")
+
+      test(m"a single-field sum variant round-trips"):
+        val shape: Tests.Shape2 = Tests.Shape2.Circle(7)
+        shape.encode.as[Tests.Shape2]
+      . assert(_ == Tests.Shape2.Circle(7))
+
+      test(m"a multi-field sum variant round-trips"):
+        val shape: Tests.Shape2 = Tests.Shape2.Rectangle(3, 4)
+        shape.encode.as[Tests.Shape2]
+      . assert(_ == Tests.Shape2.Rectangle(3, 4))
+
+      test(m"a fieldless sum variant round-trips"):
+        val shape: Tests.Shape2 = Tests.Shape2.Dot
+        shape.encode.as[Tests.Shape2]
+      . assert(_ == Tests.Shape2.Dot)
 
     suite(m"`over Tel` decoder shorthand"):
       test(m"`read[T over Tel]` resolves a value directly from text"):


### PR DESCRIPTION
Sum types (sealed traits and enums) previously didn't round-trip through stratiform's TEL codec at all: the encoder emitted a variant's fields with no discriminator, the decoder looked for one that was never written, and the schema derivation for a sum was a stub returning an empty struct. This change completes sum support end to end — a sum encodes as a document whose single child is the chosen variant (keyed by the variant's kebab-cased name, with its fields as children), the decoder dispatches on that variant, and the schema derivation produces a named `SelectDefinition` registered in the schema namespace. Because the binary layer (`Bintel`, type-assignment and schema signatures) already understood selects, deriving the schema is enough to make sums round-trip through BinTEL as well as text.

### Sum types in the TEL codec

Sealed traits and enums now round-trip through the TEL codec, as both text and BinTEL:

```scala
enum Shape derives CanEqual:
  case Circle(radius: Int)
  case Rectangle(width: Int, height: Int)
  case Dot

val shape: Shape = Shape.Rectangle(3, 4)
shape.encode.as[Shape]          // round-trips through text TEL
```

A sum encodes as a document whose single child is the chosen variant, keyed by the variant's kebab-cased name (e.g. `rectangle`), with the variant's fields as its children — the same shape you get by parsing that document from text.

### Derived `select` schemas

`Tels.tels[T](name)` now derives a `SelectDefinition` for a sum `T` — one `Variant` per case, each carrying the variant's own derived struct — registered in the schema namespace, with the document root referencing it via a `SelectRef`. This is what enables BinTEL:

```scala
val schema = Tels.tels[Shape](t"shape")
val bytes  = shape.encode.bintel(schema)   // binary, schema-driven
Bintel.decode(bytes, schema)               // → the variant's fields
```

### `value.bintel`

A value-level `bintel` derives the schema from the value's type, so you don't need to build one by hand:

```scala
shape.bintel                                // was: shape.encode.bintel(Tels.tels[Shape](…))
```

A sum nested as a field of a product is not yet supported (the keyword-based product decoder can't yet locate a keyword-less select member); top-level sums — message-protocol ADTs and the like — are fully supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)