### PR TITLE
Add `specifically` for per-field-path derivation overrides

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1454,7 +1454,7 @@ object vicarious extends Library:
   object test extends Tests(core)
 
 object wisteria extends Library:
-  object core extends Component(contingency.core):
+  object core extends Component(contingency.core, vicarious.core):
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -34,6 +34,8 @@ package jacinta
 
 import soundness.*
 
+import scala.language.dynamics
+
 import charEncoders.utf8Encoder
 import strategies.throwUnsafely
 import formatting.compactJsonFormatting
@@ -91,6 +93,9 @@ case class Org(name: String, leader: Entity)
 enum Animal:
   case Dog(name: Text)
   case Cat(name: Text)
+
+case class Worker(name: Text, age: Int) derives CanEqual
+case class Firm(boss: Worker, deputy: Worker) derives CanEqual
 
 object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
@@ -1170,6 +1175,22 @@ object Tests extends Suite(m"Jacinta Tests"):
           jp"#/foo~2bar"
         . map(_.focus)
       . assert(_ == List("~"))
+
+    suite(m"Specific per-path overrides"):
+      val firm = Firm(Worker(t"ann", 30), Worker(t"bob", 40))
+      val shout: Text is Json.Encodable = Json.Encodable(Morphology.Str): text => Json(text.upper)
+
+      test(m"Without a Specific, all fields use default encoders"):
+        firm.json.show
+      . assert(_ == t"""{"boss":{"name":"ann","age":30},"deputy":{"name":"bob","age":40}}""")
+
+      test(m"A Specific overrides one field path along its spine only"):
+        given (Firm is Specific over Json.Encodable) =
+          specifically:
+            case root.deputy.name() => shout
+
+        firm.json.show
+      . assert(_ == t"""{"boss":{"name":"ann","age":30},"deputy":{"name":"BOB","age":40}}""")
 
     ValidationTests()
     PositionTests()

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -97,6 +97,8 @@ enum Animal:
 case class Worker(name: Text, age: Int) derives CanEqual
 case class Firm(boss: Worker, deputy: Worker) derives CanEqual
 
+case class Crew(lead: Worker, members: List[Worker]) derives CanEqual
+
 object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
     suite(m"Parsing tests"):
@@ -1191,6 +1193,16 @@ object Tests extends Suite(m"Jacinta Tests"):
 
         firm.json.show
       . assert(_ == t"""{"boss":{"name":"ann","age":30},"deputy":{"name":"BOB","age":40}}""")
+
+      test(m"specialized overrides the element of a collection-typed field"):
+        val nameOnly: Worker is Json.Encodable = Json.Encodable(Morphology.Str): w => Json(w.name)
+
+        given (Crew is Specific over Json.Encodable) =
+          specifically:
+            case root.members() => specialized[List[Worker], Json.Encodable](nameOnly)
+
+        Crew(Worker(t"al", 30), List(Worker(t"bo", 40), Worker(t"cy", 50))).json.show
+      . assert(_ == t"""{"lead":{"name":"al","age":30},"members":["bo","cy"]}""")
 
     ValidationTests()
     PositionTests()

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1194,12 +1194,14 @@ object Tests extends Suite(m"Jacinta Tests"):
         firm.json.show
       . assert(_ == t"""{"boss":{"name":"ann","age":30},"deputy":{"name":"BOB","age":40}}""")
 
-      test(m"specialized overrides the element of a collection-typed field"):
+      test(m"a collection element is overridden via a local given + re-derive"):
         val nameOnly: Worker is Json.Encodable = Json.Encodable(Morphology.Str): w => Json(w.name)
 
         given (Crew is Specific over Json.Encodable) =
           specifically:
-            case root.members() => specialized[List[Worker], Json.Encodable](nameOnly)
+            case root.members() =>
+              given Worker is Json.Encodable = nameOnly
+              summon[List[Worker] is Json.Encodable]
 
         Crew(Worker(t"al", 30), List(Worker(t"bo", 40), Worker(t"cy", 50))).json.show
       . assert(_ == t"""{"lead":{"name":"al","age":30},"members":["bo","cy"]}""")

--- a/lib/vicarious/src/core/soundness_vicarious_core.scala
+++ b/lib/vicarious/src/core/soundness_vicarious_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export vicarious.{Catalog, catalog, Proxy, Specific, root, specifically, specialized}
+export vicarious.{Catalog, catalog, Proxy, Specific, root, specifically}

--- a/lib/vicarious/src/core/soundness_vicarious_core.scala
+++ b/lib/vicarious/src/core/soundness_vicarious_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export vicarious.{Catalog, catalog, Proxy}
+export vicarious.{Catalog, catalog, Proxy, Specific, root, specifically}

--- a/lib/vicarious/src/core/soundness_vicarious_core.scala
+++ b/lib/vicarious/src/core/soundness_vicarious_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export vicarious.{Catalog, catalog, Proxy, Specific, root, specifically}
+export vicarious.{Catalog, catalog, Proxy, Specific, root, specifically, specialized}

--- a/lib/vicarious/src/core/vicarious.Catalog.scala
+++ b/lib/vicarious/src/core/vicarious.Catalog.scala
@@ -47,14 +47,14 @@ object Catalog:
 
       Catalog(IArray.tabulate(catalog.size): index =>
         partialFunction.applyOrElse
-          ( Proxy[key, value, index.type](), _ => catalog.values(index) ))
+          ( Proxy[key, value, index.type](index), _ => catalog.values(index) ))
 
 //case class Catalog[key, value](values: Map[Text, value]):
 case class Catalog[key, value: ClassTag](values: IArray[value]) extends Findable:
   def size: Int = values.length
 
   inline def apply(accessor: (`*`: Proxy[key, value, 0]) ?=> Proxy[key, value, ?]): value =
-    values(accessor(using Proxy()).id.vouch)
+    values(accessor(using Proxy(0)).id.vouch)
 
   def map[value2: ClassTag](lambda: value => value2): Catalog[key, value2] =
     Catalog(values.map(lambda))

--- a/lib/vicarious/src/core/vicarious.Specific.scala
+++ b/lib/vicarious/src/core/vicarious.Specific.scala
@@ -32,22 +32,18 @@
                                                                                                   */
 package vicarious
 
-import language.dynamics
+object Specific:
+  // A partial function of field-path cases — `case root.cto.joined() => instance` — matched on the
+  // path proxy. Built via the top-level `specifically` builder.
+  type Cases[key] = PartialFunction[Proxy[key, Any, Nat], Any]
 
