### PR TITLE
Carry Quanta divisions in a `Form` member over a base-unit parameter

### DIFF
--- a/lib/abacist/src/core/abacist.UnitsNames.scala
+++ b/lib/abacist/src/core/abacist.UnitsNames.scala
@@ -34,7 +34,7 @@ package abacist
 
 import anticipation.*
 
-trait UnitsNames[units <: Tuple]:
+trait UnitsNames[quanta]:
   def prefix: Text = "".tt
   def separator: Text = " ".tt
   def units(): List[Text]

--- a/lib/abacist/src/core/abacist.anteprotointernal.scala
+++ b/lib/abacist/src/core/abacist.anteprotointernal.scala
@@ -36,13 +36,13 @@ import hypotenuse.*
 
 trait anteprotointernal:
   trait Quanta2:
-    inline given commensurable: [units <: Tuple] => Quanta[units] is Commensurable:
-      type Contrast = Quanta[units]
+    given commensurable: [base <: AnyUnit, quanta <: Quanta[base]] => quanta is Commensurable:
+      type Contrast = quanta
 
 
       inline def compare
-        ( inline left:        Quanta[units],
-          inline right:       Quanta[units],
+        ( inline left:        quanta,
+          inline right:       quanta,
           inline strict:      Boolean,
           inline greaterThan: Boolean )
       :   Boolean =

--- a/lib/abacist/src/core/abacist.internal.scala
+++ b/lib/abacist/src/core/abacist.internal.scala
@@ -48,10 +48,10 @@ import vacuous.*
 object internal:
   import quantitative.internal.*
 
-  def quanta[units <: Tuple: Type](values: Expr[Seq[Int]]): Macro[Quanta[units]] =
-    val inputs: List[Expr[Int]] = values.absolve match
-      case Varargs(values) => values.to(List).reverse
-
+  // Encodes the (reversed, smallest-first) unit values against the (reversed, smallest-first)
+  // multipliers into the packed `Long` representation.
+  private def encode(using Quotes)(multipliers: List[Multiplier], values: List[Expr[Int]])
+  :   Expr[Long] =
 
     def recur(multipliers: List[Multiplier], values: List[Expr[Int]], expr: Expr[Long])
     :   Expr[Long] =
@@ -83,14 +83,39 @@ object internal:
 
             case Nil => halt:
               m"""
-                ${inputs.length} unit values were provided, but this Quanta only has
-                ${multipliers.length} units
+                ${values.length} unit values were provided, but this Quanta has fewer units
               """
 
-    '{Quanta.fromLong[units](${recur(multipliers[units].reverse, inputs, '{0L})})}
+    recur(multipliers, values, '{0L})
 
 
-  def describeQuanta[units <: Tuple: Type](count: Expr[Quanta[units]])
+  private def inputsOf(using Quotes)(values: Expr[Seq[Int]]): List[Expr[Int]] =
+    values.absolve match
+      case Varargs(values) => values.to(List).reverse
+
+
+  // Construction (`Quanta(...)`): `base` and `form` come from the expected type, so the cascade
+  // is built directly from them rather than by decomposing an opaque `Quanta` type (whose parent
+  // would dealias to `Long` within this scope).
+  def assembleParts[base <: AnyUnit: Type, form <: Divisions: Type](values: Expr[Seq[Int]])
+  :   Macro[Quanta[base] { type Form = form }] =
+
+    import quotes.reflect.*
+
+    // A bare single-unit `Quanta` (no `Form` in the expected type) leaves `form` unconstrained,
+    // so it is inferred as `Nothing`, `Any`, or its bound `Divisions`; either way the form is
+    // empty. (An `=:=` check is needed because the `'[Any]` quote pattern would match every type.)
+    val formRepr = TypeRepr.of[form]
+    val empty = List(TypeRepr.of[Nothing], TypeRepr.of[Any], TypeRepr.of[Divisions])
+    val formUnits = if empty.exists(_ =:= formRepr) then Nil else elements(formRepr)
+
+    val multipliers = multipliersOf(TypeRepr.of[base] :: formUnits)
+    val long = encode(multipliers.reverse, inputsOf(values))
+
+    '{Quanta.fromLong[Quanta[base] { type Form = form }]($long)}
+
+
+  def describeQuanta[quanta: Type](count: Expr[quanta])
   :   Macro[ListMap[Text, Long]] =
 
     def recur(slices: List[Multiplier], expr: Expr[ListMap[Text, Long]])
@@ -112,81 +137,129 @@ object internal:
                       ( ${unitPower.ref.designation}+${Expr(power)}.asInstanceOf[Text], $value ) )
                 } )
 
