### PR TITLE
Rename Emitter to Producer and produce every format's output through it

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -468,7 +468,9 @@ object bitumen extends Library:
   object test extends Tests(core, galilei.core, guillotine.core)
 
 object breviloquence extends Library:
-  object core extends Component(urticose.url, panopticon.core, turbulence.core, adversaria.core):
+  object core
+      extends Component(urticose.url, panopticon.core, turbulence.core, adversaria.core,
+                       zephyrine.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, sedentary.core, eucalyptus.core)
@@ -1039,7 +1041,7 @@ object mandible extends Library:
 object locomotion extends Library:
   object core
       extends Component(turbulence.core, wisteria.core, adversaria.core, hypotenuse.core,
-        gossamer.core, spectacular.core, panopticon.core):
+        gossamer.core, spectacular.core, panopticon.core, zephyrine.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/breviloquence/src/core/breviloquence.CborPrinter.scala
+++ b/lib/breviloquence/src/core/breviloquence.CborPrinter.scala
@@ -32,59 +32,69 @@
                                                                                                   */
 package breviloquence
 
-import scala.collection.mutable.ArrayBuffer
+import anticipation.*
+import parasite.*
+import rudiments.*
+import vacuous.*
+import zephyrine.*
 
 object CborPrinter:
-  def encode(cbor: Cbor.Ast): IArray[Byte] =
-    val buffer = ArrayBuffer.empty[Byte]
-    write(buffer, cbor)
-    val out = new Array[Byte](buffer.length)
-    var index = 0
-    while index < buffer.length do { out(index) = buffer(index); index += 1 }
-    out.asInstanceOf[IArray[Byte]]
+  def encode(cbor: Cbor.Ast): Data =
+    Producer.collect[Data](): producer =>
+      write(producer, cbor)
 
-  private def head(out: ArrayBuffer[Byte], major: Int, value: Long): Unit =
+  // Stream the encoded bytes incrementally; the producing code runs on a separate fiber.
+  def emit(cbor: Cbor.Ast)(using Monitor, Probate): Iterator[Data] =
+    val producer = Producer[Data](4096)
+
+    async:
+      write(producer, cbor)
+      producer.finish()
+
+    producer.iterator
+
+  private def head(out: Producer.Bytes, major: Int, value: Long): Unit =
     val majorBits = major << 5
 
     if value < 0 then
-      out += (majorBits | 27).toByte
+      out.push((majorBits | 27).toByte)
       u64(out, value)
     else if value < 24 then
-      out += (majorBits | value.toInt).toByte
+      out.push((majorBits | value.toInt).toByte)
     else if value < (1 << 8) then
-      out += (majorBits | 24).toByte
-      out += value.toByte
+      out.push((majorBits | 24).toByte)
+      out.push(value.toByte)
     else if value < (1 << 16) then
-      out += (majorBits | 25).toByte
+      out.push((majorBits | 25).toByte)
       u16(out, value.toInt)
     else if value < (1L << 32) then
-      out += (majorBits | 26).toByte
+      out.push((majorBits | 26).toByte)
       u32(out, value)
     else
-      out += (majorBits | 27).toByte
+      out.push((majorBits | 27).toByte)
       u64(out, value)
 
-  private def u16(out: ArrayBuffer[Byte], value: Int): Unit =
-    out += ((value >>> 8) & 0xFF).toByte
-    out += (value & 0xFF).toByte
+  private def u16(out: Producer.Bytes, value: Int): Unit =
+    out.push(((value >>> 8) & 0xFF).toByte)
+    out.push((value & 0xFF).toByte)
 
-  private def u32(out: ArrayBuffer[Byte], value: Long): Unit =
-    out += ((value >>> 24) & 0xFF).toByte
-    out += ((value >>> 16) & 0xFF).toByte
-    out += ((value >>> 8) & 0xFF).toByte
-    out += (value & 0xFF).toByte
+  private def u32(out: Producer.Bytes, value: Long): Unit =
+    out.push(((value >>> 24) & 0xFF).toByte)
+    out.push(((value >>> 16) & 0xFF).toByte)
+    out.push(((value >>> 8) & 0xFF).toByte)
+    out.push((value & 0xFF).toByte)
 
-  private def u64(out: ArrayBuffer[Byte], value: Long): Unit =
-    out += ((value >>> 56) & 0xFF).toByte
-    out += ((value >>> 48) & 0xFF).toByte
-    out += ((value >>> 40) & 0xFF).toByte
-    out += ((value >>> 32) & 0xFF).toByte
-    out += ((value >>> 24) & 0xFF).toByte
-    out += ((value >>> 16) & 0xFF).toByte
-    out += ((value >>> 8) & 0xFF).toByte
-    out += (value & 0xFF).toByte
+  private def u64(out: Producer.Bytes, value: Long): Unit =
+    out.push(((value >>> 56) & 0xFF).toByte)
+    out.push(((value >>> 48) & 0xFF).toByte)
+    out.push(((value >>> 40) & 0xFF).toByte)
+    out.push(((value >>> 32) & 0xFF).toByte)
+    out.push(((value >>> 24) & 0xFF).toByte)
+    out.push(((value >>> 16) & 0xFF).toByte)
+    out.push(((value >>> 8) & 0xFF).toByte)
+    out.push((value & 0xFF).toByte)
 
-  private def write(out: ArrayBuffer[Byte], cbor: Cbor.Ast): Unit =
+  private def write(out: Producer.Bytes, cbor: Cbor.Ast): Unit =
     if cbor.isInteger then
       val long = cbor.asInstanceOf[Long]
 
@@ -92,32 +102,27 @@ object CborPrinter:
       else head(out, 1, -1L - long)
 
     else if cbor.isFloat then
-      out += (0xE0 | 27).toByte
+      out.push((0xE0 | 27).toByte)
       u64(out, java.lang.Double.doubleToLongBits(cbor.asInstanceOf[Double]))
 
     else if cbor.isTextString then
       val text = cbor.asInstanceOf[String]
       val bytes = text.getBytes("UTF-8").nn
       head(out, 3, bytes.length.toLong)
-      var index = 0
-
-      while index < bytes.length do
-        out += bytes(index)
-        index += 1
+      out.put(bytes.immutable(using Unsafe))
 
     else if cbor.isByteString then
       val bytes = cbor.asInstanceOf[Array[Byte]]
       head(out, 2, bytes.length.toLong)
-      var index = 0
-      while index < bytes.length do { out += bytes(index); index += 1 }
+      out.put(bytes.immutable(using Unsafe))
 
     else if cbor.isBoolean then
-      out += (if cbor.asInstanceOf[Boolean] then 0xF5.toByte else 0xF4.toByte)
+      out.push(if cbor.asInstanceOf[Boolean] then 0xF5.toByte else 0xF4.toByte)
 
     else if cbor.nullary then
-      out += 0xF6.toByte
+      out.push(0xF6.toByte)
     else if cbor.unset then
-      out += 0xF7.toByte
+      out.push(0xF7.toByte)
 
     else if cbor.isTag then
       val tag = cbor.asInstanceOf[Cbor.Tag]

--- a/lib/cataclysm/src/core/cataclysm.CssSerializer.scala
+++ b/lib/cataclysm/src/core/cataclysm.CssSerializer.scala
@@ -40,21 +40,23 @@ import vacuous.*
 import zephyrine.*
 
 // Serializes a `Css` tree back to CSS text. Output is produced lazily through a
-// `zephyrine.Emitter` (the same streaming mechanism Honeycomb uses for HTML), so
+// `zephyrine.Producer` (the same streaming mechanism Honeycomb uses for HTML), so
 // a large stylesheet never needs to be held in memory at once. The output style
 // is chosen by a contextual `CssFormatter` (`cssFormatters.standardCssFormatter` or
 // `.compact`).
 object CssSerializer:
   def emit(css: Css)(using CssFormatter, Monitor, Probate): Iterator[Text] =
-    val emitter = Emitter[Text](4096)
+    val producer = Producer[Text](4096)
 
     async:
-      write(css)(emitter.put(_))
-      emitter.finish()
+      write(css)(producer.put(_))
+      producer.finish()
 
-    emitter.iterator
+    producer.iterator
 
-  def render(css: Css)(using CssFormatter): Text = Text.build(write(css) { text => append(text) })
+  def render(css: Css)(using CssFormatter): Text =
+    Producer.collect[Text](): producer =>
+      write(css)(producer.put(_))
 
   private def write(css: Css)(put: Text => Unit)(using formatter: CssFormatter): Unit =
     def newline(indent: Int): Unit = if formatter.newlines then put(indentText(indent))

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -234,114 +234,132 @@ object Html extends Tag.Container
   :   Iterator[Text] =
 
     val dom = document.metadata
-    val emitter = Emitter[Text](4096)
+    val producer = Producer[Text](4096)
 
     async:
-      def recur(node: Html, indent: Int, block: Boolean, mode: Mode): Unit =
-        node match
-          case Fragment(nodes*) => nodes.each(recur(_, indent, block, mode))
+      writeHtml(producer, dom, document.metadata.doctype, 0, true, Mode.Whitespace)
+      writeHtml(producer, dom, document.root, 0, true, Mode.Whitespace)
+      producer.finish()
 
-          case Comment(comment) =>
-            emitter.put("<!--")
-            emitter.put(comment)
-            emitter.put("-->")
+    producer.iterator
 
-          case Doctype(text) =>
-            emitter.put("<!DOCTYPE ")
-            emitter.put(text) // FIXME: entities
-            emitter.put(">")
+  // `.show` serializes against the standard WHATWG (HTML5) DOM and without indentation, so a bare
+  // node renders correctly (void elements, escaping) even outside a `Document`. `emit` uses the
+  // document's own DOM and indents.
+  given showable: [html <: Html] => html is Showable = node =>
+    Producer.collect[Text](): producer =>
+      writeHtml(producer, doms.html.whatwg, node, 0, false, Mode.Whitespace)
 
-          case TextNode(text) =>
-            mode match
-              case Mode.Raw =>
-                emitter.put(text)
+  // HTML5 text-content escaping: `&`, `<` and `>`. Raw-text elements such as `script` and `style`
+  // use `Mode.Raw` and are written verbatim by `writeHtml`.
+  private def writeEscapedText(producer: Producer[Text], text: Text): Unit =
+    val source = text.s
+    val length = source.length
+    var start = 0
+    var index = 0
 
-              case _ =>
-                var position: Int = 0
+    inline def escape(entity: Text): Unit =
+      if index > start then producer.put(text, start.z, index - start)
+      producer.put(entity)
+      start = index + 1
 
-                while position < text.length do
-                  val amp = text.s.indexOf('&', position)
-                  val lt = text.s.indexOf('<', position)
-                  val next = if amp < 0 then lt else if lt < 0 then amp else amp.min(lt)
+    while index < length do
+      source.charAt(index) match
+        case '&' => escape(t"&amp;")
+        case '<' => escape(t"&lt;")
+        case '>' => escape(t"&gt;")
+        case _   => ()
 
-                  if next >= 0 then
-                    emitter.put(text, position.z, next - position)
-                    if next == lt then emitter.put("&lt;")
-                    if next == amp then emitter.put("&amp;")
-                    position = next + 1
-                  else
-                    emitter.put(text, position.z, text.length - position)
-                    position = text.length
+      index += 1
 
-          case Element(label, attributes, nodes, _) =>
-            if block then emitter.put(indentation, Prim, indent*2 + 1)
-            emitter.put("<")
-            emitter.put(label)
+    if length > start then producer.put(text, start.z, length - start)
 
-            if !attributes.nil then
-              attributes.each: (key, value) =>
-                emitter.put(" ")
-                emitter.put(key)
+  // HTML5 escaping for a double-quoted attribute value: `&` and the `"` delimiter. `<` and `>` are
+  // permitted literally in attribute values.
+  private def writeEscapedAttribute(producer: Producer[Text], text: Text): Unit =
+    val source = text.s
+    val length = source.length
+    var start = 0
+    var index = 0
 
-                value.let: value =>
-                  emitter.put("=\"")
-                  var position: Int = 0
+    inline def escape(entity: Text): Unit =
+      if index > start then producer.put(text, start.z, index - start)
+      producer.put(entity)
+      start = index + 1
 
-                  while position < value.length do
-                    val amp = value.s.indexOf('&', position)
-                    val quot = value.s.indexOf('\"', position)
-                    val next = if amp < 0 then quot else if quot < 0 then amp else amp.min(quot)
+    while index < length do
+      source.charAt(index) match
+        case '&' => escape(t"&amp;")
+        case '"' => escape(t"&quot;")
+        case _   => ()
 
-                    if next >= 0 then
-                      emitter.put(value, position.z, next - position)
-                      if next == quot then emitter.put("&quot;")
-                      if next == amp then emitter.put("&amp;")
-                      position = next + 1
-                    else
-                      emitter.put(value, position.z, value.length - position)
-                      position = value.length
+      index += 1
 
-                  emitter.put("\"")
+    if length > start then producer.put(text, start.z, length - start)
 
-            emitter.put(">")
+  // The single, spec-correct HTML serializer, shared by streaming `emit` and synchronous
+  // `showable` so the two cannot drift. Void elements omit their close tag; raw-text elements
+  // suppress escaping; whitespace-mode elements are indented when `block` is set.
+  private def writeHtml
+    ( producer: Producer[Text],
+      dom:      Dom,
+      node:     Html,
+      indent:   Int,
+      block:    Boolean,
+      mode:     Mode )
+  :   Unit =
 
-            val mode = dom.elements(label).lay(Mode.Normal)(_.mode)
+    node match
+      case Fragment(nodes*) =>
+        nodes.each(writeHtml(producer, dom, _, indent, block, mode))
 
