### PR TITLE
Resolve remaining Decorum house-style warnings

### DIFF
--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -460,7 +460,9 @@ object internal:
     def weekend(using hebdomad: Hebdomad): Boolean = weekday.weekend
 
     def anniversary: Anniversary =
-      Anniversary(calendars.gregorianCalendar.mensual(date), calendars.gregorianCalendar.diurnal(date))
+      Anniversary
+        ( calendars.gregorianCalendar.mensual(date),
+          calendars.gregorianCalendar.diurnal(date) )
 
     def jdn: Int = date
 

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -47,30 +47,38 @@ export aviation.internal.{Date, Year, Day, Anniversary, WorkingDays}
 export Month.{Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec}
 
 package instantDecodables:
-  given iso8601InstantDecodable: Tactic[TimeError] => Instant is Decodable in Text = Iso8601.parse(_)
-  given rfc1123InstantDecodable: Tactic[TimeError] => Instant is Decodable in Text = Rfc1123.parse(_)
+  given iso8601InstantDecodable: Tactic[TimeError] => Instant is Decodable in Text =
+    Iso8601.parse(_)
+
+  given rfc1123InstantDecodable: Tactic[TimeError] => Instant is Decodable in Text =
+    Rfc1123.parse(_)
 
 package dateFormats:
   private given calendar: RomanCalendar = calendars.gregorianCalendar
 
   given europeanDateFormat: Date is Showable =
-    import endianness.littleEndian, numerics.fixedWidthDateNumerics, separators.dotDateSeparator, years.fullYears
+    import endianness.littleEndian, numerics.fixedWidthDateNumerics, separators.dotDateSeparator
+    import years.fullYears
     Date.showable.text(_)
 
   given americanDateFormat: Date is Showable =
-    import endianness.middleEndian, numerics.fixedWidthDateNumerics, separators.slashDateSeparator, years.fullYears
+    import endianness.middleEndian, numerics.fixedWidthDateNumerics, separators.slashDateSeparator
+    import years.fullYears
     Date.showable.text(_)
 
   given unitedKingdomDateFormat: Date is Showable =
-    import endianness.littleEndian, numerics.fixedWidthDateNumerics, separators.slashDateSeparator, years.fullYears
+    import endianness.littleEndian, numerics.fixedWidthDateNumerics, separators.slashDateSeparator
+    import years.fullYears
     Date.showable.text(_)
 
   given southEastAsiaDateFormat: Date is Showable =
-    import endianness.littleEndian, numerics.fixedWidthDateNumerics, separators.hyphenDateSeparator, years.fullYears
+    import endianness.littleEndian, numerics.fixedWidthDateNumerics, separators.hyphenDateSeparator
+    import years.fullYears
     Date.showable.text(_)
 
   given iso8601DateFormat: Date is Showable =
-    import endianness.bigEndian, numerics.fixedWidthDateNumerics, separators.hyphenDateSeparator, years.fullYears
+    import endianness.bigEndian, numerics.fixedWidthDateNumerics, separators.hyphenDateSeparator
+    import years.fullYears
     Date.showable.text(_)
 
   package endianness:
@@ -189,34 +197,41 @@ package dateFormats:
 
 package timeFormats:
   given militaryTimeFormat: Clockface is Showable =
-    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.noneTimeSeparator, specificity.minutesSpecificity
+    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.noneTimeSeparator
+    import specificity.minutesSpecificity
     Clockface.showable.text(_)
 
   given civilianTimeFormat: Clockface is Showable =
-    import hours.twelveHourClock, meridiems.upperMeridiem, numerics.fixedWidthTimeNumerics, separators.colonTimeSeparator
+    import hours.twelveHourClock, meridiems.upperMeridiem, numerics.fixedWidthTimeNumerics
+    import separators.colonTimeSeparator
     import specificity.minutesSpecificity
 
     Clockface.showable.text(_)
 
   given associatedPressTimeFormat: Clockface is Showable =
-    import hours.twelveHourClock, meridiems.lowerPunctuatedMeridiem, numerics.variableWidthTimeNumerics, separators.colonTimeSeparator
+    import hours.twelveHourClock, meridiems.lowerPunctuatedMeridiem
+    import numerics.variableWidthTimeNumerics, separators.colonTimeSeparator
     import specificity.minutesSpecificity
     Clockface.showable.text(_)
 
   given frenchTimeFormat: Clockface is Showable =
