### PR TITLE
Decouple native runner stubs from the Mill build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ xeq-release:
 runners-build:
 	./etc/ci/runners-build.sh
 
+runners-fetch:
+	@if [ -z "$(RUNNERS_VERSION)" ]; then echo "Usage: make runners-fetch RUNNERS_VERSION=X [REPO=owner/repo]" >&2; exit 1; fi
+	./etc/ci/runners-fetch.sh "$(RUNNERS_VERSION)" "$(REPO)"
+
 runners-release:
 	@if [ -z "$(RUNNERS_VERSION)" ]; then echo "Usage: make runners-release RUNNERS_VERSION=X [REPO=owner/repo]" >&2; exit 1; fi
 	./etc/ci/runners-release.sh "$(RUNNERS_VERSION)" "$(REPO)"
@@ -74,4 +78,4 @@ matrix:
 	    $(foreach scala,3.6.1 3.6.2 3.6.3 3.6.4 3.7.0 3.7.1 3.7.1 main, \
 			    $(MAKE) bootstrap/$(scala):$(jdk);))
 
-.PHONY: publishLocal build dev ci test matrix attest verify-attest push release xeq-release runners-build runners-release
+.PHONY: publishLocal build dev ci test matrix attest verify-attest push release xeq-release runners-build runners-fetch runners-release

--- a/build.mill
+++ b/build.mill
@@ -680,40 +680,16 @@ object ethereal extends Library:
   object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.core, quantitative.units):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-    val rustTargets: Seq[(String, String, String)] = Seq(
-      ("x86_64-pc-windows-gnu",       "windows-x64",   "runner.exe"),
-      ("x86_64-unknown-linux-gnu",    "linux-x64",     "runner"),
-      ("aarch64-unknown-linux-gnu",   "linux-arm64",   "runner"),
-      ("x86_64-apple-darwin",         "macos-x64",     "runner"),
-      ("aarch64-apple-darwin",        "macos-arm64",   "runner"))
-
-    def rustSources: T[Seq[PathRef]] = Task.Sources(
-      moduleDir / ".." / ".." / "Cargo.toml",
-      moduleDir / ".." / ".." / "src" / "runner")
-
-    def rustRunners: T[PathRef] = Task:
-      val _ = rustSources()
-      val ethDir = moduleDir / ".." / ".."
-      val manifest = ethDir / "Cargo.toml"
-      val targetDir = Task.dest / "target"
-      os.makeDir.all(targetDir)
-      val cmd = Seq("cargo", "zigbuild", "--release",
-        "--manifest-path", manifest.toString,
-        "--target-dir", targetDir.toString) ++
-        rustTargets.flatMap { case (triple, _, _) => Seq("--target", triple) }
-      os.proc(cmd).call(cwd = ethDir, stdout = os.Inherit, stderr = os.Inherit)
-      val outDir = Task.dest / "ethereal"
-      os.makeDir.all(outDir)
-      rustTargets.foreach { case (triple, label, binary) =>
-        val src = targetDir / triple / "release" / binary
-        val ext = if binary.endsWith(".exe") then ".exe" else ""
-        val dst = outDir / s"runner-$label$ext"
-        os.copy.over(src, dst)
-      }
-      PathRef(Task.dest)
-
-    override def resources: T[Seq[PathRef]] =
-      Task(super.resources() ++ Seq(rustRunners()))
+    // The platforms the reusable native runner stubs target — (label, binary filename).
+    // The stubs are built and published independently of this build (see `make
+    // runners-build` / `make runners-release`); the Soundness build never compiles them,
+    // and they are not embedded in any JAR.
+    val runnerTargets: Seq[(String, String)] = Seq(
+      ("windows-x64",   "runner.exe"),
+      ("linux-x64",     "runner"),
+      ("linux-arm64",   "runner"),
+      ("macos-x64",     "runner"),
+      ("macos-arm64",   "runner"))
 
   object example extends Internal(core, exoskeleton.completions):
     override def scalacOptions = Task:
@@ -724,16 +700,23 @@ object ethereal extends Library:
     // (`ethereal.run` and `ethereal.fixture`).
     override def mainClass: Task.Simple[Option[String]] = Some("ethereal.run")
 
