### PR TITLE
Add wss:// (TLS) support and an Autobahn client harness to Perihelion

### DIFF
--- a/lib/coaxial/src/core/coaxial.SecureEndpoint.scala
+++ b/lib/coaxial/src/core/coaxial.SecureEndpoint.scala
@@ -32,70 +32,41 @@
                                                                                                   */
 package coaxial
 
-import java.io as ji
-import java.nio.ByteBuffer
-import java.nio.channels as jnc
+import java.net as jn
+import java.util as ju
+import javax.net.ssl as jns
 
 import anticipation.*
-import rudiments.*
+import gigantism.*
+import urticose.*
 import vacuous.*
 
-object Duplex:
-  // Wraps a blocking `InputStream`/`OutputStream` pair — the shape a socket that has no
-  // `SocketChannel` exposes (e.g. an `SSLSocket`). `shutdown` closes the underlying
-  // resource. The read side blocks in `read` and copies each fill; EOF (`-1`) ends the
-  // stream. The stream/write shape mirrors `channel` and `Serviceable`'s socket path.
-  def streams(in: ji.InputStream, out: ji.OutputStream)(shutdown: () => Unit): Duplex = new Duplex:
-    private val buffer = new Array[Byte](65536)
+// A secure (TLS) TCP endpoint — a `host:port` reached over TLS, the counterpart of the
+// plaintext `Endpoint[TcpPort]`. Its `Connectable` opens an `SSLSocket` (trust and keys
+// from `Tls.context`, or the system default), sets SNI to `host`, verifies the peer
+// hostname unless `Tls.verify` is off, then presents the socket's streams as a `Duplex`.
+object SecureEndpoint:
+  given connectable: (Online, Every[SocketOption.Tcp], Tls) => SecureEndpoint is Connectable:
+    def connect(endpoint: SecureEndpoint, interface: Optional[MacAddress]): Duplex =
+      val tls = summon[Tls]
+      val context = tls.context.or(jns.SSLContext.getDefault.nn)
+      val socket = context.getSocketFactory.nn.createSocket().nn.asInstanceOf[jns.SSLSocket]
+      configure(socket, summon[Every[SocketOption.Tcp]].values)
 
-    def stream: Stream[Data] =
-      def recur(): Stream[Data] = in.read(buffer) match
-        case -1    => Stream()
-        case count => buffer.take(count).immutable(using Unsafe) #:: recur()
+      interface.let(interfaceFor(_)).let(bindAddress(_)).let: local =>
+        socket.bind(jn.InetSocketAddress(local, 0))
 
-      recur()
+      // SNI lets the server select its certificate; endpoint identification then checks
+      // that certificate against the hostname (skipped only when verification is off).
+      val params = socket.getSSLParameters.nn
+      params.setServerNames(ju.List.of(jns.SNIHostName(endpoint.host.s)))
+      if tls.verify then params.setEndpointIdentificationAlgorithm("HTTPS")
+      socket.setSSLParameters(params)
 
-    def send(data: Stream[Data]): Unit =
-      data.each: bytes =>
-        out.write(bytes.mutable(using Unsafe))
-        out.flush()
+      socket.connect(jn.InetSocketAddress(endpoint.host.s, endpoint.port))
+      socket.startHandshake()
 
-    def close(): Unit = shutdown()
+      Duplex.streams(socket.getInputStream.nn, socket.getOutputStream.nn): () =>
+        socket.close()
 