-    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.frenchTimeSeparator, specificity.minutesSpecificity
+    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics
+    import separators.frenchTimeSeparator, specificity.minutesSpecificity
     Clockface.showable.text(_)
 
   given iso8601TimeFormat: Clockface is Showable =
-    import hours.twentyFourHourSecondsClock, numerics.fixedWidthTimeNumerics, separators.colonTimeSeparator, specificity.secondsSpecificity
+    import hours.twentyFourHourSecondsClock, numerics.fixedWidthTimeNumerics
+    import separators.colonTimeSeparator, specificity.secondsSpecificity
     Clockface.showable.text(_)
 
   given ledgerTimeFormat: Clockface is Showable =
-    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.dotTimeSeparator, specificity.minutesSpecificity
+    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.dotTimeSeparator
+    import specificity.minutesSpecificity
     Clockface.showable.text(_)
 
   given railwayTimeFormat: Clockface is Showable =
-    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.colonTimeSeparator, specificity.minutesSpecificity
+    import hours.twentyFourHourClock, numerics.fixedWidthTimeNumerics, separators.colonTimeSeparator
+    import specificity.minutesSpecificity
     Clockface.showable.text(_)
 
   package meridiems:

--- a/lib/capricious/src/core/capricious.PolarGaussian.scala
+++ b/lib/capricious/src/core/capricious.PolarGaussian.scala
@@ -40,8 +40,9 @@ case class PolarGaussian(mean: Double = 0.0, std: Double = 1.0) extends Distribu
   def transform(random: Random): Double =
     @annotation.tailrec
     def recur(): F64 =
-      val u0: F64 = F64(randomDistributions.uniformSymmetricUnitIntervalDistribution.transform(random))
-      val u1: F64 = F64(randomDistributions.uniformSymmetricUnitIntervalDistribution.transform(random))
+      val distribution = randomDistributions.uniformSymmetricUnitIntervalDistribution
+      val u0: F64 = F64(distribution.transform(random))
+      val u1: F64 = F64(distribution.transform(random))
       val s: F64 = hyp(u0, u1)
       if s >= 1 || s == 0 then recur() else F64(std)*u0*(-ln(s)/s).sqrt*2 + mean
 

--- a/lib/cataclysm/src/html/cataclysm_html.scala
+++ b/lib/cataclysm/src/html/cataclysm_html.scala
@@ -51,5 +51,6 @@ given inlineStyle: (Css.Style is Attributive to Whatwg.Css) = _ -> _.text
 // Import this to make `Tag.foo(…)` check `foo` against the in-scope `Styles`
 // stylesheet, attaching `class="foo"` or `id="foo"` accordingly.
 package cssBindings:
-  inline given checkedBinding: [name <: Label] => NotGiven[name =:= "apply"] => Attribution of name =
+  inline given checkedBinding: [name <: Label] => NotGiven[name =:= "apply"]
+  =>  Attribution of name =
     Attribution(attributeFor[name]).asInstanceOf[Attribution of name]

--- a/lib/coaxial/src/core/coaxial.SocketOption.scala
+++ b/lib/coaxial/src/core/coaxial.SocketOption.scala
@@ -64,8 +64,9 @@ sealed trait SocketOption
 
 // Importable socket-option contributions. Each flag is a named `given` declared at its concrete
 // option type (not `SocketOption`), so the per-connection `Every[SocketOption.Tcp]` / `.Udp` /
-// `.Domain` searches collect it. Bring one into scope with, e.g., `import socketOptions.noDelaySocketOption`.
-// Options that carry a value are factory methods whose result type is the concrete option, so a
+// `.Domain` searches collect it. Bring one into scope with, e.g.,
+// `import socketOptions.noDelaySocketOption`. Options that carry a value are factory methods whose
+// result type is the concrete option, so a
 // `given SocketOption.ReceiveBuffer = socketOptions.receiveBuffer(65536)` is likewise collected.
 package socketOptions:
   given reuseAddressSocketOption: SocketOption.ReuseAddress.type = SocketOption.ReuseAddress

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -591,13 +591,19 @@ object Checker:
                       s"closing `}` of a multi-line quote/splice at column ${cols(i)} "
                         +s"does not align with its opening `{` at column ${opener.braceCol}" )
               // (d-alone) Nothing semantic before `}` on the line; only
