### PR TITLE
zeppelin: enforce entry-name rules on read, closing a Zip-Slip gap

### DIFF
--- a/lib/zeppelin/src/core/zeppelin.Zip.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zip.scala
@@ -48,15 +48,12 @@ object Zip:
   type Rules =
     MustNotContain["\\"] & MustNotContain["\""] & MustNotContain["/"] & MustNotContain[":"]
     & MustNotContain["*"] & MustNotContain["?"] & MustNotContain["<"] & MustNotContain[">"]
-    & MustNotContain["|"]
+    & MustNotContain["|"] & MustNotEqual["."] & MustNotEqual[".."]
 
   inline given compliant: Linux is Compliant on Zip = !!
   inline given compliant2: MacOs is Compliant on Zip = !!
   inline given nominative: Zip is Nominative under Rules = !!
   given submissible: %.type is Submissible on Zip = _ => ()
-
-  class ZipRoot() extends Root(t""):
-    type Plane = Zip
 
   given filesystem: Zip is Filesystem:
     type UniqueRoot = false

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -244,7 +244,12 @@ object Zipfile:
           case PathError(_, _)    => ZipError(ZipError.Reason.InvalidName(cleanName))
           case NameError(_, _, _) => ZipError(ZipError.Reason.InvalidName(cleanName))
 
-        . mitigate(cleanName.decode[Path on Zip])
+        . mitigate:
+          // `decode` performs no per-segment validation, so check each name component
+          // against `Zip.Rules` (which also forbids the `.`/`..` traversal segments) to
+          // make `InvalidName` reachable and reject Zip-Slip / path-traversing entry names.
+          cleanName.cut(t"/").each(Name[Zip](_))
+          cleanName.decode[Path on Zip]
 
       val payloadOffset = localOffset + prefixDelta
       if payloadOffset < earliestEntry then earliestEntry = payloadOffset

--- a/lib/zeppelin/src/test/zeppelin_test.scala
+++ b/lib/zeppelin/src/test/zeppelin_test.scala
@@ -264,6 +264,16 @@ object Tests extends Suite(m"Zeppelin tests"):
         readEntries(writeRawZip(t"foreign2.zip", t"solo.txt")).head.read[Text]
       . assert(_ == t"data")
 
+      test(m"an entry name with a forbidden character raises InvalidName"):
+        import errorDiagnostics.empty
+        capture[ZipError](readEntries(writeRawZip(t"badchar.zip", t"bad:name.txt"))).reason
+      . assert(_ == ZipError.Reason.InvalidName(t"bad:name.txt"))
+
+      test(m"a path-traversing entry name raises InvalidName"):
+        import errorDiagnostics.empty
+        capture[ZipError](readEntries(writeRawZip(t"slip.zip", t"../escape.txt"))).reason
+      . assert(_ == ZipError.Reason.InvalidName(t"../escape.txt"))
+
     suite(m"Entry reuse between archives"):
       val source = writeZip(t"src.zip", entry(t"x.txt", (t"reuse me "*32)))
       val reused: Zip.Entry = Zipfile.read(source).entries.head


### PR DESCRIPTION
Zeppelin's random-access ZIP reader decoded each archive entry name straight into a `Path on Zip` without validating it, so a foreign archive containing rule-violating names (e.g. `bad:name.txt`) or path-traversing names (e.g. `../escape.txt`) was accepted silently and `ZipError.InvalidName` was unreachable. Reading now validates every name component against `Zip.Rules`, raising `ZipError.InvalidName` for any entry whose name breaks those rules — including `.`/`..` traversal segments — which closes a Zip-Slip exposure.

Reading a ZIP archive now rejects entries whose names are not valid ZIP entry names. Each `/`-separated component of an entry name is checked against `Zip.Rules`, so an archive built elsewhere that contains a forbidden character or a path-traversal segment fails fast:

```scala
import soundness.*

// An archive containing an entry named "../escape.txt" or "bad:name.txt"
// now raises ZipError(InvalidName(...)) instead of being read silently:
val zip = Zipfile.read(maliciousArchive)
```

`Zip.Rules` additionally forbids the `.` and `..` segments (previously only individual characters were disallowed, which did not stop traversal). This also removes the unused `Zip.ZipRoot` class, dead since the native ZIP reimplementation.

Closes #1212.