-  // Wraps a blocking `SocketChannel` (TCP or Unix-domain). The read side fills a
-  // reusable buffer and blocks in `read`; EOF (`-1`) terminates the stream.
-  def channel(socketChannel: jnc.SocketChannel): Duplex = new Duplex:
-    private val buffer = ByteBuffer.allocate(65536).nn
-
-    def stream: Stream[Data] =
-      def recur(): Stream[Data] =
-        buffer.clear()
-
-        socketChannel.read(buffer) match
-          case -1 => Stream()
-
-          case _ =>
-            buffer.flip()
-            val array = new Array[Byte](buffer.remaining)
-            buffer.get(array)
-            array.immutable(using Unsafe) #:: recur()
-
-      recur()
-
-    def send(data: Stream[Data]): Unit =
-      data.each: bytes =>
-        val out = ByteBuffer.wrap(bytes.mutable(using Unsafe)).nn
-        while out.hasRemaining do socketChannel.write(out)
-
-    def close(): Unit = socketChannel.close()
-
-// A persistent, bidirectional connection: unlike `Serviceable`'s request/response
-// `transmit`/`receive` (which shuts down the output side after sending), a `Duplex`
-// stays open for repeated, independent reads and writes — the shape a multiplexing
-// protocol such as HTTP/2 needs, where one side both streams requests and receives
-// server-initiated frames concurrently. Reads block until data arrives or the peer
-// closes; `send` may be called many times and never half-closes the connection.
-trait Duplex:
-  def stream: Stream[Data]
-  def send(data: Stream[Data]): Unit
-  def close(): Unit
+case class SecureEndpoint(host: Text, port: Int)

--- a/lib/coaxial/src/core/coaxial.Tls.scala
+++ b/lib/coaxial/src/core/coaxial.Tls.scala
@@ -32,70 +32,17 @@
                                                                                                   */
 package coaxial
 
-import java.io as ji
-import java.nio.ByteBuffer
-import java.nio.channels as jnc
+import javax.net.ssl.SSLContext
 
-import anticipation.*
-import rudiments.*
 import vacuous.*
 
-object Duplex:
-  // Wraps a blocking `InputStream`/`OutputStream` pair — the shape a socket that has no
-  // `SocketChannel` exposes (e.g. an `SSLSocket`). `shutdown` closes the underlying
-  // resource. The read side blocks in `read` and copies each fill; EOF (`-1`) ends the
-  // stream. The stream/write shape mirrors `channel` and `Serviceable`'s socket path.
-  def streams(in: ji.InputStream, out: ji.OutputStream)(shutdown: () => Unit): Duplex = new Duplex:
-    private val buffer = new Array[Byte](65536)
+// Configuration for a TLS client connection (a `SecureEndpoint`). `context` supplies the
+// trust and key material — `Unset` means the JVM default `SSLContext` (the system trust
+// store), which is what you want for a public `wss`/HTTPS peer. `verify` toggles hostname
+// verification (RFC 2818 endpoint identification); it is ON by default and should only be
+// turned off for a self-signed peer whose certificate you already trust out of band. The
+// default `given` is fully secure.
+object Tls:
+  given Tls = Tls()
 
-    def stream: Stream[Data] =
-      def recur(): Stream[Data] = in.read(buffer) match
-        case -1    => Stream()
-        case count => buffer.take(count).immutable(using Unsafe) #:: recur()
-
-      recur()
-
-    def send(data: Stream[Data]): Unit =
-      data.each: bytes =>
-        out.write(bytes.mutable(using Unsafe))
-        out.flush()
-
-    def close(): Unit = shutdown()
-
-  // Wraps a blocking `SocketChannel` (TCP or Unix-domain). The read side fills a
-  // reusable buffer and blocks in `read`; EOF (`-1`) terminates the stream.
-  def channel(socketChannel: jnc.SocketChannel): Duplex = new Duplex:
-    private val buffer = ByteBuffer.allocate(65536).nn
-
-    def stream: Stream[Data] =
-      def recur(): Stream[Data] =
-        buffer.clear()
-
-        socketChannel.read(buffer) match
-          case -1 => Stream()
-
-          case _ =>
-            buffer.flip()
-            val array = new Array[Byte](buffer.remaining)
-            buffer.get(array)
-            array.immutable(using Unsafe) #:: recur()
-
-      recur()
-
-    def send(data: Stream[Data]): Unit =
-      data.each: bytes =>
-        val out = ByteBuffer.wrap(bytes.mutable(using Unsafe)).nn
-        while out.hasRemaining do socketChannel.write(out)
-
-    def close(): Unit = socketChannel.close()
-
-// A persistent, bidirectional connection: unlike `Serviceable`'s request/response
-// `transmit`/`receive` (which shuts down the output side after sending), a `Duplex`
-// stays open for repeated, independent reads and writes — the shape a multiplexing
-// protocol such as HTTP/2 needs, where one side both streams requests and receives
-// server-initiated frames concurrently. Reads block until data arrives or the peer
-// closes; `send` may be called many times and never half-closes the connection.
-trait Duplex:
-  def stream: Stream[Data]
-  def send(data: Stream[Data]): Unit
-  def close(): Unit
+case class Tls(context: Optional[SSLContext] = Unset, verify: Boolean = true)

