### PR TITLE
Support WIT resources in Xenophile, with WASI-backed standard streams

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1521,6 +1521,12 @@ object turbulence extends Library:
     override def scalaJs = false
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // WASI-backed standard streams: a `Stdio` whose output writes through the `wasi:io/streams`
+  // `output-stream` resource, materialized by xenophile's `invoke` at the downstream (Wasm-linked)
+  // summoning site. Target-neutral `.sjsir` here; only meaningful linked as a component.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, jvm)
 
 object typonym extends Library:

--- a/lib/turbulence/res/wasi/turbulence/cli.wit
+++ b/lib/turbulence/res/wasi/turbulence/cli.wit
@@ -1,0 +1,21 @@
+// The subset of the WASI interfaces that turbulence uses for standard output and error: the
+// `output-stream` resource (from `wasi:io/streams`) and the `wasi:cli` functions that provide the
+// standard streams.
+
+package wasi:io@0.2.0;
+
+interface streams {
+  resource output-stream {
+    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+  }
+}
+
+package wasi:cli@0.2.0;
+
+interface stdout {
+  get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+  get-stderr: func() -> output-stream;
+}

--- a/lib/turbulence/src/wasi/soundness_turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/soundness_turbulence_wasi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export turbulence.{WasiCliApi, wasiCliApi}
+
+package stdios:
+  export turbulence.stdios.wasiStdio

--- a/lib/turbulence/src/wasi/turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/turbulence_wasi.scala
@@ -1,0 +1,92 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+import java.io as ji
+
+import scala.annotation.nowarn
+
+import anticipation.*
+import hellenism.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+import soundness.{invoke, dispose}
+import xenophile.*
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for module ids and resource methods.
+type WasiCliApi = Interface in Wit at "/turbulence/cli.wit"
+given wasiCliApi: WasiCliApi = Interface[Wit](cp"/turbulence/cli.wit")
+
+package stdios:
+  // A `Stdio` whose standard output and error write through the WASI `output-stream` resource:
+  // each write obtains the stream handle (`get-stdout`/`get-stderr`), invokes its
+  // `blocking-write-and-flush` method, and disposes of the handle. `inline`, so the `invoke`s
+  // expand at the downstream summoning site: the Wasm Component imports only materialize in code
+  // compiled for a Wasm target. Summoning it requires `wasiCliApi` (and this module's WIT
+  // resource) to be visible at that site.
+  //
+  // The per-site duplication the compiler warns about is the point: the instances must materialize
+  // at the downstream summoning site, and a WASI-linked application summons them once.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasiStdio: (termcap0: Termcap) => Stdio =
+    def send(error: Boolean, data: Data): Unit =
+      val handle =
+        if error then Foreign["stderr", Wit].`get-stderr`.invoke[WitHandle of "output-stream"]
+        else Foreign["stdout", Wit].`get-stdout`.invoke[WitHandle of "output-stream"]
+
+      val stream: Foreign of "output-stream" from Wit = handle
+      stream.`blocking-write-and-flush`(data).invoke[Unit]
+      handle.dispose()
+
+    // Byte-level writes follow the same path. (The `PrintStream`s exist for `Stdio`'s API;
+    // `print`/`printErr` below bypass them, sending the text's UTF-8 bytes directly.)
+    def wasiStream(error: Boolean): ji.OutputStream = new ji.OutputStream:
+      def write(byte: Int): Unit = write(Array[Byte](byte.toByte), 0, 1)
+
+      override def write(array: Array[Byte] | Null, offset: Int, length: Int): Unit =
+        if array != null && length > 0 then
+          val slice = java.util.Arrays.copyOfRange(array, offset, offset + length).nn
+          send(error, slice.immutable(using Unsafe))
+
+    def bytes(text: Text): Data = text.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+
+    new Stdio:
+      val termcap: Termcap = termcap0
+      val out: ji.PrintStream = ji.PrintStream(wasiStream(false), true)
+      val err: ji.PrintStream = ji.PrintStream(wasiStream(true), true)
+      val in: ji.InputStream = Stdio.MuteInputStream
+
+      override def print(text: Text): Unit = send(false, bytes(text))
+      override def printErr(text: Text): Unit = send(true, bytes(text))

