### PR TITLE
Coerce encodable values in lens assignments

### DIFF
--- a/lib/breviloquence/src/core/breviloquence.cborConversion.scala
+++ b/lib/breviloquence/src/core/breviloquence.cborConversion.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import anticipation.*
+import prepositional.*
+
+// Importing `cborConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Cbor` value be supplied directly at lens-assignment positions, such as
+// `cbor.lens(_.field = value)`, without an explicit `.cbor`.
+object cborConversion:
+  given encodable: [entity: Encodable in Cbor] => Conversion[entity, Cbor] = _.encode

--- a/lib/breviloquence/src/core/soundness_breviloquence_core.scala
+++ b/lib/breviloquence/src/core/soundness_breviloquence_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export breviloquence.{Cbor, Cbor2, DynamicCborEnabler, dynamicCborAccess}
+export breviloquence.{Cbor, Cbor2, cborConversion, DynamicCborEnabler, dynamicCborAccess}

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -328,7 +328,7 @@ object Tests extends Suite(m"Breviloquence Tests"):
       . assert(_ == Person(t"Alice", 30))
 
     suite(m"Optics"):
-      import dynamicCborAccess.enabled
+      import dynamicCborAccess.enabled, cborConversion.encodable
 
       val team = Team(Person(t"John", 40), 3).cbor
       val list = Wrapper(List(1, 2, 3), t"hi").cbor
@@ -342,7 +342,7 @@ object Tests extends Suite(m"Breviloquence Tests"):
       . assert(_ == Team(Person(t"John", 40), 5))
 
       test(m"lens sets a nested field"):
-        team.lens(_.lead.name = t"Bob".cbor).as[Team]
+        team.lens(_.lead.name = t"Bob").as[Team]
       . assert(_ == Team(Person(t"Bob", 40), 3))
 
       test(m"lens.modify transforms a field through a function"):
@@ -351,19 +351,19 @@ object Tests extends Suite(m"Breviloquence Tests"):
       . assert(_ == Team(Person(t"John", 40), 4))
 
       test(m"ordinal optic updates an array element"):
-        list.lens(_.values(Sec) = 9.cbor).as[Wrapper]
+        list.lens(_.values(Sec) = 9).as[Wrapper]
       . assert(_ == Wrapper(List(1, 9, 3), t"hi"))
 
       test(m"each optic updates every array element"):
-        list.lens(_.values(Each) = 0.cbor).as[Wrapper]
+        list.lens(_.values(Each) = 0).as[Wrapper]
       . assert(_ == Wrapper(List(0, 0, 0), t"hi"))
 
       test(m"filter optic updates only matching elements"):
-        list.lens(_.values(Filter[Cbor](_.as[Int] > 1)) = 0.cbor).as[Wrapper]
+        list.lens(_.values(Filter[Cbor](_.as[Int] > 1)) = 0).as[Wrapper]
       . assert(_ == Wrapper(List(1, 0, 0), t"hi"))
 
       test(m"setting an absent field inserts it"):
-        list.lens(_.extra = 7.cbor).selectDynamic("extra").as[Int]
+        list.lens(_.extra = 7).selectDynamic("extra").as[Int]
       . assert(_ == 7)
 
     suite(m"Error byte-offsets"):

--- a/lib/jacinta/src/core/jacinta.jsonConversion.scala
+++ b/lib/jacinta/src/core/jacinta.jsonConversion.scala
@@ -30,89 +30,13 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package panopticon
+package jacinta
 
-import language.dynamics
-
-import scala.quoted.*
-
-import denominative.*
+import anticipation.*
 import prepositional.*
 
