### PR TITLE
Add missing Inspectable instances and fix Optional rendering

### DIFF
--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -45,22 +45,17 @@ object Inspectable extends Inspectable2:
   object Derivation extends Derivable[Inspectable]:
     inline def conjunction[derivation <: Product: ProductReflection]: derivation is Inspectable =
       value =>
-        fields(value): [field] => field =>
+        val rendered = fields(value): [field] => field =>
           val text = contextual.text(field)
           if tuple then text else s"$label:$text"
 
-        . mkString(if tuple then "(" else s"$typeName(", " ╱ ", ")").tt
+        if rendered.isEmpty && !tuple then typeName
+        else rendered.mkString(if tuple then "(" else s"$typeName(", " ╱ ", ")").tt
 
     inline def disjunction[derivation: SumReflection]: derivation is Inspectable = value =>
       variant(value):
         [variant <: derivation] => variant =>
           contextual.give(variant.inspect)
-
-  inline given derived: [value] => value is Inspectable = compiletime.summonFrom:
-    case given (`value` is Encodable in Text) => _.encode
-    case given (`value` is Showable)          => _.show
-    case given Reflection[`value`]            => Derivation.derived[value]
-    case _                                    => value => ("“"+value+"”").tt
 
   given char: Char is Inspectable = char => ("'"+escape(char).s+"'").tt
   given long: Long is Inspectable = long => (long.toString+"L").tt
@@ -87,6 +82,10 @@ object Inspectable extends Inspectable2:
     case double                  => double.toString.tt
 
   given boolean: Boolean is Inspectable = boolean => if boolean then "true".tt else "false".tt
+  given unit: Unit is Inspectable = unit => "()".tt
+  given bigInt: BigInt is Inspectable = bigInt => ("BigInt("+bigInt+")").tt
+  given bigDecimal: BigDecimal is Inspectable = bigDecimal => ("BigDecimal("+bigDecimal+")").tt
+  given unset: Unset is Inspectable = unset => "○".tt
   given reflectEnum: reflect.Enum is Inspectable = _.toString.show
 
   def escape(char: Char, eEscape: Boolean = false): Text = char match
@@ -107,6 +106,16 @@ object Inspectable extends Inspectable2:
 
   given set: [element] => (inspectable: => element is Inspectable) => Set[element] is Inspectable =
     _.map(inspectable.text(_)).mkString("{", ", ", "}").tt
+
+  given map: [key, value]
+  =>  ( inspectableKey: => key is Inspectable, inspectableValue: => value is Inspectable )
+  =>  Map[key, value] is Inspectable =
+
+    entries =>
+      entries.map: (key, value) =>
+        inspectableKey.text(key).s+" → "+inspectableValue.text(value).s
+
+      . mkString("{", ", ", "}").tt
 
 
   given series: [element] => (inspectable: => element is Inspectable)
@@ -196,11 +205,21 @@ object Inspectable extends Inspectable2:
   given none: None.type is Inspectable = none => "None".tt
 
 trait Inspectable2:
-  given optional: [value] => (inspectable: => value is Inspectable)
-  =>  Optional[value] is Inspectable =
+  inline given derived: [value] => value is Inspectable = compiletime.summonFrom:
+    case given (`value` is Encodable in Text) => _.encode
+    case given (`value` is Showable)          => _.show
 
-    _.let { value => s"⸂${inspectable.text(value)}⸃".tt }.or("⸄⸅".tt)
+    case mandatable: (`value` is Mandatable) =>
+      val inspectable = compiletime.summonInline[mandatable.Result is Inspectable]
 
+      optional =>
+        optional.let: present =>
+          s"｢${inspectable.text(present.asInstanceOf[mandatable.Result])}｣".tt
+
+        . or("○".tt)
+
+    case given Reflection[`value`] => Inspectable.Derivation.derived[value]
+    case _                         => value => ("“"+value+"”").tt
 
 trait Inspectable extends Typeclass:
   def text(value: Self): Text

--- a/lib/spectacular/src/test/spectacular_test.scala
+++ b/lib/spectacular/src/test/spectacular_test.scala
@@ -45,6 +45,17 @@ case class Depth0(child: Depth1, tag: Int)
 
 case class Branch(value: Int, kids: List[Branch])
 
+enum Colour:
+  case Red, Green, Blue
+
+enum Shape:
+  case Circle(radius: Int)
+  case Rectangle(width: Int, height: Int)
+
+sealed trait Animal
+case class Dog(name: Text) extends Animal
+case object Cat extends Animal
+
 class Underived(val x: Int):
   override def toString: String = "Underived("+x+")"
 
