### PR TITLE
Harlequin: annotate term and type tokens as bindings or usages

### DIFF
--- a/lib/harlequin/src/ansi/harlequin_ansi.scala
+++ b/lib/harlequin/src/ansi/harlequin_ansi.scala
@@ -41,12 +41,15 @@ import spectacular.*
 import symbolism.*
 import vacuous.*
 
+// A palette maps each accent to a colour, and nothing more. Whether a term or type token
+// is a binding or a usage is carried by the token's `Role`, and any additional text
+// styling (e.g. italicising bindings) is applied by a separate styling policy — not
+// encoded here.
 type ScalaSyntaxPalette = Palette:
   type Form = Srgb
   def scalaError: Color in Srgb
   def scalaNumber: Color in Srgb
   def scalaString: Color in Srgb
-  def scalaIdentifier: Color in Srgb
   def scalaTerm: Color in Srgb
   def scalaType: Color in Srgb
   def scalaKeyword: Color in Srgb
@@ -62,17 +65,16 @@ package syntaxHighlighting:
   import Accent.*
 
   given tokenTeletypeable: (palette: ScalaSyntaxPalette) => Token is Teletypeable =
-    case Token(text, Error, _, _)    => e"${palette.scalaError}($text)"
-    case Token(text, Number, _, _)   => e"${palette.scalaNumber}($text)"
-    case Token(text, Modifier, _, _) => e"${palette.scalaModifier}($text)"
-    case Token(text, Keyword, _, _)  => e"${palette.scalaKeyword}($text)"
-    case Token(text, Ident, _, _)    => e"${palette.scalaIdentifier}($text)"
-    case Token(text, Term, _, _)     => e"${palette.scalaTerm}($text)"
-    case Token(text, Typed, _, _)    => e"${palette.scalaType}($text)"
-    case Token(text, String, _, _)   => e"${palette.scalaString}($text)"
-    case Token(text, Parens, _, _)   => e"${palette.scalaParenthesis}($text)"
-    case Token(text, Symbol, _, _)   => e"${palette.scalaSymbol}($text)"
-    case Token(text, Unparsed, _, _) => e"${palette.scalaComment}($Italic($text))"
+    case Token(text, Error, _, _, _)    => e"${palette.scalaError}($text)"
+    case Token(text, Number, _, _, _)   => e"${palette.scalaNumber}($text)"
+    case Token(text, Modifier, _, _, _) => e"${palette.scalaModifier}($text)"
+    case Token(text, Keyword, _, _, _)  => e"${palette.scalaKeyword}($text)"
+    case Token(text, Term, _, _, _)     => e"${palette.scalaTerm}($text)"
+    case Token(text, Typal, _, _, _)    => e"${palette.scalaType}($text)"
+    case Token(text, String, _, _, _)   => e"${palette.scalaString}($text)"
+    case Token(text, Parens, _, _, _)   => e"${palette.scalaParenthesis}($text)"
+    case Token(text, Symbol, _, _, _)   => e"${palette.scalaSymbol}($text)"
+    case Token(text, Unparsed, _, _, _) => e"${palette.scalaComment}($Italic($text))"
 
   given numberedTeletypeable: (palette: ScalaSyntaxPalette)
   =>  SourceCode is Teletypeable = source =>

--- a/lib/harlequin/src/core/harlequin.Accent.scala
+++ b/lib/harlequin/src/core/harlequin.Accent.scala
@@ -39,5 +39,10 @@ import spectacular.*
 object Accent:
   given showable: Accent is Showable = _.toString.tt.lower
 
+// An accent is a *colour category*, and nothing more: a palette maps each accent to one
+// colour. `Term` is a term and `Typal` is a type. Whether a term or type token is a
+// binding or a usage is an orthogonal annotation carried by the token (see `Role`), not a
+// colour distinction — so a `val`'s name and a use of it share the same accent, and a
+// separate styling policy may add italic/bold to bindings.
 enum Accent:
-  case Error, Number, String, Ident, Term, Typed, Keyword, Symbol, Parens, Modifier, Unparsed
+  case Error, Number, String, Term, Typal, Keyword, Symbol, Parens, Modifier, Unparsed

--- a/lib/harlequin/src/core/harlequin.Role.scala
+++ b/lib/harlequin/src/core/harlequin.Role.scala
@@ -33,37 +33,15 @@
 package harlequin
 
 import anticipation.*
