### PR TITLE
Rename the `incurs` infix type to `emits`

### DIFF
--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -164,13 +164,13 @@ abstract class Worker(frame: Codepoint, parent: Monitor, probate: Probate) exten
 
 
   def map[result2](lambda: Result => result2)(using Monitor, Probate)
-  :   Task[result2] incurs AsyncError =
+  :   Task[result2] emits AsyncError =
 
     async(lambda(join()))
 
 
   def bind[result2](lambda: Result => Task[result2])(using Monitor, Probate)
-  :   Task[result2] incurs AsyncError =
+  :   Task[result2] emits AsyncError =
 
     async(lambda(join()).join())
 

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -75,7 +75,7 @@ object Task:
       value.map(lambda)
 
   extension [result](tasks: Seq[Task[result]])
-    def sequence(using Monitor, Probate): Task[Seq[result]] incurs AsyncError =
+    def sequence(using Monitor, Probate): Task[Seq[result]] emits AsyncError =
       async(tasks.map(_.join()))
 
   extension [result](tasks: Iterable[Task[result]])
@@ -85,8 +85,8 @@ object Task:
 
       try promise.await() finally tasks.foreach(_.cancel())
 
-// A task carries the error type its body may raise as the `Error` member, refined by the `incurs`
-// alias (`Task[result] incurs error` = `Task[result] { type Error <: error }`). It is preserved to
+// A task carries the error type its body may raise as the `Error` member, refined by the `emits`
+// alias (`Task[result] emits error` = `Task[result] { type Error <: error }`). It is preserved to
 // `await`, where it is delivered through the caller's in-scope `Tactic`. `AsyncError` (cancellation
 // or timeout) is always a possible outcome, so it is added at the `await` site, not the member.
 trait Task[+result]:
@@ -108,7 +108,7 @@ trait Task[+result]:
   :   result raises AsyncError
 
   def bind[result2](lambda: result => Task[result2])(using Monitor, Probate)
-  :   Task[result2] incurs AsyncError
+  :   Task[result2] emits AsyncError
 
   def map[result2](lambda: result => result2)(using Monitor, Probate)
-  :   Task[result2] incurs AsyncError
+  :   Task[result2] emits AsyncError

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -97,11 +97,11 @@ def daemon[error <: Exception](using Codepoint)
 def trap(handler: PartialFunction[Error, Remedy])(using outer: Probate): Trap = Trap(handler, outer)
 
 
-// `Task[result] incurs error` = `Task[result] { type Error <: error }`. The bound (not an equality)
+// `Task[result] emits error` = `Task[result] { type Error <: error }`. The bound (not an equality)
 // keeps the error covariant: a task that can fail only with `AsyncError` is usable where one that
-// `incurs FooError` is expected, and `await`'s `raises (Error | AsyncError)` is dischargeable by a
+// `emits FooError` is expected, and `await`'s `raises (Error | AsyncError)` is dischargeable by a
 // `Tactic` for the bound. `task <: Task[?]` keeps the refinement applicable only to actual tasks.
-infix type incurs[task <: Task[?], error <: Exception] = task { type Error <: error }
+infix type emits[task <: Task[?], error <: Exception] = task { type Error <: error }
 
 
 // `error` is the union of error types the body may `raise`, inferred exactly as for synchronous
@@ -111,7 +111,7 @@ infix type incurs[task <: Task[?], error <: Exception] = task { type Error <: er
 def async[result, error <: Exception](using Codepoint)
   ( evaluate: (Worker, Tactic[error]) ?=> result )
   ( using Monitor, Probate )
-:   Task[result] incurs (error | AsyncError) =
+:   Task[result] emits (error | AsyncError) =
 
   val tactic = AsyncTactic[error]()
   Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = Unset)
@@ -120,7 +120,7 @@ def async[result, error <: Exception](using Codepoint)
 def task[result, error <: Exception](using Codepoint)(name: Text)
   ( evaluate: (Worker, Tactic[error]) ?=> result )
   ( using Monitor, Probate )
-:   Task[result] incurs (error | AsyncError) =
+:   Task[result] emits (error | AsyncError) =
 
   val tactic = AsyncTactic[error]()
   Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = name)


### PR DESCRIPTION
The `parasite` infix type that refines a task's declared error member has been renamed from `incurs` to `emits`, which reads more naturally when describing the errors a task can produce. This is a pure rename with no behavioural change.

Code that refers to a task's error type by the alias should replace `incurs` with `emits`:

```scala
// before
def fetch()(using Monitor, Probate): Task[Data] incurs AsyncError = async(...)

// after
def fetch()(using Monitor, Probate): Task[Data] emits AsyncError = async(...)
```

`Task[result] emits error` continues to desugar to `Task[result] { type Error <: error }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)