### PR TITLE
Categorize log events by nature for crosscutting filtering

### DIFF
--- a/lib/anthology/src/core/anthology.CompileEvent.scala
+++ b/lib/anthology/src/core/anthology.CompileEvent.scala
@@ -44,7 +44,7 @@ object CompileEvent:
     case Running(arguments) => m"running the compiler with arguments ${arguments.join(t" ")}"
 
 enum CompileEvent:
-  case Start
-  case CompilerCrash
-  case Notice(diagnostic: Text)
-  case Running(arguments: List[Text])
+  case Start extends CompileEvent, Log.Compiler
+  case CompilerCrash extends CompileEvent, Log.Compiler
+  case Notice(diagnostic: Text) extends CompileEvent, Log.Compiler
+  case Running(arguments: List[Text]) extends CompileEvent, Log.Compiler

--- a/lib/anticipation/src/log/anticipation.Log.scala
+++ b/lib/anticipation/src/log/anticipation.Log.scala
@@ -58,70 +58,70 @@ object Log:
   abstract class Category(val reference: Class[?])
 
   object Memory extends Category(classOf[Memory])
-  trait Memory
+  transparent trait Memory
 
   object Cpu extends Category(classOf[Cpu])
-  trait Cpu
+  transparent trait Cpu
 
   object Threading extends Category(classOf[Threading])
-  trait Threading
+  transparent trait Threading
 
   object Process extends Category(classOf[Process])
-  trait Process
+  transparent trait Process
 
   object Filesystem extends Category(classOf[Filesystem])
-  trait Filesystem
+  transparent trait Filesystem
 
   object Disk extends Category(classOf[Disk])
-  trait Disk
+  transparent trait Disk
 
   object Network extends Category(classOf[Network])
-  trait Network
+  transparent trait Network
 
   object Database extends Category(classOf[Database])
-  trait Database
+  transparent trait Database
 
   object Cache extends Category(classOf[Cache])
-  trait Cache
+  transparent trait Cache
 
   object Serialization extends Category(classOf[Serialization])
-  trait Serialization
+  transparent trait Serialization
 
   object Crypto extends Category(classOf[Crypto])
-  trait Crypto
+  transparent trait Crypto
 
   object Auth extends Category(classOf[Auth])
-  trait Auth
+  transparent trait Auth
 
   object Configuration extends Category(classOf[Configuration])
-  trait Configuration
+  transparent trait Configuration
 
   object Dependency extends Category(classOf[Dependency])
-  trait Dependency
+  transparent trait Dependency
 
   object Scheduler extends Category(classOf[Scheduler])
-  trait Scheduler
+  transparent trait Scheduler
 
   object Time extends Category(classOf[Time])
-  trait Time
+  transparent trait Time
 
   object Ui extends Category(classOf[Ui])
-  trait Ui
+  transparent trait Ui
 
   object Protocol extends Category(classOf[Protocol])
-  trait Protocol
+  transparent trait Protocol
 
   object Compiler extends Category(classOf[Compiler])
-  trait Compiler
+  transparent trait Compiler
 
   object Runtime extends Category(classOf[Runtime])
-  trait Runtime
+  transparent trait Runtime
 
   object Gc extends Category(classOf[Gc])
-  trait Gc
+  transparent trait Gc
 
   object Resource extends Category(classOf[Resource])
-  trait Resource
+  transparent trait Resource
 
   object Security extends Category(classOf[Security])
-  trait Security
+  transparent trait Security

--- a/lib/anticipation/src/log/anticipation.Log.scala
+++ b/lib/anticipation/src/log/anticipation.Log.scala
@@ -48,3 +48,80 @@ object Log:
 
   def fail[loggable: Loggable](message: => loggable): Unit =
     loggable.log(Level.Fail, System.currentTimeMillis, message)