+    // The reusable runner stubs are read from `dist/runners` (the output of
+    // `make runners-build` or `make runners-fetch`); run one of those first.
+    def runnersDir = moduleDir / ".." / ".." / ".." / ".." / "dist" / "runners"
+
     def bin(): Command[PathRef] = Task.Command:
       val jar = assembly().path
       val target = moduleDir / ".." / ".." / ".." / ".." / "bin" / "hello"
       os.makeDir.all(target / os.up)
 
-      val runnersBase = core.rustRunners().path / "ethereal"
+      val runnersBase = runnersDir
+      if !os.exists(runnersBase)
+      then throw new Exception(s"$runnersBase not found — run `make runners-build` first")
+
       val staging = Task.dest / "staging"
       os.makeDir.all(staging)
 
-      core.rustTargets.foreach: (_, label, binary) =>
+      core.runnerTargets.foreach: (label, binary) =>
         val ext = if binary.endsWith(".exe") then ".exe" else ""
         val src = runnersBase / s"runner-$label$ext"
         os.copy.over(src, staging / s"runner-$label$ext")
@@ -756,14 +739,16 @@ object ethereal extends Library:
     // launcher whose embedded SHA-256s are computed from those same bytes.
     def distributable(version: String, baseUrl: String): Command[PathRef] = Task.Command:
       val jar = assembly().path
-      val runnersBase = core.rustRunners().path / "ethereal"
+      val runnersBase = runnersDir
+      if !os.exists(runnersBase)
+      then throw new Exception(s"$runnersBase not found — run `make runners-build` first")
 
       val dist = moduleDir / ".." / ".." / ".." / ".." / "dist"
       os.makeDir.all(dist)
       val staging = Task.dest / "staging"
       os.makeDir.all(staging)
 
-      core.rustTargets.foreach: (_, label, binary) =>
+      core.runnerTargets.foreach: (label, binary) =>
         val ext = if binary.endsWith(".exe") then ".exe" else ""
         val runner = runnersBase / s"runner-$label$ext"
         val complete = staging / s"runner-$label$ext"
@@ -1385,11 +1370,14 @@ object ultimatum extends Library:
       val target = moduleDir / ".." / ".." / ".." / ".." / "bin" / "demo"
       os.makeDir.all(target / os.up)
 
-      val runnersBase = ethereal.core.rustRunners().path / "ethereal"
+      val runnersBase = moduleDir / ".." / ".." / ".." / ".." / "dist" / "runners"
+      if !os.exists(runnersBase)
+      then throw new Exception(s"$runnersBase not found — run `make runners-build` first")
+
       val staging = Task.dest / "staging"
       os.makeDir.all(staging)
 
-      ethereal.core.rustTargets.foreach: (_, label, binary) =>
+      ethereal.core.runnerTargets.foreach: (label, binary) =>
         val ext = if binary.endsWith(".exe") then ".exe" else ""
         os.copy.over(runnersBase / s"runner-$label$ext", staging / s"runner-$label$ext")
 

--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -122,7 +122,11 @@ if [[ "${SOUNDNESS_CI_SKIP_BUILD:-0}" != "1" ]]; then
   set +e
   (
     cd "$WORKTREE" || exit 1
-    CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.all.compile \
+    # The reusable runner stubs are not stored in the repo or any JAR; build them into
+    # `dist/runners` so the test suite (the `Enclave` rig and the ethereal/profanity tests)
+    # can read them. They are not part of the Soundness (Mill) build.
+    make runners-build \
+      && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.all.compile \
       && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false test.assembly \
       && CLAUDECODE=1 make ci
   ) 2>&1 | tee "$LOG"

