### PR TITLE
Track source positions via read and import parsing.trackPositions

### DIFF
--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -710,29 +710,35 @@ object Json extends Json2, Dynamic:
         else expected(JsonPrimitive.Number) yet 0L
 
     // Low-level parsers building an `Ast` directly from input. Public reading
-    // goes through `source.read[Json]` (the `Aggregable` instances); these are
-    // the underlying engine and stay scoped to the `Ast` companion.
-    def parse(source: Data)(using mode: NumberMode): Json.Ast raises ParseError =
+    // goes through `source.read[Json]` (the `Aggregable` instances, which
+    // consult `PositionTracking`); these are the underlying engine and stay
+    // package-private (used by the `read` givens, the interpolator macros, and
+    // benchmarks — all within `jacinta`).
+    private[jacinta] def parse(source: Data)(using mode: NumberMode): Json.Ast raises ParseError =
       Json.Ast(Parser.parse(source, mode))
 
-    def parse(source: Data, holes: Boolean)(using mode: NumberMode): Json.Ast raises ParseError =
+    private[jacinta] def parse(source: Data, holes: Boolean)(using mode: NumberMode)
+    :   Json.Ast raises ParseError =
+
       Json.Ast(Parser.parse(source, holes, mode))
 
-    def parse(input: Iterator[Data])(using mode: NumberMode): Json.Ast raises ParseError =
+    private[jacinta] def parse(input: Iterator[Data])(using mode: NumberMode)
+    :   Json.Ast raises ParseError =
+
       Json.Ast(Parser.parse(input, mode))
 
-    def parse(input: Iterator[Data], holes: Boolean)(using mode: NumberMode)
+    private[jacinta] def parse(input: Iterator[Data], holes: Boolean)(using mode: NumberMode)
     :   Json.Ast raises ParseError =
 
       Json.Ast(Parser.parse(input, holes, mode))
 
-    def parseTracked(source: Data)(using mode: NumberMode)
+    private[jacinta] def parseTracked(source: Data)(using mode: NumberMode)
     :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
       val (raw, ints) = Parser.parseTracked(source, mode)
       (Json.Ast(raw), Json.PositionIndex(ints))
 
-    def parseTracked(input: Iterator[Data])(using mode: NumberMode)
+    private[jacinta] def parseTracked(input: Iterator[Data])(using mode: NumberMode)
     :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
       val (raw, ints) = Parser.parseTracked(input, mode)
@@ -745,19 +751,19 @@ object Json extends Json2, Dynamic:
   def apply(value: Any): Json = new Json(value)
   def apply(value: Any, positions: Optional[Json.PositionIndex]): Json = new Json(value, positions)
 
-  // Defined on the companion directly (not as a `Json.type` extension) because
-  // the companion's `Dynamic` parentage intercepts `Json.parseTracked(...)`
-  // before extension-method resolution gets a chance.
-  def parseTracked(source: Data)(using NumberMode): Json raises ParseError =
-    val (ast, index) = Json.Ast.parseTracked(source)
-    new Json(ast, index)
+  // Parse a byte-chunk iterator into a `Json`, honouring the in-scope
+  // `PositionTracking` toggle (`parsing.trackPositions`): when on, source
+  // positions are recorded and retained on the `Json` (locatable via
+  // `Positionable`); when off, the throughput path is unchanged. This is the
+  // single place the `read`/`load` givens branch on tracking.
+  private def readJson(input: Iterator[Data])(using Tactic[ParseError], PositionTracking): Json =
+    summon[PositionTracking] match
+      case PositionTracking.On =>
+        val (ast, index) = Json.Ast.parseTracked(input)
+        new Json(ast, index)
 
-  def parseTracked(input: Iterator[Data])(using NumberMode): Json raises ParseError =
-    val (ast, index) = Json.Ast.parseTracked(input)
-    new Json(ast, index)
-
-  def parseTracked(source: Text)(using NumberMode, CharEncoder): Json raises ParseError =
-    parseTracked(source.data)
+      case PositionTracking.Off =>
+        Json(Json.Ast.parse(input))
 
   // Canonical external accessor for the underlying AST. The `root`
   // method on `class Json` is package-private so that breaking through
@@ -1085,15 +1091,16 @@ object Json extends Json2, Dynamic:
     given Formatting = Formatting(Unset, false)
     json.root.show
 
-  given aggregable: Tactic[ParseError] => Json is Aggregable by Data =
-    bytes => Json(bytes.read[Json.Ast])
+  given aggregable: (Tactic[ParseError], PositionTracking) => Json is Aggregable by Data =
+    bytes => readJson(bytes.iterator)
 
 
   given aggregableDirect: [value: distillate.Decodable in Json] => Tactic[ParseError]
+  =>  PositionTracking
   =>  Tactic[JsonError]
   =>  (value in Json) is Aggregable by Data =
 
-    bytes => Json(bytes.read[Json.Ast]).as[value].asInstanceOf[value in Json]
+    bytes => readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
 
 
   given showable: Formatting => Json is Showable = _.root.show
@@ -1111,10 +1118,11 @@ object Json extends Json2, Dynamic:
         (t"application/json; charset=${encoder.encoding.name}", Stream(json.show.data))
 
 
-  given decodable: Tactic[ParseError] => Json is distillate.Decodable in Text =
+  given decodable: (Tactic[ParseError], PositionTracking) => Json is distillate.Decodable in Text =
     text => Stream(text.data(using charEncoders.utf8Encoder)).read[Json]
 
-  given instantiable: Tactic[ParseError] => Json is Instantiable across HttpRequests from Text =
+  given instantiable: Tactic[ParseError] => PositionTracking
+  =>  Json is Instantiable across HttpRequests from Text =
     text => Stream(text.data(using charEncoders.utf8Encoder)).read[Json]
 
   def applyDynamicNamed(methodName: "make")(elements: (String, Json)*): Json =

--- a/lib/jacinta/src/core/jacinta.Ndjson.scala
+++ b/lib/jacinta/src/core/jacinta.Ndjson.scala
@@ -39,7 +39,8 @@ import turbulence.*
 import zephyrine.*
 
 object Ndjson:
-  def parse[source: Streamable by Line](value: source)(using Text is Streamable by Data)
+  private[jacinta] def parse[source: Streamable by Line](value: source)
+    ( using Text is Streamable by Data )
   :   Ndjson raises ParseError =
 
     Ndjson(value.stream[Line].map { line => line.content.read[Json] })

--- a/lib/jacinta/src/test/jacinta.PositionTests.scala
+++ b/lib/jacinta/src/test/jacinta.PositionTests.scala
@@ -35,6 +35,7 @@ package jacinta
 import soundness.*
 
 import charEncoders.utf8Encoder
+import parsing.trackPositions
 import strategies.throwUnsafely
 
 object PositionTests extends Suite(m"Jacinta position-index tests"):
@@ -45,136 +46,136 @@ object PositionTests extends Suite(m"Jacinta position-index tests"):
   def run(): Unit =
     suite(m"Single-line root primitives"):
       test(m"Locate a root number"):
-        val json = Json.parseTracked(t"42")
+        val json = t"42".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 2))
 
       test(m"Locate a root string"):
-        val json = Json.parseTracked(t""""hello"""")
+        val json = t""""hello"""".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 7))
 
       test(m"Locate a root boolean"):
-        val json = Json.parseTracked(t"true")
+        val json = t"true".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 4))
 
       test(m"Locate a root null"):
-        val json = Json.parseTracked(t"null")
+        val json = t"null".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 4))
 
       test(m"Locate a negative number includes the minus sign in length"):
-        val json = Json.parseTracked(t"-42")
+        val json = t"-42".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 3))
 
     suite(m"Single-line objects"):
       test(m"Locate the root object"):
-        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        val json = t"""{"a":1,"b":2}""".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 13))
 
       test(m"Locate the value at key 'a'"):
-        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        val json = t"""{"a":1,"b":2}""".read[Json]
         json.locate(JsonPointer()(t"a"))
       . assert(_ == at(1, 6, 1))
 
       test(m"Locate the value at key 'b'"):
-        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        val json = t"""{"a":1,"b":2}""".read[Json]
         json.locate(JsonPointer()(t"b"))
       . assert(_ == at(1, 12, 1))
 
       test(m"Locate the key 'a' itself"):
