### PR TITLE
Generalise Period over any point type and add segment splitting

### DIFF
--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -40,8 +40,7 @@ import hieroglyph.*, textMetrics.uniformMetric
 import hypotenuse.*
 import prepositional.*
 import spectacular.*
-
-import abstractables.instantAbstractable
+import symbolism.*
 
 object Moment:
   given generic: RomanCalendar => Moment is Abstractable across Instants to Long =
@@ -53,6 +52,11 @@ object Moment:
     summon[(Instant over Posix) is Orderable].contramap(_.instant)
 
   given ordering: (RomanCalendar, GapPolicy) => Ordering[Moment] = Ordering.by(_.instant.long)
+
+  // The physical time between two moments — the difference of their grounded instants, in seconds —
+  // so it honours DST and (under a counting interpretation) leap seconds.
+  given subtractable: (RomanCalendar, GapPolicy) => Moment is Subtractable by Moment to Duration =
+    (later, earlier) => later.instant - earlier.instant
 
   // An ISO-8601 zoned date-time, e.g. `2016-12-31T23:59:60+00:00`. An inserted leap second renders
   // as the 61st second (`:60`); the offset is the zone's offset at this moment's instant.

--- a/lib/aviation/src/core/aviation.Period.scala
+++ b/lib/aviation/src/core/aviation.Period.scala
@@ -32,21 +32,44 @@
                                                                                                   */
 package aviation
 
-import hypotenuse.*
 import prepositional.*
 import symbolism.*
 import vacuous.*
 
-// A range between two instants on the same timeline; its `duration` is measured in that timeline's
-// seconds (so a `Period[Tai]` counts SI seconds, a `Period[Posix]` POSIX seconds).
-case class Period[transport](start: Instant over transport, finish: Instant over transport):
-  def duration: Duration = finish - start
+object Period:
+  // Split a period into consecutive `length`-long segments. The step is whatever the point can be
+  // advanced by — a `Duration` or `Timespan` for an `Instant over X`, a `Timespan` for a
+  // `Timestamp`/`Moment` (irregular spans pull in their `Calendar`/`Disambiguation`). When `length`
+  // doesn't divide the period exactly, `partial` decides whether the short final segment is kept.
+  extension [point](period: Period[point])
+    def segments[step](length: step, partial: Boolean = true)
+      ( using addable: point is Addable by step to point, order: Ordering[point] )
+    :   List[Period[point]] =
 
-  def intersect(period: Period[transport]): Optional[Period[transport]] =
-    val start2 = period.start.max(start)
-    val finish2 = period.finish.min(finish)
-    if start2 >= finish2 then Unset else Period(start2, finish2)
+      @scala.annotation.tailrec
+      def recur(current: point, acc: List[Period[point]]): List[Period[point]] =
+        if !order.gt(period.finish, current) then acc.reverse else
+          val next = current + length
 
-  def union(period: Period[transport]): Set[Period[transport]] =
+          if !order.gt(next, current) || order.gt(next, period.finish)
+          then (if partial then Period(current, period.finish) :: acc else acc).reverse
+          else recur(next, Period(current, next) :: acc)
+
+      recur(period.start, Nil)
+
+// A range between two points of the same type — an `Instant over X`, a `Timestamp`, or a `Moment`.
+// `duration` is the points' difference, whose type follows the point: a `Duration` for an
+// `Instant over X` (in that timeline's seconds), a `Timespan` for a `Timestamp`/`Moment`. (Ordering
+// uses the non-inline `Ordering`, since the point is abstract here.)
+case class Period[point](start: point, finish: point):
+  def duration(using subtractable: point is Subtractable by point): subtractable.Result =
+    subtractable.subtract(finish, start)
+
+  def intersect(period: Period[point])(using order: Ordering[point]): Optional[Period[point]] =
+    val start2 = order.max(period.start, start)
+    val finish2 = order.min(period.finish, finish)
+    if order.gteq(start2, finish2) then Unset else Period(start2, finish2)
+
+  def union(period: Period[point])(using order: Ordering[point]): Set[Period[point]] =
     if intersect(period).absent then Set(this, period)
-    else Set(Period(start.min(period.start), finish.max(period.finish)))
+    else Set(Period(order.min(start, period.start), order.max(finish, period.finish)))

--- a/lib/aviation/src/core/aviation.protointernal.scala
+++ b/lib/aviation/src/core/aviation.protointernal.scala
@@ -122,7 +122,7 @@ object protointernal:
         Instant.of(raw(instant) + (duration.normalize.value*1000.0).toLong)
 
     // The difference of two instants on the same timeline is a `Duration` measured in that