--- a/etc/ci/runners-fetch.sh
+++ b/etc/ci/runners-fetch.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Download the reusable native runner stubs for a published version from GitHub into
+# `dist/runners`, verifying each against the committed `etc/runners/<version>.tsv` manifest.
+#
+# Use this when the Rust toolchain isn't available to `make runners-build`: it fetches the
+# exact bytes published by `make runners-release`. The runners are never stored in a JAR —
+# builds and tests read them from `dist/runners` (or download them here first).
+#
+# Usage: ./etc/ci/runners-fetch.sh <version> [owner/repo]
+#         (or `make runners-fetch RUNNERS_VERSION=X [REPO=owner/repo]`)
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+VERSION="${1:-}"
+REPO="${2:-propensive/soundness}"
+TAG="runners-$VERSION"
+MANIFEST="etc/runners/$VERSION.tsv"
+
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version> [owner/repo]" >&2; exit 1
+fi
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "runners-fetch: manifest $MANIFEST not found (was version $VERSION published?)" >&2; exit 1
+fi
+
+OUT="dist/runners"
+mkdir -p "$OUT"
+base="https://github.com/$REPO/releases/download/$TAG"
+
+while IFS=$'\t' read -r label hash; do
+  [[ -z "$label" ]] && continue
+  ext=""; [[ "$label" == windows* ]] && ext=".exe"
+  name="runner-$label$ext"
+  echo "runners-fetch: downloading $name"
+  if command -v curl >/dev/null 2>&1
+  then curl -fsSL "$base/$name" -o "$OUT/$name"
+  else wget -qO "$OUT/$name" "$base/$name"
+  fi
+  got=$( { sha256sum "$OUT/$name" 2>/dev/null || shasum -a 256 "$OUT/$name"; } | cut -d' ' -f1)
+  if [[ "$got" != "$hash" ]]; then
+    echo "runners-fetch: SHA-256 mismatch for $name (got $got, expected $hash)" >&2
+    rm -f "$OUT/$name"; exit 1
+  fi
+  chmod +x "$OUT/$name"
+done < "$MANIFEST"
+
+echo "runners-fetch: $(find "$OUT" -maxdepth 1 -name 'runner-*' | wc -l | tr -d ' ') stubs verified into $OUT"

--- a/lib/ethereal/src/core/ethereal.Assembler.scala
+++ b/lib/ethereal/src/core/ethereal.Assembler.scala
@@ -70,20 +70,19 @@ object Assembler:
 
   val PublicKeyLength: Int = 1312   // ML-DSA-44 public key size
 
-  def assemble
+  // Patches a bare runner's ETHRCFG block (build id, Java version policy, ML-DSA-44
+  // public key) and returns the patched bytes, without appending a JAR. Used both by
+  // `assemble` (which then appends the JAR) and by the offline polyglot packager, which
+  // embeds the patched stub and lets the launcher append the JAR at unpack time.
+  def patch
     ( runner:        Data,           // bare runner binary
-      jarFile:       Path on Linux,  // application JAR appended at EOF
-      output:        Path on Linux,
-      platformLabel: Text,
       buildId:       Long,
       javaMinimum:   Int,
       javaPreferred: Int,
       jdk:           Boolean,
       publicKey:     Data )           // 1312 raw bytes (all-zero disables upgrades)
-    ( using WorkingDirectory )
-  :   Unit raises AssemblyError raises IoError raises StreamError =
+  :   Data raises AssemblyError =
 
-    val isWindows: Boolean = platformLabel.starts(t"windows")
     val bytes: Array[Byte] = IArray.genericWrapArray(runner).toArray
 
     val magicOffset: Int =
@@ -118,13 +117,32 @@ object Assembler:
     metaBuf.put((if jdk then 1 else 0).toByte)
     while metaBuf.hasRemaining do metaBuf.put(0.toByte)
 
-    // Write the 1312-byte public-key region at offset 32 within the ETHRCFG
-    // block (8 magic + 24 metadata). The signature slot at offset 1344 stays
-    // zero — populated later by the signer when shipped as an upgrade.
+    // Write the 1312-byte public-key region at offset 32 within the ETHRCFG block (8
+    // magic + 24 metadata). The signature slot at offset 1344 stays zero — populated
+    // later by the signer when shipped as an upgrade.
     jl.System.arraycopy(keyBytes, 0, bytes, configOffset + 24, PublicKeyLength)
 
