### PR TITLE
Aviation: resolve the three deferred discontinuity items

### DIFF
--- a/lib/aviation/src/core/aviation.LeapMode.scala
+++ b/lib/aviation/src/core/aviation.LeapMode.scala
@@ -30,100 +30,16 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Fri, Hebdomad, Holiday, Holidays, Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapMode, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, monotonic, Monotonic, Month, Months, Monthstamp, Nov, now,
-      Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      Posix, Regime, Resolution, Rfc1123, RomanCalendar, Tai,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
+// Whether adding a sub-day `Timespan` to a `Moment` counts leap seconds. `Lenient` (the default)
+// adds the duration on the leap-free POSIX line, so "two hours later" is two hours of wall-clock,
+// and a leap second crossed in between is invisible. `Exact` adds the same duration as real SI
+// seconds (routing through the TAI timeline), so crossing an inserted leap second shifts the
+// wall-clock result back by that second. The two agree except across one of the ~27 historical leap
+// instants. Import `leapModes.exact` to switch from `Lenient`.
+object LeapMode:
+  given lenient: LeapMode = LeapMode.Lenient
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
-
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
-
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
-
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
-
-package leapModes:
-  export aviation.leapModes.exact
-
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
-
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
-
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package timespanFormats:
-  export aviation.timespanFormats.relativeTimespan
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+enum LeapMode:
+  case Lenient, Exact

--- a/lib/aviation/src/core/aviation.LeapSeconds.scala
+++ b/lib/aviation/src/core/aviation.LeapSeconds.scala
@@ -38,6 +38,14 @@ object LeapSeconds:
   // Bits represent leap seconds in years from 1972 (MSB) to 2035 (LSB). Leap seconds will be
   // abolished after 2035, so a 64-bit integer is just sufficient to store all possible leap
   // seconds, including those which have not yet been determined.
+  //
+  // Edge behaviour outside that range. Before 1972 the table contributes nothing, so `before`/`tai`
+  // report a constant TAI−UTC offset of +10 s; this is an approximation — the true historical
+  // offset was sub-integer and drifting, which this integer-second model does not represent. After
+  // 2035 the bits run out and the offset saturates at its final value (37 s), reflecting the
+  // planned abolition of leap seconds: no further leaps are counted. Negative leap seconds (a
+  // second removed, not inserted) have never occurred and cannot be encoded — `addLeapSecond` only
+  // ORs bits in, so the offset is monotonically non-decreasing.
   //                            1972    1980    1988    1996    2004    2012    2020    2028   2035
   //                               ↓       ↓       ↓       ↓       ↓       ↓       ↓       ↓      ↓
   private var june:     Long = bin"1000000001110100000011100100000000000000100100000000000000000000"

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -286,8 +286,9 @@ object Timespan:
   // Adding a timespan to a zoned `Moment` splits at the day boundary: the calendar/day part
   // advances the wall-clock (so a day "ignores" DST — same local time next day), while the sub-day
   // part is applied physically through the timezone (so hours/minutes/seconds "honour" DST).
+  // Whether the sub-day part counts leap seconds is set by `LeapMode` (default `Lenient`).
   given momentAdd: [topic <: Radix]
-  =>  ( Timestamp is Addable by (Timespan of topic) to Timestamp, RomanCalendar )
+  =>  ( Timestamp is Addable by (Timespan of topic) to Timestamp, RomanCalendar, LeapMode )
   =>  Moment is Addable by (Timespan of topic) to Moment =
     (moment, span) =>
       val timestamps = summon[Timestamp is Addable by (Timespan of topic) to Timestamp]
@@ -295,8 +296,13 @@ object Timespan:
       val subSpan = Timespan(hours = span.hours, minutes = span.minutes, seconds = span.seconds)
       val wall = timestamps.add(moment.timestamp, dateSpan.asInstanceOf[Timespan of topic])
       val zoned = Moment(wall.date, wall.time, moment.timezone)
+      val seconds = physicalSeconds(subSpan)
 