-        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        val json = t"""{"a":1,"b":2}""".read[Json]
         json.locateKey(JsonPointer()(t"a"))
       . assert(_ == at(1, 2, 3))
 
       test(m"Locate the key 'b' itself"):
-        val json = Json.parseTracked(t"""{"a":1,"b":2}""")
+        val json = t"""{"a":1,"b":2}""".read[Json]
         json.locateKey(JsonPointer()(t"b"))
       . assert(_ == at(1, 8, 3))
 
       test(m"Missing key returns Unset"):
-        val json = Json.parseTracked(t"""{"a":1}""")
+        val json = t"""{"a":1}""".read[Json]
         json.locate(JsonPointer()(t"missing"))
       . assert(_ == Unset)
 
     suite(m"Single-line arrays"):
       test(m"Locate the root array"):
-        val json = Json.parseTracked(t"[10,20,30]")
+        val json = t"[10,20,30]".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 10))
 
       test(m"Locate the first array element"):
-        val json = Json.parseTracked(t"[10,20,30]")
+        val json = t"[10,20,30]".read[Json]
         json.locate(JsonPointer()(Prim))
       . assert(_ == at(1, 2, 2))
 
       test(m"Locate the last array element"):
-        val json = Json.parseTracked(t"[10,20,30]")
+        val json = t"[10,20,30]".read[Json]
         json.locate(JsonPointer()(Ter))
       . assert(_ == at(1, 8, 2))
 
       test(m"Out-of-bounds index returns Unset"):
-        val json = Json.parseTracked(t"[10,20]")
+        val json = t"[10,20]".read[Json]
         json.locate(JsonPointer()(Ter))
       . assert(_ == Unset)
 
       test(m"Empty array locates only the root"):
-        val json = Json.parseTracked(t"[]")
+        val json = t"[]".read[Json]
         json.locate(JsonPointer())
       . assert(_ == at(1, 1, 2))
 
     suite(m"Nested structures"):
       test(m"Locate a key in a nested object"):
-        val json = Json.parseTracked(t"""{"a":{"b":42}}""")
+        val json = t"""{"a":{"b":42}}""".read[Json]
         json.locate(JsonPointer()(t"a")(t"b"))
       . assert(_ == at(1, 11, 2))
 
       test(m"Locate an element of a nested array"):
-        val json = Json.parseTracked(t"""{"xs":[1,2,3]}""")
+        val json = t"""{"xs":[1,2,3]}""".read[Json]
         json.locate(JsonPointer()(t"xs")(Sec))
       . assert(_ == at(1, 10, 1))
 
       test(m"Locate an object inside an array"):
-        val json = Json.parseTracked(t"""[{"id":1},{"id":2}]""")
+        val json = t"""[{"id":1},{"id":2}]""".read[Json]
         json.locate(JsonPointer()(Sec)(t"id"))
       . assert(_ == at(1, 17, 1))
 
     suite(m"Multi-line input"):
       test(m"Second-line key is on line 2"):
         val source = t"{\n  \"a\": 42\n}"
-        val json = Json.parseTracked(source)
+        val json = source.read[Json]
         json.locate(JsonPointer()(t"a")).let(_.line)
       . assert(_ == 2)
 
       test(m"Second-line value column is past the indent"):
         val source = t"{\n  \"a\": 42\n}"
-        val json = Json.parseTracked(source)
+        val json = source.read[Json]
         json.locate(JsonPointer()(t"a")).let(_.column)
       . assert(_ == 8)
 
       test(m"Third-line element is on line 3"):
         val source = t"[\n  1,\n  2,\n  3\n]"
-        val json = Json.parseTracked(source)
+        val json = source.read[Json]
         json.locate(JsonPointer()(Sec)).let(_.line)
       . assert(_ == 3)
 
     suite(m"Number-array specialisations"):
       test(m"Small-BCD array still has per-element positions"):
-        val json = Json.parseTracked(t"[1,2,3]")
+        val json = t"[1,2,3]".read[Json]
         json.locate(JsonPointer()(Sec))
       . assert(_ == at(1, 4, 1))
 
       test(m"BCD-Long array still has per-element positions"):
-        val json = Json.parseTracked(t"[12345678901234,1]")
+        val json = t"[12345678901234,1]".read[Json]
         json.locate(JsonPointer()(Prim)).let(_.length)
       . assert(_ == 14)
 
     suite(m"Subsequence property"):
       test(m"A nested object's descriptor slice has length == slot 0"):
-        val json = Json.parseTracked(t"""{"a":{"b":42}}""")
+        val json = t"""{"a":{"b":42}}""".read[Json]
         val data = json.positionIndex.vouch.ints
         val firstEntryOff = data(5)
         val valueDescOff = firstEntryOff + 3
@@ -184,7 +185,8 @@ object PositionTests extends Suite(m"Jacinta position-index tests"):
       . assert(identity)
 
     suite(m"Non-tracking mode"):
-      test(m"Plain parse leaves positionIndex Unset"):
+      test(m"Without the import, positionIndex is Unset"):
+        given PositionTracking = PositionTracking.Off
         t"42".read[Json].positionIndex
       . assert(_ == Unset)
 

--- a/lib/jacinta/src/test/jacinta.ValidationTests.scala
+++ b/lib/jacinta/src/test/jacinta.ValidationTests.scala
@@ -175,15 +175,17 @@ object ValidationTests extends Suite(m"Jacinta validation tests"):
         . protect(decode(json)).items
 
       test(m"Missing field reports a position on a tracked Json"):
+        import parsing.trackPositions
         val source = t"""{"name": "Alice"}"""
-        val json = Json.parseTracked(source)
+        val json = source.read[Json]
         val results = validateWithPositions(json)(_.as[VPerson])
         results.map(_(0).s).to(Set)
       . assert(_ == Set("#/age", "#/email"))
 
       test(m"Wrong-type field reports the value's line/column"):
+        import parsing.trackPositions
         val source = t"{\n  \"name\": 42,\n  \"age\": 30,\n  \"email\": \"x@y\"\n}"
-        val json = Json.parseTracked(source)
+        val json = source.read[Json]
         val results = validateWithPositions(json)(_.as[VPerson])
         // `name` value 42 is on line 2; column points at the `4` of `42`.
         results.find(_(0) == t"#/name").map((_, line, col) => (line, col))

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import contingency.*
 import distillate.*
 import gossamer.*
+import hieroglyph.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
@@ -63,11 +64,21 @@ object Tel extends Tel2:
   type Error = TelError
   val Error: TelError.type = TelError
 
+  // The source `Position` type located by `tel.locate(pointer)` and carried on a
+  // `Tel.Focus`. Defined canonically on `TelError` (where it also locates parse
+  // errors); aliased here for symmetry with `Json.Ast.Position` / `Yaml.Ast.Position`.
+  type Position = TelError.Position
+  val Position: TelError.Position.type = TelError.Position
+
   // The focus carried by `Tel#as[T]` for multi-error accrual: a keyword path
   // identifying the field being decoded (and, for parser-phase errors, an
-  // optional source position). Mirrors `Json.Focus` / `Yaml.Focus`.
+  // optional source position). Mirrors `Json.Focus` / `Yaml.Focus`. The
+  // `position` is populated lazily by `withPosition(tel)`, which delegates to
+  // `tel.locate(pointer)`, so a root parsed without `Tel.parseTracked` (hence no
+  // `positionIndex`) leaves `position` Unset and the success path pays nothing.
   case class Focus(pointer: TelPath = TelPath.Root, position: Optional[TelError.Position] = Unset)
-  derives CanEqual
+  derives CanEqual:
+    def withPosition(tel: Tel): Focus = copy(position = tel.locate(pointer))
 
   extension (tel: Tel)
     def edited(revision: Revision): Tel raises MutationError = revision(tel)
@@ -146,6 +157,13 @@ object Tel extends Tel2:
 
       val rootElements =
         applyConstraints(schema.document, IArray.empty[Tel.Element], rootChildren, schema)
+
+      // Fill in a source `Position` for every accrued validation focus by
+      // locating its keyword path in the root — mirrors `Json#as`. A no-op
+      // unless the root was produced by `Tel.parseTracked` (so carries a
+      // `positionIndex`); an unresolvable path (e.g. a missing member) stays Unset.
+      val foci = summon[Foci[Tel.Focus]]
+      foci.supplement(foci.length, _.let(_.withPosition(tel)).vouch)
 
       Tel.Element.Node(keywordIndex = Unset, elementType = schema.document, children = rootElements)
 
