### PR TITLE
Export every public module into the soundness umbrella, enforced by SN-742

### DIFF
--- a/lib/apoplexy/src/core/soundness_apoplexy_core.scala
+++ b/lib/apoplexy/src/core/soundness_apoplexy_core.scala
@@ -32,4 +32,6 @@
                                                                                                   */
 package soundness
 
-export apoplexy.{OpenApi, OpenApiError}
+// unexported: Executor (clashes with `superlunary.Executor` in the umbrella; reach it via
+// `apoplexy.Executor`)
+export apoplexy.{Api, ApiError, Conformant, OpenApi, OpenApiError}

--- a/lib/austronesian/src/core/soundness_austronesian_core.scala
+++ b/lib/austronesian/src/core/soundness_austronesian_core.scala
@@ -32,4 +32,6 @@
                                                                                                   */
 package soundness
 
+// unexported: Proxy (clashes with `vicarious.Proxy` in the umbrella; reach it via
+// `austronesian.Proxy`)
 export austronesian.{PojoError, Restorable}

--- a/lib/bitumen/src/core/soundness_bitumen_core.scala
+++ b/lib/bitumen/src/core/soundness_bitumen_core.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export bitumen.{LongNameFormat, Pax, SparseSegment, Tar, Tarfile, TarError, TarHeader,
-  TarRef, TypeFlag, UnixGroup, UnixMode, UnixUser}
+  TarRef, TarCompression, TypeFlag, UnixGroup, UnixMode, UnixUser}

--- a/lib/burdock/src/core/soundness_burdock_core.scala
+++ b/lib/burdock/src/core/soundness_burdock_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export burdock.{externalize, Repackager}
+export burdock.{DepsDev, externalize, Repackager}
 
 // The repackager's command-line entry point, in the `soundness` package so it can be
 // launched as `java -cp app.jar soundness.repackage` (house style requires every file to

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -32,9 +32,12 @@
                                                                                                   */
 package soundness
 
+// unexported: Syntax (clashes with `stenography.Syntax` in the umbrella; reach it via
+// `cataclysm.Syntax`)
 export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
     Simple, Combinator, AttributeMatcher, AttributeTest, Prefix, PseudoArgument,
-    CssConvertible, Pixels, Rems, Exs, Chs, ViewportWidths,
+    CssConvertible, Outcome, PropertyDef, SyntaxMatcher, ValueToken, Pixels, Rems, Exs, Chs,
+    ViewportWidths,
     ViewportHeights, ViewportMins, ViewportMaxes, Percents, Degrees, Radians, Turns, Flexes, Px,
     Rem, Ex, Ch, Vw, Vh, Vmin, Vmax, Cm, Mm, Pt, Pc, Pct, S, Ms, Deg, Rad, Turn, Fr, css}
 

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -1993,13 +1993,16 @@ object Checker:
       out:          mutable.ListBuffer[Violation] )
   :   Unit =
 
-    siblingTypes.foreach: name =>
-      if !exports.names.contains(name) then
-        out +=
-          Violation
-            ( file, exports.firstLine, 1, "742",
-              s"`$name` is defined in the module but is not exported to the `soundness` "
-                +"package" )
+    val missing =
+      siblingTypes.filterNot(exports.names.contains).filterNot(exports.excluded.contains)
+
+    if missing.nonEmpty then
+      val listed = missing.map { name => s"`$name`" }.mkString(", ")
+      val subject = if missing.length == 1 then "module is" else "modules are"
+      out +=
+        Violation
+          ( file, exports.firstLine, 1, "742",
+            s"the $subject defined but not exported to the `soundness` package: $listed" )
 
   private def checkInterpolatorLayout
     ( file:    String,

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -45,16 +45,22 @@ object Checker:
   // before delegating to the tree-aware overload. The plugin should call the
   // overload below directly with the compilation unit's existing untyped
   // tree to avoid re-parsing.
-  def check(file: String, expectedModule: Option[String], rawText: String): LazyList[Violation] =
+  def check
+    ( file:           String,
+      expectedModule: Option[String],
+      rawText:        String,
+      siblingTypes:   List[String] = Nil )
+  :   LazyList[Violation] =
     val (tree, source) = Parsing.parse(file, rawText)
-    check(file, expectedModule, rawText, tree, source)
+    check(file, expectedModule, rawText, tree, source, siblingTypes)
 
   def check
     ( file:           String,
       expectedModule: Option[String],
       rawText:        String,
       untpdTree:      untpd.Tree,
-      source:         SourceFile )
+      source:         SourceFile,
+      siblingTypes:   List[String] )
   :   LazyList[Violation] =
 
     val out   = mutable.ListBuffer[Violation]()
@@ -90,6 +96,7 @@ object Checker:
     checkDefnAnchors(file, Definitions.extract(untpdTree, source), out)
     checkOperatorContinuation(file, operatorSites, out)
     checkInterpolatorLayout(file, interpolations, rawText, source, out)
+    checkSoundnessExports(file, siblingTypes, SoundnessExports.extract(untpdTree, source), out)
     var idx = 0
 
     while idx < lines.length do
@@ -1972,6 +1979,28 @@ object Checker:
   // leading `( ` before the opener and a trailing `,`/`)` after the closer are
   // permitted (the surrounding application syntax), so "alone" means the string
   // content does not share the opener/closer line.
