### PR TITLE
Support Optional fields in caesura product (Dsv) decoding

### DIFF
--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -61,6 +61,16 @@ object Dsv extends Dsv2:
   def apply(iterable: Iterable[Text]): Dsv = new Dsv(IArray.from(iterable))
   def apply(text: Text*): Dsv = new Dsv(IArray.from(text))
 
+  // An absent cell (a short positional row, or a header column missing from the row) decodes
+  // to `Unset`; a present cell — even an empty one — decodes its inner value. The product
+  // decoder hands an empty `Dsv` to a field whose cell is absent (see `conjunction`). Sits at
+  // the same priority as the primitive cell decoders (above the generic `decoder` in `Dsv2`),
+  // and short-circuits an absent cell to `Unset` before the inner decoder would `raise` Absent.
+  given optionalDecodable: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  ( decodable: => inner is Decodable in Dsv )
+  =>  value is Decodable in Dsv =
+    row => if row.data.length == 0 then Unset else decodable.decoded(row)
+
   given encoder: [encodable: Encodable in Text] => encodable is Encodable in Dsv =
     value => Dsv(encodable.encode(value))
 
@@ -179,9 +189,15 @@ object Dsv extends Dsv2:
 
             build[derivation]:
               [field] => context =>
-                val i = row.columns.let(_.at(label)).or(count)
+                // Positional mode (`columns` Unset): read the field's span starting at `count`.
+                // Header mode: locate the field by column name; an absent column hands the field
+                // an empty `Dsv` so `Optional` fields decode to `Unset` rather than misreading by
+                // position.
+                val row2 = row.columns.lay(Dsv(row.data.drop(count))): columns =>
+                  columns.at(label).lay(Dsv(IArray[Text]())): i =>
+                    Dsv(row.data.drop(i))
+
                 count += spans(index)
-                val row2 = Dsv(row.data.drop(i))
 
                 focus(CellRef(Prim, label)):
                   contextual.decoded(row2)

--- a/lib/caesura/src/core/caesura.Spannable.scala
+++ b/lib/caesura/src/core/caesura.Spannable.scala
@@ -35,6 +35,7 @@ package caesura
 import anticipation.*
 import distillate.*
 import prepositional.*
+import vacuous.*
 import wisteria.*
 
 object Spannable extends ProductDerivable[Spannable]:
@@ -42,6 +43,13 @@ object Spannable extends ProductDerivable[Spannable]:
     () => contexts[derivation](): [field] => context => context.spans().sum
 
   given decoder: [decodable: Decodable in Text] => decodable is Spannable = () => IArray(1)
+
+  // An `Optional[T]` field spans exactly as many cells as its inner type: a present value
+  // occupies the inner span, and an absent (trailing/missing) value leaves those cells empty.
+  given optional: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  ( spannable: inner is Spannable )
+  =>  value is Spannable =
+    () => spannable.spans()
 
 trait Spannable extends Typeclass:
   def spans(): IArray[Int]

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -280,6 +280,31 @@ object Tests extends Suite(m"Caesura tests"):
         t"foo,bar\nbaz,quux".read[Sheet].show
       . assert(_ == t"foo,bar\nbaz,quux")
 
+    suite(m"Optional fields"):
+      test(m"an Optional field spans one column"):
+        Spannable.derived[Greeting].spans().to(List)
+      . assert(_ == List(1, 1))
+
+      test(m"decode a present trailing Optional positionally"):
+        import dsvFormats.csvFormat
+        t"hello,world".read[Greeting in Dsv]
+      . assert(_ == Greeting(t"hello", t"world"))
+
+      test(m"a short row decodes a trailing Optional to Unset"):
+        import dsvFormats.csvFormat
+        t"hello".read[Greeting in Dsv]
+      . assert(_ == Greeting(t"hello", Unset))
+
+      test(m"decode a present Optional column by heading"):
+        import dsvFormats.csvWithHeaderFormat
+        t"word,name\nhello,world".read[Greeting in Dsv]
+      . assert(_ == Greeting(t"hello", t"world"))
+
+      test(m"a missing Optional column decodes to Unset"):
+        import dsvFormats.csvWithHeaderFormat
+        t"word\nhello".read[Greeting in Dsv]
+      . assert(_ == Greeting(t"hello", Unset))
+
     suite(m"Cell spanning"):
       test(m"a flat product spans one column per field"):
         Spannable.derived[Foo].spans().to(List)
@@ -314,3 +339,4 @@ object Tests extends Suite(m"Caesura tests"):
 case class Foo(one: Text, two: Text)
 case class Bar(one: Double, foo1: Foo, four: Int, foo2: Foo)
 case class Quux(name: Text, greeting: Text)
+case class Greeting(word: Text, name: Optional[Text])


### PR DESCRIPTION
caesura's product decoding is strictly positional and had no missing-field branch, so a case class with an `Optional[T]` field could not decode from a DSV row: it failed to derive (no `Spannable` for `Optional`) and threw on a short row. This adds `Optional` support to DSV decoding, following the `Mandatable`-bound pattern already used by stratiform and locomotion, and composing with the recently merged error-accrual decoder (a missing required column now accrues a clean `Absent` error rather than throwing).

Closes #1355.

caesura now decodes `Optional[T]` fields in case classes read from DSV data:

- **Positional mode** — a trailing `Optional` field decodes to `Unset` when the row is short, and decodes its value when the cell is present:
  ```scala
  case class Greeting(word: Text, name: Optional[Text])
  t"hello,world".read[Greeting in Dsv]  // Greeting(t"hello", t"world")
  t"hello".read[Greeting in Dsv]        // Greeting(t"hello", Unset)
  ```
- **Header mode** — an `Optional` field whose column is absent from the header decodes to `Unset`:
  ```scala
  import dsvFormats.csvWithHeaderFormat
  t"word\nhello".read[Greeting in Dsv]  // Greeting(t"hello", Unset)
  ```

Decoding only; encoding case classes with `Optional` fields remains unsupported, since a fixed-width row cannot faithfully represent an absent trailing cell on encode.