### PR TITLE
Spell the decoder shorthand `read[T in Format]` and extend it to DSV

### DIFF
--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -327,14 +327,14 @@ object Cbor extends Cbor2, Dynamic:
       def genericize(value: Cbor): HttpStreams.Content =
         (t"application/cbor", Stream(CborPrinter.encode(Cbor.unseal(value))))
 
-  // `source.read[Foo over Cbor]` shorthand for
+  // `source.read[Foo in Cbor]` shorthand for
   // `source.read[Cbor].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
-  // for `value over Json`. The `Transport` type-tag is added by an
-  // `asInstanceOf` cast — `value over Cbor` is just
-  // `value { type Transport = Cbor }` so the cast is a no-op at runtime.
-  given aggregableOver: [value: Decodable in Cbor] => Tactic[CborError]
-  =>  (value over Cbor) is Aggregable by Data =
-    bytes => Cbor.ast(bytes.read[Cbor.Ast]).as[value].asInstanceOf[value over Cbor]
+  // for `value in Json`. The `Form` type-tag is added by an
+  // `asInstanceOf` cast — `value in Cbor` is just
+  // `value { type Form = Cbor }` so the cast is a no-op at runtime.
+  given aggregableIn: [value: Decodable in Cbor] => Tactic[CborError]
+  =>  (value in Cbor) is Aggregable by Data =
+    bytes => Cbor.ast(bytes.read[Cbor.Ast]).as[value].asInstanceOf[value in Cbor]
 
   given unit: Tactic[CborError] => Unit is Decodable in Cbor =
     value =>

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -269,17 +269,17 @@ object Tests extends Suite(m"Breviloquence Tests"):
         Cbor.ast(Stream(bytes).read[Cbor.Ast]).as[Wrapper]
       . assert(_ == Wrapper(List(1, 2, 3), t"hi"))
 
-    suite(m"`over Cbor` decoder shorthand"):
-      test(m"`read[T over Cbor]` resolves a value directly from bytes"):
+    suite(m"`in Cbor` decoder shorthand"):
+      test(m"`read[T in Cbor]` resolves a value directly from bytes"):
         val original = Point(3, 4)
         val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
-        Stream(bytes).read[Point over Cbor]
+        Stream(bytes).read[Point in Cbor]
       . assert(_ == Point(3, 4))
 
-      test(m"`read[T over Cbor]` works for nested case classes"):
+      test(m"`read[T in Cbor]` works for nested case classes"):
         val original = Wrapper(List(1, 2, 3), t"hi")
         val bytes = CborPrinter.encode(Cbor.unseal(original.cbor))
-        Stream(bytes).read[Wrapper over Cbor]
+        Stream(bytes).read[Wrapper in Cbor]
       . assert(_ == Wrapper(List(1, 2, 3), t"hi"))
 
     suite(m"@name field renaming"):
@@ -324,7 +324,7 @@ object Tests extends Suite(m"Breviloquence Tests"):
 
       test(m"request/response body round-trips"):
         val body = Person(t"Alice", 30).cbor
-        body.generic(1).read[Person over Cbor]
+        body.generic(1).read[Person in Cbor]
       . assert(_ == Person(t"Alice", 30))
 
     suite(m"Optics"):

--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -44,6 +44,7 @@ import gossamer.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
+import turbulence.*
 import vacuous.*
 import wisteria.*
 
@@ -62,6 +63,18 @@ object Dsv:
   =>  value is Decodable in Dsv =
 
     DecodableDerivation.derived[value]