+    IArray.from(bytes.iterator): IArray[Byte]
+
+
+  def assemble
+    ( runner:        Data,           // bare runner binary
+      jarFile:       Path on Linux,  // application JAR appended at EOF
+      output:        Path on Linux,
+      platformLabel: Text,
+      buildId:       Long,
+      javaMinimum:   Int,
+      javaPreferred: Int,
+      jdk:           Boolean,
+      publicKey:     Data )           // 1312 raw bytes (all-zero disables upgrades)
+    ( using WorkingDirectory )
+  :   Unit raises AssemblyError raises IoError raises StreamError =
+
+    val isWindows: Boolean = platformLabel.starts(t"windows")
+    val patched: Data = patch(runner, buildId, javaMinimum, javaPreferred, jdk, publicKey)
+
     output.open: file =>
-      Stream(IArray.from(bytes.iterator): IArray[Byte]).writeTo(file)
+      Stream(patched).writeTo(file)
 
     if platformLabel.starts(t"macos") then
       if !isWindows then output.executable() = true

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -153,8 +153,23 @@ def cli[bus <: Matchable](using executive: Executive)
             val runnerName: Text =
               if isWindows then t"runner-$platformLabel.exe" else t"runner-$platformLabel"
 
-            val runnerResource: Path on Classpath = Classpath/"ethereal"/runnerName
-            val runnerBytes: Data = runnerResource.read[Data]
+            // The reusable runner stubs are no longer embedded in the JAR; the right one is
+            // read from the `dist/runners` directory (relative to the working directory, or
+            // `-Dethereal.runners=<dir>`), which `make runners-build`/`make runners-fetch`
+            // populate.
+            val work: Path on Linux = workingDirectory
+
+            val runnersDir: Text =
+              safely(System.properties.ethereal.runners[Text]()).or(t"$work/dist/runners")
+
+            val runnerFile: Path on Linux = t"$runnersDir/$runnerName".decode[Path on Linux]
+
+            if !runnerFile.exists() then
+              Out.println(e"Runner stub $runnerName not found in $runnersDir.")
+              Out.println(e"Run $Italic(make runners-build) or $Italic(make runners-fetch) first.")
+              Exit.Fail(1).terminate()
+
+            val runnerBytes: Data = runnerFile.open(_.stream[Data].read[Data])
 
             // ML-DSA-44 public key used by the runner to verify upgrades.
             // When `ethereal.publicKey` is unset the slot stays zero and the

--- a/lib/ziggurat/src/packager/ziggurat.Packager.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packager.scala
@@ -41,7 +41,6 @@ import eucalyptus.*
 import fulminate.*
 import galilei.*
 import gossamer.*
-import guillotine.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
@@ -62,16 +61,17 @@ import gastronomy.*, hashProviders.javaStdlibHashing
 import internetAccess.enabled
 import monotonous.*, alphabets.hex.lowerCase
 
-// Turns a `Packaging` configuration into a distributable, across all three
-// deliveries. With `RunnerSource.LocalResource` the application self-assembles
-// each per-platform binary in a subprocess; with `RunnerSource.Remote` the
-// runners are downloaded, verified, and assembled in-process via
-// `ethereal.Assembler`. Burdock remote dependencies remain unimplemented.
+// Turns a `Packaging` configuration into a distributable. Each per-platform binary is the
+// application JAR appended to a bare reusable runner stub, obtained from `RunnerSource` —
+// read from a local directory, or downloaded and SHA-256-verified against the manifest.
+// `Native` emits one self-contained binary; `EmbedAll` emits a polyglot script embedding
+// every (ETHRCFG-patched) stub plus the JAR once (`Xeq.installer`); `Download` emits a
+// polyglot launcher. Burdock remote dependencies remain unimplemented.
 object Packager:
-  def pack(config: Packaging)
-    ( using working: WorkingDirectory, environment: Environment )
-  :   Path on Linux raises PackageError =
+  // The embedded JAR payload's label — must match the launcher templates' `get_offset "data"`.
+  private val DataName: Text = t"data"
 
+  def pack(config: Packaging)(using WorkingDirectory): Path on Linux raises PackageError =
     val appJar: Path on Linux = config.dependencies.absolve match
       case Packaging.Dependencies.FatJar(jar) =>
         jar
