### PR TITLE
Add graffiti, a module for composing HTML pages from stackable traits

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -68,6 +68,7 @@ object settings:
     "-Wconf:origin=.*systems.java:s",
     "-Wconf:origin=.*overwritePreexisting.enabled:s",
     "-Wconf:origin=.*dynamicJsonAccess.enabled:s",
+    "-Wconf:origin=.*CssClass.nominative:s",
     // "-Wsafe-init",
     "-Xmax-inlines", "32",
     //"-Ycc-new",
@@ -237,7 +238,7 @@ object soundness extends ScalaModule:
     legerdemain.core, caduceus.core, caduceus.resend, orthodoxy.core, jacinta.http, jacinta.schema,
     stratiform.http, obligatory.core, obligatory.json, synesthesia.core, apoplexy.core,
     cataclysm.html, querencia.core, cordillera.core, embarcadero.containerd, obligatory.grpc,
-    xenophile.core, xenophile.typescript, xenophile.webidl, xenophile.wit)
+    xenophile.core, xenophile.typescript, xenophile.webidl, xenophile.wit, graffiti.core)
 
   object all extends Bundle(base, cli, data, sci, test, tool, web)
 
@@ -892,6 +893,12 @@ object gossamer extends Library:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, serpentine.core)
 
+object graffiti extends Library:
+  object core extends Component(honeycomb.core, cataclysm.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core)
+
 object guillotine extends Library:
   object core extends Component(turbulence.core, ambience.core):
     override def scalacOptions = Task:
@@ -1542,7 +1549,7 @@ val allLibraries: Seq[Library] = Seq(
   embarcadero, enigmatic, escapade, escritoire, ethereal, eucalyptus, exegesis,
   exoskeleton,
   frontier, fulminate, galilei, gastronomy, geodesy, gesticulate, gigantism,
-  gnossienne, gossamer, guillotine, hallucination, harlequin, hellenism, hieroglyph,
+  gnossienne, gossamer, graffiti, guillotine, hallucination, harlequin, hellenism, hieroglyph,
   honeycomb, hyperbole, hypotenuse, imperial, inimitable, iridescence, jacinta,
   kaleidoscope, larceny, legerdemain, locomotion, mandible, mercator, metamorphose,
   monotonous,

--- a/lib/graffiti/src/core/graffiti.Archetype.scala
+++ b/lib/graffiti/src/core/graffiti.Archetype.scala
@@ -1,0 +1,82 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import anticipation.*
+import cataclysm.*
+import cataclysm.cssFormatters.standardCssFormatter
+import gossamer.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// The base of every page archetype. Concrete pages are built by mixing in feature traits (each a
+// subtype of `Archetype`); their only obligation is to provide `content`, the page's central matter.
+//
+// Three members are the seams that feature traits compose through:
+//   - `frame`  — the wrapping pipeline. Layout traits override it as `decorate(super.frame)`, so a
+//                set of them simply nests in linearization order; independent panels never collide.
+//   - `styles` — the stylesheet accumulator. Traits override it as `super.styles + ownRules`.
+//   - named slots (introduced by feature traits, e.g. `verso`) — filled by the user or a trait.
+//
+// A page author rarely touches `frame`/`styles` (or `super`): each feature exposes its own hooks —
+// content (`verso`, `menu`, …), configuration (`versoWidth`, `menuGap`, …) and a self-contained
+// `…Styles` rule set — that are overridden directly, with no `super` call. The two seams stay
+// `protected` (feature traits chain through them); the page assembly (`html`/`css`) is `final`, so a
+// page can't override it and silently lose the inline stylesheet or the direction.
+trait Archetype:
+  // The central content of the page; supplied by the concrete template.
+  def content: Html of (? <: Flow)
+
+  // Document-level metadata.
+  def pageTitle: Text = t""
+
+  // Writing direction. `Ltr` by default; flipping it to `Rtl` swaps every logical-property layout
+  // (verso ⇄ recto) with no change to the emitted CSS — the browser resolves `inline-start`/`-end`.
+  def direction: HDir = HDir.Ltr
+
+  // The composition seams. Feature traits override these, chaining with `super`; a page author
+  // customises through the per-feature hooks instead and need not touch them.
+  protected def frame: Html of (? <: Flow) = content
+  protected def styles: Css = Css(Nil)
+
+  // The stylesheet rendered to text for inline embedding in a `<style>` element.
+  private def stylesheet: Text = CssSerializer.render(styles)
+
+  // The page stylesheet, as structured CSS (for serving separately, later).
+  final def css: Css = styles
+
+  // The complete single-document page: inline `<style>`, `dir` set on `<body>` from `direction`
+  // (the document `<html>` element does not admit Whatwg global attributes).
+  final def html: Html of "html" =
+    Html(Head(Title(pageTitle), Style(stylesheet)), Body(dir = direction)(frame))

--- a/lib/graffiti/src/core/graffiti.Archetype.scala
+++ b/lib/graffiti/src/core/graffiti.Archetype.scala
@@ -35,10 +35,23 @@ package graffiti
 import anticipation.*
 import cataclysm.*
 import cataclysm.cssFormatters.standardCssFormatter
+import gesticulate.*
 import gossamer.*
 import honeycomb.*
 import honeycomb.doms.html.whatwg.*
+import parasite.*
 import prepositional.*
+import turbulence.*
+
+object Archetype:
+  // Serve an archetype as an HTTP `text/html` response — exactly as `Document[Html]` is served — by
+  // pairing the media type with a text stream of the rendered page. `Servable` is then synthesised
+  // (in telekinesis) wherever a handler returns one, so graffiti needs no scintillate dependency.
+  // The instances range over every `page <: Archetype`, since a page is always a concrete subtype.
+  given media: [page <: Archetype] => page is Media = _ => media"text/html"(charset = "UTF-8")
+
+  given streamable: [page <: Archetype] => (Monitor, Probate) => page is Streamable by Text =
+    archetype => Html.emit(archetype.document).to(Stream)
 
 // The base of every page archetype. Concrete pages are built by mixing in feature traits (each a
 // subtype of `Archetype`); their only obligation is to provide `content`, the central matter.
@@ -82,3 +95,7 @@ trait Archetype:
   // set on `<body>` from `direction` (the `<html>` element admits no Whatwg global attributes).
   final def html: Html of "html" =
     Html(Head(Title(pageTitle), Style(stylesheet), head), Body(dir = direction)(frame))
+
+  // The page as a `Document[Html]` with a leading doctype — the form that is served over HTTP.
+  final def document: Document[Html] =
+    Document[Html](Fragment(Html.doctype, html), doms.html.whatwg)

--- a/lib/graffiti/src/core/graffiti.Archetype.scala
+++ b/lib/graffiti/src/core/graffiti.Archetype.scala
@@ -41,19 +41,20 @@ import honeycomb.doms.html.whatwg.*
 import prepositional.*
 
 // The base of every page archetype. Concrete pages are built by mixing in feature traits (each a
-// subtype of `Archetype`); their only obligation is to provide `content`, the page's central matter.
+// subtype of `Archetype`); their only obligation is to provide `content`, the central matter.
 //
 // Three members are the seams that feature traits compose through:
 //   - `frame`  — the wrapping pipeline. Layout traits override it as `decorate(super.frame)`, so a
 //                set of them simply nests in linearization order; independent panels never collide.
 //   - `styles` — the stylesheet accumulator. Traits override it as `super.styles + ownRules`.
+//   - `head`   — the `<head>` accumulator; traits override it as `Fragment(…, super.head)`.
 //   - named slots (introduced by feature traits, e.g. `verso`) — filled by the user or a trait.
 //
 // A page author rarely touches `frame`/`styles` (or `super`): each feature exposes its own hooks —
 // content (`verso`, `menu`, …), configuration (`versoWidth`, `menuGap`, …) and a self-contained
-// `…Styles` rule set — that are overridden directly, with no `super` call. The two seams stay
-// `protected` (feature traits chain through them); the page assembly (`html`/`css`) is `final`, so a
-// page can't override it and silently lose the inline stylesheet or the direction.
+// `…Styles` rule set — that are overridden directly, with no `super` call. The seams stay
+// `protected` (feature traits chain through them); the page assembly (`html`/`css`) is `final`, so
+// a page can't override it and silently lose the inline stylesheet or the direction.
 trait Archetype:
   // The central content of the page; supplied by the concrete template.
   def content: Html of (? <: Flow)
@@ -69,6 +70,7 @@ trait Archetype:
   // customises through the per-feature hooks instead and need not touch them.
   protected def frame: Html of (? <: Flow) = content
   protected def styles: Css = Css(Nil)
+  protected def head: Html of (? <: Metadata) = Fragment[Metadata]()
 
   // The stylesheet rendered to text for inline embedding in a `<style>` element.
   private def stylesheet: Text = CssSerializer.render(styles)
@@ -76,7 +78,7 @@ trait Archetype:
   // The page stylesheet, as structured CSS (for serving separately, later).
   final def css: Css = styles
 
-  // The complete single-document page: inline `<style>`, `dir` set on `<body>` from `direction`
-  // (the document `<html>` element does not admit Whatwg global attributes).
+  // The complete single-document page: inline `<style>`, accumulated `<head>` metadata, and `dir`
+  // set on `<body>` from `direction` (the `<html>` element admits no Whatwg global attributes).
   final def html: Html of "html" =
-    Html(Head(Title(pageTitle), Style(stylesheet)), Body(dir = direction)(frame))
+    Html(Head(Title(pageTitle), Style(stylesheet), head), Body(dir = direction)(frame))

--- a/lib/graffiti/src/core/graffiti.Author.scala
+++ b/lib/graffiti/src/core/graffiti.Author.scala
@@ -30,8 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Adds a `<meta name="author">`, from the trait parameter.
+trait Author(name: Text) extends Archetype:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Meta.Author(content = name), super.head)