+  // R-742: every public module in a component (a top-level definition living in
+  // its own `<component>.<Name>.scala` file, other than `internal` modules) must
+  // be re-exported into the `soundness` package. `siblingTypes` is the list of
+  // such module names found alongside the `soundness_<component>_<suffix>.scala`
+  // export surface; any name absent from the surface's `export` clauses is a
+  // violation. The list is empty for every file other than an export surface, so
+  // this check is a no-op elsewhere.
+  private def checkSoundnessExports
+    ( file:         String,
+      siblingTypes: List[String],
+      exports:      ExportInfo,
+      out:          mutable.ListBuffer[Violation] )
+  :   Unit =
+
+    siblingTypes.foreach: name =>
+      if !exports.names.contains(name) then
+        out +=
+          Violation
+            ( file, exports.firstLine, 1, "742",
+              s"`$name` is defined in the module but is not exported to the `soundness` "
+                +"package" )
+
   private def checkInterpolatorLayout
     ( file:    String,
       sites:   List[InterpolationInfo],

--- a/lib/decorum/src/plugin/decorum.DecorumPhase.scala
+++ b/lib/decorum/src/plugin/decorum.DecorumPhase.scala
@@ -87,9 +87,12 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
   // When `path` is a `soundness_<component>_<suffix>.scala` export surface, return
   // the names of the sibling public modules (`<component>.<Name>.scala` files in
   // the same directory, excluding any `internal` module) that R-742 requires to
-  // be re-exported. Compiler-plugin source roots (`/src/plugin/`) are excluded:
-  // their extraction helpers are deliberately unexported plugin internals. For
-  // every other file the result is empty, making the check a no-op.
+  // be re-exported. A module is included only when its file declares `Name`
+  // publicly: modules with no accessible top-level declaration (e.g. a
+  // `private[component] object`) cannot be — and need not be — re-exported.
+  // Compiler-plugin source roots (`/src/plugin/`) are excluded: their extraction
+  // helpers are deliberately unexported plugin internals. For every other file
+  // the result is empty, making the check a no-op.
   private def soundnessSiblingModules(path: String): List[String] =
     if path.contains("/src/plugin/") then Nil else
       val libParts = path.split("/lib/").nn
@@ -106,11 +109,30 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
             siblings.foreach: sibling =>
               val name = sibling.nn.getName.nn
               if name.startsWith(prefix) && name.endsWith(".scala") then
-                val mid     = name.substring(prefix.length, name.length - ".scala".length).nn
-                val module  = mid.takeWhile(_ != '.')
+                val mid    = name.substring(prefix.length, name.length - ".scala".length).nn
+                val module = mid.takeWhile(_ != '.')
                 if module.nonEmpty && !module.toLowerCase.nn.contains("internal")
+                   && declaresPublicly(sibling.nn, module)
                 then out += module
             out.to(List)
+
+  // Modifiers that may precede a public top-level declaration; `private` and
+  // `protected` are deliberately absent, so a `private[x] object Foo` line never
+  // matches the public-declaration pattern below.
+  private val PublicModifiers =
+    "(?:final|sealed|abstract|case|open|transparent|inline|erased|lazy|override|implicit)"
+
+  // Does `file` declare `module` with a publicly-accessible top-level definition?
+  // A column-0 `object`/`class`/`trait`/`enum`/`type`/`val`/`def`/`given Name`
+  // (optionally preceded by non-access modifiers) counts; a `private`/`protected`
+  // declaration does not, because the line then begins with that access modifier.
+  private def declaresPublicly(file: java.io.File, module: String): Boolean =
+    val keywords = "opaque\\s+type|object|class|trait|enum|type|val|def|given"
+    val pattern  = s"(?m)^(?:$PublicModifiers\\s+)*(?:$keywords)\\s+$module(?![A-Za-z0-9])"
+    try
+      val content = String(java.nio.file.Files.readAllBytes(file.toPath))
+      pattern.r.findFirstIn(content).isDefined
+    catch case _: Throwable => true
 
   private def position(source: SourceFile, line: Int, column: Int): SourcePosition =
     val lineStart =

--- a/lib/decorum/src/plugin/decorum.SoundnessExports.scala
+++ b/lib/decorum/src/plugin/decorum.SoundnessExports.scala
@@ -34,88 +34,38 @@ package decorum
 
 import scala.collection.mutable
 
-import dotty.tools.dotc.*, ast.tpd, core.Contexts.*, plugins.*, util.{SourceFile, SourcePosition}
-import dotty.tools.dotc.util.Spans.Span
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.util.SourceFile
 
-class DecorumPhase(options: List[String]) extends PluginPhase:
-  val phaseName: String                = "decorum"
-  override val runsAfter: Set[String]  = Set("typer")
-  override val runsBefore: Set[String] = Set("pickler")
+case class ExportInfo(names: Set[String], firstLine: Int)
 
-  private val errors: Boolean   = options.contains("errors")
-  private val seen: mutable.Set[String] = mutable.Set.empty
+object SoundnessExports:
+  // Collect the simple leaf names re-exported by every top-level `export`
+  // statement in the file (including those nested inside `package x:` blocks),
+  // together with the line of the first such statement. Used by R-742 to check
+  // that each public module in a component is re-exported into `soundness`.
+  def extract(tree: untpd.Tree, source: SourceFile): ExportInfo =
+    val names     = mutable.Set[String]()
+    var firstLine = -1
 
-  private val esc: Char = 27.toChar
-  private val bel: Char = 7.toChar
-  private val gray   = s"$esc[38;2;128;128;128m"
-  private val orange = s"$esc[38;2;255;165;0m"
-  private val cyan   = s"$esc[38;2;0;200;255m"
-  private val reset  = s"$esc[0m"
+    def record(exp: untpd.Export): Unit =
+      val span = exp.span
+      if span.exists then
+        val line = source.offsetToLine(span.start) + 1
+        if firstLine < 0 || line < firstLine then firstLine = line
 
-  private def colourPrefix(rule: String, useColor: Boolean): String =
-    if useColor then
-      val hyperlink = false
-      val rendered  = rule.replace(".", s"$gray.$cyan")
-      val d         = rule.takeWhile(_ != '.')
-      val link      = if hyperlink then s"$esc]8;;https://soundness.dev/SN-$d$bel" else ""
-      val unlink    = if hyperlink then s"$esc]8;;$bel" else ""
-      s"$link$gray[$orange↯SN$gray-$cyan$rendered$gray]$reset$unlink "
-    else
-      s"[↯SN-$rule] "
+      exp.selectors.foreach: selector =>
+        val name = selector.imported.name.toString
+        if name.nonEmpty && name != "_" && name != "*" then names += name
 
-  override def transformUnit(tree: tpd.Tree)(using context: Context): tpd.Tree =
-    val source: SourceFile = context.compilationUnit.source
-    val path: String       = source.file.path
-    if seen.add(path) then
-      val text: String = String(source.content)
-      val module       = Checker.expectedModule(path)
+    def visit(t: untpd.Tree): Unit = t match
+      case pkg: untpd.PackageDef => pkg.stats.foreach(visit)
+      case exp: untpd.Export     => record(exp)
+      case _                     => ()
 
-      val useColor     =
-        try
-          import dotty.tools.dotc.config.Settings.Setting.value
-          value(context.settings.color)(using context) != "never"
-        catch case _: Throwable => false
+    visit(tree)
+    ExportInfo(names.to(Set), if firstLine < 0 then PackageLine else firstLine)
 
-      val unitTree     = context.compilationUnit.untpdTree
-      val siblingTypes = soundnessSiblingModules(path)
-      Checker.check(path, module, text, unitTree, source, siblingTypes).foreach: violation =>
-        val pos = position(source, violation.line, violation.column)
-        val msg = colourPrefix(violation.rule, useColor)+violation.message
-        if errors then report.error(msg, pos) else report.warning(msg, pos)
-    super.transformUnit(tree)
-
-  // When `path` is a `soundness_<component>_<suffix>.scala` export surface, return
-  // the names of the sibling public modules (`<component>.<Name>.scala` files in
-  // the same directory, excluding any `internal` module) that R-742 requires to
-  // be re-exported. Compiler-plugin source roots (`/src/plugin/`) are excluded:
-  // their extraction helpers are deliberately unexported plugin internals. For
-  // every other file the result is empty, making the check a no-op.
-  private def soundnessSiblingModules(path: String): List[String] =
-    if path.contains("/src/plugin/") then Nil else
-      val libParts = path.split("/lib/").nn
-      if libParts.length < 2 then Nil else
-        val component = libParts(1).nn.split("/").nn(0).nn
-        val file      = java.io.File(path)
-        val fileName  = file.getName.nn
-        if !fileName.startsWith(s"soundness_${component}_") then Nil else
-          val parent   = file.getParentFile
-          val siblings = if parent == null then null else parent.listFiles
-          if siblings == null then Nil else
-            val prefix = s"$component."
-            val out    = mutable.ListBuffer[String]()
-            siblings.foreach: sibling =>
-              val name = sibling.nn.getName.nn
-              if name.startsWith(prefix) && name.endsWith(".scala") then
-                val mid     = name.substring(prefix.length, name.length - ".scala".length).nn
-                val module  = mid.takeWhile(_ != '.')
-                if module.nonEmpty && !module.toLowerCase.nn.contains("internal")
-                then out += module
-            out.to(List)
-
-  private def position(source: SourceFile, line: Int, column: Int): SourcePosition =
-    val lineStart =
-      try source.lineToOffset((line - 1).max(0))
-      catch case _: Throwable => 0
-
-    val offset = (lineStart + (column - 1).max(0)).min(source.content.length)
-    SourcePosition(source, Span(offset))
+  // The line of the `package soundness` declaration in export-surface files;
+  // used as the fallback violation position when a surface contains no exports.
+  private val PackageLine: Int = 33

--- a/lib/decorum/src/plugin/decorum.SoundnessExports.scala
+++ b/lib/decorum/src/plugin/decorum.SoundnessExports.scala
@@ -37,9 +37,17 @@ import scala.collection.mutable
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.util.SourceFile
 
-case class ExportInfo(names: Set[String], firstLine: Int)
+case class ExportInfo(names: Set[String], excluded: Set[String], firstLine: Int)
 
 object SoundnessExports:
+  // A directive comment, `// unexported: Foo, Bar`, marks modules that are
+  // deliberately not re-exported into `soundness` (typically because the simple
+  // name already belongs to another component's surface). R-742 treats these as
+  // satisfied. The capture stops at end of line or an opening parenthesis, so a
+  // trailing justification (`// unexported: Foo (clashes with bar.Foo)`) is fine.
+  private val ExcludeDirective = "(?m)//\\s*unexported:\\s*([^\\n(]+)".r
+  private val Identifier       = "[A-Za-z][A-Za-z0-9]*".r
+
   // Collect the simple leaf names re-exported by every top-level `export`
   // statement in the file (including those nested inside `package x:` blocks),
   // together with the line of the first such statement. Used by R-742 to check
@@ -64,7 +72,13 @@ object SoundnessExports:
       case _                     => ()
 
     visit(tree)
-    ExportInfo(names.to(Set), if firstLine < 0 then PackageLine else firstLine)
+
+    val content  = String(source.content)
+    val excluded = mutable.Set[String]()
+    ExcludeDirective.findAllMatchIn(content).foreach: directive =>
+      Identifier.findAllIn(directive.group(1).nn).foreach(excluded += _)
+
+    ExportInfo(names.to(Set), excluded.to(Set), if firstLine < 0 then PackageLine else firstLine)
 
   // The line of the `package soundness` declaration in export-surface files;
   // used as the fallback violation position when a surface contains no exports.

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -932,3 +932,14 @@ object Tests extends Suite(m"Decorum Tests"):
       test(m"No violation when there are no sibling modules"):
         exportRules("export jacinta.{Json}\n", Nil)
       . assert(r => !r.contains("742"))
+
+      test(m"An `unexported:` directive suppresses the violation"):
+        exportRules
+         ("// unexported: Timestamp (clashes with aviation.Timestamp)\nexport embarcadero.{Image}\n",
+          List("Image", "Timestamp"))
+      . assert(r => !r.contains("742"))
+
+      test(m"An `unexported:` directive only suppresses the named module"):
+        exportRules
+         ("// unexported: Timestamp\nexport embarcadero.{Image}\n", List("Image", "Timestamp", "Layer"))
+      . assert(_.contains("742"))

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -51,6 +51,9 @@ object Tests extends Suite(m"Decorum Tests"):
 
   def rules(body: String): List[String] = violations(body).map(_.rule)
 
+  def exportRules(body: String, siblings: List[String]): List[String] =
+    Checker.check("<test>", Some("soundness"), stub(body), siblings).toList.map(_.rule)
+
   def run(): Unit =
     suite(m"Phase 1: Universal rules"):
 
@@ -906,3 +909,26 @@ object Tests extends Suite(m"Decorum Tests"):
       test(m"Long content line of a multi-line string is not flagged 230"):
         rules("def msg =\n  m\"\"\"\n    "+"x".repeat(110)+"\n  \"\"\"\n")
       . assert(r => !r.contains("230"))
+
+    suite(m"Phase 7: Soundness export completeness (R742)"):
+
+      test(m"Module not re-exported to soundness is rejected (742)"):
+        exportRules("export jacinta.{Json}\n", List("Json", "NumberMode"))
+      . assert(_.contains("742"))
+
+      test(m"All modules re-exported is accepted"):
+        exportRules("export jacinta.{Json, NumberMode}\n", List("Json", "NumberMode"))
+      . assert(r => !r.contains("742"))
+
+      test(m"Module exported inside a nested package counts as exported"):
+        exportRules
+         ("package formatting:\n  export jacinta.formatting.NumberMode\n", List("NumberMode"))
+      . assert(r => !r.contains("742"))
+
+      test(m"Single-selector export without braces is recognised"):
+        exportRules("export jacinta.Json\n", List("Json"))
+      . assert(r => !r.contains("742"))
+
+      test(m"No violation when there are no sibling modules"):
+        exportRules("export jacinta.{Json}\n", Nil)
+      . assert(r => !r.contains("742"))

--- a/lib/embarcadero/src/containerd/soundness_embarcadero_containerd.scala
+++ b/lib/embarcadero/src/containerd/soundness_embarcadero_containerd.scala
@@ -35,6 +35,7 @@ package soundness
 // `Timestamp` is intentionally not exported: it collides with `aviation.Timestamp` in
 // the umbrella, and callers normally reach times through `…createdAt.instant[Instant]`
 // rather than naming it. Use `embarcadero.Timestamp` directly when constructing one.
+// unexported: Timestamp
 export embarcadero.{AnyMessage, Containerd, Container, ContentDescriptor,
     CreateContainerRequest, CreateContainerResponse, CreateNamespaceRequest,
     CreateNamespaceResponse, CreateTaskRequest, CreateTaskResponse, DeleteContainerRequest,

--- a/lib/enigmatic/src/core/soundness_enigmatic_core.scala
+++ b/lib/enigmatic/src/core/soundness_enigmatic_core.scala
@@ -39,7 +39,8 @@ export
   . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
       CipherSession, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des, Divulgence,
       Dsa, Ecb, encrypt, Encryptor, Encryption, expose,
-      Hmac, hmac, InitializationVector, Iso10126, NoPadding, Ofb, Pem, PemError, PemLabel,
+      Hmac, hmac, InitializationVector, Iso10126, JavaStdlibCrypto, NoPadding, Ofb, Pem, PemError,
+      PemLabel,
       Permits, Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing,
       Symmetric, SymmetricKey, TripleDes }
 

--- a/lib/enigmatic/src/cose/soundness_enigmatic_cose.scala
+++ b/lib/enigmatic/src/cose/soundness_enigmatic_cose.scala
@@ -35,4 +35,4 @@ package soundness
 export enigmatic
   . { Cose, CoseStructure, CoseSigned, CoseMaced, Sign, Sign1, Mac, Mac0, CoseRecipient,
       CoseAuthenticator, CoseVerifier, CoseAlgorithm, CoseError, HmacCipher, CoseTag, CoseContext,
-      verify }
+      CanonicalCbor, verify }

