### PR TITLE
Accrue multiple errors when decoding CSV and TEL (#1254)

### DIFF
--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -48,15 +48,71 @@ import turbulence.*
 import vacuous.*
 import wisteria.*
 
-object Dsv:
-  def apply(iterable: Iterable[Text]): Dsv = new Dsv(IArray.from(iterable))
-  def apply(text: Text*): Dsv = new Dsv(IArray.from(text))
-
+trait Dsv2:
+  // Generic fallback: any `Decodable in Text` (custom types, enums, `Uuid`, …)
+  // decodes from the row's first cell. Held at lower priority than the primitive
+  // `Decodable in Dsv` givens in `object Dsv` (which accrue errors via raise+yet)
+  // so those win for Int/Long/Double/… where a `Decodable in Text` also exists —
+  // mirroring how distillate keeps its generic instance in `Decodable2`.
   given decoder: [decodable: Decodable in Text] => decodable is Decodable in Dsv =
     value => decodable.decoded(value.data.head)
 
+object Dsv extends Dsv2:
+  def apply(iterable: Iterable[Text]): Dsv = new Dsv(IArray.from(iterable))
+  def apply(text: Text*): Dsv = new Dsv(IArray.from(text))
+
   given encoder: [encodable: Encodable in Text] => encodable is Encodable in Dsv =
     value => Dsv(encodable.encode(value))
+
+  // Primitive cell decoders. Unlike the generic `decoder` (which bottoms out in
+  // distillate's `abort`ing text decoders), these register an error and continue
+  // with a sentinel value (`raise … yet sentinel`), so that when a row is decoded
+  // into a product under a `validate[CellRef]` boundary every malformed cell is
+  // accrued rather than the first failure aborting the whole record. An absent
+  // cell (short row / missing column) is distinguished from a present-but-
+  // unparseable one. The real cell location is carried by the enclosing
+  // `focus(CellRef(…))` in the product derivation, so `DsvError` itself is built
+  // through the position-free companion `apply`.
+  private def decodeCell[value]
+    ( dsv: Dsv, expected: Text, sentinel: value )
+    ( parse: Text => Optional[value] )
+    ( using format: DsvFormat, tactic: Tactic[DsvError] )
+  :   value =
+
+    dsv.data.prim.lay(raise(DsvError(format, DsvError.Reason.Absent)) yet sentinel): cell =>
+      parse(cell).or:
+        raise(DsvError(format, DsvError.Reason.Unparseable(cell, expected))) yet sentinel
+
+  given int: (format: DsvFormat) => Tactic[DsvError] => Int is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"Int", 0): cell =>
+      try Integer.parseInt(cell.s) catch case _: NumberFormatException => Unset
+
+  given long: (format: DsvFormat) => Tactic[DsvError] => Long is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"Long", 0L): cell =>
+      try java.lang.Long.parseLong(cell.s) catch case _: NumberFormatException => Unset
+
+  given double: (format: DsvFormat) => Tactic[DsvError] => Double is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"Double", 0.0): cell =>
+      try java.lang.Double.parseDouble(cell.s) catch case _: NumberFormatException => Unset
+
+  given float: (format: DsvFormat) => Tactic[DsvError] => Float is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"Float", 0.0f): cell =>
+      try java.lang.Float.parseFloat(cell.s) catch case _: NumberFormatException => Unset
+
+  given boolean: (format: DsvFormat) => Tactic[DsvError] => Boolean is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"Boolean", false): cell =>
+      cell.s match
+        case "true"  => true
+        case "false" => false
+        case _       => Unset
+
+  given text: (format: DsvFormat) => Tactic[DsvError] => Text is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"Text", t""): cell =>
+      cell
+
+  given string: (format: DsvFormat) => Tactic[DsvError] => String is Decodable in Dsv = dsv =>
+    decodeCell(dsv, t"String", ""): cell =>
+      cell.s
 
 
   inline given decodableDerivation: [value <: Product: ProductReflection]
@@ -145,7 +201,7 @@ object Dsv:
         Dsv(cells)
 
 case class Dsv(data: IArray[Text], columns: Optional[Map[Text, Int]] = Unset) extends Dynamic:
-  def as[cell: Decodable in Dsv]: cell = cell.decoded(this)
+  def as[cell: Decodable in Dsv]: cell raises DsvError tracks CellRef = cell.decoded(this)
 
   def header: Optional[IArray[Text]] = columns.let: map =>
     val columns = map.map(_.swap)

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -272,7 +272,8 @@ case class Sheet
     format:  Optional[DsvFormat]    = Unset,
     columns: Optional[IArray[Text]] = Unset ):
 
-  def as[value: Decodable in Dsv]: Stream[value] tracks CellRef = rows.map(_.as[value])
+  def as[value: Decodable in Dsv]: Stream[value] raises DsvError tracks CellRef =
+    rows.map(_.as[value])
 
   override def hashCode: Int =
     (rows.hashCode*31 + format.hashCode)*31 + columns.lay(-1): array =>

--- a/lib/caesura/src/test/caesura.AccrualTests.scala
+++ b/lib/caesura/src/test/caesura.AccrualTests.scala
@@ -32,48 +32,81 @@
                                                                                                   */
 package caesura
 
-import anticipation.*
-import denominative.*
-import fulminate.*
+import soundness.*
 
-object DsvError:
-  given communicable: Reason is Communicable =
-    case Reason.MisplacedQuote =>
-      m"a quote was found after the start of a cell"
+import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
+import dsvFormats.csvWithHeaderFormat
 
-    case Reason.Absent =>
-      m"the cell was absent"
+case class ARecord(name: Text, age: Int, height: Int) derives CanEqual
 
-    case Reason.Unparseable(value, expected) =>
-      m"the value $value could not be parsed as $expected"
+object AccrualTests extends Suite(m"Caesura multi-error accrual tests"):
 
-  // `MisplacedQuote` is a parse-phase error; `Absent` and `Unparseable` are
-  // decode-phase errors (a cell missing from, or unparseable in, a row being
-  // decoded into a product). The latter accrue through a `Foci[CellRef]`, which
-  // carries the real cell location, so they construct via the position-free
-  // companion `apply` below.
-  enum Reason(val number: Int) extends Clarification:
-    case MisplacedQuote                          extends Reason(1)
-    case Absent                                  extends Reason(2)
-    case Unparseable(value: Text, expected: Text) extends Reason(3)
+  case class Issues(items: List[(Text, DsvError)] = Nil)(using Diagnostics)
+  extends Error(m"${items.length} decoding issues"):
+    def +(focus: Text, error: DsvError): Issues = Issues(items :+ (focus, error))
 
-  // Decode-phase constructor: the offending cell's position is carried by the
-  // accrued `CellRef` focus, not by the `DsvError` itself, so `row`/`column`/
-  // `offset` are filled with placeholders.
-  def apply(format: DsvFormat, reason: Reason)(using Diagnostics): DsvError =
-    DsvError(format, reason, Prim, Prim, 0)
+  private def validateDsv[result](dsv: Dsv)
+                                 (decode: Dsv => result raises DsvError tracks CellRef)
+  :   Issues =
+    validate[CellRef](Issues()):
+      case error: DsvError =>
+        accrual + (prior.let(_.column).or(t"#"), error)
+    . within(decode(dsv))
 