@@ -369,11 +387,20 @@ object Tel extends Tel2:
       while i < compounds.length do
         val compound = compounds(i)
 
-        // An unrecognised keyword is skipped (`IgnoreErroneousNode`): record it and
-        // emit no element, so remaining siblings are still validated.
-        km.get(compound.keyword) match
-          case Some(entry) => results += assignCompound(compound, entry, schema)
-          case None        => recoverNode(Reason.UnknownKeyword)(())
+        // Tag every error accrued for this compound (and its descendants) with
+        // its keyword path — mirroring the decode derivation's per-field `focus`
+        // — so that under a `validate[Tel.Focus]` boundary schema-validation
+        // errors carry a pointer (and, for a tracked root, a source position via
+        // `Focus.withPosition`) instead of the bare document root.
+        focus({
+          val base = prior.let(_.pointer).or(TelPath.Root)
+          Tel.Focus(base.prepend(compound.keyword))
+        }):
+          // An unrecognised keyword is skipped (`IgnoreErroneousNode`): record it
+          // and emit no element, so remaining siblings are still validated.
+          km.get(compound.keyword) match
+            case Some(entry) => results += assignCompound(compound, entry, schema)
+            case None        => recoverNode(Reason.UnknownKeyword)(())
 
         i += 1
 
@@ -411,12 +438,20 @@ object Tel extends Tel2:
               case Tel.Element.Node(idx, _, _)  => idx == Optional(flatStart)
               case Tel.Element.Value(idx, _, _) => idx == flatStart
 
-            if !filled then resolveType(f.fieldType, schema) match
-              case s: Scalar => f.default match
-                case t: Text => results += Tel.Element.Value(flatStart, s, t)
-                case _       => recoverNode(Reason.RequiredMemberAbsent)(())
+            // A missing required member is reported under its own keyword path.
+            // It has no compound in the source, so `withPosition` leaves the
+            // position Unset (locate finds no node) — but the pointer still names
+            // the absent field.
+            if !filled then focus({
+              val base = prior.let(_.pointer).or(TelPath.Root)
+              Tel.Focus(base.prepend(f.keyword))
+            }):
+              resolveType(f.fieldType, schema) match
+                case s: Scalar => f.default match
+                  case t: Text => results += Tel.Element.Value(flatStart, s, t)
+                  case _       => recoverNode(Reason.RequiredMemberAbsent)(())
 
-              case _ => recoverNode(Reason.RequiredMemberAbsent)(())
+                case _ => recoverNode(Reason.RequiredMemberAbsent)(())
 
           case _ => ()
 
@@ -745,6 +780,136 @@ object Tel extends Tel2:
 
   private[stratiform] def parseStream(bytes: Data): Stream[Tel] raises TelError =
     Tel.Parser.parseStream(bytes).map(Tel(_))
+
+  // ── Position tracking (editor / tooling support) ──────────────────────────
+  //
+  // A flat `IArray[Int]` of position descriptors produced alongside the
+  // presentation tree by `Tel.parseTracked`. All internal references are stored
+  // as offsets relative to the start of the containing node descriptor, so any
+  // slice taken at a descriptor boundary is itself a valid `PositionIndex` —
+  // mirrors `jacinta.Json.PositionIndex` and `ypsiloid.Yaml.PositionIndex`.
+  //
+  // Layout per node descriptor at `offset`:
+  //   data(offset)              size of this descriptor (including children)
+  //   data(offset + 1)          1-indexed source line of the node's keyword
+  //   data(offset + 2)          1-indexed source column of the node's keyword
+  //   data(offset + 3)          length in characters of the keyword
+  //   data(offset + 4)          child count
+  //   data(offset + 5 + k)      relative offset (from `offset`) of the k-th child
+  //   … child descriptors laid out contiguously …
+  // The document root occupies the outermost descriptor with a synthetic
+  // (line 1, column 1, length 0) header; its children are the top-level compounds.
+  opaque type PositionIndex = IArray[Int]
+
+  object PositionIndex:
+    private[stratiform] def apply(data: IArray[Int]): PositionIndex = data
+
+  extension (positionIndex: PositionIndex)
+    private[stratiform] def ints: IArray[Int] = positionIndex
+
+  // Parse `bytes` (or `text`) into a `Tel` carrying a `PositionIndex`, so that
+  // `tel.locate(pointer)` / `tel.locateKey(pointer)` resolve a node's keyword
+  // path to its source `Position`, and accrued `Tel.Focus`es can be located via
+  // `withPosition`. A plain `bytes.read[Tel]` leaves `positionIndex` Unset, so
+  // the throughput-optimised path is unaffected.
+  def parseTracked(bytes: Data): Tel raises TelError =
+    val (document, triples) = Tel.Parser.parseTracked(bytes)
+    Tel(document, Optional(PositionIndex(buildIndex(document, triples))))
+
+  def parseTracked(text: Text)(using CharEncoder): Tel raises TelError =
+    parseTracked(text.data)
+
+  // Fold the parser's flat pre-order stream of (line, column, length) triples —
+  // one per compound, in recursive-descent order — into the navigable packed
+  // descriptor layout documented on `PositionIndex`. The AST supplies the tree
+  // shape; the triples supply the coordinates. Runs only under `parseTracked`,
+  // never on the hot path.
+  private[stratiform] def buildIndex(document: Tel.Document, triples: IArray[Int]): IArray[Int] =
+    var cursor = 0
+
+    def build(node: Tel.Subtree, line: Int, column: Int, length: Int): Array[Int] =
+      val children = node.children.flatMap(_.compounds)
+      val childDescriptors = new Array[Array[Int]](children.length)
+      var k = 0
+
+      while k < children.length do
+        val childLine   = triples(cursor)
+        val childColumn = triples(cursor + 1)
+        val childLength = triples(cursor + 2)
+        cursor += 3
+        childDescriptors(k) = build(children(k), childLine, childColumn, childLength)
+        k += 1
+
+      val header = 5 + children.length
+      var total = header
+      k = 0
+
+      while k < children.length do
+        total += childDescriptors(k).length
+        k += 1
+
+      val buffer = new Array[Int](total)
+      buffer(0) = total
+      buffer(1) = line
+      buffer(2) = column
+      buffer(3) = length
+      buffer(4) = children.length
+      var offset = header
+      k = 0
+
+      while k < children.length do
+        buffer(5 + k) = offset
+        System.arraycopy(childDescriptors(k), 0, buffer, offset, childDescriptors(k).length)
+        offset += childDescriptors(k).length
+        k += 1
+
+      buffer
+
+    IArray.unsafeFromArray(build(document, 1, 1, 0))
+
+  // Resolves a `TelPath` to the source `Position` recorded in a tracked `Tel`'s
+  // `PositionIndex`. Exposed uniformly as `tel.locate(path)` / `tel.locateKey(path)`
+  // through zephyrine's `Positionable`, matching `jacinta.Json` and `ypsiloid.Yaml`.
+  given positionable: Tel is Positionable by TelPath to TelError.Position =
+    new Positionable:
+      type Self    = Tel
+      type Operand = TelPath
+      type Result  = TelError.Position
+
+      def locate(value: Tel, path: TelPath): Optional[TelError.Position] =
+        value.positionIndex.let: index =>
+          walkIndex(value.subtree, index.ints, 0, path.keywords.toIndexedSeq, 0, false)
+
+      def locateKey(value: Tel, path: TelPath): Optional[TelError.Position] =
+        value.positionIndex.let: index =>
+          walkIndex(value.subtree, index.ints, 0, path.keywords.toIndexedSeq, 0, true)
+
+  // Walk the packed `PositionIndex` alongside the AST, following `segments`
+  // (a root-first keyword path) from the descriptor at `offset`. TEL has no
+  // separate key/value nodes — a compound's position *is* its keyword — so
+  // `keyMode` differs from the value lookup only at the root, which has no
+  // keyword and yields `Unset`.
+  private def walkIndex
+    ( node:     Tel.Subtree,
+      data:     IArray[Int],
+      offset:   Int,
+      segments: IndexedSeq[Text],
+      i:        Int,
+      keyMode:  Boolean )
+  :   Optional[TelError.Position] =
+
+    if i >= segments.length then
+      if keyMode && i == 0 then Unset
+      else TelError.Position
+        ( line   = data(offset + 1),
+          column = data(offset + 2),
+          length = Optional(data(offset + 3)) )
+    else
+      val children = node.children.flatMap(_.compounds)
+      val k = children.indexWhere(_.keyword == segments(i))
+
+      if k < 0 then Unset
+      else walkIndex(children(k), data, offset + data(offset + 5 + k), segments, i + 1, keyMode)
 
   // Concatenate the chunks of a `Stream[Data]` source into a single byte array.
   private def concatenate(source: Stream[Data]): Data =
