### PR TITLE
Exegesis: complete native LSP request/notification coverage

### DIFF
--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -94,6 +94,8 @@ object Lsp:
       interFileDependencies: Boolean,
       workspaceDiagnostics:  Boolean )
 
+  case class ExecuteCommandOptions(commands: List[Text])
+
   case class ServerCapabilities
     ( textDocumentSync:                 Optional[TextDocumentSyncKind]            = Unset,
       completionProvider:               Optional[CompletionOptions]               = Unset,
@@ -123,7 +125,9 @@ object Lsp:
       inlineValueProvider:              Optional[Boolean]                         = Unset,
       linkedEditingRangeProvider:       Optional[Boolean]                         = Unset,
       monikerProvider:                  Optional[Boolean]                         = Unset,
-      diagnosticProvider:               Optional[DiagnosticOptions]               = Unset )
+      diagnosticProvider:               Optional[DiagnosticOptions]               = Unset,
+      workspaceSymbolProvider:          Optional[Boolean]                         = Unset,
+      executeCommandProvider:           Optional[ExecuteCommandOptions]           = Unset )
 
   case class InitializeResult
     ( capabilities: ServerCapabilities, serverInfo: Optional[ServerInfo] = Unset )
@@ -282,6 +286,46 @@ object Lsp:
   case class DocumentDiagnosticReport
     ( kind: Text = t"full", resultId: Optional[Text] = Unset, items: List[Diagnostic] = Nil )
 
+  // Workspace
+
+  case class WorkspaceSymbol
+    ( name:          Text,
+      kind:          SymbolKind,
+      tags:          Optional[List[SymbolTag]] = Unset,
+      location:      Location,
+      containerName: Optional[Text]            = Unset,
+      data:          Optional[Json]            = Unset )
+
+  object FileEvent:
+    given decodable: Tactic[JsonError] => FileEvent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class FileEvent(uri: Text, `type`: FileChangeType)
+
+  object WorkspaceFoldersChangeEvent:
+    given decodable: Tactic[JsonError] => WorkspaceFoldersChangeEvent is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class WorkspaceFoldersChangeEvent(added: List[Folder], removed: List[Folder])
+
+  object FileCreate:
+    given decodable: Tactic[JsonError] => FileCreate is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class FileCreate(uri: Text)
+
+  object FileRename:
+    given decodable: Tactic[JsonError] => FileRename is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class FileRename(oldUri: Text, newUri: Text)
+
+  object FileDelete:
+    given decodable: Tactic[JsonError] => FileDelete is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class FileDelete(uri: Text)
+
   // Diagnostics and window messages
 
   object Diagnostic:
@@ -395,6 +439,16 @@ object Lsp:
 
   enum InlayHintKind:
     case Type, Parameter
+
+  object FileChangeType:
+    given encodable: FileChangeType is Json.Encodable =
+      Json.Encodable(Morphology.Whole): kind => (kind.ordinal + 1).json
+
+    given decodable: Tactic[JsonError] => FileChangeType is Json.Decodable =
+      Json.Decodable(Morphology.Whole): json => FileChangeType.fromOrdinal(json.as[Int] - 1)
+
+  enum FileChangeType:
+    case Created, Changed, Deleted
 
 // The Language Server Protocol request/notification surface. It is split into several sub-traits
 // purely so that each can be compiled into its own JSON-RPC dispatcher class: `JsonRpc.serve`
@@ -634,8 +688,46 @@ trait LspAdvanced extends JsonRpc:
       previousResultId: Optional[Text] )
   :   Lsp.DocumentDiagnosticReport
 
+trait LspWorkspace extends JsonRpc:
+
+  @rpc
+  def `workspace/symbol`(query: Text): List[Lsp.WorkspaceSymbol]
+
+  @rpc
+  def `workspace/executeCommand`(command: Text, arguments: Optional[List[Json]]): Optional[Json]
+
+  @rpc
+  def `workspace/didChangeConfiguration`(settings: Json): Unit
+
+  @rpc
+  def `workspace/didChangeWatchedFiles`(changes: List[Lsp.FileEvent]): Unit
+
+  @rpc
+  def `workspace/didChangeWorkspaceFolders`(event: Lsp.WorkspaceFoldersChangeEvent): Unit
+
+  @rpc
+  def `workspace/willCreateFiles`(files: List[Lsp.FileCreate]): Optional[Lsp.WorkspaceEdit]
+
+  @rpc
+  def `workspace/didCreateFiles`(files: List[Lsp.FileCreate]): Unit
+
+  @rpc
+  def `workspace/willRenameFiles`(files: List[Lsp.FileRename]): Optional[Lsp.WorkspaceEdit]
+
+  @rpc
+  def `workspace/didRenameFiles`(files: List[Lsp.FileRename]): Unit
+
+  @rpc
+  def `workspace/willDeleteFiles`(files: List[Lsp.FileDelete]): Optional[Lsp.WorkspaceEdit]
+
+  @rpc
+  def `workspace/didDeleteFiles`(files: List[Lsp.FileDelete]): Unit
+
+  @rpc
+  def `$/setTrace`(value: Text): Unit
+
 // The full protocol: the union of every sub-interface, fixing `Origin` to `LspClient`. `LspServer`
-// implements this; `LspServer.dispatcher` serves each sub-interface separately and routes by method.
+// implements this; `LspServer.dispatcher` serves each sub-interface separately, routing by method.
 trait Lsp
-extends LspLifecycle, LspLanguage, LspNavigation, LspEditing, LspAdvanced:
+extends LspLifecycle, LspLanguage, LspNavigation, LspEditing, LspAdvanced, LspWorkspace:
   type Origin = LspClient

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -84,6 +84,16 @@ object Lsp:
   case class DocumentOnTypeFormattingOptions
     ( firstTriggerCharacter: Text, moreTriggerCharacter: Optional[List[Text]] = Unset )
 
+  case class SemanticTokensOptions
+    ( legend: SemanticTokensLegend,
+      range:  Optional[Boolean] = Unset,
+      full:   Optional[Boolean] = Unset )
+
+  case class DiagnosticOptions
+    ( identifier:            Optional[Text] = Unset,
+      interFileDependencies: Boolean,
+      workspaceDiagnostics:  Boolean )
+
   case class ServerCapabilities
     ( textDocumentSync:                 Optional[TextDocumentSyncKind]            = Unset,
       completionProvider:               Optional[CompletionOptions]               = Unset,
@@ -107,7 +117,13 @@ object Lsp:
       codeLensProvider:                 Optional[CodeLensOptions]                 = Unset,
       documentOnTypeFormattingProvider: Optional[DocumentOnTypeFormattingOptions] = Unset,
       callHierarchyProvider:            Optional[Boolean]                         = Unset,
-      typeHierarchyProvider:            Optional[Boolean]                         = Unset )
+      typeHierarchyProvider:            Optional[Boolean]                         = Unset,
+      semanticTokensProvider:           Optional[SemanticTokensOptions]           = Unset,
+      inlayHintProvider:                Optional[Boolean]                         = Unset,
+      inlineValueProvider:              Optional[Boolean]                         = Unset,
+      linkedEditingRangeProvider:       Optional[Boolean]                         = Unset,
+      monikerProvider:                  Optional[Boolean]                         = Unset,
+      diagnosticProvider:               Optional[DiagnosticOptions]               = Unset )
 
   case class InitializeResult
     ( capabilities: ServerCapabilities, serverInfo: Optional[ServerInfo] = Unset )
@@ -231,6 +247,41 @@ object Lsp:
       selectionRange: Range,
       data:           Optional[Json]            = Unset )
 
+  // Semantic tokens
+
+  case class SemanticTokensLegend(tokenTypes: List[Text], tokenModifiers: List[Text])
+  case class SemanticTokens(resultId: Optional[Text] = Unset, data: List[Int] = Nil)
+  case class SemanticTokensEdit(start: Int, deleteCount: Int, data: Optional[List[Int]] = Unset)
+
+  case class SemanticTokensDelta
+    ( resultId: Optional[Text] = Unset, edits: List[SemanticTokensEdit] = Nil )
+
+  // Inlay hints, inline values, linked editing and monikers
+
+  case class InlayHint
+    ( position:     Position,
+      label:        Text,
+      kind:         Optional[InlayHintKind] = Unset,
+      tooltip:      Optional[Text]          = Unset,
+      paddingLeft:  Optional[Boolean]       = Unset,
+      paddingRight: Optional[Boolean]       = Unset,
+      data:         Optional[Json]          = Unset )
+
+  object InlineValueContext:
+    given decodable: Tactic[JsonError] => InlineValueContext is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class InlineValueContext(frameId: Int, stoppedLocation: Range)
+  case class InlineValueText(range: Range, text: Text)
+
+  case class LinkedEditingRanges(ranges: List[Range], wordPattern: Optional[Text] = Unset)
+  case class Moniker(scheme: Text, identifier: Text, unique: Text, kind: Optional[Text] = Unset)
+
+  // Pull diagnostics
+
+  case class DocumentDiagnosticReport
+    ( kind: Text = t"full", resultId: Optional[Text] = Unset, items: List[Diagnostic] = Nil )
+
   // Diagnostics and window messages
 
   object Diagnostic:
@@ -335,8 +386,23 @@ object Lsp:
   enum SymbolTag:
     case Deprecated
 
-trait Lsp extends JsonRpc:
-  type Origin = LspClient
+  object InlayHintKind:
+    given encodable: InlayHintKind is Json.Encodable =
+      Json.Encodable(Morphology.Whole): kind => (kind.ordinal + 1).json
+
+    given decodable: Tactic[JsonError] => InlayHintKind is Json.Decodable =
+      Json.Decodable(Morphology.Whole): json => InlayHintKind.fromOrdinal(json.as[Int] - 1)
+
+  enum InlayHintKind:
+    case Type, Parameter
+
+// The Language Server Protocol request/notification surface. It is split into several sub-traits
+// purely so that each can be compiled into its own JSON-RPC dispatcher class: `JsonRpc.serve`
+// inlines a schema-carrying codec for every method it covers, so a single dispatcher for the whole
+// protocol would overflow the JVM per-class constant-pool limit. `LspServer.dispatcher` routes each
+// request to the sub-dispatcher whose interface declares its method (see `JsonRpc.methods`).
+
+trait LspLifecycle extends JsonRpc:
 
   @rpc
   def initialize
@@ -373,6 +439,8 @@ trait Lsp extends JsonRpc:
 
   @rpc
   def `textDocument/didClose`(textDocument: Lsp.TextDocumentIdentifier): Unit
+
+trait LspLanguage extends JsonRpc:
 
   @rpc
   def `textDocument/completion`
@@ -421,6 +489,8 @@ trait Lsp extends JsonRpc:
   def `textDocument/signatureHelp`(textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position)
   :   Optional[Lsp.SignatureHelp]
 
+trait LspNavigation extends JsonRpc:
+
   @rpc
   def `textDocument/declaration`(textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position)
   :   List[Lsp.Location]
@@ -464,6 +534,8 @@ trait Lsp extends JsonRpc:
   def `textDocument/colorPresentation`
     ( textDocument: Lsp.TextDocumentIdentifier, color: Lsp.Color, range: Lsp.Range )
   :   List[Lsp.ColorPresentation]
+
+trait LspEditing extends JsonRpc:
 
   @rpc
   def `textDocument/rangeFormatting`
@@ -518,3 +590,52 @@ trait Lsp extends JsonRpc:
 
   @rpc
   def `typeHierarchy/subtypes`(item: Lsp.TypeHierarchyItem): List[Lsp.TypeHierarchyItem]
+
+trait LspAdvanced extends JsonRpc:
+
+  @rpc
+  def `textDocument/semanticTokens/full`(textDocument: Lsp.TextDocumentIdentifier)
+  :   Lsp.SemanticTokens
+
+  @rpc
+  def `textDocument/semanticTokens/full/delta`
+    ( textDocument: Lsp.TextDocumentIdentifier, previousResultId: Text )
+  :   Lsp.SemanticTokensDelta
+
+  @rpc
+  def `textDocument/semanticTokens/range`
+    ( textDocument: Lsp.TextDocumentIdentifier, range: Lsp.Range )
+  :   Lsp.SemanticTokens
+
+  @rpc
+  def `textDocument/inlayHint`(textDocument: Lsp.TextDocumentIdentifier, range: Lsp.Range)
+  :   List[Lsp.InlayHint]
+
+  @rpc
+  def `textDocument/inlineValue`
+    ( textDocument: Lsp.TextDocumentIdentifier,
+      range:        Lsp.Range,
+      context:      Lsp.InlineValueContext )
+  :   List[Lsp.InlineValueText]
+
+  @rpc
+  def `textDocument/linkedEditingRange`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   Optional[Lsp.LinkedEditingRanges]
+
+  @rpc
+  def `textDocument/moniker`(textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position)
+  :   List[Lsp.Moniker]
+
+  @rpc
+  def `textDocument/diagnostic`
+    ( textDocument:     Lsp.TextDocumentIdentifier,
+      identifier:       Optional[Text],
+      previousResultId: Optional[Text] )
+  :   Lsp.DocumentDiagnosticReport
+
+// The full protocol: the union of every sub-interface, fixing `Origin` to `LspClient`. `LspServer`
+// implements this; `LspServer.dispatcher` serves each sub-interface separately and routes by method.
+trait Lsp
+extends LspLifecycle, LspLanguage, LspNavigation, LspEditing, LspAdvanced:
+  type Origin = LspClient

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -78,18 +78,34 @@ object Lsp:
 
   case class CompletionOptions(triggerCharacters: Optional[List[Text]] = Unset)
   case class SignatureHelpOptions(triggerCharacters: Optional[List[Text]] = Unset)
+  case class DocumentLinkOptions(resolveProvider: Optional[Boolean] = Unset)
+  case class CodeLensOptions(resolveProvider: Optional[Boolean] = Unset)
+
+  case class DocumentOnTypeFormattingOptions
+    ( firstTriggerCharacter: Text, moreTriggerCharacter: Optional[List[Text]] = Unset )
 
   case class ServerCapabilities
-    ( textDocumentSync:           Optional[TextDocumentSyncKind] = Unset,
-      completionProvider:         Optional[CompletionOptions]    = Unset,
-      hoverProvider:              Optional[Boolean]              = Unset,
-      definitionProvider:         Optional[Boolean]              = Unset,
-      referencesProvider:         Optional[Boolean]              = Unset,
-      documentSymbolProvider:     Optional[Boolean]              = Unset,
-      documentFormattingProvider: Optional[Boolean]              = Unset,
-      renameProvider:             Optional[Boolean]              = Unset,
-      codeActionProvider:         Optional[Boolean]              = Unset,
-      signatureHelpProvider:      Optional[SignatureHelpOptions] = Unset )
+    ( textDocumentSync:                 Optional[TextDocumentSyncKind]            = Unset,
+      completionProvider:               Optional[CompletionOptions]               = Unset,
+      hoverProvider:                    Optional[Boolean]                         = Unset,
+      definitionProvider:               Optional[Boolean]                         = Unset,
+      referencesProvider:               Optional[Boolean]                         = Unset,
+      documentSymbolProvider:           Optional[Boolean]                         = Unset,
+      documentFormattingProvider:       Optional[Boolean]                         = Unset,
+      renameProvider:                   Optional[Boolean]                         = Unset,
+      codeActionProvider:               Optional[Boolean]                         = Unset,
+      signatureHelpProvider:            Optional[SignatureHelpOptions]            = Unset,
+      declarationProvider:              Optional[Boolean]                         = Unset,
+      typeDefinitionProvider:           Optional[Boolean]                         = Unset,
+      implementationProvider:           Optional[Boolean]                         = Unset,
+      documentHighlightProvider:        Optional[Boolean]                         = Unset,
+      foldingRangeProvider:             Optional[Boolean]                         = Unset,
+      selectionRangeProvider:           Optional[Boolean]                         = Unset,
+      colorProvider:                    Optional[Boolean]                         = Unset,
+      documentRangeFormattingProvider:  Optional[Boolean]                         = Unset,
+      documentLinkProvider:             Optional[DocumentLinkOptions]             = Unset,
+      codeLensProvider:                 Optional[CodeLensOptions]                 = Unset,
+      documentOnTypeFormattingProvider: Optional[DocumentOnTypeFormattingOptions] = Unset )
 
   case class InitializeResult
     ( capabilities: ServerCapabilities, serverInfo: Optional[ServerInfo] = Unset )
@@ -141,6 +157,44 @@ object Lsp:
 
   case class SignatureHelp
     ( signatures: List[SignatureInformation] = Nil, activeSignature: Optional[Int] = Unset )
+
+  // Highlights, folding and selection
+
+  case class DocumentHighlight(range: Range, kind: Optional[DocumentHighlightKind] = Unset)
+
+  case class FoldingRange
+    ( startLine:      Int,
+      startCharacter: Optional[Int]  = Unset,
+      endLine:        Int,
+      endCharacter:   Optional[Int]  = Unset,
+      kind:           Optional[Text] = Unset,
+      collapsedText:  Optional[Text] = Unset )
+
+  case class SelectionRange(range: Range, parent: Optional[SelectionRange] = Unset)
+
+  // Links, lenses and commands
+
+  case class Command
+    ( title: Text, command: Text, arguments: Optional[List[Json]] = Unset )
+
+  case class CodeLens
+    ( range: Range, command: Optional[Command] = Unset, data: Optional[Json] = Unset )
+
+  case class DocumentLink
+    ( range:   Range,
+      target:  Optional[Text] = Unset,
+      tooltip: Optional[Text] = Unset,
+      data:    Optional[Json] = Unset )
+
+  // Colors
+
+  case class Color(red: Double, green: Double, blue: Double, alpha: Double)
+  case class ColorInformation(range: Range, color: Color)
+
+  case class ColorPresentation
+    ( label:               Text,
+      textEdit:            Optional[TextEdit]       = Unset,
+      additionalTextEdits: Optional[List[TextEdit]] = Unset )
 
   // Diagnostics and window messages
 
