### PR TITLE
Promote recover/mitigate/accrue to leading words; remove whereas

### DIFF
--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -63,11 +63,11 @@ trait LowPriorityConformant:
     response =>
       Conformant.successful(response)
 
-      whereas:
+      mitigate:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
         case JsonError(_)        => ApiError(ApiError.Reason.Malformed)
 
-      . mitigate(response.body.stream.read[Json].as[value])
+      . protect(response.body.stream.read[Json].as[value])
 
   // A 2xx XML body decoded to any XML-decodable type.
   given xmlDecodable: [value: Decodable in Xml]
@@ -75,11 +75,11 @@ trait LowPriorityConformant:
     response =>
       Conformant.successful(response)
 
-      whereas:
+      mitigate:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
         case _: XmlError         => ApiError(ApiError.Reason.Malformed)
 
-      . mitigate(summon[CharDecoder].decoded(response.body.stream).read[Xml].as[value])
+      . protect(summon[CharDecoder].decoded(response.body.stream).read[Xml].as[value])
 
 object Conformant extends LowPriorityConformant:
   // Raise `ApiError` unless the response status is in the 2xx range.
@@ -101,10 +101,10 @@ object Conformant extends LowPriorityConformant:
   given json: Tactic[ApiError] => (Json is Conformant) over Json = response =>
     successful(response)
 
-    whereas:
+    mitigate:
       case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
 
-    . mitigate(response.body.stream.read[Json])
+    . protect(response.body.stream.read[Json])
 
   // The raw 2xx body as XML. The body bytes are decoded to `Text` (via the
   // `CharDecoder`) before xylophone parses them.
@@ -112,10 +112,10 @@ object Conformant extends LowPriorityConformant:
     response =>
       successful(response)
 
-      whereas:
+      mitigate:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
 
-      . mitigate(summon[CharDecoder].decoded(response.body.stream).read[Xml])
+      . protect(summon[CharDecoder].decoded(response.body.stream).read[Xml])
 
 trait Conformant extends Typeclass, Transportive:
   def read(response: Http.Response): Self

--- a/lib/apoplexy/src/core/apoplexy.OpenApi.scala
+++ b/lib/apoplexy/src/core/apoplexy.OpenApi.scala
@@ -285,13 +285,13 @@ object OpenApi:
   given aggregable: Tactic[OpenApiError] => OpenApi is Aggregable by Text =
     summon[Text is Aggregable by Text].map: text =>
       val document =
-        whereas:
+        mitigate:
           case ParseError(_, _, _)    => OpenApiError(OpenApiError.Reason.Malformed)
           case JsonError(_)           => OpenApiError(OpenApiError.Reason.Malformed)
           case YamlError(_)           => OpenApiError(OpenApiError.Reason.Malformed)
           case JsonPointerError(_, _) => OpenApiError(OpenApiError.Reason.Malformed)
 
-        . mitigate:
+        . protect:
             if text.trim.starts(t"{") || text.trim.starts(t"[")
             then text.decode[Json].as[OpenApi]
             else text.decode[Yaml].as[OpenApi]

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -103,11 +103,11 @@ object timestampInternal:
 
       text match
         case r"$yr(\d{4})-$mn(\d{2})-$dy(\d{2})[ T]$hr(\d{2}):$mi(\d{2}):$sc(\d{2})" =>
-          whereas:
+          mitigate:
             case NumberError(_, _, _) => TimestampError(text, TimestampError.Reason.BadNumber)
             case TimeError(_)         => TimestampError(text, TimestampError.Reason.BadTime)
 
-          . mitigate:
+          . protect:
               Timestamp
                 ( Date(Year(yr.decode[Int]), Month(mn.decode[Int]), Day(dy.decode[Int])),
                   Clockface

--- a/lib/bitumen/src/core/bitumen.TarFilesystem.scala
+++ b/lib/bitumen/src/core/bitumen.TarFilesystem.scala
@@ -174,18 +174,18 @@ private[bitumen] object TarFilesystem:
       if fullText.startsWith(prefix) then fullText.substring(prefix.length).nn.tt
       else fullText.tt
 
-    whereas:
+    mitigate:
       case PathError(_, _) => TarError(TarError.Reason.BadName(relText))
 
-    . mitigate(relText.decode[Relative on Posix])
+    . protect(relText.decode[Relative on Posix])
 
   private def decodePath(text: Text)(using Tactic[TarError]): TarRef =
     import errorDiagnostics.emptyDiagnostics
 
-    whereas:
+    mitigate:
       case PathError(_, _) => TarError(TarError.Reason.BadName(text))
 
-    . mitigate(text.decode[Relative on Tar])
+    . protect(text.decode[Relative on Tar])
 
   private def readMode(javaPath: jnf.Path)(using Tactic[IoError]): UnixMode =
     try (jnf.Files.getAttribute(javaPath, "unix:mode").nn: Any) match

--- a/lib/bitumen/src/core/bitumen.Tarfile.scala
+++ b/lib/bitumen/src/core/bitumen.Tarfile.scala
@@ -306,10 +306,10 @@ object Tarfile:
   private def decodePath(text: Text): TarRef raises TarError =
     import errorDiagnostics.emptyDiagnostics
 
-    whereas:
+    mitigate:
       case PathError(_, _) => TarError(TarError.Reason.BadName(text))
 
-    . mitigate(text.decode[Relative on Tar])
+    . protect(text.decode[Relative on Tar])
 
   private val structuralPaxKeys: Set[Text] = Set(t"path", t"linkpath", t"uname", t"gname")
 

--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -130,7 +130,7 @@ object Repackager:
       bootstrapClass: Data )
   :   Summary raises RepackageError =
 
-    whereas:
+    mitigate:
       case IoError(_, _, _, _)  => RepackageError(m"a filesystem error occurred while repackaging")
       case StreamError(_)       => RepackageError(m"a stream error occurred while repackaging")
       case ZipError(reason)     => RepackageError(m"the JAR could not be read or written ($reason)")
@@ -138,7 +138,7 @@ object Repackager:
       case NumberError(_, _, _) => RepackageError(m"the manifest contained malformed data")
       case FqcnError(_, _)      => RepackageError(m"the Main-Class is not a valid class name")
 
-    . mitigate:
+    . protect:
         val resource: Text = burdock.internal.ResourcePath.tt
         val bootstrapName: Text = t"burdock/Bootstrap.class"
         var manifestData: Optional[Data] = Unset

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -66,12 +66,12 @@ import termcaps.environmentTermcap
 // It takes no arguments — it self-locates the application JAR it is running from and
 // rewrites it in place (see `Repackager.repackage`).
 def repackage(): Unit = application(Nil):
-  whereas:
+  recover:
     case error: Error =>
       Err.println(error.message)
       Exit.Fail(1)
 
-  . recover:
+  . protect:
       val loader: ClassLoader = summon[Classloader].java
 
       // Self-locate the application JAR: the classpath entry holding the

--- a/lib/caduceus/src/resend/caduceus_core.scala
+++ b/lib/caduceus/src/resend/caduceus_core.scala
@@ -101,14 +101,14 @@ package couriers:
 
       def error = CourierError(envelope.from, envelope.to.head, envelope.subject)
 
-      whereas:
+      mitigate:
         case ConnectError(reason)     => Out.println(reason.communicate) yet error
         case ParseError(_, _, reason) => Out.println(reason.describe) yet error
         case HttpError(status, _)     => Out.println(status.communicate) yet error
         case JsonError(reason)        => Out.println(reason.communicate) yet error
         case MediaTypeError(_, _)     => error
 
-      . mitigate:
+      . protect:
           url"https://api.resend.com/emails".submit
             ( Http.Post, authorization = Auth.Bearer(apiKey.key) )
             ( request.json )

--- a/lib/contingency/src/core/contingency.Accrual.scala
+++ b/lib/contingency/src/core/contingency.Accrual.scala
@@ -30,18 +30,33 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package contingency
 
-export
-  contingency
-  . { abort, abortive, accrual, Accrual, accrue, amalgamate, AmalgamateTactic, Attempt, attempt,
-      AttemptTactic, capture, certify, dare, defer, Deferred, EitherTactic, Emit, Errors,
-      ExpectationError, Fatal, Foci, focus, HaltTactic, handle, Handler, lest, Mitigable, mitigate,
-      Mitigation, mitigates, OptionalTactic, Pointer, raise, raises, recover, Recovery, safely,
-      survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks, TrackTactic,
-      Unchecked, unsafely, Validate, validate, Validation, whereas, Whereas }
+import language.experimental.pureFunctions
 