@@ -1075,6 +1240,18 @@ object Tel extends Tel2:
       p.reset(Cursor[Data](input), schema: Optional[Tels])
       p.parse()
 
+    // Tracked parse: one document plus the flat pre-order (line, column, length)
+    // triples backing `Tel.PositionIndex`. Uses `untrackedData` like the plain
+    // path — coordinates come from the parser's own `lineNo` / `leadingSpaces`
+    // bookkeeping, not the cursor's lineation.
+    def parseTracked(input: Data): (Tel.Document, IArray[Int]) raises TelError =
+      import zephyrine.Lineation.untrackedData
+      val p = cached.get.nn
+      p.reset(Cursor[Data](input), Unset)
+      p.tracking = true
+
+      try (p.parse(), IArray.from(p.positionTriples)) finally p.tracking = false
+
     // Streaming parse (§6.1) of a multi-document source into the documents it
     // contains. `parseDocuments` is eager; `parseStream` parses lazily on demand.
     def parseDocuments(input: Data): List[Tel.Document] raises TelError =
@@ -1238,6 +1415,15 @@ object Tel extends Tel2:
     // just consumed is the final byte of the document; consumed exactly once
     // by the first consumeTrailingBlanksFor that reaches EOF.
     private var documentEndsWithLf: Boolean = false
+
+    // ── Position tracking (set by `Parser.parseTracked`) ──────────────────────
+    // When `tracking` is on, the parser appends one (line, column, length)
+    // triple per compound — in recursive-descent (pre-order) sequence — to
+    // `positionTriples`, from which `Tel.buildIndex` folds the navigable
+    // `PositionIndex`. Off by default, so the throughput-optimised parse path is
+    // untouched (no triple is recorded and no per-compound work is added).
+    private[stratiform] var tracking: Boolean = false
+    private[stratiform] val positionTriples = scala.collection.mutable.ArrayBuffer.empty[Int]
 
     // Ancestor stack of Struct types known for each open compound, used by
     // §19.5's schema-aware E107 recovery. The element at index `i` is the
@@ -1679,6 +1865,8 @@ object Tel extends Tel2:
       pos    = 0
       bufEnd = 0
       lineNo = 1
+      tracking = false
+      positionTriples.clear()
       margin = 0
       sigil  = '#'.toByte
       crlfMode = false
@@ -2422,6 +2610,16 @@ object Tel extends Tel2:
           parseCompoundLine(compoundLine)
           val compoundKeyword = compoundLineKeyword
           val compoundRemark  = compoundLineRemark
+
+          // Record this compound's keyword position *before* descending, so the
+          // triple stream is pre-order (parent before children) — the order
+          // `Tel.buildIndex` folds against the AST. Column is 1-indexed at the
+          // keyword's first character (just past the leading spaces).
+          if tracking then
+            positionTriples += compoundLine
+            positionTriples += compoundLeadingSpaces + 1
+            positionTriples += compoundKeyword.s.length
+
           prevContentLeadingSpaces = compoundLeadingSpaces
           prevLineWasBoundary = false
           // §19.5 recovery needs this compound's keyword on the ancestor
@@ -3228,7 +3426,9 @@ object Tel extends Tel2:
         else Text(sliceText(startMark))
 
 
-class Tel private[stratiform](private[stratiform] val subtree: Tel.Subtree)
+class Tel private[stratiform]
+  ( private[stratiform] val subtree:       Tel.Subtree,
+    private[stratiform] val positionIndex: Optional[Tel.PositionIndex] = Unset )
 extends scala.Dynamic, Documentary, Topical, Original:
   type Self = Tel
   type Metadata = Tel.Metadata

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -38,7 +38,6 @@ import anticipation.*
 import contingency.*
 import distillate.*
 import gossamer.*
-import hieroglyph.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
@@ -807,17 +806,21 @@ object Tel extends Tel2:
   extension (positionIndex: PositionIndex)
     private[stratiform] def ints: IArray[Int] = positionIndex
 
-  // Parse `bytes` (or `text`) into a `Tel` carrying a `PositionIndex`, so that
+  // Parse `bytes` into a `Tel` carrying a `PositionIndex`, so that
   // `tel.locate(pointer)` / `tel.locateKey(pointer)` resolve a node's keyword
   // path to its source `Position`, and accrued `Tel.Focus`es can be located via
-  // `withPosition`. A plain `bytes.read[Tel]` leaves `positionIndex` Unset, so
-  // the throughput-optimised path is unaffected.
-  def parseTracked(bytes: Data): Tel raises TelError =
+  // `withPosition`. Reached from the `read` / `load` givens only when
+  // `parsing.trackPositions` is in scope; otherwise the untracked `parse` runs
+  // and `positionIndex` is left Unset, so the throughput path is unaffected.
+  private def parseTracked(bytes: Data): Tel raises TelError =
     val (document, triples) = Tel.Parser.parseTracked(bytes)
     Tel(document, Optional(PositionIndex(buildIndex(document, triples))))
 
-  def parseTracked(text: Text)(using CharEncoder): Tel raises TelError =
-    parseTracked(text.data)
+  // Parse `bytes` honouring the in-scope `Tracking` toggle (`parsing.trackPositions`).
+  private def parseTracking(bytes: Data)(using PositionTracking): Tel raises TelError =
+    summon[PositionTracking] match
+      case PositionTracking.On  => parseTracked(bytes)
+      case PositionTracking.Off => parse(bytes)
 
   // Fold the parser's flat pre-order stream of (line, column, length) triples —
   // one per compound, in recursive-descent order — into the navigable packed
@@ -928,17 +931,17 @@ object Tel extends Tel2:
   // pragma, line-endings) is *not* surfaced — use `.load[Tel]` to
   // recover those alongside the value. Per §6.1, single-document parsing
   // stops at the first document separator; content after it is ignored.
-  given aggregable: Tactic[TelError] => Tel is Aggregable by Data =
-    source => parse(concatenate(source))
+  given aggregable: (Tactic[TelError], PositionTracking) => Tel is Aggregable by Data =
+    source => parseTracking(concatenate(source))
 
   // `source.read[Foo in Tel]` shorthand for
   // `source.read[Tel].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
   // for `value in Json`. The `Form` type-tag is added by an
   // `asInstanceOf` cast — `value in Tel` is just
   // `value { type Form = Tel }` so the cast is a no-op at runtime.
-  given aggregableIn: [value: distillate.Decodable in Tel] => Tactic[TelError]
+  given aggregableIn: [value: distillate.Decodable in Tel] => (Tactic[TelError], PositionTracking)
   =>  (value in Tel) is Aggregable by Data =
-    source => parse(concatenate(source)).as[value].asInstanceOf[value in Tel]
+    source => parseTracking(concatenate(source)).as[value].asInstanceOf[value in Tel]
 
   // `source.read[List[Tel]]` / `read[Stream[Tel]]` for a multi-document source
   // (§6.1). `List[Tel]` parses every document eagerly; `Stream[Tel]` parses
@@ -954,7 +957,7 @@ object Tel extends Tel2:
   // `text.load[Tel]` for any Stream[Text] source: concatenates the
   // chunks, UTF-8 encodes, parses, and pairs the resulting Tel with a
   // `Tel.Metadata` carrying the document's prologue.
-  given loadable: Tactic[TelError] => Tel is Loadable by Text = stream =>
+  given loadable: (Tactic[TelError], PositionTracking) => Tel is Loadable by Text = stream =>
     import denominative.nil
     val builder = new StringBuilder()
     var s = stream
@@ -964,10 +967,16 @@ object Tel extends Tel2:
       s = s.tail
 
     val text = builder.toString
