### PR TITLE
Fix Burdock repackager crash and add a top-level `externalize` wrapper

### DIFF
--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -95,9 +95,11 @@ object Bootstrapper:
         // `META-INF/burdock.deps` resource the build-time macro wrote. (Locating by
         // the `burdock.Bootstrap` class would find burdock's own JAR, not the app's,
         // once the app JAR is slim.)
+        val resourcePath: String = burdock.internal.ResourcePath
+
         val depsResource: jn.URL =
-          Optional(loader.getResource(Embed.ResourcePath)).lest:
-            UserError(m"this JAR was not built with Burdock (no ${Embed.ResourcePath.tt})")
+          Optional(loader.getResource(resourcePath)).lest:
+            UserError(m"this JAR was not built with Burdock (no ${resourcePath.tt})")
 
         val connection: jn.URLConnection = depsResource.openConnection().nn
 
@@ -115,7 +117,7 @@ object Bootstrapper:
         val bootstrapClass: Data = (Classpath/"burdock"/"Bootstrap.class").read[Data]
 
         // Unpublished dependencies are reconstructed from the build-time hard-links in
-        // `~/.cache/burdock/<sha256>.jar` (see `Embed`); published ones resolve via
+        // `~/.cache/burdock/<sha256>.jar` (see `externalize`); published ones resolve via
         // deps.dev and are referenced by URL rather than inlined.
         val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
         val cacheDir: Path on Linux = t"$home/.cache/burdock".decode[Path on Linux]

--- a/lib/burdock/src/core/burdock.Repackage.scala
+++ b/lib/burdock/src/core/burdock.Repackage.scala
@@ -108,7 +108,7 @@ object Repackage:
       case FqcnError(_, _)      => RepackageError(m"the Main-Class is not a valid class name")
 
     . mitigate:
-        val resource: Text = Embed.ResourcePath.tt
+        val resource: Text = burdock.internal.ResourcePath.tt
         val bootstrapName: Text = t"burdock/Bootstrap.class"
         var manifestData: Optional[Data] = Unset
         var depsData: Optional[Data] = Unset

--- a/lib/burdock/src/core/burdock.Repackage.scala
+++ b/lib/burdock/src/core/burdock.Repackage.scala
@@ -102,13 +102,14 @@ object Repackage:
     whereas:
       case IoError(_, _, _, _)  => RepackageError(m"a filesystem error occurred while repackaging")
       case StreamError(_)       => RepackageError(m"a stream error occurred while repackaging")
-      case ZipError(_)          => RepackageError(m"the JAR could not be read or written")
+      case ZipError(reason)     => RepackageError(m"the JAR could not be read or written ($reason)")
       case PathError(_, _)      => RepackageError(m"a path could not be resolved while repackaging")
       case NumberError(_, _, _) => RepackageError(m"the manifest contained malformed data")
       case FqcnError(_, _)      => RepackageError(m"the Main-Class is not a valid class name")
 
     . mitigate:
         val resource: Text = Embed.ResourcePath.tt
+        val bootstrapName: Text = t"burdock/Bootstrap.class"
         var manifestData: Optional[Data] = Unset
         var depsData: Optional[Data] = Unset
         val ownBuilder = List.newBuilder[Entry]
@@ -116,8 +117,12 @@ object Repackage:
         Zipfile.read(inputJar).entries.each: entry =>
           val name: Text = entry.ref.show
 
+          // The bootstrap class is force-included below, so drop any copy already bundled
+          // (an app whose `Main-Class` is `burdock.Bootstrap` bundles burdock) to avoid a
+          // duplicate entry.
           if name == t"META-INF/MANIFEST.MF" then manifestData = entry.read[Data]
           else if name == resource then depsData = entry.read[Data]
+          else if name == bootstrapName then ()
           else ownBuilder += Entry(name, entry.read[Data])
 
         val manifest: Manifest =
@@ -130,6 +135,13 @@ object Repackage:
         val ownEntries: List[Entry] = ownBuilder.result()
         val (requirements, inlined) = partition(hashes, resolve, cached)
 
+        // A cached entry may already be present among the application's own entries (e.g.
+        // when the input is a fat assembly); keep the bundled copy and inline only the gaps,
+        // so the output never carries two entries with the same name.
+        val ownNames: Set[Text] = ownEntries.map(_.name).to(Set)
+        val inlinedEntries: List[Entry] = inlined.filter: entry =>
+          !ownNames.contains(entry.name)
+
         import manifestAttributes.*
 
         val originalMain =
@@ -139,8 +151,8 @@ object Repackage:
           manifest - MainClass + BurdockRequire(requirements) + BurdockMain(originalMain)
           + BurdockVerbosity(t"silent") + MainClass(fqcn"burdock.Bootstrap")
 
-        val bootstrap: Entry = Entry(t"burdock/Bootstrap.class", bootstrapClass)
-        val entries: List[Entry] = bootstrap :: ownEntries ++ inlined
+        val bootstrap: Entry = Entry(bootstrapName, bootstrapClass)
+        val entries: List[Entry] = bootstrap :: ownEntries ++ inlinedEntries
 
         Zipfile.write(outputJar):
           Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifest2.serialize)

