### PR TITLE
Revise ergo directive and table-introducer glyphs

### DIFF
--- a/lib/archimedes/doc/ergo-directives.md
+++ b/lib/archimedes/doc/ergo-directives.md
@@ -2,7 +2,7 @@
 
 Ergo is a one-line shorthand for Presentation MathML. An expression is delimited
 by a bracket pair; the **first character** chooses which pair (`(`/`[`/`{`/`⟨`)
-acts as grouping syntax throughout, and every *other* bracket is a literal `<mo>`.
+acts as grouping syntax throughout, and every _other_ bracket is a literal `<mo>`.
 A grouped run is an `<mrow>` unit; operands of an operator are uniformly "an atom
 or a grouped unit".
 
@@ -15,8 +15,8 @@ equation tree, then the **attribute directives** (MathML Core) that decorate it.
 
 ### Scripts & limits
 
-- `↗` — **superscript** → `<msup>` — `x↗2` = *x²*
-- `↘` — **subscript** → `<msub>` — `x↘i` = *xᵢ*
+- `↗` — **superscript** → `<msup>` — `x↗2` = _x²_
+- `↘` — **subscript** → `<msub>` — `x↘i` = _xᵢ_
 - `↑` — **overscript / limit above** → `<mover>` (accent when the script is a single `<mo>`)
 - `↓` — **underscript / limit below** → `<munder>` (accent when the script is a single `<mo>`)
 
@@ -28,19 +28,19 @@ A base absorbs one `↘` and one `↗` → `<msubsup>`; one `↓` and one `↑` 
 
 - `/` — **fraction** → `<mfrac>` — `a/b`
 - `√` — **square root** (prefix) → `<msqrt>` — `√x`
-- `n√x` — **nth root** → `<mroot>` — an index atom immediately before `√` (no space): `3√x` = *∛x*
+- `n√x` — **nth root** → `<mroot>` — an index atom immediately before `√` (no space): `3√x` = _∛x_
 
 ### Introducers (tables)
 
 Self-delimiting; the body is one group whose child groups are the elements.
 
-- `⊞` — **matrix** → `<mtable>` — `⊞(((1)(2))((3)(4)))` = a 2×2 matrix (rows of cells)
-- `⊟` — **row vector** → `<mtable>` with one row — `⊟((1)(2)(3))`
-- `⊡` — **column vector** → `<mtable>` with one column — `⊡((a)(b))`
+- `⋱` — **matrix** → `<mtable>` — `⋱(((1)(2))((3)(4)))` = a 2×2 matrix (rows of cells)
+- `⋯` — **row vector** → `<mtable>` with one row — `⋯((1)(2)(3))`
+- `⋮` — **column vector** → `<mtable>` with one column — `⋮((a)(b))`
 
 ### Tokens & spacing
 
-- a **letter run** → one `<mi>` — `sin` = `<mi>sin</mi>`; a space splits identifiers (`x y` = *x·y*)
+- a **letter run** → one `<mi>` — `sin` = `<mi>sin</mi>`; a space splits identifiers (`x y` = _x·y_)
 - a **digit run** (interior `.` allowed) → one `<mn>` — `3.14`
 - any other character → `<mo>` — `+`, `=`, `∑`, `±`, …
 - an **operator glyph with a missing operand** degrades to a literal `<mo>` — `(↗)` writes a literal ↗
@@ -52,9 +52,9 @@ Self-delimiting; the body is one group whose child groups are the elements.
 
 Each MathML Core presentation attribute is written as a single **directive glyph**.
 The scope is MathML Core only, so the large MathML 3 table/elementary attribute
-families are absent (see *Excluded from Core* below).
+families are absent (see _Excluded from Core_ below).
 
-**Conventions** *(as implemented in the parser)*
+**Conventions** _(as implemented in the parser)_
 
 - Directives are **postfix** and bind to the primary (atom or bracketed group)
   immediately to their left; multiple directives simply **juxtapose**:
@@ -62,7 +62,7 @@ families are absent (see *Excluded from Core* below).
 - **Enumerated and boolean** attributes have **one bare glyph per value** — no
   parameter. `form` is `⊰`/`⊹`/`⊱` (prefix/infix/postfix); a boolean is `⇿`
   (true) or `↮` (false). Since these never take a group, `=◆(a)` is `=` with
-  `largeop="true"` *times* `(a)`, not `largeop="a"`.
+  `largeop="true"` _times_ `(a)`, not `largeop="a"`.
 - **Open-valued** attributes (length/colour/integer) take their value in the
   **active grouping bracket** (shown below as `[…]`), read verbatim: with `(`
   grouping, `x●(red)` sets `mathcolor="red"`; with `[` grouping it would be
@@ -73,9 +73,9 @@ families are absent (see *Excluded from Core* below).
 
 ### Document & display level
 
-- `⧊` / `⧄` — **displaystyle** = true / false — use display style (larger, limits over/under) vs inline/text style
+- `⧆` / `⧄` — **displaystyle** = true / false — use display style (larger, limits over/under) vs inline/text style
 - `⌄[±n]` — **scriptlevel** — relative script size level; `+n` shrinks, `-n` enlarges
-- `▦` / `▭` — **display** = block / inline *(on `<math>`)* — block equation vs inline in running text
+- `◻` / `▭` — **display** = block / inline _(on `<math>`)_ — block equation vs inline in running text
 
 ### Colour
 
@@ -84,33 +84,33 @@ families are absent (see *Excluded from Core* below).
 
 ### Text size & style
 
-- `⤢[length]` — **mathsize** — font size of the element
+- `⟑[length]` — **mathsize** — font size of the element
 - `⦱` — **mathvariant** = normal — render upright, cancelling the automatic italicisation of a single-letter identifier
-- `▹` / `◃` — **dir** = ltr / rtl — text/layout direction
+- `⊩` / `⫣` — **dir** = ltr / rtl — text/layout direction
 
 ### Operator role (`<mo>`)
 
 - `⊰` / `⊹` / `⊱` — **form** = prefix / infix / postfix — which spacing/role form the operator takes
-- `⧘` / `⧙` — **fence** = true / false — mark the operator as a fence (bracket/paren)
+- `∥` / `∤` — **fence** = true / false — mark the operator as a fence (bracket/paren)
 - `▮` / `▯` — **separator** = true / false — mark the operator as a separator (e.g. a comma)
 - `⇿` / `↮` — **stretchy** = true / false — allow the operator to stretch to its surrounding content
-- `⋈` / `⋇` — **symmetric** = true / false — stretch symmetrically about the maths axis
+- `⋈` / `⋊` — **symmetric** = true / false — stretch symmetrically about the maths axis
 - `◆` / `◇` — **largeop** = true / false — treat as a large operator (e.g. `∑`, `∫`) in display style
-- `⇅` / `⇳` — **movablelimits** = true / false — limits over/under in display style but as scripts inline
+- `⧳` / `⧯` — **movablelimits** = true / false — limits over/under in display style but as scripts inline
 
 ### Operator spacing & stretch (`<mo>`)
 
-- `⇤[length]` — **lspace** — space to the left of the operator
-- `⇥[length]` — **rspace** — space to the right of the operator
+- `⧔[length]` — **lspace** — space to the left of the operator
+- `⧕[length]` — **rspace** — space to the right of the operator
 - `⟰[length]` — **maxsize** — maximum stretched size
 - `⟱[length]` — **minsize** — minimum stretched size
 
 ### Box metrics (`<mspace>`, `<mpadded>`)
 
 - `↔[length]` — **width** — advance width of the box
-- `⤒[length]` — **height** — extent above the baseline
-- `⤓[length]` — **depth** — extent below the baseline
-- `↨[length]` — **voffset** *(on `<mpadded>`)* — vertical shift of the content
+- `⍏[length]` — **height** — extent above the baseline
+- `⍖[length]` — **depth** — extent below the baseline
+- `↕[length]` — **voffset** _(on `<mpadded>`)_ — vertical shift of the content
 
 ### Fraction (`<mfrac>`)
 
