### PR TITLE
Fix recursive Decodable derivation through a collection

### DIFF
--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -40,6 +40,10 @@ import errorDiagnostics.stackTracesDiagnostics
 case class Point(x: Int, y: Int) derives CanEqual
 case class Person(name: Text, age: Int) derives CanEqual
 case class Wrapper(values: List[Int], label: Text) derives CanEqual
+
+// Recursion through a collection (#1429) and a generic product used over a recursive type.
+case class Tree(value: Text, children: List[Tree]) derives CanEqual
+case class Boxed[value](value: value) derives CanEqual
 case class Team(lead: Person, size: Int) derives CanEqual
 case class OptPerson(name: Text, age: Optional[Int]) derives CanEqual
 case class Renamed
@@ -247,6 +251,18 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val cbor = original.cbor
         val bytes = Cbor.Ast.encodable.encoded(Cbor.unseal(cbor))
         Cbor.ast(Cbor.Ast.parse(bytes)).as[Wrapper] == original
+      . assert(identity)
+
+      val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+
+      test(m"Round-trip a type recursive through a List"):
+        val bytes = Cbor.Ast.encodable.encoded(Cbor.unseal(tree.cbor))
+        Cbor.ast(Cbor.Ast.parse(bytes)).as[Tree] == tree
+      . assert(identity)
+
+      test(m"A generic product over a recursive type stays structurally derived"):
+        val bytes = Cbor.Ast.encodable.encoded(Cbor.unseal(Boxed(tree).cbor))
+        Cbor.ast(Cbor.Ast.parse(bytes)).as[Boxed[Tree]] == Boxed(tree)
       . assert(identity)
 
     suite(m"Aggregable"):

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -99,6 +99,13 @@ case class Firm(boss: Worker, deputy: Worker) derives CanEqual
 
 case class Crew(lead: Worker, members: List[Worker]) derives CanEqual
 
+// Recursion through a collection (#1429), direct recursion, recursion through a map, and a generic
+// product used over a recursive type (which must stay structurally derived, not mis-read as a codec).
+case class Tree(value: Text, children: List[Tree]) derives CanEqual
+case class TreeOpt(value: Text, child: Optional[TreeOpt]) derives CanEqual
+case class Forest(trees: Map[Text, Tree]) derives CanEqual
+case class Boxed[value](value: value) derives CanEqual
+
 object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
     suite(m"Parsing tests"):
@@ -417,6 +424,38 @@ object Tests extends Suite(m"Jacinta Tests"):
         import dynamicJsonAccess.enabled, jsonConversion.encodable
         org.lens(_.extra = 9).selectDynamic("extra").as[Int]
       . assert(_ == 9)
+
+    suite(m"Recursive derivation tests"):
+      val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+
+      val treeJson =
+        t"""{"value":"root","children":[{"value":"a","children":[]},{"value":"b","children":[{"value":"c","children":[]}]}]}"""
+
+      test(m"Derive and encode a tree recursive through a List"):
+        tree.json.show
+      . assert(_ == treeJson)
+
+      test(m"Derive and decode a tree recursive through a List"):
+        treeJson.read[Json].as[Tree]
+      . assert(_ == tree)
+
+      test(m"Round-trip a directly-recursive type via Optional"):
+        val value = TreeOpt(t"a", TreeOpt(t"b", Unset))
+        value.json.show.read[Json].as[TreeOpt]
+      . assert(_ == TreeOpt(t"a", TreeOpt(t"b", Unset)))
+
+      test(m"Round-trip recursion through a Map value"):
+        val forest = Forest(Map(t"x" -> Tree(t"x", Nil), t"y" -> tree))
+        forest.json.show.read[Json].as[Forest]
+      . assert(_ == Forest(Map(t"x" -> Tree(t"x", Nil), t"y" -> tree)))
+
+      test(m"A generic product over a recursive type stays structurally derived"):
+        Boxed(tree).json.show.read[Json].as[Boxed[Tree]]
+      . assert(_ == Boxed(tree))
+
+      test(m"Summon a decoder for a collection of a recursive type at the top level"):
+        summon[List[Tree] is Decodable in Json]
+      . assert(_ != null)
 
     suite(m"Json construction"):
       test(m"Json.make with one field"):

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -66,6 +66,10 @@ case class Fixed(@field(5) value: B32) derives CanEqual
 case class Labels(@field(1) entries: Map[Text, Text]) derives CanEqual
 case class Counts(@field(1) counts: Map[Text, Int]) derives CanEqual
 
+// Recursion through a collection (#1429) and a generic product used over a recursive type.
+case class Tree(@field(1) value: Text, @field(2) children: List[Tree]) derives CanEqual
+case class Boxed[value](@field(1) value: value) derives CanEqual
+
 object Tests extends Suite(m"Locomotion Protobuf Tests"):
   def run(): Unit =
     def wire[value: Encodable in Protobuf](value: value): List[Int] =
