### PR TITLE
Aviation: Period.has, working-day subtraction, month-precise Monthstamp, ordinal dates

### DIFF
--- a/lib/aviation/src/core/aviation.Month.scala
+++ b/lib/aviation/src/core/aviation.Month.scala
@@ -64,7 +64,7 @@ object Month extends MonthRadix:
     type Result = Monthstamp
     type Operand = Month
 
-    def subtract(year: Int, month: Month) = new Monthstamp(Year(year), month)
+    def subtract(year: Int, month: Month) = Monthstamp(Year(year), month)
 
   // An inline-friendly counterpart so that, after inlining, `year - month` is the literal
   // construction `Monthstamp(Year(year), month)` — letting the `Monthstamp - day` macro recover

--- a/lib/aviation/src/core/aviation.Monthstamp.scala
+++ b/lib/aviation/src/core/aviation.Monthstamp.scala
@@ -33,31 +33,19 @@
 package aviation
 
 import contingency.*
-import gossamer.*
-import spectacular.*
+import prepositional.*
 import symbolism.*
 
+// A `Monthstamp` is a month-precise `Timestamp` — the first instant of a (Gregorian) month, tagged
+// with `Month` precision. Construction clamps to the 1st, so two `Monthstamp`s for the same month
+// are equal; whole-month/year arithmetic stays month-precise, and `monthstamp - dayOfMonth` is that
+// day's `Date` (the `2012-Mar - 8` form). Its givens/accessors live in `object Timestamp`
+// (timestampInternal), where they're in the implicit scope of `Timestamp in Month`.
+type Monthstamp = Timestamp in Month
+
 object Monthstamp:
-  given showable: (months: Months, separation: DateSeparation, endianness: Endianness, years: Years)
-  =>  Monthstamp is Showable =
-
-    monthstamp =>
-      endianness match
-        case Endianness.LittleEndian =>
-          t"${monthstamp.year}${separation.separator}${monthstamp.month}"
-
-        case _ =>
-          t"${monthstamp.month}${separation.separator}${monthstamp.year}"
-
-
-  // The result-type witness and the fallback for non-operator call sites; defaults to the
-  // Gregorian calendar, preserving the historical behaviour of `monthstamp - day`.
-  given subtractable: Monthstamp is Subtractable:
-    type Result = Date
-    type Operand = Int
-
-    def subtract(monthstamp: Monthstamp, day: Int): Date =
-      unsafely(calendars.gregorianCalendar.jdn(monthstamp.year, monthstamp.month, Day(day)))
+  def apply(year: Year, month: Month): Monthstamp =
+    unsafely(calendars.gregorianCalendar.jdn(year, month, Day(1))).asInstanceOf[Monthstamp]
 
   // The inline path the `-` operator prefers: when the year, month and day are all literals it
   // validates the date at compile time against the contextually-resolved calendar (raising a
@@ -69,7 +57,3 @@ object Monthstamp:
 
     inline def op(left: Monthstamp, right: Int): Date =
       ${aviation.internal.monthstampMinus('left, 'right)}
-
-  inline given monthstampSubtraction: MonthstampSubtraction = MonthstampSubtraction()
-
-case class Monthstamp(year: Year, month: Month)

--- a/lib/aviation/src/core/aviation.OrdinalCalendar.scala
+++ b/lib/aviation/src/core/aviation.OrdinalCalendar.scala
@@ -32,26 +32,40 @@
                                                                                                   */
 package aviation
 
+import anticipation.*
 import contingency.*
-import symbolism.*
+import gossamer.*
 
-// A `Monthstamp` is a month-precise `Timestamp` — the first instant of a (Gregorian) month, tagged
-// with `Month` precision. Construction clamps to the 1st, so same-month stamps are equal;
-// whole-month/year arithmetic stays month-precise, and `monthstamp - dayOfMonth` is that day's
-// `Date` (the `2012-Mar - 8` form). The `type Monthstamp` alias and its givens/accessors live in
-// `timestampInternal` (the implicit scope of `Timestamp in Month`); this object holds only the
-// factory and the compile-time `-` operator.
-object Monthstamp:
-  def apply(year: Year, month: Month): Monthstamp =
-    unsafely(calendars.gregorianCalendar.jdn(year, month, Day(1))).asInstanceOf[Monthstamp]
+// A calendar with no months: a date is a year plus a day-of-year (1–366) — the ISO-8601 "ordinal
+// date" form, e.g. day 247 of 2024. Year boundaries are delegated to the Gregorian calendar; the
+// single vestigial "month" (`Annus`) spans the whole year, so `diurnal` is the day-of-year.
+object OrdinalCalendar extends Calendar:
+  object Annus extends MonthRadix
+  type Mensual = Annus.type
+  type MonthUnit = Annus.type
 