-object Optic:
-  transparent inline given deref: [name <: Label, product <: Product] => name is Lens from product =
-    ${panopticon.internal.lens[name, product]}
-
-  def identity[value]: Optic from value onto value = new Optic:
-    type Origin = value
-    type Target = value
-
-    def modify(origin: Origin)(lambda: Target => Target): Origin = lambda(origin)
-
-
-  def apply[self, origin, target](lambda: (origin, target => target) => origin)
-  :   self is Optic from origin onto target =
-
-    new Optic:
-      type Self = self
-      type Origin = origin
-      type Target = target
-
-      def modify(origin: Origin)(lambda2: Target => Target): Origin = lambda(origin, lambda2)
-
-
-  given prim: [element]
-  =>  Prim.type is Optic from List[element] onto element =
-
-    Optic[Prim.type, List[element], element]: (origin, lambda) =>
-      origin match
-        case head :: tail => lambda(head) :: tail
-        case Nil          => Nil
-
-trait Optic extends Typeclass, Dynamic:
-  type Origin
-  type Target
-
-  def modify(origin: Origin)(lambda: Target => Target): Origin
-
-
-  def selectDynamic(name: Label)(using lens: name.type is Optic from Target)
-  :   Optic from Origin onto lens.Target =
-
-    Composable.optics.composition(this, lens)
-
-
-  def updateDynamic(name: Label)(using lens: name.type is Optic from Target)
-    [ source ]
-    ( value: (lens.Target aka "prior") ?=> source )
-    ( using coercible: source is Coercible to lens.Target )
-  :   Origin => Origin =
-
-    Composable.optics.composition(this, lens).modify(_): prior =>
-      coercible.coerce(value(using prior.aka["prior"]))
-
-
-  def update[source, target](traversal: Any, value: source)
-    ( using optical:  (? >: traversal.type) is Optical from Target onto target,
-            coercible: source is Coercible to target )
-  :   Origin => Origin =
-
-    Composable.optics.composition(this, optical.optic(traversal)).modify(_): _ =>
-      coercible.coerce(value)
-
-
-  def applyDynamic(name: Label)[operand](using lens: name.type is Optic from Target onto operand)
-    [ target, traversal ]
-    ( traversal: traversal )
-    ( using optical: (? >: traversal.type) is Optical from operand onto target )
-  :   Optic from Origin onto target =
-
-    Composable.optics.composition
-      ( Composable.optics.composition(this, lens), optical.optic(traversal) )
-
-
-  def apply[target, optic](traversal: optic)
-    ( using optical: (? >: traversal.type) is Optical from Target onto target )
-  :   Optic from Origin onto target =
-
-    Composable.optics.composition(this, optical.optic(traversal))
+// Importing `jsonConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Json` value be supplied directly at `into[Json]` positions — in particular,
+// panopticon lens assignments such as `json.lens(_.name = "x")` — without an explicit `.json`.
+object jsonConversion:
+  given encodable: [entity: Encodable in Json] => Conversion[entity, Json] = _.encode

--- a/lib/jacinta/src/core/soundness_jacinta_core.scala
+++ b/lib/jacinta/src/core/soundness_jacinta_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   jacinta
-  . { dynamicJsonAccess, DynamicJsonEnabler, j, jp, Json, json, Json2, JsonError, JsonPointer,
-      JsonPointerError, JsonPrimitive, Ndjson, NumberMode, parserAggregable, showable }
+  . { dynamicJsonAccess, DynamicJsonEnabler, j, jp, Json, json, Json2, jsonConversion, JsonError,
+      JsonPointer, JsonPointerError, JsonPrimitive, Ndjson, NumberMode, parserAggregable, showable }
 
 package formatting:
   export jacinta.formatting.{indentedJsonFormatting, compactJsonFormatting}

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -372,14 +372,14 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == Org("The Beatles", Entity("John", 41, List(Role("Leader")))))
 
       test(m"Lens update with optic on JSON"):
-        import dynamicJsonAccess.enabled
-        val org2 = org.lens(_.leader.roles(Prim) = Role("-").json)
+        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        val org2 = org.lens(_.leader.roles(Prim) = Role("-"))
         org2.as[Org]
       . assert(_ == Org("The Beatles", Entity("John", 40, List(Role("-")))))
 
       test(m"Deeper lens update with optic on JSON"):
-        import dynamicJsonAccess.enabled
-        val org2 = org.lens(_.leader.roles(Prim).name = "-".json)
+        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        val org2 = org.lens(_.leader.roles(Prim).name = "-")
         org2.as[Org]
       . assert(_ == Org("The Beatles", Entity("John", 40, List(Role("-")))))
 