-// `row` and `column` are the 1-based position of the offending cell, and `offset`
-// is the character (UTF-16 code-unit) offset into the input at which the failure
-// was detected. A byte offset is not available here because the parser operates on
-// already-decoded `Text`, the source bytes having been discarded upstream.
-case class DsvError
-  ( format: DsvFormat, reason: DsvError.Reason, row: Ordinal, column: Ordinal, offset: Int )
-  ( using Diagnostics )
-extends Error(364, reason.number)
-  ( reason match
-      case DsvError.Reason.MisplacedQuote =>
-        m"could not parse row data at row ${row.n1}, column ${column.n1} because $reason"
+  private def row(text: Text): Dsv = text.read[Sheet].rows.head
 
-      case _ =>
-        m"could not decode the cell because $reason" )
+  def run(): Unit =
+    suite(m"Single-error decoding (sanity)"):
+      test(m"Fully-valid row: no errors accrued"):
+        validateDsv(row(t"name,age,height\nAlice,30,170"))(_.as[ARecord]).items.length
+      . assert(_ == 0)
+
+      test(m"Single unparseable cell: one error"):
+        validateDsv(row(t"name,age,height\nAlice,thirty,170"))(_.as[ARecord]).items.length
+      . assert(_ == 1)
+
+      test(m"Single missing cell: one error"):
+        validateDsv(row(t"name,age,height\nAlice,30"))(_.as[ARecord]).items.length
+      . assert(_ == 1)
+
+    suite(m"Multiple unparseable cells"):
+      test(m"Two unparseable cells accrue two errors"):
+        validateDsv(row(t"name,age,height\nAlice,thirty,tall"))(_.as[ARecord]).items.length
+      . assert(_ == 2)
+
+      test(m"Columns identify the unparseable cells"):
+        validateDsv(row(t"name,age,height\nAlice,thirty,tall"))(_.as[ARecord])
+         .items.map(_(0).s).to(Set)
+      . assert(_ == Set("age", "height"))
+
+      test(m"Each unparseable error has reason Unparseable"):
+        validateDsv(row(t"name,age,height\nAlice,thirty,tall"))(_.as[ARecord]).items.all:
+          case (_, err) => err.reason match
+            case DsvError.Reason.Unparseable(_, _) => true
+            case _                                 => false
+      . assert(identity)
+
+    suite(m"Multiple missing cells"):
+      test(m"Two missing cells accrue two errors"):
+        validateDsv(row(t"name,age,height\nAlice"))(_.as[ARecord]).items.length
+      . assert(_ == 2)
+
+      test(m"Columns identify the missing cells"):
+        validateDsv(row(t"name,age,height\nAlice"))(_.as[ARecord]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("age", "height"))
+
+      test(m"Each missing-cell error has reason Absent"):
+        validateDsv(row(t"name,age,height\nAlice"))(_.as[ARecord]).items.all:
+          case (_, err) => err.reason == DsvError.Reason.Absent
+      . assert(identity)
+
+    suite(m"Missing + unparseable mixed"):
+      test(m"One unparseable plus one missing: two errors at the right columns"):
+        validateDsv(row(t"name,age,height\nAlice,thirty"))(_.as[ARecord]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("age", "height"))
+
+    suite(m"Regression: does not abort on the first bad cell"):
+      test(m"Both bad cells are reported, not just the first"):
+        validateDsv(row(t"name,age,height\nAlice,bad1,bad2"))(_.as[ARecord]).items.length
+      . assert(_ > 1)

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -309,6 +309,8 @@ object Tests extends Suite(m"Caesura tests"):
         summon[DsvRedesignation].transform(t"targetPerson")
       . assert(_ == t"target person")
 
+    AccrualTests()
+
 case class Foo(one: Text, two: Text)
 case class Bar(one: Double, foo1: Foo, four: Int, foo2: Foo)
 case class Quux(name: Text, greeting: Text)

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -63,6 +63,12 @@ object Tel extends Tel2:
   type Error = TelError
   val Error: TelError.type = TelError
 
+  // The focus carried by `Tel#as[T]` for multi-error accrual: a keyword path
+  // identifying the field being decoded (and, for parser-phase errors, an
+  // optional source position). Mirrors `Json.Focus` / `Yaml.Focus`.
+  case class Focus(pointer: TelPath = TelPath.Root, position: Optional[TelError.Position] = Unset)
+  derives CanEqual
+
   extension (tel: Tel)
     def edited(revision: Revision): Tel raises MutationError = revision(tel)
 
@@ -1013,7 +1019,8 @@ extends scala.Dynamic, Documentary, Topical, Original:
   type Self = Tel
   type Metadata = Tel.Metadata
 
-  inline def as[value: Decodable in Tel]: value raises TelError = value.decoded(this)
+  inline def as[value: Decodable in Tel]: value raises TelError tracks Tel.Focus =
+    value.decoded(this)
 
   // Total field access used by the schema-typed navigation macros and by
   // internal optics: an empty `Tel` for a missing field, never raising.

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -129,7 +129,18 @@ object Tel extends Tel2:
     import TelError.Reason
     import Tels.*
 
-    def assign(tel: Tel, schema: Tels): Tel.Element raises TelError =
+    // Record an E2xx/E3xx validation error and continue with `continuation` —
+    // the §19.5 `IgnoreErroneousNode` recovery: discard the offending node and
+    // keep validating siblings. Under the default `ThrowTactic` `raise` throws,
+    // preserving fail-fast validation; under a `validate[Tel.Focus]` boundary's
+    // `TrackTactic` it accrues and the continuation supplies the skipped value.
+    private inline def recoverNode[value](reason: Reason)(continuation: => value)
+      ( using Tactic[TelError], Foci[Tel.Focus] )
+    :   value =
+
+      raise(TelError(reason)) yet continuation
+
+    def assign(tel: Tel, schema: Tels): Tel.Element raises TelError tracks Tel.Focus =
       val compounds: IArray[Tel.Compound] = tel.subtree.children.flatMap(_.compounds)
       val rootChildren = assignChildren(compounds, schema.document, schema)
 
@@ -139,7 +150,7 @@ object Tel extends Tel2:
       Tel.Element.Node(keywordIndex = Unset, elementType = schema.document, children = rootElements)
 
     def assign(tel: Tel, schema: Tels, validators: Tel.Validator.Registry)
-    :   Tel.Element raises TelError =
+    :   Tel.Element raises TelError tracks Tel.Focus =
 
       val element = assign(tel, schema)
       validateElement(element, validators)
@@ -147,7 +158,7 @@ object Tel extends Tel2:
 
     private def validateElement
       ( element: Tel.Element, registry: Tel.Validator.Registry )
-    :   Unit raises TelError =
+    :   Unit raises TelError tracks Tel.Focus =
 
       element match
         case Tel.Element.Value(_, scalarType, text) =>
@@ -156,7 +167,7 @@ object Tel extends Tel2:
               case Tel.Validator.Response.Valid      => ()
 
               case Tel.Validator.Response.Invalid(_) =>
-                abort(TelError(Reason.ValidatorRejected))
+                recoverNode(Reason.ValidatorRejected)(())
 
         case Tel.Element.Node(_, elementType, children) =>
           children.each(validateElement(_, registry))
@@ -170,7 +181,7 @@ object Tel extends Tel2:
                   case Tel.Validator.Response.Valid      => ()
 
                   case Tel.Validator.Response.Invalid(_) =>
-                    abort(TelError(Reason.ValidatorRejected))
+                    recoverNode(Reason.ValidatorRejected)(())
 
             case _ => ()
 
@@ -349,7 +360,7 @@ object Tel extends Tel2:
       ( compounds: IArray[Tel.Compound],
        parent:    Struct,
        schema:    Tels )
-    :   IArray[Tel.Element] raises TelError =
+    :   IArray[Tel.Element] raises TelError tracks Tel.Focus =
 
       val km = keywordMap(parent, schema)
       val results = scala.collection.mutable.ArrayBuffer.empty[Tel.Element]
@@ -358,10 +369,12 @@ object Tel extends Tel2:
       while i < compounds.length do
         val compound = compounds(i)
 
-        val entry = km.get(compound.keyword).getOrElse:
-          abort(TelError(Reason.UnknownKeyword))
+        // An unrecognised keyword is skipped (`IgnoreErroneousNode`): record it and
+        // emit no element, so remaining siblings are still validated.
+        km.get(compound.keyword) match
+          case Some(entry) => results += assignCompound(compound, entry, schema)
+          case None        => recoverNode(Reason.UnknownKeyword)(())
 
