### PR TITLE
Validate date literals at compile time and add a hybrid calendar Regime

### DIFF
--- a/lib/aviation/src/core/aviation.Month.scala
+++ b/lib/aviation/src/core/aviation.Month.scala
@@ -63,6 +63,19 @@ object Month:
 
     def subtract(year: Int, month: Month) = new Monthstamp(Year(year), month)
 
+  // An inline-friendly counterpart so that, after inlining, `year - month` is the literal
+  // construction `Monthstamp(Year(year), month)` — letting the `Monthstamp - day` macro recover
+  // the year and month from the operand tree. The `Subtractable` above remains the result-type
+  // witness and the fallback for non-operator call sites.
+  final class MonthOfYear extends SubOp:
+    type Self = Int
+    type Operand = Month
+    type Result = Monthstamp
+
+    inline def op(left: Int, right: Month): Monthstamp = Monthstamp(Year(left), right)
+
+  inline given monthOfYearOp: MonthOfYear = MonthOfYear()
+
   given showable: (months: Months) => Month is Showable = months.name(_)
 
   given subtractable: Month is Subtractable:

--- a/lib/aviation/src/core/aviation.Monthstamp.scala
+++ b/lib/aviation/src/core/aviation.Monthstamp.scala
@@ -50,11 +50,26 @@ object Monthstamp:
           t"${monthstamp.month}${separation.separator}${monthstamp.year}"
 
 
+  // The result-type witness and the fallback for non-operator call sites; defaults to the
+  // Gregorian calendar, preserving the historical behaviour of `monthstamp - day`.
   given subtractable: Monthstamp is Subtractable:
     type Result = Date
     type Operand = Int
 
     def subtract(monthstamp: Monthstamp, day: Int): Date =
       unsafely(calendars.gregorianCalendar.jdn(monthstamp.year, monthstamp.month, Day(day)))
+
+  // The inline path the `-` operator prefers: when the year, month and day are all literals it
+  // validates the date at compile time against the contextually-resolved calendar (raising a
+  // compile error for e.g. `2012-Feb-30`); otherwise it falls back to a runtime check.
+  final class MonthstampSubtraction extends SubOp:
+    type Self = Monthstamp
+    type Operand = Int
+    type Result = Date
+
+    inline def op(left: Monthstamp, right: Int): Date =
+      ${aviation.internal.monthstampMinus('left, 'right)}
+
+  inline given monthstampSubtraction: MonthstampSubtraction = MonthstampSubtraction()
 
 case class Monthstamp(year: Year, month: Month)

