### PR TITLE
Add test coverage for under-tested format-module features

### DIFF
--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -35,11 +35,13 @@ package breviloquence
 import soundness.*
 
 import strategies.throwUnsafely
+import errorDiagnostics.stackTraces
 
 case class Point(x: Int, y: Int) derives CanEqual
 case class Person(name: Text, age: Int) derives CanEqual
 case class Wrapper(values: List[Int], label: Text) derives CanEqual
 case class Team(lead: Person, size: Int) derives CanEqual
+case class OptPerson(name: Text, age: Optional[Int]) derives CanEqual
 case class Renamed
    (@name[Cbor](t"data_files")  dataFiles:  List[Long],
     @name[Cbor](t"index_files") indexFiles: List[Long])
@@ -363,3 +365,52 @@ object Tests extends Suite(m"Breviloquence Tests"):
       test(m"setting an absent field inserts it"):
         list.lens(_.extra = 7.cbor).selectDynamic("extra").as[Int]
       . assert(_ == 7)
+
+    suite(m"Error byte-offsets"):
+      test(m"truncated input reports the offset of the missing byte"):
+        capture[CborError](Cbor.Ast.parse(hex("18"))).reason match
+          case CborError.Reason.Truncated(offset) => offset
+          case _                                   => -1L
+      . assert(_ == 1L)
+
+      test(m"trailing bytes report the offset where they begin"):
+        capture[CborError](Cbor.Ast.parse(hex("0000"))).reason match
+          case CborError.Reason.Trailing(offset) => offset
+          case _                                 => -1L
+      . assert(_ == 1L)
+
+      test(m"a reserved head byte reports its offset and byte value"):
+        capture[CborError](Cbor.Ast.parse(hex("1c"))).reason match
+          case CborError.Reason.Reserved(offset, byte) => (offset, byte)
+          case _                                        => (-1L, -1)
+      . assert(_ == (0L, 28))
+
+    suite(m"Dynamic access"):
+      import dynamicCborAccess.enabled
+
+      test(m"selectDynamic reads a map field by name"):
+        Person(t"Ada", 36).cbor.selectDynamic("name").as[Text]
+      . assert(_ == t"Ada")
+
+      test(m"applyDynamic indexes into an array-valued field"):
+        Wrapper(List(10, 20, 30), t"hi").cbor.applyDynamic("values")(1).as[Int]
+      . assert(_ == 20)
+
+      test(m"updateDynamic replaces a field's value"):
+        Person(t"Ada", 36).cbor.updateDynamic("age")(40).as[Person]
+      . assert(_ == Person(t"Ada", 40))
+
+      test(m"updateDynamic with Unset deletes a field"):
+        Person(t"Ada", 36).cbor.updateDynamic("age")(Unset).as[OptPerson]
+      . assert(_ == OptPerson(t"Ada", Unset))
+
+    suite(m"Optional fields"):
+      test(m"an Optional field round-trips when present"):
+        val bytes = CborPrinter.encode(Cbor.unseal(OptPerson(t"Ada", 36).cbor))
+        Cbor.ast(Cbor.Ast.parse(bytes)).as[OptPerson]
+      . assert(_ == OptPerson(t"Ada", 36))
+
+      test(m"an Optional field round-trips when unset"):
+        val bytes = CborPrinter.encode(Cbor.unseal(OptPerson(t"Eve", Unset).cbor))
+        Cbor.ast(Cbor.Ast.parse(bytes)).as[OptPerson]
+      . assert(_ == OptPerson(t"Eve", Unset))

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -254,6 +254,51 @@ object Tests extends Suite(m"Caesura tests"):
          .rows.to(List).map(_.data.head)
       . assert(_ == List(t"Alice", t"X"))
 
+    suite(m"Roundtrip"):
+      import dsvFormats.csv
+
+      test(m"case class survives encode, render, parse and decode"):
+        Bar(0.1, Foo(t"two", t"three"), 4, Foo(t"five", t"six")).dsv.show
+         .read[Sheet].rows.head.as[Bar]
+      . assert(_ == Bar(0.1, Foo(t"two", t"three"), 4, Foo(t"five", t"six")))
+
+      test(m"quoted cell survives a parse/render roundtrip"):
+        t""""hello, world",test""".read[Sheet].show
+      . assert(_ == t""""hello, world",test""")
+
+      test(m"multi-row data survives a parse/render roundtrip"):
+        t"foo,bar\nbaz,quux".read[Sheet].show
+      . assert(_ == t"foo,bar\nbaz,quux")
+
+    suite(m"Cell spanning"):
+      test(m"a flat product spans one column per field"):
+        Spannable.derived[Foo].spans().to(List)
+      . assert(_ == List(1, 1))
+
+      test(m"a nested product sums each field's child spans"):
+        Spannable.derived[Bar].spans().to(List)
+      . assert(_ == List(1, 2, 1, 2))
+
+      test(m"the total column count is the sum of all spans"):
+        Spannable.derived[Bar].spans().sum
+      . assert(_ == 6)
+
+    suite(m"Field renaming"):
+      test(m"unchanged redesignation preserves the field name"):
+        import dsvRedesignations.unchanged
+        summon[DsvRedesignation].transform(t"targetPerson")
+      . assert(_ == t"targetPerson")
+
+      test(m"capitalizedWords redesignation maps to capitalised words"):
+        import dsvRedesignations.capitalizedWords
+        summon[DsvRedesignation].transform(t"targetPerson")
+      . assert(_ == t"Target Person")
+
+      test(m"lowerWords redesignation maps to lower-case words"):
+        import dsvRedesignations.lowerWords
+        summon[DsvRedesignation].transform(t"targetPerson")
+      . assert(_ == t"target person")
+
 case class Foo(one: Text, two: Text)
 case class Bar(one: Double, foo1: Foo, four: Int, foo2: Foo)
 case class Quux(name: Text, greeting: Text)

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -54,6 +54,7 @@ case class OptFoo(x: Option[Int])
 case class OptionalFoo(x: Optional[Int])
 case class Bar(a: Int, b: Text)
 case class BarOpt(a: Int, b: Optional[Text])
