### PR TITLE
Add aviation.wasi: a WASI-backed monotonic clock

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -506,6 +506,12 @@ object aviation extends Library:
   object core extends Component(abacist.core, quantitative.units, cosmopolite.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // WASI-backed monotonic clock: a `MonotonicClock` given whose reading is a Wasm Component Model
+  // import of `wasi:clocks/monotonic-clock`, materialized by xenophile's `invoke` at the downstream
+  // (Wasm-linked) summoning site. Target-neutral `.sjsir` here; only meaningful linked as a component.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)
 
 object baroque extends Library:

--- a/lib/aviation/res/wasi/aviation/clocks.wit
+++ b/lib/aviation/res/wasi/aviation/clocks.wit
@@ -1,0 +1,7 @@
+// The subset of the WASI `monotonic-clock` interface that aviation uses to read elapsed time.
+
+package wasi:clocks@0.2.0;
+
+interface monotonic-clock {
+  now: func() -> u64;
+}

--- a/lib/aviation/src/core/aviation.MonotonicClock.scala
+++ b/lib/aviation/src/core/aviation.MonotonicClock.scala
@@ -30,105 +30,18 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package aviation
 
-export
-  aviation
-  . { am, AlexandrianCalendar, Anniversary, Apr, Aug, Base24, base24Extractable, Base60,
-      base60Extractable, Calendar, Chronometry, Clock, Clockface, CopticCalendar, CopticMonth, Date,
-      DateNumerics, DateSeparation, Day, Dec, dur,
-      Disambiguation, Duration, Endianness, EthiopianCalendar, EthiopianMonth, Feb,
-      FrenchRepublicanCalendar, FrenchRepublicanMonth, Frequency, Fri, Hebdomad, Holiday, Holidays,
-      Horology,
-      HebrewCalendar, HebrewMonth, Hour, IndianCalendar, IndianMonth, Instant, IslamicCalendar,
-      GapPolicy, IslamicMonth, Iso8601, Jan, Jul, Jun, Leap, LeapMode, LeapSeconds, Mar, May,
-      Meridiem, Minute, Moment, Mon, monotonic, Monotonic, MonotonicClock, Month, Months,
-      Monthstamp, Nov, now,
-      Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      following, occurrences, Posix, rec, Recurrence, RecurrenceError, recInterpolator,
-      RecurrenceLiteral, RecurrenceSet, Recurrent, Regime, Resolution, Rfc1123, RomanCalendar,
-      Rrule, RruleError, Tai, until, WeekdayOrdinal, within,
-      Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
-      TimeSeparation, TimeSpecificity, Timespan, Timestamp, TimestampError, Timezone, TimezoneError,
-      today, ts, tsInterpolator, Tue, tz, Tzdb, TzdbError, Wed, Week, WeekDate, Weekday, Weekdays,
-      WorkingDays, Year, Years }
+import beneficence.*
+import prepositional.*
 
-package calendars:
-  export aviation.calendars.{gregorianCalendar, julianCalendar, copticCalendar, ethiopianCalendar,
-      islamicCalendar, persianCalendar, indianCalendar, hebrewCalendar, frenchRepublicanCalendar,
-      buddhistCalendar, minguoCalendar, ordinalCalendar, papalCutover, britishCutover}
+// A `MonotonicClock` reads the monotonic system clock, which measures elapsed time from an
+// arbitrary origin (so its readings are `Instant over Monotonic`, never grounded to a calendar).
+// This is the seam through which `monotonic()` obtains its reading, letting a non-JVM backend (e.g.
+// `aviation.wasi`, using `wasi:clocks/monotonic-clock`) supply the reading instead of `nanoTime`.
+object MonotonicClock:
+  given current: MonotonicClock:
+    def apply(): Instant over Monotonic = Instant.of[Monotonic](System.nanoTime)
 
-package nonexistentLeapDays:
-  export aviation.calendars.nonexistentLeapDays.{raiseErrorsLeapDay, roundDownLeapDay,
-      roundUpLeapDay}
-
-package monthEnds:
-  export aviation.monthEnds.{clampMonthEnd, overflowMonthEnd, raiseMonthEnd}
-
-package gapPolicies:
-  export aviation.gapPolicies.{pushBackward, rejectGap}
-
-package leapModes:
-  export aviation.leapModes.exact
-
-package chronometries:
-  export aviation.chronometries.{posix, atomic}
-
-package dateFormats:
-  export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,
-      southEastAsiaDateFormat, unitedKingdomDateFormat}
-
-package endianness:
-  export aviation.dateFormats.endianness.{bigEndian, littleEndian, middleEndian}
-
-package dateNumerics:
-  export aviation.dateFormats.numerics.{fixedWidthDateNumerics, variableWidthDateNumerics}
-
-package dateSeparators:
-  export aviation.dateFormats.separators.{dotDateSeparator, hyphenDateSeparator, slashDateSeparator,
-      spaceDateSeparator}
-
-package yearFormats:
-  export aviation.dateFormats.years.{fullYears, twoDigitsYears}
-
-package weekdays:
-  export
-    aviation.dateFormats.weekdays
-    . { englishWeekdays, englishShortWeekdays, oneLetterAmbiguousWeekdays,
-        shortestUnambiguousWeekdays, twoLetterWeekdays, frenchWeekdays, germanWeekdays,
-        spanishWeekdays }
-
-package monthFormats:
-  export
-    aviation.dateFormats.months
-    . { englishMonths, englishShortMonths, numericMonths, oneLetterAmbiguousMonths,
-        twoDigitMonths, frenchMonths, germanMonths, spanishMonths }
-
-package timeFormats:
-  export
-    aviation.timeFormats
-    . { associatedPressTimeFormat, civilianTimeFormat, frenchTimeFormat, iso8601TimeFormat,
-        ledgerTimeFormat, militaryTimeFormat, railwayTimeFormat }
-
-package timespanFormats:
-  export aviation.timespanFormats.{englishRelative, frenchRelative, germanRelative, spanishRelative}
-
-package hourFormats:
-  export aviation.timeFormats.hours.{twelveHourClock, twentyFourHourClock}
-
-package meridiems:
-  export aviation.timeFormats.meridiems.{lowerMeridiem, lowerPunctuatedMeridiem, upperMeridiem,
-      upperPunctuatedMeridiem}
-
-package timeNumerics:
-  export aviation.timeFormats.numerics.{fixedWidthTimeNumerics, variableWidthTimeNumerics}
-
-package timeSeparators:
-  export aviation.timeFormats.separators.{colonTimeSeparator, dotTimeSeparator, frenchTimeSeparator,
-      noneTimeSeparator}
-
-package hebdomads:
-  export aviation.hebdomads.{europeanHebdomad, jewishHebdomad, northAmericanHebdomad}
-
-package instantDecodables:
-  export aviation.instantDecodables.{iso8601InstantDecodable, rfc1123InstantDecodable}
+abstract class MonotonicClock() extends Findable:
+  def apply(): Instant over Monotonic

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -503,10 +503,11 @@ package monthEnds:
 
 def now()(using clock: Clock): Instant over Posix = clock()
 