-      (zoned.instant + physicalSeconds(subSpan)).in(moment.timezone)
+      val advanced = summon[LeapMode] match
+        case LeapMode.Lenient => zoned.instant + seconds
+        case LeapMode.Exact   => (zoned.instant.over[Tai] + seconds).over[Posix]
+
+      advanced.in(moment.timezone)
 
 case class Timespan
   ( years:   Int                 = 0,

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -351,8 +351,11 @@ object timestampInternal:
 
       . nn
 
-    def instant(using timezone: Timezone, calendar: RomanCalendar): Instant over Posix =
-      Instant.of[Posix](timestamp.stdlib.atZone(timezone.stdlib).nn.toInstant.nn.toEpochMilli())
+    // Grounding goes through `Moment`, the single civil↔absolute bridge, so a `Timestamp` honours
+    // the same `GapPolicy` as a `Moment` (a bare wall-clock time carries no overlap selector, so it
+    // grounds at the earlier offset — `Occurrence.First`).
+    def instant(using Timezone, RomanCalendar, GapPolicy): Instant over Posix =
+      timestamp.in(summon[Timezone]).instant
 
   // Comparisons are defined on `Timestamp` (the whole grid is monotonic); `Date`, being a
   // `Timestamp in Day`, inherits them.

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -428,6 +428,12 @@ package gapPolicies:
   given rejectGap: Tactic[TimeError] => GapPolicy =
     (_, _) => abort(TimeError(_.Gap))
 
+// Switch sub-day `Moment` arithmetic to count leap seconds (the default `LeapMode.Lenient` works on
+// the leap-free POSIX line). Import `leapModes.exact` so adding a duration that crosses an inserted
+// leap second advances by that many real SI seconds.
+package leapModes:
+  given exact: LeapMode = LeapMode.Exact
+
 // Month-end overflow policies for adding months/years to a date (e.g. Jan 31 + 1 month). No default
 // is provided, so such arithmetic requires one of these to be imported.
 package monthEnds:

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -136,6 +136,20 @@ object Tests extends Suite(m"Aviation Tests"):
         LeapSeconds.during(Year(2100), false)
       . assert(_ == 37)
 
+      test(m"The TAI offset before 1972 is a constant +10 seconds"):
+        LeapSeconds.tai(0L) - 0L
+      . assert(_ == 10000L)
+
+      test(m"No further leap seconds are counted after 2035"):
+        val a = LeapSeconds.tai(2_500_000_000_000L) - 2_500_000_000_000L
+        val b = LeapSeconds.tai(2_600_000_000_000L) - 2_600_000_000_000L
+        a == b
+      . assert(_ == true)
+
+      test(m"TAI conversion round-trips a far-future instant"):
+        LeapSeconds.untai(LeapSeconds.tai(2_500_000_000_000L))
+      . assert(_ == 2_500_000_000_000L)
+
     suite(m"Gregorian Calendar Tests"):
       test(m"2000 is a leap year"):
         calendars.gregorianCalendar.leapYear(Year(2000))
@@ -2006,6 +2020,27 @@ object Tests extends Suite(m"Aviation Tests"):
         (later - earlier).value
       . assert(_ == 3600.0)
 
+    // A leap second was inserted at 2016-12-31T23:59:60 UTC, so 23:00 + 2h crosses it.
+    suite(m"Leap-exact moment arithmetic"):
+      import calendars.gregorianCalendar
+
+      test(m"Lenient addition ignores a crossed leap second"):
+        val start = Moment(2016-Dec-31, Clockface(23, 0, 0), tz"UTC")
+        (start + 2*Hour).instant
+      . assert(_ == Moment(2017-Jan-1, Clockface(1, 0, 0), tz"UTC").instant)
+
+      test(m"Exact addition counts a crossed leap second"):
+        import leapModes.exact
+        val start = Moment(2016-Dec-31, Clockface(23, 0, 0), tz"UTC")
+        (start + 2*Hour).instant
+      . assert(_ == Moment(2017-Jan-1, Clockface(0, 59, 59), tz"UTC").instant)
+
+      test(m"Exact and lenient agree when no leap second is crossed"):
+        import leapModes.exact
+        val start = Moment(2024-Jun-1, Clockface(12, 0, 0), tz"UTC")
+        (start + 2*Hour).instant
+      . assert(_ == Moment(2024-Jun-1, Clockface(14, 0, 0), tz"UTC").instant)
+
     suite(m"Moment and Timezone"):
       import calendars.gregorianCalendar
 
@@ -2048,6 +2083,22 @@ object Tests extends Suite(m"Aviation Tests"):
         val ts = Timestamp(2024-Jan-15, Clockface(12, 0, 0))
         ts.instant.in(tz"Europe/London").time.hour
       . assert(_ == 12)
+
+      test(m"Timestamp.instant agrees with Moment.instant in a DST gap"):
+        val london = tz"Europe/London"
+        given Timezone = london
+        val viaTimestamp = Timestamp(2024-Mar-31, Clockface(1, 30, 0)).instant
+        val viaMoment = Moment(2024-Mar-31, Clockface(1, 30, 0), london).instant
+        viaTimestamp == viaMoment
+      . assert(_ == true)
+
+      test(m"Timestamp.instant honours a non-default GapPolicy"):
+        import instantDecodables.iso8601InstantDecodable
+        import gapPolicies.pushBackward
+        given Timezone = tz"Europe/London"
+        val grounded = Timestamp(2024-Mar-31, Clockface(1, 30, 0)).instant
+        grounded == t"2024-03-31T00:30:00Z".decode[Instant over Posix]
+      . assert(_ == true)
 
       // On 2024-10-27 London clocks go back at 02:00 BST, so 01:30 local occurs twice: first at
       // 00:30 UTC (BST), then again at 01:30 UTC (GMT).


### PR DESCRIPTION
Closes the three deferred items from aviation's discontinuity model: the `Timestamp.instant` grounding path, leap-exact `Moment` arithmetic, and leap-table edge behaviour.

### `Timestamp.instant` grounds through `Moment`

Grounding a `Timestamp` previously took a parallel `atZone` path that silently pushed spring-forward gaps forward. It now routes through `Moment` — the single civil↔absolute bridge — so it honours the contextual `GapPolicy`:

```scala
given Timezone = tz"Europe/London"
import gapPolicies.pushBackward
Timestamp(2024-Mar-31, Clockface(1, 30, 0)).instant   // now respects the policy
```

Default behaviour (push forward, matching `java.time`) is unchanged.

### Leap-exact `Moment` arithmetic

A new contextual `LeapMode` decides whether the sub-day part of `moment + span` counts leap seconds. The default `Lenient` keeps the leap-free POSIX behaviour; `import leapModes.exact` routes the sub-day part through the TAI timeline so a crossed leap second is counted:

```scala
val start = Moment(2016-Dec-31, Clockface(23, 0, 0), tz"UTC")
start + 2*Hour                       // lenient → 2017-01-01 01:00:00
import leapModes.exact
start + 2*Hour                       // exact   → 2017-01-01 00:59:59 (counts the leap)
```

### Leap-table edges

Documents the behaviour outside 1972–2035 (a constant +10 s offset before 1972, saturation at +37 s after the planned 2035 abolition, and no support for negative leaps) and adds far-future/pre-1972 bounds tests.