### PR TITLE
Download Ethereal runner stubs from GitHub instead of requiring make

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -692,7 +692,7 @@ object polysyllabic extends Library:
   object bench extends Benchmarks(core, escritoire.core, hellenism.core, quantitative.units)
 
 object ethereal extends Library:
-  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.core, quantitative.units):
+  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.core, quantitative.units, telekinesis.core, urticose.url, gastronomy.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
     // The platforms the reusable native runner stubs target — (label, binary filename).

--- a/lib/ethereal/src/core/ethereal.Runners.scala
+++ b/lib/ethereal/src/core/ethereal.Runners.scala
@@ -1,0 +1,101 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ethereal
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import eucalyptus.*
+import fulminate.*
+import gossamer.*
+import rudiments.*
+import telekinesis.*
+import turbulence.*
+import urticose.*
+import vacuous.*
+
+import errorDiagnostics.emptyDiagnostics
+import gastronomy.*, providers.javaStdlibProvider
+import internetAccess.online
+import monotonous.*, alphabets.hexLowerCase
+
+case class RunnerError(detail: Message)(using Diagnostics) extends Error(detail)
+
+// The reusable native runner stubs are published independently of any application as a
+// GitHub release (`runners-<version>`), and verified against the committed
+// `etc/runners/<version>.tsv` manifest. The `-Dbuild.executable` self-packaging path
+// downloads the one stub it needs from here rather than requiring a local build, so the
+// coordinates and per-platform SHA-256 hashes are hard-coded below. Bumping to a newly
+// published release is a one-line change to `version` plus a refresh of `hashes`.
+object Runners:
+  val version: Text = t"0.1"
+
+  val baseUrl: Text =
+    t"https://github.com/propensive/soundness/releases/download/runners-$version"
+
+  // Lowercase SHA-256 hex of each published stub, copied verbatim from
+  // `etc/runners/$version.tsv`.
+  val hashes: Map[Text, Text] =
+    Map
+      ( t"linux-arm64" -> t"8578172c97897eb94dc2fa4829f112e06d9284407b08ea0970e24e232ebcd21e",
+       t"linux-x64" -> t"fb98e23e5e2861e5bd492f471668b676f9f4bef94544d37619eef4ed22f2b638",
+       t"macos-arm64" -> t"3593278b1f12fd456f545e04aae9e369b8675daf43bcb583f449b4cca8c1caf2",
+       t"macos-x64" -> t"f1f32cc2bc4ed59a2a7615413b686c4180fd65a08197046b6e6c7a72f2edef7e",
+       t"windows-x64" -> t"7d6f5c5a2e6a8ad71dcc568e494b8c34f59dcf0a6271c8205c0dfa53d9d31dae" )
+
+  // The published filename for a platform's bare runner stub (Windows stubs carry `.exe`).
+  def runnerName(label: Text): Text =
+    if label.starts(t"windows") then t"runner-$label.exe" else t"runner-$label"
+
+  // Download the bare reusable runner stub for `label` from the published release and verify
+  // it against the hard-coded SHA-256 manifest.
+  def download(label: Text): Data raises RunnerError =
+    val name: Text = runnerName(label)
+
+    val expected: Text =
+      hashes.at(label).lest(RunnerError(m"There is no published runner stub for platform $label"))
+
+    whereas:
+      case HttpError(_, _)   => RunnerError(m"Could not download the stub $name from $baseUrl")
+      case ConnectError(_)   => RunnerError(m"Could not connect to $baseUrl to download $name")
+      case UrlError(_, _, _) => RunnerError(m"The runner stub URL for $name is not valid")
+      case StreamError(_)    => RunnerError(m"The download of the stub $name was interrupted")
+
+    . mitigate:
+        val runner: Data = mute[HttpEvent](t"$baseUrl/$name".decode[HttpUrl].fetch().read[Data])
+        val actual: Text = runner.digest[Sha2[256]].serialize[Hex]
+
+        if actual != expected
+        then abort(RunnerError(m"The downloaded runner stub $name has the wrong SHA-256 ($actual)"))
+
+        runner

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -152,23 +152,47 @@ def cli[bus <: Matchable](using executive: Executive)
             val runnerName: Text =
               if isWindows then t"runner-$platformLabel.exe" else t"runner-$platformLabel"
 