@@ -223,6 +234,106 @@ object Tests extends Suite(m"Spectacular Tests"):
       test(m"derivable field with underivable leaf falls back to toString"):
         Holder(Underived(7), 3).inspect
       . assert(_ == t"Holder(item:“Underived(7)” ╱ count:3)")
+
+    suite(m"Primitive tests"):
+      test(m"serialize boolean true"):
+        true.inspect
+      . assert(_ == t"true")
+
+      test(m"serialize boolean false"):
+        false.inspect
+      . assert(_ == t"false")
+
+      test(m"serialize byte"):
+        3.toByte.inspect
+      . assert(_ == t"3.toByte")
+
+      test(m"serialize unit"):
+        ().inspect
+      . assert(_ == t"()")
+
+      test(m"serialize BigInt"):
+        BigInt(42).inspect
+      . assert(_ == t"BigInt(42)")
+
+      test(m"serialize BigDecimal"):
+        BigDecimal("1.5").inspect
+      . assert(_ == t"BigDecimal(1.5)")
+
+    suite(m"Collection tests"):
+      test(m"serialize map"):
+        Map(1 -> 2, 3 -> 4).inspect
+      . assert(_ == t"{1 → 2, 3 → 4}")
+
+      test(m"serialize map with string values"):
+        Map(t"a" -> 1).inspect
+      . assert(_ == t"""{t"a" → 1}""")
+
+      test(m"serialize empty map"):
+        Map[Int, Int]().inspect
+      . assert(_ == t"{}")
+
+      test(m"serialize set of ints (no spurious optional wrapping)"):
+        Set(1).inspect
+      . assert(_ == t"{1}")
+
+      test(m"serialize map of ints (no spurious optional wrapping)"):
+        Map(1 -> 2).inspect
+      . assert(_ == t"{1 → 2}")
+
+      test(m"serialize vector"):
+        Vector(1, 2, 3).inspect
+      . assert(_ == t"⟨ 1 2 3 ⟩")
+
+      test(m"serialize empty list"):
+        List[Int]().inspect
+      . assert(_ == t"[]")
+
+      test(m"serialize option some"):
+        (Some(3): Option[Int]).inspect
+      . assert(_ == t"Some(3)")
+
+      test(m"serialize option none"):
+        (None: Option[Int]).inspect
+      . assert(_ == t"None")
+
+      test(m"serialize nested options in list"):
+        List(Some(1), None).inspect
+      . assert(_ == t"[Some(1), None]")
+
+    suite(m"Optional tests"):
+      test(m"serialize set optional"):
+        (5: Optional[Int]).inspect
+      . assert(_ == t"｢5｣")
+
+      test(m"serialize unset optional"):
+        (Unset: Optional[Int]).inspect
+      . assert(_ == t"○")
+
+      test(m"serialize bare Unset"):
+        Unset.inspect
+      . assert(_ == t"○")
+
+    suite(m"Sum-type derivation tests"):
+      test(m"derive sealed trait product case"):
+        (Dog(t"Rex"): Animal).inspect
+      . assert(_ == t"""Dog(name:t"Rex")""")
+
+      test(m"derive sealed trait case object (no trailing parens)"):
+        (Cat: Animal).inspect
+      . assert(_ == t"Cat")
+
+      test(m"derive case object directly"):
+        Cat.inspect
+      . assert(_ == t"Cat")
+
+      test(m"inspect simple enum case"):
+        Colour.Red.inspect
+      . assert(_ == t"Red")
+
+      test(m"inspect parameterised enum case"):
+        (Shape.Circle(5): Shape).inspect
+      . assert(_ == t"Circle(5)")
 
     suite(m"Show tests"):
       test(m"Show a string"):


### PR DESCRIPTION
`.inspect` previously fell through to a quoted-`toString` fallback for several common types, and `Optional` values never rendered at all because the `optional` instance was shadowed by the catch-all `derived` given. This adds the missing instances, fixes the priority so `Optional` renders, and expands the test suite from 48 to 72 tests.

**Release notes**

`.inspect` now renders these correctly:
- `Map` → `{1 → 2, 3 → 4}`
- `BigInt` → `BigInt(3)`, `BigDecimal` → `BigDecimal(3)`
- `Unit` → `()`, `Unset` → `○`
- `Optional[T]` → `｢value｣` when set, `○` when unset (previously rendered as `“value”` / `“null”`)
- case objects now render without trailing parens (`Cat`, not `Cat()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)