+
+  // A standard, growable vocabulary describing the *nature* of a log event. An event type (or, more
+  // usually, an individual enum case) mixes in one or more marker traits; a `Logger` may then be
+  // restricted to record only certain categories, a filter which crosscuts libraries. Each marker
+  // trait is paired with a companion `Category` selector value carrying the trait's runtime
+  // `Class`, so a logger can test each event by type at runtime (the log call site only knows the
+  // event type, so the concrete case's category is not statically available).
+  abstract class Category(val reference: Class[?])
+
+  object Memory extends Category(classOf[Memory])
+  trait Memory
+
+  object Cpu extends Category(classOf[Cpu])
+  trait Cpu
+
+  object Threading extends Category(classOf[Threading])
+  trait Threading
+
+  object Process extends Category(classOf[Process])
+  trait Process
+
+  object Filesystem extends Category(classOf[Filesystem])
+  trait Filesystem
+
+  object Disk extends Category(classOf[Disk])
+  trait Disk
+
+  object Network extends Category(classOf[Network])
+  trait Network
+
+  object Database extends Category(classOf[Database])
+  trait Database
+
+  object Cache extends Category(classOf[Cache])
+  trait Cache
+
+  object Serialization extends Category(classOf[Serialization])
+  trait Serialization
+
+  object Crypto extends Category(classOf[Crypto])
+  trait Crypto
+
+  object Auth extends Category(classOf[Auth])
+  trait Auth
+
+  object Configuration extends Category(classOf[Configuration])
+  trait Configuration
+
+  object Dependency extends Category(classOf[Dependency])
+  trait Dependency
+
+  object Scheduler extends Category(classOf[Scheduler])
+  trait Scheduler
+
+  object Time extends Category(classOf[Time])
+  trait Time
+
+  object Ui extends Category(classOf[Ui])
+  trait Ui
+
+  object Protocol extends Category(classOf[Protocol])
+  trait Protocol
+
+  object Compiler extends Category(classOf[Compiler])
+  trait Compiler
+
+  object Runtime extends Category(classOf[Runtime])
+  trait Runtime
+
+  object Gc extends Category(classOf[Gc])
+  trait Gc
+
+  object Resource extends Category(classOf[Resource])
+  trait Resource
+
+  object Security extends Category(classOf[Security])
+  trait Security

--- a/lib/anticipation/src/log/anticipation.Loggable.scala
+++ b/lib/anticipation/src/log/anticipation.Loggable.scala
@@ -54,11 +54,17 @@ object Loggable:
         // Force and transcribe the event only if some sink would record it at this level; otherwise
         // (including no sinks at all) the by-name `value` is never evaluated.
         if sinks.values.exists(_.accepts(level)) then
-          if !transcribable.skip(value) then
-            val message = transcribable.record(value)
+          val forced = value
+
+          if !transcribable.skip(forced) then
+            // Lazy, so an event no admitting sink records is never transcribed. `admits` tests the
+            // concrete event against each sink's category filter (the log site knows only the
+            // general event type, so this discrimination can only happen at runtime).
+            lazy val message = transcribable.record(forced)
 
             sinks.values.foreach: sink =>
-              if sink.accepts(level) then sink.submit(level, timestamp, message)
+              if sink.accepts(level) && sink.admits(forced)
+              then sink.submit(level, timestamp, message)
 
 trait Loggable extends Typeclass:
   loggable =>

--- a/lib/anticipation/src/log/anticipation.Sink.scala
+++ b/lib/anticipation/src/log/anticipation.Sink.scala
@@ -42,4 +42,12 @@ package anticipation
 // never even constructed, and logging a disabled event costs nothing.
 trait Sink[-eventType, carrier]:
   def accepts(level: Level): Boolean
+
+  // Reports whether this sink records events of the given (concrete) type. Takes the *original*
+  // event rather than the transcribed carrier, because category membership (`Log.Category`) is a
+  // property of the event's runtime type — the log call site knows only the general event type, so
+  // a sink filtered to particular categories must test each event at runtime. Defaults to `true`,
+  // so category-agnostic sinks are unaffected.
+  def admits(event: eventType): Boolean = true
+
   def submit(level: Level, timestamp: Long, message: carrier): Unit

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -531,7 +531,7 @@ object TimeEvent:
     case ParseTzdb(name) => m"parsing the timezone database file $name"
 
 enum TimeEvent:
-  case ParseTzdb(name: Text)
+  case ParseTzdb(name: Text) extends TimeEvent, Log.Time
 
 // Which occurrence of a wall-clock time a `Moment` denotes during a fall-back DST overlap, where
 // the same local time happens twice (clocks go back). `First` is the earlier instant (under the