--- a/lib/escapade/src/core/soundness_escapade_core.scala
+++ b/lib/escapade/src/core/soundness_escapade_core.scala
@@ -36,7 +36,7 @@ export
   escapade
   . { Ansi, Ansi2, Bg, Bold, CharSpan, Colorable, Conceal, csi, e, Escape, escapes, Fg, Imprintable,
       Italic, Reverse, Ribbon, Strike, Stylize, Teletype, teletype, Teletypeable, TeletypeBuilder,
-      TextStyle, Underline }
+      TextStyle, Underline, Hyperlink, TerminalEscapes }
 
 package displayableTypes:
   export escapade.displayableTypes.messagePrintable

--- a/lib/ethereal/src/core/soundness_ethereal_core.scala
+++ b/lib/ethereal/src/core/soundness_ethereal_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   ethereal
-  . { cli, Client, DaemonEvent, DaemonLogEvent, daemonLogEvent, DaemonService, Installer,
-      LazyEnvironment, service, Stdin, Upgrade, UpgradeError }
+  . { Assembler, cli, Client, DaemonEvent, DaemonLogEvent, daemonLogEvent, DaemonService, Installer,
+      LazyEnvironment, Runners, service, Stdin, Upgrade, UpgradeError }
 
 package workingDirectories:
   export ambience.workingDirectories.daemonClientWorkingDirectory

