### PR TITLE
Read standard input in turbulence.wasi

### DIFF
--- a/lib/turbulence/res/wasi/turbulence/cli.wit
+++ b/lib/turbulence/res/wasi/turbulence/cli.wit
@@ -1,12 +1,16 @@
-// The subset of the WASI interfaces that turbulence uses for standard output and error: the
-// `output-stream` resource (from `wasi:io/streams`) and the `wasi:cli` functions that provide the
-// standard streams.
+// The subset of the WASI interfaces that turbulence uses for the standard streams: the
+// `input-stream`/`output-stream` resources (from `wasi:io/streams`) and the `wasi:cli` functions
+// that provide them.
 
 package wasi:io@0.2.0;
 
 interface streams {
   resource output-stream {
     blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+  }
+
+  resource input-stream {
+    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
   }
 }
 
@@ -18,4 +22,8 @@ interface stdout {
 
 interface stderr {
   get-stderr: func() -> output-stream;
+}
+
+interface stdin {
+  get-stdin: func() -> input-stream;
 }

--- a/lib/turbulence/src/wasi/turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/turbulence_wasi.scala
@@ -38,6 +38,7 @@ import scala.annotation.nowarn
 
 import anticipation.*
 import hellenism.*
+import hypotenuse.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -50,12 +51,12 @@ type WasiCliApi = Interface in Wit at "/turbulence/cli.wit"
 given wasiCliApi: WasiCliApi = Interface[Wit](cp"/turbulence/cli.wit")
 
 package stdios:
-  // A `Stdio` whose standard output and error write through the WASI `output-stream` resource:
-  // each write obtains the stream handle (`get-stdout`/`get-stderr`), invokes its
-  // `blocking-write-and-flush` method, and disposes of the handle. `inline`, so the `invoke`s
-  // expand at the downstream summoning site: the Wasm Component imports only materialize in code
-  // compiled for a Wasm target. Summoning it requires `wasiCliApi` (and this module's WIT
-  // resource) to be visible at that site.
+  // A `Stdio` whose standard streams go through the WASI stream resources: each write obtains the
+  // stream handle (`get-stdout`/`get-stderr`), invokes its `blocking-write-and-flush` method, and
+  // disposes of the handle; reads do likewise with `get-stdin` and `blocking-read`. `inline`, so
+  // the `invoke`s expand at the downstream summoning site: the Wasm Component imports only
+  // materialize in code compiled for a Wasm target. Summoning it requires `wasiCliApi` (and this
+  // module's WIT resource) to be visible at that site.
   //
   // The per-site duplication the compiler warns about is the point: the instances must materialize
   // at the downstream summoning site, and a WASI-linked application summons them once.
@@ -80,13 +81,37 @@ package stdios:
           val slice = java.util.Arrays.copyOfRange(array, offset, offset + length).nn
           send(error, slice.immutable(using Unsafe))
 
+    // Reads block until at least one byte is available; a closed stream (the `Err` arm of
+    // `blocking-read`'s result, raised by the decoder) is end-of-input.
+    def wasiInput(): ji.InputStream = new ji.InputStream:
+      def read(): Int =
+        val array = new Array[Byte](1)
+        if read(array, 0, 1) == -1 then -1 else array(0) & 0xff
+
+      override def read(array: Array[Byte] | Null, offset: Int, length: Int): Int =
+        if array == null || length == 0 then 0 else
+          val handle = Foreign["stdin", Wit].`get-stdin`.invoke[WitHandle of "input-stream"]
+          val stream: Foreign of "input-stream" from Wit = handle
+
+          try
+            val data = stream.`blocking-read`(U64(length.toLong.bits)).invoke[Data]
+            var index = 0
+
+            while index < data.length do
+              array(offset + index) = data(index)
+              index += 1
+
+            if data.length == 0 then -1 else data.length
+          catch case error: RuntimeException => -1
+          finally handle.dispose()
+
     def bytes(text: Text): Data = text.s.getBytes("UTF-8").nn.immutable(using Unsafe)
 
     new Stdio:
       val termcap: Termcap = termcap0
       val out: ji.PrintStream = ji.PrintStream(wasiStream(false), true)
       val err: ji.PrintStream = ji.PrintStream(wasiStream(true), true)
-      val in: ji.InputStream = Stdio.MuteInputStream
+      val in: ji.InputStream = wasiInput()
 
       override def print(text: Text): Unit = send(false, bytes(text))
       override def printErr(text: Text): Unit = send(true, bytes(text))

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -156,17 +156,11 @@ object WasmInvoke:
     //
     //  -  A `WitHandle of topic` result is a WIT resource: its carrier is the resource's facade
     //     class, and the raw handle is wrapped in a `WitHandle`.
-    //  -  A `Unit` result against a WIT `result<…>` function crosses as a `scala.scalajs.wit.Result`
-    //     and is checked: an `Err` raises an exception, an `Ok` becomes `()`.
-    val witHandleTopic: Optional[TypeRepr] = TypeRepr.of[result].dealias match
+    //  -  A result against a WIT `result<…>` function crosses as a `scala.scalajs.wit.Result`
+    //     and is checked: an `Err` raises an exception; an `Ok` becomes `()` or its decoded
+    //     payload.
+    val (carrier, decode) = TypeRepr.of[result].dealias match
       case Refinement(base, "Topic", TypeBounds(_, topic)) if base =:= TypeRepr.of[WitHandle] =>
-        topic
-
-      case _ =>
-        Unset
-
-    val (carrier, decode) = witHandleTopic.absolve match
-      case topic: TypeRepr =>
         prototype.result.absolve match
           case Foreign.Type.Named(name) =>
             val facade = facadeOf(name)
@@ -182,25 +176,46 @@ object WasmInvoke:
             halt(m"xenophile: $owner.$function does not return a WIT resource")
 
       case _ =>
-        if TypeRepr.of[result] =:= TypeRepr.of[Unit] then prototype.result match
+        prototype.result match
+          // A `result<…>` function crosses as a `scala.scalajs.wit.Result` and is checked: an
+          // `Err` raises an exception; an `Ok`'s payload — if the requested type is not `Unit` —
+          // is decoded exactly as if the function had returned the `ok` arm directly.
           case Foreign.Type.Applied(constructor, _) if constructor.s == "result" =>
             val resultClass = Symbol.requiredClass("scala.scalajs.wit.Result")
             val okClass = Symbol.requiredClass("scala.scalajs.wit.Ok")
             val okType = AppliedType(okClass.typeRef, List(TypeBounds.empty))
 
-            val decode: Expr[Any] => Expr[Any] = call =>
-              '{  val outcome = $call
+            def isOk(outcome: Expr[Any]): Expr[Boolean] =
+              TypeApply(Select.unique(outcome.asTerm, "isInstanceOf"), List(Inferred(okType)))
+                .asExprOf[Boolean]
 
-                  if !${ TypeApply(Select.unique('outcome.asTerm, "isInstanceOf"),
-                      List(Inferred(okType))).asExprOf[Boolean] }
-                  then throw new RuntimeException("WIT import returned an error: " + outcome)  }
+            def payload(outcome: Expr[Any]): Expr[Any] =
+              val cast =
+                TypeApply(Select.unique(outcome.asTerm, "asInstanceOf"), List(Inferred(okType)))
+
+              Select.unique(cast, "value").asExprOf[Any]
+
+            val decode: Expr[Any] => Expr[Any] =
+              if TypeRepr.of[result] =:= TypeRepr.of[Unit] then call =>
+                '{  val outcome = $call
+
+                    if !${isOk('outcome)}
+                    then throw new RuntimeException("WIT import returned an error: " + outcome)  }
+              else
+                val (_, payloadDecode) = deriveResult[result]
+
+                call =>
+                  '{  val outcome = $call
+
+                      if ${isOk('outcome)} then ${payloadDecode(payload('outcome))}
+                      else throw new RuntimeException("WIT import returned an error: " + outcome)  }
 
             (resultClass.typeRef, decode)
 
           case _ =>