-            val whitespace =
-              (mode == Mode.Whitespace || !nodes.exists(_.isInstanceOf[TextNode]))
-              && block
+      case Comment(comment) =>
+        producer.put("<!--")
+        producer.put(comment)
+        producer.put("-->")
 
-            if !dom.elements(label).lay(false)(_.void) then
-              nodes.each(recur(_, indent + 1, whitespace, mode))
+      case Doctype(text) =>
+        producer.put("<!DOCTYPE ")
+        producer.put(text) // FIXME: entities
+        producer.put(">")
 
-              if block && whitespace
-              then emitter.put(indentation, Prim, (indent*2 + 1).min(indentation.length))
+      case TextNode(text) =>
+        mode match
+          case Mode.Raw => producer.put(text)
+          case _        => writeEscapedText(producer, text)
 
-              emitter.put("</")
-              emitter.put(label)
-              emitter.put(">")
+      case Element(label, attributes, nodes, _) =>
+        if block then producer.put(indentation, Prim, indent*2 + 1)
+        producer.put("<")
+        producer.put(label)
 
-      recur(document.metadata.doctype, 0, true, Mode.Whitespace)
-      recur(document.root, 0, true, Mode.Whitespace)
-      emitter.finish()
+        if !attributes.nil then
+          attributes.each: (key, value) =>
+            producer.put(" ")
+            producer.put(key)
 
-    emitter.iterator
+            value.let: value =>
+              producer.put("=\"")
+              writeEscapedAttribute(producer, value)
+              producer.put("\"")
 
+        producer.put(">")
 
-  given showable: [html <: Html] => html is Showable =
-    case Fragment(nodes*)  => nodes.map(_.show).join
-    case TextNode(text)    => text
-    case Comment(text)     => t"<!--$text-->"
-    case Doctype(text)     => t"<!$text>"
+        val mode = dom.elements(label).lay(Mode.Normal)(_.mode)
 
-    case Element(tagname, attributes, children, _) =>
-      val tagContent = if attributes.nil then t"" else
-        attributes.map:
-          case (key, value) => value.lay(key): value => t"""$key="$value""""
+        val whitespace =
+          (mode == Mode.Whitespace || !nodes.exists(_.isInstanceOf[TextNode]))
+          && block
 
-        . join(t" ", t" ", t"")
+        if !dom.elements(label).lay(false)(_.void) then
+          nodes.each(writeHtml(producer, dom, _, indent + 1, whitespace, mode))
 
-      t"<$tagname$tagContent>${children.map(_.show).join}</$tagname>"
+          if block && whitespace
+          then producer.put(indentation, Prim, (indent*2 + 1).min(indentation.length))
+
+          producer.put("</")
+          producer.put(label)
+          producer.put(">")
 
 
   private enum Token:

--- a/lib/honeycomb/src/test/honeycomb_test.scala
+++ b/lib/honeycomb/src/test/honeycomb_test.scala
@@ -729,7 +729,7 @@ object Tests extends Suite(m"Honeycombd Tests"):
 
         test(m"element with attribute"):
           t"""<img alt="x">""".read[Html of "img"].show
-        . assert(_ == t"""<img alt="x"></img>""")
+        . assert(_ == t"""<img alt="x">""")
 
         test(m"nested elements"):
           t"<div><p>x</p></div>".read[Html of "div"].show
@@ -1536,7 +1536,7 @@ object Html4Tests extends Suite(m"HTML4 parsing tests"):
 
         test(m"element with attribute"):
           t"""<img alt="x">""".read[Html of "img"].show
-        . assert(_ == t"""<img alt="x"></img>""")
+        . assert(_ == t"""<img alt="x">""")
 
         test(m"nested elements"):
           t"<div><p>x</p></div>".read[Html of "div"].show

--- a/lib/jacinta/src/core/jacinta.JsonPrinter.scala
+++ b/lib/jacinta/src/core/jacinta.JsonPrinter.scala
@@ -35,54 +35,100 @@ package jacinta
 import scala.compiletime.*
 
 import anticipation.*
+import denominative.*
 import gossamer.*
-import rudiments.*
+import parasite.*
+import zephyrine.*
 
 object JsonPrinter:
-  def print(json: Json.Ast, indentation: Boolean): Text = Text.build:
-    def appendString(string: String): Unit =
-      append('"')
+  // 64 spaces, sliced for indentation.
+  private val spaces: Text =
+    t"                                                                "
 
-      string.iterator.each:
-        case '\"' => append(t"\\\"")
-        case '\t' => append(t"\\t")
-        case '\n' => append(t"\\n")
-        case '\r' => append(t"\\r")
-        case '\\' => append(t"\\\\")
-        case '\f' => append(t"\\f")
-        case ch   => append(ch)
+  def print(json: Json.Ast, indentation: Boolean): Text =
+    Producer.collect[Text](): producer =>
+      write(producer, json, indentation)
 
-      append('"')
+  def emit(json: Json.Ast, indentation: Boolean)(using Monitor, Probate): Iterator[Text] =
+    val producer = Producer[Text](4096)
 
-    def printObject(node: IArray[Any], indent: Int): Unit =
+    async:
+      write(producer, json, indentation)
+      producer.finish()
+
+    producer.iterator
+
+  private def unicode(char: Char): Text =
+    val hex = Integer.toHexString(char.toInt).nn
+    if hex.length == 1 then t"\\u000$hex" else t"\\u00$hex"
+
+  private def write(producer: Producer[Text], json: Json.Ast, indentation: Boolean): Unit =
+    def indent(count: Int): Unit =
+      var remaining = count
+
+      while remaining > 0 do
+        val chunk = remaining.min(64)
+        producer.put(spaces, Prim, chunk)
+        remaining -= chunk
+
+    // JSON string escaping (RFC 8259): the quote and backslash, the named control escapes, and any
+    // other U+0000-001F control character as a `\uXXXX` reference.
+    def writeString(string: String): Unit =
+      producer.put("\"")
+      val length = string.length
+      var start = 0
+      var index = 0
+
+      inline def escape(entity: Text): Unit =
+        if index > start then producer.put(string.tt, start.z, index - start)
+        producer.put(entity)
+        start = index + 1
+
+      while index < length do
+        string.charAt(index) match
+          case '"'          => escape(t"\\\"")
+          case '\\'         => escape(t"\\\\")
+          case '\b'         => escape(t"\\b")
+          case '\f'         => escape(t"\\f")
+          case '\n'         => escape(t"\\n")
+          case '\r'         => escape(t"\\r")
+          case '\t'         => escape(t"\\t")
+          case c if c < ' ' => escape(unicode(c))
+          case _            => ()
+
+        index += 1
+
+      if length > start then producer.put(string.tt, start.z, length - start)
+      producer.put("\"")
+
+    def writeObject(node: IArray[Any], level: Int): Unit =
       val n = node.length/2
-      append('{')
+      producer.put("{")
       val last = n - 1
-
       var index = 0
 
       while index < n do
         if indentation then
-          append('\n')
-          for i <- 0 until indent*2 do append(' ')
+          producer.put("\n")
+          indent(level*2)
 
-        appendString(node(index*2).asInstanceOf[String])
-        append(':')
-        if indentation then append(' ')
-        recur(node(index*2 + 1).asInstanceOf[Json.Ast], indent + 1)
+        writeString(node(index*2).asInstanceOf[String])
+        producer.put(":")
+        if indentation then producer.put(" ")
+        recur(node(index*2 + 1).asInstanceOf[Json.Ast], level + 1)
 
-        if index < last then append(',')
+        if index < last then producer.put(",")
         index += 1
 
       if indentation then
-        append('\n')
-        for i <- 0 until indent*2 - 2 do append(' ')
+        producer.put("\n")
+        indent(level*2 - 2)
 
-      append('}')
+      producer.put("}")
 
-    def printArray(elements: IArray[Any], indent: Int): Unit =
-      // Strip the sentinel pad if present (parity-padded heterogeneous
-      // arrays carry one for empty/even-length cases).
+    def writeArray(elements: IArray[Any], level: Int): Unit =
+      // Strip the sentinel pad if present (parity-padded heterogeneous arrays
+      // carry one for empty/even-length cases).
       val raw = elements.length
 
       val n =
@@ -90,90 +136,88 @@ object JsonPrinter:
         then raw - 1
         else raw
 
-      append('[')
+      producer.put("[")
       val last = n - 1
-
       var index = 0
 
       while index < n do
         if indentation then
-          append('\n')
-          for i <- 0 until indent*2 do append(' ')
+          producer.put("\n")
+          indent(level*2)
 
-        recur(elements(index).asInstanceOf[Json.Ast], indent + 1)
-        if index < last then append(',')
+        recur(elements(index).asInstanceOf[Json.Ast], level + 1)
+        if index < last then producer.put(",")
         index += 1
 
       if indentation then
-        append('\n')
-        for i <- 0 until indent*2 - 2 do append(' ')
+        producer.put("\n")
+        indent(level*2 - 2)
 
-      append(']')
+      producer.put("]")
 
-    def printBcdLongArray(bcds: Array[Long]): Unit =
+    def writeBcdLongArray(bcds: Array[Long]): Unit =
       val n = bcds.length
-      append('[')
+      producer.put("[")
       val last = n - 1
       var index = 0
 
       while index < n do
-        append(Bcd.bcdLongText(bcds(index)).tt)
-        if index < last then append(',')
+        producer.put(Bcd.bcdLongText(bcds(index)).tt)
+        if index < last then producer.put(",")
         index += 1
 
-      append(']')
+      producer.put("]")
 
-    def printSmallBcdArray(smalls: Array[Int]): Unit =
+    def writeSmallBcdArray(smalls: Array[Int]): Unit =
       val n = smalls.length
-      append('[')
+      producer.put("[")
       val last = n - 1
       var index = 0
 
       while index < n do
-        append(Bcd.bcdIntText(smalls(index)).tt)
-        if index < last then append(',')
+        producer.put(Bcd.bcdIntText(smalls(index)).tt)
+        if index < last then producer.put(",")
         index += 1
 
-      append(']')
+      producer.put("]")
 
-    def recur(json: Json.Ast, indent: Int): Unit = json.asMatchable match
+    def recur(json: Json.Ast, level: Int): Unit = json.asMatchable match
       case bcds: Array[Long] @unchecked =>
-        printBcdLongArray(bcds)
+        writeBcdLongArray(bcds)
 
       case smalls: Array[Int] @unchecked =>
-        printSmallBcdArray(smalls)
+        writeSmallBcdArray(smalls)
 
       case bcd: Array[Double] @unchecked =>
-        // High-precision number — emit the canonical JSON-number text from
-        // the BCD nibble stream directly; this preserves all digits the
-        // parser saw, in contrast to a `Double.toString` round-trip.
-        append(bcd.asInstanceOf[Bcd].text.tt)
+        // High-precision number — emit the canonical JSON-number text from the
+        // BCD nibble stream directly; this preserves all digits the parser saw,
+        // in contrast to a `Double.toString` round-trip.
+        producer.put(bcd.asInstanceOf[Bcd].text.tt)
 
       case smallBcd: Int =>
         // Small-BCD number — at most 7 nibbles packed into one Int.
-        append(Bcd.bcdIntText(smallBcd).tt)
+        producer.put(Bcd.bcdIntText(smallBcd).tt)
 
       case arr: IArray[Any] @unchecked =>
-        // Heterogeneous array or object, distinguished by length parity:
-        // even = object (alternating key/value); odd = array (with
-        // optional sentinel pad on the end).
-        if (arr.length & 1) == 0 then printObject(arr, indent)
-        else printArray(arr, indent)
+        // Heterogeneous array or object, distinguished by length parity: even =
+        // object (alternating key/value); odd = array (with optional sentinel
+        // pad on the end).
+        if (arr.length & 1) == 0 then writeObject(arr, level) else writeArray(arr, level)
 
       case long: Long =>
-        append(long.toString)
+        producer.put(long.toString.tt)
 
       case double: Double =>
-        append(double.toString)
+        producer.put(double.toString.tt)
 
       case string: String =>
-        appendString(string)
+        writeString(string)
 
       case boolean: Boolean =>
-        append(boolean.toString)
+        producer.put(boolean.toString.tt)
 
       case _ =>
-        append("null")
+        producer.put("null")
 
     recur(json, 1)
 

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -48,11 +48,13 @@ import distillate.*
 import gossamer.*
 import hypotenuse.*
 import panopticon.*
+import parasite.*
 import prepositional.*
 import rudiments.*
 import turbulence.*
 import vacuous.*
 import wisteria.*
+import zephyrine.*
 
 import ProtobufError.Reason
 
@@ -141,20 +143,31 @@ object Protobuf extends Protobuf2:
         val fields = ProtobufParser(origin.payload).fields()
 
         if !fields.contains(number) then origin else
-          val printer = ProtobufPrinter()
+          val bytes = printed: printer =>
+            fields.each: (key, values) =>
+              val value = Protobuf.Repeated(values)
+              printer.field(key, if key == number then lambda(value) else value)
 
-          fields.each: (key, values) =>
-            val value = Protobuf.Repeated(values)
-            printer.field(key, if key == number then lambda(value) else value)
-
-          Protobuf.Wire(WireType.Len, printer.result)
+          Protobuf.Wire(WireType.Len, bytes)
 
       . or(origin)
 
+  // Synchronously assemble wire bytes by running `lambda` against a `ProtobufPrinter`.
   private def printed(lambda: ProtobufPrinter => Unit): Data =
-    val printer = ProtobufPrinter()
-    lambda(printer)
-    printer.result
+    Producer.collect[Data](): producer =>
+      lambda(ProtobufPrinter(producer))
+
+  // Stream a message's wire bytes incrementally (chunked); the producing code runs on a separate
+  // fiber. The bytes themselves are already assembled (Protobuf length-prefixes nested messages, so
+  // their lengths must be known up front); this hands them out in bounded chunks.
+  def emit(value: Protobuf)(using Monitor, Probate): Iterator[Data] =
+    val producer = Producer[Data](4096)
+
+    async:
+      producer.put(value.payload)
+      producer.finish()
+
+    producer.iterator
 
   private def readVarint(protobuf: Protobuf)(using Tactic[ProtobufError]): Long =
     if protobuf.isAbsent then 0L else ProtobufParser(protobuf.payload).varint()