-        results += assignCompound(compound, entry, schema)
         i += 1
 
       IArray.from(results)
@@ -371,7 +384,7 @@ object Tel extends Tel2:
         atomElements:  IArray[Tel.Element],
         childElements: IArray[Tel.Element],
         schema:        Tels )
-    :   IArray[Tel.Element] raises TelError =
+    :   IArray[Tel.Element] raises TelError tracks Tel.Focus =
 
       val results = scala.collection.mutable.ArrayBuffer.empty[Tel.Element]
       results ++= atomElements
@@ -401,9 +414,9 @@ object Tel extends Tel2:
             if !filled then resolveType(f.fieldType, schema) match
               case s: Scalar => f.default match
                 case t: Text           => results += Tel.Element.Value(flatStart, s, t)
-                case unset: Unset.type => abort(TelError(Reason.RequiredMemberAbsent))
+                case unset: Unset.type => recoverNode(Reason.RequiredMemberAbsent)(())
 
-              case _ => abort(TelError(Reason.RequiredMemberAbsent))
+              case _ => recoverNode(Reason.RequiredMemberAbsent)(())
 
           case _ => ()
 
@@ -416,7 +429,7 @@ object Tel extends Tel2:
       ( compound: Tel.Compound,
        entry:    KeywordEntry,
        schema:   Tels )
-    :   Tel.Element raises TelError =
+    :   Tel.Element raises TelError tracks Tel.Focus =
 
       val resolved = resolveType(entry.entryType, schema)
 
@@ -440,12 +453,13 @@ object Tel extends Tel2:
 
         case Flag =>
           if compound.atoms.nonEmpty || compound.children.nonEmpty then
-            abort(TelError(Reason.FlagWithContent))
+            recoverNode(Reason.FlagWithContent)(())
 
           Tel.Element.Node(entry.memberIndex, Flag, IArray.empty)
 
         case _: Reference =>
-          abort(TelError(Reason.UnresolvedReference))
+          recoverNode(Reason.UnresolvedReference):
+            Tel.Element.Node(entry.memberIndex, Flag, IArray.empty)
 
   // Validator infrastructure per §21 of the TEL specification.
   object Validator:

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -146,32 +146,41 @@ trait Tel2:
         Morphology.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
       }):
         telVal =>
-          provide[Tactic[TelError]]:
-            // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
-            // verbatim; an unannotated field falls back to its camel→kebab form.
-            val renames: Map[Text, Text] = relabelling[derivation, Tel]
+          provide[Foci[Tel.Focus]]:
+            provide[Tactic[TelError]]:
+              // `@name[Tel]` / bare `@name` renames: field name -> keyword, used
+              // verbatim; an unannotated field falls back to its camel→kebab form.
+              val renames: Map[Text, Text] = relabelling[derivation, Tel]
 
-            build[derivation]: [field] =>
-              ctx =>
-                val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
+              build[derivation]: [field] =>
+                ctx =>
+                  val keyword: Text = renames.getOrElse(label, Tel.camelToKebab(label.s))
 
-                // A `List`/`Set` field (`ctx.repeatable`) is encoded as repeated
-                // keyword compounds, so gather them all into a Document for the
-                // collection decoder. Every other field — scalar, nested product,
-                // `Optional`, `Map` (a single `entries` compound) — reads one match.
-                if ctx.repeatable then
-                  val compounds = telVal.childCompounds.filter(_.keyword == keyword)
+                  // Tag every error registered while decoding this field with its
+                  // keyword path, so that under a `validate[Tel.Focus]` boundary the
+                  // primitives' `raise … yet sentinel` accrue per-field rather than the
+                  // first malformed field aborting the whole record.
+                  focus({
+                    val base = prior.let(_.pointer).or(TelPath.Root)
+                    Tel.Focus(base.prepend(keyword))
+                  }):
+                    // A `List`/`Set` field (`ctx.repeatable`) is encoded as repeated
+                    // keyword compounds, so gather them all into a Document for the
+                    // collection decoder. Every other field — scalar, nested product,
+                    // `Optional`, `Map` (a single `entries` compound) — reads one match.
+                    if ctx.repeatable then
+                      val compounds = telVal.childCompounds.filter(_.keyword == keyword)
 
-                  ctx.decoded:
-                    Tel.make
-                      ( Tel.Document
-                        ( Unset, Unset, Tel.LineEndings.Lf,
-                         IArray(Tel.Block(IArray.empty, Unset, compounds, 0)) ) )
-                else
-                  val match0 = telVal.field(keyword)
+                      ctx.decoded:
+                        Tel.make
+                          ( Tel.Document
+                            ( Unset, Unset, Tel.LineEndings.Lf,
+                             IArray(Tel.Block(IArray.empty, Unset, compounds, 0)) ) )
+                    else
+                      val match0 = telVal.field(keyword)
 
-                  if match0.absent then default.or(ctx.decoded(Tel.empty))
-                  else ctx.decoded(match0.vouch)
+                      if match0.absent then default.or(ctx.decoded(Tel.empty))
+                      else ctx.decoded(match0.vouch)
 
     inline def disjunction[derivation: SumReflection]: derivation is Tel.Decodable =
       // A sum is a document whose single child compound is the chosen variant, keyed by
@@ -183,18 +192,19 @@ trait Tel2:
       // `Schematic` / `Tels.tels`.
       Tel.Decodable(Morphology.Any):
         telVal =>
-          provide[Tactic[TelError]]:
-            provide[Tactic[VariantError]]:
-              // Map the variant's kebab keyword back to the label `delegate` dispatches on.
-              val labels: Map[Text, Text] =
-                variantLabels.map: label => Tel.camelToKebab(label.s) -> label
-                . to(Map)
+          provide[Foci[Tel.Focus]]:
+            provide[Tactic[TelError]]:
+              provide[Tactic[VariantError]]:
+                // Map the variant's kebab keyword back to the label `delegate` dispatches on.
+                val labels: Map[Text, Text] =
+                  variantLabels.map: label => Tel.camelToKebab(label.s) -> label
+                  . to(Map)
 
-              val variant: Tel = Tel.make(telVal.childCompounds.head)
-              val variantKeyword: Text = labels.getOrElse(variant.keyword, variant.keyword)
+                val variant: Tel = Tel.make(telVal.childCompounds.head)
+                val variantKeyword: Text = labels.getOrElse(variant.keyword, variant.keyword)
 