@@ -88,150 +88,90 @@ object Packager:
         ()
 
     whereas:
-      case ExecError(_, _, _)  => PackageError(m"A subprocess failed during packaging")
-      case IoError(_, _, _, _) => PackageError(m"A filesystem error occurred during packaging")
-      case StreamError(_)      => PackageError(m"A stream error occurred during packaging")
-      case PathError(_, _)     => PackageError(m"A path could not be resolved during packaging")
+      case HttpError(_, _)       => PackageError(m"A runner stub could not be downloaded")
+      case ConnectError(_)       => PackageError(m"Could not connect to download a runner stub")
+      case UrlError(_, _, _)     => PackageError(m"A runner stub URL is invalid")
+      case AssemblyError(detail) => PackageError(detail)
+      case IoError(_, _, _, _)   => PackageError(m"A filesystem error occurred during packaging")
+      case StreamError(_)        => PackageError(m"A stream error occurred during packaging")
+      case PathError(_, _)       => PackageError(m"A path could not be resolved during packaging")
 
     . mitigate:
+        val jdk: Boolean = config.java.bundle == Packaging.Bundle.Jdk
+
+        val publicKey: Data =
+          val zeros: Data = IArray.fill(Assembler.PublicKeyLength)(0.toByte)
+
+          config.signing.lay(zeros): signing =>
+            signing.publicKey.lay(zeros): key =>
+              val raw: Data = key.open(_.stream[Data].read[Data])
+
+              if raw.length != Assembler.PublicKeyLength
+              then abort(PackageError(m"The signing public key is the wrong size"))
+
+              raw
+
+        // The bare reusable stub bytes for a platform — read from a local directory, or
+        // downloaded and verified against the manifest hash.
+        def stub(label: Text): Data =
+          val name: Text =
+            if label.starts(t"windows") then t"runner-$label.exe" else t"runner-$label"
+
+          config.runnerSource.absolve match
+            case Packaging.RunnerSource.Local(directory) =>
+              val file: Path on Linux = t"$directory/$name".decode[Path on Linux]
+              file.open(_.read[Data])
+
+            case Packaging.RunnerSource.Remote(baseUrl, hashes) =>
+              val expected: Text =
+                hashes.at(label).lest(PackageError(m"No runner hash given for $label"))
+
+              val base: Text = if baseUrl.ends(t"/") then baseUrl else t"$baseUrl/"
+              val runner: Data = mute[HttpEvent](t"$base$name".decode[HttpUrl].fetch().read[Data])
+              val actual: Text = runner.digest[Sha2[256]].serialize[Hex]
+
+              if actual != expected
+              then abort(PackageError(m"The runner for $label has the wrong SHA-256 ($actual)"))
+
+              runner
+
+        // One self-contained per-platform binary: bare stub, ETHRCFG patched, JAR appended.
+        def binary(label: Text, output: Path on Linux): Unit =
+          Assembler.assemble
+            ( stub(label), appJar, output, label, config.buildId, config.java.minimum,
+              config.java.preferred, jdk, publicKey )
+
         config.delivery match
           case Packaging.Delivery.Native =>
-            buildBinary(config, appJar, config.targets.head, config.output)
+            binary(config.targets.head, config.output)
             config.output
 
           case Packaging.Delivery.EmbedAll =>
-            val dir = config.output.parent.vouch
+            val stubs: List[Payload] = config.targets.map: label =>
+              val patched: Data =
+                Assembler.patch
+                  ( stub(label), config.buildId, config.java.minimum, config.java.preferred, jdk,
+                    publicKey )
 
-            val payloads: List[Payload] = config.targets.map: label =>
-              val staged: Path on Linux = t"$dir/.xeq-$label".decode[Path on Linux]
-              buildBinary(config, appJar, label, staged)
-              val bytes: Data = staged.open(_.read[Data])
-              staged.delete()
-              Payload(label, bytes, gzip = !label.starts(t"windows"))
+              Payload(label, patched, gzip = !label.starts(t"windows"))
 