+
+  // `source.read[Foo in Dsv]` shorthand for `source.read[Sheet].rows.head.as[Foo]`:
+  // decodes a single DSV record (the first row) into `Foo`, mirroring the other
+  // formats' `value in Format` aggregables. Multi-row sources should be read as a
+  // `Sheet` instead (`Sheet.as[Foo]` yields a `Stream[Foo]`). The `Form` type-tag is
+  // added by an `asInstanceOf` cast — `value in Dsv` is just `value { type Form = Dsv }`
+  // so the cast is a no-op at runtime.
+  given aggregableIn: [value: Decodable in Dsv] => (format: DsvFormat) => Tactic[DsvError]
+  =>  (value in Dsv) is Aggregable by Text =
+    text =>
+      summon[Sheet is Aggregable by Text].aggregate(text).rows.head.as[value]
+      . asInstanceOf[value in Dsv]
 
 
   inline given encodableDerivation: [value <: Product: ProductReflection]

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -170,6 +170,16 @@ object Tests extends Suite(m"Caesura tests"):
       t"""0.1,two,three,4,five,six""".read[Sheet].rows.head.as[Bar]
     . assert(_ == Bar(0.1, Foo(t"two", t"three"), 4, Foo(t"five", t"six")))
 
+    test(m"`read[T in Dsv]` decodes a single record directly"):
+      import dsvFormats.csvFormat
+      t"""hello,world""".read[Foo in Dsv]
+    . assert(_ == Foo(t"hello", t"world"))
+
+    test(m"`read[T in Dsv]` decodes a record by headings"):
+      import dsvFormats.csvWithHeaderFormat
+      t"greeting,name\nhello,world".read[Quux in Dsv]
+    . assert(_ == Quux(t"world", t"hello"))
+
     test(m"encode case class"):
       Foo(t"hello", t"world").dsv
     . assert(_ == Dsv(t"hello", t"world"))

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -371,6 +371,6 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
 
       test(m"a Container timestamp round-trips and converts to an Aviation Instant"):
         val container = Container(t"svc", createdAt = embarcadero.Timestamp.of(moment))
-        val restored = Stream(container.protobuf.encode).read[Container over Protobuf]
+        val restored = Stream(container.protobuf.encode).read[Container in Protobuf]
         restored.createdAt.instant[Instant]
       . assert(_ == moment)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -810,9 +810,9 @@ object Json extends Json2, Dynamic:
 
   given aggregableDirect: [value: distillate.Decodable in Json] => Tactic[ParseError]
   =>  Tactic[JsonError]
-  =>  (value over Json) is Aggregable by Data =
+  =>  (value in Json) is Aggregable by Data =
 
-    bytes => Json(bytes.read[Json.Ast]).as[value].asInstanceOf[value over Json]
+    bytes => Json(bytes.read[Json.Ast]).as[value].asInstanceOf[value in Json]
 
 
   given showable: Formatting => Json is Showable = _.root.show

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -322,7 +322,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == Band(List(Person(t"John", 40), Person(t"George", 58)), ringoObj, Some(paulObj)))
 
       test(m"Extract a band directly"):
-        beatles.read[Band over Json]
+        beatles.read[Band in Json]
       . assert(_ == Band(List(Person(t"John", 40), Person(t"George", 58)), ringoObj, Some(paulObj)))
 
       val paulCoproduct = test(m"Serialize a coproduct"):

--- a/lib/locomotion/src/bench/locomotion.Benchmarks.scala
+++ b/lib/locomotion/src/bench/locomotion.Benchmarks.scala
@@ -216,12 +216,12 @@ object Benchmarks extends Suite(m"Locomotion Protobuf codec benchmarks"):
   // body. Each operation therefore goes through a fully-qualified helper method
   // the quote simply invokes.
 