--- a/lib/exoskeleton/src/core/soundness_exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/soundness_exoskeleton_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   exoskeleton
   . { Application, application, Backstop, Effectful, effectful, Entrypoint, Executive, InstallError,
-      Invocation, trap }
+      Help, Invocation, trap }
 
 package backstops:
   export exoskeleton.backstops.{exceptionMessageBackstop, genericErrorMessageBackstop,

--- a/lib/frontier/src/core/soundness_frontier_core.scala
+++ b/lib/frontier/src/core/soundness_frontier_core.scala
@@ -34,6 +34,8 @@ package soundness
 
 import frontier.*
 
+// unexported: Diagnostic (clashes with `harlequin.Diagnostic` in the umbrella; reach it via
+// `frontier.Diagnostic`)
 export frontier.Every
 
 package context:

--- a/lib/galilei/src/core/soundness_galilei_core.scala
+++ b/lib/galilei/src/core/soundness_galilei_core.scala
@@ -41,7 +41,7 @@ export
       javaFile, javaPath, modified, MoveAtomically, moveInto, moveTo, open, Openable,
       OverwritePreexisting, readable, ReadAccess, size, Socket, Substantiable, Symlink, symlinkInto,
       symlinkTo, touch, TraversalOrder, UnixEntry, Volume, volume, WindowsEntry, wipe, writable,
-      WriteAccess, WriteSynchronously }
+      WriteAccess, WriteSynchronously, Device }
 
 package filesystemOptions:
   export

