### PR TITLE
Introduce the @unexported annotation and clear compiler warnings

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -100,6 +100,17 @@ object settings:
 
   val scalaOptionsCC = scalaOptions ++ Seq("-Ycc-new")
 
+  // Override `-Xmax-inlines` to `limit`, replacing any existing setting rather
+  // than appending a second one (which the compiler reports as "Option
+  // -Xmax-inlines was updated"). The base stays 32 everywhere else.
+  def maxInlines(options: Seq[String], limit: String): Seq[String] =
+    def strip(remaining: List[String]): List[String] = remaining match
+      case "-Xmax-inlines" :: _ :: rest => strip(rest)
+      case other :: rest                => other :: strip(rest)
+      case Nil                          => Nil
+
+    strip(options.to(List)) ++ Seq("-Xmax-inlines", limit)
+
 trait BaseScalaModule extends ScalaModule:
   override def scalaVersion = settings.scalaVersion
   override def scalacOptions = settings.scalaOptions
@@ -652,11 +663,11 @@ object embarcadero extends Library:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object containerd extends Component(obligatory.grpc, cordillera.core, coaxial.core, locomotion.core, anticipation.time):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium",
-        "-Xmax-inlines", "64")
+      settings.maxInlines(super.scalacOptions() ++ Seq("-Yno-predef",
+        "-Yimports:java.lang,scala,proscenium"), "64")
   object test extends Tests(oci, containerd, aviation.core):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Xmax-inlines", "64")
+      settings.maxInlines(super.scalacOptions(), "64")
 
 object enigmatic extends Library:
   object core extends Component(gastronomy.core):
@@ -801,18 +812,18 @@ object eucalyptus extends Library:
 object exegesis extends Library:
   object core extends Component(obligatory.json):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium",
-        "-Xmax-inlines", "48")
+      settings.maxInlines(super.scalacOptions() ++ Seq("-Yno-predef",
+        "-Yimports:java.lang,scala,proscenium"), "48")
 
   object demo extends Internal(core, ethereal.core, exoskeleton.completions):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium",
-        "-Xmax-inlines", "48")
+      settings.maxInlines(super.scalacOptions() ++ Seq("-Yno-predef",
+        "-Yimports:java.lang,scala,proscenium"), "48")
     override def mainClass: Task.Simple[Option[String]] = Some("exegesis.lsp")
 
   object test extends Tests(core):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Xmax-inlines", "48")
+      settings.maxInlines(super.scalacOptions(), "48")
 
 object exoskeleton extends Library:
   object args extends Component(escapade.core, profanity.core, ambience.core, quantitative.units):
@@ -1337,8 +1348,8 @@ object symbolism extends Library:
 object synesthesia extends Library:
   object core extends Component(obligatory.json):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium",
-        "-Xmax-inlines", "48")
+      settings.maxInlines(super.scalacOptions() ++ Seq("-Yno-predef",
+        "-Yimports:java.lang,scala,proscenium"), "48")
 
   object test extends Tests(core)
 

--- a/lib/apoplexy/src/core/apoplexy.Executor.scala
+++ b/lib/apoplexy/src/core/apoplexy.Executor.scala
@@ -37,5 +37,6 @@ import telekinesis.*
 // The transport seam: turns an `Api.Request` into a raw HTTP response. The
 // production given (requiring `Online`) sends a real request; tests provide a
 // recording implementation that returns canned responses without any network.
+@unexported("clashes with superlunary.Executor in the umbrella; reach it via apoplexy.Executor")
 trait Executor:
   def execute(request: Api.Request): Http.Response

--- a/lib/apoplexy/src/core/apoplexy.Executor.scala
+++ b/lib/apoplexy/src/core/apoplexy.Executor.scala
@@ -37,6 +37,7 @@ import telekinesis.*
 // The transport seam: turns an `Api.Request` into a raw HTTP response. The
 // production given (requiring `Online`) sends a real request; tests provide a
 // recording implementation that returns canned responses without any network.
-@unexported("clashes with superlunary.Executor in the umbrella; reach it via apoplexy.Executor")
+// Not exported: clashes with superlunary.Executor in the umbrella; reach it via apoplexy.Executor
+@unexported
 trait Executor:
   def execute(request: Api.Request): Http.Response

--- a/lib/apoplexy/src/core/soundness_apoplexy_core.scala
+++ b/lib/apoplexy/src/core/soundness_apoplexy_core.scala
@@ -32,6 +32,4 @@
                                                                                                   */
 package soundness
 
-// unexported: Executor (clashes with `superlunary.Executor` in the umbrella; reach it via
-// `apoplexy.Executor`)
 export apoplexy.{Api, ApiError, Conformant, OpenApi, OpenApiError}

--- a/lib/breviloquence/src/core/breviloquence_core.scala
+++ b/lib/breviloquence/src/core/breviloquence_core.scala
@@ -42,26 +42,37 @@ import CborError.{Primitive, Reason}
 extension [entity: Encodable in Cbor](value: entity) def cbor: Cbor = value.encode
 
 extension (cbor: Cbor.Ast)
+  @unexported
   inline def unset: Boolean = cbor == vacuous.Unset
+  @unexported
   inline def isInteger: Boolean = cbor.isInstanceOf[Long]
+  @unexported
   inline def isFloat: Boolean = cbor.isInstanceOf[Double]
+  @unexported
   inline def isTextString: Boolean = cbor.isInstanceOf[String]
+  @unexported
   inline def isBoolean: Boolean = cbor.isInstanceOf[Boolean]
+  @unexported
   inline def nullary: Boolean = cbor.asInstanceOf[AnyRef] eq Cbor.CborNull
+  @unexported
   inline def isTag: Boolean = cbor.isInstanceOf[Cbor.Tag]
 
   // Byte strings have runtime class `[B`; arrays/maps have `[Ljava/lang/Object;`.
+  @unexported
   inline def isByteString: Boolean = cbor.isInstanceOf[Array[Byte]]
 
   // Maps and arrays share the `Array[AnyRef]` runtime layout. Maps have an
   // even-length backing array; arrays are odd-length (with sentinel padding
   // when the logical element count is even).
+  @unexported
   inline def isMap: Boolean =
     cbor.isInstanceOf[Array[AnyRef]] && (cbor.asInstanceOf[Array[?]].length & 1) == 0
 
+  @unexported
   inline def isArray: Boolean =
     cbor.isInstanceOf[Array[AnyRef]] && (cbor.asInstanceOf[Array[?]].length & 1) == 1
 
+  @unexported
   def primitive: Primitive =
     if isInteger then Primitive.Integer
     else if isFloat then Primitive.Float
@@ -78,14 +89,20 @@ extension (cbor: Cbor.Ast)
     if unset then abort(CborError(Reason.Absent))
     else abort(CborError(Reason.NotType(primitive, expected)))
 
+  @unexported
   inline def elements: Int = Cbor.Ast.length(cbor)