-            write(config.output, Xeq.installer(payloads))
+            val data: Payload = Payload(DataName, appJar.open(_.read[Data]), gzip = false)
+            write(config.output, Xeq.installer(stubs :+ data))
             config.output
 
           case Packaging.Delivery.Download(baseUrl, version) =>
-            val dir = config.output.parent.vouch
+            val dir: Path on Linux = config.output.parent.vouch
             val base: Text = if baseUrl.ends(t"/") then baseUrl else t"$baseUrl/"
 
             val entries: List[(Text, Text, Text)] = config.targets.map: label =>
               val asset: Text = t"xeq-$label-$version"
               val staged: Path on Linux = t"$dir/$asset".decode[Path on Linux]
-              buildBinary(config, appJar, label, staged)
+              binary(label, staged)
               val hash: Text = staged.open(_.read[Data]).digest[Sha2[256]].serialize[Hex]
               (label, t"$base$asset", hash)
 
             write(config.output, Xeq.multiDownloader(entries))
             config.output
-
-
-  // Produces one self-contained per-platform binary, dispatching on the runner
-  // source: the app self-assembles in a subprocess (LocalResource), or the
-  // runner is downloaded and assembled in-process (Remote).
-  private def buildBinary
-    ( config: Packaging, appJar: Path on Linux, label: Text, output: Path on Linux )
-    ( using working: WorkingDirectory )
-  :   Unit raises ExecError raises PackageError =
-
-    config.runnerSource match
-      case Packaging.RunnerSource.LocalResource =>
-        assembleViaSubprocess(config, appJar, label, output)
-
-      case Packaging.RunnerSource.Remote(baseUrl, hashes) =>
-        assembleRemote(config, appJar, label, output, baseUrl, hashes)
-
-
-  // Drives the application's own self-assembly (ethereal's `cli` build path) in a
-  // subprocess: `java -Dbuild.executable=… -Dbuild.target=… … -jar <appJar>`
-  // produces one self-contained per-platform binary and exits. `ethereal.name`
-  // must be left unset or the build path is not taken.
-  private def assembleViaSubprocess
-    ( config: Packaging, appJar: Path on Linux, label: Text, output: Path on Linux )
-    ( using working: WorkingDirectory )
-  :   Unit raises ExecError raises PackageError =
-
-    val bundle: Text = config.java.bundle match
-      case Packaging.Bundle.Jre => t"jre"
-      case Packaging.Bundle.Jdk => t"jdk"
-
-    val publicKey: List[Text] = config.signing.lay(Nil): signing =>
-      signing.publicKey.lay(Nil): key =>
-        List(t"-Dethereal.publicKey=$key")
-
-    val arguments: List[Text] =
-      List
-        ( t"java",
-          t"-Dbuild.executable=$output",
-          t"-Dbuild.target=$label",
-          t"-Dbuild.java.minimum=${config.java.minimum}",
-          t"-Dbuild.java.preferred=${config.java.preferred}",
-          t"-Dbuild.java.bundle=$bundle",
-          t"-Dbuild.id=${config.buildId}" )
-      ++ publicKey
-      ++ List(t"-jar", appJar.show)
-
-    if mute[ExecEvent](Command(arguments*).exec[Exit]()) != Exit.Ok
-    then abort(PackageError(m"Assembling the executable for $label failed"))
-
-
-  // Downloads `<baseUrl>/runner-<label>[.exe]`, verifies its SHA-256 against
-  // `hashes(label)`, then patches the ETHRCFG block and appends the app JAR
-  // in-process via `ethereal.Assembler`. All lower-level failures are surfaced
-  // as `PackageError`.
-  private def assembleRemote
-    ( config:  Packaging,
-     appJar:  Path on Linux,
-     label:   Text,
-     output:  Path on Linux,
-     baseUrl: Text,
-     hashes:  Map[Text, Text] )
-    ( using working: WorkingDirectory )
-  :   Unit raises PackageError =
-
-    whereas:
-      case HttpError(_, _)       => PackageError(m"Failed to download the runner for $label")
-      case AssemblyError(detail) => PackageError(detail)
-      case IoError(_, _, _, _)   => PackageError(m"A filesystem error occurred assembling $label")
-      case StreamError(_)        => PackageError(m"A stream error occurred assembling $label")
-      case UrlError(_, _, _)     => PackageError(m"The runner URL for $label is invalid")
-
-      case ConnectError(_) =>
-        PackageError(m"Could not connect to download the runner for $label")
-
-    . mitigate:
-        val expected: Text = hashes.at(label).lest(PackageError(m"No runner hash given for $label"))
-
-        val runnerName: Text =
-          if label.starts(t"windows") then t"runner-$label.exe" else t"runner-$label"
-
-        val base: Text = if baseUrl.ends(t"/") then baseUrl else t"$baseUrl/"
-
-        val runner: Data =
-          mute[HttpEvent](t"$base$runnerName".decode[HttpUrl].fetch().read[Data])
-
-        val actual: Text = runner.digest[Sha2[256]].serialize[Hex]
-
-        if actual != expected then abort:
-          PackageError(m"Downloaded runner for $label has SHA-256 $actual, expected $expected")
-
-        val zeros: Data = IArray.fill(Assembler.PublicKeyLength)(0.toByte)
-
-        val publicKey: Data = config.signing.lay(zeros): signing =>
-          signing.publicKey.lay(zeros): key =>
-            val raw: Data = key.open(_.stream[Data].read[Data])
-
-            if raw.length != Assembler.PublicKeyLength
-            then abort(PackageError(m"The public key for $label is the wrong size"))
-
-            raw
-
-        val jdk: Boolean = config.java.bundle == Packaging.Bundle.Jdk
-
-        Assembler.assemble
-          ( runner, appJar, output, label, config.buildId, config.java.minimum,
-            config.java.preferred, jdk, publicKey )
 
 
   private def write(output: Path on Linux, data: Data)

