### PR TITLE
Fix Burdock repackaging corruption from directory entries

### DIFF
--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -77,6 +77,17 @@ object Repackager:
   case class UserError(detail: Message)(using Diagnostics) extends Error(detail)
   case class RepackageError(detail: Message)(using Diagnostics) extends Error(detail)
 
+  // A record of what `repackage` did, returned so the caller can report it. The core
+  // logic stays free of I/O; the command-line entry point prints this.
+  case class Summary
+    ( inputEntries:       Int,
+      directoriesSkipped: Int,
+      ownKept:            Int,
+      externalized:       List[Requirement],
+      inlined:            Int,
+      stripped:           Int,
+      outputEntries:      Int )
+
   // Resolves a dependency hash to its public URL (deps.dev), or `Unset`.
   type Resolver = Text => Optional[HttpUrl]
 
@@ -117,7 +128,7 @@ object Repackager:
   def repackage
     ( inputJar: Path on Linux, outputJar: Path on Linux, resolve: Resolver, cached: CacheReader,
       bootstrapClass: Data )
-  :   Unit raises RepackageError =
+  :   Summary raises RepackageError =
 
     whereas:
       case IoError(_, _, _, _)  => RepackageError(m"a filesystem error occurred while repackaging")
@@ -132,18 +143,29 @@ object Repackager:
         val bootstrapName: Text = t"burdock/Bootstrap.class"
         var manifestData: Optional[Data] = Unset
         var depsData: Optional[Data] = Unset
+        var inputCount: Int = 0
+        var directoriesSkipped: Int = 0
         val ownBuilder = List.newBuilder[Entry]
 
         Zipfile.read(inputJar).entries.each: entry =>
-          val name: Text = entry.ref.show
+          inputCount += 1
 
-          // The bootstrap class is force-included below, so drop any copy already bundled
-          // (an app whose `Main-Class` is `burdock.Bootstrap` bundles burdock) to avoid a
-          // duplicate entry.
-          if name == t"META-INF/MANIFEST.MF" then manifestData = entry.read[Data]
-          else if name == resource then depsData = entry.read[Data]
-          else if name == bootstrapName then ()
-          else ownBuilder += Entry(name, entry.read[Data])
+          // Directory entries (the zeppelin reader strips their trailing slash and flags
+          // them as `directory`) must never be copied into an `Entry`, which carries no
+          // directory flag and would re-emit them as zero-byte *files* — colliding with the
+          // real directory on extraction ("exists but is not directory"). A JAR needs no
+          // explicit directory entries: extractors synthesise parents on demand. `cached`
+          // already drops them.
+          if entry.directory then directoriesSkipped += 1 else
+            val name: Text = entry.ref.show
+
+            // The bootstrap class is force-included below, so drop any copy already bundled
+            // (an app whose `Main-Class` is `burdock.Bootstrap` bundles burdock) to avoid a
+            // duplicate entry.
+            if name == t"META-INF/MANIFEST.MF" then manifestData = entry.read[Data]
+            else if name == resource then depsData = entry.read[Data]
+            else if name == bootstrapName then ()
+            else ownBuilder += Entry(name, entry.read[Data])
 
         val manifest: Manifest =
           manifestData.lest(RepackageError(m"the JAR has no manifest")).read[Manifest]
@@ -189,3 +211,13 @@ object Repackager:
           Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifest2.serialize)
           #:: entries.to(Stream).map: entry =>
             Zip.Entry(entry.name.decode[Path on Zip], () => Stream(entry.data))
+
+        // The output also carries the manifest entry, hence `entries.length + 1`.
+        Summary
+          ( inputEntries       = inputCount,
+            directoriesSkipped = directoriesSkipped,
+            ownKept            = keptEntries.length,
+            externalized       = requirements,
+            inlined            = inlined.length,
+            stripped           = ownEntries.length - keptEntries.length,
+            outputEntries      = entries.length + 1 )

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -115,7 +115,9 @@ def repackage(): Unit = application(Nil):
           . to(List)
 
       val tmpFile: Path on Linux = inputJar.parent.vouch/t"${inputJar.name}.tmp"
-      Repackager.repackage(inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass)
+
+      val summary =
+        Repackager.repackage(inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass)
 
       import filesystemOptions.overwritePreexisting.enabled
       import filesystemOptions.deleteRecursively.disabled
@@ -123,6 +125,20 @@ def repackage(): Unit = application(Nil):
       import filesystemOptions.createNonexistentParents.disabled
 
       tmpFile.moveTo(inputJar)
