### PR TITLE
Add ordering and ISO-8601 durations for time types

### DIFF
--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -37,6 +37,7 @@ import java.time as jt
 import anticipation.*
 import gossamer.*
 import hieroglyph.*, textMetrics.uniformMetric
+import hypotenuse.*
 import prepositional.*
 import spectacular.*
 
@@ -45,6 +46,13 @@ import abstractables.instantAbstractable
 object Moment:
   given generic: RomanCalendar => Moment is Abstractable across Instants to Long =
     _.instant.generic
+
+  // Moments order by their grounded instant (so a `Second`-occurrence overlap sorts after the
+  // `First`, and zones are compared on absolute time), hence the `RomanCalendar`/`GapPolicy` need.
+  given orderable: (RomanCalendar, GapPolicy) => Moment is Orderable =
+    summon[Instant is Orderable].contramap(_.instant)
+
+  given ordering: (RomanCalendar, GapPolicy) => Ordering[Moment] = Ordering.by(_.instant.long)
 
   // An ISO-8601 zoned date-time, e.g. `2016-12-31T23:59:60+00:00`. An inserted leap second renders
   // as the 61st second (`:60`); the offset is the zone's offset at this moment's instant.

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -35,6 +35,7 @@ package aviation
 import scala.util.NotGiven
 
 import anticipation.*
+import contextual.*
 import contingency.*
 import distillate.*
 import fulminate.*
@@ -94,23 +95,22 @@ object Timespan:
   given showable: Timespan is Showable = renderDuration(_)
   given encodable: Timespan is Encodable in Text = renderDuration(_)
 
-  // Parse an ISO-8601 duration. `M` is months before the `T`, minutes after it. The whole string
-  // must match, and at least one component must be present (so bare `P`/`PT` are rejected).
-  private val DurationPattern =
-    ("""P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?""" +
-      """(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?""").r
-
+  // Runtime parse of an ISO-8601 duration; shares `parseDuration` with the `dur"…"` interpolator.
   given decodable: Tactic[TimeError] => Timespan is Decodable in Text = text =>
-    def int(group: String | Null): Int = if group == null then 0 else group.nn.toInt
-    def double(group: String | Null): Double = if group == null then 0.0 else group.nn.toDouble
+    aviation.internal.parseDuration(text.s) match
+      case Right((years, months, weeks, days, hours, minutes, seconds)) =>
+        Timespan(years, months, weeks, days, hours, minutes, Quantity(seconds))
 
-    text.s match
-      case DurationPattern(y, mo, w, d, h, mi, s)
-      if List(y, mo, w, d, h, mi, s).exists(_ != null) =>
-        Timespan(int(y), int(mo), int(w), int(d), int(h), int(mi), Quantity(double(s)))
-
-      case _ =>
+      case Left(_) =>
         abort(TimeError(_.Unknown(text, t"duration")))
