### PR TITLE
Fix and test XML pattern-matching extraction (case x"…")

### DIFF
--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -113,7 +113,15 @@ object internal:
       def checkHeader(array: Expr[Array[Any]], pattern: Header, scrutinee: Expr[Header])
       :   Expr[Boolean] =
 
-        '{${Expr(pattern.version)} == $scrutinee.version} // FIXME: Check encoding/standalone too
+        val encoding: Expr[Boolean] =
+          if pattern.encoding == Unset then '{$scrutinee.encoding == Unset}
+          else '{$scrutinee.encoding == ${Expr(pattern.encoding.asInstanceOf[Text])}}
+
+        val standalone: Expr[Boolean] =
+          if pattern.standalone == Unset then '{$scrutinee.standalone == Unset}
+          else '{$scrutinee.standalone == ${Expr(pattern.standalone.asInstanceOf[Boolean])}}
+
+        '{${Expr(pattern.version)} == $scrutinee.version && $encoding && $standalone}
 
       def checkFragment(array: Expr[Array[Any]], pattern: Fragment, scrutinee: Expr[Fragment])
       :   Expr[Boolean] =
@@ -186,8 +194,10 @@ object internal:
 
         pattern match
           case Comment("\u0000") =>
+            // Comment, CDATA and processing-instruction holes are not emitted
+            // by the parser's callback, so they have no `holes`/`iterator`
+            // entry; only `index` advances to address the `extracts` slot.
             index += 1
-            iterator.next()
             types ::= TypeRepr.of[Text]
 
             ' {
@@ -200,21 +210,16 @@ object internal:
 
           case ProcessingInstruction("\u0000", t"") =>
             index += 1
-            iterator.next()
             types ::= TypeRepr.of[ProcessingInstruction]
 
             ' {
                 $expr && $scrutinee.isInstanceOf[ProcessingInstruction] &&
-                  {
-                    $array(${Expr(index)}) = $scrutinee.asInstanceOf[ProcessingInstruction].data
-                    true
-                  }
+                  { $array(${Expr(index)}) = $scrutinee; true }
               }
 
           case Cdata("\u0000") =>
             index += 1
-            iterator.next()
-            types ::= TypeRepr.of[Cdata]
+            types ::= TypeRepr.of[Text]
 
             ' {
                 $expr && $scrutinee.isInstanceOf[Cdata] &&
@@ -294,14 +299,20 @@ object internal:
             halt(m"DOCTYPE patterns are not supported in extractors")
 
 
+      // Every `$`-substitution in the pattern is one captured value, whether or
+      // not the parser emitted a structural `Hole` for it (comment/CDATA/PI
+      // holes are not captured). `holes.size` undercounts those, so the slot
+      // count is the number of string parts minus one.
+      val holeCount = parts.length - 1
+
       val result: Expr[Extrapolation[Xml]] =
         ' {
-            val extracts = new Array[Any](${Expr(holes.size)})
+            val extracts = new Array[Any](${Expr(holeCount)})
             val matches: Boolean = ${descend('extracts, xml, scrutinee, '{true})}
 
             $ {
-                if holes.size == 0 then '{matches}
-                else if holes.size == 1
+                if holeCount == 0 then '{matches}
+                else if holeCount == 1
                 then '{if !matches then None else Some(extracts(0).asInstanceOf[Xml])}
                 else '{if !matches then None else Some(Tuple.fromArray(extracts))}
               }
@@ -314,6 +325,13 @@ object internal:
           types.head.asType.absolve match
             case '[type result <: Xml; result] =>
               '{$result.asInstanceOf[Option[result]]}
+
+            case _ =>
+              halt:
+                m"""
+                  a single text value cannot be captured on its own; capture it together with
+                  another value (so the result is a tuple), or capture the enclosing node
+                """
 
         case _ =>
           AppliedType(defn.TupleClass(types.length).info.typeSymbol.typeRef, types.reverse)

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -611,6 +611,134 @@ object Tests extends Suite(m"Xylophone tests"):
       . assert(_ == List("bar>"))
 
 