-import contingency.*
 import gossamer.*
-import harlequin.*
-import honeycomb.*
-import nomenclature.*
-import prepositional.*
-import punctuation.*
 import spectacular.*
-import vacuous.*
 
-import doms.html.whatwg, whatwg.*
+object Role:
+  given showable: Role is Showable = _.toString.tt.lower
 
-trait CommonFormattable extends Formattable:
-  given lineClass: (Attribution of "line" | "amok") = Attribution.classes()
-
-  // The accent becomes a CSS class; a term/type token's `Role` (binding/usage) becomes a
-  // second class, so a stylesheet — the styling policy for this front-end — can e.g.
-  // italicise `.binding` on top of the accent's colour.
-  def classes(accent: Accent, role: Optional[Role]): ClassList =
-    def cssClass(name: Text): Name[CssClass] = unsafely(Name[CssClass](name))
-
-    val roleClass: Optional[Name[CssClass]] = role.let: role =>
-      cssClass(role.show.lower)
-
-    ClassList(Set(cssClass(accent.show.lower)) ++ roleClass.option)
-
-  def element(accent: Accent, role: Optional[Role], text: Text): Element of "code" =
-    whatwg.Code(`class` = classes(accent, role))(text)
-
-  protected def postprocess(source: SourceCode): Html of Flow =
-    val code = source.lines.map: line =>
-      Span.line(line.map { case Token(text, accent, _, _, role) => element(accent, role, text) }*)
-
-    Fragment(Div.amok(Pre(code*)))
+// The role of a term or type token: whether it is a `Binding` (a `val`/`def`/parameter or
+// pattern name, a class/type/type-parameter definition) or a `Usage` referring to one
+// bound elsewhere. It is `Unset` on tokens that are neither terms nor types (keywords,
+// literals, punctuation). A styling policy may, for example, render bindings in italic.
+enum Role:
+  case Binding, Usage

--- a/lib/harlequin/src/core/harlequin.SourceCode.scala
+++ b/lib/harlequin/src/core/harlequin.SourceCode.scala
@@ -35,6 +35,7 @@ package harlequin
 import scala.collection.mutable as scm
 
 import dotty.tools.dotc.*, core.*, parsing.*, util.*
+import dotty.tools.dotc.core.NameOps.isVarPattern
 import dotty.tools.dotc.reporting.Diagnostic as CompilerDiagnostic
 import dotty.tools.dotc.reporting.HideNonSensicalMessages
 import dotty.tools.dotc.reporting.Reporter
@@ -55,7 +56,7 @@ object SourceCode:
     else if token == 3 || token == 10 || token == 11 then Accent.String
     else if token >= 4 && token <= 9 || token == 23 || token == 24 || token == 42 || token == 43
     then Accent.Number
-    else if token == 14 then Accent.Ident
+    else if token == 14 then Accent.Term
     else if token >= 20 && token <= 62 && Tokens.modifierTokens.has(token) then Accent.Modifier
     else if token >= 20 && token <= 66 then Accent.Keyword
     else if token >= 78 && token <= 99 then Accent.Symbol
@@ -109,16 +110,16 @@ object SourceCode:
       Stream(Token(text.sub(t"\t", t"  "), Accent.Unparsed), Token.Newline)
 
     def hard(stream: Stream[Token]): Boolean = stream match
-      case Token(_, Accent.Unparsed, _, _) #:: more                   => hard(more)
-      case Token(text, Accent.Ident, _, _) #:: more if soft.has(text) => hard(more)
-      case Token(text, Accent.Keyword | Accent.Modifier, _, _) #:: _  => true
-      case other                                                      => false
+      case Token(_, Accent.Unparsed, _, _, _) #:: more                  => hard(more)
+      case Token(text, Accent.Term, _, _, _) #:: more if soft.has(text) => hard(more)
+      case Token(text, Accent.Keyword | Accent.Modifier, _, _, _) #:: _ => true
+      case other                                                        => false
 
     def soften(stream: Stream[Token]): Stream[Token] = stream match
-      case (Token(text@(t"using" | t"erased"), Accent.Ident, _, _)) #:: more =>
+      case (Token(text@(t"using" | t"erased"), Accent.Term, _, _, _)) #:: more =>
         Token(text, Accent.Modifier) #:: soften(more)
 