-  // The inline path the `-` operator prefers: when the year, month and day are all literals it
-  // validates the date at compile time against the contextually-resolved calendar (raising a
-  // compile error for e.g. `2012-Feb-30`); otherwise it falls back to a runtime check.
-  final class MonthstampSubtraction extends SubOp:
-    type Self = Monthstamp
-    type Operand = Int
-    type Result = Date
+  private def base: RomanCalendar = calendars.gregorianCalendar
 
-    inline def op(left: Monthstamp, right: Int): Date =
-      ${aviation.internal.monthstampMinus('left, 'right)}
+  def name: Text = t"Ordinal"
+  def monthsInYear(year: Year): Int = 1
+  def daysInYear(year: Year): Int = base.daysInYear(year)
+  def daysInMonth(month: Annus.type, year: Year): Int = base.daysInYear(year)
+  def monthOrdinal(year: Year, month: Annus.type): Int = 0
+  def monthOfOrdinal(year: Year, ordinal: Int): Annus.type = Annus
+  def annual(date: Date): Year = base.annual(date)
+  def mensual(date: Date): Annus.type = Annus
+  def zerothDayOfYear(year: Year): Date = base.zerothDayOfYear(year)
+
+  def diurnal(date: Date): Day = Day(date.jdn - base.zerothDayOfYear(base.annual(date)).jdn)
+
+  def jdn(year: Year, month: Annus.type, day: Day): Date raises TimeError =
+    if day() < 1 || day() > base.daysInYear(year) then
+      raise(TimeError(_.Invalid(year(), 1, day(), this)))
+      base.zerothDayOfYear(year).addDays(1)
+    else
+      base.zerothDayOfYear(year).addDays(day())
+
+  // Construct directly from a year and a day-of-year, without the vestigial month.
+  def apply(year: Year, dayOfYear: Int): Date raises TimeError = jdn(year, Annus, Day(dayOfYear))
+
+  override def format(date: Date): Text = t"${annual(date)()}-${diurnal(date)()}"

--- a/lib/aviation/src/core/aviation.Period.scala
+++ b/lib/aviation/src/core/aviation.Period.scala
@@ -33,10 +33,16 @@
 package aviation
 
 import prepositional.*
+import rudiments.*
 import symbolism.*
 import vacuous.*
 
 object Period:
+  // Membership is half-open: a point is in the period when `start <= point < finish` (so `finish`
+  // belongs to the next period, not this one). Use it as `period.has(point)`.
+  given inclusive: [point] => (order: Ordering[point]) => (Period[point] is Inclusive by point) =
+    (period, point) => order.lteq(period.start, point) && order.lt(point, period.finish)
+
   // Split a period into consecutive `length`-long segments. The step is whatever the point can be
   // advanced by — a `Duration` or `Timespan` for an `Instant over X`, a `Timespan` for a
   // `Timestamp`/`Moment` (irregular spans pull in their `Calendar`/`Disambiguation`). When `length`

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -66,6 +66,9 @@ object timestampInternal:
   // A `Date` is a day-precise `Timestamp` (time-of-day clamped to zero).
   type Date = Timestamp in Day
 
+  // A `Monthstamp` is a month-precise `Timestamp` (clamped to the 1st of the month).
+  type Monthstamp = Timestamp in Month
+
   private def underlying(timestamp: Timestamp): Long = timestamp
 
   // The shape of a `Timestamp - Timestamp` difference: a regular span of days/hours/mins/seconds.
@@ -254,16 +257,13 @@ object timestampInternal:
 
     // `Monthstamp` (= `Timestamp in Month`) givens. Like `Date`'s, they live here so they're in the
     // implicit scope of the underlying `Timestamp`, not in the transparent alias's companion.
-    given monthstampShowable
-        : (Months, DateSeparation, Endianness, Years) => Monthstamp is Showable =
-
+    given monthShowable: (Months, DateSeparation, Endianness, Years) => Monthstamp is Showable =
       monthstamp =>
-        summon[Endianness] match
-          case Endianness.LittleEndian =>
-            t"${monthstamp.year}${summon[DateSeparation].separator}${monthstamp.month}"
+        val separator = summon[DateSeparation].separator
 
