### PR TITLE
Aviation: iCalendar RRULE recurrences on a shared Recurrent interface

### DIFF
--- a/lib/aviation/src/core/aviation.Frequency.scala
+++ b/lib/aviation/src/core/aviation.Frequency.scala
@@ -30,103 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Frequency, Fri, Hebdomad, Holiday, Holidays,
-      Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapMode, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, monotonic, Monotonic, Month, Months, Monthstamp, Nov, now,
-      Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      following, occurrences, Posix, rec, Recurrence, RecurrenceError, recInterpolator,
-      RecurrenceLiteral, RecurrenceSet, Recurrent, Regime, Resolution, Rfc1123, RomanCalendar,
-      Rrule, RruleError, Tai, until, WeekdayOrdinal, within,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
-
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
-
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
-
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
-
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
-
-package leapModes:
-  export aviation.leapModes.exact
-
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
-
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
-
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package timespanFormats:
-  export aviation.timespanFormats.relativeTimespan
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+// The base cadence of an iCalendar `Rrule` (RFC 5545 `FREQ`): the unit that `interval` multiplies.
+// Sub-day frequencies (`Secondly`/`Minutely`/`Hourly`) are modelled but not yet expanded by the
+// engine, which currently generates date-level occurrences (`Daily`…`Yearly`).
+enum Frequency:
+  case Secondly, Minutely, Hourly, Daily, Weekly, Monthly, Yearly

--- a/lib/aviation/src/core/aviation.Recurrence.scala
+++ b/lib/aviation/src/core/aviation.Recurrence.scala
@@ -70,6 +70,18 @@ object Recurrence:
       val period: Timespan = recurrence.period
       t"R$number/${recurrence.start.encode}/${period.encode}"
 
+  // A plain-English description, e.g. "every 2 weeks, 5 times from <start>". `.encode` is the ISO
+  // wire form; `.show` is for people.
+  given showable: [point: Showable, span <: Timespan] => (Recurrence of point by span) is Showable =
+    recurrence =>
+      val period: Timespan = recurrence.period
+      val cadence = t"every ${aviation.internal.durationPhrase(period)}"
+
+      val number =
+        if recurrence.repetitions.absent then t"" else t", ${recurrence.repetitions.vouch} times"
+
+      t"$cadence$number from ${recurrence.start.show}"
+
   // Parsing erases the period's static radix set, so the caller names the period type they expect
   // (e.g. `decode[Recurrence of Timestamp by (Timespan of Month.type)]`); the parsed duration is
   // tagged with it. A mismatched topic mis-reads the duration, so name the one the data uses.

--- a/lib/aviation/src/core/aviation.Recurrence.scala
+++ b/lib/aviation/src/core/aviation.Recurrence.scala
@@ -95,26 +95,15 @@ object Recurrence:
         case _ =>
           abort(RecurrenceError(text))
 
-  extension [point, span](recurrence: Recurrence of point by span)
-    // The occurrences, lazily: `start`, `start + period`, … bounded by `repetitions` if it is set,
-    // otherwise an infinite stream (consume it with `until`/`within` or `.take`).
-    def occurrences(using addable: point is Addable by span to point): LazyList[point] =
-      val all = LazyList.iterate(recurrence.start)(addable.add(_, recurrence.period))
-      recurrence.repetitions.lay(all)(all.take(_))
+  // A `Recurrence` is `Recurrent`: its occurrences are `start`, `start + period`, … bounded by
+  // `repetitions` if set, otherwise infinite. The `Addable` it needs is captured here, so generic
+  // `Recurrent` code (`occurrences`/`until`/`within`) works on a `Recurrence`.
+  given recurrent: [point, span] => (addable: point is Addable by span to point)
+  =>  ( (Recurrence of point by span) is Recurrent { type Topic = point } ) =
 
-    // The occurrences strictly before `limit` — terminates even for an unbounded recurrence.
-    def until(limit: point)
-      ( using addable: point is Addable by span to point, order: Ordering[point] )
-    :   LazyList[point] =
-
-      occurrences.takeWhile(order.lt(_, limit))
-
-    // The occurrences falling within a `Period` (half-open: `start <= point < finish`).
-    def within(window: Period[point])
-      ( using addable: point is Addable by span to point, order: Ordering[point] )
-    :   LazyList[point] =
-
-      occurrences.dropWhile(order.lt(_, window.start)).takeWhile(order.lt(_, window.finish))
+    series =>
+      val all = LazyList.iterate(series.start)(addable.add(_, series.period))
+      series.repetitions.lay(all)(all.take(_))
 
 trait Recurrence extends Topical, Operable:
   def start: Topic

--- a/lib/aviation/src/core/aviation.RecurrenceSet.scala
+++ b/lib/aviation/src/core/aviation.RecurrenceSet.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package aviation
 
-import prepositional.*
-
 // An iCalendar recurrence set: the union of one or more recurrences' occurrence streams (`include`,
 // e.g. each `rrule.occurrences`) plus explicit extra dates (`rdates`, RFC 5545 `RDATE`), minus
 // excluded dates (`exdates`, `EXDATE`). It is itself `Recurrent` — the streams are merged into one

