### PR TITLE
Decode explicit JSON null to Unset for Optional fields

### DIFF
--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -104,7 +104,11 @@ trait Json2 extends Json3:
   =>  value is Json.Decodable =
 
     Json.Decodable(Morphology.Opt(decodable.shape())): json =>
-      if json.root.isAbsent then Unset else decodable.decoded(json)
+      // An `Optional` field reads `Unset` from an absent key *and* from an
+      // explicit JSON `null`: both mean "no value" on the wire. (Missing keys
+      // arrive here as `Unset`; a present `null` arrives as the `JsonNull`
+      // sentinel.)
+      if json.root.isAbsent || json.root.isNull then Unset else decodable.decoded(json)
 
 
   given bytes: Tactic[JsonError] => Bytes is Json.Decodable =

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -293,6 +293,14 @@ object Tests extends Suite(m"Jacinta Tests"):
         t"""{"y": 1}""".read[Json].as[OptionalFoo].x
       . assert(_ == Unset)
 
+      test(m"Extract an explicit null Optional as Unset"):
+        t"""{"x": null}""".read[Json].as[OptionalFoo].x
+      . assert(_ == Unset)
+
+      test(m"Decode a top-level null to an Optional as Unset"):
+        t"""null""".read[Json].as[Optional[Int]]
+      . assert(_ == Unset)
+
       test(m"Extract a None"):
         t"""{"y": 1}""".read[Json].as[OptFoo].x
       . assert(_ == None)


### PR DESCRIPTION
Jacinta's derived JSON decoders now treat an explicit `null` for an `Optional` field the same as an absent key — both decode to `Unset`. Previously a present `null` fell through to the field's inner decoder and raised a `JsonError`, which surfaced most visibly as Exegesis-based LSP servers failing `initialize` with a `-32603 Internal error` whenever a client sent `processId: null` or `rootUri: null` (both spec-legal). Fixes #1456.

`Optional[T]` fields now accept a JSON `null` as well as an omitted key, decoding either to `Unset`:

```scala
case class Params(processId: Optional[Int], rootUri: Optional[Text])

// all of these now decode to Params(Unset, …):
t"""{"rootUri": "file:///t"}""".read[Json].as[Params]                    // key omitted
t"""{"processId": null, "rootUri": "file:///t"}""".read[Json].as[Params] // explicit null
```

A top-level `null` decoded to an `Optional[T]` likewise yields `Unset`. This affects any derived `Json.Decodable`, not just LSP.