### PR TITLE
Switch the flux REPL protocol from JSON to BinTEL

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -832,14 +832,15 @@ object exoskeleton extends Library:
 
 object flux extends Library:
   object core extends Component(anthology.`scala`, inimitable.core, coaxial.core, eucalyptus.core,
-                                jacinta.core, harlequin.core):
+                                stratiform.core, stratiform.binary, harlequin.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     def mvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
 
   object client extends Component(core, ethereal.core, exoskeleton.completions, profanity.core,
-                                  coaxial.core, urticose.core, jacinta.core, escapade.core,
-                                  iridescence.core, harlequin.ansi, escritoire.core, ultimatum.core):
+                                  coaxial.core, urticose.core, stratiform.core, stratiform.binary,
+                                  escapade.core, iridescence.core, harlequin.ansi, escritoire.core,
+                                  ultimatum.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     override def mainClass: Task.Simple[Option[String]] = Some("flux.repl")

--- a/lib/flux/src/client/flux_client.scala
+++ b/lib/flux/src/client/flux_client.scala
@@ -50,7 +50,6 @@ import executives.completions
 import harlequin.Accent
 import internetAccess.enabled
 import interpreters.posix
-import jsonDiscriminables.discriminatedUnionByKind
 import logging.silent
 import probates.cancel
 import supervisors.global
@@ -366,11 +365,16 @@ private def runRepl
   // answers — not one keypress later. Other replies are a `submit` result the loop
   // awaits, or the `completions` the Tab handler blocks on.
   async:
-    while live do
-      val raw = reply(chunks).trim
+    // Construct the reader here, not on the main thread: forcing `chunks`
+    // (`duplex.stream.iterator`) blocks until the first byte arrives, and the main
+    // thread must stay free to render the editor and drive the event loop.
+    val frames: FrameReader = FrameReader(chunks)
 
-      if raw.length == 0 then live = false
-      else safely[Exception](Json.parseTracked(raw).as[Repl.Reply]).let:
+    while live do
+      val data: Optional[Data] = frames.next()
+
+      if data.absent then live = false
+      else safely[Exception](Bintel.read[Repl.Reply](data.vouch)).let:
         case Repl.Reply.Tokenized(id, highlight) =>
           pending.remove(id).foreach(state.reconcile(_, highlight))
           terminal.events.put(TerminalInfo.Redraw)
@@ -402,7 +406,7 @@ private def runRepl
         lastVersion = version
         val id = nextId.getAndIncrement
         pending(id) = version
-        duplex.send(Stream((encode(Repl.Request.Tokenize(id, editor.value)) + t"\n\n").data))
+        duplex.send(Stream(framed(encode(Repl.Request.Tokenize(id, editor.value)))))
 
     def frame(): Unit =
       val innerWidth = (terminal.knownColumns - 2).max(1)
@@ -464,12 +468,12 @@ private def runRepl
       if line == t"/disconnect" then
         running = false
       else if line == t"/quit" then
-        duplex.send(Stream((encode(Repl.Request.Quit(0)) + t"\n\n").data))
+        duplex.send(Stream(framed(encode(Repl.Request.Quit(0)))))
         running = false
       else if line.starts(t"/") then
         Out.println(t"flux: unknown command: $line")
       else
-        duplex.send(Stream((encode(Repl.Request.Submit(0, line)) + t"\n\n").data))
+        duplex.send(Stream(framed(encode(Repl.Request.Submit(0, line)))))
 
         submits.take().nn match
           case Repl.Reply.Ran(_, value, output, tpe, diagnostics, _) =>
@@ -551,7 +555,7 @@ private def completeAt
         (advanced, items)
   else
     val request = encode(Repl.Request.Complete(0, editor.value, editor.position))
-    duplex.send(Stream((request + t"\n\n").data))
+    duplex.send(Stream(framed(request)))
 
     val candidates: List[Repl.CompletionItem] = completions.take().nn
 
@@ -824,22 +828,44 @@ private def balanced(text: Text): Boolean =
   string.length > 0 && depth <= 0
 
 