--- a/lib/aviation/src/core/aviation.RecurrenceSet.scala
+++ b/lib/aviation/src/core/aviation.RecurrenceSet.scala
@@ -30,103 +30,44 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Frequency, Fri, Hebdomad, Holiday, Holidays,
-      Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapMode, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, monotonic, Monotonic, Month, Months, Monthstamp, Nov, now,
-      Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      following, occurrences, Posix, rec, Recurrence, RecurrenceError, recInterpolator,
-      RecurrenceLiteral, RecurrenceSet, Recurrent, Regime, Resolution, Rfc1123, RomanCalendar,
-      Rrule, RruleError, Tai, until, WeekdayOrdinal, within,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
+import prepositional.*
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
+// An iCalendar recurrence set: the union of one or more recurrences' occurrence streams (`include`,
+// e.g. each `rrule.occurrences`) plus explicit extra dates (`rdates`, RFC 5545 `RDATE`), minus
+// excluded dates (`exdates`, `EXDATE`). It is itself `Recurrent` — the streams are merged into one
+// ascending, de-duplicated stream with the exclusions removed — so it composes uniformly with any
+// other `Recurrent`.
+object RecurrenceSet:
+  given recurrent: [point] => Ordering[point]
+  =>  ( RecurrenceSet[point] is Recurrent { type Topic = point } ) =
 
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
+    set =>
+      val excluded = set.exdates.to(Set)
+      val streams = set.include :+ LazyList.from(set.rdates.sorted)
+      dedup(merge(streams)).filterNot(excluded.contains)
 
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
+  // Lazily merge ascending streams into one ascending stream (repeatedly emit the least head).
+  private def merge[point](streams: List[LazyList[point]])(using order: Ordering[point])
+  :   LazyList[point] =
 
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
+    streams.filter(_.nonEmpty) match
+      case Nil => LazyList.empty
 
-package leapModes:
-  export aviation.leapModes.exact
+      case nonEmpty =>
+        val index = nonEmpty.indices.minBy(nonEmpty(_).head)
+        val chosen = nonEmpty(index)
 
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
+        chosen.head #:: merge(nonEmpty.updated(index, chosen.tail))
 
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
+  // Drop duplicates from an ascending stream (equal values are adjacent).
+  private def dedup[point](stream: LazyList[point])(using order: Ordering[point]): LazyList[point] =
+    stream match
+      case head #:: tail => head #:: dedup(tail.dropWhile(order.equiv(_, head)))
+      case _             => LazyList.empty
 
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package timespanFormats:
-  export aviation.timespanFormats.relativeTimespan
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+case class RecurrenceSet[point]
+  ( include: List[LazyList[point]] = Nil,
+    rdates:  List[point]           = Nil,
+    exdates: List[point]           = Nil )

--- a/lib/aviation/src/core/aviation.Recurrent.scala
+++ b/lib/aviation/src/core/aviation.Recurrent.scala
@@ -30,103 +30,17 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Frequency, Fri, Hebdomad, Holiday, Holidays,
-      Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapMode, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, monotonic, Monotonic, Month, Months, Monthstamp, Nov, now,
-      Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      following, occurrences, Posix, rec, Recurrence, RecurrenceError, recInterpolator,
-      RecurrenceLiteral, RecurrenceSet, Recurrent, Regime, Resolution, Rfc1123, RomanCalendar,
-      Rrule, RruleError, Tai, until, WeekdayOrdinal, within,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
+import prepositional.*
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
-
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
-
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
-
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
-
-package leapModes:
-  export aviation.leapModes.exact
-
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
-
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
-
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package timespanFormats:
-  export aviation.timespanFormats.relativeTimespan
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+// A `Recurrent` value produces an ordered, lazy stream of occurrence points — the common interface
+// of every recurrence model. `Recurrence` (ISO 8601 fixed-cadence intervals) and `Rrule` (iCalendar
+// RFC 5545 calendar rules) are distinct implementations: they generate occurrences differently (and
+// disagree on month-end handling — drift vs skip), but both are "an ordered stream of points", so
+// the `occurrences`/`until`/`within`/`following` combinators (in `aviation_core`) are written once
+// over any `Recurrent`. It is a typeclass, not a base trait, because each model needs different
+// givens to generate (an `Addable` for `Recurrence`, a `Calendar` for `Rrule`); the instance
+// carries them in its given clause.
+trait Recurrent extends Typeclass, Topical:
+  def occurrences(self: Self): LazyList[Topic]

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -156,6 +156,68 @@ object Rrule:
     val prefix = string.dropRight(2)
     WeekdayOrdinal(weekday, if prefix.isEmpty then Unset else intOf(prefix.tt, context))
 
