### PR TITLE
Make the MathML encoding Form `Math`, not `Mathml`

### DIFF
--- a/lib/archimedes/src/core/archimedes.Math.scala
+++ b/lib/archimedes/src/core/archimedes.Math.scala
@@ -33,12 +33,15 @@
 package archimedes
 
 import anticipation.*
+import baroque.*
 import contingency.*
 import gossamer.*
 import hieroglyph.*
 import honeycomb.Html
 import honeycomb.Renderable
+import mosquito.*
 import prepositional.*
+import quantitative.*
 import spectacular.*
 import turbulence.*
 import vacuous.*
@@ -101,6 +104,67 @@ object Math:
     honeycomb.doms.html.whatwg.Math.node(honeycomb.Attributes(pairs*))(children*)
 
   def apply(children: Mathml*): Math = Math(children.to(List))
+
+  // `Encodable in Math` instances: any value encodes to a `<math>` document, just
+  // as `Encodable in Xml` yields an `Xml`. `Mathml.atom` collapses a root back to a
+  // single node where one is needed (the `.mathml` extension, the `ergo""` macro).
+  given int:        Int is Encodable in Math        = value => Math(Mn(value.toString.tt))
+  given long:       Long is Encodable in Math       = value => Math(Mn(value.toString.tt))
+  given short:      Short is Encodable in Math      = value => Math(Mn(value.toString.tt))
+  given byte:       Byte is Encodable in Math       = value => Math(Mn(value.toString.tt))
+  given double:     Double is Encodable in Math     = value => Math(Mn(value.toString.tt))
+  given float:      Float is Encodable in Math      = value => Math(Mn(value.toString.tt))
+  given bigInt:     BigInt is Encodable in Math     = value => Math(Mn(value.toString.tt))
+  given bigDecimal: BigDecimal is Encodable in Math = value => Math(Mn(value.toString.tt))
+  given text:       Text is Encodable in Math       = value => Math(Mtext(value))
+  given identical:  Mathml is Encodable in Math     = node => Math(List(node))
+  given self:       Math is Encodable in Math       = identity(_)
+
+  // Wraps the encoder lambda in a class (rather than an inline function value) to
+  // avoid inline-given code bloat, mirroring quantitative's `ShowableQuantity`. It
+  // must be public because the inline given inlines a reference to it.
+  class QuantityEncodable[units <: Measure](lambda: Quantity[units] => Math)
+  extends Encodable:
+    type Self = Quantity[units]
+    type Form = Math
+    def encoded(quantity: Quantity[units]): Math = lambda(quantity)
+
+  // A quantity renders its magnitude as `<mn>` followed by each unit as `<mi>`
+  // (or `<msup>` when the exponent is not 1), joined by invisible multiplication.
+  inline given quantity: [units <: Measure] => Quantity[units] is Encodable in Math =
+    QuantityEncodable[units]: quantity =>
+      Math(quantityMathml(quantity.value, quantity.units))
+
+  given complex: [component: Encodable in Math] => Complex[component] is Encodable in Math =
+    value => Math(Mrow(List(value.real.mathml, Mo(t"+"), value.imaginary.mathml, Mi(t"i"))))
+
+  given vector: [element: Encodable in Math, size <: Int]
+  =>  Vector[element, size] is Encodable in Math =
+    vector =>
+      Math(fenced(Mtable(vector.list.map { element => Mtr(Mtd(element.mathml)) }*), t"(", t")"))
+
+  given matrix: [element: Encodable in Math, height <: Int, width <: Int]
+  =>  Matrix[element, height, width] is Encodable in Math =
+    matrix =>
+      val rows = (0 until matrix.rows).to(List).map: row =>
+        Mtr((0 until matrix.columns).to(List).map { column => Mtd(matrix(row, column).mathml) }*)
+
+      Math(fenced(Mtable(rows*), t"[", t"]"))
+
+  private def quantityMathml(value: Double, units: Map[Text, Int]): Mathml =
+    val unitNodes: List[Mathml] = units.to(List).sortBy(_._1.s).map: (symbol, power) =>
+      if power == 1 then Mi(symbol) else Msup(Mi(symbol), Mn(power.toString.tt))
+
+    product(Mn(value.toString.tt) :: unitNodes)
+
+  private def product(nodes: List[Mathml]): Mathml = nodes match
+    case one :: Nil   => one
+    case head :: tail => Mrow(head :: tail.flatMap { node => List(Mo(t"⁢"), node) })
+    case Nil          => Mrow(Nil)
+
+  private def fenced(inner: Mathml, open: Text, close: Text): Mathml =
+    val stretchy = List(t"stretchy" -> t"true")
+    Mrow(List(Mo(open, stretchy), inner, Mo(close, stretchy)))
 
 
 case class Math

