### PR TITLE
Detect inline styles vs stylesheets in the css"…" interpolator

### DIFF
--- a/lib/cataclysm/src/core/cataclysm.Css.scala
+++ b/lib/cataclysm/src/core/cataclysm.Css.scala
@@ -41,6 +41,7 @@ import gossamer.*
 import parasite.*
 import prepositional.*
 import spectacular.*
+import symbolism.*
 import turbulence.*
 import vacuous.*
 
@@ -58,14 +59,20 @@ object Css:
 
   // The `css"…"` interpolator: substitutions are checked against the property they
   // sit in (see `internal.expand`). Wired through `contextual` like `x"…"`/`h"…"`.
-  inline given interpolator: Css is Interpolable:
-    type Result = Css
-
+  // The result type is decided by the content: bare declarations (`css"width: 38px"`)
+  // produce a `Css.Style`, a selector-bearing or at-rule body (`css"a { … }"`) a `Css`.
+  inline given interpolator: (Css | Css.Style) is Interpolable:
     transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
       ( inline insertions: Any* )
-    :   Css =
+    :   Css | Css.Style =
 
       ${cataclysm.internal.expand[parts, origins]('insertions)}
+
+  // Stylesheets concatenate their rule lists, so `css"a { … }" + css"b { … }"` is one
+  // stylesheet of both rules.
+  given addable: Css is Addable by Css to Css =
+    Addable: (left, right) =>
+      Css(left.rules ++ right.rules)
 
   // Serve a stylesheet as an HTTP `text/css` response body (paired with the
   // `Streamable` instance above).
@@ -84,6 +91,12 @@ object Css:
 
     inline def applyDynamicNamed(method: "apply")(inline properties: (Label, Any)*): Style =
       ${cataclysm.internal.style('properties)}
+
+    // Inline-style sets concatenate their property lists, so two `Css.Style`s (or two
+    // bare `css"…"`s) join into one.
+    given addable: Style is Addable by Style to Style =
+      Addable: (left, right) =>
+        Style.of(left.properties ++ right.properties)
 
   class Style private (val properties: List[(Text, Text)]):
     def text: Text = properties.map { (name, value) => t"$name: $value" }.join(t"; ")

--- a/lib/cataclysm/src/core/cataclysm.internal.scala
+++ b/lib/cataclysm/src/core/cataclysm.internal.scala
@@ -65,7 +65,7 @@ object internal:
   // around the quotes below, so this file branches on `Optional` with plain `match`.
   def expand[parts <: Tuple: Type, origins <: Tuple: Type]
     (insertions0: Expr[Seq[Any]])(using Quotes)
-  :   Expr[Css] =
+  :   Expr[Css | Css.Style] =
 
     import quotes.reflect.*
 
@@ -143,6 +143,19 @@ object internal:
 
       '{SelectorList.read($acc.tt)}
 
+    // The (type-checked) value of a declaration: a lone sentinel becomes the typed
+    // substitution; a substitution mixed with literal text, or in the property name,
+    // is an error. Shared by the stylesheet (`Css`) and inline-style (`Css.Style`) builds.
+    def declarationValue(property: Text, value: Text): Expr[Text] =
+      if has(property) then
+        halt(m"cataclysm: a substitution may only be a property value, not a property name")
+      else if value == placeholder then
+        hole(property)
+      else if has(value) then
+        halt(m"cataclysm: a substitution must be a whole property value, not mixed with text")
+      else
+        lift(value)
+
     def listExpr(nodes: List[Css.Node]): Expr[List[Css.Node]] = Expr.ofList(nodes.map(nodeExpr))
 
     def nodeExpr(node: Css.Node): Expr[Css.Node] = node match
@@ -154,14 +167,7 @@ object internal:
         '{Css.Node.Rule($selectorExpr, ${listExpr(body)})}
 
       case Css.Node.Declaration(property, value) =>
-        if has(property) then
-          halt(m"cataclysm: a substitution may only be a property value, not a property name")
-        else if value == placeholder then
-          '{Css.Node.Declaration(${lift(property)}, ${hole(property)})}
-        else if has(value) then
-          halt(m"cataclysm: a substitution must be a whole property value, not mixed with text")
-        else
-          '{Css.Node.Declaration(${lift(property)}, ${lift(value)})}
+        '{Css.Node.Declaration(${lift(property)}, ${declarationValue(property, value)})}
 
       case Css.Node.At(name, prelude, body) =>
         if has(name) || has(prelude) then
@@ -174,7 +180,25 @@ object internal:
           case nodes: List[Css.Node] @unchecked =>
             '{Css.Node.At(${lift(name)}, ${lift(prelude)}, ${listExpr(nodes)})}
 
-    val result = '{Css(${listExpr(css.rules)})}
+    def isDeclaration(node: Css.Node): Boolean = node match
+      case Css.Node.Declaration(_, _) => true
+      case _                          => false
+
+    // A bare declaration in inline-style position, e.g. `("color", $value)`.
+    def stylePair(node: Css.Node): Expr[(Text, Text)] = node match
+      case Css.Node.Declaration(property, value) =>
+        '{(${lift(property)}, ${declarationValue(property, value)})}
+
+      case _ =>
+        halt(m"cataclysm: only declarations may appear in an inline style")
+
+    // Detect the kind of CSS from its content: top-level declarations with no selector
+    // or at-rule are an inline style set (`Css.Style`); anything with a rule or at-rule
+    // is a stylesheet (`Css`). The `transparent inline` interpolator returns whichever.
+    val result: Expr[Css | Css.Style] =
+      if css.rules.nonEmpty && css.rules.forall(isDeclaration)
+      then '{Css.Style.of(${Expr.ofList(css.rules.map(stylePair))})}
+      else '{Css(${listExpr(css.rules)})}
 
     if holeIndex != insertions.length
     then halt(m"cataclysm: a substitution is only allowed as a property value or in a selector")

--- a/lib/cataclysm/src/core/cataclysm_core.scala
+++ b/lib/cataclysm/src/core/cataclysm_core.scala
@@ -42,9 +42,10 @@ import turbulence.*
 import vacuous.*
 
 // The `css"…"` typed CSS interpolator, wired through `contextual` like xylophone's
-// `x"…"` and honeycomb's `h"…"`.
+// `x"…"` and honeycomb's `h"…"`. The transparent result is a `Css` (stylesheet) or a
+// `Css.Style` (inline style set), decided by the content (see `internal.expand`).
 extension (inline context: StringContext)
-  transparent inline def css: Interpolation = interpolation[Css](context)
+  transparent inline def css: Interpolation = interpolation[Css | Css.Style](context)
 
 // Reading a stylesheet accumulates every `CssError` (unknown property, invalid
 // or unsupported value, …) instead of stopping at the first: the parse runs

--- a/lib/cataclysm/src/test/cataclysm_test.scala
+++ b/lib/cataclysm/src/test/cataclysm_test.scala
@@ -781,3 +781,37 @@ object Tests extends Suite(m"Cataclysm Tests"):
       test(m"a substitution mixed with literal text fails to compile"):
         demilitarize(css"a { margin: $width 0 }").nonEmpty
       . assert(_ == true)
+
+    suite(m"CSS interpolator result type"):
+      val width = 4.0*Px
+
+      test(m"bare declarations produce an inline style set"):
+        css"color: red; width: 4px".text
+      . assert(_ == t"color: red; width: 4px")
+
+      test(m"a substitution in a bare declaration is checked and rendered"):
+        css"width: $width".text
+      . assert(_ == t"width: 4px")
+
+      test(m"a rule produces a stylesheet"):
+        css"a { color: red }".rules
+      . assert(_ == t"a { color: red }".read[Css].rules)
+
+      test(m"a bare style set is statically a Css.Style, not a stylesheet"):
+        demilitarize(css"color: red".rules).nonEmpty
+      . assert(_ == true)
+
+      test(m"a stylesheet is statically a Css, not an inline style set"):
+        demilitarize(css"a { color: red }".text).nonEmpty
+      . assert(_ == true)
+
+    suite(m"Joining CSS with +"):
+      val width = 4.0*Px
+
+      test(m"two stylesheets join into one"):
+        (css"a { color: red }" + css"b { color: blue }").rules
+      . assert(_ == t"a { color: red } b { color: blue }".read[Css].rules)
+
+      test(m"two inline style sets join into one"):
+        (css"color: red" + css"width: $width").text
+      . assert(_ == t"color: red; width: 4px")


### PR DESCRIPTION
The `css"…"` interpolator now distinguishes an inline set of styles from a full stylesheet, returning a `Css.Style` for bare declarations such as `css"width: 38px"` and a `Css` for selector-bearing or at-rule content such as `css"a { … }"`; the result type is inferred transparently from the content. Two `Css` stylesheets, or two `Css.Style` style sets, can now also be combined with `+`.

The `css"…"` interpolator previously always produced a `Css` stylesheet. It now inspects the content at compile time and returns the appropriate type:

- bare declarations — no selector or at-rule — produce a `Css.Style` (the type used for an inline `style="…"` attribute):

  ```scala
  val style: Css.Style = css"color: red; width: 38px"
  ```

- selector-bearing rules or at-rules produce a `Css` stylesheet, as before:

  ```scala
  val sheet: Css = css"a { color: red }"
  ```

The type is narrowed transparently, so calling a `Css.Style`-only member on a stylesheet (or vice versa) is a compile error. Substitutions are still checked against the property they sit in:

```scala
val width = 38*Px
css"width: $width"            // Css.Style
css"a { width: $width }"      // Css
```

Both types now have `Addable` instances, so they join with `+`:

```scala
css"a { color: red }" + css"b { color: blue }"   // one Css of both rules
css"color: red" + css"width: 38px"               // one Css.Style of both
```