### PR TITLE
Urticose: add a NetworkInterface enumeration/inspection API

### DIFF
--- a/lib/urticose/src/core/urticose.InterfaceAddress.scala
+++ b/lib/urticose/src/core/urticose.InterfaceAddress.scala
@@ -1,0 +1,40 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package urticose
+
+import vacuous.*
+
+case class InterfaceAddress
+  ( address:   Ipv4 | Ipv6,
+    prefix:    Int,
+    broadcast: Optional[Ipv4] )

--- a/lib/urticose/src/core/urticose.NetworkInterface.scala
+++ b/lib/urticose/src/core/urticose.NetworkInterface.scala
@@ -1,0 +1,143 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package urticose
+
+import java.net as jn
+import java.util as ju
+
+import scala.jdk.CollectionConverters.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import spectacular.*
+import vacuous.*
+
+import NetworkInterfaceError.Reason.*
+
+object NetworkInterface:
+  given showable: NetworkInterface is Showable = _.name
+
+  def all(): List[NetworkInterface] raises NetworkInterfaceError = enumerated:
+    def recur(interfaces: ju.Enumeration[jn.NetworkInterface], acc: List[NetworkInterface])
+    :   List[NetworkInterface] =
+
+      if !interfaces.hasMoreElements then acc.reverse
+      else recur(interfaces, read(interfaces.nextElement.nn) :: acc)
+
+    Optional(jn.NetworkInterface.getNetworkInterfaces).lay(Nil)(recur(_, Nil))
+
+  def byName(name: Text): Optional[NetworkInterface] raises NetworkInterfaceError = enumerated:
+    Optional(jn.NetworkInterface.getByName(name.s)).let(read(_))
+
+  def byIndex(index: Int): Optional[NetworkInterface] raises NetworkInterfaceError = enumerated:
+    Optional(jn.NetworkInterface.getByIndex(index)).let(read(_))
+
+  def byAddress(address: Ipv4 | Ipv6): Optional[NetworkInterface] raises NetworkInterfaceError =
+    enumerated:
+      val inet = jn.InetAddress.getByAddress(bytes(address)).nn
+      Optional(jn.NetworkInterface.getByInetAddress(inet)).let(read(_))
+
+  private def enumerated[result](block: => result): result raises NetworkInterfaceError =
+    try block catch case error: jn.SocketException =>
+      abort(NetworkInterfaceError(Enumeration(message(error))))
+
+  private def message(error: jn.SocketException): Text =
+    Optional(error.getMessage).lay(t"of a socket error")(_.tt)
+
+  private def read(nic: jn.NetworkInterface): NetworkInterface raises NetworkInterfaceError =
+    val name = nic.getName.nn.tt
+
+    try
+      val hardware = Optional(nic.getHardwareAddress).let: bytes =>
+        MacAddress(bytes(0), bytes(1), bytes(2), bytes(3), bytes(4), bytes(5))
+
+      val addresses = nic.getInterfaceAddresses.nn.asScala.to(List).map: entry =>
+        val broadcast = Optional(entry.getBroadcast).let(ipv4(_))
+        InterfaceAddress(inet(entry.getAddress.nn), entry.getNetworkPrefixLength.toInt, broadcast)
+
+      NetworkInterface
+        ( name,
+          nic.getDisplayName.nn.tt,
+          nic.getIndex,
+          hardware,
+          addresses,
+          nic.getMTU,
+          nic.isUp,
+          nic.isLoopback,
+          nic.isPointToPoint,
+          nic.supportsMulticast,
+          nic.isVirtual )
+
+    catch case error: jn.SocketException =>
+      abort(NetworkInterfaceError(Inspection(name, message(error))))
+
+  private def inet(address: jn.InetAddress): Ipv4 | Ipv6 =
+    val bytes = address.getAddress.nn
+
+    if bytes.length == 4 then ipv4(address)
+    else Ipv6(longOf(bytes, 0), longOf(bytes, 8))
+
+  private def ipv4(address: jn.InetAddress): Ipv4 =
+    val bytes = address.getAddress.nn
+    Ipv4(bytes(0).toInt, bytes(1).toInt, bytes(2).toInt, bytes(3).toInt)
+
+  private def longOf(bytes: Array[Byte], offset: Int): Long =
+    (0 until 8).foldLeft(0L): (acc, index) =>
+      (acc << 8) | (bytes(offset + index) & 0xff).toLong
+
+  private def bytes(address: Ipv4 | Ipv6): Array[Byte] = address match
+    case ipv6: Ipv6 =>
+      val array = new Array[Byte](16)
+      for index <- 0 until 8 do array(index) = (ipv6.highBits >>> (56 - index*8)).toByte
+      for index <- 0 until 8 do array(index + 8) = (ipv6.lowBits >>> (56 - index*8)).toByte
+      array
+
+    case ipv4: (Ipv4 @unchecked) =>
+      Array(ipv4.byte0.toByte, ipv4.byte1.toByte, ipv4.byte2.toByte, ipv4.byte3.toByte)
+
+case class NetworkInterface
+  ( name:         Text,
+    displayName:  Text,
+    index:        Int,
+    hardware:     Optional[MacAddress],
+    addresses:    List[InterfaceAddress],
+    mtu:          Int,
+    up:           Boolean,
+    loopback:     Boolean,
+    pointToPoint: Boolean,
+    multicast:    Boolean,
+    virtual:      Boolean ):
+
+  def ipv4: List[Ipv4] = addresses.map(_.address).collect { case ip: (Ipv4 @unchecked) => ip }
+  def ipv6: List[Ipv6] = addresses.map(_.address).collect { case ip: Ipv6 => ip }

