### PR TITLE
Generalise Instant over a chronometry; remove TaiInstant

### DIFF
--- a/lib/aviation/src/core/anticipation_aviation_core.scala
+++ b/lib/aviation/src/core/anticipation_aviation_core.scala
@@ -37,15 +37,9 @@ import prepositional.*
 import quantitative.*
 
 package interfaces.instants:
-  given aviationInstant
-  :   protointernal.Instant is Abstractable & Instantiable across Instants to Long from Long =
-
-    new Abstractable with Instantiable:
-      type Self = protointernal.Instant
-      type Origin = Long
-      type Result = Long
-      type Domain = Instants
-      export protointernal.Instant.generic.{genericize, apply}
+  given aviationInstant: [transport]
+  =>  (Instant over transport) is Abstractable & Instantiable across Instants to Long from Long =
+    Instant.generic[transport]
 
 package interfaces.durations:
   given aviationDuration: [units <: Measure: Normalizable to Seconds[1]]

--- a/lib/aviation/src/core/aviation.Chronometry.scala
+++ b/lib/aviation/src/core/aviation.Chronometry.scala
@@ -30,94 +30,39 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Fri, Hebdomad, Holiday, Holidays, Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, Month, Months, Monthstamp, Nov, now, Occurrence, Oct,
-      OffsetCalendar, Period, PersianCalendar, PersianMonth, pm, Posix, Regime, Rfc1123,
-      RomanCalendar, Tai,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
+import prepositional.*
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, papalCutover, britishCutover}
+// A `Chronometry` interprets the underlying `Long` of an `Instant over X`: which timeline `X`
+// counts on, expressed as a conversion to and from TAI (International Atomic Time) — the one
+// strictly-linear scale, counting every SI second with no discontinuities. Conversions between any
+// two chronometries compose through TAI. Each chronometry is a distinct marker type (`Tai`,
+// `Posix`, …); the phantom `X` in `Instant over X` tags an instant with its chronometry at the type
+// level, so instants on different timelines never mix without an explicit `.over[…]` conversion.
+//
+// (v1 works in milliseconds; sub-millisecond timelines such as `Monotonic` or nanosecond clocks are
+// a later extension, where the conversion's working unit becomes part of the chronometry.)
+object Chronometry:
+  // The default chronometry for instants that don't state one — selected by importing one of the
+  // `chronometries.*` givens (e.g. `import chronometries.posix`). It names the marker type so a
+  // constructed `Instant` takes that chronometry at the type level.
+  trait Ambient:
+    type Transport
+    def chronometry: Transport is Chronometry
 
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
+  // TAI itself: the identity interpretation.
+  given tai: Tai is Chronometry:
+    def toTai(value: Long): Long = value
+    def fromTai(tai: Long): Long = tai
 
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
+  // Unix/POSIX time: leap seconds aren't counted, so the offset from TAI grows by one second at
+  // each leap. `fromTai` is the (table-driven) inverse; a TAI value inside an inserted leap second
+  // has no Unix preimage and maps to the following second by convention.
+  given posix: Posix is Chronometry:
+    def toTai(value: Long): Long = LeapSeconds.tai(value)
+    def fromTai(tai: Long): Long = LeapSeconds.untai(tai)
 
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
-
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
-
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
-
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+trait Chronometry extends Typeclass:
+  def toTai(value: Long): Long
+  def fromTai(tai: Long): Long

--- a/lib/aviation/src/core/aviation.Clock.scala
+++ b/lib/aviation/src/core/aviation.Clock.scala
@@ -33,20 +33,21 @@
 package aviation
 
 import anticipation.*
+import prepositional.*
 import symbolism.*
 
-import abstractables.instantAbstractable
 import beneficence.*
 
+// A `Clock` reads the wall clock, which is Unix/POSIX time, so it produces `Instant over Posix`.
 object Clock:
   given current: Clock:
-    def apply(): Instant = Instant(System.currentTimeMillis)
+    def apply(): Instant over Posix = Instant.of[Posix](System.currentTimeMillis)
 
-  def fixed(instant: into[Instant]): Clock = new Clock():
-    def apply(): Instant = instant
+  def fixed(instant: Instant over Posix): Clock = new Clock():
+    def apply(): Instant over Posix = instant
 
   def offset(diff: into[Duration]): Clock = new Clock():
-    def apply(): Instant = Instant(System.currentTimeMillis) + diff
+    def apply(): Instant over Posix = Instant.of[Posix](System.currentTimeMillis) + diff
 
 abstract class Clock() extends Findable:
-  def apply(): Instant
+  def apply(): Instant over Posix

--- a/lib/aviation/src/core/aviation.GapPolicy.scala
+++ b/lib/aviation/src/core/aviation.GapPolicy.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package aviation
 
+import prepositional.*
+
 // A `GapPolicy` resolves a spring-forward DST gap — a wall-clock time that never occurs because the
 // clocks jump forward over it (e.g. 02:30 when 02:00 becomes 03:00). Grounding such a `Moment` to
 // an `Instant` is ambiguous: it can be nudged into the new offset (`forward`, the instant you get
@@ -48,4 +50,4 @@ object GapPolicy:
   given pushForward: GapPolicy = (forward, _) => forward
 
 trait GapPolicy:
-  def resolve(forward: Instant, backward: Instant): Instant
+  def resolve(forward: Instant over Posix, backward: Instant over Posix): Instant over Posix

--- a/lib/aviation/src/core/aviation.Iso8601.scala
+++ b/lib/aviation/src/core/aviation.Iso8601.scala
@@ -38,6 +38,7 @@ import contingency.*
 import denominative.*
 import fulminate.*
 import gossamer.*
+import prepositional.*
 import quantitative.*
 import rudiments.*
 import symbolism.*
@@ -62,7 +63,7 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
   import Issue.*
 
-  def parse(text: Text): Instant raises TimeError =
+  def parse(text: Text): Instant over Posix raises TimeError =
     import calendars.gregorianCalendar
 
     given Timezone = tz"UTC"
@@ -143,14 +144,14 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
     // A `:60` second is a leap second; on the (leap-free) Unix line it collapses onto the next
     // second (`23:59:60` ≡ the following `00:00:00`), so store `:59` and add one second.
-    def clockInstant(hour: Int, minute: Int, second: Int): Instant =
+    def clockInstant(hour: Int, minute: Int, second: Int): Instant over Posix =
       if second == 60 then
         Clockface(Base24(hour), Base60(minute), Base60(59)).on(date).instant +
           Quantity[Seconds[1]](1.0)
       else
         Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
 
-    val instant: Instant = next() match
+    val instant: Instant over Posix = next() match
       case '\u0000' => Clockface(Base24(0), Base60(0), Base60(0)).on(date).instant
 
       case 'T' =>

--- a/lib/aviation/src/core/aviation.LeapSeconds.scala
+++ b/lib/aviation/src/core/aviation.LeapSeconds.scala
@@ -94,6 +94,19 @@ object LeapSeconds:
 
       unixTime + low + (high - low)*(unixTime - (hi - window))/(2*window)
 