-// Serializes a `Request` as compact JSON for the wire. `Json` is `Dynamic`, so
-// `.show` is intercepted; summon the `Encodable in Text` instance explicitly.
-private def encode(request: Repl.Request): Text =
-  summon[Json is Encodable in Text].encoded(request.json)
+// Serializes a `Request` to BinTEL body bytes, deriving the schema from the type
+// (`value.bintel`). A valid request always type-assigns, so the encode is total.
+private def encode(request: Repl.Request): Data = unsafely(request.bintel)
 
-// Pulls chunks from the (persistent) socket stream, buffering until the `"\n\n"`
-// message delimiter, and decodes the buffered bytes verbatim.
-private def reply(chunks: Iterator[Data]): Text =
-  val buffer: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
-  var done = false
+// Prefixes BinTEL body bytes with a 4-byte big-endian length, the on-wire frame the
+// server reads with `DataInputStream.readInt` + `readFully`.
+private def framed(data: Data): Data =
+  val length: Int      = data.length
+  val out:    Array[Byte] = new Array[Byte](4 + length)
+  out(0) = (length >>> 24).toByte
+  out(1) = (length >>> 16).toByte
+  out(2) = (length >>> 8).toByte
+  out(3) = length.toByte
+  var i = 0
 
-  while !done && chunks.hasNext do
-    chunks.next().each(buffer += _)
+  while i < length do
+    out(4 + i) = data(i)
+    i += 1
 
-    done =
-      buffer.length >= 2 && buffer(buffer.length - 1) == '\n'.toByte
-      && buffer(buffer.length - 2) == '\n'.toByte
+  out.immutable(using Unsafe)
 
-  IArray.from(buffer).utf8
+// Reassembles length-prefixed frames from the (chunk-at-a-time) socket stream, keeping
+// a buffer across calls so a frame split over chunks — or several frames in one chunk —
+// is handled. `next()` yields one frame's body, or `Unset` when the stream ends.
+private class FrameReader(chunks: Iterator[Data]):
+  private val buffer: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+
+  private def fill(count: Int): Boolean =
+    while buffer.length < count && chunks.hasNext do chunks.next().each(buffer += _)
+    buffer.length >= count
+
+  def next(): Optional[Data] =
+    if !fill(4) then Unset else
+      val length: Int =
+        ((buffer(0) & 0xff) << 24) | ((buffer(1) & 0xff) << 16)
+        | ((buffer(2) & 0xff) << 8) | (buffer(3) & 0xff)
+
+      if !fill(4 + length) then Unset else
+        val body: Data = IArray.from(buffer.slice(4, 4 + length))
+        buffer.remove(0, 4 + length)
+        body

--- a/lib/flux/src/core/flux.Repl.scala
+++ b/lib/flux/src/core/flux.Repl.scala
@@ -52,18 +52,17 @@ import gossamer.*
 import harlequin.*
 import hellenism.*
 import inimitable.*
-import jacinta.*
 import parasite.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
+import stratiform.*
 import turbulence.*
 import urticose.*
 import vacuous.*
 
 import hieroglyph.charEncoders.utf8
 import interfaces.paths.pathOnLinux
-import jsonDiscriminables.discriminatedUnionByKind
 import stenography.Syntax
 
 object Repl:
@@ -102,6 +101,16 @@ object Repl:
   // type, …) and its rendered type `signature`. The Harlequin `Completion`'s
   // `Syntax` signature is rendered to text here so the reply serializes simply.
   case class CompletionItem(name: Text, kind: Text, signature: Text)
+
+  // A `Reply` variant carries a `List` of these leaf products, so its Decodable
+  // derivation graph (sum → variant → `List` → product) overflows inline derivation
+  // under the REPL's minimal predef. Anchoring the leaves with explicit derived
+  // instances keeps the graph shallow enough to resolve.
+  given tokenDecodable: Tactic[TelError] => Token is Tel.Decodable =
+    Tel.DecodableDerivation.derived
+
+  given completionItemDecodable: Tactic[TelError] => CompletionItem is Tel.Decodable =
+    Tel.DecodableDerivation.derived
 
   // A request from a connected client. `id` is echoed in the reply so the client
   // can re-associate replies that arrive out of order (a fast `tokenize` may
@@ -432,38 +441,38 @@ class Repl[version <: Scalac.Versions]
     // back out of order. A write mutex stops concurrent replies interleaving.
     val writes: Mutex = Mutex()
 