--- a/lib/graffiti/src/core/graffiti.Breadcrumbs.scala
+++ b/lib/graffiti/src/core/graffiti.Breadcrumbs.scala
@@ -1,0 +1,58 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import anticipation.*
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Breadcrumbs:
+  val crumbsClass: Name[CssClass] = n"graffiti-breadcrumbs"
+
+// Prepends a breadcrumb trail, built from the path segments passed as the trait parameter. A
+// content trait that contributes near the top of the wrapping pipeline.
+trait Breadcrumbs(path: Text*) extends Archetype:
+  // The rendered breadcrumb trail; override to restructure it.
+  protected def breadcrumbs: Html of "nav" =
+    Nav(`class` = Breadcrumbs.crumbsClass)(Ol(path.map { crumb => Li(crumb) }*))
+
+  // This feature's own rules; override to restyle the trail.
+  protected def breadcrumbStyles: Css = css"${Breadcrumbs.crumbsClass} { display: flex }"
+
+  protected override def frame: Html of (? <: Flow) = Fragment[Flow](breadcrumbs, super.frame)
+  protected override def styles: Css = super.styles + breadcrumbStyles

--- a/lib/graffiti/src/core/graffiti.Canonical.scala
+++ b/lib/graffiti/src/core/graffiti.Canonical.scala
@@ -30,8 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Adds a `<link rel="canonical">` to the head, from the trait parameter (the canonical URL).
+trait Canonical(href: Text) extends Archetype:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Link.Canonical(href = href), super.head)

--- a/lib/graffiti/src/core/graffiti.Colophon.scala
+++ b/lib/graffiti/src/core/graffiti.Colophon.scala
@@ -30,8 +30,30 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Colophon:
+  val colophonClass: Name[CssClass] = n"graffiti-colophon"
+
+// Appends a `<footer>` colophon at the foot of the page. Fill it through the `colophon` slot (often
+// a sitemap, copyright or contact details); a feature contributing a sibling after the content.
+trait Colophon extends Archetype:
+  // The colophon's content; empty by default.
+  def colophon: Html of (? <: Flow) = Fragment[Flow]()
+
+  // This feature's own rules; override to restyle the footer.
+  protected def colophonStyles: Css =
+    css"${Colophon.colophonClass} { margin-block-start: 2rem; padding-block: 1rem }"
+
+  protected override def frame: Html of (? <: Flow) =
+    Fragment[Flow](super.frame, Footer(`class` = Colophon.colophonClass)(colophon))
+
+  protected override def styles: Css = super.styles + colophonStyles