+  @unexported
   inline def entries: Int = Cbor.Ast.size(cbor)
 
+  @unexported
   def element(index: Int): Cbor.Ast = cbor.asInstanceOf[IArray[Cbor.Ast]](index)
 
+  @unexported
   inline def key(index: Int): Cbor.Ast = cbor.asInstanceOf[IArray[Cbor.Ast]](index*2)
+  @unexported
   inline def value(index: Int): Cbor.Ast = cbor.asInstanceOf[IArray[Cbor.Ast]](index*2 + 1)
 
+  @unexported
   def index(key: String): Int =
     val array = cbor.asInstanceOf[IArray[Any]]
     val count = array.length
@@ -97,29 +114,36 @@ extension (cbor: Cbor.Ast)
 
     -1
 
+  @unexported
   def long: Long raises CborError =
     if isInteger then cbor.asInstanceOf[Long] else if isFloat then cbor.asInstanceOf[Double].toLong
     else expected(Primitive.Integer) yet 0L
 
+  @unexported
   def double: Double raises CborError =
     if isFloat then cbor.asInstanceOf[Double]
     else if isInteger then cbor.asInstanceOf[Long].toDouble
     else expected(Primitive.Float) yet 0.0
 
+  @unexported
   def string: String raises CborError =
     if isTextString then cbor.asInstanceOf[String] else expected(Primitive.TextString) yet ""
 
+  @unexported
   def byteString: IArray[Byte] raises CborError =
     if isByteString then cbor.asInstanceOf[IArray[Byte]]
     else expected(Primitive.ByteString) yet IArray.empty[Byte]
 
+  @unexported
   def boolean: Boolean raises CborError =
     if isBoolean then cbor.asInstanceOf[Boolean] else expected(Primitive.Boolean) yet false
 
+  @unexported
   def tag: Cbor.Tag raises CborError =
     if isTag then cbor.asInstanceOf[Cbor.Tag]
     else expected(Primitive.Tag) yet Cbor.Tag(0L, vacuous.Unset)
 
+  @unexported
   def array: IArray[Cbor.Ast] raises CborError =
     if isArray then
       val full = cbor.asInstanceOf[IArray[Cbor.Ast]]

--- a/lib/breviloquence/src/core/soundness_breviloquence_core.scala
+++ b/lib/breviloquence/src/core/soundness_breviloquence_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export breviloquence.{Cbor, Cbor2, cborConversion, DynamicCborEnabler, dynamicCborAccess}
+export breviloquence.{Cbor, Cbor2, cborConversion, DynamicCborEnabler, dynamicCborAccess, cbor}

--- a/lib/breviloquence/src/core/soundness_breviloquence_parser.scala
+++ b/lib/breviloquence/src/core/soundness_breviloquence_parser.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export breviloquence.CborError
+export breviloquence.{CborError, parse}

--- a/lib/cataclysm/src/core/cataclysm.Syntax.scala
+++ b/lib/cataclysm/src/core/cataclysm.Syntax.scala
@@ -39,6 +39,7 @@ import vacuous.*
 // property's permitted values are described. A `Syntax` is the parsed form of a
 // grammar string such as `<line-width> || <line-style> || <color>`; it is what a
 // later step matches a concrete value against.
+@unexported("clashes with stenography.Syntax in the umbrella; reach it via cataclysm.Syntax")
 enum Syntax derives CanEqual:
   case Keyword(name: Text)                          // a literal identifier, e.g. `auto`
   case Literal(token: Text)                         // a literal token, e.g. `/` `,` or quoted `'+'`

--- a/lib/cataclysm/src/core/cataclysm.Syntax.scala
+++ b/lib/cataclysm/src/core/cataclysm.Syntax.scala
@@ -39,7 +39,8 @@ import vacuous.*
 // property's permitted values are described. A `Syntax` is the parsed form of a
 // grammar string such as `<line-width> || <line-style> || <color>`; it is what a
 // later step matches a concrete value against.
-@unexported("clashes with stenography.Syntax in the umbrella; reach it via cataclysm.Syntax")
+// Not exported: clashes with stenography.Syntax in the umbrella; reach it via cataclysm.Syntax
+@unexported
 enum Syntax derives CanEqual:
   case Keyword(name: Text)                          // a literal identifier, e.g. `auto`
   case Literal(token: Text)                         // a literal token, e.g. `/` `,` or quoted `'+'`

--- a/lib/cataclysm/src/core/soundness_cataclysm_core.scala
+++ b/lib/cataclysm/src/core/soundness_cataclysm_core.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package soundness
 
-// unexported: Syntax (clashes with `stenography.Syntax` in the umbrella; reach it via
-// `cataclysm.Syntax`)
 export cataclysm.{Css, CssError, CssErrors, cssAggregable, SelectorList, Selector, Compound,
     Simple, Combinator, AttributeMatcher, AttributeTest, Prefix, PseudoArgument,
     CssConvertible, Outcome, PropertyDef, SyntaxMatcher, ValueToken, Pixels, Rems, Exs, Chs,

--- a/lib/decorum/src/plugin/decorum.Annotations.scala
+++ b/lib/decorum/src/plugin/decorum.Annotations.scala
@@ -72,6 +72,33 @@ object Annotations:
         case _ => ()
     out.toSet
 
+  // Collect the simple names of every definition annotated `@unexported`. R-742
+  // and R-742.1 skip these: they are deliberately not re-exported into the
+  // `soundness` umbrella (a name clash with another component, or a compile-time/
+  // internal helper). The annotation is read by name only, so its optional
+  // `reason` argument is ignored here.
+  def unexported(tree: untpd.Tree): Set[String] =
+    val out = mutable.Set[String]()
+    walk(tree): t =>
+      t match
+        case d: untpd.MemberDef if d.mods.annotations.exists(mentionsUnexported) =>
+          val name = d.name.toString
+          if name.nonEmpty then out += name
+        case _ => ()
+    out.to(Set)
+
+  // Does this annotation tree name the `unexported` annotation? Untyped
+  // annotations are `New`/`Apply` trees around the annotation type's `Ident`
+  // (or `Select`); we just look for the leaf name anywhere within.
+  private def mentionsUnexported(annotation: untpd.Tree): Boolean =
+    var found = false
+    walk(annotation): t =>
+      t match
+        case untpd.Ident(name)     => if name.toString == "unexported" then found = true
+        case untpd.Select(_, name) => if name.toString == "unexported" then found = true
+        case _                     => ()
+    found
+
   // Generic untyped-tree pre-order traversal driven off `productIterator`,
   // so we don't need to enumerate every tree shape. We descend into any
   // field that is itself a `Tree`, and into any `Iterable` recursively

--- a/lib/decorum/src/plugin/decorum.Checker.scala
+++ b/lib/decorum/src/plugin/decorum.Checker.scala
@@ -50,10 +50,11 @@ object Checker:
       expectedModule:   Option[String],
       rawText:          String,
       siblingTypes:     List[String] = Nil,
-      siblingExtensions: List[String] = Nil )
+      siblingExtensions: List[String] = Nil,
+      unexported:       Set[String] = Set.empty )
   :   LazyList[Violation] =
     val (tree, source) = Parsing.parse(file, rawText)
