### PR TITLE
Show a smooth progress bar while repackaging with Burdock

### DIFF
--- a/lib/burdock/src/core/burdock.ProgressBar.scala
+++ b/lib/burdock/src/core/burdock.ProgressBar.scala
@@ -30,12 +30,48 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package burdock
 
-export burdock.{DepsDev, DepsEvent, externalize, ProgressBar, Repackager}
+import anticipation.*
+import denominative.*
+import escapade.*
+import gossamer.*
+import iridescence.*
+import rudiments.*
+import spectacular.*
+import symbolism.*
+import vacuous.*
 
-// The repackager's command-line entry point, in the `soundness` package so it can be
-// launched as `java -cp app.jar soundness.repackage` (house style requires every file to
-// declare a package, so it cannot live in the default package).
-@main
-def repackage(): Unit = burdock.repackage()
+// A smooth, fixed-width progress bar for the repackager. `render` is pure (a fraction maps to a
+// styled `Teletype`) so the drawing logic stays free of I/O and is directly unit-testable; the
+// command-line entry point does the in-place redrawing. Smoothness comes from the eighth-width
+// block glyphs `▏▎▍▌▋▊▉█`: each cell is one eighth wider than the last, so the bar's right edge
+// advances sub-cell rather than jumping a whole character at a time.
+object ProgressBar:
+  val width: Int = 40
+
+  // Eighth-width left blocks, `1/8` through `8/8`; index `n` is `(n + 1)` eighths filled.
+  private val partials: Text = t"▏▎▍▌▋▊▉█"
+
+  private val foreground: Fg = Fg(rgb"#ff7d26")
+  private val background: Bg = Bg(rgb"#3b1700")
+
+  // Renders `fraction` (clamped to `[0, 1]`) as a `width`-cell bar. The bar's background is
+  // `#3b1700` throughout; filled cells are `#ff7d26` full blocks; the single boundary cell is a
+  // partial block in the foreground colour on the background colour, so its left portion reads as
+  // filled and its right portion as empty. Trailing cells are spaces (showing the background).
+  // Cell accounting is exact — `full + (partial ? 1 : 0) + trailing == width` — so the bar never
+  // changes width as it fills.
+  def render(fraction: Double): Teletype =
+    val eighths: Int = (fraction.max(0.0).min(1.0)*width*8).toInt
+    val full: Int = eighths/8
+    val remainder: Int = eighths%8
+
+    val head: Text =
+      if remainder == 0 then t""
+      else partials.at(Ordinal.zerary(remainder - 1)).let(_.show).or(t"")
+
+    val used: Int = full + (if remainder == 0 then 0 else 1)
+    val bar: Text = t"█"*full + head + t" "*(width - used)
+
+    e"$background(${foreground}($bar))"

--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -91,6 +91,11 @@ object Repackager:
   // Resolves a dependency hash to its public URL (deps.dev), or `Unset`.
   type Resolver = Text => Optional[HttpUrl]
 
+  // Reports per-dependency progress as `(completed, total)`, called once after each dependency is
+  // processed. Injected (rather than printed here) so the core stays free of I/O; the command-line
+  // entry point renders a progress bar from it.
+  type Progress = (Int, Int) => Unit
+
   // Looks up a dependency hash's entries (directories and the manifest excluded) in the
   // local cache, or `Unset`. Payloads stay lazy, so identifying an externalized
   // dependency's entry names (to strip them) does not read the cached JAR's contents.
@@ -98,11 +103,15 @@ object Repackager:
 
   // Pure partition; `resolve` (deps.dev) and `cached` (cache lookup) are injected
   // so the logic is testable without the network or the filesystem.
-  def partition(hashes: List[Text], resolve: Resolver, cached: CacheReader)
+  def partition
+    ( hashes: List[Text], resolve: Resolver, cached: CacheReader,
+      progress: Progress = (_, _) => () )
   :   (List[Requirement], List[Entry]) raises RepackageError =
 
     val requirements = List.newBuilder[Requirement]
     val inlined = List.newBuilder[Entry]
+    val total: Int = hashes.length
+    var completed: Int = 0
 
     hashes.each: hash =>
       (resolve(hash): @unchecked) match
@@ -116,6 +125,9 @@ object Repackager:
           entries.each: entry =>
             inlined += Entry(entry.ref.show, entry.read[Data])
 
+      completed += 1
+      progress(completed, total)
+
     (requirements.result(), inlined.result())
 
 
