### PR TITLE
Represent leap seconds: :60, TAI conversions, and Moment rendering

### DIFF
--- a/lib/aviation/src/core/aviation.Iso8601.scala
+++ b/lib/aviation/src/core/aviation.Iso8601.scala
@@ -141,6 +141,15 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
       case _ =>
         fail(Digit) yet 2000-Jan-1
 
+    // A `:60` second is a leap second; on the (leap-free) Unix line it collapses onto the next
+    // second (`23:59:60` ≡ the following `00:00:00`), so store `:59` and add one second.
+    def clockInstant(hour: Int, minute: Int, second: Int): Instant =
+      if second == 60 then
+        Clockface(Base24(hour), Base60(minute), Base60(59)).on(date).instant +
+          Quantity[Seconds[1]](1.0)
+      else
+        Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
+
     val instant: Instant = next() match
       case '\u0000' => Clockface(Base24(0), Base60(0), Base60(0)).on(date).instant
 
@@ -165,12 +174,12 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
                       fraction()*Second
 
                   case _ =>
-                    Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
+                    clockInstant(hour, minute, second)
 
               case d if digit =>
                 val second = number(2)
                 next()
-                Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
+                clockInstant(hour, minute, second)
 
               case _ =>
                 Clockface(Base24(hour), Base60(minute), Base60(0)).on(date).instant
@@ -192,8 +201,7 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
                       fraction()*Second
 
                   case _ =>
-                    Clockface(Base24(hour), Base60(minute), Base60(second)).on(date)
-                    . instant
+                    clockInstant(hour, minute, second)
 
               case _ =>
                 Clockface(Base24(hour), Base60(minute), Base60(0)).on(date).instant

--- a/lib/aviation/src/core/aviation.LeapSeconds.scala
+++ b/lib/aviation/src/core/aviation.LeapSeconds.scala
@@ -94,10 +94,32 @@ object LeapSeconds:
 
       unixTime + low + (high - low)*(unixTime - (hi - window))/(2*window)
 
+  // The inverse of `smearTai`: recover the Unix time from a smeared-TAI value. `smearTai` is
+  // strictly increasing (its slope is 1 ± 1/86400), so it is invertible; and the TAI−UTC offset is
+  // well under 100 seconds (and fixed after 2035), so the Unix time lies in a narrow band around
+  // `taiMillis`. Binary-search for it; the closest-match pick makes `unsmearTai(smearTai(u)) == u`
+  // exact despite the integer truncation in the forward direction.
+  def unsmearTai(taiMillis: Long): Long =
+    var lo = taiMillis - 100000L
+    var hi = taiMillis + 100000L
+
+    while hi - lo > 1 do
+      val mid = lo + (hi - lo)/2
+      if smearTai(mid) < taiMillis then lo = mid else hi = mid
+
+    if taiMillis - smearTai(lo) <= smearTai(hi) - taiMillis then lo else hi
+
   // How leap seconds are accounted for when converting a (Unix) `Instant` to a `TaiInstant`. The
   // ambient default is `ignored` (future leap seconds are unknowable); `import leapSeconds.step` or
-  // `leapSeconds.smear` opts into counting or smearing them.
+  // `leapSeconds.smear` opts into counting or smearing them. A `Reversible` strategy also defines
+  // the inverse `TaiInstant`→`Instant` conversion; the discrete `step` has no inverse (the inserted
+  // second has no Unix preimage), so it is a plain `Strategy`.
   trait Strategy:
     def tai(unixMillis: Long): Long
 
-  given ignored: Strategy = unix => unix
+  trait Reversible extends Strategy:
+    def unix(taiMillis: Long): Long
+
+  given ignored: Reversible:
+    def tai(unixMillis: Long): Long = unixMillis
+    def unix(taiMillis: Long): Long = taiMillis