+
+  // Compile-time `dur"P1Y2M3DT4H5M6S"` literal, validated by the same parser.
+  given interpolable: Timespan is Interpolable:
+    inline def interpolate[parts <: Tuple, origins <: Tuple]
+      ( inline insertions: Any* )
+    :   Timespan =
+
+      ${aviation.internal.durInterpolator[parts]('insertions)}
 
   given addable: [left <: Radix, right <: Radix]
   =>  (Timespan of left) is Addable by (Timespan of right) to (Timespan of (left & right)) =

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -36,8 +36,12 @@ import scala.util.NotGiven
 
 import anticipation.*
 import contingency.*
+import distillate.*
+import fulminate.*
+import gossamer.*
 import prepositional.*
 import quantitative.*
+import spectacular.*
 import symbolism.*
 
 // A `Timespan` is a duration expressed as a vector of radix counts (`Year`/`Month`/`Week`/`Day`/
@@ -64,6 +68,49 @@ object Timespan:
     case Hour          => Timespan(hours = n).asInstanceOf[Timespan of radix]
     case Minute        => Timespan(minutes = n).asInstanceOf[Timespan of radix]
     case _             => Timespan().asInstanceOf[Timespan of radix]
+
+  // ISO-8601 duration text, e.g. `P1Y2M3DT4H5M6S`. Zero components are omitted; the all-zero span
+  // is `PT0S`. Fractional seconds render with a decimal point.
+  private def renderDuration(span: Timespan): Text =
+    def part(value: Int, unit: Text): Text = if value == 0 then t"" else t"$value$unit"
+
+    val seconds = span.seconds.value
+
+    val secondsText =
+      if seconds == 0.0 then t""
+      else if seconds == seconds.toLong.toDouble then t"${seconds.toLong}S"
+      else t"${seconds.toString.tt}S"
+
+    val date =
+      List(part(span.years, t"Y"), part(span.months, t"M"), part(span.weeks, t"W"),
+          part(span.days, t"D")).join
+
+    val time = List(part(span.hours, t"H"), part(span.minutes, t"M"), secondsText).join
+
+    if date == t"" && time == t"" then t"PT0S"
+    else if time == t"" then t"P$date"
+    else t"P${date}T$time"
+
+  given showable: Timespan is Showable = renderDuration(_)
+  given encodable: Timespan is Encodable in Text = renderDuration(_)
+
+  // Parse an ISO-8601 duration. `M` is months before the `T`, minutes after it. The whole string
+  // must match, and at least one component must be present (so bare `P`/`PT` are rejected).
+  private val DurationPattern =
+    ("""P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?""" +
+      """(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?""").r
+
+  given decodable: Tactic[TimeError] => Timespan is Decodable in Text = text =>
+    def int(group: String | Null): Int = if group == null then 0 else group.nn.toInt
+    def double(group: String | Null): Double = if group == null then 0.0 else group.nn.toDouble
+
+    text.s match
+      case DurationPattern(y, mo, w, d, h, mi, s)
+      if List(y, mo, w, d, h, mi, s).exists(_ != null) =>
+        Timespan(int(y), int(mo), int(w), int(d), int(h), int(mi), Quantity(double(s)))
+
+      case _ =>
+        abort(TimeError(_.Unknown(text, t"duration")))
 
   given addable: [left <: Radix, right <: Radix]
   =>  (Timespan of left) is Addable by (Timespan of right) to (Timespan of (left & right)) =

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -298,6 +298,25 @@ object internal:
     else if text.head.isLetter then parseRfc(text)
     else Left(m"a timestamp must begin with a digit or a weekday name")
 
+  // ISO-8601 duration. `M` is months before the `T`, minutes after it. The whole string must match,
+  // with at least one component, so bare `P`/`PT` are rejected. Shared by the runtime `Timespan`
+  // decoder and the compile-time `dur"…"` interpolator.
+  private val DurationPattern =
+    ("""P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?""" +
+      """(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?""").r
+
+  def parseDuration(text: String): Either[Message, (Int, Int, Int, Int, Int, Int, Double)] =
+    def int(group: String | Null): Int = if group == null then 0 else group.nn.toInt
+    def double(group: String | Null): Double = if group == null then 0.0 else group.nn.toDouble
+
+    text match
+      case DurationPattern(y, mo, w, d, h, mi, s)
+      if List(y, mo, w, d, h, mi, s).exists(_ != null) =>
+        Right((int(y), int(mo), int(w), int(d), int(h), int(mi), double(s)))
+
+      case _ =>
+        Left(m"$text is not a valid ISO 8601 duration")
+
   def tsInterpolator[parts <: Tuple: Type](insertions: Expr[Seq[Any]])
   :   Macro[Year | Monthstamp | Date | Timestamp | Moment] =
 
@@ -342,6 +361,26 @@ object internal:
                   .in(unsafely(Timezone(${Expr(zone)}.tt)))}
 
         result
+
+
+  def durInterpolator[parts <: Tuple: Type](insertions: Expr[Seq[Any]]): Macro[Timespan] =
+    import quotes.reflect.*
+
+    def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case _               => strings
+
+    val parts = recur[parts](Nil)
+
+    if parts.length != 1 then halt(m"a duration literal cannot contain substitutions")
+
+    parseDuration(parts.head) match
+      case Left(error) =>
+        halt(error)
+
+      case Right((years, months, weeks, days, hours, minutes, seconds)) =>
+        '{ Timespan(${Expr(years)}, ${Expr(months)}, ${Expr(weeks)}, ${Expr(days)},
+              ${Expr(hours)}, ${Expr(minutes)}, Quantity(${Expr(seconds)})) }
 
 
   // The inline `Monthstamp - day` operator splices here. When the year, month and day are all

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -195,6 +195,21 @@ object timestampInternal:
 
     given dateOrdering: Ordering[Date] = Ordering.Long.asInstanceOf[Ordering[Date]]
 
