### PR TITLE
Slim repackaged JARs by stripping externalised dependencies

### DIFF
--- a/lib/burdock/src/core/burdock.Bootstrapper.scala
+++ b/lib/burdock/src/core/burdock.Bootstrapper.scala
@@ -122,15 +122,12 @@ object Bootstrapper:
         val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
         val cacheDir: Path on Linux = t"$home/.cache/burdock".decode[Path on Linux]
 
-        def cached(hash: Text): Optional[List[Entry]] =
+        def cached(hash: Text): Optional[List[Zip.Entry]] =
           val cacheJar: Path on Linux = cacheDir/t"$hash.jar"
 
           if !cacheJar.exists() then Unset else
             Zipfile.read(cacheJar).entries.filter: entry =>
               !entry.directory && entry.ref.show != t"META-INF/MANIFEST.MF"
-
-            . map: entry =>
-                Entry(entry.ref.show, entry.read[Data])
 
             . to(List)
 

--- a/lib/burdock/src/core/burdock.Repackage.scala
+++ b/lib/burdock/src/core/burdock.Repackage.scala
@@ -66,8 +66,10 @@ object Repackage:
   // Resolves a dependency hash to its public URL (deps.dev), or `Unset`.
   type Resolver = Text => Optional[HttpUrl]
 
-  // Looks up a dependency hash's class entries in the local cache, or `Unset`.
-  type CacheReader = Text => Optional[List[Entry]]
+  // Looks up a dependency hash's entries (directories and the manifest excluded) in the
+  // local cache, or `Unset`. Payloads stay lazy, so identifying an externalized
+  // dependency's entry names (to strip them) does not read the cached JAR's contents.
+  type CacheReader = Text => Optional[List[Zip.Entry]]
 
   // Pure partition; `resolve` (deps.dev) and `cached` (cache lookup) are injected
   // so the logic is testable without the network or the filesystem.
@@ -83,17 +85,21 @@ object Repackage:
           requirements += Requirement(url, hash)
 
         case Unset =>
-          val error = RepackageError(m"dependency $hash is neither published nor cached")
-          cached(hash).lay(abort(error))(inlined ++= _)
+          val entries: List[Zip.Entry] = cached(hash).lest:
+            RepackageError(m"dependency $hash is neither published nor cached")
+
+          entries.each: entry =>
+            inlined += Entry(entry.ref.show, entry.read[Data])
 
     (requirements.result(), inlined.result())
 
 
   // Rewrites `inputJar` into `outputJar`: keeps the application's own classes,
-  // externalizes published dependencies as `Burdock-Require` references, inlines
-  // the rest from the cache, and sets `Main-Class` to the runtime bootstrap.
-  // `resolve`/`cached` are injected; `bootstrapClass` is the `burdock.Bootstrap`
-  // class bytes (force-included since it can't itself be downloaded).
+  // externalizes published dependencies as `Burdock-Require` references (stripping their
+  // bundled entries, since they are downloaded at runtime), inlines the rest from the
+  // cache, and sets `Main-Class` to the runtime bootstrap. `resolve`/`cached` are injected;
+  // `bootstrapClass` is the `burdock.Bootstrap` class bytes (force-included since it can't
+  // itself be downloaded).
   def repackage
     ( inputJar: Path on Linux, outputJar: Path on Linux, resolve: Resolver, cached: CacheReader,
       bootstrapClass: Data )
@@ -135,10 +141,24 @@ object Repackage:
         val ownEntries: List[Entry] = ownBuilder.result()
         val (requirements, inlined) = partition(hashes, resolve, cached)
 
