### PR TITLE
Add confined ordinals for total at indexing

### DIFF
--- a/lib/aviation/src/core/aviation.Clockface.scala
+++ b/lib/aviation/src/core/aviation.Clockface.scala
@@ -69,4 +69,5 @@ object Clockface:
       t"$hour2${summon[TimeSeparation].separator}$minute$seconds$postfix"
 
 
-case class Clockface(hour: Base24, minute: Base60, second: Base60 = 0, nanos: Int = 0)
+case class Clockface(hour: Base24, minute: Base60, second: Base60 = 0, nanos: Int = 0):
+  infix def on(date: Date)(using Calendar): Timestamp = Timestamp(date, this)

--- a/lib/aviation/src/core/aviation.Iso8601.scala
+++ b/lib/aviation/src/core/aviation.Iso8601.scala
@@ -142,7 +142,7 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
         fail(Digit) yet 2000-Jan-1
 
     val instant: Instant = next() match
-      case '\u0000' => date.at(Clockface(Base24(0), Base60(0), Base60(0))).instant
+      case '\u0000' => Clockface(Base24(0), Base60(0), Base60(0)).on(date).instant
 
       case 'T' =>
         val hour = next() yet number(2)
@@ -153,7 +153,7 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
             next() match
               case '.' | ',' =>
-                date.at(Clockface(Base24(hour), Base60(minute), Base60(0))).instant
+                Clockface(Base24(hour), Base60(minute), Base60(0)).on(date).instant
                 + fraction()*Minute
 
               case ':' =>
@@ -161,26 +161,26 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
                 next() match
                   case '.' | ',' =>
-                    date.at(Clockface(Base24(hour), Base60(minute), Base60(second))).instant
+                    Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
                     + fraction()*Second
 
                   case _ =>
-                    date.at(Clockface(Base24(hour), Base60(minute), Base60(second))).instant
+                    Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
 
               case d if digit =>
                 val second = number(2)
                 next()
-                date.at(Clockface(Base24(hour), Base60(minute), Base60(second))).instant
+                Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
 
               case _ =>
-                date.at(Clockface(Base24(hour), Base60(minute), Base60(0))).instant
+                Clockface(Base24(hour), Base60(minute), Base60(0)).on(date).instant
 
           case d if digit =>
             val minute = number(2)
 
             next() match
               case '.' | ',' =>
-                date.at(Clockface(Base24(hour), Base60(minute), Base60(0))).instant
+                Clockface(Base24(hour), Base60(minute), Base60(0)).on(date).instant
                 + fraction()*Minute
 
               case d if digit =>
@@ -188,24 +188,24 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
                 next() match
                   case '.' | ',' =>
-                    date.at(Clockface(Base24(hour), Base60(minute), Base60(second))).instant
+                    Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
                     + fraction()*Second
 
                   case _ =>
-                    date.at(Clockface(Base24(hour), Base60(minute), Base60(second)))
+                    Clockface(Base24(hour), Base60(minute), Base60(second)).on(date)
                     . instant
 
               case _ =>
-                date.at(Clockface(Base24(hour), Base60(minute), Base60(0))).instant
+                Clockface(Base24(hour), Base60(minute), Base60(0)).on(date).instant
 
           case '.' | ',' =>
-            date.at(Clockface(Base24(hour), Base60(0), Base60(0))).instant + fraction()*Hour
+            Clockface(Base24(hour), Base60(0), Base60(0)).on(date).instant + fraction()*Hour
 
           case _ =>
-            date.at(Clockface(Base24(hour), Base60(0), Base60(0))).instant
+            Clockface(Base24(hour), Base60(0), Base60(0)).on(date).instant
 
       case _ =>
-        date.at(0.00.am).instant
+        0.00.am.on(date).instant
 
 
     focus match

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -306,8 +306,6 @@ object internal:
 
     def jdn: Int = date
 
-    infix def at (time: Clockface)(using Calendar): Timestamp = Timestamp(date, time)
-
     def monthstamp(using calendar: RomanCalendar): Monthstamp =
       Monthstamp(calendar.annual(date), calendar.mensual(date))
 

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -290,7 +290,7 @@ object Tests extends Suite(m"Aviation Tests"):
       import calendars.gregorian
 
       test(m"Specify datetime"):