-      case (token@Token(text, Accent.Ident, _, _)) #:: more if soft.has(text) =>
+      case (token@Token(text, Accent.Term, _, _, _)) #:: more if soft.has(text) =>
         if hard(more) then Token(text, Accent.Modifier) #:: soften(more)
         else token #:: soften(more)
 
@@ -149,10 +150,14 @@ object SourceCode:
           case Some(syntax) => Token.Meta(syntax)
           case None         => Unset
 
+        val annotation: Optional[TokenTag] = trees(start, end)
+        val tokenAccent: Accent = annotation.lay(accent(token))(_.accent)
+        val role: Optional[Role] = annotation.let(_.role)
+
         val content: Stream[Token] =
           if start == end then Stream() else
             text.segment(start.z thru end.u).cut(t"\n").to(Stream).flatMap: line =>
-              Stream(Token(line, trees(start, end).getOrElse(accent(token)), meta), Token.Newline)
+              Stream(Token(line, tokenAccent, meta, role = role), Token.Newline)
 
             . init
 
@@ -203,39 +208,120 @@ object SourceCode:
     SourceCode
       ( language, 1, IArray(positioned*), diagnostics = diagnostics, completions = completions )
 
+  // The accent (colour category) and role (binding vs usage) resolved for a token span
+  // from the parse tree.
+  private case class TokenTag(accent: Accent, role: Role)
+
   private class Trees() extends ast.untpd.UntypedTreeTraverser:
     import ast.*, untpd.*
 
-    private val trees: scm.HashMap[(Int, Int), Accent] = scm.HashMap()
+    private val trees: scm.HashMap[(Int, Int), TokenTag] = scm.HashMap()
 
-    def apply(start: Int, end: Int): Option[Accent] = trees.get((start, end))
+    def apply(start: Int, end: Int): Optional[TokenTag] = trees.get((start, end)) match
+      case Some(tag) => tag
+      case None      => Unset
+
+    private def tag(span: Spans.Span, accent: Accent, role: Role): Unit =
+      if span.exists then trees += (span.start, span.end) -> TokenTag(accent, role)
 
     def ignored(tree: NameTree): Boolean =
       val name = tree.name.toTermName
       name == StdNames.nme.ERROR || name == StdNames.nme.CONSTRUCTOR
 
+    // An `Ident` reached in pattern position that genuinely *binds* a name: a simple
+    // lowercase-led var-pattern name, not the `_` wildcard, not a backquoted
+    // stable-identifier usage (`` case `x` => ``), and not a type.
+    private def isBinderIdent(tree: Ident): Boolean =
+      tree.name != StdNames.nme.WILDCARD && tree.name.isVarPattern && !tree.isBackquoted &&
+        !tree.isType
+
+    // Walk a subtree known to be in *pattern* position. Simple var-pattern binders and
+    // `Bind` names are term bindings; everything else — extractor and stable-id usages,
+    // literals, type ascriptions — routes back through the ordinary traversal so it keeps
+    // its usage role.
+    private def traversePattern(tree: Tree)(using Contexts.Context): Unit = tree match
+      case tree: Ident if isBinderIdent(tree) =>
+        tag(tree.span, Accent.Term, Role.Binding)
+
+      case tree: Bind =>
+        tag(tree.nameSpan, Accent.Term, Role.Binding)
+        traversePattern(tree.body)
+
+      case Typed(expr, tpt) =>
+        traversePattern(expr)
+        traverse(tpt)
+
+      case Parens(pattern) =>
+        traversePattern(pattern)
+
+      case Tuple(elements) =>
+        elements.foreach(traversePattern)
+
+      case Alternative(alternatives) =>
+        alternatives.foreach(traversePattern)
+
+      case Apply(function, arguments) =>
+        traverse(function)
+        arguments.foreach(traversePattern)
+
+      case TypeApply(function, arguments) =>
+        traverse(function)
+        arguments.foreach(traverse)
+
+      case NamedArg(_, pattern) =>
+        traversePattern(pattern)
+
+      case other =>
+        traverse(other)
+
     def traverse(tree: Tree)(using Contexts.Context): Unit =
       tree match
-        case tree: NameTree if ignored(tree) => ()
+        case tree: NameTree if ignored(tree) => traverseChildren(tree)
+
+        case tree: TypeDef if tree.mods.is(Flags.Param) =>
+          tag(tree.nameSpan, Accent.Typal, Role.Binding)
+          traverseChildren(tree)
 
         case tree: ValOrDefDef =>