-    val bytes = text.getBytes("UTF-8").nn
-    val doc = Tel.Parser.parse(IArray.unsafeFromArray(bytes))
-    val meta = Tel.Metadata(doc.interpreterDirective, doc.pragma, doc.lineEndings)
-    turbulence.Document(Tel(doc): Tel, meta)
+    val bytes = IArray.unsafeFromArray(text.getBytes("UTF-8").nn)
+    val tel = parseTracking(bytes)
+
+    tel.subtree match
+      case doc: Tel.Document =>
+        turbulence.Document
+          ( tel, Tel.Metadata(doc.interpreterDirective, doc.pragma, doc.lineEndings) )
+
+      case _ =>
+        turbulence.Document(tel, Tel.Metadata(Unset, Unset, Tel.LineEndings.Lf))
 
   // Renders a document's presentation back to text, reversing the presentation parser. The whole
   // line-based serialization lives in this instance so that `.show` is the single route to TEL

--- a/lib/stratiform/src/core/stratiform.TelError.scala
+++ b/lib/stratiform/src/core/stratiform.TelError.scala
@@ -36,6 +36,7 @@ import anticipation.*
 import denominative.*
 import fulminate.*
 import vacuous.*
+import zephyrine.*
 
 object TelError:
 
@@ -49,8 +50,24 @@ object TelError:
   // character of the line (including any leading spaces). Parse errors
   // that pre-date the document body (e.g. `BomPresent` at offset 0)
   // report `(1, 1)`. Post-parse / validation errors leave `position`
-  // `Unset` because they apply to AST nodes rather than source bytes.
-  case class Position(line: Int, column: Int) derives CanEqual
+  // `Unset` unless resolved against a tracked document's `PositionIndex`
+  // (see `Tel.parseTracked` / `Tel.Focus.withPosition`).
+  //
+  // This is also the `Positionable` `Result` for `tel.locate(pointer)`, so it
+  // extends zephyrine's `Format.Position` — `line`/`column` stay 1-based here
+  // while the uniform, public `span` is 0-based (mirrors `Json.Ast.Position` /
+  // `Yaml.Ast.Position`). `length` is the length in characters of the located
+  // token (a compound's keyword), enabling precise LSP ranges.
+  case class Position
+    ( line:                Int,
+      column:              Int,
+      override val offset: Optional[Int] = Unset,
+      override val length: Optional[Int] = Unset )
+  extends Format.Position derives CanEqual:
+    def describe: Text = Text("line "+line+", column "+column)
+
+    override def span: Span =
+      Span.line((line - 1).max(0).z, (column - 1).max(0).z, length.or(0))
 
   // Recovery strategies prescribed by §19.5 of the TEL specification. Each
   // reason carries the recovery strategy declared for its E-code.
@@ -296,5 +313,4 @@ extends Error
     . or(m"the TEL document is invalid because $reason") ):
 
   // The internal 1-indexed position rendered as a uniform 0-based `Span`.
-  def span: Span = position.lay(Span.empty): p =>
-    Span.line((p.line - 1).max(0).z, (p.column - 1).max(0).z, 0)
+  def span: Span = position.lay(Span.empty)(_.span)

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -48,6 +48,11 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
   extends Error(m"${items.length} decoding issues"):
     def +(focus: Text, error: TelError): Issues = Issues(items :+ (focus, error))
 
+  case class Located(items: List[(Text, Optional[TelError.Position])] = Nil)(using Diagnostics)
+  extends Error(m"${items.length} located issues"):
+    def +(pointer: Text, position: Optional[TelError.Position]): Located =
+      Located(items :+ (pointer, position))
+
   private def validateTel[result](tel: Tel)
                                  (decode: Tel => result raises TelError tracks Tel.Focus)
   :   Issues =
@@ -60,6 +65,18 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
     validate[Tel.Focus](Issues()):
       case error: TelError =>
         accrual + (prior.let(_.pointer.encode).or(t"#"), error)
+    . protect(Tel.Type.assign(tel, schema))
+
+  // Validate a *tracked* document against `schema`, capturing each error's
+  // keyword-path pointer alongside the source `Position` filled in by
+  // `Tel.Type.assign`'s `withPosition` enrichment.
+  private def assignPositions(text: Text, schema: Tels): Located =
+    val tel = Tel.parseTracked(text)
+
+    validate[Tel.Focus](Located()):
+      case error: TelError =>
+        accrual + (prior.let(_.pointer.encode).or(t"#"),
+                   prior.lay(Unset: Optional[TelError.Position])(_.position))
     . protect(Tel.Type.assign(tel, schema))
 
   // Parse a document under an accrual boundary: recoverable parse defects
@@ -239,3 +256,27 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
            ( TelError.Reason.BadVersion,
              TelError.Reason.OverIndentation,
              TelError.Reason.TrailingSpaces )
+
+    suite(m"Located schema-validation errors (LSP diagnostics)"):
+      test(m"Unknown-keyword errors carry their keyword pointer"):
+        assignPositions(t"foo a\nbar b\n", optionalFieldSchema).items.map(_(0).s).to(Set)
+      . assert(_ == Set("#/foo", "#/bar"))
+
+      test(m"Unknown-keyword errors are located at the offending compound"):
+        assignPositions(t"foo a\nbar b\n", optionalFieldSchema).items.map(_(1)).to(Set)
+      . assert(_ == Set(Optional(Tel.Position(1, 1, length = Optional(3))),
+                        Optional(Tel.Position(2, 1, length = Optional(3)))))
+
+      test(m"An unlocated (untracked) validation still accrues without a position"):
+        val tel = t"foo a\n".read[Tel]
+
+        validate[Tel.Focus](Issues()):
+          case error: TelError => accrual + (prior.lay(t"")(_.position.lay(t"")(_.describe)), error)
+        . protect(Tel.Type.assign(tel, optionalFieldSchema))
+        . items.map(_(0).s).to(Set)
+      . assert(_ == Set(""))
+
+      test(m"Missing required members carry a pointer but no source position"):
+        assignPositions(t"", twoRequiredSchema).items.map { case (p, pos) => (p.s, pos.present) }
+        . to(Set)
+      . assert(_ == Set(("#/name", false), ("#/email", false)))

--- a/lib/stratiform/src/test/stratiform.AccrualTests.scala
+++ b/lib/stratiform/src/test/stratiform.AccrualTests.scala
@@ -71,7 +71,8 @@ object AccrualTests extends Suite(m"Stratiform multi-error accrual tests"):
   // keyword-path pointer alongside the source `Position` filled in by
   // `Tel.Type.assign`'s `withPosition` enrichment.
   private def assignPositions(text: Text, schema: Tels): Located =
-    val tel = Tel.parseTracked(text)
+    import parsing.trackPositions
+    val tel = text.read[Tel]
 
     validate[Tel.Focus](Located()):
       case error: TelError =>

