### PR TITLE
Isolate and close per-connection failures in coaxial listen

### DIFF
--- a/lib/coaxial/src/core/coaxial.Bindable.scala
+++ b/lib/coaxial/src/core/coaxial.Bindable.scala
@@ -41,13 +41,11 @@ import frontier.*
 import hypotenuse.*
 import prepositional.*
 import rudiments.*
-import turbulence.*
 import urticose.*
 import vacuous.*
 
 object Bindable:
-  given domainSocket: (Tactic[StreamError], Every[SocketOption.Domain])
-  =>  DomainSocket is Bindable:
+  given domainSocket: Every[SocketOption.Domain] => DomainSocket is Bindable:
     type Binding = jnc.ServerSocketChannel
     type Output = Data
     type Input = Connection
@@ -61,25 +59,33 @@ object Bindable:
         configure(channel, summon[Every[SocketOption.Domain]].values)
         channel.bind(address)
 
-    def connect(channel: jnc.ServerSocketChannel): Connection =
-      val clientChannel: jnc.SocketChannel = channel.accept().nn
-      val in = jnc.Channels.newInputStream(clientChannel).nn
-      val out = jnc.Channels.newOutputStream(clientChannel).nn
+    def connect(channel: jnc.ServerSocketChannel): Connection raises ConnectionError =
+      try
+        val clientChannel: jnc.SocketChannel = channel.accept().nn
+        val in = jnc.Channels.newInputStream(clientChannel).nn
+        val out = jnc.Channels.newOutputStream(clientChannel).nn
 
-      Connection(in, out)
+        Connection(in, out)
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Accept))
 
-    def transmit(channel: jnc.ServerSocketChannel, connection: Connection, bytes: Data): Unit =
-      connection.out.write(bytes.mutable(using Unsafe))
-      connection.out.flush()
+    def transmit(channel: jnc.ServerSocketChannel, connection: Connection, bytes: Data)
+    :   Unit raises ConnectionError =
+
+      try
+        connection.out.write(bytes.mutable(using Unsafe))
+        connection.out.flush()
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Transmit))
 
     def stop(channel: jnc.ServerSocketChannel): Unit =
       channel.close()
 
-    def close(connection: Connection): Unit =
-      connection.in.close()
-      connection.out.close()
+    def close(connection: Connection): Unit raises ConnectionError =
+      try
+        connection.in.close()
+        connection.out.close()
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Close))
 
-  given tcpPort: (Tactic[StreamError], Every[SocketOption.Tcp]) => TcpPort is Bindable:
+  given tcpPort: Every[SocketOption.Tcp] => TcpPort is Bindable:
     type Binding = jn.ServerSocket
     type Output = Data
     type Input = jn.Socket
@@ -93,13 +99,20 @@ object Bindable:
       configure(socket, summon[Every[SocketOption.Tcp]].values)
       socket
 
-    def connect(binding: Binding): jn.Socket = binding.accept().nn
+    def connect(binding: Binding): jn.Socket raises ConnectionError =
+      try binding.accept().nn
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Accept))
 
-    def transmit(socket: jn.ServerSocket, input: Input, bytes: Data): Unit =
-      input.getOutputStream.nn.write(bytes.mutable(using Unsafe))
-      input.getOutputStream.nn.flush()
+    def transmit(socket: jn.ServerSocket, input: Input, bytes: Data): Unit raises ConnectionError =
+      try
+        input.getOutputStream.nn.write(bytes.mutable(using Unsafe))
+        input.getOutputStream.nn.flush()
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Transmit))
 
-    def close(socket: jn.Socket): Unit = socket.close()
+    def close(socket: jn.Socket): Unit raises ConnectionError =
+      try socket.close()
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Close))
+
     def stop(socket: jn.ServerSocket): Unit = socket.close()
 
   given udpPort: Every[SocketOption.Udp] => UdpPort is Bindable:
@@ -116,10 +129,13 @@ object Bindable:
 
       socket
 
-    def connect(binding: Binding): Packet =
+    def connect(binding: Binding): Packet raises ConnectionError =
       val array = new Array[Byte](1472)
       val packet = jn.DatagramPacket(array, 1472)
-      val socket = binding.receive(packet)
+
+      try binding.receive(packet)
+      catch case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Accept))
+
       val address = packet.getSocketAddress.nn.asInstanceOf[jn.InetSocketAddress]
 
       val ip = address.getAddress.nn.absolve match
@@ -139,7 +155,9 @@ object Bindable:
           ip,
           Port.unsafe[Udp](address.getPort) )
 
-    def transmit(socket: jn.DatagramSocket, input: Packet, response: UdpResponse): Unit =
+    def transmit(socket: jn.DatagramSocket, input: Packet, response: UdpResponse)
+    :   Unit raises ConnectionError =
+
       response match
         case UdpResponse.Ignore => ()
 
@@ -162,10 +180,12 @@ object Bindable:
           val packet =
             jn.DatagramPacket(data.mutable(using Unsafe), data.length, ip, input.port.number)
 
-          socket.send(packet)
+          try socket.send(packet)
+          catch
+            case _: java.io.IOException => abort(ConnectionError(ConnectionError.Reason.Transmit))
 
     def stop(binding: Binding): Unit = binding.close()