--- a/lib/burdock/src/core/burdock.internal.scala
+++ b/lib/burdock/src/core/burdock.internal.scala
@@ -40,21 +40,20 @@ import scala.quoted.*
 
 import anticipation.*
 
-// The compile-time half of the Burdock redesign. `dependencyHashes` captures the
-// build's classpath, computes each dependency JAR's SHA-256, hard-links it into
-// the Burdock cache (`~/.cache/burdock/<sha256>.jar`) so its bytes stay
-// retrievable by hash locally, and embeds the SHA-256 list as compiled-in
-// literals. The published-vs-unpublished decision is deferred to repackage (where
-// deps.dev is queried); the cache covers anything deps.dev cannot resolve.
-object Embed:
-  // Resource path (within the compiled JAR) holding the newline-separated
-  // dependency SHA-256 hashes; read by the repackager and, in turn, the runtime
-  // bootstrap. Keep in sync with the repackager.
+// The compile-time half of Burdock. The `externalize` macro captures the build's
+// classpath, computes each dependency JAR's SHA-256, hard-links it into the Burdock
+// cache (`~/.cache/burdock/<sha256>.jar`) so its bytes stay retrievable by hash
+// locally, and embeds the SHA-256 list as the `META-INF/burdock.deps` resource. The
+// published-vs-unpublished decision is deferred to repackage (where deps.dev is
+// queried); the cache covers anything deps.dev cannot resolve.
+object internal:
+  // Resource path (within the compiled JAR) holding the newline-separated dependency
+  // SHA-256 hashes; read by the repackager and, in turn, the runtime bootstrap.
   final val ResourcePath: String = "META-INF/burdock.deps"
 
-  inline def dependencyHashes: List[Text] = ${Embed.dependencyHashesMacro}
-
-  def dependencyHashesMacro(using Quotes): Expr[List[Text]] =
+  // Performs the compile-time side effects (hash + cache + embed the resource) and
+  // returns `block` unchanged, so `externalize` runs the application's body at runtime.
+  def externalize[result: Type](block: Expr[result])(using Quotes): Expr[result] =
     val (classpath, outputDir) = quotes.absolve match
       case quotes: runtime.impl.QuotesImpl =>
         import dotty.tools.dotc.config.Settings.Setting.value
@@ -66,18 +65,18 @@ object Embed:
     val hashes: List[String] = hashAndCache(classpath)
     writeResource(outputDir, hashes)
 
-    '{${Expr(hashes)}.map(_.tt)}
+    block
 
-  // Writes the hash list into the compile output as `META-INF/burdock.deps`, so
-  // it is packaged into the JAR as an ordinary resource.
+  // Writes the hash list into the compile output as `META-INF/burdock.deps`, so it is
+  // packaged into the JAR as an ordinary resource.
   private def writeResource(outputDir: jnf.Path, hashes: List[String]): Unit =
     val metaInf: jnf.Path = outputDir.resolve("META-INF").nn
     jnf.Files.createDirectories(metaInf)
     val content: String = hashes.mkString("\n")
     jnf.Files.write(metaInf.resolve("burdock.deps").nn, content.getBytes("UTF-8").nn)
 
-  // Runs at compile time, in the compiler JVM: pure java.* so it needs nothing
-  // from the soundness runtime. Hard-links fall back to a copy across filesystems.
+  // Runs at compile time, in the compiler JVM: pure java.* so it needs nothing from the
+  // soundness runtime. Hard-links fall back to a copy across filesystems.
   private def hashAndCache(classpath: String): List[String] =
     val home: String = System.getProperty("user.home").nn
     val cacheDir: jnf.Path = jnf.Paths.get(home, ".cache", "burdock").nn

--- a/lib/burdock/src/core/burdock_core.scala
+++ b/lib/burdock/src/core/burdock_core.scala
@@ -30,6 +30,17 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package burdock
 
