### PR TITLE
Build and publish reusable native runner stubs separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ out
 boot
 .bsp
 bin
+dist
 tests/JSONTestSuite
 lib/ethereal/target

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,13 @@ xeq-release:
 	@if [ -z "$(VERSION)" ]; then echo "Usage: make xeq-release VERSION=X.Y.Z [REPO=owner/repo] [TAG=tag]" >&2; exit 1; fi
 	./etc/ci/xeq-release.sh "$(VERSION)" "$(REPO)" "$(TAG)"
 
+runners-build:
+	./etc/ci/runners-build.sh
+
+runners-release:
+	@if [ -z "$(RUNNERS_VERSION)" ]; then echo "Usage: make runners-release RUNNERS_VERSION=X [REPO=owner/repo]" >&2; exit 1; fi
+	./etc/ci/runners-release.sh "$(RUNNERS_VERSION)" "$(REPO)"
+
 scala/%:
 	TAG=$(word 1, $(subst :, ,$*)); \
 	JDK=$(word 2, $(subst :, ,$*)); \
@@ -67,4 +74,4 @@ matrix:
 	    $(foreach scala,3.6.1 3.6.2 3.6.3 3.6.4 3.7.0 3.7.1 3.7.1 main, \
 			    $(MAKE) bootstrap/$(scala):$(jdk);))
 
-.PHONY: publishLocal build dev ci test matrix attest verify-attest push release xeq-release
+.PHONY: publishLocal build dev ci test matrix attest verify-attest push release xeq-release runners-build runners-release

--- a/etc/ci/runners-build.sh
+++ b/etc/ci/runners-build.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Compile the reusable native runner stubs (one per platform) with `cargo zigbuild`.
+#
+# These are the small (~0.5 MB), generic, version-independent launchers. An application
+# binary is built by appending the app's JAR to the right stub; the stubs themselves are
+# reusable across applications and versions. This build is deliberately *separate* from the
+# Soundness (Mill) build — runners only change when the Rust source under `lib/ethereal`
+# changes, and are published independently by `runners-release.sh`.
+#
+# Usage: ./etc/ci/runners-build.sh [output-dir]      (default: dist/runners)
+#
+# Produces <output-dir>/runner-<label>[.exe] for each platform.
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+OUT="${1:-dist/runners}"
+ETHDIR="lib/ethereal"
+
+# triple|label|binary — the platforms the runner is cross-compiled for.
+TARGETS=(
+  "x86_64-pc-windows-gnu|windows-x64|runner.exe"
+  "x86_64-unknown-linux-gnu|linux-x64|runner"
+  "aarch64-unknown-linux-gnu|linux-arm64|runner"
+  "x86_64-apple-darwin|macos-x64|runner"
+  "aarch64-apple-darwin|macos-arm64|runner"
+)
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "runners-build: cargo (with the zigbuild subcommand) is required" >&2; exit 1
+fi
+
+target_dir=$(mktemp -d)
+trap 'rm -rf "$target_dir"' EXIT
+
+triple_args=()
+for entry in "${TARGETS[@]}"; do
+  IFS='|' read -r triple _ _ <<< "$entry"
+  triple_args+=(--target "$triple")
+done
+
+echo "runners-build: cross-compiling ${#TARGETS[@]} runner stubs (release)…"
+cargo zigbuild --release \
+  --manifest-path "$ETHDIR/Cargo.toml" \
+  --target-dir "$target_dir" \
+  "${triple_args[@]}"
+
+mkdir -p "$OUT"
+for entry in "${TARGETS[@]}"; do
+  IFS='|' read -r triple label binary <<< "$entry"
+  ext=""; [[ "$binary" == *.exe ]] && ext=".exe"
+  cp -f "$target_dir/$triple/release/$binary" "$OUT/runner-$label$ext"
+  chmod +x "$OUT/runner-$label$ext"
+done
+
+echo "runners-build: built into $OUT:"
+ls -la "$OUT"/runner-*

