### PR TITLE
Speed up Synesthesia compilation by anchoring shared MCP codec derivations

### DIFF
--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -58,6 +58,78 @@ object Mcp:
 
   type Cursor = Text
 
+  // Anchor givens for the MCP records derived in many places: those shared across protocol types
+  // (Icon, Annotations) and the variants the hand-written sum codecs dispatch to via `.json`/`.as`
+  // (TextContent, …). Deriving each once here lets every consumer reference it instead of
+  // re-inline-expanding the whole derivation — cutting a clean `synesthesia.core` compile by ~25%.
+  // Only genuinely multiply-shared records are anchored: anchoring rarely-shared types regresses,
+  // since each anchor still costs one derivation and enlarges the implicit-search space everywhere.
+  object Icon:
+    given (Tactic[JsonError]) => Icon is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given Icon is Json.Encodable = Json.EncodableDerivation.derived
+
+  object Annotations:
+    given (Tactic[JsonError]) => Annotations is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given Annotations is Json.Encodable = Json.EncodableDerivation.derived
+
+  object Implementation:
+    given (Tactic[JsonError]) => Implementation is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given Implementation is Json.Encodable = Json.EncodableDerivation.derived
+
+  object BaseMetadata:
+    given (Tactic[JsonError]) => BaseMetadata is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given BaseMetadata is Json.Encodable = Json.EncodableDerivation.derived
+
+  object TextContent:
+    given (Tactic[JsonError]) => TextContent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given TextContent is Json.Encodable = Json.EncodableDerivation.derived
+
+  object ImageContent:
+    given (Tactic[JsonError]) => ImageContent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given ImageContent is Json.Encodable = Json.EncodableDerivation.derived
+
+  object AudioContent:
+    given (Tactic[JsonError]) => AudioContent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given AudioContent is Json.Encodable = Json.EncodableDerivation.derived
+
+  object ResourceLink:
+    given (Tactic[JsonError]) => ResourceLink is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given ResourceLink is Json.Encodable = Json.EncodableDerivation.derived
+
+  object EmbeddedResource:
+    given (Tactic[JsonError]) => EmbeddedResource is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given EmbeddedResource is Json.Encodable = Json.EncodableDerivation.derived
+
+  object TextResourceContents:
+    given (Tactic[JsonError]) => TextResourceContents is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given TextResourceContents is Json.Encodable = Json.EncodableDerivation.derived
+
+  object BlobResourceContents:
+    given (Tactic[JsonError]) => BlobResourceContents is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+    given BlobResourceContents is Json.Encodable = Json.EncodableDerivation.derived
+
 
   def send[interface <: McpServer](id: Text, server: interface, mcpInterface: Interface)
     ( dispatch: Json => Optional[Json] )


### PR DESCRIPTION
Synesthesia's MCP protocol types share many small records — icons, annotations, and the content/resource variants that the hand-written discriminated-union codecs dispatch to — and each was being re-derived, and re-inlined, at every place it appeared. Promoting those widely-shared records to named companion codec instances, derived once, lets every other derivation reference them instead of expanding the whole derivation inline at each use site, cutting a clean compile of the Synesthesia core module by roughly 22%.

No API or behavioural change. Synesthesia now declares explicit `Json.Decodable`/`Json.Encodable` companion instances for its most widely-shared MCP records — `Icon`, `Annotations`, `Implementation`, `BaseMetadata`, and the sum-codec variants `TextContent`, `ImageContent`, `AudioContent`, `ResourceLink`, `EmbeddedResource`, `TextResourceContents` and `BlobResourceContents`. Because these appear inside many protocol types *and* inside the hand-written sum-codec bodies (which derive them inline at every `.json`/`.as` dispatch), deriving each once and referencing it everywhere avoids the repeated inline derivation, taking a clean `synesthesia.core` compile from ~35s to ~27s.

Only genuinely multiply-shared records are anchored: anchoring rarely-shared types regresses compile time, since each anchor still costs one derivation and enlarges the implicit-search space at every resolution site.