--- a/lib/gastronomy/src/core/soundness_gastronomy_core.scala
+++ b/lib/gastronomy/src/core/soundness_gastronomy_core.scala
@@ -35,8 +35,8 @@ package soundness
 export
   gastronomy
   . { Algorithm, Blake3, checksum, Concession, Crc32, Digest, digest, Digester, Digestible,
-      Digestion, Feistel, Hash, Hashing, Md5, Permit, ProcessingPermit, Sha1, Sha2, Sha384,
-      Sha512 }
+      Digestion, Feistel, Hash, Hashing, JavaStdlibHashing, Md5, Permit, ProcessingPermit, Provider,
+      Sha1, Sha2, Sha384, Sha512, SoundnessHashing }
 
 package providers:
   export gastronomy.providers.{javaStdlibProvider, soundnessProvider}

--- a/lib/harlequin/src/core/soundness_harlequin_core.scala
+++ b/lib/harlequin/src/core/soundness_harlequin_core.scala
@@ -35,5 +35,6 @@ package soundness
 // `Completion`/`Completions` are intentionally not re-exported here: those names
 // already belong to `exoskeleton` in the `soundness` namespace. Reach harlequin's
 // via `harlequin.Completion` / `harlequin.Completions`.
+// unexported: Completion
 export harlequin.{Accent, Diagnostic, Highlight, Java, Depth, ProgrammingLanguage, Scala,
     SourceCode, Token, highlighting}

--- a/lib/jacinta/src/core/soundness_jacinta_core.scala
+++ b/lib/jacinta/src/core/soundness_jacinta_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   jacinta
-  . { dynamicJsonAccess, DynamicJsonEnabler, Json, json, Json2, JsonError, JsonPointer,
-      JsonPrimitive, Ndjson, parserAggregable, showable }
+  . { dynamicJsonAccess, DynamicJsonEnabler, j, jp, Json, json, Json2, JsonError, JsonPointer,
+      JsonPointerError, JsonPrimitive, Ndjson, NumberMode, parserAggregable, showable }
 
 package formatting:
   export jacinta.formatting.{indentedJsonFormatting, compactJsonFormatting}

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -38,7 +38,8 @@ export
       Destruction, Fault, Fulfillment, GarbageCollection, Heap, hibernate, Hook, intercept,
       Interceptable, Monitor, monitor, Observation, Os, Perseverance, PlatformSupervisor, Promise,
       relent, retry, RetryError, Shutdown, sleep, snooze, supervise, Supervisor, Task, task,
-      Tenacity, Threading, Timeout, Transgression, VirtualSupervisor, Worker }
+      Tenacity, Threading, Timeout, Transgression, Trap, VirtualSupervisor, Worker, AsyncTactic,
+      Remedy }
 
 package threading:
   export parasite.threading.{adaptiveThreading, platformThreading, virtualThreading}

--- a/lib/plutocrat/src/core/soundness_plutocrat_core.scala
+++ b/lib/plutocrat/src/core/soundness_plutocrat_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export plutocrat.{Currency, CurrencyStyle, IsinError, Luhn, Money, Price}
+export plutocrat.{Currency, CurrencyStyle, isin, IsinError, Luhn, Money, Price}
 
 package currencyStyles:
   export plutocrat.currencyStyles.{genericCurrencyStyle, localCurrencyStyle}

--- a/lib/profanity/src/core/soundness_profanity_core.scala
+++ b/lib/profanity/src/core/soundness_profanity_core.scala
@@ -37,7 +37,7 @@ export
   . { Console, CtrlChar, DismissError, Interaction, interactive, Interactivity, Keyboard,
       Keypress, LineEditor, Question, SelectMenu, Signal, SignalResponse, stdio, Canvas,
       Terminal, TerminalError, TerminalEvent, TerminalFeature, TerminalInfo, TerminalCanvas,
-      UnixSignal, WindowsSignal }
+      InlineCanvas, UnixSignal, WindowsSignal }
 
 package keyboards:
   export profanity.keyboards.{numericKeyboard, rawKeyboard, standardKeyboard}