@@ -215,6 +269,26 @@ object Lsp:
     case File, Module, Namespace, Package, Class, Method, Property, Field, Constructor, Enum,
       Interface, Function, Variable, Constant, `String`, Number, `Boolean`, `Array`, `Object`,
       Key, `Null`, EnumMember, Struct, Event, Operator, TypeParameter
+
+  object DocumentHighlightKind:
+    given encodable: DocumentHighlightKind is Json.Encodable =
+      Json.Encodable(Morphology.Whole): kind => (kind.ordinal + 1).json
+
+    given decodable: Tactic[JsonError] => DocumentHighlightKind is Json.Decodable =
+      Json.Decodable(Morphology.Whole): json => DocumentHighlightKind.fromOrdinal(json.as[Int] - 1)
+
+  enum DocumentHighlightKind:
+    case Text, Read, Write
+
+  object TextDocumentSaveReason:
+    given encodable: TextDocumentSaveReason is Json.Encodable =
+      Json.Encodable(Morphology.Whole): reason => (reason.ordinal + 1).json
+
+    given decodable: Tactic[JsonError] => TextDocumentSaveReason is Json.Decodable =
+      Json.Decodable(Morphology.Whole): json => TextDocumentSaveReason.fromOrdinal(json.as[Int] - 1)
+
+  enum TextDocumentSaveReason:
+    case Manual, AfterDelay, FocusOut
 
 trait Lsp extends JsonRpc:
   type Origin = LspClient
@@ -301,3 +375,77 @@ trait Lsp extends JsonRpc:
   @rpc
   def `textDocument/signatureHelp`(textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position)
   :   Optional[Lsp.SignatureHelp]
+
+  @rpc
+  def `textDocument/declaration`(textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position)
+  :   List[Lsp.Location]
+
+  @rpc
+  def `textDocument/typeDefinition`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   List[Lsp.Location]
+
+  @rpc
+  def `textDocument/implementation`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   List[Lsp.Location]
+
+  @rpc
+  def `textDocument/documentHighlight`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   List[Lsp.DocumentHighlight]
+
+  @rpc
+  def `textDocument/foldingRange`(textDocument: Lsp.TextDocumentIdentifier)
+  :   List[Lsp.FoldingRange]
+
+  @rpc
+  def `textDocument/selectionRange`
+    ( textDocument: Lsp.TextDocumentIdentifier, positions: List[Lsp.Position] )
+  :   List[Lsp.SelectionRange]
+
+  @rpc
+  def `textDocument/documentLink`(textDocument: Lsp.TextDocumentIdentifier)
+  :   List[Lsp.DocumentLink]
+
+  @rpc
+  def `textDocument/codeLens`(textDocument: Lsp.TextDocumentIdentifier): List[Lsp.CodeLens]
+
+  @rpc
+  def `textDocument/documentColor`(textDocument: Lsp.TextDocumentIdentifier)
+  :   List[Lsp.ColorInformation]
+
+  @rpc
+  def `textDocument/colorPresentation`
+    ( textDocument: Lsp.TextDocumentIdentifier, color: Lsp.Color, range: Lsp.Range )
+  :   List[Lsp.ColorPresentation]
+
+  @rpc
+  def `textDocument/rangeFormatting`
+    ( textDocument: Lsp.TextDocumentIdentifier,
+      range:        Lsp.Range,
+      options:      Lsp.FormattingOptions )
+  :   List[Lsp.TextEdit]
+
+  @rpc
+  def `textDocument/onTypeFormatting`
+    ( textDocument: Lsp.TextDocumentIdentifier,
+      position:     Lsp.Position,
+      ch:           Text,
+      options:      Lsp.FormattingOptions )
+  :   List[Lsp.TextEdit]
+
+  @rpc
+  def `textDocument/prepareRename`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   Optional[Lsp.Range]
+
+  @rpc
+  def `textDocument/willSave`
+    ( textDocument: Lsp.TextDocumentIdentifier, reason: Lsp.TextDocumentSaveReason )
+  :   Unit
+
+  @rpc
+  def `textDocument/willSaveWaitUntil`
+    ( textDocument: Lsp.TextDocumentIdentifier, reason: Lsp.TextDocumentSaveReason )
+  :   List[Lsp.TextEdit]

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -76,7 +76,9 @@ object Lsp:
   case class ServerInfo(name: Text, version: Optional[Text] = Unset)
   case class Folder(uri: Text, name: Text)
 
-  case class CompletionOptions(triggerCharacters: Optional[List[Text]] = Unset)
+  case class CompletionOptions
+    ( triggerCharacters: Optional[List[Text]] = Unset, resolveProvider: Optional[Boolean] = Unset )
+
   case class SignatureHelpOptions(triggerCharacters: Optional[List[Text]] = Unset)
   case class DocumentLinkOptions(resolveProvider: Optional[Boolean] = Unset)
   case class CodeLensOptions(resolveProvider: Optional[Boolean] = Unset)
@@ -138,12 +140,17 @@ object Lsp:
 
   case class CompletionContext(triggerKind: Int, triggerCharacter: Optional[Text] = Unset)
 
+  object CompletionItem:
+    given decodable: Tactic[JsonError] => CompletionItem is Json.Decodable =
+      Json.DecodableDerivation.derived
+
   case class CompletionItem
     ( label:         Text,
       kind:          Optional[CompletionItemKind] = Unset,
       detail:        Optional[Text]               = Unset,
       documentation: Optional[MarkupContent]      = Unset,
-      insertText:    Optional[Text]               = Unset )
+      insertText:    Optional[Text]               = Unset,
+      data:          Optional[Json]               = Unset )
 
   case class CompletionList(isIncomplete: Boolean = false, items: List[CompletionItem] = Nil)
 
@@ -161,14 +168,24 @@ object Lsp:
 
   case class FormattingOptions(tabSize: Int, insertSpaces: Boolean)
   case class TextEdit(range: Range, newText: Text)
+
+  object WorkspaceEdit:
+    given decodable: Tactic[JsonError] => WorkspaceEdit is Json.Decodable =
+      Json.DecodableDerivation.derived
+
   case class WorkspaceEdit(changes: Optional[Map[Text, List[TextEdit]]] = Unset)
 
   case class CodeActionContext(diagnostics: List[Diagnostic] = Nil)
 
+  object CodeAction:
+    given decodable: Tactic[JsonError] => CodeAction is Json.Decodable =
+      Json.DecodableDerivation.derived
+
   case class CodeAction
     ( title: Text,
       kind:  Optional[Text]          = Unset,
-      edit:  Optional[WorkspaceEdit] = Unset )
+      edit:  Optional[WorkspaceEdit] = Unset,
+      data:  Optional[Json]          = Unset )
 
   case class ParameterInformation(label: Text)
 
@@ -196,11 +213,20 @@ object Lsp:
 
   // Links, lenses and commands
 
+  // `arguments` is an arbitrary JSON array (`LSPAny[]`), kept as raw `Json`.
   case class Command
-    ( title: Text, command: Text, arguments: Optional[List[Json]] = Unset )
+    ( title: Text, command: Text, arguments: Optional[Json] = Unset )
+
+  object CodeLens:
+    given decodable: Tactic[JsonError] => CodeLens is Json.Decodable =
+      Json.DecodableDerivation.derived
 
   case class CodeLens
     ( range: Range, command: Optional[Command] = Unset, data: Optional[Json] = Unset )