+    // Each message is a 4-byte big-endian length prefix followed by that many BinTEL
+    // body bytes (binary, so no textual delimiter is safe). `readInt` raises at EOF.
     try
-      val reader = ji.BufferedReader(ji.InputStreamReader(input, "UTF-8"))
-      val writer = ji.OutputStreamWriter(output, "UTF-8")
-      val buffer: StringBuilder = StringBuilder()
-      var line: String | Null = reader.readLine()
+      val in: ji.DataInputStream  = ji.DataInputStream(ji.BufferedInputStream(input))
+      val out: ji.DataOutputStream = ji.DataOutputStream(ji.BufferedOutputStream(output))
+      var continue: Boolean = true
 
-      while line != null do
-        if line.nn.isEmpty then
-          if buffer.length > 0 then
-            val message: Text = buffer.toString.tt.trim
-            buffer.clear()
+      while continue do
+        val length: Int = try in.readInt() catch case _: ji.IOException => -1
 
-            async:
-              // A stray throwable in one message becomes an error reply, not a
-              // dropped connection, so the session survives. `Unset` (a `quit`) is
-              // not answered.
-              val response: Optional[Text] =
-                try respond(message)
-                catch case error: Throwable =>
-                  encode(Repl.Reply.Failed(0, error.toString.tt))
-
-              response.let: payload =>
-                writes:
-                  try
-                    writer.write(payload.s)
-                    writer.write("\n\n")
-                    writer.flush()
-                  catch case _: Throwable => ()
+        if length < 0 then continue = false
         else
-          buffer.append(line.nn).append("\n")
+          val bytes: Array[Byte] = new Array[Byte](length)
+          in.readFully(bytes)
+          val message: Data = bytes.immutable(using Unsafe)
 
-        line = reader.readLine()
+          async:
+            // A stray throwable in one message becomes an error reply, not a
+            // dropped connection, so the session survives. `Unset` (a `quit`) is
+            // not answered.
+            val response: Optional[Data] =
+              try respond(message)
+              catch case error: Throwable =>
+                encode(Repl.Reply.Failed(0, error.toString.tt))
+
+            response.let: payload =>
+              writes:
+                try
+                  out.writeInt(payload.length)
+                  out.write(payload.mutable(using Unsafe))
+                  out.flush()
+                catch case _: Throwable => ()
 
     catch case _: Throwable => ()
 
@@ -471,11 +480,11 @@ class Repl[version <: Scalac.Versions]
   // for live editing); a `submit` compiles and runs; a `quit` signals the server to
   // shut down and is not answered. A malformed request becomes a `Failed` reply
   // rather than a dropped connection. `Unset` means no reply is sent.
-  private def respond(message: Text)(using Monitor, System, Probate)
-  :   Optional[Text] logs CompileEvent =
+  private def respond(message: Data)(using Monitor, System, Probate)
+  :   Optional[Data] logs CompileEvent =
 
     val request: Optional[Repl.Request] =
-      safely[Exception](Json.parseTracked(message).as[Repl.Request])
+      safely[Exception](Bintel.read[Repl.Request](message))
 
     request.lay(encode(Repl.Reply.Failed(0, t"the request could not be parsed"))):
       case Repl.Request.Tokenize(id, code)         => tokenized(id, code)
@@ -483,13 +492,13 @@ class Repl[version <: Scalac.Versions]
       case Repl.Request.Complete(id, code, offset) => complete(id, code, offset)
       case Repl.Request.Quit(_)                    => quit.offer(()) yet Unset
 
-  private def tokenized(id: Int, code: Text): Text =
+  private def tokenized(id: Int, code: Text): Data =
     encode(Repl.Reply.Tokenized(id, Repl.tokenize(code)))
 
   // Computes tab completions at `offset` in `code` and replies (with `id`). Holds
   // `mutex` like `submit`, since the shared compiler is not reentrant.
   private def complete(id: Int, code: Text, offset: Int)(using Monitor, System, Probate)
-  :   Text logs CompileEvent =
+  :   Data logs CompileEvent =
 
     given LocalClasspath = classpath
 