--- a/lib/graffiti/src/core/graffiti.Dashboard.scala
+++ b/lib/graffiti/src/core/graffiti.Dashboard.scala
@@ -30,8 +30,48 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata, Dashboard}
+import anticipation.*
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Dashboard:
+  val gridClass: Name[CssClass] = n"graffiti-dashboard"
+  val cardClass: Name[CssClass] = n"graffiti-card"
+
+  // One tile of a dashboard: a heading and its own flow content.
+  case class Card(heading: Text, body: Html of (? <: Flow))
+
+// A typical dashboard view, composed from the `Mainstay` (a `<main>` landmark) and `Masthead`
+// features. It lays the cards out in a responsive grid as the page's main content and shows the
+// `brand` in the masthead. A concrete dashboard supplies just the details left abstract below.
+trait Dashboard extends Archetype, Mainstay, Masthead:
+  // The details a concrete dashboard must provide.
+  def brand: Text
+  def cards: List[Dashboard.Card]
+
+  // Title the document after the brand.
+  override def pageTitle: Text = brand
+
+  // Renders one card; override to restructure it.
+  protected def card(entry: Dashboard.Card): Html of (? <: Flow) =
+    Article(`class` = Dashboard.cardClass)(H2(entry.heading), entry.body)
+
+  // The masthead shows the brand; the main content is the grid of cards.
+  override def masthead: Html of (? <: Flow) = Strong(brand)
+  def content: Html of (? <: Flow) = Div(`class` = Dashboard.gridClass)(cards.map(card)*)
+
+  // This view's own rules; override to restyle the grid or the cards.
+  protected def dashboardStyles: Css =
+    val grid = Dashboard.gridClass
+    css"$grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr)) }"
+    + css"$grid { gap: 1rem }"
+    + css"${Dashboard.cardClass} { padding: 1rem; border: 1px solid; border-radius: 0.5rem }"
+
+  protected override def styles: Css = super.styles + dashboardStyles

--- a/lib/graffiti/src/core/graffiti.Description.scala
+++ b/lib/graffiti/src/core/graffiti.Description.scala
@@ -30,8 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Adds a `<meta name="description">` to the document head, from the trait parameter.
+trait Description(text: Text) extends Archetype:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Meta.Description(content = text), super.head)

--- a/lib/graffiti/src/core/graffiti.Favicon.scala
+++ b/lib/graffiti/src/core/graffiti.Favicon.scala
@@ -30,8 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Adds a `<link rel="icon">` favicon to the head, from the trait parameter (a URL or path).
+trait Favicon(href: Text) extends Archetype:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Link.Icon(href = href), super.head)

--- a/lib/graffiti/src/core/graffiti.FoldableRectoPanel.scala
+++ b/lib/graffiti/src/core/graffiti.FoldableRectoPanel.scala
@@ -1,0 +1,52 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import cataclysm.*
+import quantitative.*
+import symbolism.*
+
+// A recto panel that can fold away. It adds nothing structural over `RectoPanel`; it only layers
+// further rules onto the accumulated stylesheet (clipping the panel and bounding its inline size
+// with a transition), showing how a trait refines another purely through `super.styles`.
+trait FoldableRectoPanel extends RectoPanel:
+  // The bounded inline size the panel folds down to.
+  def maxRectoWidth: Quantity[Rems[1]] = 16.0*Rem
+
+  // The fold's own rules, layered over `RectoPanel`'s; override to change the fold behaviour.
+  protected def foldedStyles: Css =
+    val recto = RectoPanel.rectoClass
+    css"$recto { overflow: clip; max-inline-size: ${maxRectoWidth} }"
+    + css"$recto { transition: max-inline-size 0.2s }"
+
+  protected override def styles: Css = super.styles + foldedStyles

--- a/lib/graffiti/src/core/graffiti.Headline.scala
+++ b/lib/graffiti/src/core/graffiti.Headline.scala
@@ -30,8 +30,30 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Headline:
+  val headlineClass: Name[CssClass] = n"graffiti-headline"
+
+// Sets the document title and prepends a top-level heading. A content trait: it fills no slot of
+// its own, it just contributes a heading at the head of the wrapping pipeline.
+trait Headline(title: Text) extends Archetype:
+  override def pageTitle: Text = title
+
+  // The heading rendered at the top of the page; override to restructure it.
+  protected def heading: Html of (? <: Heading) = H1(`class` = Headline.headlineClass)(title)
+
+  // This feature's own rules; override to restyle the heading without affecting other features.
+  protected def headlineStyles: Css = css"${Headline.headlineClass} { margin-block: 0 0.5rem }"
+
+  protected override def frame: Html of (? <: Flow) = Fragment[Flow](heading, super.frame)
+  protected override def styles: Css = super.styles + headlineStyles

--- a/lib/graffiti/src/core/graffiti.Hero.scala
+++ b/lib/graffiti/src/core/graffiti.Hero.scala
@@ -30,8 +30,33 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Hero:
+  val heroClass: Name[CssClass] = n"graffiti-hero"
+
+// Prepends a prominent banner introducing the page, with its `headline` as the trait parameter and
+// any further banner material supplied through the `hero` slot.
+trait Hero(headline: Text) extends Archetype:
+  // Additional banner content, beneath the headline; empty by default.
+  def hero: Html of (? <: Flow) = Fragment[Flow]()
+
+  // The rendered banner; override to restructure it.
+  protected def heroBanner: Html of (? <: Flow) =
+    Section(`class` = Hero.heroClass)(H1(headline), hero)
+
+  // This feature's own rules; override to restyle the banner.
+  protected def heroStyles: Css =
+    css"${Hero.heroClass} { padding-block: 3rem; text-align: center }"
+
+  protected override def frame: Html of (? <: Flow) = Fragment[Flow](heroBanner, super.frame)
+  protected override def styles: Css = super.styles + heroStyles

--- a/lib/graffiti/src/core/graffiti.Keywords.scala
+++ b/lib/graffiti/src/core/graffiti.Keywords.scala
@@ -33,27 +33,12 @@
 package graffiti
 
 import anticipation.*