+
+  object DocumentLink:
+    given decodable: Tactic[JsonError] => DocumentLink is Json.Decodable =
+      Json.DecodableDerivation.derived
 
   case class DocumentLink
     ( range:   Range,
@@ -262,6 +288,10 @@ object Lsp:
 
   // Inlay hints, inline values, linked editing and monikers
 
+  object InlayHint:
+    given decodable: Tactic[JsonError] => InlayHint is Json.Decodable =
+      Json.DecodableDerivation.derived
+
   case class InlayHint
     ( position:     Position,
       label:        Text,
@@ -287,6 +317,10 @@ object Lsp:
     ( kind: Text = t"full", resultId: Optional[Text] = Unset, items: List[Diagnostic] = Nil )
 
   // Workspace
+
+  object WorkspaceSymbol:
+    given decodable: Tactic[JsonError] => WorkspaceSymbol is Json.Decodable =
+      Json.DecodableDerivation.derived
 
   case class WorkspaceSymbol
     ( name:          Text,
@@ -726,8 +760,31 @@ trait LspWorkspace extends JsonRpc:
   @rpc
   def `$/setTrace`(value: Text): Unit
 
+// The `*/resolve` requests: the client sends back an item it received earlier for the server to
+// fill in lazily-computed fields. Their wire `params` is the bare item, not a `params` object with
+// named fields, so each parameter is marked `@bare` (see `obligatory.bare`).
+trait LspResolve extends JsonRpc:
+
+  @rpc
+  def `completionItem/resolve`(@bare item: Lsp.CompletionItem): Lsp.CompletionItem
+
+  @rpc
+  def `codeAction/resolve`(@bare codeAction: Lsp.CodeAction): Lsp.CodeAction
+
+  @rpc
+  def `codeLens/resolve`(@bare codeLens: Lsp.CodeLens): Lsp.CodeLens
+
+  @rpc
+  def `documentLink/resolve`(@bare documentLink: Lsp.DocumentLink): Lsp.DocumentLink
+
+  @rpc
+  def `inlayHint/resolve`(@bare inlayHint: Lsp.InlayHint): Lsp.InlayHint
+
+  @rpc
+  def `workspaceSymbol/resolve`(@bare workspaceSymbol: Lsp.WorkspaceSymbol): Lsp.WorkspaceSymbol
+
 // The full protocol: the union of every sub-interface, fixing `Origin` to `LspClient`. `LspServer`
 // implements this; `LspServer.dispatcher` serves each sub-interface separately, routing by method.
 trait Lsp
-extends LspLifecycle, LspLanguage, LspNavigation, LspEditing, LspAdvanced, LspWorkspace:
+extends LspLifecycle, LspLanguage, LspNavigation, LspEditing, LspAdvanced, LspWorkspace, LspResolve:
   type Origin = LspClient

--- a/lib/exegesis/src/core/exegesis.Lsp.scala
+++ b/lib/exegesis/src/core/exegesis.Lsp.scala
@@ -105,7 +105,9 @@ object Lsp:
       documentRangeFormattingProvider:  Optional[Boolean]                         = Unset,
       documentLinkProvider:             Optional[DocumentLinkOptions]             = Unset,
       codeLensProvider:                 Optional[CodeLensOptions]                 = Unset,
-      documentOnTypeFormattingProvider: Optional[DocumentOnTypeFormattingOptions] = Unset )
+      documentOnTypeFormattingProvider: Optional[DocumentOnTypeFormattingOptions] = Unset,
+      callHierarchyProvider:            Optional[Boolean]                         = Unset,
+      typeHierarchyProvider:            Optional[Boolean]                         = Unset )
 
   case class InitializeResult
     ( capabilities: ServerCapabilities, serverInfo: Optional[ServerInfo] = Unset )
@@ -195,6 +197,39 @@ object Lsp:
     ( label:               Text,
       textEdit:            Optional[TextEdit]       = Unset,
       additionalTextEdits: Optional[List[TextEdit]] = Unset )
+
+  // Call and type hierarchies
+
+  object CallHierarchyItem:
+    given decodable: Tactic[JsonError] => CallHierarchyItem is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class CallHierarchyItem
+    ( name:           Text,
+      kind:           SymbolKind,
+      tags:           Optional[List[SymbolTag]] = Unset,
+      detail:         Optional[Text]            = Unset,
+      uri:            Text,
+      range:          Range,
+      selectionRange: Range,
+      data:           Optional[Json]            = Unset )
+
+  case class CallHierarchyIncomingCall(from: CallHierarchyItem, fromRanges: List[Range])
+  case class CallHierarchyOutgoingCall(to: CallHierarchyItem, fromRanges: List[Range])
+
+  object TypeHierarchyItem:
+    given decodable: Tactic[JsonError] => TypeHierarchyItem is Json.Decodable =
+      Json.DecodableDerivation.derived
+
+  case class TypeHierarchyItem
+    ( name:           Text,
+      kind:           SymbolKind,
+      tags:           Optional[List[SymbolTag]] = Unset,
+      detail:         Optional[Text]            = Unset,
+      uri:            Text,
+      range:          Range,
+      selectionRange: Range,
+      data:           Optional[Json]            = Unset )
 
   // Diagnostics and window messages
 
@@ -289,6 +324,16 @@ object Lsp:
 
   enum TextDocumentSaveReason:
     case Manual, AfterDelay, FocusOut
+
+  object SymbolTag:
+    given encodable: SymbolTag is Json.Encodable =
+      Json.Encodable(Morphology.Whole): tag => (tag.ordinal + 1).json
+
+    given decodable: Tactic[JsonError] => SymbolTag is Json.Decodable =
+      Json.Decodable(Morphology.Whole): json => SymbolTag.fromOrdinal(json.as[Int] - 1)
+
+  enum SymbolTag:
+    case Deprecated
 
 trait Lsp extends JsonRpc:
   type Origin = LspClient
@@ -449,3 +494,27 @@ trait Lsp extends JsonRpc:
   def `textDocument/willSaveWaitUntil`
     ( textDocument: Lsp.TextDocumentIdentifier, reason: Lsp.TextDocumentSaveReason )
   :   List[Lsp.TextEdit]
+
+  @rpc
+  def `textDocument/prepareCallHierarchy`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   List[Lsp.CallHierarchyItem]
+
+  @rpc
+  def `callHierarchy/incomingCalls`(item: Lsp.CallHierarchyItem)
+  :   List[Lsp.CallHierarchyIncomingCall]
+
+  @rpc
+  def `callHierarchy/outgoingCalls`(item: Lsp.CallHierarchyItem)
+  :   List[Lsp.CallHierarchyOutgoingCall]
+
+  @rpc
+  def `textDocument/prepareTypeHierarchy`
+    ( textDocument: Lsp.TextDocumentIdentifier, position: Lsp.Position )
+  :   List[Lsp.TypeHierarchyItem]
+
+  @rpc
+  def `typeHierarchy/supertypes`(item: Lsp.TypeHierarchyItem): List[Lsp.TypeHierarchyItem]
+
+  @rpc
+  def `typeHierarchy/subtypes`(item: Lsp.TypeHierarchyItem): List[Lsp.TypeHierarchyItem]

--- a/lib/exegesis/src/core/exegesis.LspClient.scala
+++ b/lib/exegesis/src/core/exegesis.LspClient.scala
@@ -34,6 +34,7 @@ package exegesis
 
 import anticipation.*
 import beneficence.*
+import jacinta.*
 import obligatory.*
 import vacuous.*
 
@@ -56,8 +57,26 @@ trait LspClient extends Findable:
   @rpc
   protected def `window/logMessage`(`type`: MessageType, message: Text): Unit
 
+  @rpc
+  protected def `telemetry/event`(params: Json): Unit
+
+  @rpc
+  protected def `$/logTrace`(message: Text, verbose: Optional[Text]): Unit
+
+  // A `ProgressToken` is a string or integer, and a progress `value` is protocol-specific, so both
+  // are passed as raw JSON.
+  @rpc
+  protected def `$/progress`(token: Json, value: Json): Unit
+
+  @rpc
+  protected def `$/cancelRequest`(id: Json): Unit
+
   def publishDiagnostics(uri: Text, diagnostics: List[Diagnostic]): Unit =
     `textDocument/publishDiagnostics`(uri, Unset, diagnostics)
 
   def showMessage(message: Text): Unit = `window/showMessage`(MessageType.Info, message)
   def logMessage(message: Text): Unit = `window/logMessage`(MessageType.Log, message)
+  def telemetry(params: Json): Unit = `telemetry/event`(params)
+  def logTrace(message: Text): Unit = `$/logTrace`(message, Unset)
+  def progress(token: Json, value: Json): Unit = `$/progress`(token, value)
+  def cancelRequest(id: Json): Unit = `$/cancelRequest`(id)

--- a/lib/exegesis/src/core/exegesis.LspServer.scala
+++ b/lib/exegesis/src/core/exegesis.LspServer.scala
@@ -91,6 +91,11 @@ object LspServer:
       import strategies.throwUnsafely
       JsonRpc.serve[LspAdvanced](server)
 
+  private object workspaceRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspWorkspace](server)
+
   def dispatcher(server: Lsp): Json => Optional[Json] =
     import dynamicJsonAccess.enabled
     import strategies.throwUnsafely
@@ -101,7 +106,8 @@ object LspServer:
           JsonRpc.methods[LspLanguage]   -> languageRoute(server),
           JsonRpc.methods[LspNavigation] -> navigationRoute(server),
           JsonRpc.methods[LspEditing]    -> editingRoute(server),
-          JsonRpc.methods[LspAdvanced]   -> advancedRoute(server) )
+          JsonRpc.methods[LspAdvanced]   -> advancedRoute(server),
+          JsonRpc.methods[LspWorkspace]  -> workspaceRoute(server) )
 
     json =>
       safely(json.method.as[Text]).lay(routes.head._2(json)): method =>
@@ -201,6 +207,19 @@ trait LspServer() extends Lsp:
   :   DocumentDiagnosticReport =
 
     DocumentDiagnosticReport()