-package strategies:
-  export
-    contingency.strategies
-    . { fatalErrors, mitigation, throwSafely, throwUnsafely, uncheckedErrors }
+import fulminate.*
+
+// Captures an `accrue` handler together with its initial accrual and combining function. Unlike
+// `recover`/`mitigate`, the block may raise *several* covered errors; each is folded into the
+// accrual via `combine`, and if anything accrued, `.protect` aborts the enclosing `Tactic[accrual]`
+// with the accumulated error. `accrue(initial)(combine) { case … => … }.protect { … }`.
+object Accrual:
+  extension [accrual <: Exception, lambda[_]](inline accrual: Accrual[accrual, lambda])
+    inline def protect[result](inline body: lambda[result])
+      ( using outer: Tactic[accrual], diagnostics: Diagnostics )
+    :   result =
+
+      $ {
+          contingency.internal.accrueBody[accrual, lambda, result]
+            ( 'accrual,
+              '{accrual.initial},
+              '{accrual.combine},
+              'body,
+              'outer,
+              'diagnostics )
+        }
+
+class Accrual[accrual <: Exception, lambda[_]]
+  ( val handler: PartialFunction[Exception, Any],
+    val initial: accrual,
+    val combine: (accrual, Exception) => accrual )

--- a/lib/contingency/src/core/contingency.Accrual.scala
+++ b/lib/contingency/src/core/contingency.Accrual.scala
@@ -34,6 +34,10 @@ package contingency
 
 import language.experimental.pureFunctions
 
+import java.util.concurrent.atomic as juca
+
+import scala.language.unsafeNulls
+
 import fulminate.*
 
 // Captures an `accrue` handler together with its initial accrual and combining function. Unlike
@@ -41,6 +45,28 @@ import fulminate.*
 // accrual via `combine`, and if anything accrued, `.protect` aborts the enclosing `Tactic[accrual]`
 // with the accumulated error. `accrue(initial)(combine) { case … => … }.protect { … }`.
 object Accrual:
+  // The `Tactic` injected into an `accrue` block: each covered error is folded into the accrual
+  // rather than escaping; `accumulated`/`changed` report the result to `.protect`.
+  class AccrueTactic[error <: Exception, accrual <: Exception]
+    ( initial: accrual, combine: (accrual, Exception) => accrual )
+    ( using val diagnostics: Diagnostics )
+  extends Tactic[error]:
+
+    private val ref: juca.AtomicReference[accrual] = juca.AtomicReference(initial)
+
+    def record(error: Diagnostics ?=> error): Unit =
+      ref.updateAndGet: curr => combine(curr.nn, error(using diagnostics))
+
+    def abort(error: Diagnostics ?=> error): Nothing =
+      import scala.unsafeExceptions.canThrowAny
+      record(error)
+      throw accumulated
+
+    def certify(): Unit = ()
+
+    def accumulated: accrual = ref.get().nn
+    def changed: Boolean = ref.get().nn != initial
+
   extension [accrual <: Exception, lambda[_]](inline accrual: Accrual[accrual, lambda])
     inline def protect[result](inline body: lambda[result])
       ( using outer: Tactic[accrual], diagnostics: Diagnostics )

--- a/lib/contingency/src/core/contingency.Deferred.scala
+++ b/lib/contingency/src/core/contingency.Deferred.scala
@@ -34,73 +34,7 @@ package contingency
 
 import language.experimental.pureFunctions
 
-import java.util.concurrent.atomic as juca
-
-import scala.language.unsafeNulls
-import scala.util.boundary
-
-import fulminate.*
-
-
+// Holds an unevaluated `Tactic[error] ?=> result` body; `apply()` re-evaluates it under whichever
+// `Tactic[error]` is in scope at the call, allowing late binding to different error handlers.
 final class Deferred[result, error <: Exception](body: Tactic[error] ?=> result):
   def apply()(using Tactic[error]): result = body
-
-object Whereas:
-  final case class Escape[+result](value: result) extends Exception:
-    override def fillInStackTrace(): Throwable = this
-
-
-  class AccrueTactic[error <: Exception, accrual <: Exception]
-    ( initial: accrual, combine: (accrual, Exception) => accrual )
-    ( using val diagnostics: Diagnostics )
-  extends Tactic[error]:
-
-    private val ref: juca.AtomicReference[accrual] = juca.AtomicReference(initial)
-
-    def record(error: Diagnostics ?=> error): Unit =
-      ref.updateAndGet: curr => combine(curr.nn, error(using diagnostics))
-
-    def abort(error: Diagnostics ?=> error): Nothing =
-      import scala.unsafeExceptions.canThrowAny
-      record(error)
-      throw accumulated
-
-    def certify(): Unit = ()
-
-    def accumulated: accrual = ref.get().nn
-    def changed: Boolean = ref.get().nn != initial
-
-
-  class EscapeTactic[result](label: boundary.Label[result]) extends Tactic[Escape[result]]:
-    def diagnostics: Diagnostics = Diagnostics.omit
-
-    def record(error: Diagnostics ?=> Escape[result]): Unit =
-      boundary.break(error(using diagnostics).value)(using label)
-
-    def abort(error: Diagnostics ?=> Escape[result]): Nothing =
-      boundary.break(error(using diagnostics).value)(using label)
-
-    def certify(): Unit = ()
-
-
-  extension [lambda[_]](inline w: Whereas[lambda])
-
-    inline def mitigate[result](inline body: lambda[result]): result =
-      ${contingency.internal.mitigateBody[lambda, result]('w, 'body)}
-
-    inline def recover[result](inline body: lambda[result]): result =
-      ${contingency.internal.recoverBody[lambda, result]('w, 'body)}
-
-    inline def accrue[accrual <: Exception, result](initial: accrual)
-      ( combine: (accrual, Exception) => accrual )
-      ( inline body: lambda[result] )
-      ( using outer: Tactic[accrual], diagnostics: Diagnostics )
-    :   result =
-
-      $ {
-          contingency.internal.accrueBody[accrual, lambda, result]
-            ( 'w, 'initial, 'combine, 'body, 'outer, 'diagnostics )
-        }
-
-
-class Whereas[lambda[_]](val handler: PartialFunction[Exception, Any])

--- a/lib/contingency/src/core/contingency.Mitigation.scala
+++ b/lib/contingency/src/core/contingency.Mitigation.scala
@@ -30,18 +30,16 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package contingency
 
-export
-  contingency
-  . { abort, abortive, accrual, Accrual, accrue, amalgamate, AmalgamateTactic, Attempt, attempt,
-      AttemptTactic, capture, certify, dare, defer, Deferred, EitherTactic, Emit, Errors,
-      ExpectationError, Fatal, Foci, focus, HaltTactic, handle, Handler, lest, Mitigable, mitigate,
-      Mitigation, mitigates, OptionalTactic, Pointer, raise, raises, recover, Recovery, safely,
-      survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks, TrackTactic,
-      Unchecked, unsafely, Validate, validate, Validation, whereas, Whereas }
+import language.experimental.pureFunctions
 
-package strategies:
-  export
-    contingency.strategies
-    . { fatalErrors, mitigation, throwSafely, throwUnsafely, uncheckedErrors }
+// Captures a `mitigate` handler: cases that map each covered error type to a *replacement error* of
+// another type. `mitigate { case FooError(n) => BarError(n) }.protect { … }` runs the block and
+// translates a covered error into the case body's error, which then propagates (`raises BarError`).
+object Mitigation:
+  extension [lambda[_]](inline mitigation: Mitigation[lambda])
+    inline def protect[result](inline body: lambda[result]): result =
+      ${contingency.internal.mitigateBody[lambda, result]('mitigation, 'body)}
+
+class Mitigation[lambda[_]](val handler: PartialFunction[Exception, Any])

--- a/lib/contingency/src/core/contingency.Recovery.scala
+++ b/lib/contingency/src/core/contingency.Recovery.scala
@@ -34,10 +34,29 @@ package contingency
 
 import language.experimental.pureFunctions
 
+import scala.util.boundary
+
+import fulminate.*
+
 // Captures a `recover` handler: cases that map each covered error type to a *replacement value* of
 // the protected block's result type. `recover { case FooError(n) => fallback }.protect { … }` runs
 // the block and, on the first covered error, escapes with the case body's value instead.
 object Recovery:
+  // A case body's recovered value, escaping the block via `boundary`.
+  final case class Escape[+result](value: result) extends Exception:
+    override def fillInStackTrace(): Throwable = this
+
+  class EscapeTactic[result](label: boundary.Label[result]) extends Tactic[Escape[result]]:
+    def diagnostics: Diagnostics = Diagnostics.omit
+
+    def record(error: Diagnostics ?=> Escape[result]): Unit =
+      boundary.break(error(using diagnostics).value)(using label)
+
+    def abort(error: Diagnostics ?=> Escape[result]): Nothing =
+      boundary.break(error(using diagnostics).value)(using label)
+
+    def certify(): Unit = ()
+
   extension [lambda[_]](inline recovery: Recovery[lambda])
     inline def protect[result](inline body: lambda[result]): result =
       ${contingency.internal.recoverBody[lambda, result]('recovery, 'body)}

--- a/lib/contingency/src/core/contingency.Recovery.scala
+++ b/lib/contingency/src/core/contingency.Recovery.scala
@@ -30,18 +30,16 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package contingency
 
-export
-  contingency
-  . { abort, abortive, accrual, Accrual, accrue, amalgamate, AmalgamateTactic, Attempt, attempt,
-      AttemptTactic, capture, certify, dare, defer, Deferred, EitherTactic, Emit, Errors,
-      ExpectationError, Fatal, Foci, focus, HaltTactic, handle, Handler, lest, Mitigable, mitigate,
-      Mitigation, mitigates, OptionalTactic, Pointer, raise, raises, recover, Recovery, safely,
-      survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks, TrackTactic,
-      Unchecked, unsafely, Validate, validate, Validation, whereas, Whereas }
+import language.experimental.pureFunctions
 
-package strategies:
-  export
-    contingency.strategies
-    . { fatalErrors, mitigation, throwSafely, throwUnsafely, uncheckedErrors }
+// Captures a `recover` handler: cases that map each covered error type to a *replacement value* of
+// the protected block's result type. `recover { case FooError(n) => fallback }.protect { … }` runs
+// the block and, on the first covered error, escapes with the case body's value instead.
+object Recovery:
+  extension [lambda[_]](inline recovery: Recovery[lambda])
+    inline def protect[result](inline body: lambda[result]): result =
+      ${contingency.internal.recoverBody[lambda, result]('recovery, 'body)}
+
+class Recovery[lambda[_]](val handler: PartialFunction[Exception, Any])

--- a/lib/contingency/src/core/contingency.internal.scala
+++ b/lib/contingency/src/core/contingency.internal.scala
@@ -317,6 +317,47 @@ object internal:
         '{Whereas[typeLambda]($handler)}
 
 
+  // The type lambda `[result] => (Tactic[E1], …, Tactic[En]) ?=> result` capturing the handled
+  // error types of a `recover`/`mitigate`/`accrue` handler, so `.protect` injects one tactic each.
+  private def tacticLambda(using Quotes)(handler: Expr[PartialFunction[Exception, Any]])
+  :   quotes.reflect.TypeLambda =
+
+    import quotes.reflect.*
+
+    val errors = mapping[Exception](handler.asTerm)
+    val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
+    val functionType = defn.FunctionClass(errors.size, true).typeRef
+
+    TypeLambda
+      ( List("result"),
+        void => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
+        typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)) )
+
+
+  def recoverBuild(handler: Expr[PartialFunction[Exception, Any]])(using Quotes): Expr[Recovery[?]] =
+    tacticLambda(handler).asType.absolve match
+      case '[type typeLambda[_]; typeLambda] => '{Recovery[typeLambda]($handler)}
+
+
+  def mitigateBuild(handler: Expr[PartialFunction[Exception, Any]])(using Quotes)
+  :   Expr[Mitigation[?]] =
+
+    tacticLambda(handler).asType.absolve match
+      case '[type typeLambda[_]; typeLambda] => '{Mitigation[typeLambda]($handler)}
+
+
+  def accrueBuild[accrual <: Exception: Type]
+    ( initial: Expr[accrual],
+      combine: Expr[(accrual, Exception) => accrual],
+      handler: Expr[PartialFunction[Exception, Any]] )
+    ( using Quotes )
+  :   Expr[Accrual[accrual, ?]] =
+
+    tacticLambda(handler).asType.absolve match
+      case '[type typeLambda[_]; typeLambda] =>
+        '{Accrual[accrual, typeLambda]($handler, $initial, $combine)}
+
+
   def handleBuild(handler: Expr[PartialFunction[Exception, Unit]])(using Quotes): Expr[Handler[?]] =
     import quotes.reflect.*
 
