### PR TITLE
Fix recursive Decodable derivation through a collection for Austronesian

### DIFF
--- a/lib/austronesian/src/core/austronesian.internal.scala
+++ b/lib/austronesian/src/core/austronesian.internal.scala
@@ -147,15 +147,19 @@ object internal:
       inline def decoded(value: Pojo): Boolean = value.asInstanceOf[Boolean]
 
 
-    inline given collection
-    :   [ collection <: Iterable, element: Decodable in Pojo ]
-    =>  Tactic[PojoError]
-    =>  ( factory: scala.collection.Factory[element, collection[element]] )
+    // The element decoder is taken by-name (not as a context bound) so that a type recursive
+    // through a collection (`case class Tree(…, children: List[Tree])`) derives: wisteria's
+    // `deriveGraph` recognises this single-by-name-element codec shape and ties the recursion
+    // through a lazy sibling instead of structurally sum-deriving `List` (issue #1431).
+    given collection: [collection <: Iterable, element]
+    =>  ( factory: scala.collection.Factory[element, collection[element]],
+          tactic:  Tactic[PojoError] )
+    =>  ( decodable: => element is Decodable in Pojo )
     =>  collection[element] is Decodable in Pojo =
 
       case array: Array[Pojo @unchecked] =>
         factory.newBuilder.pipe: builder =>
-          array.iterator.each(builder += _.decode)
+          array.iterator.each(builder += decodable.decoded(_))
           builder.result()
 
       case other =>

--- a/lib/austronesian/src/test/austronesian_test.scala
+++ b/lib/austronesian/src/test/austronesian_test.scala
@@ -37,6 +37,9 @@ import soundness.*
 case class Person(name: Text, age: Int)
 case class Group(persons: List[Person], size: Int)
 
+// Recursion through a collection (#1431).
+case class Tree(value: Text, children: List[Tree]) derives CanEqual
+
 enum Color:
   case Red, Green, Blue
 
@@ -70,3 +73,9 @@ object Tests extends Suite(m"Austronesian tests"):
       val color: Color = Color.Green
       unsafely(color.pojo.decode[Color])
     . assert(_ == Color.Green)
+
+    val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+
+    test(m"Roundtrip a type recursive through a List"):
+      unsafely(tree.pojo.decode[Tree])
+    . assert(_ == tree)


### PR DESCRIPTION
Recursion through a collection for a derived `Decodable` now works for the Austronesian (`Pojo`) format too, matching the fix already in place for JSON, TEL, YAML, Protobuf and CBOR. Previously a case class with a `List[Self]` field failed to compile when decoded to/from a POJO.

```scala
case class Tree(value: Text, children: List[Tree])

unsafely(tree.pojo.decode[Tree]) // now compiles and round-trips
```

Austronesian's collection decoder took its element instance as a context bound on an `inline given`, a shape Wisteria's derivation-graph codec probe doesn't recognise — so the collection was structurally derived (reaching `List`'s `::`/`Nil` cons cells) instead of being treated as a codec, and failed to compile. The decoder is now defined in the same by-name single-element form the other formats use, which the probe recognises, so the recursion is tied through a lazy sibling.

Note: a generic product *wrapping* a recursive type (e.g. `Box[Tree]`) still hits a separate, pre-existing Wisteria scope-escape (`$_lazy_implicit_ … used outside the scope where it was defined`) specific to Austronesian; that is a distinct issue from this one and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
