### PR TITLE
Overwrite pre-existing files when building an executable

### DIFF
--- a/lib/ethereal/src/core/ethereal.Assembler.scala
+++ b/lib/ethereal/src/core/ethereal.Assembler.scala
@@ -141,8 +141,9 @@ object Assembler:
     val isWindows: Boolean = platformLabel.starts(t"windows")
     val patched: Data = patch(runner, buildId, javaMinimum, javaPreferred, jdk, publicKey)
 
-    output.open: file =>
-      Stream(patched).writeTo(file)
+    output.open
+      ( file => Stream(patched).writeTo(file),
+        List(jnio.file.StandardOpenOption.TRUNCATE_EXISTING) )
 
     if platformLabel.starts(t"macos") then
       if !isWindows then output.executable() = true


### PR DESCRIPTION
Building a self-contained executable over a path that already held an earlier build could produce a corrupt binary: the runner stub only overwrote the leading bytes of the old file and the application JAR was then appended after whatever stale bytes remained, so the resulting executable failed to run. The output file is now truncated before the stub is written, so rebuilding over an existing file yields a correct, byte-identical result.

Rebuilding an executable to a path that already exists now always produces a clean binary, regardless of the size of the file previously at that location. No API changes — existing build commands and the ziggurat packager simply produce correct output on rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)