### PR TITLE
Fix Http.Method.payload crashing through the erased base type

### DIFF
--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -99,18 +99,53 @@ object Http:
       case t"GET"     => Http.Get
       case _          => Http.Get
 
-  sealed trait Method(tracked val payload: Boolean):
+  sealed trait Method:
+    // `Payload` carries, at the type level, whether this method has a request
+    // body (e.g. `Get.Payload =:= false`, `Post.Payload =:= true`). It has no
+    // runtime accessor, so — unlike the former `tracked val payload` — it can
+    // never throw `AbstractMethodError` when read through the erased `Method`
+    // base type (issue #1307). `payload` is the safe runtime counterpart.
+    type Payload <: Boolean
+
+    def payload: Boolean = this match
+      case Get     => valueOf[Get.Payload]
+      case Head    => valueOf[Head.Payload]
+      case Post    => valueOf[Post.Payload]
+      case Put     => valueOf[Put.Payload]
+      case Delete  => valueOf[Delete.Payload]
+      case Connect => valueOf[Connect.Payload]
+      case Options => valueOf[Options.Payload]
+      case Trace   => valueOf[Trace.Payload]
+      case Patch   => valueOf[Patch.Payload]
+
     def unapply(request: Request): Boolean = request.method == this
 
-  case object Get extends Method(false)
-  case object Head extends Method(false)
-  case object Post extends Method(true)
-  case object Put extends Method(true)
-  case object Delete extends Method(false)
-  case object Connect extends Method(false)
-  case object Options extends Method(false)
-  case object Trace extends Method(false)
-  case object Patch extends Method(false)
+  case object Get extends Method:
+    type Payload = false
+
+  case object Head extends Method:
+    type Payload = false
+
+  case object Post extends Method:
+    type Payload = true
+
+  case object Put extends Method:
+    type Payload = true
+
+  case object Delete extends Method:
+    type Payload = false
+
+  case object Connect extends Method:
+    type Payload = false
+
+  case object Options extends Method:
+    type Payload = false
+
+  case object Trace extends Method:
+    type Payload = false
+
+  case object Patch extends Method:
+    type Payload = false
 
   object Status:
     private lazy val all: Map[Int, Status] =

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -348,6 +348,23 @@ object Tests extends Suite(m"Telekinesis tests"):
 
         . assert(_ == method)
 
+      test(m"Read payload flag through erased Http.Method type"):
+        val method: Http.Method = Http.Post
+        method.payload
+
+      . assert(_ == true)
+
+      test(m"Read payload flag for a bodyless method through erased type"):
+        val method: Http.Method = Http.Get
+        method.payload
+
+      . assert(_ == false)
+
+      test(m"Payload flag is available at the type level"):
+        valueOf[Http.Post.Payload]
+
+      . assert(_ == true)
+
       test(m"Parse HTTP/1.0 version"):
         val fixture = t"GET / HTTP/1.0\r\nHost: example.com\r\n\r\n"
         Http.Request.parse(chunks(fixture, 4096)).version


### PR DESCRIPTION
`Http.Method.payload` previously threw `AbstractMethodError` at runtime whenever it was read through a value typed as the base `Http.Method`, because the flag was carried as an experimental `tracked val` whose accessor was only constant-folded on each method's precise type. The flag is now carried as a `type Payload <: Boolean` member, which has no runtime accessor and so cannot crash, alongside an ordinary concrete `def payload: Boolean` for safe runtime reads.

`Http.Method` now exposes a type-level `Payload` member recording whether each method carries a request body (`Http.Get.Payload =:= false`, `Http.Post.Payload =:= true`), and a `payload: Boolean` accessor that is safe to read through the erased `Http.Method` type:

```scala
val method: Http.Method = request.method
if method.payload then handleBody()   // no longer throws

summon[Http.Post.Payload =:= true]     // body carried, known statically
```

The per-method values are unchanged (`Post` and `Put` carry a body; all others do not).

Closes #1307.