### PR TITLE
Discard benign closed-socket exceptions when a connection daemon loses the stop race

### DIFF
--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -71,7 +71,15 @@ extension [bindable: Bindable](socket: bindable)
     . within:
         val bindLoop = loop:
           val connection = bindable.connect(binding)
-          daemon(bindable.transmit(binding, connection, lambda(connection)))
+
+          daemon:
+            // A reply write can lose the race with `stop()` closing the socket; the resulting
+            // `IOException` (e.g. `SocketException`/`ClosedChannelException`) is benign connection
+            // teardown. Raw Java throwables bypass the `trap` above (which routes only
+            // `fulminate.Error`), so they would otherwise escalate to the uncaught-exception
+            // handler and print.
+            try bindable.transmit(binding, connection, lambda(connection))
+            catch case _: java.io.IOException => ()
 
         val task = async(bindLoop.run())
 


### PR DESCRIPTION
A Coaxial `listen` server that replies to a connection while `stop()` is concurrently closing the socket no longer prints a stray stack trace; the benign teardown `IOException` is now absorbed where the per-connection failures were always meant to be handled, making the close race deterministic and quiet.

When a server bound with `listen` writes its reply on a per-connection daemon, a `stop()` call closing the socket at the same moment would make that write throw a raw `java.io.IOException` (`SocketException` or `ClosedChannelException`). The surrounding `trap { case _ => Remedy.Accept }` was intended to absorb such per-connection failures, but Parasite only routes `fulminate.Error` values through traps, so a raw Java throwable escaped to the uncaught-exception handler and printed a stack trace — for example during the test suite — even though the teardown was harmless. The exception is now caught at the connection daemon and treated as normal teardown, so the outcome of the close race is silent and deterministic regardless of which side wins.