-import cataclysm.*
+import gossamer.*
 import honeycomb.*
 import honeycomb.doms.html.whatwg.*
-import nomenclature.*
-import nomenclature.CssClass.nominative
 import prepositional.*
-import symbolism.*
 
-object Title:
-  val titleClass: Name[CssClass] = n"graffiti-title"
-
-// Sets the document title and prepends a top-level heading. A content trait: it fills no slot of
-// its own, it just contributes a heading at the head of the wrapping pipeline.
-trait Title(title: Text) extends Archetype:
-  override def pageTitle: Text = title
-
-  // The heading rendered at the top of the page; override to restructure it.
-  protected def heading: Html of (? <: Heading) = H1(`class` = Title.titleClass)(title)
-
-  // This feature's own rules; override to restyle the heading without affecting other features.
-  protected def titleStyles: Css = css"${Title.titleClass} { margin-block: 0 0.5rem }"
-
-  protected override def frame: Html of (? <: Flow) = Fragment[Flow](heading, super.frame)
-  protected override def styles: Css = super.styles + titleStyles
+// Adds a `<meta name="keywords">`, from the comma-joined trait parameters.
+trait Keywords(keywords: Text*) extends Archetype:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Meta.Keywords(content = keywords.join(t", ")), super.head)

--- a/lib/graffiti/src/core/graffiti.Logo.scala
+++ b/lib/graffiti/src/core/graffiti.Logo.scala
@@ -1,0 +1,61 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import anticipation.*
+import cataclysm.*
+import gossamer.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Logo:
+  val logoClass: Name[CssClass] = n"graffiti-logo"
+
+// Exposes a `logo` helper — a phrasing-level mark that other traits or the page may drop wherever
+// they like (in the top menu, a panel, the header). Supply its wording through `logoText`; it
+// contributes styling but no structure of its own.
+trait Logo extends Archetype:
+  // The logo's wording.
+  def logoText: Text = t""
+
+  // The rendered logo — a phrasing-level mark a page may drop wherever it likes.
+  protected def logo: Html of (? <: Phrasing) = Span(`class` = Logo.logoClass)(logoText)
+
+  // This feature's own rules; override to restyle the logo.
+  protected def logoStyles: Css = css"${Logo.logoClass} { font-weight: bold }"
+
+  protected override def styles: Css = super.styles + logoStyles

--- a/lib/graffiti/src/core/graffiti.Mainstay.scala
+++ b/lib/graffiti/src/core/graffiti.Mainstay.scala
@@ -30,8 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+
+object Mainstay:
+  val mainstayClass: Name[CssClass] = n"graffiti-mainstay"
+
+// Wraps the content in a `<main>` landmark at this point in the pipeline. Mix in before the
+// page chrome (masthead, colophon) so the landmark encloses the content but not the chrome.
+trait Mainstay extends Archetype:
+  protected override def frame: Html of (? <: Flow) =
+    Main(`class` = Mainstay.mainstayClass)(super.frame)

--- a/lib/graffiti/src/core/graffiti.Masthead.scala
+++ b/lib/graffiti/src/core/graffiti.Masthead.scala
@@ -30,8 +30,30 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Masthead:
+  val mastheadClass: Name[CssClass] = n"graffiti-masthead"
+
+// Prepends a `<header>` masthead at the top of the page. Fill it through the `masthead` slot (often
+// with a logo, headline and menu); a layout feature contributing a sibling before the content.
+trait Masthead extends Archetype:
+  // The masthead's content; empty by default.
+  def masthead: Html of (? <: Flow) = Fragment[Flow]()
+
+  // This feature's own rules; override to restyle the banner.
+  protected def mastheadStyles: Css =
+    css"${Masthead.mastheadClass} { display: flex; gap: 1rem; align-items: center }"
+
+  protected override def frame: Html of (? <: Flow) =
+    Fragment[Flow](Header(`class` = Masthead.mastheadClass)(masthead), super.frame)
+
+  protected override def styles: Css = super.styles + mastheadStyles

--- a/lib/graffiti/src/core/graffiti.RectoPanel.scala
+++ b/lib/graffiti/src/core/graffiti.RectoPanel.scala
@@ -64,6 +64,7 @@ trait RectoPanel extends Archetype:
   protected def rectoArrangement
     ( content: Html of (? <: Flow), panel: Html of (? <: Flow) )
   :   Html of (? <: Flow) =
+
     Fragment[Flow](Div(`class` = RectoPanel.layoutClass)(content, panel))
 
   // This feature's own rules; override to restyle the panel and its grid.

--- a/lib/graffiti/src/core/graffiti.RectoPanel.scala
+++ b/lib/graffiti/src/core/graffiti.RectoPanel.scala
@@ -1,0 +1,80 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import quantitative.*
+import symbolism.*
+
+object RectoPanel:
+  val layoutClass: Name[CssClass] = n"graffiti-recto-layout"
+  val rectoClass: Name[CssClass] = n"graffiti-recto"
+  val contentClass: Name[CssClass] = n"graffiti-recto-content"
+
+// A layout trait that places a side panel on the inline-end edge (the right in left-to-right text,
+// the left in right-to-left text — the "recto" page of a spread) beside the main content. The
+// panel's material is supplied through the `recto` slot, which defaults to empty.
+//
+// The source order is content-then-recto, so the panel lands on the inline-end column; like its
+// verso counterpart it uses only logical properties, so `direction = Rtl` mirrors it for free.
+trait RectoPanel extends Archetype:
+  // The panel's content; empty by default (the slot renders nothing until filled).
+  def recto: Html of (? <: Flow) = Fragment[Flow]()
+
+  // The panel's inline size, and the gap between content and panel.
+  def rectoWidth: Quantity[Rems[1]] = 16.0*Rem
+  def rectoGap: Quantity[Rems[1]] = 1.0*Rem
+
+  // How content and panel are arranged; override to change the container.
+  protected def rectoArrangement
+    ( content: Html of (? <: Flow), panel: Html of (? <: Flow) )
+  :   Html of (? <: Flow) =
+    Fragment[Flow](Div(`class` = RectoPanel.layoutClass)(content, panel))
+
+  // This feature's own rules; override to restyle the panel and its grid.
+  protected def rectoStyles: Css =
+    val layout = RectoPanel.layoutClass
+    css"$layout { display: grid; grid-template-columns: 1fr auto; gap: ${rectoGap} }"
+    + css"${RectoPanel.rectoClass} { inline-size: ${rectoWidth} }"
+
+  protected override def frame: Html of (? <: Flow) =
+    val content = Div(`class` = RectoPanel.contentClass)(super.frame)
+    val panel = Aside(`class` = RectoPanel.rectoClass)(recto)
+    rectoArrangement(content, panel)
+
+  protected override def styles: Css = super.styles + rectoStyles

