### PR TITLE
Ultimatum: make inline rendering policy selectable via context

### DIFF
--- a/lib/ultimatum/src/core/ultimatum.InlinePolicy.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlinePolicy.scala
@@ -30,8 +30,48 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ultimatum
 
-export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, Axis, Sizing, Limits, Frame, Placement,
-    Pane, Panes, Mode, BorderStyle, panel, file, rank, border, layout, paint, Focus, EditorField,
-    MenuField, Form, dirtyCells, editor, menu, form, InlineAnchoring, InlineGrowth, InlineShrink}
+// How an inline block relocates when the terminal is resized. `InlineRoot` reads
+// this from context; the default (`TopAfterResize`) is provided in the companion,
+// and a caller overrides it by importing one alternative from `inlineAnchoring`.
+enum InlineAnchoring:
+  case BottomDocked    // never switch; clear and re-dock on every resize
+  case TopAnchored     // pinned to rows 1..height from the first frame
+  case TopAfterResize  // bottom-docked, then top-anchored after the first resize
+  case Fullscreen      // take over the alternate screen buffer, top-anchored
+
+object InlineAnchoring:
+  given default: InlineAnchoring = TopAfterResize
+
+package inlineAnchoring:
+  given bottomDocked: InlineAnchoring = InlineAnchoring.BottomDocked
+  given topAnchored: InlineAnchoring = InlineAnchoring.TopAnchored
+  given topAfterResize: InlineAnchoring = InlineAnchoring.TopAfterResize
+  given fullscreen: InlineAnchoring = InlineAnchoring.Fullscreen
+
+// What happens when a frame is taller than the last while bottom-docked. The
+// default (`ScrollIntoScrollback`) preserves the historic behaviour.
+enum InlineGrowth:
+  case ScrollIntoScrollback  // scroll the screen up, pushing rows into scrollback
+  case ClampToScreen         // grow upward in place, overwriting the rows above
+
+object InlineGrowth:
+  given default: InlineGrowth = ScrollIntoScrollback
+
+package inlineGrowth:
+  given scrollIntoScrollback: InlineGrowth = InlineGrowth.ScrollIntoScrollback
+  given clampToScreen: InlineGrowth = InlineGrowth.ClampToScreen
+
+// What happens when a frame is shorter than the last. The default
+// (`RedockBottom`) preserves the historic behaviour.
+enum InlineShrink:
+  case RedockBottom  // re-dock at the bottom, clearing the rows vacated above
+  case KeepTop       // hold the top row and clear below (no re-dock gap)
+
+object InlineShrink:
+  given default: InlineShrink = RedockBottom
+
+package inlineShrink:
+  given redockBottom: InlineShrink = InlineShrink.RedockBottom
+  given keepTop: InlineShrink = InlineShrink.KeepTop

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -42,33 +42,55 @@ import turbulence.*
 
 object InlineRoot:
   // The root for inline mode over a real terminal: width and the height clamp are
-  // read live, so a resize is reflected on the next frame.
-  def apply(terminal: Terminal): InlineRoot =
-    new InlineRoot(() => terminal.knownColumns, () => terminal.knownRows)(using terminal.stdio)
+  // read live, so a resize is reflected on the next frame. The rendering policy is
+  // read from context (`InlineAnchoring`/`InlineGrowth`/`InlineShrink`), so it is
+  // fixed at the caller's site rather than inside the library.
+  def apply(terminal: Terminal)
+    ( using anchoring: InlineAnchoring, growth: InlineGrowth, shrink: InlineShrink )
+  :   InlineRoot =
 
-  def apply(width: Int, height: Int)(using Stdio): InlineRoot =
+    new InlineRoot(() => terminal.knownColumns, () => terminal.knownRows)
+      ( using terminal.stdio, anchoring, growth, shrink )
+
+  def apply(width: Int, height: Int)
+    ( using Stdio, InlineAnchoring, InlineGrowth, InlineShrink )
+  :   InlineRoot =
+
     new InlineRoot(() => width, () => height)
 
 // The root `Canvas` for INLINE mode: panels composite into its character grid
 // (inherited from `GridSurface`), and `flush` presents the grid with ABSOLUTE row
 // addressing (`cup`) so a redraw always lands in the same place and never drifts —
 // the property a relative, cursor-tracking present loses the moment a resize reflows