--- a/lib/ziggurat/src/packager/ziggurat.Packaging.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packaging.scala
@@ -48,12 +48,16 @@ object Packaging:
     case Download(baseUrl: Text, version: Text)
     case Native
 
-  // Where each platform's bare runner binary comes from.
+  // Where each platform's bare reusable runner stub comes from. The stubs are published
+  // independently (see `make runners-release`); a build never compiles them.
   enum RunnerSource:
-    case LocalResource  // the app self-assembles using `Classpath/"ethereal"/runner-<label>`
+    // Read `<directory>/runner-<label>[.exe]` from a local directory (e.g. the output of
+    // `make runners-build`). For development and testing — no download, no hash check.
+    case Local(directory: Path on Linux)
 
-    // Each runner is downloaded from `<baseUrl>/runner-<label>[.exe]` and verified
-    // against `hashes(label)` (lowercase SHA-256 hex), then assembled in-process.
+    // Download each stub from `<baseUrl>/runner-<label>[.exe]` and verify it against
+    // `hashes(label)` (lowercase SHA-256 hex, from the committed `etc/runners/<v>.tsv`
+    // manifest). The production source.
     case Remote(baseUrl: Text, hashes: Map[Text, Text])
 
   // The bundled Java runtime *preference* recorded in the ETHRCFG block. Records
@@ -81,7 +85,7 @@ case class Packaging
    delivery:     Packaging.Delivery,
    dependencies: Packaging.Dependencies,
    output:       Path on Linux,
-   runnerSource: Packaging.RunnerSource      = Packaging.RunnerSource.LocalResource,
+   runnerSource: Packaging.RunnerSource,
    java:         Packaging.JavaPolicy        = Packaging.JavaPolicy(),
    signing:      Optional[Packaging.Signing] = Unset,
    buildId:      Long                        = 0L )

--- a/lib/ziggurat/src/test/ziggurat_test.scala
+++ b/lib/ziggurat/src/test/ziggurat_test.scala
@@ -169,7 +169,7 @@ object Tests extends Suite(m"Ziggurat tests"):
       def config
          (delivery:     Packaging.Delivery,
           dependencies: Packaging.Dependencies,
-          runnerSource: Packaging.RunnerSource = Packaging.RunnerSource.LocalResource,
+          runnerSource: Packaging.RunnerSource = Packaging.RunnerSource.Remote(t"https://x.test/", Map()),
           targets:      List[Text]             = List(t"linux-x64"))
       :   Packaging =
         val dir = tempDir()
