### PR TITLE
Rename the repackager entry point to `soundness.repackage`

### DIFF
--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -1,5 +1,5 @@
                                                                                                   /*
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃                                                                                                  ┃
 ┃                                                   ╭───╮                                          ┃
 ┃                                                   │   │                                          ┃
@@ -50,8 +50,6 @@ import urticose.*
 import vacuous.*
 import zeppelin.*
 
-import Bootstrapper.given
-import Bootstrapper.{BurdockMain, BurdockRequire, BurdockVerbosity, Entry, Requirement}
 import errorDiagnostics.empty
 
 // The repackager. Reads the dependency hashes embedded by the compile-time macro
@@ -60,7 +58,23 @@ import errorDiagnostics.empty
 // copying the cached JAR's classes into the artifact. The completeness invariant:
 // every dependency is either externalized or inlined — a hash that is neither is
 // an error.
-object Repackage:
+object Repackager:
+  object BurdockMain extends ManifestAttribute["Burdock-Main"]
+  object BurdockVerbosity extends ManifestAttribute["Burdock-Verbosity"]
+  object BurdockRequire extends ManifestAttribute["Burdock-Require"]
+
+  given burdockMain: ("Burdock-Main" is EncodableManifest of Fqcn) = _.text
+
+  given burdockRequire: ("Burdock-Require" is EncodableManifest of List[Requirement]) =
+    _.map(_.text).join(t" ")
+
+  given burdockVerbosity: ("Burdock-Verbosity" is EncodableManifest of Text) = identity(_)
+
+  case class Requirement(url: into[HttpUrl], digest: Text):
+    def text = t"$digest:$url"
+
+  case class Entry(name: Text, data: Data)
+  case class UserError(detail: Message)(using Diagnostics) extends Error(detail)
   case class RepackageError(detail: Message)(using Diagnostics) extends Error(detail)
 
   // Resolves a dependency hash to its public URL (deps.dev), or `Unset`.

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -55,6 +55,7 @@ import urticose.*
 import vacuous.*
 import zeppelin.*
 
+import Repackager.UserError
 import backstops.stackTrace
 import environments.java
 import executives.direct
@@ -64,82 +65,67 @@ import stdios.virtualMachine
 import systems.java
 import termcaps.environment
 
-object Bootstrapper:
-  object BurdockMain extends ManifestAttribute["Burdock-Main"]
-  object BurdockVerbosity extends ManifestAttribute["Burdock-Verbosity"]
-  object BurdockRequire extends ManifestAttribute["Burdock-Require"]
+// The repackager's command-line logic, launched by the `soundness.repackage` entry point.
+// It takes no arguments — it self-locates the application JAR it is running from and
+// rewrites it in place (see `Repackager.repackage`).
+def repackage(): Unit = application(Nil):
+  whereas:
+    case error: Error =>
+      Err.println(error.message)
+      Exit.Fail(1)
 
-  given burdockMain: ("Burdock-Main" is EncodableManifest of Fqcn) = _.text
+  . recover:
+      val loader: ClassLoader = summon[Classloader].java
 
-  given burdockRequire: ("Burdock-Require" is EncodableManifest of List[Requirement]) =
-    _.map(_.text).join(t" ")
+      // Self-locate the application JAR: the classpath entry holding the
+      // `META-INF/burdock.deps` resource the build-time macro wrote. (Locating by
+      // the `burdock.Bootstrap` class would find burdock's own JAR, not the app's,
+      // once the app JAR is slim.)
+      val resourcePath: String = burdock.internal.ResourcePath
 
-  given burdockVerbosity: ("Burdock-Verbosity" is EncodableManifest of Text) = identity(_)
+      val depsResource: jn.URL =
+        Optional(loader.getResource(resourcePath)).lest:
+          UserError(m"this JAR was not built with Burdock (no ${resourcePath.tt})")
 
-  case class Requirement(url: into[HttpUrl], digest: Text):
-    def text = t"$digest:$url"
+      val connection: jn.URLConnection = depsResource.openConnection().nn
 
-  case class Entry(name: Text, data: Data)
-  case class UserError(detail: Message)(using Diagnostics) extends Error(detail)
+      val inputJar: Path on Linux = connection match
+        case jar: jn.JarURLConnection =>
+          jnf.Paths.get(jar.getJarFileURL.nn.toURI.nn).nn.toString.nn.tt.decode[Path on Linux]
 
-  def main(input: IArray[Text]): Unit = application(input):
-    whereas:
-      case error: Error =>
-        Err.println(error.message)
-        Exit.Fail(1)
+        case _ =>
+          abort(UserError(m"Burdock can only repackage a JAR file, not a directory"))
 
-    . recover:
-        val loader: ClassLoader = summon[Classloader].java
+      Out.println(m"Repackaging $inputJar")
 
-        // Self-locate the application JAR: the classpath entry holding the
-        // `META-INF/burdock.deps` resource the build-time macro wrote. (Locating by
-        // the `burdock.Bootstrap` class would find burdock's own JAR, not the app's,
-        // once the app JAR is slim.)
-        val resourcePath: String = burdock.internal.ResourcePath
+      // The bootstrap loader cannot be downloaded — it does the downloading — so
+      // its bytes are force-included from burdock's own (boot) JAR on the classpath.
+      val bootstrapClass: Data = (Classpath/"burdock"/"Bootstrap.class").read[Data]
 
-        val depsResource: jn.URL =
-          Optional(loader.getResource(resourcePath)).lest:
-            UserError(m"this JAR was not built with Burdock (no ${resourcePath.tt})")
+      // Unpublished dependencies are reconstructed from the build-time hard-links in
+      // `~/.cache/burdock/<sha256>.jar` (see `externalize`); published ones resolve via
+      // deps.dev and are referenced by URL rather than inlined.
+      val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
+      val cacheDir: Path on Linux = t"$home/.cache/burdock".decode[Path on Linux]
 
-        val connection: jn.URLConnection = depsResource.openConnection().nn
+      def cached(hash: Text): Optional[List[Zip.Entry]] =
+        val cacheJar: Path on Linux = cacheDir/t"$hash.jar"
 
-        val inputJar: Path on Linux = connection match
-          case jar: jn.JarURLConnection =>
-            jnf.Paths.get(jar.getJarFileURL.nn.toURI.nn).nn.toString.nn.tt.decode[Path on Linux]
+        if !cacheJar.exists() then Unset else
+          Zipfile.read(cacheJar).entries.filter: entry =>
+            !entry.directory && entry.ref.show != t"META-INF/MANIFEST.MF"
 
-          case _ =>
-            abort(UserError(m"Burdock can only repackage a JAR file, not a directory"))
+          . to(List)
 
-        Out.println(m"Repackaging $inputJar")
+      val tmpFile: Path on Linux = inputJar.parent.vouch/t"${inputJar.name}.tmp"
+      Repackager.repackage(inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass)
 
-        // The bootstrap loader cannot be downloaded — it does the downloading — so
-        // its bytes are force-included from burdock's own (boot) JAR on the classpath.
-        val bootstrapClass: Data = (Classpath/"burdock"/"Bootstrap.class").read[Data]
+      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.deleteRecursively.disabled
+      import filesystemOptions.moveAtomically.enabled
+      import filesystemOptions.createNonexistentParents.disabled
 
-        // Unpublished dependencies are reconstructed from the build-time hard-links in
-        // `~/.cache/burdock/<sha256>.jar` (see `externalize`); published ones resolve via
-        // deps.dev and are referenced by URL rather than inlined.
-        val home: Text = _root_.java.lang.System.getProperty("user.home").nn.tt
-        val cacheDir: Path on Linux = t"$home/.cache/burdock".decode[Path on Linux]
+      tmpFile.moveTo(inputJar)
+      Out.println(m"Repackaged $inputJar")
 
-        def cached(hash: Text): Optional[List[Zip.Entry]] =
-          val cacheJar: Path on Linux = cacheDir/t"$hash.jar"
-
-          if !cacheJar.exists() then Unset else
-            Zipfile.read(cacheJar).entries.filter: entry =>
-              !entry.directory && entry.ref.show != t"META-INF/MANIFEST.MF"
-
-            . to(List)
-
-        val tmpFile: Path on Linux = inputJar.parent.vouch/t"${inputJar.name}.tmp"
-        Repackage.repackage(inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass)
-
-        import filesystemOptions.overwritePreexisting.enabled
-        import filesystemOptions.deleteRecursively.disabled
-        import filesystemOptions.moveAtomically.enabled
-        import filesystemOptions.createNonexistentParents.disabled
-
-        tmpFile.moveTo(inputJar)
-        Out.println(m"Repackaged $inputJar")
-
-        Exit.Ok
+      Exit.Ok

--- a/lib/burdock/src/core/soundness_burdock_core.scala
+++ b/lib/burdock/src/core/soundness_burdock_core.scala
@@ -32,4 +32,10 @@
                                                                                                   */
 package soundness
 
