### PR TITLE
Generate structured Help trees for CLI applications

### DIFF
--- a/lib/ethereal/src/core/ethereal.DaemonService.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonService.scala
@@ -41,6 +41,7 @@ import exoskeleton.*
 import guillotine.*
 import prepositional.*
 import serpentine.*
+import vacuous.*
 
 case class DaemonService[bus <: Matchable]
   ( pid:        Pid,
@@ -50,9 +51,14 @@ case class DaemonService[bus <: Matchable]
     deliver:    bus => Unit,
     bus:        Stream[bus],
     script:     Text,
-    startTime:  Long )
+    startTime:  Long,
+    helpThunk:  () => Optional[Help] )
 extends Entrypoint:
   def broadcast(message: bus): Unit = deliver(message)
+
+  // The structured help tree for this command, generated lazily by re-running the application
+  // in tab-completion mode. Falls back to a name-only root if the executive cannot generate it.
+  def help(): Help = helpThunk().or(Help(script, Unset, Nil, Nil))
 
   def started[instant: Instantiable across Instants from Long]: instant =
     instant(startTime)

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -395,7 +395,14 @@ def cli[bus <: Matchable](using executive: Executive)
           clients.each: (pid, client) =>
             if sourcePid != pid then client.receive(message)
 
-        val service: DaemonService[bus] =
+        // Generated lazily and memoized: re-runs the application's pure portion in
+        // tab-completion mode to discover its subcommand/flag tree. Only the completions
+        // executive can produce a tree; others yield `Unset` and `service.help()` falls back.
+        lazy val helpValue: Optional[Help] =
+          executive.help(name, environment, () => directory, stdio, login):
+            (interface: executive.Interface) ?=> block(using service, interface, environment)
+
+        lazy val service: DaemonService[bus] =
           DaemonService[bus]
             ( pid,
               () => shutdown(pid),
@@ -404,7 +411,8 @@ def cli[bus <: Matchable](using executive: Executive)
               deliver(pid, _),
               clientState.bus.stream,
               name,
-              startTime )
+              startTime,
+              () => helpValue )
 
         Log.fine(DaemonLogEvent.NewCli)
 

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -37,6 +37,7 @@ import anticipation.*
 import contingency.*
 import denominative.*
 import distillate.*
+import escapade.*
 import eucalyptus.*
 import fulminate.*
 import gossamer.*
@@ -53,6 +54,70 @@ def execute(block: (erased Effectful) ?=> Invocation ?=> Exit)(using cli: Cli): 
 
 def explain(explanation: (Optional[Text] aka "prior") ?=> Optional[Text])(using cli: Cli): Unit =
   cli.explain(explanation(using Unset.aka["prior"]))
+
+// Build a structured `Help` tree for an application by re-running its pure portion in
+// tab-completion mode with synthesized argument prefixes. In completion mode `execute` does no
+// IO, so the block runs harmlessly; each run discovers the subcommands and flags reachable at
+// one prefix, and the driver descends into every non-hidden subcommand to build the tree.
+def helpTree
+  ( command:          Text,
+    environment:      Environment,
+    workingDirectory: WorkingDirectory,
+    stdio:            Stdio,
+    login:            Login )
+  ( block: Cli ?=> Execution )
+  ( using interpreter: Interpreter )
+:   Help =
+
+  def probe(prefix: List[Text]): (List[Suggestion], List[Flag]) =
+    val focus = prefix.length
+    val textArguments = prefix :+ t""
+    val synthesized = Cli.arguments(textArguments, focus, Unset, Prim)
+
+    val completion =
+      Completion
+        ( synthesized,
+          synthesized,
+          environment,
+          workingDirectory,
+          Shell.Zsh,
+          focus,
+          Unset,
+          stdio,
+          t"",
+          Prim,
+          login )
+
+    block(using completion)
+    (completion.cursorSuggestions, completion.flags.keySet.to(List))
+
+  def build
+    ( prefix:      List[Text],
+      command:     Text,
+      description: Optional[Text | Teletype],
+      seen:        Set[List[Text]] )
+  :   Help =
+
+    if seen.contains(prefix) then Help(command, description, Nil, Nil) else
+      val (suggestions, flags) = probe(prefix)
+
+      val parameters = flags.to(List).map: flag =>
+        Help.Param
+          ( Flag.serialize(flag.name),
+            flag.aliases.map(Flag.serialize(_)),
+            flag.description,
+            flag.repeatable )
+
+      val children =
+        suggestions.distinctBy(_.core).flatMap: suggestion =>
+          val childPrefix = prefix :+ suggestion.core
+
+          if suggestion.hidden || suggestion.incomplete then Nil
+          else List(build(childPrefix, suggestion.core, suggestion.description, seen + prefix))
+
+      Help(command, description, parameters, children.sortBy(_.command))
+
+  build(Nil, command, Unset, Set())
 
 package executives:
   given completions: (backstop: Backstop) => Executive:
@@ -197,3 +262,16 @@ package executives:
 
         try execution(using invocation).exitStatus
         catch case error: Throwable => backstop.handle(error)(using invocation.stdio)
+
+
+    override def help
+      ( command:          Text,
+        environment:      Environment,
+        workingDirectory: WorkingDirectory,
+        stdio:            Stdio,
+        login:            Login )
+      ( block: Cli ?=> Execution )
+      ( using interpreter: Interpreter )
+    :   Optional[Help] =
+
+      helpTree(command, environment, workingDirectory, stdio, login)(block)

--- a/lib/exoskeleton/src/core/exoskeleton.Help.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Help.scala
@@ -32,39 +32,52 @@
                                                                                                   */
 package exoskeleton
 
-import ambience.*
+import language.experimental.pureFunctions
+
 import anticipation.*
-import beneficence.*
-import rudiments.*
-import turbulence.*
+import escapade.*
+import gossamer.*
+import hieroglyph.*, textMetrics.uniform
+import symbolism.*
 import vacuous.*
 
-trait Executive extends Findable:
-  type Return
-  type Interface <: Cli
+object Help:
+  case class Param
+    ( name:        Text,
+      aliases:     List[Text],
+      description: Optional[Text | Teletype],
+      repeatable:  Boolean )
 
-  def invocation
-    ( fullArguments:    Iterable[Text],
-      environment:      Environment,
-      workingDirectory: WorkingDirectory,
-      stdio:            Stdio,
-      entrypoint:       Entrypoint,
-      login:            Login )
-    ( using interpreter: Interpreter )
-  :   Interface
+  // Render the tree to a `Teletype`, then borrow escapade's `Teletype is Printable` so that a
+  // `Help` value can be passed straight to `Out.println` and print nicely on the terminal.
+  given printable: Help is Printable = summon[Teletype is Printable].contramap(_.teletype)
 
-  def process(cli: Interface)(result: Interface ?=> Return): Exit
+case class Help
+  ( command:     Text,
+    description: Optional[Text | Teletype],
+    parameters:  List[Help.Param],
+    subcommands: List[Help] ):
 
-  // Re-run the application's pure portion in tab-completion mode with synthesized argument
-  // prefixes to discover its subcommand/flag structure as a `Help` tree, rooted at `command`.
-  // Only the completions executive can do this (its `Interface` is `Cli`, so a `Completion` is
-  // a valid interface); every other executive returns `Unset`.
-  def help
-    ( command:          Text,
-      environment:      Environment,
-      workingDirectory: WorkingDirectory,
-      stdio:            Stdio,
-      login:            Login )
-    ( block: Interface ?=> Return )
-    ( using interpreter: Interpreter )
-  :   Optional[Help] = Unset
+  def teletype: Teletype = lines(0).join(e"\n")
+
+  private def label(param: Help.Param): Text = (param.name :: param.aliases).join(t", ")
+
+  private def lines(depth: Int): List[Teletype] =
+    val indent: Text = t"  "*depth
+
+    val title: Teletype = description.absolve match
+      case Unset              => e"$indent$Bold($command)"
+      case text: Text         => e"$indent$Bold($command)  $text"
+      case teletype: Teletype => e"$indent$Bold($command)  $teletype"
+
+    val width: Int = parameters.map(label(_).length).maxOption.getOrElse(0)
+
+    val paramLines: List[Teletype] = parameters.map: param =>
+      param.description.absolve match
+        case Unset              => e"$indent    ${label(param)}"
+        case text: Text         => e"$indent    ${label(param).fit(width)}  $text"
+        case teletype: Teletype => e"$indent    ${label(param).fit(width)}  $teletype"
+
+    val subLines: List[Teletype] = subcommands.flatMap(_.lines(depth + 1))
+
+    title :: paramLines ::: subLines

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -410,3 +410,65 @@ object Tests extends Suite(m"Exoskeleton Tests"):
           test(m"fish focus=0 exits cleanly"):
             sh"$tool '{completions}' fish 0 0 /dev/null -- abcd".exec[Exit]()
           .assert(_ == Exit.Ok)