-// the lines already on screen. There are two anchorings: on launch the block is
-// BOTTOM-docked, so it appears inline immediately beneath the shell command (growing
-// by scrolling content into scrollback, shrinking by clearing the rows it vacates
-// above). On the first resize it switches to TOP-anchored — pinned to rows 1..height
-// — because a bottom-docked block leaves a gap (and strands a ghost) when the
-// terminal grows taller, whereas a top-anchored one is simply overdrawn in place. A
-// top-anchored resize clears the whole screen first (the block relocates here and the
-// terminal may have moved the old one); otherwise each row is cleared in place.
-// `widthFn`/`heightFn` supply the live terminal columns and rows, re-read every
-// frame; an oversize block is clamped to the terminal height.
-class InlineRoot(widthFn: () => Int, heightFn: () => Int)(using Stdio)
+// the lines already on screen. Anchoring, growth and shrink are each governed by a
+// contextual policy (`InlineAnchoring`/`InlineGrowth`/`InlineShrink`); the defaults
+// reproduce the historic behaviour. Under the default `TopAfterResize` anchoring the
+// block is BOTTOM-docked on launch (appearing inline beneath the shell command) and
+// switches to TOP-anchored — pinned to rows 1..height — on the first resize, because
+// a bottom-docked block leaves a gap (and strands a ghost) when the terminal grows
+// taller, whereas a top-anchored one is simply overdrawn in place. A top-anchored
+// resize clears the whole screen first (the block relocates here and the terminal may
+// have moved the old one); otherwise each row is cleared in place. `Fullscreen`
+// additionally wraps the session in the alternate screen buffer. `widthFn`/`heightFn`
+// supply the live terminal columns and rows, re-read every frame; an oversize block
+// is clamped to the terminal height.
+class InlineRoot(widthFn: () => Int, heightFn: () => Int)
+  ( using stdio:     Stdio,
+          anchoring: InlineAnchoring,
+          growth:    InlineGrowth,
+          shrink:    InlineShrink )
 extends GridSurface(widthFn(), 0):
   private var presentedRows: Int = 0
   private var presentedColumns: Int = 0
   private var invalidated: Boolean = false
-  private var topAnchored: Boolean = false
+
+  // Start top-anchored only when the policy pins the block from the first frame;
+  // `TopAfterResize` starts bottom-docked and flips on the first `invalidate`.
+  private var topAnchored: Boolean = anchoring match
+    case InlineAnchoring.TopAnchored | InlineAnchoring.Fullscreen      => true
+    case InlineAnchoring.BottomDocked | InlineAnchoring.TopAfterResize => false
+
+  private var started: Boolean = false
   private var caretColumn: Int = 0
   private var caretRow: Int = 0
   private var caretVisible: Boolean = true
@@ -83,12 +105,12 @@ extends GridSurface(widthFn(), 0):
   // so a focused editor shows it and a focused menu keeps it hidden.
   def cursor(visible: Boolean): Unit = caretVisible = visible
 
-  // Mark the next present as a resize repaint, and switch to top-anchoring (the first
-  // resize trips this). The driver calls it on every `WindowSize` event (a width-only
-  // resize counts too).
+  // Mark the next present as a resize repaint. Under `TopAfterResize` the first resize
+  // also switches to top-anchoring; the other anchorings keep their fixed reference.
+  // The driver calls it on every `WindowSize` event (a width-only resize counts too).
   def invalidate(): Unit =
     invalidated = true
-    topAnchored = true
+    if anchoring == InlineAnchoring.TopAfterResize then topAnchored = true
 
   // Record the caret's block-local target; `flush` positions the hardware cursor at
   // the corresponding absolute screen cell.
@@ -108,6 +130,11 @@ extends GridSurface(widthFn(), 0):
     // interleave between our escapes and corrupt the redraw.
     val frame = StringBuilder()
     def emit(text: Text): Unit = frame.append(text.s)