@@ -127,7 +139,7 @@ object Repackager:
   // itself be downloaded).
   def repackage
     ( inputJar: Path on Linux, outputJar: Path on Linux, resolve: Resolver, cached: CacheReader,
-      bootstrapClass: Data )
+      bootstrapClass: Data, progress: Progress = (_, _) => () )
   :   Summary raises RepackageError =
 
     mitigate:
@@ -175,7 +187,7 @@ object Repackager:
           . cut(t"\n").filter(_ != t"")
 
         val ownEntries: List[Entry] = ownBuilder.result()
-        val (requirements, inlined) = partition(hashes, resolve, cached)
+        val (requirements, inlined) = partition(hashes, resolve, cached, progress)
 
         // Published dependencies are downloaded and added to the classpath at runtime, so
         // their bundled entries can be stripped from the repackaged JAR to slim it. Identify

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -39,6 +39,7 @@ import ambience.*
 import anticipation.*
 import contingency.*
 import distillate.*
+import escapade.*
 import exoskeleton.*
 import fulminate.*
 import galilei.*
@@ -116,8 +117,28 @@ def repackage(): Unit = application(Nil):
 
       val tmpFile: Path on Linux = inputJar.parent.vouch/t"${inputJar.name}.tmp"
 
+      // Only animate on a real terminal; when stdout is redirected the carriage-return redraws
+      // and cursor escapes would garble the output, so we suppress them and let the final summary
+      // stand on its own.
+      val animate: Boolean = summon[Stdio].termcap.ansi
+
+      // Redraw a fixed-width progress bar in place (a leading carriage-return returns to column 0;
+      // a trailing erase-to-end-of-line wipes any residue from a longer previous frame) as each
+      // dependency is resolved and externalized or inlined.
+      def onProgress(done: Int, total: Int): Unit =
+        if animate && total > 0 then
+          Out.print(e"\r${ProgressBar.render(done.toDouble/total)} $done/$total${csi.el()}")
+
+      if animate then Out.print(csi.dectcem(false))
+
       val summary =
-        Repackager.repackage(inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass)
+        Repackager.repackage
+          ( inputJar, tmpFile, DepsDev.mavenUrl, cached, bootstrapClass, onProgress )
+
+      // Move off the bar's line and restore the cursor before printing the summary.
+      if animate then
+        Out.print(csi.dectcem(true))
+        Out.println()
 
       import filesystemOptions.overwritePreexisting.enabled
       import filesystemOptions.deleteRecursively.disabled

--- a/lib/burdock/src/test/burdock_test.scala
+++ b/lib/burdock/src/test/burdock_test.scala
@@ -89,6 +89,27 @@ object Tests extends Suite(m"Burdock Tests"):
         capture[Repackager.RepackageError](Repackager.partition(List(t"ccc"), resolve, cached))
       .assert(_ => true)
 
+    suite(m"Progress bar"):
+      test(m"an empty bar is all spaces"):
+        ProgressBar.render(0.0).plain
+      .assert(_ == t" "*40)
+
+      test(m"a full bar is all full blocks"):
+        ProgressBar.render(1.0).plain
+      .assert(_ == t"█"*40)
+
+      test(m"a half bar is twenty blocks then twenty spaces"):
+        ProgressBar.render(0.5).plain
+      .assert(_ == t"█"*20 + t" "*20)
+
+      test(m"a sub-cell fraction renders one partial block"):
+        ProgressBar.render(4.0/320).plain
+      .assert(_ == t"▌" + t" "*39)
+
+      test(m"the bar is always forty cells wide"):
+        List(0.0, 0.1, 0.333, 0.5, 0.9, 1.0).all(ProgressBar.render(_).plain.length == 40)
+      .assert(_ == true)
+
     suite(m"Repackager (end-to-end)"):
       val tmp: Path on Linux = temporaryDirectory[Path on Linux]
       val inputJar: Path on Linux = tmp/t"burdock-in-${Uuid().show}.jar"


### PR DESCRIPTION
`soundness.repackage` now shows a live progress bar as it processes each dependency, instead of going silent between the initial message and the final summary.

## Release notes

Running `repackage` on a Burdock-built JAR now displays a fixed-width (40-character) progress bar that fills as each external dependency is resolved and externalized or inlined. The bar uses eighth-width block glyphs (`▏▎▍▌▋▊▉█`) for a smooth, sub-character edge, rendered in `#ff7d26` on a `#3b1700` track. It animates only on an interactive terminal, so redirected/piped output stays clean.