@@ -397,18 +397,18 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == Org("The Beatles!", Entity("John", 40, List(Role("Leader")))))
 
       test(m"Each optic updates every array element"):
-        import dynamicJsonAccess.enabled
-        band.lens(_.leader.roles(Each).name = "x".json).as[Org]
+        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        band.lens(_.leader.roles(Each).name = "x").as[Org]
       . assert(_ == Org("Q", Entity("John", 40, List(Role("x"), Role("x"), Role("x")))))
 
       test(m"Filter optic updates only matching elements"):
-        import dynamicJsonAccess.enabled
-        band.lens(_.leader.roles(Filter[Json](_.name.as[String] == "b")).name = "x".json).as[Org]
+        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        band.lens(_.leader.roles(Filter[Json](_.name.as[String] == "b")).name = "x").as[Org]
       . assert(_ == Org("Q", Entity("John", 40, List(Role("a"), Role("x"), Role("c")))))
 
       test(m"Setting an absent field inserts it"):
-        import dynamicJsonAccess.enabled
-        org.lens(_.extra = 9.json).selectDynamic("extra").as[Int]
+        import dynamicJsonAccess.enabled, jsonConversion.encodable
+        org.lens(_.extra = 9).selectDynamic("extra").as[Int]
       . assert(_ == 9)
 
     suite(m"Json construction"):

--- a/lib/locomotion/src/core/locomotion.protobufConversion.scala
+++ b/lib/locomotion/src/core/locomotion.protobufConversion.scala
@@ -35,8 +35,8 @@ package locomotion
 import anticipation.*
 import prepositional.*
 
-// Importing `protobufConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
-// any `Encodable in Protobuf` value be supplied directly at lens-assignment positions, such as
-// `protobuf.lens(_.field = value)`, without an explicit `.protobuf`.
+// Importing `protobufConversion.encodable` brings a scoped `Conversion` into lexical scope that
+// lets any `Encodable in Protobuf` value be supplied directly at lens-assignment positions, such
+// as `protobuf.lens(_.field = value)`, without an explicit `.protobuf`.
 object protobufConversion:
   given encodable: [entity: Encodable in Protobuf] => Conversion[entity, Protobuf] = _.encode

--- a/lib/locomotion/src/core/locomotion.protobufConversion.scala
+++ b/lib/locomotion/src/core/locomotion.protobufConversion.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import anticipation.*
+import prepositional.*
+
+// Importing `protobufConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Protobuf` value be supplied directly at lens-assignment positions, such as
+// `protobuf.lens(_.field = value)`, without an explicit `.protobuf`.
+object protobufConversion:
+  given encodable: [entity: Encodable in Protobuf] => Conversion[entity, Protobuf] = _.encode

--- a/lib/locomotion/src/core/soundness_locomotion_core.scala
+++ b/lib/locomotion/src/core/soundness_locomotion_core.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package soundness
 
-export locomotion.{Protobuf, Protobuf2, ProtobufError, ProtobufParser, ProtobufPrinter,
-    Packable, WireType, field, protobuf}
+export locomotion.{Protobuf, Protobuf2, protobufConversion, ProtobufError, ProtobufParser,
+    ProtobufPrinter, Packable, WireType, field, protobuf}

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -232,6 +232,7 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       . assert(_ == Person(t"Alice", 30))
 
     suite(m"Optics"):
+      import protobufConversion.encodable
       // Protobuf is number-keyed: the `Ordinal` selects a field by number (Prim =
       // field 1). Wrapper encodes `point` at field 1 and `label` at field 2.
       def wrapper: Protobuf = Wrapper(Point(3, 4), t"origin").protobuf
@@ -241,9 +242,9 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       . assert(_ == Wrapper(Point(7, 8), t"origin"))
 
       test(m"field optic leaves other fields unchanged"):
-        wrapper.lens(_(Prim) = Point(7, 8).protobuf).as[Wrapper].label
+        wrapper.lens(_(Prim) = Point(7, 8)).as[Wrapper].label
       . assert(_ == t"origin")
 
       test(m"an absent field number is a no-op"):
