### PR TITLE
Fix duplicate `burdock/Bootstrap.class` when inlining an unpublished burdock

### DIFF
--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -168,14 +168,6 @@ object Repackager:
         val keptEntries: List[Entry] = ownEntries.filter: entry =>
           !stripped.contains(entry.name)
 
-        // A cached entry may still be present among the kept entries (e.g. an unpublished
-        // dependency bundled in a fat assembly); keep that copy and inline only the gaps, so
-        // the output never carries two entries with the same name.
-        val ownNames: Set[Text] = keptEntries.map(_.name).to(Set)
-
-        val inlinedEntries: List[Entry] = inlined.filter: entry =>
-          !ownNames.contains(entry.name)
-
         import manifestAttributes.*
 
         val originalMain =
@@ -186,7 +178,12 @@ object Repackager:
           + BurdockVerbosity(t"silent") + MainClass(fqcn"burdock.Bootstrap")
 
         val bootstrap: Entry = Entry(bootstrapName, bootstrapClass)
-        val entries: List[Entry] = bootstrap :: keptEntries ++ inlinedEntries
+
+        // Keep the first occurrence of each entry name: the force-included bootstrap over any
+        // bundled or inlined copy (an unpublished `burdock` dependency's cached JAR also
+        // carries `burdock/Bootstrap.class`), and a bundled class over an inlined cache copy.
+        // Without this, `Zipfile.write` rejects the duplicate entry.
+        val entries: List[Entry] = (bootstrap :: keptEntries ++ inlined).distinctBy(_.name)
 
         Zipfile.write(outputJar):
           Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifest2.serialize)

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -142,9 +142,11 @@ object Tests extends Suite(m"Burdock Tests"):
 
     suite(m"Repackager (duplicate-safety)"):
       // A real assembly bundles burdock (its `Main-Class` is `burdock.Bootstrap`), so the
-      // input already contains `burdock/Bootstrap.class`; and a cached dependency may be a
-      // class already present among the application's own entries. Neither must produce a
-      // duplicate entry in the output (which would fail as a `ZipError`). See issue #1333.
+      // input already contains `burdock/Bootstrap.class`; a cached dependency may be a class
+      // already present among the application's own entries; and an inlined (unpublished, e.g.
+      // locally-published) burdock dependency's cached JAR also carries `burdock/Bootstrap.class`.
+      // None of these must produce a duplicate entry in the output (which fails as a
+      // `ZipError`). See issue #1333.
       val tmp: Path on Linux = temporaryDirectory[Path on Linux]
       val inputJar: Path on Linux = tmp/t"burdock-dup-in-${Uuid().show}.jar"
       val outputJar: Path on Linux = tmp/t"burdock-dup-out-${Uuid().show}.jar"
@@ -161,10 +163,12 @@ object Tests extends Suite(m"Burdock Tests"):
 
       val resolve: Repackager.Resolver = _ => Unset
 
-      val cached: Repackager.CacheReader =
-        h => if h == t"bbb"
-             then List(Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"cached-lib".data))
-             else Unset
+      val cached: Repackager.CacheReader = h =>
+        if h == t"bbb"
+        then Zip.Entry(t"dep/Lib.class".decode[Path on Zip], t"cached-lib".data)
+             :: Zip.Entry(t"burdock/Bootstrap.class".decode[Path on Zip], t"cached-bootstrap".data)
+             :: Nil
+        else Unset
 
       Repackager.repackage(inputJar, outputJar, resolve, cached, t"real-bootstrap".data)
 


### PR DESCRIPTION
Repackaging an application that depends on a locally-published (unpublished) `burdock` failed with `the JAR could not be read or written (the path burdock/Bootstrap.class is a duplicate entry)`. The unpublished burdock gets inlined from its cached JAR, which carries `burdock/Bootstrap.class`, colliding with the bootstrap class the repackager force-includes.

The repackager now assembles its output keeping the first occurrence of each entry name — the force-included bootstrap over any bundled or inlined copy, and a bundled class over an inlined cache copy — so no duplicate entry can reach the JAR writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)