-        2018-Aug-11 at 5.25.pm
+        5.25.pm on 2018-Aug-11
       . assert(_ == Timestamp(Date(Year(2018), Aug, Day(11)), Clockface(17, 25, 0)))
 
       test(m"Add two months to a date"):

--- a/lib/denominative/src/core/denominative.internal.scala
+++ b/lib/denominative/src/core/denominative.internal.scala
@@ -78,6 +78,11 @@ object internal:
     inline def subsequent(size: Int): Interval = Interval(ordinal + 1, ordinal + size)
     inline def preceding(size: Int): Interval = Interval((ordinal - size).max(0), ordinal - 1)
 
+    inline def within[collection: Countable](value: collection): Optional[Ordinal in value.type] =
+      if ordinal >= 0 && ordinal < collection.size(value)
+      then ordinal.asInstanceOf[Ordinal in value.type]
+      else Unset
+
 
   object Ordinal:
     inline def zerary(inline cardinal: Int): Ordinal = cardinal

--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -33,6 +33,7 @@
 package denominative
 
 import anticipation.*
+import prepositional.*
 import symbolism.*
 
 final val Prim: Ordinal = Ordinal.zerary(0)
@@ -52,6 +53,13 @@ extension (inline cardinal: Int)
 extension [countable: Countable](value: countable)
   inline def gamut: Interval = Interval.initial(countable.size(value))
   inline def nil: Boolean = countable.nil(value)
+
+  inline def iterate(inline lambda: (Ordinal in value.type) => Unit): Unit =
+    var index: Int = 0
+
+    while index < countable.size(value) do
+      lambda(Ordinal.zerary(index).asInstanceOf[Ordinal in value.type])
+      index += 1
 
 export denominative.internal.{Ordinal, Interval, Span}
 

--- a/lib/denominative/src/core/soundness_denominative_core.scala
+++ b/lib/denominative/src/core/soundness_denominative_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   denominative
-  . { aka, Countable, gamut, Interval, nil, Ordinal, Prim, Quat, Quin, Sec, Sen, Sept, Span, Ter,
-      u, z, Zerary }
+  . { aka, Countable, gamut, Interval, iterate, nil, Ordinal, Prim, Quat, Quin, Sec, Sen, Sept,
+      Span, Ter, u, z, Zerary }
 
 package ordinalShowables:
   export

--- a/lib/escapade/src/core/escapade.Teletype.scala
+++ b/lib/escapade/src/core/escapade.Teletype.scala
@@ -78,7 +78,7 @@ object Teletype:
       stream.flow(())(Err.print(next) yet write(target, more))
 
   given textual: Teletype is Textual:
-    type Operand = Char
+    type Result = Char
     type Show[value] = value is Teletypeable
 
     def classTag: ClassTag[Teletype] = summon[ClassTag[Teletype]]
@@ -103,7 +103,7 @@ object Teletype:
     val empty: Teletype = Teletype.empty
 
     def concat(left: Teletype, right: Teletype): Teletype = left.append(right)
-    def at(text: Teletype, index: Ordinal): Char = text.plain.s.charAt(index.n0)
+    def access(text: Teletype, index: Ordinal): Char = text.plain.s.charAt(index.n0)
 
     def indexOf(text: Teletype, sub: Text, start: Ordinal): Optional[Ordinal] =
       text.plain.s.indexOf(sub.s, start.n0).puncture(-1).let(_.z)

--- a/lib/gossamer/src/core/gossamer.Textual.scala
+++ b/lib/gossamer/src/core/gossamer.Textual.scala
@@ -47,7 +47,7 @@ object Textual:
     def concat(left: textual, right: textual): textual = textual.concat(left, right)
 
   given text: Text is Textual:
-    type Operand = Char
+    type Result = Char
     type Show[value] = value is spectacular.Showable
 
     val classTag: ClassTag[Text] = summon[ClassTag[Text]]
@@ -69,7 +69,7 @@ object Textual:
 
     def empty: Text = Text("")
     def concat(left: Text, right: Text): Text = Text(left.s+right.s)
