### PR TITLE
Make stenography type-name rendering total over all TypeReprs

### DIFF
--- a/lib/stenography/src/core/stenography.internal.scala
+++ b/lib/stenography/src/core/stenography.internal.scala
@@ -42,12 +42,11 @@ object internal:
 
   def typename[typename <: AnyKind: Type]: Macro[Text] = Expr(name[typename])
 
-  def name(using Quotes)(typeRepr: quotes.reflect.TypeRepr): Text =
-    typeRepr.asType.absolve match case '[tpe] => name[tpe]
-
   def name[typename <: AnyKind: Type](using Quotes): Text =
     import quotes.reflect.*
+    name(TypeRepr.of[typename])
 
+  def name(using Quotes)(typeRepr: quotes.reflect.TypeRepr): Text =
     given Bindings = Bindings()
 
     val outer: List[Typename] = quotes.absolve match
@@ -88,7 +87,7 @@ object internal:
     given Imports =
       Imports(Set(Typename("scala"), Typename("scala.Predef")) ++ imports ++ outer, direct)
 
-    Syntax(TypeRepr.of[typename]).text
+    Syntax(typeRepr).text
 
   private def exportedTargets(using Quotes, dotty.tools.dotc.core.Contexts.Context)
     ( rootSym: dotty.tools.dotc.core.Symbols.Symbol )


### PR DESCRIPTION
Rendering a type's name through stenography no longer aborts macro expansion when it encounters a type that isn't a proper type; such types now degrade gracefully instead of throwing a `MatchError`. This most visibly fixes hyperbole's TASTy introspection (`Introspect.syntax`), which walks every type child of a term and previously crashed on certain nested applied types.

`stenography.internal.name(TypeRepr)` used to round-trip a `TypeRepr` through `.asType` and assert it matched the `'[tpe]` proper-type pattern. For some `TypeRepr`s reached while expanding a type tree — certain `TypeRef`s deep inside a nested `AppliedType` — that pattern doesn't match, so the `.absolve` assertion threw `scala.MatchError` and aborted the whole macro. Since the imports/scope context that `name` builds never depended on the specific type, and `Syntax.apply(TypeRepr)` is already total, `name` now renders the `TypeRepr` directly rather than round-tripping through the partial quote pattern. Code that relied on the working path is unaffected; the only behavioural change is that previously-crashing types now render (falling back to stenography's existing `<unknown>` handling in the rare cases nothing better applies).