--- a/lib/archimedes/src/core/archimedes.Mathml.scala
+++ b/lib/archimedes/src/core/archimedes.Mathml.scala
@@ -33,12 +33,8 @@
 package archimedes
 
 import anticipation.*
-import baroque.*
-import gossamer.*
 import honeycomb.Html
-import mosquito.*
 import prepositional.*
-import quantitative.*
 import vacuous.*
 import xylophone.*
 
@@ -55,64 +51,13 @@ import xylophone.*
 //   - `html` builds a `honeycomb.Html` foreign-element tree (used for embedding
 //     MathML inside HTML, where honeycomb reserves `<math>` as a foreign tag).
 
-// `Encodable in Mathml` instances live here (the `Form` companion), so `.mathml`
-// and `.math` (defined in `archimedes_core.scala`) resolve without an import.
+// `Encodable in Math` instances live in the `Math` companion (the `Form`, mirroring
+// `Encodable in Xml`); `atom` collapses an encoded `<math>` root back to a single
+// node for callers — the `.mathml` extension and the `ergo""` macro — that want one.
 object Mathml:
-  given int:        Int is Encodable in Mathml        = value => Mn(value.toString.tt)
-  given long:       Long is Encodable in Mathml       = value => Mn(value.toString.tt)
-  given short:      Short is Encodable in Mathml      = value => Mn(value.toString.tt)
-  given byte:       Byte is Encodable in Mathml       = value => Mn(value.toString.tt)
-  given double:     Double is Encodable in Mathml     = value => Mn(value.toString.tt)
-  given float:      Float is Encodable in Mathml      = value => Mn(value.toString.tt)
-  given bigInt:     BigInt is Encodable in Mathml     = value => Mn(value.toString.tt)
-  given bigDecimal: BigDecimal is Encodable in Mathml = value => Mn(value.toString.tt)
-  given text:       Text is Encodable in Mathml       = Mtext(_)
-  given identical:  Mathml is Encodable in Mathml     = identity(_)
-
-  // Wraps the encoder lambda in a class (rather than an inline function value) to
-  // avoid inline-given code bloat, mirroring quantitative's `ShowableQuantity`. It
-  // must be public because the inline given inlines a reference to it.
-  class QuantityEncodable[units <: Measure](lambda: Quantity[units] => Mathml)
-  extends Encodable:
-    type Self = Quantity[units]
-    type Form = Mathml
-    def encoded(quantity: Quantity[units]): Mathml = lambda(quantity)
-
-  // A quantity renders its magnitude as `<mn>` followed by each unit as `<mi>`
-  // (or `<msup>` when the exponent is not 1), joined by invisible multiplication.
-  inline given quantity: [units <: Measure] => Quantity[units] is Encodable in Mathml =
-    QuantityEncodable[units]: quantity =>
-      quantityMathml(quantity.value, quantity.units)
-
-  given complex: [component: Encodable in Mathml] => Complex[component] is Encodable in Mathml =
-    value => Mrow(List(value.real.mathml, Mo(t"+"), value.imaginary.mathml, Mi(t"i")))
-
-  given vector: [element: Encodable in Mathml, size <: Int]
-  =>  Vector[element, size] is Encodable in Mathml =
-    vector => fenced(Mtable(vector.list.map { element => Mtr(Mtd(element.mathml)) }*), t"(", t")")
-
-  given matrix: [element: Encodable in Mathml, height <: Int, width <: Int]
-  =>  Matrix[element, height, width] is Encodable in Mathml =
-    matrix =>
-      val rows = (0 until matrix.rows).to(List).map: row =>
-        Mtr((0 until matrix.columns).to(List).map { column => Mtd(matrix(row, column).mathml) }*)
-
-      fenced(Mtable(rows*), t"[", t"]")
-
-  private def quantityMathml(value: Double, units: Map[Text, Int]): Mathml =
-    val unitNodes: List[Mathml] = units.to(List).sortBy(_._1.s).map: (symbol, power) =>
-      if power == 1 then Mi(symbol) else Msup(Mi(symbol), Mn(power.toString.tt))
-
-    product(Mn(value.toString.tt) :: unitNodes)
-
-  private def product(nodes: List[Mathml]): Mathml = nodes match
-    case one :: Nil   => one
-    case head :: tail => Mrow(head :: tail.flatMap { node => List(Mo(t"⁢"), node) })
-    case Nil          => Mrow(Nil)
-
-  private def fenced(inner: Mathml, open: Text, close: Text): Mathml =
-    val stretchy = List(t"stretchy" -> t"true")
-    Mrow(List(Mo(open, stretchy), inner, Mo(close, stretchy)))
+  def atom(math: Math): Mathml = math.contents match
+    case List(node) => node
+    case nodes      => Mrow(nodes)
 
 trait Mathml:
   def label: Text