-              delegate(variantKeyword): [variant <: derivation] =>
-                ctx => ctx.decoded(variant)
+                delegate(variantKeyword): [variant <: derivation] =>
+                  ctx => ctx.decoded(variant)
 
   object EncodableDerivation extends Derivable[Tel.Encodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
@@ -256,33 +266,55 @@ trait Tel2:
   // atom. These mirror jacinta.Json's primitive decoders but go through
   // the atom text rather than a JSON AST.
 
+  // Register a decode error and continue with `sentinel` instead of aborting, so
+  // that sibling fields of a product can each accrue their own error under a
+  // `validate[Tel.Focus]` boundary. A field with no atom (the empty `Tel` handed
+  // to a primitive by `conjunction` for an absent field) raises `Absent`; an atom
+  // that fails to parse raises `NotScalar`, distinguishing "missing" from
+  // "wrong shape". Outside a `validate` boundary the ambient `ThrowTactic` makes
+  // `raise` throw, preserving fail-fast decoding.
+  private def primitiveFault[value]
+    ( tel: Tel, expected: Text, sentinel: value )
+    ( parse: Text => Optional[value] )
+    ( using Tactic[TelError] )
+  :   value =
+
+    if tel.atomTexts.isEmpty then raise(TelError(TelError.Reason.Absent)) yet sentinel
+    else parse(tel.primaryAtom).or:
+      raise(TelError(TelError.Reason.NotScalar(tel.primaryAtom, expected))) yet sentinel
+
   given textDecodable: Tactic[TelError] => Text is Tel.Decodable =
-    Tel.Decodable(Morphology.Str)(_.primaryAtom)
+    Tel.Decodable(Morphology.Str): tel =>
+      primitiveFault(tel, t"Text", t""): atom =>
+        atom
 
   given stringDecodable: Tactic[TelError] => String is Tel.Decodable =
-    Tel.Decodable(Morphology.Str)(_.primaryAtom.s)
+    Tel.Decodable(Morphology.Str): tel =>
+      primitiveFault(tel, t"String", ""): atom =>
+        atom.s
 
   given intDecodable: Tactic[TelError] => Int is Tel.Decodable =
-    Tel.Decodable(Morphology.Whole): telVal =>
-      try telVal.primaryAtom.s.toInt
-      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+    Tel.Decodable(Morphology.Whole): tel =>
+      primitiveFault(tel, t"Int", 0): atom =>
+        try atom.s.toInt catch case _: NumberFormatException => Unset
 
   given longDecodable: Tactic[TelError] => Long is Tel.Decodable =
-    Tel.Decodable(Morphology.Whole): telVal =>
-      try telVal.primaryAtom.s.toLong
-      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+    Tel.Decodable(Morphology.Whole): tel =>
+      primitiveFault(tel, t"Long", 0L): atom =>
+        try atom.s.toLong catch case _: NumberFormatException => Unset
 
   given doubleDecodable: Tactic[TelError] => Double is Tel.Decodable =
-    Tel.Decodable(Morphology.Real): telVal =>
-      try telVal.primaryAtom.s.toDouble
-      catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
+    Tel.Decodable(Morphology.Real): tel =>
+      primitiveFault(tel, t"Double", 0.0): atom =>
+        try atom.s.toDouble catch case _: NumberFormatException => Unset
 
   given booleanDecodable: Tactic[TelError] => Boolean is Tel.Decodable =
-    Tel.Decodable(Morphology.Bool): telVal =>
-      telVal.primaryAtom.s match
-        case "true"  => true
-        case "false" => false
-        case _       => abort(TelError(TelError.Reason.BadVersion))
+    Tel.Decodable(Morphology.Bool): tel =>
+      primitiveFault(tel, t"Boolean", false): atom =>
+        atom.s match
+          case "true"  => true
+          case "false" => false
+          case _       => Unset
 
   given telDecodable: Tel is Tel.Decodable = Tel.Decodable(Morphology.Any)(identity(_))
 

--- a/lib/stratiform/src/core/stratiform.TelError.scala
+++ b/lib/stratiform/src/core/stratiform.TelError.scala
@@ -170,8 +170,15 @@ object TelError:
       case MembersNonContiguous     => m"compound children of the same member are not contiguous"
       case ValidatorRejected        => m"a scalar value or struct failed a named validator"
       case FlagWithContent          => m"the Flag-typed compound has atoms or compound children"
+      case Absent                   => m"a required value was absent"
 
-    def recoveryOf(reason: Reason): Recovery = reason match
+      case NotScalar(value, expected) =>
+        m"the value $value could not be parsed as $expected"
+
+    // The §19.5 recovery strategy for a parse/validation reason, or `Unset` for a
+    // decode reason (E4xx), which accrues through `Foci` rather than the parser's
+    // recovery model.
+    def recoveryOf(reason: Reason): Optional[Recovery] = reason match
       case BomPresent               => Recovery.SkipBom
       case PragmaNotFirst           => Recovery.RestartFromPragma
       case PragmaTooLong            => Recovery.AllowOversize
@@ -210,6 +217,10 @@ object TelError:
         | RequiredMemberAbsent | NonRepeatableTooMany | MembersNonContiguous
         | ValidatorRejected | FlagWithContent =>
         Recovery.IgnoreErroneousNode
+
+      // E4xx decode reasons have no parser-level recovery.
+      case Absent | NotScalar(_, _) =>
+        Unset
 
   enum Reason(val number: Int) extends Clarification:
     case BomPresent              extends Reason(101)
@@ -268,6 +279,12 @@ object TelError:
     case MembersNonContiguous    extends Reason(309)
     case ValidatorRejected       extends Reason(310)
     case FlagWithContent         extends Reason(311)
+
+    // E4xx — decode errors (mapping a TEL value onto a Scala type). Surfaced via
+    // `Foci`-based accrual at decode time, not the §19.5 parser/validation
+    // recovery model, so they carry no `Recovery` strategy.
+    case Absent                                 extends Reason(401)
+    case NotScalar(value: Text, expected: Text) extends Reason(402)
 
 case class TelError(reason: TelError.Reason, position: Optional[TelError.Position] = Unset)
   ( using Diagnostics )

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -1260,7 +1260,9 @@ private final class TelParser():
       if !shallowerValid && deeperValid then deeper else shallower
 
     . or:
-      errorAt(Reason.OddIndentation, line, 1)
+      // §19.5 ShallowerIndent: round an odd indent down to the nearer level. The
+      // leading spaces are already consumed, so returning a level cannot stall.
+      recoverAt(Reason.OddIndentation, line, 1)(rel / 2)
 
   // ── Line-head fill ───────────────────────────────────────────────────────
 
@@ -1305,7 +1307,8 @@ private final class TelParser():
       val rel = spaces - margin
 
       head.indentLevels =
-        if rel < 0 then errorAt(Reason.LessThanMargin, head.startLine, 1)
+        // §19.5 AdjustMargin: a line indented less than the margin sits at level 0.
+        if rel < 0 then recoverAt(Reason.LessThanMargin, head.startLine, 1)(0)
         else if rel % 2 == 0 then rel / 2
         else recoverOddIndent(spaces, head.startLine)
 

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -629,7 +629,7 @@ private final class TelParser():
     continuation
 
   private inline def recoverAt[T](reason: Reason, line: Int, column: Int)
-    (continuation: => T)
+    ( continuation: => T )
   :   T raises TelError =
 
     raise(TelError(reason, TelError.Position(line, column)))
@@ -1067,19 +1067,21 @@ private final class TelParser():
 
         val isBase256 = s.nonEmpty && s.forall: c => Character.isLetter(c) || (c >= '0' && c <= '9')
 
+        // §19.5 IgnoreSchemaId: a malformed schema identifier is dropped (Unset).
         if !isUrl && !isBase256
-        then errorAt(Reason.BadSchemaIdentifier, line, 1)
-
-        Text(s): Optional[Text]
+        then recoverAt(Reason.BadSchemaIdentifier, line, 1)(Unset)
+        else Text(s): Optional[Text]
       else
         Unset
 
     val pragmaSigil: Optional[Char] =
       if parts.length >= 4 && parts(3).length == 1 then
         val c = parts(3).charAt(0)
-        if c.isLetterOrDigit then errorAt(Reason.BadSigil, line, 1)
-        sigil = c.toByte
-        c: Optional[Char]
+        // §19.5 UseDefaultSigil: an invalid sigil is dropped, keeping the default.
+        if c.isLetterOrDigit then recoverAt(Reason.BadSigil, line, 1)(Unset)
+        else
+          sigil = c.toByte
+          c: Optional[Char]
       else
         Unset
 
@@ -1091,13 +1093,16 @@ private final class TelParser():
     // §19.5 IgnoreVersion: a malformed version falls back to (0, 0) so the rest
     // of the document is still parsed (and its defects accrued).
     val dot = s.indexOf('.')
+
     if dot <= 0 || dot == s.length - 1 then recoverAt(Reason.BadVersion, line, 1)((0, 0))
     else
       try
         val major = s.substring(0, dot).toInt
         val minor = s.substring(dot + 1).toInt
+
         if major < 0 || minor < 0 then recoverAt(Reason.BadVersion, line, 1)((0, 0))
         else (major, minor)
+
       catch case _: NumberFormatException => recoverAt(Reason.BadVersion, line, 1)((0, 0))
 
   private def splitPragmaPhrases(content: String): List[String] =

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -1332,30 +1332,30 @@ private final class TelParser():
     else
       val start = blockScratchIx
 
-      while !head.eof && !head.separator && head.indentLevels == expected do
-        parseBlock(expected)  // pushes one block onto scratchBlocks
+      // A line more indented than `expected` is misplaced. Under fail-fast the
+      // first such line raises (unchanged); under a `validate` boundary we record
+      // it and recover (SkipOverIndented / ShallowerIndent) by clamping it to
+      // `expected` so `parseBlock` consumes it as a sibling — guaranteeing the
+      // cursor advances every iteration, so the parser keeps going to EOF and
+      // accrues every defect (e.g. for LSP diagnostics) without ever stalling.
+      while !head.eof && !head.separator && head.indentLevels >= expected do
+        if head.indentLevels > expected then
+          val line   = head.startLine
+          val lastIx = blockScratchIx - 1
 
-      // After consuming children at `expected`, a remaining non-blank line
-      // more indented than `expected` is an error. A document separator
-      // (always at column zero) is never over-indented, so it is excluded.
-      if !head.eof && !head.separator && head.indentLevels > expected then
-        val line = head.startLine
-        val lastIx = blockScratchIx - 1
+          val reason =
+            if lastIx < start then Reason.OverIndentation
+            else
+              val last = scratchBlocks(lastIx)
 
-        if lastIx >= start then
-          val last = scratchBlocks(lastIx)
+              if last.tabulation.present && last.compounds.nil then Reason.RowWrongIndent
+              else if last.tabulation.present || last.compounds.nil then Reason.ChildOfNonCompound
+              else Reason.OverIndentation
 
-          if last.tabulation.present && last.compounds.nil then
-            errorAt(Reason.RowWrongIndent, line, 1)
-          else if last.tabulation.present then
-            errorAt(Reason.ChildOfNonCompound, line, 1)
-          else if last.compounds.nil then
-            errorAt(Reason.ChildOfNonCompound, line, 1)
-          else
-            errorAt(Reason.OverIndentation, line, 1)
+          recoverAt(reason, line, 1)(())
+          head.indentLevels = expected
 
-        else
-          errorAt(Reason.OverIndentation, line, 1)
+        parseBlock(expected)  // pushes one block onto scratchBlocks; consumes ≥1 line
 
       takeBlocks(blockScratchIx - start)
 

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -1044,7 +1044,9 @@ private final class TelParser():
   :   Tel.Pragma raises TelError =
 
     val parts = splitPragmaPhrases(content)
-    if parts.head != "tel" then errorAt(Reason.PragmaNotFirst, line, 1)
+
+    // §19.5 RestartFromPragma: a non-`tel` head is recorded but parsing continues.
+    if parts.head != "tel" then recoverAt(Reason.PragmaNotFirst, line, 1)(())
 
     val version =
       if parts.length >= 2 then parseVersion(parts(1), line)
@@ -1377,9 +1379,10 @@ private final class TelParser():
     do
       // §9 E109 check — fires only if the immediately preceding line was a
       // content line (compound / tabulation) at indent ≥ this comment's.
+      // §19.5 AttachComment: record the misplacement but attach the comment.
       if !prevLineWasBoundary && prevContentLeadingSpaces >= 0 &&
         prevContentLeadingSpaces >= margin + indent * 2
-      then errorAt(Reason.CommentNotPreceded, head.startLine, 1)
+      then recoverAt(Reason.CommentNotPreceded, head.startLine, 1)(())
 
       val text = parseCommentLine()
       pushComment(Tel.Comment(text))
@@ -1786,8 +1789,10 @@ private final class TelParser():
                 val phraseWidth = runStart - phraseStart
                 val colMax = markers(columnIdx + 1) - markers(columnIdx) - 2
 
+                // §19.5 SuppressColumnAlignment: record but keep scanning (the
+                // loop self-advances and the row is re-read by parseCompoundLine).
                 if phraseWidth > colMax then
-                  errorAt(Reason.ColumnValueTooWide, lineNumber, phraseStart + 1)
+                  recoverAt(Reason.ColumnValueTooWide, lineNumber, phraseStart + 1)(())
 
               var foundIdx = -1
               var k = 1
@@ -1796,8 +1801,9 @@ private final class TelParser():
                 if markers(k) == col then foundIdx = k
                 k += 1
 
+              // §19.5 SuppressColumnAlignment: record but keep scanning.
               if foundIdx < 0 then
-                errorAt(Reason.HardSpaceWrongPosition, lineNumber, col + 1)
+                recoverAt(Reason.HardSpaceWrongPosition, lineNumber, col + 1)(())
 
               columnIdx = foundIdx
               phraseStart = col
@@ -1825,12 +1831,18 @@ private final class TelParser():
         else if head.leadingSpaces == sourceIndent then Optional(parseSourceAtom(sourceIndent))
         else Unset
 
-      // §10.4 / §11.1: at most one source / literal atom per compound.
+      // §10.4 / §11.1: at most one source / literal atom per compound. §19.5
+      // IgnoreDuplicateAtom: record the duplicate but consume (and discard) it so
+      // the cursor advances past it and parsing continues.
       if first.present && !head.eof && !head.blank then
-        if head.leadingSpaces == literalIndent
-        then errorAt(Reason.DuplicateLiteral, head.startLine, 1)
-        else if head.leadingSpaces == sourceIndent
-        then errorAt(Reason.DuplicateSource, head.startLine, 1)
+        if head.leadingSpaces == literalIndent then
+          recoverAt(Reason.DuplicateLiteral, head.startLine, 1):
+            parseLiteralAtom(literalIndent)
+            ()
+        else if head.leadingSpaces == sourceIndent then
+          recoverAt(Reason.DuplicateSource, head.startLine, 1):
+            parseSourceAtom(sourceIndent)
+            ()
 
       first
 
@@ -1982,12 +1994,14 @@ private final class TelParser():
     var done = false
 
     while !done do
-      if !more then errorAt(Reason.UnclosedLiteral, openingLine, 1)
+      // §19.5 PayloadToEof: an unterminated literal ends at EOF rather than
+      // aborting, so the rest of the document can still be parsed and accrued.
+      if !more then done = recoverAt(Reason.UnclosedLiteral, openingLine, 1)(true)
       // Read a line. Inside the literal payload, line endings are not
       // subject to the document's LF/CRLF mode (per §15 the payload is
       // verbatim, with CRLF normalised to LF). One hold per payload line so
       // the cursor can compact between lines.
-      done = inHold:
+      else done = inHold:
         val lineMk = beginMark()
 
         while
@@ -2017,14 +2031,18 @@ private final class TelParser():
 
           true
         else
-          // Payload line — must have an LF terminator; EOF here is E115.
-          if !more then errorAt(Reason.UnclosedLiteral, openingLine, 1)
-          advance()  // consume LF
-          lineNo += 1
-          if !more then documentEndsWithLf = true
-          sb.append(raw)
-          sb.append('\n')
-          false
+          // Payload line — must have an LF terminator; EOF here is E115. §19.5
+          // PayloadToEof: an unterminated final line ends the payload at EOF.
+          if !more then
+            sb.append(raw)
+            recoverAt(Reason.UnclosedLiteral, openingLine, 1)(true)
+          else
+            advance()  // consume LF
+            lineNo += 1
+            if !more then documentEndsWithLf = true
+            sb.append(raw)
+            sb.append('\n')
+            false
 
     fillHead()
     // §15: the payload is the verbatim bytes between structural LFs — CR is
@@ -2049,8 +2067,10 @@ private final class TelParser():
     // E102: a `tel` or `tel …` line at column 0 after the first non-blank
     // line is a misplaced pragma. The valid pragma was already consumed
     // earlier by parsePragma; anything matching here is a violation.
+    // §19.5 RestartFromPragma: record the misplaced pragma but parse the line as
+    // an ordinary compound (the keyword is already read; the rest follows).
     if mayBeMisplacedPragma && keyword == t"tel" then
-      errorAt(Reason.PragmaNotFirst, lineNumber, 1)
+      recoverAt(Reason.PragmaNotFirst, lineNumber, 1)(())
 
     hasConsumedNonBlankLine = true
 

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -616,6 +616,25 @@ private final class TelParser():
 
     abort(TelError(reason, TelError.Position(line, column)))
 
+  // Recoverable-error variants of `errorHere`/`errorAt`. They `raise` the error
+  // (rather than `abort`) and continue with `continuation`, which realises the
+  // §19.5 `recoveryOf(reason)` strategy. Under the default `ThrowTactic` `raise`
+  // throws, so parsing stays fail-fast and identical to `errorHere`/`errorAt`;
+  // under a `validate`-installed `TrackTactic` the error accrues and parsing
+  // continues, so a document with several recoverable defects reports them all.
+  // The continuation MUST advance the cursor past the offending input (or the
+  // surrounding flow must), otherwise an enclosing scan loop would not progress.
+  private inline def recoverHere[T](reason: Reason)(continuation: => T): T raises TelError =
+    raise(TelError(reason, TelError.Position(lineNo, columnForCurrentBytePos())))
+    continuation
+
+  private inline def recoverAt[T](reason: Reason, line: Int, column: Int)
+    (continuation: => T)
+  :   T raises TelError =
+
+    raise(TelError(reason, TelError.Position(line, column)))
+    continuation
+
   // ── Mark / hold plumbing ──────────────────────────────────────────────────
   //
   // The streaming parser uses narrow per-leaf holds: every method that takes
@@ -975,8 +994,9 @@ private final class TelParser():
   private def consumeLineEnding(): Unit raises TelError =
     if !more then ()
     else if peek == LF then
+      // §19.5 CollapseLineEndings: accept the inconsistent ending and carry on.
       if !lineEndingsDetected then detectLineEndingMode(crBefore = false)
-      else if crlfMode then errorHere(Reason.BadLineEnding)
+      else if crlfMode then recoverHere(Reason.BadLineEnding)(())
 
       advance()
       lineNo += 1
@@ -984,10 +1004,12 @@ private final class TelParser():
     else if peek == CR then
       val next = peekNext()
 
+      // A bare CR (not followed by LF) cannot be consumed coherently, so it stays
+      // fatal; an LF-mode CR LF is recoverable (CollapseLineEndings).
       if next != LF.toInt then errorHere(Reason.BadLineEnding)
       else
         if !lineEndingsDetected then detectLineEndingMode(crBefore = true)
-        else if !crlfMode then errorHere(Reason.BadLineEnding)
+        else if !crlfMode then recoverHere(Reason.BadLineEnding)(())
 
         advance()  // CR
         advance()  // LF
@@ -2117,9 +2139,11 @@ private final class TelParser():
     // Inside the outer `hold`, the buffer byte just before the current pos
     // is still resident — peek it directly. (`pos > 0` because we have
     // consumed at least the keyword.)
+    // §19.5 StripTrailing: the keyword/atoms already exclude the trailing space,
+    // so recording the error and continuing yields the stripped line.
     if remark.absent && more && (peek == LF || peek == CR) &&
       pos > 0 && bytes(pos - 1) == SP
-    then errorAt(Reason.TrailingSpaces, lineNumber, head.leadingSpaces + 1)
+    then recoverAt(Reason.TrailingSpaces, lineNumber, head.leadingSpaces + 1)(())
 
     consumeLineEnding()
     compoundLineKeyword = keyword

--- a/lib/stratiform/src/core/stratiform.TelParser.scala
+++ b/lib/stratiform/src/core/stratiform.TelParser.scala
@@ -871,7 +871,12 @@ private final class TelParser():
   // ── BOM ──────────────────────────────────────────────────────────────────
 
   private def checkBom(): Unit raises TelError =
-    if more && peek == BOM0 then errorHere(Reason.BomPresent)
+    if more && peek == BOM0 then
+      // §19.5 SkipBom: drop the byte-order mark and parse from the next byte.
+      recoverHere(Reason.BomPresent):
+        advance()
+        if more && peek == BOM1 then advance()
+        if more && peek == BOM2 then advance()
 
   // ── Line endings ─────────────────────────────────────────────────────────
 
@@ -944,8 +949,9 @@ private final class TelParser():
           syncTo()
           val pragmaStartAbs = cursor.position.n0
 
+          // §19.5 AllowOversize: record the cap breach but keep parsing the pragma.
           if pragmaStartAbs >= 4096 then
-            errorAt(Reason.PragmaTooLong, pragmaLine, 1)
+            recoverAt(Reason.PragmaTooLong, pragmaLine, 1)(())
 
           val pragmaMk = beginMark()
           while more && peek != LF && peek != CR do advance()
@@ -954,7 +960,7 @@ private final class TelParser():
           val pragmaEndAbs = cursor.position.n0
 
           if pragmaEndAbs > 4096 then
-            errorAt(Reason.PragmaTooLong, pragmaLine, 1)
+            recoverAt(Reason.PragmaTooLong, pragmaLine, 1)(())
 
           consumeLineEnding()
           prevLineWasBoundary = true
@@ -1044,7 +1050,9 @@ private final class TelParser():
       if parts.length >= 2 then parseVersion(parts(1), line)
       else (1, 0)
 
-    if parts.length > 4 then errorAt(Reason.ExtraPragmaContent, line, 1)
+    // §19.5 IgnoreExtraPragmaAtoms: only parts 2 and 3 are read below, so excess
+    // atoms are already ignored once the error is recorded.
+    if parts.length > 4 then recoverAt(Reason.ExtraPragmaContent, line, 1)(())
 
     val schemaText: Optional[Text] =
       if parts.length >= 3 then
@@ -1080,15 +1088,17 @@ private final class TelParser():
   private def parseVersion(s: String, line: Int)
   :   (Int, Int) raises TelError =
 
+    // §19.5 IgnoreVersion: a malformed version falls back to (0, 0) so the rest
+    // of the document is still parsed (and its defects accrued).
     val dot = s.indexOf('.')
-    if dot <= 0 || dot == s.length - 1 then errorAt(Reason.BadVersion, line, 1)
-
-    try
-      val major = s.substring(0, dot).toInt
-      val minor = s.substring(dot + 1).toInt
-      if major < 0 || minor < 0 then errorAt(Reason.BadVersion, line, 1)
-      (major, minor)
-    catch case _: NumberFormatException => errorAt(Reason.BadVersion, line, 1)
+    if dot <= 0 || dot == s.length - 1 then recoverAt(Reason.BadVersion, line, 1)((0, 0))
+    else
+      try
+        val major = s.substring(0, dot).toInt
+        val minor = s.substring(dot + 1).toInt
+        if major < 0 || minor < 0 then recoverAt(Reason.BadVersion, line, 1)((0, 0))
+        else (major, minor)
+      catch case _: NumberFormatException => recoverAt(Reason.BadVersion, line, 1)((0, 0))
 
   private def splitPragmaPhrases(content: String): List[String] =
     val parts = scala.collection.mutable.ListBuffer.empty[String]

--- a/lib/stratiform/src/core/stratiform.TelPath.scala
+++ b/lib/stratiform/src/core/stratiform.TelPath.scala
@@ -1,0 +1,55 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import gossamer.*
+import prepositional.*
+
+// A keyword path identifying a node within a TEL document, used as the focus for
+// multi-error accrual during decoding. Kept deliberately light (a root-first list
+// of kebab-case keywords) — it only needs to render a stable pointer like
+// `#/person/name`, mirroring jacinta's `JsonPointer` and ypsiloid's `YamlPath`
+// for the error-report focus, without their full navigation machinery.
+object TelPath:
+  val Root: TelPath = TelPath(Nil)
+
+  given encodable: TelPath is Encodable in Text = path =>
+    if path.keywords.isEmpty then t"#" else t"#/${path.keywords.join(t"/")}"
+
+case class TelPath(keywords: List[Text]) derives CanEqual:
+  // Push a keyword onto the root (front) of the path. The product derivation's
+  // outer `focus` blocks run *after* the inner ones (contingency's try/finally
+  // order), so each level prepends its own keyword to the root side, building a
+  // root-first descent like `#/person/name`.
+  def prepend(keyword: Text): TelPath = TelPath(keyword :: keywords)

--- a/lib/stratiform/src/core/stratiform.Tels.scala
+++ b/lib/stratiform/src/core/stratiform.Tels.scala
@@ -298,23 +298,25 @@ object Tels extends Tels2:
   // presentation-model-driven Tel.as[T] decoder.
   object Decoder:
     extension (tel: Tel)
-      // Validate `tel` against the schema in scope and return it for
-      // chaining. Raises a TelError on the first E2xx/E3xx violation;
-      // returns the same `tel` value unchanged on success.
-      def validate(using schema: Tels): Tel raises TelError =
+      // Validate `tel` against the schema in scope and return it for chaining.
+      // Under the default fail-fast tactic this raises a TelError on the first
+      // E2xx/E3xx violation; under a `validate[Tel.Focus]` boundary the document-
+      // level violations (unknown keyword, missing required member, failed
+      // validator, flag-with-content) accrue. Returns the same `tel` on success.
+      def validate(using schema: Tels): Tel raises TelError tracks Tel.Focus =
         Tel.Type.assign(tel, schema)
         tel
 
       // Same as `validate` but also applies the registry's validators.
       def validate(using schema: Tels, validators: Tel.Validator.Registry)
-      :   Tel raises TelError =
+      :   Tel raises TelError tracks Tel.Focus =
 
         Tel.Type.assign(tel, schema, validators)
         tel
 
       // Convenience: validate-then-decode in a single call.
       inline def asValidated[value: Decodable in Tel](using schema: Tels)
-      :   value raises TelError =
+      :   value raises TelError tracks Tel.Focus =
 
         Tel.Type.assign(tel, schema)
         tel.as[value]

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -219,3 +219,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"The accrued reasons span the pragma and the body"):
         validateRead(t"tel bad\ngood \n").items.map(_(1).reason).to(Set)
       . assert(_ == Set(TelError.Reason.BadVersion, TelError.Reason.TrailingSpaces))