-    def at(text: Text, index: Ordinal): Char = text.s.charAt(index.n0)
+    def access(text: Text, index: Ordinal): Char = text.s.charAt(index.n0)
 
     def indexOf(text: Text, sub: Text, start: Ordinal): Optional[Ordinal] =
       text.s.indexOf(sub.s, start.n0).puncture(-1).let(_.z)
@@ -80,21 +80,23 @@ object Textual:
     def builder(size: Optional[Int]): Builder[Text] = TextBuilder(size)
     def size(text: Self): Int = text.length
 
-trait Textual extends Typeclass, Countable, Segmentable, Zeroic:
-  type Operand
+trait Textual extends Typeclass, Countable, Segmentable, Zeroic, Indexable:
+  type Operand = Ordinal
+  type Result
   type Show[value]
 
   def show[value](value: value)(using show: Show[value]): Self
   def apply(text: Text): Self
-  def single(operand: Operand): Self
-  def fromChar(char: Char): Operand
+  def single(operand: Result): Self
+  def fromChar(char: Char): Result
   def classTag: ClassTag[Self]
   def length(text: Self): Int
   def text(text: Self): Text
-  def map(text: Self)(lambda: Operand => Operand): Self
+  def map(text: Self)(lambda: Result => Result): Self
   def empty: Self
   def concat(left: Self, right: Self): Self
-  def at(text: Self, index: Ordinal): Operand
+  def access(text: Self, index: Ordinal): Result
+  def contains(text: Self, index: Ordinal): Boolean = index.n0 >= 0 && index.n0 < length(text)
   def indexOf(text: Self, sub: Text, start: Ordinal = Prim): Optional[Ordinal]
 
   def lastIndexOf(text: Self, sub: Text): Optional[Ordinal] =

--- a/lib/gossamer/src/core/gossamer.Writing.scala
+++ b/lib/gossamer/src/core/gossamer.Writing.scala
@@ -72,7 +72,7 @@ object Writing:
     total
 
   given textual: Writing is Textual:
-    type Operand = Grapheme
+    type Result = Grapheme
     type Show[value] = value is Showable
 
     val classTag: ClassTag[Writing] = summon[ClassTag[Writing]]
@@ -100,7 +100,7 @@ object Writing:
     def empty: Writing = Writing.empty
     def concat(left: Writing, right: Writing): Writing = Writing(Text(left.text.s+right.text.s))
 
-    def at(writing: Writing, index: Ordinal): Grapheme =
+    def access(writing: Writing, index: Ordinal): Grapheme =
       Grapheme:
         writing.text.s.substring(writing.boundaries(index.n0), writing.boundaries(index.n0 + 1)).nn
 

--- a/lib/gossamer/src/core/gossamer.internal.scala
+++ b/lib/gossamer/src/core/gossamer.internal.scala
@@ -159,7 +159,7 @@ object internal:
       extension (ascii: Ascii) def bytes: Data = ascii
 
       given textual: Ascii is Textual:
-        type Operand = Byte
+        type Result = Byte
         type Show[value] = value is Showable
 
         val empty: Ascii = IArray.from[Byte](Nil)
@@ -170,7 +170,7 @@ object internal:
         def fromChar(char: Char): Byte = char.toByte
         def length(ascii: Ascii): Int = ascii.size
         def text(ascii: Ascii): Text = String(ascii.mutable(using Unsafe), "ASCII").nn.tt
-        def at(ascii: Ascii, index: Ordinal): Byte = ascii(index.n0)
+        def access(ascii: Ascii, index: Ordinal): Byte = ascii(index.n0)
         def builder(size: Optional[Int]): Builder[Ascii] = AsciiBuilder(size)
         def size(ascii: Ascii): Int = ascii.length
 

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -131,7 +131,7 @@ extension [textual](text: textual)
 
     cuttable.cut(text, delimiter, limit)
 
-extension [textual: Textual { type Operand = Char }](words: Iterable[textual])
+extension [textual: Textual { type Result = Char }](words: Iterable[textual])
   def pascal: textual = words.map(_.lower.capitalize).join
   def camel: textual = pascal.uncapitalize
   def snake: textual = words.join(textual("_".tt))