@@ -283,14 +296,14 @@ object Protobuf extends Protobuf2:
       val list = values.to(List)
 
       if list.isEmpty then Absent else
-        val printer = ProtobufPrinter()
-        var rest = list
+        val bytes = printed: printer =>
+          var rest = list
 
-        while rest.nonEmpty do
-          printer.raw(encodable.encode(rest.head).payload)
-          rest = rest.tail
+          while rest.nonEmpty do
+            printer.raw(encodable.encode(rest.head).payload)
+            rest = rest.tail
 
-        Wire(WireType.Len, printer.result)
+        Wire(WireType.Len, bytes)
 
   given packedDecodable: [collection <: Iterable, element]
   =>  ( factory:   Factory[element, collection[element]],
@@ -323,10 +336,11 @@ object Protobuf extends Protobuf2:
     map =>
       if map.isEmpty then Absent else
         val entries = map.to(List).map: (key, value) =>
-          val printer = ProtobufPrinter()
-          printer.field(1, keyEncodable.encode(key))
-          printer.field(2, valueEncodable.encode(value))
-          Wire(WireType.Len, printer.result)
+          val bytes = printed: printer =>
+            printer.field(1, keyEncodable.encode(key))
+            printer.field(2, valueEncodable.encode(value))
+
+          Wire(WireType.Len, bytes)
 
         Repeated(entries)
 
@@ -352,13 +366,12 @@ object Protobuf extends Protobuf2:
       val numbers = fieldNumbers[derivation]
 
       value =>
-        val printer = ProtobufPrinter()
+        val bytes = printed: printer =>
+          fields(value):
+            [field0] => fieldValue =>
+              printer.field(numbers(label), contextual.encode(fieldValue))
 
-        fields(value):
-          [field0] => fieldValue =>
-            printer.field(numbers(label), contextual.encode(fieldValue))
-
-        Protobuf.Wire(WireType.Len, printer.result)
+        Protobuf.Wire(WireType.Len, bytes)
 
     inline def disjunction[derivation: SumReflection]: derivation is Encodable in Protobuf =
       value =>

--- a/lib/locomotion/src/core/locomotion.ProtobufPrinter.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufPrinter.scala
@@ -32,26 +32,17 @@
                                                                                                   */
 package locomotion
 
-import scala.collection.mutable as scm
-
 import anticipation.*
-import rudiments.*
-import vacuous.*
+import zephyrine.*
 
-// Accumulates Protocol Buffers wire bytes. Varints are LEB128; fixed32/fixed64 are
-// little-endian; a field is its tag varint followed by the value (length-prefixed
-// for the length-delimited wire type).
-class ProtobufPrinter():
-  private val buffer = scm.ArrayBuilder.make[Byte]
+// Writes Protocol Buffers wire bytes into a `Producer[Data]`. Varints are LEB128; fixed32/fixed64
+// are little-endian; a field is its tag varint followed by the value (length-prefixed for the
+// length-delimited wire type). Drive it through `Protobuf.printed` (synchronous) or `Protobuf.emit`
+// (streaming).
+class ProtobufPrinter(out: Producer.Bytes):
+  def byte(value: Int): Unit = out.push(value.toByte)
 
-  def byte(value: Int): Unit = buffer.addOne(value.toByte)
-
-  def raw(data: Data): Unit =
-    var i = 0
-
-    while i < data.length do
-      buffer.addOne(data(i))
-      i += 1
+  def raw(data: Data): Unit = out.put(data)
 
   def varint(value: Long): Unit =
     var rest = value
@@ -89,5 +80,3 @@ class ProtobufPrinter():
       tag(number, wireType)
       if wireType == WireType.Len then varint(bytes.length)
       raw(bytes)
-
-  def result: Data = buffer.result().immutable(using Unsafe)

--- a/lib/punctuation/src/core/punctuation.MarkdownWidth.scala
+++ b/lib/punctuation/src/core/punctuation.MarkdownWidth.scala
@@ -1,0 +1,43 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package punctuation
+
+// The column width at which the Markdown `Serializer` wraps paragraph text onto further lines. The
+// default is unbounded — each paragraph stays on one line, so the output re-parses to an identical
+// AST. Provide a bounded `given` to opt into wrapping, e.g.
+// `given MarkdownWidth = MarkdownWidth.bounded(80)`.
+object MarkdownWidth:
+  given unbounded: MarkdownWidth = MarkdownWidth(Int.MaxValue)
+  def bounded(columns: Int): MarkdownWidth = MarkdownWidth(columns)
+
+case class MarkdownWidth(columns: Int)

--- a/lib/punctuation/src/core/punctuation.Serializer.scala
+++ b/lib/punctuation/src/core/punctuation.Serializer.scala
@@ -35,43 +35,65 @@ package punctuation
 import anticipation.*
 import denominative.*
 import gossamer.*
+import parasite.*
 import prepositional.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
+import zephyrine.*
 
 // Round-trips a `Markdown` AST back into CommonMark source text. The output is
 // not byte-identical to whatever the parser originally consumed, but is
 // guaranteed to re-parse to an equal AST (modulo `Ordinal` `line` metadata).
 object Serializer:
-  def apply(markdown: Markdown of Layout): Text =
-    val builder = StringBuilder()
-    layoutSeq(builder, markdown.children, t"")
-    appendLinkRefs(builder, markdown.linkRefs)
-    builder.text
+  def apply(markdown: Markdown of Layout)(using width: MarkdownWidth): Text =
+    Producer.collect[Text](): producer =>
+      writeDocument(Writer(producer, width.columns), markdown)
 
   @scala.annotation.targetName("applyProse")
-  def apply(markdown: Markdown of Prose): Text =
-    val builder = StringBuilder()
-    markdown.children.each(prose(builder, _))
-    builder.text
+  def apply(markdown: Markdown of Prose)(using width: MarkdownWidth): Text =
+    Producer.collect[Text](): producer =>
+      flow(Writer(producer, width.columns), markdown.children, protectFirst = false)
 
-  private def appendLinkRefs(builder: StringBuilder, refs: List[Markdown.LinkRef]): Unit =
+  // Stream a document's source incrementally; the producing code runs on a separate fiber.
+  def emit(markdown: Markdown of Layout)
+    ( using width: MarkdownWidth, monitor: Monitor, probate: Probate )
+  :   Iterator[Text] =
+
+    val producer = Producer[Text](4096)
+
+    async:
+      writeDocument(Writer(producer, width.columns), markdown)
+      producer.finish()
+
+    producer.iterator
+
+  private def writeDocument(writer: Writer, markdown: Markdown of Layout): Unit =
+    var first = true
+
+    markdown.children.each: node =>
+      if !first then writer.blankLine()
+      first = false
+      layout(writer, node)
+
+    linkRefs(writer, markdown.linkRefs)
+
+  private def linkRefs(writer: Writer, refs: List[Markdown.LinkRef]): Unit =
     if !refs.nil then
-      if builder.length > 0 && !builder.text.ends(t"\n") then builder.add(t"\n")
+      if writer.written && !writer.atLineStart then writer.newline()
 
       refs.each: ref =>
-        builder.add('[')
-        builder.add(escapeLinkLabel(ref.label))
-        builder.add(t"]: ")
-        builder.add(linkDestination(ref.destination))
+        writer.raw(t"[")
+        writer.raw(escapeLinkLabel(ref.label))
+        writer.raw(t"]: ")
+        writer.raw(linkDestination(ref.destination))
 
         ref.title.let: title =>
-          builder.add(t" \"")
-          builder.add(title.sub(t"\"", t"\\\""))
-          builder.add('"')
+          writer.raw(t" \"")
+          writer.raw(title.sub(t"\"", t"\\\""))
+          writer.raw(t"\"")
 
-        builder.add('\n')
+        writer.newline()
 
   // Characters that, if unescaped in a `Textual` node, could start a new
   // inline construct when the output is re-parsed. We escape conservatively:
@@ -261,9 +283,8 @@ object Serializer:
     case Prose.HtmlInline(html) =>
       builder.add(html)
 
-  // Render the inline content of a paragraph or heading to a fresh `Text`,
-  // applying first-character block-start protection so a leading `#` etc.
-  // does not re-parse as a new block.
+  // Render the inline content of a heading to a fresh `Text`, applying first-character block-start
+  // protection so a leading `#` etc. does not re-parse as a new block.
   private def inlineLine(children: Seq[Prose]): Text =
     val buf = StringBuilder()
     children.each(prose(buf, _))
@@ -273,131 +294,202 @@ object Serializer:
     else if blockStart(out.s.charAt(0)) then t"\\$out"
     else out
 
-  private def layoutSeq(builder: StringBuilder, nodes: Seq[Layout], indent: Text): Unit =
-    var first = true
+  // Render one inline construct (code span, emphasis, link, …) to a `Text`, emitted as a single
+  // unbreakable unit by the paragraph word-wrapper.
+  private def inlineUnit(node: Prose): Text =
+    val buf = StringBuilder()
+    prose(buf, node)
+    buf.text
 
-    nodes.each: node =>
-      if !first then ensureBlankLine(builder)
-      first = false
-      layout(builder, node, indent)
+  // Render a sequence of blocks to a `Text` — the indented body of a block quote or list item,
+  // which is then re-emitted with a line prefix.
+  private def render(nodes: Seq[Layout], width: Int): Text =
+    Producer.collect[Text](): producer =>
+      val inner = Writer(producer, width)
+      var first = true
 
-  private def ensureBlankLine(builder: StringBuilder): Unit =
-    val txt = builder.text
+      nodes.each: node =>
+        if !first then inner.blankLine()
+        first = false
+        layout(inner, node)
 
-    if txt.length == 0 then ()
-    else if txt.ends(t"\n\n") then ()
-    else if txt.ends(t"\n") then builder.add('\n')
-    else builder.add(t"\n\n")
+  private def trimNewline(text: Text): Text = if text.ends(t"\n") then text.skip(1, Rtl) else text
 
-  private def writeWithIndent(builder: StringBuilder, text: Text, indent: Text): Unit =
-    val s = text.s
-    var lineStart = true
-    var i = 0
+  // Word-wrap a paragraph's inline content: textual nodes break at their spaces, inline constructs
+  // are atomic. `protectFirst` backslash-escapes a leading block-start character.
+  private def flow(writer: Writer, children: Seq[Prose], protectFirst: Boolean): Unit =
+    if protectFirst then writer.protectNext()
 
-    while i < s.length do
-      val c = s.charAt(i)
-      if lineStart && indent.length > 0 then builder.add(indent)
-      builder.add(c)
-      lineStart = c == '\n'
-      i += 1
+    children.each:
+      case Prose.Textual(text) => writer.text(escapeTextual(text))
+      case Prose.Softbreak     => writer.soft()
+      case Prose.Linebreak     => writer.hard()
+      case node                => writer.atom(inlineUnit(node))
 
-  private def layout(builder: StringBuilder, node: Layout, indent: Text): Unit = node match
+    writer.endFlow()
+
+  private def layout(writer: Writer, node: Layout): Unit = node match
     case Layout.Heading(_, level, children*) =>
-      builder.add(indent)
-      builder.add(t"#"*level)
-      builder.add(' ')
-      builder.add(inlineLine(children))
-      builder.add('\n')
+      writer.raw(t"#"*level)
+      writer.raw(t" ")
+      writer.raw(inlineLine(children))
+      writer.newline()
 
     case Layout.Paragraph(_, children*) =>
-      writeWithIndent(builder, inlineLine(children), indent)
-      builder.add('\n')
+      flow(writer, children, protectFirst = true)
+      writer.newline()
 
     case Layout.ThematicBreak(_) =>
-      builder.add(indent)
-      builder.add(t"---\n")
+      writer.raw(t"---")
+      writer.newline()
 
     case Layout.CodeBlock(_, info, code) =>
       val fence = codeBlockFence(code)
-      builder.add(indent)
-      builder.add(fence)
-      if !info.nil then builder.add(info.map(_.s).mkString(" ").tt)
-      builder.add('\n')
-      writeWithIndent(builder, code, indent)
-      if !code.ends(t"\n") then builder.add('\n')
-      builder.add(indent)
-      builder.add(fence)
-      builder.add('\n')
+      writer.raw(fence)
+      if !info.nil then writer.raw(info.map(_.s).mkString(" ").tt)
+      writer.newline()
+      writer.raw(code)
+      if !code.ends(t"\n") then writer.newline()
+      writer.raw(fence)
+      writer.newline()
 
     case Layout.BlockQuote(_, children*) =>
-      val inner = StringBuilder()
-      layoutSeq(inner, children, t"")
-      val text = inner.text
-      // Strip a single trailing newline so the loop doesn't emit a phantom
-      // empty final line.
-      val body = if text.ends(t"\n") then text.skip(1, Rtl) else text
-
-      body.cut(t"\n").each: line =>
-        builder.add(indent)
-
-        if line.length == 0 then builder.add('>')
+      trimNewline(render(children, writer.width)).cut(t"\n").each: line =>
+        if line.length == 0 then writer.raw(t">")
         else
-          builder.add(t"> ")
-          builder.add(line)
+          writer.raw(t"> ")
+          writer.raw(line)
 
-        builder.add('\n')
+        writer.newline()
 
     case Layout.HtmlBlock(_, html) =>
-      writeWithIndent(builder, html, indent)
-      if !html.ends(t"\n") then builder.add('\n')
+      writer.raw(html)
+      if !html.ends(t"\n") then writer.newline()
 
     case Layout.BulletList(_, tight, items*) =>
       var first = true
 
       items.each: item =>
-        if !first && !tight then ensureBlankLine(builder)
+        if !first && !tight then writer.blankLine()
         first = false
-        builder.add(indent)
-        builder.add(t"- ")
-        renderItemBody(builder, item, t"$indent  ", tight)
+        listItem(writer, item, t"- ", t"  ")
 
     case Layout.OrderedList(_, start, tight, delimiter, items*) =>
       var n = start
       var first = true
 
       items.each: item =>
-        if !first && !tight then ensureBlankLine(builder)
+        if !first && !tight then writer.blankLine()
         first = false
         val marker = t"$n${delimiter.or('.')} "
-        val hangingSpaces = t" "*marker.length
-        builder.add(indent)
-        builder.add(marker)
-        renderItemBody(builder, item, t"$indent$hangingSpaces", tight)
+        listItem(writer, item, marker, t" "*marker.length)
         n += 1
 
-  // A list item is itself a sequence of `Layout` blocks. We emit the first
-  // block's first line right after the marker, then everything else with
-  // the hanging-indent applied. Tight lists collapse the inter-paragraph
-  // blank lines exactly as the parser does.
-  private def renderItemBody
-    ( builder: StringBuilder, item: List[Layout], hangingIndent: Text, tight: Boolean )
-  :   Unit =
+  // Emit a list item: the first line carries the marker, subsequent lines the hanging indent.
+  private def listItem(writer: Writer, item: List[Layout], marker: Text, hanging: Text): Unit =
+    if item.nil then writer.newline() else
+      var first = true
 
-    if item.nil then builder.add('\n')
-    else
-      val inner = StringBuilder()
-      layoutSeq(inner, item, t"")
-      val rendered = inner.text.s
+      trimNewline(render(item, writer.width)).cut(t"\n").each: line =>
+        writer.raw(if first then marker else hanging)
+        writer.raw(line)
+        writer.newline()
+        first = false
 
+  // A streaming sink for Markdown source. Block separation, indentation and the first-character
+  // block-start escape are carried as state (no looking back at emitted output), and paragraph text
+  // is word-wrapped at `width` (the default `Int.MaxValue` never wraps, preserving the AST).
+  class Writer(producer: Producer[Text], val width: Int):
+    private var trailing = 0          // consecutive trailing newlines just emitted
+    private var col = 0               // current column, for wrapping
+    private var pendingSpaces = 0     // spaces buffered before the current word
+    private val seg = StringBuilder() // the current unbreakable run (word + adjacent atoms)
+    private var protect = false       // escape the next word's leading block-start char
+    var written: Boolean = false
+
+    def atLineStart: Boolean = col == 0
+
+    // Emit text verbatim (it may contain newlines), tracking the trailing-newline count and column.
+    def raw(text: Text): Unit =
+      val s = text.s
+
+      if s.length > 0 then
+        producer.put(text)
+        written = true
+        var nls = 0
+        var k = s.length
+
+        while k > 0 && s.charAt(k - 1) == '\n' do
+          nls += 1
+          k -= 1
+
+        if k == 0 then
+          trailing += nls
+          col = 0
+        else
+          trailing = nls
+          val lastNl = s.lastIndexOf('\n')
+          col = if lastNl < 0 then col + s.length else s.length - lastNl - 1
+
+    def newline(): Unit =
+      producer.put(t"\n")
+      written = true
+      trailing += 1
+      col = 0
+
+    // Ensure blocks are separated by a blank line (two trailing newlines), once content exists.
+    def blankLine(): Unit =
+      if written then
+        if trailing == 0 then
+          newline()
+          newline()
+        else if trailing == 1 then
+          newline()
+
+    def protectNext(): Unit = protect = true
+
+    def text(content: Text): Unit =
+      val s = content.s
       var i = 0
-      var lineStart = false
 
-      while i < rendered.length do
-        val c = rendered.charAt(i)
-        if lineStart then builder.add(hangingIndent)
-        builder.add(c)
-        lineStart = c == '\n'
+      while i < s.length do
+        if s.charAt(i) == ' ' then
+          flushSeg()
+          pendingSpaces += 1
+        else
+          seg.add(s.charAt(i))
+
         i += 1
 
-      if rendered.isEmpty || rendered.charAt(rendered.length - 1) != '\n'
-      then builder.add('\n')
+    def atom(content: Text): Unit = seg.add(content)
+
+    def soft(): Unit =
+      flushSeg()
+      pendingSpaces = 0
+      newline()
+
+    def hard(): Unit =
+      flushSeg()
+      pendingSpaces = 0
+      raw(t"\\")
+      newline()
+
+    def endFlow(): Unit = flushSeg()
+
+    private def flushSeg(): Unit =
+      if seg.length > 0 then
+        val word = seg.text
+        seg.clear()
+
+        if pendingSpaces > 0 then
+          if width != Int.MaxValue && col > 0 && col + pendingSpaces + word.length > width
+          then newline()
+          else raw(t" "*pendingSpaces)
+
+          pendingSpaces = 0
+
+        if protect then
+          protect = false
+          if blockStart(word.s.charAt(0)) then raw(t"\\")
+
+        raw(word)

--- a/lib/punctuation/src/test/punctuation_test.scala
+++ b/lib/punctuation/src/test/punctuation_test.scala
@@ -124,6 +124,30 @@ object Tests extends Suite(m"Punctuation tests"):
           case Layout.OrderedList(_, 1, true, _, items*) if items.size == 2 => true
           case _                                                            => false
 
+    suite(m"Serializer wrapping"):
+      def squash(text: Text): Text = text.cut(t"\n").join(t"").cut(t" ").join(t"")
+      val src = t"alpha beta gamma delta epsilon zeta eta theta iota kappa"
+      val document = Parser.parse(src+t"\n")
+
+      test(m"bounded width keeps every line within the limit"):
+        val wrapped = Serializer(document)(using MarkdownWidth.bounded(20))
+        wrapped.cut(t"\n").filter(_ != t"").all(_.length <= 20)
+      . assert(_ == true)
+
+      test(m"wrapping actually breaks the paragraph onto several lines"):
+        val wrapped = Serializer(document)(using MarkdownWidth.bounded(20))
+        wrapped.cut(t"\n").filter(_ != t"").length
+      . assert(_ > 1)
+
+      test(m"wrapping preserves the words and their order"):
+        val wrapped = Serializer(document)(using MarkdownWidth.bounded(20))
+        squash(wrapped)
+      . assert(_ == squash(src))
+
+      test(m"the default width never wraps"):
+        Serializer(document).cut(t"\n").filter(_ != t"").length
+      . assert(_ == 1)
+
     suite(m"Terminal renderer"):
       import hyphenations.englishHyphenation
       import termcapDefinitions.xtermTrueColorTermcap

--- a/lib/stratiform/src/core/stratiform.TelPrinter.scala
+++ b/lib/stratiform/src/core/stratiform.TelPrinter.scala
@@ -35,8 +35,10 @@ package stratiform
 import scala.language.unsafeNulls
 
 import anticipation.*
+import parasite.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 // Reverses the presentation parser. The printer is line-based: each
 // emission appends one or more strings to a buffer that is finally joined
@@ -47,11 +49,35 @@ import vacuous.*
 
 object TelPrinter:
   def print(document: Tel.Document): Text =
-    val buffer = scala.collection.mutable.ArrayBuffer.empty[String]
+    Producer.collect[Text](): producer =>
+      write(producer, document)
+
+  def emit(document: Tel.Document)(using Monitor, Probate): Iterator[Text] =
+    val producer = Producer[Text](4096)
+
+    async:
+      write(producer, document)
+      producer.finish()
+
+    producer.iterator
+
+  private def write(producer: Producer[Text], document: Tel.Document): Unit =
+    val newline = document.lineEndings match
+      case Tel.LineEndings.Lf   => "\n"
+      case Tel.LineEndings.Crlf => "\r\n"
+
+    var first = true
+
+    // Emit one line, inserting the document's line ending between lines but never after the last,
+    // so the joined output matches the former buffer-and-`mkString` exactly.
+    def out(text: String): Unit =
+      if first then first = false else producer.put(Text(newline))
+      producer.put(Text(text))
+
     val sigil = document.pragma.let(_.sigil.or('#')).or('#')
 
     document.interpreterDirective.let: payload =>
-      buffer += "#!" + payload.s
+      out("#!" + payload.s)
 
     document.pragma.let: pragma =>
       val parts = scala.collection.mutable.ArrayBuffer.empty[String]
@@ -59,31 +85,18 @@ object TelPrinter:
       parts += s"${pragma.version._1}.${pragma.version._2}"
       pragma.schema.let: s => parts += s.s
       pragma.sigil.let: c => parts += c.toString
-      buffer += parts.mkString(" ")
-      buffer += ""
+      out(parts.mkString(" "))
+      out("")
 
-    document.children.each(emitBlock(buffer, _, 0, sigil))
+    document.children.each(emitBlock(out, _, 0, sigil))
 
-    val newline = document.lineEndings match
-      case Tel.LineEndings.Lf   => "\n"
-      case Tel.LineEndings.Crlf => "\r\n"
-
-    Text(buffer.mkString(newline))
-
-  private def emitBlock
-    ( buffer: scala.collection.mutable.ArrayBuffer[String],
-      block: Tel.Block,
-      indent: Int,
-      sigil: Char )
-  :   Unit =
-
+  private def emitBlock(out: String => Unit, block: Tel.Block, indent: Int, sigil: Char): Unit =
     val pad = "  " * indent
 
     block.comments.each: comment =>
       val text = comment.text.s
 
-      if text.isEmpty then buffer += s"$pad$sigil"
-      else buffer += s"$pad$sigil $text"
+      if text.isEmpty then out(s"$pad$sigil") else out(s"$pad$sigil $text")
 
     block.tabulation.let: tab =>
       val line = StringBuilder()
@@ -101,18 +114,18 @@ object TelPrinter:
 
         i += 1
 
-      buffer += line.toString
+      out(line.toString)
 
-    block.compounds.each(emitCompound(buffer, _, indent, sigil))
+    block.compounds.each(emitCompound(out, _, indent, sigil))
 
     var b = 0
 
     while b < block.trailingBlankLines do
-      buffer += ""
+      out("")
       b += 1
 
   private def emitCompound
-    ( buffer:   scala.collection.mutable.ArrayBuffer[String],
+    ( out:      String => Unit,
       compound: Tel.Compound,
       indent:   Int,
       sigil:    Char )
@@ -135,25 +148,22 @@ object TelPrinter:
         line.append(text.s)
 
     compound.remark.let: remark =>
-      // Two spaces before the sigil ensure correct re-parsing regardless of
-      // whether the preceding atoms put the line into hard-space mode: in
-      // hard mode only hard spaces terminate phrases, so a single space
-      // before `#` would be absorbed as atom content instead of marking the
-      // remark introducer. §18.1 permits the serialiser to use a minimum
+      // Two spaces before the sigil ensure correct re-parsing regardless of whether the preceding
+      // atoms put the line into hard-space mode: in hard mode only hard spaces terminate phrases,
+      // so a single space before `#` would be absorbed as atom content. §18.1 permits a minimum
       // hard space before remark introducers.
       line.append("  ")
       line.append(sigil)
       line.append(' ')
       line.append(remark.s)
 
-    buffer += line.toString
+    out(line.toString)
 
     trailingAtom match
       case Tel.Atom.Source(text) =>
         val sourcePad = "  " * (indent + 2)
-        // §14 "Convention A": `text` is LF-separated with no trailing LF, so
-        // each LF-delimited segment is one source line (an empty segment is a
-        // blank line emitted with no indentation).
+        // §14 "Convention A": `text` is LF-separated with no trailing LF, so each LF-delimited
+        // segment is one source line (an empty segment is a blank line with no indentation).
         val sourceText = text.s
         var start = 0
 
@@ -161,22 +171,22 @@ object TelPrinter:
           val nl = sourceText.indexOf('\n', start)
           val end = if nl < 0 then sourceText.length else nl
           val seg = sourceText.substring(start, end)
-          buffer += (if seg.isEmpty then "" else sourcePad + seg)
+          out(if seg.isEmpty then "" else sourcePad + seg)
           if nl < 0 then start = sourceText.length + 1 else start = nl + 1
 
       case Tel.Atom.Literal(delimiter, text) =>
-        buffer += "  " * (indent + 3) + delimiter.s
+        out("  " * (indent + 3) + delimiter.s)
         val payload = text.s
         var start = 0
 
         while start <= payload.length do
           val nl = payload.indexOf('\n', start)
           val end = if nl < 0 then payload.length else nl
-          buffer += payload.substring(start, end)
+          out(payload.substring(start, end))
           if nl < 0 then start = payload.length + 1 else start = nl + 1
 
-        buffer += delimiter.s
+        out(delimiter.s)
 
       case _ => ()
 
-    compound.children.each(emitBlock(buffer, _, indent + 1, sigil))
+    compound.children.each(emitBlock(out, _, indent + 1, sigil))

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -556,219 +556,140 @@ object Xml extends Tag.Container
     Tracked(xml, PositionIndex(if index == null then IArray.empty[Int] else index))
 
   def emit(document: Document[Xml], flat: Boolean = false)(using Monitor, Probate): Iterator[Text] =
-
-    val emitter = Emitter[Text](4096)
+    val producer = Producer[Text](4096)
 
     async:
-      def recur(node: Xml, indent: Int): Unit =
-        node match
-          case Fragment(nodes*) => nodes.each(recur(_, indent))
+      writeXml(producer, document.metadata)
+      writeXml(producer, document.root)
+      producer.finish()
 
-          case Comment(comment) =>
-            emitter.put("<!--")
-            emitter.put(comment)
-            emitter.put("-->")
+    producer.iterator
 
-          case Cdata(text) =>
-            emitter.put("<![CDATA[")
-            emitter.put(text)
-            emitter.put("]]>")
-
-          case Doctype(text) =>
-            emitter.put("<!DOCTYPE ")
-            emitter.put(text)
-            emitter.put(">")
-
-          case ProcessingInstruction(target, data) =>
-            emitter.put("<?")
-            emitter.put(target)
-
-            if !data.nil then
-              emitter.put(" ")
-              emitter.put(data)
-
-            emitter.put("?>")
-
-          case Header(version, encoding, standalone) =>
-            emitter.put("""<?xml version="""")
-            emitter.put(version)
-            emitter.put("\"")
-
-            encoding.let: encoding =>
-              emitter.put(""" encoding="""")
-              emitter.put(encoding)
-              emitter.put("\"")
-
-            standalone.let: standalone =>
-              emitter.put(if standalone then """ standalone="yes"""" else """ standalone="no"""")
-
-            emitter.put("?>")
-
-          case TextNode(text) =>
-            var position: Int = 0
-
-            while position < text.length do
-              val amp = text.s.indexOf('&', position)
-              val lt = text.s.indexOf('<', position)
-              val next = if amp < 0 then lt else if lt < 0 then amp else amp.min(lt)
-
-              if next >= 0 then
-                emitter.put(text, position.z, next - position)
-                if next == lt then emitter.put("&lt;")
-                if next == amp then emitter.put("&amp;")
-                position = next + 1
-              else
-                emitter.put(text, position.z, text.length - position)
-                position = text.length
-
-          case Element(label, attributes, nodes) =>
-            emitter.put("<")
-            emitter.put(label)
-
-            if !attributes.nil then
-              attributes.each: (key, value) =>
-                emitter.put(" ")
-                emitter.put(key)
-                emitter.put("=\"")
-                var position: Int = 0
-
-                while position < value.length do
-                  val amp = value.s.indexOf('&', position)
-                  val quot = value.s.indexOf(Sqt, position)
-                  val next = if amp < 0 then quot else if quot < 0 then amp else amp.min(quot)
-
-                  if next >= 0 then
-                    emitter.put(value, position.z, next - position)
-                    if next == quot then emitter.put("&quot;")
-                    if next == amp then emitter.put("&amp;")
-                    position = next + 1
-                  else
-                    emitter.put(value, position.z, value.length - position)
-                    position = value.length
-
-                emitter.put("\"")
-
-            emitter.put(">")
-
-            nodes.each(recur(_, indent + 1))
-
-            emitter.put("</")
-            emitter.put(label)
-            emitter.put(">")
-
-      recur(document.metadata, 0)
-      recur(document.root, 0)
-      emitter.finish()
-
-    emitter.iterator
-
-
-  private def appendEscapedText(builder: jl.StringBuilder, text: Text): Unit =
+  // Escape text content so the result is well-formed and round-trips exactly. `&` and `<` must be
+  // escaped; `>` is escaped too so the `]]>` sequence can never appear; and a carriage return is
+  // written as a character reference so XML line-ending normalization cannot rewrite it to `\n`.
+  private def writeEscapedText(producer: Producer[Text], text: Text): Unit =
     val source = text.s
     val length = source.length
+    var start = 0
     var index = 0
+
+    inline def escape(entity: Text): Unit =
+      if index > start then producer.put(text, start.z, index - start)
+      producer.put(entity)
+      start = index + 1
 
     while index < length do
       source.charAt(index) match
-        case '<' => builder.append("&lt;")
-        case '&' => builder.append("&amp;")
-        case chr => builder.append(chr)
+        case '&'  => escape(t"&amp;")
+        case '<'  => escape(t"&lt;")
+        case '>'  => escape(t"&gt;")
+        case '\r' => escape(t"&#xD;")
+        case _    => ()
 
       index += 1
 
-  private def appendEscapedAttribute(builder: jl.StringBuilder, text: Text): Unit =
+    if length > start then producer.put(text, start.z, length - start)
+
+  // Escape an attribute value delimited by double quotes. Besides the text escapes, the delimiter
+  // and the whitespace characters tab, line feed and carriage return become character references,
+  // since attribute-value normalization would otherwise collapse literal whitespace to spaces.
+  private def writeEscapedAttribute(producer: Producer[Text], text: Text): Unit =
     val source = text.s
     val length = source.length
+    var start = 0
     var index = 0
+
+    inline def escape(entity: Text): Unit =
+      if index > start then producer.put(text, start.z, index - start)
+      producer.put(entity)
+      start = index + 1
 
     while index < length do
       source.charAt(index) match
-        case '<' => builder.append("&lt;")
-        case '&' => builder.append("&amp;")
-        case '"' => builder.append("&quot;")
-        case chr => builder.append(chr)
+        case '&'  => escape(t"&amp;")
+        case '<'  => escape(t"&lt;")
+        case '>'  => escape(t"&gt;")
+        case '"'  => escape(t"&quot;")
+        case '\t' => escape(t"&#x9;")
+        case '\n' => escape(t"&#xA;")
+        case '\r' => escape(t"&#xD;")
+        case _    => ()
 
       index += 1
 
-  private def appendXml(builder: jl.StringBuilder, node: Xml): Unit = node match
-    case fragment: Fragment =>
-      val nodes = fragment.nodes
-      var index = 0
+    if length > start then producer.put(text, start.z, length - start)
 
-      while index < nodes.length do
-        appendXml(builder, nodes(index))
-        index += 1
+  // The single, spec-correct XML serializer. `emit` drives it through a streaming `Producer` and
+  // `showable` through a synchronous one, so the two never drift.
+  private def writeXml(producer: Producer[Text], node: Xml): Unit = node match
+    case Fragment(nodes*) =>
+      nodes.each(writeXml(producer, _))
 
     case TextNode(text) =>
-      appendEscapedText(builder, text)
+      writeEscapedText(producer, text)
 
-    case Comment(text) =>
-      builder.append("<!--")
-      builder.append(text.s)
-      builder.append("-->")
+    case Comment(comment) =>
+      producer.put("<!--")
+      producer.put(comment)
+      producer.put("-->")
 
     case Cdata(text) =>
-      builder.append("<![CDATA[")
-      builder.append(text.s)
-      builder.append("]]>")
+      producer.put("<![CDATA[")
+      producer.put(text)
+      producer.put("]]>")
 
     case Doctype(text) =>
-      builder.append("<!DOCTYPE ")
-      builder.append(text.s)
-      builder.append('>')
+      producer.put("<!DOCTYPE ")
+      producer.put(text)
+      producer.put(">")
 
     case ProcessingInstruction(target, data) =>
-      builder.append("<?")
-      builder.append(target.s)
+      producer.put("<?")
+      producer.put(target)
 
-      if data.length > 0 then
-        builder.append(' ')
-        builder.append(data.s)
+      if !data.nil then
+        producer.put(" ")
+        producer.put(data)
 
-      builder.append("?>")
+      producer.put("?>")
 
     case Header(version, encoding, standalone) =>
-      builder.append("<?xml version=\"")
-      builder.append(version.s)
-      builder.append('"')
+      producer.put("<?xml version=\"")
+      producer.put(version)
+      producer.put("\"")
 
       encoding.let: encoding =>
-        builder.append(" encoding=\"")
-        builder.append(encoding.s)
-        builder.append('"')
+        producer.put(" encoding=\"")
+        producer.put(encoding)
+        producer.put("\"")
 
       standalone.let: standalone =>
-        builder.append(if standalone then " standalone=\"yes\"" else " standalone=\"no\"")
+        producer.put(if standalone then " standalone=\"yes\"" else " standalone=\"no\"")
 
-      builder.append("?>")
+      producer.put("?>")
 
-    case Element(tagname, attributes, children) =>
-      builder.append('<')
-      builder.append(tagname.s)
+    case Element(label, attributes, children) =>
+      producer.put("<")
+      producer.put(label)
 
-      if !attributes.nil then attributes.foreach: (key, value) =>
-        builder.append(' ')
-        builder.append(key.s)
-        builder.append("=\"")
-        appendEscapedAttribute(builder, value)
-        builder.append('"')
+      if !attributes.nil then attributes.each: (key, value) =>
+        producer.put(" ")
+        producer.put(key)
+        producer.put("=\"")
+        writeEscapedAttribute(producer, value)
+        producer.put("\"")
 
-      if children.nil then builder.append("/>") else
-        builder.append('>')
-        var index = 0
-
-        while index < children.length do
-          appendXml(builder, children(index))
-          index += 1
-
-        builder.append("</")
-        builder.append(tagname.s)
-        builder.append('>')
+      if children.nil then producer.put("/>") else
+        producer.put(">")
+        children.each(writeXml(producer, _))
+        producer.put("</")
+        producer.put(label)
+        producer.put(">")
 
   given showable: [xml <: Xml] => xml is Showable = node =>
-    val builder = jl.StringBuilder()
-    appendXml(builder, node)
-    builder.toString.tt
+    Producer.collect[Text](): producer =>
+      writeXml(producer, node)
 
 
   private enum Token:

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -671,7 +671,7 @@ object Tests extends Suite(m"Xylophone tests"):
 
       test(m"Element escapes special characters in text"):
         elem(t"a", TextNode(t"<&>")).show
-      . assert(_ == t"<a>&lt;&amp;></a>")
+      . assert(_ == t"<a>&lt;&amp;&gt;</a>")
 
       test(m"Element escapes special characters in attribute"):
         elem(t"a", Map(t"x" -> t"\"&'<")).show

--- a/lib/ypsiloid/src/core/ypsiloid.YamlPrinter.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlPrinter.scala
@@ -35,7 +35,10 @@ package ypsiloid
 import scala.compiletime.asMatchable
 
 import anticipation.*
+import denominative.*
 import gossamer.*
+import parasite.*
+import zephyrine.*
 
 // Renders a `Yaml.Ast` back to YAML text in block style. Mirrors
 // `jacinta.JsonPrinter`. The emitter is deliberately conservative so that
@@ -58,139 +61,159 @@ import gossamer.*
 // `IArray[Any]` (with a trailing `arrayPad` sentinel when the item count is
 // even). Mappings and sequences are told apart by length parity.
 object YamlPrinter:
-  def print(yaml: Yaml.Ast): Text = Text.build:
-    def spaces(n: Int): Unit =
-      var i = 0
+  private val spaces: Text =
+    t"                                                                "
 
-      while i < n do
-        append(' ')
-        i += 1
+  def print(yaml: Yaml.Ast): Text =
+    Producer.collect[Text](): producer =>
+      write(producer, yaml)
 
-    // A string is safe to emit as a plain scalar when it is a leading-letter
-    // run of `[A-Za-z0-9_-]` (no whitespace or indicator characters, never
-    // empty) that the parser would not resolve as a boolean or null.
-    def plainSafe(string: String): Boolean =
-      val length = string.length
+  def emit(yaml: Yaml.Ast)(using Monitor, Probate): Iterator[Text] =
+    val producer = Producer[Text](4096)
 
-      if length == 0 then false else
-        val head = string.charAt(0)
+    async:
+      write(producer, yaml)
+      producer.finish()
 
-        if !((head >= 'A' && head <= 'Z') || (head >= 'a' && head <= 'z')) then false
-        else
-          var ok = true
-          var i = 0
+    producer.iterator
 
-          while i < length && ok do
-            val c = string.charAt(i)
-            if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-                || (c >= '0' && c <= '9') || c == '_' || c == '-')
-            then ok = false
+  // A string is safe to emit as a plain scalar when it is a leading-letter run of `[A-Za-z0-9_-]`
+  // (no whitespace or indicator characters, never empty) that the parser would not resolve as a
+  // boolean or null.
+  private def plainSafe(string: String): Boolean =
+    val length = string.length
 
-            i += 1
+    if length == 0 then false else
+      val head = string.charAt(0)
 
-          ok && (string match
-            case "null" | "Null" | "NULL" | "true" | "True" | "TRUE"
-                | "false" | "False" | "FALSE" => false
-            case _                            => true)
-
-    def appendString(string: String): Unit =
-      if plainSafe(string) then append(string) else
-        append('"')
+      if !((head >= 'A' && head <= 'Z') || (head >= 'a' && head <= 'z')) then false
+      else
+        var ok = true
         var i = 0
 
-        while i < string.length do
-          string.charAt(i) match
-            case '"'  => append(t"\\\"")
-            case '\\' => append(t"\\\\")
-            case '\n' => append(t"\\n")
-            case '\r' => append(t"\\r")
-            case '\t' => append(t"\\t")
-
-            case c =>
-              if c < ' ' then
-                val hex = Integer.toHexString(c.toInt).nn
-                append(t"\\u")
-                var z = hex.length
-
-                while z < 4 do
-                  append('0')
-                  z += 1
-
-                append(hex.tt)
-              else
-                append(c)
+        while i < length && ok do
+          val c = string.charAt(i)
+          if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
+              || (c >= '0' && c <= '9') || c == '_' || c == '-')
+          then ok = false
 
           i += 1
 
-        append('"')
+        if !ok then false else string match
+          case "null" | "Null" | "NULL" | "true" | "True" | "TRUE" | "false" | "False"
+          | "FALSE" =>
+            false
+
+          case _ =>
+            true
+
+  private def unicode(char: Char): Text =
+    val hex = Integer.toHexString(char.toInt).nn
+    Text("\\u" + "0"*(4 - hex.length) + hex)
+
+  private def write(producer: Producer[Text], yaml: Yaml.Ast): Unit =
+    def indent(count: Int): Unit =
+      var remaining = count
+
+      while remaining > 0 do
+        val chunk = remaining.min(64)
+        producer.put(spaces, Prim, chunk)
+        remaining -= chunk
+
+    def writeString(string: String): Unit =
+      if plainSafe(string) then producer.put(string.tt) else
+        producer.put("\"")
+        val length = string.length
+        var start = 0
+        var index = 0
+
+        inline def escape(entity: Text): Unit =
+          if index > start then producer.put(string.tt, start.z, index - start)
+          producer.put(entity)
+          start = index + 1
+
+        while index < length do
+          string.charAt(index) match
+            case '"'          => escape(t"\\\"")
+            case '\\'         => escape(t"\\\\")
+            case '\n'         => escape(t"\\n")
+            case '\r'         => escape(t"\\r")
+            case '\t'         => escape(t"\\t")
+            case c if c < ' ' => escape(unicode(c))
+            case _            => ()
+
+          index += 1
+
+        if length > start then producer.put(string.tt, start.z, length - start)
+        producer.put("\"")
 
     // Emit a scalar (or an empty collection) with no surrounding newlines.
     def scalar(ast: Yaml.Ast): Unit = ast.asMatchable match
-      case bcd: Array[Double] @unchecked => append(bcd.asInstanceOf[jacinta.Bcd].text.tt)
-      case n: Long                       => append(n.toString)
+      case bcd: Array[Double] @unchecked => producer.put(bcd.asInstanceOf[jacinta.Bcd].text.tt)
+      case n: Long                       => producer.put(n.toString.tt)
 
       case d: Double =>
-        if d.isNaN then append(t".nan")
-        else if d == Double.PositiveInfinity then append(t".inf")
-        else if d == Double.NegativeInfinity then append(t"-.inf")
-        else append(d.toString)
+        if d.isNaN then producer.put(".nan")
+        else if d == Double.PositiveInfinity then producer.put(".inf")
+        else if d == Double.NegativeInfinity then producer.put("-.inf")
+        else producer.put(d.toString.tt)
 
-      case b: Boolean => append(if b then t"true" else t"false")
-      case s: String  => appendString(s)
+      case b: Boolean => producer.put(if b then "true" else "false")
+      case s: String  => writeString(s)
 
       case xs: IArray[Any] @unchecked =>
-        if (xs.length & 1) == 0 then append(t"{}") else append(t"[]")
+        if (xs.length & 1) == 0 then producer.put("{}") else producer.put("[]")
 
-      case _ => append(t"null")
+      case _ => producer.put("null")
 
-    // Scalars and empty collections render on one line; non-empty collections
-    // span multiple indented lines.
+    // Scalars and empty collections render on one line; non-empty collections span multiple lines.
     def inlineable(ast: Yaml.Ast): Boolean = ast.asMatchable match
       case xs: IArray[Any] @unchecked =>
         if (xs.length & 1) == 0 then xs.length == 0 else Yaml.Ast.sequenceLength(xs) == 0
 
       case _ => true
 
-    // Emit the value after a `key:` or `- ` marker: inline when scalar/empty,
-    // otherwise on following lines indented one step deeper.
-    def value(ast: Yaml.Ast, indent: Int): Unit =
+    // Emit the value after a `key:` or `- ` marker: inline when scalar/empty, otherwise on
+    // following lines indented one step deeper.
+    def value(ast: Yaml.Ast, level: Int): Unit =
       if inlineable(ast) then
-        append(' ')
+        producer.put(" ")
         scalar(ast)
-        append('\n')
+        producer.put("\n")
       else
-        append('\n')
-        block(ast, indent + 2)
+        producer.put("\n")
+        block(ast, level + 2)
 
-    def block(ast: Yaml.Ast, indent: Int): Unit = ast.asMatchable match
+    def block(ast: Yaml.Ast, level: Int): Unit = ast.asMatchable match
       case xs: IArray[Any] @unchecked =>
         if (xs.length & 1) == 0 then
           val n = xs.length/2
           var i = 0
 
           while i < n do
-            spaces(indent)
+            indent(level)
             scalar(xs(i*2).asInstanceOf[Yaml.Ast])
-            append(':')
-            value(xs(i*2 + 1).asInstanceOf[Yaml.Ast], indent)
+            producer.put(":")
+            value(xs(i*2 + 1).asInstanceOf[Yaml.Ast], level)
             i += 1
         else
           val n = Yaml.Ast.sequenceLength(xs)
           var i = 0
 
           while i < n do
-            spaces(indent)
-            append('-')
-            value(xs(i).asInstanceOf[Yaml.Ast], indent)
+            indent(level)
+            producer.put("-")
+            value(xs(i).asInstanceOf[Yaml.Ast], level)
             i += 1
 
       case _ => ()
 
     if inlineable(yaml) then
       scalar(yaml)
-      append('\n')
+      producer.put("\n")
     else
       block(yaml, 0)
+
 
 trait YamlPrinter:
   def print(yaml: Yaml.Ast): Text

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Cursor, Datum, Emittable, Emitter, Format, Lineation, ParseError}
+export zephyrine.{Addressable, Cursor, Datum, Format, Lineation, ParseError, Producer, Producible}

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Cursor, Datum, Format, Lineation, ParseError, Producer, Producible}
+export zephyrine.{Addressable, Cursor, Datum, Format, Lineation, ParseError, Producer}

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -68,6 +68,12 @@ object Addressable:
     inline def storageSize(storage: Array[Byte]): Int = storage.length
     inline def storageAddress(storage: Array[Byte], index: Int): Byte = storage(index)
 
+    inline def storageUpdate(storage: Array[Byte], index: Int, operand: Byte): Unit =
+      storage(index) = operand
+
+    inline def append(target: ji.ByteArrayOutputStream, operand: Byte): Unit =
+      target.write(operand.toInt)
+
     inline def copyChunk
       ( source:  Data,
        srcOff:  Int,
@@ -121,6 +127,11 @@ object Addressable:
     inline def storageSize(storage: Array[Char]): Int = storage.length
     inline def storageAddress(storage: Array[Char], index: Int): Char = storage(index)
 
+    inline def storageUpdate(storage: Array[Char], index: Int, operand: Char): Unit =
+      storage(index) = operand
+
+    inline def append(target: jl.StringBuilder, operand: Char): Unit = target.append(operand)
+
     inline def copyChunk
       ( source:  Text,
        srcOff:  Int,
@@ -171,6 +182,11 @@ trait Addressable extends Typeclass, Operable, Targetable:
   def allocate(size: Int): Storage
   def storageSize(storage: Storage): Int
   def storageAddress(storage: Storage, index: Int): Operand
+
+  // Single-`Operand` writes: one element into the chunk storage (`storageUpdate`) or appended to
+  // the builder (`append`). These back `Producer.push` for element-at-a-time producers.
+  def storageUpdate(storage: Storage, index: Int, operand: Operand): Unit
+  def append(target: Target, operand: Operand): Unit
 
   def copyChunk
     ( source: Self, srcOff: Int, dest: Storage, destOff: Int, len: Int )

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -34,6 +34,7 @@ package zephyrine
 
 import java.util.concurrent as juc
 
+import anticipation.Data
 import denominative.*
 
 // A sink into which a value of one medium is written in pieces. The same producing code can be
@@ -43,6 +44,11 @@ import denominative.*
 // allocates per `put` along a contiguous run. `Operand` is the element type — `Char` for
 // `Producer[Text]`, `Byte` for `Producer[Data]` — and types the element-at-a-time `push`.
 object Producer:
+  // A byte producer: `Producer[Data]` with its element type pinned to `Byte`, the shape binary
+  // encoders (CBOR, Protobuf, …) write into. `Producer[Data](…)` / `Producer.collect[Data]` already
+  // surface this refinement; this alias names it for helper signatures.
+  type Bytes = Producer[Data] { type Operand = Byte }
+
   // Streaming: chunks are queued (with backpressure) and drained through `iterator`. The producing
   // code must run on a separate fiber, since `put` blocks once the window is full.
   def apply[medium](block: Int = 4096, window: Int = 2)(using addr: medium is Addressable)

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import java.io as ji
+import java.lang as jl
 import java.util.concurrent as juc
 
 import anticipation.*
@@ -39,26 +41,30 @@ import denominative.*
 import rudiments.*
 import vacuous.*
 
-object Emittable:
-  inline given text: Emittable:
+object Producible:
+  inline given text: Producible:
     type Self = Text
-    type Source = Text
     type Transport = Array[Char]
+    type Builder = jl.StringBuilder
 
     def length(text: Text): Int = text.s.length
-    def produce(block: Array[Char], size: Int): Text = new String(block, 0, size).tt
+    def produce(block: Array[Char], size: Int): Text = String(block, 0, size).tt
     def allocate(size: Int): Array[Char] = new Array[Char](size)
 
-
-    inline def copy(source: Text, start: Ordinal, target: Array[Char], index: Ordinal, size: Int)
-    :   Unit =
-
+    def copy(source: Text, start: Ordinal, target: Array[Char], index: Ordinal, size: Int): Unit =
       source.s.getChars(start.n0, start.n0 + size, target, index.n0)
 
-  inline given bytes: Emittable:
+    def builder(hint: Int): jl.StringBuilder = jl.StringBuilder(hint)
+
+    def append(builder: jl.StringBuilder, source: Text, start: Ordinal, size: Int): Unit =
+      builder.append(source.s, start.n0, start.n0 + size)
+
+    def build(builder: jl.StringBuilder): Text = builder.toString.tt
+
+  inline given bytes: Producible:
     type Self = Data
-    type Source = Data
     type Transport = Array[Byte]
+    type Builder = ji.ByteArrayOutputStream
 
     def produce(block: Array[Byte], size: Int): Data =
       java.util.Arrays.copyOfRange(block, 0, size).nn.immutable(using Unsafe)
@@ -66,71 +72,120 @@ object Emittable:
     def length(bytes: Data): Int = bytes.length
     def allocate(size: Int): Array[Byte] = new Array[Byte](size)
 
+    def copy(source: Data, start: Ordinal, target: Array[Byte], index: Ordinal, size: Int): Unit =
+      System.arraycopy(source.mutable(using Unsafe), start.n0, target, index.n0, size)
 
-    inline def copy(source: Data, start: Ordinal, target: Array[Byte], index: Ordinal, size: Int)
-    :   Unit =
+    def builder(hint: Int): ji.ByteArrayOutputStream = ji.ByteArrayOutputStream(hint)
 
-      System.arraycopy(source.mutable(using Unsafe), start.n0, target, index.n0, index.n0 + size)
+    def append(builder: ji.ByteArrayOutputStream, source: Data, start: Ordinal, size: Int): Unit =
+      builder.write(source.mutable(using Unsafe), start.n0, size)
+
+    def build(builder: ji.ByteArrayOutputStream): Data =
+      builder.toByteArray.nn.immutable(using Unsafe)
 
 
-trait Emittable:
+// A medium (text or bytes) that output can be produced into. The `allocate`/`copy`/`produce`
+// trio backs the chunked streaming path; the `builder`/`append`/`build` trio backs synchronous
+// collection. `Self` is both the medium written in pieces and the value finally produced.
+trait Producible:
   type Self
-  type Source
   type Transport
+  type Builder
 
   def allocate(size: Int): Transport
-  def length(input: Source): Int
+  def length(value: Self): Int
   def produce(block: Transport, size: Int): Self
 
-  inline def copy
-    ( source: Source,
+  def copy
+    ( source: Self,
       start:  Ordinal,
       target: Transport,
       index:  Ordinal,
       size:   Int )
   :   Unit
 
+  def builder(hint: Int): Builder
+  def append(builder: Builder, source: Self, start: Ordinal, size: Int): Unit
+  def build(builder: Builder): Self
 
-class Emitter[data: Emittable](block: Int = 4096, window: Int = 2):
-  private object Done
 
-  private val queue: juc.ArrayBlockingQueue[data | Done.type] = juc.ArrayBlockingQueue(window)
-  private val current: data.Transport = data.allocate(block)
+// A sink into which a value of one medium is written in pieces. The same producing code can be
+// driven two ways without duplicating it: `Producer.collect` runs it synchronously and returns the
+// whole result, while `Producer.apply` (streaming) writes chunks into a bounded buffer drained
+// lazily through `iterator` — the producing code then runs on a separate fiber. Neither path
+// allocates per `put` along a contiguous run.
+object Producer:
+  // Streaming: chunks are queued (with backpressure) and drained through `iterator`. The producing
+  // code must run on a separate fiber, since `put` blocks once the window is full.
+  def apply[medium: Producible](block: Int = 4096, window: Int = 2): Channel[medium] =
+    Channel(block, window)
 
-  private var index: Ordinal = Prim
+  // Synchronous: run `body`, accumulating directly into a builder, and return the whole value. No
+  // concurrency, no chunk buffer, and none of the streaming path's single-thread deadlock risk.
+  def collect[medium: Producible as medium2](hint: Int = 4096)
+    ( body: Producer[medium] => Unit )
+  :   medium =
 
-  inline def free: Int = block - index.n0
+    val builder = medium2.builder(hint)
 
-  inline def finish(): Unit =
-    publish()
-    queue.put(Done)
+    val producer = new Producer[medium]:
+      def put(source: medium): Unit =
+        medium2.append(builder, source, Prim, medium2.length(source))
 
-  inline def put(input: data.Source): Unit = put(input, Prim, data.length(input))
+      def put(source: medium, offset: Ordinal, size: Int): Unit =
+        medium2.append(builder, source, offset, size)
 
-  inline def publish(): Unit =
-    if index != Prim then
-      queue.put(data.produce(current, index.n0))
-      index = Prim
+    body(producer)
+    medium2.build(builder)
 
-  inline def put(source: data.Source, offset: Ordinal, size: Int): Unit =
-    var done = 0
+  final class Channel[medium: Producible as medium2](block: Int, window: Int)
+  extends Producer[medium]:
 
-    while size - done > free do
-      data.copy(source, (offset.n0 + done).z, current, index, free)
-      done += free
-      index = (index.n0 + free).z
+    private object Done
+
+    private val queue: juc.ArrayBlockingQueue[medium | Done.type] =
+      juc.ArrayBlockingQueue(window)
+
+    private val current: medium2.Transport = medium2.allocate(block)
+    private var index: Ordinal = Prim
+
+    private inline def free: Int = block - index.n0
+
+    private inline def publish(): Unit =
+      if index != Prim then
+        queue.put(medium2.produce(current, index.n0))
+        index = Prim
+
+    def put(source: medium): Unit = put(source, Prim, medium2.length(source))
+
+    def put(source: medium, offset: Ordinal, size: Int): Unit =
+      var done = 0
+
+      while size - done > free do
+        medium2.copy(source, (offset.n0 + done).z, current, index, free)
+        done += free
+        index = (index.n0 + free).z
+        publish()
+
+      medium2.copy(source, (offset.n0 + done).z, current, index, size - done)
+      index = (index.n0 + size - done).z
+
+      if free == 0 then publish()
+
+    def finish(): Unit =
       publish()
+      queue.put(Done)
 
-    data.copy(source, (offset.n0 + done).z, current, index, size - done)
-    index = (index.n0 + size - done).z
+    lazy val iterator: Iterator[medium] = new Iterator[medium]:
+      private var ready: medium | Done.type = Done
 
-    if free == 0 then publish()
+      def hasNext: Boolean =
+        ready = queue.take().nn
+        ready != Done
 
-  lazy val iterator: Iterator[data] = new Iterator[data]:
-    private var ready: data | Done.type = Done
+      def next(): medium = ready.asInstanceOf[medium]
 
-    def hasNext: Boolean =
-      ready = queue.take().nn
-      ready != Done
 
-    def next(): data = ready.asInstanceOf[data]
+trait Producer[medium]:
+  def put(source: medium): Unit
+  def put(source: medium, offset: Ordinal, size: Int): Unit

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -32,173 +32,85 @@
                                                                                                   */
 package zephyrine
 
-import java.io as ji
-import java.lang as jl
 import java.util.concurrent as juc
 
-import anticipation.*
 import denominative.*
-import rudiments.*
-import vacuous.*
-
-object Producible:
-  inline given text: Producible:
-    type Self = Text
-    type Transport = Array[Char]
-    type Builder = jl.StringBuilder
-    type Element = Char
-
-    def length(text: Text): Int = text.s.length
-    def produce(block: Array[Char], size: Int): Text = String(block, 0, size).tt
-    def allocate(size: Int): Array[Char] = new Array[Char](size)
-
-    def copy(source: Text, start: Ordinal, target: Array[Char], index: Ordinal, size: Int): Unit =
-      source.s.getChars(start.n0, start.n0 + size, target, index.n0)
-
-    def builder(hint: Int): jl.StringBuilder = jl.StringBuilder(hint)
-
-    def append(builder: jl.StringBuilder, source: Text, start: Ordinal, size: Int): Unit =
-      builder.append(source.s, start.n0, start.n0 + size)
-
-    def build(builder: jl.StringBuilder): Text = builder.toString.tt
-    def writeElement(builder: jl.StringBuilder, element: Char): Unit = builder.append(element)
-
-    def setElement(target: Array[Char], index: Ordinal, element: Char): Unit =
-      target(index.n0) = element
-
-  inline given bytes: Producible:
-    type Self = Data
-    type Transport = Array[Byte]
-    type Builder = ji.ByteArrayOutputStream
-    type Element = Byte
-
-    def produce(block: Array[Byte], size: Int): Data =
-      java.util.Arrays.copyOfRange(block, 0, size).nn.immutable(using Unsafe)
-
-    def length(bytes: Data): Int = bytes.length
-    def allocate(size: Int): Array[Byte] = new Array[Byte](size)
-
-    def copy(source: Data, start: Ordinal, target: Array[Byte], index: Ordinal, size: Int): Unit =
-      System.arraycopy(source.mutable(using Unsafe), start.n0, target, index.n0, size)
-
-    def builder(hint: Int): ji.ByteArrayOutputStream = ji.ByteArrayOutputStream(hint)
-
-    def append(builder: ji.ByteArrayOutputStream, source: Data, start: Ordinal, size: Int): Unit =
-      builder.write(source.mutable(using Unsafe), start.n0, size)
-
-    def build(builder: ji.ByteArrayOutputStream): Data =
-      builder.toByteArray.nn.immutable(using Unsafe)
-
-    def writeElement(builder: ji.ByteArrayOutputStream, element: Byte): Unit =
-      builder.write(element.toInt)
-
-    def setElement(target: Array[Byte], index: Ordinal, element: Byte): Unit =
-      target(index.n0) = element
-
-
-// A medium (text or bytes) that output can be produced into. The `allocate`/`copy`/`produce`
-// trio backs the chunked streaming path; the `builder`/`append`/`build` trio backs synchronous
-// collection. `Self` is both the medium written in pieces and the value finally produced.
-trait Producible:
-  type Self
-  type Transport
-  type Builder
-  type Element
-
-  def allocate(size: Int): Transport
-  def length(value: Self): Int
-  def produce(block: Transport, size: Int): Self
-
-  def copy
-    ( source: Self,
-      start:  Ordinal,
-      target: Transport,
-      index:  Ordinal,
-      size:   Int )
-  :   Unit
-
-  def builder(hint: Int): Builder
-  def append(builder: Builder, source: Self, start: Ordinal, size: Int): Unit
-  def build(builder: Builder): Self
-
-  // Single-element writes (`Char` for text, `Byte` for bytes), backing `Producer.push` for
-  // element-at-a-time producers such as binary encoders.
-  def writeElement(builder: Builder, element: Element): Unit
-  def setElement(target: Transport, index: Ordinal, element: Element): Unit
-
 
 // A sink into which a value of one medium is written in pieces. The same producing code can be
 // driven two ways without duplicating it: `Producer.collect` runs it synchronously and returns the
 // whole result, while `Producer.apply` (streaming) writes chunks into a bounded buffer drained
 // lazily through `iterator` — the producing code then runs on a separate fiber. Neither path
-// allocates per `put` along a contiguous run.
+// allocates per `put` along a contiguous run. `Operand` is the element type — `Char` for
+// `Producer[Text]`, `Byte` for `Producer[Data]` — and types the element-at-a-time `push`.
 object Producer:
   // Streaming: chunks are queued (with backpressure) and drained through `iterator`. The producing
   // code must run on a separate fiber, since `put` blocks once the window is full.
-  def apply[medium: Producible](block: Int = 4096, window: Int = 2): Channel[medium] =
-    Channel(block, window)
+  def apply[medium](block: Int = 4096, window: Int = 2)(using addr: medium is Addressable)
+  :   Channel[medium] { type Operand = addr.Operand } =
 
-  // Write a single element: a `Char` for `Producer[Text]`, a `Byte` for `Producer[Data]`.
-  extension [medium](producer: Producer[medium])(using element: ElementType[medium])
-    def push(value: element.Element): Unit = producer.pushElement(value)
+    Channel(block, window)(using addr)
 
   // Synchronous: run `body`, accumulating directly into a builder, and return the whole value. No
   // concurrency, no chunk buffer, and none of the streaming path's single-thread deadlock risk.
-  def collect[medium: Producible as medium2](hint: Int = 4096)
-    ( body: Producer[medium] => Unit )
+  def collect[medium](using addressable: medium is Addressable)(hint: Int = 4096)
+    ( body: (Producer[medium] { type Operand = addressable.Operand }) => Unit )
   :   medium =
 
-    val builder = medium2.builder(hint)
+    val target = addressable.blank(hint)
 
     val producer = new Producer[medium]:
+      type Operand = addressable.Operand
+
       def put(source: medium): Unit =
-        medium2.append(builder, source, Prim, medium2.length(source))
+        val size = addressable.length(source)
+        if size > 0 then addressable.clone(source, Prim, (size - 1).z)(target)
 
       def put(source: medium, offset: Ordinal, size: Int): Unit =
-        medium2.append(builder, source, offset, size)
+        if size > 0 then addressable.clone(source, offset, (offset.n0 + size - 1).z)(target)
 
-      def pushElement(element: Any): Unit =
-        medium2.writeElement(builder, element.asInstanceOf[medium2.Element])
+      def push(operand: Operand): Unit = addressable.append(target, operand)
 
     body(producer)
-    medium2.build(builder)
+    addressable.build(target)
 
-  final class Channel[medium: Producible as medium2](block: Int, window: Int)
+  final class Channel[medium](block: Int, window: Int)(using val addressable: medium is Addressable)
   extends Producer[medium]:
+
+    type Operand = addressable.Operand
 
     private object Done
 
     private val queue: juc.ArrayBlockingQueue[medium | Done.type] =
       juc.ArrayBlockingQueue(window)
 
-    private val current: medium2.Transport = medium2.allocate(block)
+    private val current: addressable.Storage = addressable.allocate(block)
     private var index: Ordinal = Prim
 
     private inline def free: Int = block - index.n0
 
     private inline def publish(): Unit =
       if index != Prim then
-        queue.put(medium2.produce(current, index.n0))
+        queue.put(addressable.materialize(current, 0, index.n0))
         index = Prim
 
-    def put(source: medium): Unit = put(source, Prim, medium2.length(source))
+    def put(source: medium): Unit = put(source, Prim, addressable.length(source))
 
     def put(source: medium, offset: Ordinal, size: Int): Unit =
       var done = 0
 
       while size - done > free do
-        medium2.copy(source, (offset.n0 + done).z, current, index, free)
+        addressable.copyChunk(source, offset.n0 + done, current, index.n0, free)
         done += free
         index = (index.n0 + free).z
         publish()
 
-      medium2.copy(source, (offset.n0 + done).z, current, index, size - done)
+      addressable.copyChunk(source, offset.n0 + done, current, index.n0, size - done)
       index = (index.n0 + size - done).z
 
       if free == 0 then publish()
 
-    def pushElement(element: Any): Unit =
-      medium2.setElement(current, index, element.asInstanceOf[medium2.Element])
+    def push(operand: Operand): Unit =
+      addressable.storageUpdate(current, index.n0, operand)
       index = (index.n0 + 1).z
       if free == 0 then publish()
 
@@ -216,25 +128,10 @@ object Producer:
       def next(): medium = ready.asInstanceOf[medium]
 
 
-// Maps a medium to its element type — a `Char` for `Text`, a `Byte` for `Data` — so that the
-// `push` extension below is statically typed per medium. (A match type can't do this: `Text` is
-// opaque, so `Text`/`Data` disjointness isn't provable either way round.)
-object ElementType:
-  given text: (ElementType[Text] { type Element = Char }) =
-    new ElementType[Text]:
-      type Element = Char
-
-  given bytes: (ElementType[Data] { type Element = Byte }) =
-    new ElementType[Data]:
-      type Element = Byte
-
-trait ElementType[medium]:
-  type Element
-
 trait Producer[medium]:
+  type Operand
   def put(source: medium): Unit
   def put(source: medium, offset: Ordinal, size: Int): Unit
 
-  // Append one element. The typed entry point is the `push` extension; the parameter here is `Any`
-  // because the trait can't name the element type without it erasing identically to `put(medium)`.
-  def pushElement(element: Any): Unit
+  // Write a single element: a `Char` for `Producer[Text]`, a `Byte` for `Producer[Data]`.
+  def push(operand: Operand): Unit

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -46,6 +46,7 @@ object Producible:
     type Self = Text
     type Transport = Array[Char]
     type Builder = jl.StringBuilder
+    type Element = Char
 
     def length(text: Text): Int = text.s.length
     def produce(block: Array[Char], size: Int): Text = String(block, 0, size).tt
@@ -60,11 +61,16 @@ object Producible:
       builder.append(source.s, start.n0, start.n0 + size)
 
     def build(builder: jl.StringBuilder): Text = builder.toString.tt
+    def writeElement(builder: jl.StringBuilder, element: Char): Unit = builder.append(element)
+
+    def setElement(target: Array[Char], index: Ordinal, element: Char): Unit =
+      target(index.n0) = element
 
   inline given bytes: Producible:
     type Self = Data
     type Transport = Array[Byte]
     type Builder = ji.ByteArrayOutputStream
+    type Element = Byte
 
     def produce(block: Array[Byte], size: Int): Data =
       java.util.Arrays.copyOfRange(block, 0, size).nn.immutable(using Unsafe)
@@ -83,6 +89,12 @@ object Producible:
     def build(builder: ji.ByteArrayOutputStream): Data =
       builder.toByteArray.nn.immutable(using Unsafe)
 
+    def writeElement(builder: ji.ByteArrayOutputStream, element: Byte): Unit =
+      builder.write(element.toInt)
+
+    def setElement(target: Array[Byte], index: Ordinal, element: Byte): Unit =
+      target(index.n0) = element
+
 
 // A medium (text or bytes) that output can be produced into. The `allocate`/`copy`/`produce`
 // trio backs the chunked streaming path; the `builder`/`append`/`build` trio backs synchronous
@@ -91,6 +103,7 @@ trait Producible:
   type Self
   type Transport
   type Builder
+  type Element
 
   def allocate(size: Int): Transport
   def length(value: Self): Int
@@ -108,6 +121,11 @@ trait Producible:
   def append(builder: Builder, source: Self, start: Ordinal, size: Int): Unit
   def build(builder: Builder): Self
 
+  // Single-element writes (`Char` for text, `Byte` for bytes), backing `Producer.push` for
+  // element-at-a-time producers such as binary encoders.
+  def writeElement(builder: Builder, element: Element): Unit
+  def setElement(target: Transport, index: Ordinal, element: Element): Unit
+
 
 // A sink into which a value of one medium is written in pieces. The same producing code can be
 // driven two ways without duplicating it: `Producer.collect` runs it synchronously and returns the
@@ -119,6 +137,10 @@ object Producer:
   // code must run on a separate fiber, since `put` blocks once the window is full.
   def apply[medium: Producible](block: Int = 4096, window: Int = 2): Channel[medium] =
     Channel(block, window)
+
+  // Write a single element: a `Char` for `Producer[Text]`, a `Byte` for `Producer[Data]`.
+  extension [medium](producer: Producer[medium])(using element: ElementType[medium])
+    def push(value: element.Element): Unit = producer.pushElement(value)
 
   // Synchronous: run `body`, accumulating directly into a builder, and return the whole value. No
   // concurrency, no chunk buffer, and none of the streaming path's single-thread deadlock risk.
@@ -134,6 +156,9 @@ object Producer:
 
       def put(source: medium, offset: Ordinal, size: Int): Unit =
         medium2.append(builder, source, offset, size)
+
+      def pushElement(element: Any): Unit =
+        medium2.writeElement(builder, element.asInstanceOf[medium2.Element])
 
     body(producer)
     medium2.build(builder)
@@ -172,6 +197,11 @@ object Producer:
 
       if free == 0 then publish()
 
+    def pushElement(element: Any): Unit =
+      medium2.setElement(current, index, element.asInstanceOf[medium2.Element])
+      index = (index.n0 + 1).z
+      if free == 0 then publish()
+
     def finish(): Unit =
       publish()
       queue.put(Done)
@@ -186,6 +216,25 @@ object Producer:
       def next(): medium = ready.asInstanceOf[medium]
 
 
+// Maps a medium to its element type — a `Char` for `Text`, a `Byte` for `Data` — so that the
+// `push` extension below is statically typed per medium. (A match type can't do this: `Text` is
+// opaque, so `Text`/`Data` disjointness isn't provable either way round.)
+object ElementType:
+  given text: (ElementType[Text] { type Element = Char }) =
+    new ElementType[Text]:
+      type Element = Char
+
+  given bytes: (ElementType[Data] { type Element = Byte }) =
+    new ElementType[Data]:
+      type Element = Byte
+
+trait ElementType[medium]:
+  type Element
+
 trait Producer[medium]:
   def put(source: medium): Unit
   def put(source: medium, offset: Ordinal, size: Int): Unit
+
+  // Append one element. The typed entry point is the `push` extension; the parameter here is `Any`
+  // because the trait can't name the element type without it erasing identically to `put(medium)`.
+  def pushElement(element: Any): Unit

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -177,6 +177,33 @@ object Tests extends Suite(m"Zephyrine tests"):
           producer.put(Data.fill(5)(i => (i + 10).toByte))
       . assert(_.to(List) == List[Byte](0, 1, 2, 10, 11, 12, 13, 14))
 
+      test(m"Push bytes one at a time (synchronous)"):
+        Producer.collect[Data](): producer =>
+          var i = 0
+          while i < 6 do
+            producer.push((i*2).toByte)
+            i += 1
+      . assert(_.to(List) == List[Byte](0, 2, 4, 6, 8, 10))
+
+      test(m"Push bytes across a block boundary (streaming)"):
+        val producer = Producer[Data](4)
+        val output = async(producer.iterator.to(List))
+        var i = 0
+
+        while i < 10 do
+          producer.push(i.toByte)
+          i += 1
+
+        producer.finish()
+        unsafely(output.await()).flatMap(_.to(List))
+      . assert(_ == (0 until 10).map(_.toByte).to(List))
+
+      test(m"Push chars (synchronous text)"):
+        Producer.collect[Text](): producer =>
+          producer.push('h')
+          producer.push('i')
+      . assert(_ == "hi")
+
 
 
     suite(m"Cursor tests"):

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -43,111 +43,139 @@ object Tests extends Suite(m"Zephyrine tests"):
   val bytes = Data.fill(1000)(_.toByte)
   def run(): Unit = stochastic:
 
-    suite(m"Emitter tests"):
+    suite(m"Producer tests"):
       test(m"mismatched block size"):
-        val emitter = Emitter[Text](4, 20)
-        emitter.put("one")
-        emitter.put("two")
-        emitter.finish()
-        val it = async(emitter.iterator.to(List))
+        val producer = Producer[Text](4, 20)
+        producer.put("one")
+        producer.put("two")
+        producer.finish()
+        val it = async(producer.iterator.to(List))
 
         unsafely(it.await())
       . assert(_ == List("onet", "wo"))
 
       test(m"One block, exact size, ready immediately"):
-        val emitter = Emitter[Text](4, 3)
-        emitter.put("zero")
-        emitter.iterator
-        if emitter.iterator.hasNext then emitter.iterator.next() else ""
+        val producer = Producer[Text](4, 3)
+        producer.put("zero")
+        producer.iterator
+        if producer.iterator.hasNext then producer.iterator.next() else ""
       . assert(_ == "zero")
 
       test(m"Two blocks, exact size, ready immediately"):
-        val emitter = Emitter[Text](4, 2)
-        emitter.put("zerofour")
-        emitter.iterator
+        val producer = Producer[Text](4, 2)
+        producer.put("zerofour")
+        producer.iterator
         var out = ""
-        if emitter.iterator.hasNext then out += emitter.iterator.next()
-        if emitter.iterator.hasNext then out += emitter.iterator.next()
+        if producer.iterator.hasNext then out += producer.iterator.next()
+        if producer.iterator.hasNext then out += producer.iterator.next()
         out
       . assert(_ == "zerofour")
 
       test(m"More than two blocks, ready immediately"):
-        val emitter = Emitter[Text](4, 2)
-        emitter.put("zerofoursix")
-        emitter.iterator
+        val producer = Producer[Text](4, 2)
+        producer.put("zerofoursix")
+        producer.iterator
         var out = ""
-        if emitter.iterator.hasNext then out += emitter.iterator.next()
-        if emitter.iterator.hasNext then out += emitter.iterator.next()
+        if producer.iterator.hasNext then out += producer.iterator.next()
+        if producer.iterator.hasNext then out += producer.iterator.next()
         out
       . assert(_ == "zerofour")
 
       test(m"More than two blocks, fragmented, ready immediately"):
-        val emitter = Emitter[Text](4, 2)
-        emitter.put("12")
-        emitter.put("3")
-        emitter.put("4")
-        emitter.put("5")
-        emitter.put("6")
-        emitter.put("7")
-        emitter.put("8")
-        emitter.iterator
+        val producer = Producer[Text](4, 2)
+        producer.put("12")
+        producer.put("3")
+        producer.put("4")
+        producer.put("5")
+        producer.put("6")
+        producer.put("7")
+        producer.put("8")
+        producer.iterator
         var out = ""
-        if emitter.iterator.hasNext then out += emitter.iterator.next()
-        if emitter.iterator.hasNext then out += emitter.iterator.next()
+        if producer.iterator.hasNext then out += producer.iterator.next()
+        if producer.iterator.hasNext then out += producer.iterator.next()
         out
       . assert(_ == "12345678")
 
       test(m"Single long message, with blocking"):
-        val emitter = Emitter[Text](4, 2)
-        val out = async(emitter.iterator.to(List))
-        emitter.put("12345678901234567890")
-        emitter.finish()
+        val producer = Producer[Text](4, 2)
+        val out = async(producer.iterator.to(List))
+        producer.put("12345678901234567890")
+        producer.finish()
         unsafely(out.await())
       . assert(_ == List("1234", "5678", "9012", "3456", "7890"))
 
       test(m"Single long message, with blocking; incomplete final block"):
-        val emitter = Emitter[Text](4, 2)
-        val out = async(emitter.iterator.to(List))
-        emitter.put("123456789012345678")
-        emitter.finish()
+        val producer = Producer[Text](4, 2)
+        val out = async(producer.iterator.to(List))
+        producer.put("123456789012345678")
+        producer.finish()
         unsafely(out.await())
       . assert(_ == List("1234", "5678", "9012", "3456", "78"))
 
       for i <- 0 to 30 do
         val string = (0 to i).map(_.toString).foldLeft("")(_ + _)
         test(m"String length $i, sent whole, async puts"):
-          val emitter = Emitter[Text](5, 2)
-          val producer = async:
-            emitter.put(string)
-            emitter.finish()
-          emitter.iterator.foldLeft("")(_ + _)
+          val producer = Producer[Text](5, 2)
+          val fiber = async:
+            producer.put(string)
+            producer.finish()
+          producer.iterator.foldLeft("")(_ + _)
         . assert(_ == string)
 
         test(m"String length $i, sent unitarily, async puts"):
-          val emitter = Emitter[Text](5, 2)
-          val producer = async:
+          val producer = Producer[Text](5, 2)
+          val fiber = async:
             string.tt.chars.foreach: char =>
-              emitter.put(char.toString)
-            emitter.finish()
-          emitter.iterator.foldLeft("")(_ + _)
+              producer.put(char.toString)
+            producer.finish()
+          producer.iterator.foldLeft("")(_ + _)
         . assert(_ == string)
 
         test(m"String length $i, sent whole, async reads"):
-          val emitter = Emitter[Text](5, 2)
-          val output = async(emitter.iterator.foldLeft("")(_ + _))
-          emitter.put(string)
-          emitter.finish()
+          val producer = Producer[Text](5, 2)
+          val output = async(producer.iterator.foldLeft("")(_ + _))
+          producer.put(string)
+          producer.finish()
           unsafely(output.await())
         . assert(_ == string)
 
         test(m"String length $i, sent unitarily, async reads"):
-          val emitter = Emitter[Text](5, 2)
-          val output = async(emitter.iterator.foldLeft("")(_ + _))
+          val producer = Producer[Text](5, 2)
+          val output = async(producer.iterator.foldLeft("")(_ + _))
           string.tt.chars.each: char =>
-            emitter.put(char.toString)
-          emitter.finish()
+            producer.put(char.toString)
+          producer.finish()
           unsafely(output.await())
         . assert(_ == string)
+
+      test(m"Bytes producer copies a non-zero-offset put correctly"):
+        // The second `put` lands at buffer index 3, exercising the bytes-path
+        // `arraycopy` length (a regression here over-reads the source).
+        val producer = Producer[Data](8)
+        val output = async(producer.iterator.to(List))
+        producer.put(Data.fill(3)(_.toByte))
+        producer.put(Data.fill(5)(i => (i + 10).toByte))
+        producer.finish()
+        unsafely(output.await()).flatMap(_.to(List))
+      . assert(_ == List[Byte](0, 1, 2, 10, 11, 12, 13, 14))
+
+      test(m"Synchronous text collection joins puts"):
+        Producer.collect[Text](4): producer =>
+          producer.put("hello ")
+          producer.put("world")
+      . assert(_ == "hello world")
+
+      test(m"Synchronous collection of a sub-range"):
+        Producer.collect[Text](): producer =>
+          producer.put("--hello--", 2.z, 5)
+      . assert(_ == "hello")
+
+      test(m"Synchronous bytes collection"):
+        Producer.collect[Data](): producer =>
+          producer.put(Data.fill(3)(_.toByte))
+          producer.put(Data.fill(5)(i => (i + 10).toByte))
+      . assert(_.to(List) == List[Byte](0, 1, 2, 10, 11, 12, 13, 14))
 
 
 


### PR DESCRIPTION
Zephyrine's `Emitter` — the chunked, allocation-free output buffer — is renamed to `Producer` (its `Emittable` medium typeclass folded into the existing `Addressable`), and gains a synchronous `collect` driver alongside the streaming one, so producing a whole value no longer needs a background fiber. Every serialized format in Soundness — JSON, TEL, XML, CSS, YAML, HTML, CBOR, Protobuf and Markdown — now produces its output through `Producer`, allocation-free and with an optional streaming `emit`; several formats also pick up spec-correctness fixes uncovered while unifying their serializers.

## `Emitter` is now `Producer`

`zephyrine.Emitter` is renamed to `Producer`; its `Emittable` typeclass is gone, folded into the existing `Addressable`. A `Producer[medium]` is a sink you write pieces into, with two drivers:

```scala
// synchronous — returns the whole value, no fiber
val text: Text = Producer.collect[Text](): producer =>
  producer.put(t"hello, ")
  producer.put(t"world")

// streaming — chunks drained lazily through `iterator`, fed on a separate fiber
val producer = Producer[Text](4096)
```

`collect` is new: previously the only way to drive the buffer was a fiber plus a bounded queue, which deadlocks if used single-threaded. `collect` accumulates straight into a builder with no concurrency.

## Every format streams now

JSON, TEL, XML, CSS, YAML, HTML, CBOR, Protobuf and Markdown all produce through `Producer`. Each printer/serializer gained a streaming `emit` returning `Iterator[Text]` (or `Iterator[Data]` for the binary formats) alongside its synchronous entry point.

## Spec-correctness fixes

- **XML**: empty elements now self-close (`<a/>`), and text/attribute escaping is complete (`&`, `<`, `>`, the quote, and whitespace character references).
- **HTML**: `.show` now escapes text and attributes (previously it did not at all) and is DOM-aware, so void elements no longer get a bogus close tag — `<img>`, not `<img></img>`.
- **JSON**: string escaping now covers `\b` and every other `U+0000`–`U+001F` control character as `\uXXXX`.

## Markdown line wrapping

The Markdown serializer streams, and can word-wrap paragraphs at a configurable width:

```scala
given MarkdownWidth = MarkdownWidth.bounded(80)
val wrapped = markdown.source  // paragraphs wrapped at 80 columns
```

The default is unbounded, so existing output is unchanged.

## Byte-level output

`Producer.push` writes a single element — a `Char` for `Producer[Text]`, a `Byte` for `Producer[Data]` — which the CBOR and Protobuf encoders use to write wire bytes.