+
+    // `Fullscreen` takes over the alternate screen buffer for the session: enter it on
+    // the first present (restored by `finish`), so the block owns a blank screen.
+    if anchoring == InlineAnchoring.Fullscreen && !started then emit(t"\e[?1049h")
+    started = true
 
     emit(csi.dectcem(false))
 
@@ -130,15 +157,28 @@ extends GridSurface(widthFn(), 0):
           val cleared = (presentedRows*wrap).max(h)
           emit(csi.cup((rows - cleared + 1).max(1), 1))
           emit(csi.ed(0))
+          (rows - h + 1).max(1)
         else if h > presentedRows then
-          // Grow in place: scroll the screen up so the extra rows are free at the
-          // bottom, pushing the content above into scrollback. `cud` to the bottom
-          // first, since only a `\n` on the bottom line scrolls.
-          emit(csi.cud(9999))
-          emit(t"\r")
-          emit(t"\n"*(h - presentedRows))
+          // Grow beyond the previous height. `ScrollIntoScrollback` scrolls the screen
+          // up so the extra rows are free at the bottom, pushing the content above into
+          // scrollback (`cud` to the bottom first, since only a `\n` on the bottom line
+          // scrolls); `ClampToScreen` instead grows upward in place, overwriting the
+          // rows above without touching scrollback.
+          growth match
+            case InlineGrowth.ScrollIntoScrollback =>
+              emit(csi.cud(9999))
+              emit(t"\r")
+              emit(t"\n"*(h - presentedRows))
 
-        (rows - h + 1).max(1)
+            case InlineGrowth.ClampToScreen =>
+              ()
+
+          (rows - h + 1).max(1)
+        else if presentedRows > h && shrink == InlineShrink.KeepTop then
+          // Hold the top row where the taller block began, rather than re-docking down.
+          (rows - presentedRows + 1).max(1)
+        else
+          (rows - h + 1).max(1)
 
     // Draw the block from its absolute `top` down, clipping each row to the live width
     // so it can never wrap (a wrapped row would scroll the screen and break addressing).
@@ -161,10 +201,12 @@ extends GridSurface(widthFn(), 0):
       if r < h - 1 then emit(t"\n")
       r += 1
 
-    // Shrink: clear the rows a taller previous block vacated — below the block when
-    // top-anchored, above it when bottom-docked (a resize already cleared them).
+    // Shrink: clear the rows a taller previous block vacated. Clearing happens BELOW
+    // the block when top-anchored or when `KeepTop` holds the top in place; when
+    // bottom-docked under `RedockBottom` the block re-docks down and the vacated rows
+    // above are cleared instead (a resize already cleared them).
     if !resized && presentedRows > h then
-      if topAnchored then
+      if topAnchored || shrink == InlineShrink.KeepTop then
         var k = h
 
         while k < presentedRows do
@@ -192,8 +234,11 @@ extends GridSurface(widthFn(), 0):
 
   // On exit, drop the cursor onto a fresh line below the block and re-show it, so
   // subsequent output continues after the rendered block (like a submitted prompt).
+  // A `Fullscreen` session leaves the alternate screen buffer, restoring what was
+  // there before it started.
   def finish(): Unit =
     val below = if topAnchored then (presentedRows + 1).min(heightFn()) else heightFn()
     Out.print(csi.cup(below.max(1), 1))
     Out.print(t"\r\n")
     Out.print(csi.dectcem(true))
+    if anchoring == InlineAnchoring.Fullscreen && started then Out.print(t"\e[?1049l")

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -152,7 +152,12 @@ def border
 // height; in `Inline` mode it renders a variable-height block at the cursor
 // without the alternate buffer, leaving scrollback intact.
 def form(mode: Mode = Mode.Fullscreen)(pane: Pane)
-  ( using terminal: Terminal, monitor: Monitor, probate: Probate )
+  ( using terminal: Terminal,
+          monitor:   Monitor,
+          probate:   Probate,
+          anchoring: InlineAnchoring,
+          growth:    InlineGrowth,
+          shrink:    InlineShrink )
 :   Unit =
 
   // A container mutation wakes the loop by putting a redraw event on the spool.