--- a/lib/stratiform/src/test/stratiform.PositionTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionTests.scala
@@ -1,0 +1,123 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import soundness.*
+
+import charEncoders.utf8Encoder
+import strategies.throwUnsafely
+
+object PositionTests extends Suite(m"Stratiform position-index tests"):
+
+  // A compound's keyword position: 1-based line/column with the keyword's
+  // character length (mirrors `jacinta.PositionTests.at`).
+  private def at(line: Int, column: Int, length: Int): Tel.Position =
+    Tel.Position(line, column, length = Optional(length))
+
+  def run(): Unit =
+    suite(m"Top-level compounds"):
+      test(m"Locate the document root"):
+        Tel.parseTracked(t"greeting hello\n").locate(TelPath(Nil))
+      . assert(_ == at(1, 1, 0))
+
+      test(m"Locate a top-level compound by keyword"):
+        Tel.parseTracked(t"greeting hello\n").locate(TelPath(List(t"greeting")))
+      . assert(_ == at(1, 1, 8))
+
+      test(m"Locate the second of two top-level compounds"):
+        Tel.parseTracked(t"first a\nsecond b\n").locate(TelPath(List(t"second")))
+      . assert(_ == at(2, 1, 6))
+
+      test(m"An unknown keyword returns Unset"):
+        Tel.parseTracked(t"greeting hello\n").locate(TelPath(List(t"absent")))
+      . assert(_ == Unset)
+
+    suite(m"Nested compounds"):
+      test(m"Locate a child compound"):
+        Tel.parseTracked(t"person\n  name Alice\n  age 30\n")
+        . locate(TelPath(List(t"person", t"name")))
+      . assert(_ == at(2, 3, 4))
+
+      test(m"Locate a sibling child on a later line"):
+        Tel.parseTracked(t"person\n  name Alice\n  age 30\n")
+        . locate(TelPath(List(t"person", t"age")))
+      . assert(_ == at(3, 3, 3))
+
+      test(m"Locate a grandchild compound"):
+        Tel.parseTracked(t"a\n  b\n    c hello\n").locate(TelPath(List(t"a", t"b", t"c")))
+      . assert(_ == at(3, 5, 1))
+
+      test(m"A missing intermediate segment returns Unset"):
+        Tel.parseTracked(t"person\n  name Alice\n").locate(TelPath(List(t"person", t"absent")))
+      . assert(_ == Unset)
+
+    suite(m"Column tracks indentation"):
+      test(m"A top-level keyword is at column 1"):
+        Tel.parseTracked(t"root\n  child value\n").locate(TelPath(List(t"root"))).let(_.column)
+      . assert(_ == 1)
+
+      test(m"A one-level-deep keyword is at column 3"):
+        Tel.parseTracked(t"root\n  child value\n")
+        . locate(TelPath(List(t"root", t"child"))).let(_.column)
+      . assert(_ == 3)
+
+      test(m"A one-level-deep keyword is on the second line"):
+        Tel.parseTracked(t"root\n  child value\n")
+        . locate(TelPath(List(t"root", t"child"))).let(_.line)
+      . assert(_ == 2)
+
+    suite(m"Tracking mode"):
+      test(m"A tracked parse records a position index"):
+        Tel.parseTracked(t"greeting hello\n").positionIndex.absent
+      . assert(_ == false)
+
+      test(m"A plain parse leaves the position index Unset"):
+        t"greeting hello\n".read[Tel].positionIndex
+      . assert(_ == Unset)
+
+      test(m"Locating in a plain (untracked) document returns Unset"):
+        t"greeting hello\n".read[Tel].locate(TelPath(List(t"greeting")))
+      . assert(_ == Unset)
+
+    suite(m"Span derivation"):
+      test(m"a position's span carries its line as a 0-based ordinal"):
+        at(2, 8, 3).span.startLine.vouch
+      . assert(_ == 1.z)
+
+      test(m"a position's span carries its column as a 0-based ordinal"):
+        at(2, 8, 3).span.startColumn.vouch
+      . assert(_ == 7.z)
+
+      test(m"a position's span carries its length"):
+        at(2, 8, 3).span.length.vouch
+      . assert(_ == 3)

--- a/lib/stratiform/src/test/stratiform.PositionTests.scala
+++ b/lib/stratiform/src/test/stratiform.PositionTests.scala
@@ -35,6 +35,7 @@ package stratiform
 import soundness.*
 
 import charEncoders.utf8Encoder
+import parsing.trackPositions
 import strategies.throwUnsafely
 
 object PositionTests extends Suite(m"Stratiform position-index tests"):
@@ -47,65 +48,67 @@ object PositionTests extends Suite(m"Stratiform position-index tests"):
   def run(): Unit =
     suite(m"Top-level compounds"):
       test(m"Locate the document root"):
-        Tel.parseTracked(t"greeting hello\n").locate(TelPath(Nil))
+        t"greeting hello\n".read[Tel].locate(TelPath(Nil))
       . assert(_ == at(1, 1, 0))
 
       test(m"Locate a top-level compound by keyword"):
-        Tel.parseTracked(t"greeting hello\n").locate(TelPath(List(t"greeting")))
+        t"greeting hello\n".read[Tel].locate(TelPath(List(t"greeting")))
       . assert(_ == at(1, 1, 8))
 
       test(m"Locate the second of two top-level compounds"):
-        Tel.parseTracked(t"first a\nsecond b\n").locate(TelPath(List(t"second")))
+        t"first a\nsecond b\n".read[Tel].locate(TelPath(List(t"second")))
       . assert(_ == at(2, 1, 6))
 
       test(m"An unknown keyword returns Unset"):
-        Tel.parseTracked(t"greeting hello\n").locate(TelPath(List(t"absent")))
+        t"greeting hello\n".read[Tel].locate(TelPath(List(t"absent")))
       . assert(_ == Unset)
 
     suite(m"Nested compounds"):
       test(m"Locate a child compound"):
-        Tel.parseTracked(t"person\n  name Alice\n  age 30\n")
+        t"person\n  name Alice\n  age 30\n".read[Tel]
         . locate(TelPath(List(t"person", t"name")))
       . assert(_ == at(2, 3, 4))
 
       test(m"Locate a sibling child on a later line"):
-        Tel.parseTracked(t"person\n  name Alice\n  age 30\n")
+        t"person\n  name Alice\n  age 30\n".read[Tel]
         . locate(TelPath(List(t"person", t"age")))
       . assert(_ == at(3, 3, 3))
 
       test(m"Locate a grandchild compound"):
-        Tel.parseTracked(t"a\n  b\n    c hello\n").locate(TelPath(List(t"a", t"b", t"c")))
+        t"a\n  b\n    c hello\n".read[Tel].locate(TelPath(List(t"a", t"b", t"c")))
       . assert(_ == at(3, 5, 1))
 
       test(m"A missing intermediate segment returns Unset"):
-        Tel.parseTracked(t"person\n  name Alice\n").locate(TelPath(List(t"person", t"absent")))
+        t"person\n  name Alice\n".read[Tel].locate(TelPath(List(t"person", t"absent")))
       . assert(_ == Unset)
 
     suite(m"Column tracks indentation"):
       test(m"A top-level keyword is at column 1"):
-        Tel.parseTracked(t"root\n  child value\n").locate(TelPath(List(t"root"))).let(_.column)
+        t"root\n  child value\n".read[Tel].locate(TelPath(List(t"root"))).let(_.column)
       . assert(_ == 1)
 
       test(m"A one-level-deep keyword is at column 3"):
-        Tel.parseTracked(t"root\n  child value\n")
+        t"root\n  child value\n".read[Tel]
         . locate(TelPath(List(t"root", t"child"))).let(_.column)
       . assert(_ == 3)
 
       test(m"A one-level-deep keyword is on the second line"):
-        Tel.parseTracked(t"root\n  child value\n")
+        t"root\n  child value\n".read[Tel]
         . locate(TelPath(List(t"root", t"child"))).let(_.line)
       . assert(_ == 2)
 
     suite(m"Tracking mode"):
-      test(m"A tracked parse records a position index"):
-        Tel.parseTracked(t"greeting hello\n").positionIndex.absent
+      test(m"`import parsing.trackPositions` records a position index"):
+        t"greeting hello\n".read[Tel].positionIndex.absent
       . assert(_ == false)
 
-      test(m"A plain parse leaves the position index Unset"):
+      test(m"Without the import, the position index is Unset"):
+        given PositionTracking = PositionTracking.Off
         t"greeting hello\n".read[Tel].positionIndex
       . assert(_ == Unset)
 
-      test(m"Locating in a plain (untracked) document returns Unset"):
+      test(m"Locating in an untracked document returns Unset"):
+        given PositionTracking = PositionTracking.Off
         t"greeting hello\n".read[Tel].locate(TelPath(List(t"greeting")))
       . assert(_ == Unset)
 

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1969,3 +1969,4 @@ object Tests extends Suite(m"Stratiform Tests"):
     RecordsTests()
     VerifyTests()
     AccrualTests()
+    PositionTests()

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -296,21 +296,9 @@ object Yaml extends Yaml2, Dynamic:
     YamlString | YamlInteger | YamlDecimal | YamlBoolean | YamlNull | YamlSequence | YamlMapping |
       Unset
 
-  // Whether `Yaml.Parser` captures line/column/length descriptors
-  // alongside the AST. The default is `Off`, matching the historic
-  // behaviour. Bring `Yaml.Tracking.On` into scope before calling
-  // `.read[Yaml]` / `.load[Yaml]` / `Yaml.parseAll(...)` to get a
-  // `Yaml` with `positionIndex` populated and `locate(pointer)`
-  // returning concrete `Position`s. Mirrors the precedent set by
-  // `jacinta.NumberMode`.
-  object Tracking:
-    given default: Tracking = Off
-
-  enum Tracking:
-    case On, Off
 
   // A flat `IArray[Int]` of position descriptors, produced alongside the AST