@@ -360,7 +401,7 @@ object internal:
 
 
   def mitigateBody[context[_]: Type, result: Type]
-    ( w: Expr[Whereas[context]], body: Expr[context[result]] )
+    ( w: Expr[Any], body: Expr[context[result]] )
     ( using Quotes )
   :   Expr[result] =
 
@@ -390,7 +431,7 @@ object internal:
 
 
   def recoverBody[context[_]: Type, result: Type]
-    ( w: Expr[Whereas[context]], body: Expr[context[result]] )
+    ( w: Expr[Any], body: Expr[context[result]] )
     ( using Quotes )
   :   Expr[result] =
 
@@ -431,7 +472,7 @@ object internal:
 
 
   def accrueBody[accrual <: Exception: Type, context[_]: Type, result: Type]
-    ( w:           Expr[Whereas[context]],
+    ( w:           Expr[Any],
       initial:     Expr[accrual],
       combine:     Expr[(accrual, Exception) => accrual],
       body:        Expr[context[result]],
@@ -443,11 +484,11 @@ object internal:
     import quotes.reflect.*
 
     val cases = unwrap(w.asTerm) match
-      case Apply(_, List(Inlined(_, _, matches))) =>
+      case Apply(_, Inlined(_, _, matches) :: _) =>
         mapping[Exception](matches)
 
       case _ =>
-        halt(114, m"argument to `whereas` should be a partial function implemented as match cases")
+        halt(114, m"argument to `accrue` should be a partial function implemented as match cases")
 
     ' {
         val acc: Whereas.AccrueTactic[Exception, accrual] =

--- a/lib/contingency/src/core/contingency.internal.scala
+++ b/lib/contingency/src/core/contingency.internal.scala
@@ -296,27 +296,6 @@ object internal:
       }
 
 
-  def whereas(handler: Expr[PartialFunction[Exception, Any]])
-    ( using Quotes )
-  :   Expr[Whereas[?]] =
-
-    import quotes.reflect.*
-
-    val errors = mapping[Exception](handler.asTerm)
-    val tactics = errors.keys.to(List).map(_.typeRef).map(TypeRepr.of[Tactic].appliedTo(_))
-    val functionType = defn.FunctionClass(errors.size, true).typeRef
-
-    val typeLambda =
-      TypeLambda
-        ( List("result"),
-          void => List(TypeBounds(TypeRepr.of[Nothing], TypeRepr.of[Any])),
-          typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)) )
-
-    typeLambda.asType.absolve match
-      case '[type typeLambda[_]; typeLambda] =>
-        '{Whereas[typeLambda]($handler)}
-
-
   // The type lambda `[result] => (Tactic[E1], …, Tactic[En]) ?=> result` capturing the handled
   // error types of a `recover`/`mitigate`/`accrue` handler, so `.protect` injects one tactic each.
   private def tacticLambda(using Quotes)(handler: Expr[PartialFunction[Exception, Any]])
@@ -334,7 +313,9 @@ object internal:
         typeLambda => functionType.appliedTo(tactics :+ typeLambda.param(0)) )
 
 
-  def recoverBuild(handler: Expr[PartialFunction[Exception, Any]])(using Quotes): Expr[Recovery[?]] =
+  def recoverBuild(handler: Expr[PartialFunction[Exception, Any]])(using Quotes)
+  :   Expr[Recovery[?]] =
+
     tacticLambda(handler).asType.absolve match
       case '[type typeLambda[_]; typeLambda] => '{Recovery[typeLambda]($handler)}
 
@@ -424,7 +405,7 @@ object internal:
                       m"There is no available handler for ${TypeRepr.of[errorType].show}" )
 
       case _ =>
-        halt(648, m"argument to `whereas` should be a partial function implemented as match cases")
+        halt(648, m"argument to `mitigate` should be a partial function written as match cases")
 
     val method = TypeRepr.of[context[result]].typeSymbol.declaredMethod("apply").head
     body.asTerm.select(method).appliedToArgs(tactics.to(List)).asExprOf[result]