-    check(file, expectedModule, rawText, tree, source, siblingTypes, siblingExtensions)
+    check(file, expectedModule, rawText, tree, source, siblingTypes, siblingExtensions, unexported)
 
   def check
     ( file:             String,
@@ -62,7 +63,8 @@ object Checker:
       untpdTree:        untpd.Tree,
       source:           SourceFile,
       siblingTypes:     List[String],
-      siblingExtensions: List[String] )
+      siblingExtensions: List[String],
+      unexported:       Set[String] )
   :   LazyList[Violation] =
 
     val out   = mutable.ListBuffer[Violation]()
@@ -99,8 +101,8 @@ object Checker:
     checkOperatorContinuation(file, operatorSites, out)
     checkInterpolatorLayout(file, interpolations, rawText, source, out)
     val soundnessExports = SoundnessExports.extract(untpdTree, source)
-    checkSoundnessExports(file, siblingTypes, soundnessExports, out)
-    checkSoundnessExtensionExports(file, siblingExtensions, soundnessExports, out)
+    checkSoundnessExports(file, siblingTypes, soundnessExports, unexported, out)
+    checkSoundnessExtensionExports(file, siblingExtensions, soundnessExports, unexported, out)
     var idx = 0
 
     while idx < lines.length do
@@ -1994,11 +1996,12 @@ object Checker:
     ( file:         String,
       siblingTypes: List[String],
       exports:      ExportInfo,
+      unexported:   Set[String],
       out:          mutable.ListBuffer[Violation] )
   :   Unit =
 
     val missing =
-      siblingTypes.filterNot(exports.names.contains).filterNot(exports.excluded.contains)
+      siblingTypes.filterNot(exports.names.contains).filterNot(unexported.contains)
 
     if missing.nonEmpty then
       val listed = missing.map { name => s"`$name`" }.mkString(", ")
@@ -2013,17 +2016,18 @@ object Checker:
   // its leaf name. `siblingExtensions` is the list of such method names found in
   // the `<component>_<suffix>.scala` definition files alongside the export
   // surface; any name absent from the surface's `export` clauses (and not marked
-  // `// unexported:`) is a violation. The list is empty for every file other
-  // than an export surface, so this check is a no-op elsewhere.
+  // `@unexported`) is a violation. The list is empty for every file other than an
+  // export surface, so this check is a no-op elsewhere.
   private def checkSoundnessExtensionExports
     ( file:              String,
       siblingExtensions: List[String],
       exports:           ExportInfo,
+      unexported:        Set[String],
       out:               mutable.ListBuffer[Violation] )
   :   Unit =
 
     val missing =
-      siblingExtensions.filterNot(exports.names.contains).filterNot(exports.excluded.contains)
+      siblingExtensions.filterNot(exports.names.contains).filterNot(unexported.contains)
 
     if missing.nonEmpty then
       val listed  = missing.map { name => s"`$name`" }.mkString(", ")

--- a/lib/decorum/src/plugin/decorum.DecorumPhase.scala
+++ b/lib/decorum/src/plugin/decorum.DecorumPhase.scala
@@ -79,7 +79,7 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
       val unitTree          = context.compilationUnit.untpdTree
       val siblingTypes      = soundnessSiblingModules(path)
       val siblingExtensions = soundnessSiblingExtensions(path)
-      val unexported        = soundnessUnexported(path)
+      val unexported        = soundnessUnexported(path) ++ soundnessSiblingSurfaceExports(path)
 
       val violations =
         Checker.check
@@ -192,6 +192,38 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
       val content        = String(java.nio.file.Files.readAllBytes(file.toPath))
       val (tree, source) = Parsing.parse(file.getPath.nn, content)
       Annotations.unexported(tree)
+    catch case _: Throwable => Set.empty
+
+  // When `path` is an export surface, return the export names from the *other*
+  // `soundness_<component>_<suffix>.scala` surfaces in the same directory. A
+  // component split across several surfaces (e.g. breviloquence's `core`/`parser`)
+  // re-exports each module from exactly one of them; a module exported by a sibling
+  // surface is therefore not missing from this one. Empty for non-surface files.
+  private def soundnessSiblingSurfaceExports(path: String): Set[String] =
+    if path.contains("/src/plugin/") then Set.empty else
+      val libParts = path.split("/lib/").nn
+      if libParts.length < 2 then Set.empty else
+        val component = libParts(1).nn.split("/").nn(0).nn
+        val file      = java.io.File(path)
+        val fileName  = file.getName.nn
+        if !fileName.startsWith(s"soundness_${component}_") then Set.empty else
+          val parent   = file.getParentFile
+          val siblings = if parent == null then null else parent.listFiles
+          if siblings == null then Set.empty else
+            val out = mutable.Set[String]()
+            siblings.foreach: sibling =>
+              val name = sibling.nn.getName.nn
+              if name != fileName && name.startsWith(s"soundness_${component}_")
+                 && name.endsWith(".scala")
+              then out ++= surfaceExportNames(sibling.nn)
+            out.to(Set)
+
+  // Parse an export-surface `file` and return the simple names it re-exports.
+  private def surfaceExportNames(file: java.io.File): Set[String] =
+    try
+      val content        = String(java.nio.file.Files.readAllBytes(file.toPath))
+      val (tree, source) = Parsing.parse(file.getPath.nn, content)
+      SoundnessExports.extract(tree, source).names
     catch case _: Throwable => Set.empty
 
   // Modifiers that may precede a public top-level declaration; `private` and

--- a/lib/decorum/src/plugin/decorum.DecorumPhase.scala
+++ b/lib/decorum/src/plugin/decorum.DecorumPhase.scala
@@ -79,9 +79,11 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
       val unitTree          = context.compilationUnit.untpdTree
       val siblingTypes      = soundnessSiblingModules(path)
       val siblingExtensions = soundnessSiblingExtensions(path)
+      val unexported        = soundnessUnexported(path)
 
       val violations =
-        Checker.check(path, module, text, unitTree, source, siblingTypes, siblingExtensions)
+        Checker.check
+          ( path, module, text, unitTree, source, siblingTypes, siblingExtensions, unexported )
 
       violations.foreach: violation =>
         val pos = position(source, violation.line, violation.column)
@@ -158,6 +160,39 @@ class DecorumPhase(options: List[String]) extends PluginPhase:
       val (tree, source) = Parsing.parse(file.getPath.nn, content)
       Extensions.extract(tree, source)
     catch case _: Throwable => Nil