--- a/lib/graffiti/src/core/graffiti.StandardMetadata.scala
+++ b/lib/graffiti/src/core/graffiti.StandardMetadata.scala
@@ -30,8 +30,20 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Aggregates the metadata most pages want: a responsive viewport and a description (from the trait
+// parameter). Mix in `StandardMetadata(t"…")` instead of wiring each `<meta>` separately; add
+// `Keywords`, `Author`, `Favicon`, `Canonical`, … alongside it as needed.
+//
+// A trait can't pass a constructor argument to a parameterized parent trait (only a class can), so
+// rather than extending `Description(description)` this reuses the param-less `Viewport` by
+// inheritance and contributes the description `<meta>` directly.
+trait StandardMetadata(description: Text) extends Viewport:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Meta.Description(content = description), super.head)

--- a/lib/graffiti/src/core/graffiti.ThemeColor.scala
+++ b/lib/graffiti/src/core/graffiti.ThemeColor.scala
@@ -30,8 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Adds a `<meta name="theme-color">`, from the trait parameter (a CSS colour string).
+trait ThemeColor(color: Text) extends Archetype:
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Meta.ThemeColor(content = color), super.head)

--- a/lib/graffiti/src/core/graffiti.Title.scala
+++ b/lib/graffiti/src/core/graffiti.Title.scala
@@ -1,0 +1,59 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import anticipation.*
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import symbolism.*
+
+object Title:
+  val titleClass: Name[CssClass] = n"graffiti-title"
+
+// Sets the document title and prepends a top-level heading. A content trait: it fills no slot of
+// its own, it just contributes a heading at the head of the wrapping pipeline.
+trait Title(title: Text) extends Archetype:
+  override def pageTitle: Text = title
+
+  // The heading rendered at the top of the page; override to restructure it.
+  protected def heading: Html of (? <: Heading) = H1(`class` = Title.titleClass)(title)
+
+  // This feature's own rules; override to restyle the heading without affecting other features.
+  protected def titleStyles: Css = css"${Title.titleClass} { margin-block: 0 0.5rem }"
+
+  protected override def frame: Html of (? <: Flow) = Fragment[Flow](heading, super.frame)
+  protected override def styles: Css = super.styles + titleStyles

--- a/lib/graffiti/src/core/graffiti.TopMenu.scala
+++ b/lib/graffiti/src/core/graffiti.TopMenu.scala
@@ -1,0 +1,64 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import quantitative.*
+import symbolism.*
+
+object TopMenu:
+  val menuClass: Name[CssClass] = n"graffiti-top-menu"
+
+// Adds a horizontal navigation bar across the top of the page, and exposes `menu` as a helper that
+// other traits or the page itself may reuse (e.g. `def verso = menu`). The bar's links are supplied
+// through the `menuItems` slot, which defaults to empty.
+trait TopMenu extends Archetype:
+  // The menu's links; override to populate the bar.
+  def menuItems: List[Html of (? <: Phrasing)] = Nil
+
+  // The spacing between menu items.
+  def menuGap: Quantity[Rems[1]] = 1.0*Rem
+
+  // The rendered nav bar — a helper a page may reuse elsewhere (e.g. `def verso = menu`).
+  protected def menu: Html of "nav" = Nav(`class` = TopMenu.menuClass)(menuItems*)
+
+  // This feature's own rules; override to restyle the bar.
+  protected def menuStyles: Css = css"${TopMenu.menuClass} { display: flex; gap: ${menuGap} }"
+
+  protected override def frame: Html of (? <: Flow) = Fragment[Flow](menu, super.frame)
+  protected override def styles: Css = super.styles + menuStyles

--- a/lib/graffiti/src/core/graffiti.VersoPanel.scala
+++ b/lib/graffiti/src/core/graffiti.VersoPanel.scala
@@ -64,6 +64,7 @@ trait VersoPanel extends Archetype:
   protected def versoArrangement
     ( panel: Html of (? <: Flow), content: Html of (? <: Flow) )
   :   Html of (? <: Flow) =
+
     Fragment[Flow](Div(`class` = VersoPanel.layoutClass)(panel, content))
 
   // This feature's own rules; override to restyle the panel and its grid.

--- a/lib/graffiti/src/core/graffiti.VersoPanel.scala
+++ b/lib/graffiti/src/core/graffiti.VersoPanel.scala
@@ -1,0 +1,80 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import cataclysm.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import nomenclature.*
+import nomenclature.CssClass.nominative
+import prepositional.*
+import quantitative.*
+import symbolism.*
+
+object VersoPanel:
+  val layoutClass: Name[CssClass] = n"graffiti-verso-layout"
+  val versoClass: Name[CssClass] = n"graffiti-verso"
+  val contentClass: Name[CssClass] = n"graffiti-verso-content"
+
+// A layout trait that places a side panel on the inline-start edge (the left in left-to-right text,
+// the right in right-to-left text — the "verso" page of a spread) beside the main content. The
+// panel's material is supplied through the `verso` slot, which defaults to empty.
+//
+// Implemented as a two-column grid whose source order is verso-then-content; as the grid follows
+// the writing direction, no `left`/`right` ever appears and `direction = Rtl` mirrors it for free.
+trait VersoPanel extends Archetype:
+  // The panel's content; empty by default (the slot renders nothing until filled).
+  def verso: Html of (? <: Flow) = Fragment[Flow]()
+
+  // The panel's inline size, and the gap between panel and content.
+  def versoWidth: Quantity[Rems[1]] = 16.0*Rem
+  def versoGap: Quantity[Rems[1]] = 1.0*Rem
+
+  // How panel and content are arranged; override to change the container.
+  protected def versoArrangement
+    ( panel: Html of (? <: Flow), content: Html of (? <: Flow) )
+  :   Html of (? <: Flow) =
+    Fragment[Flow](Div(`class` = VersoPanel.layoutClass)(panel, content))
+
+  // This feature's own rules; override to restyle the panel and its grid.
+  protected def versoStyles: Css =
+    val layout = VersoPanel.layoutClass
+    css"$layout { display: grid; grid-template-columns: auto 1fr; gap: ${versoGap} }"
+    + css"${VersoPanel.versoClass} { inline-size: ${versoWidth} }"
+
+  protected override def frame: Html of (? <: Flow) =
+    val panel = Aside(`class` = VersoPanel.versoClass)(verso)
+    val content = Div(`class` = VersoPanel.contentClass)(super.frame)
+    versoArrangement(panel, content)
+
+  protected override def styles: Css = super.styles + versoStyles