@@ -190,7 +190,7 @@ extension [textual: Textual](text: textual)
     var index = n - 1
 
     while index >= 0 do
-      builder.append(textual.single(textual.at(text, index.z)))
+      builder.append(textual.single(textual.access(text, index.z)))
       index -= 1
 
     builder()
@@ -235,7 +235,7 @@ extension [textual: Textual](text: textual)
     case Ltr => if text.starts(affix) then text.skip(affix.length) else text
     case Rtl => if text.ends(affix) then text.skip(affix.length, Rtl) else text
 
-extension [textual: Textual { type Operand = Char }](text: textual)
+extension [textual: Textual { type Result = Char }](text: textual)
   inline def lower: textual = textual.map(text)(_.toLower)
   inline def upper: textual = textual.map(text)(_.toUpper)
 
@@ -249,7 +249,7 @@ extension [textual: Textual { type Operand = Char }](text: textual)
         builder.append(text.from(from))
         builder()
       else
-        if !predicate(textual.at(text, index - 1), textual.at(text, index))
+        if !predicate(textual.access(text, index - 1), textual.access(text, index))
         then recur(from, index + 1)
         else
           builder.append(text.segment(from till index))
@@ -295,7 +295,7 @@ extension [textual: Textual { type Operand = Char }](text: textual)
 
     def recur(ordinal: Ordinal): Optional[Ordinal] =
       if ordinal >= text.limit || ordinal < Prim then Unset
-      else if predicate(textual.at(text, ordinal)) then ordinal
+      else if predicate(textual.access(text, ordinal)) then ordinal
       else recur(ordinal + step)
 
     recur(first)
@@ -323,7 +323,7 @@ extension [textual: Textual { type Operand = Char }](text: textual)
 
   inline def count(predicate: Char => Boolean): Int =
     def recur(index: Ordinal, sum: Int): Int = if index >= text.limit then sum else
-      val increment = if predicate(textual.at(text, index)) then 1 else 0
+      val increment = if predicate(textual.access(text, index)) then 1 else 0
       recur(index + 1, sum + increment)
 
     recur(Prim, 0)

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -149,7 +149,7 @@ object Tag:
 
           val value =
             if attribution.attribute == t"class"
-            then presets.at("class").lay(name): preset => t"$preset $name"
+            then presets.at(t"class").lay(name): preset => t"$preset $name"
             else name
 
           presets.updated(attribution.attribute, value)
@@ -195,7 +195,7 @@ object Tag:
 
           val value =
             if attribution.attribute == t"class"
-            then presets.at("class").lay(name): preset => t"$preset $name"
+            then presets.at(t"class").lay(name): preset => t"$preset $name"
             else name
 
           presets.updated(attribution.attribute, value)

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -372,12 +372,25 @@ extension [element](sequence: Seq[element])
 extension (bytes: Data)
   def javaInputStream: ji.InputStream = new ji.ByteArrayInputStream(bytes.mutable(using Unsafe))
 
-extension [indexable: Indexable](inline value: indexable)
+extension [indexable: Indexable](value: indexable)
   inline def has(index: indexable.Operand): Boolean = indexable.contains(value, index)
 
-  inline def at(index: indexable.Operand): Optional[indexable.Result] =
-    optimizable[indexable.Result]: default =>
-      if indexable.contains(value, index) then indexable.access(value, index) else default
+  // A single `at` that dispatches at compile time on the index type: an index statically known to be
+  // confined to *this* `value` (an `Operand in value.type`, hence in range) returns a bare `Result`;
+  // any other index is bounds-checked and returns `Optional`. The declared return type is `Optional`,
+  // so non-reducing (e.g. generic) call sites are safe; a confined index narrows to a bare `Result`.
+  transparent inline def at[index](ordinal: index)(using sub: index <:< indexable.Operand)
+  :   Optional[indexable.Result] =
+
+    summonFrom:
+      case _: (`index` <:< (indexable.Operand in value.type)) =>
+        indexable.access(value, sub(ordinal))
+
+      case _ =>
+        val key: indexable.Operand = sub(ordinal)
+
+        optimizable[indexable.Result]: default =>
+          if indexable.contains(value, key) then indexable.access(value, key) else default
 
 extension [indexable: Indexable by Ordinal](inline value: indexable)
   inline def prim: Optional[indexable.Result] = value.at(Prim)