+  // The inverse of `tai` (the discrete step): recover Unix time from a TAI value. `tai` is strictly
+  // increasing but skips the inserted leap second, so a TAI value inside that second has no Unix
+  // preimage; the closest-match binary search maps it to the following second by convention.
+  def untai(taiMillis: Long): Long =
+    var lo = taiMillis - 100000L
+    var hi = taiMillis + 100000L
+
+    while hi - lo > 1 do
+      val mid = lo + (hi - lo)/2
+      if tai(mid) < taiMillis then lo = mid else hi = mid
+
+    if taiMillis - tai(lo) <= tai(hi) - taiMillis then lo else hi
+
   // The inverse of `smearTai`: recover the Unix time from a smeared-TAI value. `smearTai` is
   // strictly increasing (its slope is 1 ± 1/86400), so it is invertible; and the TAI−UTC offset is
   // well under 100 seconds (and fixed after 2035), so the Unix time lies in a narrow band around
@@ -108,18 +121,3 @@ object LeapSeconds:
       if smearTai(mid) < taiMillis then lo = mid else hi = mid
 
     if taiMillis - smearTai(lo) <= smearTai(hi) - taiMillis then lo else hi
-
-  // How leap seconds are accounted for when converting a (Unix) `Instant` to a `TaiInstant`. The
-  // ambient default is `ignored` (future leap seconds are unknowable); `import leapSeconds.step` or
-  // `leapSeconds.smear` opts into counting or smearing them. A `Reversible` strategy also defines
-  // the inverse `TaiInstant`→`Instant` conversion; the discrete `step` has no inverse (the inserted
-  // second has no Unix preimage), so it is a plain `Strategy`.
-  trait Strategy:
-    def tai(unixMillis: Long): Long
-
-  trait Reversible extends Strategy:
-    def unix(taiMillis: Long): Long
-
-  given ignored: Reversible:
-    def tai(unixMillis: Long): Long = unixMillis
-    def unix(taiMillis: Long): Long = taiMillis

--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -50,7 +50,7 @@ object Moment:
   // Moments order by their grounded instant (so a `Second`-occurrence overlap sorts after the
   // `First`, and zones are compared on absolute time), hence the `RomanCalendar`/`GapPolicy` need.
   given orderable: (RomanCalendar, GapPolicy) => Moment is Orderable =
-    summon[Instant is Orderable].contramap(_.instant)
+    summon[(Instant over Posix) is Orderable].contramap(_.instant)
 
   given ordering: (RomanCalendar, GapPolicy) => Ordering[Moment] = Ordering.by(_.instant.long)
 
@@ -81,7 +81,8 @@ case class Moment
     occurrence: Occurrence = Occurrence.First,
     leap:       Leap       = Leap.None ):
 
