### PR TITLE
Add a WASI wall-clock backend to aviation

### DIFF
--- a/lib/aviation/res/wasi/aviation/clocks.wit
+++ b/lib/aviation/res/wasi/aviation/clocks.wit
@@ -1,7 +1,14 @@
-// The subset of the WASI `monotonic-clock` interface that aviation uses to read elapsed time.
+// The subset of the WASI clock interfaces that aviation uses: the monotonic clock for elapsed time
+// and the wall clock for calendar time. `wall-clock` returns a `datetime` record `{ seconds: u64,
+// nanoseconds: u32 }`, declared here as the ABI-identical `tuple<u64, u32>` so its value crosses the
+// boundary as a `(U64, U32)` pair.
 
 package wasi:clocks@0.2.0;
 
 interface monotonic-clock {
   now: func() -> u64;
+}
+
+interface wall-clock {
+  now: func() -> tuple<u64, u32>;
 }

--- a/lib/aviation/src/wasi/aviation_wasi.scala
+++ b/lib/aviation/src/wasi/aviation_wasi.scala
@@ -57,3 +57,11 @@ package clocks:
   inline given wasiMonotonicClock: MonotonicClock = new MonotonicClock:
     def apply(): Instant over Monotonic =
       Instant.of[Monotonic](Foreign["monotonic-clock", Wit].`now`.invoke[U64].bits.s64.long)
+
+  // The wall clock reads `wasi:clocks/wall-clock` `now`, whose `datetime` record crosses the
+  // boundary as a `(seconds: U64, nanoseconds: U32)` pair, converted to POSIX millisecond ticks.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasiClock: Clock = new Clock:
+    def apply(): Instant over Posix =
+      val (seconds, nanoseconds) = Foreign["wall-clock", Wit].`now`.invoke[(U64, U32)]
+      Instant.of[Posix](seconds.bits.s64.long*1000 + nanoseconds.bits.s32.int/1000000)

--- a/lib/aviation/src/wasi/soundness_aviation_wasi.scala
+++ b/lib/aviation/src/wasi/soundness_aviation_wasi.scala
@@ -35,4 +35,4 @@ package soundness
 export aviation.{WasiClockApi, wasiClockApi}
 
 package clocks:
-  export aviation.clocks.wasiMonotonicClock
+  export aviation.clocks.{wasiMonotonicClock, wasiClock}

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -157,41 +157,53 @@ object WasmInvoke:
 
     val listClass = Symbol.requiredClass("scala.collection.immutable.List")
 
