### PR TITLE
Enable contrast expectations in tests by default

### DIFF
--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -91,7 +91,7 @@ object Contrastable:
     given int: Int is Contrastable.Foundation = long.juxtaposition(_, _)
     given short: Short is Contrastable.Foundation = long.juxtaposition(_, _)
     given byte: Byte is Contrastable.Foundation = long.juxtaposition(_, _)
-    given float: Byte is Contrastable.Foundation = long.juxtaposition(_, _)
+    given float: Float is Contrastable.Foundation = double.juxtaposition(_, _)
 
     given set: [element: Showable] => Set[element] is Contrastable.Foundation =
       (left, right) =>

--- a/lib/probably/src/core/probably.Autopsy.scala
+++ b/lib/probably/src/core/probably.Autopsy.scala
@@ -32,5 +32,9 @@
                                                                                                   */
 package probably
 
+object Autopsy:
+  given contrastByDefault: Autopsy:
+    type Analyse = true
+
 trait Autopsy:
   type Analyse <: Boolean

--- a/lib/probably/src/core/probably.internal.scala
+++ b/lib/probably/src/core/probably.internal.scala
@@ -89,44 +89,10 @@ object internal:
           case Some('{type analyse; $autopsy: (Autopsy { type Analyse = analyse })}) =>
             TypeRepr.of[analyse].literal[Boolean]
 
-        if analyse.or(false) then exp match
-          case Some('{type testType >: test; $expr: testType}) =>
-            val decomposable: Expr[testType is Decomposable] =
-              Expr.summon[testType is Decomposable].getOrElse('{Decomposable.any[testType]})
-
-            ' {
-                given decompose: testType is Decomposable = $decomposable
-                val contrast = infer[testType is Contrastable]
-
-                assertion[testType, test, report, result]
-                  ( $runner,
-                    $test,
-                    $predicate,
-                    $action,
-                    contrast,
-                    Some($expr),
-                    $inclusion,
-                    $inclusion2,
-                    decompose,
-                    $aspirationalExpr )
-              }
-
-          case _ =>
-            ' {
-                assertion[test, test, report, result]
-                  ( $runner,
-                    $test,
-                    $predicate,
-                    $action,
-                    Contrastable.nothing[test],
-                    None,
-                    $inclusion,
-                    $inclusion2,
-                    Decomposable.any[test],
-                    $aspirationalExpr )
-              }
-
-        else
+        // The non-contrast assertion, used whenever contrast expectations are disabled or no
+        // `Contrastable` instance can be derived for the expected value's type (e.g. when the
+        // test body carries an effect type, or the type is otherwise not contrastable).
+        val plain: Expr[result] =
           ' {
               assertion[test, test, report, result]
                 ( $runner,
@@ -140,6 +106,37 @@ object internal:
                   Decomposable.any[test],
                   $aspirationalExpr )
             }
+
+        if analyse.or(false) then exp match
+          case Some('{type testType >: test; $expr: testType}) =>
+            Expr.summon[testType is Contrastable] match
+              case Some(contrast) =>
+                val decomposable: Expr[testType is Decomposable] =
+                  Expr.summon[testType is Decomposable].getOrElse('{Decomposable.any[testType]})
+
+                ' {
+                    given decompose: testType is Decomposable = $decomposable
+
+                    assertion[testType, test, report, result]
+                      ( $runner,
+                        $test,
+                        $predicate,
+                        $action,
+                        $contrast,
+                        Some($expr),
+                        $inclusion,
+                        $inclusion2,
+                        decompose,
+                        $aspirationalExpr )
+                  }
+
+              case None =>
+                plain
+
+          case _ =>
+            plain
+
+        else plain
 
 
   def check[test: Type](test: Expr[Test[test]], predicate: Expr[test => Boolean]): Macro[test] =

--- a/lib/probably/src/core/probably.internal.scala
+++ b/lib/probably/src/core/probably.internal.scala
@@ -72,10 +72,13 @@ object internal:
           case Inlined(_, _, predicate) => lift(predicate.asExpr)
 
           case Block(List(DefDef(a, _, _, Some(expression))), Closure(Ident(b), _)) if a == b =>
+            // Only lift when one side of the `==` is exactly the lambda parameter, so the other
+            // side (the expected value) is a closed term safe to splice. A projection such as
+            // `_.field == x` matches neither case and yields no contrast.
             expression match
-              case Apply(Select(Ident(_), "=="), List(term)) => Some(term.asExpr)
-              case Apply(Select(term, "=="), List(Ident(_))) => Some(term.asExpr)
-              case other                                     => None
+              case Apply(Select(Ident(`a`), "=="), List(term)) => Some(term.asExpr)
+              case Apply(Select(term, "=="), List(Ident(`a`))) => Some(term.asExpr)
+              case other                                       => None
 
           case other =>
             None
@@ -108,30 +111,32 @@ object internal:
             }
 
         if analyse.or(false) then exp match