-export burdock.{externalize, Bootstrapper}
+export burdock.{externalize, Repackager}
+
+// The repackager's command-line entry point, in the `soundness` package so it can be
+// launched as `java -cp app.jar soundness.repackage` (house style requires every file to
+// declare a package, so it cannot live in the default package).
+@main
+def repackage(): Unit = burdock.repackage()

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -72,21 +72,21 @@ object Tests extends Suite(m"Burdock Tests"):
       val published = url"https://repo1.maven.org/maven2/g/a/1/a-1.jar"
       val resolve: Text => Optional[HttpUrl] = h => if h == t"aaa" then published else Unset
       val classEntry = Zip.Entry(t"pkg/X.class".decode[Path on Zip], t"bytes".data)
-      val cached: Repackage.CacheReader =
+      val cached: Repackager.CacheReader =
         h => if h == t"bbb" then List(classEntry) else Unset
 
       test(m"a published hash becomes a remote requirement"):
-        val (requirements, inlined) = Repackage.partition(List(t"aaa"), resolve, cached)
+        val (requirements, inlined) = Repackager.partition(List(t"aaa"), resolve, cached)
         (requirements.length, inlined.length)
       .assert(_ == (1, 0))
 
       test(m"an unpublished but cached hash is inlined"):
-        val (requirements, inlined) = Repackage.partition(List(t"bbb"), resolve, cached)
+        val (requirements, inlined) = Repackager.partition(List(t"bbb"), resolve, cached)
         (requirements.length, inlined.length)
       .assert(_ == (0, 1))
 
       test(m"a hash that is neither published nor cached is rejected"):