+    suite(m"Extractor tests"):
+      test(m"Extract a text node from an element"):
+        val scrutinee: Xml = x"<message>hello</message>"
+        scrutinee.absolve match
+          case x"<message>$text</message>" => text
+      . assert(_ == TextNode(t"hello"))
+
+      test(m"Capture a whole child element"):
+        val scrutinee: Xml = x"<a><b>1</b></a>"
+        scrutinee.absolve match
+          case x"<a>$child</a>" => child
+      . assert(_ == x"<b>1</b>")
+
+      test(m"Non-matching tag falls through to the wildcard"):
+        val scrutinee: Xml = x"<a>hello</a>"
+        scrutinee match
+          case x"<b>$text</b>" => true
+          case _               => false
+      . assert(!_)
+
+      test(m"Zero-hole literal match returns a Boolean result"):
+        val scrutinee: Xml = x"<a>hello</a>"
+        scrutinee match
+          case x"<a>hello</a>" => 1
+          case _               => 2
+      . assert(_ == 1)
+
+      test(m"Zero-hole literal mismatch falls through"):
+        val scrutinee: Xml = x"<a>hello</a>"
+        scrutinee match
+          case x"<a>goodbye</a>" => 1
+          case _                 => 2
+      . assert(_ == 2)
+
+      test(m"Capture a child element via a tag hole"):
+        val scrutinee: Xml = x"<a><b>1</b></a>"
+        scrutinee.absolve match
+          case x"<a><$element></a>" => element
+      . assert(_ == x"<b>1</b>")
+
+      test(m"Extract an attribute value and a child as a tuple"):
+        val scrutinee: Xml = x"""<a id="5"><b>1</b></a>"""
+        scrutinee.absolve match
+          case x"<a id=$value>$child</a>" => (value, child)
+      . assert(_ == (t"5", x"<b>1</b>"))
+
+      test(m"Extract comment content alongside an attribute"):
+        val scrutinee: Xml = x"""<a id="1"><!--note--></a>"""
+        scrutinee.absolve match
+          case x"<a id=$value><!--$text--></a>" => (value, text)
+      . assert(_ == (t"1", t"note"))
+
+      test(m"Extract CDATA content alongside an attribute"):
+        val scrutinee: Xml = x"""<a id="1"><![CDATA[data]]></a>"""
+        scrutinee.absolve match
+          case x"<a id=$value><![CDATA[$text]]></a>" => (value, text)
+      . assert(_ == (t"1", t"data"))
+
+      test(m"Extract from a nested element"):
+        val scrutinee: Xml = x"""<a><b id="9">deep</b></a>"""
+        scrutinee.absolve match
+          case x"<a><b id=$value>$child</b></a>" => (value, child)
+      . assert(_ == (t"9", TextNode(t"deep")))
+
+      test(m"A child-count mismatch falls through"):
+        val scrutinee: Xml = x"<a><b/><c/></a>"
+        scrutinee match
+          case x"<a>$only</a>" => true
+          case _               => false
+      . assert(!_)
+
+      test(m"Match a literal processing instruction"):
+        val scrutinee: Xml = x"<a><?foo bar?>hi</a>"
+        scrutinee.absolve match
+          case x"<a><?foo bar?>$node</a>" => node
+      . assert(_ == TextNode(t"hi"))
+
+      test(m"Capture the remaining attributes as a map"):
+        val scrutinee: Xml = x"""<a x="1" y="2">t</a>"""
+        scrutinee.absolve match
+          case x"<a $attrs>$body</a>" => (attrs, body)
+      . assert(_ == (Map(t"x" -> t"1", t"y" -> t"2"), TextNode(t"t")))
+
+      test(m"A literal attribute value that differs falls through"):
+        val scrutinee: Xml = x"""<a id="5">x</a>"""
+        scrutinee match
+          case x"""<a id="6">$body</a>""" => true
+          case _                          => false
+      . assert(!_)
+
+
+    suite(m"Compile-time extractor errors"):
+      test(m"A single text value cannot be captured on its own"):
+        demilitarize:
+          (x"""<a id="5">x</a>""": Xml).absolve match
+            case x"<a id=$value>x</a>" => value
+        . map(_.message)
+      . assert(_.exists(_.contains("single text value")))
+
+      test(m"A hole inside comment text is rejected"):
+        demilitarize:
+          (x"<a/>": Xml).absolve match
+            case x"<a><!--pre$middle-->post</a>" => middle
+        . map(_.message)
+      . assert(_.exists(_.contains("entire comment text")))
+
+      test(m"A hole inside CDATA content is rejected"):
+        demilitarize:
+          (x"<a/>": Xml).absolve match
+            case x"<a><![CDATA[pre$middle]]></a>" => middle
+        . map(_.message)
+      . assert(_.exists(_.contains("entire CDATA content")))
+
+      test(m"A DOCTYPE pattern is rejected"):
+        demilitarize:
+          (x"<a/>": Xml) match
+            case x"<!DOCTYPE html>" => 1
+            case _                  => 2
+        . map(_.message)
+      . assert(_.exists(_.contains("DOCTYPE")))
+
+      test(m"A hole in processing-instruction position is rejected"):
+        demilitarize:
+          (x"<a/>": Xml).absolve match
+            case x"<a><?$pi?></a>" => pi
+      . assert(_.nonEmpty)
+
+
     suite(m"Namespaces"):
       test(m"Element with default namespace declaration"):
         t"""<a xmlns="http://example.com"/>""".read[Xml]


### PR DESCRIPTION
XML values can now be reliably deconstructed by pattern-matching against an `x"…"` literal — the mirror image of the interpolator used to build them. The extractor existed but had never been exercised by a test, so several latent bugs were fixed (capturing text, attributes, child nodes, comments and CDATA all work now), and a thorough runtime and compile-time test suite was added.

An `x"…"` literal can be used in a pattern to deconstruct XML, capturing child nodes, attribute values, the remaining attributes, and comment or CDATA text:

```scala
xml match
  case x"<a id=$id>$child</a>"        => (id, child)   // (Text, Node)
  case x"<a $attrs>$body</a>"         => attrs         // Map[Text, Text]
  case x"<a id=$id><!--$note--></a>"  => (id, note)    // (Text, Text)
```

A single value that is not itself XML (such as a lone attribute or comment) must be captured alongside another value, so the result is a tuple; capturing it on its own is now a clear compile error rather than a crash. Holes inside comment or CDATA text, holes in processing-instruction positions, and `DOCTYPE` patterns are rejected at compile time.

Closes #1253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)