-  // when a `Yaml` is parsed with `Tracking.On`. All internal offsets are
+  // when a `Yaml` is parsed with `PositionTracking.On`. All internal offsets are
   // stored relative to the start of the containing descriptor, so any slice
   // taken at a descriptor boundary is itself a valid `PositionIndex` —
   // mirrors `jacinta.Json.PositionIndex`.
@@ -1435,45 +1423,47 @@ object Yaml extends Yaml2, Dynamic:
   // ── Parser entry-points ─────────────────────────────────────────────────
 
   // Whether parsing captures line/column/length descriptors alongside the
-  // AST is controlled by the contextual `Tracking` mode in scope —
-  // mirrors `jacinta.NumberMode`. Default is `Tracking.Off` (no
+  // AST is controlled by the contextual `PositionTracking` mode in scope —
+  // mirrors `jacinta.NumberMode`. Default is `PositionTracking.Off` (no
   // descriptor capture). Callers wanting position-aware `Yaml.locate`
   // (and, in subsequent PRs, focus-aware decoding) bring
-  // `Tracking.On` into scope before calling `.read[Yaml]` / `.load[Yaml]`
+  // `PositionTracking.On` into scope before calling `.read[Yaml]` / `.load[Yaml]`
   // / `Yaml.parseAll(...)`.
 
-  given decodable: (Tactic[ParseError], Yaml.Tracking) => Yaml is Decodable in Text =
-    text => summon[Yaml.Tracking] match
-      case Yaml.Tracking.On =>
+  given decodable: (Tactic[ParseError], PositionTracking) => Yaml is Decodable in Text =
+    text => summon[PositionTracking] match
+      case PositionTracking.On =>
         val (ast, ints) = Yaml.Parser.parseTracked(text)
         new Yaml(ast, Yaml.PositionIndex(ints))
 
-      case Yaml.Tracking.Off =>
+      case PositionTracking.Off =>
         Yaml(Yaml.Parser.parse(text))
 
-  def parseAll(input: Text)(using Tactic[ParseError], Yaml.Tracking): List[Yaml] =
-    summon[Yaml.Tracking] match
-      case Yaml.Tracking.On =>
+  private[ypsiloid] def parseAll(input: Text)(using Tactic[ParseError], PositionTracking)
+  :   List[Yaml] =
+
+    summon[PositionTracking] match
+      case PositionTracking.On =>
         Yaml.Parser.parseAllTracked(input).map: (ast, ints) =>
           new Yaml(ast, Yaml.PositionIndex(ints))
 
-      case Yaml.Tracking.Off =>
+      case PositionTracking.Off =>
         Yaml.Parser.parseAll(input).map(Yaml(_))
 
-  given aggregable: (Tactic[ParseError], Yaml.Tracking) => Yaml is Aggregable by Text =
+  given aggregable: (Tactic[ParseError], PositionTracking) => Yaml is Aggregable by Text =
     summon[Text is Aggregable by Text].map: text =>
-      summon[Yaml.Tracking] match
-        case Yaml.Tracking.On =>
+      summon[PositionTracking] match
+        case PositionTracking.On =>
           val (ast, ints) = Yaml.Parser.parseTracked(text)
           new Yaml(ast, Yaml.PositionIndex(ints))
 
-        case Yaml.Tracking.Off =>
+        case PositionTracking.Off =>
           Yaml(Yaml.Parser.parse(text))
 
   // Multi-document reads (`---`-separated YAML) through the uniform `.read`
   // API: `text.read[List[Yaml]]` yields one `Yaml` per document. Backed by
   // `parseAll`, this replaces the former bespoke `Text.readAll` extension.
-  given aggregableAll: (Tactic[ParseError], Yaml.Tracking) => List[Yaml] is Aggregable by Text =
+  given aggregableAll: (Tactic[ParseError], PositionTracking) => List[Yaml] is Aggregable by Text =
     summon[Text is Aggregable by Text].map(parseAll(_))
 
   // HTTP content-type integration. `Abstractable across HttpStreams` makes a
@@ -1493,7 +1483,7 @@ object Yaml extends Yaml2, Dynamic:
         ( t"application/yaml; charset=${encoder.encoding.name}",
           Stream(Yaml.unseal(value).show.data) )
 
-  given instantiable: (Tactic[ParseError], Yaml.Tracking)
+  given instantiable: (Tactic[ParseError], PositionTracking)
   =>  Yaml is Instantiable across HttpRequests from Text =
 
     text => Stream(text).read[Yaml]
@@ -1504,16 +1494,16 @@ object Yaml extends Yaml2, Dynamic:
   // `asInstanceOf` cast — `value in Yaml` is just `value { type
   // Form = Yaml }` so the cast is a no-op at runtime.
   given aggregableIn: [value: Decodable in Yaml]
-  =>  ( Tactic[ParseError], Tactic[YamlError], Yaml.Tracking )
+  =>  ( Tactic[ParseError], Tactic[YamlError], PositionTracking )
   =>  (value in Yaml) is Aggregable by Text =
 
     summon[Text is Aggregable by Text].map: text =>
-      val yaml = summon[Yaml.Tracking] match
-        case Yaml.Tracking.On =>
+      val yaml = summon[PositionTracking] match
+        case PositionTracking.On =>
           val (ast, ints) = Yaml.Parser.parseTracked(text)
           new Yaml(ast, Yaml.PositionIndex(ints))
 
-        case Yaml.Tracking.Off =>
+        case PositionTracking.Off =>
           Yaml(Yaml.Parser.parse(text))
 
       yaml.as[value].asInstanceOf[value in Yaml]
@@ -1567,7 +1557,7 @@ object Yaml extends Yaml2, Dynamic:
 
     // Tracked entry points — produce the AST plus a flat `IArray[Int]`
     // descriptor index. Used by the tracking-aware `Decodable`/`Aggregable`
-    // givens in `object Yaml` when `Yaml.Tracking.On` is in scope.
+    // givens in `object Yaml` when `PositionTracking.On` is in scope.
     def parseTracked(input: Text)(using Tactic[ParseError]): (Yaml.Ast, IArray[Int]) =
       val parser = pool.get.nn
       parser.tracking = true
@@ -5670,7 +5660,7 @@ extends Dynamic derives CanEqual:
   private[ypsiloid] def root: Yaml.Ast = rootValue.asInstanceOf[Yaml.Ast]
 
   // The flat position-descriptor index produced alongside the AST when this
-  // `Yaml` was parsed under `Tracking.On`. `Unset` for non-tracking parses
+  // `Yaml` was parsed under `PositionTracking.On`. `Unset` for non-tracking parses
   // and for any `Yaml` built from a decoded/computed value.
   def positionIndex: Optional[Yaml.PositionIndex] = positions
 

--- a/lib/ypsiloid/src/test/ypsiloid.PositionTests.scala
+++ b/lib/ypsiloid/src/test/ypsiloid.PositionTests.scala
@@ -34,6 +34,7 @@ package ypsiloid
 
 import soundness.*
 
+import parsing.trackPositions
 import strategies.throwUnsafely
 
 object PositionTests extends Suite(m"Ypsiloid position-index tests"):
@@ -41,9 +42,8 @@ object PositionTests extends Suite(m"Ypsiloid position-index tests"):
   private def at(line: Int, column: Int, length: Int): Yaml.Ast.Position =
     Yaml.Ast.Position(line, column, length = length)
 
-  // Tracking-on context — every test in this suite parses under
-  // `Yaml.Tracking.On` so `.read[Yaml]` produces a tracked `Yaml`.
-  private given Yaml.Tracking = Yaml.Tracking.On
+  // Tracking-on context — the suite-level `import parsing.trackPositions` makes
+  // every `.read[Yaml]` below produce a tracked `Yaml`.
 
   def run(): Unit =
     suite(m"Single-line root primitives"):
@@ -176,9 +176,9 @@ object PositionTests extends Suite(m"Ypsiloid position-index tests"):
       . assert(identity)
 
     suite(m"Non-tracking mode"):