-    recur(multipliers[units], '{ListMap()})
+    recur(multipliers[quanta], '{ListMap()})
 
 
-  def multiplyQuanta[units <: Tuple: Type]
-    ( count: Expr[Quanta[units]], multiplier: Expr[Double], division: Boolean )
+  def multiplyQuanta[quanta: Type]
+    ( count: Expr[quanta], multiplier: Expr[Double], division: Boolean )
   :   Macro[Any] =
 
-    if division then '{Quanta.fromLong[units](($count.long/$multiplier + 0.5).toLong)}
-    else '{Quanta.fromLong[units](($count.long*$multiplier + 0.5).toLong)}
+    val long = '{$count.asInstanceOf[Long]}
+
+    if division then '{Quanta.fromLong[quanta](($long/$multiplier + 0.5).toLong)}
+    else '{Quanta.fromLong[quanta](($long*$multiplier + 0.5).toLong)}
 
 
-  def toQuantity[units <: Tuple: Type](count: Expr[Quanta[units]]): Macro[Any] =
-    val lastUnit = multipliers[units].last
+  def toQuantity[quanta: Type](count: Expr[quanta]): Macro[Any] =
+    val lastUnit = multipliers[quanta].last
     val quantityUnit = lastUnit.unitPower.ref.dimensionRef.principal
     val ratioExpr = ratio(lastUnit.unitPower.ref, quantityUnit, lastUnit.unitPower.power)
 
     quantityUnit.power(1).asType.absolve match
       case '[type quantity <: Measure; quantity] =>
-        '{Quantity[quantity]($count.long*$ratioExpr)}
+        '{Quantity[quantity]($count.asInstanceOf[Long]*$ratioExpr)}
 
 
-  def fromQuantity[quantity <: Measure: Type, units <: Tuple: Type]
+  def fromQuantity[quantity <: Measure: Type, result: Type]
     ( quantity: Expr[Quantity[quantity]] )
-  :   Macro[Quanta[units]] =
+  :   Macro[result] =
 
     import quotes.reflect.*
 
-    val lastUnit = multipliers[units].last.unitPower
+    val lastUnit = multipliers[result].last.unitPower
     val quantityUnit = readUnitPower(TypeRepr.of[quantity].dealias)
     val ratioExpr = ratio(quantityUnit.ref, lastUnit.ref, lastUnit.power)
 
-    '{($quantity.value*$ratioExpr + 0.5).toLong.asInstanceOf[Quanta[units]]}
+    '{($quantity.value*$ratioExpr + 0.5).toLong.asInstanceOf[result]}
 
 
-  def get[units <: Tuple: Type, unit <: Units[1, ? <: Dimension]: Type](value: Expr[Quanta[units]])
+  def get[quanta: Type, unit <: Units[1, ? <: Dimension]: Type]
+    ( value: Expr[quanta] )
   :   Macro[Int] =
 
     import quotes.reflect.*
 
     val lookupUnit = readUnitPower(TypeRepr.of[unit])
 
-    val multiplier: Multiplier = multipliers[units].where(_.unitPower == lookupUnit).or:
+    val multiplier: Multiplier = multipliers[quanta].where(_.unitPower == lookupUnit).or:
       halt(557, m"the Quanta does not include this unit")
 
-    '{(($value.long/${Expr(multiplier.subdivision)})%${Expr(multiplier.max)}).toInt}
+    '{(($value.asInstanceOf[Long]/${Expr(multiplier.subdivision)})%${Expr(multiplier.max)}).toInt}
+
+
+  def collapse[quanta: Type](count: Expr[quanta], length: Expr[Int]): Macro[Any] =
+    import quotes.reflect.*
+
+    val drop = length.valueOrAbort
+    val (parent, formElements) = decompose(TypeRepr.of[quanta])
+
+    if drop < 0 || drop > formElements.length then halt:
+      m"""
+        cannot collapse $drop units; this Quanta has ${formElements.length} divisions above its base
+        unit
+      """
+
+    val consCtor = TypeRepr.of[Any *: EmptyTuple].absolve match
+      case AppliedType(tycon, _) => tycon
+
+    def tupleType(elements: List[TypeRepr]): TypeRepr =
+      elements.foldRight(TypeRepr.of[EmptyTuple]): (head, tail) =>
+        consCtor.appliedTo(List(head, tail))
+
+    val remaining = formElements.dropRight(drop)
+
+    val resultType =
+      if remaining.isEmpty then parent
+      else Refinement(parent, "Form", TypeBounds(tupleType(remaining), tupleType(remaining)))
+
+    resultType.asType.absolve match
+      case '[result] => '{Quanta.fromLong[result]($count.asInstanceOf[Long])}
 
 
   private case class Multiplier(unitPower: UnitPower, subdivision: Int, max: Int)
 
-  private def multipliers[units: Type](using Quotes): List[Multiplier] =
+  private def elements(using Quotes)(tpe: quotes.reflect.TypeRepr): List[quotes.reflect.TypeRepr] =
     import quotes.reflect.*
 
-
-    def untuple[tuple: Type](dimension: Optional[DimensionRef], result: List[UnitPower])
-    :   List[UnitPower] =
-
-      TypeRepr.of[tuple].dealias.asType match
-        case '[head *: tail] =>
-          val unitPower = readUnitPower(TypeRepr.of[head])
-
-          dimension.let: current =>
-            if unitPower.ref.dimensionRef != current
-            then halt:
-              m"""
-                the Quanta type incorrectly mixes units of ${unitPower.ref.dimensionRef.name} and
-                ${current.name}
-              """
-
-          untuple[tail](unitPower.ref.dimensionRef, unitPower :: result)
-
-        case _ =>
-          result
+    tpe.dealias.asType match
+      case '[EmptyTuple]   => Nil
+      case '[head *: tail] => TypeRepr.of[head] :: elements(TypeRepr.of[tail])
+      case _               => List(tpe)
 
 
-    val cascade: List[UnitPower] = untuple[units](Unset, Nil)
+  private def decompose(using Quotes)(repr: quotes.reflect.TypeRepr)
+  :   (quotes.reflect.TypeRepr, List[quotes.reflect.TypeRepr]) =
+
+    import quotes.reflect.*
+
+    repr.dealias match
+      case Refinement(parent, "Form", info) =>
+        val form = info match
+          case TypeBounds(_, hi) => hi
+          case other             => other
+
+        (parent, elements(form))
+
+      // An unreduced `prepositional.in[Quanta[base], form]` applied alias (the `Quanta` opaque
+      // can dealias to `Long` here, so the refinement is not always recovered).
+      case AppliedType(_, List(parent, form)) =>
+        (parent, elements(form))
+
+      case other =>
+        (other, Nil)
+
+
+  // Computes the `Multiplier`s from the units in smallest-to-largest (base-first) order.
+  private def multipliersOf(using Quotes)(units: List[quotes.reflect.TypeRepr]): List[Multiplier] =
+    val cascade: List[UnitPower] = units.map(readUnitPower)
+    val dimension = cascade.head.ref.dimensionRef
+
+    cascade.tail.foreach: unitPower =>
+      if unitPower.ref.dimensionRef != dimension then halt:
+        m"""
+          the Quanta type incorrectly mixes units of ${unitPower.ref.dimensionRef.name} and
+          ${dimension.name}
+        """
 
     def recur(todo: List[UnitPower], units: List[Multiplier] = Nil): List[Multiplier] = todo match
       case Nil => units
@@ -200,3 +273,17 @@ object internal:
             Multiplier(head, (value + 0.5).toInt, value2.let(_.toInt).or(Int.MaxValue)) :: units )
 
     recur(cascade)
+
+
+  private def multipliers[quanta: Type](using Quotes): List[Multiplier] =
+    import quotes.reflect.*
+
+    val (parent, formElements) = decompose(TypeRepr.of[quanta])
+
+    // Match the application directly without dealiasing: the `Quanta` opaque type can dealias
+    // to `Long` in this scope, which would discard the base unit.
+    val base = parent match
+      case AppliedType(_, List(baseRepr)) => baseRepr
+      case _                              => halt(m"this is not a valid Quanta type")
+
+    multipliersOf(base :: formElements)

--- a/lib/abacist/src/core/abacist.protointernal.scala
+++ b/lib/abacist/src/core/abacist.protointernal.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package abacist
 
-import scala.compiletime.*, ops.int.*
+import scala.compiletime.*
 
 import anticipation.*
 import gossamer.*
@@ -43,54 +43,74 @@ import spectacular.*
 import symbolism.*
 
 object protointernal extends anteprotointernal:
-  opaque type Quanta[units <: Tuple] = Long
+  opaque type Quanta[base <: AnyUnit] = Long
 
   object Quanta extends Quanta2:
-    inline given underlying: [units <: Tuple] => Underlying[Quanta[units], Long] = !!
+    inline given underlying: [base <: AnyUnit, form <: Divisions]
+    =>  Underlying[Quanta[base] in form, Long] = !!
 
-    given zeroic: [units <: Tuple] => Quanta[units] is Zeroic:
-      inline def zero: Quanta[units] = 0L
+    inline given underlyingBare: [base <: AnyUnit] => Underlying[Quanta[base], Long] = !!
 
-    given typeable: [units <: Tuple] => Typeable[Quanta[units]]:
-      def unapply(count: Any): Option[count.type & Quanta[units]] = count.asMatchable match
-        case count: Long => Some(count)
+    // Two givens with structured `Self` types (rather than a single `quanta <: Quanta[base]`)
+    // so that a `(? <: value) is Zeroic` search cannot collapse the wildcard to `Nothing`
+    // (whose `zero` would throw on the cast in `fromLong`).
+    given zeroic: [base <: AnyUnit] => Quanta[base] is Zeroic:
+      inline def zero: Quanta[base] = fromLong(0L)
+
+    given zeroic2: [base <: AnyUnit, form <: Divisions] => (Quanta[base] in form) is Zeroic:
+      inline def zero: Quanta[base] in form = fromLong(0L)
+
+    given typeable: [base <: AnyUnit, quanta <: Quanta[base]] => Typeable[quanta]:
+      def unapply(count: Any): Option[count.type & quanta] = count.asMatchable match
+        case count: Long => Some(count.asInstanceOf[count.type & quanta])
         case _           => None
 
-    def fromLong[units <: Tuple](long: Long): Quanta[units] = long
+    def fromLong[quanta](long: Long): quanta = long.asInstanceOf[quanta]
 
-    given integral: [units <: Tuple] => Integral[Quanta[units]] = summon[Integral[Long]]
+    given integral: [base <: AnyUnit, quanta <: Quanta[base]] => Integral[quanta] =
+      summon[Integral[Long]].asInstanceOf[Integral[quanta]]
 
-    inline def apply[units <: Tuple](inline values: Int*): Quanta[units] =
-      ${abacist.internal.quanta[units]('values)}
+    // `base` and `form` are taken from the expected type, e.g. `val weight: Weight =
+    // Quanta(5, 6)`, `date + Quanta(2)`, or — where no expected type is available — a type
+    // ascription such as `(Quanta(5, 6): Weight)`.
+    inline def apply[base <: AnyUnit, form <: Divisions](inline values: Int*)
+    :   Quanta[base] { type Form = form } =
 
-    given addable: [units <: Tuple] => Quanta[units] is Addable:
-      type Operand = Quanta[units]
-      type Result = Quanta[units]
+      ${abacist.internal.assembleParts[base, form]('values)}
 
-      def add(left: Quanta[units], right: Quanta[units]): Quanta[units] = left + right
+    given addable: [base <: AnyUnit, quanta <: Quanta[base]] => quanta is Addable:
+      type Operand = quanta
+      type Result = quanta
 
-    given subtractable: [units <: Tuple] => Quanta[units] is Subtractable:
-      type Operand = Quanta[units]
-      type Result = Quanta[units]
+      def add(left: quanta, right: quanta): quanta = fromLong(left.long + right.long)
 
-      def subtract(left: Quanta[units], right: Quanta[units]): Quanta[units] = left - right
+    given subtractable: [base <: AnyUnit, quanta <: Quanta[base]] => quanta is Subtractable:
+      type Operand = quanta
+      type Result = quanta
 
-    given multiplicable: [units <: Tuple] => Quanta[units] is Multiplicable:
+      def subtract(left: quanta, right: quanta): quanta = fromLong(left.long - right.long)
+
+    given multiplicable: [base <: AnyUnit, quanta <: Quanta[base]] => quanta is Multiplicable:
       type Operand = Double
-      type Result = Quanta[units]
+      type Result = quanta
 
-      def multiply(left: Quanta[units], right: Double): Quanta[units] = left.multiply(right)
+      def multiply(left: quanta, right: Double): quanta = fromLong((left.long*right + 0.5).toLong)
 
-    given divisible: [units <: Tuple] => Quanta[units] is Divisible:
+    given divisible: [base <: AnyUnit, quanta <: Quanta[base]] => quanta is Divisible:
       type Operand = Double
-      type Result = Quanta[units]
+      type Result = quanta
 
-      def divide(left: Quanta[units], right: Double): Quanta[units] = left.divide(right)
+      def divide(left: quanta, right: Double): quanta = fromLong((left.long/right + 0.5).toLong)
 
-    given negatable: [units <: Tuple] => Quanta[units] is Negatable to Quanta[units] = -_
+    given negatable: [base <: AnyUnit, quanta <: Quanta[base]] => quanta is Negatable to quanta =
+      count => fromLong(-count.long)
 
-    inline given showable: [units <: Tuple] => Quanta[units] is Showable = summonFrom:
-      case names: UnitsNames[units] =>
+    // `showable`/`distributive2` are provided as a pair each: one for refined `Quanta` types
+    // (carrying a `Form`) and one for bare single-unit types. Their structured `Self` types let
+    // `base`/`form` be unified exactly, rather than maximised to `Any` as a `quanta <: Quanta
+    // [base]` bound would be in an inline given.
+    inline def showQuanta[base <: AnyUnit, quanta <: Quanta[base]]: quanta is Showable = summonFrom:
+      case names: UnitsNames[quanta] =>
         count =>
         val nonzeroComponents = count.components.filter(_(1) != 0)
         val nonzeroUnits = nonzeroComponents.map(_(1).toString.tt).to(List)
@@ -102,37 +122,53 @@ object protointernal extends anteprotointernal:
         val nonzeroComponents = count.components.filter(_(1) != 0)
         nonzeroComponents.map { (unit, count) => count.toString+unit }.mkString(" ").tt
 
-    inline given distributive2: [units <: Tuple] => Quanta[units] is Distributive by Long =
-      distributive[units](_.components.map(_(1)).to(List)): (value, parts) =>
+    inline given showable: [base <: AnyUnit, form <: Divisions]
+    =>  (Quanta[base] in form) is Showable =
+      showQuanta[base, Quanta[base] in form]
+
+    inline given showableBare: [base <: AnyUnit] => Quanta[base] is Showable =
+      showQuanta[base, Quanta[base]]
+
+    inline def distributiveQuanta[base <: AnyUnit, quanta <: Quanta[base]]
+    :   quanta is Distributive by Long =
+
+      distributive[quanta](_.components.map(_(1)).to(List)): (value, parts) =>
         parts.zip(value.components.map(_(0))).map: (number, units) =>
           t"$number $units"
 
         . join(t", ")
 
+    inline given distributive2: [base <: AnyUnit, form <: Divisions]
+    =>  (Quanta[base] in form) is Distributive by Long =
+      distributiveQuanta[base, Quanta[base] in form]
 
-    def distributive[units <: Tuple]
-      ( parts0: Quanta[units] => List[Long] )
-      ( place0: (Quanta[units], List[Text]) => Text )
-    :   Quanta[units] is Distributive by Long =
+    inline given distributive2Bare: [base <: AnyUnit] => Quanta[base] is Distributive by Long =
+      distributiveQuanta[base, Quanta[base]]
+
+
+    def distributive[quanta]
+      ( parts0: quanta => List[Long] )
+      ( place0: (quanta, List[Text]) => Text )
+    :   quanta is Distributive by Long =
 
       new Distributive:
-        type Self = Quanta[units]
+        type Self = quanta
         type Operand = Long
-        def parts(value: Quanta[units]): List[Long] = parts0(value)
-        def place(value: Quanta[units], parts: List[Text]): Text = place0(value, parts)
+        def parts(value: quanta): List[Long] = parts0(value)
+        def place(value: quanta, parts: List[Text]): Text = place0(value, parts)
 
 
-  extension [units <: Tuple](count: Quanta[units])
+  extension [base <: AnyUnit, quanta <: Quanta[base]](count: quanta)
     def long: Long = count
 
 
-  extension [units <: Tuple](inline count: Quanta[units])
+  extension [base <: AnyUnit, quanta <: Quanta[base]](inline count: quanta)
     inline def apply[unit[power <: Nat] <: Units[power, ? <: Dimension]]: Int =
 
-      ${abacist.internal.get[units, unit[1]]('count)}
+      ${abacist.internal.get[quanta, unit[1]]('count)}
 
-    transparent inline def quantity: Any = ${abacist.internal.toQuantity[units]('count)}
-    inline def components: ListMap[Text, Long] = ${abacist.internal.describeQuanta[units]('count)}
+    transparent inline def quantity: Any = ${abacist.internal.toQuantity[quanta]('count)}
+    inline def components: ListMap[Text, Long] = ${abacist.internal.describeQuanta[quanta]('count)}
 
     transparent inline def multiply(inline multiplier: Double): Any =
       ${abacist.internal.multiplyQuanta('count, 'multiplier, false)}
@@ -141,7 +177,5 @@ object protointernal extends anteprotointernal:
       ${abacist.internal.multiplyQuanta('count, 'multiplier, true)}
 
 
-    transparent inline def collapse(length: Int)(using length.type < Tuple.Size[units] =:= true)
-    :   Quanta[Tuple.Drop[units, length.type]] =
-
-      count
+    transparent inline def collapse(inline length: Int): Any =
+      ${abacist.internal.collapse[quanta]('count, 'length)}

--- a/lib/abacist/src/core/abacist_core.scala
+++ b/lib/abacist/src/core/abacist_core.scala
@@ -34,14 +34,21 @@ package abacist
 
 import scala.quoted.*
 
+import prepositional.*
 import quantitative.*
 
 export protointernal.Quanta
 
-type TimeMinutes = (Hours[1], Minutes[1])
-type TimeSeconds = (Hours[1], Minutes[1], Seconds[1])
+// The bound for a `Quanta` base unit: a single unit raised to any power.
+type AnyUnit = Units[?, ?]
+
+// The bound for a `Quanta` `Form`: a tuple of divisions, or a single division.
+type Divisions = Tuple | AnyUnit
+
+type TimeMinutes = Quanta[Minutes[1]] in (Hours[1])
+type TimeSeconds = Quanta[Seconds[1]] in (Minutes[1], Hours[1])
 
 extension [units <: Measure](inline quantity: Quantity[units])
-  inline def quanta[count <: Tuple]: Quanta[count] =
-    ${abacist.internal.fromQuantity[units, count]('quantity)}
+  inline def quanta[result]: result =
+    ${abacist.internal.fromQuantity[units, result]('quantity)}
 

--- a/lib/abacist/src/test/abacist_test.scala
+++ b/lib/abacist/src/test/abacist_test.scala
@@ -39,31 +39,38 @@ given decimalizer: Decimalizer = Decimalizer(3)
 object Tests extends Suite(m"Abacist Tests"):
   def run(): Unit =
     suite(m"Quanta tests"):
-      type Height = (Feet[1], Inches[1])
+      type Height = Quanta[Inches[1]] in (Feet[1])
 
       test(m"Access seconds in an HMS time"):
-        val hmsTime = Quanta[TimeSeconds](27, 18, 9)
+        val hmsTime: TimeSeconds = Quanta(27, 18, 9)
         hmsTime[Seconds]
       . assert(_ == 9)
 
       test(m"Access minutes in an HMS time"):
-        val hmsTime = Quanta[TimeSeconds](27, 18, 9)
+        val hmsTime: TimeSeconds = Quanta(27, 18, 9)
         hmsTime[Minutes]
       . assert(_ == 18)
 
       test(m"Access hours in an HMS time"):
-        val hmsTime = Quanta[TimeSeconds](27, 18, 9)
+        val hmsTime: TimeSeconds = Quanta(27, 18, 9)
         hmsTime[Hours]
       . assert(_ == 27)
 
+      type ImperialDistance = Quanta[Inches[1]] in (Feet[1], Yards[1], Miles[1])
+
       test(m"Access inches in an imperial distance"):
-        val imperialDistance = Quanta[(Miles[1], Yards[1], Feet[1], Inches[1])](1800, 4, 2, 11)
+        val imperialDistance: ImperialDistance = Quanta(1800, 4, 2, 11)
         imperialDistance[Feet]
       . assert(_ == 2)
 
       test(m"Units of different dimensions cannot be mixed"):
         demilitarize:
-          Quanta[(Miles[1], Yards[1], Seconds[1], Inches[1])](1, 2, 3)
+          (Quanta(1, 2, 3): Quanta[Inches[1]] in (Seconds[1], Yards[1], Miles[1]))
+      . assert(_.nonEmpty)
+
+      test(m"A non-unit base is rejected by the type bound"):
+        demilitarize:
+          val bad: Quanta[String] = ???
       . assert(_.nonEmpty)
 
       test(m"Convert a length to a Quanta"):
@@ -72,7 +79,7 @@ object Tests extends Suite(m"Abacist Tests"):
         (count[Feet], count[Inches])
       . assert(_ == (6, 9))
 
-      type Weight = (Stones[1], Pounds[1], Ounces[1])
+      type Weight = Quanta[Ounces[1]] in (Pounds[1], Stones[1])
 
       test(m"Convert a mass Quantity to a Quanta"):
         val weight: Quantity[Kilograms[1]] = 20.0*Kilo(Gram)
@@ -81,112 +88,128 @@ object Tests extends Suite(m"Abacist Tests"):
       . assert(_ == (3, 2, 1))
 
       test(m"Convert a Quanta to a Quantity"):
-        val weight: Quanta[Weight] = Quanta(5, 6)
+        val weight: Weight = Quanta(5, 6)
         weight.quantity
       . assert(_ == 2.438057*Kilo(Gram))
 
       test(m"Convert a Quanta to a Quantity in pounds"):
-        val weight: Quanta[Weight] = Quanta(5, 6)
+        val weight: Weight = Quanta(5, 6)
         weight.quantity.in[Pounds]
       . assert(_ == 5.375*Pound)
 
       test(m"Add two Quantas"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val sum: Quanta[Weight] = weight + Quanta[Weight](1)
+        val weight: Weight = Quanta(12, 9)
+        val sum: Weight = weight + Quanta(1)
         (sum[Stones], sum[Pounds], sum[Ounces])
       . assert(_ == (0, 12, 10))
 
       test(m"Add two Quantas 2"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val sum: Quanta[Weight] = weight + Quanta[Weight](2)
+        val weight: Weight = Quanta(12, 9)
+        val sum: Weight = weight + Quanta(2)
         (sum[Stones], sum[Pounds], sum[Ounces])
       . assert(_ == (0, 12, 11))
 
       test(m"Add two Quantas 3"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val sum: Quanta[Weight] = weight + Quanta[Weight](5)
+        val weight: Weight = Quanta(12, 9)
+        val sum: Weight = weight + Quanta(5)
         (sum[Stones], sum[Pounds], sum[Ounces])
       . assert(_ == (0, 12, 14))
 
       test(m"Add two Quantas 4"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val sum: Quanta[Weight] = weight + Quanta[Weight](7)
+        val weight: Weight = Quanta(12, 9)
+        val sum: Weight = weight + Quanta(7)
         (sum[Stones], sum[Pounds], sum[Ounces])
       . assert(_ == (0, 13, 0))
 
       test(m"Add two Quantas 5"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val sum: Quanta[Weight] = weight + Quanta[Weight](8)
+        val weight: Weight = Quanta(12, 9)
+        val sum: Weight = weight + Quanta(8)
         (sum[Stones], sum[Pounds], sum[Ounces])
       . assert(_ == (0, 13, 1))
 
       test(m"Subtract two Quantas 1"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val weight2: Quanta[Weight] = Quanta(0, 2)
+        val weight: Weight = Quanta(12, 9)
+        val weight2: Weight = Quanta(0, 2)
         val result = weight - weight2
         (result[Stones], result[Pounds], result[Ounces])
       . assert(_ == (0, 12, 7))
 
       test(m"Subtract two Quantas 2"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
-        val weight2: Quanta[Weight] = Quanta(0, 2)
+        val weight: Weight = Quanta(12, 9)
+        val weight2: Weight = Quanta(0, 2)
         val result = weight2 - weight
         (result[Stones], result[Pounds], result[Ounces])
       . assert(_ == (0, -12, -7))
 
       test(m"Multiply a Quanta by a double"):
-        val weight: Quanta[Weight] = Quanta(12, 9)
+        val weight: Weight = Quanta(12, 9)
         val result = weight*2.5
         (result[Stones], result[Pounds], result[Ounces])
       . assert(_ == (2, 3, 7))
 
       test(m"Adding with double carry"):
-        val weight: Quanta[Weight] = Quanta(100, 13, 15)
-        val sum: Quanta[Weight] = weight + Quanta[Weight](1)
+        val weight: Weight = Quanta(100, 13, 15)
+        val sum: Weight = weight + Quanta(1)
         (sum[Stones], sum[Pounds], sum[Ounces])
       . assert(_ == (101, 0, 0))
 
       test(m"Collapse a weight value"):
-        val weight: Quanta[Weight] = Quanta(2, 3, 4)
+        val weight: Weight = Quanta(2, 3, 4)
         val weight2 = weight.collapse(1)
         (weight2[Pounds], weight2[Ounces])
       . assert(_ == (31, 4))
 
       test(m"Collapse a weight value 2"):
-        val weight: Quanta[Weight] = Quanta(2, 3, 4)
+        val weight: Weight = Quanta(2, 3, 4)
         val weight2 = weight.collapse(2)
         weight2[Ounces]
       . assert(_ == 500)
 
       test(m"Cannot collapse beyond last unit"):
         demilitarize:
-          val weight: Quanta[Weight] = Quanta(2, 3, 4)
+          val weight: Weight = Quanta(2, 3, 4)
           weight.collapse(3)
       . assert(_.length == 1)
 
+      suite(m"Shared base-unit supertype"):
+        type Hms = Quanta[Seconds[1]] in (Minutes[1], Hours[1])
+        type Ms = Quanta[Seconds[1]] in (Minutes[1])
+
+        test(m"Differently-divided quanta share a common base-unit supertype"):
+          val a: Hms = Quanta(0, 1, 0)
+          val b: Ms = Quanta(0, 30)
+          List[Quanta[Seconds[1]]](a, b).length
+        . assert(_ == 2)
+
+        test(m"Quanta with the same base unit but different divisions are comparable"):
+          val a: Quanta[Seconds[1]] = (Quanta(0, 1, 0): Hms)
+          val b: Quanta[Seconds[1]] = (Quanta(0, 30): Ms)
+          a > b
+        . assert(_ == true)
+
       suite(m"Showing Quanta values"):
         test(m"Show a single-unit weight"):
-          Quanta[Weight](2).show
+          (Quanta(2): Weight).show
         . assert(_ == t"2oz")
 
         test(m"Show a more complex weight"):
-          Quanta[Weight](3, 2).show
+          (Quanta(3, 2): Weight).show
         . assert(_ == t"3lb 2oz")
 
         test(m"Show a weight of three parts"):
-          Quanta[Weight](1, 3, 2).show
+          (Quanta(1, 3, 2): Weight).show
         . assert(_ == t"1st 3lb 2oz")
 
         test(m"Show with custom unit rendering"):
           given UnitsNames[Height] = () => List(t"'", t"\"")
-          Quanta[Height](5, 9).show
+          (Quanta(5, 9): Height).show
         . assert(_ == t"5' 9\"")
 
       suite(m"Aggregate tests"):
         test(m"Total of several values"):
-          List[Quanta[Weight]](Quanta(10), Quanta(1, 6), Quanta(2, 4, 1)).total
-        . assert(_ == Quanta(2, 6, 1))
+          List[Weight](Quanta(10), Quanta(1, 6), Quanta(2, 4, 1)).total
+        . assert(_ == (Quanta(2, 6, 1): Weight))
 
         test(m"Mean of several values"):
-          List[Quanta[Weight]](Quanta(10), Quanta(1, 6), Quanta(2, 4, 1)).mean
-        . assert(_ == Quanta(11, 6))
+          List[Weight](Quanta(10), Quanta(1, 6), Quanta(2, 4, 1)).mean
+        . assert(_ == (Quanta(11, 6): Weight))

--- a/lib/aviation/src/core/aviation.Iso8601.scala
+++ b/lib/aviation/src/core/aviation.Iso8601.scala
@@ -95,8 +95,8 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
       import hebdomads.europeanHebdomad
 
-      val firstMonday = jan4 - Quanta[Mono[Days[1]]](jan4.weekday.number.n0)
-      firstMonday + Quanta[Mono[Days[1]]](days)
+      val firstMonday = jan4 - (Quanta(jan4.weekday.number.n0): Quanta[Days[1]])
+      firstMonday + (Quanta(days): Quanta[Days[1]])
 
     val date: Date = next() match
       case '-' =>

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -353,16 +353,16 @@ object internal:
     trait Format(val name: Text):
       type Issue: Communicable
 
-    given subtractable: Date is Subtractable by Date to Quanta[Mono[Days[1]]] = (end, start) =>
-      Quanta(end - start)
+    given subtractable: Date is Subtractable by Date to Quanta[Days[1]] = (end, start) =>
+      (Quanta(end - start): Quanta[Days[1]])
 
-    given subtractable2: Date is Subtractable by Quanta[Mono[Days[1]]] to Date = (end, start) =>
+    given subtractable2: Date is Subtractable by Quanta[Days[1]] to Date = (end, start) =>
       end - start[Days]
 
-    given addable: Date is Addable by Quanta[Mono[Days[1]]] to Date = (left, right) =>
+    given addable: Date is Addable by Quanta[Days[1]] to Date = (left, right) =>
       left + right[Days]
 
-    given addable2: Quanta[Mono[Days[1]]] is Addable by Date to Date = (left, right) =>
+    given addable2: Quanta[Days[1]] is Addable by Date to Date = (left, right) =>
       left[Days] + right
 
     given showable: (Endianness, DateNumerics, DateSeparation, Years) => Date is Showable = date =>

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -197,18 +197,18 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"Subtract dates"):
         2018-Nov-19 - (2017-Sep-1)
-      . assert(_ == Quanta[Mono[Days[1]]](444))
+      . assert(_ == (Quanta(444): Quanta[Days[1]]))
 
       test(m"Subtract days from a date"):
-        2018-Nov-19 - Quanta[Mono[Days[1]]](2)
+        2018-Nov-19 - (Quanta(2): Quanta[Days[1]])
       . assert(_ == 2018-Nov-17)
 
       test(m"Add days to a date"):
-        2018-Nov-19 + Quanta[Mono[Days[1]]](2)
+        2018-Nov-19 + (Quanta(2): Quanta[Days[1]])
       . assert(_ == 2018-Nov-21)
 
       test(m"Add days to a date, order reversed"):
-        Quanta[Mono[Days[1]]](2) + (2018-Nov-19)
+        (Quanta(2): Quanta[Days[1]]) + (2018-Nov-19)
       . assert(_ == 2018-Nov-21)
 
       test(m"Get Gregorian date"):
@@ -1191,11 +1191,11 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"Subtract a date from itself yields zero"):
         2024-Jul-15 - (2024-Jul-15)
-      . assert(_ == Quanta[Mono[Days[1]]](0))
+      . assert(_ == (Quanta(0): Quanta[Days[1]]))
 
       test(m"Cross-year date difference"):
         2025-Jan-1 - (2024-Jan-1)
-      . assert(_ == Quanta[Mono[Days[1]]](366))
+      . assert(_ == (Quanta(366): Quanta[Days[1]]))
 
       test(m"Date less-than"):
         (2024-Jan-1) < (2024-Jan-2)

--- a/lib/baroque/src/test/baroque_test.scala
+++ b/lib/baroque/src/test/baroque_test.scala
@@ -67,7 +67,7 @@ object Tests extends Suite(m"Baroque tests"):
     . assert(_ == t"1.00 m·s¯¹")
 
     test(m"Show a quantity value in feet and inches"):
-      type Distance = Quanta[(Yards[1], Feet[1], Inches[1])]
+      type Distance = Quanta[Inches[1]] in (Feet[1], Yards[1])
       val re: Distance = Quanta(1, 2, 0)
       val im: Distance = Quanta(2, 0, 6)
       Complex[Distance](re, im).show

--- a/sample/tube/src/core/tube.scala
+++ b/sample/tube/src/core/tube.scala
@@ -33,7 +33,7 @@ given Online => StationRow is Embeddable in HttpUrl by UrlFragment =
 
 given Decimalizer = Decimalizer(significantFigures = 2)
 val timezone = tz"Europe/London"
-type HoursAndMinutes = Quanta[(Hours[1], Minutes[1])]
+type HoursAndMinutes = Quanta[Minutes[1]] in (Hours[1])
 
 given quantaDecoder: Tactic[JsonError] => HoursAndMinutes is Decodable in Json =
   summon[Int is Decodable in Json].map(Quanta(_))


### PR DESCRIPTION
Abacist's `Quanta` now takes its base (smallest) unit as its type parameter and carries the coarser divisions in a `Form` type member, so two quantities measured in the same base unit but divided differently — hours-minutes-seconds and minutes-seconds, say — share the common supertype `Quanta[Seconds[1]]` and can be compared with one another.

A `Quanta` type is now written with the base unit as the parameter and the divisions after `in`:

```scala
type Hms = Quanta[Seconds[1]] in (Minutes[1], Hours[1])
type Ms  = Quanta[Seconds[1]] in (Minutes[1])
```

Both are subtypes of `Quanta[Seconds[1]]`, so differently-divided values can be held together and compared:

```scala
val a: Hms = Quanta(1, 2, 3)
val b: Ms  = Quanta(4, 5)
val times: List[Quanta[Seconds[1]]] = List(a, b)
a > b   // compared by their common base unit
```

Values are constructed with `Quanta(…)`, inferring the base and divisions from the expected type; where there is no expected type, ascribe it — `(Quanta(3, 2): Weight).show`. The base unit is bounded `<: Units[?, ?]` and the divisions `<: Tuple | Units[?, ?]`, so non-unit `Quanta` types are rejected at compile time.