--- a/lib/aviation/src/core/aviation.Regime.scala
+++ b/lib/aviation/src/core/aviation.Regime.scala
@@ -30,78 +30,70 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, Anniversary, Apr, Aug, Base24, base24Extractable, Base60, base60Extractable, Calendar,
-      Chronology, Clock, Clockface, Date, DateNumerics, DateSeparation, Day, days, Dec, Duration,
-      Endianness, Feb, Fri, Hebdomad, Holiday, Holidays, Horology, hours, Instant, Iso8601, Jan,
-      Jul, Jun, LeapSeconds, Mar, May, Meridiem, minutes, Moment, Mon, Month, Months, months,
-      Monthstamp, Nov, now, Oct, Period, pm, Regime, Rfc1123, RomanCalendar, Sat, seconds, Sep,
-      StandardTime, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics, TimeSeparation,
-      Timespan, TimeSpecificity, Timestamp, TimestampError, Timezone, TimezoneError, today, ts,
-      tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Weekday, Weekdays, weeks, WorkingDays, Year,
-      Years, years }
+import anticipation.*
+import contingency.*
+import fulminate.*
+import vacuous.*
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, papalCutover, britishCutover}
+// A `Regime` is the calendar in force as it changed through history: an ordered sequence of
+// segments, each handing over to the next at a Julian day number. Because the Julian day number is
+// a calendar-independent axis, a date is located in whichever segment governs it, and translation
+// across a boundary is automatic. The two-segment case is a Julian-to-Gregorian hybrid; the dates
+// that exist in neither adjacent calendar (the cutover gap, e.g. 1582-10-05..14) are rejected.
+object Regime:
+  case class Segment(from: Date, calendar: RomanCalendar)
 
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
+  def apply(name: Text, segments: Segment*): Regime =
+    new Regime(name, segments.to(List).sortBy(_.from.jdn))
 
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
+class Regime(name: Text, segments: List[Regime.Segment]) extends RomanCalendar(name):
+  import Regime.Segment
 
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
+  // Each segment paired with the inclusive upper Julian-day bound at which the next takes over. The
+  // bound is the next segment's first day: the two calendars are aligned so that the last day of
+  // one and the first day of the next share a Julian day number (Julian 1582-10-04 and Gregorian
+  // 1582-10-15 are the same day), so that shared day is valid under both — the bound is inclusive.
+  private val bounded: List[(Segment, Int)] =
+    segments.zip(segments.drop(1).map(_.from.jdn) :+ Int.MaxValue)
 
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
+  // The calendar governing a Julian day number: the latest segment to have taken effect by then.
+  private def at(date: Date): RomanCalendar =
+    bounded.filter(_(0).from.jdn <= date.jdn).lastOption.map(_(0).calendar).getOrElse:
+      segments.head.calendar
 
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
+  // The regime's Julian day number for a field date, or `Unset` if it falls in a gap between two
+  // calendars (e.g. 1582-10-10 under the Papal cutover) or is otherwise an invalid date.
+  private def locate(year: Year, month: Month, day: Day): Optional[Date] =
+    def recur(remaining: List[(Segment, Int)]): Optional[Date] = remaining match
+      case (segment, upper) :: tail =>
+        val candidate: Optional[Date] = safely(segment.calendar.jdn(year, month, day))
+        val jdn: Optional[Int] = candidate.let(_.jdn)
 
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
+        if jdn.present && segment.from.jdn <= jdn.vouch && jdn.vouch <= upper
+        then candidate
+        else recur(tail)
 
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
+      case Nil =>
+        Unset
 
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
+    recur(bounded)
 
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
+  // The calendar governing a year, sampled at its midpoint (never inside a historical cutover gap).
+  private def governing(year: Year): RomanCalendar =
+    locate(year, Jun, Day(15)).let(at).or(segments.last.calendar)
 
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
+  override def annual(date: Date): Year = at(date).annual(date)
+  override def mensual(date: Date): Month = at(date).mensual(date)
+  override def diurnal(date: Date): Day = at(date).diurnal(date)
 
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
+  def leapYear(year: Year): Boolean = governing(year).leapYear(year)
+  def leapYearsSinceEpoch(year: Year): Int = governing(year).leapYearsSinceEpoch(year)
 
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
+  override def jdn(year: Year, month: Month, day: Day): Date raises TimeError =
+    val located = locate(year, month, day)
 
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+    if located.present then located.vouch else
+      raise(TimeError(_.Invalid(year(), month.numerical, day(), this)))
+      Date.julianDay(0)

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -313,6 +313,86 @@ object internal:
         result
 
 