+
+  def workspaceSymbols(query: Text): List[WorkspaceSymbol] = Nil
+  def executeCommand(command: Text, arguments: Optional[List[Json]]): Optional[Json] = Unset
+  def onConfigurationChange(settings: Json): Unit = ()
+  def onWatchedFilesChange(changes: List[FileEvent]): Unit = ()
+  def onWorkspaceFoldersChange(event: WorkspaceFoldersChangeEvent): Unit = ()
+  def willCreateFiles(files: List[FileCreate]): Optional[WorkspaceEdit] = Unset
+  def onCreateFiles(files: List[FileCreate]): Unit = ()
+  def willRenameFiles(files: List[FileRename]): Optional[WorkspaceEdit] = Unset
+  def onRenameFiles(files: List[FileRename]): Unit = ()
+  def willDeleteFiles(files: List[FileDelete]): Optional[WorkspaceEdit] = Unset
+  def onDeleteFiles(files: List[FileDelete]): Unit = ()
+  def onSetTrace(value: Text): Unit = ()
 
   // The current contents of an open document, if any.
   def document(uri: Text): Optional[TextDocumentItem] = documents.at(uri)
@@ -433,6 +452,35 @@ trait LspServer() extends Lsp:
   :   DocumentDiagnosticReport =
 
     diagnostics(textDocument.uri, identifier, previousResultId)
+
+  def `workspace/symbol`(query: Text): List[WorkspaceSymbol] = workspaceSymbols(query)
+
+  def `workspace/executeCommand`(command: Text, arguments: Optional[List[Json]]): Optional[Json] =
+    executeCommand(command, arguments)
+
+  def `workspace/didChangeConfiguration`(settings: Json): Unit = onConfigurationChange(settings)
+
+  def `workspace/didChangeWatchedFiles`(changes: List[FileEvent]): Unit =
+    onWatchedFilesChange(changes)
+
+  def `workspace/didChangeWorkspaceFolders`(event: WorkspaceFoldersChangeEvent): Unit =
+    onWorkspaceFoldersChange(event)
+
+  def `workspace/willCreateFiles`(files: List[FileCreate]): Optional[WorkspaceEdit] =
+    willCreateFiles(files)
+
+  def `workspace/didCreateFiles`(files: List[FileCreate]): Unit = onCreateFiles(files)
+
+  def `workspace/willRenameFiles`(files: List[FileRename]): Optional[WorkspaceEdit] =
+    willRenameFiles(files)
+
+  def `workspace/didRenameFiles`(files: List[FileRename]): Unit = onRenameFiles(files)
+
+  def `workspace/willDeleteFiles`(files: List[FileDelete]): Optional[WorkspaceEdit] =
+    willDeleteFiles(files)
+
+  def `workspace/didDeleteFiles`(files: List[FileDelete]): Unit = onDeleteFiles(files)
+  def `$/setTrace`(value: Text): Unit = onSetTrace(value)
 
   // The stdio transport. Reads `Content-Length`-framed JSON-RPC messages from standard input and
   // dispatches each to the methods above; a single asynchronous writer drains the outgoing channel

--- a/lib/exegesis/src/core/exegesis.LspServer.scala
+++ b/lib/exegesis/src/core/exegesis.LspServer.scala
@@ -56,6 +56,59 @@ import probates.awaitProbate
 import strategies.throwUnsafely
 import threading.virtualThreading
 
+object LspServer:
+  // The JSON-RPC dispatch is generated split across one dispatcher per `Lsp` sub-interface, rather
+  // than as a single `serve[Lsp]` inside the trait. `JsonRpc.serve` inlines a schema-carrying codec
+  // for every method it covers, so one dispatcher for the whole protocol — or even one on the
+  // `LspServer` trait alongside its handlers and `main` — overflows the JVM per-class constant-pool
+  // limit. Each sub-dispatcher is expanded in its own object, so it compiles into its own small
+  // class; `dispatcher` routes an incoming request to the one whose interface declares its method
+  // (a JSON-RPC response, which carries no method, is handled by any dispatcher, so the first
+  // suffices).
+
+  private object lifecycleRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspLifecycle](server)
+
+  private object languageRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspLanguage](server)
+
+  private object navigationRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspNavigation](server)
+
+  private object editingRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspEditing](server)
+
+  private object advancedRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspAdvanced](server)
+
+  def dispatcher(server: Lsp): Json => Optional[Json] =
+    import dynamicJsonAccess.enabled
+    import strategies.throwUnsafely
+
+    val routes: List[(Set[Text], Json => Optional[Json])] =
+      List
+        ( JsonRpc.methods[LspLifecycle]  -> lifecycleRoute(server),
+          JsonRpc.methods[LspLanguage]   -> languageRoute(server),
+          JsonRpc.methods[LspNavigation] -> navigationRoute(server),
+          JsonRpc.methods[LspEditing]    -> editingRoute(server),
+          JsonRpc.methods[LspAdvanced]   -> advancedRoute(server) )
+
+    json =>
+      safely(json.method.as[Text]).lay(routes.head._2(json)): method =>
+        routes.find(_._1.contains(method)) match
+          case Some((_, dispatch)) => dispatch(json)
+          case None                => Unset
+
 // A base for Language Server implementations. Subclasses provide their `name`, `capabilities` and
 // any of the overridable handler hooks they support; everything else (the JSON-RPC method dispatch,
 // the document store, and the stdio transport) is provided here. This is deliberately simpler than
@@ -129,6 +182,25 @@ trait LspServer() extends Lsp:
   def prepareTypeHierarchy(uri: Text, position: Position): List[TypeHierarchyItem] = Nil
   def supertypes(item: TypeHierarchyItem): List[TypeHierarchyItem] = Nil
   def subtypes(item: TypeHierarchyItem): List[TypeHierarchyItem] = Nil
+
+  def semanticTokens(uri: Text): SemanticTokens = SemanticTokens()
+  def semanticTokensRange(uri: Text, range: Range): SemanticTokens = SemanticTokens()
+
+  def semanticTokensDelta(uri: Text, previousResultId: Text): SemanticTokensDelta =
+    SemanticTokensDelta()
+
+  def inlayHints(uri: Text, range: Range): List[InlayHint] = Nil
+
+  def inlineValues(uri: Text, range: Range, context: InlineValueContext): List[InlineValueText] =
+    Nil
+
+  def linkedEditingRange(uri: Text, position: Position): Optional[LinkedEditingRanges] = Unset
+  def monikers(uri: Text, position: Position): List[Moniker] = Nil
+
+  def diagnostics(uri: Text, identifier: Optional[Text], previousResultId: Optional[Text])
+  :   DocumentDiagnosticReport =
+
+    DocumentDiagnosticReport()
 
   // The current contents of an open document, if any.
   def document(uri: Text): Optional[TextDocumentItem] = documents.at(uri)
@@ -319,6 +391,49 @@ trait LspServer() extends Lsp:
   def `typeHierarchy/subtypes`(item: TypeHierarchyItem): List[TypeHierarchyItem] =
     subtypes(item)
 
+  def `textDocument/semanticTokens/full`(textDocument: TextDocumentIdentifier): SemanticTokens =
+    semanticTokens(textDocument.uri)
+
+  def `textDocument/semanticTokens/full/delta`
+    ( textDocument: TextDocumentIdentifier, previousResultId: Text )
+  :   SemanticTokensDelta =
+
+    semanticTokensDelta(textDocument.uri, previousResultId)
+
+  def `textDocument/semanticTokens/range`(textDocument: TextDocumentIdentifier, range: Range)
+  :   SemanticTokens =
+
+    semanticTokensRange(textDocument.uri, range)
+
+  def `textDocument/inlayHint`(textDocument: TextDocumentIdentifier, range: Range)
+  :   List[InlayHint] =
+
+    inlayHints(textDocument.uri, range)
+
+  def `textDocument/inlineValue`
+    ( textDocument: TextDocumentIdentifier, range: Range, context: InlineValueContext )
+  :   List[InlineValueText] =
+
+    inlineValues(textDocument.uri, range, context)
+
+  def `textDocument/linkedEditingRange`(textDocument: TextDocumentIdentifier, position: Position)
+  :   Optional[LinkedEditingRanges] =
+
+    linkedEditingRange(textDocument.uri, position)
+
+  def `textDocument/moniker`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[Moniker] =
+
+    monikers(textDocument.uri, position)
+
+  def `textDocument/diagnostic`
+    ( textDocument: TextDocumentIdentifier,
+      identifier: Optional[Text],
+      previousResultId: Optional[Text] )
+  :   DocumentDiagnosticReport =
+
+    diagnostics(textDocument.uri, identifier, previousResultId)
+
   // The stdio transport. Reads `Content-Length`-framed JSON-RPC messages from standard input and
   // dispatches each to the methods above; a single asynchronous writer drains the outgoing channel
   // (both request responses, funnelled in via `put`, and server-initiated notifications such as
@@ -328,7 +443,7 @@ trait LspServer() extends Lsp:
     import charEncoders.utf8Encoder
     import strategies.throwUnsafely
 
-    val dispatch: Json => Optional[Json] = JsonRpc.serve[Lsp](this)
+    val dispatch: Json => Optional[Json] = LspServer.dispatcher(this)
 
     // The writer drains the channel and frames each message onto stdout.
     val writer: Task[Unit] = async:

--- a/lib/exegesis/src/core/exegesis.LspServer.scala
+++ b/lib/exegesis/src/core/exegesis.LspServer.scala
@@ -123,6 +123,13 @@ trait LspServer() extends Lsp:
 
     Nil
 
+  def prepareCallHierarchy(uri: Text, position: Position): List[CallHierarchyItem] = Nil
+  def incomingCalls(item: CallHierarchyItem): List[CallHierarchyIncomingCall] = Nil
+  def outgoingCalls(item: CallHierarchyItem): List[CallHierarchyOutgoingCall] = Nil
+  def prepareTypeHierarchy(uri: Text, position: Position): List[TypeHierarchyItem] = Nil
+  def supertypes(item: TypeHierarchyItem): List[TypeHierarchyItem] = Nil
+  def subtypes(item: TypeHierarchyItem): List[TypeHierarchyItem] = Nil
+
   // The current contents of an open document, if any.
   def document(uri: Text): Optional[TextDocumentItem] = documents.at(uri)
 
@@ -289,6 +296,28 @@ trait LspServer() extends Lsp:
   :   List[TextEdit] =
 
     willSaveWaitUntil(textDocument, reason)
+
+  def `textDocument/prepareCallHierarchy`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[CallHierarchyItem] =
+
+    prepareCallHierarchy(textDocument.uri, position)
+
+  def `callHierarchy/incomingCalls`(item: CallHierarchyItem): List[CallHierarchyIncomingCall] =
+    incomingCalls(item)
+
+  def `callHierarchy/outgoingCalls`(item: CallHierarchyItem): List[CallHierarchyOutgoingCall] =
+    outgoingCalls(item)
+
+  def `textDocument/prepareTypeHierarchy`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[TypeHierarchyItem] =
+
+    prepareTypeHierarchy(textDocument.uri, position)
+
+  def `typeHierarchy/supertypes`(item: TypeHierarchyItem): List[TypeHierarchyItem] =
+    supertypes(item)
+
+  def `typeHierarchy/subtypes`(item: TypeHierarchyItem): List[TypeHierarchyItem] =
+    subtypes(item)
 
   // The stdio transport. Reads `Content-Length`-framed JSON-RPC messages from standard input and
   // dispatches each to the methods above; a single asynchronous writer drains the outgoing channel

--- a/lib/exegesis/src/core/exegesis.LspServer.scala
+++ b/lib/exegesis/src/core/exegesis.LspServer.scala
@@ -96,6 +96,33 @@ trait LspServer() extends Lsp:
   def codeActions(uri: Text, range: Range, context: CodeActionContext): List[CodeAction] = Nil
   def signatureHelp(uri: Text, position: Position): Optional[SignatureHelp] = Unset
 
+  def declaration(uri: Text, position: Position): List[Location] = Nil
+  def typeDefinition(uri: Text, position: Position): List[Location] = Nil
+  def implementation(uri: Text, position: Position): List[Location] = Nil
+  def documentHighlights(uri: Text, position: Position): List[DocumentHighlight] = Nil
+  def foldingRanges(uri: Text): List[FoldingRange] = Nil
+  def selectionRanges(uri: Text, positions: List[Position]): List[SelectionRange] = Nil
+  def documentLinks(uri: Text): List[DocumentLink] = Nil
+  def codeLenses(uri: Text): List[CodeLens] = Nil
+  def documentColors(uri: Text): List[ColorInformation] = Nil
+
+  def colorPresentations(uri: Text, color: Color, range: Range): List[ColorPresentation] = Nil
+
+  def formatRange(uri: Text, range: Range, options: FormattingOptions): List[TextEdit] = Nil
+
+  def formatOnType(uri: Text, position: Position, character: Text, options: FormattingOptions)
+  :   List[TextEdit] =
+
+    Nil
+
+  def prepareRename(uri: Text, position: Position): Optional[Range] = Unset
+  def onWillSave(document: TextDocumentIdentifier, reason: TextDocumentSaveReason): Unit = ()
+
+  def willSaveWaitUntil(document: TextDocumentIdentifier, reason: TextDocumentSaveReason)
+  :   List[TextEdit] =
+
+    Nil
+
   // The current contents of an open document, if any.
   def document(uri: Text): Optional[TextDocumentItem] = documents.at(uri)
 
@@ -186,6 +213,82 @@ trait LspServer() extends Lsp:
   :   Optional[SignatureHelp] =
 
     signatureHelp(textDocument.uri, position)
+
+  def `textDocument/declaration`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[Location] =
+
+    declaration(textDocument.uri, position)
+
+  def `textDocument/typeDefinition`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[Location] =
+
+    typeDefinition(textDocument.uri, position)
+
+  def `textDocument/implementation`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[Location] =
+
+    implementation(textDocument.uri, position)
+
+  def `textDocument/documentHighlight`(textDocument: TextDocumentIdentifier, position: Position)
+  :   List[DocumentHighlight] =
+
+    documentHighlights(textDocument.uri, position)
+
+  def `textDocument/foldingRange`(textDocument: TextDocumentIdentifier): List[FoldingRange] =
+    foldingRanges(textDocument.uri)
+
+  def `textDocument/selectionRange`
+    ( textDocument: TextDocumentIdentifier, positions: List[Position] )
+  :   List[SelectionRange] =
+
+    selectionRanges(textDocument.uri, positions)
+
+  def `textDocument/documentLink`(textDocument: TextDocumentIdentifier): List[DocumentLink] =
+    documentLinks(textDocument.uri)
+
+  def `textDocument/codeLens`(textDocument: TextDocumentIdentifier): List[CodeLens] =
+    codeLenses(textDocument.uri)
+
+  def `textDocument/documentColor`(textDocument: TextDocumentIdentifier): List[ColorInformation] =
+    documentColors(textDocument.uri)
+
+  def `textDocument/colorPresentation`
+    ( textDocument: TextDocumentIdentifier, color: Color, range: Range )
+  :   List[ColorPresentation] =
+
+    colorPresentations(textDocument.uri, color, range)
+
+  def `textDocument/rangeFormatting`
+    ( textDocument: TextDocumentIdentifier, range: Range, options: FormattingOptions )
+  :   List[TextEdit] =
+
+    formatRange(textDocument.uri, range, options)
+
+  def `textDocument/onTypeFormatting`
+    ( textDocument: TextDocumentIdentifier,
+      position:     Position,
+      ch:           Text,
+      options:      FormattingOptions )
+  :   List[TextEdit] =
+
+    formatOnType(textDocument.uri, position, ch, options)
+
+  def `textDocument/prepareRename`(textDocument: TextDocumentIdentifier, position: Position)
+  :   Optional[Range] =
+
+    prepareRename(textDocument.uri, position)
+
+  def `textDocument/willSave`
+    ( textDocument: TextDocumentIdentifier, reason: TextDocumentSaveReason )
+  :   Unit =
+
+    onWillSave(textDocument, reason)
+
+  def `textDocument/willSaveWaitUntil`
+    ( textDocument: TextDocumentIdentifier, reason: TextDocumentSaveReason )
+  :   List[TextEdit] =
+
+    willSaveWaitUntil(textDocument, reason)
 
   // The stdio transport. Reads `Content-Length`-framed JSON-RPC messages from standard input and
   // dispatches each to the methods above; a single asynchronous writer drains the outgoing channel

--- a/lib/exegesis/src/core/exegesis.LspServer.scala
+++ b/lib/exegesis/src/core/exegesis.LspServer.scala
@@ -96,6 +96,11 @@ object LspServer:
       import strategies.throwUnsafely
       JsonRpc.serve[LspWorkspace](server)
 
+  private object resolveRoute:
+    def apply(server: Lsp): Json => Optional[Json] =
+      import strategies.throwUnsafely
+      JsonRpc.serve[LspResolve](server)
+
   def dispatcher(server: Lsp): Json => Optional[Json] =
     import dynamicJsonAccess.enabled
     import strategies.throwUnsafely
@@ -107,7 +112,8 @@ object LspServer:
           JsonRpc.methods[LspNavigation] -> navigationRoute(server),
           JsonRpc.methods[LspEditing]    -> editingRoute(server),
           JsonRpc.methods[LspAdvanced]   -> advancedRoute(server),
-          JsonRpc.methods[LspWorkspace]  -> workspaceRoute(server) )
+          JsonRpc.methods[LspWorkspace]  -> workspaceRoute(server),
+          JsonRpc.methods[LspResolve]    -> resolveRoute(server) )
 
     json =>
       safely(json.method.as[Text]).lay(routes.head._2(json)): method =>
@@ -220,6 +226,14 @@ trait LspServer() extends Lsp:
   def willDeleteFiles(files: List[FileDelete]): Optional[WorkspaceEdit] = Unset
   def onDeleteFiles(files: List[FileDelete]): Unit = ()
   def onSetTrace(value: Text): Unit = ()
