### PR TITLE
Resolve DST overlaps and gaps when grounding a Moment

### DIFF
--- a/lib/aviation/src/core/aviation.GapPolicy.scala
+++ b/lib/aviation/src/core/aviation.GapPolicy.scala
@@ -32,50 +32,20 @@
                                                                                                   */
 package aviation
 
-import java.time as jt
+// A `GapPolicy` resolves a spring-forward DST gap — a wall-clock time that never occurs because the
+// clocks jump forward over it (e.g. 02:30 when 02:00 becomes 03:00). Grounding such a `Moment` to
+// an `Instant` is ambiguous: it can be nudged into the new offset (`forward`, the instant you get
+// by keeping the pre-transition offset on the same wall-clock, which lands just after the gap) or
+// held in the old offset (`backward`, just before the gap), or rejected. The policy is supplied
+// contextually; unlike `Disambiguation` there is a default (`pushForward`, matching `java.time`),
+// so grounding stays total and non-breaking. Import `gapPolicies.pushBackward` /
+// `gapPolicies.rejectGap` to override it.
+//
+// `resolve` receives the two candidate instants and returns one (or aborts). The rejecting policy
+// captures a `Tactic[TimeError]` when constructed, so it doesn't widen grounding's effect type.
 
-import anticipation.*
-import prepositional.*
+object GapPolicy:
+  given pushForward: GapPolicy = (forward, _) => forward
 
-import abstractables.instantAbstractable
-
-object Moment:
-  given generic: RomanCalendar => Moment is Abstractable across Instants to Long =
-    _.instant.generic
-
-case class Moment
-  ( date:       Date,
-    time:       Clockface,
-    timezone:   Timezone,
-    occurrence: Occurrence = Occurrence.First ):
-
-  def instant(using calendar: RomanCalendar, gap: GapPolicy): Instant =
-    val ldt =
-      jt.LocalDateTime.of
-        ( date.year(),
-          date.month.numerical,
-          date.day(),
-          time.hour,
-          time.minute,
-          time.second,
-          time.nanos ).nn
-
-    val rules = jt.ZoneId.of(timezone.name.s).nn.getRules.nn
-
-    def at(offset: jt.ZoneOffset): Instant = Instant(ldt.toInstant(offset).nn.toEpochMilli)
-
-    rules.getTransition(ldt) match
-      case null       => at(rules.getOffset(ldt).nn)
-
-      case transition =>
-        val before = transition.getOffsetBefore.nn
-        val after = transition.getOffsetAfter.nn
-
-        // A gap (the wall-clock time was skipped) is resolved by the contextual policy; an overlap
-        // (the wall-clock time occurs twice) is resolved by the stored `occurrence`.
-        if transition.isGap then gap.resolve(at(before), at(after))
-        else occurrence match
-          case Occurrence.First  => at(before)
-          case Occurrence.Second => at(after)
-
-  def timestamp: Timestamp = Timestamp(date, time)
+trait GapPolicy:
+  def resolve(forward: Instant, backward: Instant): Instant

--- a/lib/aviation/src/core/aviation.TimeError.scala
+++ b/lib/aviation/src/core/aviation.TimeError.scala
@@ -51,12 +51,16 @@ object TimeError:
       case Unknown(text, kind) =>
         m"$text is not a recognized $kind"
 
+      case Gap =>
+        m"the wall-clock time does not exist in its timezone (a spring-forward DST gap)"
+
   enum Reason(val number: Int) extends Clarification:
     case Format(text: Text, format: Date.Format, offset: Ordinal)(val issue: format.Issue)
     extends Reason(1)
 
     case Invalid(year: Int, month: Int, day: Int, calendar: Calendar) extends Reason(2)
     case Unknown(text: Text, kind: Text) extends Reason(3)
+    case Gap extends Reason(4)
 
 case class TimeError(reason: TimeError.Reason)(using Diagnostics)
 extends Error(333, reason.number)(m"the date was not valid because $reason")

--- a/lib/aviation/src/core/aviation.protointernal.scala
+++ b/lib/aviation/src/core/aviation.protointernal.scala
@@ -162,7 +162,8 @@ object protointernal:
     def tai(using strategy: LeapSeconds.Strategy): TaiInstant = strategy.tai(instant)
 
     infix def in (using RomanCalendar)(timezone: Timezone): Moment =