--- a/lib/punctuation/src/core/punctuation.BlockBuilder.scala
+++ b/lib/punctuation/src/core/punctuation.BlockBuilder.scala
@@ -44,7 +44,7 @@ import vacuous.*
 // own prefix) to the next-deeper open block. Leaves accumulate raw line
 // content and finalize to a single `Layout` value.
 
-sealed trait BlockBuilder:
+private[punctuation] sealed trait BlockBuilder:
   val line: Ordinal
 
 sealed trait LeafBuilder extends BlockBuilder:

--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -54,7 +54,7 @@ import vacuous.*
 //   4. The leftover content goes into a leaf — heading, code block, or
 //      paragraph (start new or continue existing).
 
-final class BlockParser:
+private[punctuation] final class BlockParser:
   private val refs: LinkRefs = LinkRefs()
   private val docBuilder: DocumentBuilder = DocumentBuilder()
   private val openStack: ArrayBuffer[BlockBuilder] = ArrayBuffer(docBuilder)

--- a/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
+++ b/lib/punctuation/src/core/punctuation.EmphasisProcessor.scala
@@ -115,7 +115,7 @@ final class InlineList:
       cur = n.next
       n
 
-object EmphasisProcessor:
+private[punctuation] object EmphasisProcessor:
 
   // CommonMark left-flanking: not followed by Unicode whitespace AND
   // (not followed by Unicode punctuation OR preceded by Unicode whitespace

--- a/lib/punctuation/src/core/punctuation.HtmlEntities.scala
+++ b/lib/punctuation/src/core/punctuation.HtmlEntities.scala
@@ -42,7 +42,7 @@ import turbulence.*
 // `entities-extra.tsv` for the HTML5 additions). Only entries with a
 // trailing semicolon are kept, since CommonMark requires the `;` terminator
 // for named entities to be valid.
-object HtmlEntities:
+private[punctuation] object HtmlEntities:
   private lazy val table: Map[String, String] =
     val builder = Map.newBuilder[String, String]
     loadInto(cp"/honeycomb/entities-html4.tsv".read[Text].s, builder)

--- a/lib/punctuation/src/core/punctuation.InlineParser.scala
+++ b/lib/punctuation/src/core/punctuation.InlineParser.scala
@@ -48,7 +48,7 @@ import vacuous.*
 //      delimiters outside successfully-matched links.
 // The resulting list is then converted to a `Seq[Prose]`.
 
-object InlineParser:
+private[punctuation] object InlineParser:
 
   // Must stay in sync with the `c match` cases in `parse` below: any character
   // handled there must also be flagged here, otherwise it'll be silently

--- a/lib/punctuation/src/core/punctuation.InlineSupport.scala
+++ b/lib/punctuation/src/core/punctuation.InlineSupport.scala
@@ -42,7 +42,7 @@ case class EntityMatch(decoded: String, end: Int)
 case class CodeSpanMatch(content: Text, end: Int)
 case class AutolinkMatch(link: Prose, end: Int)
 
-object InlineSupport:
+private[punctuation] object InlineSupport:
 
   // CommonMark "ASCII punctuation": !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
   def isAsciiPunctuation(c: Char): Boolean = c match

--- a/lib/punctuation/src/core/punctuation.LinkRefs.scala
+++ b/lib/punctuation/src/core/punctuation.LinkRefs.scala
@@ -40,7 +40,7 @@ import anticipation.*
 // pass; consulted by the inline-parse pass for shortcut/collapsed/full
 // reference links. Stage 4 will populate this from `[label]: dest "title"`
 // definitions in paragraphs; for now it stays empty.
-final class LinkRefs:
+private[punctuation] final class LinkRefs:
   private val table: mutable.LinkedHashMap[Text, Markdown.LinkRef] =
     mutable.LinkedHashMap()
 

--- a/lib/punctuation/src/core/punctuation.ParserSupport.scala
+++ b/lib/punctuation/src/core/punctuation.ParserSupport.scala
@@ -46,7 +46,7 @@ case class OrderedMarker
     contentIndent: Ordinal,
     rest:          Text )
 
-object ParserSupport:
+private[punctuation] object ParserSupport:
 
   // CommonMark treats a tab as advancing to the next 4-column boundary.
   // Block-parser indent counting (`indentColumn`) returns those expanded

--- a/lib/punctuation/src/core/soundness_punctuation_core.scala
+++ b/lib/punctuation/src/core/soundness_punctuation_core.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export punctuation.{ Formattable, Layout, Markdown, Parser, Prose, Translator }
+export
+  punctuation
+  . { BlockBuilder, BlockParser, EmphasisProcessor, Formattable, HtmlEntities, InlineParser,
+      InlineSupport, Layout, LinkRefs, Markdown, Parser, ParserSupport, Prose, Translator }
 
 package formatting:
   export punctuation.formatting.unboundedMarkdownFormatting

--- a/lib/punctuation/src/core/soundness_punctuation_core.scala
+++ b/lib/punctuation/src/core/soundness_punctuation_core.scala
@@ -32,10 +32,7 @@
                                                                                                   */
 package soundness
 
-export
-  punctuation
-  . { BlockBuilder, BlockParser, EmphasisProcessor, Formattable, HtmlEntities, InlineParser,
-      InlineSupport, Layout, LinkRefs, Markdown, Parser, ParserSupport, Prose, Translator }
+export punctuation.{ Formattable, Layout, Markdown, Parser, Prose, Translator }
 
 package formatting:
   export punctuation.formatting.unboundedMarkdownFormatting