@@ -220,7 +225,13 @@ def paint(root: Canvas, pane: Pane): Unit =
 
 // Present `pane` as a static, variable-height block inline at the cursor, leaving
 // the cursor on a fresh line below it.
-def layout(pane: Pane)(using terminal: Terminal): Unit =
+def layout(pane: Pane)
+  ( using terminal:  Terminal,
+          anchoring: InlineAnchoring,
+          growth:    InlineGrowth,
+          shrink:    InlineShrink )
+:   Unit =
+
   val root = InlineRoot(terminal)
   paint(root, pane)
   root.finish()

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -393,6 +393,79 @@ object Tests extends Suite(m"Ultimatum Tests"):
         String(bytes.toByteArray.nn, "UTF-8").tt
       . assert(_ == t"\e[?25l\e[1;1H\e[0J\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
 
+      // With `bottomDocked`, a resize never switches to top-anchoring: the block stays
+      // docked and its rows are cleared at the bottom (row 3), not the top-left corner.
+      test(m"bottomDocked keeps the block docked across a resize"):
+        import inlineAnchoring.bottomDocked
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.invalidate()
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[3;1H\e[0J\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
+
+      // With `topAnchored`, the very first frame is pinned to rows 1..h (no bottom dock,
+      // no scroll into scrollback).
+      test(m"topAnchored pins the first frame to the top rows"):
+        import inlineAnchoring.topAnchored
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
+
+      // With `fullscreen`, the first present enters the alternate screen buffer.
+      test(m"fullscreen enters the alternate screen on the first present"):
+        import inlineAnchoring.fullscreen
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?1049h\e[?25l\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
+
+      // ...and leaves it again on finish, restoring the pre-session screen.
+      test(m"fullscreen leaves the alternate screen on finish"):
+        import inlineAnchoring.fullscreen
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.finish()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[3;1H\r\n\e[?25h\e[?1049l")
+
+      // With `keepTop`, a shrink holds the top row and clears below (row 4), rather than
+      // re-docking down and clearing the row it vacated above.
+      test(m"keepTop clears below the block on a shrink, holding the top"):
+        import inlineShrink.keepTop
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.reframe(3, 1); root.move(Prim, Prim); root.put(t"ef"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[3;1H\e[2Kef \r\n\e[2K\e[3;1H\e[?25h")
+
+      // With `clampToScreen`, a growing block grows upward in place; it never scrolls the
+      // screen into scrollback (no `\e[9999B`).
+      test(m"clampToScreen grows without scrolling into scrollback"):
+        import inlineGrowth.clampToScreen
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 1); root.move(Prim, Prim); root.put(t"a"); root.flush()
+        bytes.reset()
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
+
     suite(m"Dynamic panes"):
       def cell(): Pane = panel()(())
 


### PR DESCRIPTION
`ultimatum.InlineRoot` previously rendered inline blocks with a single hard-coded policy for how the block anchors, grows and shrinks; this makes each of those choices selectable through importable contextual values, keeping the existing behaviour as the default so no existing caller needs to change.

Inline layouts now read their rendering policy from context, along three orthogonal axes. Import one alternative to override the default:

```scala
import ultimatum.inlineAnchoring.bottomDocked   // never re-anchor on resize
import ultimatum.inlineShrink.keepTop           // clear below on shrink, no re-dock gap

form(Mode.Inline)(myLayout)
```

- **`inlineAnchoring`** — `bottomDocked`, `topAnchored`, `topAfterResize` (default), `fullscreen` (takes over the alternate screen buffer for the session).
- **`inlineGrowth`** — `scrollIntoScrollback` (default), `clampToScreen` (grow upward in place, never scroll content into scrollback).
- **`inlineShrink`** — `redockBottom` (default), `keepTop` (hold the top row and clear below, avoiding the accumulating blank rows that grow/shrink cycles otherwise strand).

A REPL front-end, for example, can choose `bottomDocked` + `keepTop` for consistent, artifact-free inline rendering, or opt into `fullscreen` explicitly — rather than reverse-engineering and fighting the one built-in policy.

Closes #1433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)