-          case _ =>
-            t"${monthstamp.month}${summon[DateSeparation].separator}${monthstamp.year}"
+        summon[Endianness] match
+          case Endianness.LittleEndian => t"${monthstamp.year}$separator${monthstamp.month}"
+          case _                       => t"${monthstamp.month}$separator${monthstamp.year}"
 
     // `monthstamp - dayOfMonth` → the `Date` of that day; the result-type witness and runtime
     // fallback for the `2012-Mar - 8` operator.
@@ -277,14 +277,14 @@ object timestampInternal:
     inline given monthstampSubtraction: Monthstamp.MonthstampSubtraction =
       Monthstamp.MonthstampSubtraction()
 
-    // Form-preserving month arithmetic: only whole months/years apply (finer components ignored), so
-    // the result stays month-precise.
+    // Form-preserving month arithmetic: only whole months/years apply (finer components are
+    // ignored), so the result stays month-precise.
     given monthstampAddable: [topic <: Radix]
-    =>  (Monthstamp is Addable by (Timespan of topic) to Monthstamp) =
+    =>  Monthstamp is Addable by (Timespan of topic) to Monthstamp =
       (monthstamp, span) => monthstampShift(monthstamp, span.years*12 + span.months)
 
     given monthstampTimespanSubtractable: [topic <: Radix]
-    =>  (Monthstamp is Subtractable by (Timespan of topic) to Monthstamp) =
+    =>  Monthstamp is Subtractable by (Timespan of topic) to Monthstamp =
       (monthstamp, span) => monthstampShift(monthstamp, -(span.years*12 + span.months))
 
     private def monthstampShift(monthstamp: Monthstamp, months: Int): Monthstamp =

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -252,6 +252,45 @@ object timestampInternal:
 
         recur(date, days())
 
+    // `Monthstamp` (= `Timestamp in Month`) givens. Like `Date`'s, they live here so they're in the
+    // implicit scope of the underlying `Timestamp`, not in the transparent alias's companion.
+    given monthstampShowable
+        : (Months, DateSeparation, Endianness, Years) => Monthstamp is Showable =
+
+      monthstamp =>
+        summon[Endianness] match
+          case Endianness.LittleEndian =>
+            t"${monthstamp.year}${summon[DateSeparation].separator}${monthstamp.month}"
+
+          case _ =>
+            t"${monthstamp.month}${summon[DateSeparation].separator}${monthstamp.year}"
+
+    // `monthstamp - dayOfMonth` → the `Date` of that day; the result-type witness and runtime
+    // fallback for the `2012-Mar - 8` operator.
+    given monthstampSubtractable: Monthstamp is Subtractable:
+      type Result = Date
+      type Operand = Int
+
+      def subtract(monthstamp: Monthstamp, day: Int): Date =
+        unsafely(calendars.gregorianCalendar.jdn(monthstamp.year, monthstamp.month, Day(day)))
+
+    inline given monthstampSubtraction: Monthstamp.MonthstampSubtraction =
+      Monthstamp.MonthstampSubtraction()
+
+    // Form-preserving month arithmetic: only whole months/years apply (finer components ignored), so
+    // the result stays month-precise.
+    given monthstampAddable: [topic <: Radix]
+    =>  (Monthstamp is Addable by (Timespan of topic) to Monthstamp) =
+      (monthstamp, span) => monthstampShift(monthstamp, span.years*12 + span.months)
+
+    given monthstampTimespanSubtractable: [topic <: Radix]
+    =>  (Monthstamp is Subtractable by (Timespan of topic) to Monthstamp) =
+      (monthstamp, span) => monthstampShift(monthstamp, -(span.years*12 + span.months))
+
+    private def monthstampShift(monthstamp: Monthstamp, months: Int): Monthstamp =
+      val total = monthstamp.year()*12 + monthstamp.month.ordinal + months
+      Monthstamp(Year(Math.floorDiv(total, 12)), Month.fromOrdinal(Math.floorMod(total, 12)))
+
   object Date:
     def julianDay(day: Int): Date = (day.toLong*aviation.internal.MillisPerDay).asInstanceOf[Date]
 
@@ -333,3 +372,9 @@ object timestampInternal:
   extension (date: Date)
     def addDays(count: Int): Date =
       (underlying(date) + count.toLong*aviation.internal.MillisPerDay).asInstanceOf[Date]
+
+  // Calendar-free (Gregorian) accessors for a `Monthstamp`, matching the `Month` enum it is tagged
+  // with — so `monthstamp.year`/`.month` need no calendar in scope.
+  extension (monthstamp: Monthstamp)
+    def year: Year = calendars.gregorianCalendar.annual(monthstamp.date)
+    def month: Month = calendars.gregorianCalendar.mensual(monthstamp.date)

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -231,6 +231,27 @@ object timestampInternal:
 
         recur(date, days())
 