-    def close(input: Packet): Unit = ()
+    def close(input: Packet): Unit raises ConnectionError = ()
 
 trait Bindable extends Typeclass:
   type Binding
@@ -173,7 +193,7 @@ trait Bindable extends Typeclass:
   type Output
 
   def bind(socket: Self, interface: Optional[MacAddress]): Binding
-  def connect(binding: Binding): Input
-  def transmit(binding: Binding, input: Input, output: Output): Unit
-  def close(connection: Input): Unit
+  def connect(binding: Binding): Input raises ConnectionError
+  def transmit(binding: Binding, input: Input, output: Output): Unit raises ConnectionError
+  def close(connection: Input): Unit raises ConnectionError
   def stop(binding: Binding): Unit

--- a/lib/coaxial/src/core/coaxial.ConnectionError.scala
+++ b/lib/coaxial/src/core/coaxial.ConnectionError.scala
@@ -30,16 +30,20 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package coaxial
 
-export
-  coaxial
-  . { Bindable, BindError, Connectable, Connection, ConnectionError, Control, DomainSocket,
-      DomainSocketEndpoint, duplex, Duplex, exchange, Ingressive, listen, Packet, Routable,
-      Serviceable, SocketOption, SocketService, Transmissible, transmit, UdpResponse }
+import fulminate.*
 
-package socketOptions:
-  export
-    coaxial.socketOptions
-    . { reuseAddressSocketOption, reusePortSocketOption, noDelaySocketOption, keepAliveSocketOption,
-        broadcastSocketOption, receiveBuffer, sendBuffer, linger, trafficClass, timeout }
+object ConnectionError:
+  enum Reason(val number: Int) extends Clarification:
+    case Accept   extends Reason(1)
+    case Transmit extends Reason(2)
+    case Close    extends Reason(3)
+
+  given communicable: Reason is Communicable =
+    case Reason.Accept   => m"a new connection could not be accepted"
+    case Reason.Transmit => m"data could not be transmitted to the connection"
+    case Reason.Close    => m"the connection could not be closed cleanly"
+
+case class ConnectionError(reason: ConnectionError.Reason)(using Diagnostics)
+extends Error(266, reason.number)(m"the connection failed because $reason")

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -62,24 +62,21 @@ extension [bindable: Bindable](socket: bindable)
     val binding = bindable.bind(socket, interface)
 
     // Each accepted connection is handled on its own daemon, so connections are served
-    // concurrently and a failure in one — a handler error or a dropped client — is
-    // isolated by the trap (it ends that connection's daemon and the loop keeps
-    // accepting) rather than tearing down the whole accept loop.
+    // concurrently and a per-connection failure — a handler error, a dropped client, or a
+    // failure to write the reply — surfaces as a raised `ConnectionError` that the trap below
+    // turns into `Remedy.Accept`, ending only that connection's daemon while the accept loop
+    // keeps running. The connection is always closed afterwards. A failure to *accept* a
+    // connection runs on the loop thread (not a daemon), so `safely` skips that iteration; on
+    // `stop()` the loop is already `Stopping`, so the interrupted `accept()` simply unwinds.
     trap:
       case _ => Remedy.Accept
 
     . within:
         val bindLoop = loop:
-          val connection = bindable.connect(binding)
-
-          daemon:
-            // A reply write can lose the race with `stop()` closing the socket; the resulting
-            // `IOException` (e.g. `SocketException`/`ClosedChannelException`) is benign connection
-            // teardown. Raw Java throwables bypass the `trap` above (which routes only
-            // `fulminate.Error`), so they would otherwise escalate to the uncaught-exception
-            // handler and print.
-            try bindable.transmit(binding, connection, lambda(connection))
-            catch case _: java.io.IOException => ()
+          safely(bindable.connect(binding)).let: connection =>
+            daemon:
+              try bindable.transmit(binding, connection, lambda(connection))
+              finally bindable.close(connection)
 
         val task = async(bindLoop.run())
 


### PR DESCRIPTION
A coaxial server started with `listen` now survives a failure in any single
connection and always closes each connection it accepts. Previously a reply
write to a connection the peer had already closed threw an `IOException` that
escaped the accept loop and silently killed the whole server — it still
reported as running but accepted nothing further — and accepted connections
were never closed, leaking sockets until garbage collection. Per-connection
I/O failures are now surfaced as a typed `ConnectionError` that flows through
parasite's `trap`/`Remedy` machinery, so one bad connection ends only its own
handler while the loop keeps accepting.

This fixes issue #1286.

The `Bindable` typeclass's `connect`, `transmit` and `close` operations now
declare a `ConnectionError` error effect, converting the underlying Java
`IOException`s into a `fulminate.Error`:

```scala
def connect(binding: Binding): Input raises ConnectionError
def transmit(binding: Binding, input: Input, output: Output): Unit raises ConnectionError
def close(connection: Input): Unit raises ConnectionError
```

Inside `listen`, each connection is handled on its own daemon whose raised
`ConnectionError` is routed to the loop's trap as `Remedy.Accept`, and the
connection is closed in a `finally`. A failure to *accept* a connection no
longer tears down the listener — that iteration is skipped and the loop
continues. No change is required at call sites: `port.listen[Data](handler)`
works exactly as before.