@@ -439,7 +420,7 @@ object internal:
 
     ' {
         scala.util.boundary[result]: label ?=>
-          val tactic: Tactic[Whereas.Escape[result]] = Whereas.EscapeTactic(label)
+          val tactic: Tactic[Recovery.Escape[result]] = Recovery.EscapeTactic(label)
 
           $ {
               import quotes.reflect.*
@@ -451,7 +432,7 @@ object internal:
                   halt
                     ( 29,
                       m"""
-                        argument to `whereas` should be a partial function implemented as match
+                        argument to `recover` should be a partial function implemented as match
                         cases
                       """ )
 
@@ -460,7 +441,7 @@ object internal:
               val tactics = mapping[Exception](partialFunction).map: (_, _) =>
                 ' {
                     tactic.contramap: error =>
-                      Whereas.Escape[result]($pfExpr(error).asInstanceOf[result])
+                      Recovery.Escape[result]($pfExpr(error).asInstanceOf[result])
                   }
 
                 . asTerm
@@ -491,8 +472,8 @@ object internal:
         halt(114, m"argument to `accrue` should be a partial function implemented as match cases")
 
     ' {
-        val acc: Whereas.AccrueTactic[Exception, accrual] =
-          Whereas.AccrueTactic[Exception, accrual]($initial, $combine)(using $diagnostics)
+        val acc: Accrual.AccrueTactic[Exception, accrual] =
+          Accrual.AccrueTactic[Exception, accrual]($initial, $combine)(using $diagnostics)
 
         val outcome: Either[accrual, result] =
           try Right:

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -238,10 +238,6 @@ def defer[result, error <: Exception](body: Tactic[error] ?=> result)
   Deferred(body)
 
 