-        capture[Repackage.RepackageError](Repackage.partition(List(t"ccc"), resolve, cached))
+        capture[Repackager.RepackageError](Repackager.partition(List(t"ccc"), resolve, cached))
       .assert(_ => true)
 
     suite(m"Repackager (end-to-end)"):
@@ -102,14 +102,14 @@ object Tests extends Suite(m"Burdock Tests"):
         #:: Zip.Entry(t"com/example/Main.class".decode[Path on Zip], t"main".data)
         #:: LazyList()
 
-      val resolve: Repackage.Resolver =
+      val resolve: Repackager.Resolver =
         h => if h == t"aaa" then url"https://repo1.maven.org/maven2/g/a/1/a-1.jar" else Unset
 
-      val cached: Repackage.CacheReader =
+      val cached: Repackager.CacheReader =
         h => if h == t"bbb" then List(Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"lib".data))
              else Unset
 
-      Repackage.repackage(inputJar, outputJar, resolve, cached, t"bootstrap-bytes".data)
+      Repackager.repackage(inputJar, outputJar, resolve, cached, t"bootstrap-bytes".data)
 
       val names: List[Text] = Zipfile.read(outputJar).entries.map(_.ref.show).to(List)
 
@@ -159,14 +159,14 @@ object Tests extends Suite(m"Burdock Tests"):
         #:: Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"bundled-lib".data)
         #:: LazyList()
 
-      val resolve: Repackage.Resolver = _ => Unset
+      val resolve: Repackager.Resolver = _ => Unset
 
-      val cached: Repackage.CacheReader =
+      val cached: Repackager.CacheReader =
         h => if h == t"bbb"
              then List(Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"cached-lib".data))
              else Unset
 
-      Repackage.repackage(inputJar, outputJar, resolve, cached, t"real-bootstrap".data)
+      Repackager.repackage(inputJar, outputJar, resolve, cached, t"real-bootstrap".data)
 
       val names: List[Text] = Zipfile.read(outputJar).entries.map(_.ref.show).to(List)
 
@@ -203,19 +203,19 @@ object Tests extends Suite(m"Burdock Tests"):
         #:: LazyList()
 
       val published = url"https://repo1.maven.org/maven2/g/a/1/a-1.jar"
-      val resolve: Repackage.Resolver = h => if h == t"pub" then published else Unset
+      val resolve: Repackager.Resolver = h => if h == t"pub" then published else Unset
 
       // The published dep's cached JAR lists the class bundled in the assembly (so it can be
       // identified and stripped); the unpublished dep stays bundled.
       val pubEntry = Zip.Entry(t"published/Lib.class".decode[Path on Zip], t"x".data)
       val unpubEntry = Zip.Entry(t"unpublished/Lib.class".decode[Path on Zip], t"y".data)
 
-      val cached: Repackage.CacheReader = h =>
+      val cached: Repackager.CacheReader = h =>
         if h == t"pub" then List(pubEntry)
         else if h == t"unpub" then List(unpubEntry)
         else Unset
 
-      Repackage.repackage(inputJar, outputJar, resolve, cached, t"bootstrap".data)
+      Repackager.repackage(inputJar, outputJar, resolve, cached, t"bootstrap".data)
 
       val names: List[Text] = Zipfile.read(outputJar).entries.map(_.ref.show).to(List)
 


### PR DESCRIPTION
The class invoked to slim an application JAR (previously `burdock.Bootstrapper`) is now `soundness.repackage`, run with `java -cp app.jar soundness.repackage`. The slimming logic and its shared types move into a renamed `Repackager` object, leaving the entry point a thin launcher.

## Entry point

The repackager is launched as:

```
java -cp app.jar soundness.repackage
```

It takes no arguments — it self-locates the application JAR it is running from and rewrites it in place. (It cannot be a bare `repackage` in the default package, because the house-style lint requires every source file to declare a package; so the `@main` lives in the `soundness` umbrella file and delegates to the CLI logic in `burdock`.)

## Internal restructure

The repackaging logic and its domain types (`Requirement`, `Entry`, the `Burdock-*` manifest attributes, `UserError`) move out of the old `Bootstrapper` object into an object renamed `Repackage` → `Repackager`. `burdock.Bootstrapper` no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)