-      test(m"Default Tracking.Off leaves positionIndex Unset"):
-        // Locally override the suite-level `Tracking.On` to verify the
+      test(m"Default PositionTracking.Off leaves positionIndex Unset"):
+        // Locally override the suite-level `trackPositions` import to verify the
         // untracked path.
-        given Yaml.Tracking = Yaml.Tracking.Off
+        given PositionTracking = PositionTracking.Off
         t"42".read[Yaml].positionIndex
       . assert(_ == Unset)

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,5 +32,8 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Cursor, Datum, Format, Formatting, Lineation, ParseError, Producer,
-    Positionable, locate, locateKey}
+export zephyrine.{Addressable, Cursor, Datum, Format, Formatting, Lineation, ParseError,
+    PositionTracking, Producer, Positionable, locate, locateKey}
+
+package parsing:
+  export zephyrine.parsing.trackPositions

--- a/lib/zephyrine/src/core/zephyrine.PositionTracking.scala
+++ b/lib/zephyrine/src/core/zephyrine.PositionTracking.scala
@@ -30,107 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package ypsiloid
+package zephyrine
 
-import soundness.*
+// A contextual toggle shared by the soundness parsers (`jacinta`, `ypsiloid`,
+// `stratiform`, …) that record source positions. The default given is `Off`,
+// so the generic `read`/`load` entry points parse without tracking and pay no
+// cost. Bringing the `parsing.trackPositions` given into scope (see
+// `zephyrine_core`) overrides that default with `On`, so the same `read` call
+// produces a value carrying a `PositionIndex` — locatable through `Positionable`
+// (`value.locate(path)`). Mirrors the default-off / import-on shape of `Lineation`.
+// (Named `PositionTracking` rather than `Tracking` to avoid clashing with
+// `contingency.Tracking` under `import soundness.*`.)
+object PositionTracking:
+  given default: PositionTracking = Off
 
-import strategies.throwUnsafely
-import errorDiagnostics.stackTracesDiagnostics
-
-case class FPerson(name: Text, age: Int, email: Text) derives CanEqual
-case class FAddress(street: Text, city: Text, zip: Text) derives CanEqual
-case class FContact(person: FPerson, address: FAddress) derives CanEqual
-
-object FocusTests extends Suite(m"Ypsiloid focus + position tests"):
-
-  case class Captured
-    ( items: List[(Text, Optional[Int], Optional[Int])] = Nil )
-    ( using Diagnostics )
-  extends Error(m"${items.length} validation issues"):
-    def +(focus: Text, line: Optional[Int], column: Optional[Int]): Captured =
-      Captured(items :+ (focus, line, column))
-
-  private def captureFoci[result](yaml: Yaml)
-                                 (decode: Yaml => result raises YamlError tracks Yaml.Focus)
-  :   List[(Text, Optional[Int], Optional[Int])] =
-    validate[Yaml.Focus](Captured()):
-      case error: YamlError =>
-        val position = prior.let(_.position)
-        accrual + ( prior.let(_.pointer.encode).or(t"#"),
-                    position.let(_.line),
-                    position.let(_.column) )
-    . protect(decode(yaml)).items
-
-  def run(): Unit =
-    suite(m"Pointer-only focus (untracked Yaml)"):
-      test(m"Missing field reports the focus pointer (no position)"):
-        val yaml = t"name: Alice\nage: 30".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/email"))
-
-      test(m"Wrong-type field reports the focus pointer (no position)"):
-        val yaml = t"name: Alice\nage: thirty\nemail: a@b".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/age"))
-
-      test(m"Nested case-class missing field reports root-first path"):
-        val yaml = t"""
-person:
-  name: X
-  age: 1
-  email: x@y
-address:
-  street: S
-""".read[Yaml]
-        // address is missing both `city` and `zip`; primitive
-        // decoders raise+yet on the `Unset` sentinel so both accrue
-        // their own errors rather than the first one aborting the
-        // whole decode.
-        captureFoci(yaml)(_.as[FContact]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/address/city", "#/address/zip"))
-
-      test(m"Untracked roots leave the focus position Unset"):
-        val yaml = t"name: Alice\nage: 30".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).forall((_, line, _) => line == Unset)
-      . assert(identity)
-
-    suite(m"Position-aware focus (tracked Yaml)"):
-      import parsing.trackPositions
-
-      test(m"Tracked root: focus pointers are still correct"):
-        // The decoder still aborts on first error (raise+yet is a PR 3
-        // change), so position population via `as[T]`'s Foci.supplement
-        // doesn't fire when an error short-circuits the decode. The
-        // focus *path* is registered by the focus block's try/finally
-        // either way, so we verify that path here and exercise the
-        // `withPosition` plumbing in a separate direct test below.
-        val yaml = t"name: Alice\nage: 30".read[Yaml]
-        captureFoci(yaml)(_.as[FPerson]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/email"))
-
-      test(m"Nested missing field reports root-first path on a tracked root"):
-        val source = t"""person:
-  name: C
-  age: 25
-  email: c@x
-address:
-  street: X
-"""
-        captureFoci(source.read[Yaml])(_.as[FContact]).map(_(0).s).to(Set)
-      . assert(_ == Set("#/address/city", "#/address/zip"))
-
-      test(m"withPosition on a tracked Yaml resolves the pointer to a real position"):
-        // Direct exercise of `Yaml.Focus#withPosition`. Even though the
-        // current decoder aborts before `as[T]`'s `Foci.supplement` can
-        // run, the plumbing is wired correctly — once primitive
-        // decoders gain raise+yet sentinels in PR 3, wrong-type errors
-        // will land with `position` populated through this same path.
-        val source = t"name: Alice\nage: 30\nemail: a@b\n"
-        val yaml = source.read[Yaml]
-        Yaml.Focus(YamlPath()(t"age")).withPosition(yaml).position.let(_.line)
-      . assert(_ == 2)
-
-      test(m"withPosition leaves position Unset when the pointer doesn't resolve"):
-        val yaml = t"name: Alice".read[Yaml]
-        Yaml.Focus(YamlPath()(t"missing")).withPosition(yaml).position
-      . assert(_ == Unset)
+enum PositionTracking derives CanEqual:
+  case On, Off

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -74,4 +74,10 @@ package lineation:
     inline def active: Boolean = true
     inline def track(datum: Byte): Boolean = datum == 13
 
+package parsing:
+  // Bring into scope with `import parsing.trackPositions` to make the generic
+  // `read`/`load` entry points of the position-aware parsers record source
+  // positions, overriding the `PositionTracking.Off` companion default.
+  given trackPositions: PositionTracking = PositionTracking.On
+
 export Cursor.{Mark, Offset}


### PR DESCRIPTION
Source-position tracking for the JSON, YAML and TEL parsers is now enabled by bringing a single import, `parsing.trackPositions`, into scope rather than by calling a bespoke `parseTracked` method: the ordinary `read`/`load` entry points record positions when the import is present and stay allocation-free otherwise. Stratiform additionally gains a source-position side-table for its parsed `Tel` tree, locatable through `tel.locate(pointer)`, and now locates schema-validation errors at the offending compound instead of the document root. The public `parse`/`parseTracked`/`parseAll` methods are withdrawn in favour of the generic `read` entry points.

Position tracking is now opt-in through a single import, uniform across formats:

```scala
import soundness.*
import parsing.trackPositions
import charEncoders.utf8Encoder

val tel = t"person\n  name Alice\n".read[Tel]   // carries a PositionIndex
tel.locate(TelPath(List(t"person", t"name")))    // Optional[Position] → line 2, column 3
```

Without the import, `read`/`load` parse exactly as before and carry no positions, so the throughput path is unaffected. The same `parsing.trackPositions` import governs `read[Json]` and `read[Yaml]`.

Each located `Position` exposes a 0-based `denominative.Span` (`position.span`) that drops straight into editor tooling (e.g. LSP ranges). Schema-validation errors raised by `Tel.Type.assign` under a `validate[Tel.Focus]` boundary now carry the keyword path *and* — for a tracked document — the source position of the offending node.

The bespoke `Json.parseTracked`, `Tel.parseTracked` and `Yaml.parseAll`/`Yaml.Tracking` entry points have been removed; parse exclusively through `read`/`load`. XML (xylophone) and HTML (honeycomb) keep their current scheme for now and will migrate separately (#1472).

🤖 Generated with [Claude Code](https://claude.com/claude-code)