-          if tree.nameSpan.exists
-          then trees += (tree.nameSpan.start, tree.nameSpan.end) -> Accent.Term
+          tag(tree.nameSpan, Accent.Term, Role.Binding)
+          traverseChildren(tree)
 
         case tree: MemberDef =>
-          if tree.nameSpan.exists
-          then trees += (tree.nameSpan.start, tree.nameSpan.end) -> Accent.Typed
+          tag(tree.nameSpan, Accent.Typal, Role.Binding)
+          traverseChildren(tree)
 
         case tree: Ident if tree.isType =>
-          if tree.span.exists then trees += (tree.span.start, tree.span.end) -> Accent.Typed
+          tag(tree.span, Accent.Typal, Role.Usage)
+          traverseChildren(tree)
+
+        case tree: Ident =>
+          tag(tree.span, Accent.Term, Role.Usage)
+          traverseChildren(tree)
 
         case tree: TypTree =>
-          if tree.span.exists then trees += (tree.span.start, tree.span.end) -> Accent.Typed
+          tag(tree.span, Accent.Typal, Role.Usage)
+          traverseChildren(tree)
+
+        case CaseDef(pattern, guard, body) =>
+          traversePattern(pattern)
+          traverse(guard)
+          traverse(body)
+
+        case GenFrom(pattern, expr, _) =>
+          traversePattern(pattern)
+          traverse(expr)
+
+        case GenAlias(pattern, expr) =>
+          traversePattern(pattern)
+          traverse(expr)
+
+        case tree: PatDef =>
+          tree.pats.foreach(traversePattern)
+          traverse(tree.tpt)
+          traverse(tree.rhs)
 
         case other =>
-          ()
-
-      traverseChildren(tree)
+          traverseChildren(tree)
 
   // Render a classpath to the `-classpath` argument string without needing an
   // ambient `System` capability (we only have directory and jar entries here).

--- a/lib/harlequin/src/core/harlequin.Token.scala
+++ b/lib/harlequin/src/core/harlequin.Token.scala
@@ -47,11 +47,17 @@ object Token:
 
 // `span` locates the token in its `SourceCode`: a `Line`-mode `Span` carrying the
 // token's 0-based line and column and its length. It is `Span.empty` until the
-// token is placed into a `SourceCode`'s line grid.
+// token is placed into a `SourceCode`'s line grid. `role` distinguishes a binding from a
+// usage for term (`Term`) and type (`Typal`) tokens, and is `Unset` for all others.
 case class Token
-  ( text: Text, accent: Accent, meta: Optional[Token.Meta] = Unset, span: Span = Span.empty ):
+  ( text:   Text,
+    accent: Accent,
+    meta:   Optional[Token.Meta] = Unset,
+    span:   Span                 = Span.empty,
+    role:   Optional[Role]       = Unset ):
+
   def length: Int = text.length
 
   def snip(point: Int): (Token, Token) =
-    ( Token(text.keep(point), accent, meta, span),
-      Token(text.skip(point), accent, meta, span) )
+    ( Token(text.keep(point), accent, meta, span, role),
+      Token(text.skip(point), accent, meta, span, role) )

--- a/lib/harlequin/src/core/soundness_harlequin_core.scala
+++ b/lib/harlequin/src/core/soundness_harlequin_core.scala
@@ -35,5 +35,5 @@ package soundness
 // `Completion`/`Completions` are intentionally not re-exported here: those names
 // already belong to `exoskeleton` in the `soundness` namespace. Reach harlequin's
 // via `harlequin.Completion` / `harlequin.Completions`.
