### PR TITLE
Xenophile: `invoke` JS materializer (Foreign → Scala.js dynamic call)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1604,6 +1604,13 @@ object xenophile extends Library:
     gossamer.core, prepositional.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // The JavaScript materializer: emits Scala.js dynamic calls for WebIDL/TypeScript navigations.
+  // The `invoke` extension it exports collides by design with `wasm`'s (they target different
+  // Scala.js link outputs), so it is not bundled into the `test` module alongside `wasm`.
+  object js extends Component(core, hypotenuse.core, anticipation.codec, distillate.core,
+    gossamer.core, prepositional.core):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(typescript, native, wit, webidl, wasm)
 
 object querencia extends Library:
@@ -1739,4 +1746,4 @@ object jslink extends ScalaJSModule:
     settings.scalaOptions ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   def sources = Task.Sources(mill.api.BuildCtx.workspaceRoot / "jslink" / "src")
   override def mainClass = Some("jslink.Main")
-  override def moduleDeps = Seq(gossamer.core.js, jacinta.core.js, wisteria.core.js, ypsiloid.core.js, hypotenuse.core.js, spectacular.core.js, aviation.core.js)
+  override def moduleDeps = Seq(gossamer.core.js, jacinta.core.js, wisteria.core.js, ypsiloid.core.js, hypotenuse.core.js, spectacular.core.js, aviation.core.js, xenophile.typescript.js, xenophile.js.js)

--- a/jslink/src/JsLinkCheck.scala
+++ b/jslink/src/JsLinkCheck.scala
@@ -6,11 +6,22 @@ import soundness.*
 // modules, so `jslink.fastLinkJS` forces their code reachable and the linker
 // reports any reachable reference to a `java.*`/`javax.*` class Scala.js lacks —
 // the runtime (link-level) counterpart to the static reference audit.
+// The TypeScript definitions reused from xenophile's test resources; the `Interface` given points
+// the `Foreign` navigation at them so `foo.ping()` type-checks against the `ping(): string` member.
+type TsDefs = Interface in Typescript at "/xenophile/definitions.ts"
+given tsDefs: TsDefs = Interface[Typescript](cp"/xenophile/definitions.ts")
+
 object Main:
   case class Point(x: Int, y: Int)
 
   def main(args: Array[String]): Unit =
     val out = java.lang.System.out.nn
+
+    // xenophile (JS materializer): `Foreign["Foo", Typescript].ping().invoke[Text]` expands to a
+    // real Scala.js dynamic call — `js.Dynamic.global.selectDynamic("Foo").applyDynamic("ping")()` —
+    // decoded through the `Text` boundary codec. Linking it proves the emitted interop is valid.
+    // The chain must be inline (not bound to a `val`), exactly like the `Wasm` `invoke`.
+    out.println(Foreign["Foo", Typescript].ping().invoke[Text].s)
 
     // gossamer (Text) + kaleidoscope (regex, via interpolation/text ops)
     out.println(t"hello, ${args.length} args".s)