@@ -123,7 +123,7 @@ families are absent (see *Excluded from Core* below).
 
 ### Legacy (present in Core but behaviour undefined)
 
-- `⚙[type]` — **actiontype** *(on `<maction>`)* — legacy action type; behaviour is undefined in MathML Core
+- `⚙[type]` — **actiontype** _(on `<maction>`)_ — legacy action type; behaviour is undefined in MathML Core
 
 ---
 

--- a/lib/archimedes/src/core/archimedes.Ergo.scala
+++ b/lib/archimedes/src/core/archimedes.Ergo.scala
@@ -51,7 +51,7 @@ import vacuous.*
 //   /                     → Mfrac
 //   juxtaposition         → Mrow
 //
-// Introducers ⊞/⊟/⊡ start a matrix / row-vector / column-vector from the run of
+// Introducers ⋱/⋯/⋮ start a matrix / row-vector / column-vector from the run of
 // bracket groups that immediately follows. A space separates adjacent atoms
 // (`x y` = two `<mi>`, `xy` = one), and any operator glyph with a missing
 // operand degrades to a literal `Mo` (so `(↗)` writes a literal ↗).
@@ -65,9 +65,9 @@ object Ergo:
   private final val Over   = '↑' // ↑
   private final val Under  = '↓' // ↓
   private final val Radical = '√' // √
-  private final val Matrix = '⊞' // ⊞
-  private final val RowVec = '⊟' // ⊟
-  private final val ColVec = '⊡' // ⊡
+  private final val Matrix = '⋱' // ⋱
+  private final val RowVec = '⋯' // ⋯
+  private final val ColVec = '⋮' // ⋮
   private final val Hole   = '\uE000' // interpolator substitution placeholder
 
   // A postfix attribute directive (see `doc/ergo-directives.md`). `Fixed` sets a