-  def decodeSmall:      Small      = Stream(bytes1).read[Small over Protobuf]
-  def decodeUsers:      Users      = Stream(bytes2).read[Users over Protobuf]
-  def decodeLogs:       Logs       = Stream(bytes3).read[Logs over Protobuf]
-  def decodeInts:       Ints       = Stream(bytes4).read[Ints over Protobuf]
-  def decodeAttributes: Attributes = Stream(bytes5).read[Attributes over Protobuf]
-  def decodeNested:     Deep1      = Stream(bytes6).read[Deep1 over Protobuf]
+  def decodeSmall:      Small      = Stream(bytes1).read[Small in Protobuf]
+  def decodeUsers:      Users      = Stream(bytes2).read[Users in Protobuf]
+  def decodeLogs:       Logs       = Stream(bytes3).read[Logs in Protobuf]
+  def decodeInts:       Ints       = Stream(bytes4).read[Ints in Protobuf]
+  def decodeAttributes: Attributes = Stream(bytes5).read[Attributes in Protobuf]
+  def decodeNested:     Deep1      = Stream(bytes6).read[Deep1 in Protobuf]
 
   def encodeSmall:      Data = value1.protobuf.encode
   def encodeUsers:      Data = value2.protobuf.encode

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -122,13 +122,13 @@ object Protobuf extends Protobuf2:
   // `bytes.read[Protobuf]` aggregates the byte stream and wraps it as a message.
   given aggregable: Protobuf is Aggregable by Data = bytes => message(bytes.read[Data])
 
-  // `bytes.read[Foo over Protobuf]` shorthand for `bytes.read[Protobuf].as[Foo]`,
-  // mirroring jacinta's `value over Json` and breviloquence's `value over Cbor`.
-  // `value over Protobuf` is just `value { type Transport = Protobuf }`, so the
+  // `bytes.read[Foo in Protobuf]` shorthand for `bytes.read[Protobuf].as[Foo]`,
+  // mirroring jacinta's `value in Json` and breviloquence's `value in Cbor`.
+  // `value in Protobuf` is just `value { type Form = Protobuf }`, so the
   // cast is a no-op at runtime.
-  given aggregableOver: [value: Decodable in Protobuf] => Tactic[ProtobufError]
-  =>  (value over Protobuf) is Aggregable by Data =
-    bytes => message(bytes.read[Data]).as[value].asInstanceOf[value over Protobuf]
+  given aggregableIn: [value: Decodable in Protobuf] => Tactic[ProtobufError]
+  =>  (value in Protobuf) is Aggregable by Data =
+    bytes => message(bytes.read[Data]).as[value].asInstanceOf[value in Protobuf]
 
   // Number-keyed optic: Protobuf fields are addressed by number, not name, so an
   // `Ordinal` selects field `n` (`Prim` = field 1). Updating parses the message's

--- a/lib/locomotion/src/core/locomotion_core.scala
+++ b/lib/locomotion/src/core/locomotion_core.scala
@@ -37,6 +37,6 @@ import prepositional.*
 
 // Encodes any value with an `Encodable in Protobuf` instance to its `Protobuf` wire
 // form; `.encode` then yields the message bytes (`Data`). Decoding is
-// `bytes.read[Protobuf].as[T]` or the `bytes.read[T over Protobuf]` shorthand.
+// `bytes.read[Protobuf].as[T]` or the `bytes.read[T in Protobuf]` shorthand.
 extension [value: Encodable in Protobuf](value: value)
   def protobuf: Protobuf = value.encode

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -86,15 +86,15 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
     suite(m"Round-trips"):
       test(m"single int field"):
-        Stream(Sample(150).protobuf.encode).read[Sample over Protobuf]
+        Stream(Sample(150).protobuf.encode).read[Sample in Protobuf]
       . assert(_ == Sample(150))
 
       test(m"two int fields, one at its default"):
-        Stream(Point(0, 5).protobuf.encode).read[Point over Protobuf]
+        Stream(Point(0, 5).protobuf.encode).read[Point in Protobuf]
       . assert(_ == Point(0, 5))
 
       test(m"string and int fields"):
-        Stream(Person(t"Alice", 30).protobuf.encode).read[Person over Protobuf]
+        Stream(Person(t"Alice", 30).protobuf.encode).read[Person in Protobuf]
       . assert(_ == Person(t"Alice", 30))
 
       test(m"read[Protobuf] then as[T] (two-step)"):
@@ -102,20 +102,20 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       . assert(_ == Person(t"Alice", 30))
 
       test(m"nested message"):