+  // ── plain-English description ────────────────────────────────────────────────────────────────
+  // `.encode` is the RFC 5545 wire form; `.show` describes the rule in English, e.g. "every month
+  // on the 3rd Monday" or "every year on the 4th Thursday of November".
+
+  private def unitName(frequency: Frequency, plural: Boolean): Text = frequency match
+    case Frequency.Secondly => if plural then t"seconds" else t"second"
+    case Frequency.Minutely => if plural then t"minutes" else t"minute"
+    case Frequency.Hourly   => if plural then t"hours" else t"hour"
+    case Frequency.Daily    => if plural then t"days" else t"day"
+    case Frequency.Weekly   => if plural then t"weeks" else t"week"
+    case Frequency.Monthly  => if plural then t"months" else t"month"
+    case Frequency.Yearly   => if plural then t"years" else t"year"
+
+  private def ordinalWord(n: Int): Text =
+    if n == -1 then t"last"
+    else if n < 0 then t"${aviation.internal.englishOrdinal(-n)}-to-last"
+    else aviation.internal.englishOrdinal(n)
+
+  given showable: [point] => (Months, Weekdays) => Rrule[point] is Showable = rule =>
+    val join = aviation.internal.joinAnd
+
+    val cadence =
+      if rule.interval == 1 then t"every ${unitName(rule.frequency, false)}"
+      else t"every ${rule.interval} ${unitName(rule.frequency, true)}"
+
+    val byDayText: Optional[Text] =
+      if rule.byDay.isEmpty then Unset else
+        val hasOrdinal = rule.byDay.exists(_.ordinal.present)
+
+        val entries = rule.byDay.map: entry =>
+          if entry.ordinal.absent then entry.weekday.show
+          else t"${ordinalWord(entry.ordinal.vouch)} ${entry.weekday.show}"
+
+        t"on ${if hasOrdinal then t"the " else t""}${join(entries)}"
+
+    val byMonthDayText: Optional[Text] =
+      if rule.byMonthDay.isEmpty then Unset
+      else t"on the ${join(rule.byMonthDay.map(monthDayWord))}"
+
+    val onText: Optional[Text] = if rule.byDay.nonEmpty then byDayText else byMonthDayText
+
+    val monthText: Optional[Text] =
+      if rule.byMonth.isEmpty then Unset else
+        val names = join(rule.byMonth.map(_.show))
+        if onText.present then t"of $names" else t"in $names"
+
+    val setPosText: Optional[Text] =
+      if rule.bySetPos.isEmpty then Unset else t"taking the ${join(rule.bySetPos.map(ordinalWord))}"
+
+    val countText = if rule.count.absent then t"" else t", ${rule.count.vouch} times"
+
+    val clauses =
+      List(cadence) ++ onText.lay(Nil)(List(_)) ++ monthText.lay(Nil)(List(_)) ++
+        setPosText.lay(Nil)(List(_))
+
+    t"${clauses.join(t" ")}$countText"
+
+  private def monthDayWord(day: Int): Text =
+    if day == -1 then t"last day"
+    else if day < 0 then t"${aviation.internal.englishOrdinal(-day)}-to-last day"
+    else aviation.internal.englishOrdinal(day)
+
   // ── the expansion engine (Gregorian) ────────────────────────────────────────────────────────
 
   private def yearOf(date: Date)(using calendar: RomanCalendar): Int = date.year(using calendar)()
@@ -213,19 +275,20 @@ object Rrule:
   :   List[Date] =
 
     val byDayDates: Optional[List[Date]] =
-      if rule.byDay.isEmpty then Unset else rule.byDay.flatMap:
-        case WeekdayOrdinal(weekday, Unset)    => weekdaysOfMonth(year, month, weekday)
-        case WeekdayOrdinal(weekday, ord: Int) => list(nthWeekday(year, month, weekday, ord))
+      if rule.byDay.isEmpty then Unset else rule.byDay.flatMap: entry =>
+        if entry.ordinal.absent then weekdaysOfMonth(year, month, entry.weekday)
+        else list(nthWeekday(year, month, entry.weekday, entry.ordinal.vouch))
 
     val byMonthDayDates: Optional[List[Date]] =
       if rule.byMonthDay.isEmpty then Unset else rule.byMonthDay.flatMap: day =>
         list(monthDay(year, month, day))
 