-// A reading of the monotonic system clock (`System.nanoTime`), for measuring elapsed time. It has
-// an arbitrary origin, so it can only be compared/subtracted with other `Monotonic` readings, never
-// grounded to a calendar instant.
-def monotonic(): Instant over Monotonic = Instant.of[Monotonic](System.nanoTime)
+// A reading of the monotonic system clock, for measuring elapsed time. It has an arbitrary origin,
+// so it can only be compared/subtracted with other `Monotonic` readings, never grounded to a
+// calendar instant. The reading is taken through a `MonotonicClock` (the JVM default reads
+// `System.nanoTime`), so a non-JVM backend can supply it instead.
+def monotonic()(using clock: MonotonicClock): Instant over Monotonic = clock()
 
 def today()(using clock: Clock, calendar: RomanCalendar, timezone: Timezone): Date =
   (now() in timezone).date

--- a/lib/aviation/src/wasi/aviation_wasi.scala
+++ b/lib/aviation/src/wasi/aviation_wasi.scala
@@ -1,0 +1,59 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package aviation
+
+import scala.annotation.nowarn
+
+import hellenism.*
+import hypotenuse.*
+import prepositional.*
+import soundness.invoke
+import xenophile.*
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for the function's module id.
+type WasiClockApi = Interface in Wit at "/aviation/clocks.wit"
+given wasiClockApi: WasiClockApi = Interface[Wit](cp"/aviation/clocks.wit")
+
+package clocks:
+  // `inline`, so the `invoke` macro expands at the downstream summoning site: the Wasm Component
+  // import (`scala.scalajs.wit.witImportCall`) only materializes in code compiled for a Wasm
+  // target, where that intrinsic is on the classpath. Summoning it requires `wasiClockApi` (and
+  // this module's WIT resource) to be visible at that site.
+  //
+  // The per-site duplication the compiler warns about is the point: the instance must materialize
+  // at the downstream summoning site, and a WASI-linked application summons it once.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasiMonotonicClock: MonotonicClock = new MonotonicClock:
+    def apply(): Instant over Monotonic =
+      Instant.of[Monotonic](Foreign["monotonic-clock", Wit].`now`.invoke[U64].bits.s64.long)

--- a/lib/aviation/src/wasi/soundness_aviation_wasi.scala
+++ b/lib/aviation/src/wasi/soundness_aviation_wasi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export aviation.{WasiClockApi, wasiClockApi}
+
+package clocks:
+  export aviation.clocks.wasiMonotonicClock


### PR DESCRIPTION
Aviation's `monotonic()` now reads its value through a `MonotonicClock` capability rather than calling `System.nanoTime` directly, and a new `aviation.wasi` module provides a `MonotonicClock` backed by the WebAssembly Component Model's `wasi:clocks/monotonic-clock` interface, so elapsed-time measurement works in a standalone WebAssembly component; as with `capricious.wasi`, the module compiles in the ordinary build with no WebAssembly-specific dependency, because the Component Model import is materialised only where the given is used in code compiled for WebAssembly.

## A seam for the monotonic clock

`monotonic()` now obtains its reading from a `MonotonicClock` given, mirroring how `now()` reads a `Clock`:

```scala
val elapsed = monotonic()   // reads the default `MonotonicClock` (JVM: `System.nanoTime`)
```

The default given reads `System.nanoTime`, so existing code is unaffected; the reading is now a swappable seam.

## WASI-backed monotonic clock

The new `aviation.wasi` module provides a `MonotonicClock` whose reading comes from the host via WASI:

```scala
import aviation.*
import aviation.clocks.wasiMonotonicClock
import aviation.wasiClockApi  // brings the `wasi:clocks/monotonic-clock` interface into scope

val elapsed = monotonic()   // reads `wasi:clocks/monotonic-clock`'s `now`
```

On the JVM the given simply doesn't apply; compiled and linked as a WebAssembly component it lowers to a real `wasi:clocks/monotonic-clock` import — verified end-to-end under `wasmtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)