+
+  // When `path` is a `soundness_<component>_<suffix>.scala` export surface, return
+  // the simple names of every sibling definition annotated `@unexported` — both in
+  // the `<component>.<Name>.scala` module files and the `<component>_<suffix>.scala`
+  // definition files in the same directory. R-742 and R-742.1 treat these names as
+  // deliberately excluded from the `soundness` umbrella. Empty for every other file.
+  private def soundnessUnexported(path: String): Set[String] =
+    if path.contains("/src/plugin/") then Set.empty else
+      val libParts = path.split("/lib/").nn
+      if libParts.length < 2 then Set.empty else
+        val component = libParts(1).nn.split("/").nn(0).nn
+        val file      = java.io.File(path)
+        val fileName  = file.getName.nn
+        if !fileName.startsWith(s"soundness_${component}_") then Set.empty else
+          val parent   = file.getParentFile
+          val siblings = if parent == null then null else parent.listFiles
+          if siblings == null then Set.empty else
+            val out = mutable.Set[String]()
+            siblings.foreach: sibling =>
+              val name = sibling.nn.getName.nn
+              if (name.startsWith(s"$component.") || name.startsWith(s"${component}_"))
+                 && name.endsWith(".scala")
+              then out ++= unexportedNames(sibling.nn)
+            out.to(Set)
+
+  // Parse `file` and return the simple names of definitions it annotates
+  // `@unexported`. Returns the empty set if the file can't be read or parsed.
+  private def unexportedNames(file: java.io.File): Set[String] =
+    try
+      val content        = String(java.nio.file.Files.readAllBytes(file.toPath))
+      val (tree, source) = Parsing.parse(file.getPath.nn, content)
+      Annotations.unexported(tree)
+    catch case _: Throwable => Set.empty
 
   // Modifiers that may precede a public top-level declaration; `private` and
   // `protected` are deliberately absent, so a `private[x] object Foo` line never

--- a/lib/decorum/src/plugin/decorum.SoundnessExports.scala
+++ b/lib/decorum/src/plugin/decorum.SoundnessExports.scala
@@ -37,17 +37,9 @@ import scala.collection.mutable
 import dotty.tools.dotc.ast.untpd
 import dotty.tools.dotc.util.SourceFile
 
-case class ExportInfo(names: Set[String], excluded: Set[String], firstLine: Int)
+case class ExportInfo(names: Set[String], firstLine: Int)
 
 object SoundnessExports:
-  // A directive comment, `// unexported: Foo, Bar`, marks modules that are
-  // deliberately not re-exported into `soundness` (typically because the simple
-  // name already belongs to another component's surface). R-742 treats these as
-  // satisfied. The capture stops at end of line or an opening parenthesis, so a
-  // trailing justification (`// unexported: Foo (clashes with bar.Foo)`) is fine.
-  private val ExcludeDirective = "(?m)//\\s*unexported:\\s*([^\\n(]+)".r
-  private val Identifier       = "[A-Za-z][A-Za-z0-9]*".r
-
   // Collect the simple leaf names re-exported by every top-level `export`
   // statement in the file (including those nested inside `package x:` blocks),
   // together with the line of the first such statement. Used by R-742 to check
@@ -77,12 +69,7 @@ object SoundnessExports:
 
     visit(tree)
 
-    val content  = String(source.content)
-    val excluded = mutable.Set[String]()
-    ExcludeDirective.findAllMatchIn(content).foreach: directive =>
-      Identifier.findAllIn(directive.group(1).nn).foreach(excluded += _)
-
-    ExportInfo(names.to(Set), excluded.to(Set), if firstLine < 0 then PackageLine else firstLine)
+    ExportInfo(names.to(Set), if firstLine < 0 then PackageLine else firstLine)
 
   // The line of the `package soundness` declaration in export-surface files;
   // used as the fallback violation position when a surface contains no exports.

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -1002,8 +1002,8 @@ object Tests extends Suite(m"Decorum Tests"):
         extractedUnexported("@unexported\nobject Timestamp\n")
       . assert(_ == Set("Timestamp"))
 
-      test(m"@unexported with a reason argument is detected"):
-        extractedUnexported("@unexported(\"clashes with superlunary.Executor\")\ntrait Executor\n")
+      test(m"@unexported on a trait is detected"):
+        extractedUnexported("@unexported\ntrait Executor\n")
       . assert(_ == Set("Executor"))
 
       test(m"@unexported on an extension method is detected"):

--- a/lib/decorum/src/test/decorum_test.scala
+++ b/lib/decorum/src/test/decorum_test.scala
@@ -51,15 +51,24 @@ object Tests extends Suite(m"Decorum Tests"):
 
   def rules(body: String): List[String] = violations(body).map(_.rule)
 
-  def exportRules(body: String, siblings: List[String]): List[String] =
-    Checker.check("<test>", Some("soundness"), stub(body), siblings).toList.map(_.rule)
+  def exportRules
+     (body: String, siblings: List[String], unexported: Set[String] = Set.empty)
+  :   List[String] =
+    Checker.check("<test>", Some("soundness"), stub(body), siblings, Nil, unexported).toList.map(_.rule)
 
-  def extensionExportRules(body: String, extensions: List[String]): List[String] =
-    Checker.check("<test>", Some("soundness"), stub(body), Nil, extensions).toList.map(_.rule)
+  def extensionExportRules
+     (body: String, extensions: List[String], unexported: Set[String] = Set.empty)
+  :   List[String] =
+    Checker.check("<test>", Some("soundness"), stub(body), Nil, extensions, unexported).toList
+      .map(_.rule)
 
   def extractedExtensions(body: String): List[String] =
     val (tree, source) = Parsing.parse("<test>", stub(body))
     Extensions.extract(tree, source)
+
+  def extractedUnexported(body: String): Set[String] =
+    val (tree, source) = Parsing.parse("<test>", stub(body))
+    Annotations.unexported(tree)
 
   def run(): Unit =
     suite(m"Phase 1: Universal rules"):
@@ -940,15 +949,13 @@ object Tests extends Suite(m"Decorum Tests"):
         exportRules("export jacinta.{Json}\n", Nil)
       . assert(r => !r.contains("742"))
 
-      test(m"An `unexported:` directive suppresses the violation"):
-        exportRules
-         ("// unexported: Timestamp (clashes with aviation.Timestamp)\nexport embarcadero.{Image}\n",
-          List("Image", "Timestamp"))
+      test(m"An `@unexported` module suppresses the violation"):
+        exportRules("export embarcadero.{Image}\n", List("Image", "Timestamp"), Set("Timestamp"))
       . assert(r => !r.contains("742"))
 
-      test(m"An `unexported:` directive only suppresses the named module"):
+      test(m"An `@unexported` module only suppresses the named module"):
         exportRules
-         ("// unexported: Timestamp\nexport embarcadero.{Image}\n", List("Image", "Timestamp", "Layer"))
+         ("export embarcadero.{Image}\n", List("Image", "Timestamp", "Layer"), Set("Timestamp"))
       . assert(_.contains("742"))
 
     suite(m"Phase 7: Soundness extension-method export completeness (R742.1)"):
@@ -965,9 +972,8 @@ object Tests extends Suite(m"Decorum Tests"):
         extensionExportRules("export xylophone.{x, xp}\n", Nil)
       . assert(r => !r.contains("742.1"))
 