--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -47,7 +47,8 @@ case class Moment
   ( date:       Date,
     time:       Clockface,
     timezone:   Timezone,
-    occurrence: Occurrence = Occurrence.First ):
+    occurrence: Occurrence = Occurrence.First,
+    leap:       Leap       = Leap.None ):
 
   def instant(using calendar: RomanCalendar, gap: GapPolicy): Instant =
     val ldt =
@@ -64,18 +65,31 @@ case class Moment
 
     def at(offset: jt.ZoneOffset): Instant = Instant(ldt.toInstant(offset).nn.toEpochMilli)
 
-    rules.getTransition(ldt) match
-      case null       => at(rules.getOffset(ldt).nn)
+    val base =
+      rules.getTransition(ldt) match
+        case null       => at(rules.getOffset(ldt).nn)
 
-      case transition =>
-        val before = transition.getOffsetBefore.nn
-        val after = transition.getOffsetAfter.nn
+        case transition =>
+          val before = transition.getOffsetBefore.nn
+          val after = transition.getOffsetAfter.nn
 
-        // A gap (the wall-clock time was skipped) is resolved by the contextual policy; an overlap
-        // (the wall-clock time occurs twice) is resolved by the stored `occurrence`.
-        if transition.isGap then gap.resolve(at(before), at(after))
-        else occurrence match
-          case Occurrence.First  => at(before)
-          case Occurrence.Second => at(after)
+          // A gap (the wall-clock time was skipped) is resolved by the contextual policy; an
+          // overlap (the wall-clock time occurs twice) is resolved by the stored `occurrence`.
+          if transition.isGap then gap.resolve(at(before), at(after))
+          else occurrence match
+            case Occurrence.First  => at(before)
+            case Occurrence.Second => at(after)
+
+    // An inserted leap second is stored as `:59`; on the (leap-free) Unix line it shares the next
+    // second's instant, so grounding it advances by one second.
+    leap match
+      case Leap.None     => base
+      case Leap.Inserted => Instant(base.long + 1000L)
+
+  // The absolute SI instant, counting leap seconds per the contextual strategy. For an inserted
+  // leap second the TAI value is exactly one SI second before the following second's.
+  def tai(using RomanCalendar, GapPolicy, LeapSeconds.Strategy): TaiInstant = leap match
+    case Leap.None     => instant.tai
+    case Leap.Inserted => TaiInstant(instant.tai.long - 1000L)
 
   def timestamp: Timestamp = Timestamp(date, time)

--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -35,13 +35,36 @@ package aviation
 import java.time as jt
 
 import anticipation.*
+import gossamer.*
+import hieroglyph.*, textMetrics.uniformMetric
 import prepositional.*
+import spectacular.*
 
 import abstractables.instantAbstractable
 
 object Moment:
   given generic: RomanCalendar => Moment is Abstractable across Instants to Long =
     _.instant.generic
+
+  // An ISO-8601 zoned date-time, e.g. `2016-12-31T23:59:60+00:00`. An inserted leap second renders
+  // as the 61st second (`:60`); the offset is the zone's offset at this moment's instant.
+  given showable: (RomanCalendar, GapPolicy) => Moment is Showable = moment =>
+    def pad(value: Int, width: Int): Text = value.show.pad(width, Bidi.Rtl, '0')
+
+    val second = moment.leap match
+      case Leap.None     => moment.time.second: Int
+      case Leap.Inserted => 60
+
+    val rules = jt.ZoneId.of(moment.timezone.name.s).nn.getRules.nn
+    val offset = rules.getOffset(jt.Instant.ofEpochMilli(moment.instant.long)).nn.getId.nn
+
+    val year = pad(moment.date.year(), 4)
+    val month = pad(moment.date.month.numerical, 2)
+    val day = pad(moment.date.day(), 2)
+    val hour = pad(moment.time.hour, 2)
+    val minute = pad(moment.time.minute, 2)
+
+    t"$year-$month-${day}T$hour:$minute:${pad(second, 2)}${offset.tt}"
 
 case class Moment
   ( date:       Date,

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -231,12 +231,22 @@ object internal:
       zone:   String | Null )
   :   Either[Message, TsParsed] =
 