--- a/lib/archimedes/src/core/archimedes.internal.scala
+++ b/lib/archimedes/src/core/archimedes.internal.scala
@@ -45,7 +45,7 @@ import vacuous.*
 
 object internal:
   // The macro behind the `ergo""` interpolator. It recovers the literal parts and
-  // converts each `$`-substitution (any value that is `Encodable in Mathml`) into a
+  // converts each `$`-substitution (any value that is `Encodable in Math`) into a
   // single atom node, parses the whole expression *at compile time* so a malformed
   // literal fails compilation with the parser's own diagnostic, then emits runtime
   // code that re-parses with the substitutions woven in.
@@ -63,13 +63,14 @@ object internal:
 
     val atoms: List[Expr[Mathml]] = insertionExprs.map: insertion =>
       insertion.absolve match
-        case '{$value: valueType} => Expr.summon[(? >: valueType) is Encodable in Mathml] match
-          case Some('{$encodable: Encodable}) => '{$encodable.encoded($value)}.asExprOf[Mathml]
+        case '{$value: valueType} => Expr.summon[(? >: valueType) is Encodable in Math] match
+          case Some('{$encodable: Encodable}) =>
+            '{Mathml.atom($encodable.encoded($value))}.asExprOf[Mathml]
 
           case _ =>
             val kind = TypeRepr.of[valueType].widen.show
             val position = insertion.asTerm.underlyingArgument.pos
-            halt(m"a $kind cannot be embedded in ergo: it is not Encodable in Mathml", position)
+            halt(m"a $kind cannot be embedded in ergo: it is not Encodable in Math", position)
 
     locally:
       import strategies.throwUnsafely

--- a/lib/archimedes/src/core/archimedes_core.scala
+++ b/lib/archimedes/src/core/archimedes_core.scala
@@ -41,15 +41,13 @@ import prepositional.*
 // `<math>` element.
 val mathmlNamespace: Text = t"http://www.w3.org/1998/Math/MathML"
 
-// Converts any type with an `Encodable in Mathml` instance to a MathML node or a
-// `<math>` root — `5.math`, `complex.mathml`, `quantity.math`, etc. Instances
-// live in the `Mathml` companion; see `object Mathml` in `archimedes.Mathml.scala`.
-extension [ValueType: Encodable in Mathml as encodable](value: ValueType)
-  def mathml: Mathml = encodable.encoded(value)
+// Converts any type with an `Encodable in Math` instance to a `<math>` root or a
+// single MathML node — `5.math`, `complex.mathml`, `quantity.math`, etc. Instances
+// live in the `Math` companion; see `object Math` in `archimedes.Math.scala`.
+extension [ValueType: Encodable in Math as encodable](value: ValueType)
+  def math: Math = encodable.encoded(value)
 
-  def math: Math = mathml match
-    case Mrow(nodes, _) => Math(nodes)
-    case node           => Math(List(node))
+  def mathml: Mathml = Mathml.atom(encodable.encoded(value))
 
 // The `ergo""` interpolator: `ergo"(x↗y)"` parses an ergo shorthand literal into
 // a `Math` value, checking it at compile time (see `internal.ergoInterpolator`).


### PR DESCRIPTION
The `Encodable` typeclass that turns values into MathML now uses `Math` — a whole `<math>` document — as its form, matching every other codec in the library where the form is the format's top-level type (`Encodable in Text`, `Encodable in Xml`, `Encodable in Data`). Previously it used `Mathml`, the internal node-tree base trait, which leaked an implementation detail into the public API.

Give a type a MathML representation by writing `Encodable in Math` (previously `Encodable in Mathml`):

```
given Temperature is Encodable in Math =
  temperature => Math(Mn(temperature.kelvin.toString.tt), Mi(t"K"))
```

`value.math` returns the `<math>` root; `value.mathml` collapses it to a single node. Instances for numbers, `Text`, Quantitative quantities, Baroque complex numbers and Mosquito vectors/matrices are built in, and the `ergo""` interpolator embeds any `Encodable in Math` value as a single atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