+
+  // The `*/resolve` hooks default to returning the item unchanged.
+  def resolveCompletion(item: CompletionItem): CompletionItem = item
+  def resolveCodeAction(codeAction: CodeAction): CodeAction = codeAction
+  def resolveCodeLens(codeLens: CodeLens): CodeLens = codeLens
+  def resolveDocumentLink(documentLink: DocumentLink): DocumentLink = documentLink
+  def resolveInlayHint(inlayHint: InlayHint): InlayHint = inlayHint
+  def resolveWorkspaceSymbol(workspaceSymbol: WorkspaceSymbol): WorkspaceSymbol = workspaceSymbol
 
   // The current contents of an open document, if any.
   def document(uri: Text): Optional[TextDocumentItem] = documents.at(uri)
@@ -481,6 +495,18 @@ trait LspServer() extends Lsp:
 
   def `workspace/didDeleteFiles`(files: List[FileDelete]): Unit = onDeleteFiles(files)
   def `$/setTrace`(value: Text): Unit = onSetTrace(value)
+
+  def `completionItem/resolve`(item: CompletionItem): CompletionItem = resolveCompletion(item)
+  def `codeAction/resolve`(codeAction: CodeAction): CodeAction = resolveCodeAction(codeAction)
+  def `codeLens/resolve`(codeLens: CodeLens): CodeLens = resolveCodeLens(codeLens)
+
+  def `documentLink/resolve`(documentLink: DocumentLink): DocumentLink =
+    resolveDocumentLink(documentLink)
+
+  def `inlayHint/resolve`(inlayHint: InlayHint): InlayHint = resolveInlayHint(inlayHint)
+
+  def `workspaceSymbol/resolve`(workspaceSymbol: WorkspaceSymbol): WorkspaceSymbol =
+    resolveWorkspaceSymbol(workspaceSymbol)
 
   // The stdio transport. Reads `Content-Length`-framed JSON-RPC messages from standard input and
   // dispatches each to the methods above; a single asynchronous writer drains the outgoing channel

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -67,6 +67,9 @@ object TestServer extends LspServer():
   override def prepareRename(uri: Text, position: Lsp.Position): Optional[Lsp.Range] =
     Lsp.Range(position, position)
 
+  override def incomingCalls(item: Lsp.CallHierarchyItem): List[Lsp.CallHierarchyIncomingCall] =
+    List(Lsp.CallHierarchyIncomingCall(from = item, fromRanges = List(item.range)))
+
   // Expand the `serve` dispatch macro once, here, rather than at each test call
   // site: each expansion inlines a codec (now schema-carrying) for every LSP
   // method, which repeated would exceed the JVM per-class size limit in `Tests`.
@@ -151,3 +154,14 @@ object Tests extends Suite(m"Exegesis Tests"):
 
         dispatch(request).let(_.as[JsonRpc.Response].result.as[Lsp.Range].start.line)
       . assert(_ == 3)
