### PR TITLE
Add a compile-time-checked subnet interpolator to Urticose

### DIFF
--- a/lib/urticose/src/core/urticose.IpAddressError.scala
+++ b/lib/urticose/src/core/urticose.IpAddressError.scala
@@ -43,6 +43,7 @@ object IpAddressError:
       case Ipv6GroupNotHex(group)         => m"the group '$group' is not a hexadecimal number"
       case Ipv6WrongNumberOfGroups(count) => m"the address has $count groups, but should have 8"
       case Ipv6MultipleDoubleColons       => m":: appears more than once"
+      case SubnetPrefixNotNumeric(prefix) => m"the prefix length $prefix is not a number"
 
       case Ipv4WrongNumberOfGroups(count) =>
         m"the address contains $count period-separated groups instead of 4"
@@ -53,15 +54,28 @@ object IpAddressError:
       case Ipv6GroupWrongLength(group) =>
         m"the group is more than 4 hexadecimal characters long"
 
+      case Ipv4SubnetPrefixOutOfRange(prefix) =>
+        m"the prefix length $prefix is not in the range 0-32"
+
+      case Ipv6SubnetPrefixOutOfRange(prefix) =>
+        m"the prefix length $prefix is not in the range 0-128"
+
+      case SubnetWrongFormat(count) =>
+        m"the subnet contains $count slash-separated parts instead of 2"
+
   enum Reason(val number: Int) extends Clarification:
-    case Ipv4ByteOutOfRange(byte: Int)         extends Reason(1)
-    case Ipv4ByteNotNumeric(byte: Text)        extends Reason(2)
-    case Ipv4WrongNumberOfGroups(count: Int)   extends Reason(3)
-    case Ipv6GroupWrongLength(group: Text)     extends Reason(4)
-    case Ipv6GroupNotHex(group: Text)          extends Reason(5)
-    case Ipv6TooManyNonzeroGroups(count: Int)  extends Reason(6)
-    case Ipv6WrongNumberOfGroups(count: Int)   extends Reason(7)
-    case Ipv6MultipleDoubleColons              extends Reason(8)
+    case Ipv4ByteOutOfRange(byte: Int)            extends Reason(1)
+    case Ipv4ByteNotNumeric(byte: Text)           extends Reason(2)
+    case Ipv4WrongNumberOfGroups(count: Int)      extends Reason(3)
+    case Ipv6GroupWrongLength(group: Text)        extends Reason(4)
+    case Ipv6GroupNotHex(group: Text)             extends Reason(5)
+    case Ipv6TooManyNonzeroGroups(count: Int)     extends Reason(6)
+    case Ipv6WrongNumberOfGroups(count: Int)      extends Reason(7)
+    case Ipv6MultipleDoubleColons                 extends Reason(8)
+    case Ipv4SubnetPrefixOutOfRange(prefix: Int)  extends Reason(9)
+    case Ipv6SubnetPrefixOutOfRange(prefix: Int)  extends Reason(10)
+    case SubnetPrefixNotNumeric(prefix: Text)     extends Reason(11)
+    case SubnetWrongFormat(count: Int)            extends Reason(12)
 
 case class IpAddressError(reason: IpAddressError.Reason)(using Diagnostics)
 extends Error(77, reason.number)(m"the IP address is not valid because $reason")

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -53,6 +53,11 @@ import vacuous.*
 import IpAddressError.Reason, Reason.*
 
 object internal:
+  // Resolve `Ipv4` to the nested opaque type directly rather than via the
+  // package-level re-export; exporting `Ipv4Subnet` (whose field is typed `Ipv4`)
+  // would otherwise create a cross-file cycle through that re-export.
+  import Opaques.Ipv4
+
   private lazy val serviceNames: Map[(Boolean, Text), Int] =
     val stream =
       Optional(getClass.getResourceAsStream("/urticose/service-names-port-numbers.csv")).or:
@@ -230,8 +235,33 @@ object internal:
 
       def int: Int = ip
 
+  def subnetPrefix(text: Text, max: Int)(outOfRange: Int => Reason)
+  :     Int raises IpAddressError =
+
+    val prefix =
+      whereas:
+        case error@NumberError(_, _, _) =>
+          given diagnostics: Diagnostics = error.diagnostics
+          IpAddressError(SubnetPrefixNotNumeric(text))
+
+      . mitigate:
+          Decodable.int.decoded(text)
+
+    if !(0 <= prefix <= max) then abort(IpAddressError(outOfRange(prefix)))
+    prefix
+
   object Ipv4Subnet:
     given showable: Ipv4Subnet is Showable = subnet => t"${subnet.ipv4}/${subnet.size}"