--- a/lib/coaxial/src/core/soundness_coaxial_core.scala
+++ b/lib/coaxial/src/core/soundness_coaxial_core.scala
@@ -36,8 +36,8 @@ export
   coaxial
   . { Bindable, BindError, Connectable, Connection, ConnectionError, Control, DomainSocket,
       DomainSocketEndpoint, duplex, Duplex, Duplexable, exchange, Ingressive, listen, Packet,
-      Routable, Sender, Serviceable, SocketEvent, SocketOption, SocketService, transceive,
-      Transmissible, transmit, UdpResponse }
+      Routable, SecureEndpoint, Sender, Serviceable, SocketEvent, SocketOption, SocketService, Tls,
+      transceive, Transmissible, transmit, UdpResponse }
 
 package socketOptions:
   export

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -123,8 +123,9 @@ extension [self](value: self)
 
 // A `ws://` or `wss://` URL. `Url` decoding is scheme-generic, so a `WsUrl` parses with
 // no bespoke scheme machinery; the port defaults to 80 (`ws`) or 443 (`wss`) when the
-// authority omits it. `wss://` parses but is not yet connectable (see `wsClient`),
-// pending client-side TLS.
+// authority omits it. A `wss://` connection is opened over TLS (via Coaxial's
+// `SecureEndpoint`), configured by the `Tls` capability in scope (system trust store and
+// hostname verification by default).
 type WsUrl = Url["ws" | "wss"]
 
 // Split a byte stream at the first CRLFCRLF: returns the header block (up to and
@@ -166,6 +167,7 @@ given wsClient: ( Online,
                   Monitor,
                   Probate,
                   Every[SocketOption.Tcp],
+                  Tls,
                   Tactic[WebsocketError],
                   Tactic[HttpResponseError],
                   Tactic[PortError] )