--- a/lib/xenophile/src/core/xenophile.Dialect.scala
+++ b/lib/xenophile/src/core/xenophile.Dialect.scala
@@ -39,11 +39,14 @@ import vacuous.*
 // records its parameter types. `result` is the foreign type the member produces. `module`, when
 // set, qualifies the member with the fully-qualified module it belongs to — used by ecosystems
 // (such as WIT) whose members must be addressed by a module identifier at the point of invocation;
-// it is `Unset` for grammars that need no such qualifier.
+// it is `Unset` for grammars that need no such qualifier. `resource`, when set, names the stateful
+// foreign type (a WIT `resource`) the member is a method of, so an invocation can address it (e.g.
+// `[method]output-stream.blocking-write-and-flush`) and thread the receiver's handle.
 case class Prototype
   ( parameters: Optional[List[Foreign.Type]],
     result:     Foreign.Type,
-    module:     Optional[Text] = Unset )
+    module:     Optional[Text] = Unset,
+    resource:   Optional[Text] = Unset )
 
 // A grammar for a particular foreign type system: parses a definitions source into a map from each
 // foreign type name to its members' prototypes. Keyed on an ecosystem so the macro stays agnostic.

--- a/lib/xenophile/src/wasm/soundness_xenophile_wasm.scala
+++ b/lib/xenophile/src/wasm/soundness_xenophile_wasm.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export xenophile.{Wasm, WasmInvoke}
+export xenophile.{Wasm, WasmInvoke, WitHandle}
 
 // Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
 // call. Must be applied directly to an inline navigation chain — e.g.
