### PR TITLE
Rename Coaxial's reactive exchange to react, and transceive to exchange

### DIFF
--- a/lib/coaxial/src/core/coaxial.Duplexable.scala
+++ b/lib/coaxial/src/core/coaxial.Duplexable.scala
@@ -35,7 +35,7 @@ package coaxial
 // A `Serviceable` whose connection is full-duplex and persistent: `transmit` may be
 // called repeatedly, and concurrently with `receive` and with itself, without ever
 // half-closing the connection. Only such a transport can send *proactively* — before
-// the first inbound message, or from another task — so `exchange`'s `Sender`-carrying
-// overload is offered only for a `Duplexable`. A request/response `Serviceable` (which
-// may shut its output down after transmitting) is deliberately not one.
+// the first inbound message, or from another task — so `exchange` (which hands the caller
+// a `Sender`) is offered only for a `Duplexable`, while a request/response `Serviceable`
+// (which may shut its output down after transmitting) has only the reactive `react`.
 trait Duplexable extends Serviceable

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -103,7 +103,10 @@ extension [endpoint: {Serviceable as serviceable, Showable}](endpoint: endpoint)
     serviceable.receive(connection)
 
 
-  def exchange[state](initialState: state)[message: Ingressive]
+  // React to each inbound message with a `Control`: `Reply`/`Conclude` send a response,
+  // `Continue` waits for more, `Terminate` stops. A `Serviceable` can only respond, never
+  // initiate; a `Duplexable` additionally offers `exchange`, which can also send proactively.
+  def react[state](initialState: state)[message: Ingressive]
     ( handle: (state: state) ?=> message => Control[state] )
   :   state logs SocketEvent =
 
@@ -127,14 +130,14 @@ extension [endpoint: {Serviceable as serviceable, Showable}](endpoint: endpoint)
 
 
 extension [endpoint: {Duplexable as duplexable, Showable}](endpoint: endpoint)
-  // A full-duplex `exchange`: as soon as the connection opens — before the `handle` loop
+  // A full-duplex exchange: as soon as the connection opens — before the `handle` loop
   // begins — `interact` is handed a `Sender`, so a client can send *proactively* (send
   // first, or push from a task it spawns), concurrently with the reactive `handle` loop
   // (which still replies via `Control`). `handle` precedes `interact` so the message type
   // is fixed by the (annotated) handler. Available only for a `Duplexable` transport,
   // whose `transmit` is safe to call concurrently; a request/response `Serviceable` has
-  // only the reactive `exchange`.
-  def transceive[state](initialState: state)[message: {Ingressive, Transmissible}]
+  // only the reactive `react`.
+  def exchange[state](initialState: state)[message: {Ingressive, Transmissible}]
     ( handle: (state: state) ?=> message => Control[state] )
     ( interact: Sender[message] => Unit )
   :   state logs SocketEvent =

--- a/lib/coaxial/src/core/soundness_coaxial_core.scala
+++ b/lib/coaxial/src/core/soundness_coaxial_core.scala
@@ -36,8 +36,8 @@ export
   coaxial
   . { Bindable, BindError, Connectable, Connection, ConnectionError, Control, DomainSocket,
       DomainSocketEndpoint, duplex, Duplex, Duplexable, exchange, Ingressive, listen, Packet,
-      Routable, SecureEndpoint, Sender, Serviceable, SocketEvent, SocketOption, SocketService, Tls,
-      transceive, Transmissible, transmit, UdpResponse }
+      react, Routable, SecureEndpoint, Sender, Serviceable, SocketEvent, SocketOption,
+      SocketService, Tls, Transmissible, transmit, UdpResponse }
 
 package socketOptions:
   export

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -32,11 +32,11 @@
                                                                                                   */
 package coaxial
 
-// The `transmit`, `listen`, `exchange` and `duplex` extensions are defined in this
+// The `transmit`, `listen`, `react` and `duplex` extensions are defined in this
 // package, so they are already in scope; re-importing them through `soundness`
 // would make the two same-shaped `transmit` overloads (from `Serviceable` and
 // `Routable`) ambiguous, so they are excluded from the wildcard.