-export harlequin.{Accent, Diagnostic, Highlight, Java, Depth, ProgrammingLanguage, Scala,
+export harlequin.{Accent, Diagnostic, Highlight, Java, Depth, ProgrammingLanguage, Role, Scala,
     SourceCode, Token, highlighting}

--- a/lib/harlequin/src/test/harlequin_test.scala
+++ b/lib/harlequin/src/test/harlequin_test.scala
@@ -42,7 +42,7 @@ object Tests extends Suite(m"Harlequin Tests"):
 
     def typeOf(tokens: List[Token], text: Text): Optional[Text] =
       tokens.find(_.text == text) match
-        case Some(Token(_, _, meta, _)) => meta.let(_.tpe.qualified)
+        case Some(Token(_, _, meta, _, _)) => meta.let(_.tpe.qualified)
         case _                          => Unset
 
     test(m"tokenized highlighting attaches no type metadata"):
@@ -55,6 +55,48 @@ object Tests extends Suite(m"Harlequin Tests"):
       tokens.map: token =>
         (token.text, token.span.startLine.lay(-1)(_.n0), token.span.startColumn.lay(-1)(_.n0))
     .assert(_.contains((t"List", 1, 2)))
+
+    // The binding/usage tagging runs on the parser output alone, so it is
+    // exercised by the tokenized (no-typer) path. `tagOf` reads the accent and role (as
+    // their rendered names) of the first token whose text matches.
+    def tagOf(source: Text, word: Text): (Text, Text) =
+      Scala.highlight(source).lines.to(List).flatten.find(_.text == word) match
+        case Some(token) => (token.accent.show, token.role.lay(t"")(_.show))
+        case None        => (t"", t"")
+
+    test(m"a val name is a term binding"):
+      tagOf(t"val alpha = 1", t"alpha")
+    .assert(_ == (t"term", t"binding"))
+
+    test(m"a term usage is a term reference"):
+      tagOf(t"val beta = gamma", t"gamma")
+    .assert(_ == (t"term", t"usage"))
+
+    test(m"a type usage is a typal usage"):
+      tagOf(t"val n: List = xs", t"List")
+    .assert(_ == (t"typal", t"usage"))
+
+    test(m"a tuple-pattern val binds each name as a term"):
+      val source = t"val (aa, bb) = pair"
+      (tagOf(source, t"aa"), tagOf(source, t"bb"))
+    .assert(_ == ((t"term", t"binding"), (t"term", t"binding")))
+
+    test(m"a case-clause pattern binder is a term binding"):
+      tagOf(t"val qq = nums.map { case xx => xx }", t"xx")
+    .assert(_ == (t"term", t"binding"))
+
+    test(m"a for-comprehension binder is a term binding"):
+      val source = t"val qq = for cc <- items yield cc"
+      (tagOf(source, t"cc"), tagOf(source, t"items"))
+    .assert(_ == ((t"term", t"binding"), (t"term", t"usage")))
+
+    test(m"a defined type parameter is a typal binding"):
+      tagOf(t"def gg[TT](vv: TT) = vv", t"TT")
+    .assert(_ == (t"typal", t"binding"))
+
+    test(m"a value parameter is a term binding"):
+      tagOf(t"def gg[TT](vv: TT) = vv", t"vv")
+    .assert(_ == (t"term", t"binding"))
 
     test(m"typechecked highlighting resolves the type of a val"):
       given Scalac[3.8] = Scalac[3.8](Nil)


### PR DESCRIPTION
Harlequin's syntax highlighter now records, for every term and type token, whether it introduces a binding or refers to one bound elsewhere, exposing this as a `Role` on each `Token` alongside its colour `Accent`. Accents become purely colour categories — a term is `Term` and a type is `Typal` whether bound or used — so palettes stay colour-only, and any extra styling of bindings (such as italics) is left to the consuming front-end: the HTML renderer emits the role as a CSS class, and terminal front-ends can read the role directly.

Every `harlequin.Token` now carries an `Optional[Role]`:

- `Role.Binding` — the token introduces a name: a `val`/`def`/parameter name, a pattern binder (`case foo =>`, `val (a, b) = …`, `x @ …`), a for-comprehension binder, or a class/type/type-parameter definition.
- `Role.Usage` — the token refers to a name bound elsewhere.
- `Unset` — the token is neither a term nor a type (keywords, literals, punctuation).

`Accent` is now purely a colour category. The term accent is `Term` (previously `Ident`) and the type accent is `Typal` (previously `Typed`); the binding-vs-usage distinction is no longer encoded as a separate accent.

A terminal front-end can style bindings by inspecting the role:

```scala
Scala.highlight(t"val greeting = message").lines.flatten.foreach: token =>
  token.role match
    case Role.Binding => // e.g. render italic
    case Role.Usage   => // render normally
    case Unset        => // not a term or type
```

The HTML renderer adds the role as a second CSS class, so a stylesheet can italicise bindings on top of the accent colour:

```css
code.term.binding { font-style: italic; }
```

Note for anyone defining a `ScalaSyntaxPalette`: it remains colour-only, but the `scalaIdentifier` field is renamed to `scalaTerm` (colouring all term tokens), and the previous binding-specific `scalaTerm` colour is gone.