--- a/lib/quantitative/src/core/soundness_quantitative_core.scala
+++ b/lib/quantitative/src/core/soundness_quantitative_core.scala
@@ -40,7 +40,7 @@ export
       Metric, MetricUnit, Micro, Milli, Moles, Nano, NoPrefix, Normalizable, Pebi, Peta, Pico,
       Prefixes, Principal, Quantifiable, Quantity, Quecto, Quetta, Rankine, Ratio, Redesignation,
       Ronna, Ronto, Seconds, Tebi, Temperature, TemperatureScale, Tera, Time, Units, Yobi, Yocto,
-      Yotta, Zebi, Zepto, Zetta }
+      Yotta, Zebi, Zepto, Zetta, Rankines }
 
 package temperatureScales:
   export quantitative.temperatureScales.{celsiusScale, fahrenheitScale, kelvinScale, rankineScale}

--- a/lib/savagery/src/core/soundness_savagery_core.scala
+++ b/lib/savagery/src/core/soundness_savagery_core.scala
@@ -36,4 +36,4 @@ export
   savagery
   . { Affine, Circle, Delta, Down, Ellipse, Figure, Left, LinearGradient, Orientation, Outline,
       Point, Rectangle, Right, Segment, Stop, Stroke, Svg, SvgDef, SvgError, SvgId, SvgParser,
-      Sweep, Transform, Up }
+      Sweep, Transform, Transformable, Up }

--- a/lib/scintillate/src/server/soundness_scintillate_server.scala
+++ b/lib/scintillate/src/server/soundness_scintillate_server.scala
@@ -35,7 +35,8 @@ package soundness
 export
   scintillate
   . { Acceptable, basicAuth, cookie, HttpConnection, HttpServer, HttpServerEvent, NoCache, NotFound,
-      Redirect, request, RequestServable, Responder, ServerError, Unfulfilled, WebserverErrorPage }
+      Redirect, request, RequestServable, Responder, ServerError, SocketServer, Unfulfilled,
+      WebserverErrorPage }
 
 package httpServers:
   export scintillate.httpServers.{stdlibHttpServer, stdlibPublicHttpServer}

--- a/lib/stenography/src/core/soundness_stenography_core.scala
+++ b/lib/stenography/src/core/soundness_stenography_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export stenography.{Imports, Syntax, Typename}
+export stenography.{Bindings, Imports, Syntax, Typename}

--- a/lib/stratiform/src/core/soundness_stratiform_core.scala
+++ b/lib/stratiform/src/core/soundness_stratiform_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   stratiform
-  . { DynamicTelEnabler, dynamicTelAccess, Revision, Mutation, MutationError, Tel, Tel2, TelError,
-      Tels, tel }
+  . { DynamicTelEnabler, dynamicTelAccess, Revision, Mutation, MutationError, Stratiform, Tel, Tel2,
+      TelError, TelPath, Tels, Tels2, tel }

--- a/lib/surveillance/src/core/soundness_surveillance_core.scala
+++ b/lib/surveillance/src/core/soundness_surveillance_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export surveillance.{Watch, watch, Watcher, WatchError, WatchEvent}
+export surveillance.{NativeWatcher, PollingWatcher, Watch, watch, Watcher, WatchError, WatchEvent}
 
 package watchers:
   export surveillance.watchers.{nativeWatcher, polling}

--- a/lib/synesthesia/src/core/soundness_synesthesia_core.scala
+++ b/lib/synesthesia/src/core/soundness_synesthesia_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   synesthesia
-  . { about, Agent, Discourse, Human, Mcp, McpClient, McpError, McpServer, McpSession,
-      McpSpecification, prompt, resource, title, tool, ui }
+  . { about, agent, Agent, Discourse, human, Human, Mcp, McpClient, McpError, McpServer,
+      McpSession, McpSpecification, prompt, resource, title, tool, ui }

--- a/lib/telekinesis/src/core/soundness_telekinesis_core.scala
+++ b/lib/telekinesis/src/core/soundness_telekinesis_core.scala
@@ -35,9 +35,9 @@ package soundness
 export
   telekinesis
   . { Acceptance, Auth, AuthError, ConnectError, Context, Cookie, Directive, fetch, Fetchable, Http,
-      HttpClient, HttpError, HttpEvent, HttpRedirection, HttpResponseError, Orchestrate,
-      orchestrate, Parameter, Postable, query, Receivable, Receivable2, Redirects, Servable,
-      Session, Submission, submit, TransferEncoding }
+      HttpClient, HttpError, HttpEvent, HttpRedirection, HttpRequestError, HttpResponseError,
+      Orchestrate, orchestrate, Parameter, Postable, query, Receivable, Receivable2, Redirects,
+      Servable, Session, Submission, submit, TransferEncoding }
 
 package queryParameters:
   export telekinesis.queryParameters.arbitraryQueryParameter

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -38,8 +38,8 @@ export
       defer, Deflate, discard, Document, Documentary, Eof, Err, gunzip, Gzip, gzip, In, inputStream,
       Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
       multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool,
-      Stdio, stream, Streamable, StreamError, StreamOutputStream, strict, take, Tap, Writable,
-      writeTo, Zlib }
+      Readable, Stdio, stream, Streamable, StreamError, StreamOutputStream, strict, take, Tap,
+      Writable, writeTo, Zlib }
 
 package stdios:
   export turbulence.stdios.{muteStdio, systemStdio, virtualMachineStdio}