@@ -175,15 +177,23 @@ given wsClient: ( Online,
   type Connection = WsConnection
 
   def connect(url: WsUrl, interface: Optional[MacAddress]): WsConnection =
-    if url.scheme.name == t"wss" then
-      abort(WebsocketError(WebsocketError.Reason.Handshake(t"wss:// (TLS) is not yet supported")))
+    val secure: Boolean = url.scheme.name == t"wss"
 
     val host: Host = url.host.or:
       abort(WebsocketError(WebsocketError.Reason.Handshake(t"the URL had no host")))
 
-    val portNumber: Int = url.authority.lay(80)(_.port.or(80))
-    val endpoint: Endpoint[TcpPort] = Endpoint(host.show, Port[Tcp](portNumber))
-    val duplex: Duplex = summon[Endpoint[TcpPort] is Connectable].connect(endpoint, interface)
+    val defaultPort: Int = if secure then 443 else 80
+    val portNumber: Int = url.authority.lay(defaultPort)(_.port.or(defaultPort))
+
+    // `wss` connects over TLS (`SecureEndpoint`), `ws` over plain TCP; everything after is
+    // transport-agnostic, over the `Duplex`.
+    val duplex: Duplex =
+      if secure then
+        val endpoint = SecureEndpoint(host.show, portNumber)
+        summon[SecureEndpoint is Connectable].connect(endpoint, interface)
+      else
+        val endpoint = Endpoint(host.show, Port[Tcp](portNumber))
+        summon[Endpoint[TcpPort] is Connectable].connect(endpoint, interface)
 
     // RFC 6455 §4.1: a fresh 16-byte nonce, Base64-encoded, is the `Sec-WebSocket-Key`;
     // the server's `Sec-WebSocket-Accept` must echo `base64(sha1(key ++ magic))`.

--- a/lib/perihelion/src/test/perihelion.AutobahnClient.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnClient.scala
@@ -1,0 +1,95 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.54.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package perihelion
+
+import soundness.*
+
+import logging.silentLogging
+import internetAccess.online
+import strategies.throwUnsafely
+import threading.virtualThreading
+import probates.awaitProbate
+
+// A conformance harness for driving the WebSocket *client* against the Autobahn|Testsuite
+// `fuzzingserver` — the counterpart of `AutobahnServer` (which drives the server against a
+// `fuzzingclient`). Start `wstest -m fuzzingserver` (listening on 9001 by default), then run
+// `java -cp <test-classpath> perihelion.AutobahnClient [host] [port]` and read its HTML report.
+// Not part of the test suite — it only runs when invoked directly.
+//
+// The fuzzingserver drives every exchange, so the client is a pure echo: for each case it
+// connects, replies to every message verbatim, and answers Ping/Close per the RFC (handled by
+// the shared `Reader`). It drives that `Reader`/`Channel` directly rather than through Coaxial's
+// `exchange`, because `exchange` flattens each message to bytes — losing the Text/Binary frame
+// type an echo must preserve — and has no hook to send an RFC close code on a protocol violation.
+object AutobahnClient:
+  private val agent: Text = t"soundness-perihelion"
+
+  def main(args: Array[String]): Unit =
+    val host: Text = (if args.length > 0 then args(0) else "localhost").tt
+    val port: Int = if args.length > 1 then Integer.parseInt(args(1)) else 9001
+
+    supervise:
+      // Open one connection, hand each inbound message to `consume`, and always close cleanly;
+      // a protocol violation surfaces as a `WebsocketError` and is answered with its close code.
+      def session(path: Text)(consume: Channel => perihelion.Message => Unit): Unit =
+        val url = t"ws://$host:$port$path".decode[WsUrl]
+        val connection = summon[WsUrl is Duplexable].connect(url, Unset)
+        given Masking = connection.masking
+
+        try
+          recover:
+            case error: WebsocketError =>
+              safely(connection.channel.close(error.reason.closeCode))
+
+          . protect:
+              Reader(() => connection.inbound, connection.channel).messages.each:
+                consume(connection.channel)(_)
+
+        finally
+          connection.channel.stop()
+          safely(connection.pump.attend())
+          connection.duplex.close()
+
+      var count: Int = 0
+
+      // How many cases does the fuzzingserver have? It sends the count as one Text message.
+      session(t"/getCaseCount"): channel =>
+        case perihelion.Message.Text(text) => count = safely(Integer.parseInt(text.s.trim)).or(count)
+        case _                             => ()
+
+      // Echo each case verbatim, preserving the Text/Binary frame type.
+      for index <- 1 to count do
+        safely(session(t"/runCase?case=$index&agent=$agent")(channel => channel.send(_)))
+
+      // Ask the server to write its reports.
+      safely(session(t"/updateReports?agent=$agent")(_ => _ => ()))

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -59,6 +59,41 @@ object Tests extends Suite(m"Perihelion tests"):
       socket.close()
       port
 
+    // A throwaway self-signed `CN=localhost` certificate (via the JDK's keytool) and the
+    // matching contexts: a server context that presents it, and a trust-all client context
+    // (used with `verify = false`, since the cert carries no SAN). Mirrors the scintillate
+    // TLS test.
+    def tlsContexts(): (javax.net.ssl.SSLContext, javax.net.ssl.SSLContext) =
+      val dir = java.nio.file.Files.createTempDirectory("perihelion-tls").nn
+      val path = dir.resolve("test.p12").nn.toString.nn
+
+      val keytool = java.lang.ProcessBuilder("keytool", "-genkeypair", "-alias", "test",
+          "-keyalg", "RSA", "-keysize", "2048", "-validity", "1", "-storetype", "PKCS12",
+          "-keystore", path, "-storepass", "changeit", "-dname", "CN=localhost")
+
+      keytool.redirectErrorStream(true)
+      keytool.redirectOutput(java.lang.ProcessBuilder.Redirect.DISCARD)
+      keytool.start().nn.waitFor()
+
+      val password = "changeit".toCharArray.nn
+      val keystore = java.security.KeyStore.getInstance("PKCS12").nn
+      keystore.load(java.io.FileInputStream(path), password)
+      val keyManagers = javax.net.ssl.KeyManagerFactory.getInstance("SunX509").nn
+      keyManagers.init(keystore, password)
+      val serverContext = javax.net.ssl.SSLContext.getInstance("TLS").nn
+      serverContext.init(keyManagers.getKeyManagers, null, null)
+
+      val trustManager = new javax.net.ssl.X509TrustManager:
+        type Certs = Array[java.security.cert.X509Certificate | Null] | Null
+        def getAcceptedIssuers: Certs = scala.Array.empty[java.security.cert.X509Certificate | Null]
+        def checkClientTrusted(chain: Certs, kind: String | Null): Unit = ()
+        def checkServerTrusted(chain: Certs, kind: String | Null): Unit = ()
+
+      val clientContext = javax.net.ssl.SSLContext.getInstance("TLS").nn
+      clientContext.init(null, scala.Array(trustManager), java.security.SecureRandom())
+
+      (serverContext, clientContext)
+
     // Build a masked client frame (clients must mask).
     def clientFrame(opcode: Int, payload: Array[Byte]): Array[Byte] =
       val mask = Array[Byte](0x12, 0x34, 0x56, 0x78)
@@ -400,12 +435,26 @@ object Tests extends Suite(m"Perihelion tests"):
 
         . assert(_ == 8)
 
-        test(m"A wss:// URL is rejected pending client TLS support"):
-          val url = t"wss://example.com/".decode[WsUrl]
+        // The whole client stack over TLS: a self-signed `wss://` echo server, and a client
+        // that trusts it (verification off for the self-signed cert). Proves the TLS
+        // `Duplex` carries the handshake and framed, masked messages.
+        test(m"A wss:// client completes a TLS handshake and round-trips a message"):
+          val (serverContext, clientContext) = tlsContexts()
+          val port = freePort()
 
-          capture[WebsocketError](url.exchange(())((_: perihelion.Message) => Terminate)).reason
-          match
-            case WebsocketError.Reason.Handshake(_) => true
-            case _                                  => false
+          val server = SocketServer(port, ssl = serverContext).handle:
+            webSocket(): (ping: Ping over Json) =>
+              Reply(Ping(ping.value + 1).over[Json], ())
 
-        . assert(_ == true)
+          given Tls = Tls(clientContext, verify = false)
+          val url = t"wss://localhost:$port/".decode[WsUrl]
+
+          val handle: (state: Int) ?=> (Ping over Json) => Control[Int] =
+            ping => Conclude(Ping(0).over[Json], ping.value)
+
+          val value = url.transceive(0)(handle)(_.send(Ping(7).over[Json]))
+
+          server.cancel()
+          value
+
+        . assert(_ == 8)


### PR DESCRIPTION
Completes the two items deferred from #1465. `wss://` WebSocket connections now work, over a reusable Coaxial TLS transport, and there's a client-side Autobahn conformance harness to complement the server's.

### `wss://` support

A `wss://` URL now connects over TLS with hostname verification — no API change; the same `exchange`/`transceive` calls work:

```scala
t"wss://example.com/socket".decode[WsUrl].transceive(state) { reply => … } { _.send(request) }
```

TLS is added as a first-class Coaxial transport, reusable beyond WebSockets:
- `Duplex.streams(in, out)(close)` — the missing InputStream/OutputStream-backed `Duplex` (for sockets with no `SocketChannel`, such as `SSLSocket`).
- `SecureEndpoint(host, port)` — a `Connectable` that opens an `SSLSocket` with SNI and RFC 2818 hostname verification.
- `Tls(context, verify)` — trust/verification config, with a fully-secure default `given` (system trust store, verification on). `verify = false` / a custom `SSLContext` covers self-signed or pinned peers.

### Autobahn client harness

A standalone `AutobahnClient` main (mirror of `AutobahnServer`) drives the client against Autobahn's `fuzzingserver` — run manually via `java -cp <test-classpath> perihelion.AutobahnClient [host] [port]`.

### Known limitation

The client still doesn't emit graceful RFC close codes on inbound protocol violations when driven through Coaxial's `exchange` (the harness drives the `Reader`/`Channel` directly to work around this, and to preserve the Text/Binary frame type that `exchange` flattens away). Full `exchange`-level conformance — unifying close-on-violation into the shared `Reader` — remains a follow-up.