-        Stream(Wrapper(Point(3, 4), t"origin").protobuf.encode).read[Wrapper over Protobuf]
+        Stream(Wrapper(Point(3, 4), t"origin").protobuf.encode).read[Wrapper in Protobuf]
       . assert(_ == Wrapper(Point(3, 4), t"origin"))
 
       test(m"sparse field numbers"):
-        Stream(Sparse(9, t"x").protobuf.encode).read[Sparse over Protobuf]
+        Stream(Sparse(9, t"x").protobuf.encode).read[Sparse in Protobuf]
       . assert(_ == Sparse(9, t"x"))
 
     suite(m"Repeated fields"):
       test(m"repeated strings round-trip in order"):
-        Stream(Tags(List(t"a", t"b", t"c")).protobuf.encode).read[Tags over Protobuf]
+        Stream(Tags(List(t"a", t"b", t"c")).protobuf.encode).read[Tags in Protobuf]
       . assert(_ == Tags(List(t"a", t"b", t"c")))
 
       test(m"repeated ints round-trip, keeping default elements"):
-        Stream(Numbers(List(0, 1, 2)).protobuf.encode).read[Numbers over Protobuf]
+        Stream(Numbers(List(0, 1, 2)).protobuf.encode).read[Numbers in Protobuf]
       . assert(_ == Numbers(List(0, 1, 2)))
 
       test(m"repeated ints are packed into one length-delimited field"):
@@ -125,7 +125,7 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       test(m"a packed field produced elsewhere decodes back to a List"):
         // The canonical packed encoding of [3, 270, 86942] (matches `protoc`).
         val packed = IArray[Byte](0x0a, 0x06, 0x03, 0x8e.toByte, 0x02, 0x9e.toByte, 0xa7.toByte, 0x05)
-        Stream(packed).read[Numbers over Protobuf]
+        Stream(packed).read[Numbers in Protobuf]
       . assert(_ == Numbers(List(3, 270, 86942)))
 
       test(m"empty repeated field writes nothing"):
@@ -134,22 +134,22 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
     suite(m"Optional presence"):
       test(m"a set optional round-trips"):
-        Stream(MaybeName(t"set").protobuf.encode).read[MaybeName over Protobuf]
+        Stream(MaybeName(t"set").protobuf.encode).read[MaybeName in Protobuf]
       . assert(_ == MaybeName(t"set"))
 
       test(m"an unset optional writes nothing and round-trips to Unset"):
-        Stream(MaybeName(Unset).protobuf.encode).read[MaybeName over Protobuf]
+        Stream(MaybeName(Unset).protobuf.encode).read[MaybeName in Protobuf]
       . assert(_ == MaybeName(Unset))
 
     suite(m"Sum types (oneof)"):
       test(m"the Circle variant round-trips"):
         val shape: Shape = Shape.Circle(5)
-        Stream(shape.protobuf.encode).read[Shape over Protobuf]
+        Stream(shape.protobuf.encode).read[Shape in Protobuf]
       . assert(_ == Shape.Circle(5))
 
       test(m"the Rectangle variant round-trips"):
         val shape: Shape = Shape.Rectangle(3, 4)
-        Stream(shape.protobuf.encode).read[Shape over Protobuf]
+        Stream(shape.protobuf.encode).read[Shape in Protobuf]
       . assert(_ == Shape.Rectangle(3, 4))
 
     suite(m"Field-number fallback"):
@@ -158,14 +158,14 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       . assert(_ == List(0x08, 0x96))
 
       test(m"unannotated message round-trips"):
-        Stream(Unnumbered(7, 9).protobuf.encode).read[Unnumbered over Protobuf]
+        Stream(Unnumbered(7, 9).protobuf.encode).read[Unnumbered in Protobuf]
       . assert(_ == Unnumbered(7, 9))
 
     suite(m"Typed integer encodings"):
       val typed = Typed(7.bits.u32, 8L.bits.u64, -3.bits.s32, -4L.bits.s64, 5.bits, 6L.bits)
 
       test(m"all typed integers round-trip"):