+    given encodable: Ipv4Subnet is Encodable in Text = _.show
+    given decodable: Tactic[IpAddressError] => Ipv4Subnet is Decodable in Text = parse(_)
+
+    def parse(text: Text): Ipv4Subnet raises IpAddressError =
+      text.cut(t"/").to(List) match
+        case List(address, prefixText) =>
+          Ipv4.parse(address).subnet(subnetPrefix(prefixText, 32)(Ipv4SubnetPrefixOutOfRange(_)))
+
+        case other =>
+          abort(IpAddressError(SubnetWrongFormat(other.length)))
 
   case class Ipv4Subnet(ipv4: Ipv4, size: Int)
 
@@ -309,6 +339,39 @@ object internal:
 
   case class Ipv6(highBits: Long, lowBits: Long)
 
+  extension (ip: Ipv6)
+    def subnet(size: Int): Ipv6Subnet =
+      val high =
+        if size <= 0 then 0L
+        else if size >= 64 then ip.highBits
+        else ip.highBits & (-1L << (64 - size))
+
+      val low =
+        if size <= 64 then 0L
+        else if size >= 128 then ip.lowBits
+        else ip.lowBits & (-1L << (128 - size))
+
+      Ipv6Subnet(Ipv6(high, low), size)
+
+  object Ipv6Subnet:
+    // Reference `Ipv6.showable` by name rather than summoning `Ipv6 is Showable`
+    // implicitly: this given is completed eagerly when `Ipv6Subnet` is re-exported,
+    // and an implicit search would re-enter the (also-exported) `Ipv6` companion.
+    given showable: Ipv6Subnet is Showable = subnet =>
+      t"${Ipv6.showable.text(subnet.ipv6)}/${subnet.size}"
+    given encodable: Ipv6Subnet is Encodable in Text = _.show
+    given decodable: Tactic[IpAddressError] => Ipv6Subnet is Decodable in Text = parse(_)
+
+    def parse(text: Text): Ipv6Subnet raises IpAddressError =
+      text.cut(t"/").to(List) match
+        case List(address, prefixText) =>
+          Ipv6.parse(address).subnet(subnetPrefix(prefixText, 128)(Ipv6SubnetPrefixOutOfRange(_)))
+
+        case other =>
+          abort(IpAddressError(SubnetWrongFormat(other.length)))
+
+  case class Ipv6Subnet(ipv6: Ipv6, size: Int)
+
 
   def emailAddress(context: Expr[StringContext]): Macro[EmailAddress] = abortive:
     val text: Text = context.valueOrAbort.parts.head.tt
@@ -364,6 +427,19 @@ object internal:
       else
         val ipv6 = text.decode[Ipv6]
         '{Ipv6(${Expr(ipv6.highBits)}, ${Expr(ipv6.lowBits)})}
+
+  def subnet(context: Expr[StringContext]): Macro[Ipv4Subnet | Ipv6Subnet] =
+    val text = Text(context.valueOrAbort.parts.head)
+
+    abortive:
+      if text.cut(t"/").head.contains(t".") then
+        val subnet = Ipv4Subnet.parse(text)
+        '{Ipv4Subnet(Ipv4(${Expr(subnet.ipv4.int)}), ${Expr(subnet.size)})}
+
+      else
+        val subnet = Ipv6Subnet.parse(text)
+        val ipv6 = '{Ipv6(${Expr(subnet.ipv6.highBits)}, ${Expr(subnet.ipv6.lowBits)})}
+        '{Ipv6Subnet($ipv6, ${Expr(subnet.size)})}
 
   def mac(context: Expr[StringContext]): Macro[MacAddress] = abortive:
     val macAddress = context.valueOrAbort.parts.head.tt.decode[MacAddress]

--- a/lib/urticose/src/core/urticose_core.scala
+++ b/lib/urticose/src/core/urticose_core.scala
@@ -37,6 +37,8 @@ import contingency.*
 import prepositional.*
 
 export urticose.internal.Ipv6
+export urticose.internal.Ipv4Subnet
+export urticose.internal.Ipv6Subnet
 export urticose.internal.Opaques.Ipv4
 export urticose.internal.Opaques.MacAddress
 export urticose.internal.Opaques.DnsLabel
