### PR TITLE
Generalise before/upto/from/after slicing across sequence types

### DIFF
--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -47,8 +47,6 @@ final val Sept: Ordinal = Ordinal.zerary(6)
 extension (inline cardinal: Int)
   inline def z: Ordinal = Ordinal.zerary(cardinal)
   inline def u: Ordinal = Ordinal.uniary(cardinal)
-  inline def from(ordinal: Ordinal): Interval = ordinal till (ordinal + cardinal)
-  inline def upto(ordinal: Ordinal): Interval = (ordinal - cardinal) till ordinal
 
 extension [countable: Countable](value: countable)
   inline def gamut: Interval = Interval.initial(countable.size(value))

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -138,6 +138,12 @@ extension [textual: Textual { type Result = Char }](words: Iterable[textual])
   def kebab: textual = words.join(textual("-".tt))
   def spaced: textual = words.join(textual(" ".tt))
 
+extension [value: {Segmentable, Countable}](value: value)
+  def before(ordinal: Ordinal): value = value.segment(Prim till ordinal)
+  def upto(ordinal: Ordinal): value = value.segment(Prim thru ordinal)
+  def from(ordinal: Ordinal): value = value.segment(ordinal thru value.limit)
+  def after(ordinal: Ordinal): value = value.segment((ordinal + 1) till value.limit)
+
 extension [textual: Textual](text: textual)
   inline def length: Int = textual.length(text)
   def plain: Text = textual.text(text)
@@ -153,11 +159,6 @@ extension [textual: Textual](text: textual)
         recur(word - 1, spaces - gap, result+textual(t" "*(gap + 1))+words(words.length - word.n0))
 
     recur(Prim, extra, words(0))
-
-  def before(ordinal: Ordinal): textual = text.segment(Prim till ordinal)
-  def after(ordinal: Ordinal): textual = text.segment((ordinal + 1) till text.limit)
-  def upto(ordinal: Ordinal): textual = text.segment(Prim thru ordinal)
-  def from(ordinal: Ordinal): textual = text.segment(ordinal thru text.limit)
 
   def slices(size: Int): List[textual] =
     val length = text.length

--- a/lib/gossamer/src/test/gossamer_test.scala
+++ b/lib/gossamer/src/test/gossamer_test.scala
@@ -290,6 +290,39 @@ object Tests extends Suite(m"Gossamer Tests"):
 
       . assert(_ == t"Hello")
 
+      test(m"from includes the anchor to the end"):
+        t"hello".from(Ter)
+      . assert(_ == t"llo")
+
+      test(m"upto includes the anchor from the start"):
+        t"hello".upto(Ter)
+      . assert(_ == t"hel")
+
+      test(m"before excludes the anchor from the start"):
+        t"hello".before(Ter)
+      . assert(_ == t"he")
+
+      test(m"after excludes the anchor to the end"):
+        t"hello".after(Ter)
+      . assert(_ == t"lo")
+
+      test(m"from slices a List by ordinal"):
+        List(0, 1, 2, 3, 4).from(Ter)
+      . assert(_ == List(2, 3, 4))
+
+      test(m"after slices a List by ordinal"):
+        List(0, 1, 2, 3, 4).after(Ter)
+      . assert(_ == List(3, 4))
+
+      test(m"upto slices an IArray by ordinal"):
+        IArray(0, 1, 2, 3, 4).upto(Ter).to(List)
+      . assert(_ == List(0, 1, 2))
+
+      test(m"before slices an IndexedSeq by ordinal"):
+        val sequence: IndexedSeq[Int] = Vector(0, 1, 2, 3, 4)
+        sequence.before(Ter).to(List)
+      . assert(_ == List(0, 1))
+
       test(m"snip a Text in two"):
         t"Hello".snip(2): (Text, Text)
 

--- a/lib/rudiments/src/core/rudiments.Segmentable.scala
+++ b/lib/rudiments/src/core/rudiments.Segmentable.scala
@@ -43,6 +43,12 @@ object Segmentable:
   given iarray: [element] => IArray[element] is Segmentable =
     (iarray, interval) => iarray.slice(interval.start.n0, interval.limit.n0)
 
+  given seq: [element] => Seq[element] is Segmentable =
+    (seq, interval) => seq.slice(interval.start.n0, interval.limit.n0)
+
+  given list: [element] => List[element] is Segmentable =
+    (list, interval) => list.slice(interval.start.n0, interval.limit.n0)
+
   given text: Text is Segmentable = (text, interval) =>
     val min = interval.start.n0.max(0)
     val max = interval.limit.n0.min(text.s.length)


### PR DESCRIPTION
The text-slicing operators `before`, `upto`, `from` and `after` now work on any indexed sequence — `Text`, `IArray`, `IndexedSeq`, `List` and `Seq` — rather than only on textual values, giving a single consistent vocabulary for taking the part of a sequence on either side of an ordinal. This also resolves a name clash that made Denominative's cardinal `Int.from`/`Int.upto` constructors unreachable whenever Gossamer was imported (#1231); those unused constructors have been removed.

### Anchor-relative slicing on any sequence

`before`, `upto`, `from` and `after` take an `Ordinal` and return the portion of a sequence relative to that anchor. They previously existed only for `Text`; they now apply to any type that is both `Segmentable` and `Countable`:

```scala
import soundness.*

List(0, 1, 2, 3, 4).from(Ter)    // List(2, 3, 4)
List(0, 1, 2, 3, 4).upto(Ter)    // List(0, 1, 2)
List(0, 1, 2, 3, 4).before(Ter)  // List(0, 1)
List(0, 1, 2, 3, 4).after(Ter)   // List(3, 4)

IArray(1, 2, 3, 4).from(Sec)     // IArray(2, 3, 4)
t"hello".upto(Ter)               // t"hel"
```

- `from`/`upto` are inclusive of the anchor; `after`/`before` are exclusive.
- `List` and `Seq` gain `Segmentable` instances, alongside the existing `IArray`, `IndexedSeq` and `Text`.
- The `Char`-predicate overloads of `before`/`upto` on textual values are unchanged.

Denominative's cardinal `Int.from(ordinal)`/`Int.upto(ordinal)` interval constructors have been removed — they were unused and collided with these slicing verbs. Use `ordinal span n`, `ordinal thru end` or `ordinal till limit` to build intervals instead.