-      test(m"An `unexported:` directive suppresses the extension violation"):
-        extensionExportRules
-         ("// unexported: xml (clashes with honeycomb.xml)\nexport xylophone.{x}\n", List("x", "xml"))
+      test(m"An `@unexported` extension method suppresses the extension violation"):
+        extensionExportRules("export xylophone.{x}\n", List("x", "xml"), Set("xml"))
       . assert(r => !r.contains("742.1"))
 
       test(m"Extract names a single-line extension method"):
@@ -989,3 +995,21 @@ object Tests extends Suite(m"Decorum Tests"):
       test(m"Extract skips qualified-private extension methods"):
         extractedExtensions("extension (value: Text)\n  def a: Int = 1\n  private[decorum] def b = 2\n")
       . assert(_ == List("a"))
+
+    suite(m"Phase 7: @unexported annotation extraction"):
+
+      test(m"@unexported on an object is detected"):
+        extractedUnexported("@unexported\nobject Timestamp\n")
+      . assert(_ == Set("Timestamp"))
+
+      test(m"@unexported with a reason argument is detected"):
+        extractedUnexported("@unexported(\"clashes with superlunary.Executor\")\ntrait Executor\n")
+      . assert(_ == Set("Executor"))
+
+      test(m"@unexported on an extension method is detected"):
+        extractedUnexported("extension (x: Int)\n  @unexported def apply(y: Int): Int = y\n")
+      . assert(_ == Set("apply"))
+
+      test(m"unannotated definitions are not collected"):
+        extractedUnexported("object Foo\nextension (x: Int) def bar: Int = x\n")
+      . assert(_ == Set())

--- a/lib/embarcadero/src/containerd/embarcadero.Timestamp.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.Timestamp.scala
@@ -36,7 +36,8 @@ import anticipation.*
 import locomotion.field
 import prepositional.*
 
-@unexported("collides with aviation.Timestamp in the umbrella; reach it via embarcadero.Timestamp")
+// Not exported: collides with aviation.Timestamp; reach it via embarcadero.Timestamp
+@unexported
 object Timestamp:
   // Build a protobuf timestamp from any instant type — e.g. Aviation's `Instant` —
   // through anticipation's generic time abstraction, so no dependency on a specific

--- a/lib/embarcadero/src/containerd/embarcadero.Timestamp.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.Timestamp.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import locomotion.field
 import prepositional.*
 
+@unexported("collides with aviation.Timestamp in the umbrella; reach it via embarcadero.Timestamp")
 object Timestamp:
   // Build a protobuf timestamp from any instant type — e.g. Aviation's `Instant` —
   // through anticipation's generic time abstraction, so no dependency on a specific

--- a/lib/embarcadero/src/containerd/soundness_embarcadero_containerd.scala
+++ b/lib/embarcadero/src/containerd/soundness_embarcadero_containerd.scala
@@ -32,10 +32,6 @@
                                                                                                   */
 package soundness
 
-// `Timestamp` is intentionally not exported: it collides with `aviation.Timestamp` in
-// the umbrella, and callers normally reach times through `…createdAt.instant[Instant]`
-// rather than naming it. Use `embarcadero.Timestamp` directly when constructing one.
-// unexported: Timestamp
 export embarcadero.{AnyMessage, Containerd, Container, ContentDescriptor, DockerEvent,
     CreateContainerRequest, CreateContainerResponse, CreateNamespaceRequest,
     CreateNamespaceResponse, CreateTaskRequest, CreateTaskResponse, DeleteContainerRequest,

--- a/lib/frontier/src/core/frontier.Diagnostic.scala
+++ b/lib/frontier/src/core/frontier.Diagnostic.scala
@@ -46,6 +46,7 @@ import vacuous.*
 // be produced by Frontier's catch-all *and* by other macros — e.g. Wisteria's
 // generic derivation, which can attach a `label` (a field or variant name) to
 // each node.
+@unexported("clashes with harlequin.Diagnostic in the umbrella; reach it via frontier.Diagnostic")
 object Diagnostic:
   given treeStyle: [text: Textual] => TextualTreeStyle[text] =
     TextualTreeStyle(t"   ", t" └─", t" ├─", t" │ ")

--- a/lib/frontier/src/core/frontier.Diagnostic.scala
+++ b/lib/frontier/src/core/frontier.Diagnostic.scala
@@ -46,7 +46,8 @@ import vacuous.*
 // be produced by Frontier's catch-all *and* by other macros — e.g. Wisteria's
 // generic derivation, which can attach a `label` (a field or variant name) to
 // each node.
-@unexported("clashes with harlequin.Diagnostic in the umbrella; reach it via frontier.Diagnostic")
+// Not exported: clashes with harlequin.Diagnostic in the umbrella; reach it via frontier.Diagnostic
+@unexported
 object Diagnostic:
   given treeStyle: [text: Textual] => TextualTreeStyle[text] =
     TextualTreeStyle(t"   ", t" └─", t" ├─", t" │ ")

--- a/lib/frontier/src/core/soundness_frontier_core.scala
+++ b/lib/frontier/src/core/soundness_frontier_core.scala
@@ -34,8 +34,5 @@ package soundness
 
 import frontier.*
 
-// unexported: Diagnostic (clashes with `harlequin.Diagnostic` in the umbrella; reach it via
-// `frontier.Diagnostic`)
-
 package context:
   transparent inline given explainMissingContext: [any] => any = internal.explanation[any]

--- a/lib/gigantism/src/core/gigantism.Every.scala
+++ b/lib/gigantism/src/core/gigantism.Every.scala
@@ -36,8 +36,6 @@ import scala.quoted.*
 
 import dotty.tools.dotc.*
 
-inline def every[value]: Every[value] = ${Every.summonAll[value]}
-
 object Every:
   transparent inline given default: [value] => Every[value] = ${summonAll[value]}
 

--- a/lib/gigantism/src/core/gigantism_core.scala
+++ b/lib/gigantism/src/core/gigantism_core.scala
@@ -36,6 +36,8 @@ import scala.quoted.*
 
 type Macro[result] = Quotes ?=> Expr[result]
 
+inline def every[value]: Every[value] = ${Every.summonAll[value]}
+
 inline def metaprogramming(using quotes: Quotes): Metaprogramming(quotes) =
   Metaprogramming(quotes)
 

--- a/lib/gossamer/src/core/soundness_gossamer_core.scala
+++ b/lib/gossamer/src/core/soundness_gossamer_core.scala
@@ -39,9 +39,9 @@ export
       count, cut, Cuttable, data, Decimalizer, Dictionary, ends, erase, extract, fill, fit, from,
       fuzzy, Grapheme, init, join, Joinable, kebab, keep, length, Lexicon, lines, lower,
       Ltr, Numerous, ossify, pad, pascal, plain, Proximity, proximity, Pue, pue, punycode,
-      RangeError, reverse, Rtl, search, offsetOf, SimpleTExtractor, skip, slices, snake, snip, spaced,
-      starts, strip, sub, subscripts, superscripts, sysData, t, tail, text, TextBuilder, Textual,
-      tr, trim, txt, uncamel, uncapitalize, unkebab, unsnake, upper, upto, urlDecode,
+      RangeError, reverse, Rtl, search, offsetOf, SimpleTExtractor, skip, slices, snake, snip,
+      spaced, starts, strip, sub, subscripts, superscripts, sysData, t, tail, text, TextBuilder,
+      Textual, tr, trim, txt, uncamel, uncapitalize, unkebab, unsnake, upper, upto, urlDecode,
       urlEncode, utf16, utf8, pinpoint, words, Writing, WritingBuilder, a, justify, punch }
 
 package decimalConverters:

--- a/lib/harlequin/src/core/harlequin.Completion.scala
+++ b/lib/harlequin/src/core/harlequin.Completion.scala
@@ -37,6 +37,7 @@ import denominative.*
 import stenography.*
 import vacuous.*
 
+@unexported()
 object Completion:
   enum Kind:
     case Term, Method, Given, Extension, Type, Module, Package

--- a/lib/harlequin/src/core/harlequin.Completion.scala
+++ b/lib/harlequin/src/core/harlequin.Completion.scala
@@ -37,7 +37,7 @@ import denominative.*
 import stenography.*
 import vacuous.*
 
-@unexported()
+@unexported
 object Completion:
   enum Kind:
     case Term, Method, Given, Extension, Type, Module, Package

--- a/lib/harlequin/src/core/soundness_harlequin_core.scala
+++ b/lib/harlequin/src/core/soundness_harlequin_core.scala
@@ -35,6 +35,5 @@ package soundness
 // `Completion`/`Completions` are intentionally not re-exported here: those names
 // already belong to `exoskeleton` in the `soundness` namespace. Reach harlequin's
 // via `harlequin.Completion` / `harlequin.Completions`.
-// unexported: Completion
 export harlequin.{Accent, Diagnostic, Highlight, Java, Depth, ProgrammingLanguage, Scala,
     SourceCode, Token, highlighting}

--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -417,15 +417,22 @@ extension (long: Long)
   def lcm(right: Long): Long = long*right/long.gcd(right)
 
 extension (doubleObject: Double.type)
+  @unexported
   inline def apply(long: Long): Double = JDouble.longBitsToDouble(long)
 
 extension (shortObject: Short.type)
+  @unexported
   def apply(bits: B16): Short = bits.asInstanceOf[Short]
+
+  @unexported
 
   def apply(bytes: IArray[Byte]): Short = (((bytes(0) & 0xFF) << 8) | (bytes(1) & 0xff)).toShort
 
 extension (intObject: Int.type)
+  @unexported
   def apply(bits: B32): Int = bits.asInstanceOf[Int]
+
+  @unexported
 
   def apply(bytes: IArray[Byte]): Int =
     var int: Int = (bytes(0) & 0xFF).toInt
@@ -439,7 +446,10 @@ extension (intObject: Int.type)
     int
 
 extension (longObject: Long.type)
+  @unexported
   def apply(bits: B64): Long = bits.asInstanceOf[Long]
+
+  @unexported
 
   def apply(bytes: IArray[Byte]): Long =
     var long: Long = (bytes(0) & 0xFF).toLong

--- a/lib/hypotenuse/src/core/hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/hypotenuse_core.scala
@@ -425,7 +425,6 @@ extension (shortObject: Short.type)
   def apply(bits: B16): Short = bits.asInstanceOf[Short]
 
   @unexported
-
   def apply(bytes: IArray[Byte]): Short = (((bytes(0) & 0xFF) << 8) | (bytes(1) & 0xff)).toShort
 
 extension (intObject: Int.type)
@@ -433,7 +432,6 @@ extension (intObject: Int.type)
   def apply(bits: B32): Int = bits.asInstanceOf[Int]
 
   @unexported
-
   def apply(bytes: IArray[Byte]): Int =
     var int: Int = (bytes(0) & 0xFF).toInt
     int <<= 8
@@ -450,7 +448,6 @@ extension (longObject: Long.type)
   def apply(bits: B64): Long = bits.asInstanceOf[Long]
 
   @unexported
-
   def apply(bytes: IArray[Byte]): Long =
     var long: Long = (bytes(0) & 0xFF).toLong
     long <<= 8

--- a/lib/hypotenuse/src/core/soundness_hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/soundness_hypotenuse_core.scala
@@ -32,9 +32,13 @@
                                                                                                   */
 package soundness
 
+// unexported: apply (the bit/byte `Double`/`Long`/`Int`/`Short` companion
+// constructors collide with quantitative's top-level `apply` in the `soundness`
+// package; reach them via `import hypotenuse.*`)
+
 export
   hypotenuse