-export burdock.{externalize, Bootstrapper}
+// Wraps an application's main entry point to make its dependencies externalizable by
+// Burdock. At compile time, `externalize` captures the build's dependency JARs, hashes
+// each (SHA-256), hard-links them into the Burdock cache (`~/.cache/burdock/<sha256>.jar`)
+// so their bytes stay retrievable by hash, and embeds the hash list as the
+// `META-INF/burdock.deps` resource; at runtime it simply runs `block`. The
+// published-vs-unpublished decision is deferred to repackage (where deps.dev is queried).
+//
+//     @main def myApp(): Unit = externalize:
+//       // the application's body
+//
+inline def externalize[result](inline block: result): result =
+  ${internal.externalize('block)}

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -136,3 +136,45 @@ object Tests extends Suite(m"Burdock Tests"):
       test(m"records the published dependency as a requirement"):
         manifest.contains(t"aaa")
       .assert(_ == true)
+
+    suite(m"Repackager (duplicate-safety)"):
+      // A real assembly bundles burdock (its `Main-Class` is `burdock.Bootstrap`), so the
+      // input already contains `burdock/Bootstrap.class`; and a cached dependency may be a
+      // class already present among the application's own entries. Neither must produce a
+      // duplicate entry in the output (which would fail as a `ZipError`). See issue #1333.
+      val tmp: Path on Linux = temporaryDirectory[Path on Linux]
+      val inputJar: Path on Linux = tmp/t"burdock-dup-in-${Uuid().show}.jar"
+      val outputJar: Path on Linux = tmp/t"burdock-dup-out-${Uuid().show}.jar"
+
+      val manifestText: Text = t"Manifest-Version: 1.0\nMain-Class: com.example.Main\n\n"
+
+      Zipfile.write(inputJar):
+        Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifestText.data)
+        #:: Zip.Entry(t"META-INF/burdock.deps".decode[Path on Zip], t"bbb".data)
+        #:: Zip.Entry(t"com/example/Main.class".decode[Path on Zip], t"main".data)
+        #:: Zip.Entry(t"burdock/Bootstrap.class".decode[Path on Zip], t"stale-bootstrap".data)
+        #:: Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"bundled-lib".data)
+        #:: LazyList()
+
+      val resolve: Repackage.Resolver = _ => Unset
+
+      val cached: Repackage.CacheReader =
+        h => if h == t"bbb" then List(Bootstrapper.Entry(t"dep/Lib.class", t"cached-lib".data))
+             else Unset
+
+      Repackage.repackage(inputJar, outputJar, resolve, cached, t"real-bootstrap".data)
+
+      val names: List[Text] = Zipfile.read(outputJar).entries.map(_.ref.show).to(List)
+
+      test(m"a bundled bootstrap class is not duplicated"):
+        names.count(_ == t"burdock/Bootstrap.class")
+      .assert(_ == 1)
+
+      test(m"the force-included bootstrap bytes win over the bundled copy"):
+        Zipfile.read(outputJar).entries.find(_.ref.show == t"burdock/Bootstrap.class").get
+        . read[Data].utf8
+      .assert(_ == t"real-bootstrap")
+
+      test(m"a cached class already bundled is not duplicated"):
+        names.count(_ == t"dep/Lib.class")
+      .assert(_ == 1)

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -42,11 +42,19 @@ import temporaryDirectories.system
 
 object Tests extends Suite(m"Burdock Tests"):
   def run(): Unit =
-    suite(m"Dependency-hashing macro"):
-      val hashes: List[Text] = Embed.dependencyHashes
+    suite(m"Externalizing macro"):
       val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
 
-      test(m"captures a non-empty set of dependency hashes"):
+      // Invoking `externalize` embeds `META-INF/burdock.deps` into this module's compiled
+      // output and hard-links each dependency JAR into the Burdock cache.
+      externalize(())
+
+      val hashes: List[Text] =
+        val stream = getClass.nn.getResourceAsStream("/META-INF/burdock.deps").nn
+        val content: Text = _root_.java.lang.String(stream.readAllBytes().nn, "UTF-8").tt
+        content.cut(t"\n").filter(_ != t"")
+
+      test(m"embeds a non-empty set of dependency hashes as a resource"):
         hashes.length
       .assert(_ > 0)
 
@@ -59,12 +67,6 @@ object Tests extends Suite(m"Burdock Tests"):
           val jar: Text = t"$home/.cache/burdock/$hash.jar"
           _root_.java.nio.file.Files.exists(_root_.java.nio.file.Paths.get(jar.s).nn)
       .assert(_ == true)
-
-      test(m"the hash list is written as a packaged resource"):
-        val stream = getClass.nn.getResourceAsStream("/META-INF/burdock.deps").nn
-        val content: Text = _root_.java.lang.String(stream.readAllBytes().nn, "UTF-8").tt
-        content.cut(t"\n").to(Set)
-      .assert(_ == hashes.to(Set))
 
     suite(m"Repackager partition"):
       val published = url"https://repo1.maven.org/maven2/g/a/1/a-1.jar"


### PR DESCRIPTION
Burdock's repackager could fail with a `ZipError` ("the JAR could not be read or written") when run against a real application assembly, because it force-included `burdock/Bootstrap.class` even when the input already bundled it, producing a duplicate entry; this is now resolved by dropping any pre-bundled copy (and any cached class already present among the application's own entries) before writing, and the underlying error reason is now surfaced. Separately, the dependency-capture step is no longer a free-floating `Embed.dependencyHashes` call that must appear somewhere in the code — it is now a top-level `externalize` wrapper around the application's entry point.

## Repackager duplicate-entry fix

Repackaging a real assembly (which bundles burdock, since the application's `Main-Class` is `burdock.Bootstrap`) previously aborted with an opaque "the JAR could not be read or written". The repackager now guarantees a collision-free output and includes the underlying `ZipError` reason in its message when something genuinely goes wrong.

## `externalize` entry-point wrapper

Make an application's dependencies externalizable by wrapping its entry point in `externalize`, rather than calling `Embed.dependencyHashes` somewhere:

```scala
@main def myApp(): Unit = externalize:
  // the application's body
```

At compile time this embeds the dependency hash list (`META-INF/burdock.deps`) and hard-links each dependency JAR into the Burdock cache; at runtime it simply runs the body. The macro implementation now lives in `object internal`, consistent with other Soundness macros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)