+
+      val bytes: Long = jnf.Files.size(jnf.Paths.get(inputJar.show.s).nn)
       Out.println(m"Repackaged $inputJar")
+      Out.println(m"  input entries:          ${summary.inputEntries}")
+      Out.println(m"  directory entries skipped: ${summary.directoriesSkipped}")
+      Out.println(m"  application classes kept:  ${summary.ownKept}")
+      Out.println(m"  dependencies externalized: ${summary.externalized.length}")
+
+      summary.externalized.each: requirement =>
+        Out.println(m"    - ${requirement.text}")
+
+      Out.println(m"  dependency classes inlined: ${summary.inlined}")
+      Out.println(m"  bundled classes stripped:  ${summary.stripped}")
+      Out.println(m"  output entries:         ${summary.outputEntries}")
+      Out.println(m"  output size (bytes):    $bytes")
 
       Exit.Ok

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -140,6 +140,49 @@ object Tests extends Suite(m"Burdock Tests"):
         manifest.contains(t"aaa")
       .assert(_ == true)
 
+    suite(m"Repackager (directory entries)"):
+      // A fat assembly contains directory entries (e.g. `com/example/`). The zeppelin reader
+      // strips their trailing slash and flags them as directories; if copied through as plain
+      // entries they would be re-emitted as zero-byte *files* (`com/example`), colliding with
+      // the real directory on extraction ("exists but is not directory"). They must be dropped.
+      val tmp: Path on Linux = temporaryDirectory[Path on Linux]
+      val inputJar: Path on Linux = tmp/t"burdock-dir-in-${Uuid().show}.jar"
+      val outputJar: Path on Linux = tmp/t"burdock-dir-out-${Uuid().show}.jar"
+
+      val manifestText: Text = t"Manifest-Version: 1.0\nMain-Class: com.example.Main\n\n"
+
+      Zipfile.write(inputJar):
+        Zip.Entry(t"META-INF/MANIFEST.MF".decode[Path on Zip], manifestText.data)
+        #:: Zip.Entry(t"META-INF/burdock.deps".decode[Path on Zip], t"".data)
+        #:: Zip.Entry(t"com/example".decode[Path on Zip], t"".data).copy(directory = true)
+        #:: Zip.Entry(t"com/example/Main.class".decode[Path on Zip], t"main".data)
+        #:: LazyList()
+
+      val resolve: Repackager.Resolver = _ => Unset
+      val cached: Repackager.CacheReader = _ => Unset
+
+      val summary =
+        Repackager.repackage(inputJar, outputJar, resolve, cached, t"bootstrap".data)
+
+      val entries = Zipfile.read(outputJar).entries.to(List)
+      val names: List[Text] = entries.map(_.ref.show)
+
+      test(m"the output contains no directory entries"):
+        entries.all(!_.directory)
+      .assert(_ == true)
+
+      test(m"no zero-byte slash-less package entry remains"):
+        names.contains(t"com/example")
+      .assert(_ == false)
+
+      test(m"the application's own class is kept"):
+        names.contains(t"com/example/Main.class")
+      .assert(_ == true)
+
+      test(m"the summary records the skipped directory entry"):
+        summary.directoriesSkipped
+      .assert(_ == 1)
+
     suite(m"Repackager (duplicate-safety)"):
       // A real assembly bundles burdock (its `Main-Class` is `burdock.Bootstrap`), so the
       // input already contains `burdock/Bootstrap.class`; a cached dependency may be a class


### PR DESCRIPTION
Burdock's repackager preserved the directory entries from a fat assembly when rewriting it, but its internal entry representation discarded the directory flag, so each directory was re-emitted as a zero-byte file named after the package. On extraction this collided with the real directory (`checkdir error: … exists but is not directory`) and inflated the entry count. Burdock now drops directory entries when reading the input JAR — a JAR needs no explicit directory entries, since extraction tools synthesise parent directories on demand — and the repackager reports a summary of what it did.

Repackaging a JAR with Burdock no longer produces spurious zero-byte directory-name entries, so the resulting JAR extracts cleanly.

The `soundness.repackage` command now prints a breakdown of the work it did, which is helpful for understanding the size of a repackaged JAR:

```
Repackaged /path/to/app.jar
  input entries:          7073
  directory entries skipped: 346
  application classes kept:  812
  dependencies externalized: 14
    - <sha256>:https://repo1.maven.org/maven2/...
  dependency classes inlined: 5901
  bundled classes stripped:  0
  output entries:         6727
  output size (bytes):    14931202
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)