-        Stream(typed.protobuf.encode).read[Typed over Protobuf]
+        Stream(typed.protobuf.encode).read[Typed in Protobuf]
       . assert(_ == typed)
 
       test(m"sint32 uses zig-zag (field 3, -1 ⇒ tag 0x18, 0x01)"):
@@ -179,12 +179,12 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
     suite(m"Maps"):
       test(m"a string→string map round-trips"):
         val labels = Labels(Map(t"a" -> t"1", t"b" -> t"2"))
-        Stream(labels.protobuf.encode).read[Labels over Protobuf]
+        Stream(labels.protobuf.encode).read[Labels in Protobuf]
       . assert(_ == Labels(Map(t"a" -> t"1", t"b" -> t"2")))
 
       test(m"a string→int map round-trips"):
         val counts = Counts(Map(t"x" -> 10, t"y" -> 20))
-        Stream(counts.protobuf.encode).read[Counts over Protobuf]
+        Stream(counts.protobuf.encode).read[Counts in Protobuf]
       . assert(_ == Counts(Map(t"x" -> 10, t"y" -> 20)))
 
       test(m"an empty map writes nothing"):
@@ -197,7 +197,7 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
     suite(m"Parse errors carry a byte offset"):
       def decode(bytes: Byte*): Sample raises ProtobufError =
-        Stream(IArray.from(bytes)).read[Sample over Protobuf]
+        Stream(IArray.from(bytes)).read[Sample in Protobuf]
 
       test(m"a truncated length-delimited payload reports the offset where data ran out"):
         // field 1, wire type Len, length 5, but only one payload byte present.
@@ -211,7 +211,7 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
       test(m"a varint longer than ten bytes is malformed"):
         capture[ProtobufError]:
-          Stream(IArray.fill(11)(0x80.toByte)).read[Sample over Protobuf]
+          Stream(IArray.fill(11)(0x80.toByte)).read[Sample in Protobuf]
       . assert(_ == ProtobufError(ProtobufError.Reason.MalformedVarint(0)))
 
       test(m"a varint whose value overflows 64 bits is rejected"):
@@ -228,7 +228,7 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
 
       test(m"request/response body round-trips"):
         val message = Person(t"Alice", 30).protobuf
-        message.generic(1).read[Person over Protobuf]
+        message.generic(1).read[Person in Protobuf]
       . assert(_ == Person(t"Alice", 30))
 
     suite(m"Optics"):

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -722,14 +722,14 @@ object Tel extends Tel2:
   given aggregable: Tactic[TelError] => Tel is Aggregable by Data =
     source => parse(concatenate(source))
 
-  // `source.read[Foo over Tel]` shorthand for
+  // `source.read[Foo in Tel]` shorthand for
   // `source.read[Tel].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
-  // for `value over Json`. The `Transport` type-tag is added by an
-  // `asInstanceOf` cast — `value over Tel` is just
-  // `value { type Transport = Tel }` so the cast is a no-op at runtime.
-  given aggregableOver: [value: distillate.Decodable in Tel] => Tactic[TelError]
-  =>  (value over Tel) is Aggregable by Data =
-    source => parse(concatenate(source)).as[value].asInstanceOf[value over Tel]
+  // for `value in Json`. The `Form` type-tag is added by an
+  // `asInstanceOf` cast — `value in Tel` is just
+  // `value { type Form = Tel }` so the cast is a no-op at runtime.
+  given aggregableIn: [value: distillate.Decodable in Tel] => Tactic[TelError]
+  =>  (value in Tel) is Aggregable by Data =
+    source => parse(concatenate(source)).as[value].asInstanceOf[value in Tel]
 
   // `source.read[List[Tel]]` / `read[Stream[Tel]]` for a multi-document source
   // (§6.1). `List[Tel]` parses every document eagerly; `Stream[Tel]` parses

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -271,9 +271,9 @@ object Tests extends Suite(m"Stratiform Tests"):
         . to(List)
       . assert(_ == List(t"Shape2"))
 