-          case Some('{type testType >: test; $expr: testType}) =>
-            Expr.summon[testType is Contrastable] match
-              case Some(contrast) =>
-                val decomposable: Expr[testType is Decomposable] =
-                  Expr.summon[testType is Decomposable].getOrElse('{Decomposable.any[testType]})
+          // Only emit the contrast path when a `Contrastable` can actually be derived for the
+          // expected value's type; `Expr.summon` is used purely to test derivability, while the
+          // instance itself is summoned by `infer` *inside* the quote so its captured givens stay
+          // in scope at the splice site.
+          case Some('{type testType >: test; $expr: testType})
+            if Expr.summon[testType is Contrastable].isDefined =>
 
-                ' {
-                    given decompose: testType is Decomposable = $decomposable
+            val decomposable: Expr[testType is Decomposable] =
+              Expr.summon[testType is Decomposable].getOrElse('{Decomposable.any[testType]})
 
-                    assertion[testType, test, report, result]
-                      ( $runner,
-                        $test,
-                        $predicate,
-                        $action,
-                        $contrast,
-                        Some($expr),
-                        $inclusion,
-                        $inclusion2,
-                        decompose,
-                        $aspirationalExpr )
-                  }
+            ' {
+                given decompose: testType is Decomposable = $decomposable
+                val contrast = infer[testType is Contrastable]
 
-              case None =>
-                plain
+                assertion[testType, test, report, result]
+                  ( $runner,
+                    $test,
+                    $predicate,
+                    $action,
+                    contrast,
+                    Some($expr),
+                    $inclusion,
+                    $inclusion2,
+                    decompose,
+                    $aspirationalExpr )
+              }
 
           case _ =>
             plain


### PR DESCRIPTION
Probably now reports a structured, field-by-field contrast between the expected and actual values whenever an `assert(_ == expected)` comparison fails, with no opt-in required. Generic derivation has become fast enough that the instances this needs can be derived universally without the compile-time cost that originally forced the feature to be opt-in. Where a value's type can't be compared structurally the assertion degrades quietly to its previous behaviour, and two latent bugs uncovered while enabling it have been fixed.

When a test such as `test(m"…")(compute()).assert(_ == expected)` fails, the report now shows how the actual value differs from `expected`, field by field, rather than just reporting a failure. This is driven by a `Contrastable` instance derived for the compared type, and is now on by default for every test.

To turn it off for a particular test file — for instance one whose compared types are expensive to derive — import the opt-out given:

```scala
import soundness.autopsies.none
```

Contrast applies only to whole-value comparisons (`_ == expected`); a projection such as `_.field == expected`, or a test body carrying an effect type (e.g. `value raises Error`), falls back to a plain pass/fail with no contrast.

This release also fixes the `Float` instance of `Contrastable.Foundation` (previously mistyped as `Byte`, which left `Float` and `Byte` comparisons unable to derive a contrast), and hardens the assertion macro so that comparisons against effect-typed or non-structural values no longer fail to compile.