-import beneficence.Findable
-
-object Proxy:
-  transparent inline given derived: [key, value] => Proxy[key, value, 0] =
-    ${internal.proxy[key, value]}
-
-// `index` is the runtime witness of the type-level `id` (the flattened path index), so navigation
-// and pattern-matching work for a proxy whose `id` is statically abstract (`Nat`) — e.g. the
-// scrutinee of a `case root.cto.joined() => …` pattern, whose `id` cannot be read via `ValueOf`.
-class Proxy[key, value, +id <: Nat](index: Int) extends Selectable, Dynamic, Findable:
-  transparent inline def selectDynamic(key: String): value | Proxy[key, value, Nat] =
-    ${internal.dereference[key, value, id]('key)}
-
-
-  def id: Int = index
-  inline def apply()(using catalog: Catalog[key, value]): value = catalog.values(index)
-  inline def unapply(scrutinee: Proxy[key, value, Nat]): Boolean = scrutinee.id == index
+// A `key is Specific over typeclass` instance records per-field-path exceptions for a generic
+// derivation: for one or more flattened field paths of `key`, the typeclass instance that should be
+// used at that exact path instead of the one a generic derivation would otherwise resolve. The
+// paths are validated, and each instance type-checked against the path's field type, at the
+// definition site (via the `Proxy` path-DSL); `instances` maps each dotted path (e.g. "cto.joined")
+// to the (type-erased) instance, which a Wisteria derivation reads and re-types at the field site.
+trait Specific:
+  type Self
+  type Transport
+  def instances: Map[String, Any]

--- a/lib/vicarious/src/core/vicarious.internal.scala
+++ b/lib/vicarious/src/core/vicarious.internal.scala
@@ -114,34 +114,6 @@ object internal:
       case '[type id <: Nat; id] => '{Proxy[key, value, id](${Expr(target)})}
 
 
-  // Re-derives `target is transport` with each override instance installed as a `given` for its own
-  // type, so the (generic) derivation picks it up for that component. Emits a block of the override
-  // givens followed by a `summonInline` of the instance — deferring resolution to the splice site
-  // where the givens are in scope, exactly the "local given + re-derive" idiom, packaged.
-  def specialized[target: Type, transport <: { type Self }: Type](overrides: Expr[Seq[transport]])
-  :   Macro[target is transport] =
-
-    import quotes.reflect.*
-
-    val instances = overrides.absolve match
-      case Varargs(instances) => instances.toList
-
-    // Nest a `given` per override (each typed as the override's precise `component is transport`),
-    // then `summonInline` the target inside — so the re-derivation resolves each component to its
-    // override. Nested quotes let the compiler own the given symbols (a hand-built `given` val
-    // breaks the re-derivation's later traversal).
-    def build(remaining: List[Expr[transport]])(using Quotes): Expr[target is transport] =
-      remaining match
-        case Nil =>
-          '{compiletime.summonInline[target is transport]}
-
-        case head :: tail =>
-          head.asTerm.tpe.widen.asType.absolve match
-            case '[component] =>
-              '{given local: component = ${head.asExprOf[component]}; ${build(tail)}}
-
-    build(instances)
-
   // Builds a `key is Specific over transport` from a partial function of field-path cases. Reads
   // each `case root.a.b() => instance` from the lambda's tree: the proxy in the pattern carries the
   // path's flattened index in its type, giving the dotted path and the field type to check the

--- a/lib/vicarious/src/core/vicarious.internal.scala
+++ b/lib/vicarious/src/core/vicarious.internal.scala
@@ -114,6 +114,34 @@ object internal:
       case '[type id <: Nat; id] => '{Proxy[key, value, id](${Expr(target)})}
 
 
+  // Re-derives `target is transport` with each override instance installed as a `given` for its own
+  // type, so the (generic) derivation picks it up for that component. Emits a block of the override
+  // givens followed by a `summonInline` of the instance — deferring resolution to the splice site
+  // where the givens are in scope, exactly the "local given + re-derive" idiom, packaged.
+  def specialized[target: Type, transport <: { type Self }: Type](overrides: Expr[Seq[transport]])
+  :   Macro[target is transport] =
+
+    import quotes.reflect.*
+
+    val instances = overrides.absolve match
+      case Varargs(instances) => instances.toList
+
+    // Nest a `given` per override (each typed as the override's precise `component is transport`),
+    // then `summonInline` the target inside — so the re-derivation resolves each component to its
+    // override. Nested quotes let the compiler own the given symbols (a hand-built `given` val
+    // breaks the re-derivation's later traversal).
+    def build(remaining: List[Expr[transport]])(using Quotes): Expr[target is transport] =
+      remaining match
+        case Nil =>
+          '{compiletime.summonInline[target is transport]}
+
+        case head :: tail =>
+          head.asTerm.tpe.widen.asType.absolve match
+            case '[component] =>
+              '{given local: component = ${head.asExprOf[component]}; ${build(tail)}}
+
+    build(instances)
+
   // Builds a `key is Specific over transport` from a partial function of field-path cases. Reads
   // each `case root.a.b() => instance` from the lambda's tree: the proxy in the pattern carries the
   // path's flattened index in its type, giving the dotted path and the field type to check the

--- a/lib/vicarious/src/core/vicarious.internal.scala
+++ b/lib/vicarious/src/core/vicarious.internal.scala
@@ -35,7 +35,9 @@ package vicarious
 import scala.compiletime.*
 import scala.quoted.*
 
+import denominative.*
 import gigantism.*
+import prepositional.*
 import rudiments.*
 
 object internal:
@@ -53,9 +55,14 @@ object internal:
           case '{$field: field} =>
             '{$lambda[field]($field)}.asTerm :: fields[field](field.asTerm)
 
+    // The root value (`$lambda[key]($value)`) is prepended so the values align with the
+    // root-inclusive `paths`/`fieldReprs` scheme: index 0 is the root, then each field depth-first.
+    val rootValue = '{$lambda[key]($value)}.asExprOf[value]
+    val values = rootValue :: fields[key](value.asTerm).map(_.asExprOf[value])
+
     ' {
         given classTag0: ClassTag[value] = $classTag
-        Catalog(IArray(${Varargs(fields[key](value.asTerm).map(_.asExprOf[value]))}*))
+        Catalog(IArray(${Varargs(values)}*))
       }
 
 
@@ -69,6 +76,24 @@ object internal:
         case '[fieldType] => label :: fieldNames[fieldType](label)
 
 
+  // All flattened paths of `product`, depth-first, with the empty root path "" at index 0. A
+  // `Proxy`'s `id` indexes into this list, so navigation from the root (`id` 0, path "") resolves
+  // each field correctly — distinguishing the root from the first field (which both collided at 0).
+  def paths[product: Type](using Quotes): List[String] = "" :: fieldNames[product]("")
+
+
+  // The flattened field types, aligned with `paths`: index 0 is the whole `product`, then each
+  // field's type depth-first, matching the order `fieldNames` flattens labels.
+  def fieldReprs[product: Type](using Quotes): List[quotes.reflect.TypeRepr] =
+    import quotes.reflect.*
+
+    def recur(repr: TypeRepr): List[TypeRepr] =
+      repr.typeSymbol.caseFields.flatMap: field =>
+        field.info :: recur(field.info)
+
+    TypeRepr.of[product] :: recur(TypeRepr.of[product])
+
+
   def dereference[key: Type, value: Type, id <: Nat: Type](key: Expr[String])
   :   Macro[value | Proxy[key, value, Nat]] =
 
@@ -77,20 +102,85 @@ object internal:
     val index = TypeRepr.of[id].asMatchable.absolve match
       case ConstantType(IntConstant(index)) => index
 
-    val fields = fieldNames[key]("")
-    val label = fields(index)+"."+key.valueOrAbort
+    val all = paths[key]
+    val prefix = all(index)
+    val name = key.valueOrAbort
+    val label = if prefix == "" then name else prefix+"."+name
+    val target = all.indexOf(label)
 
-    ConstantType(IntConstant(fields.indexOf(label))).asType.absolve match
-      case '[type id <: Nat; id] => '{Proxy[key, value, id]()}
+    if target < 0 then report.errorAndAbort("vicarious: "+label+" is not a valid field path")
+
+    ConstantType(IntConstant(target)).asType.absolve match
+      case '[type id <: Nat; id] => '{Proxy[key, value, id](${Expr(target)})}
+
+
+  // Builds a `key is Specific over transport` from a partial function of field-path cases. Reads
+  // each `case root.a.b() => instance` from the lambda's tree: the proxy in the pattern carries the
+  // path's flattened index in its type, giving the dotted path and the field type to check the
+  // instance (`transport { type Self = fieldType }`) against. The instances are paired with their
+  // paths into the runtime `instances` map; the partial function itself is never run.
+  def specific[key: Type, transport: Type]
+    ( lambda: Expr[(Proxy[key, Any, 0] aka "root") ?=> Specific.Cases[key]] )
+  :   Macro[key is Specific over transport] =
+
+    import quotes.reflect.*
+
+    val all = paths[key]
+    val reprs = fieldReprs[key]
+
+    // Collect every `case` of the partial function, wherever the literal's desugaring placed it.
+    val caseDefs =
+      val accumulator = new TreeAccumulator[List[CaseDef]]:
+        def foldTree(state: List[CaseDef], tree: Tree)(owner: Symbol): List[CaseDef] = tree match
+          case caseDef: CaseDef => foldOverTree(caseDef :: state, tree)(owner)
+          case _                => foldOverTree(state, tree)(owner)
+
+      accumulator.foldTree(Nil, lambda.asTerm)(Symbol.spliceOwner).reverse
+
+    // The proxy whose `unapply` drives a pattern — drilling through the `unapply` selection to its
+    // qualifier (`root.cto.joined`), whose type carries the path index.
+    def proxyOf(tree: Tree): Term = tree.absolve match
+      case Unapply(fun, _, _)   => proxyOf(fun)
+      case Select(qualifier, _) => qualifier
+      case Apply(fun, _)        => proxyOf(fun)
+      case TypeApply(fun, _)    => proxyOf(fun)
+      case Inlined(_, _, body)  => proxyOf(body)
+
+    val pairs: List[Expr[(String, Any)]] = caseDefs.map: caseDef =>
+      val index = proxyOf(caseDef.pattern).tpe.widen.dealias.asMatchable.absolve match
+        case AppliedType(_, List(_, _, idType)) => idType.asMatchable.absolve match
+          case ConstantType(IntConstant(index)) => index
+
+      val fieldType = reprs(index)
+      val required = Refinement(TypeRepr.of[transport], "Self", TypeBounds(fieldType, fieldType))
+      val body = caseDef.rhs
+
+      if !(body.tpe.widen <:< required) then
+        report.errorAndAbort
+          ( "vicarious: the instance for this path is not a "+required.show, body.pos )
+
+      '{(${Expr(all(index))}, ${body.asExpr})}
+
+    val instancesExpr = '{Map(${Varargs(pairs)}*)}
+
+    val result =
+      ' {
+          new Specific:
+            type Self = key
+            type Transport = transport
+            def instances: Map[String, Any] = $instancesExpr
+        }
+
+    result.asExprOf[key is Specific over transport]
 
 
   def proxy[key: Type, value: Type]: Macro[Proxy[key, value, 0]] =
     import quotes.reflect.*
 
