### PR TITLE
Add ambience.wasi: WASI-backed environment variables

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -416,6 +416,12 @@ object ambience extends Library:
   object core extends Component(gossamer.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // WASI-backed environment: an `Environment` given whose variables come from a Wasm Component
+  // Model import of `wasi:cli/environment` `get-environment` (`list<tuple<string, string>>`),
+  // materialized by xenophile's `invoke` at the downstream (Wasm-linked) summoning site.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)
 
 object anamnesis extends Library:

--- a/lib/ambience/res/wasi/ambience/environment.wit
+++ b/lib/ambience/res/wasi/ambience/environment.wit
@@ -1,0 +1,7 @@
+// The subset of the WASI `environment` interface that ambience uses to read environment variables.
+
+package wasi:cli@0.2.0;
+
+interface environment {
+  get-environment: func() -> list<tuple<string, string>>;
+}

--- a/lib/ambience/src/wasi/ambience_wasi.scala
+++ b/lib/ambience/src/wasi/ambience_wasi.scala
@@ -1,0 +1,62 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package ambience
+
+import scala.annotation.nowarn
+
+import anticipation.*
+import hellenism.*
+import prepositional.*
+import rudiments.*
+import soundness.invoke
+import vacuous.*
+import xenophile.*
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for the function's module id.
+type WasiEnvironmentApi = Interface in Wit at "/ambience/environment.wit"
+given wasiEnvironmentApi: WasiEnvironmentApi = Interface[Wit](cp"/ambience/environment.wit")
+
+package environments:
+  // `inline`, so the `invoke` macro expands at the downstream summoning site: the Wasm Component
+  // import (`scala.scalajs.wit.witImportCall`) only materializes in code compiled for a Wasm
+  // target. `get-environment` returns `list<tuple<string, string>>`, decoded to
+  // `List[(Text, Text)]`.
+  //
+  // The per-site duplication the compiler warns about is the point: the instance must materialize
+  // at the downstream summoning site, and a WASI-linked application summons it once.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasiEnvironment: Environment = new Environment:
+    def variable(name: Text): Optional[Text] =
+      Foreign["environment", Wit].`get-environment`.invoke[List[(Text, Text)]]
+        .filter(_._1 == name).prim.let(_._2)

--- a/lib/ambience/src/wasi/soundness_ambience_wasi.scala
+++ b/lib/ambience/src/wasi/soundness_ambience_wasi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export ambience.{WasiEnvironmentApi, wasiEnvironmentApi}
+
+package environments:
+  export ambience.environments.wasiEnvironment

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -37,6 +37,7 @@ import scala.quoted.*
 import anticipation.*
 import distillate.*
 import fulminate.*
+import gossamer.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -102,21 +103,26 @@ object WasmInvoke:
     val module = prototype.module.or:
       halt(m"xenophile: $owner.$function is not addressable as a WIT import (it has no module id)")
 
-    // The result crosses the boundary via its `Decodable in Wasm` codec; its `Carrier` type is what
-    // the import returns and what `witImportCall` is told (as `classOf[Carrier]`).
-    val decodable = Expr.summon[result is Decodable in Wasm].getOrElse:
-      halt(m"xenophile: no way to read a ${TypeRepr.of[result].show} from a WIT boundary")
+    // The requested result type determines both the WIT carrier the import returns (told to
+    // `witImportCall` as `classOf[Carrier]`) and how that carrier is decoded. `deriveResult`
+    // computes the pair; the carrier for a `list<tuple<…>>` mentions the scala-wasm `Tuple2` class,
+    // which is resolved (and only ever appears) in this downstream-expanded code.
+    val (carrier, decode) = deriveResult[result]
 
-    val carrier = carrierType(decodable)
-
-    // Emit `decodable.decoded(Wasm(witImportCall(module, function, classOf[Carrier])))`. The import
-    // call is built by looking up `witImportCall` in the *downstream* classpath (the scala-wasm
-    // library), so this macro needs no dependency on it.
+    // Emit `<decode>(witImportCall(module, function, classOf[Carrier]))`. The import call is built
+    // by looking up `witImportCall` in the *downstream* classpath (the scala-wasm library), so this
+    // macro needs no dependency on it.
     val witImportCall = Symbol.requiredMethod("scala.scalajs.wit.witImportCall")
 
     // A raw class literal (not a quoted `classOf[T]`, which arrives at the backend wrapped in
     // adaptation nodes that its literal-`classOf` check rejects).
     val classOfCarrier = Literal(ClassOfConstant(carrier))
+
+    // The WIT result type as text, straight from the `.wit` definition, so the backend has the full
+    // shape (e.g. `list<tuple<string, string>>`) that `classOf` cannot carry: `classOf` erases
+    // nested type arguments, collapsing a `tuple<string, string>` to a fieldless tuple. `classOf`
+    // still supplies the (erasure-safe) IR result type.
+    val witType = Literal(StringConstant(prototype.result.text.s))
 
     // The `sigAndArgs` argument must be a `Repeated` ascribed with the tree-level repeated type
     // (`scala.<repeated>[Any]` — not `Seq[Any]`, which reads as a single sequence value and gets
@@ -124,16 +130,82 @@ object WasmInvoke:
     val repeatedAny = defn.RepeatedParamClass.typeRef.appliedTo(TypeRepr.of[Any])
 
     val varargs =
-      Typed(Repeated(List(classOfCarrier), TypeTree.of[Any]), Inferred(repeatedAny))
+      Typed(Repeated(List(classOfCarrier, witType), TypeTree.of[Any]), Inferred(repeatedAny))
 
     val callTerm =
       Apply
         ( Ref(witImportCall),
           List(Expr(module.s).asTerm, Expr(function.s).asTerm, varargs) )
 
-    val call = callTerm.asExprOf[Any]
+    decode(callTerm.asExprOf[Any]).asExprOf[result]
 
-    '{$decodable.decoded(Wasm($call))}
+  // The WIT carrier a result type crosses the boundary as, paired with a function decoding that
+  // carrier (an `Any`, the erased `witImportCall` result) back to the result. A leaf type uses its
+  // `Decodable in Wasm` codec directly; a `List[(A, B)]` is a `list<tuple<Ac, Bc>>`, carried as an
+  // `Array[scala.scalajs.wit.Tuple2[Ac, Bc]]` and decoded element-wise.
+  private def deriveResult[result: Type](using quotes: Quotes)
+  :   (quotes.reflect.TypeRepr, Expr[Any] => Expr[Any]) =
+
+    import quotes.reflect.*
+
+    def leaf(tpe: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      tpe.asType.absolve match
+        case '[leafType] =>
+          val decodable = Expr.summon[leafType is Decodable in Wasm].getOrElse:
+            halt(m"xenophile: no way to read a ${tpe.show} from a WIT boundary")
+
+          (carrierType(decodable), call => '{$decodable.decoded(Wasm($call))})
+
+    val listClass = Symbol.requiredClass("scala.collection.immutable.List")
+
+    // A `list<tuple<Ac, Bc>>` (Scala `List[(A, B)]`), if that is the shape of the result.
+    def listOfPairs(leftType: TypeRepr, rightType: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      leftType.asType.absolve match case '[left] => rightType.asType.absolve match
+        case '[right] =>
+          val (leftCarrier, leftDecode) = leaf(leftType)
+          val (rightCarrier, rightDecode) = leaf(rightType)
+
+          // The carrier element is scala-wasm's `Tuple2`, whose name is resolved here (downstream),
+          // so it never appears in `xenophile.wasm`'s own (scala-wasm-free) compilation.
+          val witTuple2 = Symbol.requiredClass("scala.scalajs.wit.Tuple2")
+          val tupleCarrier = witTuple2.typeRef.appliedTo(List(leftCarrier, rightCarrier))
+          val arrayCarrier = defn.ArrayClass.typeRef.appliedTo(tupleCarrier)
+          val pairType = TypeRepr.of[(left, right)]
+
+          val decode: Expr[Any] => Expr[Any] = call =>
+            // Each element is a `scala.scalajs.wit.Tuple2`; read `_1`/`_2`, decode them, and build
+            // a Scala `(left, right)`. Done through a reflective `map` because the element type is
+            // not nameable in this module.
+            val method = MethodType(List("tuple"))(_ => List(TypeRepr.of[Any]), _ => pairType)
+
+            val mapper = Lambda(Symbol.spliceOwner, method, (_, params) =>
+              val tuple = TypeApply(Select.unique(params.head.asInstanceOf[Term], "asInstanceOf"),
+                  List(Inferred(tupleCarrier)))
+
+              val leftValue = leftDecode(Select.unique(tuple, "_1").asExprOf[Any])
+              val rightValue = rightDecode(Select.unique(tuple, "_2").asExprOf[Any])
+              '{(${leftValue.asExprOf[left]}, ${rightValue.asExprOf[right]})}.asTerm)
+
+            val wrapped =
+              '{scala.collection.immutable.ArraySeq.unsafeWrapArray($call.asInstanceOf[Array[Any]])}
+
+            val mapped = Select.overloaded(wrapped.asTerm, "map", List(pairType), List(mapper))
+            Select.unique(mapped, "toList").asExprOf[Any]
+
+          (arrayCarrier, decode)
+
+    TypeRepr.of[result].dealias match
+      case AppliedType(list, List(element)) if list.typeSymbol == listClass =>
+        element.dealias match
+          case AppliedType(tuple, List(leftType, rightType))
+          if tuple.typeSymbol == defn.TupleClass(2) =>
+            listOfPairs(leftType, rightType)
+
+          case _ =>
+            leaf(TypeRepr.of[result])
+
+      case _ =>
+        leaf(TypeRepr.of[result])
 
   // The `Carrier` type of a summoned `Encodable`/`Decodable in Wasm` codec, read from the `Carrier`
   // refinement member of the codec's (precise) type.


### PR DESCRIPTION
Ambience gains a `wasiEnvironment` given that reads environment variables from the WebAssembly Component Model's `wasi:cli/environment` interface, so code using `Environment` runs in a standalone WebAssembly component; as with the other `.wasi` modules it compiles in the ordinary build with no WebAssembly-specific dependency, because the Component Model import materialises only where the given is used in code compiled for WebAssembly. Supporting this, Xenophile's `invoke` now handles WIT `list<tuple<…>>` results (decoded to `List[(A, B)]`), the first non-scalar Component Model result type it can read.

## WASI-backed environment

```scala
import ambience.*
import ambience.environments.wasiEnvironment
import ambience.wasiEnvironmentApi  // brings the `wasi:cli/environment` interface into scope

val home = summon[Environment].variable(t"HOME")
```

On the JVM the given doesn't apply; compiled and linked as a WebAssembly component it lowers to a real `wasi:cli/environment` `get-environment` import — verified end-to-end under `wasmtime`.

## `list<tuple<…>>` results in `invoke`

`invoke` can now read a WIT `list<tuple<A, B>>` result as a Scala `List[(A, B)]`. The WIT result type is conveyed to the WebAssembly backend as text rather than only through `classOf`, since `classOf` erases the nested type arguments such a result needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)