--- a/lib/urticose/src/core/soundness_urticose_core.scala
+++ b/lib/urticose/src/core/soundness_urticose_core.scala
@@ -36,8 +36,8 @@ export
   urticose
   . { Remotable, EmailAddress, EmailAddressError, Endpoint, Host, Hostname, HostnameError,
       Internet, internet, ip, IpAddressError, Localhost, LocalPart, mac, MacAddressError,
-      OfflineError, Online, online, Allocatable, Port, PortError, Protocolic, Quic, serve, Service,
-      Tcp, tcp, TcpPort, Udp, udp, UdpPort, via }
+      OfflineError, Online, online, Allocatable, Port, PortError, PortType, Protocolic, Quic, serve,
+      Service, subnet, Tcp, tcp, TcpPort, Udp, udp, UdpPort, via }
 
 package internetAccess:
   export urticose.internetAccess.{offline, online}

--- a/lib/xenophile/src/native/soundness_xenophile_native.scala
+++ b/lib/xenophile/src/native/soundness_xenophile_native.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export xenophile.{Native, ForeignLibrary}
+export xenophile.{CHeaderDialect, Native, ForeignLibrary}

--- a/lib/xenophile/src/typescript/soundness_xenophile_typescript.scala
+++ b/lib/xenophile/src/typescript/soundness_xenophile_typescript.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export xenophile.Typescript
+export xenophile.{Typescript, TypescriptDialect}

--- a/lib/xenophile/src/webidl/soundness_xenophile_webidl.scala
+++ b/lib/xenophile/src/webidl/soundness_xenophile_webidl.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export xenophile.WebIdl
+export xenophile.{WebIdl, WebIdlDialect}

--- a/lib/xenophile/src/wit/soundness_xenophile_wit.scala
+++ b/lib/xenophile/src/wit/soundness_xenophile_wit.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export xenophile.Wit
+export xenophile.{Wit, WitDialect}

--- a/lib/xylophone/src/core/soundness_xylophone_core.scala
+++ b/lib/xylophone/src/core/soundness_xylophone_core.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export xylophone.{Xml, XmlError, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess}
+export
+  xylophone
+  . { Xml, XmlError, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess, Attributive, Renderable,
+      Tag, x, xp, XPath, XPathError }
 
 package formatting:
   export xylophone.formatting.{compactXmlFormatting, indentedXmlFormatting}

--- a/lib/xylophone/src/core/soundness_xylophone_core.scala
+++ b/lib/xylophone/src/core/soundness_xylophone_core.scala
@@ -32,10 +32,12 @@
                                                                                                   */
 package soundness
 
+// `Attributive`, `Renderable` and `Tag` clash with `honeycomb`'s names in the umbrella;
+// reach xylophone's via `xylophone.Attributive` etc.
+// unexported: Attributive, Renderable, Tag
 export
   xylophone
-  . { Xml, XmlError, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess, Attributive, Renderable,
-      Tag, x, xp, XPath, XPathError }
+  . { Xml, XmlError, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess, x, xp, XPath, XPathError }
 
 package formatting:
   export xylophone.formatting.{compactXmlFormatting, indentedXmlFormatting}

--- a/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
@@ -32,7 +32,10 @@
                                                                                                   */
 package soundness
 
-export ypsiloid.{Yaml, YamlError, YamlPrimitive}
+export
+  ypsiloid
+  . { Yaml, YamlError, YamlPrimitive, DynamicYamlEnabler, dynamicYamlAccess, y, yp, YamlParser,
+      YamlPath, YamlPathError }
 
 package formatting:
   export ypsiloid.formatting.blockYamlFormatting

--- a/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
+++ b/lib/ypsiloid/src/core/soundness_ypsiloid_core.scala
@@ -34,8 +34,8 @@ package soundness
 
 export
   ypsiloid
-  . { Yaml, YamlError, YamlPrimitive, DynamicYamlEnabler, dynamicYamlAccess, y, yp, YamlParser,
-      YamlPath, YamlPathError }
+  . { Yaml, YamlError, YamlPrimitive, DynamicYamlEnabler, dynamicYamlAccess, y, yp, YamlPath,
+      YamlPathError }
 
 package formatting:
   export ypsiloid.formatting.blockYamlFormatting


### PR DESCRIPTION
`import soundness.*` now surfaces every publicly-accessible module from each component — including the `j`, `jp`, `x`, `xp`, `y`, `yp`, `isin`, `subnet`, `human` and `agent` string interpolators and around forty-five public types that had drifted out of the umbrella's curated export lists — and a new Decorum rule, SN-742, flags any public module a component fails to re-export so the lists cannot silently fall out of sync again.

Interpolators and types that were already public in their own components but missing from the `soundness` umbrella are now reachable directly:

```scala
import soundness.*
val doc  = j"""{ "name": "soundness" }"""   // jacinta, previously unavailable
val node = x"<tag>text</tag>"               // xylophone, previously unavailable
```

Newly re-exported types include `escapade.Hyperlink`, `galilei.Device`, `gastronomy.{Provider, SoundnessHashing, JavaStdlibHashing}`, `scintillate.SocketServer`, `turbulence.Readable`, `telekinesis.HttpRequestError`, `parasite.{Trap, Remedy, AsyncTactic}`, the four `xenophile` dialects, and more.

A new house-style rule, **SN-742**, warns when a component defines a public module (a `<component>.<Name>.scala` file) that its `soundness_<component>_*.scala` surface does not re-export. Where a simple name is deliberately omitted — usually because it already belongs to another component in the umbrella (e.g. `xylophone.Tag` vs `honeycomb.Tag`) — mark it with an `// unexported: Name` directive. Private modules (`private[component]`) and compiler-plugin internals are ignored, so the rule's two remedies are to export a public module or make a genuinely-internal one private (as done here for punctuation's Markdown-parser machinery).