+
+      test(m"A bad schema identifier recovers and the body still accrues"):
+        validateRead(t"tel 1.0 bad!id\ngood \n").items.map(_(1).reason).to(Set)
+      . assert(_ == Set(TelError.Reason.BadSchemaIdentifier, TelError.Reason.TrailingSpaces))

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -62,6 +62,15 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
     . within(Tel.Type.assign(tel, schema))
 
+  // Parse a document under an accrual boundary: recoverable parse defects
+  // (§19.5) accrue rather than aborting on the first, because `read[Tel]` parses
+  // through the installed `TrackTactic`.
+  private def validateRead(text: Text): Issues =
+    validate[Tel.Focus](Issues()):
+      case error: TelError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(text.read[Tel])
+
   // A document schema with two required scalar fields and no defaults: a document
   // omitting both yields two `RequiredMemberAbsent` violations.
   private val twoRequiredSchema: Tels = Tels(
@@ -188,3 +197,17 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         validateAssign(doc, optionalFieldSchema).items.all:
           case (_, err) => err.reason == TelError.Reason.UnknownKeyword
       . assert(identity)
+
+    suite(m"Parser-recovery accrual (E1xx)"):
+      test(m"Two trailing-space lines accrue two errors"):
+        validateRead(t"good \nbad \n").items.length
+      . assert(_ == 2)
+
+      test(m"Both are TrailingSpaces errors"):
+        validateRead(t"good \nbad \n").items.all:
+          case (_, err) => err.reason == TelError.Reason.TrailingSpaces
+      . assert(identity)
+
+      test(m"A single recoverable defect still accrues one error"):
+        validateRead(t"good \nfine\n").items.length
+      . assert(_ == 1)

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -231,3 +231,11 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"An over-indented line recovers and a later defect still accrues"):
         validateRead(t"parent\n        too-deep\nc \n").items.map(_(1).reason).to(Set)
       . assert(_ == Set(TelError.Reason.OverIndentation, TelError.Reason.TrailingSpaces))