-      val zonedTime = jt.Instant.ofEpochMilli(instant).nn.atZone(jt.ZoneId.of(timezone.name.s)).nn
+      val zone = jt.ZoneId.of(timezone.name.s).nn
+      val zonedTime = jt.Instant.ofEpochMilli(instant).nn.atZone(zone).nn
 
       val date = zonedTime.getMonthValue.absolve match
         case Month(month) =>
@@ -171,7 +172,16 @@ object protointernal:
       val time = (zonedTime.getHour, zonedTime.getMinute, zonedTime.getSecond).absolve match
         case (Base24(hour), Base60(minute), Base60(second)) => Clockface(hour, minute, second)
 
-      Moment(date, time, timezone)
+      // During a fall-back overlap the same wall-clock time occurs twice; if this instant uses the
+      // post-transition (later) offset, it is the second occurrence — record that so grounding the
+      // `Moment` back to an `Instant` round-trips instead of silently picking the earlier offset.
+      val transition = zone.getRules.nn.getTransition(zonedTime.toLocalDateTime.nn)
+
+      val laterOffset =
+        transition != null && transition.nn.isOverlap &&
+          zonedTime.getOffset.nn.getTotalSeconds == transition.nn.getOffsetAfter.nn.getTotalSeconds
+
+      Moment(date, time, timezone, if laterOffset then Occurrence.Second else Occurrence.First)
 
     def timestamp(using calendar: RomanCalendar, timezone: Timezone): Timestamp =
       in(timezone).timestamp

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -370,6 +370,15 @@ package leapSeconds:
   given step: LeapSeconds.Strategy = LeapSeconds.tai(_)
   given smear: LeapSeconds.Strategy = LeapSeconds.smearTai(_)
 
+// Overrides for the spring-forward DST gap, used to ground a `Moment` whose wall-clock time doesn't
+// exist. The ambient default is `GapPolicy.pushForward` (matching `java.time`); import one of these
+// to push the other way or to reject the gap.
+package gapPolicies:
+  given pushBackward: GapPolicy = (_, backward) => backward
+
+  given rejectGap: Tactic[TimeError] => GapPolicy =
+    (_, _) => abort(TimeError(_.Gap))
+
 // Month-end overflow policies for adding months/years to a date (e.g. Jan 31 + 1 month). No default
 // is provided, so such arithmetic requires one of these to be imported.
 package monthEnds:
@@ -412,6 +421,13 @@ object TimeEvent:
 
 enum TimeEvent:
   case ParseTzdb(name: Text)