@@ -50,6 +52,10 @@ type UdpPort = Port over Udp
 
 extension (inline context: StringContext)
   transparent inline def ip(): Ipv4 | Ipv6 = ${urticose.internal.ip('context)}
+
+  transparent inline def subnet(): Ipv4Subnet | Ipv6Subnet =
+    ${urticose.internal.subnet('context)}
+
   inline def mac(): MacAddress = ${urticose.internal.mac('context)}
   transparent inline def tcp(): Port = ${urticose.internal.portService('context, true)}
   transparent inline def udp(): Port = ${urticose.internal.portService('context, false)}

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -158,6 +158,51 @@ object Tests extends Suite(m"Urticose tests"):
         capture(t"::8:abcde:abc:1234".decode[Ipv6])
       . assert(_ == IpAddressError(IpAddressError.Reason.Ipv6GroupWrongLength(t"abcde")))
 
+    suite(m"Subnet tests"):
+      test(m"Create an IPv4 subnet at compiletime"):
+        subnet"192.168.0.0/24"
+      . assert(_ == ip"192.168.0.0".subnet(24))
+
+      test(m"IPv4 subnet at compiletime masks host bits"):
+        subnet"255.123.143.0/12".show
+      . assert(_ == t"255.112.0.0/12")
+
+      test(m"Create an IPv6 subnet at compiletime"):
+        subnet"2001:db8::/32"
+      . assert(_ == ip"2001:db8::".subnet(32))
+
+      test(m"Show an IPv6 subnet"):
+        subnet"2001:db8::/32".show
+      . assert(_ == t"2001:db8::/32")
+
+      test(m"Parse an IPv4 subnet at runtime"):
+        t"10.0.0.0/8".decode[Ipv4Subnet]
+      . assert(_ == Ipv4(10, 0, 0, 0).subnet(8))
+
+      test(m"Parse an IPv6 subnet at runtime"):
+        t"2001:db8::/32".decode[Ipv6Subnet]
+      . assert(_ == Ipv6(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0).subnet(32))
+
+      test(m"IPv4 subnet prefix out of range"):
+        capture(t"10.0.0.0/40".decode[Ipv4Subnet])
+      . assert(_ == IpAddressError(IpAddressError.Reason.Ipv4SubnetPrefixOutOfRange(40)))
+
+      test(m"IPv6 subnet prefix out of range"):
+        capture(t"2001:db8::/130".decode[Ipv6Subnet])
+      . assert(_ == IpAddressError(IpAddressError.Reason.Ipv6SubnetPrefixOutOfRange(130)))
+
+      test(m"Subnet prefix not numeric"):
+        capture(t"10.0.0.0/x".decode[Ipv4Subnet])
+      . assert(_ == IpAddressError(IpAddressError.Reason.SubnetPrefixNotNumeric(t"x")))
+
+      test(m"Subnet without a prefix is wrong format"):
+        capture(t"10.0.0.0".decode[Ipv4Subnet])
+      . assert(_ == IpAddressError(IpAddressError.Reason.SubnetWrongFormat(1)))
+
+      test(m"Invalid subnet prefix is compile error"):
+        demilitarize(subnet"10.0.0.0/40").map(_.message)
+      . assert(_ == List(t"[↯SN-077.9] the IP address is not valid because the prefix length 40 is not in the range 0-32"))
+
     suite(m"Email address tests"):
       import EmailAddressError.Reason.*
 


### PR DESCRIPTION
Urticose can now build IPv4 and IPv6 subnets from CIDR text with a `subnet"…"` interpolator that is validated at compile time, mirroring the existing `ip"…"` interpolator. The same change exports `Ipv4Subnet` and gives both subnet types runtime decoding, and adds an `Ipv6Subnet` type that was previously missing entirely.

Subnets in CIDR notation can now be written with the `subnet"…"` interpolator and are checked when your code compiles:

```scala
val lan = subnet"192.168.0.0/24"   // Ipv4Subnet
val v6  = subnet"2001:db8::/32"    // Ipv6Subnet

subnet"10.0.0.0/40"                // compile error: prefix length 40 is not in the range 0-32
```

Host bits below the prefix are masked off, so `subnet"255.123.143.0/12"` is `255.112.0.0/12`.

Both `Ipv4Subnet` and `Ipv6Subnet` are now exported from the package and can be decoded from `Text` at runtime, alongside the other network types:

```scala
import strategies.throwUnsafely
t"10.0.0.0/8".decode[Ipv4Subnet]
t"2001:db8::/32".decode[Ipv6Subnet]
```

`Ipv6Subnet` is new — IPv6 addresses already existed, but had no subnet representation. It comes with an `Ipv6.subnet(size)` extension matching the existing `Ipv4.subnet(size)`.