### PR TITLE
Make Timespan's ISO-8601 form encode-only; add a relative Showable

### DIFF
--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -92,7 +92,8 @@ object Timespan:
     else if time == t"" then t"P$date"
     else t"P${date}T$time"
 
-  given showable: Timespan is Showable = renderDuration(_)
+  // The ISO-8601 duration is the encoded (machine) form; a human-readable `Showable` is opt-in via
+  // `import timespanFormats.relativeTimespan`.
   given encodable: Timespan is Encodable in Text = renderDuration(_)
 
   // Runtime parse of an ISO-8601 duration; shares `parseDuration` with the `dur"…"` interpolator.

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -322,6 +322,36 @@ package timeFormats:
     given noneTimeSeparator: TimeSeparation = () => t""
     given frenchTimeSeparator: TimeSeparation = () => t"h"
 
+// A human-readable, relative rendering of a `Timespan`, in place of the default ISO-8601 duration:
+// "in 18 minutes", "in 1 hour and 6 seconds", "8 minutes ago", "12 hours and 38 minutes ago", and
+// "just now" for a zero span. Only the non-zero components are shown (coarsest first); the sign
+// chooses "in …" / "… ago". `import timespanFormats.relativeTimespan` to use it.
+package timespanFormats:
+  given relativeTimespan: Timespan is Showable = timespan =>
+    val fields: List[(Long, Text, Text)] =
+      List
+        ( (timespan.years.toLong,         t"year",   t"years"),
+          (timespan.months.toLong,        t"month",  t"months"),
+          (timespan.weeks.toLong,         t"week",   t"weeks"),
+          (timespan.days.toLong,          t"day",    t"days"),
+          (timespan.hours.toLong,         t"hour",   t"hours"),
+          (timespan.minutes.toLong,       t"minute", t"minutes"),
+          (timespan.seconds.value.toLong, t"second", t"seconds") )
+
+    val nonZero = fields.filter(_._1 != 0)
+
+    if nonZero.isEmpty then t"just now" else
+      val rendered = nonZero.map: field =>
+        val magnitude = field._1.abs
+        t"$magnitude ${if magnitude == 1 then field._2 else field._3}"
+
+      val joined =
+        rendered match
+          case List(one) => one
+          case many      => t"${many.init.join(t", ")} and ${many.last}"
+
+      if nonZero.head._1 < 0 then t"$joined ago" else t"in $joined"
+
 package calendars:
   given julianCalendar: RomanCalendar(t"Julian"):
     def leapYear(year: Annual): Boolean = year()%4 == 0
@@ -370,8 +400,8 @@ package calendars:
       import calendars.gregorianCalendar
       unsafely(Date(year, Feb, Day(29)))
 
-// The default interpretation of an `Instant`'s `Long` (used by `Instant(…)`, decoding, etc.). Import
-// one of these to choose the timeline bare instants count on; convert explicitly with `.over[…]`.
+// The default interpretation of an `Instant`'s `Long` (used by `Instant(…)`, decoding, etc.).
+// Import one of these to choose the timeline bare instants count on; convert with `.over[…]`.
 package chronometries:
   given posix: (Chronometry.Ambient { type Transport = Posix }) =
     new Chronometry.Ambient:

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -102,6 +102,9 @@ package timeFormats:
     . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
         ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
 
+package timespanFormats:
+  export aviation.timespanFormats.relativeTimespan
+
 package hourFormats:
   export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
 

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2150,17 +2150,17 @@ object Tests extends Suite(m"Aviation Tests"):
         List(later, earlier).sorted == List(earlier, later)
       . assert(_ == true)
 
-      test(m"A Timespan renders as an ISO-8601 duration"):
+      test(m"A Timespan encodes as an ISO-8601 duration"):
         Timespan(years = 1, months = 2, days = 3, hours = 4, minutes = 5, seconds = Quantity(6.0))
-        . show
+        . encode
       . assert(_ == t"P1Y2M3DT4H5M6S")
 
-      test(m"A zero Timespan renders as PT0S"):
-        Timespan().show
+      test(m"A zero Timespan encodes as PT0S"):
+        Timespan().encode
       . assert(_ == t"PT0S")
 
-      test(m"Fractional seconds render with a decimal point"):
-        Timespan(seconds = Quantity(1.5)).show
+      test(m"Fractional seconds encode with a decimal point"):
+        Timespan(seconds = Quantity(1.5)).encode
       . assert(_ == t"PT1.5S")
 
       test(m"An ISO-8601 duration parses to a Timespan"):
@@ -2170,7 +2170,7 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"A week-and-time duration round-trips through text"):
         val span = Timespan(weeks = 2, hours = 12, minutes = 30)
-        span.show.decode[Timespan] == span
+        span.encode.decode[Timespan] == span
       . assert(_ == true)
 
       test(m"A bare P is not a valid duration"):
@@ -2193,6 +2193,37 @@ object Tests extends Suite(m"Aviation Tests"):
       test(m"A dur literal with a substitution is a compile error"):
         demilitarize(dur"${1}")
       . assert(_.nonEmpty)
+
+    suite(m"Relative timespan formatting"):
+      import timespanFormats.relativeTimespan
+
+      test(m"A future single component reads as \"in …\""):
+        Timespan(minutes = 18).show
+      . assert(_ == t"in 18 minutes")
+
+      test(m"A future two-component span joins with \"and\""):
+        Timespan(hours = 1, seconds = Quantity(6.0)).show
+      . assert(_ == t"in 1 hour and 6 seconds")
+
+      test(m"A past single component reads as \"… ago\""):
+        Timespan(minutes = -8).show
+      . assert(_ == t"8 minutes ago")
+
+      test(m"A past two-component span reads as \"… ago\""):
+        Timespan(hours = -12, minutes = -38).show
+      . assert(_ == t"12 hours and 38 minutes ago")
+
+      test(m"A singular component is not pluralised"):
+        Timespan(hours = 1).show
+      . assert(_ == t"in 1 hour")
+
+      test(m"Three components use commas and a final \"and\""):
+        Timespan(hours = 2, minutes = 5, seconds = Quantity(3.0)).show
+      . assert(_ == t"in 2 hours, 5 minutes and 3 seconds")
+
+      test(m"A zero timespan reads as \"just now\""):
+        Timespan().show
+      . assert(_ == t"just now")
 
     suite(m"Horology sexagesimal"):
       val horology = Horology.sexagesimal


### PR DESCRIPTION
`Timespan`'s ISO-8601 duration is now only its `Encodable in Text` (the machine form, via `.encode`); the companion `Showable` is dropped, so a `Timespan` has no default `.show`. In its place, an import-only `Showable` renders a span as relative natural language:

```scala
import timespanFormats.relativeTimespan
Timespan(minutes = 18).show                       // "in 18 minutes"
Timespan(hours = 1, seconds = Quantity(6.0)).show // "in 1 hour and 6 seconds"
Timespan(minutes = -8).show                       // "8 minutes ago"
Timespan(hours = -12, minutes = -38).show         // "12 hours and 38 minutes ago"
Timespan().show                                   // "just now"
```

Only the non-zero components are shown (coarsest first) with singular/plural agreement; the sign chooses "in …" / "… ago", and multiple components join with commas and a final "and". No module depends on a `Showable[Timespan]`, so dropping the default is safe.