@@ -131,6 +135,16 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       test(m"empty repeated field writes nothing"):
         wire(Tags(Nil))
       . assert(_ == Nil)
+
+      val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+
+      test(m"a type recursive through a List round-trips"):
+        Stream(tree.protobuf.encode).read[Protobuf].as[Tree]
+      . assert(_ == tree)
+
+      test(m"a generic product over a recursive type stays structurally derived"):
+        Stream(Boxed(tree).protobuf.encode).read[Protobuf].as[Boxed[Tree]]
+      . assert(_ == Boxed(tree))
 
     suite(m"Optional presence"):
       test(m"a set optional round-trips"):

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -67,6 +67,12 @@ object Tests extends Suite(m"Stratiform Tests"):
   case class PersonAge(name: Text, age: Int) derives CanEqual
   case class Team(name: Text, members: List[Person]) derives CanEqual
 
+  // Recursion through a collection (#1429), direct recursion via Optional, and a generic product
+  // used over a recursive type (which must stay structurally derived, not mis-read as a codec).
+  case class Tree(value: Text, children: List[Tree]) derives CanEqual
+  case class TreeOpt(value: Text, child: Optional[TreeOpt]) derives CanEqual
+  case class Boxed[value](value: value) derives CanEqual
+
   enum Shape2 derives CanEqual:
     case Circle(radius: Int)
     case Rectangle(width: Int, height: Int)
@@ -251,6 +257,27 @@ object Tests extends Suite(m"Stratiform Tests"):
         val shape: Tests.Shape2 = Tests.Shape2.Dot
         shape.encode.as[Tests.Shape2]
       . assert(_ == Tests.Shape2.Dot)
+
+      val tree =
+        Tests.Tree(t"root", List(Tests.Tree(t"a", Nil),
+            Tests.Tree(t"b", List(Tests.Tree(t"c", Nil)))))
+
+      test(m"a type recursive through a List round-trips"):
+        tree.encode.as[Tests.Tree]
+      . assert(_ == tree)
+
+      test(m"a directly-recursive type via Optional round-trips"):
+        val value = Tests.TreeOpt(t"a", Tests.TreeOpt(t"b", Unset))
+        value.encode.as[Tests.TreeOpt]
+      . assert(_ == Tests.TreeOpt(t"a", Tests.TreeOpt(t"b", Unset)))
+
+      test(m"a generic product over a recursive type stays structurally derived"):
+        Tests.Boxed(tree).encode.as[Tests.Boxed[Tests.Tree]]
+      . assert(_ == Tests.Boxed(tree))
+
+      test(m"a decoder for a collection of a recursive type summons at the top level"):
+        summon[List[Tests.Tree] is Tel.Decodable]
+      . assert(_ != null)
 
     suite(m"sum-type schema derivation"):
       test(m"a sum derives a select with one variant per case"):

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -349,22 +349,26 @@ object internal:
 
     Select(selfTerm, method).appliedToType(TypeRepr.of(using elem)).asExpr
 
-  // Whether `tree` (the result of an implicit search) is the re-entry sentinel — i.e. the search
-  // fell through to the derivation macro, which bailed. Unwraps the layers an implicit resolution
-  // may add.
-  private def isSentinel(using Quotes)(tree: quotes.reflect.Term): Boolean =
+  // The symbol the resolved given ultimately refers to — the head of the application/inlining the
+  // implicit search produced. Unwraps the layers an implicit resolution may add.
+  private def rootSymbol(using Quotes)(tree: quotes.reflect.Term): quotes.reflect.Symbol =
     import quotes.reflect.*
-    val sentinel = Symbol.requiredMethod("wisteria.internal.reentrySentinel")
 
-    def loop(term: Term): Boolean = term match
+    def loop(term: Term): Symbol = term match
       case Inlined(_, _, body) => loop(body)
       case TypeApply(fun, _)   => loop(fun)
       case Apply(fun, _)       => loop(fun)
       case Typed(expr, _)      => loop(expr)
       case Block(_, expr)      => loop(expr)
-      case other               => other.symbol == sentinel
+      case other               => other.symbol
 
     loop(tree)
+
+  // Whether `tree` (the result of an implicit search) is the re-entry sentinel — i.e. the search
+  // fell through to the derivation macro, which bailed.
+  private def isSentinel(using Quotes)(tree: quotes.reflect.Term): Boolean =
+    import quotes.reflect.*
+    rootSymbol(tree) == Symbol.requiredMethod("wisteria.internal.reentrySentinel")
 
   // Does `typeclass[tpe]` resolve to a *non-derivation* instance — a handwritten codec, a leaf, or
   // a bridge resolution such as `Encodable in Text` → JSON? We run the compiler's own implicit