--- a/lib/urticose/src/core/urticose.NetworkInterfaceError.scala
+++ b/lib/urticose/src/core/urticose.NetworkInterfaceError.scala
@@ -1,0 +1,52 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package urticose
+
+import anticipation.*
+import fulminate.*
+
+object NetworkInterfaceError:
+  object Reason:
+    given communicable: Reason is Communicable =
+      case Enumeration(message) =>
+        m"the network interfaces could not be enumerated because $message"
+
+      case Inspection(name, message) =>
+        m"the interface $name could not be inspected because $message"
+
+  enum Reason(val number: Int) extends Clarification:
+    case Enumeration(message: Text)             extends Reason(1)
+    case Inspection(name: Text, message: Text)  extends Reason(2)
+
+case class NetworkInterfaceError(reason: NetworkInterfaceError.Reason)(using Diagnostics)
+extends Error(418, reason.number)(m"the network interface could not be read because $reason")

--- a/lib/urticose/src/test/urticose_test.scala
+++ b/lib/urticose/src/test/urticose_test.scala
@@ -725,5 +725,38 @@ object Tests extends Suite(m"Urticose tests"):
         try socket.getLocalPort finally socket.close()
       . assert(_ > 0)
 
+    suite(m"Network interface tests"):
+      test(m"Enumerate the machine's network interfaces"):
+        NetworkInterface.all()
+      . assert(_.nonEmpty)
+
+      test(m"There is a loopback interface"):
+        NetworkInterface.all().exists(_.loopback)
+      . assert(_ == true)
+
+      test(m"An interface can be looked up by its name"):
+        val interface = NetworkInterface.all().head
+        NetworkInterface.byName(interface.name).let(_.name)
+      . assert(_ == NetworkInterface.all().head.name)
+
+      test(m"An interface can be looked up by its index"):
+        val interface = NetworkInterface.all().head
+        NetworkInterface.byIndex(interface.index).let(_.index)
+      . assert(_ == NetworkInterface.all().head.index)
+
+      test(m"Looking up a nonexistent interface name yields Unset"):
+        NetworkInterface.byName(t"definitely-not-an-interface")
+      . assert(_ == Unset)
+
+      test(m"An interface's addresses partition into IPv4 and IPv6"):
+        val interface = NetworkInterface.all().head
+        interface.ipv4.length + interface.ipv6.length
+      . assert(_ == NetworkInterface.all().head.addresses.length)
+
+      test(m"The loopback interface can be found by its address"):
+        val loopback = NetworkInterface.all().filter(_.loopback).head
+        NetworkInterface.byAddress(loopback.addresses.head.address).let(_.loopback)
+      . assert(_ == true)
+
 object example:
   val com = Hostname(DnsLabel(t"example"), DnsLabel(t"com"))


### PR DESCRIPTION
Urticose now provides a native API for enumerating and inspecting the current machine's network interfaces, wrapping `java.net.NetworkInterface` in the module's idioms — `Text`, `Optional`/`Unset`, `Ipv4 | Ipv6`, `MacAddress`, and `raises`-style error handling. Enumeration is purely local, so it needs no `Online` capability.

A `NetworkInterface` is composed of `InterfaceAddress` entries and exposes the interface's name, display name, index, hardware (MAC) address, MTU, and status flags. The companion offers enumeration and lookup, with `java.net`'s `SocketException` captured as a `NetworkInterfaceError` so callers stay within `Tactic`/`raises`.

```scala
import soundness.*
import strategies.throwUnsafely

for interface <- NetworkInterface.all() do
  println(interface.show)         // the interface name, e.g. "en0"
  interface.hardware.let: mac =>
    println(mac.show)             // e.g. "a4-83-e7-1c-09-5f"
  interface.ipv4.foreach(ip => println(ip.show))

val loopback: Optional[NetworkInterface] = NetworkInterface.byName(t"lo0")
val first:    Optional[NetworkInterface] = NetworkInterface.byIndex(1)
val owner:    Optional[NetworkInterface] = NetworkInterface.byAddress(ip"127.0.0.1")
```

Each `InterfaceAddress` carries the bound `address` (`Ipv4 | Ipv6`), the CIDR `prefix` length, and an IPv4-only `broadcast` address (`Unset` for IPv6). `NetworkInterface#ipv4` and `#ipv6` narrow the addresses to each family.