-    // A `list<tuple<Ac, Bc>>` (Scala `List[(A, B)]`), if that is the shape of the result.
-    def listOfPairs(leftType: TypeRepr, rightType: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+    // The carrier and a decode for a single `tuple<Lc, Rc>` (Scala `(L, R)`): scala-wasm's `Tuple2`
+    // (whose name is resolved here, downstream, so it never appears in `xenophile.wasm`'s own
+    // scala-wasm-free compilation), and a `Term => Term` reading `_1`/`_2` off a raw `Tuple2` term.
+    // A WIT `record` of two fields shares a `tuple`'s ABI, so this also serves a two-field record.
+    def pairCodec(leftType: TypeRepr, rightType: TypeRepr)
+    :   (TypeRepr, TypeRepr, Term => Term) =
+
       leftType.asType.absolve match case '[left] => rightType.asType.absolve match
         case '[right] =>
           val (leftCarrier, leftDecode) = leaf(leftType)
           val (rightCarrier, rightDecode) = leaf(rightType)
-
-          // The carrier element is scala-wasm's `Tuple2`, whose name is resolved here (downstream),
-          // so it never appears in `xenophile.wasm`'s own (scala-wasm-free) compilation.
           val witTuple2 = Symbol.requiredClass("scala.scalajs.wit.Tuple2")
           val tupleCarrier = witTuple2.typeRef.appliedTo(List(leftCarrier, rightCarrier))
-          val arrayCarrier = defn.ArrayClass.typeRef.appliedTo(tupleCarrier)
           val pairType = TypeRepr.of[(left, right)]
 
-          val decode: Expr[Any] => Expr[Any] = call =>
-            // Each element is a `scala.scalajs.wit.Tuple2`; read `_1`/`_2`, decode them, and build
-            // a Scala `(left, right)`. Done through a reflective `map` because the element type is
-            // not nameable in this module.
-            val method = MethodType(List("tuple"))(_ => List(TypeRepr.of[Any]), _ => pairType)
+          val decodeTuple: Term => Term = raw =>
+            val tuple = TypeApply(Select.unique(raw, "asInstanceOf"), List(Inferred(tupleCarrier)))
+            val leftValue = leftDecode(Select.unique(tuple, "_1").asExprOf[Any])
+            val rightValue = rightDecode(Select.unique(tuple, "_2").asExprOf[Any])
+            '{(${leftValue.asExprOf[left]}, ${rightValue.asExprOf[right]})}.asTerm
 
-            val mapper = Lambda(Symbol.spliceOwner, method, (_, params) =>
-              val tuple = TypeApply(Select.unique(params.head.asInstanceOf[Term], "asInstanceOf"),
-                  List(Inferred(tupleCarrier)))
+          (tupleCarrier, pairType, decodeTuple)
 
-              val leftValue = leftDecode(Select.unique(tuple, "_1").asExprOf[Any])
-              val rightValue = rightDecode(Select.unique(tuple, "_2").asExprOf[Any])
-              '{(${leftValue.asExprOf[left]}, ${rightValue.asExprOf[right]})}.asTerm)
+    // A bare `tuple<A, B>` (Scala `(A, B)`).
+    def pairOf(leftType: TypeRepr, rightType: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      val (tupleCarrier, _, decodeTuple) = pairCodec(leftType, rightType)
+      (tupleCarrier, call => decodeTuple(call.asTerm).asExprOf[Any])
 
-            val wrapped =
-              '{scala.collection.immutable.ArraySeq.unsafeWrapArray($call.asInstanceOf[Array[Any]])}
+    // A `list<tuple<Ac, Bc>>` (Scala `List[(A, B)]`).
+    def listOfPairs(leftType: TypeRepr, rightType: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      val (tupleCarrier, pairType, decodeTuple) = pairCodec(leftType, rightType)
+      val arrayCarrier = defn.ArrayClass.typeRef.appliedTo(tupleCarrier)
 
-            val mapped = Select.overloaded(wrapped.asTerm, "map", List(pairType), List(mapper))
-            Select.unique(mapped, "toList").asExprOf[Any]
+      val decode: Expr[Any] => Expr[Any] = call =>
+        // A reflective `map` because the element type (`Tuple2`) is not nameable in this module.
+        val method = MethodType(List("tuple"))(_ => List(TypeRepr.of[Any]), _ => pairType)
 
-          (arrayCarrier, decode)
+        val mapper = Lambda(Symbol.spliceOwner, method,
+            (_, params) => decodeTuple(params.head.asInstanceOf[Term]))
+
+        val wrapped =
+          '{scala.collection.immutable.ArraySeq.unsafeWrapArray($call.asInstanceOf[Array[Any]])}
+
+        val mapped = Select.overloaded(wrapped.asTerm, "map", List(pairType), List(mapper))
+        Select.unique(mapped, "toList").asExprOf[Any]
+
+      (arrayCarrier, decode)
 
     val optionClass = Symbol.requiredClass("java.util.Optional")
 
@@ -214,6 +226,10 @@ object WasmInvoke:
 
       case OrType(left, right) if right =:= TypeRepr.of[Unset] =>
         optionOf(left)
+
+      case AppliedType(tuple, List(leftType, rightType))
+      if tuple.typeSymbol == defn.TupleClass(2) =>
+        pairOf(leftType, rightType)
 
       case AppliedType(list, List(element)) if list.typeSymbol == listClass =>
         element.dealias match


### PR DESCRIPTION
Aviation gains a `wasiClock` given that reads calendar time from the WebAssembly Component Model's `wasi:clocks/wall-clock` interface, so `now()` works in a standalone WebAssembly component; like the other `.wasi` backends it compiles in the ordinary build with no WebAssembly-specific dependency. Supporting this, Xenophile's `invoke` now reads bare WIT `tuple<A, B>` results (as `(A, B)`), and — because a WIT `record`'s canonical ABI is identical to the tuple of its fields — an ABI-equivalent tuple declaration can stand in for a flat record result such as `wall-clock`'s `datetime`.

## WASI-backed wall clock

```scala
import aviation.*
import aviation.clocks.wasiClock
import aviation.wasiClockApi  // brings the `wasi:clocks` interfaces into scope

val instant = now()   // reads `wasi:clocks/wall-clock`'s `now`
```

The `datetime` record (`{seconds: u64, nanoseconds: u32}`) crosses the boundary as a `(U64, U32)` pair and is converted to POSIX millisecond ticks; the component's imported interface remains the true `datetime` record. Verified end-to-end under `wasmtime`.

## Bare `tuple<A, B>` results in `invoke`

`invoke` can now read a WIT `tuple<A, B>` result as a Scala `(A, B)`, not only inside a `list`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)