--- a/lib/graffiti/src/core/graffiti.Viewport.scala
+++ b/lib/graffiti/src/core/graffiti.Viewport.scala
@@ -30,8 +30,17 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package graffiti
 
-export graffiti.{Archetype, Headline, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel,
-    Breadcrumbs, Logo, Masthead, Colophon, Mainstay, Hero, Description, Viewport, Keywords, Author,
-    ThemeColor, Favicon, Canonical, StandardMetadata}
+import anticipation.*
+import gossamer.*
+import honeycomb.*
+import honeycomb.doms.html.whatwg.*
+import prepositional.*
+
+// Adds a responsive `<meta name="viewport">`. Override `viewport` to change the directive.
+trait Viewport extends Archetype:
+  def viewport: Text = t"width=device-width, initial-scale=1"
+
+  protected override def head: Html of (? <: Metadata) =
+    Fragment[Metadata](Meta.Viewport(content = viewport), super.head)

--- a/lib/graffiti/src/core/graffiti_core.scala
+++ b/lib/graffiti/src/core/graffiti_core.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package graffiti
 
+import anticipation.*
 import honeycomb.*
 import prepositional.*
 import spectacular.*
@@ -39,3 +40,7 @@ import spectacular.*
 // The `dir` attribute is typed `of Dir`, but honeycomb ships no value instance for it; this makes
 // the directionality enum usable directly, e.g. `Body(dir = HDir.Rtl)(…)`.
 given hdir: HDir is Attributive to Whatwg.Dir = (key, value) => (key, value.show)
+
+// `href` is typed `of Url`; honeycomb accepts an `HttpUrl` or abstractable URL, but page metadata
+// (a favicon, a canonical link) is naturally an arbitrary path string, so accept `Text` directly.
+given urlText: Text is Attributive to Whatwg.Url = (key, value) => (key, value)

--- a/lib/graffiti/src/core/graffiti_core.scala
+++ b/lib/graffiti/src/core/graffiti_core.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import honeycomb.*
+import prepositional.*
+import spectacular.*
+
+// The `dir` attribute is typed `of Dir`, but honeycomb ships no value instance for it; this makes
+// the directionality enum usable directly, e.g. `Body(dir = HDir.Rtl)(…)`.
+given hdir: HDir is Attributive to Whatwg.Dir = (key, value) => (key, value.show)

--- a/lib/graffiti/src/core/soundness_graffiti_core.scala
+++ b/lib/graffiti/src/core/soundness_graffiti_core.scala
@@ -1,0 +1,36 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export graffiti.{Archetype, Title, TopMenu, VersoPanel, RectoPanel, FoldableRectoPanel, Breadcrumbs,
+    Logo}

--- a/lib/graffiti/src/test/graffiti_test.scala
+++ b/lib/graffiti/src/test/graffiti_test.scala
@@ -37,6 +37,8 @@ import soundness.*
 import doms.html.whatwg.*
 import cssFormatters.standardCssFormatter
 import strategies.throwUnsafely
+import parasite.probates.awaitProbate
+import parasite.threading.virtualThreading
 
 // A page assembled from a modest set of independent template traits, mirroring the README example.
 // `content` and `verso` are the only slots the page fills; everything else is contributed by traits.
@@ -216,3 +218,13 @@ object Tests extends Suite(m"Graffiti tests"):
             def content: Html of (? <: Flow) = P("x")
         . exists(_.message.contains("sidebar"))
       . assert(_ == true)
+
+    suite(m"Serving over HTTP"):
+      test(m"an archetype declares the text/html media type"):
+        Page(t"Demo", Nil).mediaType.show
+      . assert(_.starts(t"text/html"))
+
+      test(m"serving an archetype streams the full HTML document, with a doctype"):
+        supervise(Page(t"Demo", Nil).read[Text])
+      . assert: served =>
+          served.contains(t"<!DOCTYPE html>") && served.contains(t"Hello, world!")

--- a/lib/graffiti/src/test/graffiti_test.scala
+++ b/lib/graffiti/src/test/graffiti_test.scala
@@ -41,7 +41,7 @@ import strategies.throwUnsafely
 // A page assembled from a modest set of independent template traits, mirroring the README example.
 // `content` and `verso` are the only slots the page fills; everything else is contributed by traits.
 class Page(title: Text, path: List[Text], dir: HDir = HDir.Ltr)
-extends Archetype, VersoPanel, FoldableRectoPanel, TopMenu, Title(title), Breadcrumbs(path*), Logo:
+extends Archetype, VersoPanel, FoldableRectoPanel, TopMenu, Headline(title), Breadcrumbs(path*), Logo:
   override def direction: HDir = dir
   override def menuItems: List[Html of (? <: Phrasing)] = List(Strong("Home"), Strong("About"))
   def content: Html of (? <: Flow) = P("Hello, world!")
@@ -58,6 +58,27 @@ class RectoFirst extends Archetype, RectoPanel, VersoPanel:
 class WideVerso extends Archetype, VersoPanel:
   def content: Html of (? <: Flow) = P("body")
   override def versoWidth = 20.0*Rem