-            halt(m"xenophile: `invoke[Unit]` requires a WIT `result<…>` function")
-
-        else deriveResult[result]
+            if TypeRepr.of[result] =:= TypeRepr.of[Unit]
+            then halt(m"xenophile: `invoke[Unit]` requires a WIT `result<…>` function")
+            else deriveResult[result]
 
     // Emit `<decode>(witImportCall(module, function, classOf[Carrier]))`. The import call is built
     // by looking up `witImportCall` in the *downstream* classpath (the scala-wasm library), so this
@@ -278,8 +293,11 @@ object WasmInvoke:
       // bound `val`, not only an inline chain.
       val handle =
         '{  ${receiverNode.asExprOf[Foreign.Expression]} match
-              case Foreign.Expression.Literal(handle: WitHandle) => handle.value
-              case _ => throw new RuntimeException("xenophile: not a WIT resource handle")  }
+              case Foreign.Expression.Literal(handle: WitHandle) =>
+                handle.value
+
+              case _ =>
+                throw new RuntimeException("xenophile: not a WIT resource handle")  }
 
       List(Literal(ClassOfConstant(facade.typeRef)), handle.asTerm)
 
@@ -318,7 +336,9 @@ object WasmInvoke:
 
     val topic: Text = self.asTerm.tpe.widen.dealias match
       case Refinement(_, "Topic", TypeBounds(_, ConstantType(StringConstant(name)))) => name.tt
-      case _ => halt(m"xenophile: the handle does not have a known WIT resource type")
+
+      case _ =>
+        halt(m"xenophile: the handle does not have a known WIT resource type")
 
     val origin = TypeRepr.of[Wit]
     val definitions = Xenophile.definitions(origin, Xenophile.locusOf(origin))

--- a/lib/xenophile/src/wasm/xenophile.WitHandle.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitHandle.scala
@@ -42,7 +42,7 @@ import prepositional.*
 // resource's methods, and eventually `dispose()`d.
 object WitHandle:
   given interoperable: [topic <: Label]
-  =>  ((WitHandle of topic) is Interoperable in Wit of topic) =
+  =>  ( (WitHandle of topic) is Interoperable in Wit of topic ) =
     Interoperable()
 
 final class WitHandle(val value: Any) extends Topical


### PR DESCRIPTION
Turbulence's WASI `Stdio` becomes bidirectional: reads now obtain the `wasi:io/streams` `input-stream` resource (via `wasi:cli/stdin`), invoke its `blocking-read` method, and dispose of the handle, with a closed stream reading as end-of-input — so a Soundness program compiled as a WebAssembly component can consume piped input like any other filter. Supporting this, Xenophile's `invoke` now decodes the payload of a WIT `result<T, E>` return.

## Standard input

```scala
import turbulence.*
import turbulence.stdios.wasiStdio

val buffer = new Array[Byte](256)
val count = summon[Stdio].in.read(buffer, 0, buffer.length)
```

Verified end-to-end under `wasmtime`, echoing piped input and handling end-of-input.

## `result<T, E>` payloads in `invoke`

A WIT `result<…>`-returning function may now be `invoke`d at a non-`Unit` type: an `Ok` outcome's payload is decoded exactly as if the function had returned the `ok` arm directly, while an `Err` raises. This is the shape of nearly every WIT resource method — stream reads, filesystem operations, HTTP handling — so it opens the read side of the WASI world generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)