### PR TITLE
Re-enable the wisteria test suite

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1486,8 +1486,7 @@ object wisteria extends Library:
   object core extends Component(contingency.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core):
-    override def enabled = false
+  object test extends Tests(core)
 
 object xenophile extends Library:
   object core extends Component(gossamer.core, prepositional.core, gigantism.core, fulminate.core,

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -145,7 +145,7 @@ object Tests extends Suite(m"Soundness tests"):
     vicarious.Tests()
     jacinta.RecordsTests()
     jacinta.ValidationTests()
-    // wisteria.Tests() - temporarily disabled
+    wisteria.Tests()
     xylophone.Tests()
     ypsiloid.Tests()
     yossarian.Tests()


### PR DESCRIPTION
The `wisteria` test suite, which had been switched off, runs again as part of the full test suite. Of the seven suites that were disabled, it is the only one whose tests still compile and pass (45 tests); the rest are dormant stubs or no longer match the current API and stay disabled.

Re-enabling a suite requires two coordinated changes, both of which are made here for `wisteria`: clearing `enabled = false` in `build.mill` so the test module is on the aggregator's classpath, and uncommenting the `wisteria.Tests()` call in `src/test/soundness.Tests.scala`, the runner that actually invokes each suite. The full run now reports 6095 passing tests, up 45.

The other six disabled suites are left off deliberately: `cosmopolite`, `eucalyptus`, `gigantism`, `legerdemain` and `orthodoxy` have empty or commented-out `run()` bodies (no active tests), and `escritoire`'s suite no longer compiles against the current API (`Column.constrain` / `Breaks.Space` were removed) and would need a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