-import soundness.{transmit as _, listen as _, exchange as _, duplex as _, *}
+import soundness.{transmit as _, listen as _, react as _, duplex as _, *}
 
 import charEncoders.utf8Encoder
 import charDecoders.utf8Decoder
@@ -195,11 +195,11 @@ object Tests extends Suite(m"Coaxial tests"):
         . assert(_ == t"ping")
 
       suite(m"TCP server and client"):
-        test(m"A client exchange receives the server's pushed message"):
+        test(m"A client reacts to the server's pushed message"):
           val port = Port[Tcp]()
           val server = port.listen[Data](socket => ascii(t"greeting"))
 
-          val received: Data = port.exchange(Data())[Data]: message =>
+          val received: Data = port.react(Data())[Data]: message =>
             Conclude(ascii(t""), message)
 
           bytes(received).also(server.stop())

--- a/lib/perihelion/src/core/perihelion.WsConnection.scala
+++ b/lib/perihelion/src/core/perihelion.WsConnection.scala
@@ -39,8 +39,8 @@ import parasite.*
 // A live WebSocket client connection: the underlying byte `Duplex`, the outgoing frame
 // `Channel` (masking each frame with `Masking.Client`), the reassembled inbound frame
 // stream left after the `101` handshake, and the background pump copying spooled frames