-              // enclosing closing brackets (`)`, `}`) may trail it.
+              // enclosing closing brackets (`)`, `}`) may trail it — plus a
+              // trailing symbolic infix operator that is the last token on the
+              // line, which is an R616 operator continuation (`'{ … } ::` cons'd
+              // with an operand on the next line) and is governed by that rule.
+              val lastSemantic =
+                arr.lastIndexWhere(t => t.kind != Sort.Space && t.kind != Sort.Comment)
               val semanticBefore = firstSemantic >= 0 && firstSemantic < i
               val badAfter =
                 (i + 1 until arr.length).exists: k =>
                   val t = arr(k)
                   t.kind != Sort.Space && t.kind != Sort.Comment
                     && t.text != ")" && t.text != "}" && t.text != "=>"
+                    && !(k == lastSemantic && isSymbolicOperator(t.text))
               if semanticBefore || badAfter then
                 out +=
                   Violation

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -868,3 +868,7 @@ object Tests extends Suite(m"Decorum Tests"):
       test(m"Operator-continuation expression does not trigger 315"):
         rules("def f =\n  val a = 1\n  a == 1 ||\n    a == 2\n")
       . assert(r => !r.contains("315"))
+
+      test(m"Trailing operator after a quote-block `}` defers to 616, not 473.6"):
+        rules("val x =\n  ' {\n      foo\n    } ::\n    tail\n")
+      . assert(r => !r.contains("473.6"))

--- a/lib/denominative/src/core/denominative_core.scala
+++ b/lib/denominative/src/core/denominative_core.scala
@@ -81,7 +81,9 @@ package ordinalTextualizables:
   given zeraryOrdinal: Ordinal is Textualizable = ordinal => ""+ordinal.n0+"♯"
   given unmarkedUniaryOrdinal: Ordinal is Textualizable = ordinal => ""+ordinal.n1
   given unmarkedZeraryOrdinal: Ordinal is Textualizable = ordinal => ""+ordinal.n0
-  given intermediateOrdinal: Ordinal is Textualizable = ordinal => "⌞"+ordinal.n0+"⌟|⌞"+ordinal.n1+"⌟"
+
+  given intermediateOrdinal: Ordinal is Textualizable =
+    ordinal => "⌞"+ordinal.n0+"⌟|⌞"+ordinal.n1+"⌟"
 
   given englishOrdinal: Ordinal is Textualizable = ordinal =>
     ordinal.n1%100 match

--- a/lib/escritoire/src/core/escritoire_core.scala
+++ b/lib/escritoire/src/core/escritoire_core.scala
@@ -60,13 +60,14 @@ package columnAttenuation:
 
 package tableStyles:
   import BoxLine.*
+  import LineCharset.{Default, Rounded}
 
-  given defaultTableStyle: TableStyle = TableStyle(1, Thick, Thick, Thin, Thick, Thin, LineCharset.Default)
-  given thinRoundedTableStyle: TableStyle = TableStyle(1, Thin, Thin, Thin, Thin, Thin, LineCharset.Rounded)
-  given horizontalTableStyle: TableStyle = TableStyle(1, Thin, Thin, Thin, Blank, Blank, LineCharset.Default)
-  given midOnlyTableStyle: TableStyle = TableStyle(1, Blank, Blank, Thin, Blank, Blank, LineCharset.Default)
-  given verticalTableStyle: TableStyle = TableStyle(1, Blank, Blank, Blank, Thin, Thin, LineCharset.Default)
-  given minimalTableStyle: TableStyle = TableStyle(1, Unset, Unset, Thin, Blank, Blank, LineCharset.Default)
+  given defaultTableStyle: TableStyle = TableStyle(1, Thick, Thick, Thin, Thick, Thin, Default)
+  given thinRoundedTableStyle: TableStyle = TableStyle(1, Thin, Thin, Thin, Thin, Thin, Rounded)
+  given horizontalTableStyle: TableStyle = TableStyle(1, Thin, Thin, Thin, Blank, Blank, Default)
+  given midOnlyTableStyle: TableStyle = TableStyle(1, Blank, Blank, Thin, Blank, Blank, Default)
+  given verticalTableStyle: TableStyle = TableStyle(1, Blank, Blank, Blank, Thin, Thin, Default)
+  given minimalTableStyle: TableStyle = TableStyle(1, Unset, Unset, Thin, Blank, Blank, Default)
 
 package columnar:
   // Cumulative display width up to each char position; `widths(i)` is the width

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -54,7 +54,8 @@ import galilei.*
 import gossamer.*
 import guillotine.*
 import hellenism.*, classloaders.threadContextClassloader