-    checkTime(hour, minute, second).flatMap: _ =>
-      zone match
-        case null =>
-          Right(TsParsed.TimeOnly(jdn, hour, minute, second, nanos))
+    zone match
+      case null =>
+        // A leap second (`:60`) can't be represented zonelessly — it only exists relative to UTC.
+        checkTime(hour, minute, second).map: _ =>
+          TsParsed.TimeOnly(jdn, hour, minute, second, nanos)
 
-        case zoneText: String =>
+      case zoneText: String =>
+        // A leap second is valid only at `:59:60`; it is stored as `:60` for the macro to detect.
+        val timeCheck =
+          if second == 60 then
+            if minute == 59 then checkTime(hour, 59, 59)
+            else Left(m"a leap second can only occur at :59:60")
+          else
+            checkTime(hour, minute, second)
+
+        timeCheck.flatMap: _ =>
           normalizeZone(zoneText).map: zoneName =>
             TsParsed.ZoneOnly(jdn, hour, minute, second, nanos, zoneName)
 
@@ -321,9 +331,15 @@ object internal:
                 Base60(${Expr(minute)}), Base60(${Expr(second)}), ${Expr(nanos)}))}
 
           case TsParsed.ZoneOnly(jdn, hour, minute, second, nanos, zone) =>
-            '{Timestamp(Date.julianDay(${Expr(jdn)}), Clockface(Base24(${Expr(hour)}),
-                Base60(${Expr(minute)}), Base60(${Expr(second)}), ${Expr(nanos)}))
-                .in(unsafely(Timezone(${Expr(zone)}.tt)))}
+            // A leap second is stored as `:60`; build the moment at `:59` and flag it `Inserted`.
+            if second == 60 then
+              '{Timestamp(Date.julianDay(${Expr(jdn)}), Clockface(Base24(${Expr(hour)}),
+                  Base60(${Expr(minute)}), Base60(59), ${Expr(nanos)}))
+                  .in(unsafely(Timezone(${Expr(zone)}.tt))).copy(leap = Leap.Inserted)}
+            else
+              '{Timestamp(Date.julianDay(${Expr(jdn)}), Clockface(Base24(${Expr(hour)}),
+                  Base60(${Expr(minute)}), Base60(${Expr(second)}), ${Expr(nanos)}))
+                  .in(unsafely(Timezone(${Expr(zone)}.tt)))}
 
         result
 

--- a/lib/aviation/src/core/aviation.protointernal.scala
+++ b/lib/aviation/src/core/aviation.protointernal.scala
@@ -47,6 +47,15 @@ object protointernal:
   opaque type TaiInstant = Long
 
   object TaiInstant:
+    def apply(taiMillis: Long): TaiInstant = taiMillis
+
+    extension (tai: TaiInstant)
+      def long: Long = tai
+
+      // The inverse of `Instant.tai`: recover the Unix `Instant` from this `TaiInstant`. Only a
+      // `Reversible` strategy (e.g. `smear`) can do this; `step` is not reversible.
+      def instant(using strategy: LeapSeconds.Reversible): Instant = strategy.unix(tai)
+
     inline given underlying: Underlying[TaiInstant, Long] = !!
 
 

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -45,7 +45,7 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
-export protointernal.{Instant, Duration}
+export protointernal.{Instant, Duration, TaiInstant}
 export aviation.internal.{Year, Day, Anniversary, WorkingDays}
 export aviation.timestampInternal.{Timestamp, Date}
 export Month.{Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec}
@@ -368,7 +368,10 @@ package calendars:
 // ambient default; import one of these to count (`step`) or smear (`smear`) leap seconds instead.
 package leapSeconds:
   given step: LeapSeconds.Strategy = LeapSeconds.tai(_)