-    val candidates = (byDayDates, byMonthDayDates) match
-      case (days: List[Date], monthDays: List[Date]) => days.filter(monthDays.contains)
-      case (days: List[Date], _)                     => days
-      case (_, monthDays: List[Date])                => monthDays
-      case _                                         => list(monthDay(year, month, dayOf(start)))
+    val candidates =
+      if byDayDates.present && byMonthDayDates.present
+      then byDayDates.vouch.filter(byMonthDayDates.vouch.contains)
+      else if byDayDates.present then byDayDates.vouch
+      else if byMonthDayDates.present then byMonthDayDates.vouch
+      else list(monthDay(year, month, dayOf(start)))
 
     candidates.distinct.sortBy(_.jdn)
 

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -1,0 +1,305 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package aviation
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import gossamer.*
+import prepositional.*
+import spectacular.*
+import vacuous.*
+
+// One `BYDAY` entry: a weekday, optionally with an ordinal — `3MO` (3rd Monday), `-1FR` (last
+// Friday), or a bare `TU` (every Tuesday in the period). The ordinal is meaningful only under
+// `Monthly`/`Yearly`; under `Weekly`/`Daily` a bare weekday acts as a filter.
+case class WeekdayOrdinal(weekday: Weekday, ordinal: Optional[Int] = Unset)
+
+// An iCalendar recurrence rule (RFC 5545 `RRULE`), pairing the rule with its start (`DTSTART`).
+// Occurrences expand each `frequency`×`interval` period and apply the `by*` anchors; invalid dates
+// (e.g. Feb 30) are skipped and the day-of-month re-anchors to `start`, so `Monthly` from Jan 31
+// yields Jan 31, Mar 31, May 31, … (RFC behaviour, deliberately unlike `Recurrence`'s drift). The
+// engine currently expands `Daily`…`Yearly` with `byMonth`, `byMonthDay`, `byDay` and `bySetPos`;
+// sub-day frequencies and `byYearDay`/`byWeekNo`/`byHour`/… are not yet expanded.
+object Rrule:
+  given dateRecurrent: (RomanCalendar, Ordering[Date])
+  =>  ( Rrule[Date] is Recurrent { type Topic = Date } ) =
+    rule => bounded(dates(rule.start, rule), rule.until, rule.count)
+
+  given timestampRecurrent: (RomanCalendar, Ordering[Timestamp])
+  =>  ( Rrule[Timestamp] is Recurrent { type Topic = Timestamp } ) =
+    rule =>
+      val stamps = dates(rule.start.date, rule).map(Timestamp(_, rule.start.time))
+      bounded(stamps, rule.until, rule.count)
+
+  // Apply COUNT (take) and UNTIL (inclusive upper bound) to a generated, ascending stream.
+  private def bounded[point](stream: LazyList[point], until: Optional[point], count: Optional[Int])
+    ( using order: Ordering[point] )
+  :   LazyList[point] =
+
+    val capped = until.lay(stream): limit =>
+      stream.takeWhile(!order.gt(_, limit))
+
+    count.lay(capped)(capped.take)
+
+  // ── RFC 5545 text form ───────────────────────────────────────────────────────────────────────
+  // The rule is serialised on its own (the `DTSTART`/`start` is separate in iCalendar), e.g.
+  // `FREQ=MONTHLY;INTERVAL=2;BYDAY=3MO;COUNT=10`. `parse` reattaches a supplied `start`.
+
+  private val weekdayCodes: List[Text] = List(t"MO", t"TU", t"WE", t"TH", t"FR", t"SA", t"SU")
+
+  private def code(weekday: Weekday): Text = weekdayCodes(weekday.ordinal)
+
+  private def renderDay(entry: WeekdayOrdinal): Text =
+    entry.ordinal.lay(code(entry.weekday)): ordinal =>
+      t"$ordinal${code(entry.weekday)}"
+
+  given encodable: [point: Encodable in Text] => Rrule[point] is Encodable in Text = rule =>
+    def part(condition: Boolean, text: => Text): List[Text] = if condition then List(text) else Nil
+
+    val parts =
+      part(true, t"FREQ=${rule.frequency.toString.tt.upper}") ++
+        part(rule.interval != 1, t"INTERVAL=${rule.interval}") ++
+        part(rule.count.present, t"COUNT=${rule.count.vouch}") ++
+        part(rule.until.present, t"UNTIL=${rule.until.vouch.encode}") ++
+        part(rule.byMonth.nonEmpty, t"BYMONTH=${rule.byMonth.map(_.numerical.show).join(t",")}") ++
+        part(rule.byMonthDay.nonEmpty, t"BYMONTHDAY=${rule.byMonthDay.map(_.show).join(t",")}") ++
+        part(rule.byDay.nonEmpty, t"BYDAY=${rule.byDay.map(renderDay).join(t",")}") ++
+        part(rule.bySetPos.nonEmpty, t"BYSETPOS=${rule.bySetPos.map(_.show).join(t",")}") ++
+        part(rule.weekStart != Weekday.Mon, t"WKST=${code(rule.weekStart)}")
+
+    parts.join(t";")
+
+  def parse[point: Decodable in Text](text: Text, start: point)(using Tactic[RruleError])
+  :   Rrule[point] =
+
+    val fields: Map[Text, Text] =
+      text.cut(t";").flatMap: pair =>
+        pair.cut(t"=") match
+          case List(key, value) => List(key.upper -> value)
+          case _                => Nil
+
+      . to(Map)
+
+    def field(key: Text): Optional[Text] = fields.get(key).getOrElse(Unset)
+
+    Rrule
+      ( start,
+        field(t"FREQ").lay(abort(RruleError(text)))(frequencyOf(_, text)),
+        field(t"INTERVAL").lay(1)(intOf(_, text)),
+        field(t"COUNT").lay(Unset)(intOf(_, text)),
+        field(t"UNTIL").lay(Unset)(_.decode[point]),
+        field(t"BYMONTH").lay(Nil)(ints(_, text).map { n => Month.fromOrdinal(n - 1) }),
+        field(t"BYMONTHDAY").lay(Nil)(ints(_, text)),
+        field(t"BYDAY").lay(Nil) { value => value.cut(t",").to(List).map(dayOf(_, text)) },
+        field(t"BYSETPOS").lay(Nil)(ints(_, text)),
+        field(t"WKST").lay(Weekday.Mon)(weekdayOf(_, text)) )
+
+  private def frequencyOf(text: Text, context: Text)(using Tactic[RruleError]): Frequency =
+    text.upper match
+      case t"SECONDLY" => Frequency.Secondly
+      case t"MINUTELY" => Frequency.Minutely
+      case t"HOURLY"   => Frequency.Hourly
+      case t"DAILY"    => Frequency.Daily
+      case t"WEEKLY"   => Frequency.Weekly
+      case t"MONTHLY"  => Frequency.Monthly
+      case t"YEARLY"   => Frequency.Yearly
+      case _           => abort(RruleError(context))
+
+  private def intOf(text: Text, context: Text)(using Tactic[RruleError]): Int =
+    val string = text.s
+    val body = if string.startsWith("-") || string.startsWith("+") then string.drop(1) else string
+    if body.nonEmpty && body.forall(_.isDigit) then string.toInt else abort(RruleError(context))
+
+  private def ints(text: Text, context: Text)(using Tactic[RruleError]): List[Int] =
+    text.cut(t",").map(intOf(_, context))
+
+  private def weekdayOf(text: Text, context: Text)(using Tactic[RruleError]): Weekday =
+    weekdayCodes.indexOf(text.upper) match
+      case -1    => abort(RruleError(context))
+      case index => Weekday.fromOrdinal(index)
+
+  private def dayOf(text: Text, context: Text)(using Tactic[RruleError]): WeekdayOrdinal =
+    val string = text.s
+    if string.length < 2 then abort(RruleError(context))
+    val weekday = weekdayOf(string.takeRight(2).tt, context)
+    val prefix = string.dropRight(2)
+    WeekdayOrdinal(weekday, if prefix.isEmpty then Unset else intOf(prefix.tt, context))
+
+  // ── the expansion engine (Gregorian) ────────────────────────────────────────────────────────
+
+  private def yearOf(date: Date)(using calendar: RomanCalendar): Int = date.year(using calendar)()
+  private def monthOf(date: Date)(using calendar: RomanCalendar): Int = date.month.numerical
+  private def dayOf(date: Date)(using calendar: RomanCalendar): Int = date.day(using calendar)()
+  private def list(date: Optional[Date]): List[Date] = date.lay(Nil)(List(_))
+
+  // The ascending stream of dates matching the rule, starting at or after `start` (COUNT/UNTIL are
+  // applied later, on the point stream). Each period is expanded independently and concatenated;
+  // since periods are ascending and disjoint, the result is ascending.
+  private def dates(start: Date, rule: Rrule[?])(using calendar: RomanCalendar): LazyList[Date] =
+    val raw: LazyList[Date] = rule.frequency match
+      case Frequency.Yearly =>
+        LazyList.iterate(yearOf(start))(_ + rule.interval).flatMap: year =>
+          yearMonths(year, start, rule).flatMap: month =>
+            setPos(expandMonth(year, month, start, rule), rule.bySetPos)
+
+      case Frequency.Monthly =>
+        months(start, rule.interval).flatMap: (year, month) =>
+          setPos(expandMonth(year, month, start, rule), rule.bySetPos)
+
+      case Frequency.Weekly =>
+        weeks(start, rule).flatMap: weekStart =>
+          setPos(expandWeek(weekStart, start, rule), rule.bySetPos)
+
+      case Frequency.Daily =>
+        LazyList.iterate(start)(_.addDays(rule.interval)).filter(dailyMatch(_, rule))
+
+      case _ =>
+        LazyList.empty // sub-day frequencies not yet expanded
+
+    raw.dropWhile(_.jdn < start.jdn)
+
+  // The months to expand within a `Yearly` period: the listed `byMonth`s, or every month if a
+  // day-level rule is present, or else the start's own month.
+  private def yearMonths(year: Int, start: Date, rule: Rrule[?])(using RomanCalendar): List[Int] =
+    if rule.byMonth.nonEmpty then rule.byMonth.map(_.numerical).sorted
+    else if rule.byDay.nonEmpty || rule.byMonthDay.nonEmpty then (1 to 12).to(List)
+    else List(monthOf(start))
+
+  // The ascending (year, month) periods for `Monthly`, stepping `interval` months from the start.
+  private def months(start: Date, interval: Int)(using RomanCalendar): LazyList[(Int, Int)] =
+    val first = yearOf(start)*12 + (monthOf(start) - 1)
+
+    LazyList.iterate(first)(_ + interval).map: n =>
+      (n/12, n%12 + 1)
+
+  // The ascending week-start dates for `Weekly`, aligned to `weekStart`, stepping `interval` weeks.
+  private def weeks(start: Date, rule: Rrule[?]): LazyList[Date] =
+    val offset = (start.weekday.ordinal - rule.weekStart.ordinal + 7)%7
+    LazyList.iterate(start.addDays(-offset))(_.addDays(7*rule.interval))
+
+  // The sorted, deduplicated candidate dates within one month, per the day-level rules.
+  private def expandMonth(year: Int, month: Int, start: Date, rule: Rrule[?])(using RomanCalendar)
+  :   List[Date] =
+
+    val byDayDates: Optional[List[Date]] =
+      if rule.byDay.isEmpty then Unset else rule.byDay.flatMap:
+        case WeekdayOrdinal(weekday, Unset)    => weekdaysOfMonth(year, month, weekday)
+        case WeekdayOrdinal(weekday, ord: Int) => list(nthWeekday(year, month, weekday, ord))
+
+    val byMonthDayDates: Optional[List[Date]] =
+      if rule.byMonthDay.isEmpty then Unset else rule.byMonthDay.flatMap: day =>
+        list(monthDay(year, month, day))
+
+    val candidates = (byDayDates, byMonthDayDates) match
+      case (days: List[Date], monthDays: List[Date]) => days.filter(monthDays.contains)
+      case (days: List[Date], _)                     => days
+      case (_, monthDays: List[Date])                => monthDays
+      case _                                         => list(monthDay(year, month, dayOf(start)))
+
+    candidates.distinct.sortBy(_.jdn)
+
+  // The candidate dates within one week (the 7 days from `weekStart`), per `byDay` (or the start's
+  // weekday), filtered by `byMonth`.
+  private def expandWeek(weekStart: Date, start: Date, rule: Rrule[?])(using RomanCalendar)
+  :   List[Date] =
+
+    val weekdays = if rule.byDay.nonEmpty then rule.byDay.map(_.weekday) else List(start.weekday)
+
+    (0 to 6).to(List).map(weekStart.addDays(_)).filter: date =>
+      weekdays.contains(date.weekday) && monthAllowed(date, rule)
+
+  private def dailyMatch(date: Date, rule: Rrule[?])(using RomanCalendar): Boolean =
+    monthAllowed(date, rule) &&
+      (rule.byMonthDay.isEmpty || rule.byMonthDay.exists(monthDayMatches(date, _))) &&
+      (rule.byDay.isEmpty || rule.byDay.map(_.weekday).contains(date.weekday))
+
+  private def monthAllowed(date: Date, rule: Rrule[?])(using RomanCalendar): Boolean =
+    rule.byMonth.isEmpty || rule.byMonth.map(_.numerical).contains(monthOf(date))
+
+  // ── calendar helpers ─────────────────────────────────────────────────────────────────────────
+
+  private def daysInMonth(year: Int, month: Int)(using calendar: RomanCalendar): Int =
+    calendar.daysInMonth(Month.fromOrdinal(month - 1), Year(year))
+
+  private def date(year: Int, month: Int, day: Int)(using RomanCalendar): Optional[Date] =
+    safely(Date(Year(year), Month.fromOrdinal(month - 1), Day(day)))
+
+  // A `byMonthDay` value resolved against a month: positive from the 1st, negative from the end.
+  private def monthDay(year: Int, month: Int, day: Int)(using RomanCalendar): Optional[Date] =
+    if day > 0 then date(year, month, day)
+    else date(year, month, daysInMonth(year, month) + day + 1)
+
+  private def monthDayMatches(value: Date, day: Int)(using RomanCalendar): Boolean =
+    val days = daysInMonth(yearOf(value), monthOf(value))
+    dayOf(value) == (if day > 0 then day else days + day + 1)
+
+  private def weekdaysOfMonth(year: Int, month: Int, weekday: Weekday)(using RomanCalendar)
+  :   List[Date] =
+
+    list(date(year, month, 1)).flatMap: first =>
+      val offset = (weekday.ordinal - first.weekday.ordinal + 7)%7
+      LazyList.iterate(first.addDays(offset))(_.addDays(7))
+        .takeWhile(monthOf(_) == month).to(List)
+
+  // The `ordinal`-th `weekday` of the month (positive from the start, negative from the end).
+  private def nthWeekday(year: Int, month: Int, weekday: Weekday, ordinal: Int)(using RomanCalendar)
+  :   Optional[Date] =
+
+    val all = weekdaysOfMonth(year, month, weekday)
+    val index = if ordinal > 0 then ordinal - 1 else all.length + ordinal
+    if index >= 0 && index < all.length then all(index) else Unset
+
+  // `BYSETPOS`: from each period's expanded set, keep the listed positions (1-based; negatives from
+  // the end).
+  private def setPos(candidates: List[Date], positions: List[Int]): List[Date] =
+    if positions.isEmpty then candidates else
+      val count = candidates.length
+
+      val chosen = positions.flatMap: position =>
+        val index = if position > 0 then position - 1 else count + position
+        if index >= 0 && index < count then List(candidates(index)) else Nil
+
+      chosen.distinct.sortBy(_.jdn)
+
+case class Rrule[point]
+  ( start:      point,
+    frequency:  Frequency,
+    interval:   Int                  = 1,
+    count:      Optional[Int]        = Unset,
+    until:      Optional[point]      = Unset,
+    byMonth:    List[Month]          = Nil,
+    byMonthDay: List[Int]            = Nil,
+    byDay:      List[WeekdayOrdinal] = Nil,
+    bySetPos:   List[Int]            = Nil,
+    weekStart:  Weekday              = Weekday.Mon )