+    given dateWorkingDaysSubtractable: Holidays => (hebdomad: Hebdomad) => Date is Subtractable:
+      type Operand = WorkingDays
+      type Result = Date
+
+      def subtract(date: Date, days: WorkingDays): Date =
+        def recur(current: Date, count: Int): Date =
+          if count == 0 then
+            if current.weekend || summon[Holidays].holiday(current).present
+            then recur(current.addDays(-1), 0)
+            else current
+          else
+            val previous = current.addDays(-count)
+            val holidays = summon[Holidays].between(previous, current)
+            val weekends = Weekday.all.to(List).filter(_.weekend)
+            val weekendDays = weekends.map(Weekday.count(previous, current, _)).sum
+            val weekdayHolidays = holidays.filter(!_.date.weekend).length
+            val skipped = weekdayHolidays + weekendDays
+            recur(previous, skipped)
+
+        recur(date, days())
+
   object Date:
     def julianDay(day: Int): Date = (day.toLong*aviation.internal.MillisPerDay).asInstanceOf[Date]
 

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -47,7 +47,7 @@ import vacuous.*
 
 export protointernal.{Instant, Duration}
 export aviation.internal.{Year, Day, Anniversary, WorkingDays}
-export aviation.timestampInternal.{Timestamp, Date}
+export aviation.timestampInternal.{Timestamp, Date, Monthstamp}
 export Month.{Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec}
 
 // A `MonthRadix` is the "month" radix of some calendar (Gregorian `Month`, `IslamicMonth`,
@@ -371,6 +371,9 @@ package calendars:
 
   given buddhistCalendar: OffsetCalendar = OffsetCalendar(gregorianCalendar, 543, t"Buddhist")
   given minguoCalendar: OffsetCalendar = OffsetCalendar(gregorianCalendar, -1911, t"Minguo")
+
+  // Year + day-of-year (no months); construct with `OrdinalCalendar(year, dayOfYear)`.
+  given ordinalCalendar: OrdinalCalendar.type = OrdinalCalendar
 
   // The Julian-to-Gregorian cutovers of the two best-known reforms, as two-segment `Regime`s. The
   // first day of each segment is given as a Julian day number; the gap between (the dates in

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -42,7 +42,8 @@ export
       HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
       GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapSeconds, Mar, May,
       Meridiem, Minute, Moment, Mon, Month, Months, Monthstamp, Nov, now, Occurrence, Oct,
-      OffsetCalendar, Period, PersianCalendar, PersianMonth, pm, Posix, Regime, Rfc1123,
+      OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm, Posix, Regime,
+      Rfc1123,
       RomanCalendar, Tai,
       Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
       TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
@@ -52,7 +53,7 @@ export
 package calendars:
   export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
       islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, papalCutover, britishCutover}
+      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
 
 package nonexistentLeapDays:
   export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -677,6 +677,26 @@ object Tests extends Suite(m"Aviation Tests"):
             2025-Aug-11 + WorkingDays(5)
           . assert(_ == 2025-Aug-18)
 
+          test(m"One working day before Tuesday is Monday"):
+            import hebdomads.europeanHebdomad
+            2025-Aug-19 - WorkingDays(1)
+          . assert(_ == 2025-Aug-18)
+
+          test(m"One working day before Monday is the previous Friday"):
+            import hebdomads.europeanHebdomad
+            2025-Aug-18 - WorkingDays(1)
+          . assert(_ == 2025-Aug-15)
+
+          test(m"One working day before a post-holiday Tuesday skips the holiday and weekend"):
+            import hebdomads.europeanHebdomad
+            2025-Aug-26 - WorkingDays(1)
+          . assert(_ == 2025-Aug-22)
+
+          test(m"Adding then subtracting the same working days round-trips"):
+            import hebdomads.europeanHebdomad
+            (2025-Aug-18 + WorkingDays(4)) - WorkingDays(4)
+          . assert(_ == 2025-Aug-18)
+
           test(m"Check one working days after a Friday is Monday"):
             import hebdomads.europeanHebdomad
             2025-Apr-11 + WorkingDays(1)
@@ -1835,6 +1855,22 @@ object Tests extends Suite(m"Aviation Tests"):
         val b = Instant(2000L) ~ Instant(3000L)
         a.union(b).size
       . assert(_ == 2)