+
+      test(m"Many defects across a document all accrue (LSP scenario)"):
+        validateRead(t"tel bad\nparent\n        too-deep\ntail \n").items.map(_(1).reason).to(Set)
+      . assert: reasons =>
+          reasons == Set
+           ( TelError.Reason.BadVersion,
+             TelError.Reason.OverIndentation,
+             TelError.Reason.TrailingSpaces )

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -227,3 +227,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"Two odd-indented lines accrue two OddIndentation errors"):
         validateRead(t"a\n b\n c\n").items.map(_(1).reason).to(List)
       . assert(_ == List(TelError.Reason.OddIndentation, TelError.Reason.OddIndentation))
+
+      test(m"An over-indented line recovers and a later defect still accrues"):
+        validateRead(t"parent\n        too-deep\nc \n").items.map(_(1).reason).to(Set)
+      . assert(_ == Set(TelError.Reason.OverIndentation, TelError.Reason.TrailingSpaces))

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -211,3 +211,11 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"A single recoverable defect still accrues one error"):
         validateRead(t"good \nfine\n").items.length
       . assert(_ == 1)
+
+      test(m"A malformed pragma version and a trailing-space line accrue together"):
+        validateRead(t"tel bad\ngood \n").items.length
+      . assert(_ == 2)
+
+      test(m"The accrued reasons span the pragma and the body"):
+        validateRead(t"tel bad\ngood \n").items.map(_(1).reason).to(Set)
+      . assert(_ == Set(TelError.Reason.BadVersion, TelError.Reason.TrailingSpaces))

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -56,6 +56,47 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
     . within(decode(tel))
 
