### PR TITLE
Hieroglyph: accruing TextSanitizer for byte→char decode errors

### DIFF
--- a/lib/hieroglyph/src/core/hieroglyph.CharDecoder.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharDecoder.scala
@@ -43,6 +43,8 @@ import rudiments.*
 import vacuous.*
 
 object CharDecoder:
+  case class Focus(position: Int) derives CanEqual
+
   def system(using TextSanitizer): CharDecoder =
     unapply(jnc.Charset.defaultCharset.nn.displayName.nn.tt).get
 

--- a/lib/hieroglyph/src/core/hieroglyph_core.scala
+++ b/lib/hieroglyph/src/core/hieroglyph_core.scala
@@ -75,6 +75,15 @@ package textSanitizers:
   given skipSanitizer: TextSanitizer = (position, encoding) => Unset
   given substituteSanitizer: TextSanitizer = (position, encoding) => '?'
 
+  given accrueSanitizer
+  :   (Tactic[CharDecodeError], Foci[CharDecoder.Focus]) => TextSanitizer =
+
+    (position, encoding) =>
+      focus(CharDecoder.Focus(position)):
+        raise(CharDecodeError(position, encoding))
+
+      '?'
+
 package communication:
   given unicodeCharNamesCommunicable: Char is Communicable = char => Message:
     val name =

--- a/lib/hieroglyph/src/core/soundness_hieroglyph_core.scala
+++ b/lib/hieroglyph/src/core/soundness_hieroglyph_core.scala
@@ -40,7 +40,8 @@ export
       WideCharacterWidth, whitespace, control, designation, printable, unicode }
 
 package textSanitizers:
-  export hieroglyph.textSanitizers.{skipSanitizer, strictSanitizer, substituteSanitizer}
+  export hieroglyph.textSanitizers.{skipSanitizer, strictSanitizer, substituteSanitizer,
+      accrueSanitizer}
 
 package textMetrics:
   export hieroglyph.textMetrics.{eastAsianScriptsMetric, wideCharacterWidthMetric, uniformMetric}

--- a/lib/hieroglyph/src/test/hieroglyph_test.scala
+++ b/lib/hieroglyph/src/test/hieroglyph_test.scala
@@ -40,6 +40,11 @@ import strategies.throwUnsafely
 import textMetrics.eastAsianScriptsMetric
 import errorDiagnostics.stackTracesDiagnostics
 
+case class DecodeIssues(items: List[(Int, CharDecodeError)] = Nil)(using Diagnostics)
+extends Error(m"${items.length} decoding issues"):
+  def +(position: Int, error: CharDecodeError): DecodeIssues =
+    DecodeIssues(items :+ (position, error))
+
 object Tests extends Suite(m"Hieroglyph tests"):
   def run(): Unit =
     val japanese = t"平ぱ記動テ使村方島おゃぎむ万離ワ学つス携"
@@ -93,6 +98,44 @@ object Tests extends Suite(m"Hieroglyph tests"):
         given CharEncoder = enc"UTF-8".encoder
         capture[CharDecodeError](charDecoders.utf8Decoder.decoded(t"café".data.dropRight(1)))
       . assert(_ == CharDecodeError(4, enc"UTF-8"))
+
+    suite(m"Accruing decode errors"):
+      val badUtf8 = Data(45, -62, 49, 48)
+      val worseUtf8 = Data(45, -62, 49, -62, 48)
+
+      test(m"Valid UTF-8 accrues no errors"):
+        validate[CharDecoder.Focus](DecodeIssues()):
+          case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
+        . protect:
+            import textSanitizers.accrueSanitizer
+            charDecoders.utf8Decoder.decoded(japaneseData)
+      . assert(_.items.length == 0)
+
+      test(m"A single bad sequence accrues one error"):
+        validate[CharDecoder.Focus](DecodeIssues()):
+          case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
+        . protect:
+            import textSanitizers.accrueSanitizer
+            charDecoders.utf8Decoder.decoded(badUtf8)
+      . assert(_.items == List((1, CharDecodeError(1, enc"UTF-8"))))
+
+      test(m"Both bad sequences accrue (decoding does not stop at the first)"):
+        validate[CharDecoder.Focus](DecodeIssues()):
+          case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
+        . protect:
+            import textSanitizers.accrueSanitizer
+            charDecoders.utf8Decoder.decoded(worseUtf8)
+      . assert(_.items == List((1, CharDecodeError(1, enc"UTF-8")), (3, CharDecodeError(3, enc"UTF-8"))))
+
+      test(m"Decoded text substitutes the replacement character at each error"):
+        var text: Text = t""
+        validate[CharDecoder.Focus](DecodeIssues()):
+          case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
+        . protect:
+            import textSanitizers.accrueSanitizer
+            text = charDecoders.utf8Decoder.decoded(worseUtf8)
+        text
+      . assert(_ == t"-?1?0")
 
     suite(m"Compile-time tests"):
       test(m"Check that an invalid encoding produces an error"):


### PR DESCRIPTION
Adds an accruing `TextSanitizer` for byte→character decoding. Where `strictSanitizer` aborts on the first malformed byte, `accrueSanitizer` registers every `CharDecodeError` into a `Foci[CharDecoder.Focus]` accumulator (tracking the byte position) and keeps decoding, mirroring how TEL and JSON accrue multiple decode errors. A caller can recover both the decoded text and the full list of positioned errors via the existing `contingency` combinators — no new public combinator is introduced.

## Release notes

A new `accrueSanitizer` joins `skipSanitizer`, `substituteSanitizer`, and `strictSanitizer` in `textSanitizers`. Unlike the others, it collects **all** encoding errors with their byte positions instead of failing on the first, using the same `Foci`-based accrual pattern as JSON and TEL decoding. It substitutes `?` at each bad sequence so decoding continues.

```scala
import textSanitizers.accrueSanitizer

val issues = validate[CharDecoder.Focus](DecodeIssues()):
  case error: CharDecodeError => accrual + (prior.let(_.position).or(0), error)
. protect(charDecoders.utf8Decoder.decoded(bytes))
```

Each accrued error carries the byte position of the malformed sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)