--- a/lib/aviation/src/core/aviation.RruleError.scala
+++ b/lib/aviation/src/core/aviation.RruleError.scala
@@ -30,103 +30,10 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Frequency, Fri, Hebdomad, Holiday, Holidays,
-      Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapMode, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, monotonic, Monotonic, Month, Months, Monthstamp, Nov, now,
-      Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      following, occurrences, Posix, rec, Recurrence, RecurrenceError, recInterpolator,
-      RecurrenceLiteral, RecurrenceSet, Recurrent, Regime, Resolution, Rfc1123, RomanCalendar,
-      Rrule, RruleError, Tai, until, WeekdayOrdinal, within,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
+import anticipation.*
+import fulminate.*
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
-
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
-
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
-
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
-
-package leapModes:
-  export aviation.leapModes.exact
-
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
-
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
-
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package timespanFormats:
-  export aviation.timespanFormats.relativeTimespan
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+case class RruleError(value: Text)(using Diagnostics)
+extends Error(m"the value $value is not a valid RFC 5545 recurrence rule")

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -317,6 +317,40 @@ object internal:
       case _ =>
         Left(m"$text is not a valid ISO 8601 duration")
 
+  // Plain-English helpers shared by the recurrence `Showable`s.
+  def englishOrdinal(n: Int): Text =
+    val suffix =
+      if (n%100)/10 == 1 then t"th"
+      else n%10 match
+        case 1 => t"st"
+        case 2 => t"nd"
+        case 3 => t"rd"
+        case _ => t"th"
+
+    t"$n$suffix"
+
+  // Join with commas and a final "and": "a", "a and b", "a, b and c".
+  def joinAnd(items: List[Text]): Text = items match
+    case Nil        => t""
+    case List(item) => item
+    case _          => t"${items.init.join(t", ")} and ${items.last}"
+
+  // A duration in plain English: "2 weeks", "1 month", "1 day and 12 hours".
+  def durationPhrase(span: Timespan): Text =
+    def text(n: Int, singular: Text): List[Text] =
+      if n == 0 then Nil else if n == 1 then List(t"1 $singular") else List(t"$n ${singular}s")
+
+    val seconds = span.seconds.value
+
+    val parts =
+      text(span.years, t"year") ++ text(span.months, t"month") ++ text(span.weeks, t"week") ++
+        text(span.days, t"day") ++ text(span.hours, t"hour") ++ text(span.minutes, t"minute") ++
+        (if seconds == 0.0 then Nil
+         else if seconds == 1.0 then List(t"1 second")
+         else List(t"${seconds.toLong} seconds"))
+
+    if parts.isEmpty then t"no time" else joinAnd(parts)
+
   def tsInterpolator[parts <: Tuple: Type](insertions: Expr[Seq[Any]])
   :   Macro[Year | Monthstamp | Date | Timestamp | Moment] =
 

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -532,6 +532,27 @@ extension (inline context: StringContext)
 
   transparent inline def rec: Interpolation = interpolation[RecurrenceLiteral](context)
 
