### PR TITLE
Type-check asynchronous error handling: split Tactic into Emit, add a typed handler

### DIFF
--- a/lib/caesura/src/test/caesura.AccrualTests.scala
+++ b/lib/caesura/src/test/caesura.AccrualTests.scala
@@ -52,7 +52,7 @@ object AccrualTests extends Suite(m"Caesura multi-error accrual tests"):
     validate[CellRef](Issues()):
       case error: DsvError =>
         accrual + (prior.let(_.column).or(t"#"), error)
-    . within(decode(dsv))
+    . protect(decode(dsv))
 
   private def row(text: Text): Dsv = text.read[Sheet].rows.head
 

--- a/lib/cataclysm/src/core/cataclysm_core.scala
+++ b/lib/cataclysm/src/core/cataclysm_core.scala
@@ -55,7 +55,7 @@ given cssAggregable: (Tactic[CssErrors], Diagnostics) => Css is Aggregable by Te
   track[Text](CssErrors(Nil)):
     case error: CssError => accrual + error
 
-  . within:
+  . protect:
       CssParser.parse(source.iterator)
 
 // The class and id names referenced anywhere in a stylesheet, including inside

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -70,7 +70,7 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
     // keeps running. The connection is always closed afterwards. A failure to *accept* a
     // connection runs on the loop thread (not a daemon), so `safely` skips that iteration; on
     // `stop()` the loop is already `Stopping`, so the interrupted `accept()` simply unwinds.
-    trap:
+    contain:
       case _ => Remedy.Accept
 
     . within:

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -73,7 +73,7 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
     contain:
       case _ => Remedy.Accept
 
-    . within:
+    . protect:
         val bindLoop = loop:
           safely(bindable.connect(binding)).let: connection =>
             daemon:

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -77,6 +77,10 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
         val bindLoop = loop:
           safely(bindable.connect(binding)).let: connection =>
             daemon:
+              // A connection failure aborts just this handler; throw it to the enclosing
+              // `contain`, which closes the connection and carries on accepting others.
+              given Tactic[ConnectionError] = AsyncTactic()
+
               try bindable.transmit(binding, connection, lambda(connection))
               finally bindable.close(connection)
 

--- a/lib/contingency/src/core/contingency.Emit.scala
+++ b/lib/contingency/src/core/contingency.Emit.scala
@@ -34,20 +34,20 @@ package contingency
 
 import language.experimental.pureFunctions
 
+import beneficence.*
 import fulminate.*
 
-// A `Tactic` is an `Emit` that can additionally `abort`: a value-replacing abnormal exit. `raises
-// error` (`Tactic[error] ?=>`) is therefore the stronger obligation than `emits error`; code with a
-// `Tactic` can satisfy either, but a fire-and-forget context offering only an `Emit` cannot supply
-// the `abort` half. See [[Emit]].
-trait Tactic[-error <: Exception] extends Emit[error]:
-  private inline def tactic: this.type = this
-  def abort(error: Diagnostics ?=> error): Nothing
-  def certify(): Unit
+// The capability to *emit* an error of type `error` as a side-effect: `record` reports it but does
+// not, of itself, abort — control may continue (whether it actually does is the implementation's
+// choice). `Tactic` adds the value-replacing `abort`. `raise` needs only an `Emit`; `abort` needs a
+// full `Tactic`. So `emits error` (`Emit[error] ?=>`) is the weaker obligation than `raises error`
+// (`Tactic[error] ?=>`), and a `Tactic` in scope discharges either.
+trait Emit[-error <: Exception] extends Findable:
+  private inline def emitter: this.type = this
+  def diagnostics: Diagnostics
+  def record(error: Diagnostics ?=> error): Unit
 
-  override def contramap[error2 <: Exception](lambda: error2 => error): Tactic[error2] =
-    new Tactic[error2]:
-      def diagnostics: Diagnostics = tactic.diagnostics
-      def record(error: Diagnostics ?=> error2): Unit = tactic.record(lambda(error))
-      def abort(error: Diagnostics ?=> error2): Nothing = tactic.abort(lambda(error))
-      def certify(): Unit = tactic.certify()
+  def contramap[error2 <: Exception](lambda: error2 => error): Emit[error2] =
+    new Emit[error2]:
+      def diagnostics: Diagnostics = emitter.diagnostics
+      def record(error: Diagnostics ?=> error2): Unit = emitter.record(lambda(error))

--- a/lib/contingency/src/core/contingency.Emit.scala
+++ b/lib/contingency/src/core/contingency.Emit.scala
@@ -37,6 +37,16 @@ import language.experimental.pureFunctions
 import beneficence.*
 import fulminate.*
 
+object Emit:
+  // Builds an `Emit` whose `record` simply runs `handler` as a side-effect at the emit point — the
+  // basis of a typed `trap`, where each handled error type gets an `Emit` backed by its case body.
+  def handle[error <: Exception](handler: error => Unit)(using diagnostics0: Diagnostics)
+  :   Emit[error] =
+
+    new Emit[error]:
+      def diagnostics: Diagnostics = diagnostics0
+      def record(error: Diagnostics ?=> error): Unit = handler(error(using diagnostics0))
+
 // The capability to *emit* an error of type `error` as a side-effect: `record` reports it but does
 // not, of itself, abort — control may continue (whether it actually does is the implementation's
 // choice). `Tactic` adds the value-replacing `abort`. `raise` needs only an `Emit`; `abort` needs a

--- a/lib/contingency/src/core/contingency.Emit.scala
+++ b/lib/contingency/src/core/contingency.Emit.scala
@@ -39,8 +39,8 @@ import fulminate.*
 
 object Emit:
   // Builds an `Emit` whose `record` simply runs `handler` as a side-effect at the emit point — the
-  // basis of a typed `trap`, where each handled error type gets an `Emit` backed by its case body.
-  def handle[error <: Exception](handler: error => Unit)(using diagnostics0: Diagnostics)
+  // basis of `handle`, where each covered error type gets an `Emit` backed by its case body.
+  def apply[error <: Exception](handler: error => Unit)(using diagnostics0: Diagnostics)
   :   Emit[error] =
 
     new Emit[error]:

--- a/lib/contingency/src/core/contingency.Handler.scala
+++ b/lib/contingency/src/core/contingency.Handler.scala
@@ -36,14 +36,16 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-object Trap:
-  extension [lambda[_]](inline trap: Trap[lambda])
-    inline def within[result](inline body: lambda[result])(using diagnostics: Diagnostics): result =
-      ${contingency.internal.trapWithin[lambda, result]('trap, 'body, 'diagnostics)}
+object Handler:
+  extension [lambda[_]](inline handler: Handler[lambda])
+    inline def protect[result](inline body: lambda[result])(using diagnostics: Diagnostics)
+    :   result =
 
-// Captures a typed error handler. `trap { case FooError(n) => … }` records, at compile time, which
-// error types the cases cover (encoded in `lambda`); `.within { … }` then injects one
+      ${contingency.internal.protectBody[lambda, result]('handler, 'body, 'diagnostics)}
+
+// Captures a typed error handler. `handle { case FooError(n) => … }` records, at compile time, the
+// error types the cases cover (in `lambda`); `.protect { … }` then injects one
 // handler-backed `Emit` per covered type into the block, so an `emit`/`raise` of a covered error
 // runs its case body as a side-effect, while any *uncovered* (or *re-emitted*) error stays a free
 // `Emit` requirement and propagates outward as `emits …`. The case bodies return `Unit`.
-class Trap[lambda[_]](val handler: PartialFunction[Exception, Unit])
+class Handler[lambda[_]](val handler: PartialFunction[Exception, Unit])

--- a/lib/contingency/src/core/contingency.Tracking.scala
+++ b/lib/contingency/src/core/contingency.Tracking.scala
@@ -38,7 +38,7 @@ import vacuous.*
 
 object Tracking:
   extension [accrual <: Exception, lambda[_], focus](inline track: Tracking[accrual, lambda, focus])
-    inline def within[result](inline lambda: Foci[focus] ?=> lambda[result])
+    inline def protect[result](inline lambda: Foci[focus] ?=> lambda[result])
       ( using tactic: Tactic[accrual], diagnostics: Diagnostics )
     :   result =
 

--- a/lib/contingency/src/core/contingency.Trap.scala
+++ b/lib/contingency/src/core/contingency.Trap.scala
@@ -30,18 +30,20 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package contingency
 
-export
-  contingency
-  . { abort, abortive, accrual, amalgamate, AmalgamateTactic, Attempt, attempt, AttemptTactic,
-      capture, certify, dare, defer, Deferred, EitherTactic, Emit, Errors, ExpectationError, Fatal,
-      Foci, focus, HaltTactic, lest, Mitigable, mitigates, OptionalTactic, Pointer, raise, raises,
-      safely, survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks,
-      TrackTactic, trap, Trap, Unchecked, unsafely, Validate, validate, Validation, whereas,
-      Whereas }
+import language.experimental.pureFunctions
 
-package strategies:
-  export
-    contingency.strategies
-    . { fatalErrors, mitigation, throwSafely, throwUnsafely, uncheckedErrors }
+import fulminate.*
+
+object Trap:
+  extension [lambda[_]](inline trap: Trap[lambda])
+    inline def within[result](inline body: lambda[result])(using diagnostics: Diagnostics): result =
+      ${contingency.internal.trapWithin[lambda, result]('trap, 'body, 'diagnostics)}
+
+// Captures a typed error handler. `trap { case FooError(n) => … }` records, at compile time, which
+// error types the cases cover (encoded in `lambda`); `.within { … }` then injects one
+// handler-backed `Emit` per covered type into the block, so an `emit`/`raise` of a covered error
+// runs its case body as a side-effect, while any *uncovered* (or *re-emitted*) error stays a free
+// `Emit` requirement and propagates outward as `emits …`. The case bodies return `Unit`.
+class Trap[lambda[_]](val handler: PartialFunction[Exception, Unit])

--- a/lib/contingency/src/core/contingency.Validate.scala
+++ b/lib/contingency/src/core/contingency.Validate.scala
@@ -40,7 +40,7 @@ object Validate:
   extension [accrual <: Exception, lambda[_],
     focus](inline validate: Validate[accrual, lambda, focus])
 
-    inline def within(inline lambda: Foci[focus] ?=> lambda[Any])(using diagnostics: Diagnostics)
+    inline def protect(inline lambda: Foci[focus] ?=> lambda[Any])(using diagnostics: Diagnostics)
     :   accrual =
 
       $ {

--- a/lib/contingency/src/core/contingency.internal.scala
+++ b/lib/contingency/src/core/contingency.internal.scala
@@ -317,7 +317,7 @@ object internal:
         '{Whereas[typeLambda]($handler)}
 
 
-  def trapBuild(handler: Expr[PartialFunction[Exception, Unit]])(using Quotes): Expr[Trap[?]] =
+  def handleBuild(handler: Expr[PartialFunction[Exception, Unit]])(using Quotes): Expr[Handler[?]] =
     import quotes.reflect.*
 
     val errors = mapping[Exception](handler.asTerm)
@@ -332,17 +332,17 @@ object internal:
 
     typeLambda.asType.absolve match
       case '[type typeLambda[_]; typeLambda] =>
-        '{Trap[typeLambda]($handler)}
+        '{Handler[typeLambda]($handler)}
 
 
-  def trapWithin[context[_]: Type, result: Type]
-    ( trap: Expr[Trap[context]], body: Expr[context[result]], diagnostics: Expr[Diagnostics] )
+  def protectBody[context[_]: Type, result: Type]
+    ( handler: Expr[Handler[context]], body: Expr[context[result]], diagnostics: Expr[Diagnostics] )
     ( using Quotes )
   :   Expr[result] =
 
     import quotes.reflect.*
 
-    val emits = unwrap(trap.asTerm) match
+    val emits = unwrap(handler.asTerm) match
       case Apply(_, List(Inlined(_, _, matches))) =>
         val partialFunction = matches.asExprOf[PartialFunction[Exception, Unit]]
 
@@ -350,10 +350,10 @@ object internal:
           errorType.typeRef.asType.absolve match
             case '[type errorType <: Exception; errorType] =>
               val handler = '{(error: errorType) => $partialFunction(error)}
-              '{Emit.handle[errorType]($handler)(using $diagnostics)}.asTerm
+              '{Emit($handler)(using $diagnostics)}.asTerm
 
       case _ =>
-        halt(648, m"argument to `trap` should be a partial function implemented as match cases")
+        halt(648, m"argument to `handle` should be a partial function implemented as match cases")
 
     val method = TypeRepr.of[context[result]].typeSymbol.declaredMethod("apply").head
     body.asTerm.select(method).appliedToArgs(emits.to(List)).asExprOf[result]

--- a/lib/contingency/src/core/contingency.internal.scala
+++ b/lib/contingency/src/core/contingency.internal.scala
@@ -317,6 +317,48 @@ object internal:
         '{Whereas[typeLambda]($handler)}
 
 
+  def trapBuild(handler: Expr[PartialFunction[Exception, Unit]])(using Quotes): Expr[Trap[?]] =
+    import quotes.reflect.*
+
+    val errors = mapping[Exception](handler.asTerm)
+    val emits = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Emit].appliedTo(_))
+    val functionType = defn.FunctionClass(errors.size, true).typeRef
+
+    val typeLambda =
+      TypeLambda
+        ( List("result"),
+          void => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
+          typeLambda => functionType.appliedTo(emits :+ typeLambda.param(0)) )
+
+    typeLambda.asType.absolve match
+      case '[type typeLambda[_]; typeLambda] =>
+        '{Trap[typeLambda]($handler)}
+
+
+  def trapWithin[context[_]: Type, result: Type]
+    ( trap: Expr[Trap[context]], body: Expr[context[result]], diagnostics: Expr[Diagnostics] )
+    ( using Quotes )
+  :   Expr[result] =
+
+    import quotes.reflect.*
+
+    val emits = unwrap(trap.asTerm) match
+      case Apply(_, List(Inlined(_, _, matches))) =>
+        val partialFunction = matches.asExprOf[PartialFunction[Exception, Unit]]
+
+        mapping[Exception](matches).keys.map: errorType =>
+          errorType.typeRef.asType.absolve match
+            case '[type errorType <: Exception; errorType] =>
+              val handler = '{(error: errorType) => $partialFunction(error)}
+              '{Emit.handle[errorType]($handler)(using $diagnostics)}.asTerm
+
+      case _ =>
+        halt(648, m"argument to `trap` should be a partial function implemented as match cases")
+
+    val method = TypeRepr.of[context[result]].typeSymbol.declaredMethod("apply").head
+    body.asTerm.select(method).appliedToArgs(emits.to(List)).asExprOf[result]
+
+
   def mitigateBody[context[_]: Type, result: Type]
     ( w: Expr[Whereas[context]], body: Expr[context[result]] )
     ( using Quotes )

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -77,10 +77,10 @@ def certify[error <: Exception: Tactic](): Unit = error.certify()
 
 def raise[exception <: Exception]
   ( error: Diagnostics ?=> exception )
-  ( using tactic: Tactic[exception] )
+  ( using emitter: Emit[exception] )
 :   Unit =
 
-  tactic.record(error)
+  emitter.record(error)
 
 
 def abort[success, exception <: Exception: Tactic](error: Diagnostics ?=> exception): Nothing =

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -242,5 +242,5 @@ transparent inline def whereas(inline handler: PartialFunction[Exception, Any]):
   ${contingency.internal.whereas('handler)}
 
 
-transparent inline def trap(inline handler: PartialFunction[Exception, Unit]): Trap[?] =
-  ${contingency.internal.trapBuild('handler)}
+transparent inline def handle(inline handler: PartialFunction[Exception, Unit]): Handler[?] =
+  ${contingency.internal.handleBuild('handler)}

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -240,3 +240,7 @@ def defer[result, error <: Exception](body: Tactic[error] ?=> result)
 
 transparent inline def whereas(inline handler: PartialFunction[Exception, Any]): Whereas[?] =
   ${contingency.internal.whereas('handler)}
+
+
+transparent inline def trap(inline handler: PartialFunction[Exception, Unit]): Trap[?] =
+  ${contingency.internal.trapBuild('handler)}

--- a/lib/contingency/src/core/soundness_contingency_core.scala
+++ b/lib/contingency/src/core/soundness_contingency_core.scala
@@ -36,10 +36,9 @@ export
   contingency
   . { abort, abortive, accrual, amalgamate, AmalgamateTactic, Attempt, attempt, AttemptTactic,
       capture, certify, dare, defer, Deferred, EitherTactic, Emit, Errors, ExpectationError, Fatal,
-      Foci, focus, HaltTactic, lest, Mitigable, mitigates, OptionalTactic, Pointer, raise, raises,
-      safely, survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks,
-      TrackTactic, trap, Trap, Unchecked, unsafely, Validate, validate, Validation, whereas,
-      Whereas }
+      Foci, focus, HaltTactic, handle, Handler, lest, Mitigable, mitigates, OptionalTactic, Pointer,
+      raise, raises, safely, survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking,
+      tracks, TrackTactic, Unchecked, unsafely, Validate, validate, Validation, whereas, Whereas }
 
 package strategies:
   export

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -201,6 +201,43 @@ object Tests extends Suite(m"Contingency"):
         capture[ErrorA](raisedStatement).value
       . assert(_ == 1)
 
+    suite(m"trap / within"):
+      test(m"A handled error runs its case body in place"):
+        var caught = 0
+        trap:
+          case ErrorA(n) => caught = n
+        . within:
+            raise(ErrorA(42))
+
+        caught
+      . assert(_ == 42)
+
+      test(m"Control returns after a handled emit (record, not abort)"):
+        var steps = 0
+        trap:
+          case ErrorA(_) => ()
+        . within:
+            raise(ErrorA(1))
+            steps += 1
+            raise(ErrorA(2))
+            steps += 1
+
+        steps
+      . assert(_ == 2)
+
+      test(m"A case may re-emit a different error to an outer trap"):
+        var outer = 0
+        trap:
+          case ErrorB(n) => outer = n
+        . within:
+            trap:
+              case ErrorA(n) => raise(ErrorB(n + 1))
+            . within:
+                raise(ErrorA(10))
+
+        outer
+      . assert(_ == 11)
+
     suite(m"safely / unsafely"):
       test(m"safely returns the value when no error is raised"):
         safely(succeed(t"present"))

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -201,12 +201,12 @@ object Tests extends Suite(m"Contingency"):
         capture[ErrorA](raisedStatement).value
       . assert(_ == 1)
 
-    suite(m"trap / within"):
+    suite(m"handle / protect"):
       test(m"A handled error runs its case body in place"):
         var caught = 0
-        trap:
+        handle:
           case ErrorA(n) => caught = n
-        . within:
+        . protect:
             raise(ErrorA(42))
 
         caught
@@ -214,9 +214,9 @@ object Tests extends Suite(m"Contingency"):
 
       test(m"Control returns after a handled emit (record, not abort)"):
         var steps = 0
-        trap:
+        handle:
           case ErrorA(_) => ()
-        . within:
+        . protect:
             raise(ErrorA(1))
             steps += 1
             raise(ErrorA(2))
@@ -225,14 +225,14 @@ object Tests extends Suite(m"Contingency"):
         steps
       . assert(_ == 2)
 
-      test(m"A case may re-emit a different error to an outer trap"):
+      test(m"A case may re-emit a different error to an outer handler"):
         var outer = 0
-        trap:
+        handle:
           case ErrorB(n) => outer = n
-        . within:
-            trap:
+        . protect:
+            handle:
               case ErrorA(n) => raise(ErrorB(n + 1))
-            . within:
+            . protect:
                 raise(ErrorA(10))
 
         outer
@@ -497,7 +497,7 @@ object Tests extends Suite(m"Contingency"):
         . recover:
             track[Pointer](Accumulated(Nil)):
               case ErrorA(n) => Accumulated(accrual.values :+ n)
-            . within:
+            . protect:
                 raise(ErrorA(1))
                 raise(ErrorA(2))
                 List.empty[Int]
@@ -514,7 +514,7 @@ object Tests extends Suite(m"Contingency"):
       test(m"validate yields the accrual when errors are raised"):
         val v: Accumulated = validate[Pointer](Accumulated(Nil)):
           case ErrorA(n) => Accumulated(accrual.values :+ n)
-        . within:
+        . protect:
             raise(ErrorA(7))
             raise(ErrorA(8))
         v.values

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -176,7 +176,7 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
     contain:
       case _ => tearDown(); Remedy.Accept
 
-    . within:
+    . protect:
         val writer = daemon:
           duplex.send(Stream(connectionPreface))
 

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -173,7 +173,7 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
   // isolated to this connection — it neither escalates nor leaves a request awaiter
   // hanging — rather than being swallowed or escaping the daemon.
   private val (writer, reader): (Daemon, Daemon) =
-    trap:
+    contain:
       case _ => tearDown(); Remedy.Accept
 
     . within:

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -184,6 +184,10 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
             duplex.send(Stream(frame.serialize))
 
         val reader = daemon:
+          // A protocol error tears down just this connection; throw it to the enclosing
+          // `contain`, which runs `tearDown()` and stops the reader.
+          given Tactic[Http2Error] = AsyncTactic()
+
           val frameReader = FrameReader(duplex.stream.iterator)
           val decoder = Hpack()
           var continue = true

--- a/lib/eucalyptus/src/core/eucalyptus.Logger.scala
+++ b/lib/eucalyptus/src/core/eucalyptus.Logger.scala
@@ -73,10 +73,10 @@ object Logger:
     new Logger(level, enqueue)
 
   // The write runs in a fire-and-forget daemon. A write failure `raise`s a `StreamError`, discharged
-  // by the `Emit` captured when the caller summoned the `Writable` — typically a `trap` enclosing
+  // by the `Emit` captured when the caller summoned the `Writable` — typically a `handle` enclosing
   // the `Logger(…)` construction. Because that handler runs in place and control returns, the write
-  // is simply re-established (a fresh `spool.stream` resumes from the same queue) so one failure does
-  // not permanently silence the logger. The loop ends only once the spool is stopped.
+  // is simply re-established (a fresh `spool.stream` resumes from the same queue) so one failure
+  // does not permanently silence the logger. The loop ends only once the spool is stopped.
   private def establish[format, target]
     ( destination: target )
     ( using writable:  target is Writable by format,

--- a/lib/eucalyptus/src/core/eucalyptus.Logger.scala
+++ b/lib/eucalyptus/src/core/eucalyptus.Logger.scala
@@ -50,13 +50,10 @@ object Logger:
   // the same resource instead of leaking a fresh thread per log call.
   private val registry: juc.ConcurrentHashMap[Codepoint, Spool[?]] = juc.ConcurrentHashMap()
 
-  def emitToStderr(error: Exception): Unit = System.err.nn.println(error.getMessage)
-
   def apply[eventType, loggingType, format, target]
     ( destination: target,
-      level:       Level             = Level.Info,
-      name:        Optional[Text]    = Unset,
-      onError:     Exception => Unit = emitToStderr )
+      level:       Level          = Level.Info,
+      name:        Optional[Text] = Unset )
     ( using inscribable: loggingType is Inscribable in format,
             writable:    target is Writable by format,
             monitor:     Monitor,
@@ -66,7 +63,7 @@ object Logger:
 
     val spool: Spool[format] =
       registry
-      . computeIfAbsent(codepoint, _ => establish[format, target](destination, onError))
+      . computeIfAbsent(codepoint, _ => establish[format, target](destination))
       . nn
       . asInstanceOf[Spool[format]]
 
@@ -75,28 +72,28 @@ object Logger:
 
     new Logger(level, enqueue)
 
-  // The write runs in a fire-and-forget daemon. Whether a write failure surfaces as a thrown
-  // exception is decided by the `Tactic` baked into the (caller-summoned) `Writable`; any exception
-  // that does escape the write is reported to `onError`, after which the write is re-established (a
-  // fresh `spool.stream` resumes taking from the same queue) so one failure does not permanently
-  // silence the logger.
+  // The write runs in a fire-and-forget daemon. A write failure `raise`s a `StreamError`, discharged
+  // by the `Emit` captured when the caller summoned the `Writable` — typically a `trap` enclosing
+  // the `Logger(…)` construction. Because that handler runs in place and control returns, the write
+  // is simply re-established (a fresh `spool.stream` resumes from the same queue) so one failure does
+  // not permanently silence the logger. The loop ends only once the spool is stopped.
   private def establish[format, target]
-    ( destination: target, onError: Exception => Unit )
+    ( destination: target )
     ( using writable:  target is Writable by format,
             monitor:   Monitor,
             codepoint: Codepoint,
             probate:   Probate )
   :   Spool[format] =
 
+    val stopped: juc.atomic.AtomicBoolean = juc.atomic.AtomicBoolean(false)
+
     Spool[format]().tap: spool =>
       daemon:
-        def loop(): Unit =
-          try spool.stream.writeTo(destination)
-          catch case error: Exception => onError(error); loop()
+        while !stopped.get() do spool.stream.writeTo(destination)
 
-        loop()
-
-      Os.intercept[Shutdown](spool.stop())
+      Os.intercept[Shutdown]:
+        stopped.set(true)
+        spool.stop()
 
 class Logger[-eventType, loggingType] private
   ( threshold: Level, enqueue: (loggingType, Level, Long) => Unit )

--- a/lib/eucalyptus/src/test/eucalyptus_test.scala
+++ b/lib/eucalyptus/src/test/eucalyptus_test.scala
@@ -34,6 +34,7 @@ package eucalyptus
 
 import soundness.*
 
+import errorDiagnostics.stackTracesDiagnostics
 import logFormats.untimestampedLogFormat
 import probates.cancelProbate
 import strategies.throwUnsafely
@@ -52,12 +53,12 @@ object Tests extends Suite(m"Eucalyptus tests"):
   object Capture:
     given writable: Capture is Writable by Text = (capture, stream) => stream.each(capture.queue.put)
 
-  // A `Writable` that consumes each line then throws, to exercise the `onError` path.
-  class Boom() extends Exception("boom")
+  // A `Writable` that `raise`s a `StreamError` for each line, to exercise the typed `trap` path.
   case class Failing()
 
   object Failing:
-    given writable: Failing is Writable by Text = (failing, stream) => stream.each(_ => throw Boom())
+    given writable: Emit[StreamError] => Failing is Writable by Text =
+      (failing, stream) => stream.each(_ => raise(StreamError(0.b)))
 
   def run(): Unit = supervise:
     test(m"A Warn-threshold logger drops Fine and Info but keeps Warn and Fail"):
@@ -81,10 +82,14 @@ object Tests extends Suite(m"Eucalyptus tests"):
 
     . assert(_ == List(t"[INFO] hello\n", t"[INFO] hello\n"))
 
-    test(m"A write failure is reported to onError"):
+    test(m"A write failure is handled by an enclosing trap"):
       val errors: juc.LinkedBlockingQueue[Text] = juc.LinkedBlockingQueue()
-      given Logger[Any, Message] = Logger(Failing(), onError = error => errors.put(error.getMessage.nn.tt))
-      Log.info(m"trigger")
-      errors.take()
 
-    . assert(_ == t"boom")
+      trap:
+        case StreamError(_) => errors.put(t"cut")
+      . within:
+          given Logger[Any, Message] = Logger(Failing())
+          Log.info(m"trigger")
+          errors.take()
+
+    . assert(_ == t"cut")

--- a/lib/eucalyptus/src/test/eucalyptus_test.scala
+++ b/lib/eucalyptus/src/test/eucalyptus_test.scala
@@ -53,7 +53,7 @@ object Tests extends Suite(m"Eucalyptus tests"):
   object Capture:
     given writable: Capture is Writable by Text = (capture, stream) => stream.each(capture.queue.put)
 
-  // A `Writable` that `raise`s a `StreamError` for each line, to exercise the typed `trap` path.
+  // A `Writable` that `raise`s a `StreamError` for each line, to exercise the typed `handle` path.
   case class Failing()
 
   object Failing:
@@ -82,12 +82,12 @@ object Tests extends Suite(m"Eucalyptus tests"):
 
     . assert(_ == List(t"[INFO] hello\n", t"[INFO] hello\n"))
 
-    test(m"A write failure is handled by an enclosing trap"):
+    test(m"A write failure is handled by an enclosing handler"):
       val errors: juc.LinkedBlockingQueue[Text] = juc.LinkedBlockingQueue()
 
-      trap:
+      handle:
         case StreamError(_) => errors.put(t"cut")
-      . within:
+      . protect:
           given Logger[Any, Message] = Logger(Failing())
           Log.info(m"trigger")
           errors.take()

--- a/lib/galilei/src/core/galilei.Handle.scala
+++ b/lib/galilei/src/core/galilei.Handle.scala
@@ -39,6 +39,6 @@ import turbulence.*
 
 object Handle:
   given streamable: Tactic[StreamError] => Handle is Streamable by Data = _.reader()
-  given writable: Tactic[StreamError] => Handle is Writable by Data = _.writer(_)
+  given writable: Emit[StreamError] => Handle is Writable by Data = _.writer(_)
 
 class Handle(val reader: () => Stream[Data], val writer: Stream[Data] => Unit)

--- a/lib/guillotine/src/core/guillotine.Job.scala
+++ b/lib/guillotine/src/core/guillotine.Job.scala
@@ -54,7 +54,7 @@ object Job:
     (process, stream) => process.stdin(stream)
 
 
-  given writableText: [command <: Label, result] => Tactic[StreamError]
+  given writableText: [command <: Label, result] => Emit[StreamError]
   =>  Job[command, result] is Writable by Text =
 
     (process, stream) => process.stdin(stream.map(_.sysData))

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -53,7 +53,7 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
   :   Issues =
     validate[Json.Focus](Issues()):
       case error: JsonError => accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(decode(json))
+    . protect(decode(json))
 
   def run(): Unit =
     suite(m"Single-error decoding (sanity)"):
@@ -172,7 +172,7 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
             accrual + ( prior.let(_.pointer.encode).or(t"#"),
                         position.let(_.line),
                         position.let(_.column) )
-        . within(decode(json)).items
+        . protect(decode(json)).items
 
       test(m"Missing field reports a position on a tracked Json"):
         val source = t"""{"name": "Alice"}"""

--- a/lib/parasite/src/core/parasite.Containment.scala
+++ b/lib/parasite/src/core/parasite.Containment.scala
@@ -36,11 +36,12 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-// A `Probate` that handles errors escaping fire-and-forget workers spawned within its region. Its
-// child-fate policy (`cleanup`) is delegated unchanged to the enclosing probate; only the failure
-// branch (`trap`) is overridden. A handled error whose remedy is `Reject` — like one the handler
-// does not match — bubbles to the enclosing trap, so traps compose as they nest lexically.
-class Trap(handler: PartialFunction[Error, Remedy], outer: Probate) extends Probate:
+// A `Probate` that contains *thrown* exceptions escaping fire-and-forget workers spawned within its
+// region — a catch-all distinct from the typed `contingency.trap`, which handles declared *emitted*
+// errors. Its child-fate policy (`cleanup`) is delegated unchanged to the enclosing probate; only
+// the failure branch (`trap`) is overridden. A handled error whose remedy is `Reject` — like one
+// the handler does not match — bubbles to the enclosing containment, so they compose as they nest.
+class Containment(handler: PartialFunction[Error, Remedy], outer: Probate) extends Probate:
   def cleanup(worker: Worker): Unit = outer.cleanup(worker)
 
   override def trap(worker: Worker, error: Error): Remedy =
@@ -50,6 +51,6 @@ class Trap(handler: PartialFunction[Error, Remedy], outer: Probate) extends Prob
       case Remedy.Escalate(other) => outer.trap(worker, other)
     else outer.trap(worker, error)
 
-  // Installs this trap as the `Probate` in scope for `body`; daemons and abandoned tasks spawned
-  // within it route their escaped errors here.
+  // Installs this containment as the `Probate` in scope for `body`; daemons and abandoned tasks
+  // spawned within it route their escaped exceptions here.
   def within[result](body: Probate ?=> result): result = body(using this)

--- a/lib/parasite/src/core/parasite.Containment.scala
+++ b/lib/parasite/src/core/parasite.Containment.scala
@@ -53,4 +53,4 @@ class Containment(handler: PartialFunction[Error, Remedy], outer: Probate) exten
 
   // Installs this containment as the `Probate` in scope for `body`; daemons and abandoned tasks
   // spawned within it route their escaped exceptions here.
-  def within[result](body: Probate ?=> result): result = body(using this)
+  def protect[result](body: Probate ?=> result): result = body(using this)

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -98,11 +98,17 @@ def daemon[error <: Exception](using Codepoint)
 def trap(handler: PartialFunction[Error, Remedy])(using outer: Probate): Trap = Trap(handler, outer)
 
 
-// `Task[result] emits error` = `Task[result] { type Error <: error }`. The bound (not an equality)
-// keeps the error covariant: a task that can fail only with `AsyncError` is usable where one that
-// `emits FooError` is expected, and `await`'s `raises (Error | AsyncError)` is dischargeable by a
-// `Tactic` for the bound. `task <: Task[?]` keeps the refinement applicable only to actual tasks.
-infix type emits[task <: Task[?], error <: Exception] = task { type Error <: error }
+// `X emits error` is the one concept "X can produce these errors as an out-of-band side-channel",
+// reified two ways. For a `Task`, it is the `Error`-member bound `Task[result] { type Error <: error }`:
+// the bound (not an equality) keeps the error covariant, so a task failing only with `AsyncError` is
+// usable where one that `emits FooError` is expected, and `await`'s `raises (Error | AsyncError)`
+// converts the emission to a value-replacing exit in the caller's scope. For anything else it is the
+// side-effect obligation `Emit[error] ?=> X` — the weaker sibling of `raises error`
+// (`Tactic[error] ?=>`). The `Task` branch reduces to a refinement (not a context function), so it is
+// clear of the match-type-in-return-position erasure crash documented on `raising`.
+infix type emits[left, error <: Exception] = left match
+  case Task[?] => left { type Error <: error }
+  case _       => Emit[error] ?=> left
 
 
 // `error` is the union of error types the body may `raise`, inferred exactly as for synchronous

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -92,20 +92,22 @@ def daemon[error <: Exception](using Codepoint)
     evaluate(using worker, tactic)
 
 
-// Establishes a trap over a region of asynchronous work: `trap { case … => … }.within { … }`. The
-// handler maps an escaped error to a `Remedy`; the enclosing `Probate` (the default for unmatched
-// or rejected errors) is captured so traps chain outwards to the supervision root.
-def trap(handler: PartialFunction[Error, Remedy])(using outer: Probate): Trap = Trap(handler, outer)
+// Contains *thrown* exceptions escaping a region of fire-and-forget work:
+// `contain { case … => … }.within { … }`. The handler maps an escaped exception to a `Remedy`; the
+// enclosing `Probate` (the default for unmatched or rejected errors) is captured so containments
+// chain outwards to the supervision root. Distinct from the typed `trap` (declared emitted errors).
+def contain(handler: PartialFunction[Error, Remedy])(using outer: Probate): Containment =
+  Containment(handler, outer)
 
 
 // `X emits error` is the one concept "X can produce these errors as an out-of-band side-channel",
-// reified two ways. For a `Task`, it is the `Error`-member bound `Task[result] { type Error <: error }`:
-// the bound (not an equality) keeps the error covariant, so a task failing only with `AsyncError` is
-// usable where one that `emits FooError` is expected, and `await`'s `raises (Error | AsyncError)`
-// converts the emission to a value-replacing exit in the caller's scope. For anything else it is the
-// side-effect obligation `Emit[error] ?=> X` — the weaker sibling of `raises error`
-// (`Tactic[error] ?=>`). The `Task` branch reduces to a refinement (not a context function), so it is
-// clear of the match-type-in-return-position erasure crash documented on `raising`.
+// reified two ways. For a `Task`, it is the bound `Task[result] { type Error <: e }` on its member;
+// the bound (not an equality) keeps the error covariant, so a task failing only with `AsyncError`
+// is usable where `emits FooError` is expected, and `await`'s `raises (Error | AsyncError)` simply
+// converts the emission to a value-replacing exit in the caller's scope. For anything else it is
+// the side-effect obligation `Emit[error] ?=> X` — the weaker sibling of `raises error`
+// (`Tactic[error] ?=>`). The `Task` branch reduces to a refinement, not a context function, so it
+// avoids the match-type-in-return-position erasure crash documented on `raising`.
 infix type emits[left, error <: Exception] = left match
   case Task[?] => left { type Error <: error }
   case _       => Emit[error] ?=> left

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -78,18 +78,19 @@ package retryTenacities:
 
 transparent inline def monitor: Monitor = infer[Monitor]
 
-// Like `async`, but fire-and-forget: a daemon is never joined, so a raised error cannot surface at
-// a join. The body runs with an `AsyncTactic[error]`; a raised error fails the worker and is routed
-// to the nearest `trap` (and escalated if unhandled) rather than tracked in the return type.
-def daemon[error <: Exception](using Codepoint)
-  ( evaluate: (Worker, Tactic[error]) ?=> Unit )
+// Like `async`, but fire-and-forget: a daemon is never joined, so an error cannot surface at a
+// join. The body is `emits`-typed — it may only *emit* (not `abort`), since there is no value an
+// error could replace and no caller to receive it. Each emit resolves an `Emit` from the call
+// site's lexical scope (typically a `trap`-injected one, captured into the worker's closure); an
+// unhandled emit is a compile error that propagates as `emits …`. A genuine *thrown* exception
+// still fails the worker and reaches the nearest `contain`/`Probate`.
+def daemon(using Codepoint)
+  ( evaluate: Worker ?=> Unit )
   ( using Monitor, Probate )
 :   Daemon =
 
-  val tactic = AsyncTactic[error]()
-
   Daemon: worker =>
-    evaluate(using worker, tactic)
+    evaluate(using worker)
 
 
 // Contains *thrown* exceptions escaping a region of fire-and-forget work:

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -38,8 +38,8 @@ export
       Destruction, Fault, Fulfillment, GarbageCollection, Heap, hibernate, Hook, intercept,
       Interceptable, Monitor, monitor, Observation, Os, Perseverance, PlatformSupervisor, Promise,
       relent, retry, RetryError, Shutdown, sleep, snooze, supervise, Supervisor, Task, task,
-      Tenacity, Threading, Timeout, Transgression, Trap, VirtualSupervisor, Worker, AsyncTactic,
-      Remedy, concurrent }
+      Tenacity, Threading, Timeout, Transgression, contain, Containment, VirtualSupervisor, Worker,
+      AsyncTactic, Remedy, concurrent }
 
 package threading:
   export parasite.threading.{adaptiveThreading, platformThreading, virtualThreading}

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -1480,13 +1480,13 @@ object Tests extends Suite(m"Parasite tests"):
         . assert(_ == 1)
 
       suite(m"Asynchronous error traps"):
-        test(m"A trap accepts a daemon's escaped error"):
+        test(m"A trap handles a daemon's emitted error"):
           val caught = juca.AtomicInteger(0)
 
           trap:
-            case FooError(n) => caught.set(n); Remedy.Accept
+            case FooError(n) => caught.set(n)
           . within:
-              daemon(abort(FooError(5))).attend()
+              daemon(raise(FooError(5))).attend()
 
           caught.get()
         . assert(_ == 5)
@@ -1496,47 +1496,51 @@ object Tests extends Suite(m"Parasite tests"):
           val ran = juca.AtomicBoolean(false)
 
           trap:
-            case FooError(_) => trapped.set(true); Remedy.Accept
+            case FooError(_) => trapped.set(true)
           . within:
-              daemon(ran.set(true)).attend()
+              daemon:
+                if false then raise(FooError(0))
+                ran.set(true)
+
+              . attend()
 
           (ran.get(), trapped.get())
         . assert(_ == (true, false))
 
-        test(m"An error unmatched by an inner trap bubbles to the outer trap"):
+        test(m"An error uncovered by an inner trap is handled by the outer trap"):
           val caught = juca.AtomicReference[Text](t"none")
 
           trap:
-            case BarError(s) => caught.set(s); Remedy.Accept
+            case BarError(s) => caught.set(s)
           . within:
               trap:
-                case FooError(_) => caught.set(t"foo"); Remedy.Accept
+                case FooError(_) => caught.set(t"foo")
               . within:
-                  daemon(abort(BarError(t"outer"))).attend()
+                  daemon(raise(BarError(t"outer"))).attend()
 
           caught.get()
         . assert(_ == t"outer")
 
-        test(m"Escalate substitutes a different error for the enclosing trap"):
+        test(m"A case may re-emit a different error to the enclosing trap"):
           val caught = juca.AtomicReference[Text](t"none")
 
           trap:
-            case BarError(s) => caught.set(s); Remedy.Accept
+            case BarError(s) => caught.set(s)
           . within:
               trap:
-                case FooError(_) => Remedy.Escalate(BarError(t"swapped"))
+                case FooError(_) => raise(BarError(t"swapped"))
               . within:
-                  daemon(abort(FooError(9))).attend()
+                  daemon(raise(FooError(9))).attend()
 
           caught.get()
         . assert(_ == t"swapped")
 
-        test(m"An unhandled daemon error escalates rather than vanishing silently"):
+        test(m"A thrown exception in a daemon escalates rather than vanishing silently"):
           val signal = Promise[Int]()
           val hook = Os.intercept[Fault]:
             signal.offer(1)
 
-          daemon(abort(FooError(42)))
+          daemon(throw RuntimeException("boom"))
           val delivered = safely(signal.await(2.0*Second)).or(0)
           hook.cancel()
           delivered

--- a/lib/parasite/src/test/parasite_test.scala
+++ b/lib/parasite/src/test/parasite_test.scala
@@ -1479,25 +1479,25 @@ object Tests extends Suite(m"Parasite tests"):
           capture[FooError](make(true).await()).value
         . assert(_ == 1)
 
-      suite(m"Asynchronous error traps"):
-        test(m"A trap handles a daemon's emitted error"):
+      suite(m"Asynchronous error handlers"):
+        test(m"A handler handles a daemon's emitted error"):
           val caught = juca.AtomicInteger(0)
 
-          trap:
+          handle:
             case FooError(n) => caught.set(n)
-          . within:
+          . protect:
               daemon(raise(FooError(5))).attend()
 
           caught.get()
         . assert(_ == 5)
 
-        test(m"A successful daemon never invokes the trap"):
+        test(m"A successful daemon never invokes the handler"):
           val trapped = juca.AtomicBoolean(false)
           val ran = juca.AtomicBoolean(false)
 
-          trap:
+          handle:
             case FooError(_) => trapped.set(true)
-          . within:
+          . protect:
               daemon:
                 if false then raise(FooError(0))
                 ran.set(true)
@@ -1507,29 +1507,29 @@ object Tests extends Suite(m"Parasite tests"):
           (ran.get(), trapped.get())
         . assert(_ == (true, false))
 
-        test(m"An error uncovered by an inner trap is handled by the outer trap"):
+        test(m"An error uncovered by an inner handler is handled by the outer handler"):
           val caught = juca.AtomicReference[Text](t"none")
 
-          trap:
+          handle:
             case BarError(s) => caught.set(s)
-          . within:
-              trap:
+          . protect:
+              handle:
                 case FooError(_) => caught.set(t"foo")
-              . within:
+              . protect:
                   daemon(raise(BarError(t"outer"))).attend()
 
           caught.get()
         . assert(_ == t"outer")
 
-        test(m"A case may re-emit a different error to the enclosing trap"):
+        test(m"A case may re-emit a different error to the enclosing handler"):
           val caught = juca.AtomicReference[Text](t"none")
 
-          trap:
+          handle:
             case BarError(s) => caught.set(s)
-          . within:
-              trap:
+          . protect:
+              handle:
                 case FooError(_) => raise(BarError(t"swapped"))
-              . within:
+              . protect:
                   daemon(raise(FooError(9))).attend()
 
           caught.get()

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -104,7 +104,7 @@ extends Interactivity[TerminalEvent]:
   // the event spool is stopped so the session consuming `events.stream` sees the input end
   // and can exit cleanly, rather than blocking forever on a pump that has silently died.
   val pumpInput: Daemon =
-    trap:
+    contain:
       case _ => events.stop(); Remedy.Accept
 
     . within:

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -107,7 +107,7 @@ extends Interactivity[TerminalEvent]:
     contain:
       case _ => events.stop(); Remedy.Accept
 
-    . within:
+    . protect:
         daemon:
           keyboard.process(In.stream[Char]).each:
             case resize@TerminalInfo.WindowSize(rows2, columns2) =>

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -255,7 +255,7 @@ extends RequestServable:
     contain:
       case error => Log.fail(HttpServerEvent.ConnectionFailed(error)); Remedy.Accept
 
-    . within:
+    . protect:
         val acceptLoop = loop:
           safely(serverSocket.accept().nn).let: socket =>
             daemon:

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -252,7 +252,7 @@ extends RequestServable:
     // A failure in a per-connection daemon (anything not already turned into an HTTP
     // response) is logged and accepted, isolating it to that connection: the server
     // keeps accepting, and the error neither escalates nor is dumped to stderr.
-    trap:
+    contain:
       case error => Log.fail(HttpServerEvent.ConnectionFailed(error)); Remedy.Accept
 
     . within:

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -54,13 +54,13 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
     validate[Tel.Focus](Issues()):
       case error: TelError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(decode(tel))
+    . protect(decode(tel))
 
   private def validateAssign(tel: Tel, schema: Tels): Issues =
     validate[Tel.Focus](Issues()):
       case error: TelError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(Tel.Type.assign(tel, schema))
+    . protect(Tel.Type.assign(tel, schema))
 
   // Parse a document under an accrual boundary: recoverable parse defects
   // (§19.5) accrue rather than aborting on the first, because `read[Tel]` parses
@@ -69,7 +69,7 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
     validate[Tel.Focus](Issues()):
       case error: TelError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(text.read[Tel])
+    . protect(text.read[Tel])
 
   // A document schema with two required scalar fields and no defaults: a document
   // omitting both yields two `RequiredMemberAbsent` violations.

--- a/lib/turbulence/src/core/turbulence.Multiplexer.scala
+++ b/lib/turbulence/src/core/turbulence.Multiplexer.scala
@@ -67,7 +67,7 @@ case class Multiplexer[key, element]()(using Monitor):
       contain:
         case _ => remove(key); Remedy.Accept
 
-      . within(daemon(pump(key, stream)))
+      . protect(daemon(pump(key, stream)))
 
   private def remove(key: key): Unit = if !active.nil then queue.put(Removal(key))
 

--- a/lib/turbulence/src/core/turbulence.Multiplexer.scala
+++ b/lib/turbulence/src/core/turbulence.Multiplexer.scala
@@ -59,12 +59,12 @@ case class Multiplexer[key, element]()(using Monitor):
       pump(key, stream.tail)
 
   // Each source is drained by its own daemon. If one fails (the source stream throws),
-  // a trap removes its key — so the consumer sees that source end rather than blocking
-  // forever on a `Removal` the failed pump never enqueued — and isolates the failure to
-  // that source rather than letting it escape.
+  // a containment removes its key — so the consumer sees that source end rather than
+  // blocking forever on a `Removal` the failed pump never enqueued — and isolates the
+  // failure to that source rather than letting it escape.
   def add(key: key, stream: Stream[element]): Unit =
     active(key) =
-      trap:
+      contain:
         case _ => remove(key); Remedy.Accept
 
       . within(daemon(pump(key, stream)))

--- a/lib/turbulence/src/core/turbulence.Writable.scala
+++ b/lib/turbulence/src/core/turbulence.Writable.scala
@@ -44,26 +44,33 @@ import symbolism.*
 import vacuous.*
 
 object Writable:
-  given outputStreamData: [output <: ji.OutputStream] => (streamCut: Tactic[StreamError])
+  // A write failure `raise`s a typed `StreamError`, so the obligation is discharged by an `Emit`
+  // from the scope where the `Writable` is summoned (a `trap`-injected one, or one propagated as
+  // `emits StreamError`). `Emit` rather than `Tactic`: a writer only reports a cut, never `abort`s.
+  given outputStreamData: [output <: ji.OutputStream] => (streamCut: Emit[StreamError])
   =>  output is Writable by Data =
 
     (outputStream, stream) =>
-      stream.each: bytes =>
-        outputStream.write(bytes.mutable(using Unsafe))
-        outputStream.flush()
+      @tailrec
+      def recur(total: Bytes, todo: Stream[Data]): Unit =
+        todo.flow(close(outputStream, total)):
+          val array = next.mutable(using Unsafe)
+          if write(outputStream, array, total) then recur(total + array.length.b, more)
 
-      outputStream.close()
+      recur(0.b, stream)
 
 
-  given outputStreamText: (streamCut: Tactic[StreamError], encoder: CharEncoder)
+  given outputStreamText: (streamCut: Emit[StreamError], encoder: CharEncoder)
   =>  ji.OutputStream is Writable by Text =
 
     (outputStream, stream) =>
-      stream.each: text =>
-        outputStream.write(encoder.encode(text).mutable(using Unsafe))
-        outputStream.flush()
+      @tailrec
+      def recur(total: Bytes, todo: Stream[Text]): Unit =
+        todo.flow(close(outputStream, total)):
+          val array = encoder.encode(next).mutable(using Unsafe)
+          if write(outputStream, array, total) then recur(total + array.length.b, more)
 
-      outputStream.close()
+      recur(0.b, stream)
 
 
   given decodingAdapter: [writable: Writable by Text] => (decoder: CharDecoder)
@@ -78,7 +85,7 @@ object Writable:
     (target, stream) => writable.write(target, encoder.encoded(stream))
 
 
-  given channel: Tactic[StreamError]
+  given channel: Emit[StreamError]
   =>  jn.channels.WritableByteChannel is Writable by Data =
 
     (channel, stream) =>
@@ -91,6 +98,21 @@ object Writable:
           else recur(total + count.b, if next.hasRemaining then todo else more)
 
       recur(0.b, stream.map { bytes => jn.ByteBuffer.wrap(bytes.mutable(using Unsafe)).nn })
+
+  // Writes one chunk to an `OutputStream`, `raise`-ing a `StreamError` (and returning `false`) on
+  // an `IOException` so the caller stops; `true` means continue.
+  private def write(outputStream: ji.OutputStream, array: Array[Byte], total: Bytes)
+    ( using Emit[StreamError] )
+  :   Boolean =
+
+    try
+      outputStream.write(array)
+      outputStream.flush()
+      true
+    catch case _: ji.IOException => raise(StreamError(total)) yet false
+
+  private def close(outputStream: ji.OutputStream, total: Bytes)(using Emit[StreamError]): Unit =
+    try outputStream.close() catch case _: ji.IOException => raise(StreamError(total))
 
 trait Writable extends Typeclass, Operable:
   def write(target: Self, stream: Stream[Operand]): Unit

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -60,7 +60,7 @@ object DefaultPersonScope:
     val xml = x"<root><company>Acme</company></root>"
     validate[Xml.Focus](XmlIssues()):
       case error: XmlError => accrual + (prior.let(_.path.encode).or(t"#"), error)
-    . within(xml.as[DContact]).items.map(_(0).s).to(Set)
+    . protect(xml.as[DContact]).items.map(_(0).s).to(Set)
 
 case class DDrawing(shape: DShape, label: Text) derives CanEqual
 
@@ -77,7 +77,7 @@ object DefaultShapeScope:
     val xml = x"<Triangle><foo>bar</foo></Triangle>"
     val accrued = validate[Xml.Focus](XmlIssues()):
       case error: XmlError => accrual + (prior.let(_.path.encode).or(t"#"), error)
-    . within(xml.as[DShape])
+    . protect(xml.as[DShape])
 
     (accrued.items.map(_(0).s).to(Set), accrued.items.length)
 
@@ -88,7 +88,7 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
   :   XmlIssues =
     validate[Xml.Focus](XmlIssues()):
       case error: XmlError => accrual + (prior.let(_.path.encode).or(t"#"), error)
-    . within(decode(xml))
+    . protect(decode(xml))
 
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform
@@ -235,7 +235,7 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
             accrual + ( prior.let(_.path.encode).or(t"#"),
                         position.let(_.line.n1),
                         position.let(_.column.n1) )
-        . within(decode(tracked)).items
+        . protect(decode(tracked)).items
 
       test(m"Missing-field error on a tracked Xml reports the parent's position"):
         val source = t"<root>\n  <name>Alice</name>\n  <age>30</age>\n</root>"
@@ -254,7 +254,7 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
           validate[Xml.Focus](Tagged()):
             case error: XmlError =>
               accrual + prior.let(_.position).let(_.line.n1)
-          . within(xml.as[DPerson]).items
+          . protect(xml.as[DPerson]).items
 
         lines.forall(_ == Unset)
       . assert(identity)

--- a/lib/ypsiloid/src/test/ypsiloid.AccrualTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.AccrualTests.scala
@@ -52,7 +52,7 @@ object AccrualTests extends Suite(m"Ypsiloid multi-error accrual tests"):
     validate[Yaml.Focus](Issues()):
       case error: YamlError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(decode(yaml))
+    . protect(decode(yaml))
 
   def run(): Unit =
     suite(m"Single-error decoding (sanity)"):

--- a/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.DefaultTests.scala
@@ -57,7 +57,7 @@ object DefaultPersonScope:
     validate[Yaml.Focus](Issues2()):
       case error: YamlError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(yaml.as[DContact]).items.map(_(0).s).to(Set)
+    . protect(yaml.as[DContact]).items.map(_(0).s).to(Set)
 
 object DefaultShapeScope:
   given Default[DShape] = () => DShape.Circle(-1)
@@ -67,7 +67,7 @@ object DefaultShapeScope:
     val issues = validate[Yaml.Focus](Issues2()):
       case error: YamlError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(yaml.as[DShape])
+    . protect(yaml.as[DShape])
     (issues.items.map(_(0).s).to(Set), issues.items.length)
 
 object DefaultTests extends Suite(m"Ypsiloid Default-driven sentinel tests"):
@@ -78,7 +78,7 @@ object DefaultTests extends Suite(m"Ypsiloid Default-driven sentinel tests"):
     validate[Yaml.Focus](Issues2()):
       case error: YamlError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
-    . within(decode(yaml))
+    . protect(decode(yaml))
 
   def run(): Unit =
     suite(m"Default-driven sentinels"):

--- a/lib/ypsiloid/src/test/ypsiloid.FocusTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.FocusTests.scala
@@ -59,7 +59,7 @@ object FocusTests extends Suite(m"Ypsiloid focus + position tests"):
         accrual + ( prior.let(_.pointer.encode).or(t"#"),
                     position.let(_.line),
                     position.let(_.column) )
-    . within(decode(yaml)).items
+    . protect(decode(yaml)).items
 
   def run(): Unit =
     suite(m"Pointer-only focus (untracked Yaml)"):


### PR DESCRIPTION
Contingency's `Tactic` is split into a weaker `Emit` capability — the right to *report* an error as a side-effect — with `Tactic` extending it to add the value-replacing `abort`; `raise` now needs only an `Emit` while `abort` needs a full `Tactic`, so a method's signature distinguishes `emits E` (an out-of-band side-effect that leaves the result intact) from `raises E` (an abnormal, value-replacing exit). On top of this, a compile-time-checked `handle { case … => … }.protect { … }` handles errors emitted by asynchronous, fire-and-forget work: each covered error type runs its case body in place, anything uncovered (or re-emitted by a case) propagates outward as `emits …` and must be handled higher up, and `parasite.daemon` bodies are now `emits`-typed so a fire-and-forget worker can only emit, never abort. The previous untyped `Remedy`-based async `trap` becomes `contain` (a catch-all for thrown exceptions escaping a worker), `turbulence.Writable` reports a cut as an emitted `StreamError`, and `eucalyptus.Logger` drops its `onError` callback in favour of an enclosing `handle`.

## `Emit` and `Tactic`

`Tactic[E]` is now `Emit[E]` plus `abort`. `raise` needs only `Emit[E]`; `abort` still needs `Tactic[E]`. Since `Tactic <: Emit`, existing `raises`/`Tactic` code is unaffected. Two obligations are now distinguishable in a signature:

- `result raises E` = `Tactic[E] ?=> result` — `E` may be the abnormal alternative to the result.
- `result emits E` = `Emit[E] ?=> result` — `E` is reported out-of-band; the result is still produced.

## Typed `handle`

```scala
handle:
  case StreamError(total) => Log.warn(m"write cut after $total")
.protect:
  data.writeTo(target)   // emits StreamError → handled in place
```

Omitting a case for an error the protected block can emit is a compile error: the obligation propagates as `emits …`. A case may re-emit a different error to an enclosing handler:

```scala
handle:
  case BarError(n) => …
.protect:
  handle:
    case FooError(n) => raise(BarError(n))   // re-emit; the block now emits BarError
  .protect:
    work()
```

## `daemon`, and the `contain` rename

A `daemon` body is `emits`-typed — a fire-and-forget worker may `emit` (handled by an enclosing `handle`) but not `abort`. The old `Remedy`-based async error trap, which catches *thrown* exceptions escaping a worker, is renamed `contain`:

```scala
contain:
  case _ => Remedy.Accept   // swallow any thrown exception from a connection handler
.protect:
  …
```

## `eucalyptus.Logger`

`Logger` no longer takes an `onError` callback. A `Writable` reports a write failure as an emitted `StreamError`, so wrapping the logger's construction in a `handle` handles those failures, typed:

```scala
handle:
  case StreamError(_) => …
.protect:
  given Logger[Any, Message] = Logger(target)
  Log.info(m"…")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
