### PR TITLE
Support WIT resource constructors and static functions

### DIFF
--- a/lib/xenophile/src/core/xenophile.Dialect.scala
+++ b/lib/xenophile/src/core/xenophile.Dialect.scala
@@ -41,12 +41,15 @@ import vacuous.*
 // (such as WIT) whose members must be addressed by a module identifier at the point of invocation;
 // it is `Unset` for grammars that need no such qualifier. `resource`, when set, names the stateful
 // foreign type (a WIT `resource`) the member is a method of, so an invocation can address it (e.g.
-// `[method]output-stream.blocking-write-and-flush`) and thread the receiver's handle.
+// `[method]output-stream.blocking-write-and-flush`) and thread the receiver's handle. A `static`
+// member of a resource (a WIT `static` function or `constructor`) is addressed through the
+// resource but takes no receiver.
 case class Prototype
   ( parameters: Optional[List[Foreign.Type]],
     result:     Foreign.Type,
     module:     Optional[Text] = Unset,
-    resource:   Optional[Text] = Unset )
+    resource:   Optional[Text] = Unset,
+    static:     Boolean = false )
 
 // A grammar for a particular foreign type system: parses a definitions source into a map from each
 // foreign type name to its members' prototypes. Keyed on an ecosystem so the macro stays agnostic.

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -281,25 +281,31 @@ object WasmInvoke:
 
     // A resource method is imported under its Component Model name, `[method]resource.function`,
     // and takes the resource's handle — the underlying value of the `WitHandle` receiver — as its
-    // first (borrow) parameter.
+    // first (borrow) parameter. A constructor or static function is addressed through the resource
+    // (`[constructor]resource`, `[static]resource.function`) but takes no receiver.
     val importName: Text = prototype.resource.lay(function): resource =>
-      t"[method]$resource.$function"
+      if prototype.static then
+        if function == t"constructor" then t"[constructor]$resource"
+        else t"[static]$resource.$function"
+      else
+        t"[method]$resource.$function"
 
     val receiverPair: List[Term] = prototype.resource.lay(List()): resource =>
-      val facade = facadeOf(resource)
+      if prototype.static then List() else
+        val facade = facadeOf(resource)
 
-      // The receiver's handle is recovered at runtime from the `Foreign` value's expression — a
-      // converted `WitHandle` is an `Expression.Literal` wrapping it — so the receiver may be a
-      // bound `val`, not only an inline chain.
-      val handle =
-        '{  ${receiverNode.asExprOf[Foreign.Expression]} match
-              case Foreign.Expression.Literal(handle: WitHandle) =>
-                handle.value
+        // The receiver's handle is recovered at runtime from the `Foreign` value's expression — a
+        // converted `WitHandle` is an `Expression.Literal` wrapping it — so the receiver may be a
+        // bound `val`, not only an inline chain.
+        val handle =
+          '{  ${receiverNode.asExprOf[Foreign.Expression]} match
+                case Foreign.Expression.Literal(handle: WitHandle) =>
+                  handle.value
 
-              case _ =>
-                throw new RuntimeException("xenophile: not a WIT resource handle")  }
+                case _ =>
+                  throw new RuntimeException("xenophile: not a WIT resource handle")  }
 
-      List(Literal(ClassOfConstant(facade.typeRef)), handle.asTerm)
+        List(Literal(ClassOfConstant(facade.typeRef)), handle.asTerm)
 
     // Each declared argument crosses the boundary through its `Encodable in Wasm` codec, passed as
     // a `(classOf[Carrier], encoded)` pair.

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -250,11 +250,22 @@ object WitDialect extends Dialect:
       case Nil =>
         (methods, Nil)
 
+      // A constructor is registered as the member `constructor`, returning the resource itself; a
+      // `static func` is a member addressed through the resource but taking no receiver.
       case "constructor" :: "(" :: rest =>
-        resourceBody(skipTo(rest, t";"), resource, module, methods)
+        val (parameters, after) = params(rest, Nil)
+        val signature = Prototype(parameters, Foreign.Type.Named(resource), module, resource, true)
+        resourceBody(skipTo(after, t";"), resource, module, methods.updated(t"constructor", signature))
 
-      case method :: ":" :: "static" :: rest =>
-        resourceBody(skipTo(rest, t";"), resource, module, methods)
+      case method :: ":" :: "static" :: "func" :: "(" :: rest =>
+        val (parameters, after) = params(rest, Nil)
+
+        val (result, after2) = after match
+          case "->" :: more => typeOf(more)
+          case more         => (Foreign.Type.Named(t"unit"), more)
+
+        val signature = Prototype(parameters, result, module, resource, true)
+        resourceBody(skipTo(after2, t";"), resource, module, methods.updated(method.tt, signature))
 
       case method :: ":" :: "func" :: "(" :: rest =>
         val (parameters, after) = params(rest, Nil)
@@ -327,7 +338,12 @@ object WitDialect extends Dialect:
         Foreign.Type.Applied(constructor, arguments.map(expand))
 
     def signature(sig: Prototype): Prototype =
-      Prototype(sig.parameters.let(_.map(expand)), expand(sig.result), sig.module, sig.resource)
+      Prototype
+        ( sig.parameters.let(_.map(expand)),
+          expand(sig.result),
+          sig.module,
+          sig.resource,
+          sig.static )
 
     definitions.map: (name, members) =>
       (name, members.map { (member, sig) => (member, signature(sig)) })


### PR DESCRIPTION
Xenophile's WIT integration now handles a `resource`'s `constructor` and `static func` declarations, completing the Component Model surface needed to drive stateful WASI resources end-to-end — constructors, methods, statics, payload-carrying `result`s and disposal — and clearing the way for an HTTP client backend over `wasi:http`.

## Constructors and statics

A resource's constructor and static functions are members of the resource's foreign type, addressed through it but taking no receiver:

```scala
val handle = Foreign["fields", Wit].constructor.invoke[WitHandle of "fields"]
val fields: Foreign of "fields" from Wit = handle
fields.`append`(t"x-library", data).invoke[Unit]
val present = fields.`has`(t"x-library").invoke[Boolean]
handle.dispose()
```

A constructor lowers to the Component Model's `[constructor]resource` import and returns the resource's handle; a static function to `[static]resource.function`. Verified end-to-end under `wasmtime` by constructing a `wasi:http/types` `fields` resource, appending a header and querying it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)