@@ -500,7 +509,7 @@ class Repl[version <: Scalac.Versions]
   // Typecheck-highlights, compiles, and runs `code`, replying (with `id`) with the
   // highlighting, the result value, and any diagnostics. The whole body holds
   // `mutex`, so concurrent submits serialize and never drive the compiler at once.
-  private def submit(id: Int, code: Text)(using Monitor, System, Probate): Text logs CompileEvent =
+  private def submit(id: Int, code: Text)(using Monitor, System, Probate): Data logs CompileEvent =
     given LocalClasspath = classpath
 
     val reply: Repl.Reply = mutex:
@@ -525,7 +534,6 @@ class Repl[version <: Scalac.Versions]
 
     encode(reply)
 
-  // `Json` is `Dynamic`, so `.show`/`.root` are intercepted; summon the
-  // `Encodable in Text` instance explicitly to render compact JSON.
-  private def encode(reply: Repl.Reply): Text =
-    summon[Json is Encodable in Text].encoded(reply.json)
+  // Serializes a `Reply` to BinTEL body bytes, deriving the schema from the type
+  // (`value.bintel`). A valid reply always type-assigns, so the encode is total.
+  private def encode(reply: Repl.Reply): Data = unsafely(reply.bintel)

--- a/lib/flux/src/test/flux_test.scala
+++ b/lib/flux/src/test/flux_test.scala
@@ -47,6 +47,31 @@ import systems.java
 import temporaryDirectories.system
 import threading.platform
 
+// Sends `request` to `output` as a length-prefixed BinTEL frame — the on-wire protocol
+// the server speaks (a 4-byte big-endian length, then that many BinTEL body bytes).
+private def send(output: ji.OutputStream, request: Repl.Request): Unit =
+  val body = request.bintel
+  val out  = ji.DataOutputStream(output)
+  out.writeInt(body.length)
+  out.write(body.mutable(using Unsafe))
+  out.flush()
+
+private def send(socket: jn.Socket, request: Repl.Request): Unit =
+  send(socket.getOutputStream.nn, request)
+
+// Sends `request` and reads the framed BinTEL reply, decoding it to a typed `Reply`.
+private def exchange(input: ji.InputStream, output: ji.OutputStream, request: Repl.Request)
+:   Repl.Reply =
+  send(output, request)
+  val in     = ji.DataInputStream(input)
+  val length = in.readInt()
+  val bytes  = new Array[Byte](length)
+  in.readFully(bytes)
+  Bintel.read[Repl.Reply](bytes.immutable(using Unsafe))
+
+private def exchange(socket: jn.Socket, request: Repl.Request): Repl.Reply =
+  exchange(socket.getInputStream.nn, socket.getOutputStream.nn, request)
+
 // Mimics a standard-REPL session: `size` references `greeting`, a field of the
 // enclosing object, by simple name (as `var name = …` would be in the Scala REPL).
 // `session` reads `size` once, mutates `greeting`, then reads it again — the
@@ -173,31 +198,22 @@ object Tests extends Suite(m"Flux Tests"):
     suite(m"REPL TCP server"):
       given Scalac[3.8] = Scalac(Nil)
 
-      test(m"a JSON reply carries the value, type and highlighting"):
+      test(m"a reply carries the value, type and highlighting"):
         supervise:
           val tcpPort = Port[Tcp]()
           val service = Repl().serve(tcpPort)
           val socket  = jn.Socket("localhost", tcpPort.number)
 
-          try
-            val output = socket.getOutputStream.nn
-            output.write("{\"id\":1,\"code\":\"1 + 1\",\"kind\":\"Submit\"}\n\n".getBytes("UTF-8").nn)
-            output.flush()
-
-            val input   = ji.BufferedReader(ji.InputStreamReader(socket.getInputStream.nn, "UTF-8"))
-            val builder = StringBuilder()
-            var line: String | Null = input.readLine()
-
-            while line != null && !line.nn.isEmpty do
-              builder.append(line.nn).append("\n")
-              line = input.readLine()
-
-            builder.toString
+          try exchange(socket, Repl.Request.Submit(1, t"1 + 1"))
           finally
             socket.close()
             service.stop()