-        wrapper.lens(_(Sen) = Point(7, 8).protobuf).as[Wrapper]
+        wrapper.lens(_(Sen) = Point(7, 8)).as[Wrapper]
       . assert(_ == Wrapper(Point(3, 4), t"origin"))

--- a/lib/panopticon/src/core/panopticon.Coercible.scala
+++ b/lib/panopticon/src/core/panopticon.Coercible.scala
@@ -32,87 +32,24 @@
                                                                                                   */
 package panopticon
 
-import language.dynamics
-
-import scala.quoted.*
-
-import denominative.*
 import prepositional.*
 
-object Optic:
-  transparent inline given deref: [name <: Label, product <: Product] => name is Lens from product =
-    ${panopticon.internal.lens[name, product]}
+// Evidence that a value of type `Self` may be supplied where a `Result` is required in a lens
+// assignment. The identity instance handles the usual case where the assigned value already has
+// the target type (or a subtype); format modules add instances that encode an `Encodable` value
+// into the format's value type, so that, e.g., `json.lens(_.name = "x")` accepts a bare `"x"`.
+object Coercible extends Coercible2:
+  // Any value already convertible to the target type (including a format module's
+  // `Encodable`-backed conversion, or gossamer's `String`/`Text` conversion) may be coerced.
+  given conversion: [value, target] => (conversion: Conversion[value, target])
+  =>  value is Coercible to target =
+    conversion(_)
 
-  def identity[value]: Optic from value onto value = new Optic:
-    type Origin = value
-    type Target = value
+trait Coercible2:
+  // A value whose type is already the target type (or a subtype) needs no coercion.
+  given identity: [value, target >: value] => value is Coercible to target = value => value
 
-    def modify(origin: Origin)(lambda: Target => Target): Origin = lambda(origin)
-
-
-  def apply[self, origin, target](lambda: (origin, target => target) => origin)
-  :   self is Optic from origin onto target =
-
-    new Optic:
-      type Self = self
-      type Origin = origin
-      type Target = target
-
-      def modify(origin: Origin)(lambda2: Target => Target): Origin = lambda(origin, lambda2)
-
-
-  given prim: [element]
-  =>  Prim.type is Optic from List[element] onto element =
-
-    Optic[Prim.type, List[element], element]: (origin, lambda) =>
-      origin match
-        case head :: tail => lambda(head) :: tail
-        case Nil          => Nil
-
-trait Optic extends Typeclass, Dynamic:
-  type Origin
-  type Target
-
-  def modify(origin: Origin)(lambda: Target => Target): Origin
-
-
-  def selectDynamic(name: Label)(using lens: name.type is Optic from Target)
-  :   Optic from Origin onto lens.Target =
-
-    Composable.optics.composition(this, lens)
-
-
-  def updateDynamic(name: Label)(using lens: name.type is Optic from Target)
-    [ source ]
-    ( value: (lens.Target aka "prior") ?=> source )
-    ( using coercible: source is Coercible to lens.Target )
-  :   Origin => Origin =
-
-    Composable.optics.composition(this, lens).modify(_): prior =>
-      coercible.coerce(value(using prior.aka["prior"]))
-
-
-  def update[source, target](traversal: Any, value: source)
-    ( using optical:  (? >: traversal.type) is Optical from Target onto target,
-            coercible: source is Coercible to target )
-  :   Origin => Origin =
-
-    Composable.optics.composition(this, optical.optic(traversal)).modify(_): _ =>
-      coercible.coerce(value)
-
-
-  def applyDynamic(name: Label)[operand](using lens: name.type is Optic from Target onto operand)
-    [ target, traversal ]
-    ( traversal: traversal )
-    ( using optical: (? >: traversal.type) is Optical from operand onto target )
-  :   Optic from Origin onto target =
-
-    Composable.optics.composition
-      ( Composable.optics.composition(this, lens), optical.optic(traversal) )
-
-
-  def apply[target, optic](traversal: optic)
-    ( using optical: (? >: traversal.type) is Optical from Target onto target )
-  :   Optic from Origin onto target =
-
-    Composable.optics.composition(this, optical.optic(traversal))
+trait Coercible:
+  type Self
+  type Result
+  def coerce(value: Self): Result