@@ -199,6 +199,46 @@ object Tests extends Suite(m"Ziggurat tests"):
         capture[PackageError]:
           Packager.pack(config(Packaging.Delivery.Native, fatJar, targets = labels))
       .assert(_ => true)
+
+    suite(m"Packager assembly (offline, local stubs)"):
+      // A fake bare stub carrying the ETHRCFG marker so `Assembler.patch` can patch it,
+      // followed by enough zero bytes for the 24-byte metadata and public-key regions.
+      def writeStub(dir: Path on Linux, label: Text): Unit =
+        val file: Path on Linux = t"$dir/runner-$label".decode[Path on Linux]
+
+        val bytes: Array[Byte] =
+          Array.fill(64)(0.toByte)
+          ++ ethereal.Assembler.MagicMarker
+          ++ Array.fill(64 + ethereal.Assembler.PublicKeyLength)(0.toByte)
+
+        file.create[File]()
+        file.open(Stream(bytes.immutable(using Unsafe): Data).writeTo(_))
+
+      test(m"EmbedAll bundles the JAR once and every patched stub"):
+        val dir: Path on Linux = tempDir()
+        labels.each(writeStub(dir, _))
+
+        val jar: Path on Linux = dir/t"app.jar"
+        jar.create[File]()
+        jar.open(Stream(t"JARBYTES".data).writeTo(_))
+
+        val out: Path on Linux = dir/t"hello"
+
+        val packaging: Packaging =
+          Packaging
+            ( name         = t"hello",
+              targets      = labels,
+              delivery     = Packaging.Delivery.EmbedAll,
+              dependencies = Packaging.Dependencies.FatJar(jar),
+              output       = out,
+              runnerSource = Packaging.RunnerSource.Local(dir) )
+
+        Packager.pack(packaging)
+        val text: Text = out.open(_.read[Data]).utf8
+
+        text.starts(t"#!/usr/bin/env bash") && text.contains(t"data=")
+        && labels.all { label => text.contains(t"$label=") }
+      .assert(_ == true)
 
     // Docker on macOS cannot run macOS containers, so macOS coverage is host-native only.
     if !dockerOk then Out.println(t"Docker unavailable; skipping Linux container tests")


### PR DESCRIPTION
The reusable native runner stubs are no longer compiled by the Soundness (Mill) build or embedded in any JAR. They are built and published independently (`make runners-build` / `make runners-release`), and everything that needs them now reads them from `dist/runners` — building them, or downloading and verifying them against the committed hash manifest.

## Build decoupling

- The Mill build no longer runs `cargo zigbuild` or embeds runners in `ethereal.core`'s resources.
- `ethereal`'s `-Dbuild.executable` self-assembly reads the stub from `dist/runners` (relative to the working directory, or `-Dethereal.runners=<dir>`). The `Enclave` test rig — and the `ethereal`/`profanity` suites that build real executables through it — work unchanged (validated: ethereal 49/49, profanity 51/52).
- `make runners-fetch RUNNERS_VERSION=X` downloads the published stubs from the GitHub `runners-X` release and verifies each against `etc/runners/X.tsv`, for hosts without the Rust toolchain.
- `make attest` builds the stubs into its throwaway worktree before running the suite.

The runners are built/fetched into `dist/runners` and read from there; they are never stored in the repo or a JAR — only their hashes, in the committed manifest, so downloads are verifiable.

## Packager reworked to build from reusable stubs

`ziggurat.Packager` no longer self-assembles per-platform binaries in a subprocess from embedded runners. Each binary is the app JAR appended to a bare stub from a `RunnerSource` — `Local(directory)` (read) or `Remote(baseUrl, hashes)` (download + SHA-256-verify). `RunnerSource.LocalResource` is dropped; the offline polyglot delivery embeds the JAR once plus every ETHRCFG-patched bare stub; and `Assembler.patch` is factored out of `assemble`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)