-    suite(m"`over Tel` decoder shorthand"):
-      test(m"`read[T over Tel]` resolves a value directly from text"):
-        t"name Alice\nage 30\n".read[Tests.Person over Tel]
+    suite(m"`in Tel` decoder shorthand"):
+      test(m"`read[T in Tel]` resolves a value directly from text"):
+        t"name Alice\nage 30\n".read[Tests.Person in Tel]
       . assert(_ == Tests.Person(t"Alice", 30))
 
     suite(m"tel\"…\" interpolator"):

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -520,18 +520,18 @@ object Xml extends Tag.Container
 
     text => Stream(text).read[Xml]
 
-  // `source.read[Foo over Xml]` shorthand for
+  // `source.read[Foo in Xml]` shorthand for
   // `source.read[Xml].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
-  // for `value over Json`. The `Transport` type-tag is added by an
-  // `asInstanceOf` cast — `value over Xml` is just `value { type
-  // Transport = Xml }` so the cast is a no-op at runtime.
-  given aggregableOver: [value: Decodable in Xml] => (schema: XmlSchema)
+  // for `value in Json`. The `Form` type-tag is added by an
+  // `asInstanceOf` cast — `value in Xml` is just `value { type
+  // Form = Xml }` so the cast is a no-op at runtime.
+  given aggregableIn: [value: Decodable in Xml] => (schema: XmlSchema)
   =>  ( Tactic[ParseError], Tactic[XmlError] )
-  =>  (value over Xml) is Aggregable by Text =
+  =>  (value in Xml) is Aggregable by Text =
 
     input =>
       XmlParser.fromIterator(input.iterator).parseXml(headers0 = false).as[value]
-      . asInstanceOf[value over Xml]
+      . asInstanceOf[value in Xml]
 
   given loadable: (schema: XmlSchema) => Tactic[ParseError] => Xml is Loadable by Text = stream =>
     XmlParser.fromIterator(stream.iterator).parseXml(headers0 = true) match

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -80,14 +80,14 @@ object Tests extends Suite(m"Xylophone tests"):
           unsafely(t"""<?xml  version="1.0"?><message>hello world</message>""".load[Xml].read[Text])
       . assert(_ == t"""<?xml version="1.0"?><message>hello world</message>""")
 
-    suite(m"`over Xml` decoder shorthand"):
-      test(m"`read[T over Xml]` resolves a value directly from text"):
-        t"<Worker><name>Alice</name><age>30</age></Worker>".read[Worker over Xml]
+    suite(m"`in Xml` decoder shorthand"):
+      test(m"`read[T in Xml]` resolves a value directly from text"):
+        t"<Worker><name>Alice</name><age>30</age></Worker>".read[Worker in Xml]
       . assert(_ == Worker(t"Alice", 30))
 
-      test(m"`read[T over Xml]` works for nested case classes"):
+      test(m"`read[T in Xml]` works for nested case classes"):
         t"<Firm><name>Acme</name><ceo><name>Alice</name><age>30</age></ceo></Firm>"
-          . read[Firm over Xml]
+          . read[Firm in Xml]
       . assert(_ == Firm(t"Acme", Worker(t"Alice", 30)))
 
     test(m"extract integer"):

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -1320,14 +1320,14 @@ object Yaml extends Yaml2, Dynamic:
 
     text => Stream(text).read[Yaml]
 
-  // `source.read[Foo over Yaml]` shorthand for
+  // `source.read[Foo in Yaml]` shorthand for
   // `source.read[Yaml].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
