### PR TITLE
Add capricious.wasi: WASI-backed randomness for WebAssembly

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -595,6 +595,12 @@ object capricious extends Library:
   object core extends Component(wisteria.core, hypotenuse.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // WASI-backed entropy: a `Randomization` given whose randomness is a Wasm Component Model import
+  // of `wasi:random/random`, materialized by xenophile's `invoke` at the downstream (Wasm-linked)
+  // summoning site. Target-neutral `.sjsir` in this build; only meaningful linked as a component.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)
 
 object cardinality extends Library:

--- a/lib/capricious/res/wasi/capricious/random.wit
+++ b/lib/capricious/res/wasi/capricious/random.wit
@@ -1,0 +1,7 @@
+// The subset of the WASI `random` interface that capricious uses for entropy.
+
+package wasi:random@0.2.0;
+
+interface random {
+  get-random-u64: func() -> u64;
+}

--- a/lib/capricious/src/wasi/capricious.WasiRandom.scala
+++ b/lib/capricious/src/wasi/capricious.WasiRandom.scala
@@ -1,0 +1,41 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package capricious
+
+import java.util as ju
+
+// Adapts an external 64-bit entropy source (such as WASI's `wasi:random/random`) to
+// `java.util.Random`'s `next` contract, so that it can back a `scala.util.Random` and hence a
+// `Randomization`. The inherited seed is never used.
+final class WasiRandom(entropy: () => Long) extends ju.Random(0L):
+  override def next(bits: Int): Int = (entropy() >>> (64 - bits)).toInt

--- a/lib/capricious/src/wasi/capricious_wasi.scala
+++ b/lib/capricious/src/wasi/capricious_wasi.scala
@@ -1,0 +1,61 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package capricious
+
+import scala.annotation.nowarn
+import scala.util as su
+
+import hellenism.*
+import hypotenuse.*
+import prepositional.*
+import soundness.invoke
+import xenophile.*
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for the function's module id.
+type WasiRandomApi = Interface in Wit at "/capricious/random.wit"
+given wasiRandomApi: WasiRandomApi = Interface[Wit](cp"/capricious/random.wit")
+
+package randomization:
+  // `inline`, so the `invoke` macro expands at the downstream summoning site: the Wasm Component
+  // import (`scala.scalajs.wit.witImportCall`) only materializes in code compiled for a Wasm
+  // target, where that intrinsic is on the classpath. Summoning it requires `wasiRandomApi` (and
+  // this module's WIT resource) to be visible at that site.
+  // The per-site duplication the compiler warns about is the point: the instance must materialize
+  // at the downstream summoning site, and a WASI-linked application summons it once.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasiRandomization: Randomization = new Randomization:
+    def initialize(): su.Random =
+      su.Random:
+        WasiRandom: () =>
+          Foreign["random", Wit].`get-random-u64`.invoke[U64].bits.s64.long

--- a/lib/capricious/src/wasi/soundness_capricious_wasi.scala
+++ b/lib/capricious/src/wasi/soundness_capricious_wasi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export capricious.{WasiRandom, WasiRandomApi, wasiRandomApi}
+
+package randomization:
+  export capricious.randomization.wasiRandomization

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -225,8 +225,13 @@ object Xenophile:
     val signature = typeMembers.at(fieldName).or:
       halt(m"xenophile: the foreign type $topic has no member $fieldName")
 
-    signature.parameters.let: _ =>
-      halt(m"xenophile: $fieldName is a method of $topic and must be called with arguments")
+    // A method with parameters cannot be bare-selected, but a zero-parameter method can: the
+    // selection is typed by its result, so a terminal materializer (e.g. WIT `invoke`) can treat it
+    // as a nullary call — avoiding an empty-varargs application, which trips path-dependent type
+    // avoidance when the navigation is re-inlined from an enclosing `inline` definition.
+    signature.parameters.let: parameters =>
+      if !parameters.isEmpty
+      then halt(m"xenophile: $fieldName is a method of $topic and must be called with arguments")
 
     foreignType(signature.result, originRepr).asType.absolve match
       case '[type result <: Foreign; result] =>

--- a/lib/xenophile/src/wasm/soundness_xenophile_wasm.scala
+++ b/lib/xenophile/src/wasm/soundness_xenophile_wasm.scala
@@ -36,7 +36,11 @@ export xenophile.{Wasm, WasmInvoke}
 
 // Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
 // call. Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["random", Wit].getRandomU64().invoke[U64]` — not to a value bound to a `val`.
+// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
+// Plain `inline` (not `transparent`): the return type is fully determined by the type argument,
+// and non-transparency defers the macro when `invoke` appears inside another `inline` definition,
+// so a library can publish an inline given whose import call only materializes at the downstream
+// (Wasm-linked) call site — where `scala.scalajs.wit.witImportCall` is on the classpath.
 extension (foreign: xenophile.Foreign)
-  transparent inline def invoke[result]: result =
+  inline def invoke[result]: result =
     ${xenophile.WasmInvoke.invoke[result]('foreign)}

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -54,20 +54,43 @@ object WasmInvoke:
     // was reached through is recovered from the `Foreign.Expression` the navigation built.
     val (_, origin) = Xenophile.receiver(self)
 
-    val expression: Expr[Foreign.Expression] =
-      self.asTerm.underlyingArgument.asExpr.absolve match
-        case '{Foreign.make($tree)} => tree
+    // The navigation expands to `Foreign.make(<AST>).asInstanceOf[…]`, and reaching this macro
+    // through further `inline` definitions (e.g. an inline given publishing a deferred import)
+    // nests it in `Inlined`/`Typed` layers that `underlyingArgument` cannot fold away. So the AST
+    // is recovered by term-level stripping, as in `JsInvoke`, rather than quote-pattern matching.
+    def strip(term: Term): Term = term match
+      case Inlined(_, _, body)                        => strip(body)
+      case Typed(expr, _)                             => strip(expr)
+      case Block(Nil, expr)                           => strip(expr)
+      case TypeApply(Select(expr, "asInstanceOf"), _) => strip(expr)
+      case _                                          => term
 
-    // A `Foreign.Expression` string operand is `"…".tt`; recover the literal `String`.
-    def literal(text: Expr[Text]): Text = text.absolve match
-      case '{($string: String).tt} => string.valueOrAbort.tt
+    // `.tt` desugars to `tt("…")`; recover the string from the operand (or a bare string literal).
+    def stringOf(term: Term): Text = strip(term).absolve match
+      case Literal(StringConstant(string)) => string.tt
 
-    val (owner, function) = expression.absolve match
-      case '{Foreign.Expression.Apply(Foreign.Expression.Select($_, $member, $owner), $_)} =>
-        (literal(owner), literal(member))
+    def literal(term: Term): Text = strip(term).absolve match
+      case Apply(Ident("tt"), List(argument)) => stringOf(argument)
 
-      case _ =>
-        halt(m"xenophile: `invoke` expects a foreign method call, `interface.function(args)`")
+    def notCall: Nothing =
+      halt(m"xenophile: `invoke` expects a foreign function invocation, `interface.function(args)`")
+
+    val expression = strip(self.asTerm.underlyingArgument).absolve match
+      case Apply(Select(_, "make"), List(argument)) => strip(argument)
+      case _                                        => notCall
+
+    // Either an applied call — `Expression.Apply(select, args)`, whose companion `apply` takes two
+    // arguments — or the bare selection of a zero-parameter WIT function (`Expression.Select`,
+    // whose companion `apply` takes three): `interface.function.invoke[R]`. The latter is
+    // preferred inside `inline` definitions, where re-inlining an empty-varargs application trips
+    // path-dependent type avoidance.
+    val selectNode = expression match
+      case Apply(Select(_, "apply"), List(node, _)) => strip(node)
+      case _                                        => expression
+
+    val (owner, function) = selectNode.absolve match
+      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
+      case _                                                 => notCall
 
     // Look up the function's module id (e.g. `wasi:random/random@0.2.0`) from the definitions.
     val members = Xenophile.definitions(origin, Xenophile.locusOf(origin)).at(owner).or:
@@ -91,13 +114,17 @@ object WasmInvoke:
     // library), so this macro needs no dependency on it.
     val witImportCall = Symbol.requiredMethod("scala.scalajs.wit.witImportCall")
 
-    val classOfCarrier = carrier.asType.absolve match
-      case '[carrierType] => '{classOf[carrierType]}
+    // A raw class literal (not a quoted `classOf[T]`, which arrives at the backend wrapped in
+    // adaptation nodes that its literal-`classOf` check rejects).
+    val classOfCarrier = Literal(ClassOfConstant(carrier))
+
+    // The `sigAndArgs` argument must be a `Repeated` ascribed with the tree-level repeated type
+    // (`scala.<repeated>[Any]` — not `Seq[Any]`, which reads as a single sequence value and gets
+    // re-wrapped as one vararg element).
+    val repeatedAny = defn.RepeatedParamClass.typeRef.appliedTo(TypeRepr.of[Any])
 
     val varargs =
-      Typed
-        ( Repeated(List(classOfCarrier.asTerm), TypeTree.of[Any]),
-          TypeTree.of[Seq[Any]] )
+      Typed(Repeated(List(classOfCarrier), TypeTree.of[Any]), Inferred(repeatedAny))
 
     val callTerm =
       Apply


### PR DESCRIPTION
Capricious gains a `wasiRandomization` given that sources randomness from the WebAssembly Component Model's `wasi:random/random` interface, so code using `stochastic`/`arbitrary`/`random` runs unchanged in a standalone WebAssembly component; the module compiles in the ordinary build with no WebAssembly-specific dependency, because the Component Model import is materialised only when the given is used in code compiled for WebAssembly. This is the first module to exercise Xenophile's `invoke` materialiser as a *deferred* import, and `invoke` has been adjusted so it can be published inside an `inline` definition.

## WASI-backed randomness

The new `capricious.wasi` module provides a `Randomization` whose entropy comes from the host, via WASI, rather than from `java.util.Random`:

```scala
import capricious.*
import capricious.randomization.wasiRandomization
import capricious.wasiRandomApi  // brings the `wasi:random/random` interface into scope

stochastic:
  val n = arbitrary[Long]()   // drawn from `wasi:random/random`'s `get-random-u64`
```

When this is compiled for the JVM the given simply doesn't apply (no WASI host); when compiled and linked as a WebAssembly component it lowers to a real `wasi:random/random` import — verified end-to-end under `wasmtime`.

## Deferred `invoke`

`xenophile`'s `invoke` now materialises correctly when reached through another `inline` definition, so a library can publish an `inline given` whose WIT import only comes into being at the downstream call site (where the WebAssembly toolchain is in use). It is now a plain `inline` rather than `transparent inline`, and a zero-parameter WIT function may be invoked from a bare selection (`interface.function.invoke[R]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)