@@ -379,25 +383,43 @@ object internal:
     ( typeclassConstructor: quotes.reflect.TypeRepr, tpe: quotes.reflect.TypeRepr )
   :   Boolean =
 
+    inferWith(typeclassConstructor.appliedTo(tpe), Nil).let(!isSentinel(_)).or(false)
+
+  // Runs the compiler's implicit search for `instance` in a context augmented with synthetic
+  // `given`s: always a `Reentrant[instance]` (so the derivation macro, reached only as a last
+  // resort, self-bails to `reentrySentinel` rather than recursing), plus one `given` for each type
+  // in `extraGivens`. Returns the resolved tree on success (including a sentinel tree), `Unset`
+  // otherwise (no match, or an ambiguity, which `inferImplicit` reports as a non-success result).
+  // This is the one place wisteria reaches into `dotty.tools.dotc`: there is no public API to
+  // search with extra givens injected.
+  private def inferWith(using Quotes)
+    ( instance: quotes.reflect.TypeRepr, extraGivens: List[quotes.reflect.TypeRepr] )
+  :   Optional[quotes.reflect.Term] =
+
     import quotes.reflect.*
     import dotty.tools.dotc as dotc
 
     given context: dotc.core.Contexts.Context =
       quotes.asInstanceOf[runtime.impl.QuotesImpl].ctx
 
-    val instance = typeclassConstructor.appliedTo(tpe)
-    val reentrant = TypeRepr.of[Reentrant].appliedTo(instance)
-
-    val marker =
+    def syntheticGiven(name: String, info: TypeRepr): dotc.core.Symbols.Symbol =
       dotc.core.Symbols.newSymbol
         ( context.owner,
-          dotc.core.Names.termName("$wisteriaReentrant"),
+          dotc.core.Names.termName(name),
           dotc.core.Flags.Given,
-          reentrant.asInstanceOf[dotc.core.Types.Type],
+          info.asInstanceOf[dotc.core.Types.Type],
           dotc.core.Symbols.NoSymbol,
           dotc.util.Spans.NoCoord )
 
-    val augmented = context.fresh.setScope(dotc.core.Scopes.newScopeWith(marker))
+    val reentrant = TypeRepr.of[Reentrant].appliedTo(instance)
+
+    val elementGivens =
+      extraGivens.zipWithIndex.map: (tpe, index) =>
+        syntheticGiven("$wisteriaGiven$"+index, tpe)
+
+    val markers = syntheticGiven("$wisteriaReentrant", reentrant) :: elementGivens
+
+    val augmented = context.fresh.setScope(dotc.core.Scopes.newScopeWith(markers*))
 
     val result =
       new dotc.typer.Typer(0).inferImplicit
@@ -407,11 +429,8 @@ object internal:
         ( using augmented )
 
     result match
-      case success: dotc.typer.Implicits.SearchSuccess =>
-        !isSentinel(success.tree.asInstanceOf[Term])
-
-      case _ =>
-        false
+      case success: dotc.typer.Implicits.SearchSuccess => success.tree.asInstanceOf[Term]
+      case _                                           => Unset
 
   // Derives `typeclass[derivation]` by emitting a block of mutually-recursive synthetic
   // `given lazy val`s — one per distinct product/sum type reachable from `derivation` that a
@@ -445,6 +464,23 @@ object internal:
               case _: ImplicitSearchSuccess => true
               case _                        => false)
 
+    // A fallback for codecs whose given carries capability parameters beyond the element instances
+    // (a decoder's `Factory`/`Tactic`/`Foci`, …), which `isCodec`'s single-shape `codecFunction`
+    // search cannot express. We resolve the *applied* instance (`typeclass[F[args]]`) with a
+    // synthetic `given typeclass[arg]` injected per type-arg — so the codec's (by-name) element
+    // parameter is satisfiable without deriving the element (re-entering this very type would
+    // diverge) — while its other capabilities resolve from the ambient scope. A `Reentrant` marker
+    // makes the catch-all derivation self-bail to the sentinel; a genuine codec resolves to a more
+    // specific given. It is a codec iff the search lands on a non-sentinel given that is not one of
+    // the derivation's own wrappers. Used only in `visit` (never the root `.apply` branch, which
+    // needs the contextual-function shape).
+    def codecProbe(tpe: TypeRepr, args: List[TypeRepr]): Boolean =
+      args.nonEmpty && inferWith(instanceOf(tpe), args.map(instanceOf)).let: tree =>
+
+        !isSentinel(tree) && !wrappers.contains(rootSymbol(tree))
+
+      . or(false)
+
     def fullGraph: Expr[typeclass[derivation]] =
       val reachable = scala.collection.mutable.LinkedHashMap[String, TypeRepr]()
       val seen = scala.collection.mutable.HashSet[String]()