+
+// A fuller page: the regions (hero, masthead, mainstay, colophon) plus a head full of metadata.
+class FullPage(title: Text)
+extends Archetype, Mainstay, Masthead, Colophon, Hero(t"Big Headline"), Headline(title),
+    StandardMetadata(t"A demo page"), Author(t"Jon Pretty"), Keywords(t"scala", t"html"),
+    Favicon(t"/icon.png"), Canonical(t"https://example.com/"):
+  def content: Html of (? <: Flow) = P("Main body")
+  override def masthead: Html of (? <: Flow) = P("Site name")
+  override def colophon: Html of (? <: Flow) = P("Copyright")
+
+// A page carrying only the aggregated standard metadata.
+class MetaPage extends Archetype, StandardMetadata(t"Just a description"):
+  def content: Html of (? <: Flow) = P("x")
+
+// Two features that each introduce a `sidebar` slot of their own — a genuinely incompatible pair:
+// the two independent definitions collide, and a page must say which it means to keep.
+trait LeftRail extends Archetype:
+  def sidebar: Html of (? <: Flow) = Fragment[Flow]()
+
+trait RightRail extends Archetype:
+  def sidebar: Html of (? <: Flow) = Fragment[Flow]()
 
 object Tests extends Suite(m"Graffiti tests"):
   def run(): Unit =
@@ -147,4 +168,51 @@ object Tests extends Suite(m"Graffiti tests"):
             def content: Html of (? <: Flow) = P("x")
             override def css: Css = Css(Nil)
         . exists(_.message.contains("final"))
+      . assert(_ == true)
+
+    suite(m"Page regions"):
+      val html = FullPage(t"Demo").html.show
+
+      test(m"the content is wrapped in a <main> landmark"):
+        html.contains(t"graffiti-mainstay")
+      . assert(_ == true)
+
+      test(m"the masthead region and its content are present"):
+        html.contains(t"graffiti-masthead") && html.contains(t"Site name")
+      . assert(_ == true)
+
+      test(m"the colophon region and its content are present"):
+        html.contains(t"graffiti-colophon") && html.contains(t"Copyright")
+      . assert(_ == true)
+
+      test(m"the hero banner and its headline are present"):
+        html.contains(t"graffiti-hero") && html.contains(t"Big Headline")
+      . assert(_ == true)
+
+    suite(m"Head metadata"):
+      val html = FullPage(t"Demo").html.show
+
+      test(m"StandardMetadata contributes a description and a viewport"):
+        html.contains(t"A demo page") && html.contains(t"width=device-width")
+      . assert(_ == true)
+
+      test(m"author and keywords reach the head"):
+        html.contains(t"Jon Pretty") && html.contains(t"scala, html")
+      . assert(_ == true)
+
+      test(m"favicon and canonical links reach the head"):
+        html.contains(t"/icon.png") && html.contains(t"https://example.com/")
+      . assert(_ == true)
+
+      test(m"StandardMetadata alone yields a description and a viewport"):
+        val head = MetaPage().html.show
+        head.contains(t"Just a description") && head.contains(t"viewport")
+      . assert(_ == true)
+
+    suite(m"Incompatible combinations"):
+      test(m"two features that each introduce a sidebar cannot be combined"):
+        demilitarize:
+          class Clash extends Archetype, LeftRail, RightRail:
+            def content: Html of (? <: Flow) = P("x")
+        . exists(_.message.contains("sidebar"))
       . assert(_ == true)