-import hieroglyph.*, charEncoders.utf8Encoder, charDecoders.utf8Decoder, textSanitizers.strictSanitizer
+import hieroglyph.*, charEncoders.utf8Encoder, charDecoders.utf8Decoder
+import textSanitizers.strictSanitizer
 import nomenclature.*
 import parasite.*
 import prepositional.*

--- a/lib/harlequin/src/ansi/harlequin_ansi.scala
+++ b/lib/harlequin/src/ansi/harlequin_ansi.scala
@@ -74,7 +74,8 @@ package syntaxHighlighting:
     case Token(text, Symbol, _, _)   => e"${palette.scalaSymbol}($text)"
     case Token(text, Unparsed, _, _) => e"${palette.scalaComment}($Italic($text))"
 
-  given numberedTeletypeable: (palette: ScalaSyntaxPalette) => SourceCode is Teletypeable = source =>
+  given numberedTeletypeable: (palette: ScalaSyntaxPalette)
+  =>  SourceCode is Teletypeable = source =>
     val indent = source.lastLine.show.length
     lazy val error = e"${Fg(palette.subdued)}(║)"
 

--- a/lib/hieroglyph/src/core/hieroglyph_core.scala
+++ b/lib/hieroglyph/src/core/hieroglyph_core.scala
@@ -89,6 +89,7 @@ extension (inline context: StringContext)
 package textMetrics:
   given uniformMetric: Char is Measurable = _ => 1
   given eastAsianScriptsMetric: Char is Measurable = Unicode.eastAsianWidth(_).let(_.width).or(1)
+
   given wideCharacterWidthMetric: Char is Measurable =
     char => WideCharacterWidth.width(char.toInt).max(0)
 

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -1820,6 +1820,7 @@ extends Node, Topical, Transportive, Dynamic:
 
         attributive.attribute(name, value).match
           case Unset => Element(label, attributes.removed(name.tt), children, foreign)
+
           case pair  =>
             val (key, value) = pair.asInstanceOf[(Text, Optional[Text])]
             Element(label, attributes.updated(key, value), children, foreign)
@@ -1833,6 +1834,7 @@ extends Node, Topical, Transportive, Dynamic:
 
         attributive.attribute(name, value).match
           case Unset => Element(label, attributes.removed(name.tt), children, foreign)
+
           case pair  =>
             val (key, value) = pair.asInstanceOf[(Text, Optional[Text])]
             Element(label, attributes.updated(key, value), children, foreign)

--- a/lib/jacinta/src/core/jacinta_core.scala
+++ b/lib/jacinta/src/core/jacinta_core.scala
@@ -402,7 +402,9 @@ extension (inline context: StringContext)
   transparent inline def jp: Interpolation = interpolation[JsonPointer](context)
 
 package formatting:
-  given indentedJsonFormatting: Json.Formatting = Json.Formatting(Text("  "), trailingNewline = false)
+  given indentedJsonFormatting: Json.Formatting =
+    Json.Formatting(Text("  "), trailingNewline = false)
+
   given compactJsonFormatting: Json.Formatting = Json.Formatting(Unset, trailingNewline = false)
 
 package discriminables:

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -130,7 +130,7 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
     case entity: JsonSchema.Ref     => entity.copy(optional = true)
 
   given optionalSchematic: [inner <: value, value >: Unset.type: Mandatable to inner]
-  =>  (schematic: inner is Schematic over JsonSchema)
+  =>  ( schematic: inner is Schematic over JsonSchema )
   =>  value is Schematic over JsonSchema =
     () => JsonSchema.optional(schematic.schema())
 

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -98,6 +98,7 @@ object Subcompiler:
 
           case null =>
             var outer = position.outer