@@ -44,3 +44,9 @@ export xenophile.{Wasm, WasmInvoke}
 extension (foreign: xenophile.Foreign)
   inline def invoke[result]: result =
     ${xenophile.WasmInvoke.invoke[result]('foreign)}
+
+// Releases a WIT resource handle, emitting its `[resource-drop]` Component Model import. Like
+// `invoke`, plain `inline` so the import materializes at the downstream (Wasm-linked) call site.
+extension (handle: xenophile.WitHandle)
+  inline def dispose(): Unit =
+    ${xenophile.WasmInvoke.dispose('handle)}

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -117,19 +117,58 @@ object WasmInvoke:
     // adaptation nodes that its literal-`classOf` check rejects).
     val classOfCarrier = Literal(ClassOfConstant(carrier))
 
-    // The WIT result type as text, straight from the `.wit` definition, so the backend has the full
-    // shape (e.g. `list<tuple<string, string>>`) that `classOf` cannot carry: `classOf` erases
-    // nested type arguments, collapsing a `tuple<string, string>` to a fieldless tuple. `classOf`
-    // still supplies the (erasure-safe) IR result type.
-    val witType = Literal(StringConstant(prototype.result.text.s))
-
     // The `sigAndArgs` argument must be a `Repeated` ascribed with the tree-level repeated type
     // (`scala.<repeated>[Any]` — not `Seq[Any]`, which reads as a single sequence value and gets
     // re-wrapped as one vararg element).
     val repeatedAny = defn.RepeatedParamClass.typeRef.appliedTo(TypeRepr.of[Any])
 
+    // The WIT result type as a structured descriptor, straight from the `.wit` definition, so the
+    // backend has the full shape (e.g. `list<tuple<string, string>>`) that `classOf` cannot carry:
+    // `classOf` erases nested type arguments, collapsing a `tuple<string, string>` to a fieldless
+    // tuple. The descriptor is a tree of calls to the `wit*` markers in `scala.scalajs.wit`
+    // (resolved here, downstream, like `witImportCall` itself), which the backend deconstructs by
+    // symbol; `classOf` still supplies the (erasure-safe) IR result type.
+    def marker(name: String): Term = Ref(Symbol.requiredMethod("scala.scalajs.wit." + name))
+
+    val primitives =
+      Set("bool", "u8", "u16", "u32", "u64", "s8", "s16", "s32", "s64", "f32", "f64", "char",
+          "string")
+
+    def descriptor(witType: Foreign.Type): Term = witType match
+      case Foreign.Type.Named(name) if primitives(name.s) =>
+        Apply(marker("witPrim"), List(Literal(StringConstant(name.s))))
+
+      case Foreign.Type.Union(List(inner, Foreign.Type.Named(none))) if none.s == "none" =>
+        Apply(marker("witOption"), List(descriptor(inner)))
+
+      case Foreign.Type.Applied(constructor, arguments) => constructor.s match
+        case "list" =>
+          Apply(marker("witList"), List(descriptor(arguments.head)))
+
+        case "option" =>
+          Apply(marker("witOption"), List(descriptor(arguments.head)))
+
+        case "tuple" =>
+          val elements = Repeated(arguments.map(descriptor), TypeTree.of[Any])
+          Apply(marker("witTuple"), List(Typed(elements, Inferred(repeatedAny))))
+
+        case "result" =>
+          def arm(tpe: Foreign.Type): Term = tpe match
+            case Foreign.Type.Named(name) if name.s == "_" => marker("witUnit")
+            case other                                     => descriptor(other)
+
+          Apply(marker("witResult"), List(arm(arguments.head), arm(arguments(1))))
+
+        case other =>
+          halt(m"xenophile: the WIT type constructor $other cannot cross a WIT boundary yet")
+
+      case other =>
+        halt(m"xenophile: the WIT type ${other.text} cannot cross a WIT boundary yet")
+
     val varargs =
-      Typed(Repeated(List(classOfCarrier, witType), TypeTree.of[Any]), Inferred(repeatedAny))
+      Typed
+        ( Repeated(List(classOfCarrier, descriptor(prototype.result)), TypeTree.of[Any]),
+          Inferred(repeatedAny) )
 
     val callTerm =
       Apply

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -37,6 +37,7 @@ import scala.quoted.*
 import anticipation.*
 import distillate.*
 import fulminate.*
+import gossamer.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -79,21 +80,57 @@ object WasmInvoke:
       case Apply(Select(_, "make"), List(argument)) => strip(argument)
       case _                                        => notCall
 
+    // The elements of the `Expr.ofList`-built argument list of an `Expression.Apply`.
+    def argumentList(term: Term): List[Term] = strip(term) match
+      case Apply(_, List(varargs)) => strip(varargs) match
+        case Repeated(elements, _) => elements.map(strip)
+        case _                     => Nil
+
+      case _ =>
+        Nil
+
+    // The Scala value wrapped by the `Foreign.converter` `Conversion` in a navigation operand (a
+    // converted argument, or a `WitHandle` receiver): the argument of the conversion's `apply`.
+    def convertedValue(term: Term): Term =
+      var found: Optional[Term] = Unset
+
+      val traverser = new TreeTraverser:
+        override def traverseTree(tree: Tree)(owner: Symbol): Unit = tree match
+          case Apply(Select(qualifier, "apply"), List(value))
+          if qualifier.tpe <:< TypeRepr.of[Conversion[Nothing, Foreign]] =>
+            if found.absent then found = value
+
+          case _ =>
+            traverseTreeChildren(tree)(owner)
+
+      traverser.traverseTree(term)(Symbol.spliceOwner)
+
+      found.or:
+        halt(m"xenophile: a foreign operand must be a Scala value with an `Interoperable` instance")
+
     // Either an applied call — `Expression.Apply(select, args)`, whose companion `apply` takes two
     // arguments — or the bare selection of a zero-parameter WIT function (`Expression.Select`,
     // whose companion `apply` takes three): `interface.function.invoke[R]`. The latter is
     // preferred inside `inline` definitions, where re-inlining an empty-varargs application trips
     // path-dependent type avoidance.
-    val selectNode = expression match
-      case Apply(Select(_, "apply"), List(node, _)) => strip(node)
-      case _                                        => expression
+    val (selectNode, argumentTerms) = expression match
+      case Apply(Select(_, "apply"), List(node, arguments)) =>
+        (strip(node), argumentList(arguments))
 
-    val (owner, function) = selectNode.absolve match
-      case Apply(Select(_, "apply"), List(_, member, owner)) => (literal(owner), literal(member))
-      case _                                                 => notCall
+      case _ =>
+        (expression, Nil)
+
+    val (receiverNode, owner, function) = selectNode.absolve match
+      case Apply(Select(_, "apply"), List(receiver, member, owner)) =>
+        (strip(receiver), literal(owner), literal(member))
+
+      case _ =>
+        notCall
 
     // Look up the function's module id (e.g. `wasi:random/random@0.2.0`) from the definitions.
-    val members = Xenophile.definitions(origin, Xenophile.locusOf(origin)).at(owner).or:
+    val allDefinitions = Xenophile.definitions(origin, Xenophile.locusOf(origin))
+
+    val members = allDefinitions.at(owner).or:
       halt(m"xenophile: the foreign type $owner is not defined")
 
     val prototype = members.at(function).or:
@@ -102,11 +139,68 @@ object WasmInvoke:
     val module = prototype.module.or:
       halt(m"xenophile: $owner.$function is not addressable as a WIT import (it has no module id)")
 
+    // The module in which a named WIT type is defined: for a resource, taken from its methods; for
+    // other named types (variants, records), the referencing function's own module — WASI types
+    // are used within the interface that declares them.
+    def definingModule(name: Text): Optional[Text] =
+      allDefinitions.at(name).let(_.values.to(List).prim.let(_.module).or(Unset)).or(module)
+
+    def facadeOf(name: Text): Symbol =
+      facadeClass(definingModule(name).or(halt(m"xenophile: $name has no defining module")), name)
+
     // The requested result type determines both the WIT carrier the import returns (told to
     // `witImportCall` as `classOf[Carrier]`) and how that carrier is decoded. `deriveResult`
     // computes the pair; the carrier for a `list<tuple<…>>` mentions the scala-wasm `Tuple2` class,
-    // which is resolved (and only ever appears) in this downstream-expanded code.
-    val (carrier, decode) = deriveResult[result]
+    // which is resolved (and only ever appears) in this downstream-expanded code. Two result shapes
+    // are handled here rather than in `deriveResult`, because they need the WIT prototype:
+    //
+    //  -  A `WitHandle of topic` result is a WIT resource: its carrier is the resource's facade
+    //     class, and the raw handle is wrapped in a `WitHandle`.
+    //  -  A `Unit` result against a WIT `result<…>` function crosses as a `scala.scalajs.wit.Result`
+    //     and is checked: an `Err` raises an exception, an `Ok` becomes `()`.
+    val witHandleTopic: Optional[TypeRepr] = TypeRepr.of[result].dealias match
+      case Refinement(base, "Topic", TypeBounds(_, topic)) if base =:= TypeRepr.of[WitHandle] =>
+        topic
+
+      case _ =>
+        Unset
+
+    val (carrier, decode) = witHandleTopic.absolve match
+      case topic: TypeRepr =>
+        prototype.result.absolve match
+          case Foreign.Type.Named(name) =>
+            val facade = facadeOf(name)
+
+            val decode: Expr[Any] => Expr[Any] = call =>
+              val handle = '{new WitHandle($call)}.asTerm
+              TypeApply(Select.unique(handle, "asInstanceOf"), List(TypeTree.of[result]))
+                .asExprOf[Any]
+
+            (facade.typeRef, decode)
+
+          case other =>
+            halt(m"xenophile: $owner.$function does not return a WIT resource")
+
+      case _ =>
+        if TypeRepr.of[result] =:= TypeRepr.of[Unit] then prototype.result match
+          case Foreign.Type.Applied(constructor, _) if constructor.s == "result" =>
+            val resultClass = Symbol.requiredClass("scala.scalajs.wit.Result")
+            val okClass = Symbol.requiredClass("scala.scalajs.wit.Ok")
+            val okType = AppliedType(okClass.typeRef, List(TypeBounds.empty))
+
+            val decode: Expr[Any] => Expr[Any] = call =>
+              '{  val outcome = $call
+
+                  if !${ TypeApply(Select.unique('outcome.asTerm, "isInstanceOf"),
+                      List(Inferred(okType))).asExprOf[Boolean] }
+                  then throw new RuntimeException("WIT import returned an error: " + outcome)  }
+
+            (resultClass.typeRef, decode)
+
+          case _ =>
+            halt(m"xenophile: `invoke[Unit]` requires a WIT `result<…>` function")
+
+        else deriveResult[result]
 
     // Emit `<decode>(witImportCall(module, function, classOf[Carrier]))`. The import call is built
     // by looking up `witImportCall` in the *downstream* classpath (the scala-wasm library), so this
@@ -138,6 +232,11 @@ object WasmInvoke:
       case Foreign.Type.Named(name) if primitives(name.s) =>
         Apply(marker("witPrim"), List(Literal(StringConstant(name.s))))
 
+      // A non-primitive name is a WIT resource, variant, record, flags or enum, conveyed by its
+      // facade class, from which the backend derives the WIT type (via the class's annotations).
+      case Foreign.Type.Named(name) =>
+        Apply(marker("witNamed"), List(Literal(ClassOfConstant(facadeOf(name).typeRef))))
+
       case Foreign.Type.Union(List(inner, Foreign.Type.Named(none))) if none.s == "none" =>
         Apply(marker("witOption"), List(descriptor(inner)))
 
@@ -165,17 +264,115 @@ object WasmInvoke:
       case other =>
         halt(m"xenophile: the WIT type ${other.text} cannot cross a WIT boundary yet")
 
+    // A resource method is imported under its Component Model name, `[method]resource.function`,
+    // and takes the resource's handle — the underlying value of the `WitHandle` receiver — as its
+    // first (borrow) parameter.
+    val importName: Text = prototype.resource.lay(function): resource =>
+      t"[method]$resource.$function"
+
+    val receiverPair: List[Term] = prototype.resource.lay(List()): resource =>
+      val facade = facadeOf(resource)
+
+      // The receiver's handle is recovered at runtime from the `Foreign` value's expression — a
+      // converted `WitHandle` is an `Expression.Literal` wrapping it — so the receiver may be a
+      // bound `val`, not only an inline chain.
+      val handle =
+        '{  ${receiverNode.asExprOf[Foreign.Expression]} match
+              case Foreign.Expression.Literal(handle: WitHandle) => handle.value
+              case _ => throw new RuntimeException("xenophile: not a WIT resource handle")  }
+
+      List(Literal(ClassOfConstant(facade.typeRef)), handle.asTerm)
+
+    // Each declared argument crosses the boundary through its `Encodable in Wasm` codec, passed as
+    // a `(classOf[Carrier], encoded)` pair.
+    val argumentPairs: List[Term] = argumentTerms.flatMap: argument =>
+      val value = convertedValue(argument)
+
+      value.tpe.widen.asType.absolve match
+        case '[argument] =>
+          val encodable = Expr.summon[argument is Encodable in Wasm].getOrElse:
+            halt(m"xenophile: no way to pass a ${value.tpe.widen.show} across a WIT boundary")
+
+          val encoded = '{$encodable.encoded(${value.asExprOf[argument]}).value}.asTerm
+
+          List(Literal(ClassOfConstant(carrierType(encodable))), encoded)
+
     val varargs =
       Typed
-        ( Repeated(List(classOfCarrier, descriptor(prototype.result)), TypeTree.of[Any]),
+        ( Repeated
+            ( List(classOfCarrier, descriptor(prototype.result)) ++ receiverPair ++ argumentPairs,
+              TypeTree.of[Any] ),
           Inferred(repeatedAny) )
 
     val callTerm =
       Apply
         ( Ref(witImportCall),
-          List(Expr(module.s).asTerm, Expr(function.s).asTerm, varargs) )
+          List(Expr(module.s).asTerm, Expr(importName.s).asTerm, varargs) )
 
     decode(callTerm.asExprOf[Any]).asExprOf[result]
+
+  // Releases a WIT resource: emits the `[resource-drop]<resource>` Component Model import for the
+  // handle's resource type, passing the handle as its only parameter.
+  def dispose(self: Expr[WitHandle])(using quotes: Quotes): Expr[Unit] =
+    import quotes.reflect.*
+
+    val topic: Text = self.asTerm.tpe.widen.dealias match
+      case Refinement(_, "Topic", TypeBounds(_, ConstantType(StringConstant(name)))) => name.tt
+      case _ => halt(m"xenophile: the handle does not have a known WIT resource type")
+
+    val origin = TypeRepr.of[Wit]
+    val definitions = Xenophile.definitions(origin, Xenophile.locusOf(origin))
+
+    val module = definitions.at(topic).let(_.values.to(List).prim.let(_.module).or(Unset)).or:
+      halt(m"xenophile: the WIT resource $topic has no known module")
+
+    val facade = facadeClass(module, topic)
+    val witImportCall = Symbol.requiredMethod("scala.scalajs.wit.witImportCall")
+    val repeatedAny = defn.RepeatedParamClass.typeRef.appliedTo(TypeRepr.of[Any])
+    val unitMarker = Ref(Symbol.requiredMethod("scala.scalajs.wit.witUnit"))
+    val handle = Select.unique(self.asTerm, "value")
+
+    val varargs =
+      Typed
+        ( Repeated
+            ( List(Literal(ClassOfConstant(TypeRepr.of[Unit])), unitMarker,
+                  Literal(ClassOfConstant(facade.typeRef)), handle),
+              TypeTree.of[Any] ),
+          Inferred(repeatedAny) )
+
+    val call =
+      Apply
+        ( Ref(witImportCall),
+          List(Expr(module.s).asTerm, Expr(s"[resource-drop]$topic").asTerm, varargs) )
+
+    '{  ${call.asExprOf[Any]}
+        ()  }
+
+  // The facade class representing a named WIT type on the downstream classpath, following
+  // scala-wasm's layout: module `wasi:io/streams@0.2.0` and name `output-stream` give
+  // `scala.scalajs.wasi.io.streams.OutputStream` (kebab-case package path → snake_case, type
+  // name → UpperCamelCase).
+  private def facadeClass(using quotes: Quotes)(definedIn: Text, name: Text)
+  :   quotes.reflect.Symbol =
+
+    import quotes.reflect.*
+
+    def camel(part: String): String =
+      if part.isEmpty then part
+      else part.substring(0, 1).nn.toUpperCase.nn + part.substring(1).nn
+
+    val base = definedIn.s.split("@").nn.head.toString
+    val namespace = base.split(":").nn.head.toString
+    val path = base.split(":").nn.last.toString.replace("/", ".").nn.replace("-", "_").nn
+    val parts = name.s.split("-").nn
+    val className = new java.lang.StringBuilder()
+    var index = 0
+
+    while index < parts.length do
+      className.append(camel(parts(index).nn.toString))
+      index += 1
+
+    Symbol.requiredClass(s"scala.scalajs.$namespace.$path.$className")
 
   // The WIT carrier a result type crosses the boundary as, paired with a function decoding that
   // carrier (an `Any`, the erased `witImportCall` result) back to the result. A leaf type uses its

--- a/lib/xenophile/src/wasm/xenophile.WitHandle.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitHandle.scala
@@ -32,75 +32,17 @@
                                                                                                   */
 package xenophile
 
-import anticipation.*
-import distillate.*
-import hypotenuse.*
 import prepositional.*
-import rudiments.*
-import vacuous.*
 
-// The uniform form of a value marshalled across a WIT function boundary (see the `Wasm` class). A
-// single form lets a codec be summoned for any Scala type without knowing its carrier in advance;
-// the concrete carrier (a type the scala-wasm compiler accepts in a WIT signature) is recovered
-// from the codec's `Carrier` member. `Encodable in Wasm` / `Decodable in Wasm` are summoned per WIT
-// parameter/result by the emission backend; a value lacking a codec cannot cross a WIT boundary,
-// which is reported at compile time.
-object Wasm:
-  def apply(value: Any): Wasm = new Wasm(value)
+// An opaque handle to a WIT resource — a stateful foreign value such as an output stream or file
+// descriptor — obtained by `invoke`ing a resource-returning WIT function. The underlying value (a
+// `@WitResourceImport` facade instance, only meaningful in Wasm-compiled code) is held untyped, so
+// this module never names it; the phantom `Topic` records the WIT resource type, so the handle can
+// be navigated like any other foreign value (via the `Interoperable` instance below) to invoke the
+// resource's methods, and eventually `dispose()`d.
+object WitHandle:
+  given interoperable: [topic <: Label]
+  =>  ((WitHandle of topic) is Interoperable in Wit of topic) =
+    Interoperable()
 
-  extension (wasm: Wasm) def as[carrier]: carrier = wasm.value.asInstanceOf[carrier]
-
-  // Builds an `Encodable in Wasm` that also exposes the `Carrier` type the value is passed as.
-  private def enc[self, carrier0](lambda: self => carrier0)
-  :   (self is Encodable in Wasm) { type Carrier = carrier0 } =
-
-    new Encodable:
-      type Self = self
-      type Form = Wasm
-      type Carrier = carrier0
-      def encoded(value: self): Wasm = Wasm(lambda(value))
-
-  private def dec[self, carrier0](lambda: carrier0 => self)
-  :   (self is Decodable in Wasm) { type Carrier = carrier0 } =
-
-    new Decodable:
-      type Self = self
-      type Form = Wasm
-      type Carrier = carrier0
-      type Locus = Text
-      def decoded(value: Wasm): self = lambda(value.as[carrier0])
-
-  given s8Encodable: ((S8 is Encodable in Wasm) { type Carrier = Byte }) = enc(_.byte)
-  given s8Decodable: ((S8 is Decodable in Wasm) { type Carrier = Byte }) = dec(_.bits.s8)
-  given s16Encodable: ((S16 is Encodable in Wasm) { type Carrier = Short }) = enc(_.short)
-  given s16Decodable: ((S16 is Decodable in Wasm) { type Carrier = Short }) = dec(_.bits.s16)
-  given s32Encodable: ((S32 is Encodable in Wasm) { type Carrier = Int }) = enc(_.int)
-  given s32Decodable: ((S32 is Decodable in Wasm) { type Carrier = Int }) = dec(_.bits.s32)
-  given s64Encodable: ((S64 is Encodable in Wasm) { type Carrier = Long }) = enc(_.long)
-  given s64Decodable: ((S64 is Decodable in Wasm) { type Carrier = Long }) = dec(_.bits.s64)
-  given u8Encodable: ((U8 is Encodable in Wasm) { type Carrier = Byte }) = enc(_.byte)
-  given u8Decodable: ((U8 is Decodable in Wasm) { type Carrier = Byte }) = dec(_.bits.u8)
-  given u16Encodable: ((U16 is Encodable in Wasm) { type Carrier = Short }) = enc(_.bits.s16.short)
-  given u16Decodable: ((U16 is Decodable in Wasm) { type Carrier = Short }) = dec(_.bits.u16)
-  given u32Encodable: ((U32 is Encodable in Wasm) { type Carrier = Int }) = enc(_.bits.s32.int)
-  given u32Decodable: ((U32 is Decodable in Wasm) { type Carrier = Int }) = dec(_.bits.u32)
-  given u64Encodable: ((U64 is Encodable in Wasm) { type Carrier = Long }) = enc(_.bits.s64.long)
-  given u64Decodable: ((U64 is Decodable in Wasm) { type Carrier = Long }) = dec(_.bits.u64)
-  given boolEncodable: ((Boolean is Encodable in Wasm) { type Carrier = Boolean }) = enc(identity)
-  given boolDecodable: ((Boolean is Decodable in Wasm) { type Carrier = Boolean }) = dec(identity)
-  given charEncodable: ((Char is Encodable in Wasm) { type Carrier = Char }) = enc(identity)
-  given charDecodable: ((Char is Decodable in Wasm) { type Carrier = Char }) = dec(identity)
-  given textEncodable: ((Text is Encodable in Wasm) { type Carrier = String }) = enc(_.s)
-  given textDecodable: ((Text is Decodable in Wasm) { type Carrier = String }) = dec(_.tt)
-
-  given dataEncodable: ((Data is Encodable in Wasm) { type Carrier = Array[Byte] }) =
-    enc(_.mutable(using Unsafe))
-
-  given dataDecodable: ((Data is Decodable in Wasm) { type Carrier = Array[Byte] }) =
-    dec(_.immutable(using Unsafe))
-
-  // TODO: `F32`/`F64` (need the `Float`/`Double`->`F32`/`F64` constructors) and a WIT `list<T>`
-  // codec (crosses the boundary as an `Array` of the element carrier) are not yet provided.
-
-// A value marshalled to the carrier type it crosses a WIT function boundary as.
-final class Wasm(val value: Any)
+final class WitHandle(val value: Any) extends Topical

--- a/lib/xenophile/src/wit/xenophile.Wit.scala
+++ b/lib/xenophile/src/wit/xenophile.Wit.scala
@@ -61,6 +61,10 @@ object Wit:
   given char: (Char is Interoperable in Wit of "char") = Interoperable[Char, Wit, "char"]()
   given string: (Text is Interoperable in Wit of "string") = Interoperable[Text, Wit, "string"]()
 
+  // Binary data (an immutable byte array) corresponds to a WIT `list<u8>`.
+  given data: (Data is Interoperable in Wit of ("list" over "u8")) =
+    Interoperable[Data, Wit, ("list" over "u8")]()
+
   // A WIT `list<T>` corresponds to a Scala `List` of the element type.
   given list: [element, topic]
   =>  ( element is Interoperable in Wit of topic )

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -198,11 +198,12 @@ object WitDialect extends Dialect:
           val updated = types.updated(variant.tt, ListMap[Text, Prototype]())
           recur(skipBraces(rest, 1), functions, updated, typedefs)
 
-        case "resource" :: _ :: "{" :: rest =>
-          recur(skipBraces(rest, 1), functions, types, typedefs)
+        case "resource" :: resource :: "{" :: rest =>
+          val (methods, after) = resourceBody(rest, resource.tt, module, ListMap())
+          recur(after, functions, types.updated(resource.tt, methods), typedefs)
 
-        case "resource" :: _ :: ";" :: rest =>
-          recur(rest, functions, types, typedefs)
+        case "resource" :: resource :: ";" :: rest =>
+          recur(rest, functions, types.updated(resource.tt, ListMap()), typedefs)
 
         case "use" :: rest =>
           recur(skipTo(rest, t";"), functions, types, typedefs)
@@ -230,6 +231,43 @@ object WitDialect extends Dialect:
           recur(rest, functions, types, typedefs)
 
     recur(tokens, ListMap(), types, typedefs)
+
+  // Walks a `resource … { … }` body: its methods become members of a type named after the
+  // resource, each marked with the resource it belongs to (so an invocation can address it as
+  // `[method]resource.name` and thread the receiver's handle). `constructor` and `static`
+  // declarations are recognised but skipped for now.
+  private def resourceBody
+    ( tokens:   List[String],
+      resource: Text,
+      module:   Optional[Text],
+      methods:  Map[Text, Prototype] )
+  :   (Map[Text, Prototype], List[String]) =
+
+    tokens match
+      case "}" :: rest =>
+        (methods, rest)
+
+      case Nil =>
+        (methods, Nil)
+
+      case "constructor" :: "(" :: rest =>
+        resourceBody(skipTo(rest, t";"), resource, module, methods)
+
+      case method :: ":" :: "static" :: rest =>
+        resourceBody(skipTo(rest, t";"), resource, module, methods)
+
+      case method :: ":" :: "func" :: "(" :: rest =>
+        val (parameters, after) = params(rest, Nil)
+
+        val (result, after2) = after match
+          case "->" :: more => typeOf(more)
+          case more         => (Foreign.Type.Named(t"unit"), more)
+
+        val signature = Prototype(parameters, result, module, resource)
+        resourceBody(skipTo(after2, t";"), resource, module, methods.updated(method.tt, signature))
+
+      case _ :: rest =>
+        resourceBody(rest, resource, module, methods)
 
   private def recordFields(tokens: List[String], acc: Map[Text, Prototype])
   :   (Map[Text, Prototype], List[String]) =
@@ -289,7 +327,7 @@ object WitDialect extends Dialect:
         Foreign.Type.Applied(constructor, arguments.map(expand))
 
     def signature(sig: Prototype): Prototype =
-      Prototype(sig.parameters.let(_.map(expand)), expand(sig.result), sig.module)
+      Prototype(sig.parameters.let(_.map(expand)), expand(sig.result), sig.module, sig.resource)
 
     definitions.map: (name, members) =>
       (name, members.map { (member, sig) => (member, signature(sig)) })


### PR DESCRIPTION
Xenophile's WIT integration now handles Component Model *resources* — stateful handles such as streams and file descriptors — and a new `turbulence.wasi` module uses them to provide a `Stdio` whose standard output and error write through the WASI `output-stream` resource. As with the other `.wasi` backends, everything compiles in the ordinary build with no WebAssembly-specific dependency; the Component Model imports materialise only where the givens are used in code compiled for WebAssembly.

## WIT resources

A WIT `resource` declaration is now parsed and navigable. A resource-returning function is `invoke`d as an opaque `WitHandle`, which can be navigated like any foreign value to invoke the resource's methods, and eventually disposed of:

```scala
val handle = Foreign["stdout", Wit].`get-stdout`.invoke[WitHandle of "output-stream"]
val stream: Foreign of "output-stream" from Wit = handle
stream.`blocking-write-and-flush`(data).invoke[Unit]
handle.dispose()
```

Method calls lower to the Component Model's `[method]resource.name` imports with the handle as their borrow parameter, and `dispose()` to `[resource-drop]`. Method arguments cross the boundary through their `Encodable in Wasm` codecs (binary data as WIT `list<u8>`), and a `result<…>`-returning method invoked as `Unit` checks its outcome. The WIT result type is conveyed to the WebAssembly backend as a structured descriptor rather than text.

## WASI-backed standard streams

The new `turbulence.wasi` module provides `stdios.wasiStdio`:

```scala
import turbulence.*
import turbulence.stdios.wasiStdio
import turbulence.wasiCliApi  // brings the `wasi:cli`/`wasi:io` interfaces into scope

summon[Stdio].print(t"Hello from a WebAssembly component")
```

Each write obtains the stream (`get-stdout`/`get-stderr`), invokes `blocking-write-and-flush` with the UTF-8 bytes, and drops the handle. Verified end-to-end under `wasmtime`, with output and error correctly separated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)