### PR TITLE
Add Decorum rule SN-560 for multi-line interpolated-string layout

### DIFF
--- a/doc/syntax.md
+++ b/doc/syntax.md
@@ -847,6 +847,43 @@ the leading `:` and the return type on a heavy-signature return-type line.**
 - `m"…"` for `Message`.
 - `s"…"` and plain `"…"` only where a raw `String` is genuinely needed.
 
+### Multi-line interpolated strings
+
+The interpolators whose leading and trailing whitespace is *insignificant* —
+`m` (messages), `j` (JSON), `x` (XML), `y` (YAML) and `tel` (TEL) — lay a
+multi-line `"""…"""` string out as a block:
+
+1. the opening quotes end their line (the content begins on the *next* line);
+2. the content is indented two columns beyond the opening prefix;
+3. no content line is indented less than the first content line;
+4. the closing `"""` sits alone on its line, in the same column as the opening
+   prefix.
+
+```scala
+def message =
+  m"""
+    This is the message.
+    It spans two lines.
+  """
+```
+
+A leading `( ` before the opening quotes and a trailing `,` / `)` after the
+closing quotes are permitted — the string content simply must not share the
+opener or closer line — so the heavy-argument form stays compliant:
+
+```scala
+extends Error
+  ( m"""
+      the table required a minimum width of $minimumWidth, but only $availableWidth was available
+    """ )
+```
+
+This applies only to those five interpolators, because their whitespace does
+not affect the result. Every other interpolator (`t`, `s`, `sh`, …) and raw
+`"""` string carries significant whitespace, so the layout of their content is
+left entirely to the author — and the line-length and trailing-whitespace rules
+do not apply to the interior of any multi-line string.
+
 ### Macro quotes and splices
 
 Scala 3 macro quote (`'{ … }`, `'[ … ]`) and splice (`${ … }`) syntax
@@ -986,6 +1023,10 @@ scope is always preceded by a blank.
   layouts. The multi-line layout requires `' {` (or `$ {`) — with a
   space — alone on its line, the body indented to `{`+2, and the `}`
   alone on its line at the column of `{`.
+- Multi-line `m`/`j`/`x`/`y`/`tel` strings: opening `"""` ends its line, content
+  indented +2 from the prefix, no line less-indented than the first, closing
+  `"""` alone and aligned with the prefix. Other interpolators' and raw `"""`
+  content is left alone.
 - Keyword sequences (`if`/`then`/`else`, `for`/`yield`, `for`/`do`,
   `while`/`do`, `try`/`catch`/`finally`): broken keywords align with K₁;
   once one keyword breaks, all later keywords break (forward cascade);

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -79,6 +79,7 @@ object Checker:
     val stmtGroups           = Statements.extract(untpdTree, source)
     val lambdaSites          = Lambdas.extract(untpdTree, source)
     val operatorSites        = Operators.extract(untpdTree, source)
+    val interpolations       = Interpolations.extract(untpdTree, source)
     checkFileNaming(file, untpdTree, out)
     checkPackageRules(file, expectedModule, state.packageInfo, out)
     checkImportRules(file, imports, lines, out)
@@ -88,6 +89,7 @@ object Checker:
     checkLambdaLayout(file, lambdaSites, out)
     checkDefnAnchors(file, Definitions.extract(untpdTree, source), out)
     checkOperatorContinuation(file, operatorSites, out)
+    checkInterpolatorLayout(file, interpolations, rawText, source, out)
     var idx = 0
 
     while idx < lines.length do
@@ -249,13 +251,21 @@ object Checker:
       out += Violation(s.file, lineNum, col, rule, message)
 
     val isStringContent = firstReal.exists(_.kind == Sort.Strs)
-    checkR2LineLength(visibleLen, emit)
+    // The interior (and closing) lines of a multi-line triple-quoted string are
+    // tokenised as a single `Strs` token with no leading `Space` (so
+    // `leadingWs` is empty). Their text is string content — for `sh`/raw
+    // strings the whitespace is significant, for `m`/`j`/`x`/`y`/`tel` it is
+    // prose — so R2 (line length) and R4 (trailing whitespace) must not fire on
+    // them. The R560 layout rule governs the structure of the listed
+    // interpolators instead.
+    val isStringContinuation = isStringContent && leadingWs.isEmpty
+    if !isStringContinuation then checkR2LineLength(visibleLen, emit)
     // Skip R3 inside open `(...)` blocks: continuation rows inside parameter
     // lists align under names from the opener line and may need an odd
     // number of leading spaces (e.g. under `inline commensurable` at col 18).
     if !isStringContent && s.openParens == 0 then
       checkR3IndentWidth(isBlank, leadingCols, emit)