-      . assert: reply =>
-          reply.contains("Ran") && reply.contains("2") && reply.contains("Int")
+      . assert:
+          case Repl.Reply.Ran(_, value, _, tpe, _, _) =>
+            value.let(_ == t"2").or(false) && tpe.let(_.contains(t"Int")).or(false)
+
+          case _ =>
+            false
 
       test(m"a quit request fulfils the server's quit signal"):
         supervise:
@@ -207,9 +223,7 @@ object Tests extends Suite(m"Flux Tests"):
           val socket  = jn.Socket("localhost", tcpPort.number)
 
           try
-            val output = socket.getOutputStream.nn
-            output.write("{\"id\":0,\"kind\":\"Quit\"}\n\n".getBytes("UTF-8").nn)
-            output.flush()
+            send(socket, Repl.Request.Quit(0))
 
             // Wait (bounded) for the quit signal rather than blocking forever.
             val runnable: Runnable = () => repl.awaitQuit()
@@ -231,25 +245,15 @@ object Tests extends Suite(m"Flux Tests"):
           val channel      = jnc.SocketChannel.open(address).nn
 
           try
-            val output = jnc.Channels.newOutputStream(channel).nn
-            output.write("{\"id\":3,\"code\":\"6 * 7\",\"kind\":\"Submit\"}\n\n".getBytes("UTF-8").nn)
-            output.flush()
-
-            val stream  = jnc.Channels.newInputStream(channel).nn
-            val input   = ji.BufferedReader(ji.InputStreamReader(stream, "UTF-8"))
-            val builder = StringBuilder()
-            var line: String | Null = input.readLine()
-
-            while line != null && !line.nn.isEmpty do
-              builder.append(line.nn).append("\n")
-              line = input.readLine()
-
-            builder.toString
+            exchange
+             (jnc.Channels.newInputStream(channel).nn, jnc.Channels.newOutputStream(channel).nn,
+              Repl.Request.Submit(3, t"6 * 7"))
           finally
             channel.close()
             service.stop()
-      . assert: reply =>
-          reply.contains("Ran") && reply.contains("42")
+      . assert:
+          case Repl.Reply.Ran(_, value, _, _, _, _) => value.let(_ == t"42").or(false)
+          case _                                    => false
 
       test(m"a completion request returns matching completions"):
         supervise:
@@ -257,26 +261,13 @@ object Tests extends Suite(m"Flux Tests"):
           val service = Repl().serve(tcpPort)
           val socket  = jn.Socket("localhost", tcpPort.number)
 
-          try
-            val output = socket.getOutputStream.nn
-            val message = "{\"id\":1,\"code\":\"List(1, 2, 3).m\",\"offset\":15,\"kind\":\"Complete\"}\n\n"
-            output.write(message.getBytes("UTF-8").nn)
-            output.flush()
-
-            val input   = ji.BufferedReader(ji.InputStreamReader(socket.getInputStream.nn, "UTF-8"))
-            val builder = StringBuilder()
-            var line: String | Null = input.readLine()
-
-            while line != null && !line.nn.isEmpty do
-              builder.append(line.nn).append("\n")
-              line = input.readLine()
-
-            builder.toString
+          try exchange(socket, Repl.Request.Complete(1, t"List(1, 2, 3).m", 15))
           finally
             socket.close()
             service.stop()
-      . assert: reply =>
-          reply.contains("Completed") && reply.contains("map")
+      . assert:
+          case Repl.Reply.Completed(_, items) => items.exists(_.name.contains(t"map"))
+          case _                              => false
 
     suite(m"REPL block captures outside references"):
       given Scalac[3.8] = Scalac(Nil)

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -431,6 +431,44 @@ object Bintel:
 
     IArray.from(buf)
 