-// onto the socket. It is the `Connection` type of the `WsUrl is Serviceable` instance
-// (`wsClient`), so a client is driven by Coaxial's `exchange`.
+// onto the socket. It is the `Connection` type of the `WsUrl is Duplexable` instance
+// (`wsClient`), so a client is driven by Coaxial's `react`/`exchange`.
 class WsConnection
   ( private[perihelion] val duplex:  Duplex,
     private[perihelion] val channel: Channel,

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -71,7 +71,7 @@ private type RawMessage[message] <: Boolean = message match
   case _       => false
 
 // Handle an upgraded connection as a stateful WebSocket message loop, mirroring
-// Coaxial's `exchange`. Each reassembled message is decoded to the handler's
+// Coaxial's `react`. Each reassembled message is decoded to the handler's
 // `message` type and passed to `handle` with the current `state`, returning a
 // `Control`. The message type is inferred from the handler's parameter, so it is
 // usually annotated there: the raw `Message` (text or binary) with `(message:
@@ -153,11 +153,11 @@ private def readHandshake(chunks: Stream[Data], acc: Data): (Data, Stream[Data])
     readHandshake(chunks.tail, acc ++ chunks.head)
 
 // Makes a `WsUrl` a Coaxial client transport, so a WebSocket client is just Coaxial's
-// own client loop: `url.exchange(initialState) { message => … }`, symmetric with the
+// own client loop: `url.react(initialState) { message => … }`, symmetric with the
 // server's `webSocket(initial) { … }`. It is a `Duplexable` (not merely a `Serviceable`)
-// because its `transmit` spools through a thread-safe `Channel`, so Coaxial's `transceive`
-// (the `Sender`-carrying, full-duplex counterpart of `exchange`) also works — a client can
-// send proactively (`url.transceive(state) { sender => sender.send(request) } { reply => … }`),
+// because its `transmit` spools through a thread-safe `Channel`, so Coaxial's `exchange`
+// (the `Sender`-carrying, full-duplex counterpart of `react`) also works — a client can
+// send proactively (`url.exchange(state) { reply => … } { sender => sender.send(request) }`),
 // not only in reply. `connect` opens the TCP connection and performs the RFC 6455 handshake;
 // `receive` runs the shared `Reader` (Ping/Pong and Close handled there) and yields one
 // reassembled message per element; `transmit` masks and spools at the `Channel` boundary.

--- a/lib/perihelion/src/test/perihelion.AutobahnClient.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnClient.scala
@@ -46,11 +46,11 @@ import probates.awaitProbate
 // `java -cp <test-classpath> perihelion.AutobahnClient [host] [port]` and read its HTML report.
 // Not part of the test suite — it only runs when invoked directly.
 //
-// The fuzzingserver drives every exchange, so the client is a pure echo: for each case it
+// The fuzzingserver drives every interaction, so the client is a pure echo: for each case it
 // connects, replies to every message verbatim, and answers Ping/Close per the RFC (handled by
 // the shared `Reader`). It drives that `Reader`/`Channel` directly rather than through Coaxial's
-// `exchange`, because `exchange` flattens each message to bytes — losing the Text/Binary frame
-// type an echo must preserve — and has no hook to send an RFC close code on a protocol violation.
+// `react`/`exchange`, which flatten each message to bytes — losing the Text/Binary frame type an
+// echo must preserve — and offer no hook to send an RFC close code on a protocol violation.
 object AutobahnClient:
   private val agent: Text = t"soundness-perihelion"
 

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -393,7 +393,7 @@ object Tests extends Suite(m"Perihelion tests"):
         . assert(_ == (true, 0x1, 8))
 
       suite(m"WebSocket client"):
-        // The client is Coaxial's `exchange` over the `WsUrl is Serviceable` transport. It
+        // The client is Coaxial's `react` over the `WsUrl is Duplexable` transport. It
         // is reactive (it acts on inbound messages), so the server greets on connect via
         // its `Channel`, and the client decodes the typed greeting and concludes.
         test(m"A client handshakes and decodes a server-pushed typed message"):
@@ -406,7 +406,7 @@ object Tests extends Suite(m"Perihelion tests"):
 
           val url = t"ws://localhost:$port/".decode[WsUrl]
 
-          val value = url.exchange(0): (ping: Ping over Json) =>
+          val value = url.react(0): (ping: Ping over Json) =>
             Conclude(Ping(ping.value + 1).over[Json], ping.value)
 
           server.cancel()
@@ -414,7 +414,7 @@ object Tests extends Suite(m"Perihelion tests"):
 
         . assert(_ == 7)
 
-        // The full-duplex `transceive` gives the caller a `Sender` before the loop, so
+        // The full-duplex `exchange` gives the caller a `Sender` before the loop, so
         // the client speaks first: it sends `Ping(7)`, the server replies `Ping(8)`.
         test(m"A client sends proactively, then reacts to the reply"):
           val port = freePort()
@@ -428,7 +428,7 @@ object Tests extends Suite(m"Perihelion tests"):
           val handle: (state: Int) ?=> (Ping over Json) => Control[Int] =
             ping => Conclude(Ping(0).over[Json], ping.value)
 
-          val value = url.transceive(0)(handle)(_.send(Ping(7).over[Json]))
+          val value = url.exchange(0)(handle)(_.send(Ping(7).over[Json]))
 
           server.cancel()
           value
@@ -452,7 +452,7 @@ object Tests extends Suite(m"Perihelion tests"):
           val handle: (state: Int) ?=> (Ping over Json) => Control[Int] =
             ping => Conclude(Ping(0).over[Json], ping.value)
 
-          val value = url.transceive(0)(handle)(_.send(Ping(7).over[Json]))
+          val value = url.exchange(0)(handle)(_.send(Ping(7).over[Json]))
 
           server.cancel()
           value


### PR DESCRIPTION
The two client-loop forms are now named for what distinguishes them. The reactive form only responds to inbound messages — it can't initiate — so it is now `react`; the proactive, `Sender`-carrying form (offered only on a `Duplexable`, which can send at any time) takes over the name `exchange`, which better fits a two-way interchange. This also retires the `transceive` jargon for two plain verbs, and since the two are now distinct names there is no overload ambiguity between them.

A `Serviceable` offers `react`; a `Duplexable` additionally offers `exchange`:

```scala
endpoint.react(state)    { message => Reply(…) }                        // respond only
endpoint.exchange(state) { message => … } { sender => sender.send(…) }  // initiate + respond
```

Perihelion's WebSocket client follows suit — `url.react(state)(handle)` (reactive) and `url.exchange(state)(handle)(interact)` (proactive). Pure rename, no behavioural change.