+    // `Orderable`'s `Self` is invariant, so `Date` (above) and `Timestamp` each need their own
+    // instance even though the comparison is identical.
+    inline given timestampOrderable: Timestamp is Orderable:
+      inline def compare
+        ( inline left:        Timestamp,
+          inline right:       Timestamp,
+          inline strict:      Boolean,
+          inline greaterThan: Boolean )
+      :   Boolean =
+
+        if left == right then !strict else (left < right)^greaterThan
+
+    given timestampOrdering: Ordering[Timestamp] =
+      Ordering.Long.asInstanceOf[Ordering[Timestamp]]
+
     given dateWorkingDays: Holidays => (hebdomad: Hebdomad) => Date is Addable:
       type Operand = WorkingDays
       type Result = Date
@@ -280,18 +295,21 @@ object timestampInternal:
       import abstractables.instantAbstractable
       Instant(timestamp.stdlib.atZone(timezone.stdlib).nn.toInstant.nn.toEpochMilli())
 
+  // Comparisons are defined on `Timestamp` (the whole grid is monotonic); `Date`, being a
+  // `Timestamp in Day`, inherits them.
+  extension (timestamp: Timestamp)
+    @targetName("gt")
+    infix def > (right: Timestamp): Boolean = underlying(timestamp) > underlying(right)
+
+    @targetName("lt")
+    infix def < (right: Timestamp): Boolean = underlying(timestamp) < underlying(right)
+
+    @targetName("lte")
+    infix def <= (right: Timestamp): Boolean = underlying(timestamp) <= underlying(right)
+
+    @targetName("gte")
+    infix def >= (right: Timestamp): Boolean = underlying(timestamp) >= underlying(right)
+
   extension (date: Date)
     def addDays(count: Int): Date =
       (underlying(date) + count.toLong*aviation.internal.MillisPerDay).asInstanceOf[Date]
-
-    @targetName("gt")
-    infix def > (right: Date): Boolean = underlying(date) > underlying(right)
-
-    @targetName("lt")
-    infix def < (right: Date): Boolean = underlying(date) < underlying(right)
-
-    @targetName("lte")
-    infix def <= (right: Date): Boolean = underlying(date) <= underlying(right)
-
-    @targetName("gte")
-    infix def >= (right: Date): Boolean = underlying(date) >= underlying(right)

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -454,6 +454,8 @@ inline given tsInterpolator: (Year | Monthstamp | Date | Timestamp | Moment) is 
 extension (inline context: StringContext)
   transparent inline def tz: Interpolation = interpolation[Timezone](context)
 
+  transparent inline def dur: Interpolation = interpolation[Timespan](context)
+
   transparent inline def ts: Interpolation =
     interpolation[Year | Monthstamp | Date | Timestamp | Moment](context)
 

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -36,7 +36,7 @@ export
   aviation
   . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
       base60Extractable, Calendar, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec,
+      DateNumerics, DateSeparation, Day, Dec, dur,
       Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
       FrenchRepublicanCalendar, FrenchRepublicanMonth, Fri, Hebdomad, Holiday, Holidays, Horology,
       HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2086,6 +2086,54 @@ object Tests extends Suite(m"Aviation Tests"):
         nextSecond.tai.long - leapMoment.tai.long
       . assert(_ == 1000L)
 