--- a/lib/panopticon/src/core/panopticon.internal.scala
+++ b/lib/panopticon/src/core/panopticon.internal.scala
@@ -309,10 +309,32 @@ object internal:
       if opts.forall(_.isDefined) then Some(opts.flatten) else None
 
 
+    def coerce[T: Type](sourceTerm: Term): Expr[T] =
+      val sourceTpe = sourceTerm.tpe.widen
+
+      if sourceTpe <:< TypeRepr.of[T] then sourceTerm.asExprOf[T]
+      else sourceTpe.asType.absolve match
+        case '[source] =>
+          val sourceExpr = sourceTerm.asExprOf[source]
+
+          Expr.summon[source is Coercible to T] match
+            case Some(coercible) => '{$coercible.coerce($sourceExpr)}
+
+            case None =>
+              halt(m"cannot coerce ${sourceTpe.show} to ${TypeRepr.of[T].show} in this assignment")
+
     def applyLeaf[T: Type](acc: Expr[T], leafTerm: Term, isCtxFn: Boolean): Expr[T] =
-      if isCtxFn
-      then '{${leafTerm.asExprOf[(T `aka` "prior") ?=> T]}(using $acc.aka["prior"])}
-      else leafTerm.asExprOf[T]
+      if isCtxFn then
+        val sourceTpe = leafTerm.tpe match
+          case AppliedType(_, List(_, result)) => result
+          case other                           => other
+
+        sourceTpe.asType.absolve match
+          case '[source] =>
+            val fn = leafTerm.asExprOf[(T `aka` "prior") ?=> source]
+            coerce[T]('{$fn(using $acc.aka["prior"])}.asTerm)
+      else
+        coerce[T](leafTerm)
 
     def emit[T: Type](origin: Expr[T], branches: List[Resolved]): Expr[T] =
       if branches.nil then origin else

--- a/lib/panopticon/src/core/soundness_panopticon_core.scala
+++ b/lib/panopticon/src/core/soundness_panopticon_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export panopticon.{Composable, Each, Filter, Lens, lens, Optic, Optical}
+export panopticon.{Coercible, Composable, Each, Filter, Lens, lens, Optic, Optical}

--- a/lib/stratiform/src/core/soundness_stratiform_core.scala
+++ b/lib/stratiform/src/core/soundness_stratiform_core.scala
@@ -35,4 +35,4 @@ package soundness
 export
   stratiform
   . { DynamicTelEnabler, dynamicTelAccess, Revision, Mutation, MutationError, Stratiform, Tel, Tel2,
-      TelError, TelPath, Tels, Tels2, tel }
+      telConversion, TelError, TelPath, Tels, Tels2, tel }

--- a/lib/stratiform/src/core/stratiform.telConversion.scala
+++ b/lib/stratiform/src/core/stratiform.telConversion.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import prepositional.*
+
+// Importing `telConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Tel` value be supplied directly at lens-assignment positions, such as
+// `tel.lens(_.field = value)`, without an explicit `.tel`.
+object telConversion:
+  given encodable: [entity: Encodable in Tel] => Conversion[entity, Tel] = _.encode

--- a/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   ypsiloid
-  . { Yaml, YamlError, YamlPrimitive, DynamicYamlEnabler, dynamicYamlAccess, y, yp, YamlPath,
-      YamlPathError }
+  . { Yaml, yamlConversion, YamlError, YamlPrimitive, DynamicYamlEnabler, dynamicYamlAccess, y, yp,
+      YamlPath, YamlPathError }
 
 package formatting:
   export ypsiloid.formatting.blockYamlFormatting