--- a/lib/burdock/src/core/burdock.DepsEvent.scala
+++ b/lib/burdock/src/core/burdock.DepsEvent.scala
@@ -41,5 +41,5 @@ object DepsEvent:
     case Resolved(hash, url) => m"resolved hash $hash to $url"
 
 enum DepsEvent:
-  case Querying(hash: Text)
-  case Resolved(hash: Text, url: Text)
+  case Querying(hash: Text) extends DepsEvent, Log.Network, Log.Dependency
+  case Resolved(hash: Text, url: Text) extends DepsEvent, Log.Dependency

--- a/lib/coaxial/src/core/coaxial.SocketEvent.scala
+++ b/lib/coaxial/src/core/coaxial.SocketEvent.scala
@@ -42,6 +42,6 @@ object SocketEvent:
     case Closed(endpoint)    => m"closed the connection to $endpoint"
 
 enum SocketEvent:
-  case Listening(endpoint: Text)
-  case Connected(endpoint: Text)
-  case Closed(endpoint: Text)
+  case Listening(endpoint: Text) extends SocketEvent, Log.Network
+  case Connected(endpoint: Text) extends SocketEvent, Log.Network
+  case Closed(endpoint: Text) extends SocketEvent, Log.Network

--- a/lib/cordillera/src/core/cordillera.Http2Event.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Event.scala
@@ -41,5 +41,5 @@ object Http2Event:
     case GoAway(lastStream)     => m"received GOAWAY; the last processed stream was $lastStream"
 
 enum Http2Event:
-  case RequestSent(authority: Text)
-  case GoAway(lastStream: Int)
+  case RequestSent(authority: Text) extends Http2Event, Log.Network, Log.Protocol
+  case GoAway(lastStream: Int) extends Http2Event, Log.Network, Log.Protocol

--- a/lib/embarcadero/src/containerd/embarcadero.DockerEvent.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.DockerEvent.scala
@@ -46,10 +46,10 @@ object DockerEvent:
     case TaskDeleted(container)        => m"deleted the task for container $container"
 
 enum DockerEvent:
-  case ContainerCreated(id: Text)
-  case ContainerDeleted(id: Text)
-  case ImageDeleted(name: Text)
-  case TaskCreated(container: Text)
-  case TaskStarted(container: Text, pid: Int)
-  case TaskKilled(container: Text, signal: Int)
-  case TaskDeleted(container: Text)
+  case ContainerCreated(id: Text) extends DockerEvent, Log.Process
+  case ContainerDeleted(id: Text) extends DockerEvent, Log.Process
+  case ImageDeleted(name: Text) extends DockerEvent, Log.Resource
+  case TaskCreated(container: Text) extends DockerEvent, Log.Process
+  case TaskStarted(container: Text, pid: Int) extends DockerEvent, Log.Process
+  case TaskKilled(container: Text, signal: Int) extends DockerEvent, Log.Process
+  case TaskDeleted(container: Text) extends DockerEvent, Log.Process

--- a/lib/ethereal/src/core/ethereal.DaemonLogEvent.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonLogEvent.scala
@@ -57,15 +57,15 @@ object DaemonLogEvent:
     case Init(pid)                 => m"initialising $pid"
 
 enum DaemonLogEvent:
-  case WriteExecutable(location: Text)
-  case Shutdown
-  case Termination
-  case IdleTimeout
-  case Failure
-  case NewCli
-  case UnrecognizedMessage
-  case ReceivedSignal(signal: UnixSignal | WindowsSignal)
-  case ExitStatusRequest(pid: Pid)
-  case CloseConnection(pid: Pid)
-  case StderrRequest(pid: Pid)
-  case Init(pid: Pid)
+  case WriteExecutable(location: Text) extends DaemonLogEvent, Log.Filesystem
+  case Shutdown extends DaemonLogEvent, Log.Process
+  case Termination extends DaemonLogEvent, Log.Network
+  case IdleTimeout extends DaemonLogEvent, Log.Scheduler
+  case Failure extends DaemonLogEvent, Log.Runtime
+  case NewCli extends DaemonLogEvent, Log.Process
+  case UnrecognizedMessage extends DaemonLogEvent, Log.Protocol
+  case ReceivedSignal(signal: UnixSignal | WindowsSignal) extends DaemonLogEvent, Log.Process
+  case ExitStatusRequest(pid: Pid) extends DaemonLogEvent, Log.Process
+  case CloseConnection(pid: Pid) extends DaemonLogEvent, Log.Network
+  case StderrRequest(pid: Pid) extends DaemonLogEvent, Log.Process
+  case Init(pid: Pid) extends DaemonLogEvent, Log.Process