@@ -462,13 +498,16 @@ object internal:
           seen += key
           val args = tpe.typeArgs
 
-          // `resolvableNonStructural` is asked ONLY about product/sum types — and only those reach
-          // it, never codecs or leaves. The probe bails fast at the type's own `deriveGraph` (its
-          // `Reentrant` marker is injected), so it never recurses into fields. Probing a codec
-          // instead (e.g. `Map[K, V]` whose `isCodec` we failed to recognise) would let the search
-          // descend through the codec into its elements' full derivations — for a deep graph that
-          // explodes. Such a type simply isn't made a sibling here; it resolves at the field site.
-          if isCodec(tpe, args) then args.foreach(visit(_, false))
+          // A codec is recognised by the fast `isCodec` (single contextual-function shape) or, for
+          // codecs with extra capability parameters (decoders' `Factory`/`Tactic`/`Foci`), the
+          // `codecProbe` fallback; either way its element types are followed so a structural
+          // element wrapped in a collection still becomes a shared sibling (the recursion-through-
+          // a-collection case). Only a non-codec product/sum reaches `resolvableNonStructural`,
+          // which bails at the type's own `deriveGraph` (its `Reentrant` marker is injected) so it
+          // never recurses into fields. A codec the probe still cannot recognise (e.g. `Map[K, V]`
+          // whose key uses a different typeclass) is simply not made a sibling here; it resolves at
+          // the field site.
+          if isCodec(tpe, args) || codecProbe(tpe, args) then args.foreach(visit(_, false))
           else if isSumType(tpe) then
             if isRoot || !resolvableNonStructural(typeclassConstructor, tpe) then
               reachable(key) = tpe

--- a/lib/ypsiloid/src/test/ypsiloid_test.scala
+++ b/lib/ypsiloid/src/test/ypsiloid_test.scala
@@ -56,6 +56,10 @@ enum YStatus derives CanEqual:
   @name(t"gone")     case Removed(at: Int)
                      case Pending(at: Int)
 
+// Recursion through a collection (#1429) and a generic product used over a recursive type.
+case class Tree(value: Text, children: List[Tree]) derives CanEqual
+case class Boxed[value](value: value) derives CanEqual
+
 object Tests extends Suite(m"Ypsiloid Tests"):
   def run(): Unit =
     suite(m"Plain scalar parsing"):
@@ -720,6 +724,16 @@ object Tests extends Suite(m"Ypsiloid Tests"):
       test(m"Round-trip a list of case classes"):
         List(Person(t"A", 1), Person(t"B", 2)).yaml.as[List[Person]]
       . assert(_ == List(Person(t"A", 1), Person(t"B", 2)))
+
+      val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+
+      test(m"Round-trip a type recursive through a List"):
+        tree.yaml.as[Tree]
+      . assert(_ == tree)
+
+      test(m"A generic product over a recursive type stays structurally derived"):
+        Boxed(tree).yaml.as[Boxed[Tree]]
+      . assert(_ == Boxed(tree))
 
       test(m"Encoded case class produces a Yaml.Ast.Mapping"):
         Person(t"Alice", 30).yaml.root match


### PR DESCRIPTION
Deriving a Decodable for a product type that recurses through a collection — for example a case class with a `List[Self]` field — previously failed to compile, even though the matching Encodable, direct recursion via `Optional[Self]`, and non-recursive collection fields all worked. This restores recursion-through-a-collection for derived decoders across every codec format that builds on the shared Wisteria derivation.

Recursive data types whose recursion passes through a collection now derive their decoders correctly:

```scala
case class Tree(value: Text, children: List[Tree])

// now compiles for every format
summon[Tree is Decodable in Json]
summon[Tree is Decodable in Tel]
```

Previously this reported a confusing error — `No given instance of type List[Tree] is wisteria.Discriminable` for JSON, or an ambiguous-given error for TEL — and the only workaround was to hand-write an explicit decoder given for the recursive type. No workaround is needed any more.

Under the hood, Wisteria's derivation graph would mis-classify a collection like `List[Tree]` as a sum type (because `List` is sealed with `::`/`Nil`) whenever it failed to recognise the collection's decoder as a codec. Collection decoders carry extra capability parameters (such as a `Factory` and the error-handling `Tactic`) that the previous codec check couldn't express. The derivation now falls back to a more robust probe that recognises these decoders, so the collection's element type is followed correctly instead of being structurally derived. The fix benefits all derivation-based formats — JSON, TEL, YAML, Protobuf and CBOR — and regression tests covering recursion through a list, direct recursion, recursion through a map, and a generic product over a recursive type were added across those modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