+// Combinators over any `Recurrent` (a `Recurrence`, an `Rrule`, …): its occurrence stream and ways
+// to bound it. `occurrences` is lazy and may be infinite — bound it with `until`/`within`/`take`.
+extension [series](series: series)(using recurrent: series is Recurrent)
+  def occurrences: LazyList[recurrent.Topic] = recurrent.occurrences(series)
+
+  def until(limit: recurrent.Topic)(using order: Ordering[recurrent.Topic])
+  :   LazyList[recurrent.Topic] =
+
+    recurrent.occurrences(series).takeWhile(order.lt(_, limit))
+
+  def within(window: Period[recurrent.Topic])(using order: Ordering[recurrent.Topic])
+  :   LazyList[recurrent.Topic] =
+
+    recurrent.occurrences(series).dropWhile(order.lt(_, window.start))
+      .takeWhile(order.lt(_, window.finish))
+
+  def following(after: recurrent.Topic)(using order: Ordering[recurrent.Topic])
+  :   Optional[recurrent.Topic] =
+
+    recurrent.occurrences(series).dropWhile(order.lteq(_, after)).headOption.getOrElse(Unset)
+
 export Weekday.{Mon, Tue, Wed, Thu, Fri, Sat, Sun}
 
 package hebdomads:

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2157,6 +2157,37 @@ object Tests extends Suite(m"Aviation Tests"):
         RecurrenceSet(include = List(a.occurrences, b.occurrences)).occurrences.to(List)
       . assert(_ == List(2024-Jan-1, 2024-Jan-3, 2024-Jan-8, 2024-Jan-10))
 
