### PR TITLE
Aviation: multilingual recurrence & timespan descriptions (en/fr/de/es)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -459,7 +459,7 @@ object austronesian extends Library:
   object test extends Tests(core)
 
 object aviation extends Library:
-  object core extends Component(abacist.core, quantitative.units):
+  object core extends Component(abacist.core, quantitative.units, cosmopolite.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/aviation/src/core/aviation.Recurrence.scala
+++ b/lib/aviation/src/core/aviation.Recurrence.scala
@@ -34,7 +34,7 @@ package aviation
 
 import anticipation.*
 import contingency.*
-import cosmopolite.{Locale, en}
+import cosmopolite.{Locale, en, fr, de, es}
 import distillate.*
 import gossamer.*
 import prepositional.*
@@ -71,19 +71,23 @@ object Recurrence:
       val period: Timespan = recurrence.period
       t"R$number/${recurrence.start.encode}/${period.encode}"
 
-  // A plain-English description, e.g. "every 2 weeks, 5 times from <start>". `.encode` is the ISO
-  // wire form; `.show` is for people. Gated on `Locale[en]` so other languages can supply their own.
-  given showable: [point: Showable, span <: Timespan] => Locale[en]
+  // A natural-language description, e.g. "every 2 weeks, 5 times from <start>". `.encode` is the
+  // ISO wire form; `.show` is for people. Each language is a `Vernacular`, gated on its `Locale`.
+  given englishShowable: [point: Showable, span <: Timespan] => Locale[en]
   =>  (Recurrence of point by span) is Showable =
+    r => Vernacular.english.recurrence(r.period, r.repetitions, r.start.show)
 
-    recurrence =>
-      val period: Timespan = recurrence.period
-      val cadence = t"every ${aviation.internal.durationPhrase(period)}"
+  given frenchShowable: [point: Showable, span <: Timespan] => Locale[fr]
+  =>  (Recurrence of point by span) is Showable =
+    r => Vernacular.french.recurrence(r.period, r.repetitions, r.start.show)
 
-      val number =
-        if recurrence.repetitions.absent then t"" else t", ${recurrence.repetitions.vouch} times"
+  given germanShowable: [point: Showable, span <: Timespan] => Locale[de]
+  =>  (Recurrence of point by span) is Showable =
+    r => Vernacular.german.recurrence(r.period, r.repetitions, r.start.show)
 
-      t"$cadence$number from ${recurrence.start.show}"
+  given spanishShowable: [point: Showable, span <: Timespan] => Locale[es]
+  =>  (Recurrence of point by span) is Showable =
+    r => Vernacular.spanish.recurrence(r.period, r.repetitions, r.start.show)
 
   // Parsing erases the period's static radix set, so the caller names the period type they expect
   // (e.g. `decode[Recurrence of Timestamp by (Timespan of Month.type)]`); the parsed duration is

--- a/lib/aviation/src/core/aviation.Recurrence.scala
+++ b/lib/aviation/src/core/aviation.Recurrence.scala
@@ -34,6 +34,7 @@ package aviation
 
 import anticipation.*
 import contingency.*
+import cosmopolite.{Locale, en}
 import distillate.*
 import gossamer.*
 import prepositional.*
@@ -71,8 +72,10 @@ object Recurrence:
       t"R$number/${recurrence.start.encode}/${period.encode}"
 
   // A plain-English description, e.g. "every 2 weeks, 5 times from <start>". `.encode` is the ISO
-  // wire form; `.show` is for people.
-  given showable: [point: Showable, span <: Timespan] => (Recurrence of point by span) is Showable =
+  // wire form; `.show` is for people. Gated on `Locale[en]` so other languages can supply their own.
+  given showable: [point: Showable, span <: Timespan] => Locale[en]
+  =>  (Recurrence of point by span) is Showable =
+
     recurrence =>
       val period: Timespan = recurrence.period
       val cadence = t"every ${aviation.internal.durationPhrase(period)}"

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -34,7 +34,7 @@ package aviation
 
 import anticipation.*
 import contingency.*
-import cosmopolite.{Locale, en}
+import cosmopolite.{Locale, en, fr, de, es}
 import distillate.*
 import gossamer.*
 import prepositional.*
@@ -51,7 +51,7 @@ case class WeekdayOrdinal(weekday: Weekday, ordinal: Optional[Int] = Unset)
 // (e.g. Feb 30) are skipped and the day-of-month re-anchors to `start`, so `Monthly` from Jan 31
 // yields Jan 31, Mar 31, May 31, … (RFC behaviour, deliberately unlike `Recurrence`'s drift). The
 // engine expands every `frequency` (`Secondly`…`Yearly`) with all the `by*` anchors — `byMonth`,
-// `byWeekNo`, `byYearDay`, `byMonthDay`, `byDay`, `byHour`, `byMinute`, `bySecond` and `bySetPos`. A
+// `byWeekNo`, `byYearDay`, `byMonthDay`, `byDay`, `byHour`, `byMinute`, `bySecond`, `bySetPos`. A
 // `Rrule[Date]` yields dates, a `Rrule[Timestamp]` yields zoneless date-times (expanded by
 // `byHour`/…), and a `Rrule[Moment]` grounds each in the start's timezone.
 object Rrule:
@@ -174,67 +174,21 @@ object Rrule:
     val prefix = string.dropRight(2)
     WeekdayOrdinal(weekday, if prefix.isEmpty then Unset else intOf(prefix.tt, context))
 
-  // ── plain-English description ────────────────────────────────────────────────────────────────
-  // `.encode` is the RFC 5545 wire form; `.show` describes the rule in English, e.g. "every month
-  // on the 3rd Monday" or "every year on the 4th Thursday of November".
+  // ── natural-language description ─────────────────────────────────────────────────────────────
+  // `.encode` is the RFC 5545 wire form; `.show` describes the rule in prose, e.g. "every month on
+  // the 3rd Monday". Each language is a `Vernacular`, gated on its `Locale`.
 
-  private def unitName(frequency: Frequency, plural: Boolean): Text = frequency match
-    case Frequency.Secondly => if plural then t"seconds" else t"second"
-    case Frequency.Minutely => if plural then t"minutes" else t"minute"
-    case Frequency.Hourly   => if plural then t"hours" else t"hour"
-    case Frequency.Daily    => if plural then t"days" else t"day"
-    case Frequency.Weekly   => if plural then t"weeks" else t"week"
-    case Frequency.Monthly  => if plural then t"months" else t"month"
-    case Frequency.Yearly   => if plural then t"years" else t"year"
+  given englishShowable: [point] => (Months, Weekdays, Locale[en]) => Rrule[point] is Showable =
+    Vernacular.english.rrule(_)
 
-  private def ordinalWord(n: Int): Text =
-    if n == -1 then t"last"
-    else if n < 0 then t"${aviation.internal.englishOrdinal(-n)}-to-last"
-    else aviation.internal.englishOrdinal(n)
+  given frenchShowable: [point] => (Months, Weekdays, Locale[fr]) => Rrule[point] is Showable =
+    Vernacular.french.rrule(_)
 
-  given showable: [point] => (Months, Weekdays, Locale[en]) => Rrule[point] is Showable = rule =>
-    val join = aviation.internal.joinAnd
+  given germanShowable: [point] => (Months, Weekdays, Locale[de]) => Rrule[point] is Showable =
+    Vernacular.german.rrule(_)
 
-    val cadence =
-      if rule.interval == 1 then t"every ${unitName(rule.frequency, false)}"
-      else t"every ${rule.interval} ${unitName(rule.frequency, true)}"
-
-    val byDayText: Optional[Text] =
-      if rule.byDay.isEmpty then Unset else
-        val hasOrdinal = rule.byDay.exists(_.ordinal.present)
-
-        val entries = rule.byDay.map: entry =>
-          if entry.ordinal.absent then entry.weekday.show
-          else t"${ordinalWord(entry.ordinal.vouch)} ${entry.weekday.show}"
-
-        t"on ${if hasOrdinal then t"the " else t""}${join(entries)}"
-
-    val byMonthDayText: Optional[Text] =
-      if rule.byMonthDay.isEmpty then Unset
-      else t"on the ${join(rule.byMonthDay.map(monthDayWord))}"
-
-    val onText: Optional[Text] = if rule.byDay.nonEmpty then byDayText else byMonthDayText
-
-    val monthText: Optional[Text] =
-      if rule.byMonth.isEmpty then Unset else
-        val names = join(rule.byMonth.map(_.show))
-        if onText.present then t"of $names" else t"in $names"
-
-    val setPosText: Optional[Text] =
-      if rule.bySetPos.isEmpty then Unset else t"taking the ${join(rule.bySetPos.map(ordinalWord))}"
-
-    val countText = if rule.count.absent then t"" else t", ${rule.count.vouch} times"
-
-    val clauses =
-      List(cadence) ++ onText.lay(Nil)(List(_)) ++ monthText.lay(Nil)(List(_)) ++
-        setPosText.lay(Nil)(List(_))
-
-    t"${clauses.join(t" ")}$countText"
-
-  private def monthDayWord(day: Int): Text =
-    if day == -1 then t"last day"
-    else if day < 0 then t"${aviation.internal.englishOrdinal(-day)}-to-last day"
-    else aviation.internal.englishOrdinal(day)
+  given spanishShowable: [point] => (Months, Weekdays, Locale[es]) => Rrule[point] is Showable =
+    Vernacular.spanish.rrule(_)
 
   // ── the expansion engine (Gregorian) ────────────────────────────────────────────────────────
 
@@ -298,15 +252,15 @@ object Rrule:
     rule.byYearDay.flatMap { day => list(yearDay(year, day)) }.filter(monthAllowed(_, rule))
 
   // The `byWeekNo` dates within a week-year (ISO weeks, Monday-based): for each selected week number
-  // (negatives count back from the year's last week), the `byDay` weekdays — or the start's weekday —
-  // of that week, filtered by `byMonth`.
+  // (negatives count back from the last week), the `byDay` weekdays — or the start's weekday — of
+  // that week, filtered by `byMonth`.
   private def weekNoDates(year: Int, start: Date, rule: Rrule[?])(using RomanCalendar): List[Date] =
     val count = WeekDate.weekOfYear(unsafely(Date(Year(year), Month.Dec, Day(28))))
     val weekdays = if rule.byDay.nonEmpty then rule.byDay.map(_.weekday) else List(start.weekday)
 
     val weeks =
-      rule.byWeekNo.map { week => if week > 0 then week else count + week + 1 }
-        .filter { week => week >= 1 && week <= count }
+      rule.byWeekNo.map(week => if week > 0 then week else count + week + 1)
+        .filter(week => week >= 1 && week <= count)
 
     val dates =
       for

--- a/lib/aviation/src/core/aviation.Rrule.scala
+++ b/lib/aviation/src/core/aviation.Rrule.scala
@@ -34,6 +34,7 @@ package aviation
 
 import anticipation.*
 import contingency.*
+import cosmopolite.{Locale, en}
 import distillate.*
 import gossamer.*
 import prepositional.*
@@ -191,7 +192,7 @@ object Rrule:
     else if n < 0 then t"${aviation.internal.englishOrdinal(-n)}-to-last"
     else aviation.internal.englishOrdinal(n)
 
-  given showable: [point] => (Months, Weekdays) => Rrule[point] is Showable = rule =>
+  given showable: [point] => (Months, Weekdays, Locale[en]) => Rrule[point] is Showable = rule =>
     val join = aviation.internal.joinAnd
 
     val cadence =

--- a/lib/aviation/src/core/aviation.Vernacular.scala
+++ b/lib/aviation/src/core/aviation.Vernacular.scala
@@ -1,0 +1,297 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package aviation
+
+import anticipation.*
+import gossamer.*
+import prepositional.*
+import spectacular.*
+import vacuous.*
+
+// The time units a duration or frequency is built from, coarsest first.
+enum TimeUnit:
+  case Years, Months, Weeks, Days, Hours, Minutes, Seconds
+
+object Vernacular:
+  def components(span: Timespan): List[(Long, TimeUnit)] =
+    List
+     ( (span.years.toLong, TimeUnit.Years), (span.months.toLong, TimeUnit.Months),
+       (span.weeks.toLong, TimeUnit.Weeks), (span.days.toLong, TimeUnit.Days),
+       (span.hours.toLong, TimeUnit.Hours), (span.minutes.toLong, TimeUnit.Minutes),
+       (span.seconds.value.toLong, TimeUnit.Seconds) )
+    . filter(_(0) != 0)
+
+  def unitOf(frequency: Frequency): TimeUnit = frequency match
+    case Frequency.Secondly => TimeUnit.Seconds
+    case Frequency.Minutely => TimeUnit.Minutes
+    case Frequency.Hourly   => TimeUnit.Hours
+    case Frequency.Daily    => TimeUnit.Days
+    case Frequency.Weekly   => TimeUnit.Weeks
+    case Frequency.Monthly  => TimeUnit.Months
+    case Frequency.Yearly   => TimeUnit.Years
+
+  val english: Vernacular = English
+  val french: Vernacular = French
+  val german: Vernacular = German
+  val spanish: Vernacular = Spanish
+
+  private object English extends Vernacular:
+    private def word(unit: TimeUnit): (Text, Text) = unit match
+      case TimeUnit.Years   => (t"year", t"years")
+      case TimeUnit.Months  => (t"month", t"months")
+      case TimeUnit.Weeks   => (t"week", t"weeks")
+      case TimeUnit.Days    => (t"day", t"days")
+      case TimeUnit.Hours   => (t"hour", t"hours")
+      case TimeUnit.Minutes => (t"minute", t"minutes")
+      case TimeUnit.Seconds => (t"second", t"seconds")
+
+    private def ordinal(n: Int): Text = aviation.internal.englishOrdinal(n)
+    private def monthDay(n: Int): Text =
+      if n == -1 then t"last day" else if n < 0 then t"${ordinal(-n)}-to-last day" else ordinal(n)
+
+    def conjunction: Text = t"and"
+    def justNow: Text = t"just now"
+    def future(body: Text): Text = t"in $body"
+    def past(body: Text): Text = t"$body ago"
+    def times(count: Int): Text = t", $count times"
+    def from(start: Text): Text = t"from $start"
+
+    def position(n: Int): Text =
+      if n == -1 then t"last" else if n < 0 then t"${ordinal(-n)}-to-last" else ordinal(n)
+
+    def units(count: Long, unit: TimeUnit): Text =
+      t"$count ${if count == 1 then word(unit)(0) else word(unit)(1)}"
+
+    def everyDuration(span: Timespan): Text = t"every ${conjoin(durations(span))}"
+
+    def everyUnit(interval: Int, unit: TimeUnit): Text =
+      if interval == 1 then t"every ${word(unit)(0)}" else t"every $interval ${word(unit)(1)}"
+
+    def onDays(entries: List[(Optional[Int], Text)]): Text =
+      val article = if entries.exists(_(0).present) then t"the " else t""
+      t"on $article${conjoin(entries.map(dayPhrase))}"
+
+    def onMonthDays(days: List[Int]): Text = t"on the ${conjoin(days.map(monthDay))}"
+
+    def inMonths(names: List[Text], withDay: Boolean): Text =
+      if withDay then t"of ${conjoin(names)}" else t"in ${conjoin(names)}"
+
+    def takingPositions(positions: List[Int]): Text = t"taking the ${conjoin(positions.map(position))}"
+
+  private object French extends Vernacular:
+    private def word(unit: TimeUnit): (Text, Text, Boolean) = unit match
+      case TimeUnit.Years   => (t"an", t"ans", true)
+      case TimeUnit.Months  => (t"mois", t"mois", true)
+      case TimeUnit.Weeks   => (t"semaine", t"semaines", false)
+      case TimeUnit.Days    => (t"jour", t"jours", true)
+      case TimeUnit.Hours   => (t"heure", t"heures", false)
+      case TimeUnit.Minutes => (t"minute", t"minutes", false)
+      case TimeUnit.Seconds => (t"seconde", t"secondes", false)
+
+    private def ordinal(n: Int): Text = if n == 1 then t"1er" else t"${n}e"
+    private def monthDay(n: Int): Text = if n == -1 then t"dernier jour" else t"$n"
+    private def article(unit: TimeUnit): Text = if word(unit)(2) then t"tous les" else t"toutes les"
+
+    def conjunction: Text = t"et"
+    def justNow: Text = t"à l'instant"
+    def future(body: Text): Text = t"dans $body"
+    def past(body: Text): Text = t"il y a $body"
+    def times(count: Int): Text = t", $count fois"
+    def from(start: Text): Text = t"à partir du $start"
+    def position(n: Int): Text = if n == -1 then t"dernier" else ordinal(n.abs)
+
+    def units(count: Long, unit: TimeUnit): Text =
+      t"$count ${if count == 1 then word(unit)(0) else word(unit)(1)}"
+
+    def everyDuration(span: Timespan): Text =
+      val first = Vernacular.components(span).headOption.map(_(1)).getOrElse(TimeUnit.Days)
+      t"${article(first)} ${conjoin(durations(span))}"
+
+    def everyUnit(interval: Int, unit: TimeUnit): Text =
+      if interval == 1 then t"${article(unit)} ${word(unit)(1)}"
+      else t"${article(unit)} $interval ${word(unit)(1)}"
+
+    def onDays(entries: List[(Optional[Int], Text)]): Text = t"le ${conjoin(entries.map(dayPhrase))}"
+    def onMonthDays(days: List[Int]): Text = t"le ${conjoin(days.map(monthDay))}"
+
+    def inMonths(names: List[Text], withDay: Boolean): Text =
+      if withDay then t"de ${conjoin(names)}" else t"en ${conjoin(names)}"
+
+    def takingPositions(positions: List[Int]): Text =
+      t"en prenant le ${conjoin(positions.map(position))}"
+
+  private object German extends Vernacular:
+    private def word(unit: TimeUnit): (Text, Text, Text) = unit match
+      case TimeUnit.Years   => (t"Jahr", t"Jahre", t"jedes")
+      case TimeUnit.Months  => (t"Monat", t"Monate", t"jeden")
+      case TimeUnit.Weeks   => (t"Woche", t"Wochen", t"jede")
+      case TimeUnit.Days    => (t"Tag", t"Tage", t"jeden")
+      case TimeUnit.Hours   => (t"Stunde", t"Stunden", t"jede")
+      case TimeUnit.Minutes => (t"Minute", t"Minuten", t"jede")
+      case TimeUnit.Seconds => (t"Sekunde", t"Sekunden", t"jede")
+
+    private def ordinal(n: Int): Text = t"$n."
+    private def monthDay(n: Int): Text = if n == -1 then t"letzten Tag" else t"$n."
+    private def setPos(n: Int): Text = if n == -1 then t"der letzte" else t"der ${ordinal(n.abs)}"
+
+    def conjunction: Text = t"und"
+    def justNow: Text = t"gerade eben"
+    def future(body: Text): Text = t"in $body"
+    def past(body: Text): Text = t"vor $body"
+    def times(count: Int): Text = t", $count Mal"
+    def from(start: Text): Text = t"ab $start"
+    def position(n: Int): Text = if n == -1 then t"letzte" else ordinal(n.abs)
+
+    def units(count: Long, unit: TimeUnit): Text =
+      t"$count ${if count == 1 then word(unit)(0) else word(unit)(1)}"
+
+    def everyDuration(span: Timespan): Text = Vernacular.components(span) match
+      case List((1, unit)) => t"${word(unit)(2)} ${word(unit)(0)}"
+      case parts           => t"alle ${conjoin(parts.map(quantity))}"
+
+    def everyUnit(interval: Int, unit: TimeUnit): Text =
+      if interval == 1 then t"${word(unit)(2)} ${word(unit)(0)}"
+      else t"alle $interval ${word(unit)(1)}"
+
+    def onDays(entries: List[(Optional[Int], Text)]): Text = t"am ${conjoin(entries.map(dayPhrase))}"
+    def onMonthDays(days: List[Int]): Text = t"am ${conjoin(days.map(monthDay))}"
+    def inMonths(names: List[Text], withDay: Boolean): Text = t"im ${conjoin(names)}"
+
+    def takingPositions(positions: List[Int]): Text = t"davon ${conjoin(positions.map(setPos))}"
+
+  private object Spanish extends Vernacular:
+    private def word(unit: TimeUnit): (Text, Text) = unit match
+      case TimeUnit.Years   => (t"año", t"años")
+      case TimeUnit.Months  => (t"mes", t"meses")
+      case TimeUnit.Weeks   => (t"semana", t"semanas")
+      case TimeUnit.Days    => (t"día", t"días")
+      case TimeUnit.Hours   => (t"hora", t"horas")
+      case TimeUnit.Minutes => (t"minuto", t"minutos")
+      case TimeUnit.Seconds => (t"segundo", t"segundos")
+
+    private val ordinalWords: List[Text] =
+      List(t"primer", t"segundo", t"tercer", t"cuarto", t"quinto", t"sexto", t"séptimo", t"octavo",
+          t"noveno", t"décimo")
+
+    private def ordinal(n: Int): Text =
+      if n >= 1 && n <= ordinalWords.length then ordinalWords(n - 1) else t"$n.º"
+
+    private def monthDay(n: Int): Text = if n == -1 then t"último día" else t"día $n"
+
+    def conjunction: Text = t"y"
+    def justNow: Text = t"justo ahora"
+    def future(body: Text): Text = t"en $body"
+    def past(body: Text): Text = t"hace $body"
+    def times(count: Int): Text = t", $count veces"
+    def from(start: Text): Text = t"desde $start"
+    def position(n: Int): Text = if n == -1 then t"último" else ordinal(n.abs)
+
+    def units(count: Long, unit: TimeUnit): Text =
+      t"$count ${if count == 1 then word(unit)(0) else word(unit)(1)}"
+
+    def everyDuration(span: Timespan): Text = t"cada ${conjoin(durations(span))}"
+
+    def everyUnit(interval: Int, unit: TimeUnit): Text =
+      if interval == 1 then t"cada ${word(unit)(0)}" else t"cada $interval ${word(unit)(1)}"
+
+    def onDays(entries: List[(Optional[Int], Text)]): Text = t"el ${conjoin(entries.map(dayPhrase))}"
+    def onMonthDays(days: List[Int]): Text = t"el ${conjoin(days.map(monthDay))}"
+
+    def inMonths(names: List[Text], withDay: Boolean): Text =
+      if withDay then t"de ${conjoin(names)}" else t"en ${conjoin(names)}"
+
+    def takingPositions(positions: List[Int]): Text = t"tomando el ${conjoin(positions.map(position))}"
+
+// A `Vernacular` supplies one language's vocabulary and grammar for describing recurrences and
+// relative timespans in prose. The structural assembly (which clauses apply, in what order) is
+// shared in the `final` methods; each language fills in the words and the grammatical hooks. These
+// translations are a first pass intended for refinement by native speakers.
+trait Vernacular:
+  def units(count: Long, unit: TimeUnit): Text
+  def conjunction: Text
+  def position(n: Int): Text
+  def justNow: Text
+  def future(body: Text): Text
+  def past(body: Text): Text
+  def everyDuration(span: Timespan): Text
+  def everyUnit(interval: Int, unit: TimeUnit): Text
+  def times(count: Int): Text
+  def from(start: Text): Text
+  def onDays(entries: List[(Optional[Int], Text)]): Text
+  def onMonthDays(days: List[Int]): Text
+  def inMonths(names: List[Text], withDay: Boolean): Text
+  def takingPositions(positions: List[Int]): Text
+
+  protected final def conjoin(items: List[Text]): Text = items match
+    case Nil        => t""
+    case List(item) => item
+    case other      => t"${other.init.join(t", ")} $conjunction ${other.last}"
+
+  protected final def quantity(pair: (Long, TimeUnit)): Text = units(pair(0).abs, pair(1))
+  protected final def durations(span: Timespan): List[Text] = Vernacular.components(span).map(quantity)
+
+  protected final def dayPhrase(entry: (Optional[Int], Text)): Text =
+    if entry(0).absent then entry(1) else t"${position(entry(0).vouch)} ${entry(1)}"
+
+  final def relativeTimespan(span: Timespan): Text = Vernacular.components(span) match
+    case Nil => justNow
+
+    case parts =>
+      val body = conjoin(parts.map(quantity))
+      if parts.head(0) < 0 then past(body) else future(body)
+
+  final def recurrence(period: Timespan, repetitions: Optional[Int], start: Text): Text =
+    t"${everyDuration(period)}${repetitions.lay(t"")(times)} ${from(start)}"
+
+  final def rrule(rule: Rrule[?])(using Months, Weekdays): Text =
+    def dayEntry(entry: WeekdayOrdinal): (Optional[Int], Text) = (entry.ordinal, entry.weekday.show)
+    def monthName(month: Month): Text = month.show
+
+    val cadence = everyUnit(rule.interval, Vernacular.unitOf(rule.frequency))
+
+    val onClause: Optional[Text] =
+      if rule.byDay.nonEmpty then onDays(rule.byDay.map(dayEntry))
+      else if rule.byMonthDay.nonEmpty then onMonthDays(rule.byMonthDay)
+      else Unset
+
+    val monthClause: Optional[Text] =
+      if rule.byMonth.isEmpty then Unset else inMonths(rule.byMonth.map(monthName), onClause.present)
+
+    val setPosClause: Optional[Text] =
+      if rule.bySetPos.isEmpty then Unset else takingPositions(rule.bySetPos)
+
+    val clauses =
+      List(cadence) ++ onClause.lay(Nil)(List(_)) ++ monthClause.lay(Nil)(List(_))
+        ++ setPosClause.lay(Nil)(List(_))
+
+    t"${clauses.join(t" ")}${rule.count.lay(t"")(times)}"

--- a/lib/aviation/src/core/aviation.internal.scala
+++ b/lib/aviation/src/core/aviation.internal.scala
@@ -317,7 +317,7 @@ object internal:
       case _ =>
         Left(m"$text is not a valid ISO 8601 duration")
 
-  // Plain-English helpers shared by the recurrence `Showable`s.
+  // English ordinal ("1st", "2nd", "3rd", "4th", …), used by the English `Vernacular`.
   def englishOrdinal(n: Int): Text =
     val suffix =
       if (n%100)/10 == 1 then t"th"
@@ -328,28 +328,6 @@ object internal:
         case _ => t"th"
 
     t"$n$suffix"
-
-  // Join with commas and a final "and": "a", "a and b", "a, b and c".
-  def joinAnd(items: List[Text]): Text = items match
-    case Nil        => t""
-    case List(item) => item
-    case _          => t"${items.init.join(t", ")} and ${items.last}"
-
-  // A duration in plain English: "2 weeks", "1 month", "1 day and 12 hours".
-  def durationPhrase(span: Timespan): Text =
-    def text(n: Int, singular: Text): List[Text] =
-      if n == 0 then Nil else if n == 1 then List(t"1 $singular") else List(t"$n ${singular}s")
-
-    val seconds = span.seconds.value
-
-    val parts =
-      text(span.years, t"year") ++ text(span.months, t"month") ++ text(span.weeks, t"week") ++
-        text(span.days, t"day") ++ text(span.hours, t"hour") ++ text(span.minutes, t"minute") ++
-        (if seconds == 0.0 then Nil
-         else if seconds == 1.0 then List(t"1 second")
-         else List(t"${seconds.toLong} seconds"))
-
-    if parts.isEmpty then t"no time" else joinAnd(parts)
 
   def tsInterpolator[parts <: Tuple: Type](insertions: Expr[Seq[Any]])
   :   Macro[Year | Monthstamp | Date | Timestamp | Moment] =

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -35,7 +35,7 @@ package aviation
 import anticipation.*
 import contextual.*
 import contingency.*
-import cosmopolite.{Locale, en}
+import cosmopolite.{Locale, en, fr, de, es}
 import distillate.*
 import fulminate.*
 import gossamer.*
@@ -186,6 +186,33 @@ package dateFormats:
       case Weekday.Sat => t"Sa"
       case Weekday.Sun => t"Su"
 
+    given frenchWeekdays: Weekdays =
+      case Weekday.Mon => t"lundi"
+      case Weekday.Tue => t"mardi"
+      case Weekday.Wed => t"mercredi"
+      case Weekday.Thu => t"jeudi"
+      case Weekday.Fri => t"vendredi"
+      case Weekday.Sat => t"samedi"
+      case Weekday.Sun => t"dimanche"
+
+    given germanWeekdays: Weekdays =
+      case Weekday.Mon => t"Montag"
+      case Weekday.Tue => t"Dienstag"
+      case Weekday.Wed => t"Mittwoch"
+      case Weekday.Thu => t"Donnerstag"
+      case Weekday.Fri => t"Freitag"
+      case Weekday.Sat => t"Samstag"
+      case Weekday.Sun => t"Sonntag"
+
+    given spanishWeekdays: Weekdays =
+      case Weekday.Mon => t"lunes"
+      case Weekday.Tue => t"martes"
+      case Weekday.Wed => t"miércoles"
+      case Weekday.Thu => t"jueves"
+      case Weekday.Fri => t"viernes"
+      case Weekday.Sat => t"sábado"
+      case Weekday.Sun => t"domingo"
+
   package months:
     given englishMonths: Months =
       case Jan => t"January"
@@ -214,6 +241,48 @@ package dateFormats:
       case Oct => t"Oct"
       case Nov => t"Nov"
       case Dec => t"Dec"
+
+    given frenchMonths: Months =
+      case Jan => t"janvier"
+      case Feb => t"février"
+      case Mar => t"mars"
+      case Apr => t"avril"
+      case May => t"mai"
+      case Jun => t"juin"
+      case Jul => t"juillet"
+      case Aug => t"août"
+      case Sep => t"septembre"
+      case Oct => t"octobre"
+      case Nov => t"novembre"
+      case Dec => t"décembre"
+
+    given germanMonths: Months =
+      case Jan => t"Januar"
+      case Feb => t"Februar"
+      case Mar => t"März"
+      case Apr => t"April"
+      case May => t"Mai"
+      case Jun => t"Juni"
+      case Jul => t"Juli"
+      case Aug => t"August"
+      case Sep => t"September"
+      case Oct => t"Oktober"
+      case Nov => t"November"
+      case Dec => t"Dezember"
+
+    given spanishMonths: Months =
+      case Jan => t"enero"
+      case Feb => t"febrero"
+      case Mar => t"marzo"
+      case Apr => t"abril"
+      case May => t"mayo"
+      case Jun => t"junio"
+      case Jul => t"julio"
+      case Aug => t"agosto"
+      case Sep => t"septiembre"
+      case Oct => t"octubre"
+      case Nov => t"noviembre"
+      case Dec => t"diciembre"
 
     given oneLetterAmbiguousMonths: Months =
       case Jan => t"J"
@@ -327,34 +396,15 @@ package timeFormats:
     given frenchTimeSeparator: TimeSeparation = () => t"h"
 
 // A human-readable, relative rendering of a `Timespan`, in place of the default ISO-8601 duration:
-// "in 18 minutes", "in 1 hour and 6 seconds", "8 minutes ago", "12 hours and 38 minutes ago", and
-// "just now" for a zero span. Only the non-zero components are shown (coarsest first); the sign
-// chooses "in …" / "… ago". `import timespanFormats.relativeTimespan` to use it.
+// "in 18 minutes", "8 minutes ago", "just now", and their French/German/Spanish equivalents. Only
+// the non-zero components are shown (coarsest first); the sign chooses the future/past form. Import
+// the variant for the language(s) you want (e.g. `timespanFormats.frenchRelative`); the in-scope
+// `Locale` selects which applies.
 package timespanFormats:
-  given relativeTimespan: Locale[en] => Timespan is Showable = timespan =>
-    val fields: List[(Long, Text, Text)] =
-      List
-        ( (timespan.years.toLong,         t"year",   t"years"),
-          (timespan.months.toLong,        t"month",  t"months"),
-          (timespan.weeks.toLong,         t"week",   t"weeks"),
-          (timespan.days.toLong,          t"day",    t"days"),
-          (timespan.hours.toLong,         t"hour",   t"hours"),
-          (timespan.minutes.toLong,       t"minute", t"minutes"),
-          (timespan.seconds.value.toLong, t"second", t"seconds") )
-
-    val nonZero = fields.filter(_._1 != 0)
-
-    if nonZero.isEmpty then t"just now" else
-      val rendered = nonZero.map: field =>
-        val magnitude = field._1.abs
-        t"$magnitude ${if magnitude == 1 then field._2 else field._3}"
-
-      val joined =
-        rendered match
-          case List(one) => one
-          case many      => t"${many.init.join(t", ")} and ${many.last}"
-
-      if nonZero.head._1 < 0 then t"$joined ago" else t"in $joined"
+  given englishRelative: Locale[en] => Timespan is Showable = Vernacular.english.relativeTimespan(_)
+  given frenchRelative: Locale[fr] => Timespan is Showable = Vernacular.french.relativeTimespan(_)
+  given germanRelative: Locale[de] => Timespan is Showable = Vernacular.german.relativeTimespan(_)
+  given spanishRelative: Locale[es] => Timespan is Showable = Vernacular.spanish.relativeTimespan(_)
 
 package calendars:
   given julianCalendar: RomanCalendar(t"Julian"):

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -35,6 +35,7 @@ package aviation
 import anticipation.*
 import contextual.*
 import contingency.*
+import cosmopolite.{Locale, en}
 import distillate.*
 import fulminate.*
 import gossamer.*
@@ -330,7 +331,7 @@ package timeFormats:
 // "just now" for a zero span. Only the non-zero components are shown (coarsest first); the sign
 // chooses "in …" / "… ago". `import timespanFormats.relativeTimespan` to use it.
 package timespanFormats:
-  given relativeTimespan: Timespan is Showable = timespan =>
+  given relativeTimespan: Locale[en] => Timespan is Showable = timespan =>
     val fields: List[(Long, Text, Text)] =
       List
         ( (timespan.years.toLong,         t"year",   t"years"),

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -94,13 +94,14 @@ package weekdays:
   export
     aviation.dateFormats.weekdays
     . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays }
+        shortestUnambiguousWeekdays, twoLetterWeekdays, frenchWeekdays, germanWeekdays,
+        spanishWeekdays }
 
 package monthFormats:
   export
     aviation.dateFormats.months
     . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths }
+        twoDigitMonths, frenchMonths, germanMonths, spanishMonths }
 
 package timeFormats:
   export
@@ -109,7 +110,7 @@ package timeFormats:
         ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
 
 package timespanFormats:
-  export aviation.timespanFormats.relativeTimespan
+  export aviation.timespanFormats.{englishRelative, frenchRelative, germanRelative, spanishRelative}
 
 package hourFormats:
   export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2243,6 +2243,72 @@ object Tests extends Suite(m"Aviation Tests"):
         Recurrence(2024-Jan-1, 2*Week, 5).show
       . assert(_ == t"every 2 weeks, 5 times from 2024-01-01")
 
+    suite(m"French descriptions"):
+      given Locale[fr] = Locale(fr)
+      import monthFormats.frenchMonths
+      import weekdays.frenchWeekdays
+      import timespanFormats.frenchRelative
+
+      test(m"The 3rd Monday of each month, in French"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
+      . assert(_ == t"tous les mois le 3e lundi")
+
+      test(m"Thanksgiving, in French"):
+        Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov),
+            byDay = List(WeekdayOrdinal(Thu, 4))).show
+      . assert(_ == t"tous les ans le 4e jeudi de novembre")
+
+      test(m"A relative timespan, in French"):
+        Timespan(minutes = 18).show
+      . assert(_ == t"dans 18 minutes")
+
+      test(m"A recurrence, in French"):
+        import dateFormats.iso8601DateFormat
+        Recurrence(2024-Jan-1, 2*Week, 5).show
+      . assert(_ == t"toutes les 2 semaines, 5 fois à partir du 2024-01-01")
+
+    suite(m"German descriptions"):
+      given Locale[de] = Locale(de)
+      import monthFormats.germanMonths
+      import weekdays.germanWeekdays
+      import timespanFormats.germanRelative
+
+      test(m"The 3rd Monday of each month, in German"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
+      . assert(_ == t"jeden Monat am 3. Montag")
+
+      test(m"Thanksgiving, in German"):
+        Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov),
+            byDay = List(WeekdayOrdinal(Thu, 4))).show
+      . assert(_ == t"jedes Jahr am 4. Donnerstag im November")
+
+      test(m"A relative timespan, in German"):
+        Timespan(minutes = 18).show
+      . assert(_ == t"in 18 Minuten")
+
+    suite(m"Spanish descriptions"):
+      given Locale[es] = Locale(es)
+      import monthFormats.spanishMonths
+      import weekdays.spanishWeekdays
+      import timespanFormats.spanishRelative
+
+      test(m"The 3rd Monday of each month, in Spanish"):
+        Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
+      . assert(_ == t"cada mes el tercer lunes")
+
+      test(m"Thanksgiving, in Spanish"):
+        Rrule(2024-Jan-1, Frequency.Yearly, byMonth = List(Nov),
+            byDay = List(WeekdayOrdinal(Thu, 4))).show
+      . assert(_ == t"cada año el cuarto jueves de noviembre")
+
+      test(m"A future relative timespan, in Spanish"):
+        Timespan(minutes = 18).show
+      . assert(_ == t"en 18 minutos")
+
+      test(m"A past relative timespan, in Spanish"):
+        Timespan(minutes = -18).show
+      . assert(_ == t"hace 18 minutos")
+
     suite(m"Locale gating"):
       import monthFormats.englishMonths
       import weekdays.englishWeekdays