+
+// Which occurrence of a wall-clock time a `Moment` denotes during a fall-back DST overlap, where
+// the same local time happens twice (clocks go back). `First` is the earlier instant (under the
+// offset before the transition); `Second` is the later one (after it). For unambiguous times it is
+// always `First`, and grounding ignores it.
+enum Occurrence derives CanEqual:
+  case First, Second
 
 extension (inline double: Double)
   inline def am: Clockface = ${aviation.internal.validTime('double, false)}

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -40,10 +40,10 @@ export
       Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
       FrenchRepublicanCalendar, FrenchRepublicanMonth, Fri, Hebdomad, Holiday, Holidays, Horology,
       HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      IslamicMonth, Iso8601, Jan, Jul, Jun, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, Month, Months, Monthstamp, Nov, now, Oct, OffsetCalendar,
-      Period, PersianCalendar, PersianMonth, pm, Regime, Rfc1123, RomanCalendar, Sat, Sep, Sun, Thu,
-      TimeError, TimeEvent, TimeFormat, TimeNumerics,
+      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, LeapSeconds, Mar, May,
+      Meridiem, Minute, Moment, Mon, Month, Months, Monthstamp, Nov, now, Occurrence, Oct,
+      OffsetCalendar, Period, PersianCalendar, PersianMonth, pm, Regime, Rfc1123, RomanCalendar,
+      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
       TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
       today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
       WorkingDays, Year, Years }
@@ -59,6 +59,9 @@ package nonexistentLeapDays:
 
 package monthEnds:
   export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
+
+package gapPolicies:
+  export aviation.gapPolicies.{pushBackward, rejectGap}
 
 package leapSeconds:
   export aviation.leapSeconds.{step, smear}

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -1875,6 +1875,57 @@ object Tests extends Suite(m"Aviation Tests"):
         ts.instant.in(tz"Europe/London").time.hour
       . assert(_ == 12)
 
+      // On 2024-10-27 London clocks go back at 02:00 BST, so 01:30 local occurs twice: first at
+      // 00:30 UTC (BST), then again at 01:30 UTC (GMT).
+      test(m"DST fall-back: earlier overlap occurrence round-trips through London"):
+        import instantDecodables.iso8601InstantDecodable
+        val earlier = t"2024-10-27T00:30:00Z".decode[Instant]
+        earlier.in(tz"Europe/London").instant == earlier
+      . assert(_ == true)
+
+      test(m"DST fall-back: later overlap occurrence round-trips through London"):
+        import instantDecodables.iso8601InstantDecodable
+        val later = t"2024-10-27T01:30:00Z".decode[Instant]
+        later.in(tz"Europe/London").instant == later
+      . assert(_ == true)
+
+      test(m"DST fall-back: later overlap occurrence is flagged Second"):
+        import instantDecodables.iso8601InstantDecodable
+        t"2024-10-27T01:30:00Z".decode[Instant].in(tz"Europe/London").occurrence
+      . assert(_ == Occurrence.Second)
+
+      test(m"DST fall-back: earlier overlap occurrence is flagged First"):
+        import instantDecodables.iso8601InstantDecodable
+        t"2024-10-27T00:30:00Z".decode[Instant].in(tz"Europe/London").occurrence
+      . assert(_ == Occurrence.First)
+
+      test(m"The two overlap occurrences ground one hour apart"):
+        val london = tz"Europe/London"
+        val clock = Clockface(1, 30, 0)
+        val earlier = Moment(2024-Oct-27, clock, london).instant
+        val later = Moment(2024-Oct-27, clock, london, Occurrence.Second).instant
+        later.long - earlier.long
+      . assert(_ == 3600000L)
+
+      // On 2024-03-31 London clocks jump 01:00 GMT → 02:00 BST, so 01:30 local never happens.
+      test(m"Spring-forward gap pushes forward by default"):
+        import instantDecodables.iso8601InstantDecodable
+        val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
+        grounded == t"2024-03-31T01:30:00Z".decode[Instant]
+      . assert(_ == true)
+
+      test(m"Spring-forward gap can push backward"):
+        import instantDecodables.iso8601InstantDecodable
+        import gapPolicies.pushBackward
+        val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
+        grounded == t"2024-03-31T00:30:00Z".decode[Instant]
+      . assert(_ == true)
+
+      test(m"Spring-forward gap can be rejected"):
+        import gapPolicies.rejectGap
+        capture(Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant)
+      . assert(_ == TimeError(_.Gap))
+
       test(m"Timezone(t\"NotARealZone\") raises TimezoneError"):
         capture(Timezone(t"NotARealZone"))
       . matches:


### PR DESCRIPTION
Grounding a `Moment` to an `Instant` now handles the two daylight-saving discontinuities explicitly. During an autumn fall-back overlap a wall-clock time occurs twice, and a `Moment` records which occurrence it is; during a spring-forward gap a wall-clock time doesn't occur at all, and a contextual policy decides how to resolve it. This also fixes a latent bug where converting an `Instant` in the repeated hour to a `Moment` and back silently shifted it by an hour.

`Moment` gains an `Occurrence` field (`First` or `Second`), defaulted to `First` so existing code is unaffected. Converting an `Instant` to a `Moment` now records whether it is the earlier or later occurrence of a fall-back overlap, and grounding a `Moment` back to an `Instant` honours that choice, so the round-trip is stable:

```scala
import calendars.gregorianCalendar
// 01:30 in London on 2024-10-27 happens twice
val later = t"2024-10-27T01:30:00Z".decode[Instant].in(tz"Europe/London")
later.occurrence       // Occurrence.Second
later.instant          // back to 2024-10-27T01:30:00Z, not 00:30
```

A spring-forward gap (a wall-clock time the clocks jump over) is resolved by a contextual `GapPolicy`. The default, `GapPolicy.pushForward`, matches `java.time`; import an alternative to change it:

```scala
import gapPolicies.pushBackward   // or gapPolicies.rejectGap to raise a TimeError
// 2024-03-31 01:30 doesn't exist in London (clocks jump 01:00→02:00)
Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
```