### PR TITLE
Add the ergo shorthand language and value encoders to Archimedes

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1251,10 +1251,11 @@ object rudiments extends Library:
   object test extends Tests(core, abacist.core, quantitative.units)
 
 object archimedes extends Library:
-  object core extends Component(xylophone.core, honeycomb.core):
+  object core extends Component(xylophone.core, honeycomb.core, contextual.core, gigantism.core,
+    quantitative.core, baroque.core, mosquito.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core)
+  object test extends Tests(core, quantitative.units)
 
 object savagery extends Library:
   object core extends Component(cataclysm.core, xylophone.core, geodesy.core, iridescence.core,

--- a/lib/archimedes/doc/ergo-directives.md
+++ b/lib/archimedes/doc/ergo-directives.md
@@ -1,0 +1,144 @@
+# Ergo glyph reference
+
+Ergo is a one-line shorthand for Presentation MathML. An expression is delimited
+by a bracket pair; the **first character** chooses which pair (`(`/`[`/`{`/`⟨`)
+acts as grouping syntax throughout, and every *other* bracket is a literal `<mo>`.
+A grouped run is an `<mrow>` unit; operands of an operator are uniformly "an atom
+or a grouped unit".
+
+This file lists every glyph Ergo uses: the **structural** glyphs that build the
+equation tree, then the **attribute directives** (MathML Core) that decorate it.
+
+---
+
+## Structure
+
+### Scripts & limits
+
+- `↗` — **superscript** → `<msup>` — `x↗2` = *x²*
+- `↘` — **subscript** → `<msub>` — `x↘i` = *xᵢ*
+- `↑` — **overscript / limit above** → `<mover>` (accent when the script is a single `<mo>`)
+- `↓` — **underscript / limit below** → `<munder>` (accent when the script is a single `<mo>`)
+
+A base absorbs one `↘` and one `↗` → `<msubsup>`; one `↓` and one `↑` →
+`<munderover>`. Big operators need no special syntax: `∑` is a plain `<mo>`, and
+`∑↓(i = 1)↑n` gives it under/over limits.
+
+### Fraction & roots
+
+- `/` — **fraction** → `<mfrac>` — `a/b`
+- `√` — **square root** (prefix) → `<msqrt>` — `√x`
+- `n√x` — **nth root** → `<mroot>` — an index atom immediately before `√` (no space): `3√x` = *∛x*
+
+### Introducers (tables)
+
+Self-delimiting; the body is one group whose child groups are the elements.
+
+- `⊞` — **matrix** → `<mtable>` — `⊞(((1)(2))((3)(4)))` = a 2×2 matrix (rows of cells)
+- `⊟` — **row vector** → `<mtable>` with one row — `⊟((1)(2)(3))`
+- `⊡` — **column vector** → `<mtable>` with one column — `⊡((a)(b))`
+
+### Tokens & spacing
+
+- a **letter run** → one `<mi>` — `sin` = `<mi>sin</mi>`; a space splits identifiers (`x y` = *x·y*)
+- a **digit run** (interior `.` allowed) → one `<mn>` — `3.14`
+- any other character → `<mo>` — `+`, `=`, `∑`, `±`, …
+- an **operator glyph with a missing operand** degrades to a literal `<mo>` — `(↗)` writes a literal ↗
+- a **space** is a separator and is not rendered
+
+---
+
+## Attribute directives (MathML Core)
+
+Each MathML Core presentation attribute is written as a single **directive glyph**.
+The scope is MathML Core only, so the large MathML 3 table/elementary attribute
+families are absent (see *Excluded from Core* below).
+
+**Conventions** *(as implemented in the parser)*
+
+- Directives are **postfix** and bind to the primary (atom or bracketed group)
+  immediately to their left; multiple directives simply **juxtapose**:
+  `=◆⇿` sets both `largeop="true"` and `stretchy="true"` on the operator `=`.
+- **Enumerated and boolean** attributes have **one bare glyph per value** — no
+  parameter. `form` is `⊰`/`⊹`/`⊱` (prefix/infix/postfix); a boolean is `⇿`
+  (true) or `↮` (false). Since these never take a group, `=◆(a)` is `=` with
+  `largeop="true"` *times* `(a)`, not `largeop="a"`.
+- **Open-valued** attributes (length/colour/integer) take their value in the
+  **active grouping bracket** (shown below as `[…]`), read verbatim: with `(`
+  grouping, `x●(red)` sets `mathcolor="red"`; with `[` grouping it would be
+  `x●[red]`. Values are lengths (`0.5em`, `2px`, `40%`), colours (`red`,
+  `#3366cc`), or signed integers (`+1`, `-2`).
+- To attach a directive to a whole sub-expression, group it: `(x↗2)●(red)` colours
+  the `<msup>`, whereas `x↗2●(red)` colours only the `2`.
+
+### Document & display level
+
+- `⧊` / `⧄` — **displaystyle** = true / false — use display style (larger, limits over/under) vs inline/text style
+- `⌄[±n]` — **scriptlevel** — relative script size level; `+n` shrinks, `-n` enlarges
+- `▦` / `▭` — **display** = block / inline *(on `<math>`)* — block equation vs inline in running text
+
+### Colour
+
+- `●[color]` — **mathcolor** — foreground (ink) colour of the content
+- `▨[color]` — **mathbackground** — background colour behind the content
+
+### Text size & style
+
+- `⤢[length]` — **mathsize** — font size of the element
+- `⦱` — **mathvariant** = normal — render upright, cancelling the automatic italicisation of a single-letter identifier
+- `▹` / `◃` — **dir** = ltr / rtl — text/layout direction
+
+### Operator role (`<mo>`)
+
+- `⊰` / `⊹` / `⊱` — **form** = prefix / infix / postfix — which spacing/role form the operator takes
+- `⧘` / `⧙` — **fence** = true / false — mark the operator as a fence (bracket/paren)
+- `▮` / `▯` — **separator** = true / false — mark the operator as a separator (e.g. a comma)
+- `⇿` / `↮` — **stretchy** = true / false — allow the operator to stretch to its surrounding content
+- `⋈` / `⋇` — **symmetric** = true / false — stretch symmetrically about the maths axis
+- `◆` / `◇` — **largeop** = true / false — treat as a large operator (e.g. `∑`, `∫`) in display style
+- `⇅` / `⇳` — **movablelimits** = true / false — limits over/under in display style but as scripts inline
+
+### Operator spacing & stretch (`<mo>`)
+
+- `⇤[length]` — **lspace** — space to the left of the operator
+- `⇥[length]` — **rspace** — space to the right of the operator
+- `⟰[length]` — **maxsize** — maximum stretched size
+- `⟱[length]` — **minsize** — minimum stretched size
+
+### Box metrics (`<mspace>`, `<mpadded>`)
+
+- `↔[length]` — **width** — advance width of the box
+- `⤒[length]` — **height** — extent above the baseline
+- `⤓[length]` — **depth** — extent below the baseline
+- `↨[length]` — **voffset** *(on `<mpadded>`)* — vertical shift of the content
+
+### Fraction (`<mfrac>`)
+
+- `═[length]` — **linethickness** — thickness of the fraction bar (`0` = no bar)
+
+### Under/over accents (`<munder>`, `<mover>`, `<munderover>`)
+
+- `◠` / `⌢` — **accent** = true / false — treat the overscript as a tight accent
+- `◡` / `⌣` — **accentunder** = true / false — treat the underscript as a tight accent
+
+### Legacy (present in Core but behaviour undefined)
+
+- `⚙[type]` — **actiontype** *(on `<maction>`)* — legacy action type; behaviour is undefined in MathML Core
+
+---
+
+## Excluded from Core (no glyph assigned)
+
+These MathML 3 features are **not** in MathML Core, so Ergo assigns no glyph for
+them; they would only be reachable through a generic named-element escape:
+
+- **Table attributes** — `columnalign`, `rowalign`, `columnlines`, `rowlines`,
+  `frame`, `framespacing`, `rowspan`, `columnspan`, `align`, `side`, … (Core keeps
+  `<mtable>`/`<mtr>`/`<mtd>` as elements but defines none of these attributes)
+- **`<menclose>`** and its `notation` values — not in Core
+- **`<ms>` `lquote`/`rquote`** — removed in Core
+- **Elementary math** — `<mstack>`, `<mlongdiv>`, `<msgroup>`, `<msrow>`,
+  `<mscarries>`, `<mscarry>`, `<msline>` and their attributes — not in Core
+- **`mathvariant`** values other than `normal` — Core requires the corresponding
+  Unicode Mathematical Alphanumeric characters instead
+- **Reserved** — `intent`, `arg`, `alttext` (declared but undefined in Core)

--- a/lib/archimedes/src/core/archimedes.Ergo.scala
+++ b/lib/archimedes/src/core/archimedes.Ergo.scala
@@ -1,0 +1,510 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package archimedes
+
+import scala.collection.mutable.ListBuffer
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import vacuous.*
+
+// A parser for "ergo": a one-line shorthand for Presentation MathML that emits
+// `archimedes` nodes. The whole expression is delimited by a bracket pair; the
+// first character chooses which pair (`(`/`[`/`{`/`⟨`) acts as grouping syntax,
+// and every other bracket is a literal `Mo`. Grouped runs are `Mrow` units.
+//
+// Operators, tightest-binding first:
+//   √ prefix              → Msqrt        (an index atom immediately before √ → Mroot)
+//   ↗ ↘ (corner scripts)  → Msup/Msub    (one of each on a base merges → Msubsup)
+//   ↑ ↓ (centred limits)  → Mover/Munder (one of each merges → Munderover)
+//   /                     → Mfrac
+//   juxtaposition         → Mrow
+//
+// Introducers ⊞/⊟/⊡ start a matrix / row-vector / column-vector from the run of
+// bracket groups that immediately follows. A space separates adjacent atoms
+// (`x y` = two `<mi>`, `xy` = one), and any operator glyph with a missing
+// operand degrades to a literal `Mo` (so `(↗)` writes a literal ↗).
+
+object Ergo:
+  private val pairs: Map[Char, Char] =
+    Map('(' -> ')', '[' -> ']', '{' -> '}', '⟨' -> '⟩')
+
+  private final val Sup    = '↗' // ↗
+  private final val Sub    = '↘' // ↘
+  private final val Over   = '↑' // ↑
+  private final val Under  = '↓' // ↓
+  private final val Radical = '√' // √
+  private final val Matrix = '⊞' // ⊞
+  private final val RowVec = '⊟' // ⊟
+  private final val ColVec = '⊡' // ⊡
+  private final val Hole   = '\uE000' // interpolator substitution placeholder
+
+  // A postfix attribute directive (see `doc/ergo-directives.md`). `Fixed` sets a
+  // constant value with a bare glyph (one glyph per enumerated/boolean value);
+  // `Param` reads an open value (length/colour/integer) in the active bracket.
+  private enum Directive(val attribute: Text):
+    case Param(name: Text)              extends Directive(name)
+    case Fixed(name: Text, value: Text) extends Directive(name)
+
+  private val directives: List[(Char, Directive)] = List(
+    '⧊' -> Directive.Fixed(t"displaystyle", t"true"),
+    '⧄' -> Directive.Fixed(t"displaystyle", t"false"),
+    '⌄' -> Directive.Param(t"scriptlevel"),
+    '▦' -> Directive.Fixed(t"display", t"block"),
+    '▭' -> Directive.Fixed(t"display", t"inline"),
+    '●' -> Directive.Param(t"mathcolor"),
+    '▨' -> Directive.Param(t"mathbackground"),
+    '⤢' -> Directive.Param(t"mathsize"),
+    '⦱' -> Directive.Fixed(t"mathvariant", t"normal"),
+    '▹' -> Directive.Fixed(t"dir", t"ltr"),
+    '◃' -> Directive.Fixed(t"dir", t"rtl"),
+    '⊰' -> Directive.Fixed(t"form", t"prefix"),
+    '⊹' -> Directive.Fixed(t"form", t"infix"),
+    '⊱' -> Directive.Fixed(t"form", t"postfix"),
+    '⧘' -> Directive.Fixed(t"fence", t"true"),
+    '⧙' -> Directive.Fixed(t"fence", t"false"),
+    '▮' -> Directive.Fixed(t"separator", t"true"),
+    '▯' -> Directive.Fixed(t"separator", t"false"),
+    '⇿' -> Directive.Fixed(t"stretchy", t"true"),
+    '↮' -> Directive.Fixed(t"stretchy", t"false"),
+    '⋈' -> Directive.Fixed(t"symmetric", t"true"),
+    '⋇' -> Directive.Fixed(t"symmetric", t"false"),
+    '◆' -> Directive.Fixed(t"largeop", t"true"),
+    '◇' -> Directive.Fixed(t"largeop", t"false"),
+    '⇅' -> Directive.Fixed(t"movablelimits", t"true"),
+    '⇳' -> Directive.Fixed(t"movablelimits", t"false"),
+    '⇤' -> Directive.Param(t"lspace"),
+    '⇥' -> Directive.Param(t"rspace"),
+    '⟰' -> Directive.Param(t"maxsize"),
+    '⟱' -> Directive.Param(t"minsize"),
+    '↔' -> Directive.Param(t"width"),
+    '⤒' -> Directive.Param(t"height"),
+    '⤓' -> Directive.Param(t"depth"),
+    '↨' -> Directive.Param(t"voffset"),
+    '═' -> Directive.Param(t"linethickness"),
+    '◠' -> Directive.Fixed(t"accent", t"true"),
+    '⌢' -> Directive.Fixed(t"accent", t"false"),
+    '◡' -> Directive.Fixed(t"accentunder", t"true"),
+    '⌣' -> Directive.Fixed(t"accentunder", t"false"),
+    '⚙' -> Directive.Param(t"actiontype"))
+
+  private def directive(char: Char): Optional[Directive] =
+    directives.collectFirst { case (glyph, entry) if glyph == char => entry }.optional
+
+  def parse(input: Text)(using Tactic[ErgoError]): Math =
+    Parser(input.s, Iterator.empty).parseTop()
+
+  // Parses an interpolated `ergo""` literal: the `parts` are joined with a hole
+  // sentinel, and each hole yields the corresponding already-encoded `atoms` node
+  // as a single atom, in left-to-right order.
+  def interpolate(parts: Seq[Text], atoms: Seq[Mathml])(using Tactic[ErgoError]): Math =
+    Parser(parts.map(_.s).mkString(Hole.toString), atoms.iterator).parseTop()
+
+  // Parse-or-throw, for callers (in particular the `ergo""` interpolator's
+  // generated code) that have already established the literal is well-formed.
+  def unsafe(input: Text): Math =
+    import strategies.throwUnsafely
+    parse(input)
+
+  def unsafeInterpolate(parts: Seq[Text], atoms: Seq[Mathml]): Math =
+    import strategies.throwUnsafely
+    interpolate(parts, atoms)
+
+  // ── Serialisation: an archimedes `Math` tree → ergo shorthand text ──────────
+  //
+  // Emits the ergo-expressible subset of Presentation MathML (the elements Ergo
+  // has structural syntax for, plus every MathML Core attribute as a directive).
+  // An element outside that subset — e.g. `<mtext>`, `<mspace>`, `<mstyle>` — has
+  // no ergo form and raises `ErgoError`. The root `<math>`'s own attributes are
+  // not representable and are dropped.
+
+  private val special: Set[Char] =
+    Set('(', ')', '[', ']', '{', '}', '⟨', '⟩', '↗', '↘', '↑', '↓', '/', '√', '⊞', '⊟', '⊡')
+
+  def serialize(math: Math)(using Tactic[ErgoError]): Text = t"(${sequence(math.contents)})"
+
+  private def group(core: Text): Text = t"($core)"
+
+  private def operand(node: Mathml)(using Tactic[ErgoError]): Text = emit(node, true)
+
+  private def rowOf(nodes: List[Mathml]): Mathml = nodes match
+    case one :: Nil => one
+    case many       => Mrow(many)
+
+  // Joins a juxtaposed run, inserting a space only where two tokens would
+  // otherwise merge (letter+letter into one `<mi>`, or digit+digit into one `<mn>`).
+  private def sequence(nodes: List[Mathml])(using Tactic[ErgoError]): Text =
+    val parts = nodes.map(emit(_, false)).filter(!_.s.isEmpty)
+
+    parts.foldLeft(t""): (acc, next) =>
+      if acc.s.isEmpty then next
+      else if merges(acc.s.charAt(acc.s.length - 1), next.s.charAt(0)) then t"$acc $next"
+      else t"$acc$next"
+
+  private def merges(left: Char, right: Char): Boolean =
+    Character.isLetter(left) && Character.isLetter(right) ||
+      Character.isDigit(left) && Character.isDigit(right)
+
+  // Wraps a compound in the grouping bracket when it is used as an operand or
+  // carries attributes (so trailing directives bind to the whole unit).
+  private def finish(core: Text, attributes: List[(Text, Text)], asOperand: Boolean, safe: Boolean)
+  :   Text =
+
+    if attributes.nonEmpty then t"${group(core)}${directivesFor(attributes)}"
+    else if asOperand && !safe then group(core)
+    else core
+
+  private def emit(node: Mathml, asOperand: Boolean)(using Tactic[ErgoError]): Text = node match
+    case Mo(value, attributes) if value.s.length == 1 && special(value.s.charAt(0)) =>
+      t"${group(value)}${directivesFor(attributes)}"
+
+    case Mi(value, attributes) => t"$value${directivesFor(attributes)}"
+    case Mn(value, attributes) => t"$value${directivesFor(attributes)}"
+    case Mo(value, attributes) => t"$value${directivesFor(attributes)}"
+
+    case Msqrt(contents, attributes) =>
+      finish(t"√${operand(rowOf(contents))}", attributes, asOperand, true)
+
+    case Mroot(base, index, attributes) =>
+      finish(t"${operand(index)}√${operand(base)}", attributes, asOperand, true)
+
+    case table: Mtable => finish(serializeTable(table), table.attributes, asOperand, true)
+
+    case Mrow(contents, attributes) => finish(sequence(contents), attributes, asOperand, false)
+
+    case Mfrac(numerator, denominator, attributes) =>
+      finish(t"${operand(numerator)}/${operand(denominator)}", attributes, asOperand, false)
+
+    case Msub(base, sub, attributes) =>
+      finish(t"${operand(base)}↘${operand(sub)}", attributes, asOperand, false)
+
+    case Msup(base, sup, attributes) =>
+      finish(t"${operand(base)}↗${operand(sup)}", attributes, asOperand, false)
+
+    case Msubsup(base, sub, sup, attributes) =>
+      finish(t"${operand(base)}↘${operand(sub)}↗${operand(sup)}", attributes, asOperand, false)
+
+    case Munder(base, under, attributes) =>
+      val kept = accentless(attributes, under, t"accentunder")
+      finish(t"${operand(base)}↓${operand(under)}", kept, asOperand, false)
+
+    case Mover(base, over, attributes) =>
+      val kept = accentless(attributes, over, t"accent")
+      finish(t"${operand(base)}↑${operand(over)}", kept, asOperand, false)
+
+    case Munderover(base, under, over, attributes) =>
+      val kept = accentless(accentless(attributes, under, t"accentunder"), over, t"accent")
+      finish(t"${operand(base)}↓${operand(under)}↑${operand(over)}", kept, asOperand, false)
+
+    case other => abort(ErgoError(ErgoError.Reason.Unsupported(other.label)))
+
+  // A `↑`/`↓` script that is a single `<mo>` re-acquires its accent on parsing, so
+  // the corresponding accent attribute is implied and not emitted.
+  private def accentless(attributes: List[(Text, Text)], script: Mathml, name: Text)
+  :   List[(Text, Text)] =
+
+    val accent = script match
+      case _: Mo => true
+      case _     => false
+
+    if accent then attributes.filter { pair => pair != (name, t"true") } else attributes
+
+  private def serializeTable(table: Mtable)(using Tactic[ErgoError]): Text =
+    val rows: List[List[Text]] = table.contents.collect:
+      case Mtr(cells, _) => cells.map(cellText)
+
+    if rows.length == 1 then t"⊟(${rows.head.join})"
+    else if rows.forall(_.length == 1) then t"⊡(${rows.map(_.head).join})"
+    else t"⊞(${rows.map { cells => group(cells.join) }.join})"
+
+  private def cellText(node: Mathml)(using Tactic[ErgoError]): Text = node match
+    case Mtd(contents, _) => group(sequence(contents))
+    case other            => group(emit(other, false))
+
+  private def directivesFor(attributes: List[(Text, Text)]): Text =
+    attributes.map { case (name, value) => directiveText(name, value) }
+    . collect { case text: Text => text }.join
+
+  // Prefers a `Fixed` glyph matching both attribute and value (enums/booleans);
+  // otherwise a `Param` glyph for the attribute, with the value in brackets.
+  private def directiveText(name: Text, value: Text): Optional[Text] =
+    val matched = directives.collectFirst:
+      case (glyph, Directive.Fixed(n, v)) if n == name && v == value =>
+        glyph.toString.tt
+
+      case (glyph, Directive.Param(n)) if n == name =>
+        t"${glyph.toString.tt}($value)"
+
+    matched.optional
+
+  private class Parser(s: String, holes: Iterator[Mathml])(using Tactic[ErgoError]):
+    private var pos = 0
+    private var open = '('
+    private var close = ')'
+
+    private def peek: Char = if pos < s.length then s.charAt(pos) else ' '
+
+    private def peekAt(offset: Int): Char =
+      if pos + offset < s.length then s.charAt(pos + offset) else ' '
+
+    private def advance(): Char =
+      val c = peek
+      pos += 1
+      c
+
+    private def skipSpaces(): Unit = while pos < s.length && s.charAt(pos) == ' ' do pos += 1
+
+    private def letter(c: Char): Boolean = Character.isLetter(c)
+    private def digit(c: Char): Boolean = Character.isDigit(c)
+
+    def parseTop(): Math =
+      if s.isEmpty then abort(ErgoError(ErgoError.Reason.Empty))
+      open = s.charAt(0)
+
+      if !pairs.contains(open)
+      then abort(ErgoError(ErgoError.Reason.BadOpener(open.toString.tt)))
+
+      close = pairs(open)
+
+      parseGroup() match
+        case Mrow(nodes, _) => Math(nodes)
+        case other          => Math(List(other))
+
+    // Consumes `open … close`, returning the inner sequence (unwrapped if single).
+    private def parseGroup(): Mathml =
+      advance()
+      val inner = parseSequence()
+      skipSpaces()
+      if peek != close then abort(ErgoError(ErgoError.Reason.Unclosed(close.toString.tt)))
+      advance()
+      inner
+
+    // Juxtaposition — the loosest binding; a run of fraction-level terms → Mrow.
+    private def parseSequence(): Mathml =
+      val terms = ListBuffer[Mathml]()
+      skipSpaces()
+
+      while pos < s.length && peek != close do
+        terms += parseFraction()
+        skipSpaces()
+
+      terms.to(List) match
+        case one :: Nil => one
+        case many       => Mrow(many)
+
+    private def parseFraction(): Mathml =
+      var left = parseScripts()
+      skipSpaces()
+
+      while peek == '/' do
+        advance()
+        left = Mfrac(left, parseScripts())
+        skipSpaces()
+
+      left
+
+    private def parseScripts(): Mathml =
+      val base = parsePrimary()
+      var sub, sup, under, over: Optional[Mathml] = Unset
+      var scanning = true
+
+      while scanning do
+        skipSpaces()
+
+        peek match
+          case Sup if sup.absent     => advance(); sup = parsePrimary()
+          case Sub if sub.absent     => advance(); sub = parsePrimary()
+          case Over if over.absent   => advance(); over = parsePrimary()
+          case Under if under.absent => advance(); under = parsePrimary()
+          case _                     => scanning = false
+
+      // An `↑`/`↓` script that is a single `Mo` (a bar/hat/vec-style mark) is an
+      // accent; an identifier or group is an ordinary limit.
+      def accent(script: Mathml, name: Text): List[(Text, Text)] = script match
+        case _: Mo => List(name -> t"true")
+        case _     => Nil
+
+      val limited = (under, over) match
+        case (Unset, Unset) => base
+
+        case (u, Unset) =>
+          val script = u.or(base)
+          Munder(base, script, accent(script, t"accentunder"))
+
+        case (Unset, o) =>
+          val script = o.or(base)
+          Mover(base, script, accent(script, t"accent"))
+
+        case (u, o) =>
+          val below = u.or(base)
+          val above = o.or(base)
+          Munderover(base, below, above, accent(below, t"accentunder") ++ accent(above, t"accent"))
+
+      (sub, sup) match
+        case (Unset, Unset) => limited
+        case (b, Unset)     => Msub(limited, b.or(limited))
+        case (Unset, p)     => Msup(limited, p.or(limited))
+        case (b, p)         => Msubsup(limited, b.or(limited), p.or(limited))
+
+    // A primary is a unit plus any postfix attribute directives bound to it.
+    private def parsePrimary(): Mathml = withDirectives(parseUnit())
+
+    // Reads `open … close` as a raw attribute value (its content is not parsed).
+    private def readValue(): Text =
+      advance() // open
+      val start = pos
+      var depth = 1
+
+      while pos < s.length && depth > 0 do
+        val ch = s.charAt(pos)
+        if ch == open then depth += 1 else if ch == close then depth -= 1
+        if depth > 0 then pos += 1
+
+      val raw = s.substring(start, pos).nn.tt
+      if peek != close then abort(ErgoError(ErgoError.Reason.Unclosed(close.toString.tt)))
+      advance() // close
+      raw
+
+    private def withDirectives(unit: Mathml): Mathml =
+      val attributes = ListBuffer[(Text, Text)]()
+      var scanning = true
+
+      while scanning do
+        directive(peek) match
+          case Directive.Param(name) =>
+            if peekAt(1) == open then { advance(); attributes += name -> readValue() }
+            else scanning = false
+
+          case Directive.Fixed(name, value) =>
+            advance()
+            attributes += name -> value
+
+          case _ =>
+            scanning = false
+
+      applyAttributes(unit, attributes.to(List))
+
+    private def applyAttributes(node: Mathml, extra: List[(Text, Text)]): Mathml =
+      if extra.isEmpty then node else node match
+        case n: Mi         => n.copy(attributes = n.attributes ++ extra)
+        case n: Mn         => n.copy(attributes = n.attributes ++ extra)
+        case n: Mo         => n.copy(attributes = n.attributes ++ extra)
+        case n: Mrow       => n.copy(attributes = n.attributes ++ extra)
+        case n: Mfrac      => n.copy(attributes = n.attributes ++ extra)
+        case n: Msqrt      => n.copy(attributes = n.attributes ++ extra)
+        case n: Mroot      => n.copy(attributes = n.attributes ++ extra)
+        case n: Msub       => n.copy(attributes = n.attributes ++ extra)
+        case n: Msup       => n.copy(attributes = n.attributes ++ extra)
+        case n: Msubsup    => n.copy(attributes = n.attributes ++ extra)
+        case n: Munder     => n.copy(attributes = n.attributes ++ extra)
+        case n: Mover      => n.copy(attributes = n.attributes ++ extra)
+        case n: Munderover => n.copy(attributes = n.attributes ++ extra)
+        case n: Mtable     => n.copy(attributes = n.attributes ++ extra)
+        case other         => Mrow(List(other), extra)
+
+    private def parseUnit(): Mathml =
+      skipSpaces()
+      val c = peek
+
+      if c == Hole then { advance(); holes.next() }
+      else if c == open then rooted(parseGroup())
+      else if c == Radical then { advance(); Msqrt(parsePrimary()) }
+      else if c == Matrix then parseMatrix()
+      else if c == RowVec then parseVector(row = true)
+      else if c == ColVec then parseVector(row = false)
+      else if letter(c) then
+        val start = pos
+        while pos < s.length && letter(s.charAt(pos)) do pos += 1
+        rooted(Mi(s.substring(start, pos).nn.tt))
+      else if digit(c) then
+        val start = pos
+
+        while pos < s.length && (digit(s.charAt(pos)) ||
+          s.charAt(pos) == '.' && pos + 1 < s.length && digit(s.charAt(pos + 1)))
+        do pos += 1
+
+        rooted(Mn(s.substring(start, pos).nn.tt))
+      else if c == ' ' then
+        abort(ErgoError(ErgoError.Reason.UnexpectedEnd))
+      else
+        // a content glyph, or an operator glyph degraded for want of an operand
+        advance()
+        Mo(c.toString.tt)
+
+    // If a `√` immediately follows an atom/group (no space), that atom is the
+    // index of a root: `3√x` = Mroot(x, 3).
+    private def rooted(index: Mathml): Mathml =
+      if peek == Radical then { advance(); Mroot(parsePrimary(), index) } else index
+
+    // Consumes the self-delimiting body `open <group>… close` that follows an
+    // introducer, returning the parsed child groups. A body with no nested
+    // groups is treated as a single element (so `⊟(a)` is a one-cell vector).
+    private def parseBody(introducer: Char): List[Mathml] =
+      if peek != open then abort(ErgoError(ErgoError.Reason.MissingBody(introducer.toString.tt)))
+      advance() // body open
+      val items = ListBuffer[Mathml]()
+      while peek == open do items += parseGroup()
+      if items.isEmpty && peek != close then items += parseSequence()
+      skipSpaces()
+      if peek != close then abort(ErgoError(ErgoError.Reason.Unclosed(close.toString.tt)))
+      advance() // body close
+      items.to(List)
+
+    private def parseVector(row: Boolean): Mathml =
+      val introducer = advance()
+      val tds = parseBody(introducer).map(Mtd(_))
+      if row then Mtable(Mtr(tds*)) else Mtable(tds.map(Mtr(_))*)
+
+    private def parseMatrix(): Mathml =
+      val introducer = advance()
+      if peek != open then abort(ErgoError(ErgoError.Reason.MissingBody(introducer.toString.tt)))
+      advance() // body open
+      val rows = ListBuffer[Mathml]()
+
+      while peek == open do
+        advance() // row-group open
+        val cells = ListBuffer[Mathml]()
+        while peek == open do cells += parseGroup()
+
+        // A row group with no nested cell-groups is a single-cell row.
+        if cells.isEmpty && peek != close then cells += parseSequence()
+        skipSpaces()
+        if peek != close then abort(ErgoError(ErgoError.Reason.Unclosed(close.toString.tt)))
+        advance() // row-group close
+        rows += Mtr(cells.to(List).map { cell => Mtd(cell) }*)
+
+      skipSpaces()
+      if peek != close then abort(ErgoError(ErgoError.Reason.Unclosed(close.toString.tt)))
+      advance() // body close
+      Mtable(rows.to(List)*)

--- a/lib/archimedes/src/core/archimedes.ErgoError.scala
+++ b/lib/archimedes/src/core/archimedes.ErgoError.scala
@@ -30,12 +30,27 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package archimedes
 
-export archimedes.{Math, Mathml, Token, Mi, Mn, Mo, Mtext, Ms, Mspace, Mglyph, Layout, Mrow,
-    Mfrac, Msqrt, Mroot, Mstyle, Merror, Mpadded, Mphantom, Menclose, Mfenced, Script, Msub, Msup,
-    Msubsup, Munder, Mover, Munderover, Mmultiscripts, Mprescripts, Mnone, Tabular, Mtable, Mtr,
-    Mlabeledtr, Mtd, Maligngroup, Malignmark, Elementary, Mstack, Mlongdiv, Msgroup, Msrow,
-    Mscarries, Mscarry, Msline, Semantic, Maction, Semantics, Annotation, AnnotationXml, Display,
-    MathmlError, MathmlParser, MathmlReader, mathmlNamespace, Ergo, ErgoError, ergo,
-    ergoInterpolable, mathml, math}
+import anticipation.*
+import fulminate.*
+
+object ErgoError:
+  enum Reason(val number: Int) extends Clarification:
+    case Empty                    extends Reason(1)
+    case BadOpener(char: Text)    extends Reason(2)
+    case Unclosed(expected: Text) extends Reason(3)
+    case UnexpectedEnd            extends Reason(4)
+    case MissingBody(char: Text)  extends Reason(5)
+    case Unsupported(label: Text) extends Reason(6)
+
+  given communicable: Reason is Communicable =
+    case Reason.Empty              => m"the expression was empty"
+    case Reason.BadOpener(char)    => m"the expression must start with a bracket, not $char"
+    case Reason.Unclosed(expected) => m"a group was not closed with $expected"
+    case Reason.UnexpectedEnd      => m"the expression ended unexpectedly"
+    case Reason.MissingBody(char)  => m"the $char introducer must be followed by a group"
+    case Reason.Unsupported(label) => m"the <$label> element has no ergo representation"
+
+case class ErgoError(reason: ErgoError.Reason)(using Diagnostics)
+extends Error(431, reason.number)(m"the ergo expression could not be parsed because $reason")

--- a/lib/archimedes/src/core/archimedes.Mathml.scala
+++ b/lib/archimedes/src/core/archimedes.Mathml.scala
@@ -33,8 +33,12 @@
 package archimedes
 
 import anticipation.*
+import baroque.*
+import gossamer.*
 import honeycomb.Html
+import mosquito.*
 import prepositional.*
+import quantitative.*
 import vacuous.*
 import xylophone.*
 
@@ -50,6 +54,65 @@ import xylophone.*
 //     standalone XML, and as the payload embedded in an XML document);
 //   - `html` builds a `honeycomb.Html` foreign-element tree (used for embedding
 //     MathML inside HTML, where honeycomb reserves `<math>` as a foreign tag).
+
+// `Encodable in Mathml` instances live here (the `Form` companion), so `.mathml`
+// and `.math` (defined in `archimedes_core.scala`) resolve without an import.
+object Mathml:
+  given int:        Int is Encodable in Mathml        = value => Mn(value.toString.tt)
+  given long:       Long is Encodable in Mathml       = value => Mn(value.toString.tt)
+  given short:      Short is Encodable in Mathml      = value => Mn(value.toString.tt)
+  given byte:       Byte is Encodable in Mathml       = value => Mn(value.toString.tt)
+  given double:     Double is Encodable in Mathml     = value => Mn(value.toString.tt)
+  given float:      Float is Encodable in Mathml      = value => Mn(value.toString.tt)
+  given bigInt:     BigInt is Encodable in Mathml     = value => Mn(value.toString.tt)
+  given bigDecimal: BigDecimal is Encodable in Mathml = value => Mn(value.toString.tt)
+  given text:       Text is Encodable in Mathml       = Mtext(_)
+  given identical:  Mathml is Encodable in Mathml     = identity(_)
+
+  // Wraps the encoder lambda in a class (rather than an inline function value) to
+  // avoid inline-given code bloat, mirroring quantitative's `ShowableQuantity`. It
+  // must be public because the inline given inlines a reference to it.
+  class QuantityEncodable[units <: Measure](lambda: Quantity[units] => Mathml)
+  extends Encodable:
+    type Self = Quantity[units]
+    type Form = Mathml
+    def encoded(quantity: Quantity[units]): Mathml = lambda(quantity)
+
+  // A quantity renders its magnitude as `<mn>` followed by each unit as `<mi>`
+  // (or `<msup>` when the exponent is not 1), joined by invisible multiplication.
+  inline given quantity: [units <: Measure] => Quantity[units] is Encodable in Mathml =
+    QuantityEncodable[units]: quantity =>
+      quantityMathml(quantity.value, quantity.units)
+
+  given complex: [component: Encodable in Mathml] => Complex[component] is Encodable in Mathml =
+    value => Mrow(List(value.real.mathml, Mo(t"+"), value.imaginary.mathml, Mi(t"i")))
+
+  given vector: [element: Encodable in Mathml, size <: Int]
+  =>  Vector[element, size] is Encodable in Mathml =
+    vector => fenced(Mtable(vector.list.map { element => Mtr(Mtd(element.mathml)) }*), t"(", t")")
+
+  given matrix: [element: Encodable in Mathml, height <: Int, width <: Int]
+  =>  Matrix[element, height, width] is Encodable in Mathml =
+    matrix =>
+      val rows = (0 until matrix.rows).to(List).map: row =>
+        Mtr((0 until matrix.columns).to(List).map { column => Mtd(matrix(row, column).mathml) }*)
+
+      fenced(Mtable(rows*), t"[", t"]")
+
+  private def quantityMathml(value: Double, units: Map[Text, Int]): Mathml =
+    val unitNodes: List[Mathml] = units.to(List).sortBy(_._1.s).map: (symbol, power) =>
+      if power == 1 then Mi(symbol) else Msup(Mi(symbol), Mn(power.toString.tt))
+
+    product(Mn(value.toString.tt) :: unitNodes)
+
+  private def product(nodes: List[Mathml]): Mathml = nodes match
+    case one :: Nil   => one
+    case head :: tail => Mrow(head :: tail.flatMap { node => List(Mo(t"⁢"), node) })
+    case Nil          => Mrow(Nil)
+
+  private def fenced(inner: Mathml, open: Text, close: Text): Mathml =
+    val stretchy = List(t"stretchy" -> t"true")
+    Mrow(List(Mo(open, stretchy), inner, Mo(close, stretchy)))
 
 trait Mathml:
   def label: Text

--- a/lib/archimedes/src/core/archimedes.internal.scala
+++ b/lib/archimedes/src/core/archimedes.internal.scala
@@ -30,12 +30,55 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package archimedes
 
-export archimedes.{Math, Mathml, Token, Mi, Mn, Mo, Mtext, Ms, Mspace, Mglyph, Layout, Mrow,
-    Mfrac, Msqrt, Mroot, Mstyle, Merror, Mpadded, Mphantom, Menclose, Mfenced, Script, Msub, Msup,
-    Msubsup, Munder, Mover, Munderover, Mmultiscripts, Mprescripts, Mnone, Tabular, Mtable, Mtr,
-    Mlabeledtr, Mtd, Maligngroup, Malignmark, Elementary, Mstack, Mlongdiv, Msgroup, Msrow,
-    Mscarries, Mscarry, Msline, Semantic, Maction, Semantics, Annotation, AnnotationXml, Display,
-    MathmlError, MathmlParser, MathmlReader, mathmlNamespace, Ergo, ErgoError, ergo,
-    ergoInterpolable, mathml, math}
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import fulminate.*
+import gigantism.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+object internal:
+  // The macro behind the `ergo""` interpolator. It recovers the literal parts and
+  // converts each `$`-substitution (any value that is `Encodable in Mathml`) into a
+  // single atom node, parses the whole expression *at compile time* so a malformed
+  // literal fails compilation with the parser's own diagnostic, then emits runtime
+  // code that re-parses with the substitutions woven in.
+  def ergoInterpolator[parts <: Tuple: Type](insertions: Expr[Seq[Any]]): Macro[Math] =
+    import quotes.reflect.*
+
+    def recur[tuple: Type](strings: List[String]): List[String] = Type.of[tuple] match
+      case '[head *: tail] => recur[tail](TypeRepr.of[head].literal[String].vouch :: strings)
+      case _               => strings
+
+    val parts = recur[parts](Nil)
+
+    val insertionExprs: List[Expr[Any]] = insertions.absolve match
+      case Varargs(exprs) => exprs.to(List)
+
+    val atoms: List[Expr[Mathml]] = insertionExprs.map: insertion =>
+      insertion.absolve match
+        case '{$value: valueType} => Expr.summon[(? >: valueType) is Encodable in Mathml] match
+          case Some('{$encodable: Encodable}) => '{$encodable.encoded($value)}.asExprOf[Mathml]
+
+          case _ =>
+            val kind = TypeRepr.of[valueType].widen.show
+            val position = insertion.asTerm.underlyingArgument.pos
+            halt(m"a $kind cannot be embedded in ergo: it is not Encodable in Mathml", position)
+
+    locally:
+      import strategies.throwUnsafely
+      import errorDiagnostics.emptyDiagnostics
+
+      try Ergo.interpolate(parts.map(_.tt), List.fill(atoms.length)(Mi(t"?")))
+      catch case error: ErgoError =>
+        halt(m"the ergo expression could not be parsed because ${error.reason}")
+
+    val partExprs: Expr[Seq[Text]] = Expr.ofSeq(parts.map { part => '{${Expr(part)}.tt} })
+
+    '{Ergo.unsafeInterpolate($partExprs, ${Expr.ofSeq(atoms)})}

--- a/lib/archimedes/src/core/archimedes_core.scala
+++ b/lib/archimedes/src/core/archimedes_core.scala
@@ -33,8 +33,32 @@
 package archimedes
 
 import anticipation.*
+import contextual.*
 import gossamer.*
+import prepositional.*
 
 // The MathML namespace URI, written as the `xmlns` attribute on the root
 // `<math>` element.
 val mathmlNamespace: Text = t"http://www.w3.org/1998/Math/MathML"
+
+// Converts any type with an `Encodable in Mathml` instance to a MathML node or a
+// `<math>` root — `5.math`, `complex.mathml`, `quantity.math`, etc. Instances
+// live in the `Mathml` companion; see `object Mathml` in `archimedes.Mathml.scala`.
+extension [ValueType: Encodable in Mathml as encodable](value: ValueType)
+  def mathml: Mathml = encodable.encoded(value)
+
+  def math: Math = mathml match
+    case Mrow(nodes, _) => Math(nodes)
+    case node           => Math(List(node))
+
+// The `ergo""` interpolator: `ergo"(x↗y)"` parses an ergo shorthand literal into
+// a `Math` value, checking it at compile time (see `internal.ergoInterpolator`).
+inline given ergoInterpolable: Math is Interpolable:
+  transparent inline def interpolate[parts <: Tuple, origins <: Tuple]
+    ( inline insertions: Any* )
+  :   Math =
+
+    ${archimedes.internal.ergoInterpolator[parts]('insertions)}
+
+extension (inline context: StringContext)
+  transparent inline def ergo: Interpolation = interpolation[Math](context)

--- a/lib/archimedes/src/test/archimedes_test.scala
+++ b/lib/archimedes/src/test/archimedes_test.scala
@@ -101,3 +101,238 @@ object Tests extends Suite(m"Archimedes tests"):
       test(m"Extract MathML back out of the HTML tree"):
         MathmlReader.read(expression.html)
       .assert(_ == expression)
+
+    def body(ergo: Text): Text =
+      Ergo.parse(ergo).xml.show.sub(t"""<math xmlns="http://www.w3.org/1998/Math/MathML">""", t"")
+      . sub(t"</math>", t"")
+
+    suite(m"Scripts and fractions"):
+      test(m"superscript"):
+        body(t"(x↗y)")
+      .assert(_ == t"<msup><mi>x</mi><mi>y</mi></msup>")
+
+      test(m"superscript of a group"):
+        body(t"(x↗(y + 1))")
+      .assert(_ == t"<msup><mi>x</mi><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></msup>")
+
+      test(m"combined sub and superscript merge into msubsup"):
+        body(t"(x↘i↗2)")
+      .assert(_ == t"<msubsup><mi>x</mi><mi>i</mi><mn>2</mn></msubsup>")
+
+      test(m"fraction binds looser than scripts"):
+        body(t"(a/b↗2)")
+      .assert(_ == t"<mfrac><mi>a</mi><msup><mi>b</mi><mn>2</mn></msup></mfrac>")
+
+      test(m"multi-digit number is one mn"):
+        body(t"(x↗123)")
+      .assert(_ == t"<msup><mi>x</mi><mn>123</mn></msup>")
+
+      test(m"multi-letter run is one identifier"):
+        body(t"(sin)")
+      .assert(_ == t"<mi>sin</mi>")
+
+    suite(m"Roots"):
+      test(m"square root"):
+        body(t"(√x)")
+      .assert(_ == t"<msqrt><mi>x</mi></msqrt>")
+
+      test(m"nth root from an adjacent index"):
+        body(t"(3√x)")
+      .assert(_ == t"<mroot><mi>x</mi><mn>3</mn></mroot>")
+
+    suite(m"Big operators via under/over"):
+      test(m"sum with limits"):
+        body(t"(∑↓(i = 1)↑n x)")
+      .assert: result =>
+        result == t"<munderover><mo>∑</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow>"
+            + t"<mi>n</mi></munderover><mi>x</mi>"
+
+    suite(m"Accents"):
+      test(m"an mo over a base is an accent"):
+        body(t"(x↑^)")
+      .assert(_ == t"""<mover accent="true"><mi>x</mi><mo>^</mo></mover>""")
+
+      test(m"an identifier over a base is an ordinary limit"):
+        body(t"(x↑n)")
+      .assert(_ == t"<mover><mi>x</mi><mi>n</mi></mover>")
+
+    suite(m"Vectors and matrices (self-delimiting)"):
+      test(m"row vector"):
+        body(t"(⊟((1)(2)(3)))")
+      .assert(_ == t"<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd>"
+          + t"<mtd><mn>3</mn></mtd></mtr></mtable>")
+
+      test(m"column vector"):
+        body(t"(⊡((a)(b)))")
+      .assert(_ == t"<mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd></mtr>"
+          + t"</mtable>")
+
+      test(m"2x2 matrix"):
+        body(t"(⊞(((1)(2))((3)(4))))")
+      .assert(_ == t"<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr>"
+          + t"<mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>")
+
+      test(m"a single-cell row keeps a multi-token expression together"):
+        body(t"(⊞(((a b))((c))))")
+      .assert(_ == t"<mtable><mtr><mtd><mrow><mi>a</mi><mi>b</mi></mrow></mtd></mtr><mtr>"
+          + t"<mtd><mi>c</mi></mtd></mtr></mtable>")
+
+    suite(m"A whole formula"):
+      test(m"the quadratic formula"):
+        body(t"(x = (-b ± √(b↗2 - 4 a c))/(2 a))")
+      .assert: result =>
+        result == t"<mi>x</mi><mo>=</mo><mfrac><mrow><mo>-</mo><mi>b</mi><mo>±</mo><msqrt>"
+            + t"<mrow><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mn>4</mn><mi>a</mi><mi>c</mi>"
+            + t"</mrow></msqrt></mrow><mrow><mn>2</mn><mi>a</mi></mrow></mfrac>"
+
+    suite(m"Escaping"):
+      test(m"a lone operator glyph is a literal mo"):
+        body(t"((↗))")
+      .assert(_ == t"<mo>↗</mo>")
+
+    suite(m"Attribute directives"):
+      test(m"a parameterised colour directive"):
+        body(t"(x●(red))")
+      .assert(_ == t"""<mi mathcolor="red">x</mi>""")
+
+      test(m"a boolean true glyph"):
+        body(t"(=⇿)")
+      .assert(_ == t"""<mo stretchy="true">=</mo>""")
+
+      test(m"a boolean false glyph"):
+        body(t"(=↮)")
+      .assert(_ == t"""<mo stretchy="false">=</mo>""")
+
+      test(m"an enumerated value glyph"):
+        body(t"(+⊰)")
+      .assert(_ == t"""<mo form="prefix">+</mo>""")
+
+      test(m"multiple directives juxtapose"):
+        body(t"(=◆⇿)")
+      .assert(_ == t"""<mo largeop="true" stretchy="true">=</mo>""")
+
+      test(m"a fixed directive"):
+        body(t"(x⦱)")
+      .assert(_ == t"""<mi mathvariant="normal">x</mi>""")
+
+      test(m"a directive binds to a grouped unit"):
+        body(t"((a/b)═(0))")
+      .assert(_ == t"""<mfrac linethickness="0"><mi>a</mi><mi>b</mi></mfrac>""")
+
+      test(m"a boolean directive does not swallow a following group"):
+        body(t"(=◆(a))")
+      .assert(_ == t"""<mo largeop="true">=</mo><mi>a</mi>""")
+
+    suite(m"Serialising MathML to ergo"):
+      def rt(ergo: Text): Text = Ergo.serialize(Ergo.parse(ergo))
+
+      test(m"a superscript"):
+        rt(t"(x↗2)")
+      .assert(_ == t"(x↗2)")
+
+      test(m"a fraction"):
+        rt(t"(a/b)")
+      .assert(_ == t"(a/b)")
+
+      test(m"insignificant spaces are dropped"):
+        rt(t"(x↗(y + 1))")
+      .assert(_ == t"(x↗(y+1))")
+
+      test(m"a colour directive"):
+        rt(t"(x●(red))")
+      .assert(_ == t"(x●(red))")
+
+      test(m"a boolean directive"):
+        rt(t"(=⇿)")
+      .assert(_ == t"(=⇿)")
+
+      test(m"an enumerated directive value round-trips to its glyph"):
+        rt(t"(+⊰)")
+      .assert(_ == t"(+⊰)")
+
+      test(m"an accent omits the implied attribute"):
+        rt(t"(x↑^)")
+      .assert(_ == t"(x↑^)")
+
+      test(m"a matrix"):
+        rt(t"(⊞(((1)(2))((3)(4))))")
+      .assert(_ == t"(⊞(((1)(2))((3)(4))))")
+
+      test(m"a row vector"):
+        rt(t"(⊟((1)(2)(3)))")
+      .assert(_ == t"(⊟((1)(2)(3)))")
+
+      test(m"the quadratic formula round-trips to an equal tree"):
+        val quadratic = t"(x = (-b ± √(b↗2 - 4 a c))/(2 a))"
+        Ergo.parse(rt(quadratic))
+      .assert(_ == Ergo.parse(t"(x = (-b ± √(b↗2 - 4 a c))/(2 a))"))
+
+      test(m"an element outside the ergo subset is rejected"):
+        capture[ErgoError](Ergo.serialize(Math(List(Mtext(t"hi"))))).reason
+      .assert(_ == ErgoError.Reason.Unsupported(t"mtext"))
+
+    suite(m"The ergo interpolator"):
+      test(m"a literal is parsed at compile time to a Math value"):
+        ergo"(x↗(y + 1))"
+      .assert(_ == Ergo.parse(t"(x↗(y + 1))"))
+
+      test(m"an interpolated matrix renders"):
+        ergo"(⊞(((1)(2))((3)(4))))".xml.show.contains(t"<mtable>")
+      .assert(_ == true)
+
+    suite(m"Interpolator substitutions"):
+      test(m"an integer substitution is a single atom"):
+        val exponent = 2
+        ergo"(x↗$exponent)".xml.show
+      .assert(_ == t"""<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi>"""
+          + t"<mn>2</mn></msup></math>")
+
+      test(m"two substitutions in sequence"):
+        val left = 1
+        val right = 2
+        ergo"($left + $right)".xml.show.contains(t"<mn>1</mn><mo>+</mo><mn>2</mn>")
+      .assert(_ == true)
+
+      test(m"a directive binds to a substituted atom"):
+        val value = 3
+        ergo"($value●(red))".xml.show.contains(t"""<mn mathcolor="red">3</mn>""")
+      .assert(_ == true)
+
+      test(m"an Encodable value is embedded as an atom"):
+        val vector = Vector(1, 2, 3)
+        ergo"($vector)".xml.show.contains(t"<mtable>")
+      .assert(_ == true)
+
+    suite(m"Encoding values as MathML"):
+      test(m"an integer becomes a math root"):
+        42.math.xml.show
+      .assert(_ == t"""<math xmlns="http://www.w3.org/1998/Math/MathML"><mn>42</mn></math>""")
+
+      test(m"a double becomes mn"):
+        3.14.mathml.xml.show
+      .assert(_ == t"<mn>3.14</mn>")
+
+      test(m"text becomes mtext"):
+        t"speed".mathml.xml.show
+      .assert(_ == t"<mtext>speed</mtext>")
+
+      test(m"a complex number"):
+        Complex(3, 4).mathml.xml.show
+      .assert(_ == t"<mrow><mn>3</mn><mo>+</mo><mn>4</mn><mi>i</mi></mrow>")
+
+      test(m"a quantity renders its units"):
+        (5*Metre/Second).mathml.xml.show
+      .assert: result =>
+        result.contains(t"<mn>5.0</mn>") && result.contains(t"<mi>m</mi>")
+            && result.contains(t"<msup><mi>s</mi><mn>-1</mn></msup>")
+
+      test(m"a vector is a bracketed column"):
+        Vector(1, 2, 3).mathml.xml.show
+      .assert: result =>
+        result.contains(t"<mtable>") && result.contains(t"<mtr><mtd><mn>1</mn></mtd></mtr>")
+
+      test(m"a matrix is a bracketed table"):
+        Matrix[2, 2]((1, 2), (3, 4)).mathml.xml.show
+      .assert: result =>
+        result.contains(t"<mtable>")
+            && result.contains(t"<mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>")


### PR DESCRIPTION
Archimedes gains "ergo" — a concise one-line notation for MathML — and an `Encodable in Mathml` typeclass for rendering arbitrary values as MathML.

## Ergo — one-line MathML

```scala
ergo"(x↗2 + √(b↗2 - 4 a c))"   // parsed and type-checked at compile time
Ergo.parse(t"(a/b)")            // → a Math tree
Ergo.serialize(math)            // the inverse
```

Brackets group units, `↗`/`↘`/`↑`/`↓` are scripts and limits, `/` is a fraction, `√` roots, and `⊞`/`⊟`/`⊡` build matrices and vectors. MathML Core attributes attach as postfix directive glyphs (one glyph per enumerated/boolean value); `lib/archimedes/doc/ergo-directives.md` is the full glyph reference.

## Interpolator substitutions

`ergo"(x↗$n)"` embeds any value that is `Encodable in Mathml` as a single atom, checked at compile time (a non-encodable substitution fails compilation with a diagnostic at the substitution).

## Encoding values as MathML

```scala
42.math                  // <math><mn>42</mn></math>
(5*Metre/Second).mathml  // magnitude with units rendered as mi/msup
Complex(3, 4).mathml     // 3 + 4i
Vector(1, 2, 3).mathml   // a bracketed column
```

`Encodable in Mathml` (with `.mathml`/`.math` extensions) has instances for numbers, text, Quantitative quantities (with units), Baroque complex numbers, and Mosquito vectors/matrices — all composing through each element's own instance. `archimedes.core` gains dependencies on `contextual`, `gigantism`, `quantitative`, `baroque`, and `mosquito`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)