--- a/etc/ci/runners-release.sh
+++ b/etc/ci/runners-release.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Publish the reusable native runner stubs to a versioned GitHub release, and record their
+# SHA-256 hashes in a committed manifest (`etc/runners/<version>.tsv`).
+#
+# The stubs are version-independent and reusable, so they are published *separately* from —
+# and far less frequently than — application releases (only when the Rust runner source
+# changes). An application build then consumes a given runner version: a monoglot build
+# downloads the one stub for its platform; an offline polyglot build downloads all five and
+# embeds them; an online polyglot build embeds the five (url, hash) pairs from the manifest
+# and downloads the right stub at runtime. In every case the app's JAR is appended to a bare
+# stub — the stub bytes are never re-published per application.
+#
+# Usage: ./etc/ci/runners-release.sh <version> [owner/repo]
+#         (or `make runners-release RUNNERS_VERSION=X [REPO=owner/repo]`)
+#
+# Side effects: uploads to the GitHub release `runners-<version>`, and writes
+# `etc/runners/<version>.tsv` (commit it — it is the source of truth for the hashes that get
+# embedded in online downloaders).
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION="${1:-}"
+REPO="${2:-propensive/soundness}"
+TAG="runners-$VERSION"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version> [owner/repo]" >&2; exit 1
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  echo "runners-release: the GitHub CLI (gh) is required" >&2; exit 1
+fi
+
+OUT="dist/runners"
+./etc/ci/runners-build.sh "$OUT"
+
+# Record the SHA-256 of every stub into the committed manifest, keyed by platform label.
+# These are computed from the exact bytes uploaded below, so they always match.
+mkdir -p etc/runners
+MANIFEST="etc/runners/$VERSION.tsv"
+: > "$MANIFEST"
+for f in "$OUT"/runner-*; do
+  name=$(basename "$f")
+  label=${name#runner-}; label=${label%.exe}
+  hash=$( { sha256sum "$f" 2>/dev/null || shasum -a 256 "$f"; } | cut -d' ' -f1)
+  printf '%s\t%s\n' "$label" "$hash" >> "$MANIFEST"
+done
+sort -o "$MANIFEST" "$MANIFEST"
+echo "runners-release: wrote $MANIFEST"
+
+# Create the release if it doesn't exist yet, then upload the bare stubs (clobber on re-run).
+if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+  gh release create "$TAG" --repo "$REPO" --title "$TAG" \
+    --notes "Reusable native runner stubs, version $VERSION"
+fi
+gh release upload "$TAG" --repo "$REPO" --clobber "$OUT"/runner-*
+
+count=$(find "$OUT" -maxdepth 1 -name 'runner-*' | wc -l | tr -d ' ')
+echo "runners-release: uploaded $count stubs to $REPO@$TAG"
+echo "runners-release: commit $MANIFEST to record the published hashes"

--- a/etc/ci/xeq-release.sh
+++ b/etc/ci/xeq-release.sh
@@ -38,7 +38,7 @@ BASE="https://github.com/$REPO/releases/download/$TAG/"
 
 # Build the per-platform binaries and the launcher into ./dist. The base URL
 # baked into the launcher must match where we upload to below.
-./mill ethereal.example.distributable "$VERSION" "$BASE"
+./mill ethereal.example.distributable --version "$VERSION" --baseUrl "$BASE"
 
 # Create the release if it doesn't exist yet, then upload (clobber on re-run so
 # the script is idempotent).

--- a/etc/runners/README.md
+++ b/etc/runners/README.md
@@ -1,0 +1,19 @@
+# Runner stub manifests
+
+Each `<version>.tsv` records the SHA-256 hashes of the reusable native runner stubs published
+as the GitHub release `runners-<version>` (assets `runner-<label>[.exe]`). It is generated and
+committed by `etc/ci/runners-release.sh` (`make runners-release RUNNERS_VERSION=<version>`).
+
+Format — one tab-separated line per platform, sorted by label:
+
+```
+<label>	<sha256>
+```
+
+where `<label>` is one of `linux-x64`, `linux-arm64`, `macos-x64`, `macos-arm64`, `windows-x64`.
+
+These hashes are the source of truth for application packaging: an online polyglot launcher
+embeds them to verify the stub it downloads at runtime; a monoglot or offline build verifies
+the stub bytes it downloads at build time against them. The stubs are version-independent and
+reusable across applications — they are republished only when the Rust runner source under
+`lib/ethereal` changes.


### PR DESCRIPTION
The native runner stubs — the small (~0.5 MB), generic, version-independent launchers an application binary is built from — are now built and published independently of the Soundness build, as a prerequisite for switching the application builder to *download* these reusable stubs instead of rebuilding and baking them into every per-platform artifact.

## New targets

- `make runners-build` cross-compiles the five stubs (`runner-<label>[.exe]`) with `cargo zigbuild` into `dist/runners`.
- `make runners-release RUNNERS_VERSION=X` builds them, uploads the bare stubs to the GitHub release `runners-X`, and records their SHA-256s in the committed manifest `etc/runners/X.tsv` — the source of truth for the hashes embedded in online downloaders.

The stubs are reusable across applications and versions, so they are republished only when the Rust runner source under `lib/ethereal` changes — separately from, and far less frequently than, application releases.

## Also

Fixes `xeq-release.sh` to pass the mill `distributable` command its arguments as named flags (`--version`/`--baseUrl`), which Mill 1.x requires (it was passing them positionally and failing).

This change is build/release tooling only (shell, Makefile, docs); the Mill build and the application packaging path are unchanged for now and will be reworked in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)