--- a/lib/rudiments/src/test/rudiments_test.scala
+++ b/lib/rudiments/src/test/rudiments_test.scala
@@ -100,6 +100,28 @@ object Tests extends Suite(m"Rudiments Tests"):
         Map(t"a" -> 1, t"b" -> 2).has(t"c")
       . assert(_ == false)
 
+    suite(m"Confined index tests"):
+      val text = t"hello"
+      val array = IArray(10, 20, 30)
+
+      test(m"Plain `at` returns Optional"):
+        text.at(Prim).vouch
+      . assert(_ == 'h')
+
+      test(m"`within` + confined `at` returns a bare element"):
+        Ter.within(text).let { i => val c: Char = text.at(i); c }
+      . assert(_ == 'l')
+
+      test(m"`within` returns Unset for an out-of-range Ordinal"):
+        Ordinal.zerary(99).within(text)
+      . assert(_ == Unset)
+
+      test(m"`iterate` yields confined indices usable with bare `at`"):
+        var total = 0
+        array.iterate { i => total += array.at(i) }
+        total
+      . assert(_ == 60)
+
     // test(m"Display a PID"):
     //   Pid(2999).toString
     // .assert(_ == "↯2999")

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -753,6 +753,14 @@ object internal:
   object Attributes:
     val empty: Attributes = IArray.empty[String]
 
+    // `Attributes` is a `Text`-keyed map, so it indexes through the shared `at` (giving `Optional`).
+    given indexable: Attributes is Indexable:
+      type Operand = Text
+      type Result = Text
+
+      def contains(attrs: Attributes, key: Text): Boolean = attrs.contains(key)
+      def access(attrs: Attributes, key: Text): Text = attrs(key)
+
     def apply(pairs: (Text, Text)*): Attributes =
       if pairs.isEmpty then empty else
         val n = pairs.length
@@ -808,18 +816,6 @@ object internal:
           i += 2
 
         throw new NoSuchElementException(s"key not found: $key")
-
-      def at(key: Text): Optional[Text] =
-        val a = storage(attrs)
-        val keyStr: String = key.s
-        val n = a.length
-        var i = 0
-
-        while i < n do
-          if a(i) == keyStr then return a(i + 1).asInstanceOf[Text]
-          i += 2
-
-        Unset
 
       def contains(key: Text): Boolean =
         val a = storage(attrs)


### PR DESCRIPTION
Indexing a collection with `at` now returns the element directly, rather than an `Optional`, whenever the index is statically known to lie within that collection — for example an index produced by iterating the collection with `iterate`, or one narrowed with `within`. This in-range guarantee is carried in the type as `Ordinal in collection.type`. Text-like types are now `Indexable` too, so `Text`, `Ascii`, `Writing` and `Teletype` index through the same `at`.

Indexing with an ordinary `Ordinal` is unchanged — bounds-checked, returning `Optional`:
```scala
val text = t"hello"
text.at(Prim)              // Optional[Char]
```
A confined index — one whose type ties it to a specific collection — indexes *totally*, returning a bare element. `collection.iterate` yields such indices, and `ordinal.within(collection)` narrows an arbitrary ordinal to one:
```scala
var total = 0
bytes.iterate { i => total += bytes.at(i) }     // bytes.at(i): the element, not Optional

Prim.within(text).let { i => text.at(i) }       // Char, not Optional[Char]
```

**Breaking changes**
- `Textual` now extends `Indexable`. For custom `Textual` instances, the element type member is renamed `Operand` → `Result`, and the per-instance `at(self, index)` method is renamed to `access`.
- In Aviation, combining a date and a time-of-day is now written `time on date` (a method on `Clockface`) rather than `date at time`, e.g. `5.25.pm on 2018-Aug-11`. This frees the `at` name for the general indexing operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