+  private def validateAssign(tel: Tel, schema: Tels): Issues =
+    validate[Tel.Focus](Issues()):
+      case error: TelError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(Tel.Type.assign(tel, schema))
+
+  // A document schema with two required scalar fields and no defaults: a document
+  // omitting both yields two `RequiredMemberAbsent` violations.
+  private val twoRequiredSchema: Tels = Tels(
+    name     = t"pair",
+    document = Tels.Struct(
+      members = IArray(
+        Tels.Field
+         ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+           t"name", Tels.Scalar(IArray(t"string")), Unset ),
+        Tels.Field
+         ( Tels.Polarity.Implicit, Tels.Polarity.Implicit,
+           t"email", Tels.Scalar(IArray(t"string")), Unset )),
+      validators = IArray.empty),
+    layers   = IArray.empty,
+    sigil    = Unset,
+    records  = IArray.empty,
+    scalars  = IArray.empty,
+    selects  = IArray.empty)
+
+  // A document schema with a single optional field: unrecognised keywords yield
+  // `UnknownKeyword` violations without any required-member errors.
+  private val optionalFieldSchema: Tels = Tels(
+    name     = t"loose",
+    document = Tels.Struct(
+      members = IArray(
+        Tels.Field
+         ( Tels.Polarity.Loose, Tels.Polarity.Implicit,
+           t"name", Tels.Scalar(IArray(t"string")), Unset )),
+      validators = IArray.empty),
+    layers   = IArray.empty,
+    sigil    = Unset,
+    records  = IArray.empty,
+    scalars  = IArray.empty,
+    selects  = IArray.empty)
+
   def run(): Unit =
     suite(m"Single-error decoding (sanity)"):
       test(m"Fully-valid record: no errors accrued"):
@@ -124,3 +165,26 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
         val tel = t"width wide\nheight tall\n".read[Tel]
         validateTel(tel)(_.as[APair]).items.length
       . assert(_ > 1)