-  given smear: LeapSeconds.Strategy = LeapSeconds.smearTai(_)
+
+  given smear: LeapSeconds.Reversible:
+    def tai(unixMillis: Long): Long = LeapSeconds.smearTai(unixMillis)
+    def unix(taiMillis: Long): Long = LeapSeconds.unsmearTai(taiMillis)
 
 // Overrides for the spring-forward DST gap, used to ground a `Moment` whose wall-clock time doesn't
 // exist. The ambient default is `GapPolicy.pushForward` (matching `java.time`); import one of these
@@ -428,6 +431,12 @@ enum TimeEvent:
 // always `First`, and grounding ignores it.
 enum Occurrence derives CanEqual:
   case First, Second
+
+// Whether a `Moment` is the leap second inserted at the end of some UTC days (`23:59:60`). A
+// `Clockface` second is a `Base60` (0–59), so an inserted leap second is stored as `:59` with this
+// flag set; only a `Moment` grounds or renders it as the 61st second. `None` is every other moment.
+enum Leap derives CanEqual:
+  case None, Inserted
 
 extension (inline double: Double)
   inline def am: Clockface = ${aviation.internal.validTime('double, false)}

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -40,10 +40,10 @@ export
       Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
       FrenchRepublicanCalendar, FrenchRepublicanMonth, Fri, Hebdomad, Holiday, Holidays, Horology,
       HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, LeapSeconds, Mar, May,
+      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapSeconds, Mar, May,
       Meridiem, Minute, Moment, Mon, Month, Months, Monthstamp, Nov, now, Occurrence, Oct,
       OffsetCalendar, Period, PersianCalendar, PersianMonth, pm, Regime, Rfc1123, RomanCalendar,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
+      Sat, Sep, Sun, Thu, TaiInstant, TimeError, TimeEvent, TimeFormat, TimeNumerics,
       TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
       today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
       WorkingDays, Year, Years }

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -382,9 +382,9 @@ object Tests extends Suite(m"Aviation Tests"):
           t"2020-12-31".decode[Instant]
         . assert(_ == Instant(1609372800000L))
 
-        // test(m"ISO 8601 leap second accepted as next second"):
-        //   t"2016-12-31T23:59:60Z".decode[Instant]
-        // . assert(_ == Instant(1483228800000L))
+        test(m"ISO 8601 leap second accepted as next second"):
+          t"2016-12-31T23:59:60Z".decode[Instant]
+        . assert(_ == Instant(1483228800000L))
 
         test(m"Month-only format"):
           t"2012-11".decode[Instant]
@@ -2012,6 +2012,9 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_.nonEmpty)
 
     suite(m"TaiInstant and leap-second conversion"):
+      import calendars.gregorianCalendar
+      import instantDecodables.iso8601InstantDecodable
+
       test(m"Instant 0 (UNIX epoch) has 10-second TAI offset"):
         LeapSeconds.tai(0L) - 0L
       . assert(_ == 10_000L)
@@ -2030,6 +2033,35 @@ object Tests extends Suite(m"Aviation Tests"):
         val later = t"2017-06-15T00:00:00Z".decode[Instant](using instantDecodables.iso8601InstantDecodable)
         LeapSeconds.tai(later.long) - later.long
       . assert(_ == 37_000L)