@@ -78,40 +78,40 @@ object Ergo:
     case Fixed(name: Text, value: Text) extends Directive(name)
 
   private val directives: List[(Char, Directive)] = List(
-    '⧊' -> Directive.Fixed(t"displaystyle", t"true"),
+    '⧆' -> Directive.Fixed(t"displaystyle", t"true"),
     '⧄' -> Directive.Fixed(t"displaystyle", t"false"),
     '⌄' -> Directive.Param(t"scriptlevel"),
-    '▦' -> Directive.Fixed(t"display", t"block"),
+    '◻' -> Directive.Fixed(t"display", t"block"),
     '▭' -> Directive.Fixed(t"display", t"inline"),
     '●' -> Directive.Param(t"mathcolor"),
     '▨' -> Directive.Param(t"mathbackground"),
-    '⤢' -> Directive.Param(t"mathsize"),
+    '⟑' -> Directive.Param(t"mathsize"),
     '⦱' -> Directive.Fixed(t"mathvariant", t"normal"),
-    '▹' -> Directive.Fixed(t"dir", t"ltr"),
-    '◃' -> Directive.Fixed(t"dir", t"rtl"),
+    '⊩' -> Directive.Fixed(t"dir", t"ltr"),
+    '⫣' -> Directive.Fixed(t"dir", t"rtl"),
     '⊰' -> Directive.Fixed(t"form", t"prefix"),
     '⊹' -> Directive.Fixed(t"form", t"infix"),
     '⊱' -> Directive.Fixed(t"form", t"postfix"),
-    '⧘' -> Directive.Fixed(t"fence", t"true"),
-    '⧙' -> Directive.Fixed(t"fence", t"false"),
+    '∥' -> Directive.Fixed(t"fence", t"true"),
+    '∤' -> Directive.Fixed(t"fence", t"false"),
     '▮' -> Directive.Fixed(t"separator", t"true"),
     '▯' -> Directive.Fixed(t"separator", t"false"),
     '⇿' -> Directive.Fixed(t"stretchy", t"true"),
     '↮' -> Directive.Fixed(t"stretchy", t"false"),
     '⋈' -> Directive.Fixed(t"symmetric", t"true"),
-    '⋇' -> Directive.Fixed(t"symmetric", t"false"),
+    '⋊' -> Directive.Fixed(t"symmetric", t"false"),
     '◆' -> Directive.Fixed(t"largeop", t"true"),
     '◇' -> Directive.Fixed(t"largeop", t"false"),
-    '⇅' -> Directive.Fixed(t"movablelimits", t"true"),
-    '⇳' -> Directive.Fixed(t"movablelimits", t"false"),
-    '⇤' -> Directive.Param(t"lspace"),
-    '⇥' -> Directive.Param(t"rspace"),
+    '⧳' -> Directive.Fixed(t"movablelimits", t"true"),
+    '⧯' -> Directive.Fixed(t"movablelimits", t"false"),
+    '⧔' -> Directive.Param(t"lspace"),
+    '⧕' -> Directive.Param(t"rspace"),
     '⟰' -> Directive.Param(t"maxsize"),
     '⟱' -> Directive.Param(t"minsize"),
     '↔' -> Directive.Param(t"width"),
-    '⤒' -> Directive.Param(t"height"),
-    '⤓' -> Directive.Param(t"depth"),
-    '↨' -> Directive.Param(t"voffset"),
+    '⍏' -> Directive.Param(t"height"),
+    '⍖' -> Directive.Param(t"depth"),
+    '↕' -> Directive.Param(t"voffset"),
     '═' -> Directive.Param(t"linethickness"),
     '◠' -> Directive.Fixed(t"accent", t"true"),
     '⌢' -> Directive.Fixed(t"accent", t"false"),
@@ -150,7 +150,7 @@ object Ergo:
   // not representable and are dropped.
 
   private val special: Set[Char] =
-    Set('(', ')', '[', ']', '{', '}', '⟨', '⟩', '↗', '↘', '↑', '↓', '/', '√', '⊞', '⊟', '⊡')
+    Set('(', ')', '[', ']', '{', '}', '⟨', '⟩', '↗', '↘', '↑', '↓', '/', '√', '⋱', '⋯', '⋮')
 
   def serialize(math: Math)(using Tactic[ErgoError]): Text = t"(${sequence(math.contents)})"
 
@@ -244,9 +244,9 @@ object Ergo:
     val rows: List[List[Text]] = table.contents.collect:
       case Mtr(cells, _) => cells.map(cellText)
 
-    if rows.length == 1 then t"⊟(${rows.head.join})"
-    else if rows.forall(_.length == 1) then t"⊡(${rows.map(_.head).join})"
-    else t"⊞(${rows.map { cells => group(cells.join) }.join})"
+    if rows.length == 1 then t"${RowVec.toString.tt}(${rows.head.join})"
+    else if rows.forall(_.length == 1) then t"${ColVec.toString.tt}(${rows.map(_.head).join})"
+    else t"${Matrix.toString.tt}(${rows.map { cells => group(cells.join) }.join})"
 
   private def cellText(node: Mathml)(using Tactic[ErgoError]): Text = node match
     case Mtd(contents, _) => group(sequence(contents))
@@ -469,7 +469,7 @@ object Ergo:
 
     // Consumes the self-delimiting body `open <group>… close` that follows an
     // introducer, returning the parsed child groups. A body with no nested
-    // groups is treated as a single element (so `⊟(a)` is a one-cell vector).
+    // groups is treated as a single element (so `⋯(a)` is a one-cell vector).
     private def parseBody(introducer: Char): List[Mathml] =
       if peek != open then abort(ErgoError(ErgoError.Reason.MissingBody(introducer.toString.tt)))
       advance() // body open

--- a/lib/archimedes/src/test/archimedes_test.scala
+++ b/lib/archimedes/src/test/archimedes_test.scala
@@ -158,22 +158,22 @@ object Tests extends Suite(m"Archimedes tests"):
 
     suite(m"Vectors and matrices (self-delimiting)"):
       test(m"row vector"):
-        body(t"(⊟((1)(2)(3)))")
+        body(t"(⋯((1)(2)(3)))")
       .assert(_ == t"<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd>"
           + t"<mtd><mn>3</mn></mtd></mtr></mtable>")
 
       test(m"column vector"):
-        body(t"(⊡((a)(b)))")
+        body(t"(⋮((a)(b)))")
       .assert(_ == t"<mtable><mtr><mtd><mi>a</mi></mtd></mtr><mtr><mtd><mi>b</mi></mtd></mtr>"
           + t"</mtable>")
 
       test(m"2x2 matrix"):
-        body(t"(⊞(((1)(2))((3)(4))))")
+        body(t"(⋱(((1)(2))((3)(4))))")
       .assert(_ == t"<mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr>"
           + t"<mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>")
 
       test(m"a single-cell row keeps a multi-token expression together"):
-        body(t"(⊞(((a b))((c))))")
+        body(t"(⋱(((a b))((c))))")
       .assert(_ == t"<mtable><mtr><mtd><mrow><mi>a</mi><mi>b</mi></mrow></mtd></mtr><mtr>"
           + t"<mtd><mi>c</mi></mtd></mtr></mtable>")
 
@@ -255,12 +255,12 @@ object Tests extends Suite(m"Archimedes tests"):
       .assert(_ == t"(x↑^)")
 
       test(m"a matrix"):
-        rt(t"(⊞(((1)(2))((3)(4))))")
-      .assert(_ == t"(⊞(((1)(2))((3)(4))))")
+        rt(t"(⋱(((1)(2))((3)(4))))")
+      .assert(_ == t"(⋱(((1)(2))((3)(4))))")
 
       test(m"a row vector"):
-        rt(t"(⊟((1)(2)(3)))")
-      .assert(_ == t"(⊟((1)(2)(3)))")
+        rt(t"(⋯((1)(2)(3)))")
+      .assert(_ == t"(⋯((1)(2)(3)))")
 
       test(m"the quadratic formula round-trips to an equal tree"):
         val quadratic = t"(x = (-b ± √(b↗2 - 4 a c))/(2 a))"
@@ -277,7 +277,7 @@ object Tests extends Suite(m"Archimedes tests"):
       .assert(_ == Ergo.parse(t"(x↗(y + 1))"))
 
       test(m"an interpolated matrix renders"):
-        ergo"(⊞(((1)(2))((3)(4))))".xml.show.contains(t"<mtable>")
+        ergo"(⋱(((1)(2))((3)(4))))".xml.show.contains(t"<mtable>")
       .assert(_ == true)
 
     suite(m"Interpolator substitutions"):


### PR DESCRIPTION
Several of Ergo's attribute-directive and table-introducer glyphs have been changed, for better font coverage and mnemonic value. Any `ergo""` literals — or serialized Ergo output — using the previous glyphs must be updated to the new ones.

The revised glyphs:

| meaning | old | new |
|---|---|---|
| matrix / row vector / column vector | `⊞` / `⊟` / `⊡` | `⋱` / `⋯` / `⋮` |
| `displaystyle=true` | `⧊` | `⧆` |
| `display=block` | `▦` | `◻` |
| `mathsize` | `⤢` | `⟑` |
| `dir` ltr / rtl | `▹` / `◃` | `⊩` / `⫣` |
| `fence` true / false | `⧘` / `⧙` | `∥` / `∤` |
| `symmetric=false` | `⋇` | `⋊` |
| `movablelimits` true / false | `⇅` / `⇳` | `⧳` / `⧯` |
| `lspace` / `rspace` | `⇤` / `⇥` | `⧔` / `⧕` |
| `height` / `depth` / `voffset` | `⤒` / `⤓` / `↨` | `⍏` / `⍖` / `↕` |

See `archimedes/doc/ergo-directives.md` for the full glyph reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