+
+      test(m"Period.has is true for a point inside"):
+        (Instant(0L) ~ Instant(1000L)).has(Instant(500L))
+      . assert(_ == true)
+
+      test(m"Period.has includes the start"):
+        (Instant(0L) ~ Instant(1000L)).has(Instant(0L))
+      . assert(_ == true)
+
+      test(m"Period.has excludes the finish"):
+        (Instant(0L) ~ Instant(1000L)).has(Instant(1000L))
+      . assert(_ == false)
+
+      test(m"Period.has is false for a point outside"):
+        (Instant(0L) ~ Instant(1000L)).has(Instant(2000L))
+      . assert(_ == false)
 
     suite(m"Period segments"):
       import calendars.gregorianCalendar

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -1009,6 +1009,35 @@ object Tests extends Suite(m"Aviation Tests"):
         ((2024 - Jan) + 7*Month) - 7*Month
       . assert(_ == 2024 - Jan)
 
+    suite(m"Ordinal dates"):
+      import calendars.gregorianCalendar
+      import calendars.ordinalCalendar
+
+      test(m"Day 1 is the 1st of January"):
+        OrdinalCalendar(Year(2024), 1)
+      . assert(_ == 2024-Jan-1)
+
+      test(m"Day 247 of leap-year 2024 is the 3rd of September"):
+        OrdinalCalendar(Year(2024), 247)
+      . assert(_ == 2024-Sep-3)
+
+      test(m"Day 60 of common-year 2023 is the 1st of March"):
+        OrdinalCalendar(Year(2023), 60)
+      . assert(_ == 2023-Mar-1)
+
+      test(m"The day-of-year reads back from a date"):
+        (2024-Sep-3).day(using ordinalCalendar)()
+      . assert(_ == 247)
+
+      test(m"The year reads back from a date"):
+        (2024-Sep-3).year(using ordinalCalendar)()
+      . assert(_ == 2024)
+
+      test(m"Day 366 in a common year is rejected"):
+        capture(OrdinalCalendar(Year(2023), 366))
+      . matches:
+          case _: TimeError =>
+
     suite(m"Holidays methods"):
       val holidays = Holidays(List
         ( Holiday(2025-Jan-1, t"New Year's Day"),

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -985,6 +985,30 @@ object Tests extends Suite(m"Aviation Tests"):
         (2024 - Mar).show
       . assert(_ == t"2024.Mar")
 
+      test(m"Adding months to a Monthstamp stays a Monthstamp"):
+        val ms: Monthstamp = (2024 - Jan) + 2*Month
+        (ms.year(), ms.month)
+      . assert(_ == (2024, Mar))
+
+      test(m"Adding months rolls over the year"):
+        val ms = (2024 - Nov) + 3*Month
+        (ms.year(), ms.month)
+      . assert(_ == (2025, Feb))
+
+      test(m"Subtracting months rolls back across the year"):
+        val ms = (2024 - Mar) - 5*Month
+        (ms.year(), ms.month)
+      . assert(_ == (2023, Oct))
+
+      test(m"Adding a year to a Monthstamp"):
+        val ms = (2024 - Jun) + 1*Year
+        (ms.year(), ms.month)
+      . assert(_ == (2025, Jun))
+
+      test(m"Month arithmetic round-trips"):
+        ((2024 - Jan) + 7*Month) - 7*Month
+      . assert(_ == 2024 - Jan)
+
     suite(m"Holidays methods"):
       val holidays = Holidays(List
         ( Holiday(2025-Jan-1, t"New Year's Day"),


### PR DESCRIPTION
Four additions to aviation's point/period model.

`Period` gains a `rudiments.Inclusive` instance — `period.has(point)` tests membership for any point type, half-open (`start <= point < finish`).

`Date` gains working-day **subtraction** (`Date - WorkingDays`), the mirror of the existing addable, stepping back over weekends and holidays.

`Monthstamp` is now `Timestamp in Month` — the 1st instant of a Gregorian month tagged with `Month` precision — rather than a separate case class. It inherits the whole `Timestamp` point family, and Form-preserving month arithmetic falls out: `monthstamp + 2*Month` / `- 5*Month` / `+ 1*Year` return a `Monthstamp`. The `2012-Mar - 8 → Date` operator is unchanged (its `Int` operand is distinct from the `Timespan` month operand); construction clamps to the 1st.

`OrdinalCalendar` adds year + day-of-year ("ordinal date") support — `OrdinalCalendar(Year(2024), 247)` is the 247th day of 2024, and `date.day(using ordinalCalendar)` reads the day-of-year back. It's a `Calendar` whose single vestigial month spans the year, delegating year boundaries to Gregorian.