### PR TITLE
Add a WASI working-directory backend to ambience

### DIFF
--- a/lib/ambience/res/wasi/ambience/environment.wit
+++ b/lib/ambience/res/wasi/ambience/environment.wit
@@ -1,7 +1,9 @@
-// The subset of the WASI `environment` interface that ambience uses to read environment variables.
+// The subset of the WASI `environment` interface that ambience uses: environment variables and the
+// initial working directory.
 
 package wasi:cli@0.2.0;
 
 interface environment {
   get-environment: func() -> list<tuple<string, string>>;
+  initial-cwd: func() -> option<string>;
 }

--- a/lib/ambience/src/wasi/ambience_wasi.scala
+++ b/lib/ambience/src/wasi/ambience_wasi.scala
@@ -35,6 +35,7 @@ package ambience
 import scala.annotation.nowarn
 
 import anticipation.*
+import gossamer.*
 import hellenism.*
 import prepositional.*
 import rudiments.*
@@ -60,3 +61,11 @@ package environments:
     def variable(name: Text): Optional[Text] =
       Foreign["environment", Wit].`get-environment`.invoke[List[(Text, Text)]]
         .filter(_._1 == name).prim.let(_._2)
+
+package workingDirectories:
+  // The component's initial working directory, from `wasi:cli/environment` `initial-cwd`
+  // (`option<string>` → `Optional[Text]`); a component without one falls back to `/`.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasiWorkingDirectory: WorkingDirectory = new WorkingDirectory:
+    def directory(): Text =
+      Foreign["environment", Wit].`initial-cwd`.invoke[Optional[Text]].or(t"/")

--- a/lib/ambience/src/wasi/soundness_ambience_wasi.scala
+++ b/lib/ambience/src/wasi/soundness_ambience_wasi.scala
@@ -36,3 +36,6 @@ export ambience.{WasiEnvironmentApi, wasiEnvironmentApi}
 
 package environments:
   export ambience.environments.wasiEnvironment
+
+package workingDirectories:
+  export ambience.workingDirectories.wasiWorkingDirectory

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -37,7 +37,6 @@ import scala.quoted.*
 import anticipation.*
 import distillate.*
 import fulminate.*
-import gossamer.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -194,7 +193,28 @@ object WasmInvoke:
 
           (arrayCarrier, decode)
 
+    val optionClass = Symbol.requiredClass("java.util.Optional")
+
+    // An `option<T>` (Scala `Optional[T]` = `Unset | T`), carried as a `java.util.Optional[Tc]`.
+    def optionOf(inner: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      val (innerCarrier, innerDecode) = leaf(inner)
+      val carrier = optionClass.typeRef.appliedTo(List(innerCarrier))
+
+      // `java.util.Optional` is nameable here, so ordinary quotes suffice (no reflective decode);
+      // an absent value becomes `Unset`.
+      val decode: Expr[Any] => Expr[Any] = call =>
+        '{  val option = $call.asInstanceOf[java.util.Optional[Any]]
+            if option.isPresent then ${innerDecode('{option.get})} else Unset  }
+
+      (carrier, decode)
+
     TypeRepr.of[result].dealias match
+      case OrType(left, right) if left =:= TypeRepr.of[Unset] =>
+        optionOf(right)
+
+      case OrType(left, right) if right =:= TypeRepr.of[Unset] =>
+        optionOf(left)
+
       case AppliedType(list, List(element)) if list.typeSymbol == listClass =>
         element.dealias match
           case AppliedType(tuple, List(leftType, rightType))


### PR DESCRIPTION
Ambience gains a `wasiWorkingDirectory` given that reads the component's initial working directory from the WebAssembly Component Model's `wasi:cli/environment` interface, complementing the environment-variable backend; as with the others it compiles in the ordinary build with no WebAssembly-specific dependency. Supporting this, Xenophile's `invoke` now reads WIT `option<T>` results (as `Optional[T]`).

## WASI-backed working directory

```scala
import ambience.*
import ambience.workingDirectories.wasiWorkingDirectory
import ambience.wasiEnvironmentApi  // brings the `wasi:cli/environment` interface into scope

val cwd = summon[WorkingDirectory].directory()
```

The directory comes from `wasi:cli/environment`'s `initial-cwd`; a component that has none falls back to `/`. On the JVM the given doesn't apply. Verified end-to-end under `wasmtime`.

## `option<T>` results in `invoke`

`invoke` can now read a WIT `option<T>` result as a Scala `Optional[T]` — an absent value decodes to `Unset`. This completes the set of "simple" Component Model result shapes it handles (scalars, `list`, `tuple`, and now `option`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)