--- a/lib/xenophile/res/typescript/xenophile/definitions.ts
+++ b/lib/xenophile/res/typescript/xenophile/definitions.ts
@@ -2,6 +2,7 @@ interface Foo {
   bar: Bar;
   baz: string;
   greet(name: string): string;
+  ping(): string;
   link(other: Bar): Foo;
   tags: string[];
   counts: number[];

--- a/lib/xenophile/src/js/soundness_xenophile_js.scala
+++ b/lib/xenophile/src/js/soundness_xenophile_js.scala
@@ -1,0 +1,44 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export xenophile.{Js, JsInvoke}
+
+// Materializes a fully-applied JavaScript `Foreign` navigation into a real Scala.js dynamic call.
+// Must be applied directly to an inline navigation chain — e.g.
+// `Foreign["Math", Typescript].random().invoke[F64]` — not to a value bound to a `val`. It mirrors
+// the `Wasm` module's `invoke`; the two target different Scala.js link outputs (JS vs the Wasm
+// Component Model) and are never on the same application's classpath.
+extension (foreign: xenophile.Foreign)
+  transparent inline def invoke[result]: result =
+    ${xenophile.JsInvoke.invoke[result]('foreign)}

--- a/lib/xenophile/src/js/xenophile.Js.scala
+++ b/lib/xenophile/src/js/xenophile.Js.scala
@@ -1,0 +1,92 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import anticipation.*
+import distillate.*
+import hypotenuse.*
+import prepositional.*
+
+// The uniform form of a value marshalled across a JavaScript call boundary — the JS analogue of the
+// `Wasm` form. A single form lets a codec be summoned for any Scala type without knowing its JS
+// carrier in advance; the carrier (a type Scala.js accepts as a `js.Any`) is recovered from the
+// codec's `Carrier` member. `Encodable in Js` / `Decodable in Js` are summoned per argument/result
+// by `JsInvoke`; a value lacking a codec cannot cross a JS boundary, reported at compile time.
+object Js:
+  def apply(value: Any): Js = new Js(value)
+  extension (js: Js) def as[carrier]: carrier = js.value.asInstanceOf[carrier]
+
+  // Builds an `Encodable in Js` that also exposes the `Carrier` type the value is passed as.
+  private def enc[self, carrier0](lambda: self => carrier0)
+  :   (self is Encodable in Js) { type Carrier = carrier0 } =
+
+    new Encodable:
+      type Self = self
+      type Form = Js
+      type Carrier = carrier0
+      def encoded(value: self): Js = Js(lambda(value))
+
+  private def dec[self, carrier0](lambda: carrier0 => self)
+  :   (self is Decodable in Js) { type Carrier = carrier0 } =
+
+    new Decodable:
+      type Self = self
+      type Form = Js
+      type Carrier = carrier0
+      type Locus = Text
+      def decoded(value: Js): self = lambda(value.as[carrier0])
+
+  // JavaScript's sole number type is an IEEE-754 double, which Scala.js represents faithfully for
+  // integral carriers up to 32 bits; the fixed-width Hypotenuse types canonicalise onto `Byte`/
+  // `Short`/`Int` (all Scala.js `number`s), exactly as the `Wasm` form does. (`S64`/`U64` are
+  // omitted: JS has no native 64-bit integer, so they cannot cross faithfully without `BigInt` — a
+  // follow-up, mirroring the `Wasm` form's `list<T>`/float TODO.)
+  given s8Encodable: ((S8 is Encodable in Js) { type Carrier = Byte }) = enc(_.byte)
+  given s8Decodable: ((S8 is Decodable in Js) { type Carrier = Byte }) = dec(_.bits.s8)
+  given s16Encodable: ((S16 is Encodable in Js) { type Carrier = Short }) = enc(_.short)
+  given s16Decodable: ((S16 is Decodable in Js) { type Carrier = Short }) = dec(_.bits.s16)
+  given s32Encodable: ((S32 is Encodable in Js) { type Carrier = Int }) = enc(_.int)
+  given s32Decodable: ((S32 is Decodable in Js) { type Carrier = Int }) = dec(_.bits.s32)
+  given u8Encodable: ((U8 is Encodable in Js) { type Carrier = Byte }) = enc(_.byte)
+  given u8Decodable: ((U8 is Decodable in Js) { type Carrier = Byte }) = dec(_.bits.u8)
+  given u16Encodable: ((U16 is Encodable in Js) { type Carrier = Short }) = enc(_.bits.s16.short)
+  given u16Decodable: ((U16 is Decodable in Js) { type Carrier = Short }) = dec(_.bits.u16)
+  given u32Encodable: ((U32 is Encodable in Js) { type Carrier = Int }) = enc(_.bits.s32.int)
+  given u32Decodable: ((U32 is Decodable in Js) { type Carrier = Int }) = dec(_.bits.u32)
+  given boolEncodable: ((Boolean is Encodable in Js) { type Carrier = Boolean }) = enc(identity)
+  given boolDecodable: ((Boolean is Decodable in Js) { type Carrier = Boolean }) = dec(identity)
+  given textEncodable: ((Text is Encodable in Js) { type Carrier = String }) = enc(_.s)
+  given textDecodable: ((Text is Decodable in Js) { type Carrier = String }) = dec(_.tt)
+
+// A value marshalled to the carrier type it crosses a JavaScript call boundary as.
+final class Js(val value: Any)

--- a/lib/xenophile/src/js/xenophile.JsInvoke.scala
+++ b/lib/xenophile/src/js/xenophile.JsInvoke.scala
@@ -1,0 +1,128 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xenophile
+
+import scala.quoted.*
+
+import anticipation.*
+import distillate.*
+import fulminate.*
+import prepositional.*
+
+// The terminal materializer for JavaScript ecosystems (WebIDL, TypeScript): turns a fully-applied
+// `Foreign` navigation into a real Scala.js dynamic call — `js.Dynamic.global.<owner>.<method>()` —
+// decoded through the value's `Decodable in Js` codec. It is the JS analogue of `WasmInvoke`:
+// where that emits a Wasm Component Model import (`witImportCall`), this emits the Scala.js dynamic
+// interop nodes (`selectDynamic`/`applyDynamic` on `js.Dynamic`). Both are looked up in the
+// *downstream* classpath by name, so this module needs no dependency on `scalajs-library` and still
+// compiles for the JVM (the macro runs there); the call is lowered by Scala.js at link time.
+//
+// Like `WasmInvoke`, this v1 materializes nullary method calls (`receiver.method()`); argument
+// marshalling through `Encodable in Js` is a follow-up, tracked alongside the `Wasm` form's.
+object JsInvoke:
+  def invoke[result: Type](self: Expr[Foreign])(using quotes: Quotes): Expr[result] =
+    import quotes.reflect.*
+
+    // The `js.Dynamic` interop entry points, resolved from the downstream Scala.js library. Named
+    // rather than referenced, so this module compiles without depending on `scalajs-library`.
+    val globalMethod = Symbol.requiredMethod("scala.scalajs.js.Dynamic.global")
+    val dynamic = Symbol.requiredClass("scala.scalajs.js.Dynamic")
+    val selectDynamic = dynamic.methodMember("selectDynamic").head
+    val applyDynamic = dynamic.methodMember("applyDynamic").head
+    // A concrete `js.Any` tree for the empty varargs element (an inferred one fails to resolve).
+    val jsAnyTree = TypeTree.ref(Symbol.requiredClass("scala.scalajs.js.Any"))
+
+    // The navigation the `invoke` is applied to expands to `Foreign.make(<AST>).asInstanceOf[…]`,
+    // itself wrapped in `Inlined`/`Typed` layers (the inline `applyDynamic` leaves a `Foreign_this`
+    // binding, so `underlyingArgument` cannot fold the `Inlined` away). Rather than quote-match
+    // through those layers, we peel them at tree level and read the `Foreign.Expression` AST the
+    // navigation macros built directly. (`.tt` desugars to a plain `tt("…")` application.)
+    def strip(term: Term): Term = term match
+      case Inlined(_, _, body)                        => strip(body)
+      case Typed(expr, _)                             => strip(expr)
+      case Block(Nil, expr)                           => strip(expr)
+      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
+      case _                                          => term
+
+    // `.tt` desugars to `tt("…")`; recover the string from the operand (or a bare string literal).
+    def stringOf(term: Term): Text = strip(term).absolve match
+      case Literal(StringConstant(string)) => string.tt
+
+    def literal(term: Term): Text = strip(term).absolve match
+      case Apply(Ident("tt"), List(argument)) => stringOf(argument)
+      case other                              => stringOf(other)
+
+    // `receiver.selectDynamic("name")`, yielding another `js.Dynamic`.
+    def select(receiver: Term, name: Text): Term =
+      Apply(Select(receiver, selectDynamic), List(Literal(StringConstant(name.s))))
+
+    // `receiver.applyDynamic("method")()` — a nullary JS method call. The empty `js.Any*` argument
+    // must be a `Repeated` (concrete element type) ascribed with the method's own repeated param
+    // type (`js.Any*`, not `Seq[js.Any]`, which reads as a single sequence value).
+    val varargType = applyDynamic.paramSymss.last.head.info
+
+    def applyNullary(receiver: Term, method: Text): Term =
+      val arguments = varargType.asType.absolve match
+        case '[repeated] => Typed(Repeated(Nil, jsAnyTree), TypeTree.of[repeated])
+
+      Apply
+        ( Apply(Select(receiver, applyDynamic), List(Literal(StringConstant(method.s)))),
+          List(arguments) )
+
+    def notCall: Nothing = halt(m"xenophile: `invoke` expects a call, `receiver.method()`")
+
+    // Peel to the `Foreign.make(<AST>)` application; take its argument — the expression AST.
+    val expression = strip(self.asTerm.underlyingArgument).absolve match
+      case Apply(Select(_, "make"), List(argument)) => strip(argument)
+      case _                                        => notCall
+
+    // Like `WasmInvoke`, the `owner` recorded on the `Select` names the type the method belongs to;
+    // for a global JavaScript object (`Math`, `crypto`, …) that is the global property to read, so
+    // the call is `global.<owner>.<method>()`. AST: `Apply(Select(_, member, owner), _)`
+    // (`Apply.apply` has two arguments; the nested `Select.apply` has three).
+    val selectNode = expression match
+      case Apply(Select(_, "apply"), List(node, _)) => strip(node)
+      case _                                        => notCall
+
+    val (owner, function) = selectNode.absolve match
+      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
+      case _                                                 => notCall
+
+    val call = applyNullary(select(Ref(globalMethod), owner), function)
+
+    // The result crosses the boundary via its `Decodable in Js` codec, which reads the `js.Dynamic`
+    // return value at its `Carrier` type (via `Js.as`) and lifts it to the Scala type.
+    val decodable = Expr.summon[result is Decodable in Js].getOrElse:
+      halt(m"xenophile: no way to read a ${TypeRepr.of[result].show} from a JavaScript boundary")
+
+    '{$decodable.decoded(Js(${call.asExprOf[Any]}))}


### PR DESCRIPTION
Xenophile can now materialize a call to a JavaScript interface directly from a `Foreign` navigation, with no hand-written `@js.native` facade — the exact counterpart to the WebAssembly `invoke` it already provides for WIT. Navigating a JavaScript ecosystem (WebIDL or TypeScript) and calling `.invoke` expands, through the macro alone, into a real Scala.js dynamic call that the linker lowers to a plain property access.

Xenophile's `Foreign` navigation gains a JavaScript materializer to sit alongside the WebAssembly one. Given a TypeScript (or WebIDL) interface, a navigation invokes a real JavaScript function with no stub declarations:

```scala
import soundness.*

type Api = Interface in Typescript at "/api.d.ts"
given Api = Interface[Typescript](cp"/api.d.ts")

// expands to `js.Dynamic.global.selectDynamic("Math").applyDynamic("random")()`,
// which Scala.js lowers to a direct `Math.random()` call at link time:
val r: F64 = Foreign["Math", Typescript].random().invoke[F64]
```

The macro resolves the member against the interface definitions at compile time (the same navigation and type-checking used for the WIT and native ecosystems), then emits the Scala.js interop directly. Like the WebAssembly materializer, it references the Scala.js interop entry points by name in the downstream classpath, so the module carries no dependency on `scalajs-library` and the JVM macro is unaffected.

This first version materializes nullary calls (matching the WebAssembly materializer's current scope); argument marshalling through `Encodable in Js` is a follow-up. Result values cross the boundary through `Decodable in Js` codecs (`Text`, the fixed-width integer types, `Boolean`).