+  // Reconstruct a presentation `Tel` from a schema-typed element tree — the inverse of
+  // `Tel.Type.assign`. Each element's keyword comes from its parent struct's flattened
+  // keyword sequence (looked up by the index BinTEL stored), so a decoded element can be
+  // re-decoded to a typed value through `Tel.Decodable`.
+  private def present(element: Tel.Element, schema: Tels): Tel = element match
+    case Tel.Element.Node(_, struct: Tels.Struct, children) =>
+      val flat = flattenKeywords(struct, schema)
+      Tel.make(Tel.Compound(Text(""), IArray.empty, Unset, blocks(children.map(presentCompound(_, flat, schema)))))
+
+    case _ =>
+      Tel.empty
+
+  private def presentCompound
+       (element: Tel.Element, flat: IArray[(Text, Tels.Type)], schema: Tels)
+  :     Tel.Compound =
+    element match
+      case Tel.Element.Value(kidx, _, text) =>
+        Tel.Compound(flat(kidx)._1, IArray(Tel.Atom.Inline(text, 1)), Unset, IArray.empty)
+
+      case Tel.Element.Node(kidx, struct: Tels.Struct, children) =>
+        val keyword   = kidx.let(flat(_)._1).or(Text(""))
+        val childFlat = flattenKeywords(struct, schema)
+        Tel.Compound(keyword, IArray.empty, Unset, blocks(children.map(presentCompound(_, childFlat, schema))))
+
+      case Tel.Element.Node(kidx, _, _) =>
+        Tel.Compound(kidx.let(flat(_)._1).or(Text("")), IArray.empty, Unset, IArray.empty)
+
+  private def blocks(compounds: IArray[Tel.Compound]): IArray[Tel.Block] =
+    if compounds.isEmpty then IArray.empty
+    else IArray(Tel.Block(IArray.empty, Unset, compounds, 0))
+
+  // Decode BinTEL body bytes to a typed value, deriving the schema from the value's type
+  // — the inverse of `value.bintel`.
+  def read[value: Tel.Decodable](data: Data)(using value is TelSchematic over Tels.Type)
+  :     value raises BintelError raises TelError =
+    val schema = Tels.tels[value](Text("root"))
+    present(decode(data, schema), schema).as[value]
+
   private def resolveType(t: Tels.Type, schema: Tels): Tels.Type = t match
     case Tels.Reference(name) =>
       schema.records.find(_.name == name) match

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1425,6 +1425,20 @@ object Tests extends Suite(m"Stratiform Tests"):
         values(Bintel.decode(shape.bintel, schema))
       . assert(_ == List(t"3", t"4"))
 
+      test(m"a sum round-trips bytes-to-typed-value through bintel/read"):
+        val shape: Tests.Shape2 = Tests.Shape2.Rectangle(3, 4)
+        Bintel.read[Tests.Shape2](shape.bintel)
+      . assert(_ == Tests.Shape2.Rectangle(3, 4))
+
+      test(m"a fieldless variant round-trips bytes-to-typed-value"):
+        val shape: Tests.Shape2 = Tests.Shape2.Dot
+        Bintel.read[Tests.Shape2](shape.bintel)
+      . assert(_ == Tests.Shape2.Dot)
+
+      test(m"a product round-trips bytes-to-typed-value through bintel/read"):
+        Bintel.read[Tests.Person](Tests.Person(t"Alice", 30).bintel)
+      . assert(_ == Tests.Person(t"Alice", 30))
+
       test(m"empty scalar value round-trips"):
         val scalar = Tels.Scalar(IArray.empty)
         val root = Tel.Element.Node


### PR DESCRIPTION
The flux REPL's client↔server protocol now uses stratiform BinTEL — a compact, schema-derived binary format — in place of JSON. The `Repl.Request`/`Reply` ADTs are encoded with `value.bintel` and decoded with the new `Bintel.read[T]`, framed with a 4-byte length prefix over the socket. This also adds `Bintel.read` (the typed decode counterpart of `value.bintel`) to stratiform's binary module.

### `Bintel.read` — typed decode

`stratiform`'s binary module gains `Bintel.read[T](data)`, the inverse of `value.bintel`: it reconstructs a presentation `Tel` from the schema-typed element tree and decodes it to a typed value, deriving the schema from the type. Encode and decode are now symmetric:

```scala
val bytes: Data = request.bintel
val request    = Bintel.read[Repl.Request](bytes)
```

### flux over BinTEL

The REPL transport is now binary: each message is a 4-byte big-endian length prefix followed by the BinTEL body. The server reads and writes frames with `DataInputStream`/`DataOutputStream`; the client reassembles them from the duplex byte stream with a small buffering frame reader. JSON (jacinta) is no longer used for the protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)