--- a/lib/ypsiloid/src/core/ypsiloid.yamlConversion.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.yamlConversion.scala
@@ -1,0 +1,42 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ypsiloid
+
+import anticipation.*
+import prepositional.*
+
+// Importing `yamlConversion.encodable` brings a scoped `Conversion` into lexical scope that lets
+// any `Encodable in Yaml` value be supplied directly at lens-assignment positions, such as
+// `yaml.lens(_.field = value)`, without an explicit `.yaml`.
+object yamlConversion:
+  given encodable: [entity: Encodable in Yaml] => Conversion[entity, Yaml] = _.encode

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -1008,7 +1008,7 @@ object Tests extends Suite(m"Ypsiloid Tests"):
       . assert(_ == List("~"))
 
     suite(m"Lens"):
-      import dynamicYamlAccess.enabled
+      import dynamicYamlAccess.enabled, yamlConversion.encodable
 
       val org = Yaml.ast(NamedOuter(t"a", Inner(7)).yaml.root)
 
@@ -1018,13 +1018,13 @@ object Tests extends Suite(m"Ypsiloid Tests"):
       . assert(_ == NamedOuter(t"a", Inner(99)))
 
       test(m"Lens update of top-level field"):
-        val updated = org.lens(_.name = t"b".yaml)
+        val updated = org.lens(_.name = t"b")
         updated.as[NamedOuter]
       . assert(_ == NamedOuter(t"b", Inner(7)))
 
       test(m"Optical update on a sequence element"):
         val y = t"items: [10, 20, 30]".read[Yaml]
-        val updated = y.lens(_.items(Prim) = 99.yaml)
+        val updated = y.lens(_.items(Prim) = 99)
         updated.items.as[List[Int]]
       . assert(_ == List(99, 20, 30))
 
@@ -1040,16 +1040,16 @@ object Tests extends Suite(m"Ypsiloid Tests"):
 
       test(m"Each optic updates every sequence element"):
         val y = t"items: [10, 20, 30]".read[Yaml]
-        y.lens(_.items(Each) = 0.yaml).items.as[List[Int]]
+        y.lens(_.items(Each) = 0).items.as[List[Int]]
       . assert(_ == List(0, 0, 0))
 
       test(m"Filter optic updates only matching elements"):
         val y = t"items: [10, 20, 30]".read[Yaml]
-        y.lens(_.items(Filter[Yaml](_.as[Int] > 15)) = 0.yaml).items.as[List[Int]]
+        y.lens(_.items(Filter[Yaml](_.as[Int] > 15)) = 0).items.as[List[Int]]
       . assert(_ == List(10, 0, 0))
 
       test(m"Setting an absent field inserts it"):
-        org.lens(_.extra = 7.yaml).selectDynamic("extra").as[Int]
+        org.lens(_.extra = 7).selectDynamic("extra").as[Int]
       . assert(_ == 7)
 
     suite(m"Serializer roundtrip"):


### PR DESCRIPTION
Lens assignments through panopticon optics now accept any value convertible to the field's type, rather than requiring it to already be the target type. For the format modules this removes the need to pre-convert a right-hand side with `.json`, `.cbor`, `.yaml`, `.tel`, or `.protobuf`; importing the corresponding conversion lets an encodable value be assigned directly. A small `Coercible` typeclass underpins this, bridging any existing `Conversion` over a subtype pass-through and driving the coercion off a `source` type parameter so traversal targets are still inferred from the optic rather than the assigned value.

Optics lens assignments are now terser. Previously the right-hand side of a lens assignment had to already be the format's value type:

```scala
json.lens(_.leader.roles(Each).name = "x".json)
cbor.lens(_.values(Filter[Cbor](_.as[Int] > 1)) = 0.cbor)
```

By importing the format's conversion, you can now assign an encodable value directly and have it coerced at the assignment position:

```scala
import jacinta.jsonConversion.encodable
json.lens(_.leader.roles(Each).name = "x")

import breviloquence.cborConversion.encodable
cbor.lens(_.values(Each) = 0)
```

The same applies to `ypsiloid.yamlConversion`, `stratiform.telConversion`, and `locomotion.protobufConversion`. Case-class optics, `prior`, nested chains, and traversal fusion are unaffected, and values that are already the target type continue to work without an import.

Resolves the bulk of #1272; xylophone (Xml) is tracked separately as #1384 because its `Encodable in Xml` derivation is transparent-inline and does not compose with the generic conversion mechanism.
