### PR TITLE
Infer Name's plane set from every Nominative in scope

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1079,6 +1079,7 @@ object urticose extends Library:
 
 object nomenclature extends Library:
   object core extends Component(gossamer.core, turbulence.core):
+    def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, hellenism.core)

--- a/lib/nomenclature/src/core/nomenclature.NameExtractor.scala
+++ b/lib/nomenclature/src/core/nomenclature.NameExtractor.scala
@@ -36,8 +36,7 @@ import scala.quoted.*
 
 
 class NameExtractor[text <: Label]():
-  inline def apply[plane: Nominative](): Name[plane] =
-    ${protointernal.parse[plane, text]}
+  transparent inline def apply(): Any = ${protointernal.inferName[text]}
 
   inline def unapply[plane](inline scrutinee: Name[plane]): Boolean =
     ${protointernal.parse2[plane, text]('scrutinee)}

--- a/lib/nomenclature/src/core/nomenclature.internal.scala
+++ b/lib/nomenclature/src/core/nomenclature.internal.scala
@@ -38,7 +38,7 @@ import distillate.*
 import prepositional.*
 
 object internal:
-  opaque type Name[plane] <: anticipation.Text = anticipation.Text
+  opaque type Name[+plane] <: anticipation.Text = anticipation.Text
 
   object Name:
     given encodable: [plane] => Name[plane] is Encodable in Text = identity(_)

--- a/lib/nomenclature/src/core/nomenclature.protointernal.scala
+++ b/lib/nomenclature/src/core/nomenclature.protointernal.scala
@@ -35,6 +35,8 @@ package nomenclature
 import scala.compiletime.*
 import scala.quoted.*
 
+import dotty.tools.dotc.*
+
 import anticipation.*
 import contingency.*
 import fulminate.*
@@ -66,6 +68,71 @@ object protointernal:
     build(decompose(TypeRepr.of[intersection].dealias).to(List)).asType.absolve match
       case '[type tupleType <: Tuple; tupleType] => '{null.asInstanceOf[tupleType]}
 
+  // Collects the reference trees of every `Nominative` given instance in scope at the macro
+  // expansion point. Modelled on `frontier.internal.every`: it repeatedly runs an implicit search
+  // that ignores the symbols already found, folding ambiguous candidate pairs in, so that all
+  // matching givens are recovered rather than just the single best one.
+  def everyNominative(using Quotes)(): List[quotes.reflect.Term] =
+    import quotes.reflect.*
+
+    given context: core.Contexts.Context = quotes.absolve match
+      case quotes: runtime.impl.QuotesImpl => quotes.ctx
+
+    def underlying(tree: Term): Symbol = tree match
+      case Inlined(_, _, body) => underlying(body)
+      case Apply(fun, _)       => underlying(fun)
+      case TypeApply(fun, _)   => underlying(fun)
+      case Block(_, expr)      => underlying(expr)
+      case Typed(expr, _)      => underlying(expr)
+      case other               => other.symbol
+
+    def collect(ignored: List[Symbol], acc: List[Term]): List[Term] =
+      Implicits.searchIgnoring(TypeRepr.of[Nominative])(ignored*).absolve match
+        case success: ImplicitSearchSuccess =>
+          val symbol = underlying(success.tree)
+
+          if symbol.isNoSymbol || ignored.contains(symbol) then acc.reverse
+          else collect(symbol :: ignored, success.tree :: acc)
+
+        case failure: ImplicitSearchFailure =>
+          failure.asInstanceOf[ast.tpd.Tree].tpe match
+            case ambiguous: typer.Implicits.AmbiguousImplicits =>
+              val tree1 = ambiguous.alt1.tree.asInstanceOf[Term]
+              val tree2 = ambiguous.alt2.tree.asInstanceOf[Term]
+              val symbol1 = underlying(tree1)
+              val symbol2 = underlying(tree2)
+
+              val unusable =
+                symbol1.isNoSymbol || symbol2.isNoSymbol
+                || ignored.contains(symbol1) || ignored.contains(symbol2)
+
+              if unusable then acc.reverse
+              else collect(symbol1 :: symbol2 :: ignored, tree2 :: tree1 :: acc)
+
+            case _ =>
+              acc.reverse
+
+    collect(Nil, Nil)
+
+  // Tests `name` against every rule in the `limit` intersection, returning `true` only if all
+  // rules accept it. A rule whose parameter is not a string literal (and so cannot be evaluated at
+  // compile time) causes the plane to be excluded rather than failing compilation.
+  def planeAccepts(using Quotes)(name: Text, limit: quotes.reflect.TypeRepr): Boolean =
+    import quotes.reflect.*
+
+    decompose(limit).forall: repr =>
+      repr.asMatchable match
+        case AppliedType(_, List(param)) =>
+          param.asMatchable match
+            case ConstantType(StringConstant(text)) =>
+              companion[Rule](repr.typeSymbol).check(name, text.tt)
+
+            case _ =>
+              false
+
+        case _ =>
+          false
+
   def extractor(context: Expr[StringContext]): Macro[Any] =
     import quotes.reflect.*
 
@@ -76,6 +143,35 @@ object protointernal:
 
       case _ =>
         panic(m"StringContext did not contains Strings")
+
+  // Infers the most precise `Name` type for the literal `text`: the intersection of the `Self`
+  // planes of every in-scope `Nominative` whose rules all accept it. If no plane in scope accepts
+  // the identifier, compilation fails.
+  def inferName[text <: Label: Type]: Macro[Any] =
+    import quotes.reflect.*
+
+    val name: Text = constant[text].tt
+
+    val planes: List[TypeRepr] =
+      everyNominative().flatMap: tree =>
+        tree.asExpr match
+          case '{ type self
+                  type limit
+                  type nominative <: Nominative { type Self = self; type Limit = limit }
+                  $value: nominative } =>
+
+            if planeAccepts(name, TypeRepr.of[limit]) then List(TypeRepr.of[self]) else Nil
+
+          case _ =>
+            Nil
+
+      . foldLeft(List[TypeRepr]()): (acc, self) =>
+          if acc.exists(_ =:= self) then acc else self :: acc
+
+    if planes.isEmpty
+    then halt(914, m"the name $name is not a valid identifier in any namespace in scope")
+    else planes.reduce(AndType(_, _)).asType.absolve match
+      case '[type plane; plane] => '{${Expr(name)}.asInstanceOf[Name[plane]]}
 
   def makeName[system: Type](name: Expr[Text]): Macro[Name[system]] =
     import quotes.reflect.*

--- a/lib/nomenclature/src/test/nomenclature_test.scala
+++ b/lib/nomenclature/src/test/nomenclature_test.scala
@@ -40,6 +40,7 @@ import classloaders.threadContext
 
 sealed trait Id
 sealed trait Id2
+sealed trait EndsO
 sealed trait Session
 sealed trait Other
 
@@ -47,6 +48,7 @@ object Tests extends Suite(m"Nomenclature tests"):
   def run(): Unit =
     inline given id: Id is Nominative under MustEnd["!"] & MustNotStart["0"] & MustNotContain["."] = !!
     inline given id2: Id2 is Nominative under MustNotEqual["."] & MustNotEqual[".."] = !!
+    inline given endsO: EndsO is Nominative under MustEnd["o"] = !!
 
     test(m"Create a successful new name"):
       Name[Id](t"hello!")
@@ -77,9 +79,41 @@ object Tests extends Suite(m"Nomenclature tests"):
       capture[NameError](Name[Id2](t"..")).message.show
     . assert(_ == t"the name .. is not valid because it must not equal ..")
 
-    test(m"Construct a new name at compiletime"):
-      n"hello": Name[Id2]
+    test(m"Covariance probe: a wider plane intersection is a subtype"):
+      val wide: Name[Id2 & EndsO] = t"hello".asInstanceOf[Name[Id2 & EndsO]]
+      val narrow: Name[EndsO] = wide
+      narrow
     . assert(_ == t"hello")
+
+    test(m"Construct a name at compiletime with no expected type"):
+      val name = n"hello"
+      name
+    . assert(_ == t"hello")
+
+    test(m"An inferred name is usable where one of its planes is required"):
+      val name: Name[EndsO] = n"hello"
+      name
+    . assert(_ == t"hello")
+
+    test(m"An inferred name conforms to the intersection of all its planes"):
+      val name: Name[Id2 & EndsO] = n"hello"
+      name
+    . assert(_ == t"hello")
+
+    test(m"An inferred name is usable where another of its planes is required"):
+      val name: Name[Id2] = n"world"
+      name
+    . assert(_ == t"world")
+
+    test(m"An inferred name is rejected where a non-matching plane is required"):
+      demilitarize:
+        val name: Name[EndsO] = n"world"
+    . assert(_.nonEmpty)
+
+    test(m"An identifier valid in no plane in scope is a compile error"):
+      demilitarize:
+        val name = n"."
+    . assert(_.nonEmpty)
 
     test(m"Name is required"):
       capture[NameError](Name[Required](t"")).message.show
@@ -92,10 +126,6 @@ object Tests extends Suite(m"Nomenclature tests"):
     test(m"A CSS class name may not start with a digit"):
       capture[NameError](Name[CssClass](t"1col")).message.show
     . assert(_ == t"the name 1col is not valid because it must be a valid CSS identifier")
-
-    test(m"A CSS class name is constructed at compiletime"):
-      n"button": Name[CssClass]
-    . assert(_ == t"button")
 
     test(m"A valid DOM id is accepted"):
       Name[DomId](t"main-content")


### PR DESCRIPTION
The `n"…"` interpolator for constructing validated `Name` values no longer needs a known expected type. It now considers every `Nominative` namespace in lexical scope, checks the identifier against each one's rules, and gives the name the intersection type of every namespace it is valid for; because `Name` is now covariant in its namespace, a name valid in several namespaces can be used anywhere a name in any one of them is required.

## Names infer their namespaces

Previously, constructing a name with `n"…"` required the target namespace to be known from the expected type:

```scala
n"button": Name[CssClass]
```

Now `n"…"` resolves on its own. It tests the identifier against every `Nominative` namespace in scope and types the result as the intersection of all the namespaces that accept it:

```scala
// with the `Id2` and `EndsO` namespaces in scope, both of which accept "hello"
val name = n"hello"   // : Name[Id2 & EndsO]
```

`Name` is now covariant in its namespace parameter, so a name valid in more namespaces satisfies any position requiring fewer:

```scala
val name: Name[EndsO] = n"hello"   // Name[Id2 & EndsO] <: Name[EndsO]
```

If the identifier is valid in no namespace in scope, it is a compile error.

Only namespaces whose `Nominative` given is in lexical scope are considered. A namespace defined by a companion-object given (such as the built-in `CssClass`, `DomId` or `Required`) must therefore be imported — e.g. `import CssClass.nominative` — for `n"…"` to take it into account.