+
             while outer != null && outer != NoSourcePosition do
               position = outer.nn
               outer = position.outer

--- a/lib/plutocrat/src/core/plutocrat_core.scala
+++ b/lib/plutocrat/src/core/plutocrat_core.scala
@@ -36,8 +36,11 @@ import gossamer.*
 import prepositional.*
 
 package currencyStyles:
-  given localCurrencyStyle: CurrencyStyle = (code, symbol, unit, subunit) => t"$symbol$unit.$subunit"
-  given genericCurrencyStyle: CurrencyStyle = (code, symbol, unit, subunit) => t"$unit.$subunit $code"
+  given localCurrencyStyle: CurrencyStyle =
+    (code, symbol, unit, subunit) => t"$symbol$unit.$subunit"
+
+  given genericCurrencyStyle: CurrencyStyle =
+    (code, symbol, unit, subunit) => t"$unit.$subunit $code"
 
 extension (inline context: StringContext)
   inline def isin(): Isin = ${plutocrat.internal.interpolator('context)}

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -90,7 +90,8 @@ package keyboards:
 
     def process(stream: Stream[Char]): Stream[Int] = stream.map(_.toInt)
 
-  given standardKeyboard: (monitor: Monitor, probate: Probate) => Keyboard.Standard = Keyboard.Standard()
+  given standardKeyboard: (monitor: Monitor, probate: Probate) => Keyboard.Standard =
+    Keyboard.Standard()
 
 // The standard terminal features, each a turn-on/turn-off escape-sequence pair.
 // Import the ones a session should enable (or `terminalFeatures.*` for all);

--- a/lib/punctuation/src/ansi/punctuation_ansi.scala
+++ b/lib/punctuation/src/ansi/punctuation_ansi.scala
@@ -47,7 +47,8 @@ import vacuous.*
 // content through Harlequin's highlighter and out via the `unnumbered` token
 // stream. Callers supply a `ScalaSyntaxPalette` to colour the tokens.
 package teletypeFormattables:
-  given scalaTeletypeFormattable: (palette: ScalaSyntaxPalette) => ("scala" is TeletypeFormattable) =
+  given scalaTeletypeFormattable: (palette: ScalaSyntaxPalette)
+  =>  ( "scala" is TeletypeFormattable ) =
     new TeletypeFormattable:
       type Self = "scala"
 

--- a/lib/punctuation/src/core/punctuation.Serializer.scala
+++ b/lib/punctuation/src/core/punctuation.Serializer.scala
@@ -49,12 +49,15 @@ import zephyrine.*
 private[punctuation] object Serializer:
   def apply(markdown: Markdown of Layout)(using formatting: Markdown.Formatting): Text =
     Producer.collect[Text](): producer =>
-      writeDocument(Writer(producer, formatting.width.lay(Int.MaxValue)(c => c)), markdown)
+      writeDocument(Writer(producer, formatting.width.lay(Int.MaxValue) { c => c }), markdown)
 
   @scala.annotation.targetName("applyProse")
   def apply(markdown: Markdown of Prose)(using formatting: Markdown.Formatting): Text =
     Producer.collect[Text](): producer =>
-      flow(Writer(producer, formatting.width.lay(Int.MaxValue)(c => c)), markdown.children, protectFirst = false)
+      flow
+        ( Writer(producer, formatting.width.lay(Int.MaxValue) { c => c }),
+          markdown.children,
+          protectFirst = false )
 
   private def writeDocument(writer: Writer, markdown: Markdown of Layout): Unit =
     var first = true

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -375,10 +375,11 @@ extension (bytes: Data)
 extension [indexable: Indexable](value: indexable)
   inline def has(index: indexable.Operand): Boolean = indexable.contains(value, index)
 
-  // A single `at` that dispatches at compile time on the index type: an index statically known to be
-  // confined to *this* `value` (an `Operand in value.type`, hence in range) returns a bare `Result`;
-  // any other index is bounds-checked and returns `Optional`. The declared return type is `Optional`,
-  // so non-reducing (e.g. generic) call sites are safe; a confined index narrows to a bare `Result`.
+  // A single `at` that dispatches at compile time on the index type: an index statically known to
+  // be confined to *this* `value` (an `Operand in value.type`, hence in range) returns a bare
+  // `Result`; any other index is bounds-checked and returns `Optional`. The declared return type is
+  // `Optional`, so non-reducing (e.g. generic) call sites are safe; a confined index narrows to a
+  // bare `Result`.
   transparent inline def at[index](ordinal: index)(using sub: index <:< indexable.Operand)
   :   Optional[indexable.Result] =
 

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -344,14 +344,14 @@ trait Tel2:
   // recognises and flattens with the field's label.
 
   given optionalEncodable: [inner <: value, value >: Unset.type: Mandatable to inner]
-  =>  (encodable: inner is Tel.Encodable)
+  =>  ( encodable: inner is Tel.Encodable )
   =>  value is Tel.Encodable =
     Tel.Encodable(Morphology.Opt(encodable.shape())): opt =>
       opt.let(_.asInstanceOf[inner]).lay(Tel.empty)(_.encode)
 
   given optionalDecodable: [inner <: value, value >: Unset.type: Mandatable to inner]
   =>  Tactic[TelError]
-  =>  (decodable: => inner is Tel.Decodable)
+  =>  ( decodable: => inner is Tel.Decodable )
   =>  value is Tel.Decodable =
     Tel.Decodable(Morphology.Opt(decodable.shape())): telVal =>
       if telVal.childCompounds.nil && telVal.atomTexts.nil then Unset

--- a/lib/stratiform/src/core/stratiform.Tels2.scala
+++ b/lib/stratiform/src/core/stratiform.Tels2.scala
@@ -146,7 +146,7 @@ trait Tels2:
   given boolean: Boolean is TelSchematic over Tels.Type = () => Tels.Scalar(IArray.empty)
 
   given optional: [inner <: value, value >: Unset.type: Mandatable to inner]
-  =>  (schematic: inner is Schematic over Tels.Type)
+  =>  ( schematic: inner is Schematic over Tels.Type )
   =>  value is TelSchematic over Tels.Type =
     new TelSchematic:
       type Self = value

--- a/lib/tarantula/src/core/tarantula.WebDriver.scala
+++ b/lib/tarantula/src/core/tarantula.WebDriver.scala
@@ -38,7 +38,8 @@ import distillate.*
 import gesticulate.*
 import gossamer.*
 import hallucination.*
-import hieroglyph.*, charEncoders.utf8Encoder, charDecoders.utf8Decoder, textSanitizers.strictSanitizer
+import hieroglyph.*, charEncoders.utf8Encoder, charDecoders.utf8Decoder
+import textSanitizers.strictSanitizer
 import jacinta.*, formatting.compactJsonFormatting, dynamicJsonAccess.enabled
 import monotonous.*, alphabets.base64Standard
 import prepositional.*

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -194,12 +194,14 @@ extension [element](stream: Stream[element])
     out.stream
 
 package lineSeparation:
-  given carriageReturnLineSeparation: LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Skip, Action.Nl, Action.Nl)
+  given carriageReturnLineSeparation
+  :   LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Skip, Action.Nl, Action.Nl)
 
   given strictCarriageReturnLineSeparation
   :   LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Lf, Action.NlLf, Action.LfNl)
 