-        // A cached entry may already be present among the application's own entries (e.g.
-        // when the input is a fat assembly); keep the bundled copy and inline only the gaps,
-        // so the output never carries two entries with the same name.
-        val ownNames: Set[Text] = ownEntries.map(_.name).to(Set)
+        // Published dependencies are downloaded and added to the classpath at runtime, so
+        // their bundled entries can be stripped from the repackaged JAR to slim it. Identify
+        // them by name from each published dependency's cached JAR (payloads are not read); a
+        // dependency absent from the cache can't be identified, so its entries stay bundled —
+        // still correct, just not slimmed.
+        val publishedEntries: List[Zip.Entry] = requirements.flatMap: requirement =>
+          cached(requirement.digest).or(Nil)
+
+        val stripped: Set[Text] = publishedEntries.map(_.ref.show).to(Set)
+
+        val keptEntries: List[Entry] = ownEntries.filter: entry =>
+          !stripped.contains(entry.name)
+
+        // A cached entry may still be present among the kept entries (e.g. an unpublished
+        // dependency bundled in a fat assembly); keep that copy and inline only the gaps, so
+        // the output never carries two entries with the same name.
+        val ownNames: Set[Text] = keptEntries.map(_.name).to(Set)
+
         val inlinedEntries: List[Entry] = inlined.filter: entry =>
           !ownNames.contains(entry.name)
 
@@ -152,7 +172,7 @@ object Repackage:
           + BurdockVerbosity(t"silent") + MainClass(fqcn"burdock.Bootstrap")
 
         val bootstrap: Entry = Entry(bootstrapName, bootstrapClass)
-        val entries: List[Entry] = bootstrap :: ownEntries ++ inlinedEntries
+        val entries: List[Entry] = bootstrap :: keptEntries ++ inlinedEntries
 
         Zipfile.write(outputJar):
           Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifest2.serialize)

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -71,8 +71,8 @@ object Tests extends Suite(m"Burdock Tests"):
     suite(m"Repackager partition"):
       val published = url"https://repo1.maven.org/maven2/g/a/1/a-1.jar"
       val resolve: Text => Optional[HttpUrl] = h => if h == t"aaa" then published else Unset
-      val classEntry = Bootstrapper.Entry(t"pkg/X.class", t"bytes".data)
-      val cached: Text => Optional[List[Bootstrapper.Entry]] =
+      val classEntry = Zip.Entry(t"pkg/X.class".decode[Path on Zip], t"bytes".data)
+      val cached: Repackage.CacheReader =
         h => if h == t"bbb" then List(classEntry) else Unset
 
       test(m"a published hash becomes a remote requirement"):
@@ -106,7 +106,8 @@ object Tests extends Suite(m"Burdock Tests"):
         h => if h == t"aaa" then url"https://repo1.maven.org/maven2/g/a/1/a-1.jar" else Unset
 
       val cached: Repackage.CacheReader =
-        h => if h == t"bbb" then List(Bootstrapper.Entry(t"dep/Lib.class", t"lib".data)) else Unset
+        h => if h == t"bbb" then List(Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"lib".data))
+             else Unset
 
       Repackage.repackage(inputJar, outputJar, resolve, cached, t"bootstrap-bytes".data)
 
@@ -161,7 +162,8 @@ object Tests extends Suite(m"Burdock Tests"):
       val resolve: Repackage.Resolver = _ => Unset
 
       val cached: Repackage.CacheReader =
-        h => if h == t"bbb" then List(Bootstrapper.Entry(t"dep/Lib.class", t"cached-lib".data))
+        h => if h == t"bbb"
+             then List(Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"cached-lib".data))
              else Unset
 
       Repackage.repackage(inputJar, outputJar, resolve, cached, t"real-bootstrap".data)
@@ -180,3 +182,59 @@ object Tests extends Suite(m"Burdock Tests"):
       test(m"a cached class already bundled is not duplicated"):
         names.count(_ == t"dep/Lib.class")
       .assert(_ == 1)