-    checkR4TrailingWs(line, emit)
+    if !isStringContinuation then checkR4TrailingWs(line, emit)
     checkR45BodyScopeIndent(s, lineNum, isBlank, leadingCols, firstReal, emit)
     checkR31ContinuationIndent(s, lineNum, leadingCols, isBlank, firstReal, emit)
     checkR44BodyIndent(s, lineNum, isBlank, leadingCols, firstReal, emit)
@@ -1948,6 +1958,87 @@ object Checker:
               ( file, op.rightLine, op.rightCol, "616.2",
                 s"a multi-line infix continuation must be indented ${op.anchorIndent + 2} "
                   +s"columns (found ${op.rightCol - 1})" )
+
+  // Interpolators whose leading/trailing whitespace is insignificant, so a
+  // multi-line `"""…"""` may be laid out as a block (R560). Other interpolators
+  // (`t`, `s`, `sh`, …) and raw `"""` strings carry significant whitespace and
+  // are exempt — see the R2/R4 relaxation in `checkLine`.
+  private val LayoutInterpolators: Set[String] = Set("m", "j", "x", "y", "tel")
+
+  // R560: a multi-line `m`/`j`/`x`/`y`/`tel` triple-quoted string is laid out as
+  // a block — the opening quotes end their line, the content is indented two
+  // columns beyond the prefix, no content line is indented less than the first,
+  // and the closing `"""` is alone on its line aligned with the prefix. A
+  // leading `( ` before the opener and a trailing `,`/`)` after the closer are
+  // permitted (the surrounding application syntax), so "alone" means the string
+  // content does not share the opener/closer line.
+  private def checkInterpolatorLayout
+    ( file:    String,
+      sites:   List[InterpolationInfo],
+      rawText: String,
+      source:  SourceFile,
+      out:     mutable.ListBuffer[Violation] )
+  :   Unit =
+
+    val lines = rawText.split("\n", -1).nn
+    def lineText(n: Int): String = if n >= 1 && n <= lines.length then lines(n - 1).nn else ""
+    // 1-based column of the first non-space character, or 0 if the line is blank.
+    def firstCol(text: String): Int =
+      var i = 0
+      while i < text.length && (text.charAt(i) == ' ' || text.charAt(i) == '\t') do i += 1
+      if i >= text.length then 0 else i + 1
+
+    sites.foreach: info =>
+      if LayoutInterpolators.contains(info.prefix) && info.triple
+        && info.closeLine > info.openLine
+      then
+        val col      = info.openCol         // column of the prefix character
+        val expected = col + 2              // required column of the content
+        val q        = "\"\"\""
+        val openText = lineText(info.openLine)
+        val afterOpen = (info.openCol - 1) + info.prefix.length + 3
+
+        val openerEndsLine =
+          afterOpen >= openText.length || openText.substring(afterOpen).nn.trim.nn.isEmpty
+
+        if !openerEndsLine then
+          out +=
+            Violation
+              ( file, info.openLine, afterOpen + 1, "560.1",
+                s"the content of a multi-line `${info.prefix}$q` string must begin on the "
+                  +"line after the opening quotes" )
+        else
+          var first = -1
+          var ln    = info.openLine + 1
+          while ln < info.closeLine do
+            val fc = firstCol(lineText(ln))
+            if fc != 0 then
+              if first < 0 then first = fc
+              if fc < expected then
+                out +=
+                  Violation
+                    ( file, ln, fc, "560.3",
+                      s"a line of a multi-line `${info.prefix}$q` string must not be indented "
+                        +s"less than the first content line (column $expected)" )
+            ln += 1
+          if first >= 0 && first != expected then
+            out +=
+              Violation
+                ( file, info.openLine + 1, first, "560.2",
+                  s"the content of a multi-line `${info.prefix}$q` string must be indented to "
+                    +s"column $expected" )
+
+        val closeText  = lineText(info.closeLine)
+        val closeFirst = firstCol(closeText)
+        val afterClose = (info.closeCol - 1) + 3
+        val trailing   = if afterClose <= closeText.length then closeText.substring(afterClose).nn else ""
+        val trailingOk = trailing.forall(c => c == ' ' || c == '\t' || c == ',' || c == ')')
+        if closeFirst != info.closeCol || info.closeCol != col || !trailingOk then
+          out +=
+            Violation
+              ( file, info.closeLine, (if closeFirst == 0 then 1 else closeFirst), "560.4",
+                s"the closing `$q` of a multi-line `${info.prefix}$q` string must be alone on "
+                  +s"its line, aligned with the opening quotes (column $col)" )
 
   private def checkReturnTypeBlank
     ( s:       State,

--- a/lib/decorum/src/plugin/decorum.Interpolations.scala
+++ b/lib/decorum/src/plugin/decorum.Interpolations.scala
@@ -1,0 +1,99 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package decorum
+
+import scala.collection.mutable
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
+
+// One string-interpolation site. `prefix` is the interpolator name (e.g. "m",
+// "tel", "t"); `openLine`/`openCol` locate the prefix character (the `m` of
+// `m"""`); `closeLine`/`closeCol` locate the first quote of the closing `"""`.
+// All positions are 1-based. `triple` is true for a `"""…"""` string (the only
+// kind that can span lines).
+case class InterpolationInfo
+  ( prefix:    String,
+    openLine:  Int,
+    openCol:   Int,
+    closeLine: Int,
+    closeCol:  Int,
+    triple:    Boolean )
+
+object Interpolations:
+  // Walk the untyped tree and emit one `InterpolationInfo` per
+  // `untpd.InterpolatedString` node. These survive in the pre-desugar
+  // `untpdTree` that Decorum reads (desugaring to `StringContext` happens
+  // later, during typing), just like `untpd.InfixOp`.
+  def extract(tree: untpd.Tree, source: SourceFile): List[InterpolationInfo] =
+    val content = String(source.content)
+    val out     = mutable.ListBuffer[InterpolationInfo]()
+
+    def visit(t: untpd.Tree): Unit =
+      t match
+        case interp: untpd.InterpolatedString => infoFor(interp, source, content).foreach(out += _)
+        case _                                => ()
+      t.productIterator.foreach(descend(_, visit))
+
+    visit(tree)
+    out.toList
+
+  private def descend(x: Any, visit: untpd.Tree => Unit): Unit = x match
+    case sub: untpd.Tree  => visit(sub)
+    case it:  Iterable[?] => it.foreach(descend(_, visit))
+    case _                => ()
+
+  private def infoFor
+    ( node: untpd.InterpolatedString, source: SourceFile, content: String )
+  :   Option[InterpolationInfo] =
+
+    val sp = node.span
+    if !sp.exists then None
+    else
+      val prefix     = node.id.toString
+      val openOffset = sp.start
+      // The node span starts at the prefix character. The opening quote(s)
+      // begin just after the prefix; a triple-quoted string opens with `"""`.
+      val quoteStart = openOffset + prefix.length
+      val triple =
+        quoteStart + 2 < content.length && content.charAt(quoteStart) == '"'
+          && content.charAt(quoteStart + 1) == '"' && content.charAt(quoteStart + 2) == '"'
+      // The closing quote run ends the span. For a triple-quoted string the
+      // closing `"""` occupies the three code units before `span.end`.
+      val closeQuoteLen = if triple then 3 else 1
+      val closeStart    = (sp.end - closeQuoteLen).max(openOffset)
+      val openLine      = source.offsetToLine(openOffset) + 1
+      val openCol       = source.column(openOffset) + 1
+      val closeLine     = source.offsetToLine(closeStart) + 1
+      val closeCol      = source.column(closeStart) + 1
+      Some(InterpolationInfo(prefix, openLine, openCol, closeLine, closeCol, triple))

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -872,3 +872,37 @@ object Tests extends Suite(m"Decorum Tests"):
       test(m"Trailing operator after a quote-block `}` defers to 616, not 473.6"):
         rules("val x =\n  ' {\n      foo\n    } ::\n    tail\n")
       . assert(r => !r.contains("473.6"))
+
+    suite(m"Phase 5: Multi-line interpolated strings"):
+
+      test(m"Canonical multi-line m-string is accepted"):
+        rules("def message =\n  m\"\"\"\n    line one\n    line two\n  \"\"\"\n")
+      . assert(r => !r.exists(_.startsWith("560")))
+
+      test(m"Heavy-block `( m\"\"\" )` argument form is accepted"):
+        rules("val x =\n  ( m\"\"\"\n      content here\n    \"\"\" )\n")
+      . assert(r => !r.exists(_.startsWith("560")))
+
+      test(m"Content on the opener line is rejected (560.1)"):
+        rules("def msg =\n  m\"\"\"the content\n    more\n  \"\"\"\n")
+      . assert(_.contains("560.1"))
+
+      test(m"Content not indented +2 is rejected (560.2)"):
+        rules("def msg =\n  m\"\"\"\n   content\n  \"\"\"\n")
+      . assert(_.contains("560.2"))
+
+      test(m"Under-indented content line is rejected (560.3)"):
+        rules("def msg =\n  m\"\"\"\n    first line\n  second\n  \"\"\"\n")
+      . assert(_.contains("560.3"))
+
+      test(m"Closer not aligned with opener is rejected (560.4)"):
+        rules("def msg =\n  m\"\"\"\n    content\n    \"\"\"\n")
+      . assert(_.contains("560.4"))
+
+      test(m"Other interpolators' multi-line content is exempt from 560"):
+        rules("def t1 =\n  t\"\"\"\nunindented significant content\n  \"\"\"\n")
+      . assert(r => !r.exists(_.startsWith("560")))
+
+      test(m"Long content line of a multi-line string is not flagged 230"):
+        rules("def msg =\n  m\"\"\"\n    "+"x".repeat(110)+"\n  \"\"\"\n")
+      . assert(r => !r.contains("230"))

--- a/lib/iridescence/src/core/iridescence.internal.scala
+++ b/lib/iridescence/src/core/iridescence.internal.scala
@@ -60,8 +60,10 @@ object internal:
       ch.isDigit || ((ch | 32) >= 'a' && (ch | 32) <= 'f')
 
     if hex.length != 6 || !hex.forall(isHex) then halt:
-      m"""the color must be in the form ${"rgb\"#rrggbb\"".tt} or ${"rgb\"rrggbb\"".tt} where
-         rr, gg and bb are 2-digit hex values"""
+      m"""
+        the color must be in the form ${"rgb\"#rrggbb\"".tt} or ${"rgb\"rrggbb\"".tt} where
+        rr, gg and bb are 2-digit hex values
+      """
 
     val red = Integer.parseInt(hex.substring(0, 2), 16)
     val green = Integer.parseInt(hex.substring(2, 4), 16)

--- a/lib/jacinta/src/core/jacinta.internal.scala
+++ b/lib/jacinta/src/core/jacinta.internal.scala
@@ -206,8 +206,11 @@ object internal:
           '{$self.indexValue($idx)(using $tactic)}
 
         case None =>
-          halt(m"""indexing a `Json` array may raise `JsonError`; a `Tactic[JsonError]`
-                   must be in scope (e.g. via `raises JsonError`)""")
+          halt:
+            m"""
+              indexing a `Json` array may raise `JsonError`; a `Tactic[JsonError]`
+              must be in scope (e.g. via `raises JsonError`)
+            """
 
   def applied(self: Expr[Json], field: Expr[String], idx: Expr[Int]): Macro[Json] =
     import quotes.reflect.*


### PR DESCRIPTION
Adds a Decorum house-style rule (SN-560) for multi-line triple-quoted interpolated strings whose whitespace is insignificant — `m`, `j`, `x`, `y` and `tel`. Such a string is laid out as a block: the opening quotes end their line, the content is indented two columns beyond the prefix, no content line is indented less than the first, and the closing `"""` sits alone on its line aligned with the prefix. A leading `( ` before the opener and a trailing `,`/`)` after the closer are permitted, so the heavy-argument form stays compliant. Every other interpolator (`t`, `s`, `sh`, …) and raw `"""` string carries significant whitespace, so the layout of its content is left to the author, and the line-length (SN-230) and trailing-whitespace (SN-015) rules no longer apply to the interior of any multi-line string. Documented in `doc/syntax.md`; the two non-compliant sites in the library (iridescence, jacinta) are reformatted.

### SN-560: multi-line interpolated-string layout

For `m`/`j`/`x`/`y`/`tel`, a multi-line `"""…"""` must be written as a block:

```scala
def message =
  m"""
    This is the message.
    It spans two lines.
  """
```

— opening `"""` ends its line (560.1), content indented +2 from the prefix (560.2), no content line indented less than the first (560.3), closing `"""` alone and aligned with the prefix (560.4). The heavy-argument form is fine:

```scala
extends Error
  ( m"""
      the table required a minimum width of $minimumWidth, but only $availableWidth was available
    """ )
```

Other interpolators' and raw `"""` content — where whitespace is significant — are left entirely alone, and SN-230/SN-015 no longer fire on the interior of any multi-line string.