-  def instant(using calendar: RomanCalendar, gap: GapPolicy): Instant =
+  // A `Moment` grounds to the Unix/POSIX timeline (`java.time` works in epoch milliseconds).
+  def instant(using calendar: RomanCalendar, gap: GapPolicy): Instant over Posix =
     val ldt =
       jt.LocalDateTime.of
         ( date.year(),
@@ -94,7 +95,8 @@ case class Moment
 
     val rules = jt.ZoneId.of(timezone.name.s).nn.getRules.nn
 
-    def at(offset: jt.ZoneOffset): Instant = Instant(ldt.toInstant(offset).nn.toEpochMilli)
+    def at(offset: jt.ZoneOffset): Instant over Posix =
+      Instant.of[Posix](ldt.toInstant(offset).nn.toEpochMilli)
 
     val base =
       rules.getTransition(ldt) match
@@ -115,12 +117,12 @@ case class Moment
     // second's instant, so grounding it advances by one second.
     leap match
       case Leap.None     => base
-      case Leap.Inserted => Instant(base.long + 1000L)
+      case Leap.Inserted => Instant.of[Posix](base.long + 1000L)
 
-  // The absolute SI instant, counting leap seconds per the contextual strategy. For an inserted
-  // leap second the TAI value is exactly one SI second before the following second's.
-  def tai(using RomanCalendar, GapPolicy, LeapSeconds.Strategy): TaiInstant = leap match
-    case Leap.None     => instant.tai
-    case Leap.Inserted => TaiInstant(instant.tai.long - 1000L)
+  // The absolute SI instant on the atomic (TAI) timeline. For an inserted leap second the TAI value
+  // is exactly one SI second before the following second's.
+  def tai(using RomanCalendar, GapPolicy): Instant over Tai = leap match
+    case Leap.None     => instant.over[Tai]
+    case Leap.Inserted => Instant.of[Tai](instant.over[Tai].long - 1000L)
 
   def timestamp: Timestamp = Timestamp(date, time)

--- a/lib/aviation/src/core/aviation.Period.scala
+++ b/lib/aviation/src/core/aviation.Period.scala
@@ -33,17 +33,20 @@
 package aviation
 
 import hypotenuse.*
+import prepositional.*
 import symbolism.*
 import vacuous.*
 
-case class Period(start: into[Instant], finish: into[Instant]):
-  def duration = finish - start
+// A range between two instants on the same timeline; its `duration` is measured in that timeline's
+// seconds (so a `Period[Tai]` counts SI seconds, a `Period[Posix]` POSIX seconds).
+case class Period[transport](start: Instant over transport, finish: Instant over transport):
+  def duration: Duration = finish - start
 
-  def intersect(period: Period): Optional[Period] =
+  def intersect(period: Period[transport]): Optional[Period[transport]] =
     val start2 = period.start.max(start)
     val finish2 = period.finish.min(finish)
     if start2 >= finish2 then Unset else Period(start2, finish2)
 
-  def union(period: Period): Set[Period] =
+  def union(period: Period[transport]): Set[Period[transport]] =
     if intersect(period).absent then Set(this, period)
     else Set(Period(start.min(period.start), finish.max(period.finish)))

--- a/lib/aviation/src/core/aviation.Rfc1123.scala
+++ b/lib/aviation/src/core/aviation.Rfc1123.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import fulminate.*
 import gossamer.*
+import prepositional.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
@@ -55,7 +56,7 @@ object Rfc1123 extends Date.Format(t"RFC 1123"):
     case Expect(char: Char)
     case Digit
 
-  def parse(text: Text): Instant raises TimeError =
+  def parse(text: Text): Instant over Posix raises TimeError =
     import Rfc1123.Issue.*
     import Weekday.*
 

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -242,14 +242,14 @@ object Timespan:
     val whole = days*86400 + span.hours.toLong*3600 + span.minutes.toLong*60
     Quantity[Seconds[1]](whole.toDouble) + span.seconds
 
-  // A regular timespan (no Month/Year) is a fixed physical duration, so it adds to/subtracts from a
-  // bare `Instant`; an irregular span cannot (it needs a calendar — add it to a date instead).
-  given instantPlus: [topic <: Radix] => NotGiven[topic <:< Radix.Irregular]
-  =>  Instant is Addable by (Timespan of topic) to Instant =
+  // A regular timespan (no Month/Year) is a fixed physical duration, so it adds to/subtracts from an
+  // `Instant` (on any timeline); an irregular span cannot (it needs a calendar — add it to a date).
+  given instantPlus: [transport, topic <: Radix] => NotGiven[topic <:< Radix.Irregular]
+  =>  (Instant over transport) is Addable by (Timespan of topic) to (Instant over transport) =
     (instant, span) => instant + physicalSeconds(span)
 
-  given instantMinus: [topic <: Radix] => NotGiven[topic <:< Radix.Irregular]
-  =>  Instant is Subtractable by (Timespan of topic) to Instant =
+  given instantMinus: [transport, topic <: Radix] => NotGiven[topic <:< Radix.Irregular]
+  =>  (Instant over transport) is Subtractable by (Timespan of topic) to (Instant over transport) =
     (instant, span) => instant - physicalSeconds(span)
 
   // Adding a timespan to a (zoneless) timestamp applies the date/calendar part to the date (reusing

--- a/lib/aviation/src/core/aviation.protointernal.scala
+++ b/lib/aviation/src/core/aviation.protointernal.scala
@@ -43,104 +43,14 @@ import rudiments.*
 import symbolism.*
 
 object protointernal:
+  // An `Instant` is an absolute point in time, stored as a `Long` whose interpretation — which
+  // timeline it counts on (Unix/POSIX, TAI, …) — is the phantom `Transport` set by `over`. So
+  // `Instant over Posix` and `Instant over Tai` are distinct types over the same grid; a
+  // `Chronometry` given converts between them (through TAI). The unrefined `Instant` is abstract in
+  // its chronometry and is rarely used directly.
   opaque type Instant = Long
-  opaque type TaiInstant = Long
 
-  object TaiInstant:
-    def apply(taiMillis: Long): TaiInstant = taiMillis
-
-    extension (tai: TaiInstant)
-      def long: Long = tai
-
-      // The inverse of `Instant.tai`: recover the Unix `Instant` from this `TaiInstant`. Only a
-      // `Reversible` strategy (e.g. `smear`) can do this; `step` is not reversible.
-      def instant(using strategy: LeapSeconds.Reversible): Instant = strategy.unix(tai)
-
-    inline given underlying: Underlying[TaiInstant, Long] = !!
-
-
-    given generic
-    :   protointernal.TaiInstant is Abstractable & Instantiable across Instants to Long from Long =
-
-      new Abstractable with Instantiable:
-        type Self = protointernal.TaiInstant
-        type Origin = Long
-        type Result = Long
-        type Domain = Instants
-        def apply(long: Long): protointernal.TaiInstant = long
-        def genericize(instant: protointernal.TaiInstant): Long = instant
-
-  object InstantSubtractable:
-    given instant: Instant is InstantSubtractable to Duration = new InstantSubtractable:
-      type Self = Instant
-      type Result = Duration
-
-      def subtract(left: Instant, right: Instant): Duration = Quantity((left - right)/1000.0)
-
-
-    given duration: [units <: Measure: Normalizable to Seconds[1]]
-    =>  Quantity[units] is InstantSubtractable to Instant =
-
-      new InstantSubtractable:
-        type Self = Quantity[units]
-        type Result = Instant
-
-        def subtract(left: Instant, right: Quantity[units]): Instant =
-          left - (right.normalize.value*1000.0).toLong
-
-  trait InstantSubtractable extends Typeclass, Resultant:
-    def subtract(left: Instant, right: Self): Result
-
-  object Instant:
-    final val Min: Instant = Long.MinValue
-    final val Max: Instant = Long.MaxValue
-
-    def apply[instant: Abstractable across Instants to Long](instant: instant): Instant =
-      instant.generic
-
-    inline given underlying: Underlying[Instant, Long] = !!
-
-
-    given generic
-    :   protointernal.Instant is Abstractable & Instantiable across Instants to Long from Long =
-
-      new Abstractable with Instantiable:
-        type Self = protointernal.Instant
-        type Result = Long
-        type Origin = Long
-        type Domain = Instants
-        def apply(long: Long): protointernal.Instant = long
-        def genericize(instant: protointernal.Instant): Long = instant
-
-
-    inline given orderable: Instant is Orderable:
-      inline def compare
-        ( inline left:        Instant,
-          inline right:       Instant,
-          inline strict:      Boolean,
-          inline greaterThan: Boolean )
-      :   Boolean =
-
-        if left.long == right.long then !strict else (left.long < right.long) ^ greaterThan
-
-    given ordering: Ordering[Instant] = Ordering.Long
-
-
-    given plus: [units <: Measure: Normalizable to Seconds[1]]
-    =>  Instant is Addable by Quantity[units] to Instant = new Addable:
-
-      type Self = Instant
-      type Operand = Quantity[units]
-      type Result = Instant
-
-      def add(instant: Instant, duration: Quantity[units]): Instant =
-        instant + (duration.normalize.value*1000.0).toLong
-
-
-    given minus: [operand: InstantSubtractable]
-    =>  Instant is Subtractable by operand to operand.Result =
-
-      operand.subtract(_, _)
+  private def raw(instant: Instant): Long = instant
 
   type Duration = Quantity[Seconds[1]]
 
@@ -163,16 +73,81 @@ object protointernal:
         def genericize(duration: Quantity[units]): Long =
           (duration.normalize.value*1_000_000_000L).toLong
 
+  object Instant:
+    def Min[transport]: Instant over transport = Long.MinValue.asInstanceOf[Instant over transport]
+    def Max[transport]: Instant over transport = Long.MaxValue.asInstanceOf[Instant over transport]
 
-  extension (instant: into[Instant])
+    // Construct in an explicit chronometry (grounding code uses `Instant.of[Posix]`).
+    def of[transport](millis: Long): Instant over transport =
+      millis.asInstanceOf[Instant over transport]
+
+    // Construct in the import-selected default chronometry.
+    def apply(millis: Long)(using ambient: Chronometry.Ambient): Instant over ambient.Transport =
+      millis.asInstanceOf[Instant over ambient.Transport]
+
+    inline given underlying: [transport] => Underlying[Instant over transport, Long] = !!
+
+
+    // Generic interop: an instant on any timeline abstracts to/from an epoch `Long` (the `Long` is
+    // tagged with the transport, not reinterpreted — conversion between timelines is `.over`).
+    given generic: [transport]
+    =>  (Instant over transport) is Abstractable & Instantiable across Instants to Long from Long =
+
+      new Abstractable with Instantiable:
+        type Self = Instant over transport
+        type Origin = Long
+        type Result = Long
+        type Domain = Instants
+        def apply(long: Long): Self = long.asInstanceOf[Self]
+        def genericize(instant: Self): Long = raw(instant)
+
+
+    inline given orderable: [transport] => (Instant over transport) is Orderable:
+      inline def compare
+        ( inline left:        Instant over transport,
+          inline right:       Instant over transport,
+          inline strict:      Boolean,
+          inline greaterThan: Boolean )
+      :   Boolean =
+
+        if left.long == right.long then !strict else (left.long < right.long) ^ greaterThan
+
+    given ordering: [transport] => Ordering[Instant over transport] =
+      Ordering.Long.asInstanceOf[Ordering[Instant over transport]]
+
+
+    given plus: [transport, units <: Measure: Normalizable to Seconds[1]]
+    =>  (Instant over transport) is Addable by Quantity[units] to (Instant over transport) =
+      (instant, duration) =>
+        Instant.of(raw(instant) + (duration.normalize.value*1000.0).toLong)
+
+    // The difference of two instants on the same timeline is a `Duration` measured in that
+    // timeline's seconds; subtracting across timelines is a type error (convert with `.over` first).
+    given minus: [transport]
+    =>  (Instant over transport) is Subtractable by (Instant over transport) to Duration =
+      (left, right) => Quantity((raw(left) - raw(right))/1000.0)
+
+    given minusDuration: [transport, units <: Measure: Normalizable to Seconds[1]]
+    =>  (Instant over transport) is Subtractable by Quantity[units] to (Instant over transport) =
+      (instant, duration) =>
+        Instant.of(raw(instant) - (duration.normalize.value*1000.0).toLong)
+
+
+  extension [transport](instant: Instant over transport)
+    def long: Long = raw(instant)
+
+    // Re-interpret this instant on another timeline, composing through TAI.
+    def over[target](using from: transport is Chronometry, to: target is Chronometry)
+    :   Instant over target =
+      Instant.of(to.fromTai(from.toTai(raw(instant))))
+
     @targetName("to")
-    infix def ~ (that: into[Instant]): Period = Period(instant, that)
+    infix def ~ (that: Instant over transport): Period[transport] = Period(instant, that)
 
-    def tai(using strategy: LeapSeconds.Strategy): TaiInstant = strategy.tai(instant)
-
-    infix def in (using RomanCalendar)(timezone: Timezone): Moment =
+    infix def in (using RomanCalendar, transport is Chronometry)(timezone: Timezone): Moment =
+      val unix = instant.over[Posix].long
       val zone = jt.ZoneId.of(timezone.name.s).nn
-      val zonedTime = jt.Instant.ofEpochMilli(instant).nn.atZone(zone).nn
+      val zonedTime = jt.Instant.ofEpochMilli(unix).nn.atZone(zone).nn
 
       val date = zonedTime.getMonthValue.absolve match
         case Month(month) =>
@@ -192,11 +167,10 @@ object protointernal:
 
       Moment(date, time, timezone, if laterOffset then Occurrence.Second else Occurrence.First)
 
-    def timestamp(using calendar: RomanCalendar, timezone: Timezone): Timestamp =
-      in(timezone).timestamp
-
-    def long: Long = instant
+    def timestamp(using RomanCalendar, transport is Chronometry, Timezone): Timestamp =
+      in(summon[Timezone]).timestamp
 
 
   extension (duration: into[Duration])
-    def from(instant: into[Instant]): Period = Period(instant, Instant.plus.add(instant, duration))
+    def from[transport](instant: Instant over transport): Period[transport] =
+      Period(instant, Instant.plus.add(instant, duration))

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -291,9 +291,8 @@ object timestampInternal:
 
       . nn
 
-    def instant(using timezone: Timezone, calendar: RomanCalendar): Instant =
-      import abstractables.instantAbstractable
-      Instant(timestamp.stdlib.atZone(timezone.stdlib).nn.toInstant.nn.toEpochMilli())
+    def instant(using timezone: Timezone, calendar: RomanCalendar): Instant over Posix =
+      Instant.of[Posix](timestamp.stdlib.atZone(timezone.stdlib).nn.toInstant.nn.toEpochMilli())
 
   // Comparisons are defined on `Timestamp` (the whole grid is monotonic); `Date`, being a
   // `Timestamp in Day`, inherits them.

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -45,7 +45,7 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
-export protointernal.{Instant, Duration, TaiInstant}
+export protointernal.{Instant, Duration}
 export aviation.internal.{Year, Day, Anniversary, WorkingDays}
 export aviation.timestampInternal.{Timestamp, Date}
 export Month.{Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec}
@@ -76,11 +76,17 @@ trait Hour
 trait Minute
 trait Second
 
+// Phantom chronometry markers for `Instant over <chronometry>` (the `Transport` type member): which
+// timeline an instant's `Long` counts on. `Tai` is atomic time; `Posix` is leap-free Unix time.
+// Each is interpreted by a `Chronometry` given. Purely type-level tags.
+trait Tai
+trait Posix
+
 package instantDecodables:
-  given iso8601InstantDecodable: Tactic[TimeError] => Instant is Decodable in Text =
+  given iso8601InstantDecodable: Tactic[TimeError] => (Instant over Posix) is Decodable in Text =
     Iso8601.parse(_)
 
-  given rfc1123InstantDecodable: Tactic[TimeError] => Instant is Decodable in Text =
+  given rfc1123InstantDecodable: Tactic[TimeError] => (Instant over Posix) is Decodable in Text =
     Rfc1123.parse(_)
 
 package dateFormats:
@@ -364,14 +370,18 @@ package calendars:
       import calendars.gregorianCalendar
       unsafely(Date(year, Feb, Day(29)))
 
-// Leap-second strategies for converting a Unix `Instant` to a `TaiInstant`. `ignored` is the
-// ambient default; import one of these to count (`step`) or smear (`smear`) leap seconds instead.
-package leapSeconds:
-  given step: LeapSeconds.Strategy = LeapSeconds.tai(_)
+// The default interpretation of an `Instant`'s `Long` (used by `Instant(…)`, decoding, etc.). Import
+// one of these to choose the timeline bare instants count on; convert explicitly with `.over[…]`.
+package chronometries:
+  given posix: (Chronometry.Ambient { type Transport = Posix }) =
+    new Chronometry.Ambient:
+      type Transport = Posix
+      def chronometry: Posix is Chronometry = Chronometry.posix
 
-  given smear: LeapSeconds.Reversible:
-    def tai(unixMillis: Long): Long = LeapSeconds.smearTai(unixMillis)
-    def unix(taiMillis: Long): Long = LeapSeconds.unsmearTai(taiMillis)
+  given atomic: (Chronometry.Ambient { type Transport = Tai }) =
+    new Chronometry.Ambient:
+      type Transport = Tai
+      def chronometry: Tai is Chronometry = Chronometry.tai
 
 // Overrides for the spring-forward DST gap, used to ground a `Moment` whose wall-clock time doesn't
 // exist. The ambient default is `GapPolicy.pushForward` (matching `java.time`); import one of these
@@ -398,7 +408,7 @@ package monthEnds:
     def resolve(using calendar: Calendar)(year: Year, month: calendar.Mensual, day: Int): Date =
       abort(TimeError(_.Invalid(year(), calendar.monthOrdinal(year, month) + 1, day, calendar)))
 
-def now()(using clock: Clock): Instant = clock()
+def now()(using clock: Clock): Instant over Posix = clock()
 
 def today()(using clock: Clock, calendar: RomanCalendar, timezone: Timezone): Date =
   (now() in timezone).date

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -37,6 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import abstractables.instantAbstractable
+import chronometries.posix
 
 object Tests extends Suite(m"Aviation Tests"):
   def run(): Unit =
@@ -359,205 +360,205 @@ object Tests extends Suite(m"Aviation Tests"):
       suite(m"ISO 8601"):
         import instantDecodables.iso8601InstantDecodable
         test(m"with Z suffix (UTC)"):
-          t"1994-11-06T08:49:37Z".decode[Instant]
+          t"1994-11-06T08:49:37Z".decode[Instant over Posix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with positive timezone offset"):
-          t"1994-11-06T09:49:37+01:00".decode[Instant]
+          t"1994-11-06T09:49:37+01:00".decode[Instant over Posix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with negative timezone offset"):
-          t"1994-11-06T03:49:37-05:00".decode[Instant]
+          t"1994-11-06T03:49:37-05:00".decode[Instant over Posix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with fractional seconds (.123)"):
-          t"2020-02-29T12:34:56.123Z".decode[Instant]
+          t"2020-02-29T12:34:56.123Z".decode[Instant over Posix]
         . assert(_ == Instant(1582979696123L))
 
         test(m"with nanosecond precision (.123456789)"):
-          t"2020-02-29T12:34:56.123456789Z".decode[Instant]
+          t"2020-02-29T12:34:56.123456789Z".decode[Instant over Posix]
         . assert(_ == Instant(1582979696123L))
 
         test(m"date-only format (midnight UTC)"):
-          t"2020-12-31".decode[Instant]
+          t"2020-12-31".decode[Instant over Posix]
         . assert(_ == Instant(1609372800000L))
 
         test(m"ISO 8601 leap second accepted as next second"):
-          t"2016-12-31T23:59:60Z".decode[Instant]
+          t"2016-12-31T23:59:60Z".decode[Instant over Posix]
         . assert(_ == Instant(1483228800000L))
 
         test(m"Month-only format"):
-          t"2012-11".decode[Instant]
+          t"2012-11".decode[Instant over Posix]
         . assert(_ == Instant(1351728000000L))
 
         test(m"ISO 8601 with timezone offset and fractional seconds"):
-          t"2023-03-25T10:15:30.456+02:00".decode[Instant]
+          t"2023-03-25T10:15:30.456+02:00".decode[Instant over Posix]
         . assert(_ == Instant(1679732130456L))
 
         test(m"Calendar date, full time, Z"):
-          t"2023-05-28T14:30:59Z".decode[Instant]
+          t"2023-05-28T14:30:59Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Calendar date, basic format, full time, Z"):
-          t"20230528T143059Z".decode[Instant]
+          t"20230528T143059Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Calendar date, full time, offset +00:00"):
-          t"2023-05-28T14:30:59+00:00".decode[Instant]
+          t"2023-05-28T14:30:59+00:00".decode[Instant over Posix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Calendar date, full time, offset +02:00"):
-          t"2023-05-28T14:30:59+02:00".decode[Instant]
+          t"2023-05-28T14:30:59+02:00".decode[Instant over Posix]
         . assert(_ == Instant(1685277059000L))
 
         test(m"Calendar date, full time, offset -05:00"):
-          t"2023-05-28T14:30:59-05:00".decode[Instant]
+          t"2023-05-28T14:30:59-05:00".decode[Instant over Posix]
         . assert(_ == Instant(1685302259000L))
 
         test(m"Calendar date, fractional seconds, Z"):
-          t"2023-05-28T14:30:59.123Z".decode[Instant]
+          t"2023-05-28T14:30:59.123Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284259123L))
 
         test(m"Calendar date, comma as decimal separator, Z"):
-          t"2023-05-28T14:30:59,123Z".decode[Instant]
+          t"2023-05-28T14:30:59,123Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284259123L))
 
         test(m"Calendar date, hours and minutes, Z"):
-          t"2023-05-28T14:30Z".decode[Instant]
+          t"2023-05-28T14:30Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284200000L))
 
         test(m"Calendar date, hour only, Z"):
-          t"2023-05-28T14Z".decode[Instant]
+          t"2023-05-28T14Z".decode[Instant over Posix]
         . assert(_ == Instant(1685282400000L))
 
         test(m"Week date, Sunday of week 21, full time, Z"):
-          t"2023-W21-7T14:30:59Z".decode[Instant]
+          t"2023-W21-7T14:30:59Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Week date, Monday of week 21, full time, Z"):
-          t"2023-W21-1T14:30:59Z".decode[Instant]
+          t"2023-W21-1T14:30:59Z".decode[Instant over Posix]
         . assert(_ == Instant(1684765859000L))
 
         test(m"Week date, basic format, Sunday of week 21, full time, Z"):
-          t"2023W217T143059Z".decode[Instant]
+          t"2023W217T143059Z".decode[Instant over Posix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Start of UNIX epoch"):
-          t"1970-01-01T00:00:00Z".decode[Instant]
+          t"1970-01-01T00:00:00Z".decode[Instant over Posix]
         . assert(_ == Instant(0L))
 
         test(m"Leap day 2020"):
-          t"2020-02-29T12:00:00Z".decode[Instant]
+          t"2020-02-29T12:00:00Z".decode[Instant over Posix]
         . assert(_ == Instant(1582977600000L))
 
         test(m"End of 1999"):
-          t"1999-12-31T23:59:59Z".decode[Instant]
+          t"1999-12-31T23:59:59Z".decode[Instant over Posix]
         . assert(_ == Instant(946684799000L))
 
         test(m"Start of 2000"):
-          t"2000-01-01T00:00:00Z".decode[Instant]
+          t"2000-01-01T00:00:00Z".decode[Instant over Posix]
         . assert(_ == Instant(946684800000L))
 
         test(m"Far future 2199"):
-          t"2199-12-31T23:59:59Z".decode[Instant]
+          t"2199-12-31T23:59:59Z".decode[Instant over Posix]
         . assert(_ == Instant(7258118399000L))
 
         test(m"Far past 1800"):
-          t"1800-01-01T00:00:00Z".decode[Instant]
+          t"1800-01-01T00:00:00Z".decode[Instant over Posix]
         . assert(_ == Instant(-5364662400000L))
 
         test(m"Middle of the day"):
-          t"2023-06-15T12:00:00Z".decode[Instant]
+          t"2023-06-15T12:00:00Z".decode[Instant over Posix]
         . assert(_ == Instant(1686830400000L))
 
         test(m"New Year 2023"):
-          t"2023-01-01T00:00:00Z".decode[Instant]
+          t"2023-01-01T00:00:00Z".decode[Instant over Posix]
         . assert(_ == Instant(1672531200000L))
 
         test(m"DST change irrelevant (UTC)"):
-          t"2021-03-28T01:30:00Z".decode[Instant]
+          t"2021-03-28T01:30:00Z".decode[Instant over Posix]
         . assert(_ == Instant(1616895000000L))
 
         test(m"Millisecond rounding test"):
-          t"2022-11-15T23:59:59Z".decode[Instant]
+          t"2022-11-15T23:59:59Z".decode[Instant over Posix]
         . assert(_ == Instant(1668556799000L))
 
       suite(m"RFC 1123"):
         import instantDecodables.rfc1123InstantDecodable
         test(m"basic with GMT timezone"):
-          t"Sun, 06 Nov 1994 08:49:37 GMT".decode[Instant]
+          t"Sun, 06 Nov 1994 08:49:37 GMT".decode[Instant over Posix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with unusual day of week (consistency check)"):
-          t"Tue, 01 Jan 2019 00:00:00 GMT".decode[Instant]
+          t"Tue, 01 Jan 2019 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1546300800000L))
 
         test(m"Standard RFC1123 date with full weekday and month names"):
-          t"Sun, 06 Nov 1994 08:49:37 GMT".decode[Instant]
+          t"Sun, 06 Nov 1994 08:49:37 GMT".decode[Instant over Posix]
         . assert(_ == Instant(784111777000L))
 
         test(m"Leap day in a leap year"):
-          t"Mon, 29 Feb 2016 12:00:00 GMT".decode[Instant]
+          t"Mon, 29 Feb 2016 12:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1456747200000L))
 
         test(m"Epoch start date"):
-          t"Thu, 01 Jan 1970 00:00:00 GMT".decode[Instant]
+          t"Thu, 01 Jan 1970 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(0L))
 
         test(m"Last second before Y2K"):
-          t"Fri, 31 Dec 1999 23:59:59 GMT".decode[Instant]
+          t"Fri, 31 Dec 1999 23:59:59 GMT".decode[Instant over Posix]
         . assert(_ == Instant(946684799000L))
 
         test(m"First second of Y2K"):
-          t"Sat, 01 Jan 2000 00:00:00 GMT".decode[Instant]
+          t"Sat, 01 Jan 2000 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(946684800000L))
 
         test(m"Date with single-digit day"):
-          capture(t"Wed, 3 Jul 2002 17:45:00 GMT".decode[Instant])
+          capture(t"Wed, 3 Jul 2002 17:45:00 GMT".decode[Instant over Posix])
         . assert(_ == TimeError(_.Format(t"Wed, 3 Jul 2002 17:45:00 GMT", Rfc1123, Prim + 6)(Rfc1123.Issue.Digit)))
 
         test(m"Date with single-digit hour, minute, and second"):
-          t"Tue, 02 Mar 2021 07:08:09 GMT".decode[Instant]
+          t"Tue, 02 Mar 2021 07:08:09 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1614668889000L))
 
         test(m"Date with correct day of week (Monday)"):
-          t"Mon, 15 Aug 2022 18:30:00 GMT".decode[Instant]
+          t"Mon, 15 Aug 2022 18:30:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1660588200000L))
 
         test(m"Incorrect weekday (should be Sunday, not Monday)"):
-          t"Mon, 31 Dec 2006 23:59:59 GMT".decode[Instant]
+          t"Mon, 31 Dec 2006 23:59:59 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1167609599000L))
 
         test(m"Date around DST end (should be in UTC, so no DST effect)"):
-          t"Sun, 01 Nov 2020 01:30:00 GMT".decode[Instant]
+          t"Sun, 01 Nov 2020 01:30:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1604194200000L))
 
         test(m"Far future date (2100)"):
-          t"Fri, 01 Jan 2100 00:00:00 GMT".decode[Instant]
+          t"Fri, 01 Jan 2100 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(4102444800000L))
 
         test(m"Far past date (1900)"):
-          t"Mon, 01 Jan 1900 00:00:00 GMT".decode[Instant]
+          t"Mon, 01 Jan 1900 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(-2208988800000L))
 
         test(m"Time with 2-digit hour 23"):
-          t"Wed, 08 Sep 2021 23:00:00 GMT".decode[Instant]
+          t"Wed, 08 Sep 2021 23:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1631142000000L))
 
         test(m"Midday exactly (12:00:00)"):
-          t"Sat, 25 Dec 2021 12:00:00 GMT".decode[Instant]
+          t"Sat, 25 Dec 2021 12:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1640433600000L))
 
         test(m"New Year's Eve (2022)"):
-          t"Sat, 31 Dec 2022 23:59:59 GMT".decode[Instant]
+          t"Sat, 31 Dec 2022 23:59:59 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1672531199000L))
 
         test(m"Short month name test (Jan)"):
-          t"Sun, 01 Jan 2023 00:00:00 GMT".decode[Instant]
+          t"Sun, 01 Jan 2023 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1672531200000L))
 
         test(m"Minimum valid time (00:00:00)"):
-          t"Sun, 10 Oct 2021 00:00:00 GMT".decode[Instant]
+          t"Sun, 10 Oct 2021 00:00:00 GMT".decode[Instant over Posix]
         . assert(_ == Instant(1633824000000L))
 
       suite(m"Working days tests"):
@@ -1311,22 +1312,22 @@ object Tests extends Suite(m"Aviation Tests"):
       import instantDecodables.iso8601InstantDecodable
 
       test(m"Non-digit at year start raises"):
-        capture(t"abcd-01-01".decode[Instant])
+        capture(t"abcd-01-01".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
       test(m"Truncated year raises"):
-        capture(t"20".decode[Instant])
+        capture(t"20".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
       test(m"Trailing junk after seconds raises"):
-        capture(t"2024-01-01T12:00:00garbage".decode[Instant])
+        capture(t"2024-01-01T12:00:00garbage".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
       test(m"Bad week-date letter raises"):
-        capture(t"2024-X21-1".decode[Instant])
+        capture(t"2024-X21-1".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
@@ -1334,22 +1335,22 @@ object Tests extends Suite(m"Aviation Tests"):
       import instantDecodables.rfc1123InstantDecodable
 
       test(m"Lowercase day name raises"):
-        capture(t"sun, 06 Nov 1994 08:49:37 GMT".decode[Instant])
+        capture(t"sun, 06 Nov 1994 08:49:37 GMT".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
       test(m"Wrong month abbreviation raises"):
-        capture(t"Sun, 06 Jux 1994 08:49:37 GMT".decode[Instant])
+        capture(t"Sun, 06 Jux 1994 08:49:37 GMT".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
       test(m"Missing trailing GMT raises"):
-        capture(t"Sun, 06 Nov 1994 08:49:37".decode[Instant])
+        capture(t"Sun, 06 Nov 1994 08:49:37".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
       test(m"Truncated input raises"):
-        capture(t"Sun, ".decode[Instant])
+        capture(t"Sun, ".decode[Instant over Posix])
       . matches:
           case _: TimeError =>
 
@@ -1658,26 +1659,29 @@ object Tests extends Suite(m"Aviation Tests"):
           gregorianCalendar.diurnal(date)() )
       . assert(_ == (1799, Nov, 9))
 
-    suite(m"Leap-second strategies"):
+    suite(m"Chronometry conversions"):
       val newYear = 1483228800000L // 2017-01-01 00:00:00 UTC, just after the 2016 leap second
 
-      test(m"Leap seconds are ignored by default"):
-        summon[LeapSeconds.Strategy].tai(newYear)
-      . assert(_ == newYear)
-
-      test(m"The step strategy counts elapsed leap seconds"):
-        import leapSeconds.step
-        summon[LeapSeconds.Strategy].tai(newYear) - newYear
+      test(m"Converting a POSIX instant to TAI counts elapsed leap seconds"):
+        Instant(newYear).over[Tai].long - newYear
       . assert(_ == LeapSeconds.tai(newYear) - newYear)
 
       test(m"Across the 2016 leap second the TAI offset gains one second"):
         LeapSeconds.tai(newYear) - LeapSeconds.tai(newYear - 60000L)
       . assert(_ == 61000L)
 
-      test(m"The smear strategy is chosen by import"):
-        import leapSeconds.smear
-        summon[LeapSeconds.Strategy].tai(newYear)
-      . assert(_ == LeapSeconds.smearTai(newYear))
+      test(m"A POSIX instant round-trips through TAI"):
+        val instant = Instant(newYear)
+        instant.over[Tai].over[Posix] == instant
+      . assert(_ == true)
+
+      test(m"Subtracting instants on different timelines is a compile error"):
+        demilitarize(Instant(newYear).over[Tai] - Instant(newYear))
+      . assert(_.nonEmpty)
+
+      test(m"untai inverts the discrete step"):
+        LeapSeconds.untai(LeapSeconds.tai(newYear)) == newYear
+      . assert(_ == true)
 
       test(m"Smearing matches discrete TAI far from any leap second"):
         val midYear = 1490000000000L // 2017-03-20, no nearby leap second
@@ -1764,7 +1768,7 @@ object Tests extends Suite(m"Aviation Tests"):
       test(m"Clock.offset reflects an offset"):
         val before = java.lang.System.currentTimeMillis
         val clock = Clock.offset(60*Second)
-        val result: Instant = clock()
+        val result = clock()
         val after = java.lang.System.currentTimeMillis
         result.long >= (before + 60_000L) && result.long <= (after + 60_001L)
       . assert(_ == true)
@@ -1850,22 +1854,22 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_ == Timestamp(1970-Jan-1, Clockface(0, 0, 0)))
 
       test(m"Same instant in London during winter is GMT (offset 0)"):
-        val winter = t"2024-01-15T12:00:00Z".decode[Instant](using instantDecodables.iso8601InstantDecodable)
+        val winter = t"2024-01-15T12:00:00Z".decode[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
         winter.in(tz"Europe/London").time.hour
       . assert(_ == 12)
 
       test(m"Same instant in London during summer is BST (offset +1)"):
-        val summer = t"2024-07-15T12:00:00Z".decode[Instant](using instantDecodables.iso8601InstantDecodable)
+        val summer = t"2024-07-15T12:00:00Z".decode[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
         summer.in(tz"Europe/London").time.hour
       . assert(_ == 13)
 
       test(m"New York winter offset (UTC-5)"):
-        val winter = t"2024-01-15T12:00:00Z".decode[Instant](using instantDecodables.iso8601InstantDecodable)
+        val winter = t"2024-01-15T12:00:00Z".decode[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
         winter.in(tz"America/New_York").time.hour
       . assert(_ == 7)
 
       test(m"New York summer offset (UTC-4)"):
-        val summer = t"2024-07-15T12:00:00Z".decode[Instant](using instantDecodables.iso8601InstantDecodable)
+        val summer = t"2024-07-15T12:00:00Z".decode[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
         summer.in(tz"America/New_York").time.hour
       . assert(_ == 8)
 
@@ -1879,24 +1883,24 @@ object Tests extends Suite(m"Aviation Tests"):
       // 00:30 UTC (BST), then again at 01:30 UTC (GMT).
       test(m"DST fall-back: earlier overlap occurrence round-trips through London"):
         import instantDecodables.iso8601InstantDecodable
-        val earlier = t"2024-10-27T00:30:00Z".decode[Instant]
+        val earlier = t"2024-10-27T00:30:00Z".decode[Instant over Posix]
         earlier.in(tz"Europe/London").instant == earlier
       . assert(_ == true)
 
       test(m"DST fall-back: later overlap occurrence round-trips through London"):
         import instantDecodables.iso8601InstantDecodable
-        val later = t"2024-10-27T01:30:00Z".decode[Instant]
+        val later = t"2024-10-27T01:30:00Z".decode[Instant over Posix]
         later.in(tz"Europe/London").instant == later
       . assert(_ == true)
 
       test(m"DST fall-back: later overlap occurrence is flagged Second"):
         import instantDecodables.iso8601InstantDecodable
-        t"2024-10-27T01:30:00Z".decode[Instant].in(tz"Europe/London").occurrence
+        t"2024-10-27T01:30:00Z".decode[Instant over Posix].in(tz"Europe/London").occurrence
       . assert(_ == Occurrence.Second)
 
       test(m"DST fall-back: earlier overlap occurrence is flagged First"):
         import instantDecodables.iso8601InstantDecodable
-        t"2024-10-27T00:30:00Z".decode[Instant].in(tz"Europe/London").occurrence
+        t"2024-10-27T00:30:00Z".decode[Instant over Posix].in(tz"Europe/London").occurrence
       . assert(_ == Occurrence.First)
 
       test(m"The two overlap occurrences ground one hour apart"):
@@ -1911,14 +1915,14 @@ object Tests extends Suite(m"Aviation Tests"):
       test(m"Spring-forward gap pushes forward by default"):
         import instantDecodables.iso8601InstantDecodable
         val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
-        grounded == t"2024-03-31T01:30:00Z".decode[Instant]
+        grounded == t"2024-03-31T01:30:00Z".decode[Instant over Posix]
       . assert(_ == true)
 
       test(m"Spring-forward gap can push backward"):
         import instantDecodables.iso8601InstantDecodable
         import gapPolicies.pushBackward
         val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
-        grounded == t"2024-03-31T00:30:00Z".decode[Instant]
+        grounded == t"2024-03-31T00:30:00Z".decode[Instant over Posix]
       . assert(_ == true)
 
       test(m"Spring-forward gap can be rejected"):
@@ -2034,7 +2038,7 @@ object Tests extends Suite(m"Aviation Tests"):
         demilitarize(ts"${2024}")
       . assert(_.nonEmpty)
 
-    suite(m"TaiInstant and leap-second conversion"):
+    suite(m"Atomic time (TAI) conversion"):
       import calendars.gregorianCalendar
       import instantDecodables.iso8601InstantDecodable
 
@@ -2053,20 +2057,18 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_ == 12_000L)
 
       test(m"Instant in 2017 has +37 offset"):
-        val later = t"2017-06-15T00:00:00Z".decode[Instant](using instantDecodables.iso8601InstantDecodable)
+        val later = t"2017-06-15T00:00:00Z".decode[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
         LeapSeconds.tai(later.long) - later.long
       . assert(_ == 37_000L)
 
-      test(m"Instant.tai counts leap seconds under the step strategy"):
-        import leapSeconds.step
-        val later = t"2017-06-15T00:00:00Z".decode[Instant]
-        later.tai.long - later.long
+      test(m"Instant.over[Tai] counts leap seconds"):
+        val later = t"2017-06-15T00:00:00Z".decode[Instant over Posix]
+        later.over[Tai].long - later.long
       . assert(_ == 37_000L)
 
-      test(m"TaiInstant.instant inverts Instant.tai under the smear strategy"):
-        import leapSeconds.smear
-        val instant = t"2017-06-15T00:00:00Z".decode[Instant]
-        instant.tai.instant == instant
+      test(m"An instant round-trips through TAI and back to POSIX"):
+        val instant = t"2017-06-15T00:00:00Z".decode[Instant over Posix]
+        instant.over[Tai].over[Posix] == instant
       . assert(_ == true)
 
       test(m"unsmearTai inverts smearTai across a leap window"):
@@ -2076,11 +2078,10 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"An inserted leap second grounds to the following second"):
         val leapMoment = Moment(2016-Dec-31, Clockface(23, 59, 59), tz"UTC", leap = Leap.Inserted)
-        leapMoment.instant == t"2017-01-01T00:00:00Z".decode[Instant]
+        leapMoment.instant == t"2017-01-01T00:00:00Z".decode[Instant over Posix]
       . assert(_ == true)
 
       test(m"An inserted leap second's TAI is one second before the following second"):
-        import leapSeconds.step
         val leapMoment = Moment(2016-Dec-31, Clockface(23, 59, 59), tz"UTC", leap = Leap.Inserted)
         val nextSecond = Moment(2017-Jan-1, Clockface(0, 0, 0), tz"UTC")
         nextSecond.tai.long - leapMoment.tai.long

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -374,6 +374,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       // millis; Aviation's own `Instant` abstractable/instantiable instances are found
       // via its companion, so `embarcadero` needs no dependency on Aviation.
       import abstractables.instantAbstractable
+      import chronometries.posix
       val moment = Instant(1_700_000_001_000L)
 
       test(m"a Container timestamp round-trips and converts to an Aviation Instant"):

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -379,5 +379,5 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       test(m"a Container timestamp round-trips and converts to an Aviation Instant"):
         val container = Container(t"svc", createdAt = embarcadero.Timestamp.of(moment))
         val restored = Stream(container.protobuf.encode).read[Container in Protobuf]
-        restored.createdAt.instant[Instant]
+        restored.createdAt.instant[Instant over Posix]
       . assert(_ == moment)

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -854,6 +854,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       import decodables.instantJsonDecodable
       import decodables.durationJsonDecodable
       import aviation.*
+      import chronometries.posix
       import abstractables.instantAbstractable
 
       test(m"Encode an Instant as a Long"):
@@ -861,11 +862,11 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == t"1700000000000")
 
       test(m"Decode an Instant from a Long"):
-        t"1700000000000".read[Json].as[Instant].long
+        t"1700000000000".read[Json].as[Instant over Posix].long
       . assert(_ == 1700000000000L)
 
       test(m"Round-trip an Instant"):
-        Instant(1234567890L).json.as[Instant].long
+        Instant(1234567890L).json.as[Instant over Posix].long
       . assert(_ == 1234567890L)
 
       test(m"Encode a Duration as a Long of milliseconds"):

--- a/lib/jacinta/src/time/jacinta_time.scala
+++ b/lib/jacinta/src/time/jacinta_time.scala
@@ -35,19 +35,19 @@ package jacinta
 import anticipation.*
 import aviation.*
 import contingency.*
+import prepositional.*
 
 package encodables:
-  given instantJsonEncodable: Instant is Json.Encodable =
+  given instantJsonEncodable: (Instant over Posix) is Json.Encodable =
     Json.Encodable(Morphology.Whole): instant => Json(instant.long)
 
   given durationJsonEncodable: Duration is Json.Encodable =
     Json.Encodable(Morphology.Whole): duration => Json((duration.value*1000).toLong)
 
 package decodables:
-  given instantJsonDecodable: Tactic[JsonError] => Instant is Json.Decodable =
+  given instantJsonDecodable: Tactic[JsonError] => (Instant over Posix) is Json.Decodable =
     Json.Decodable(Morphology.Whole): json =>
-      import abstractables.instantAbstractable
-      Instant(json.as[Long])
+      Instant.of[Posix](json.as[Long])
 
   given durationJsonDecodable: Tactic[JsonError] => Duration is Json.Decodable =
     Json.Decodable(Morphology.Whole): json => Duration(json.as[Long])

--- a/lib/stratiform/src/time/stratiform_time.scala
+++ b/lib/stratiform/src/time/stratiform_time.scala
@@ -35,6 +35,7 @@ package stratiform
 import anticipation.*
 import aviation.*
 import contingency.*
+import prepositional.*
 
 // Aviation integration: encode TEL atom values to/from Aviation's
 // Instant and Duration types. Mirroring jacinta.time, the codecs are
@@ -42,7 +43,7 @@ import contingency.*
 // clash with project-wide default encodings.
 
 package encodables:
-  given instantTelEncodable: Instant is Tel.Encodable =
+  given instantTelEncodable: (Instant over Posix) is Tel.Encodable =
     Tel.Encodable(Morphology.Whole): instant => Tel.scalar(instant.long.toString.tt)
 
   given durationTelEncodable: Duration is Tel.Encodable =
@@ -51,11 +52,9 @@ package encodables:
 
 package decodables:
   given instantTelDecodable: Tactic[TelError]
-  =>  Instant is Tel.Decodable =
+  =>  (Instant over Posix) is Tel.Decodable =
     Tel.Decodable(Morphology.Whole): tel =>
-      import abstractables.instantAbstractable
-
-      try Instant(tel.primaryAtom.s.toLong)
+      try Instant.of[Posix](tel.primaryAtom.s.toLong)
       catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
 
   given durationTelDecodable: Tactic[TelError]


### PR DESCRIPTION
An `Instant` is now `Instant over X`, where the phantom `X` — a *chronometry* — says which timeline its underlying `Long` counts on (Unix/POSIX, TAI, …). It's set by the unbounded `over` preposition, so an instant stays an unboxed `long`, and `Instant over Posix` and `Instant over Tai` are distinct types over the same grid.

A `Chronometry` given interprets each timeline by converting to and from TAI (the one strictly-linear scale), and `instant.over[X]` re-interprets across timelines, composing through TAI. Subtracting two instants on *different* timelines is a compile error; on the same timeline it yields a `Duration` in that timeline's seconds — so a `Period[Tai]` measures SI seconds and a `Period[Posix]` POSIX seconds (the type-safety #1409 asked for).

```scala
import calendars.gregorianCalendar, chronometries.posix
val t = Instant(1483228800000L)   // Instant over Posix (default chosen by import)
t.over[Tai]                       // counts the elapsed leap seconds
t.over[Tai].over[Posix] == t      // round-trips
```

`TaiInstant` is removed — it is `Instant over Tai`. The old `LeapSeconds.Strategy` (step/smear/ignored) collapses into chronometries: `Posix`'s conversion is the leap-second step, with a new `LeapSeconds.untai` as its inverse. The default interpretation of plain `Instant`s, `now()`, and decoded epoch-millis is chosen by importing a `chronometries.*` given (e.g. `import chronometries.posix`). `Moment.instant`, `Clock`, and the ISO-8601/RFC-1123 parsers ground to `Instant over Posix`; `Moment.tai` is `instant.over[Tai]`.

Nanosecond and monotonic-clock chronometries are a planned follow-up (the conversion's working unit becomes part of the chronometry).