--- a/lib/eucalyptus/src/core/eucalyptus.Logger.scala
+++ b/lib/eucalyptus/src/core/eucalyptus.Logger.scala
@@ -52,8 +52,9 @@ object Logger:
 
   def apply[eventType, loggingType, format, target]
     ( destination: target,
-      level:       Level          = Level.Info,
-      name:        Optional[Text] = Unset )
+      level:       Level               = Level.Info,
+      name:        Optional[Text]      = Unset,
+      categories:  Set[Log.Category]   = Set() )
     ( using inscribable: loggingType is Inscribable in format,
             writable:    target is Writable by format,
             monitor:     Monitor,
@@ -70,7 +71,7 @@ object Logger:
     def enqueue(message: loggingType, level: Level, timestamp: Long): Unit =
       spool.put(inscribable.formatter(message, level, timestamp))
 
-    new Logger(level, enqueue)
+    new Logger(level, categories, enqueue)
 
   // The write runs in a fire-and-forget daemon. A write failure `raise`s a `StreamError`, discharged
   // by the `Emit` captured when the caller summoned the `Writable` — typically a `handle` enclosing
@@ -96,10 +97,15 @@ object Logger:
         spool.stop()
 
 class Logger[-eventType, loggingType] private
-  ( threshold: Level, enqueue: (loggingType, Level, Long) => Unit )
+  ( threshold: Level, categories: Set[Log.Category], enqueue: (loggingType, Level, Long) => Unit )
 extends Sink[eventType, loggingType]:
 
   def accepts(level: Level): Boolean = level.ordinal >= threshold.ordinal
+
+  // With no categories configured, record everything (the level threshold is the only filter);
+  // otherwise record only events whose runtime type mixes in one of the selected categories.
+  override def admits(event: eventType): Boolean =
+    categories.isEmpty || categories.exists(_.reference.isInstance(event))
 
   def submit(level: Level, timestamp: Long, message: loggingType): Unit =
     enqueue(message, level, timestamp)

--- a/lib/eucalyptus/src/test/eucalyptus_test.scala
+++ b/lib/eucalyptus/src/test/eucalyptus_test.scala
@@ -60,6 +60,18 @@ object Tests extends Suite(m"Eucalyptus tests"):
     given writable: Emit[StreamError] => Failing is Writable by Text =
       (failing, stream) => stream.each(_ => raise(StreamError(0.b)))
 
+  // An event enum whose cases carry *different* categories. Because the marker traits are
+  // transparent, `Log.info(Signal.Net(…))` is typed at the general `Signal`, so the concrete case's
+  // category is known only at runtime — exactly what a category-filtered `Logger` must test.
+  enum Signal:
+    case Net(text: Text) extends Signal, Log.Network
+    case Fs(text: Text) extends Signal, Log.Filesystem
+
+  object Signal:
+    given communicable: Signal is Communicable =
+      case Net(text) => m"net: $text"
+      case Fs(text)  => m"fs: $text"
+
   def run(): Unit = supervise:
     test(m"A Warn-threshold logger drops Fine and Info but keeps Warn and Fail"):
       val capture = Capture()
@@ -93,3 +105,21 @@ object Tests extends Suite(m"Eucalyptus tests"):
           errors.take()
 
     . assert(_ == t"cut")
+
+    test(m"A category-filtered logger records only events in its categories"):
+      val capture = Capture()
+      given Logger[Any, Message] = Logger(capture, categories = Set(Log.Network))
+      Log.info(Signal.Net(t"a"))
+      Log.info(Signal.Fs(t"b"))
+      capture.queue.take()
+
+    . assert(_ == t"[INFO] net: a\n")
+
+    test(m"A logger with no categories records events of every category"):
+      val capture = Capture()
+      given Logger[Any, Message] = Logger(capture)
+      Log.info(Signal.Net(t"a"))
+      Log.info(Signal.Fs(t"b"))
+      List(capture.queue.take(), capture.queue.take())
+
+    . assert(_ == List(t"[INFO] net: a\n", t"[INFO] fs: b\n"))

--- a/lib/galilei/src/core/galilei.IoEvent.scala
+++ b/lib/galilei/src/core/galilei.IoEvent.scala
@@ -48,11 +48,11 @@ object IoEvent:
     case Touch(path)           => m"touched $path"
 
 enum IoEvent:
-  case Exec(event: ExecEvent)
-  case Create(path: Text)
-  case Delete(path: Text)
-  case Move(from: Text, to: Text)
-  case Copy(from: Text, to: Text)
-  case HardLink(from: Text, to: Text)
-  case Symlink(link: Text, target: Text)
-  case Touch(path: Text)
+  case Exec(event: ExecEvent) extends IoEvent, Log.Process
+  case Create(path: Text) extends IoEvent, Log.Filesystem
+  case Delete(path: Text) extends IoEvent, Log.Filesystem
+  case Move(from: Text, to: Text) extends IoEvent, Log.Filesystem
+  case Copy(from: Text, to: Text) extends IoEvent, Log.Filesystem
+  case HardLink(from: Text, to: Text) extends IoEvent, Log.Filesystem
+  case Symlink(link: Text, target: Text) extends IoEvent, Log.Filesystem
+  case Touch(path: Text) extends IoEvent, Log.Filesystem

--- a/lib/guillotine/src/core/guillotine.ExecEvent.scala
+++ b/lib/guillotine/src/core/guillotine.ExecEvent.scala
@@ -46,8 +46,8 @@ object ExecEvent:
     case ProcessExit(pid, code)  => m"the process with PID $pid exited with code $code"
 
 enum ExecEvent:
-  case ProcessStart(command: Command)
-  case AbortProcess(pid: Pid)
-  case PipelineStart(commands: Seq[Command])
-  case KillProcess(pid: Pid)
-  case ProcessExit(pid: Pid, code: Int)
+  case ProcessStart(command: Command) extends ExecEvent, Log.Process
+  case AbortProcess(pid: Pid) extends ExecEvent, Log.Process
+  case PipelineStart(commands: Seq[Command]) extends ExecEvent, Log.Process
+  case KillProcess(pid: Pid) extends ExecEvent, Log.Process
+  case ProcessExit(pid: Pid, code: Int) extends ExecEvent, Log.Process

--- a/lib/hellenism/src/core/hellenism.ClasspathEvent.scala
+++ b/lib/hellenism/src/core/hellenism.ClasspathEvent.scala
@@ -41,5 +41,5 @@ object ClasspathEvent:
     case ResourceMissing(path) => m"the classpath resource $path was not found"
 
 enum ClasspathEvent:
-  case ResourceLoaded(path: Text)
-  case ResourceMissing(path: Text)
+  case ResourceLoaded(path: Text) extends ClasspathEvent, Log.Runtime, Log.Resource
+  case ResourceMissing(path: Text) extends ClasspathEvent, Log.Runtime, Log.Resource

--- a/lib/octogenarian/src/core/octogenarian.GitEvent.scala
+++ b/lib/octogenarian/src/core/octogenarian.GitEvent.scala
@@ -43,4 +43,4 @@ object GitEvent:
     case Exec(reason) => m"the git operation did not execute: $reason"
 
 enum GitEvent:
-  case Exec(event: ExecEvent)
+  case Exec(event: ExecEvent) extends GitEvent, Log.Process

--- a/lib/perihelion/src/core/perihelion.WebsocketEvent.scala
+++ b/lib/perihelion/src/core/perihelion.WebsocketEvent.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package perihelion
 
+import anticipation.Log
 import fulminate.*
 
 object WebsocketEvent:
@@ -41,6 +42,6 @@ object WebsocketEvent:
     case Closed(code)    => m"closed the websocket connection with code $code"
 
 enum WebsocketEvent:
-  case Sent(bytes: Int)
-  case Received(bytes: Int)
-  case Closed(code: Int)
+  case Sent(bytes: Int) extends WebsocketEvent, Log.Network, Log.Protocol
+  case Received(bytes: Int) extends WebsocketEvent, Log.Network, Log.Protocol
+  case Closed(code: Int) extends WebsocketEvent, Log.Network, Log.Protocol

--- a/lib/scintillate/src/server/scintillate.HttpServerEvent.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServerEvent.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package scintillate
 
+import anticipation.Log
 import fulminate.*
 import rudiments.*
 import telekinesis.*
@@ -44,7 +45,7 @@ object HttpServerEvent:
     case ConnectionFailed(error)      => m"the connection handler failed: ${error.message}"
 
 enum HttpServerEvent:
-  case Received(request: Http.Request)
-  case Processed(request: Http.Request, duration: Long)
-  case BrokenStream(length: Bytes)
-  case ConnectionFailed(error: Error)
+  case Received(request: Http.Request) extends HttpServerEvent, Log.Network, Log.Protocol
+  case Processed(request: Http.Request, duration: Long) extends HttpServerEvent, Log.Network
+  case BrokenStream(length: Bytes) extends HttpServerEvent, Log.Network
+  case ConnectionFailed(error: Error) extends HttpServerEvent, Log.Network

--- a/lib/telekinesis/src/core/telekinesis.HttpEvent.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpEvent.scala
@@ -44,7 +44,10 @@ object HttpEvent:
     case Redirect(from, to)         => m"following a redirect from $from to $to"
 
 enum HttpEvent:
-  case Response(status: Http.Status)
-  case Request(preview: Text)
+  case Response(status: Http.Status) extends HttpEvent, Log.Network
+  case Request(preview: Text) extends HttpEvent, Log.Network
+
   case Send(method: Http.Method, url: into[HttpUrl], headers: Seq[Http.Header])
-  case Redirect(from: Text, to: Text)
+  extends HttpEvent, Log.Network, Log.Protocol
+
+  case Redirect(from: Text, to: Text) extends HttpEvent, Log.Network, Log.Protocol

--- a/lib/zeppelin/src/core/zeppelin.ZipEvent.scala
+++ b/lib/zeppelin/src/core/zeppelin.ZipEvent.scala
@@ -41,5 +41,5 @@ object ZipEvent:
     case Read(path, entries)  => m"read $entries entries from the zip archive $path"
 
 enum ZipEvent:
-  case Wrote(path: Text, entries: Int)
-  case Read(path: Text, entries: Int)
+  case Wrote(path: Text, entries: Int) extends ZipEvent, Log.Serialization
+  case Read(path: Text, entries: Int) extends ZipEvent, Log.Serialization


### PR DESCRIPTION
Log events can now be categorised by their nature — Network, Filesystem, Process, and so on — using a standard, growable set of marker traits, and a `Logger` can be configured to record only the categories it cares about, a filter that crosscuts libraries. Because categories are assigned to individual message cases rather than whole event types, and the log call site knows only the general event type, the `Logger` performs the category test on each event at runtime.

## Categorising log events

Every log event can now be tagged with one or more *categories* from a standard, growable vocabulary defined in `Log`, describing the nature of the event (`Log.Network`, `Log.Filesystem`, `Log.Process`, `Log.Compiler`, `Log.Time`, …). Categories are mixed into individual message cases, so different messages within one event type can differ:

```scala
enum HttpEvent:
  case Response(status: Http.Status) extends HttpEvent, Log.Network
  case Send(...)                     extends HttpEvent, Log.Network, Log.Protocol
```

A `Logger` may be restricted to certain categories when constructed:

```scala
given Logger[Any, Message] = Logger(target, categories = Set(Log.Network, Log.Filesystem))
```

It then records only events whose runtime message type carries one of those categories; others are dropped. A logger constructed without `categories` records everything, filtered only by level, as before. The marker traits are `transparent`, so tagging a message case does not change the type seen at the log-call site and existing logging code is unaffected. The filter crosscuts libraries — one `Logger(target, categories = Set(Log.Network))` captures HTTP, socket, WebSocket and dependency-resolution events from telekinesis, coaxial, perihelion and burdock alike.