+    suite(m"Recurrence descriptions"):
+      import monthFormats.englishMonths
+      import weekdays.englishWeekdays
+
+      test(m"An rrule reads as plain English"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
+      . assert(_ == t"every month on the 3rd Monday")
+
+      test(m"A yearly rule names the month and weekday"):
+        Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov),
+            byDay = List(WeekdayOrdinal(Thu, 4))).show
+      . assert(_ == t"every year on the 4th Thursday of November")
+
+      test(m"A multi-weekday weekly rule with a count"):
+        Rrule(2024-Jan-1, Frequency.Weekly, byDay = List(WeekdayOrdinal(Mon), WeekdayOrdinal(Wed),
+            WeekdayOrdinal(Fri)), count = 10).show
+      . assert(_ == t"every week on Monday, Wednesday and Friday, 10 times")
+
+      test(m"The last day of the month"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byMonthDay = List(-1)).show
+      . assert(_ == t"every month on the last day")
+
+      test(m"An interval reads as 'every N units'"):
+        Rrule(2024-Jan-1, Frequency.Daily, interval = 3).show
+      . assert(_ == t"every 3 days")
+
+      test(m"A Recurrence reads as plain English"):
+        import dateFormats.iso8601DateFormat
+        Recurrence(2024-Jan-1, 2*Week, 5).show
+      . assert(_ == t"every 2 weeks, 5 times from 2024-01-01")
+
     suite(m"Moment subtraction"):
       import calendars.gregorianCalendar
 

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2066,6 +2066,97 @@ object Tests extends Suite(m"Aviation Tests"):
         demilitarize(rec"R5/2024-02-30/P1M")
       . assert(_.nonEmpty)
 
