### PR TITLE
Fix Inspectable derivation overflowing the inline limit on nested types

### DIFF
--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -59,7 +59,7 @@ object Inspectable extends Inspectable2:
   inline given derived: [value] => value is Inspectable = compiletime.summonFrom:
     case given (`value` is Encodable in Text) => _.encode
     case given (`value` is Showable)          => _.show
-    case given Reflection[`value`]            => Derivation.derived[value].text(_)
+    case given Reflection[`value`]            => Derivation.derived[value]
     case _                                    => value => ("“"+value+"”").tt
 
   given char: Char is Inspectable = char => ("'"+escape(char).s+"'").tt

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -36,6 +36,20 @@ import soundness.*
 
 case class Person(name: Text, age: Int)
 
+case class Leaf(value: Int)
+case class Depth4(leaf: Leaf, tag: Int)
+case class Depth3(child: Depth4, tag: Int)
+case class Depth2(child: Depth3, tag: Int)
+case class Depth1(child: Depth2, tag: Int)
+case class Depth0(child: Depth1, tag: Int)
+
+case class Branch(value: Int, kids: List[Branch])
+
+class Underived(val x: Int):
+  override def toString: String = "Underived("+x+")"
+
+case class Holder(item: Underived, count: Int)
+
 object Tests extends Suite(m"Spectacular Tests"):
   def run(): Unit =
     suite(m"Debug tests"):
@@ -196,6 +210,19 @@ object Tests extends Suite(m"Spectacular Tests"):
       test(m"serialize IArray of strings"):
         IArray(t"one", t"two", t"three").inspect
       . assert(_ == t"""🅻⁅₀t"one"╱₁t"two"╱₂t"three"⁆""")
+
+    suite(m"Derivation tests"):
+      test(m"derive deeply-nested case class graph (issue #666)"):
+        Depth0(Depth1(Depth2(Depth3(Depth4(Leaf(5), 4), 3), 2), 1), 0).inspect
+      . assert(_ == t"Depth0(child:Depth1(child:Depth2(child:Depth3(child:Depth4(leaf:Leaf(value:5) ╱ tag:4) ╱ tag:3) ╱ tag:2) ╱ tag:1) ╱ tag:0)")
+
+      test(m"derive recursive case class via collection field"):
+        Branch(1, List(Branch(2, Nil), Branch(3, Nil))).inspect
+      . assert(_ == t"Branch(value:1 ╱ kids:[Branch(value:2 ╱ kids:[]), Branch(value:3 ╱ kids:[])])")
+
+      test(m"derivable field with underivable leaf falls back to toString"):
+        Holder(Underived(7), 3).inspect
+      . assert(_ == t"Holder(item:“Underived(7)” ╱ count:3)")
 
     suite(m"Show tests"):
       test(m"Show a string"):


### PR DESCRIPTION
Deriving an `Inspectable` for a case class nested more than about five levels deep previously failed to compile with "Maximal number of successive inlines (32) exceeded", and shallower deep graphs derived far more slowly than they should. The structural-derivation branch wrapped Wisteria's result in an eta-expanded lambda (`Derivation.derived[value].text(_)`), which hid the re-entry sentinel Wisteria uses to decide whether a nested type has already been cached; as a result every nested field re-entered the inline derivation instead of sharing a cached instance. Returning the derived instance directly restores the whole-graph cache, so arbitrarily deep graphs now derive quickly and the rendered output is unchanged.

Deriving an `Inspectable` for a deeply-nested case-class graph now works:

```scala
case class Leaf(value: Int)
case class Wrap1(leaf: Leaf, tag: Int)
case class Wrap2(child: Wrap1, tag: Int)
// …nested arbitrarily deep…

summon[Wrap2 is Inspectable]   // previously failed to compile beyond ~5 levels
```

Recursive types (e.g. a tree whose children are a `List` of itself) and types with fields that have no `Inspectable` of their own (which fall back to `toString`) continue to work as before.

Closes #666.