+  // The inline `Monthstamp - day` operator splices here. When the year, month and day are all
+  // compile-time literals (the `2012-Mar-8` form), validate the date against the Gregorian
+  // calendar at compile time and emit its Julian day number directly. Otherwise emit the runtime
+  // check, preserving today's behaviour. (Calendar-awareness is layered on in a later step.)
+  def monthstampMinus(left: Expr[Monthstamp], right: Expr[Int]): Macro[Date] =
+    import quotes.reflect.*
+
+    // `underlyingArgument` beta-reduces the inlined operators and exposes the proxy-val bindings as
+    // part of the tree; gather every `ValDef` so proxy references can be followed to their values.
+    val leftTree = left.asTerm.underlyingArgument
+    val rightTree = right.asTerm.underlyingArgument
+
+    val collector = new TreeAccumulator[Map[Symbol, Term]]:
+      def foldTree(env: Map[Symbol, Term], tree: Tree)(owner: Symbol): Map[Symbol, Term] =
+        val env2 = tree match
+          case valDef: ValDef => valDef.rhs match
+            case Some(rhs) => env.updated(valDef.symbol, rhs)
+            case None      => env
+
+          case _ =>
+            env
+
+        foldOverTree(env2, tree)(owner)
+
+    val owner = Symbol.spliceOwner
+    val leftEnv = collector.foldTree(Map(), leftTree)(owner)
+    val env: Map[Symbol, Term] = collector.foldTree(leftEnv, rightTree)(owner)
+
+    // Matches the synthesized `asInstanceOf`/`$asInstanceOf$` casts inlining inserts.
+    object Cast:
+      def unapply(term: Term): Option[Term] = term match
+        case TypeApply(Select(body, "asInstanceOf" | "$asInstanceOf$"), _) => Some(body)
+        case _                                                             => None
+
+    // Strip the wrappers inlining inserts (`Typed`, `Block`, `Inlined`, casts) and follow proxy
+    // `Ident`s to their bound right-hand sides.
+    def strip(term: Term): Term = term match
+      case Inlined(_, _, body)                         => strip(body)
+      case Typed(body, _)                              => strip(body)
+      case Block(_, body)                              => strip(body)
+      case Cast(body)                                  => strip(body)
+      case ident: Ident if env.contains(ident.symbol)  => strip(env(ident.symbol))
+      case _                                           => term
+
+    // An `Int` constant, also peering through opaque wrappers like `Year(_)`/`Day(_)`.
+    def constInt(term: Term): Optional[Int] = strip(term) match
+      case Literal(IntConstant(value))                       => value
+      case Apply(fn, List(arg)) if fn.symbol.name == "apply" => constInt(arg)
+      case _                                                 => Unset
+
+    // The zero-based ordinal of a `Month` enum-case reference (e.g. `Mar`).
+    def monthOrdinal(term: Term): Optional[Int] =
+      monthNames.indexOf(strip(term).symbol.name) match
+        case -1      => Unset
+        case ordinal => ordinal
+
+    // The runtime check, used whenever the operands aren't all compile-time literals; defaults to
+    // the Gregorian calendar, preserving today's behaviour.
+    def runtime: Expr[Date] =
+      '{unsafely(calendars.gregorianCalendar.jdn($left.year, $left.month, Day($right)))}
+
+    // Validate a literal `Monthstamp(Year(y), month)` minus a literal `day` at compile time. Note
+    // the plain control flow (no `Optional.lay`/`let` around the quoted trees): wrapping inline
+    // `Optional` combinators around quotes crashes the compiler in `pickleQuotes`.
+    strip(leftTree) match
+      case Apply(fn, List(yearArg, monthArg))
+      if fn.symbol.name == "apply" || fn.symbol.name == "<init>" =>
+        val year = constInt(yearArg)
+        val month = monthOrdinal(monthArg)
+        val day = constInt(rightTree)
+
+        if !(year.present && month.present && day.present) then runtime
+        else jdnOf(year.vouch, month.vouch + 1, day.vouch) match
+          case Right(jdn)  => '{Date.julianDay(${Expr(jdn)})}
+          case Left(error) => halt(error)
+
+      case _ =>
+        runtime
+
+
   def validTime(time: Expr[Double], pm: Boolean): Macro[Clockface] =
     import quotes.reflect.*
 

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -386,16 +386,19 @@ object internal:
       val calendar = summoned.getOrElse('{calendars.gregorianCalendar})
       '{unsafely($calendar.jdn($left.year, $left.month, Day($right)))}
 
-    // Identify a contextual calendar as one whose validation we can run here, or `Unset` if it is a
-    // user calendar we don't recognise (in which case compile-time validation is skipped).
-    val gregorianSymbol = strip('{calendars.gregorianCalendar}.asTerm).symbol
-    val julianSymbol = strip('{calendars.julianCalendar}.asTerm).symbol
-
+    // Identify a contextual calendar as one of this module's calendar givens (matched by leaf name,
+    // since it may be reached through the `soundness` re-export rather than its `aviation` origin;
+    // the `.calendars.` guard stops an unrelated user calendar being misidentified), or `Unset` if
+    // we don't recognise it, in which case compile-time validation is skipped.
     def recognise(expr: Expr[RomanCalendar]): Optional[RomanCalendar] =
-      strip(expr.asTerm).symbol match
-        case `gregorianSymbol` => calendars.gregorianCalendar
-        case `julianSymbol`    => calendars.julianCalendar
-        case _                 => Unset
+      val symbol = strip(expr.asTerm).symbol
+
+      if !symbol.fullName.contains(".calendars.") then Unset else symbol.name match
+        case "gregorianCalendar" => calendars.gregorianCalendar
+        case "julianCalendar"    => calendars.julianCalendar
+        case "papalCutover"      => calendars.papalCutover
+        case "britishCutover"    => calendars.britishCutover
+        case _                   => Unset
 
     // The calendar to validate against at compile time: the recognised contextual one, or the
     // Gregorian default when none is in scope.

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -180,17 +180,19 @@ object internal:
       """(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) """ +
       """(\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT""").r
 
-  // Validate a date against the Gregorian calendar (rejecting e.g. month 13 or 31 February)
-  // and return its Julian day number, which the macro emits directly via `Date.julianDay`.
-  private def jdnOf(year: Int, month: Int, day: Int): Either[Message, Int] =
-    import calendars.gregorianCalendar
+  // Validate a date against the given calendar (rejecting e.g. month 13 or 31 February) and return
+  // its Julian day number, which the macro emits directly via `Date.julianDay`.
+  private def jdnOf(calendar: RomanCalendar, year: Int, month: Int, day: Int)
+  :   Either[Message, Int] =
 
     if month < 1 || month > 12 then Left(m"$month is not a valid month number")
     else
       val computed: Optional[Int] =
-        safely(Date(Year(year), Month.fromOrdinal(month - 1), Day(day)).jdn)
+        safely(calendar.jdn(Year(year), Month.fromOrdinal(month - 1), Day(day)).jdn)
 
-      computed.lay(Left(m"$year-$month-$day is not a valid date"))(Right(_))
+      val invalid = m"$year-$month-$day is not a valid date in the ${calendar.name} calendar"
+
+      computed.lay(Left(invalid))(Right(_))
 
   private def checkTime(hour: Int, minute: Int, second: Int): Either[Message, Unit] =
     if hour > 23 then Left(m"$hour is not a valid hour")
@@ -241,13 +243,16 @@ object internal:
       else Right(TsParsed.MonthOnly(year.nn.toInt, monthValue))
 
     case IsoPattern(year, month, day, null, _, _, _, _) =>
-      jdnOf(year.nn.toInt, month.nn.toInt, day.nn.toInt).map(TsParsed.DateOnly(_))
+      jdnOf(calendars.gregorianCalendar, year.nn.toInt, month.nn.toInt, day.nn.toInt)
+      . map(TsParsed.DateOnly(_))
 
     case IsoPattern(year, month, day, hour, minute, second, frac, zone) =>
       val secondValue = if second == null then 0 else second.nn.toInt
       val nanos = if frac == null then 0 else (frac.nn + "000000000").take(9).toInt
 
-      jdnOf(year.nn.toInt, month.nn.toInt, day.nn.toInt).flatMap: jdn =>
+      val parsed = jdnOf(calendars.gregorianCalendar, year.nn.toInt, month.nn.toInt, day.nn.toInt)
+
+      parsed.flatMap: jdn =>
         isoTime(jdn, hour.nn.toInt, minute.nn.toInt, secondValue, nanos, zone)
 
     case _ =>
@@ -260,7 +265,9 @@ object internal:
       val secondValue = second.nn.toInt
       val monthValue = monthNames.indexOf(month.nn) + 1
 
-      jdnOf(year.nn.toInt, monthValue, day.nn.toInt).flatMap: jdn =>
+      val parsed = jdnOf(calendars.gregorianCalendar, year.nn.toInt, monthValue, day.nn.toInt)
+
+      parsed.flatMap: jdn =>
         checkTime(hourValue, minuteValue, secondValue).map: _ =>
           TsParsed.ZoneOnly(jdn, hourValue, minuteValue, secondValue, 0, "GMT")
 
@@ -369,10 +376,31 @@ object internal:
         case -1      => Unset
         case ordinal => ordinal
 
+    // The calendar contextually in scope, if any. Used at runtime for the deferred check, and at
+    // compile time when we recognise it as one whose validation we can run here.
+    val summoned: Option[Expr[RomanCalendar]] = Expr.summon[RomanCalendar]
+
     // The runtime check, used whenever the operands aren't all compile-time literals; defaults to
-    // the Gregorian calendar, preserving today's behaviour.
+    // the Gregorian calendar when nothing is in scope, preserving today's behaviour.
     def runtime: Expr[Date] =
-      '{unsafely(calendars.gregorianCalendar.jdn($left.year, $left.month, Day($right)))}
+      val calendar = summoned.getOrElse('{calendars.gregorianCalendar})
+      '{unsafely($calendar.jdn($left.year, $left.month, Day($right)))}
+
+    // Identify a contextual calendar as one whose validation we can run here, or `Unset` if it is a
+    // user calendar we don't recognise (in which case compile-time validation is skipped).
+    val gregorianSymbol = strip('{calendars.gregorianCalendar}.asTerm).symbol
+    val julianSymbol = strip('{calendars.julianCalendar}.asTerm).symbol
+
+    def recognise(expr: Expr[RomanCalendar]): Optional[RomanCalendar] =
+      strip(expr.asTerm).symbol match
+        case `gregorianSymbol` => calendars.gregorianCalendar
+        case `julianSymbol`    => calendars.julianCalendar
+        case _                 => Unset
+
+    // The calendar to validate against at compile time: the recognised contextual one, or the
+    // Gregorian default when none is in scope.
+    val staticCalendar: Optional[RomanCalendar] =
+      summoned.map(recognise).getOrElse(calendars.gregorianCalendar)
 
     // Validate a literal `Monthstamp(Year(y), month)` minus a literal `day` at compile time. Note
     // the plain control flow (no `Optional.lay`/`let` around the quoted trees): wrapping inline
@@ -384,10 +412,16 @@ object internal:
         val month = monthOrdinal(monthArg)
         val day = constInt(rightTree)
 
-        if !(year.present && month.present && day.present) then runtime
-        else jdnOf(year.vouch, month.vouch + 1, day.vouch) match
-          case Right(jdn)  => '{Date.julianDay(${Expr(jdn)})}
-          case Left(error) => halt(error)
+        val literal = year.present && month.present && day.present
+
+        if !literal then runtime else staticCalendar match
+          case calendar: RomanCalendar =>
+            jdnOf(calendar, year.vouch, month.vouch + 1, day.vouch) match
+              case Right(jdn)  => '{Date.julianDay(${Expr(jdn)})}
+              case Left(error) => halt(error)
+
+          case _ =>
+            runtime
 
       case _ =>
         runtime

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -295,6 +295,21 @@ package calendars:
     def leapYear(year: Annual): Boolean = year()%4 == 0 && year()%100 != 0 || year()%400 == 0
     def leapYearsSinceEpoch(year: Year): Int = year()/4 - year()/100 + year()/400 + 1
 
+  // The Julian-to-Gregorian cutovers of the two best-known reforms, as two-segment `Regime`s. The
+  // first day of each segment is given as a Julian day number; the gap between (the dates in
+  // neither calendar) is rejected. Provided for explicit import, like the calendars above.
+  given papalCutover: Regime =
+    Regime
+      ( t"Papal",
+        Regime.Segment(Date.julianDay(Int.MinValue), julianCalendar),
+        Regime.Segment(Date.julianDay(2299161), gregorianCalendar) )
+
+  given britishCutover: Regime =
+    Regime
+      ( t"British",
+        Regime.Segment(Date.julianDay(Int.MinValue), julianCalendar),
+        Regime.Segment(Date.julianDay(2361222), gregorianCalendar) )
+
   package nonexistentLeapDays:
     given roundUpLeapDay: Anniversary.NonexistentLeapDay = year =>
       import calendars.gregorianCalendar

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -176,6 +176,21 @@ object Tests extends Suite(m"Aviation Tests"):
         (2012-Mar-8)
       . assert(_ == ts"2012-03-08")
 
+      test(m"1900-Feb-29 fails to compile under the default Gregorian calendar"):
+        demilitarize((1900-Feb-29).jdn)
+      . assert(_.nonEmpty)
+
+      test(m"1900-Feb-29 compiles under a contextual Julian calendar"):
+        demilitarize:
+          import calendars.julianCalendar
+          (1900-Feb-29).jdn
+      . assert(_.isEmpty)
+
+      test(m"A contextual Julian calendar yields the Julian Julian-day for the literal"):
+        import calendars.julianCalendar
+        (1900-Feb-29).jdn
+      . assert(_ == unsafely(calendars.julianCalendar.jdn(Year(1900), Feb, Day(29))).jdn)
+
       test(m"Check recent Julian Day"):
         (2022-Dec-16).jdn
       . assert(_ == 2459930)

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -187,7 +187,7 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_.isEmpty)
 
       test(m"A contextual Julian calendar yields the Julian Julian-day for the literal"):
-        import calendars.julianCalendar
+        given julian: RomanCalendar = calendars.julianCalendar
         (1900-Feb-29).jdn
       . assert(_ == unsafely(calendars.julianCalendar.jdn(Year(1900), Feb, Day(29))).jdn)
 
@@ -359,6 +359,55 @@ object Tests extends Suite(m"Aviation Tests"):
       // test(m"Read TZDB file"):
       //   Tzdb.parseFile(t"europe")
       // .assert(_ == List())
+
+    suite(m"Regime / calendar cutover tests"):
+      test(m"Papal cutover accepts the last Julian date"):
+        given papal: Regime = calendars.papalCutover
+        (1582-Oct-4).jdn
+      . assert(_ == 2299161)
+
+      test(m"Papal cutover accepts the first Gregorian date"):
+        given papal: Regime = calendars.papalCutover
+        (1582-Oct-15).jdn
+      . assert(_ == 2299161)
+
+      test(m"The last Julian day and first Gregorian day are the same day"):
+        given papal: Regime = calendars.papalCutover
+        (1582-Oct-15).jdn == (1582-Oct-4).jdn
+      . assert(_ == true)
+
+      test(m"Papal cutover rejects a gap date at compile time"):
+        demilitarize:
+          import calendars.papalCutover
+          (1582-Oct-10).jdn
+      . assert(_.nonEmpty)
+
+      test(m"Papal cutover rejects a gap date at runtime"):
+        import calendars.papalCutover
+        val day = 10
+        capture((1582-Oct-day).jdn)
+      . assert(_ == TimeError(_.Invalid(1582, 10, 10, calendars.papalCutover)))
+
+      test(m"A pre-cutover date uses the Julian calendar under the Papal regime"):
+        given papal: Regime = calendars.papalCutover
+        (1500-Mar-10).jdn
+      . assert(_ == unsafely(calendars.julianCalendar.jdn(Year(1500), Mar, Day(10))).jdn)
+
+      test(m"A post-cutover date uses the Gregorian calendar under the Papal regime"):
+        given papal: Regime = calendars.papalCutover
+        (1700-Mar-10).jdn
+      . assert(_ == unsafely(calendars.gregorianCalendar.jdn(Year(1700), Mar, Day(10))).jdn)
+
+      test(m"British cutover rejects a date in its gap at compile time"):
+        demilitarize:
+          import calendars.britishCutover
+          (1752-Sep-5).jdn
+      . assert(_.nonEmpty)
+
+      test(m"British cutover accepts the day after its gap"):
+        given british: Regime = calendars.britishCutover
+        (1752-Sep-14).jdn
+      . assert(_ == 2361222)
 
     suite(m"Decoding instants"):
       suite(m"ISO 8601"):

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -148,6 +148,34 @@ object Tests extends Suite(m"Aviation Tests"):
         List(Year(1985), Year(200), Year(202), Year(1843)).map(calendars.gregorianCalendar.leapYear)
       . assert(_.all(!_))
 
+      test(m"A valid literal date compiles"):
+        demilitarize((2012-Mar-8).jdn)
+      . assert(_.isEmpty)
+
+      test(m"An impossible day-of-month literal fails to compile"):
+        demilitarize((2012-Feb-30).jdn)
+      . assert(_.nonEmpty)
+
+      test(m"A 31st of a thirty-day-month literal fails to compile"):
+        demilitarize((2012-Apr-31).jdn)
+      . assert(_.nonEmpty)
+
+      test(m"A non-leap-year 29 February literal fails to compile"):
+        demilitarize((2011-Feb-29).jdn)
+      . assert(_.nonEmpty)
+
+      test(m"A leap-year 29 February literal compiles"):
+        demilitarize((2012-Feb-29).jdn)
+      . assert(_.isEmpty)
+
+      test(m"A zero day-of-month literal fails to compile"):
+        demilitarize((2012-Mar-0).jdn)
+      . assert(_.nonEmpty)
+
+      test(m"A literal date equals its `ts` string counterpart"):
+        (2012-Mar-8)
+      . assert(_ == ts"2012-03-08")
+
       test(m"Check recent Julian Day"):
         (2022-Dec-16).jdn
       . assert(_ == 2459930)


### PR DESCRIPTION
Aviation date literals such as `2012-Mar-8` are now validated at compile time against the contextually-resolved calendar, and a new `Regime` calendar models the historical Julian-to-Gregorian cutovers so that dates which never existed are rejected.

Previously a date literal like `2012-Feb-30` compiled and only threw when evaluated, and the literal form always assumed the Gregorian calendar. Now, when the year, month and day are literals, the date is checked as it is written:

```scala
val valid = 2012-Mar-8        // compiles
val wrong = 2012-Feb-30       // compile error: not a valid date
```

The check uses whichever calendar is in contextual scope. Importing a different calendar changes which literals are valid:

```scala
import calendars.julianCalendar
val leap = 1900-Feb-29        // valid in the Julian calendar; a compile error under Gregorian
```

A `Regime` is the calendar in force as it changed through history — an ordered sequence of calendars, each taking over from the previous one at a given day. The two best-known Julian-to-Gregorian reforms are provided as `calendars.papalCutover` and `calendars.britishCutover`, and dates falling in a cutover gap are rejected:

```scala
import calendars.papalCutover
val skipped = 1582-Oct-10     // compile error: this date was skipped by the 1582 reform
```

Non-literal expressions, and calendars the compiler doesn't recognise, fall back to a runtime check as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)