+    suite(m"Ordering and ISO-8601 durations"):
+      import calendars.gregorianCalendar
+
+      test(m"Timestamps sort chronologically"):
+        val a = Timestamp(2020-Jan-1, Clockface(0, 0, 0))
+        val b = Timestamp(2020-Jan-1, Clockface(12, 0, 0))
+        val c = Timestamp(2021-Jan-1, Clockface(0, 0, 0))
+        List(c, a, b).sorted == List(a, b, c)
+      . assert(_ == true)
+
+      test(m"A Timestamp compares with < to a later Timestamp"):
+        Timestamp(2020-Jan-1, Clockface(0, 0, 0)) < Timestamp(2020-Jan-1, Clockface(0, 0, 1))
+      . assert(_ == true)
+
+      test(m"Moments sort by their grounded instant"):
+        val tz = tz"Europe/London"
+        val earlier = Moment(2024-Oct-27, Clockface(1, 30, 0), tz, Occurrence.First)
+        val later = Moment(2024-Oct-27, Clockface(1, 30, 0), tz, Occurrence.Second)
+        List(later, earlier).sorted == List(earlier, later)
+      . assert(_ == true)
+
+      test(m"A Timespan renders as an ISO-8601 duration"):
+        Timespan(years = 1, months = 2, days = 3, hours = 4, minutes = 5, seconds = Quantity(6.0))
+        . show
+      . assert(_ == t"P1Y2M3DT4H5M6S")
+
+      test(m"A zero Timespan renders as PT0S"):
+        Timespan().show
+      . assert(_ == t"PT0S")
+
+      test(m"Fractional seconds render with a decimal point"):
+        Timespan(seconds = Quantity(1.5)).show
+      . assert(_ == t"PT1.5S")
+
+      test(m"An ISO-8601 duration parses to a Timespan"):
+        t"P1Y2M3DT4H5M6S".decode[Timespan]
+      . assert(_ == Timespan(years = 1, months = 2, days = 3, hours = 4, minutes = 5,
+            seconds = Quantity(6.0)))
+
+      test(m"A week-and-time duration round-trips through text"):
+        val span = Timespan(weeks = 2, hours = 12, minutes = 30)
+        span.show.decode[Timespan] == span
+      . assert(_ == true)
+
+      test(m"A bare P is not a valid duration"):
+        capture(t"P".decode[Timespan])
+      . assert(_ == TimeError(_.Unknown(t"P", t"duration")))
+
     suite(m"Horology sexagesimal"):
       val horology = Horology.sexagesimal
 

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2134,6 +2134,23 @@ object Tests extends Suite(m"Aviation Tests"):
         capture(t"P".decode[Timespan])
       . assert(_ == TimeError(_.Unknown(t"P", t"duration")))
 
+      test(m"A dur literal parses a duration at compile time"):
+        dur"P1Y2M3DT4H5M6S"
+      . assert(_ == Timespan(years = 1, months = 2, days = 3, hours = 4, minutes = 5,
+            seconds = Quantity(6.0)))
+
+      test(m"A dur literal accepts PT0S"):
+        dur"PT0S"
+      . assert(_ == Timespan())
+
+      test(m"A malformed dur literal is a compile error"):
+        demilitarize(dur"P1X")
+      . assert(_.nonEmpty)
+
+      test(m"A dur literal with a substitution is a compile error"):
+        demilitarize(dur"${1}")
+      . assert(_.nonEmpty)
+
     suite(m"Horology sexagesimal"):
       val horology = Horology.sexagesimal
 


### PR DESCRIPTION
Fills the ergonomic gaps that a feature-completeness pass surfaced: several core types lacked instances their siblings already had.

`Timestamp` and `Moment` are now `Orderable` and have an `Ordering`, so they sort and compare directly instead of detouring through `Instant`. The comparison operators move up from `Date` to `Timestamp` (the grid is monotonic; `Date` inherits them), and `Moment` orders by its grounded instant — so the later occurrence of a fall-back overlap sorts after the earlier one.

```scala
import calendars.gregorianCalendar
List(c, a, b).sorted          // Timestamps sort chronologically
```

`Timespan` gains a text form it never had: `Showable`, `Encodable`, and `Decodable` instances using ISO-8601 duration syntax (`P1Y2M3DT4H5M6S`, `PT0S`, fractional seconds; `M` is months before the `T`, minutes after), plus a compile-time `dur"…"` interpolator mirroring `ts"…"`/`tz"…"`:

```scala
Timespan(weeks = 2, hours = 12).show     // "P2WT12H"
t"P1Y2M".decode[Timespan]                // runtime parse
dur"P1Y2M3DT4H5M6S"                      // compile-time literal; malformed input won't compile
```

The ISO-8601 parse is factored into a single shared routine used by both the runtime decoder and the macro, so the two can't drift.