+
+    suite(m"Repackager (slimming)"):
+      // A fat assembly bundles its dependencies' classes. A published dependency is fetched
+      // at runtime (a `Burdock-Require` reference), so its bundled classes must be stripped
+      // from the repackaged JAR; the application's own classes (and an unpublished, cached
+      // dependency's classes) are kept.
+      val tmp: Path on Linux = temporaryDirectory[Path on Linux]
+      val inputJar: Path on Linux = tmp/t"burdock-slim-in-${Uuid().show}.jar"
+      val outputJar: Path on Linux = tmp/t"burdock-slim-out-${Uuid().show}.jar"
+
+      val manifestText: Text = t"Manifest-Version: 1.0\nMain-Class: com.example.Main\n\n"
+
+      Zipfile.write(inputJar):
+        Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifestText.data)
+        #:: Zip.Entry(t"META-INF/burdock.deps".decode[Path on Zip], t"pub\nunpub".data)
+        #:: Zip.Entry(t"com/example/Main.class".decode[Path on Zip], t"main".data)
+        #:: Zip.Entry(t"published/Lib.class".decode[Path on Zip], t"published-bytes".data)
+        #:: Zip.Entry(t"unpublished/Lib.class".decode[Path on Zip], t"unpublished-bytes".data)
+        #:: LazyList()
+
+      val published = url"https://repo1.maven.org/maven2/g/a/1/a-1.jar"
+      val resolve: Repackage.Resolver = h => if h == t"pub" then published else Unset
+
+      // The published dep's cached JAR lists the class bundled in the assembly (so it can be
+      // identified and stripped); the unpublished dep stays bundled.
+      val pubEntry = Zip.Entry(t"published/Lib.class".decode[Path on Zip], t"x".data)
+      val unpubEntry = Zip.Entry(t"unpublished/Lib.class".decode[Path on Zip], t"y".data)
+
+      val cached: Repackage.CacheReader = h =>
+        if h == t"pub" then List(pubEntry)
+        else if h == t"unpub" then List(unpubEntry)
+        else Unset
+
+      Repackage.repackage(inputJar, outputJar, resolve, cached, t"bootstrap".data)
+
+      val names: List[Text] = Zipfile.read(outputJar).entries.map(_.ref.show).to(List)
+
+      val manifest: Text =
+        Zipfile.read(outputJar).entries.find(_.ref.show == t"META-INF/MANIFEST.MF").get
+        . read[Data].utf8
+
+      test(m"strips a published dependency's bundled class"):
+        names.contains(t"published/Lib.class")
+      .assert(_ == false)
+
+      test(m"keeps the application's own class"):
+        names.contains(t"com/example/Main.class")
+      .assert(_ == true)
+
+      test(m"keeps an unpublished dependency's bundled class"):
+        names.contains(t"unpublished/Lib.class")
+      .assert(_ == true)
+
+      test(m"records the published dependency as a requirement"):
+        manifest.contains(t"pub")
+      .assert(_ == true)


### PR DESCRIPTION
Burdock's repackager previously kept every entry from the input JAR, so a fat assembly (Mill's default output) stayed fat even though its published dependencies were also recorded as `Burdock-Require` references to be downloaded at runtime — the artifact was never actually slimmed. The repackager now strips the bundled entries belonging to each externalised (published) dependency, so the repackaged JAR contains only the application's own classes, any inlined unpublished dependencies, and the bootstrap.

## Slimming

Each published dependency is fetched and added to the classpath at runtime by the bootstrap, so its bundled class files are redundant in the repackaged JAR. The repackager now identifies them by name from each published dependency's cached JAR and removes them. Payloads are read lazily (only the central directory is touched), so identifying the names is cheap. A dependency that isn't present in the local cache can't be identified, so its entries stay bundled — still correct, just not slimmed.

This is safe because the runtime bootstrap downloads each `Burdock-Require` JAR, verifies its SHA-256, and adds it to the same classloader as the (now slim) application JAR.

On a real ~100 MB flame assembly, repackaging now reduces the artifact from **19,577 entries / 104 MB** to **648 entries / 604 KB**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)