+
+      test(m"an incomingCalls request decodes a CallHierarchyItem param and echoes it"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":5,"method":"callHierarchy/incomingCalls","params":{"item":{"name":"foo","kind":12,"uri":"file:///x","range":{"start":{"line":0,"character":0},"end":{"line":0,"character":3}},"selectionRange":{"start":{"line":0,"character":0},"end":{"line":0,"character":3}}}}}"""
+          . decode[Json]
+
+        dispatch(request).let: response =>
+          response.as[JsonRpc.Response].result.as[List[Lsp.CallHierarchyIncomingCall]].head.from.name
+      . assert(_ == t"foo")

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -73,6 +73,9 @@ object TestServer extends LspServer():
   override def inlayHints(uri: Text, range: Lsp.Range): List[Lsp.InlayHint] =
     List(Lsp.InlayHint(range.start, label = t": Int", kind = Lsp.InlayHintKind.Type))
 
+  override def executeCommand(command: Text, arguments: Optional[List[Json]]): Optional[Json] =
+    command.json
+
   // Build the dispatcher once, here, rather than at each test call site: it expands a
   // schema-carrying codec for every LSP method, which repeated would exceed the JVM
   // per-class size limit in `Tests`.
@@ -178,3 +181,23 @@ object Tests extends Suite(m"Exegesis Tests"):
 
         dispatch(request).let(_.as[JsonRpc.Response].result.as[List[Lsp.InlayHint]].head.kind)
       . assert(_ == Lsp.InlayHintKind.Type)
+
+      test(m"a workspace/executeCommand request decodes its command name"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":7,"method":"workspace/executeCommand","params":{"command":"do.thing","arguments":[]}}"""
+          . decode[Json]
+
+        dispatch(request).let(_.as[JsonRpc.Response].result.as[Text])
+      . assert(_ == t"do.thing")
+
+      test(m"a $$/setTrace notification is dispatched without a response"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","method":"$$/setTrace","params":{"value":"verbose"}}"""
+          . decode[Json]
+
+        dispatch(request)
+      . assert(_ == Unset)

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -76,6 +76,11 @@ object TestServer extends LspServer():
   override def executeCommand(command: Text, arguments: Optional[List[Json]]): Optional[Json] =
     command.json
 
+  override def onSave(document: Lsp.TextDocumentIdentifier, text: Optional[Text])(using LspClient)
+  :   Unit =
+
+    summon[LspClient].progress(t"token".json, t"begin".json)
+
   // Build the dispatcher once, here, rather than at each test call site: it expands a
   // schema-carrying codec for every LSP method, which repeated would exceed the JVM
   // per-class size limit in `Tests`.
@@ -201,3 +206,14 @@ object Tests extends Suite(m"Exegesis Tests"):
 
         dispatch(request)
       . assert(_ == Unset)
+
+      test(m"saving a document sends a progress notification to the client"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{"uri":"file:///x"}}}"""
+          . decode[Json]
+
+        dispatch(request)
+        TestServer.outgoing.iterator.next().as[JsonRpc.Request].method
+      . assert(_ == t"$$/progress")

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -58,6 +58,15 @@ object TestServer extends LspServer():
                 severity = Lsp.DiagnosticSeverity.Error,
                 message  = t"oops" ) ) )
 
+  override def documentHighlights(uri: Text, position: Lsp.Position): List[Lsp.DocumentHighlight] =
+    List(Lsp.DocumentHighlight(Lsp.Range(position, position), Lsp.DocumentHighlightKind.Write))
+
+  override def foldingRanges(uri: Text): List[Lsp.FoldingRange] =
+    List(Lsp.FoldingRange(startLine = 0, endLine = 4, kind = t"region"))
+
+  override def prepareRename(uri: Text, position: Lsp.Position): Optional[Lsp.Range] =
+    Lsp.Range(position, position)
+
   // Expand the `serve` dispatch macro once, here, rather than at each test call
   // site: each expansion inlines a codec (now schema-carrying) for every LSP
   // method, which repeated would exceed the JVM per-class size limit in `Tests`.
@@ -112,3 +121,33 @@ object Tests extends Suite(m"Exegesis Tests"):
         dispatch(request)
         TestServer.outgoing.iterator.next().as[JsonRpc.Request].method
       . assert(_ == t"textDocument/publishDiagnostics")
+
+      test(m"a document-highlight request encodes its kind as a protocol number"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":2,"method":"textDocument/documentHighlight","params":{"textDocument":{"uri":"file:///x"},"position":{"line":1,"character":2}}}"""
+          . decode[Json]
+
+        dispatch(request).let(_.as[JsonRpc.Response].result.as[List[Lsp.DocumentHighlight]].head.kind)
+      . assert(_ == Lsp.DocumentHighlightKind.Write)
+
+      test(m"a folding-range request is answered with the folding ranges"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":3,"method":"textDocument/foldingRange","params":{"textDocument":{"uri":"file:///x"}}}"""
+          . decode[Json]
+
+        dispatch(request).let(_.as[JsonRpc.Response].result.as[List[Lsp.FoldingRange]].head.endLine)
+      . assert(_ == 4)
+
+      test(m"a prepareRename request decodes a position and returns a range"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":4,"method":"textDocument/prepareRename","params":{"textDocument":{"uri":"file:///x"},"position":{"line":3,"character":5}}}"""
+          . decode[Json]
+
+        dispatch(request).let(_.as[JsonRpc.Response].result.as[Lsp.Range].start.line)
+      . assert(_ == 3)

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -70,10 +70,13 @@ object TestServer extends LspServer():
   override def incomingCalls(item: Lsp.CallHierarchyItem): List[Lsp.CallHierarchyIncomingCall] =
     List(Lsp.CallHierarchyIncomingCall(from = item, fromRanges = List(item.range)))
 
-  // Expand the `serve` dispatch macro once, here, rather than at each test call
-  // site: each expansion inlines a codec (now schema-carrying) for every LSP
-  // method, which repeated would exceed the JVM per-class size limit in `Tests`.
-  lazy val dispatch: Json => Optional[Json] = JsonRpc.serve[Lsp](this)
+  override def inlayHints(uri: Text, range: Lsp.Range): List[Lsp.InlayHint] =
+    List(Lsp.InlayHint(range.start, label = t": Int", kind = Lsp.InlayHintKind.Type))
+
+  // Build the dispatcher once, here, rather than at each test call site: it expands a
+  // schema-carrying codec for every LSP method, which repeated would exceed the JVM
+  // per-class size limit in `Tests`.
+  lazy val dispatch: Json => Optional[Json] = LspServer.dispatcher(this)
 
 object Tests extends Suite(m"Exegesis Tests"):
   def run(): Unit =
@@ -165,3 +168,13 @@ object Tests extends Suite(m"Exegesis Tests"):
         dispatch(request).let: response =>
           response.as[JsonRpc.Response].result.as[List[Lsp.CallHierarchyIncomingCall]].head.from.name
       . assert(_ == t"foo")
+
+      test(m"an inlayHint request encodes its kind as a protocol number"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":6,"method":"textDocument/inlayHint","params":{"textDocument":{"uri":"file:///x"},"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}}}}"""
+          . decode[Json]
+
+        dispatch(request).let(_.as[JsonRpc.Response].result.as[List[Lsp.InlayHint]].head.kind)
+      . assert(_ == Lsp.InlayHintKind.Type)

--- a/lib/exegesis/src/test/exegesis_test.scala
+++ b/lib/exegesis/src/test/exegesis_test.scala
@@ -81,6 +81,9 @@ object TestServer extends LspServer():
 
     summon[LspClient].progress(t"token".json, t"begin".json)
 
+  override def resolveCompletion(item: Lsp.CompletionItem): Lsp.CompletionItem =
+    item.copy(detail = t"resolved")
+
   // Build the dispatcher once, here, rather than at each test call site: it expands a
   // schema-carrying codec for every LSP method, which repeated would exceed the JVM
   // per-class size limit in `Tests`.
@@ -217,3 +220,13 @@ object Tests extends Suite(m"Exegesis Tests"):
         dispatch(request)
         TestServer.outgoing.iterator.next().as[JsonRpc.Request].method
       . assert(_ == t"$$/progress")
+
+      test(m"a completionItem/resolve request decodes a bare item and resolves it"):
+        val dispatch = TestServer.dispatch
+
+        val request: Json =
+          t"""{"jsonrpc":"2.0","id":8,"method":"completionItem/resolve","params":{"label":"foo"}}"""
+          . decode[Json]
+
+        dispatch(request).let(_.as[JsonRpc.Response].result.as[Lsp.CompletionItem].detail)
+      . assert(_ == t"resolved")

--- a/lib/obligatory/src/core/obligatory_core.scala
+++ b/lib/obligatory/src/core/obligatory_core.scala
@@ -39,3 +39,8 @@ extension [element](stream: Iterator[element])
     framable.frames(stream)
 
 case class rpc() extends StaticAnnotation
+
+// Marks a single JSON-RPC method parameter as receiving the entire `params` value, rather than one
+// named field of a `params` object. Used for methods (such as the LSP `*/resolve` family) whose
+// wire `params` is a bare object decoded directly into the parameter.
+case class bare() extends StaticAnnotation

--- a/lib/obligatory/src/core/soundness_obligatory_core.scala
+++ b/lib/obligatory/src/core/soundness_obligatory_core.scala
@@ -34,5 +34,5 @@ package soundness
 
 export
   obligatory
-  . { Associable, CarriageReturn, ContentLength, CrLf, Framable, FrameError, frames, LengthPrefix,
-      Linefeed, rpc, RpcError }
+  . { Associable, bare, CarriageReturn, ContentLength, CrLf, Framable, FrameError, frames,
+      LengthPrefix, Linefeed, rpc, RpcError }

--- a/lib/obligatory/src/json/obligatory.JsonRpc.scala
+++ b/lib/obligatory/src/json/obligatory.JsonRpc.scala
@@ -61,6 +61,11 @@ object JsonRpc:
   inline def serve[interface](interface: interface): Json => Optional[Json] =
     ${obligatory.internal.dispatcher[interface]('interface)}
 
+  // The set of JSON-RPC method names an interface declares (its `@rpc` members). Used to route a
+  // request across several `serve` dispatchers when a single interface's dispatcher would be too
+  // large to compile into one class.
+  inline def methods[interface]: Set[Text] = ${obligatory.internal.methodNames[interface]}
+
   case class Request(jsonrpc: Text, method: Text, params: Json, id: Optional[Json])
   case class Response(jsonrpc: Text, result: Json, id: Optional[Json])
 

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -51,6 +51,20 @@ import vacuous.*
 
 
 object internal:
+  def methodNames[interface: Type]: Macro[Set[Text]] =
+    import quotes.reflect.*
+
+    val rpcType = TypeRepr.of[rpc].typeSymbol
+
+    val names = TypeRepr.of[interface].typeSymbol.declaredMethods.filter: method =>
+      val annotations = method.annotations ++ method.allOverriddenSymbols.flatMap(_.annotations)
+      annotations.exists(_.tpe.typeSymbol == rpcType)
+
+    . map: method =>
+        Expr(method.name.tt)
+
+    '{Set(${Varargs(names)}*)}
+
   def dispatcher[interface: Type](target: Expr[interface]): Macro[Json => Optional[Json]] =
     import quotes.reflect.*
 

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -69,6 +69,7 @@ object internal:
     import quotes.reflect.*
 
     val rpcType = TypeRepr.of[rpc].typeSymbol
+    val bareType = TypeRepr.of[bare].typeSymbol
     val interface = TypeRepr.of[interface]
 
     val rpcMethods = interface.typeSymbol.declaredMethods.filter: method =>
@@ -95,6 +96,10 @@ object internal:
               $ {
                   val cases = rpcMethods.map: method =>
                     val params = method.paramSymss.head.map: param =>
+                      // A `@bare` parameter is decoded from the whole `params` value; every other
+                      // parameter is decoded from the like-named field of a `params` object.
+                      val bare = param.annotations.exists(_.tpe.typeSymbol == bareType)
+
                       param.info.asType.absolve match
                         // Summon the schema-carrying `Json.Decodable` rather than a
                         // plain `Decodable in Json`: for a `Json`-typed parameter the
@@ -102,8 +107,11 @@ object internal:
                         // distillate's universal `generic` identity decoder.
                         case '[param] => Expr.summon[param is Json.Decodable] match
                           case Some(decoder) =>
-                            '{$decoder.decoded(request.params(${Expr(param.name)}))}
-                            . asTerm
+                            val source =
+                              if bare then '{request.params}
+                              else '{request.params(${Expr(param.name)})}
+
+                            '{$decoder.decoded($source)}.asTerm
 
                           case None =>
                             halt:


### PR DESCRIPTION
This implements the first part of #1440: auditing the Language Server Protocol and giving `LspServer` a native, wire-faithful handler for (almost) every request and notification in the specification, beyond the small core it started with. Every method is an overridable hook with a sensible default, so a server author implements only the features they support. The idiomatic higher-level layer (part two of the issue) is deferred.

Newly covered, each as an overridable handler:

- **Navigation & structure** — `declaration`, `typeDefinition`, `implementation`, `documentHighlight`, `foldingRange`, `selectionRange`, `documentLink`, `codeLens`, `documentColor`/`colorPresentation`, range and on-type formatting, `prepareRename`, and the will-save notifications.
- **Hierarchies** — call hierarchy (`prepareCallHierarchy`, incoming/outgoing calls) and type hierarchy (super/subtypes).
- **Rich editor features** — semantic tokens (full, delta, range), inlay hints, inline values, linked editing ranges, monikers, and pull diagnostics.
- **Workspace** — symbol search, `executeCommand`, the `didChange*` notifications, the will/did file-operation methods, and `$/setTrace`.
- **Server-to-client notifications** — `telemetry/event`, `$/logTrace`, `$/progress`, `$/cancelRequest`.
- **Resolve requests** — `completionItem/resolve` and its `codeAction`/`codeLens`/`documentLink`/`inlayHint`/`workspaceSymbol` siblings.

A server needs only the handlers it supports:

```scala
object MyServer extends LspServer():
  def name: Text = t"my-server"
  def capabilities: Lsp.ServerCapabilities =
    Lsp.ServerCapabilities(foldingRangeProvider = true, inlayHintProvider = true)

  override def foldingRanges(uri: Text): List[Lsp.FoldingRange] =
    List(Lsp.FoldingRange(startLine = 0, endLine = 9, kind = t"region"))

  override def inlayHints(uri: Text, range: Lsp.Range): List[Lsp.InlayHint] =
    List(Lsp.InlayHint(range.start, label = t": Int", kind = Lsp.InlayHintKind.Type))
```

Two supporting changes to `obligatory`: `JsonRpc.methods[Interface]` exposes an interface's declared `@rpc` method names (the LSP surface is now large enough that a single generated dispatcher exceeds the JVM per-class limit, so it is split into one dispatcher per sub-interface and routed by method name); and a `@bare` parameter annotation lets a method receive the whole JSON-RPC `params` value, as the `*/resolve` requests require.