-  given linefeedLineSeparation: LineSeparation(NewlineSeq.Lf, Action.Skip, Action.Nl, Action.Nl, Action.Nl)
+  given linefeedLineSeparation
+  :   LineSeparation(NewlineSeq.Lf, Action.Skip, Action.Nl, Action.Nl, Action.Nl)
 
   given strictLinefeedsLineSeparation
   :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Lf, Action.NlLf, Action.LfNl)
@@ -207,7 +209,8 @@ package lineSeparation:
   given carriageReturnLinefeedLineSeparation
   :   LineSeparation(NewlineSeq.CrLf, Action.Skip, Action.Lf, Action.Nl, Action.LfNl)
 
-  given adaptiveLinefeedLineSeparation: LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Nl, Action.Nl, Action.Nl)
+  given adaptiveLinefeedLineSeparation
+  :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Nl, Action.Nl, Action.Nl)
 
   given virtualMachineLineSeparation: LineSeparation = jl.System.lineSeparator.nn match
     case "\r\n"    => carriageReturnLinefeedLineSeparation

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -236,7 +236,7 @@ object internal:
       def int: Int = ip
 
   def subnetPrefix(text: Text, max: Int)(outOfRange: Int => Reason)
-  :     Int raises IpAddressError =
+  :   Int raises IpAddressError =
 
     val prefix =
       whereas:
@@ -359,6 +359,7 @@ object internal:
     // and an implicit search would re-enter the (also-exported) `Ipv6` companion.
     given showable: Ipv6Subnet is Showable = subnet =>
       t"${Ipv6.showable.text(subnet.ipv6)}/${subnet.size}"
+
     given encodable: Ipv6Subnet is Encodable in Text = _.show
     given decodable: Tactic[IpAddressError] => Ipv6Subnet is Decodable in Text = parse(_)
 

--- a/lib/xylophone/src/core/xylophone.XPath.scala
+++ b/lib/xylophone/src/core/xylophone.XPath.scala
@@ -92,6 +92,7 @@ object XPath extends Root("/"):
 
         parseStep(string.substring(offset, end).nn.tt) match
           case Unset => abort(XPathError(XPathError.Reason.BadStep, offset))
+
           case step  => step.asInstanceOf[Either[Text, (Text, Int)]] match
             case Left(name)       => xpath = xpath.attribute(name)
             case Right((name, n)) => xpath = xpath.element(name, n)

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -890,6 +890,7 @@ object Xml extends Tag.Container
 
         XPath.parseStep(segment) match
           case Unset => Unset
+
           case step => step.asInstanceOf[Either[Text, (Text, Int)]] match
             case Left(attrName) =>
               xml match

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -748,7 +748,8 @@ object internal:
   object Attributes:
     val empty: Attributes = IArray.empty[String]
 
-    // `Attributes` is a `Text`-keyed map, so it indexes through the shared `at` (giving `Optional`).
+    // `Attributes` is a `Text`-keyed map, so it indexes through the shared `at` (giving
+    // `Optional`).
     given indexable: Attributes is Indexable:
       type Operand = Text
       type Result = Text

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -828,10 +828,10 @@ object Yaml extends Yaml2, Dynamic:
 
     def deepHash(ast: Yaml.Ast): Int = ast match
       case Yaml.YamlNull => 0
-      case b: Boolean   => b.hashCode
-      case n: Long      => n.hashCode
-      case d: Double    => d.hashCode
-      case s: String    => s.hashCode
+      case b: Boolean    => b.hashCode
+      case n: Long       => n.hashCode
+      case d: Double     => d.hashCode
+      case s: String     => s.hashCode
 
       case b: Array[Double] @unchecked =>
         // Hash via the BigDecimal projection so a `Bcd` whose value equals

--- a/lib/ypsiloid/src/core/ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/ypsiloid_core.scala
@@ -79,8 +79,8 @@ given astShowable: (formatting: Yaml.Formatting) => Yaml.Ast is Showable = yaml 
 
         while i < length && ok do
           val c = string.charAt(i)
-          if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
-              || (c >= '0' && c <= '9') || c == '_' || c == '-')
+          if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+            (c >= '0' && c <= '9') || c == '_' || c == '-')
           then ok = false
 
           i += 1


### PR DESCRIPTION
Makes the linted (non-test) sources Decorum-clean by resolving the 67 pre-existing house-style warnings a full attest reported: over-long comments are reflowed, multi-selector imports split, `given`/`val` right-hand sides wrapped (or shortened via an import or local `val` where wrapping would disturb an aligned block), the blank-line separators the chunk rule requires are added, a `match` run's `=>` operators aligned, a named-parameter lambda braced, a heavy-signature `:` indent corrected, and one operator continuation laid out per SN-616. One rule is refined: SN-473.6 (a multi-line quote/splice's closing `}` must be alone) now permits a trailing symbolic infix operator that is the last token on the line, since `'{ … } :: tail` puts the `::` there per SN-616 — mirroring the existing SN-833.4 deferral.

This is a formatting-and-lint cleanup only; no library behaviour changes. The single user-visible Decorum change is that an `'{ … } ::`-style quoted pattern cons'd onto an operand no longer trips SN-473.6, deferring to SN-616's operator-at-line-end rule.
