### PR TITLE
Use the t"" interpolator instead of s"" in Gossamer-downstream code

### DIFF
--- a/lib/aviation/src/core/aviation.Timestamp.scala
+++ b/lib/aviation/src/core/aviation.Timestamp.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import contingency.*
 import distillate.*
 import fulminate.*
+import gossamer.t
 import kaleidoscope.*
 import prepositional.*
 import spectacular.*
@@ -49,7 +50,7 @@ object Timestamp:
   import calendars.gregorianCalendar
 
   given showable: (Clockface is Showable, Date is Showable) => Timestamp is Showable =
-    timestamp => s"${timestamp.time.show}, ${timestamp.date.show}".tt
+    timestamp => t"${timestamp.time.show}, ${timestamp.date.show}"
 
   given decodable: Tactic[TimestampError] => Timestamp is Decodable in Text = text => text match
     case r"$year(\d{4})-$month(\d{2})-$day(\d{2})[ T]$hour(\d{2}):$minute(\d{2}):$second(\d{2})" =>

--- a/lib/breviloquence/src/bench/breviloquence.TimingMain.scala
+++ b/lib/breviloquence/src/bench/breviloquence.TimingMain.scala
@@ -33,6 +33,7 @@
 package breviloquence
 
 import contingency.*, strategies.throwUnsafely
+import gossamer.t
 
 object TimingMain:
   def time(label: String, payload: IArray[Byte], iterations: Int)
@@ -63,7 +64,7 @@ object TimingMain:
     val iterations =
       if args.length > 0 then args(0).toInt else 1_000_000
 
-    println(s"Timing $iterations iterations per benchmark.")
+    println(t"Timing $iterations iterations per benchmark.")
     println()
 
     println:

--- a/lib/gossamer/src/core/gossamer.Decimalizer.scala
+++ b/lib/gossamer/src/core/gossamer.Decimalizer.scala
@@ -144,6 +144,6 @@ extends DecimalConverter:
     else if double.isNaN then
       nan
     else if double.isNegInfinity then
-      s"$minusSign$infinity".tt
+      t"$minusSign$infinity"
     else
       infinity

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -101,7 +101,7 @@ object Markdown:
     case Prose.Strong(children*)   => Strong(children.map(phrasing(_))*)
     case Prose.Softbreak           => "\n"
     case Prose.Linebreak           => Fragment(Br, "\n")
-    case Prose.HtmlInline(content) => Comment(s"[CDATA[$content]]")
+    case Prose.HtmlInline(content) => Comment(t"[CDATA[$content]]")
 
     case Prose.Link(destination, title, content*) =>
       val destination2 = url(destination)
@@ -193,7 +193,7 @@ object Markdown:
           Hr
 
         case Layout.HtmlBlock(line, content) =>
-          Comment(s"[CDATA[$content]]")
+          Comment(t"[CDATA[$content]]")
 
         case Layout.Heading(line, level, content*) =>
           level match

--- a/lib/ypsiloid/src/test/ypsiloid_conformance.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_conformance.scala
@@ -51,6 +51,7 @@ import scala.jdk.CollectionConverters.*
 
 import anticipation.Text
 import contingency.strategies
+import gossamer.t
 import hieroglyph.charEncoders
 import jacinta.Json
 import turbulence.read
@@ -259,8 +260,8 @@ object Conformance:
 
     val inScopeFailures = inScopeResults.filterNot(_.passed)
     if inScopeFailures.nonEmpty then
-      println(s"In-scope failures (${inScopeFailures.length.min(maxFailuresShown)}"
-            + s" of ${inScopeFailures.length} shown):")
+      val shown = inScopeFailures.length.min(maxFailuresShown)
+      println(t"In-scope failures ($shown of ${inScopeFailures.length} shown):")
       inScopeFailures.take(maxFailuresShown).foreach: result =>
         printFailure(result)
 
@@ -270,19 +271,19 @@ object Conformance:
         val matching = outFailures.filter(_.testCase.tags.contains(tag))
         if matching.nonEmpty then
           println()
-          println(s"== Out-of-scope tag '$tag' (${matching.length} failing):")
+          println(t"== Out-of-scope tag '$tag' (${matching.length} failing):")
           matching.foreach: r =>
             val descShort = r.testCase.description.linesIterator.next().take(60)
             val tagsShort = r.testCase.tags.toList.sorted.mkString("{", ",", "}")
-            println(s"  ${r.testCase.id} $tagsShort  $descShort")
+            println(t"  ${r.testCase.id} $tagsShort  $descShort")
             r.outcome match
               case Outcome.Mismatch(actual, expected) =>
-                println(s"    expected: ${expected.take(120)}")
-                println(s"    actual:   ${actual.take(120)}")
+                println(t"    expected: ${expected.take(120)}")
+                println(t"    actual:   ${actual.take(120)}")
               case Outcome.ShouldHaveErrored =>
-                println(s"    (should have errored)")
+                println(t"    (should have errored)")
               case Outcome.UnexpectedError(msg) =>
-                println(s"    error: ${msg.take(120)}")
+                println(t"    error: ${msg.take(120)}")
               case Outcome.Passed => ()
 
     if inScopeFailures.nonEmpty then System.exit(1)
@@ -296,15 +297,15 @@ object Conformance:
                     else result.testCase.tags.toList.sorted.mkString(" {", ",", "}")
     result.outcome match
       case Outcome.Mismatch(actual, expected) =>
-        println(s"  ${result.testCase.id} [$descShort]$tagsShort")
-        println(s"    expected: ${expected.take(120)}")
-        println(s"    actual:   ${actual.take(120)}")
+        println(t"  ${result.testCase.id} [$descShort]$tagsShort")
+        println(t"    expected: ${expected.take(120)}")
+        println(t"    actual:   ${actual.take(120)}")
 
       case Outcome.ShouldHaveErrored =>
-        println(s"  ${result.testCase.id} [$descShort]$tagsShort: should have errored")
+        println(t"  ${result.testCase.id} [$descShort]$tagsShort: should have errored")
 
       case Outcome.UnexpectedError(msg) =>
-        println(s"  ${result.testCase.id} [$descShort]$tagsShort: unexpected error: " + msg)
+        println(t"  ${result.testCase.id} [$descShort]$tagsShort: unexpected error: $msg")
 
       case Outcome.Passed => ()
 


### PR DESCRIPTION
Several sites across the libraries built a String with the standard s""
interpolator only to convert it straight to Text with a trailing .tt, or to
feed an API that already wanted Text; these now use Gossamer's t"" interpolator
directly, producing the Text these contexts want without the intermediate
String. The change spans aviation, gossamer, punctuation, and the breviloquence
and ypsiloid output harnesses (which gain a narrow `import gossamer.t`). The one
genuine String consumer left behind — a RuntimeException message — keeps s"".

This is an internal refactor with no change to public APIs or runtime behaviour;
no action is required by users.