-            // The reusable runner stubs are no longer embedded in the JAR; the right one is
-            // read from the `dist/runners` directory (relative to the working directory, or
-            // `-Dethereal.runners=<dir>`), which `make runners-build`/`make runners-fetch`
-            // populate.
+            // The reusable runner stubs are not embedded in the JAR. A locally-built or
+            // pre-fetched directory (an explicit `-Dethereal.runners=<dir>`, or `dist/runners`
+            // relative to the working directory) takes priority; otherwise the one stub this
+            // platform needs is downloaded from the published `runners-<version>` GitHub
+            // release, verified against its SHA-256, and cached for subsequent builds.
             val work: Path on Linux = workingDirectory
 
             val runnersDir: Text =
               safely(System.properties.ethereal.runners[Text]()).or(t"$work/dist/runners")
 
-            val runnerFile: Path on Linux = t"$runnersDir/$runnerName".decode[Path on Linux]
+            val localRunner: Path on Linux = t"$runnersDir/$runnerName".decode[Path on Linux]
 
-            if !runnerFile.exists() then
-              Out.println(e"Runner stub $runnerName not found in $runnersDir.")
-              Out.println(e"Run $Italic(make runners-build) or $Italic(make runners-fetch) first.")
-              Exit.Fail(1).terminate()
+            val cacheDir: Path on Linux =
+              Directories.cacheHome[Path on Linux]/t"ethereal"/t"runners"/Runners.version
 
-            val runnerBytes: Data = runnerFile.open(_.stream[Data].read[Data])
+            val cacheRunner: Path on Linux = cacheDir/runnerName
+
+            val runnerBytes: Data =
+              if localRunner.exists() then localRunner.open(_.stream[Data].read[Data])
+              else if cacheRunner.exists() then cacheRunner.open(_.stream[Data].read[Data])
+              else
+                whereas:
+                  case RunnerError(detail) =>
+                    Out.println(detail.text)
+                    Exit.Fail(1).terminate()
+
+                  case IoError(_, _, _, _) =>
+                    Out.println(e"Could not cache the downloaded runner stub $runnerName")
+                    Exit.Fail(1).terminate()
+
+                  case StreamError(_) =>
+                    Out.println(e"The runner stub download was interrupted")
+                    Exit.Fail(1).terminate()
+
+                . mitigate:
+                    import filesystemOptions.overwritePreexisting.disabled
+                    Out.println(e"Downloading $runnerName from runners-${Runners.version}")
+                    val bytes: Data = Runners.download(platformLabel)
+                    if !cacheDir.exists() then cacheDir.create[Directory]()
+                    cacheRunner.open(Stream(bytes).writeTo(_))
+                    bytes
 
             // ML-DSA-44 public key used by the runner to verify upgrades.
             // When `ethereal.publicKey` is unset the slot stays zero and the


### PR DESCRIPTION
Building an Ethereal application with `java -Dbuild.executable=… -jar app.jar` no longer requires a local `make runners-build`/`make runners-fetch`. The self-packaging path now downloads the bare runner stub for the current platform from the published `runners-0.1` GitHub release, verifies it against a hard-coded SHA-256 manifest, and caches it for subsequent builds. A locally-built or pre-fetched `dist/runners` (or an explicit `-Dethereal.runners=<dir>`) still takes priority, so the in-repo development workflow is unchanged, and no user-facing message references the Makefile.

## Release notes

Ethereal applications can now be packaged out of the box. Previously, running

```
java -Dbuild.executable=myapp -jar myapp.jar
```

failed with `Run make runners-build or make runners-fetch first` unless the reusable runner stubs had been built or fetched locally — which is impossible for anyone building their own application outside the Soundness repository.

Now the build downloads exactly the one stub it needs from the published `runners-0.1` release, verifies its SHA-256, and caches it under your cache directory (`$XDG_CACHE_HOME/ethereal/runners/0.1/`). Subsequent builds reuse the cached stub. Setting `-Dethereal.runners=<dir>` or placing stubs in `dist/runners` still bypasses the download entirely.