+
+      test(m"Instant.tai counts leap seconds under the step strategy"):
+        import leapSeconds.step
+        val later = t"2017-06-15T00:00:00Z".decode[Instant]
+        later.tai.long - later.long
+      . assert(_ == 37_000L)
+
+      test(m"TaiInstant.instant inverts Instant.tai under the smear strategy"):
+        import leapSeconds.smear
+        val instant = t"2017-06-15T00:00:00Z".decode[Instant]
+        instant.tai.instant == instant
+      . assert(_ == true)
+
+      test(m"unsmearTai inverts smearTai across a leap window"):
+        val nearLeap = 1483228800000L
+        LeapSeconds.unsmearTai(LeapSeconds.smearTai(nearLeap)) == nearLeap
+      . assert(_ == true)
+
+      test(m"An inserted leap second grounds to the following second"):
+        val leapMoment = Moment(2016-Dec-31, Clockface(23, 59, 59), tz"UTC", leap = Leap.Inserted)
+        leapMoment.instant == t"2017-01-01T00:00:00Z".decode[Instant]
+      . assert(_ == true)
+
+      test(m"An inserted leap second's TAI is one second before the following second"):
+        import leapSeconds.step
+        val leapMoment = Moment(2016-Dec-31, Clockface(23, 59, 59), tz"UTC", leap = Leap.Inserted)
+        val nextSecond = Moment(2017-Jan-1, Clockface(0, 0, 0), tz"UTC")
+        nextSecond.tai.long - leapMoment.tai.long
+      . assert(_ == 1000L)
 
     suite(m"Horology sexagesimal"):
       val horology = Horology.sexagesimal

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -1978,6 +1978,29 @@ object Tests extends Suite(m"Aviation Tests"):
         moment.instant
       . assert(_ == Instant(784111777000L))
 
+      test(m"A zoned leap second produces a Moment flagged Inserted"):
+        val moment: Moment = ts"2016-12-31T23:59:60Z"
+        moment.leap
+      . assert(_ == Leap.Inserted)
+
+      test(m"A zoned leap second grounds to the following second"):
+        val moment: Moment = ts"2016-12-31T23:59:60Z"
+        moment.instant
+      . assert(_ == Instant(1483228800000L))
+
+      test(m"A zoned leap second renders as :60"):
+        val moment: Moment = ts"2016-12-31T23:59:60Z"
+        moment.show
+      . assert(_ == t"2016-12-31T23:59:60Z")
+
+      test(m"A zoneless leap second is a compile error"):
+        demilitarize(ts"2016-12-31T23:59:60")
+      . assert(_.nonEmpty)
+
+      test(m"A leap second not at :59 is a compile error"):
+        demilitarize(ts"2016-12-31T23:30:60Z")
+      . assert(_.nonEmpty)
+
       test(m"A year literal does not typecheck as a Monthstamp"):
         demilitarize:
           val monthstamp: Monthstamp = ts"2024"


### PR DESCRIPTION
A UTC leap second (`23:59:60`) has no place on the leap-free Unix line and is the discontinuity between civil time and the monotonic SI line (TAI). This wires leap seconds through aviation's time stack, and adds the `Instant`↔`TaiInstant` conversions (with smearing) that go with them.

A `Moment` gains a `Leap` field (`None`/`Inserted`, defaulted). Since a `Clockface` second is a `Base60` (0–59), an inserted leap second is stored as `:59` and flagged; only a `Moment` treats it as the 61st second. Grounding it to an `Instant` collapses it onto the following second (Unix convention), while the new `Moment.tai` yields the genuine extra SI second:

```scala
import calendars.gregorianCalendar, leapSeconds.step
val leap: Moment = ts"2016-12-31T23:59:60Z"   // a zoned :60 literal
leap.leap        // Leap.Inserted
leap.instant     // 2017-01-01T00:00:00Z (collapsed onto the next second)
leap.show        // "2016-12-31T23:59:60Z"  (rendered as the 61st second)
```

`TaiInstant` gains a `Long` constructor, a `.long` accessor, and a reverse `.instant` conversion. `LeapSeconds.Strategy` is split into a base `Strategy` and a `Reversible` one that also defines `TaiInstant → Instant`: `smear` (Google-style smearing, backed by a new `unsmearTai` inverse) and the default `ignored` are reversible, while the discrete `step` is not, because the inserted second has no Unix preimage.

```scala
import leapSeconds.smear
instant.tai           // smeared TAI
instant.tai.instant   // round-trips back to the original Instant
```

The ISO-8601 parser accepts `:60`, collapsing it onto the next second for a bare or `Z`-suffixed `Instant`; in a zoned `ts"…"` literal it must appear at `:59:60`, otherwise it's a compile error. `Moment` also gains its first `Showable`, an ISO-8601 zoned date-time renderer.