-    // timeline's seconds; subtracting across timelines is a type error (convert with `.over` first).
+    // timeline's seconds; subtracting across timelines is a type error (convert with `.over`).
     given minus: [transport]
     =>  (Instant over transport) is Subtractable by (Instant over transport) to Duration =
       (left, right) => Quantity((raw(left) - raw(right))/1000.0)
@@ -139,10 +139,12 @@ object protointernal:
     // Re-interpret this instant on another timeline, composing through TAI.
     def over[target](using from: transport is Chronometry, to: target is Chronometry)
     :   Instant over target =
+
       Instant.of(to.fromTai(from.toTai(raw(instant))))
 
     @targetName("to")
-    infix def ~ (that: Instant over transport): Period[transport] = Period(instant, that)
+    infix def ~ (that: Instant over transport): Period[Instant over transport] =
+      Period(instant, that)
 
     infix def in (using RomanCalendar, transport is Chronometry)(timezone: Timezone): Moment =
       val unix = instant.over[Posix].long
@@ -172,5 +174,5 @@ object protointernal:
 
 
   extension (duration: into[Duration])
-    def from[transport](instant: Instant over transport): Period[transport] =
+    def from[transport](instant: Instant over transport): Period[Instant over transport] =
       Period(instant, Instant.plus.add(instant, duration))

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -1836,6 +1836,48 @@ object Tests extends Suite(m"Aviation Tests"):
         a.union(b).size
       . assert(_ == 2)
 
+    suite(m"Period segments"):
+      import calendars.gregorianCalendar
+
+      test(m"An evenly-divisible period splits into equal segments"):
+        (Instant(0L) ~ Instant(3_600_000L)).segments(15*Minute).length
+      . assert(_ == 4)
+
+      test(m"Segment boundaries are consecutive"):
+        (Instant(0L) ~ Instant(3_600_000L)).segments(15*Minute).map(_.start.long)
+      . assert(_ == List(0L, 900_000L, 1_800_000L, 2_700_000L))
+
+      test(m"A remainder is kept as a short final segment when partial is true"):
+        (Instant(0L) ~ Instant(3_600_000L)).segments(25*Minute, partial = true).length
+      . assert(_ == 3)
+
+      test(m"A remainder is dropped when partial is false"):
+        (Instant(0L) ~ Instant(3_600_000L)).segments(25*Minute, partial = false).length
+      . assert(_ == 2)
+
+      test(m"The final partial segment ends at the period's finish"):
+        (Instant(0L) ~ Instant(3_600_000L)).segments(25*Minute).last.finish.long
+      . assert(_ == 3_600_000L)
+
+      test(m"A period can be split by a Duration"):
+        (Instant(0L) ~ Instant(3_600_000L)).segments(Quantity[Seconds[1]](1200.0)).length
+      . assert(_ == 3)
+
+      test(m"A Timestamp period splits by a Timespan"):
+        val period = Period(Timestamp(2024-Jan-1, Clockface(0, 0, 0)),
+            Timestamp(2024-Jan-2, Clockface(0, 0, 0)))
+        period.segments(6*Hour).length
+      . assert(_ == 4)
+
+    suite(m"Moment subtraction"):
+      import calendars.gregorianCalendar
+
+      test(m"Subtracting two moments gives the physical duration between them"):
+        val later = Moment(2024-Jan-1, Clockface(1, 0, 0), tz"UTC")
+        val earlier = Moment(2024-Jan-1, Clockface(0, 0, 0), tz"UTC")
+        (later - earlier).value
+      . assert(_ == 3600.0)
+
     suite(m"Moment and Timezone"):
       import calendars.gregorianCalendar
 


### PR DESCRIPTION
`Period` is now `Period[point]`, ranging over any temporal point — `Instant over X`, `Timestamp`, or `Moment` — rather than only instants (resolving #1409). Its operations follow the point type: `duration` returns whatever `point − point` yields (a `Duration` for `Instant over X`, a `Timespan` for civil points), and `intersect`/`union` use the point's `Ordering`.

The new `Period.segments` splits a period into consecutive fixed-length segments. The step is whatever the point can be advanced by, so the length type is `Duration` *or* `Timespan` depending on the period — and an irregular `Timespan` step transparently pulls in the `Calendar`/`Disambiguation` its arithmetic needs:

```scala
import calendars.gregorianCalendar
(Instant(0L) ~ Instant(3_600_000L)).segments(15*Minute)        // four 15-minute Periods
Period(ts1, ts2).segments(6*Hour)                              // civil periods split by a Timespan
(a ~ b).segments(25*Minute, partial = false)                   // drop the short final segment
```

When `length` doesn't divide the period exactly, the `partial` flag decides whether the short final segment (up to `finish`) is kept (default `true`).

`Moment − Moment` now yields the physical `Duration` between two moments (the difference of their grounded instants), so `Period[Moment]` is fully featured.

Resolves #1409.