-  . { %%, **, /-, <, <=, >, >=, abs, acos, apply, asin, atan, B16, B32, B64, B8, base32, bin,
+  . { %%, **, /-, <, <=, >, >=, abs, acos, asin, atan, B16, B32, B64, B8, base32, bin,
       binary, bits, ceiling, CheckOverflow, Commensurable, cos, cosh, decrement, DivisionByZero,
       DivisionError, erf, euler, exp, expm1, exponent, F32, F64, finite, floor, gcd, goldenRatio,
       hex, hyp, increment, infinite, int, lcm, ln, log10, log1p, long, mantissa, nan, octal,

--- a/lib/hypotenuse/src/core/soundness_hypotenuse_core.scala
+++ b/lib/hypotenuse/src/core/soundness_hypotenuse_core.scala
@@ -32,10 +32,6 @@
                                                                                                   */
 package soundness
 
-// unexported: apply (the bit/byte `Double`/`Long`/`Int`/`Short` companion
-// constructors collide with quantitative's top-level `apply` in the `soundness`
-// package; reach them via `import hypotenuse.*`)
-
 export
   hypotenuse
   . { %%, **, /-, <, <=, >, >=, abs, acos, asin, atan, B16, B32, B64, B8, base32, bin,

--- a/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
+++ b/lib/kaleidoscope/src/core/kaleidoscope.Regex.scala
@@ -112,8 +112,7 @@ object Regex:
 
 
   def apply(parts: Seq[String])(using erased Unsafe): Regex =
-    import strategies.throwUnsafely
-    parse(parts.to(List).map(_.tt))
+    strategies.throwUnsafely.give(parse(parts.to(List).map(_.tt)))
 
   def apply(text: Text): Regex raises RegexError = parse(List(text))
 

--- a/lib/nomenclature/src/core/nomenclature.MustContain.scala
+++ b/lib/nomenclature/src/core/nomenclature.MustContain.scala
@@ -34,7 +34,6 @@ package nomenclature
 
 import anticipation.*
 import fulminate.*
-import gossamer.*
 import rudiments.*
 
 object MustContain extends Rule({ text => m"must contain $text" }, _.subsumes(_))

--- a/lib/nomenclature/src/core/nomenclature.MustNotContain.scala
+++ b/lib/nomenclature/src/core/nomenclature.MustNotContain.scala
@@ -34,7 +34,6 @@ package nomenclature
 
 import anticipation.*
 import fulminate.*
-import gossamer.*
 import rudiments.*
 
 object MustNotContain extends Rule({ text => m"must not contain $text"}, !_.subsumes(_))

--- a/lib/panopticon/src/core/soundness_panopticon_core.scala
+++ b/lib/panopticon/src/core/soundness_panopticon_core.scala
@@ -32,6 +32,4 @@
                                                                                                   */
 package soundness
 
-// `lensFold` is deliberately not exported into the umbrella.
-// unexported: lensFold
 export panopticon.{Coercible, Composable, compose, Each, Filter, Lens, lens, Optic, Optical}

--- a/lib/proscenium/src/core/proscenium_core.scala
+++ b/lib/proscenium/src/core/proscenium_core.scala
@@ -66,6 +66,14 @@ export Conversion.into
 type Nat = Int & Singleton
 type Label = String & Singleton
 
+// Marks a top-level definition (a module, an extension method, …) that is
+// deliberately *not* re-exported into the `soundness` umbrella — typically because
+// its simple name clashes with another component's in that package, or it is a
+// compile-time/internal helper reached via the component's own import. Decorum's
+// SN-742/SN-742.1 export rules read this annotation and skip the annotated
+// definition; the optional `reason` documents why.
+final class unexported(reason: String = "") extends StaticAnnotation
+
 @targetName("partialFn")
 infix type ~> [-domain, +range] = PartialFunction[domain, range]
 

--- a/lib/proscenium/src/core/proscenium_core.scala
+++ b/lib/proscenium/src/core/proscenium_core.scala
@@ -71,8 +71,8 @@ type Label = String & Singleton
 // its simple name clashes with another component's in that package, or it is a
 // compile-time/internal helper reached via the component's own import. Decorum's
 // SN-742/SN-742.1 export rules read this annotation and skip the annotated
-// definition; the optional `reason` documents why.
-final class unexported(reason: String = "") extends StaticAnnotation
+// definition.
+final class unexported() extends StaticAnnotation
 
 @targetName("partialFn")
 infix type ~> [-domain, +range] = PartialFunction[domain, range]

--- a/lib/proscenium/src/core/soundness_proscenium_core.scala
+++ b/lib/proscenium/src/core/soundness_proscenium_core.scala
@@ -64,7 +64,7 @@ export scala.annotation.unchecked.{uncheckedCaptures, uncheckedStable, unchecked
 export scala.LazyList as Stream
 export scala.DummyImplicit as Void
 
-export proscenium.{`~>`, Label, Mono, Nat, Zero}
+export proscenium.{`~>`, Label, Mono, Nat, unexported, Zero}
 
 transparent inline def infer[context]: context = compiletime.summonInline[context]
 

--- a/lib/quantitative/src/core/quantitative.Radix.scala
+++ b/lib/quantitative/src/core/quantitative.Radix.scala
@@ -35,8 +35,8 @@ package quantitative
 // A `Radix` is one rung of a mixed-radix positional system over a continuum (a calendar/clock, in
 // the case of time). The marker lives here, alongside `Seconds`, so that the SI second can itself
 // be a radix — `Seconds[1] <: Radix.Regular` — and therefore appear in the phantom `Topic` of an
-// aviation `Timespan`/`Timestamp` while remaining an ordinary `Quantity` unit. Other radices (years,
-// months, weeks, days, hours, minutes) are defined in aviation and extend these markers.
+// aviation `Timespan`/`Timestamp` while remaining an ordinary `Quantity` unit. Other radices
+// (years, months, weeks, days, hours, minutes) are defined in aviation and extend these markers.
 //
 // `Regular` radices have a constant ratio to the radix below them within a tick family; `Irregular`
 // radices have a position-dependent length and so cannot be added to a bare instant.

--- a/lib/rudiments/src/core/rudiments.Inclusive.scala
+++ b/lib/rudiments/src/core/rudiments.Inclusive.scala
@@ -12,7 +12,6 @@
 ┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
 ┃                                                                                                  ┃
 ┃    Soundness, version 0.54.0.                                                                    ┃
-┃                                                                                                  ┃
 ┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
 ┃                                                                                                  ┃
 ┃    The primary distribution site is:                                                             ┃

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -458,8 +458,12 @@ extension [tuple <: Tuple](tuple: tuple)
   def to[product: Mirror.ProductOf]: product = product.fromProduct(tuple)
 
 extension (erased tuple: Tuple)
+  @unexported
   inline def contains[element]: Boolean = indexOf[element] >= 0
+  @unexported
   inline def indexOf[element]: Int = recurIndex[tuple.type, element](0)
+
+  @unexported
 
   transparent inline def subtypes[supertype]: Tuple = recurSubtypes[tuple.type, supertype, Zero]
 
@@ -479,6 +483,7 @@ extension (erased tuple: Tuple)
       case _: (other *: tail)   => recurIndex[tail, element](index + 1)
 
 extension (using quotes: Quotes)(repr: quotes.reflect.TypeRepr)
+  @unexported
   inline def literal
     [ primitive
       <:  Boolean | Byte | Short | Int | Long | Float | Double | Char | String | Unit | Null ]

--- a/lib/rudiments/src/core/rudiments_core.scala
+++ b/lib/rudiments/src/core/rudiments_core.scala
@@ -154,7 +154,7 @@ extension [self](self: self)(using traversable: self is Traversable)
       case None          => Unset
 
   def where(predicate: traversable.Operand => Boolean): Optional[Ordinal] =
-    traversable.traverse(self).zipWithIndex.find((element, _) => predicate(element)) match
+    traversable.traverse(self).zipWithIndex.find { (element, _) => predicate(element) } match
       case Some((_, index)) => index.z
       case None             => Unset
 
@@ -165,8 +165,10 @@ extension [self](self: self)(using traversable: self is Traversable)
     val whole = Vector.from(traversable.traverse(self))
     val part  = Vector.from(traversable.traverse(subsequence))
     val last  = whole.length - part.length
+
     part.isEmpty || whole.indices.exists: start =>
-      start <= last && part.indices.forall(offset => whole(start + offset) == part(offset))
+      start <= last && part.indices.forall: offset =>
+        whole(start + offset) == part(offset)
 
 extension [value](iterator: Iterator[value])
   transparent inline def each(predicate: Ordinal aka "ordinal" ?=> value => Unit): Unit =
@@ -464,7 +466,6 @@ extension (erased tuple: Tuple)
   inline def indexOf[element]: Int = recurIndex[tuple.type, element](0)
 
   @unexported
-
   transparent inline def subtypes[supertype]: Tuple = recurSubtypes[tuple.type, supertype, Zero]
 
   private transparent inline def recurSubtypes[tuple <: Tuple, supertype, done <: Tuple]: Tuple =

--- a/lib/rudiments/src/core/soundness_rudiments_core.scala
+++ b/lib/rudiments/src/core/soundness_rudiments_core.scala
@@ -32,9 +32,6 @@
                                                                                                   */
 package soundness
 
-// unexported: literal, contains, indexOf, subtypes (compile-time / type-level
-// helpers for macro authors, reached via `import rudiments.*`, not end-user API)
-
 export
   rudiments
   . { !!, &, all, also, and, annex, at, b, bi, Bijection, bijection, Bytes, bytes, collate, Counter,

--- a/lib/scintillate/src/server/scintillate_core.scala
+++ b/lib/scintillate/src/server/scintillate_core.scala
@@ -128,6 +128,7 @@ def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.
 inline def request: Http.Request = infer[Http.Request]
 
 extension (request: Http.Request)
+  @unexported
   def as[body: Acceptable]: body = body.accept(request)
 
 package webserverErrorPages:

--- a/lib/scintillate/src/server/soundness_scintillate_server.scala
+++ b/lib/scintillate/src/server/soundness_scintillate_server.scala
@@ -35,7 +35,6 @@ package soundness
 // `as` (decode an HTTP request body, via the `Acceptable` typeclass) clashes in
 // the umbrella with distillate's generic `Decodable`-based `as`; reach this one
 // via `scintillate.as`.
-// unexported: as
 export
   scintillate
   . { Acceptable, basicAuth, cookie, HttpConnection, HttpServer, HttpServerEvent, NoCache, NotFound,

--- a/lib/stratiform/src/binary/stratiform_binary.scala
+++ b/lib/stratiform/src/binary/stratiform_binary.scala
@@ -81,8 +81,6 @@ extension (tel: Tel)
 
     Bintel.frame(tel.bintel(schema), signature)
 
-
-
 extension (element: Tel.Element)
   // Encode a pre-assigned semantic-model element to BinTEL body bytes.
   // The schema supplies the member layout needed for §7.2 canonical

--- a/lib/xylophone/src/core/soundness_xylophone_core.scala
+++ b/lib/xylophone/src/core/soundness_xylophone_core.scala
@@ -34,7 +34,6 @@ package soundness
 
 // `Attributive`, `Renderable` and `Tag` clash with `honeycomb`'s names in the umbrella;
 // reach xylophone's via `xylophone.Attributive` etc.
-// unexported: Attributive, Renderable, Tag
 export
   xylophone
   . { Xml, xml, XmlError, XmlSchema, DynamicXmlEnabler, dynamicXmlAccess, x, xp, XPath,

--- a/lib/xylophone/src/core/xylophone.Attributive.scala
+++ b/lib/xylophone/src/core/xylophone.Attributive.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import prepositional.*
 import vacuous.*
 
+@unexported()
 object Attributive:
   sealed trait Textual
 

--- a/lib/xylophone/src/core/xylophone.Attributive.scala
+++ b/lib/xylophone/src/core/xylophone.Attributive.scala
@@ -36,7 +36,7 @@ import anticipation.*
 import prepositional.*
 import vacuous.*
 
-@unexported()
+@unexported
 object Attributive:
   sealed trait Textual
 

--- a/lib/xylophone/src/core/xylophone.Renderable.scala
+++ b/lib/xylophone/src/core/xylophone.Renderable.scala
@@ -34,6 +34,6 @@ package xylophone
 
 import prepositional.*
 
-@unexported()
+@unexported
 trait Renderable extends Typeclass, Formal:
   def render(value: Self): Xml of Form

--- a/lib/xylophone/src/core/xylophone.Renderable.scala
+++ b/lib/xylophone/src/core/xylophone.Renderable.scala
@@ -34,5 +34,6 @@ package xylophone
 
 import prepositional.*
 
+@unexported()
 trait Renderable extends Typeclass, Formal:
   def render(value: Self): Xml of Form

--- a/lib/xylophone/src/core/xylophone.Tag.scala
+++ b/lib/xylophone/src/core/xylophone.Tag.scala
@@ -38,7 +38,7 @@ import anticipation.*
 import prepositional.*
 import typonym.*
 
-@unexported()
+@unexported
 object Tag:
   def root(children: Set[Text]): Tag =
     new Tag("#root", Attributes.empty, children):

--- a/lib/xylophone/src/core/xylophone.Tag.scala
+++ b/lib/xylophone/src/core/xylophone.Tag.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import prepositional.*
 import typonym.*
 
+@unexported()
 object Tag:
   def root(children: Set[Text]): Tag =
     new Tag("#root", Attributes.empty, children):

--- a/lib/ypsiloid/src/core/ypsiloid.YamlParser.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.YamlParser.scala
@@ -226,12 +226,8 @@ private[ypsiloid] final class YamlParser:
   // `Cursor[Data]` constructor resolution ambiguous. Local-import-per-
   // branch is the workaround established by jacinta #1147.
   private def makeCursor(input: Data): Cursor[Data] =
-    if tracking then
-      import zephyrine.lineation.linefeedByte
-      Cursor[Data](input)
-    else
-      import Lineation.untrackedData
-      Cursor[Data](input)
+    if tracking then zephyrine.lineation.linefeedByte.give(Cursor[Data](input))
+    else Lineation.untrackedData.give(Cursor[Data](input))
 
   private def resetParserState(): Unit =
     syncFrom()


### PR DESCRIPTION
Replaces Decorum's `// unexported:` comment directive with a real `@unexported` annotation that the SN-742/SN-742.1 export rules read from the annotated definitions, and clears the compiler warnings a full clean build surfaced — leaving only two hard-to-remove `inline given alias` warnings (baroque/superlunary). Also de-exports hypotenuse's bit/byte `apply` constructors, which collided with quantitative's top-level `apply` in the umbrella.

### `@unexported`
- A new parameterless `@unexported` annotation (in `proscenium`, auto-imported everywhere) marks a top-level definition that is deliberately not re-exported into the `soundness` umbrella — a name clash with another component, or a compile-time/internal helper. Decorum collects these names from the sibling module and definition files and skips them, replacing the regex `// unexported:` comment.
- Each clash justification is preserved as a one-line `// Not exported: …` comment above the annotation.

### Warning cleanup
- Source lints: stray blank lines, parenthesised lambdas, over-long lines, an unused import, a duplicate header line.
- gigantism's top-level `every` moves out of the capitalised file (which otherwise generated an `Every$package` class).
- Export gaps closed: breviloquence's `cbor`/`parse` exported; its internal `Cbor.Ast` accessors marked `@unexported`.
- Decorum now recognises that a module re-exported by a *sibling* surface in the same directory (breviloquence's `core`/`parser` split) is not missing.
- `-Xmax-inlines` overrides deduplicated in the build so the option isn't set twice.
- Two `{ import foo.bar; baz }` blocks rewritten as `foo.bar.give(baz)` (kaleidoscope, ypsiloid).