+
+    suite(m"Schema-validation accrual (E3xx)"):
+      test(m"Two missing required members accrue two errors"):
+        val doc = t"".read[Tel]
+        validateAssign(doc, twoRequiredSchema).items.length
+      . assert(_ == 2)
+
+      test(m"Both missing-member errors have reason RequiredMemberAbsent"):
+        val doc = t"".read[Tel]
+        validateAssign(doc, twoRequiredSchema).items.all:
+          case (_, err) => err.reason == TelError.Reason.RequiredMemberAbsent
+      . assert(identity)
+
+      test(m"Two unknown keywords accrue two errors"):
+        val doc = t"foo a\nbar b\n".read[Tel]
+        validateAssign(doc, optionalFieldSchema).items.length
+      . assert(_ == 2)
+
+      test(m"Both unknown-keyword errors have reason UnknownKeyword"):
+        val doc = t"foo a\nbar b\n".read[Tel]
+        validateAssign(doc, optionalFieldSchema).items.all:
+          case (_, err) => err.reason == TelError.Reason.UnknownKeyword
+      . assert(identity)

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -223,3 +223,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
       test(m"A bad schema identifier recovers and the body still accrues"):
         validateRead(t"tel 1.0 bad!id\ngood \n").items.map(_(1).reason).to(Set)
       . assert(_ == Set(TelError.Reason.BadSchemaIdentifier, TelError.Reason.TrailingSpaces))
+
+      test(m"Two odd-indented lines accrue two OddIndentation errors"):
+        validateRead(t"a\n b\n c\n").items.map(_(1).reason).to(List)
+      . assert(_ == List(TelError.Reason.OddIndentation, TelError.Reason.OddIndentation))

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -1,0 +1,126 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import soundness.*
+
+import strategies.throwUnsafely
+import errorDiagnostics.stackTracesDiagnostics
+import charEncoders.utf8Encoder
+
+case class APerson(name: Text, age: Int, email: Text) derives CanEqual
+case class AContact(person: APerson, company: Text) derives CanEqual
+case class APair(width: Int, height: Int) derives CanEqual
+
+object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
+
+  case class Issues(items: List[(Text, TelError)] = Nil)(using Diagnostics)
+  extends Error(m"${items.length} decoding issues"):
+    def +(focus: Text, error: TelError): Issues = Issues(items :+ (focus, error))
+
+  private def validateTel[result](tel: Tel)
+                                 (decode: Tel => result raises TelError tracks Tel.Focus)
+  :   Issues =
+    validate[Tel.Focus](Issues()):
+      case error: TelError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . within(decode(tel))
+
+  def run(): Unit =
+    suite(m"Single-error decoding (sanity)"):
+      test(m"Fully-valid record: no errors accrued"):
+        val tel = t"name Alice\nage 30\nemail a@b.c\n".read[Tel]
+        validateTel(tel)(_.as[APerson]).items.length
+      . assert(_ == 0)
+
+      test(m"Single missing field: one error"):
+        val tel = t"name Alice\nage 30\n".read[Tel]
+        validateTel(tel)(_.as[APerson]).items.length
+      . assert(_ == 1)
+
+      test(m"Single wrong-type field: one error"):
+        val tel = t"width five\nheight 10\n".read[Tel]
+        validateTel(tel)(_.as[APair]).items.length
+      . assert(_ == 1)
+
+    suite(m"Multiple missing fields"):
+      test(m"Two missing fields accrue two errors"):
+        val tel = t"name Alice\n".read[Tel]
+        validateTel(tel)(_.as[APerson]).items.length
+      . assert(_ == 2)
+
+      test(m"Pointers identify the missing fields"):
+        val tel = t"name Alice\n".read[Tel]
+        validateTel(tel)(_.as[APerson]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/age", "#/email"))
+
+      test(m"Each missing-field error has reason Absent"):
+        val tel = t"name Alice\n".read[Tel]
+        validateTel(tel)(_.as[APerson]).items.all:
+          case (_, err) => err.reason == TelError.Reason.Absent
+      . assert(identity)
+
+    suite(m"Multiple wrong-type fields"):
+      test(m"Two wrong types accrue two errors"):
+        val tel = t"width wide\nheight tall\n".read[Tel]
+        validateTel(tel)(_.as[APair]).items.length
+      . assert(_ == 2)
+
+      test(m"Pointers identify the wrong-type fields"):
+        val tel = t"width wide\nheight tall\n".read[Tel]
+        validateTel(tel)(_.as[APair]).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/width", "#/height"))
+
+      test(m"Wrong-type errors have reason NotScalar"):
+        val tel = t"width wide\nheight tall\n".read[Tel]
+        validateTel(tel)(_.as[APair]).items.all:
+          case (_, err) => err.reason match
+            case TelError.Reason.NotScalar(_, _) => true
+            case _                               => false
+      . assert(identity)
+
+    suite(m"Nested case-class errors"):
+      test(m"Missing nested case-class field expands per sub-field"):
+        val tel = t"company Acme\n".read[Tel]
+        validateTel(tel)(_.as[AContact]).items.map(_(0).s).to(Set)
+      . assert: paths =>
+          paths == Set
+           ( "#/person/name",
+             "#/person/age",
+             "#/person/email" )
+
+    suite(m"Regression: does not abort on the first bad field"):
+      test(m"Both wrong-type fields are reported, not just the first"):
+        val tel = t"width wide\nheight tall\n".read[Tel]
+        validateTel(tel)(_.as[APair]).items.length
+      . assert(_ > 1)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1942,3 +1942,4 @@ object Tests extends Suite(m"Stratiform Tests"):
 
     RecordsTests()
     VerifyTests()
+    AccrualTests()


### PR DESCRIPTION
Caesura (CSV/DSV) and Stratiform (TEL) now collect every error encountered while decoding a record — and, for TEL, while validating against a schema and while parsing the document text — instead of failing on the first one, bringing them to parity with the Foci-based multi-error accrual already used by the JSON, XML and YAML codecs. Errors surface together at a `validate` boundary, each tagged with its location (the offending column for CSV, a keyword pointer for TEL), and the TEL parser now recovers from the recoverable defects in the §19.5 spec and keeps going to the end of the document, so a single pass can report every problem — exactly what an editor or LSP server needs to highlight all the mistakes at once.

## Multi-error accrual for CSV and TEL

Decoding a record with several bad fields previously stopped at the first error. Both Caesura and Stratiform now accrue every error under a `validate` boundary, matching JSON/XML/YAML:

```scala
case class Person(name: Text, age: Int, height: Int)

val issues = validate[CellRef](Issues()):
  case e: DsvError => accrual + (prior.let(_.column).or(t"#"), e)
. within:
    t"name,age,height\nAlice,thirty,tall".read[Sheet].rows.head.as[Person]

// issues now contains *both* the `age` and `height` failures, not just `age`.
```

The same works for TEL decoding (`tel.as[T]`, keyed by `#/field` pointers), TEL schema validation (`Tel.Type.assign`), and TEL parsing. Stratiform's parser now recovers from the recoverable §19.5 defects (BOM, malformed pragma fields, odd/under-margin and over-indentation, trailing spaces, inconsistent line endings, misplaced comments and pragmas, duplicate atoms, unterminated literals, and tabulated-row column issues) and continues to end-of-document, so one parse reports them all:

```scala
// A bad pragma version, an over-indented line, and a trailing space all reported at once:
validateRead(t"tel bad\nparent\n        too-deep\ntail \n").items
// → BadVersion, OverIndentation, TrailingSpaces
```

Without a `validate` boundary, behaviour is unchanged: the default fail-fast tactic still throws on the first error.

New decode-error reasons were added: `DsvError.Reason.{Absent, Unparseable}` and `TelError.Reason.{Absent, NotScalar}`. A handful of rarer TEL defects (malformed tabulation headings, a lone carriage return) and the schema-construction errors remain fail-fast for now.