@@ -2619,7 +2685,7 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_.nonEmpty)
 
     suite(m"Relative timespan formatting"):
-      import timespanFormats.relativeTimespan
+      import timespanFormats.englishRelative
       given Locale[en] = Locale(en)
 
       test(m"A future single component reads as \"in …\""):

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -2214,6 +2214,7 @@ object Tests extends Suite(m"Aviation Tests"):
     suite(m"Recurrence descriptions"):
       import monthFormats.englishMonths
       import weekdays.englishWeekdays
+      given Locale[en] = Locale(en)
 
       test(m"An rrule reads as plain English"):
         Rrule(2024-Jan-1, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show
@@ -2241,6 +2242,19 @@ object Tests extends Suite(m"Aviation Tests"):
         import dateFormats.iso8601DateFormat
         Recurrence(2024-Jan-1, 2*Week, 5).show
       . assert(_ == t"every 2 weeks, 5 times from 2024-01-01")
+
+    suite(m"Locale gating"):
+      import monthFormats.englishMonths
+      import weekdays.englishWeekdays
+
+      test(m"An English description needs a Locale[en] in scope"):
+        demilitarize(Rrule(2024-Jan-1, Frequency.Daily).show)
+      . assert(_.nonEmpty)
+
+      test(m"With a Locale[en] in scope, the description compiles"):
+        given Locale[en] = Locale(en)
+        demilitarize(Rrule(2024-Jan-1, Frequency.Daily).show)
+      . assert(_.isEmpty)
 
     suite(m"Moment subtraction"):
       import calendars.gregorianCalendar
@@ -2606,6 +2620,7 @@ object Tests extends Suite(m"Aviation Tests"):
 
     suite(m"Relative timespan formatting"):
       import timespanFormats.relativeTimespan
+      given Locale[en] = Locale(en)
 
       test(m"A future single component reads as \"in …\""):
         Timespan(minutes = 18).show

--- a/lib/cosmopolite/src/core/cosmopolite.Locale.scala
+++ b/lib/cosmopolite/src/core/cosmopolite.Locale.scala
@@ -41,8 +41,11 @@ import prepositional.*
 object Locale:
   given encodable: [language] => Locale[language] is Encodable in Text = _.language.code
 
-  given decodable: Locale[en & pl] is Decodable in Text =
+  given decodable: Locale[en & pl & fr & de & es] is Decodable in Text =
     case t"pl" => Locale(pl)
+    case t"fr" => Locale(fr)
+    case t"de" => Locale(de)
+    case t"es" => Locale(es)
     case _     => Locale(en)
 
 case class Locale[-language](language: Language) extends Findable

--- a/lib/cosmopolite/src/core/cosmopolite_core.scala
+++ b/lib/cosmopolite/src/core/cosmopolite_core.scala
@@ -45,4 +45,19 @@ object pl extends Language(t"pl"):
 
 trait pl
 
+object fr extends Language(t"fr"):
+  type Code = fr
+
+trait fr
+
+object de extends Language(t"de"):
+  type Code = de
+
+trait de
+
+object es extends Language(t"es"):
+  type Code = es
+
+trait es
+
 infix type via [value, language] = Locale[language] ?=> value

--- a/lib/cosmopolite/src/core/soundness_cosmopolite_core.scala
+++ b/lib/cosmopolite/src/core/soundness_cosmopolite_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export cosmopolite.{en, Language, Locale, pl, Polyglot, via}
+export cosmopolite.{de, en, es, fr, Language, Locale, pl, Polyglot, via}


### PR DESCRIPTION
Makes aviation's prose `Showable`s multilingual, gated on `cosmopolite` locales.

The `Showable` instances that render prose — `Recurrence`, `Rrule`, and the relative-`Timespan` format — are now gated on a `Locale`, so `.show` selects the rendering for the locale in scope. English, French, German and Spanish are provided:

```scala
given Locale[fr] = Locale(fr)
import monthFormats.frenchMonths, weekdays.frenchWeekdays
Rrule(d, Frequency.Monthly, byDay = List(WeekdayOrdinal(Mon, 3))).show   // "tous les mois le 3e lundi"
// de: "jeden Monat am 3. Montag"   es: "cada mes el tercer lunes"
Timespan(minutes = 18).show   // "dans 18 minutes" / "in 18 Minuten" / "en 18 minutos"
```

- cosmopolite gains the `fr`, `de`, `es` `Language`s (alongside `en`/`pl`).
- A new `Vernacular` abstraction holds the shared assembly (which clauses apply, in what order); each language supplies its vocabulary and grammatical hooks (plurals, gender of "every", ordinal forms, prefix-vs-suffix for the past tense).
- Localised month/weekday name givens (`frenchMonths`, `germanWeekdays`, …) are added beside the English ones.
- With no `Locale` in scope, `.show` on these no longer resolves (a compile error); bring one in with e.g. `given Locale[en] = Locale(en)`.

Numeric/ISO Showables (dates, ISO durations, `.encode`) are unchanged. The translations are a first pass intended for refinement by native speakers.