+    suite(m"Rrule expansion"):
+      import calendars.gregorianCalendar
+
+      test(m"Monthly on the 15th yields the 15th of each month"):
+        Rrule(2024-Jan-15, Frequency.Monthly, count = 4).occurrences.to(List)
+      . assert(_ == List(2024-Jan-15, 2024-Feb-15, 2024-Mar-15, 2024-Apr-15))
+
+      test(m"Monthly from the 31st skips months without a 31st (no drift)"):
+        Rrule(2024-Jan-31, Frequency.Monthly, count = 3).occurrences.to(List)
+      . assert(_ == List(2024-Jan-31, 2024-Mar-31, 2024-May-31))
+
+      test(m"The 3rd Monday of each month"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3)), count = 2)
+        . occurrences.to(List)
+      . assert(_ == List(2024-Jan-15, 2024-Feb-19))
+
+      test(m"The last Friday of each month"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Fri, -1)), count = 2)
+        . occurrences.to(List)
+      . assert(_ == List(2024-Jan-26, 2024-Feb-23))
+
+      test(m"Thanksgiving: the 4th Thursday of November each year"):
+        Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov), byDay = List(WeekdayOrdinal(Thu, 4)),
+            count = 2).occurrences.to(List)
+      . assert(_ == List(2024-Nov-28, 2025-Nov-27))
+
+      test(m"Weekly on Monday, Wednesday and Friday"):
+        Rrule(2024-Jan-1, Frequency.Weekly, byDay = List(WeekdayOrdinal(Mon), WeekdayOrdinal(Wed),
+            WeekdayOrdinal(Fri)), count = 4).occurrences.to(List)
+      . assert(_ == List(2024-Jan-1, 2024-Jan-3, 2024-Jan-5, 2024-Jan-8))
+
+      test(m"Every other week on the start's weekday"):
+        Rrule(2024-Jan-1, Frequency.Weekly, interval = 2, count = 3).occurrences.to(List)
+      . assert(_ == List(2024-Jan-1, 2024-Jan-15, 2024-Jan-29))
+
+      test(m"Daily every third day"):
+        Rrule(2024-Jan-1, Frequency.Daily, interval = 3, count = 3).occurrences.to(List)
+      . assert(_ == List(2024-Jan-1, 2024-Jan-4, 2024-Jan-7))
+
+      test(m"The last weekday of the month via BYSETPOS"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon), WeekdayOrdinal(Tue),
+            WeekdayOrdinal(Wed), WeekdayOrdinal(Thu), WeekdayOrdinal(Fri)), bySetPos = List(-1),
+            count = 2).occurrences.to(List)
+      . assert(_ == List(2024-Jan-31, 2024-Feb-29))
+
+      test(m"UNTIL bounds the occurrences inclusively"):
+        Rrule(2024-Jan-1, Frequency.Monthly, until = 2024-Mar-1).occurrences.to(List)
+      . assert(_ == List(2024-Jan-1, 2024-Feb-1, 2024-Mar-1))
+
+      test(m"A yearly rule repeats the start's date"):
+        Rrule(2024-Feb-29, Frequency.Yearly, count = 2).occurrences.to(List)
+      . assert(_ == List(2024-Feb-29, 2028-Feb-29))
+
+    suite(m"Rrule RFC 5545 text"):
+      import calendars.gregorianCalendar
+
+      test(m"An rrule renders as an RFC 5545 rule string"):
+        Rrule(2024-Jan-1, Frequency.Monthly, interval = 2, count = 10,
+            byDay = List(WeekdayOrdinal(Mon, 3))).encode
+      . assert(_ == t"FREQ=MONTHLY;INTERVAL=2;COUNT=10;BYDAY=3MO")
+
+      test(m"An rrule round-trips through its RFC 5545 string"):
+        val rule = Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov),
+            byDay = List(WeekdayOrdinal(Thu, 4)))
+        Rrule.parse(rule.encode, 2024-Jan-1).encode == rule.encode
+      . assert(_ == true)
+
+      test(m"A parsed rrule generates the right occurrences"):
+        Rrule.parse(t"FREQ=MONTHLY;BYDAY=-1FR", 2024-Jan-1).occurrences.take(2).to(List)
+      . assert(_ == List(2024-Jan-26, 2024-Feb-23))
+
+      test(m"An invalid rrule string raises RruleError"):
+        capture(Rrule.parse(t"FREQ=FORTNIGHTLY", 2024-Jan-1))
+      . matches:
+          case _: RruleError =>
+
+    suite(m"RecurrenceSet"):
+      import calendars.gregorianCalendar
+
+      test(m"A set unions a rule and rdates, minus exdates"):
+        val weekly = Rrule(2024-Jan-1, Frequency.Weekly, count = 4)
+        RecurrenceSet(include = List(weekly.occurrences), rdates = List(2024-Jan-10),
+            exdates = List(2024-Jan-15)).occurrences.to(List)
+      . assert(_ == List(2024-Jan-1, 2024-Jan-8, 2024-Jan-10, 2024-Jan-22))
+
+      test(m"A set merges two rules into one ascending stream"):
+        val a = Rrule(2024-Jan-1, Frequency.Weekly, count = 2)
+        val b = Rrule(2024-Jan-3, Frequency.Weekly, count = 2)
+        RecurrenceSet(include = List(a.occurrences, b.occurrences)).occurrences.to(List)
+      . assert(_ == List(2024-Jan-1, 2024-Jan-3, 2024-Jan-8, 2024-Jan-10))
+
     suite(m"Moment subtraction"):
       import calendars.gregorianCalendar
 


### PR DESCRIPTION
Adds calendar-anchored recurrences — iCalendar `RRULE` (RFC 5545) — addressing the remainder of #505, behind a shared interface with the ISO 8601 `Recurrence` from #1419.

### `Recurrent` — the common interface

A typeclass for any recurrence model: an ordered, lazy occurrence stream. The `occurrences`/`until`/`within`/`following` combinators are written once over it. `Recurrence` is refactored onto it; `Rrule` is a second implementation. (A typeclass, not a base trait, because the two need different givens to generate — an `Addable` vs a `Calendar`.)

### `Rrule` — calendar rules

```scala
Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3)))   // 3rd Monday each month
Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov), byDay = List(WeekdayOrdinal(Thu, 4)))  // Thanksgiving
Rrule(d, Frequency.Monthly, byDay = weekdays, bySetPos = List(-1))           // last weekday of the month
Rrule.parse(t"FREQ=MONTHLY;BYDAY=-1FR", start)                               // parse RFC 5545
```

`FREQ`/`INTERVAL`/`COUNT`/`UNTIL`/`BYMONTH`/`BYMONTHDAY`/`BYDAY` (with ordinals like `3MO`/`-1FR`)/`BYSETPOS`/`WKST`. The engine generates candidate dates directly from the rule, so invalid dates are **skipped** and the day re-anchors to the start — `Monthly` from Jan 31 → Jan 31, Mar 31, May 31 … (RFC behaviour, deliberately unlike `Recurrence`'s drift). `Encodable`/`Decodable` round-trip the RFC 5545 string.

### `RecurrenceSet`

Unions one or more recurrences' streams plus `RDATE`s, minus `EXDATE`s, and is itself `Recurrent`.

### Plain-English descriptions

`.show` describes a recurrence in English (alongside the machine `.encode` form):

```scala
Rrule(d, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show   // "every month on the 3rd Monday"
Rrule(d, Frequency.Yearly, byMonth = List(Nov),
      byDay = List(WeekdayOrdinal(Thu, 4))).show                          // "every year on the 4th Thursday of November"
Recurrence(d, 2*Week, 5).show                                            // "every 2 weeks, 5 times from 2024-01-01"
```

It reuses the existing `Months`/`Weekdays` name givens, so it's i18n-ready.

Not yet expanded (follow-ups): sub-day frequencies (`Hourly`/`Minutely`/`Secondly`) and `BYYEARDAY`/`BYWEEKNO`/`BYHOUR`/`BYMINUTE`/`BYSECOND`.