+
+    object HelpApp:
+      import interpreters.posix
+      import stdios.mute
+
+      val Alpha = Subcommand(t"alpha", e"a command to run")
+      val Beta = Subcommand(t"beta", e"another command to run")
+      val Gamma = Subcommand(t"gamma", e"a hidden command", hidden = true)
+      val Distribution = Subcommand(t"distribution", e"a different command to run")
+      val Ubuntu = Subcommand(t"ubuntu", e"Ubuntu")
+      val RedHat = Subcommand(t"red hat", e"Red Hat Linux")
+
+      def app(using Cli): Execution = arguments match
+        case Alpha() :: _ => execute(Exit.Ok)
+        case Beta() :: _  => execute(Exit.Ok)
+        case Gamma() :: _ => execute(Exit.Ok)
+
+        case Distribution() :: rest => rest match
+          case Ubuntu() :: _ =>
+            Flag(t"one", description = t"the first one")()
+            Flag(t"two", description = t"the second one")()
+            execute(Exit.Ok)
+
+          case RedHat() :: _ =>
+            Flag(t"only", description = t"there is only one")()
+            execute(Exit.Ok)
+
+          case _ => execute(Exit.Ok)
+
+        case _ => execute(Exit.Fail(1))
+
+      lazy val tree: Help =
+        helpTree
+         (t"mytool",
+          summon[Environment],
+          summon[WorkingDirectory],
+          summon[Stdio],
+          Login(t"tester", Unset))
+         (app)
+
+    test(m"Help root lists visible subcommands"):
+      HelpApp.tree.subcommands.map(_.command)
+    .assert(_ == List(t"alpha", t"beta", t"distribution"))
+
+    test(m"Help excludes hidden subcommands"):
+      HelpApp.tree.subcommands.map(_.command).contains(t"gamma")
+    .assert(_ == false)
+
+    test(m"Help descends into nested subcommands"):
+      HelpApp.tree.subcommands.filter(_.command == t"distribution").flatMap: distribution =>
+        distribution.subcommands.map(_.command)
+    .assert(_ == List(t"red hat", t"ubuntu"))
+
+    test(m"Help captures a leaf subcommand's flags"):
+      HelpApp.tree.subcommands
+       .filter(_.command == t"distribution").flatMap(_.subcommands)
+       .filter(_.command == t"ubuntu").flatMap(_.parameters.map(_.name))
+    .assert(_ == List(t"--one", t"--two"))
+
+    test(m"Help renders as Printable text mentioning a subcommand"):
+      summon[Help is Printable].print(HelpApp.tree, stdios.mute.termcap)
+    .assert(_.contains(t"alpha"))


### PR DESCRIPTION
Exoskeleton can now generate structured help for a command-line application by re-running its pure portion in tab-completion mode with synthesized argument prefixes, reusing the same machinery that already drives tab completion to discover every subcommand and flag. The result is a `Help` tree that is `Printable`, so it can be passed straight to `Out.println` and rendered nicely on the terminal, and a daemon application can obtain it through a new, lazily-cached `help()` method on its contextual service.

Because an application's pure portion (everything up to `execute`) performs no I/O in completion mode, Exoskeleton can run it repeatedly behind the scenes to map out a command's structure. This is exposed as a `Help` value:

```scala
case class Help(command: Text, description: Optional[Text | Teletype],
                parameters: List[Help.Param], subcommands: List[Help])
```

In a daemon application, ask the contextual service for it and print it:

```scala
Out.println(service.help())
```

`Help` derives a `Printable` instance from an Escapade `Teletype` renderer, so it prints with aligned columns and bold headings without any extra ceremony. Hidden subcommands are omitted. The tree is generated lazily and memoised for the lifetime of the daemon process.

Under the hood this is driven by a new `helpTree` function and an `Executive.help` hook; only the completions executive can produce a tree (its interface is a `Cli`, so a synthetic `Completion` is a valid input), and every other executive simply yields nothing.