+case class WithDefault(name: Text, age: Int = 18) derives CanEqual
 case class Marked(@memo(t"the count") n: Int)
 case class Renamed(@name[Json](t"first_name") firstName: Text, @name(t"yob") year: Int)
 derives CanEqual
@@ -287,6 +288,14 @@ object Tests extends Suite(m"Jacinta Tests"):
         import dynamicJsonAccess.enabled
         t"""{"y": 1}""".read[Json].missing.as[Optional[Int]]
       . assert(_ == Unset)
+
+      test(m"Apply a case-class default when the field is omitted"):
+        t"""{"name": "Eve"}""".read[Json].as[WithDefault]
+      . assert(_ == WithDefault(t"Eve", 18))
+
+      test(m"An explicit value overrides a case-class default"):
+        t"""{"name": "Eve", "age": 30}""".read[Json].as[WithDefault]
+      . assert(_ == WithDefault(t"Eve", 30))
 
     suite(m"Generic derivation tests"):
       val paul =

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -601,6 +601,49 @@ object Tests extends Suite(m"Stratiform Tests"):
         capture[TelError](Tel.Type.assign(doc, statusSchema)).reason
       . assert(_ == TelError.Reason.UnknownKeyword)
 
+    suite(m"Schema default-field"):
+      // Like `personSchema`, but the required `name` field carries a default,
+      // so a document omitting it is filled with the default rather than
+      // raising `RequiredMemberAbsent`.
+      val defaultingSchema = Tels(
+        name     = t"person",
+        document = Tels.Struct(
+          members = IArray(
+            Tels.Field
+             ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+               t"name", Tels.Scalar(IArray(t"string")), t"Anonymous" ),
+            Tels.Field
+             ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+               t"age", Tels.Scalar(IArray(t"identifier")), Unset )),
+          validators = IArray.empty),
+        layers   = IArray.empty,
+        sigil    = Unset,
+        records  = IArray.empty,
+        scalars  = IArray.empty,
+        selects  = IArray.empty)
+
+      test(m"applies the schema default when the field is omitted"):
+        val doc = t"age 30\n".read[Tel]
+        Tel.Type.assign(doc, defaultingSchema) match
+          case Tel.Element.Node(_, _, children) =>
+            children.collect:
+              case Tel.Element.Value(_, _, t) => t
+            .to(Set)
+
+          case _ => Set()
+      . assert(_ == Set(t"Anonymous", t"30"))
+
+      test(m"an explicit value overrides the schema default"):
+        val doc = t"name Alice\nage 30\n".read[Tel]
+        Tel.Type.assign(doc, defaultingSchema) match
+          case Tel.Element.Node(_, _, children) =>
+            children.collect:
+              case Tel.Element.Value(_, _, t) => t
+            .toList
+
+          case _ => Nil
+      . assert(_ == List(t"Alice", t"30"))
+
     suite(m"Validators"):
       val reg = Tel.Validator.Registry.builtins
 


### PR DESCRIPTION
This change adds dedicated tests for several format-module features that were implemented but previously untested, working through the checklist in #1242: CSV/TSV roundtrip fidelity, cell spanning and header renaming in Caesura; CBOR error byte-offsets, dynamic access and Optional handling in Breviloquence; TEL schema default-field decoding in Stratiform; and JSON case-class default-value decoding in Jacinta. It is test-only — no library code changes — and two checklist items that turned out to need a feature first were split into their own issues (#1354 for the XML serializer's formatting options, #1355 for Optional/Unset support in Caesura's positional decoding).

There is no API change in this release; it improves internal test coverage only.

- **Caesura**: roundtrip (`encode → render → parse → decode`) fidelity, `Spannable` column-span computation for flat and nested products, and `DsvRedesignation.transform` header remapping.
- **Breviloquence**: assertions on the byte-offsets carried by `CborError` (`Truncated`, `Trailing`, `Reserved`), direct `selectDynamic`/`applyDynamic`/`updateDynamic` access (including deletion via `Unset`), and `Optional` field round-trips when present and unset.
- **Stratiform**: schema default-field decoding — a required scalar field with a schema-declared default is filled when the document omits it, and an explicit value overrides the default.
- **Jacinta**: case-class default-value decoding — a field with a Scala-level default decodes to that default when the JSON omits it, and an explicit value overrides it.