--- a/lib/graffiti/src/test/graffiti_test.scala
+++ b/lib/graffiti/src/test/graffiti_test.scala
@@ -1,0 +1,150 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package graffiti
+
+import soundness.*
+
+import doms.html.whatwg.*
+import cssFormatters.standardCssFormatter
+import strategies.throwUnsafely
+
+// A page assembled from a modest set of independent template traits, mirroring the README example.
+// `content` and `verso` are the only slots the page fills; everything else is contributed by traits.
+class Page(title: Text, path: List[Text], dir: HDir = HDir.Ltr)
+extends Archetype, VersoPanel, FoldableRectoPanel, TopMenu, Title(title), Breadcrumbs(path*), Logo:
+  override def direction: HDir = dir
+  override def menuItems: List[Html of (? <: Phrasing)] = List(Strong("Home"), Strong("About"))
+  def content: Html of (? <: Flow) = P("Hello, world!")
+  override def verso: Html of (? <: Flow) = menu
+
+// Two pages mixing the panels in opposite orders, to check feature-independence.
+class VersoFirst extends Archetype, VersoPanel, RectoPanel:
+  def content: Html of (? <: Flow) = P("body")
+
+class RectoFirst extends Archetype, RectoPanel, VersoPanel:
+  def content: Html of (? <: Flow) = P("body")
+
+// A page that customises a feature through a single config hook — no `super`, no `frame`/`styles`.
+class WideVerso extends Archetype, VersoPanel:
+  def content: Html of (? <: Flow) = P("body")
+  override def versoWidth = 20.0*Rem
+
+object Tests extends Suite(m"Graffiti tests"):
+  def run(): Unit =
+    val page = Page(t"Welcome", List(t"home", t"docs"))
+    val html = page.html.show
+    val css = page.css.show
+
+    suite(m"Page assembly"):
+      test(m"the document title is set from the Title trait"):
+        html.contains(t"<title>Welcome</title>")
+      . assert(_ == true)
+
+      test(m"the page's own content is present"):
+        html.contains(t"Hello, world!")
+      . assert(_ == true)
+
+      test(m"the Title trait contributes a heading"):
+        html.contains(t"<h1")
+      . assert(_ == true)
+
+      test(m"the top menu is present, with its items"):
+        html.contains(t"graffiti-top-menu") && html.contains(t"Home")
+      . assert(_ == true)
+
+      test(m"the verso slot is filled by the menu helper"):
+        html.contains(t"graffiti-verso")
+      . assert(_ == true)
+
+      test(m"the recto panel is present"):
+        html.contains(t"graffiti-recto")
+      . assert(_ == true)
+
+      test(m"the breadcrumb trail is present"):
+        html.contains(t"graffiti-breadcrumbs")
+      . assert(_ == true)
+
+    suite(m"Contributed CSS"):
+      test(m"each trait's rules reach the embedded stylesheet"):
+        css.contains(t".graffiti-top-menu") && css.contains(t".graffiti-verso-layout")
+        && css.contains(t".graffiti-recto-layout")
+      . assert(_ == true)
+
+      test(m"the layout grids are real grids"):
+        css.contains(t"display: grid")
+      . assert(_ == true)
+
+    suite(m"Direction is logical, never left/right"):
+      test(m"the default page is left-to-right"):
+        html.contains(t"""dir="ltr"""")
+      . assert(_ == true)
+
+      test(m"an RTL page only changes the dir attribute"):
+        Page(t"Welcome", List(t"home"), HDir.Rtl).html.show.contains(t"""dir="rtl"""")
+      . assert(_ == true)
+
+      test(m"the CSS uses logical edges and mentions no physical left"):
+        css.contains(t"inline-size") && !css.contains(t"left")
+      . assert(_ == true)
+
+      test(m"the CSS mentions no physical right"):
+        !css.contains(t"right")
+      . assert(_ == true)
+
+      test(m"flipping direction leaves the stylesheet byte-for-byte identical"):
+        Page(t"Welcome", List(t"home"), HDir.Rtl).css.show == Page(t"Welcome", List(t"home")).css.show
+      . assert(_ == true)
+
+    suite(m"Feature independence"):
+      test(m"verso-then-recto carries both panels"):
+        val text = VersoFirst().css.show
+        text.contains(t".graffiti-verso-layout") && text.contains(t".graffiti-recto-layout")
+      . assert(_ == true)
+
+      test(m"recto-then-verso, the opposite mix-in order, carries both panels too"):
+        val text = RectoFirst().css.show
+        text.contains(t".graffiti-verso-layout") && text.contains(t".graffiti-recto-layout")
+      . assert(_ == true)
+
+    suite(m"Customisation through hooks"):
+      test(m"a config hook changes the CSS without super or a frame/styles override"):
+        WideVerso().css.show.contains(t"20rem")
+      . assert(_ == true)
+
+      test(m"the final page assembly cannot be overridden"):
+        demilitarize:
+          new Archetype:
+            def content: Html of (? <: Flow) = P("x")
+            override def css: Css = Css(Nil)
+        . exists(_.message.contains("final"))
+      . assert(_ == true)

--- a/lib/graffiti/src/test/graffiti_test.scala
+++ b/lib/graffiti/src/test/graffiti_test.scala
@@ -82,6 +82,13 @@ trait LeftRail extends Archetype:
 trait RightRail extends Archetype:
   def sidebar: Html of (? <: Flow) = Fragment[Flow]()
 
+// A concrete dashboard, supplying only the details `Dashboard` leaves abstract.
+class AdminDashboard extends Dashboard:
+  def brand: Text = t"Admin"
+
+  def cards: List[Dashboard.Card] =
+    List(Dashboard.Card(t"Users", P("128 active")), Dashboard.Card(t"Revenue", P("4200")))
+
 object Tests extends Suite(m"Graffiti tests"):
   def run(): Unit =
     val page = Page(t"Welcome", List(t"home", t"docs"))
@@ -217,6 +224,25 @@ object Tests extends Suite(m"Graffiti tests"):
           class Clash extends Archetype, LeftRail, RightRail:
             def content: Html of (? <: Flow) = P("x")
         . exists(_.message.contains("sidebar"))
+      . assert(_ == true)
+
+    suite(m"Dashboard view"):
+      val html = AdminDashboard().html.show
+
+      test(m"the brand titles the document and fills the masthead"):
+        html.contains(t"<title>Admin</title>") && html.contains(t"graffiti-masthead")
+      . assert(_ == true)
+
+      test(m"the cards are laid out in the dashboard grid"):
+        html.contains(t"graffiti-dashboard") && html.contains(t"graffiti-card")
+      . assert(_ == true)
+
+      test(m"each card shows its heading and its own content"):
+        html.contains(t"Users") && html.contains(t"128 active") && html.contains(t"Revenue")
+      . assert(_ == true)
+
+      test(m"the cards sit inside the <main> landmark"):
+        html.contains(t"graffiti-mainstay")
       . assert(_ == true)
 
     suite(m"Serving over HTTP"):


### PR DESCRIPTION
Graffiti is a new module for composing HTML pages from small, stackable feature traits. A page is an `Archetype` assembled by mixing in features — a masthead, verso/recto side panels, breadcrumbs, a logo, a hero banner, document metadata and more — each contributing independently, so they combine freely and only genuinely incompatible inclusions conflict. A page is customised by overriding small per-feature hooks (never `super`), the page assembly is `final` so a feature can't be lost by accident, and an `Archetype` can be served straight from a Scintillate handler as `text/html`, exactly like a `Document[Html]`. Higher-level views such as a `Dashboard` are composed the same way.

## Graffiti

A new module for building HTML pages by mixing stackable feature traits into a page `Archetype`. Mix in the features you want and supply the few details each needs:

```scala
class Page(title: Text, body: Markdown, path: List[Text])
extends Archetype, Headline(title), Masthead, VersoPanel, Breadcrumbs(path*), StandardMetadata(t"…"):
  def content = body.html
  override def verso = menu
```

Features compose through three internal seams — a `frame` wrapping pipeline, a `styles` accumulator and a `head` metadata accumulator — so independent features never collide. You customise a page by overriding small per-feature hooks, with no `super` calls:

```scala
class Wide extends Archetype, VersoPanel:
  def content = …
  override def versoWidth = 20.0*Rem      // typed; no frame/styles rewrite
```

A page's `html` and `css` are `final`, so a feature can't be lost by overriding them. CSS is written with cataclysm's `css"…"` interpolator (the class name doubling as the selector), and all layout uses logical properties, so `direction = HDir.Rtl` mirrors the side panels with no change to the stylesheet.

An `Archetype` is servable directly over HTTP as `text/html`, exactly like a `Document[Html]` — return one from a Scintillate handler.

Higher-level views are built from the same features. A `Dashboard` mixes the masthead and main-landmark features and lays its cards out in a responsive grid; a concrete dashboard supplies only what it leaves abstract:

```scala
class AdminDashboard extends Dashboard:
  def brand = t"Admin"
  def cards = List(Dashboard.Card(t"Users", P("128 active")), Dashboard.Card(t"Revenue", P("4200")))
```