-  // for `value over Json`. The `Transport` type-tag is added by an
-  // `asInstanceOf` cast — `value over Yaml` is just `value { type
-  // Transport = Yaml }` so the cast is a no-op at runtime.
-  given aggregableOver: [value: Decodable in Yaml]
+  // for `value in Json`. The `Form` type-tag is added by an
+  // `asInstanceOf` cast — `value in Yaml` is just `value { type
+  // Form = Yaml }` so the cast is a no-op at runtime.
+  given aggregableIn: [value: Decodable in Yaml]
   =>  ( Tactic[ParseError], Tactic[YamlError], Yaml.Tracking )
-  =>  (value over Yaml) is Aggregable by Text =
+  =>  (value in Yaml) is Aggregable by Text =
 
     summon[Text is Aggregable by Text].map: text =>
       val yaml = summon[Yaml.Tracking] match
@@ -1338,7 +1338,7 @@ object Yaml extends Yaml2, Dynamic:
         case Yaml.Tracking.Off =>
           Yaml(YamlParser.parse(text))
 
-      yaml.as[value].asInstanceOf[value over Yaml]
+      yaml.as[value].asInstanceOf[value in Yaml]
 
   def primitive(ast: Yaml.Ast): YamlPrimitive =
     if ast.asInstanceOf[AnyRef] == null then YamlPrimitive.Null

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -306,17 +306,17 @@ object Tests extends Suite(m"Ypsiloid Tests"):
           case _                        => -1
       . assert(_ == 2)
 
-    suite(m"`over Yaml` decoder shorthand"):
-      test(m"`read[T over Yaml]` resolves a value directly from text"):
-        t"{name: Alice, age: 30}".read[Person over Yaml]
+    suite(m"`in Yaml` decoder shorthand"):
+      test(m"`read[T in Yaml]` resolves a value directly from text"):
+        t"{name: Alice, age: 30}".read[Person in Yaml]
       . assert(_ == Person(t"Alice", 30))
 
-      test(m"`read[T over Yaml]` works for nested case classes"):
-        t"{inner: {n: 7}}".read[Outer over Yaml]
+      test(m"`read[T in Yaml]` works for nested case classes"):
+        t"{inner: {n: 7}}".read[Outer in Yaml]
       . assert(_ == Outer(Inner(7)))
 
-      test(m"`read[List[T] over Yaml]` decodes a sequence directly"):
-        t"[{name: Alice, age: 30}, {name: Bob, age: 25}]".read[List[Person] over Yaml]
+      test(m"`read[List[T] in Yaml]` decodes a sequence directly"):
+        t"[{name: Alice, age: 30}, {name: Bob, age: 25}]".read[List[Person] in Yaml]
       . assert(_ == List(Person(t"Alice", 30), Person(t"Bob", 25)))
 
     suite(m"Case-class derivation"):


### PR DESCRIPTION
The single-step decoder shorthand that reads a serialized payload straight into a domain type — previously written `source.read[Foo over Json]` — is now spelled `source.read[Foo in Json]`, reusing the existing `in`/`Form` supplement so it reads as "Foo in Json form" and lines up with `Decodable in Json`. The shorthand is also added to caesura, so DSV/CSV/TSV now decodes a single record directly, consistent with every other format.

The decoder shorthand for reading a payload directly into a value now uses the `in` infix type rather than `over`:

```scala
import jacinta.Json

source.read[Person in Json]   // was: read[Person over Json]
```

This works uniformly across every data format — JSON, YAML, XML, TEL, Protobuf and CBOR:

```scala
t"{name: Alice, age: 30}".read[Person in Yaml]
bytes.read[Container in Protobuf]
```

DSV/CSV/TSV gains the shorthand too, decoding a single record (the first row) into a value:

```scala
import caesura.dsvFormats.csvFormat

t"hello,world".read[Foo in Dsv]                  // a single record
t"greeting,name\nhello,world".read[Quux in Dsv]  // matched by heading
```

For multi-row input, continue reading a `Sheet` (`sheet.as[Foo]` yields a `Stream[Foo]`).

The `over` infix type itself is unchanged and still used where a value is tagged with a *transport* (e.g. `Api over Json`, WebSocket `Ping over Json` payloads).