-    val fields = fieldNames[key]("")
+    val fields = paths[key]
 
     def recur(prefix: String, repr: TypeRepr): TypeRepr =
-      val index: Int = if prefix == "" then 0 else fields.indexOf(prefix)
+      val index: Int = fields.indexOf(prefix)
       val nat = ConstantType(IntConstant(index))
 
       val base =
@@ -103,4 +193,4 @@ object internal:
 
     recur("", TypeRepr.of[key]).asType.absolve match
       case '[type proxyType <: Proxy[key, value, 0]; proxyType] =>
-        '{Proxy().asInstanceOf[proxyType]}
+        '{Proxy[key, value, 0](0).asInstanceOf[proxyType]}

--- a/lib/vicarious/src/core/vicarious_core.scala
+++ b/lib/vicarious/src/core/vicarious_core.scala
@@ -32,9 +32,27 @@
                                                                                                   */
 package vicarious
 
+import denominative.*
+import prepositional.*
+
 
 inline def catalog[key](key: key)[value](inline lambda: [field] => (field: field) => value)
   ( using classTag: ClassTag[value] )
 :   Catalog[key, value] =
 
   ${vicarious.internal.catalog[key, value]('lambda, 'key, 'classTag)}
+
+// The root proxy of a `Specific` definition's field-path cases, e.g. `root.cto.joined` in
+// `specifically: { case root.cto.joined() => instance }`. Resolves to the proxy the builder
+// provides as a `"root"`-tagged context value, so no explicit binder is needed.
+inline def root[key](using proxy: Proxy[key, Any, 0] aka "root"): Proxy[key, Any, 0] = proxy()
+
+// Build a `key is Specific over transport` from field-path cases — e.g.
+// `specifically: { case root.cto.joined() => instance }`. `key` and `transport` are driven by the
+// expected type (`Org is Specific over (Encodable in Json)`); the macro reads each case's path (the
+// proxy in the pattern) and checks its body against that path's field type.
+transparent inline def specifically[key, transport]
+  ( inline lambda: (Proxy[key, Any, 0] aka "root") ?=> Specific.Cases[key] )
+:   key is Specific over transport =
+
+  ${vicarious.internal.specific[key, transport]('lambda)}

--- a/lib/vicarious/src/core/vicarious_core.scala
+++ b/lib/vicarious/src/core/vicarious_core.scala
@@ -56,15 +56,3 @@ transparent inline def specifically[key, transport]
 :   key is Specific over transport =
 
   ${vicarious.internal.specific[key, transport]('lambda)}
-
-// Specialize a generic derivation: re-derive `target` for the typeclass `transport`, but with the
-// given component instances installed for their own types — `specialized[Contact](customEmail)`
-// re-derives the `Contact` codec using `customEmail` (an `Email is …`) for `Email`, defaults
-// elsewhere. Used to customize a sum or collection field from the RHS of a `specifically` case
-// (`case root.contact() => specialized[Contact](customEmail)`), keeping variant selection in value
-// space rather than the path. `transport` is driven by the expected type.
-transparent inline def specialized[target, transport <: { type Self }]
-  ( inline overrides: transport* )
-:   target is transport =
-
-  ${vicarious.internal.specialized[target, transport]('overrides)}

--- a/lib/vicarious/src/core/vicarious_core.scala
+++ b/lib/vicarious/src/core/vicarious_core.scala
@@ -56,3 +56,15 @@ transparent inline def specifically[key, transport]
 :   key is Specific over transport =
 
   ${vicarious.internal.specific[key, transport]('lambda)}
+
+// Specialize a generic derivation: re-derive `target` for the typeclass `transport`, but with the
+// given component instances installed for their own types — `specialized[Contact](customEmail)`
+// re-derives the `Contact` codec using `customEmail` (an `Email is …`) for `Email`, defaults
+// elsewhere. Used to customize a sum or collection field from the RHS of a `specifically` case
+// (`case root.contact() => specialized[Contact](customEmail)`), keeping variant selection in value
+// space rather than the path. `transport` is driven by the expected type.
+transparent inline def specialized[target, transport <: { type Self }]
+  ( inline overrides: transport* )
+:   target is transport =
+
+  ${vicarious.internal.specialized[target, transport]('overrides)}

--- a/lib/vicarious/src/test/vicarious_test.scala
+++ b/lib/vicarious/src/test/vicarious_test.scala
@@ -34,5 +34,53 @@ package vicarious
 
 import soundness.*
 
+import scala.language.dynamics
+
 object Tests extends Suite(m"Vicarious Tests"):
-  def run(): Unit = ()
+  trait Codec:
+    type Self
+    type Form
+
+  type Json
+
+  case class Person(name: String, age: Int)
+  case class Org(ceo: Person, cto: Person)
+
+  def run(): Unit =
+    val nameCodec: String is Codec in Json =
+      new Codec:
+        type Self = String
+        type Form = Json
+
+    val ageCodec: Int is Codec in Json =
+      new Codec:
+        type Self = Int
+        type Form = Json
+
+    val orgSpecific: Org is Specific over (Codec in Json) =
+      specifically:
+        case root.cto.name() => nameCodec
+        case root.ceo.age()  => ageCodec
+
+    suite(m"Specific builder tests"):
+      test(m"Specific records the overridden paths"):
+        orgSpecific.instances.keySet
+      . assert(_ == Set("cto.name", "ceo.age"))
+
+      test(m"Specific stores the instance for a path"):
+        orgSpecific.instances("cto.name").asInstanceOf[AnyRef] eq nameCodec
+      . assert(identity(_))
+
+      test(m"An invalid field path does not compile"):
+        demilitarize:
+          val bad: Org is Specific over (Codec in Json) =
+            specifically:
+              case root.cto.invalid() => nameCodec
+      . assert(_.nonEmpty)
+
+      test(m"An instance of the wrong type does not compile"):
+        demilitarize:
+          val bad: Org is Specific over (Codec in Json) =
+            specifically:
+              case root.cto.name() => ageCodec
+      . assert(_.nonEmpty)

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -433,12 +433,6 @@ object internal:
     val wrappers = wrappersOf[typeclass]
     val instanceTpe = typeclassConstructor.appliedTo(TypeRepr.of[derivation])
 
-    // Whether an in-scope `Specific` overrides any path of `derivation` for this typeclass. When it
-    // does, product spines are specialised (path-carrier siblings); otherwise the graph is built
-    // exactly as before — no per-type override probing, no behaviour change.
-    val specific =
-      specificOverridesRepr(typeclassConstructor, TypeRepr.of[derivation].dealias).isDefined
-
     def instanceOf(tpe: TypeRepr): TypeRepr = typeclassConstructor.appliedTo(tpe)
 
     def codecFunction(tpe: TypeRepr, args: List[TypeRepr]): TypeRepr =
@@ -483,14 +477,15 @@ object internal:
                 visit(variantWith(child, tpe), false)
           else if isProductType(tpe) then
             // A path-carrier (a specialised spine type) is always derived; else probe as before.
-            val carrier = specific && refinementMember(tpe, "VRoot").isDefined
+            val carrier = refinementMember(tpe, "VRoot").isDefined
 
             if isRoot || carrier || !resolvableNonStructural(typeclassConstructor, tpe) then
               reachable(key) = tpe
               val product = productType(tpe)
-              val context = if specific then overrideContext(typeclassConstructor, tpe) else None
 
-              context match
+              // Detection is per-type: any in-scope `Specific` for this exact type specialises its
+              // spine, whether `tpe` is the root or a component reached deeper in the graph.
+              overrideContext(typeclassConstructor, tpe) match
                 case Some((root, parentPath, _, keys)) =>
                   // Spine field → specialised carrier sibling; overridden leaf → no sibling (the
                   // value comes from the given's runtime map); else a shared default sibling.
@@ -683,6 +678,7 @@ object internal:
     val tpe = productType(TypeRepr.of[derivation])
     val symbol = tpe.typeSymbol
     val lambdaTerm = lambda.asTerm
+    val context = overrideContext(TypeRepr.of[typeclass], TypeRepr.of[derivation])
 
     val arguments: List[Expr[Any]] = symbol.caseFields.zipWithIndex.map: (field, index) =>
       val fieldName = field.name
@@ -694,7 +690,7 @@ object internal:
           val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
           val label = '{$nameExpr.tt.aka["label"]}
           val fieldIndex = '{$indexExpr.asInstanceOf[Int & FieldIndex[field]].aka["index"]}
-          val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
+          val instance = specificFieldInstance[typeclass, field](context, fieldName)
 
           sharedInstance[typeclass, field](index, instance): (reference, contextual) =>
             applyLambda[field](lambdaTerm, reference, List(contextual, default, label, fieldIndex))
@@ -711,6 +707,7 @@ object internal:
 
     val tpe = productType(TypeRepr.of[derivation])
     val lambdaTerm = lambda.asTerm
+    val context = overrideContext(TypeRepr.of[typeclass], TypeRepr.of[derivation])
 
     val results: List[Expr[result]] = tpe.typeSymbol.caseFields.zipWithIndex.map: (field, index) =>
       val fieldName = field.name
@@ -727,7 +724,7 @@ object internal:
 
           val dereference = '{$accessor.aka["dereference"]}
           val fieldIndex = '{$indexExpr.asInstanceOf[Int & FieldIndex[field]].aka["index"]}
-          val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
+          val instance = specificFieldInstance[typeclass, field](context, fieldName)
 
           sharedInstance[typeclass, field](index, instance): (reference, contextual) =>
             val arguments = List(contextual, default, label, dereference, fieldIndex)
@@ -745,6 +742,7 @@ object internal:
 
     val tpe = productType(TypeRepr.of[derivation])
     val lambdaTerm = lambda.asTerm
+    val context = overrideContext(TypeRepr.of[typeclass], TypeRepr.of[derivation])
 
     val results: List[Expr[result]] = tpe.typeSymbol.caseFields.zipWithIndex.map: (field, index) =>
       val fieldName = field.name
@@ -757,7 +755,7 @@ object internal:
           val fieldValue: Expr[Any] =
             '{$product.asInstanceOf[Product].productElement($indexExpr).asInstanceOf[field]}
 
-          val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
+          val instance = specificFieldInstance[typeclass, field](context, fieldName)
           val contextual = '{$instance.aka["contextual"]}
           val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
           val label = '{$nameExpr.tt.aka["label"]}
@@ -782,6 +780,7 @@ object internal:
     val tupleType = TypeRepr.of[Tuple]
     val constructorTuple = TypeRepr.of[constructor[Tuple]]
     val derivationType = TypeRepr.of[derivation]
+    val context = overrideContext(TypeRepr.of[typeclass], derivationType)
 
     // `pure.apply[monadic](value)`
     def applyPure(monadic: TypeRepr, value: Term): Term =
@@ -817,7 +816,7 @@ object internal:
 
           val outer = Lambda(Symbol.spliceOwner, tupleFunction, { (owner, parameters) =>
             val tupleRef = parameters.head.asInstanceOf[Term]
-            val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
+            val instance = specificFieldInstance[typeclass, field](context, fieldName)
             val contextValue: Expr[Any] = instance
             val contextual = '{$instance.aka["contextual"]}
             val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
@@ -877,16 +876,19 @@ object internal:
   private def resolveField[typeclass[_]: Type, field: Type](using Quotes): Expr[typeclass[field]] =
     '{wisteria.internal.field[typeclass, field]}
 
-  // The typeclass instance for a field of `derivation`, honoring an in-scope `Specific`: an
-  // override instance, a path-specialised sibling (resolved at a carrier type), or — with no
-  // `Specific` in scope — exactly `resolveField`, so the common path is unchanged.
-  private def specificFieldInstance[typeclass[_]: Type, derivation: Type, field: Type]
-    (fieldName: String)(using Quotes)
+  // The typeclass instance for a field, honoring `context` (the product's override context — read
+  // once per product: root type, dotted path so far, the in-scope `Specific` given reference, and
+  // its keys): an override value (from the given's runtime `instances` map), a path-specialised
+  // sibling (resolved at a carrier type), or — with no `Specific` — exactly `resolveField`, so the
+  // common path is unchanged.
+  private def specificFieldInstance[typeclass[_]: Type, field: Type](using Quotes)
+    ( context: Option[(quotes.reflect.TypeRepr, String, quotes.reflect.Term, Set[String])],
+      fieldName: String )
   :   Expr[typeclass[field]] =
 
     import quotes.reflect.*
 
-    overrideContext(TypeRepr.of[typeclass], TypeRepr.of[derivation]) match
+    context match
       case None =>
         resolveField[typeclass, field]
 

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -58,6 +58,99 @@ object internal:
   // emitted alongside it are in scope.
   inline def field[typeclass[_], elem]: typeclass[elem] = ${fieldInstance[typeclass, elem]}
 
+  // ---- vicarious.Specific integration ----
+
+  // Inline accessor (for tests / tooling): the dotted paths overridden by an in-scope
+  // `derivation is Specific over typeclass`, or `Nil` if there is none.
+  inline def overridePaths[typeclass[_], derivation]: List[Text] =
+    ${overridePathsMacro[typeclass, derivation]}
+
+  def overridePathsMacro[typeclass[_]: Type, derivation: Type]: Macro[List[Text]] =
+    Expr.ofList(specificOverrides[typeclass, derivation].keys.toList.map { k => '{${Expr(k)}.tt} })
+
+  // The override set for `derivation` and `typeclass`: the path→instance-term pairs from an
+  // in-scope `derivation is Specific over typeclass` (read from the expanded given's `instances`
+  // map) — or empty if no such `Specific` is in scope. A `Specific` whose `Transport` is for a
+  // different typeclass (its `Transport { type Self = X }` is not `typeclass[X]`) is ignored.
+  def specificOverrides[typeclass[_]: Type, derivation: Type](using Quotes)
+  :   Map[String, quotes.reflect.Term] =
+
+    import quotes.reflect.*
+
+    val self = TypeRepr.of[derivation]
+    val specificType = Refinement(TypeRepr.of[vicarious.Specific], "Self", TypeBounds(self, self))
+
+    Implicits.search(specificType) match
+      case success: ImplicitSearchSuccess =>
+        if transportMatches[typeclass](success.tree.tpe) then readOverrides(success.tree) else Map()
+
+      case _ =>
+        Map()
+
+  // Whether the `Specific`'s `Transport`, applied at a sample type, yields `typeclass[sample]` — so
+  // the override targets this typeclass and not some other.
+  private def transportMatches[typeclass[_]: Type](using Quotes)(specific: quotes.reflect.TypeRepr)
+  :   Boolean =
+
+    import quotes.reflect.*
+    val sample = TypeRepr.of[Any]
+
+    def member(repr: TypeRepr, name: String): Option[TypeRepr] = repr match
+      case Refinement(_, `name`, TypeBounds(lo, _)) => Some(lo)
+      case Refinement(parent, _, _)                 => member(parent, name)
+      case _                                        => None
+
+    member(specific.widen.dealias, "Transport") match
+      case Some(transport) =>
+        Refinement(transport, "Self", TypeBounds(sample, sample)) =:=
+          TypeRepr.of[typeclass].appliedTo(sample)
+
+      case None =>
+        false
+
+  // Reads the path→instance-term pairs from an in-scope `Specific` given's expanded
+  // `instances = Map(("path", instance), …)` body. Available for a given defined in the current
+  // compilation run (the usual case: the override is defined where the derivation is requested).
+  private def readOverrides(using Quotes)(tree: quotes.reflect.Term)
+  :   Map[String, quotes.reflect.Term] =
+
+    import quotes.reflect.*
+
+    def givenSymbol(term: Term): Symbol = term match
+      case Inlined(_, _, body) => givenSymbol(body)
+      case Typed(expr, _)      => givenSymbol(expr)
+      case Block(_, expr)      => givenSymbol(expr)
+      case other               => other.symbol
+
+    val rhs = givenSymbol(tree).tree match
+      case valDef: ValDef => valDef.rhs
+      case _              => None
+
+    val pairs = scala.collection.mutable.LinkedHashMap[String, Term]()
+
+    // Inline expansion wraps each tuple element in `Inlined`/`Typed`; strip those to reach the
+    // string-literal path and the instance term.
+    def unwrap(tree: Tree): Tree = tree match
+      case Inlined(_, _, body) => unwrap(body)
+      case Typed(expr, _)      => unwrap(expr)
+      case Block(Nil, expr)    => unwrap(expr)
+      case other               => other
+
+    val accumulator = new TreeAccumulator[Unit]:
+      def foldTree(state: Unit, tree: Tree)(owner: Symbol): Unit =
+        tree match
+          case Apply(_, List(key, value)) => unwrap(key) match
+            case Literal(StringConstant(path)) => pairs(path) = unwrap(value).asInstanceOf[Term]
+            case _                             => ()
+
+          case _ =>
+            ()
+
+        foldOverTree(state, tree)(owner)
+
+    rhs.foreach(accumulator.foldTree((), _)(Symbol.spliceOwner))
+    pairs.to(Map)
+
   // A marker that `resolvableNonStructural` injects (as a synthetic `given`) into a probe's
   // implicit scope, so the derivation macro can detect that implicit search has re-entered it for
   // this exact instance type. Never instantiated at runtime.

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -68,45 +68,102 @@ object internal:
   def overridePathsMacro[typeclass[_]: Type, derivation: Type]: Macro[List[Text]] =
     Expr.ofList(specificOverrides[typeclass, derivation].keys.toList.map { k => '{${Expr(k)}.tt} })
 
-  // The override set for `derivation` and `typeclass`: the path→instance-term pairs from an
-  // in-scope `derivation is Specific over typeclass` (read from the expanded given's `instances`
-  // map) — or empty if no such `Specific` is in scope. A `Specific` whose `Transport` is for a
-  // different typeclass (its `Transport { type Self = X }` is not `typeclass[X]`) is ignored.
   def specificOverrides[typeclass[_]: Type, derivation: Type](using Quotes)
   :   Map[String, quotes.reflect.Term] =
 
     import quotes.reflect.*
+    specificOverridesRepr(TypeRepr.of[typeclass], TypeRepr.of[derivation])
 
-    val self = TypeRepr.of[derivation]
-    val specificType = Refinement(TypeRepr.of[vicarious.Specific], "Self", TypeBounds(self, self))
+  // The override set for `root` and the typeclass `typeclassConstructor`: the path→instance-term
+  // pairs from an in-scope `root is Specific over typeclass` (read from the expanded given's
+  // `instances` map) — or empty if no such `Specific` is in scope. A `Specific` whose `Transport`
+  // is for a different typeclass (`Transport { type Self = X }` is not `typeclass[X]`) is ignored.
+  private def specificOverridesRepr(using Quotes)
+    ( typeclassConstructor: quotes.reflect.TypeRepr, root: quotes.reflect.TypeRepr )
+  :   Map[String, quotes.reflect.Term] =
+
+    import quotes.reflect.*
+
+    val specificType = Refinement(TypeRepr.of[vicarious.Specific], "Self", TypeBounds(root, root))
 
     Implicits.search(specificType) match
       case success: ImplicitSearchSuccess =>
-        if transportMatches[typeclass](success.tree.tpe) then readOverrides(success.tree) else Map()
+        if transportMatches(typeclassConstructor, success.tree.tpe) then readOverrides(success.tree)
+        else Map()
 
       case _ =>
         Map()
 
+  // The value of refinement type member `name` in `repr` (walking refinement layers), if present.
+  private def refinementMember(using Quotes)(repr: quotes.reflect.TypeRepr, name: String)
+  :   Option[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    repr match
+      case Refinement(_, `name`, TypeBounds(low, _)) =>
+        Some(low)
+
+      case Refinement(parent, _, _) =>
+        refinementMember(parent, name)
+
+      case AndType(left, right) =>
+        refinementMember(left, name).orElse(refinementMember(right, name))
+
+      case _ =>
+        None
+
   // Whether the `Specific`'s `Transport`, applied at a sample type, yields `typeclass[sample]` — so
   // the override targets this typeclass and not some other.
-  private def transportMatches[typeclass[_]: Type](using Quotes)(specific: quotes.reflect.TypeRepr)
+  private def transportMatches(using Quotes)
+    ( typeclassConstructor: quotes.reflect.TypeRepr, specific: quotes.reflect.TypeRepr )
   :   Boolean =
 
     import quotes.reflect.*
     val sample = TypeRepr.of[Any]
 
-    def member(repr: TypeRepr, name: String): Option[TypeRepr] = repr match
-      case Refinement(_, `name`, TypeBounds(lo, _)) => Some(lo)
-      case Refinement(parent, _, _)                 => member(parent, name)
-      case _                                        => None
-
-    member(specific.widen.dealias, "Transport") match
+    refinementMember(specific.widen.dealias, "Transport") match
       case Some(transport) =>
         Refinement(transport, "Self", TypeBounds(sample, sample)) =:=
-          TypeRepr.of[typeclass].appliedTo(sample)
+          typeclassConstructor.appliedTo(sample)
 
       case None =>
         false
+
+  // ---- Path-specialised field resolution (the "spine") ----
+
+  // A path-carrier type `field { type VRoot = root; type VPath = path }` — a phantom refinement
+  // threading the override root and dotted path down the derivation so type-keyed field resolution
+  // can distinguish, say, the `cto` employee from the `ceo` employee.
+  private def carrierType(using Quotes)
+    ( field: quotes.reflect.TypeRepr, root: quotes.reflect.TypeRepr, path: String )
+  :   quotes.reflect.TypeRepr =
+
+    import quotes.reflect.*
+    val pathType = ConstantType(StringConstant(path))
+
+    val withRoot = Refinement(field, "VRoot", TypeBounds(root, root))
+    Refinement(withRoot, "VPath", TypeBounds(pathType, pathType))
+
+  // The override context for deriving `derivation`: its root type, its dotted path so far, and the
+  // override set — read from a `VRoot`/`VPath` carrier if present (a deeper spine type), else from
+  // an in-scope `Specific` for `derivation` itself (root, path ""). `None` when none applies.
+  private def overrideContext(using Quotes)
+    ( typeclassConstructor: quotes.reflect.TypeRepr, derivation: quotes.reflect.TypeRepr )
+  :   Option[(quotes.reflect.TypeRepr, String, Map[String, quotes.reflect.Term])] =
+
+    import quotes.reflect.*
+
+    (refinementMember(derivation, "VRoot"), refinementMember(derivation, "VPath")) match
+      case (Some(root), Some(ConstantType(StringConstant(path)))) =>
+        Some((root, path, specificOverridesRepr(typeclassConstructor, root)))
+
+      case _ =>
+        // `derivation` may be `T & Product` (added by `derivedOne`); strip to the bare type so the
+        // `Specific` search keys on `T`.
+        val base = productType(derivation)
+        val overrides = specificOverridesRepr(typeclassConstructor, base)
+        if overrides.isEmpty then None else Some((base, "", overrides))
 
   // Reads the path→instance-term pairs from an in-scope `Specific` given's expanded
   // `instances = Map(("path", instance), …)` body. Available for a given defined in the current
@@ -370,6 +427,12 @@ object internal:
     val wrappers = wrappersOf[typeclass]
     val instanceTpe = typeclassConstructor.appliedTo(TypeRepr.of[derivation])
 
+    // Whether an in-scope `Specific` overrides any path of `derivation` for this typeclass. When it
+    // does, product spines are specialised (path-carrier siblings); otherwise the graph is built
+    // exactly as before — no per-type override probing, no behaviour change.
+    val specific =
+      specificOverridesRepr(typeclassConstructor, TypeRepr.of[derivation].dealias).nonEmpty
+
     def instanceOf(tpe: TypeRepr): TypeRepr = typeclassConstructor.appliedTo(tpe)
 
     def codecFunction(tpe: TypeRepr, args: List[TypeRepr]): TypeRepr =
@@ -413,12 +476,34 @@ object internal:
               tpe.typeSymbol.children.foreach: child =>
                 visit(variantWith(child, tpe), false)
           else if isProductType(tpe) then
-            if isRoot || !resolvableNonStructural(typeclassConstructor, tpe) then
+            // A path-carrier (a specialised spine type) is always derived; else probe as before.
+            val carrier = specific && refinementMember(tpe, "VRoot").isDefined
+
+            if isRoot || carrier || !resolvableNonStructural(typeclassConstructor, tpe) then
               reachable(key) = tpe
               val product = productType(tpe)
+              val context = if specific then overrideContext(typeclassConstructor, tpe) else None
 
-              product.typeSymbol.caseFields.foreach: field =>
-                visit(product.memberType(field), false)
+              context match
+                case Some((root, parentPath, overrides)) =>
+                  // Spine field → specialised carrier sibling; overridden leaf → no sibling (the
+                  // instance term is spliced at the field site); else a shared default sibling.
+                  product.typeSymbol.caseFields.foreach: field =>
+                    val fieldType = product.memberType(field)
+
+                    val childPath =
+                      if parentPath.isEmpty then field.name else parentPath+"."+field.name
+
+                    if overrides.contains(childPath) then
+                      ()
+                    else if overrides.keySet.exists(_.startsWith(childPath+".")) then
+                      visit(carrierType(fieldType, root, childPath), false)
+                    else
+                      visit(fieldType, false)
+
+                case None =>
+                  product.typeSymbol.caseFields.foreach: field =>
+                    visit(product.memberType(field), false)
 
       val rootType = TypeRepr.of[derivation].dealias
       visit(rootType, isRoot = true)
@@ -594,15 +679,18 @@ object internal:
     val lambdaTerm = lambda.asTerm
 
     val arguments: List[Expr[Any]] = symbol.caseFields.zipWithIndex.map: (field, index) =>
+      val fieldName = field.name
+
       tpe.memberType(field).asType.absolve match
         case '[field] =>
           val indexExpr = Expr(index)
-          val nameExpr = Expr(field.name)
+          val nameExpr = Expr(fieldName)
           val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
           val label = '{$nameExpr.tt.aka["label"]}
           val fieldIndex = '{$indexExpr.asInstanceOf[Int & FieldIndex[field]].aka["index"]}
+          val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
 
-          sharedInstance[typeclass, field](index): (reference, contextual) =>
+          sharedInstance[typeclass, field](index, instance): (reference, contextual) =>
             applyLambda[field](lambdaTerm, reference, List(contextual, default, label, fieldIndex))
 
           . asExpr
@@ -619,10 +707,12 @@ object internal:
     val lambdaTerm = lambda.asTerm
 
     val results: List[Expr[result]] = tpe.typeSymbol.caseFields.zipWithIndex.map: (field, index) =>
+      val fieldName = field.name
+
       tpe.memberType(field).asType.absolve match
         case '[field] =>
           val indexExpr = Expr(index)
-          val nameExpr = Expr(field.name)
+          val nameExpr = Expr(fieldName)
           val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
           val label = '{$nameExpr.tt.aka["label"]}
 
@@ -631,8 +721,9 @@ object internal:
 
           val dereference = '{$accessor.aka["dereference"]}
           val fieldIndex = '{$indexExpr.asInstanceOf[Int & FieldIndex[field]].aka["index"]}
+          val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
 
-          sharedInstance[typeclass, field](index): (reference, contextual) =>
+          sharedInstance[typeclass, field](index, instance): (reference, contextual) =>
             val arguments = List(contextual, default, label, dereference, fieldIndex)
             applyLambda[field](lambdaTerm, reference, arguments)
 
@@ -650,15 +741,18 @@ object internal:
     val lambdaTerm = lambda.asTerm
 
     val results: List[Expr[result]] = tpe.typeSymbol.caseFields.zipWithIndex.map: (field, index) =>
+      val fieldName = field.name
+
       tpe.memberType(field).asType.absolve match
         case '[field] =>
           val indexExpr = Expr(index)
-          val nameExpr = Expr(field.name)
+          val nameExpr = Expr(fieldName)
 
           val fieldValue: Expr[Any] =
             '{$product.asInstanceOf[Product].productElement($indexExpr).asInstanceOf[field]}
 
-          val contextual = '{${resolveField[typeclass, field]}.aka["contextual"]}
+          val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
+          val contextual = '{$instance.aka["contextual"]}
           val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
           val label = '{$nameExpr.tt.aka["label"]}
           val fieldIndex = '{$indexExpr.asInstanceOf[Int & FieldIndex[field]].aka["index"]}
@@ -706,17 +800,20 @@ object internal:
     val tupleFunction = MethodType(List("tuple"))(_ => List(tupleType), _ => constructorTuple)
 
     symbol.caseFields.zipWithIndex.foreach: (field, index) =>
+      val fieldName = field.name
+
       tpe.memberType(field).asType.absolve match
         case '[field] =>
           val indexExpr = Expr(index)
-          val nameExpr = Expr(field.name)
+          val nameExpr = Expr(fieldName)
           val fieldType = TypeRepr.of[field]
           val valueFunction = MethodType(List("value"))(_ => List(fieldType), _ => constructorTuple)
 
           val outer = Lambda(Symbol.spliceOwner, tupleFunction, { (owner, parameters) =>
             val tupleRef = parameters.head.asInstanceOf[Term]
-            val contextValue: Expr[Any] = resolveField[typeclass, field]
-            val contextual = '{${resolveField[typeclass, field]}.aka["contextual"]}
+            val instance = specificFieldInstance[typeclass, derivation, field](fieldName)
+            val contextValue: Expr[Any] = instance
+            val contextual = '{$instance.aka["contextual"]}
             val default = '{Default(wisteria.internal.default[derivation, field]($indexExpr))}
             val label = '{$nameExpr.tt.aka["label"]}
             val fieldIndex = '{$indexExpr.asInstanceOf[Int & FieldIndex[field]].aka["index"]}
@@ -774,6 +871,31 @@ object internal:
   private def resolveField[typeclass[_]: Type, field: Type](using Quotes): Expr[typeclass[field]] =
     '{wisteria.internal.field[typeclass, field]}
 
+  // The typeclass instance for a field of `derivation`, honoring an in-scope `Specific`: an
+  // override instance, a path-specialised sibling (resolved at a carrier type), or — with no
+  // `Specific` in scope — exactly `resolveField`, so the common path is unchanged.
+  private def specificFieldInstance[typeclass[_]: Type, derivation: Type, field: Type]
+    (fieldName: String)(using Quotes)
+  :   Expr[typeclass[field]] =
+
+    import quotes.reflect.*
+
+    overrideContext(TypeRepr.of[typeclass], TypeRepr.of[derivation]) match
+      case None =>
+        resolveField[typeclass, field]
+
+      case Some((root, parentPath, overrides)) =>
+        val childPath = if parentPath.isEmpty then fieldName else parentPath+"."+fieldName
+
+        if overrides.contains(childPath) then
+          overrides(childPath).asExprOf[typeclass[field]]
+        else if overrides.keySet.exists(_.startsWith(childPath+".")) then
+          carrierType(TypeRepr.of[field], root, childPath).asType.absolve match
+            case '[carrier] =>
+              '{wisteria.internal.field[typeclass, carrier].asInstanceOf[typeclass[field]]}
+        else
+          resolveField[typeclass, field]
+
   // Binds a field/variant's resolved instance to a single val, so the lambda's value argument and
   // its `"contextual"` context argument share one instance instead of resolving it twice. Without
   // that sharing each use re-emits — and, absent dedup, re-derives — the whole sub-instance,
@@ -781,7 +903,7 @@ object internal:
   // derivation. `build(ref, contextual)` produces the applied term given the shared ref and its
   // `"contextual"`-tagged view; the result is wrapped in a block that introduces the val.
   private def sharedInstance[typeclass[_]: Type, field: Type](using Quotes)
-    ( index: Int )
+    ( index: Int, instance: Expr[typeclass[field]] )
     ( build: (Expr[typeclass[field]], Expr[Any]) => quotes.reflect.Term )
   :   quotes.reflect.Term =
 
@@ -798,7 +920,7 @@ object internal:
     val reference = Ref(symbol).asExprOf[typeclass[field]]
     val applied = build(reference, '{$reference.aka["contextual"]})
 
-    Block(List(ValDef(symbol, Some(resolveField[typeclass, field].asTerm))), applied)
+    Block(List(ValDef(symbol, Some(instance.asTerm))), applied)
 
   def getDefault[product: Type, field: Type](index: Expr[Int]): Macro[Optional[field]] =
     import quotes.reflect.*

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -66,21 +66,24 @@ object internal:
     ${overridePathsMacro[typeclass, derivation]}
 
   def overridePathsMacro[typeclass[_]: Type, derivation: Type]: Macro[List[Text]] =
-    Expr.ofList(specificOverrides[typeclass, derivation].keys.toList.map { k => '{${Expr(k)}.tt} })
-
-  def specificOverrides[typeclass[_]: Type, derivation: Type](using Quotes)
-  :   Map[String, quotes.reflect.Term] =
-
     import quotes.reflect.*
-    specificOverridesRepr(TypeRepr.of[typeclass], TypeRepr.of[derivation])
 
-  // The override set for `root` and the typeclass `typeclassConstructor`: the path→instance-term
-  // pairs from an in-scope `root is Specific over typeclass` (read from the expanded given's
-  // `instances` map) — or empty if no such `Specific` is in scope. A `Specific` whose `Transport`
-  // is for a different typeclass (`Transport { type Self = X }` is not `typeclass[X]`) is ignored.
+    val paths = specificOverridesRepr(TypeRepr.of[typeclass], TypeRepr.of[derivation]) match
+      case Some((_, keys)) => keys.toList
+      case None            => Nil
+
+    Expr.ofList(paths.map { k => '{${Expr(k)}.tt} })
+
+  // The override set for `root` and the typeclass `typeclassConstructor`: a reference to the
+  // in-scope `root is Specific over typeclass` given and the dotted paths it overrides — or `None`
+  // if no such `Specific` is in scope. A `Specific` whose `Transport` is for a different typeclass
+  // (`Transport { type Self = X }` is not `typeclass[X]`) is ignored. Only the override paths
+  // (string constants) are read from the given's tree; the override *values* are taken at runtime
+  // from the given's `instances` map, never by re-splicing their trees (which would move lambdas
+  // across owners and crash the inliner).
   private def specificOverridesRepr(using Quotes)
     ( typeclassConstructor: quotes.reflect.TypeRepr, root: quotes.reflect.TypeRepr )
-  :   Map[String, quotes.reflect.Term] =
+  :   Option[(quotes.reflect.Term, Set[String])] =
 
     import quotes.reflect.*
 
@@ -88,11 +91,12 @@ object internal:
 
     Implicits.search(specificType) match
       case success: ImplicitSearchSuccess =>
-        if transportMatches(typeclassConstructor, success.tree.tpe) then readOverrides(success.tree)
-        else Map()
+        if transportMatches(typeclassConstructor, success.tree.tpe)
+        then Some((success.tree, readKeys(success.tree)))
+        else None
 
       case _ =>
-        Map()
+        None
 
   // The value of refinement type member `name` in `repr` (walking refinement layers), if present.
   private def refinementMember(using Quotes)(repr: quotes.reflect.TypeRepr, name: String)
@@ -145,32 +149,34 @@ object internal:
     val withRoot = Refinement(field, "VRoot", TypeBounds(root, root))
     Refinement(withRoot, "VPath", TypeBounds(pathType, pathType))
 
-  // The override context for deriving `derivation`: its root type, its dotted path so far, and the
-  // override set — read from a `VRoot`/`VPath` carrier if present (a deeper spine type), else from
-  // an in-scope `Specific` for `derivation` itself (root, path ""). `None` when none applies.
+  // The override context for deriving `derivation`: the root type, the dotted path so far, a
+  // reference to the in-scope `Specific` given, and the overridden paths — from a `VRoot`/`VPath`
+  // carrier if present (a deeper spine type), else from an in-scope `Specific` for `derivation`
+  // itself (root, path ""). `None` when no override applies.
   private def overrideContext(using Quotes)
     ( typeclassConstructor: quotes.reflect.TypeRepr, derivation: quotes.reflect.TypeRepr )
-  :   Option[(quotes.reflect.TypeRepr, String, Map[String, quotes.reflect.Term])] =
+  :   Option[(quotes.reflect.TypeRepr, String, quotes.reflect.Term, Set[String])] =
 
     import quotes.reflect.*
 
     (refinementMember(derivation, "VRoot"), refinementMember(derivation, "VPath")) match
       case (Some(root), Some(ConstantType(StringConstant(path)))) =>
-        Some((root, path, specificOverridesRepr(typeclassConstructor, root)))
+        specificOverridesRepr(typeclassConstructor, root).map: (given_, keys) =>
+          (root, path, given_, keys)
 
       case _ =>
         // `derivation` may be `T & Product` (added by `derivedOne`); strip to the bare type so the
         // `Specific` search keys on `T`.
         val base = productType(derivation)
-        val overrides = specificOverridesRepr(typeclassConstructor, base)
-        if overrides.isEmpty then None else Some((base, "", overrides))
 
-  // Reads the path→instance-term pairs from an in-scope `Specific` given's expanded
+        specificOverridesRepr(typeclassConstructor, base).map: (given_, keys) =>
+          (base, "", given_, keys)
+
+  // Reads the override paths (the string-literal keys) from an in-scope `Specific` given's expanded
   // `instances = Map(("path", instance), …)` body. Available for a given defined in the current
   // compilation run (the usual case: the override is defined where the derivation is requested).
-  private def readOverrides(using Quotes)(tree: quotes.reflect.Term)
-  :   Map[String, quotes.reflect.Term] =
-
+  // Only the keys are read; the values stay in the runtime map.
+  private def readKeys(using Quotes)(tree: quotes.reflect.Term): Set[String] =
     import quotes.reflect.*
 
     def givenSymbol(term: Term): Symbol = term match
@@ -183,10 +189,10 @@ object internal:
       case valDef: ValDef => valDef.rhs
       case _              => None
 
-    val pairs = scala.collection.mutable.LinkedHashMap[String, Term]()
+    val keys = scala.collection.mutable.LinkedHashSet[String]()
 
     // Inline expansion wraps each tuple element in `Inlined`/`Typed`; strip those to reach the
-    // string-literal path and the instance term.
+    // string-literal path key.
     def unwrap(tree: Tree): Tree = tree match
       case Inlined(_, _, body) => unwrap(body)
       case Typed(expr, _)      => unwrap(expr)
@@ -196,8 +202,8 @@ object internal:
     val accumulator = new TreeAccumulator[Unit]:
       def foldTree(state: Unit, tree: Tree)(owner: Symbol): Unit =
         tree match
-          case Apply(_, List(key, value)) => unwrap(key) match
-            case Literal(StringConstant(path)) => pairs(path) = unwrap(value).asInstanceOf[Term]
+          case Apply(_, List(key, _)) => unwrap(key) match
+            case Literal(StringConstant(path)) => keys += path
             case _                             => ()
 
           case _ =>
@@ -206,7 +212,7 @@ object internal:
         foldOverTree(state, tree)(owner)
 
     rhs.foreach(accumulator.foldTree((), _)(Symbol.spliceOwner))
-    pairs.to(Map)
+    keys.to(Set)
 
   // A marker that `resolvableNonStructural` injects (as a synthetic `given`) into a probe's
   // implicit scope, so the derivation macro can detect that implicit search has re-entered it for
@@ -431,7 +437,7 @@ object internal:
     // does, product spines are specialised (path-carrier siblings); otherwise the graph is built
     // exactly as before — no per-type override probing, no behaviour change.
     val specific =
-      specificOverridesRepr(typeclassConstructor, TypeRepr.of[derivation].dealias).nonEmpty
+      specificOverridesRepr(typeclassConstructor, TypeRepr.of[derivation].dealias).isDefined
 
     def instanceOf(tpe: TypeRepr): TypeRepr = typeclassConstructor.appliedTo(tpe)
 
@@ -485,18 +491,18 @@ object internal:
               val context = if specific then overrideContext(typeclassConstructor, tpe) else None
 
               context match
-                case Some((root, parentPath, overrides)) =>
+                case Some((root, parentPath, _, keys)) =>
                   // Spine field → specialised carrier sibling; overridden leaf → no sibling (the
-                  // instance term is spliced at the field site); else a shared default sibling.
+                  // value comes from the given's runtime map); else a shared default sibling.
                   product.typeSymbol.caseFields.foreach: field =>
                     val fieldType = product.memberType(field)
 
                     val childPath =
                       if parentPath.isEmpty then field.name else parentPath+"."+field.name
 
-                    if overrides.contains(childPath) then
+                    if keys.contains(childPath) then
                       ()
-                    else if overrides.keySet.exists(_.startsWith(childPath+".")) then
+                    else if keys.exists(_.startsWith(childPath+".")) then
                       visit(carrierType(fieldType, root, childPath), false)
                     else
                       visit(fieldType, false)
@@ -884,12 +890,15 @@ object internal:
       case None =>
         resolveField[typeclass, field]
 
-      case Some((root, parentPath, overrides)) =>
+      case Some((root, parentPath, given_, keys)) =>
         val childPath = if parentPath.isEmpty then fieldName else parentPath+"."+fieldName
 
-        if overrides.contains(childPath) then
-          overrides(childPath).asExprOf[typeclass[field]]
-        else if overrides.keySet.exists(_.startsWith(childPath+".")) then
+        if keys.contains(childPath) then
+          // Take the override's value from the given's runtime `instances` map (cast to the field's
+          // type) — never re-splice its tree.
+          val specific = given_.asExprOf[vicarious.Specific]
+          '{$specific.instances(${Expr(childPath)}).asInstanceOf[typeclass[field]]}
+        else if keys.exists(_.startsWith(childPath+".")) then
           carrierType(TypeRepr.of[field], root, childPath).asType.absolve match
             case '[carrier] =>
               '{wisteria.internal.field[typeclass, carrier].asInstanceOf[typeclass[field]]}

--- a/lib/wisteria/src/test/wisteria_test.scala
+++ b/lib/wisteria/src/test/wisteria_test.scala
@@ -243,12 +243,17 @@ object Tests extends Suite(m"Wisteria tests"):
   case class Employee(name: Text, age: Int)
   case class Company(ceo: Employee, cto: Employee)
 
-  // A Self-based typeclass with a product derivation, to observe overrides end-to-end.
+  sealed trait Contact
+  case class Email(address: Text) extends Contact
+  case class Phone(number: Text) extends Contact
+  case class Account(holder: Text, contact: Contact)
+
+  // A Self-based typeclass with product + sum derivation, to observe overrides end-to-end.
   trait Display:
     type Self
     def display(value: Self): Text
 
-  object Display extends ProductDerivable[Display]:
+  object Display extends Derivable[Display]:
     given (Text is Display) = identity(_)
     given (Int is Display) = _.toString.tt
 
@@ -256,6 +261,10 @@ object Tests extends Suite(m"Wisteria tests"):
       fields(value):
         [field] => field => contextual.display(field)
       .mkString(",").tt
+
+    inline def disjunction[derivation: SumReflection]: derivation is Display = value =>
+      variant(value):
+        [variant <: derivation] => variant => contextual.display(variant)
 
   extension [value](value: value)
     def display(using display: value is Display): Text = display.display(value)
@@ -558,3 +567,40 @@ object Tests extends Suite(m"Wisteria tests"):
 
         Display.derived[Company].display(company)
       . assert(_ == t"AL,30,bo,80")
+
+      test(m"A whole non-leaf field can be overridden with a custom instance"):
+        val terse: Employee is Display = e => t"<${e.name}>"
+
+        given (Company is Specific over Display) =
+          specifically:
+            case root.cto() => terse
+
+        Display.derived[Company].display(company)
+      . assert(_ == t"al,30,<bo>")
+
+      test(m"A local element given is picked up by re-derivation"):
+        given Employee is Display = e => t"E(${e.name})"
+        Display.derived[Company].display(company)
+      . assert(_ == t"E(al),E(bo)")
+
+      test(m"specialized re-derives a sum with one variant overridden"):
+        val maskedEmail: Email is Display = e => t"<hidden>"
+        val account = Account(t"ann", Email(t"ann@example.com"))
+
+        given (Account is Specific over Display) =
+          specifically:
+            case root.contact() => specialized[Contact, Display](maskedEmail)
+
+        Display.derived[Account].display(account)
+      . assert(_ == t"ann,<hidden>")
+
+      test(m"specialized leaves other variants on their defaults"):
+        val maskedEmail: Email is Display = e => t"<hidden>"
+        val account = Account(t"bob", Phone(t"555-1234"))
+
+        given (Account is Specific over Display) =
+          specifically:
+            case root.contact() => specialized[Contact, Display](maskedEmail)
+
+        Display.derived[Account].display(account)
+      . assert(_ == t"bob,555-1234")

--- a/lib/wisteria/src/test/wisteria_test.scala
+++ b/lib/wisteria/src/test/wisteria_test.scala
@@ -243,6 +243,23 @@ object Tests extends Suite(m"Wisteria tests"):
   case class Employee(name: Text, age: Int)
   case class Company(ceo: Employee, cto: Employee)
 
+  // A Self-based typeclass with a product derivation, to observe overrides end-to-end.
+  trait Display:
+    type Self
+    def display(value: Self): Text
+
+  object Display extends ProductDerivable[Display]:
+    given (Text is Display) = identity(_)
+    given (Int is Display) = _.toString.tt
+
+    inline def conjunction[derivation <: Product: ProductReflection]: derivation is Display = value =>
+      fields(value):
+        [field] => field => contextual.display(field)
+      .mkString(",").tt
+
+  extension [value](value: value)
+    def display(using display: value is Display): Text = display.display(value)
+
   // ===== Tests =====
 
   def run(): Unit =
@@ -515,3 +532,29 @@ object Tests extends Suite(m"Wisteria tests"):
 
         wisteria.internal.overridePaths[Eq, Company]
       . assert(_ == Nil)
+
+    suite(m"Specific override in derivation"):
+      val company = Company(Employee(t"al", 30), Employee(t"bo", 40))
+      val shout: Text is Display = _.upper
+      val doubled: Int is Display = n => (n*2).toString.tt
+
+      test(m"Without a Specific, all fields use default instances"):
+        Display.derived[Company].display(company)
+      . assert(_ == t"al,30,bo,40")
+
+      test(m"A Specific overrides one field path along its spine only"):
+        given (Company is Specific over Display) =
+          specifically:
+            case root.cto.name() => shout
+
+        Display.derived[Company].display(company)
+      . assert(_ == t"al,30,BO,40")
+
+      test(m"Overrides at distinct spines stay independent"):
+        given (Company is Specific over Display) =
+          specifically:
+            case root.ceo.name() => shout
+            case root.cto.age()  => doubled
+
+        Display.derived[Company].display(company)
+      . assert(_ == t"AL,30,bo,80")

--- a/lib/wisteria/src/test/wisteria_test.scala
+++ b/lib/wisteria/src/test/wisteria_test.scala
@@ -583,24 +583,47 @@ object Tests extends Suite(m"Wisteria tests"):
         Display.derived[Company].display(company)
       . assert(_ == t"E(al),E(bo)")
 
-      test(m"specialized re-derives a sum with one variant overridden"):
+      test(m"a sum field's variant is overridden via a local given + re-derive"):
         val maskedEmail: Email is Display = e => t"<hidden>"
         val account = Account(t"ann", Email(t"ann@example.com"))
 
         given (Account is Specific over Display) =
           specifically:
-            case root.contact() => specialized[Contact, Display](maskedEmail)
+            case root.contact() =>
+              given Email is Display = maskedEmail
+              Display.derived[Contact]
 
         Display.derived[Account].display(account)
       . assert(_ == t"ann,<hidden>")
 
-      test(m"specialized leaves other variants on their defaults"):
+      test(m"the same override leaves other variants on their defaults"):
         val maskedEmail: Email is Display = e => t"<hidden>"
         val account = Account(t"bob", Phone(t"555-1234"))
 
         given (Account is Specific over Display) =
           specifically:
-            case root.contact() => specialized[Contact, Display](maskedEmail)
+            case root.contact() =>
+              given Email is Display = maskedEmail
+              Display.derived[Contact]
 
         Display.derived[Account].display(account)
       . assert(_ == t"bob,555-1234")
+
+      test(m"a nested Specific specialises one branch of a component"):
+        // `Account.contact` uses a `Contact` whose `Email` variant has its `address` masked, while
+        // a top-level `Account` derivation leaves other `Contact`s alone.
+        val masked: Text is Display = _ => t"***"
+        val account = Account(t"ann", Email(t"ann@example.com"))
+
+        given (Account is Specific over Display) =
+          specifically:
+            case root.contact() =>
+              given (Email is Specific over Display) =
+                specifically:
+                  case root.address() => masked
+
+              given Email is Display = Display.derived[Email]
+              Display.derived[Contact]
+
+        Display.derived[Account].display(account)
+      . assert(_ == t"ann,***")

--- a/lib/wisteria/src/test/wisteria_test.scala
+++ b/lib/wisteria/src/test/wisteria_test.scala
@@ -34,6 +34,8 @@ package wisteria
 
 import soundness.*
 
+import scala.language.dynamics
+
 object Tests extends Suite(m"Wisteria tests"):
 
   // ===== Typeclass: Presentation =====
@@ -228,6 +230,18 @@ object Tests extends Suite(m"Wisteria tests"):
   sealed trait Shape
   case class Circle(radius: Int) extends Shape
   case class Square(side: Int) extends Shape
+
+  // ===== Specific overrides =====
+
+  trait Codec:
+    type Self
+    type Form
+
+  type Json
+  type CodecJson = [self] =>> self is Codec in Json
+
+  case class Employee(name: Text, age: Int)
+  case class Company(ceo: Employee, cto: Employee)
 
   // ===== Tests =====
 
@@ -471,3 +485,33 @@ object Tests extends Suite(m"Wisteria tests"):
           case class Bag(items: List[java.io.File])
           Readable.derived[Bag]
       . assert(_.nonEmpty)
+
+    suite(m"Specific override detection"):
+      val nameCodec: Text is Codec in Json = new Codec:
+        type Self = Text
+        type Form = Json
+
+      val ageCodec: Int is Codec in Json = new Codec:
+        type Self = Int
+        type Form = Json
+
+      test(m"No Specific in scope yields no override paths"):
+        wisteria.internal.overridePaths[CodecJson, Company]
+      . assert(_ == Nil)
+
+      test(m"A Specific in scope yields its override paths"):
+        given (Company is Specific over (Codec in Json)) =
+          specifically:
+            case root.cto.name() => nameCodec
+            case root.ceo.age()  => ageCodec
+
+        wisteria.internal.overridePaths[CodecJson, Company].to(Set)
+      . assert(_ == Set(t"cto.name", t"ceo.age"))
+
+      test(m"A Specific for a different typeclass is ignored"):
+        given (Company is Specific over (Codec in Json)) =
+          specifically:
+            case root.cto.name() => nameCodec
+
+        wisteria.internal.overridePaths[Eq, Company]
+      . assert(_ == Nil)


### PR DESCRIPTION
Vicarious now provides `specifically`, which lets a generic Wisteria derivation use a different typeclass instance at specific field paths — for example, deriving an encoder for a record but encoding one nested `Date` field differently from another field of the same type. Overrides are written as path cases, checked at compile time against the field's type, and applied only at that exact path while everything else derives as normal.

`specifically` builds a `Specific` value recording per-field-path exceptions for a derivation. Given:

```scala
case class Person(name: Text, dateOfBirth: Date, joined: Date)
case class Org(ceo: Person, cto: Person)
```

you can override the instance used at one exact path:

```scala
given (Org is Specific over (Encodable in Json)) =
  specifically:
    case root.cto.joined() => joinedAsNumber
```

`root` stands for the value being derived; `root.cto.joined` is checked at compile time to be a valid path, and `joinedAsNumber` to be an instance for that field's type. Only `cto.joined` is affected — `ceo.joined` and `cto.dateOfBirth` keep the default.

The right-hand side of a case is just the instance to use at that path, so you can build it however you like — including by re-deriving a component with a local `given` in scope, which covers sum variants and collection elements:

```scala
given (Crew is Specific over (Encodable in Json)) =
  specifically:
    case root.members() =>
      given Worker is Encodable in Json = nameOnly
      summon[List[Worker] is Encodable in Json]
```

A `T is Specific over Tc` in scope applies to every derivation of `T`, so these overrides compose and nest. (For a codec whose public type is a subtype of the type it derives — e.g. jacinta's `Json.Encodable` — name that subtype in `over`.)