-transparent inline def whereas(inline handler: PartialFunction[Exception, Any]): Whereas[?] =
-  ${contingency.internal.whereas('handler)}
-
-
 transparent inline def recover(inline handler: PartialFunction[Exception, Any]): Recovery[?] =
   ${contingency.internal.recoverBuild('handler)}
 

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -242,5 +242,21 @@ transparent inline def whereas(inline handler: PartialFunction[Exception, Any]):
   ${contingency.internal.whereas('handler)}
 
 
+transparent inline def recover(inline handler: PartialFunction[Exception, Any]): Recovery[?] =
+  ${contingency.internal.recoverBuild('handler)}
+
+
+transparent inline def mitigate(inline handler: PartialFunction[Exception, Any]): Mitigation[?] =
+  ${contingency.internal.mitigateBuild('handler)}
+
+
+transparent inline def accrue[accrual <: Exception](initial: accrual)
+  ( combine: (accrual, Exception) => accrual )
+  ( inline handler: PartialFunction[Exception, Any] )
+:   Accrual[accrual, ?] =
+
+  ${contingency.internal.accrueBuild[accrual]('initial, 'combine, 'handler)}
+
+
 transparent inline def handle(inline handler: PartialFunction[Exception, Unit]): Handler[?] =
   ${contingency.internal.handleBuild('handler)}

--- a/lib/contingency/src/core/soundness_contingency_core.scala
+++ b/lib/contingency/src/core/soundness_contingency_core.scala
@@ -39,7 +39,7 @@ export
       ExpectationError, Fatal, Foci, focus, HaltTactic, handle, Handler, lest, Mitigable, mitigate,
       Mitigation, mitigates, OptionalTactic, Pointer, raise, raises, recover, Recovery, safely,
       survive, Tactic, throwErrors, ThrowTactic, track, TrackFoci, Tracking, tracks, TrackTactic,
-      Unchecked, unsafely, Validate, validate, Validation, whereas, Whereas }
+      Unchecked, unsafely, Validate, validate, Validation }
 
 package strategies:
   export

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -201,6 +201,30 @@ object Tests extends Suite(m"Contingency"):
         capture[ErrorA](raisedStatement).value
       . assert(_ == 1)
 
+    suite(m"recover / mitigate (leading)"):
+      test(m"recover substitutes a value for a raised error"):
+        recover:
+          case ErrorA(n) => s"recovered:$n"
+        . protect(failA(7))
+      . assert(_ == "recovered:7")
+
+      test(m"recover passes through the body value when no error"):
+        recover:
+          case ErrorA(_) => "recovered"
+        . protect(succeedStr("ok"))
+      . assert(_ == "ok")
+
+      test(m"mitigate translates an inner error to an outer type"):
+        recover:
+          case ErrorB(n) => n
+        . protect:
+            mitigate:
+              case ErrorA(n) => ErrorB(n + 100)
+            . protect:
+                raise(ErrorA(5))
+                0
+      . assert(_ == 105)
+
     suite(m"handle / protect"):
       test(m"A handled error runs its case body in place"):
         var caught = 0

--- a/lib/contingency/src/test/contingency_test.scala
+++ b/lib/contingency/src/test/contingency_test.scala
@@ -63,117 +63,93 @@ object Tests extends Suite(m"Contingency"):
     "fallback"
 
   def run(): Unit =
-    suite(m"whereas / recover / mitigate / accrue"):
+    suite(m"recover / mitigate / accrue"):
       test(m"Ensure varargs parameter is handled exhaustively"):
         demilitarize:
-          whereas:
+          recover:
             case VarargsError(arguments) => ()
-          . recover(action())
+          . protect(action())
 
       . assert(_.nonEmpty)
 
       test(m"Varargs are handled safely"):
-        whereas:
+        recover:
           case VarargsError(arguments*) => ()
-        . recover(action())
+        . protect(action())
       . assert()
 
-      test(m"Recover substitutes a value for a raised error"):
-        whereas:
+      test(m"recover substitutes a value for a raised error"):
+        recover:
           case ErrorA(n) => s"recovered:$n"
-        . recover(failA(7))
+        . protect(failA(7))
       . assert(_ == "recovered:7")
 
-      test(m"Recover passes through body value when no error"):
-        whereas:
+      test(m"recover passes through the body value when no error"):
+        recover:
           case ErrorA(_) => "recovered"
-        . recover(succeedStr("ok"))
+        . protect(succeedStr("ok"))
       . assert(_ == "ok")
 
-      test(m"Recover handles the correct case among alternatives"):
-        whereas:
+      test(m"recover handles the correct case among alternatives"):
+        recover:
           case ErrorA(n) => s"a:$n"
           case ErrorB(n) => s"b:$n"
-        . recover(failB(3))
+        . protect(failB(3))
       . assert(_ == "b:3")
 
-      test(m"Mitigate transforms an inner error to an outer type"):
-        whereas:
+      test(m"mitigate transforms an inner error to an outer type"):
+        recover:
           case ErrorB(n) => n
-        . recover:
-            whereas:
+        . protect:
+            mitigate:
               case ErrorA(n) => ErrorB(n + 100)
-            . mitigate:
+            . protect:
                 raise(ErrorA(5))
                 0
       . assert(_ == 105)
 
       test(m"Mitigation chain: A becomes B becomes C"):
-        whereas:
+        recover:
           case ErrorC(n) => n
-        . recover:
-            whereas:
+        . protect:
+            mitigate:
               case ErrorB(n) => ErrorC(n + 10)
-            . mitigate:
-                whereas:
+            . protect:
+                mitigate:
                   case ErrorA(n) => ErrorB(n + 1)
-                . mitigate:
+                . protect:
                     raise(ErrorA(4))
                     0
       . assert(_ == 15)
 
-      test(m"Accrue collects multiple raises into the outer recovery"):
-        whereas:
-          case Accumulated(values) => values
-        . recover:
-            whereas:
-              case ErrorA(_) => ()
-            . accrue(Accumulated(Nil)):
-                (sum, ex) => ex match
-                  case ErrorA(n) => Accumulated(sum.values :+ n)
-                  case _         => sum
-            . and:
-                raise(ErrorA(1))
-                raise(ErrorA(2))
-                List.empty[Int]
+      test(m"accrue folds multiple raises into one accrual error"):
+        capture[Accumulated]:
+          accrue(Accumulated(Nil)) { (sum, ex) => ex match
+            case ErrorA(n) => Accumulated(sum.values :+ n)
+            case _         => sum
+          } { case ErrorA(_) => () }
+          . protect:
+              raise(ErrorA(1))
+              raise(ErrorA(2))
+              ()
+
+        . values
       . assert(_ == List(1, 2))
 
-      test(m"Accrue passes the body value through when nothing raised"):
-        whereas:
-          case Accumulated(_) => "error"
-        . recover:
-            whereas { case ErrorA(_) => () }.accrue(Accumulated(Nil))((sum, _) => sum):
-              "clean"
-      . assert(_ == "clean")
-
-      test(m"whereas.recover should compile inside `inline def` (see #534)"):
+      test(m"recover compiles inside an `inline def` (see #534)"):
         demilitarize:
           inline def inlineRecover: String =
-            whereas:
+            recover:
               case ErrorA(n) => s"recovered:$n"
-            . recover(failA(7))
+            . protect(failA(7))
           inlineRecover
       . aspire(_.isEmpty)
 
-      test(m"whereas.mitigate should compile inside `inline def` (see #534)"):
-        demilitarize:
-          inline def inlineMitigate: Int =
-            whereas:
-              case ErrorB(n) => n
-            . recover:
-                whereas:
-                  case ErrorA(n) => ErrorB(n + 100)
-                . mitigate:
-                    raise(ErrorA(5))
-                    0
-          inlineMitigate
-      . aspire(_.isEmpty)
-
-      test(m"whereas.recover works inside `inline def` via a non-inline helper"):
+      test(m"recover works inside an `inline def` via a non-inline helper"):
         def helperRecover: String =
-          whereas:
+          recover:
             case ErrorA(n) => s"recovered:$n"
-          . recover(failA(7))
+          . protect(failA(7))
 
         inline def inlineRecover: String = helperRecover
         inlineRecover
@@ -181,9 +157,9 @@ object Tests extends Suite(m"Contingency"):
 
     suite(m"raise / abort / raises type"):
       test(m"Method with raises is callable under an in-scope Tactic"):
-        whereas:
+        recover:
           case ErrorA(_) => t"unused"
-        . recover(succeed(t"hello"))
+        . protect(succeed(t"hello"))
       . assert(_ == t"hello")
 
       test(m"val without ascription gets the result type, not Tactic ?=> T"):
@@ -200,30 +176,6 @@ object Tests extends Suite(m"Contingency"):
         def raisedStatement: Unit raises ErrorA = raise(ErrorA(1))
         capture[ErrorA](raisedStatement).value
       . assert(_ == 1)
-
-    suite(m"recover / mitigate (leading)"):
-      test(m"recover substitutes a value for a raised error"):
-        recover:
-          case ErrorA(n) => s"recovered:$n"
-        . protect(failA(7))
-      . assert(_ == "recovered:7")
-
-      test(m"recover passes through the body value when no error"):
-        recover:
-          case ErrorA(_) => "recovered"
-        . protect(succeedStr("ok"))
-      . assert(_ == "ok")
-
-      test(m"mitigate translates an inner error to an outer type"):
-        recover:
-          case ErrorB(n) => n
-        . protect:
-            mitigate:
-              case ErrorA(n) => ErrorB(n + 100)
-            . protect:
-                raise(ErrorA(5))
-                0
-      . assert(_ == 105)
 
     suite(m"handle / protect"):
       test(m"A handled error runs its case body in place"):
@@ -427,9 +379,9 @@ object Tests extends Suite(m"Contingency"):
       test(m"defer holds the unapplied body; apply() runs it under the in-scope tactic"):
         def failing(n: Int): String raises ErrorA = raise(ErrorA(n)) yet "fallback"
 
-        whereas:
+        recover:
           case ErrorA(n) => s"recovered:$n"
-        . recover:
+        . protect:
             val held = contingency.defer(failing(7))
             held()
       . assert(_ == "recovered:7")
@@ -440,9 +392,9 @@ object Tests extends Suite(m"Contingency"):
           counter += 1
           counter
 
-        whereas:
+        recover:
           case ErrorA(_) => -1
-        . recover:
+        . protect:
             val held = contingency.defer(increment())
             held()
             held()
@@ -450,9 +402,9 @@ object Tests extends Suite(m"Contingency"):
       . assert(_ == 3)
 
       test(m"defer of a plain value is identity-with-wrapping"):
-        whereas:
+        recover:
           case ErrorA(n) => n
-        . recover:
+        . protect:
             contingency.defer(17)()
       . assert(_ == 17)
 
@@ -516,9 +468,9 @@ object Tests extends Suite(m"Contingency"):
       . assert(_ == 30)
 
       test(m"track collects accrued errors into accrual"):
-        whereas:
+        recover:
           case Accumulated(values) => values
-        . recover:
+        . protect:
             track[Pointer](Accumulated(Nil)):
               case ErrorA(n) => Accumulated(accrual.values :+ n)
             . protect:
@@ -635,14 +587,14 @@ object Tests extends Suite(m"Contingency"):
         try { inner.record(ErrorA(5)); -1 } catch case e: ErrorB => e.value
       . assert(_ == 105)
 
-    suite(m"Whereas internals"):
-      test(m"Whereas.Escape carries a value and has no stack trace"):
-        val e = Whereas.Escape(t"payload")
+    suite(m"Recovery and Accrual internals"):
+      test(m"Recovery.Escape carries a value and has no stack trace"):
+        val e = Recovery.Escape(t"payload")
         e.value == t"payload" && e.fillInStackTrace() == e
       . assert(_ == true)
 
-      test(m"Whereas.AccrueTactic.changed is false before any record"):
-        val acc = Whereas.AccrueTactic[ErrorA, Accumulated]
+      test(m"Accrual.AccrueTactic.changed is false before any record"):
+        val acc = Accrual.AccrueTactic[ErrorA, Accumulated]
           (Accumulated(Nil), (sum, ex) => ex match
             case ErrorA(n) => Accumulated(sum.values :+ n)
             case _         => sum)
@@ -650,8 +602,8 @@ object Tests extends Suite(m"Contingency"):
         acc.changed
       . assert(_ == false)
 
-      test(m"Whereas.AccrueTactic.accumulated reflects records"):
-        val acc = Whereas.AccrueTactic[ErrorA, Accumulated]
+      test(m"Accrual.AccrueTactic.accumulated reflects records"):
+        val acc = Accrual.AccrueTactic[ErrorA, Accumulated]
           (Accumulated(Nil), (sum, ex) => ex match
             case ErrorA(n) => Accumulated(sum.values :+ n)
             case _         => sum)

--- a/lib/enigmatic/src/core/enigmatic.Pem.scala
+++ b/lib/enigmatic/src/core/enigmatic.Pem.scala
@@ -65,10 +65,10 @@ object Pem:
       case index =>
         val joined: Text = lines.tail.take(index).join
 
-        whereas:
+        mitigate:
           case SerializationError(_, _) => PemError(PemError.Reason.BadBase64)
 
-        . mitigate(Pem(label, joined.deserialize[Base64]))
+        . protect(Pem(label, joined.deserialize[Base64]))
 
 case class Pem(label: PemLabel, data: Data):
   def serialize: Text =

--- a/lib/ethereal/src/core/ethereal.Installer.scala
+++ b/lib/ethereal/src/core/ethereal.Installer.scala
@@ -79,13 +79,13 @@ object Installer:
     ( using Environment, System )
   :   List[Path on Linux] logs DaemonLogEvent raises InstallError =
 
-    whereas:
+    mitigate:
       case PathError(_, _)     => InstallError(InstallError.Reason.Environment)
       case EnvironmentError(_) => InstallError(InstallError.Reason.Environment)
       case IoError(_, _, _, _) => InstallError(InstallError.Reason.Io)
       case NameError(_, _, _)  => InstallError(InstallError.Reason.Io)
 
-    . mitigate:
+    . protect:
         val paths: List[Path on Linux] = Environment.path
 
         val preferences: List[Path on Linux] =
@@ -113,7 +113,7 @@ object Installer:
     import workingDirectories.javaWorkingDirectory
     import systems.javaSystem
 
-    whereas:
+    mitigate:
       case PathError(_, _)      => InstallError(InstallError.Reason.Environment)
       case PropertyError(_)     => InstallError(InstallError.Reason.Environment)
       case NumberError(_, _, _) => InstallError(InstallError.Reason.Environment)
@@ -122,7 +122,7 @@ object Installer:
       case ExecError(_, _, _)   => InstallError(InstallError.Reason.Io)
       case StreamError(_)       => InstallError(InstallError.Reason.Io)
 
-    . mitigate:
+    . protect:
         val command: Text = service.script
         val scriptPath = mute[ExecEvent](sh"sh -c 'command -v $command'".exec[Text]())
 

--- a/lib/ethereal/src/core/ethereal.Runners.scala
+++ b/lib/ethereal/src/core/ethereal.Runners.scala
@@ -85,13 +85,13 @@ object Runners:
     val expected: Text =
       hashes.at(label).lest(RunnerError(m"There is no published runner stub for platform $label"))
 
-    whereas:
+    mitigate:
       case HttpError(_, _)   => RunnerError(m"Could not download the stub $name from $baseUrl")
       case ConnectError(_)   => RunnerError(m"Could not connect to $baseUrl to download $name")
       case UrlError(_, _, _) => RunnerError(m"The runner stub URL for $name is not valid")
       case StreamError(_)    => RunnerError(m"The download of the stub $name was interrupted")
 
-    . mitigate:
+    . protect:
         val runner: Data = mute[HttpEvent](t"$baseUrl/$name".decode[HttpUrl].fetch().read[Data])
         val actual: Text = runner.digest[Sha2[256]].serialize[Hex]
 

--- a/lib/ethereal/src/core/ethereal.Upgrade.scala
+++ b/lib/ethereal/src/core/ethereal.Upgrade.scala
@@ -87,14 +87,14 @@ object Upgrade:
             diagnostics: Diagnostics )
   :   Nothing raises UpgradeError =
 
-    whereas:
+    mitigate:
       case PathError(_, _)     => UpgradeError(UpgradeError.Reason.CannotResolveLauncher)
       case PropertyError(_)    => UpgradeError(UpgradeError.Reason.CannotResolveLauncher)
       case IoError(_, _, _, _) => UpgradeError(UpgradeError.Reason.CannotWritePending)
       case NameError(_, _, _)  => UpgradeError(UpgradeError.Reason.CannotWritePending)
       case StreamError(_)      => UpgradeError(UpgradeError.Reason.CannotReadSource)
 
-    . mitigate:
+    . protect:
         val name: Text = System.properties.ethereal.name[Text]()
 
         val dataHome: Path on Linux =

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -94,7 +94,7 @@ def cli[bus <: Matchable](using executive: Executive)
   import stdios.virtualMachineStdio
 
   val name: Text =
-    whereas:
+    recover:
       case PropertyError(_) =>
         val jarFile: Path on Linux = System.properties.java.`class`.path[Text]().pipe: jarFile =>
           safely(jarFile.decode[Path on Linux]).or:
@@ -174,7 +174,7 @@ def cli[bus <: Matchable](using executive: Executive)
               if localRunner.exists() then localRunner.open(_.stream[Data].read[Data])
               else if cacheRunner.exists() then cacheRunner.open(_.stream[Data].read[Data])
               else
-                whereas:
+                mitigate:
                   case RunnerError(detail) =>
                     Out.println(detail.text)
                     Exit.Fail(1).terminate()
@@ -187,7 +187,7 @@ def cli[bus <: Matchable](using executive: Executive)
                     Out.println(e"The runner stub download was interrupted")
                     Exit.Fail(1).terminate()
 
-                . mitigate:
+                . protect:
                     import filesystemOptions.overwritePreexisting.disabled
                     Out.println(e"Downloading $runnerName from runners-${Runners.version}")
                     val bytes: Data = Runners.download(platformLabel)
@@ -220,12 +220,12 @@ def cli[bus <: Matchable](using executive: Executive)
 
                   raw
 
-            whereas:
+            mitigate:
               case AssemblyError(_) =>
                 Out.println(e"Runner binary does not contain the ETHRCFG\\x02 magic marker")
                 Exit.Fail(1).terminate()
 
-            . mitigate:
+            . protect:
                 Assembler.assemble
                   ( runnerBytes, jarFile, path, platformLabel, buildId, javaMinimum,
                    javaPreferred, jdk, publicKey )
@@ -234,7 +234,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
             Exit.Ok.terminate()
 
-    . recover(System.properties.ethereal.name[Text]())
+    . protect(System.properties.ethereal.name[Text]())
 
   val userId: Optional[Int] = safely(System.properties.ethereal.user.id[Int]())
   val userName: Optional[Text] = safely(System.properties.ethereal.user.name[Text]())

--- a/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
+++ b/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
@@ -45,11 +45,11 @@ object Syslog:
   given writable: Monitor => Syslog is Writable by Text = (syslog, stream) =>
     import workingDirectories.javaWorkingDirectory
 
-    whereas:
+    recover:
       case StreamError(_)     => ()
       case ExecError(_, _, _) => ()
 
-    . recover:
+    . protect:
         syslog.tag match
           case tag: Text => mute[ExecEvent](stream.writeTo(sh"logger -t $tag".fork[Unit]()))
           case _         => mute[ExecEvent](stream.writeTo(sh"logger".fork[Unit]()))

--- a/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
@@ -129,12 +129,12 @@ object Completions:
     ( using WorkingDirectory, Diagnostics )
   :   Installation raises InstallError logs CliEvent =
 
-    whereas:
+    mitigate:
       case PathError(_, _)    => InstallError(InstallError.Reason.Environment)
       case NameError(_, _, _) => InstallError(InstallError.Reason.Environment)
       case ExecError(_, _, _) => InstallError(InstallError.Reason.Environment)
 
-    . mitigate:
+    . protect:
         val scriptPath: Optional[Path on Local] =
           safely(sh"sh -c 'command -v ${entrypoint.script}'".exec[Path on Local]())
 
@@ -209,13 +209,13 @@ object Completions:
     ( using Diagnostics )
   :   Installation.InstallResult raises InstallError logs CliEvent =
 
-    whereas:
+    mitigate:
       case IoError(_, _, _, _) => InstallError(InstallError.Reason.Io)
       case NameError(_, _, _)  => InstallError(InstallError.Reason.Io)
       case PathError(_, _)     => InstallError(InstallError.Reason.Io)
       case StreamError(_)      => InstallError(InstallError.Reason.Io)
 
-    . mitigate:
+    . protect:
         dirs.seek { dir => dir.exists() && dir.writable() }.let: dir =>
           val path = dir/scriptName
 

--- a/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
@@ -42,10 +42,10 @@ object Tmux:
 
     import logging.silentLogging
 
-    whereas:
+    mitigate:
       case ExecError(_, _, _) => TmuxError(TmuxError.Reason.ExecFailed)
 
-    . mitigate:
+    . protect:
         keypresses.each:
           case text: Text => sh"tmux send-keys -t ${tmux.id} '$text'".exec[Unit]()
           case char: Char => sh"tmux send-keys -t ${tmux.id} '$char'".exec[Unit]()
@@ -54,11 +54,11 @@ object Tmux:
   def screenshot()(using tmux: Tmux)(using WorkingDirectory): Screenshot raises TmuxError =
     import logging.silentLogging
 
-    whereas:
+    mitigate:
       case ExecError(_, _, _)   => TmuxError(TmuxError.Reason.SessionDied)
       case NumberError(_, _, _) => TmuxError(TmuxError.Reason.SessionDied)
 
-    . mitigate:
+    . protect:
         val content = IArray.from(sh"tmux capture-pane -pt ${tmux.id}".exec[List[Text]]())
         val cx = sh"tmux display-message -pt ${tmux.id} '#{cursor_x}'".exec[Text]()
         val cy = sh"tmux display-message -pt ${tmux.id} '#{cursor_y}'".exec[Text]()

--- a/lib/exoskeleton/src/rig/exoskeleton_rig.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton_rig.scala
@@ -42,13 +42,13 @@ extension (shell: Shell)
     ( using WorkingDirectory, Enclave.Tool, Monitor, TemporaryDirectory )
   :   result raises TmuxError logs ExecEvent =
 
-    whereas:
+    mitigate:
       case ExecError(_, _, _)   => TmuxError(TmuxError.Reason.ExecFailed)
       case NumberError(_, _, _) => TmuxError(TmuxError.Reason.SessionDied)
       case IoError(_, _, _, _)  => TmuxError(TmuxError.Reason.ExecFailed)
       case StreamError(_)       => TmuxError(TmuxError.Reason.ExecFailed)
 
-    . mitigate:
+    . protect:
         given tmux: Tmux = Tmux(Uuid().show, summon[WorkingDirectory], width, height, shell)
 
         val path = summon[Enclave.Tool].path.parent.vouch.encode

--- a/lib/galilei/src/core/galilei.Creatable.scala
+++ b/lib/galilei/src/core/galilei.Creatable.scala
@@ -118,12 +118,12 @@ object Creatable:
       def create(path: Path on Plane): Path on Plane = path.also:
         createNonexistentParents(path):
           overwritePreexisting(path):
-            whereas:
+            mitigate:
               case ExecError(_, _, _) =>
                 import errorDiagnostics.stackTracesDiagnostics
                 IoError(path, IoError.Operation.Create, IoError.Reason.Unsupported)
 
-            . mitigate:
+            . protect:
                 sh"mkfifo $path"() match
                   case Exit.Ok => ()
 

--- a/lib/galilei/src/core/galilei.Device.scala
+++ b/lib/galilei/src/core/galilei.Device.scala
@@ -63,12 +63,12 @@ object Device:
 
     createNonexistentParents(path):
       overwritePreexisting(path):
-        whereas:
+        mitigate:
           case ExecError(_, _, _) =>
             import errorDiagnostics.stackTracesDiagnostics
             IoError(path, IoError.Operation.Create, IoError.Reason.Unsupported)
 
-        . mitigate:
+        . protect:
             sh"mknod $path ${kind.flag} $major $minor"() match
               case Exit.Ok => ()
 

--- a/lib/jacinta/src/schema/jacinta_schema.scala
+++ b/lib/jacinta/src/schema/jacinta_schema.scala
@@ -50,14 +50,14 @@ package jsonPointerRegistries:
 
   given fetchingRegistry: (Online, HttpEvent is Loggable, HttpClient) => JsonPointer.Registry:
     protected def lookup(url: HttpUrl): Optional[Json] =
-      whereas:
+      recover:
         case VariantError(_, _, _) => Unset
         case ConnectError(_)       => Unset
         case HttpError(_, _)       => Unset
         case ParseError(_, _, _)   => Unset
         case JsonError(_)          => Unset
 
-      . recover(url.fetch().receive[Json])
+      . protect(url.fetch().receive[Json])
 
 
 extension (json: Json)

--- a/lib/mandible/src/core/mandible_core.scala
+++ b/lib/mandible/src/core/mandible_core.scala
@@ -72,11 +72,11 @@ def disassemble(using codepoint: Codepoint)(code0: Quotes ?=> Expr[Any])(using T
 
   given compiler: staging.Compiler = staging.Compiler.make(classloader.java)(using settings)
 
-  whereas:
+  mitigate:
     case IoError(_, _, _, _) => BytecodeError(BytecodeError.Reason.ClassfileMissing)
     case StreamError(_)      => BytecodeError(BytecodeError.Reason.ClassfileUnreadable)
 
-  . mitigate:
+  . protect:
       val file: Path on Linux = out/"Generated$$Code$$From$$Quoted.class"
       val code: Quotes ?=> Expr[Unit] = '{def _code(): Unit = $code0}
       staging.run(code)

--- a/lib/obligatory/src/json/obligatory.JsonRpc.scala
+++ b/lib/obligatory/src/json/obligatory.JsonRpc.scala
@@ -96,14 +96,14 @@ object JsonRpc:
     val request = Request("2.0", method, payload, uuid.json).json
 
     async:
-      whereas:
+      recover:
         case MediaTypeError(_, _)   => promise.cancel()
         case ConnectError(_)        => promise.cancel()
         case ParseError(_, _, _)    => promise.cancel()
         case HttpError(_, _)        => promise.cancel()
         case AsyncError(_)          => promise.cancel()
 
-      . recover:
+      . protect:
           promise.fulfill(target.submit(Http.Post)(request).receive[Json])
 
     promise
@@ -119,12 +119,12 @@ object JsonRpc:
 
     val request = Request("2.0", method, payload, Unset).json
 
-    whereas:
+    recover:
       case MediaTypeError(_, _) => ()
       case ConnectError(_)      => ()
       case HttpError(_, _)      => ()
 
-    . recover:
+    . protect:
         target.submit(Http.Post)(request).receive[Text]
         ()
 

--- a/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
@@ -75,7 +75,7 @@ class Issuer
 
     request.path match
       case OAuthPath =>
-        whereas:
+        mitigate:
           case error@PathError(reason, path) =>
             OAuthError(OAuthError.Reason.Other)
 
@@ -97,7 +97,7 @@ class Issuer
           case error@JsonError(reason) =>
             OAuthError(OAuthError.Reason.InvalidJsonResponse)
 
-        . mitigate:
+        . protect:
             store(session).let: state =>
               val code: Text = request.query.code
 

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -222,10 +222,10 @@ class Websocket[message, state]
     state
 
   val task: Task[state] = async:
-    whereas:
+    recover:
       case error: WebsocketError =>
         safely(channel.close(error.reason.closeCode))
         initial
 
-    . recover:
+    . protect:
         loop(Reader(() => request.body(), channel).messages, initial)

--- a/lib/revolution/src/core/revolution.Semver.scala
+++ b/lib/revolution/src/core/revolution.Semver.scala
@@ -88,10 +88,10 @@ object Semver:
           val build3: List[Text | Long] = build2.map: element =>
             safely(element.decode[Long]).or(element)
 
-          whereas:
+          mitigate:
             case NumberError(_, _, _) => SemverError(text, SemverError.Reason.BadFormat)
 
-          . mitigate:
+          . protect:
               val major2 = major.decode[Long]
 
               if major.starts(t"0") && major2 != 0

--- a/lib/scintillate/src/server/scintillate.Acceptable.scala
+++ b/lib/scintillate/src/server/scintillate.Acceptable.scala
@@ -48,10 +48,10 @@ import errorDiagnostics.stackTracesDiagnostics
 
 object Acceptable:
   given multipart: Tactic[MultipartError] => Multipart is Acceptable = request =>
-    whereas:
+    mitigate:
       case _: MediaTypeError => MultipartError(MultipartError.Reason.MediaType)
 
-    . mitigate:
+    . protect:
         val contentType = request.headers.contentType.prim.or:
           abort(MultipartError(MultipartError.Reason.MediaType))
 

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -52,7 +52,7 @@ extends RequestServable:
 
     def handle(exchange: csnh.HttpExchange | Null): Unit =
       try
-        whereas:
+        recover:
           case StreamError(length) =>
             Log.warn(HttpServerEvent.BrokenStream(length))
 
@@ -64,7 +64,7 @@ extends RequestServable:
               exchange.nn.close()
             catch case NonFatal(_) => ()
 
-        . recover:
+        . protect:
             val connection = HttpConnection(exchange.nn)
 
             connection.respond:

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -153,7 +153,7 @@ extends RequestServable:
     // Handle one request off the cursor; return whether to keep the connection
     // alive for a further request.
     def serveRequest(cursor: Cursor[Data]): Boolean =
-      whereas:
+      recover:
         case error: HttpRequestError =>
           val response = Http.Response(errorStatus(error.reason))() + closeHeader
           safely(writeAll(out, Http.Response.serialize(response)))
@@ -166,7 +166,7 @@ extends RequestServable:
           safely(writeAll(out, Http.Response.serialize(response)))
           false
 
-      . recover:
+      . protect:
           val head = Http.Request.parseHead(cursor)
           val upgrade = isUpgrade(head)
 
@@ -224,11 +224,11 @@ extends RequestServable:
     // A stream error tearing down the connection is logged and ends it; any other
     // unexpected failure is left to propagate out of the per-connection daemon, where
     // the `trap` installed in `handle` logs it and isolates it to this connection.
-    whereas:
+    recover:
       case StreamError(length) =>
         Log.warn(HttpServerEvent.BrokenStream(length))
 
-    . recover:
+    . protect:
         val cursor = Cursor[Data](Streamable.inputStream.stream(in).filter(_.nonEmpty).iterator)
 
         var continue = true

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -102,7 +102,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
 
 
   def handle(request: jsh.HttpServletRequest, response: jsh.HttpServletResponse): Unit =
-    whereas:
+    recover:
       case error @ StreamError(_) =>
         error.printStackTrace(System.out)
 
@@ -110,7 +110,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
         error.printStackTrace(System.out)
         try response.setStatus(400) catch case NonFatal(_) => ()
 
-    . recover:
+    . protect:
         val connection = makeConnection(request, response)
         connection.respond(handle(using connection))
 

--- a/lib/serpentine/src/test/serpentine_test.scala
+++ b/lib/serpentine/src/test/serpentine_test.scala
@@ -110,10 +110,10 @@ object Tests extends Suite(m"internal Benchmarks"):
       test(m"Construct a path with a label of a bad type is not permitted"):
         demilitarize:
           var dir: Char = 'x'
-          whereas:
+          recover:
             case NameError(_, _, _) => ()
 
-          . recover:
+          . protect:
               val path = (% / dir / "baz")
         .map(_.message)
 

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -134,10 +134,10 @@ object Bintel:
     val sigLenDecoded =
       import errorDiagnostics.emptyDiagnostics
 
-      whereas:
+      mitigate:
         case _: VarintError => BintelError(BintelError.Reason.VarintError)
 
-      . mitigate(Varint.decode(data, magic.length))
+      . protect(Varint.decode(data, magic.length))
 
     val sigLength = sigLenDecoded.value.toInt
 
@@ -218,10 +218,10 @@ object Bintel:
       i += 1
 
     def varint(at: Int) =
-      whereas:
+      mitigate:
         case _: VarintError => BintelError(BintelError.Reason.VarintError)
 
-      . mitigate(Varint.decode(data, at))
+      . protect(Varint.decode(data, at))
 
     val sigLenD   = varint(magicSelfContained.length)
     val sigStart  = sigLenD.next
@@ -244,11 +244,11 @@ object Bintel:
     // Decode + reconstruct the embedded schema and recompute its signature;
     // any structural failure here is B12.
     val (composed, recomputed) =
-      whereas:
+      mitigate:
         case _: TelError    => BintelError(BintelError.Reason.EmbeddedSchemaUndecodable)
         case _: BintelError => BintelError(BintelError.Reason.EmbeddedSchemaUndecodable)
 
-      . mitigate:
+      . protect:
           val schemaRoot = decode(schemaBody, axiom).asInstanceOf[Tel.Element.Node]
           val baseTels   = Tels.SemanticReconstructor.fromElement(schemaRoot)
           val sig        = SchemaSignature.fromElement(schemaRoot, axiom)
@@ -355,10 +355,10 @@ object Bintel:
     if cursor.offset >= cursor.data.length
     then abort(BintelError(BintelError.Reason.UnexpectedEoi))
 
-    whereas:
+    mitigate:
       case _: VarintError => BintelError(BintelError.Reason.VarintError)
 
-    . mitigate:
+    . protect:
         val decoded = Varint.decode(cursor.data, cursor.offset)
         cursor.offset = decoded.next
         decoded.value

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -144,7 +144,7 @@ object Mcp:
     given mcpProtocolVersion: ("mcpProtocolVersion" is Directive of Text) = identity(_)
     given lastEventId: ("lastEventId" is Directive of Text) = identity(_)
 
-    whereas:
+    recover:
       case error: ParseError =>
         Http.Response(Http.Ok):
           JsonRpc.error(-32700, t"Parse error: ${error.message}".show).json
@@ -157,7 +157,7 @@ object Mcp:
 
         . mcpSessionId = id
 
-    . recover:
+    . protect:
         try
           request.method match
             case Http.Options =>

--- a/lib/synesthesia/src/core/synesthesia.McpServer.scala
+++ b/lib/synesthesia/src/core/synesthesia.McpServer.scala
@@ -70,12 +70,12 @@ trait McpServer():
   def serve(using this.type is McpSpecification, Monitor, Probate, Online, Http.Request)
   :   Http.Response =
 
-    whereas:
+    recover:
       case error @ JsonRpcError(_) =>
         import hieroglyph.charEncoders.utf8Encoder
         Http.Response(Unfulfilled(t"JSON-RPC error: ${error.message.text}"))
 
-    . recover:
+    . protect:
         val sessionId = request.headers.mcpSessionId.prim.or(Uuid().encode)
         val interface: Mcp.Interface = Mcp.Interface(sessionId, this)
         Mcp.send(sessionId, this, interface)(JsonRpc.serve(interface))

--- a/lib/urticose/src/core/urticose.internal.scala
+++ b/lib/urticose/src/core/urticose.internal.scala
@@ -121,12 +121,12 @@ object internal:
         val bytes = text.cut(t".")
 
         if bytes.length == 4 then
-          whereas:
+          mitigate:
             case error@NumberError(text, _, _) =>
               given diagnostics: Diagnostics = error.diagnostics
               IpAddressError(Ipv4ByteNotNumeric(text))
 
-          . mitigate:
+          . protect:
               bytes.map(Decodable.int.decoded(_)).pipe: bytes =>
                 for byte <- bytes do
                   if !(0 <= byte <= 255)
@@ -243,12 +243,12 @@ object internal:
   :   Int raises IpAddressError =
 
     val prefix =
-      whereas:
+      mitigate:
         case error@NumberError(_, _, _) =>
           given diagnostics: Diagnostics = error.diagnostics
           IpAddressError(SubnetPrefixNotNumeric(text))
 
-      . mitigate:
+      . protect:
           Decodable.int.decoded(text)
 
     if !(0 <= prefix <= max) then abort(IpAddressError(outOfRange(prefix)))

--- a/lib/urticose/src/url/urticose.Url.scala
+++ b/lib/urticose/src/url/urticose.Url.scala
@@ -72,7 +72,7 @@ object Url:
 
           val (pathStart, auth) =
             if value.after(colon).keep(2) == t"//" then
-              whereas:
+              mitigate:
                 case error@HostnameError(hostname, reason) =>
                   import error.diagnostics
                   UrlError(value, colon + 3, UrlError.Reason.BadHostname(hostname, reason))
@@ -81,7 +81,7 @@ object Url:
                   import error.diagnostics
                   UrlError(value, colon + 3, UrlError.Reason.BadIpv6(reason))
 
-              . mitigate:
+              . protect:
                   val authEnd = safely:
                     value.pinpoint(c => c == '/' || c == '?' || c == '#', colon + 3)
 

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -246,11 +246,11 @@ object Zipfile:
       val ref: Path on Zip =
         import errorDiagnostics.emptyDiagnostics
 
-        whereas:
+        mitigate:
           case PathError(_, _)    => ZipError(ZipError.Reason.InvalidName(cleanName))
           case NameError(_, _, _) => ZipError(ZipError.Reason.InvalidName(cleanName))
 
-        . mitigate:
+        . protect:
           // `decode` performs no per-segment validation, so check each name component
           // against `Zip.Rules` (which also forbids the `.`/`..` traversal segments) to
           // make `InvalidName` reachable and reject Zip-Slip / path-traversing entry names.

--- a/lib/ziggurat/src/packager/ziggurat.Packager.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packager.scala
@@ -87,7 +87,7 @@ object Packager:
       case _ =>
         ()
 
-    whereas:
+    mitigate:
       case HttpError(_, _)       => PackageError(m"A runner stub could not be downloaded")
       case ConnectError(_)       => PackageError(m"Could not connect to download a runner stub")
       case UrlError(_, _, _)     => PackageError(m"A runner stub URL is invalid")
@@ -96,7 +96,7 @@ object Packager:
       case StreamError(_)        => PackageError(m"A stream error occurred during packaging")
       case PathError(_, _)       => PackageError(m"A path could not be resolved during packaging")
 
-    . mitigate:
+    . protect:
         val jdk: Boolean = config.java.bundle == Packaging.Bundle.Jdk
 
         val publicKey: Data =


### PR DESCRIPTION
The synchronous error handlers now use the same disposition-leading shape as the rest of the error-handling API (`handle`, `contain`, `track`, `validate`): `recover { case … => value }.protect { … }`, `mitigate { case … => otherError }.protect { … }`, and `accrue(initial)(combine) { … }.protect { … }`, replacing the holder-first `whereas { … }.recover` / `.mitigate` / `.accrue`. `whereas` is removed entirely. This is a pure rename of the surface — the underlying behaviour is unchanged.

## Before / after

```scala
// before
whereas:
  case ParseError(n) => 0
.recover(parse(input))

// after
recover:
  case ParseError(n) => 0
.protect(parse(input))
```

Every handler-first error construct now reads `‹disposition› { … }.protect { … }`:

```scala
mitigate { case FooError(n) => BarError(n) }.protect(work())
accrue(Tally(Nil))((sum, e) => fold(sum, e)) { case ItemError(_) => () }.protect(validateAll())
```

All 36 production call sites across 24 modules are converted; `whereas`, the `Whereas` holder, its macro and extensions, and its exports are removed, with the shared helpers relocated (`Escape`/`EscapeTactic` → `Recovery`, `AccrueTactic` → `Accrual`, `Deferred` to its own file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
