### PR TITLE
Reactive, mutable, demand-aware streaming (#1477)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1184,7 +1184,7 @@ object metamorphose extends Library:
   object test extends Tests(core)
 
 object monotonous extends Library:
-  object core extends Component(gossamer.core):
+  object core extends Component(gossamer.core, zephyrine.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/build.mill
+++ b/build.mill
@@ -1512,7 +1512,9 @@ object telekinesis extends Library:
   object test extends Tests(core)
 
 object turbulence extends Library:
-  object core extends Component(hieroglyph.core, parasite.core, capricious.core, stenography.core):
+  object core
+  extends Component(hieroglyph.core, parasite.core, capricious.core, stenography.core,
+      zephyrine.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   // JVM-only implementations (`java.util.zip` compression) split out of `core` so modules that use

--- a/lib/anticipation/src/http/anticipation.HttpStreams.scala
+++ b/lib/anticipation/src/http/anticipation.HttpStreams.scala
@@ -33,6 +33,33 @@
 package anticipation
 
 object HttpStreams:
-  type Content = (Text, LazyList[IArray[Byte]])
+  // A minimal demand-aware pull protocol for HTTP message bodies: each call
+  // to `next` produces at most `limit` bytes as one chunk, or `null` at the
+  // end of the stream, and may block until input is available. Deliberately
+  // dependency-free; richer streaming types (turbulence's `Source`,
+  // zephyrine's `Stream`) adapt to and from it.
+  object Body:
+    val empty: Body = limit => null
+
+    // A whole-value body, delivered in `limit`-bounded slices.
+    def apply(data: IArray[Byte]): Body = new Body:
+      private var position: Int = 0
+
+      def next(limit: Int): IArray[Byte] | Null =
+        if position >= data.length then null else
+          val end = data.length.min(position + limit)
+          val chunk = data.slice(position, end)
+          position = end
+          chunk
+
+    // A chunked body from a legacy iterator; `limit` cannot bound the
+    // chunks' own sizes.
+    def apply(chunks: Iterator[IArray[Byte]]): Body = limit =>
+      if chunks.hasNext then chunks.next() else null
+
+  trait Body:
+    def next(limit: Int): IArray[Byte] | Null
+
+  type Content = (Text, Body)
 
 sealed trait HttpStreams

--- a/lib/anticipation/src/log/anticipation.LogSink.scala
+++ b/lib/anticipation/src/log/anticipation.LogSink.scala
@@ -40,7 +40,7 @@ package anticipation
 // threshold). `Loggable.fanOut` consults it *before* forcing or transcribing the (by-name) event,
 // so that when no sink accepts — in particular when there are no sinks at all — the logged value is
 // never even constructed, and logging a disabled event costs nothing.
-trait Sink[-eventType, carrier]:
+trait LogSink[-eventType, carrier]:
   def accepts(level: Level): Boolean
 
   // Reports whether this sink records events of the given (concrete) type. Takes the *original*

--- a/lib/anticipation/src/log/anticipation.Loggable.scala
+++ b/lib/anticipation/src/log/anticipation.Loggable.scala
@@ -39,12 +39,13 @@ import prepositional.*
 
 object Loggable:
   // Derives the single `event is Loggable` that `Log.fine`/`info`/`warn`/`fail` summon: transcribe
-  // the event to a common `carrier` once, then fan out to EVERY in-scope `Sink` for that carrier
-  // (contravariance means a `Sink[Any, carrier]` is collected for any event). No sink in scope ⇒ an
+  // the event to a common `carrier` once, then fan out to EVERY in-scope `LogSink` for that carrier
+  // (contravariance means a `LogSink[Any, carrier]` is collected for any event). No sink in
+  // scope ⇒ an
   // empty `Every` ⇒ silent; many ⇒ fan-out with per-sink routing. Living in `Loggable`'s companion
   // keeps it in implicit scope, so no import is needed at the use site.
   given fanOut: [event, carrier]
-  =>  ( transcribable: event is Transcribable to carrier, sinks: Every[Sink[event, carrier]] )
+  =>  ( transcribable: event is Transcribable to carrier, sinks: Every[LogSink[event, carrier]] )
   =>  event is Loggable =
 
     new Loggable:

--- a/lib/anticipation/src/log/soundness_anticipation_log.scala
+++ b/lib/anticipation/src/log/soundness_anticipation_log.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export anticipation.{Level, Log, Loggable, logs, Sink, Transcribable, transcribes}
+export anticipation.{Level, Log, Loggable, logs, LogSink, Transcribable, transcribes}

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -521,7 +521,7 @@ object Cbor extends Cbor2, Dynamic:
       type Result = HttpStreams.Content
 
       def genericize(value: Cbor): HttpStreams.Content =
-        (t"application/cbor", LazyList(Ast.encodable.encoded(Cbor.unseal(value))))
+        (t"application/cbor", HttpStreams.Body(Ast.encodable.encoded(Cbor.unseal(value))))
 
   // `source.read[Foo in Cbor]` shorthand for
   // `source.read[Cbor].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`

--- a/lib/cacophony/src/core/cacophony.Audio.scala
+++ b/lib/cacophony/src/core/cacophony.Audio.scala
@@ -118,7 +118,7 @@ object Audio:
     type Result = HttpStreams.Content
 
     def genericize(audio: Audio in format): HttpStreams.Content =
-      (format.mediaType.basic, audio.read[LazyList[Data]])
+      (format.mediaType.basic, HttpStreams.Body(audio.read[LazyList[Data]].iterator))
 
   given aggregable: [format: Audible as audible] => Tactic[AudioError]
   =>  (Audio in format) is Aggregable by Data =

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -71,7 +71,7 @@ object Sheet:
             case '\t' => t"text/tab-separated-values"
             case _    => t"text/csv"
 
-        (mediaType, dsv.stream[Text].map(_.data))
+        (mediaType, HttpStreams.Body(dsv.stream[Text].map(_.data).iterator))
 
 
   given tabular: Sheet is Tabular[Text]:

--- a/lib/coaxial/src/core/coaxial.Duplex.scala
+++ b/lib/coaxial/src/core/coaxial.Duplex.scala
@@ -37,8 +37,10 @@ import java.nio.ByteBuffer
 import java.nio.channels as jnc
 
 import anticipation.*
+import prepositional.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 object Duplex:
   // Wraps a blocking `InputStream`/`OutputStream` pair — the shape a socket that has no
@@ -89,6 +91,46 @@ object Duplex:
 
     def close(): Unit = socketChannel.close()
 
+    override def source(using buffering: Buffering): Stream[Data] over Credit =
+      new Stream[Data]:
+        type Transport = Credit
+
+        private val capacity: Int = buffering.capacity(Substrate.Bytes)
+        private val storage: Array[Byte] = new Array[Byte](capacity)
+        private val wrapped: ByteBuffer = ByteBuffer.wrap(storage).nn
+        private var start0: Int = 0
+        private var limit0: Int = 0
+        private var ended: Boolean = false
+
+        protected def window0: AnyRef = storage
+        def start: Int = start0
+        def limit: Int = limit0
+        def skip(count: Int): Unit = start0 += count
+
+        def refill(demand: Credit): Optional[Int] =
+          if limit0 > start0 then limit0 - start0
+          else if ended then Unset
+          else
+            val granted = summon[Credit is Regulation].grant(demand)
+
+            if granted == 0 then 0 else
+              start0 = 0
+              limit0 = 0
+              wrapped.clear()
+              wrapped.limit(capacity.min(granted))
+
+              socketChannel.read(wrapped) match
+                case -1 =>
+                  ended = true
+                  Unset
+
+                case 0 =>
+                  refill(demand)
+
+                case count =>
+                  limit0 = count
+                  count
+
 // A persistent, bidirectional connection: unlike `Serviceable`'s request/response
 // `transmit`/`receive` (which shuts down the output side after sending), a `Duplex`
 // stays open for repeated, independent reads and writes — the shape a multiplexing
@@ -99,3 +141,41 @@ trait Duplex:
   def stream: LazyList[Data]
   def send(data: LazyList[Data]): Unit
   def close(): Unit
+
+  // Pull endpoint over the read side. The default adapts the legacy
+  // `stream`; `Duplex.channel` overrides it to read directly into the
+  // endpoint's buffer, allocation-free.
+  def source(using Buffering): Stream[Data] over Credit = Stream(stream.iterator)
+
+  // Push endpoint over the write side: repeatable, like `send`, and
+  // `finish()` flushes without half-closing the connection.
+  def intake(using buffering: Buffering): Intake[Data] over Credit =
+    new Intake[Data]:
+      type Transport = Credit
+
+      private val block: Int = buffering.capacity(Substrate.Bytes)
+      private val storage: Array[Byte] = new Array[Byte](block)
+      private var mark0: Int = 0
+
+      def demand: Credit = Credit(Long.MaxValue)
+      protected def buffer0: AnyRef = storage
+      def mark: Int = mark0
+
+      def reserve(min: Int): Int =
+        val free = block - mark0
+
+        if free >= min then free else
+          drain()
+          block
+
+      def commit(count: Int): Unit =
+        mark0 += count
+        if mark0 == block then drain()
+
+      override def flush(): Unit = drain()
+      def finish(): Unit = drain()
+
+      private def drain(): Unit =
+        if mark0 > 0 then
+          send(LazyList(storage.slice(0, mark0).nn.immutable(using Unsafe)))
+          mark0 = 0

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -36,6 +36,9 @@ package coaxial
 // package, so they are already in scope; re-importing them through `soundness`
 // would make the two same-shaped `transmit` overloads (from `Serviceable` and
 // `Routable`) ambiguous, so they are excluded from the wildcard.
+import java.net as jn
+import java.nio.channels as jnc
+
 import soundness.{transmit as _, listen as _, react as _, duplex as _, *}
 
 import charEncoders.utf8Encoder
@@ -55,6 +58,32 @@ object Tests extends Suite(m"Coaxial tests"):
     def ascii(text: Text): Data = IArray.from(text.s.getBytes("US-ASCII").nn.to(List))
     def bytes(data: Data): List[Byte] = data.to(List)
     def joined(stream: LazyList[Data]): List[Byte] = stream.to(List).flatMap(_.to(List))
+
+    suite(m"Duplex streaming endpoints"):
+      val payload = Data.fill(60000) { index => (index%97).toByte }
+
+      test(m"data flows through native socket stream endpoints"):
+        import supervisors.globalSupervisor
+
+        val server = jnc.ServerSocketChannel.open().nn
+        server.bind(jn.InetSocketAddress("127.0.0.1", 0))
+        val port = server.socket.nn.getLocalPort
+
+        val received = async:
+          val serverDuplex = Duplex.channel(server.accept().nn)
+          summon[Data is Aggregable by Data].accept(serverDuplex.source)
+
+        val client = jnc.SocketChannel.open(jn.InetSocketAddress("127.0.0.1", port)).nn
+        val clientDuplex = Duplex.channel(client)
+
+        summon[Data is Source by Data over Credit].stream(payload).flowTo(clientDuplex.intake)
+        client.shutdownOutput()
+
+        val result = received.await()
+        server.close()
+        client.close()
+        result.to(List)
+      . assert(_ == payload.to(List))
 
     suite(m"Transmissible serialization"):
       test(m"Data is transmitted as a single chunk"):

--- a/lib/dissonance/src/test/dissonance_test.scala
+++ b/lib/dissonance/src/test/dissonance_test.scala
@@ -261,7 +261,8 @@ object Tests extends Suite(m"Dissonance tests"):
     val list = Series(t"- alpha", t"- beta", t"- gamma")
 
     suite(m"Redraft parsing tests"):
-      val roundtrip = LazyList(t"line1", t"- line2", t"+ new", t"\\- escaped", t"< forced", t"> add")
+      val roundtrip =
+        LazyList(t"line1", t"- line2", t"+ new", t"\\- escaped", t"< forced", t"> add")
 
       test(m"Parse a simple redraft"):
         Redraft.parse(LazyList(t"line1", t"- line2", t"+ new line 2a", t"line3"))

--- a/lib/embarcadero/src/oci/embarcadero.Layer.scala
+++ b/lib/embarcadero/src/oci/embarcadero.Layer.scala
@@ -48,7 +48,8 @@ object Layer:
 class Layer(val tar: Tarfile):
   lazy val raw:        Data       = tar.stream[Data].foldLeft(IArray.empty[Byte])(_ ++ _)
   lazy val diffId:     Text       = sha256(raw)
-  lazy val blob:       Data       = LazyList(raw).compress[Gzip].foldLeft(IArray.empty[Byte])(_ ++ _)
+  lazy val blob:       Data       =
+    LazyList(raw).compress[Gzip].foldLeft(IArray.empty[Byte])(_ ++ _)
   lazy val digest:     Text       = sha256(blob)
 
   lazy val descriptor: Descriptor =

--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -63,7 +63,8 @@ extends Cipher, Encryption, Symmetric:
   // mirroring `turbulence.Compression`. The IV (if any) is emitted as the first
   // chunk; the `NoPadding` alignment check happens at end-of-stream, where the
   // total length is finally known.
-  def encryptStream(stream: LazyList[Data], key: Data, vector: InitializationVector): LazyList[Data] =
+  def encryptStream(stream: LazyList[Data], key: Data, vector: InitializationVector)
+  :   LazyList[Data] =
     val blockSize = cipher.blockSize(transformation)
     val iv: Optional[Data] = if mode.usesIv then vector(blockSize) else Unset
     val session = cipher.stream(transformation, key, iv)

--- a/lib/eucalyptus/src/core/eucalyptus.Logger.scala
+++ b/lib/eucalyptus/src/core/eucalyptus.Logger.scala
@@ -98,7 +98,7 @@ object Logger:
 
 class Logger[-eventType, loggingType] private
   ( threshold: Level, categories: Set[Log.Category], enqueue: (loggingType, Level, Long) => Unit )
-extends Sink[eventType, loggingType]:
+extends LogSink[eventType, loggingType]:
 
   def accepts(level: Level): Boolean = level.ordinal >= threshold.ordinal
 

--- a/lib/eucalyptus/src/core/eucalyptus_core.scala
+++ b/lib/eucalyptus/src/core/eucalyptus_core.scala
@@ -63,7 +63,8 @@ package logFormats:
 
 val dateFormat = jt.SimpleDateFormat(t"yyyy-MMM-dd HH:mm:ss.SSS".s)
 
-// Runs `lambda` with logging of `event` suppressed, regardless of any ambient `Sink`s. The silent
+// Runs `lambda` with logging of `event` suppressed, regardless of any ambient `LogSink`s. The
+// silent
 // `event is Loggable` is supplied directly to the block, so (as a lexically-scoped given) it takes
 // precedence over the companion-scoped `Loggable.fanOut`.
 def mute[event](using erased Void)[result](lambda: (event is Loggable) ?=> result): result =

--- a/lib/guillotine/src/core/guillotine.Job.scala
+++ b/lib/guillotine/src/core/guillotine.Job.scala
@@ -84,7 +84,8 @@ extends Subprocess, ProcessRef:
   def status(): Int = process.waitFor()
 
 
-  def stdin[chunk](stream: LazyList[chunk])(using writable: ProcessInput is Writable by chunk): Unit =
+  def stdin[chunk](stream: LazyList[chunk])(using writable: ProcessInput is Writable by chunk)
+  :   Unit =
     writable.write(ProcessInput(process.getOutputStream.nn), stream)
 
 

--- a/lib/hallucination/src/core/hallucination.Raster.scala
+++ b/lib/hallucination/src/core/hallucination.Raster.scala
@@ -71,7 +71,7 @@ object Raster:
     type Result = HttpStreams.Content
 
     def genericize(image: Raster in format): HttpStreams.Content =
-      (format.mediaType.basic, image.read[LazyList[Data]])
+      (format.mediaType.basic, HttpStreams.Body(image.read[LazyList[Data]].iterator))
 
   given graphical: Raster is Graphical:
     def pixel(raster: Raster, x: Int, y: Int): Chroma = raster(x, y)

--- a/lib/hieroglyph/src/core/hieroglyph.CharDecoder.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharDecoder.scala
@@ -51,7 +51,7 @@ object CharDecoder:
   def unapply(name: Text)(using TextSanitizer): Option[CharDecoder] =
     Encoding.unapply(name).map(CharDecoder(_))
 
-class CharDecoder(val encoding: Encoding)(using sanitizer: TextSanitizer) extends Findable:
+class CharDecoder(val encoding: Encoding)(using val sanitizer: TextSanitizer) extends Findable:
   type Self = Text
   type Form = Data
 

--- a/lib/hieroglyph/src/core/hieroglyph.Unicode.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.Unicode.scala
@@ -133,7 +133,8 @@ object Unicode:
         else map.updated(range, width)
 
     @tailrec
-    def recur(stream: LazyList[Text], map: TreeMap[CharRange, EaWidth]): TreeMap[CharRange, EaWidth] =
+    def recur(stream: LazyList[Text], map: TreeMap[CharRange, EaWidth])
+    :   TreeMap[CharRange, EaWidth] =
       stream match
         case
           r"${Hex(from)}([0-9A-F]{4,6})\.\.${Hex(to)}([0-9A-F]{4,6});${EaWidth(w)}([AFHNW]a?).*" #::

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -165,17 +165,33 @@ object Html extends Tag.Container
   =>  NotGiven[Html.Recovery.Permissive]
   =>  (Html of content) is Aggregable by Text =
 
-    input =>
-      val root = Tag.root(content.reify.map(_.tt).to(Set))
-      HtmlParser.fromIterator(input.iterator, permissive = false).parseHtml(root).of[content]
+    new Aggregable:
+      type Self = Html of content
+      type Operand = Text
+
+      def aggregate(input: LazyList[Text]): Html of content =
+        val root = Tag.root(content.reify.map(_.tt).to(Set))
+        HtmlParser.fromIterator(input.iterator, permissive = false).parseHtml(root).of[content]
+
+      override def accept(stream: Stream[Text] over Credit): Html of content =
+        val root = Tag.root(content.reify.map(_.tt).to(Set))
+        HtmlParser.fromStream(stream, permissive = false).parseHtml(root).of[content]
 
   given strictAggregable2: (dom: Dom)
   =>  Tactic[ParseError]
   =>  NotGiven[Html.Recovery.Permissive]
   =>  Html is Aggregable by Text =
-    input =>
-      HtmlParser.fromIterator(input.iterator, permissive = false)
-      . parseHtml(dom.generic, doctypes = false)
+    new Aggregable:
+      type Self = Html
+      type Operand = Text
+
+      def aggregate(input: LazyList[Text]): Html =
+        HtmlParser.fromIterator(input.iterator, permissive = false)
+        . parseHtml(dom.generic, doctypes = false)
+
+      override def accept(stream: Stream[Text] over Credit): Html =
+        HtmlParser.fromStream(stream, permissive = false)
+        . parseHtml(dom.generic, doctypes = false)
 
   given strictLoadable: (dom: Dom)
   =>  Tactic[ParseError]
@@ -206,22 +222,44 @@ object Html extends Tag.Container
   =>  Html.Recovery.Permissive
   =>  (Html of content) is Aggregable by Text =
 
-    input =>
-      given Tactic[ParseError] = lenientTactic
-      val root = Tag.root(content.reify.map(_.tt).to(Set))
+    new Aggregable:
+      type Self = Html of content
+      type Operand = Text
 
-      lenient(Fragment().of[content]):
-        HtmlParser.fromIterator(input.iterator, permissive = true).parseHtml(root).of[content]
+      def aggregate(input: LazyList[Text]): Html of content =
+        given Tactic[ParseError] = lenientTactic
+        val root = Tag.root(content.reify.map(_.tt).to(Set))
+
+        lenient(Fragment().of[content]):
+          HtmlParser.fromIterator(input.iterator, permissive = true).parseHtml(root).of[content]
+
+      override def accept(stream: Stream[Text] over Credit): Html of content =
+        given Tactic[ParseError] = lenientTactic
+        val root = Tag.root(content.reify.map(_.tt).to(Set))
+
+        lenient(Fragment().of[content]):
+          HtmlParser.fromStream(stream, permissive = true).parseHtml(root).of[content]
 
   given permissiveAggregable2: (dom: Dom)
   =>  Html.Recovery.Permissive
   =>  Html is Aggregable by Text =
-    input =>
-      given Tactic[ParseError] = lenientTactic
+    new Aggregable:
+      type Self = Html
+      type Operand = Text
 
-      lenient(Fragment()):
-        HtmlParser.fromIterator(input.iterator, permissive = true)
-        . parseHtml(dom.generic, doctypes = false)
+      def aggregate(input: LazyList[Text]): Html =
+        given Tactic[ParseError] = lenientTactic
+
+        lenient(Fragment()):
+          HtmlParser.fromIterator(input.iterator, permissive = true)
+          . parseHtml(dom.generic, doctypes = false)
+
+      override def accept(stream: Stream[Text] over Credit): Html =
+        given Tactic[ParseError] = lenientTactic
+
+        lenient(Fragment()):
+          HtmlParser.fromStream(stream, permissive = true)
+          . parseHtml(dom.generic, doctypes = false)
 
   given permissiveLoadable: (dom: Dom)
   =>  Html.Recovery.Permissive
@@ -547,6 +585,11 @@ object Html extends Tag.Container
       new HtmlParser(Cursor[Text](text), permissive)
 
     def fromIterator(input: Iterator[Text], permissive: Boolean = false)(using Dom): HtmlParser =
+      new HtmlParser(Cursor[Text](input), permissive)
+
+    def fromStream(input: Stream[Text] over Credit, permissive: Boolean = false)(using Dom)
+    :   HtmlParser =
+
       new HtmlParser(Cursor[Text](input), permissive)
 
   private[honeycomb] final class HtmlParser

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1153,7 +1153,7 @@ object Json extends Json2, Dynamic:
       type Result = HttpStreams.Content
 
       def genericize(json: Json): HttpStreams.Content =
-        (t"application/json; charset=${encoder.encoding.name}", LazyList(json.show.data))
+        (t"application/json; charset=${encoder.encoding.name}", HttpStreams.Body(json.show.data))
 
 
   given decodable: (Tactic[ParseError], PositionTracking) => Json is distillate.Decodable in Text =

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -744,6 +744,17 @@ object Json extends Json2, Dynamic:
       val (raw, ints) = Parser.parseTracked(input, mode)
       (Json.Ast(raw), Json.PositionIndex(ints))
 
+    private[jacinta] def parse(input: Stream[Data] over Credit)(using mode: NumberMode)
+    :   Json.Ast raises ParseError =
+
+      Json.Ast(Parser.parse(input, mode))
+
+    private[jacinta] def parseTracked(input: Stream[Data] over Credit)(using mode: NumberMode)
+    :   (Json.Ast, Json.PositionIndex) raises ParseError =
+
+      val (raw, ints) = Parser.parseTracked(input, mode)
+      (Json.Ast(raw), Json.PositionIndex(ints))
+
   def ast(value: Json.Ast): Json = new Json(value)
 
   // `object Json` extends `Dynamic`, which suppresses the universal-apply
@@ -757,6 +768,20 @@ object Json extends Json2, Dynamic:
   // `Positionable`); when off, the throughput path is unchanged. This is the
   // single place the `read`/`load` givens branch on tracking.
   private def readJson(input: Iterator[Data])(using Tactic[ParseError], PositionTracking): Json =
+    summon[PositionTracking] match
+      case PositionTracking.On =>
+        val (ast, index) = Json.Ast.parseTracked(input)
+        new Json(ast, index)
+
+      case PositionTracking.Off =>
+        Json(Json.Ast.parse(input))
+
+  // As above, but pulling from a demand-aware stream rather than a chunk
+  // iterator.
+  private def readJson(input: Stream[Data] over Credit)
+    ( using Tactic[ParseError], PositionTracking )
+  :   Json =
+
     summon[PositionTracking] match
       case PositionTracking.On =>
         val (ast, index) = Json.Ast.parseTracked(input)
@@ -1092,7 +1117,12 @@ object Json extends Json2, Dynamic:
     json.root.show
 
   given aggregable: (Tactic[ParseError], PositionTracking) => Json is Aggregable by Data =
-    bytes => readJson(bytes.iterator)
+    new Aggregable:
+      type Self = Json
+      type Operand = Data
+
+      def aggregate(bytes: LazyList[Data]): Json = readJson(bytes.iterator)
+      override def accept(stream: Stream[Data] over Credit): Json = readJson(stream)
 
 
   given aggregableDirect: [value: distillate.Decodable in Json] => Tactic[ParseError]
@@ -1100,7 +1130,15 @@ object Json extends Json2, Dynamic:
   =>  Tactic[JsonError]
   =>  (value in Json) is Aggregable by Data =
 
-    bytes => readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
+    new Aggregable:
+      type Self = value in Json
+      type Operand = Data
+
+      def aggregate(bytes: LazyList[Data]): value in Json =
+        readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
+
+      override def accept(stream: Stream[Data] over Credit): value in Json =
+        readJson(stream).as[value].asInstanceOf[value in Json]
 
 
   given showable: Formatting => Json is Showable = _.root.show
@@ -1263,6 +1301,25 @@ object Json extends Json2, Dynamic:
       val raw = parser.parse()
       (raw, parser.rootIndex.nn)
 
+    def parse(input: Stream[Data] over Credit, mode: NumberMode): Raw raises ParseError =
+      val parser = pool.get.nn
+      parser.tracking = false
+      parser.resetStream(input)
+      parser.holes = false
+      parser.numberMode = mode
+      parser.parse()
+
+    def parseTracked(input: Stream[Data] over Credit, mode: NumberMode)
+    :   (Raw, IArray[Int]) raises ParseError =
+
+      val parser = pool.get.nn
+      parser.tracking = true
+      parser.resetStream(input)
+      parser.holes = false
+      parser.numberMode = mode
+      val raw = parser.parse()
+      (raw, parser.rootIndex.nn)
+
   private[jacinta] final class Parser:
     import scala.annotation.switch
     import scala.collection.mutable.ArrayBuffer
@@ -1373,6 +1430,17 @@ object Json extends Json2, Dynamic:
       rootIndex = null
       heldToken = null
 
+    def resetStream(input: Stream[Data] over Credit): Unit =
+      cursor = makeCursor(input)
+      syncFrom()
+      stringCursor = 0
+      arrayBufferId = -1
+      bcdLongBufferId = -1
+      bcdIntBufferId = -1
+      indexBufferId = -1
+      rootIndex = null
+      heldToken = null
+
     private def makeCursor(input: Data): Cursor[Data] =
       if tracking then
         import zephyrine.lineation.linefeedByte
@@ -1382,6 +1450,14 @@ object Json extends Json2, Dynamic:
         Cursor[Data](input)
 
     private def makeCursor(input: Iterator[Data]): Cursor[Data] =
+      if tracking then
+        import zephyrine.lineation.linefeedByte
+        Cursor[Data](input)
+      else
+        import Lineation.untrackedData
+        Cursor[Data](input)
+
+    private def makeCursor(input: Stream[Data] over Credit): Cursor[Data] =
       if tracking then
         import zephyrine.lineation.linefeedByte
         Cursor[Data](input)

--- a/lib/jacinta/src/core/jacinta_parser.scala
+++ b/lib/jacinta/src/core/jacinta_parser.scala
@@ -39,4 +39,9 @@ import turbulence.*
 import zephyrine.*
 
 given parserAggregable: Tactic[ParseError] => Json.Ast is Aggregable by Data =
-  source => Json.Ast.parse(source.iterator)
+  new Aggregable:
+    type Self = Json.Ast
+    type Operand = Data
+
+    def aggregate(source: LazyList[Data]): Json.Ast = Json.Ast.parse(source.iterator)
+    override def accept(stream: Stream[Data] over Credit): Json.Ast = Json.Ast.parse(stream)

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -117,7 +117,7 @@ object Protobuf extends Protobuf2:
       type Result = HttpStreams.Content
 
       def genericize(value: Protobuf): HttpStreams.Content =
-        (t"application/protobuf", LazyList(value.encode))
+        (t"application/protobuf", HttpStreams.Body(value.encode))
 
   // `bytes.read[Protobuf]` aggregates the byte stream and wraps it as a message.
   given aggregable: Protobuf is Aggregable by Data = bytes => message(bytes.read[Data])

--- a/lib/monotonous/src/core/monotonous.Alphabet.scala
+++ b/lib/monotonous/src/core/monotonous.Alphabet.scala
@@ -36,8 +36,185 @@ import anticipation.*
 import contingency.*
 import denominative.*
 import gossamer.*
+import hypotenuse.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
+
+// An `Alphabet` is the stage descriptor for streaming serialization in both
+// directions: `stream.through(alphabets.hex.upperCase)` serializes a byte
+// stream to text, or deserializes a text stream to bytes, chosen by the
+// stream's medium. The demand conversion is the exact arithmetic of the
+// base: a downstream credit of 1024 hex chars translates to an upstream
+// credit of 512 bytes.
+object Alphabet:
+  // Bits per serialized character: alphabets have 2^bits characters, plus
+  // one for padding.
+  private def bits(alphabet: Alphabet[?]): Int =
+    31 - Integer.numberOfLeadingZeros(alphabet.chars.s.length)
+
+  given serialization: [encoding <: Serialization]
+  =>  Ductile.Of[Alphabet[encoding], Data, Text, Credit, Credit] =
+
+    new Ductile:
+      type Self = Alphabet[encoding]
+      type Operand = Data
+      type Result = Text
+      type Transport = Credit
+      type Upstream = Credit
+
+      def duct(stage: Alphabet[encoding])(using Buffering)
+      :   Duct[Data, Text] { type Transport = Credit; type Upstream = Credit } =
+
+        new Duct[Data, Text]:
+          type Transport = Credit
+          type Upstream = Credit
+
+          private val base: Int = bits(stage)
+
+          // Serialized characters per group, for terminal padding.
+          private val multiple: Int = 8/base.gcd(8)
+
+          private var accumulator: Int = 0
+          private var accumulated: Int = 0
+          private var written: Long = 0
+          private var flushing: Boolean = false
+
+          def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+          def translate(demand: Credit): Credit =
+            Credit((demand.count.min(Long.MaxValue/8)*base/8).max(1))
+
+          def step
+            ( source: input.Storage,
+              sourceOffset: Int,
+              sourceLength: Int,
+              target: output.Storage,
+              targetOffset: Int,
+              targetSpace: Int )
+          :   Duct.Progress =
+
+            val bytes = source.asInstanceOf[Array[Byte]]
+            val chars = target.asInstanceOf[Array[Char]]
+            var consumed: Int = 0
+            var produced: Int = 0
+            var continue: Boolean = true
+
+            while continue do
+              if accumulated >= base then
+                if produced < targetSpace then
+                  chars(targetOffset + produced) =
+                    stage((accumulator >>> (accumulated - base)) & ((1 << base) - 1))
+
+                  produced += 1
+                  accumulated -= base
+                  written += 1
+                else
+                  continue = false
+              else if consumed < sourceLength then
+                accumulator = (accumulator << 8) | (bytes(sourceOffset + consumed) & 0xff)
+                accumulated += 8
+                consumed += 1
+              else
+                continue = false
+
+            Duct.Progress(consumed, produced)
+
+          override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
+          :   Int =
+
+            val chars = target.asInstanceOf[Array[Char]]
+            var produced: Int = 0
+
+            if !flushing then
+              flushing = true
+
+              if accumulated > 0 then
+                chars(targetOffset) =
+                  stage((accumulator << (base - accumulated)) & ((1 << base) - 1))
+
+                produced = 1
+                accumulated = 0
+                written += 1
+
+            if stage.padding then
+              while written%multiple != 0 && produced < targetSpace do
+                chars(targetOffset + produced) = stage(1 << base)
+                produced += 1
+                written += 1
+
+            produced
+
+  given deserialization: [encoding <: Serialization] => Tactic[SerializationError]
+  =>  Ductile.Of[Alphabet[encoding], Text, Data, Credit, Credit] =
+
+    new Ductile:
+      type Self = Alphabet[encoding]
+      type Operand = Text
+      type Result = Data
+      type Transport = Credit
+      type Upstream = Credit
+
+      def duct(stage: Alphabet[encoding])(using Buffering)
+      :   Duct[Text, Data] { type Transport = Credit; type Upstream = Credit } =
+
+        new Duct[Text, Data]:
+          type Transport = Credit
+          type Upstream = Credit
+
+          private val base: Int = bits(stage)
+          private val pad: Char = if stage.padding then stage(1 << base) else ' '
+
+          private var accumulator: Int = 0
+          private var accumulated: Int = 0
+          private var position: Int = 0
+
+          def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+          def translate(demand: Credit): Credit =
+            Credit((demand.count.min(Long.MaxValue/8)*8/base).max(1))
+
+          def step
+            ( source: input.Storage,
+              sourceOffset: Int,
+              sourceLength: Int,
+              target: output.Storage,
+              targetOffset: Int,
+              targetSpace: Int )
+          :   Duct.Progress =
+
+            val chars = source.asInstanceOf[Array[Char]]
+            val bytes = target.asInstanceOf[Array[Byte]]
+            var consumed: Int = 0
+            var produced: Int = 0
+            var continue: Boolean = true
+
+            while continue do
+              if accumulated >= 8 then
+                if produced < targetSpace then
+                  bytes(targetOffset + produced) =
+                    ((accumulator >>> (accumulated - 8)) & 0xff).toByte
+
+                  produced += 1
+                  accumulated -= 8
+                else
+                  continue = false
+              else if consumed < sourceLength then
+                val char = chars(sourceOffset + consumed)
+
+                // Trailing padding characters carry no data; the bits already
+                // accumulated before them are alignment filler.
+                if stage.padding && char == pad then accumulated = 0
+                else
+                  accumulator = (accumulator << base) | stage.invert(position, char)
+                  accumulated += base
+
+                position += 1
+                consumed += 1
+              else
+                continue = false
+
+            Duct.Progress(consumed, produced)
 
 case class Alphabet[encoding <: Serialization]
   ( chars: Text, padding: Boolean, tolerance: Map[Char, Int] = Map() ):

--- a/lib/monotonous/src/test/monotonous_test.scala
+++ b/lib/monotonous/src/test/monotonous_test.scala
@@ -185,3 +185,59 @@ object Tests extends Suite(m"Monotonous tests"):
           import alphabets.binaryStandard
           arb.serialize[Binary].deserialize[Binary].to(List)
         . assert(_ == arbList)
+
+    suite(m"Streaming serialization tests"):
+      import strategies.throwUnsafely
+      import alphabets.hexUpperCase, alphabets.base64Standard
+
+      val payload = Data.fill(100)(_.toByte)
+
+      test(m"hex duct serializes a byte stream"):
+        Drain.text(Stream(payload).through(summon[Alphabet[Hex]]))
+      . assert(_ == payload.serialize[Hex])
+
+      test(m"hex duct deserializes a text stream"):
+        Drain.data(Stream(payload.serialize[Hex]).through(summon[Alphabet[Hex]])).to(List)
+      . assert(_ == payload.to(List))
+
+      test(m"base64 duct emits padding at end of stream"):
+        Drain.text(Stream(Data(1, 2, 3, 4)).through(summon[Alphabet[Base64]]))
+      . assert(_ == Data(1, 2, 3, 4).serialize[Base64])
+
+      test(m"base64 duct roundtrips through both directions"):
+        val text = Drain.text(Stream(payload).through(summon[Alphabet[Base64]]))
+        Drain.data(Stream(text).through(summon[Alphabet[Base64]])).to(List)
+      . assert(_ == payload.to(List))
+
+// Drains a duct-composed pull endpoint, for the streaming serialization
+// tests.
+object Drain:
+  def text(stream: Stream[Text] over Credit, credit: Int = 7): Text =
+    val builder = StringBuilder()
+
+    def recur(): Unit = stream.refill(Credit(credit)) match
+      case count: Int =>
+        val window = unsafely(stream.window).asInstanceOf[Array[Char]]
+        builder.append(String(window, stream.start, count))
+        stream.skip(count)
+        recur()
+
+      case _ => ()
+
+    recur()
+    builder.toString.tt
+
+  def data(stream: Stream[Data] over Credit, credit: Int = 7): Data =
+    val target = java.io.ByteArrayOutputStream()
+
+    def recur(): Unit = stream.refill(Credit(credit)) match
+      case count: Int =>
+        val window = unsafely(stream.window).asInstanceOf[Array[Byte]]
+        target.write(window, stream.start, count)
+        stream.skip(count)
+        recur()
+
+      case _ => ()
+
+    recur()
+    target.toByteArray.nn.immutable(using Unsafe)

--- a/lib/obligatory/src/grpc/obligatory.GrpcFraming.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcFraming.scala
@@ -48,7 +48,8 @@ import zephyrine.*
 // `LengthPrefix` does for the JSON-RPC stream framing.
 object GrpcFraming:
   private def gzip(message: Data): Data = Gzip.compression.compress(LazyList(message)).read[Data]
-  private def gunzip(message: Data): Data = Gzip.compression.decompress(LazyList(message)).read[Data]
+  private def gunzip(message: Data): Data =
+    Gzip.compression.decompress(LazyList(message)).read[Data]
 
   // Prefix one message for the wire, optionally gzip-compressing the payload.
   def encode(message: Data, compress: Boolean = false): Data =

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -46,6 +46,7 @@ import monotonous.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
+import turbulence.*
 import vacuous.*
 
 import alphabets.hexLowerCase
@@ -83,7 +84,7 @@ object Postable:
       type Self = response
 
       def mediaType(content: response): MediaType = content.generic(0).decode[MediaType]
-      def stream(content: response): LazyList[Data] = content.generic(1)
+      def stream(content: response): LazyList[Data] = content.generic(1).lazyList
 
 trait Postable extends Typeclass:
   def mediaType(content: Self): MediaType

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -62,7 +62,8 @@ object Servable:
 
     def mediaType(value: response): MediaType = unsafely(Media.parse(response.generic(value)(0)))
 
-    Servable[response](mediaType): value => Http.Body.Streaming(response.generic(value)(1))
+    Servable[response](mediaType): value =>
+      Http.Body.Streaming(response.generic(value)(1).lazyList)
 
 
   given data: Data is Servable =

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -38,8 +38,8 @@ export
       defer, discard, Document, Documentary, Eof, Err, In, inputStream,
       Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
       multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool,
-      Readable, Sink, Source, Stdio, stream, Streamable, StreamError, StreamOutputStream, strict,
-      take, Tap, Writable, writeTo, framed, flow, lazyList }
+      Confluence, Manifold, Readable, Sink, Source, Stdio, stream, Streamable, StreamError,
+      StreamOutputStream, strict, take, Tap, Writable, writeTo, framed, flow, lazyList }
 
 package stdios:
   export turbulence.stdios.{muteStdio, systemStdio, virtualMachineStdio}

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -38,8 +38,8 @@ export
       defer, discard, Document, Documentary, Eof, Err, In, inputStream,
       Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
       multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool,
-      Readable, Stdio, stream, Streamable, StreamError, StreamOutputStream, strict, take, Tap,
-      Writable, writeTo, framed, flow }
+      Readable, Sink, Source, Stdio, stream, Streamable, StreamError, StreamOutputStream, strict,
+      take, Tap, Writable, writeTo, framed, flow, lazyList }
 
 package stdios:
   export turbulence.stdios.{muteStdio, systemStdio, virtualMachineStdio}

--- a/lib/turbulence/src/core/turbulence.Aggregable.scala
+++ b/lib/turbulence/src/core/turbulence.Aggregable.scala
@@ -38,35 +38,65 @@ import hieroglyph.*
 import prepositional.*
 import rudiments.*
 import symbolism.*
+import vacuous.*
+import zephyrine.*
 
 object Aggregable:
-  given bytesData: Data is Aggregable by Data = source0 =>
-    val size = source0.foldLeft(0)(_ + _.length)
+  // Drain a pull endpoint into the medium's builder: one copy per window,
+  // no intermediate chunks. The native `accept` for whole-value aggregation.
+  private def gather[medium](stream: Stream[medium] over Credit): medium =
+    val target = stream.addressable.blank(4096)
 
-    var source = source0
+    def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
+      case count: Int =>
+        stream.addressable.cloneStorage(stream.window(using Unsafe), stream.start, count)(target)
+        stream.skip(count)
+        recur()
 
-    Data.build(size): array =>
-      var index = Prim
+      case _ => ()
 
-      while !source.nil do
-        val bytes = source.head
-        array.place(bytes, index)
-        index += bytes.length
-        source = source.tail
+    recur()
+    stream.addressable.build(target)
+
+  given bytesData: Data is Aggregable by Data = new Aggregable:
+    type Self = Data
+    type Operand = Data
+
+    override def accept(stream: Stream[Data] over Credit): Data = gather(stream)
+
+    def aggregate(source0: LazyList[Data]): Data =
+      val size = source0.foldLeft(0)(_ + _.length)
+
+      var source = source0
+
+      Data.build(size): array =>
+        var index = Prim
+
+        while !source.nil do
+          val bytes = source.head
+          array.place(bytes, index)
+          index += bytes.length
+          source = source.tail
 
   given bytesText: (decoder: CharDecoder) => Text is Aggregable by Data =
     bytesData.map(decoder.decoded)
 
-  given textText: Text is Aggregable by Text = source0 =>
-    var source = source0
+  given textText: Text is Aggregable by Text = new Aggregable:
+    type Self = Text
+    type Operand = Text
 
-    val builder = new StringBuilder()
+    override def accept(stream: Stream[Text] over Credit): Text = gather(stream)
 
-    while !source.nil do
-      builder.append(source.head.s)
-      source = source.tail
+    def aggregate(source0: LazyList[Text]): Text =
+      var source = source0
 
-    builder.toString.tt
+      val builder = new StringBuilder()
+
+      while !source.nil do
+        builder.append(source.head.s)
+        source = source.tail
+
+      builder.toString.tt
 
 
   given stream: [element, element2] => (aggregable: element2 is Aggregable by element)
@@ -77,6 +107,24 @@ object Aggregable:
 trait Aggregable extends Typeclass, Operable:
   aggregable =>
   def aggregate(source: LazyList[Operand]): Self
+
+  // Consume a pull endpoint. The default materializes one chunk per refill
+  // and delegates to the legacy `aggregate`; instances override it to build
+  // directly from the stream's windows.
+  def accept(stream: Stream[Operand] over Credit): Self =
+    def recur(): LazyList[Operand] =
+      stream.refill(Credit(Long.MaxValue)) match
+        case count: Int =>
+          val chunk =
+            stream.addressable.materialize(stream.window(using Unsafe), stream.start, count)
+
+          stream.skip(count)
+          chunk #:: recur()
+
+        case _ =>
+          LazyList()
+
+    aggregate(LazyList.defer(recur()))
 
   def map[self2](lambda: Self => self2): self2 is Aggregable by Operand = source =>
     lambda(aggregable.aggregate(source))

--- a/lib/turbulence/src/core/turbulence.Compression.scala
+++ b/lib/turbulence/src/core/turbulence.Compression.scala
@@ -33,9 +33,20 @@
 package turbulence
 
 import anticipation.*
+import zephyrine.*
 
 trait Compression:
   type Self <: Compressor
 
   def compress(stream: LazyList[Data]): LazyList[Data]
   def decompress(stream: LazyList[Data]): LazyList[Data]
+
+  // Streaming stages for the same transformations, applied with
+  // `stream.compress[Gzip]`/`stream.decompress[Gzip]` on a pull endpoint.
+  def compressor()(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit }
+
+  def decompressor()(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit }

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -30,138 +30,107 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package zephyrine
+package turbulence
 
 import java.util.concurrent as juc
 import java.util.concurrent.atomic as juca
 
+import anticipation.*
 import fulminate.*
+import parasite.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
-// The asynchronous boundary of a streaming pipeline: an `Intake` on its write
-// side and a `Stream` on its read side, with exactly one thread ever touching
-// each. Data crosses in blocks through a bounded queue, so a writer that
-// outpaces its reader parks in `reserve` — cross-thread backpressure — and
-// the free capacity is the credit this conduit reports as its `demand`. This
-// is the only synchronized component of a pipeline; every other stage is
-// single-owner mutable state on one side of a conduit or the other.
-//
-// A conduit is the generalization of `Producer.Channel`: block-granular
-// hand-off, but with element-granular credit, storage handed to the reader
-// without materializing an immutable chunk, and failure propagation — a
-// producer-side `fail` is rethrown from the reader's next `refill`.
-object Conduit:
+// Fan-in: merges several pull endpoints into one, in arrival order. Pull
+// architecture admits no `select` over blocked refills, so this is the
+// honest cost of multiplexing: one pump task per input, each pulling
+// block-sized credits into a shared bounded queue — a full queue parks the
+// pumps, so slow consumption backpressures every input — and a reader
+// endpoint that parks while the queue is empty. The merged stream ends when
+// every input has ended; an input's failure is rethrown from the reader's
+// next refill.
+object Confluence:
   private object End
 
   private class Block(val storage: AnyRef, val size: Int)
 
-final class Conduit[medium]
-  (using val addressable0: medium is Addressable)(using buffering: Buffering)
-extends Intake[medium](using addressable0):
-  type Transport = Credit
+  def apply[medium](sources: Stream[medium] over Credit*)
+    ( using addressable0: medium is Addressable,
+            buffering:    Buffering,
+            monitor:      Monitor,
+            probate:      Probate )
+  :   Stream[medium] over Credit =
 
-  private val block: Int = buffering.capacity(addressable0.substrate)
-  private val queue: juc.ArrayBlockingQueue[AnyRef] = juc.ArrayBlockingQueue(buffering.window)
+    val block: Int = buffering.capacity(addressable0.substrate)
 
-  private val written: juca.AtomicLong = juca.AtomicLong(0)
-  private val consumed: juca.AtomicLong = juca.AtomicLong(0)
-  @volatile private var error: Throwable | Null = null
-  @volatile private var closed: Boolean = false
+    val queue: juc.ArrayBlockingQueue[AnyRef] =
+      juc.ArrayBlockingQueue(buffering.window.max(sources.length))
 
-  private var current: addressable0.Storage = addressable0.allocate(block)
-  private var mark0: Int = 0
+    val remaining: juca.AtomicInteger = juca.AtomicInteger(sources.length)
+    @volatile var error: Throwable | Null = null
 
-  // Everything this conduit can hold: the queued blocks plus the block being
-  // written. `demand` is this allowance less what is currently buffered, so
-  // it reaches zero exactly when `reserve` would block.
-  private val allowance: Long = block.toLong * (buffering.window + 1)
+    def finish(): Unit = if remaining.decrementAndGet == 0 then queue.put(End)
 
-  def demand: Credit = Credit(allowance - (written.get - consumed.get))
+    sources.each: source =>
+      async:
+        def loop(): Unit = source.refill(Credit(block)) match
+          case count: Int =>
+            val window = source.window(using Unsafe)
+            val storage = addressable0.allocate(count)
 
-  protected def buffer0: AnyRef = current.asInstanceOf[AnyRef]
-  def mark: Int = mark0
+            addressable0.transfer
+              ( window.asInstanceOf[addressable0.Storage], source.start, storage, 0, count )
 
-  def reserve(min: Int): Int =
-    val free = block - mark0
+            source.skip(count)
+            queue.put(Block(storage.asInstanceOf[AnyRef], count))
+            loop()
 
-    if free >= min then free else
-      publish()
-      block
+          case _ =>
+            finish()
 
-  def commit(count: Int): Unit =
-    mark0 += count
-    written.addAndGet(count)
-    if mark0 == block then publish()
+        try loop() catch case exception: Exception =>
+          error = exception
+          finish()
 
-  override def flush(): Unit = if mark0 > 0 then publish()
+    new Stream[medium](using addressable0):
+      type Transport = Credit
 
-  def finish(): Unit =
-    flush()
-    queue.put(Conduit.End)
+      private var storage: addressable0.Storage = addressable0.allocate(0)
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var size: Int = 0
+      private var ended: Boolean = false
 
-  override def fail(error: Throwable): Unit =
-    this.error = error
-    queue.clear()
-    queue.put(Conduit.End)
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      def skip(count: Int): Unit = start0 += count
 
-  private def publish(): Unit =
-    if mark0 > 0 then
-      if closed then
-        written.addAndGet(-mark0)
-        mark0 = 0
-      else
-        queue.put(Conduit.Block(current.asInstanceOf[AnyRef], mark0))
-        current = addressable0.allocate(block)
-        mark0 = 0
-
-  // The read side; single reader. `refill` parks (in `queue.take`) until the
-  // writer publishes a block or finishes.
-  val stream: Stream[medium] over Credit = new Stream[medium](using addressable0):
-    type Transport = Credit
-
-    private var storage: addressable0.Storage = addressable0.allocate(0)
-    private var start0: Int = 0
-    private var limit0: Int = 0
-    private var size: Int = 0
-    private var ended: Boolean = false
-
-    protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
-    def start: Int = start0
-    def limit: Int = limit0
-
-    def skip(count: Int): Unit =
-      start0 += count
-      consumed.addAndGet(count)
-
-    def refill(demand: Credit): Optional[Int] =
-      if limit0 > start0 then limit0 - start0
-      else if ended then Unset
-      else
-        val granted = summon[Credit is Regulation].grant(demand)
-
-        if granted == 0 then 0
-        else if limit0 < size then
-          limit0 += (size - limit0).min(granted)
-          limit0 - start0
+      def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if ended then Unset
         else
-          (queue.take().nn: @unchecked) match
-            case Conduit.End =>
-              ended = true
-              val error0 = error
-              if error0 == null then Unset else throw error0
+          val granted = summon[Credit is Regulation].grant(demand)
 
-            case received: Conduit.Block =>
-              storage = received.storage.asInstanceOf[addressable0.Storage]
-              size = received.size
-              start0 = 0
-              limit0 = size.min(granted)
-              limit0
+          if granted == 0 then 0
+          else if limit0 < size then
+            limit0 += (size - limit0).min(granted)
+            limit0 - start0
+          else
+            (queue.take().nn: @unchecked) match
+              case End =>
+                ended = true
+                val error0 = error
+                if error0 == null then Unset else throw error0
 
-            case _ =>
-              panic(m"unexpected value in conduit queue")
+              case received: Block =>
+                storage = received.storage.asInstanceOf[addressable0.Storage]
+                size = received.size
+                start0 = 0
+                limit0 = size.min(granted)
+                limit0
 
-    override def close(): Unit =
-      closed = true
-      queue.clear()
+              case _ =>
+                panic(m"unexpected value in confluence queue")

--- a/lib/turbulence/src/core/turbulence.Manifold.scala
+++ b/lib/turbulence/src/core/turbulence.Manifold.scala
@@ -30,138 +30,98 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package zephyrine
+package turbulence
 
 import java.util.concurrent as juc
-import java.util.concurrent.atomic as juca
 
+import anticipation.*
 import fulminate.*
+import parasite.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
-// The asynchronous boundary of a streaming pipeline: an `Intake` on its write
-// side and a `Stream` on its read side, with exactly one thread ever touching
-// each. Data crosses in blocks through a bounded queue, so a writer that
-// outpaces its reader parks in `reserve` — cross-thread backpressure — and
-// the free capacity is the credit this conduit reports as its `demand`. This
-// is the only synchronized component of a pipeline; every other stage is
-// single-owner mutable state on one side of a conduit or the other.
-//
-// A conduit is the generalization of `Producer.Channel`: block-granular
-// hand-off, but with element-granular credit, storage handed to the reader
-// without materializing an immutable chunk, and failure propagation — a
-// producer-side `fail` is rethrown from the reader's next `refill`.
-object Conduit:
+// Fan-out: one pump task pulls the source and delivers every chunk to each
+// of `count` subscriber endpoints through bounded queues. Chunks are
+// materialized once and shared immutably between subscribers; a full
+// subscriber queue parks the pump, so the slowest subscriber gates the
+// source — the correct backpressure semantics for replication. A source
+// failure is rethrown from each subscriber's next refill.
+object Manifold:
   private object End
 
-  private class Block(val storage: AnyRef, val size: Int)
+  def apply[medium](source: Stream[medium] over Credit, count: Int)
+    ( using addressable0: medium is Addressable,
+            buffering:    Buffering,
+            monitor:      Monitor,
+            probate:      Probate )
+  :   IndexedSeq[Stream[medium] over Credit] =
 
-final class Conduit[medium]
-  (using val addressable0: medium is Addressable)(using buffering: Buffering)
-extends Intake[medium](using addressable0):
-  type Transport = Credit
+    val block: Int = buffering.capacity(addressable0.substrate)
 
-  private val block: Int = buffering.capacity(addressable0.substrate)
-  private val queue: juc.ArrayBlockingQueue[AnyRef] = juc.ArrayBlockingQueue(buffering.window)
+    val queues: IndexedSeq[juc.ArrayBlockingQueue[AnyRef]] =
+      IndexedSeq.fill(count)(juc.ArrayBlockingQueue[AnyRef](buffering.window))
 
-  private val written: juca.AtomicLong = juca.AtomicLong(0)
-  private val consumed: juca.AtomicLong = juca.AtomicLong(0)
-  @volatile private var error: Throwable | Null = null
-  @volatile private var closed: Boolean = false
+    @volatile var error: Throwable | Null = null
 
-  private var current: addressable0.Storage = addressable0.allocate(block)
-  private var mark0: Int = 0
+    async:
+      def loop(): Unit = source.refill(Credit(block)) match
+        case size: Int =>
+          val chunk =
+            addressable0.materialize
+              ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
+                source.start,
+                size )
 
-  // Everything this conduit can hold: the queued blocks plus the block being
-  // written. `demand` is this allowance less what is currently buffered, so
-  // it reaches zero exactly when `reserve` would block.
-  private val allowance: Long = block.toLong * (buffering.window + 1)
+          source.skip(size)
+          queues.each(_.put(chunk.asInstanceOf[AnyRef]))
+          loop()
 
-  def demand: Credit = Credit(allowance - (written.get - consumed.get))
+        case _ =>
+          queues.each(_.put(End))
 
-  protected def buffer0: AnyRef = current.asInstanceOf[AnyRef]
-  def mark: Int = mark0
+      try loop() catch case exception: Exception =>
+        error = exception
+        queues.each(_.put(End))
 
-  def reserve(min: Int): Int =
-    val free = block - mark0
+    queues.map: queue =>
+      new Stream[medium](using addressable0):
+        type Transport = Credit
 
-    if free >= min then free else
-      publish()
-      block
+        // The shared chunk is immutable; subscribers only read the window,
+        // so exposing its backing array directly is safe and copy-free.
+        private var storage: AnyRef = addressable0.allocate(0).asInstanceOf[AnyRef]
+        private var start0: Int = 0
+        private var limit0: Int = 0
+        private var size: Int = 0
+        private var ended: Boolean = false
 
-  def commit(count: Int): Unit =
-    mark0 += count
-    written.addAndGet(count)
-    if mark0 == block then publish()
+        protected def window0: AnyRef = storage
+        def start: Int = start0
+        def limit: Int = limit0
+        def skip(count: Int): Unit = start0 += count
 
-  override def flush(): Unit = if mark0 > 0 then publish()
+        def refill(demand: Credit): Optional[Int] =
+          if limit0 > start0 then limit0 - start0
+          else if ended then Unset
+          else
+            val granted = summon[Credit is Regulation].grant(demand)
 
-  def finish(): Unit =
-    flush()
-    queue.put(Conduit.End)
+            if granted == 0 then 0
+            else if limit0 < size then
+              limit0 += (size - limit0).min(granted)
+              limit0 - start0
+            else
+              (queue.take().nn: @unchecked) match
+                case End =>
+                  ended = true
+                  val error0 = error
+                  if error0 == null then Unset else throw error0
 
-  override def fail(error: Throwable): Unit =
-    this.error = error
-    queue.clear()
-    queue.put(Conduit.End)
-
-  private def publish(): Unit =
-    if mark0 > 0 then
-      if closed then
-        written.addAndGet(-mark0)
-        mark0 = 0
-      else
-        queue.put(Conduit.Block(current.asInstanceOf[AnyRef], mark0))
-        current = addressable0.allocate(block)
-        mark0 = 0
-
-  // The read side; single reader. `refill` parks (in `queue.take`) until the
-  // writer publishes a block or finishes.
-  val stream: Stream[medium] over Credit = new Stream[medium](using addressable0):
-    type Transport = Credit
-
-    private var storage: addressable0.Storage = addressable0.allocate(0)
-    private var start0: Int = 0
-    private var limit0: Int = 0
-    private var size: Int = 0
-    private var ended: Boolean = false
-
-    protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
-    def start: Int = start0
-    def limit: Int = limit0
-
-    def skip(count: Int): Unit =
-      start0 += count
-      consumed.addAndGet(count)
-
-    def refill(demand: Credit): Optional[Int] =
-      if limit0 > start0 then limit0 - start0
-      else if ended then Unset
-      else
-        val granted = summon[Credit is Regulation].grant(demand)
-
-        if granted == 0 then 0
-        else if limit0 < size then
-          limit0 += (size - limit0).min(granted)
-          limit0 - start0
-        else
-          (queue.take().nn: @unchecked) match
-            case Conduit.End =>
-              ended = true
-              val error0 = error
-              if error0 == null then Unset else throw error0
-
-            case received: Conduit.Block =>
-              storage = received.storage.asInstanceOf[addressable0.Storage]
-              size = received.size
-              start0 = 0
-              limit0 = size.min(granted)
-              limit0
-
-            case _ =>
-              panic(m"unexpected value in conduit queue")
-
-    override def close(): Unit =
-      closed = true
-      queue.clear()
+                case chunk =>
+                  storage = chunk
+                  size = addressable0.length(chunk.asInstanceOf[medium])
+                  start0 = 0
+                  limit0 = size.min(granted)
+                  limit0

--- a/lib/turbulence/src/core/turbulence.Readable.scala
+++ b/lib/turbulence/src/core/turbulence.Readable.scala
@@ -37,50 +37,53 @@ import scala.annotation.implicitNotFound
 import anticipation.*
 import hieroglyph.*
 import prepositional.*
+import zephyrine.*
 
-// `Readable` composes a `Streamable` for the source type and an `Aggregable`
-// for the result type into a single resolvable instance, bridging with a
-// `CharDecoder`/`CharEncoder` when the two operate on different operands
-// (`Data` vs `Text`). Expressing the four pipelines as prioritised `given`s
-// (rather than a macro that summons combinations) means a missing instance is
-// an ordinary failed implicit search — so Frontier's `explainMissingContext`,
-// when in scope, lists the candidates and what each still requires.
+// `Readable` composes a `Source` for the source type and an `Aggregable` for
+// the result type into a single resolvable instance, bridging with a
+// `CharDecoder`/`CharEncoder` duct when the two operate on different operands
+// (`Data` vs `Text`) — so a bridged read transcodes incrementally, in bounded
+// buffers, on the reading thread. Expressing the four pipelines as
+// prioritised `given`s (rather than a macro that summons combinations) means
+// a missing instance is an ordinary failed implicit search — so Frontier's
+// `explainMissingContext`, when in scope, lists the candidates and what each
+// still requires.
 //
 // Priority (highest first): same-operand pipelines before the bridged ones,
 // so a directly-streamable/aggregable pairing is preferred when both apply.
 
 trait Readable3:
   given textToData: [source, result]
-  =>  ( streamable: source is Streamable by Text )
+  =>  ( source0: source is Source by Text over Credit )
   =>  ( aggregable: result is Aggregable by Data )
-  =>  ( encoder: CharEncoder )
+  =>  ( encoder: CharEncoder, buffering: Buffering )
   =>  source is Readable to result =
-    value => aggregable.aggregate(encoder.encoded(streamable.stream(value)))
+    value => aggregable.accept(source0.stream(value).through(encoder))
 
 trait Readable2 extends Readable3:
   given dataToText: [source, result]
-  =>  ( streamable: source is Streamable by Data )
+  =>  ( source0: source is Source by Data over Credit )
   =>  ( aggregable: result is Aggregable by Text )
-  =>  ( decoder: CharDecoder )
+  =>  ( decoder: CharDecoder, buffering: Buffering )
   =>  source is Readable to result =
-    value => aggregable.aggregate(decoder.decoded(streamable.stream(value)))
+    value => aggregable.accept(source0.stream(value).through(decoder))
 
 trait Readable1 extends Readable2:
   given textToText: [source, result]
-  =>  ( streamable: source is Streamable by Text )
+  =>  ( source0: source is Source by Text over Credit )
   =>  ( aggregable: result is Aggregable by Text )
   =>  source is Readable to result =
-    value => aggregable.aggregate(streamable.stream(value))
+    value => aggregable.accept(source0.stream(value))
 
 object Readable extends Readable1:
   given dataToData: [source, result]
-  =>  ( streamable: source is Streamable by Data )
+  =>  ( source0: source is Source by Data over Credit )
   =>  ( aggregable: result is Aggregable by Data )
   =>  source is Readable to result =
-    value => aggregable.aggregate(streamable.stream(value))
+    value => aggregable.accept(source0.stream(value))
 
 @implicitNotFound("turbulence: the source cannot be read as the target type; this needs a "+
-    "`Streamable` instance for the source and an `Aggregable` instance for the target, plus a "+
+    "`Source` instance for the source and an `Aggregable` instance for the target, plus a "+
     "`CharDecoder` or `CharEncoder` if their operands (Data/Text) differ")
 trait Readable extends Typeclass, Resultant:
   def read(value: Self): Result

--- a/lib/turbulence/src/core/turbulence.Sink.scala
+++ b/lib/turbulence/src/core/turbulence.Sink.scala
@@ -1,0 +1,212 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+import java.io as ji
+import java.nio as jn
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+import zephyrine.*
+
+// A target which can be opened as a push endpoint: the successor to
+// `Writable`, accepting writes incrementally through an `Intake` instead of
+// consuming a whole `LazyList`. As with `Writable`, a write failure `raise`s
+// a typed `StreamError` through an `Emit` captured by the given — a writer
+// only reports a cut, never aborts. `finish` closes the underlying resource,
+// matching `Writable`'s end-of-stream behaviour.
+object Sink extends Sink2:
+  given outputStream: [output <: ji.OutputStream] => (Emit[StreamError], Buffering)
+  =>  output is Sink by Data over Credit =
+
+    value =>
+      new Intake[Data]:
+        type Transport = Credit
+
+        private val block: Int = summon[Buffering].capacity(Substrate.Bytes)
+        private val storage: Array[Byte] = new Array[Byte](block)
+        private var mark0: Int = 0
+        private var total: Long = 0
+        private var broken: Boolean = false
+
+        def demand: Credit = Credit(if broken then 0 else Long.MaxValue)
+        protected def buffer0: AnyRef = storage
+        def mark: Int = mark0
+
+        def reserve(min: Int): Int =
+          val free = block - mark0
+
+          if free >= min then free else
+            drain()
+            block
+
+        def commit(count: Int): Unit =
+          mark0 += count
+          if mark0 == block then drain()
+
+        override def flush(): Unit =
+          drain()
+          try value.flush() catch case _: ji.IOException => ()
+
+        def finish(): Unit =
+          drain()
+          try value.close() catch case _: ji.IOException => raise(StreamError(total.b))
+
+        private def drain(): Unit =
+          if mark0 > 0 && !broken then
+            try
+              value.write(storage, 0, mark0)
+              value.flush()
+              total += mark0
+            catch case _: ji.IOException =>
+              broken = true
+              raise(StreamError(total.b))
+
+          mark0 = 0
+
+  given channel: (Emit[StreamError], Buffering)
+  =>  jn.channels.WritableByteChannel is Sink by Data over Credit =
+
+    value =>
+      new Intake[Data]:
+        type Transport = Credit
+
+        private val block: Int = summon[Buffering].capacity(Substrate.Bytes)
+        private val storage: Array[Byte] = new Array[Byte](block)
+        private var mark0: Int = 0
+        private var total: Long = 0
+        private var broken: Boolean = false
+
+        def demand: Credit = Credit(if broken then 0 else Long.MaxValue)
+        protected def buffer0: AnyRef = storage
+        def mark: Int = mark0
+
+        def reserve(min: Int): Int =
+          val free = block - mark0
+
+          if free >= min then free else
+            drain()
+            block
+
+        def commit(count: Int): Unit =
+          mark0 += count
+          if mark0 == block then drain()
+
+        override def flush(): Unit = drain()
+
+        def finish(): Unit =
+          drain()
+          try value.close() catch case _: Exception => raise(StreamError(total.b))
+
+        private def drain(): Unit =
+          if mark0 > 0 && !broken then
+            val buffer = jn.ByteBuffer.wrap(storage, 0, mark0).nn
+
+            try
+              while buffer.hasRemaining do
+                if value.write(buffer) == -1 then
+                  broken = true
+                  raise(StreamError(total.b))
+
+              total += mark0
+            catch case _: Exception =>
+              broken = true
+              raise(StreamError(total.b))
+
+          mark0 = 0
+
+  // Adapts a whole-`LazyList` writing function to the incremental `Intake`
+  // protocol by accumulating chunks until `finish` — the basis of the
+  // transitional `Writable` bridges below.
+  private[turbulence] def buffered[target, medium]
+    ( target: target, write: (target, LazyList[medium]) => Unit )
+    ( using addressable0: medium is Addressable )
+  :   Intake[medium] over Credit =
+
+    new Intake[medium]:
+      type Transport = Credit
+
+      private val block: Int = 2048
+      private val storage: addressable0.Storage = addressable0.allocate(block)
+      private var mark0: Int = 0
+      private var chunks: List[medium] = Nil
+
+      def demand: Credit = Credit(Long.MaxValue)
+      protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
+      def mark: Int = mark0
+
+      def reserve(min: Int): Int =
+        val free = block - mark0
+
+        if free >= min then free else
+          drain()
+          block
+
+      def commit(count: Int): Unit =
+        mark0 += count
+        if mark0 == block then drain()
+
+      def finish(): Unit =
+        drain()
+        write(target, chunks.reverse.to(LazyList))
+
+      private def drain(): Unit =
+        if mark0 > 0 then
+          chunks ::= addressable0.materialize(storage, 0, mark0)
+          mark0 = 0
+
+// Transitional: any `Writable` instance over a buffer-backed medium is a
+// `Sink`, at lower priority than the native instances above. Since `Writable`
+// consumes its entire `LazyList` in one call (closing the target at its end),
+// this bridge must accumulate everything written and deliver it at `finish` —
+// memory is unbounded, so native `Sink` instances should replace it.
+trait Sink2:
+  given writableData: [target] => (writable: target is Writable by Data)
+  =>  target is Sink by Data over Credit =
+
+    Sink.buffered(_, writable.write)
+
+  given writableText: [target] => (writable: target is Writable by Text)
+  =>  target is Sink by Text over Credit =
+
+    Sink.buffered(_, writable.write)
+
+trait Sink extends Typeclass, Operable:
+  type Transport
+  def intake(target: Self): Intake[Operand] over Transport
+
+  def contramap[self2](lambda: self2 => Self): self2 is Sink by Operand over Transport =
+    target => intake(lambda(target))

--- a/lib/turbulence/src/core/turbulence.Source.scala
+++ b/lib/turbulence/src/core/turbulence.Source.scala
@@ -1,0 +1,199 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+import java.io as ji
+import java.nio as jn
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+import zephyrine.*
+
+// A value which can be opened as a pull endpoint: the successor to
+// `Streamable`, producing a demand-aware `Stream` over a mutable buffer
+// instead of a `LazyList`. Sources needing buffers or error contexts capture
+// them as contextual values of the given (`Buffering`, `Tactic[StreamError]`),
+// so the typeclass itself remains a single abstract method.
+object Source extends Source2:
+  given bytes: Data is Source by Data over Credit = Stream(_)
+  given text: [textual <: Text] => textual is Source by Text over Credit = value => Stream(value)
+
+  // Legacy views: a lazy list of chunks is a source, though its production is
+  // beyond demand control; demand bounds only the exposure of each chunk.
+  given lazyListData: LazyList[Data] is Source by Data over Credit = value =>
+    Stream(value.iterator)
+
+  given lazyListText: LazyList[Text] is Source by Text over Credit = value =>
+    Stream(value.iterator)
+
+  given inputStream: [input <: ji.InputStream] => (Tactic[StreamError], Buffering)
+  =>  input is Source by Data over Credit =
+
+    value => Source.stream(jn.channels.Channels.newChannel(value).nn)
+
+  given channel: (Tactic[StreamError], Buffering)
+  =>  jn.channels.ReadableByteChannel is Source by Data over Credit =
+
+    Source.stream(_)
+
+  given reader: [input <: ji.Reader] => (Tactic[StreamError], Buffering)
+  =>  input is Source by Text over Credit =
+
+    value =>
+      new Stream[Text]:
+        type Transport = Credit
+
+        private val capacity: Int = summon[Buffering].capacity(Substrate.Chars)
+        private val storage: Array[Char] = new Array[Char](capacity)
+        private var start0: Int = 0
+        private var limit0: Int = 0
+        private var total: Long = 0
+        private var ended: Boolean = false
+
+        protected def window0: AnyRef = storage
+        def start: Int = start0
+        def limit: Int = limit0
+        def skip(count: Int): Unit = start0 += count
+
+        def refill(demand: Credit): Optional[Int] =
+          if limit0 > start0 then limit0 - start0
+          else if ended then Unset
+          else
+            val granted = summon[Credit is Regulation].grant(demand)
+
+            if granted == 0 then 0 else
+              start0 = 0
+              limit0 = 0
+
+              try value.read(storage, 0, capacity.min(granted)) match
+                case -1 =>
+                  ended = true
+                  value.close()
+                  Unset
+
+                case count =>
+                  total += count
+                  limit0 = count
+                  count
+
+              catch case error: ji.IOException =>
+                ended = true
+                try value.close() catch case _: Exception => ()
+                abort(StreamError(total.b))
+
+        override def close(): Unit =
+          ended = true
+          try value.close() catch case _: Exception => ()
+
+  // The byte pump underlying `inputStream` and `channel` sources: reads
+  // directly into the stream's own storage, at most one granted block at a
+  // time.
+  private def stream(input: jn.channels.ReadableByteChannel)
+    ( using tactic: Tactic[StreamError], buffering: Buffering )
+  :   Stream[Data] over Credit =
+
+    new Stream[Data]:
+      type Transport = Credit
+
+      private val capacity: Int = buffering.capacity(Substrate.Bytes)
+      private val storage: Array[Byte] = new Array[Byte](capacity)
+      private val buffer: jn.ByteBuffer = jn.ByteBuffer.wrap(storage).nn
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var total: Long = 0
+      private var ended: Boolean = false
+
+      protected def window0: AnyRef = storage
+      def start: Int = start0
+      def limit: Int = limit0
+      def skip(count: Int): Unit = start0 += count
+
+      def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if ended then Unset
+        else
+          val granted = summon[Credit is Regulation].grant(demand)
+
+          if granted == 0 then 0 else
+            start0 = 0
+            limit0 = 0
+            buffer.clear()
+            buffer.limit(capacity.min(granted))
+
+            try input.read(buffer) match
+              case -1 =>
+                ended = true
+                try input.close() catch case _: Exception => ()
+                Unset
+
+              case 0 =>
+                0
+
+              case count =>
+                total += count
+                limit0 = count
+                count
+
+            catch case error: Exception =>
+              ended = true
+              try input.close() catch case _: Exception => ()
+              abort(StreamError(total.b))
+
+      override def close(): Unit =
+        ended = true
+        try input.close() catch case _: Exception => ()
+
+// Transitional: any `Streamable` instance over a buffer-backed medium is a
+// `Source`, at lower priority than the native instances above, so downstream
+// code migrates without ceremony. Production of the underlying `LazyList` is
+// not demand-controlled.
+trait Source2:
+  given streamableData: [value] => (streamable: value is Streamable by Data)
+  =>  value is Source by Data over Credit =
+
+    source => Stream(streamable.stream(source).iterator)
+
+  given streamableText: [value] => (streamable: value is Streamable by Text)
+  =>  value is Source by Text over Credit =
+
+    source => Stream(streamable.stream(source).iterator)
+
+trait Source extends Typeclass, Operable:
+  type Transport
+  def stream(value: Self): Stream[Operand] over Transport
+
+  def contramap[self2](lambda: self2 => Self): self2 is Source by Operand over Transport =
+    value => stream(lambda(value))

--- a/lib/turbulence/src/core/turbulence.Source.scala
+++ b/lib/turbulence/src/core/turbulence.Source.scala
@@ -59,6 +59,10 @@ object Source extends Source2:
   given lazyListText: LazyList[Text] is Source by Text over Credit = value =>
     Stream(value.iterator)
 
+  // The HTTP-body interchange protocol is itself a pull source, so a
+  // request or response body can be `read` directly.
+  given httpBody: Buffering => HttpStreams.Body is Source by Data over Credit = _.stream
+
   given inputStream: [input <: ji.InputStream] => (Tactic[StreamError], Buffering)
   =>  input is Source by Data over Credit =
 

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -72,6 +72,27 @@ extension [value: Streamable by Text](value: value)
   def load[result <: Documentary: Loadable by Text]: Document[result] =
     result.load(value.stream[Text])
 
+extension [medium](stream: zephyrine.Stream[medium] over zephyrine.Credit)
+  // Legacy view: drain a pull endpoint as a lazy list of materialized chunks,
+  // pulling one block per forced cell. For consumers not yet converted to the
+  // streaming kernel; conversion holds only one block at a time, but the
+  // resulting cells are immutable and GC-managed like any lazy list.
+  def lazyList(using buffering: zephyrine.Buffering): LazyList[medium] =
+    val block = buffering.capacity(stream.addressable.substrate)
+
+    def recur(): LazyList[medium] =
+      stream.refill(zephyrine.Credit(block)) match
+        case Unset =>
+          LazyList()
+
+        case count: Int =>
+          val window = stream.window(using Unsafe)
+          val chunk = stream.addressable.materialize(window, stream.start, count)
+          stream.skip(count)
+          chunk #:: recur()
+
+    LazyList.defer(recur())
+
 package stdios:
   given muteStdio: Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
 

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -80,6 +80,18 @@ extension [medium, transport](stream: Stream[medium] over transport)
   def flow(intake: Intake[medium] over transport)(using Monitor, Probate): Task[Unit] =
     async(stream.flowTo(intake))
 
+extension (stream: Stream[Data] over Credit)
+  def compress[format <: Compressor](using compression: format is Compression, buffering: Buffering)
+  :   Stream[Data] over Credit =
+
+    stream.through(compression.compressor())
+
+  def decompress[format <: Compressor]
+    ( using compression: format is Compression, buffering: Buffering )
+  :   Stream[Data] over Credit =
+
+    stream.through(compression.decompressor())
+
 extension [medium](stream: Stream[medium] over Credit)
   // Legacy view: drain a pull endpoint as a lazy list of materialized chunks,
   // pulling one block per forced cell. For consumers not yet converted to the

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -47,6 +47,7 @@ import prepositional.*
 import rudiments.*
 import symbolism.*
 import vacuous.*
+import zephyrine.*
 
 import LineSeparation.*
 import abstractables.instantAbstractable
@@ -72,16 +73,23 @@ extension [value: Streamable by Text](value: value)
   def load[result <: Documentary: Loadable by Text]: Document[result] =
     result.load(value.stream[Text])
 
-extension [medium](stream: zephyrine.Stream[medium] over zephyrine.Credit)
+extension [medium, transport](stream: Stream[medium] over transport)
+  // The detached pump: `flowTo` on its own parasite task, for fire-and-forget
+  // transfers and genuinely concurrent pipeline halves. This is the "one
+  // pumping thread" of a pipeline with an asynchronous boundary.
+  def flow(intake: Intake[medium] over transport)(using Monitor, Probate): Task[Unit] =
+    async(stream.flowTo(intake))
+
+extension [medium](stream: Stream[medium] over Credit)
   // Legacy view: drain a pull endpoint as a lazy list of materialized chunks,
   // pulling one block per forced cell. For consumers not yet converted to the
   // streaming kernel; conversion holds only one block at a time, but the
   // resulting cells are immutable and GC-managed like any lazy list.
-  def lazyList(using buffering: zephyrine.Buffering): LazyList[medium] =
+  def lazyList(using buffering: Buffering): LazyList[medium] =
     val block = buffering.capacity(stream.addressable.substrate)
 
     def recur(): LazyList[medium] =
-      stream.refill(zephyrine.Credit(block)) match
+      stream.refill(Credit(block)) match
         case Unset =>
           LazyList()
 

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -113,6 +113,67 @@ extension [medium](stream: Stream[medium] over Credit)
 
     LazyList.defer(recur())
 
+extension (stream: Stream[Data] over Credit)
+  // Adapt a pull endpoint to the HTTP-body interchange protocol: each `next`
+  // refills with `limit` credit and materializes the delivered window.
+  def httpBody: HttpStreams.Body = limit =>
+    stream.refill(Credit(limit)) match
+      case count: Int =>
+        val take = count.min(limit)
+        val chunk = stream.addressable.materialize(stream.window(using Unsafe), stream.start, take)
+        stream.skip(take)
+        chunk
+
+      case _ =>
+        null
+
+extension (body: HttpStreams.Body)
+  // View an HTTP-body interchange value as a pull endpoint, one chunk per
+  // block-sized request.
+  def stream(using buffering: Buffering): Stream[Data] over Credit =
+    new Stream[Data]:
+      type Transport = Credit
+
+      private val block: Int = buffering.capacity(Substrate.Bytes)
+      private var chunk: Data = IArray.empty[Byte]
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var ended: Boolean = false
+
+      // The chunk is immutable and only ever read through the window.
+      protected def window0: AnyRef = chunk.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      def skip(count: Int): Unit = start0 += count
+
+      def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if ended then Unset
+        else
+          val granted = summon[Credit is Regulation].grant(demand)
+
+          if granted == 0 then 0 else
+            body.next(block.min(granted)) match
+              case null =>
+                ended = true
+                Unset
+
+              case data: Data =>
+                chunk = data
+                start0 = 0
+                limit0 = data.length
+                if limit0 == 0 then refill(demand) else limit0
+
+  // Legacy view of an HTTP body as a lazy list of chunks.
+  def lazyList(using buffering: Buffering): LazyList[Data] =
+    val block = buffering.capacity(Substrate.Bytes)
+
+    def recur(): LazyList[Data] = body.next(block) match
+      case null       => LazyList()
+      case data: Data => data #:: recur()
+
+    LazyList.defer(recur())
+
 package stdios:
   given muteStdio: Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)
 

--- a/lib/turbulence/src/jvm/turbulence.Deflate.scala
+++ b/lib/turbulence/src/jvm/turbulence.Deflate.scala
@@ -39,9 +39,22 @@ import anticipation.*
 import denominative.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 object Deflate:
   given compression: Deflate is Compression:
+    def compressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      Deflation(gzip = false, nowrap = true)
+
+    def decompressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      Inflation(gzip = false, nowrap = true)
+
     def compress(stream: LazyList[Data]): LazyList[Data] =
       val deflater = juz.Deflater(-1, true)
       val buffer: Array[Byte] = new Array(4096)

--- a/lib/turbulence/src/jvm/turbulence.Deflation.scala
+++ b/lib/turbulence/src/jvm/turbulence.Deflation.scala
@@ -1,0 +1,284 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+import java.util.zip as juz
+
+import anticipation.*
+import zephyrine.*
+
+// Streaming compression as a pipeline stage, over `juz.Deflater`. The three
+// compression formats differ only in framing: `Zlib` is the deflater's own
+// wrapper, `Deflate` is the raw stream, and `Gzip` adds a manual header,
+// CRC-32 and trailer around a raw stream. Input is staged in a duct-owned
+// buffer, since the deflater holds a reference to (not a copy of) its input
+// array, which would otherwise outlive the source window's validity.
+//
+// Compression ratios are unknowable, so `translate` is a pass-through: the
+// duct's own bounded buffer and the retained-surplus rule absorb expansion.
+private[turbulence] class Deflation(gzip: Boolean, nowrap: Boolean)(using Buffering)
+extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private val deflater: juz.Deflater =
+    juz.Deflater(juz.Deflater.DEFAULT_COMPRESSION, nowrap || gzip)
+
+  private val crc: juz.CRC32 = juz.CRC32()
+  private val staging: Array[Byte] = new Array[Byte](summon[Buffering].capacity(Substrate.Bytes))
+  private var headerDone: Boolean = !gzip
+  private var size: Long = 0
+  private var finishing: Boolean = false
+  private var trailer: Int = 0
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  // The gzip header (10 bytes) must fit in one step's output space.
+  override def quantum: Int = if gzip then 10 else 1
+
+  private def header(target: Array[Byte], offset: Int): Unit =
+    target(offset) = 0x1f
+    target(offset + 1) = 0x8b.toByte
+    target(offset + 2) = 8
+
+    for index <- 3 to 8 do target(offset + index) = 0
+
+    target(offset + 9) = -1
+
+  def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    val bytes = source.asInstanceOf[Array[Byte]]
+    val out = target.asInstanceOf[Array[Byte]]
+    var consumed: Int = 0
+    var produced: Int = 0
+
+    if !headerDone then
+      header(out, targetOffset)
+      produced += 10
+      headerDone = true
+
+    if deflater.needsInput && sourceLength > 0 then
+      consumed = sourceLength.min(staging.length)
+      System.arraycopy(bytes, sourceOffset, staging, 0, consumed)
+      deflater.setInput(staging, 0, consumed)
+
+      if gzip then
+        crc.update(staging, 0, consumed)
+        size += consumed
+
+    var run: Int = 1
+
+    while run > 0 && produced < targetSpace do
+      run = deflater.deflate(out, targetOffset + produced, targetSpace - produced)
+      produced += run
+
+    Duct.Progress(consumed, produced)
+
+  override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    val out = target.asInstanceOf[Array[Byte]]
+    var produced: Int = 0
+
+    if !headerDone && targetSpace >= 10 then
+      header(out, targetOffset)
+      produced += 10
+      headerDone = true
+
+    if headerDone then
+      if !finishing then
+        deflater.finish()
+        finishing = true
+
+      var run: Int = 1
+
+      while run > 0 && produced < targetSpace do
+        run = deflater.deflate(out, targetOffset + produced, targetSpace - produced)
+        produced += run
+
+      if deflater.finished && gzip then
+        val value = crc.getValue
+
+        while trailer < 8 && produced < targetSpace do
+          val datum =
+            if trailer < 4 then (value >>> (trailer*8)) & 0xff
+            else (size >>> ((trailer - 4)*8)) & 0xff
+
+          out(targetOffset + produced) = datum.toByte
+          produced += 1
+          trailer += 1
+
+    produced
+
+// Streaming decompression, the inverse of `Deflation`, over `juz.Inflater`,
+// with the gzip header parsed by a small state machine ahead of the inflater
+// and the 8-byte trailer consumed and ignored after it finishes.
+private[turbulence] class Inflation(gzip: Boolean, nowrap: Boolean)(using Buffering)
+extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private enum Header:
+    case Fixed(remaining: Int)
+    case ExtraLength(byte: Int, low: Int)
+    case Extra(remaining: Int)
+    case Name, Comment
+    case Checksum(remaining: Int)
+    case Done
+
+  private val inflater: juz.Inflater = juz.Inflater(nowrap || gzip)
+  private val staging: Array[Byte] = new Array[Byte](summon[Buffering].capacity(Substrate.Bytes))
+  private var header: Header = if gzip then Header.Fixed(10) else Header.Done
+  private var flags: Int = 0
+  private var headerPosition: Int = 0
+  private var trailer: Int = if gzip then 8 else 0
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  // Consume one header byte, returning the successor state.
+  private def advance(byte: Int, position: Int): Header = header match
+    case Header.Fixed(remaining) =>
+      if position == 3 then flags = byte
+
+      if remaining > 1 then Header.Fixed(remaining - 1)
+      else if (flags & 4) != 0 then Header.ExtraLength(0, 0)
+      else if (flags & 8) != 0 then Header.Name
+      else if (flags & 16) != 0 then Header.Comment
+      else if (flags & 2) != 0 then Header.Checksum(2)
+      else Header.Done
+
+    case Header.ExtraLength(0, _) =>
+      Header.ExtraLength(1, byte)
+
+    case Header.ExtraLength(_, low) =>
+      val length = (byte << 8) | low
+      if length == 0 then afterExtra else Header.Extra(length)
+
+    case Header.Extra(remaining) =>
+      if remaining > 1 then Header.Extra(remaining - 1) else afterExtra
+
+    case Header.Name =>
+      if byte == 0 then afterName else Header.Name
+
+    case Header.Comment =>
+      if byte == 0 then afterComment else Header.Comment
+
+    case Header.Checksum(remaining) =>
+      if remaining > 1 then Header.Checksum(remaining - 1) else Header.Done
+
+    case Header.Done =>
+      Header.Done
+
+  private def afterExtra: Header =
+    if (flags & 8) != 0 then Header.Name
+    else if (flags & 16) != 0 then Header.Comment
+    else if (flags & 2) != 0 then Header.Checksum(2)
+    else Header.Done
+
+  private def afterName: Header =
+    if (flags & 16) != 0 then Header.Comment
+    else if (flags & 2) != 0 then Header.Checksum(2)
+    else Header.Done
+
+  private def afterComment: Header =
+    if (flags & 2) != 0 then Header.Checksum(2) else Header.Done
+
+  def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    val bytes = source.asInstanceOf[Array[Byte]]
+    val out = target.asInstanceOf[Array[Byte]]
+    var consumed: Int = 0
+    var produced: Int = 0
+
+    while header != Header.Done && consumed < sourceLength do
+      header = advance(bytes(sourceOffset + consumed) & 0xff, headerPosition)
+      headerPosition += 1
+      consumed += 1
+
+    if header == Header.Done then
+      if !inflater.finished then
+        if inflater.needsInput && consumed < sourceLength then
+          val copy = (sourceLength - consumed).min(staging.length)
+          System.arraycopy(bytes, sourceOffset + consumed, staging, 0, copy)
+          inflater.setInput(staging, 0, copy)
+          consumed += copy
+
+        var run: Int = 1
+
+        while run > 0 && produced < targetSpace && !inflater.finished do
+          run =
+            try inflater.inflate(out, targetOffset + produced, targetSpace - produced)
+            catch case error: juz.DataFormatException => throw IllegalStateException(error)
+
+          produced += run
+
+      if inflater.finished && trailer > 0 then
+        // Any input the inflater over-read belongs to the trailer.
+        trailer -= inflater.getRemaining.min(trailer)
+        inflater.setInput(staging, 0, 0)
+
+        val skip = trailer.min(sourceLength - consumed)
+        consumed += skip
+        trailer -= skip
+
+    Duct.Progress(consumed, produced)
+
+  // The inflater may hold far more pending output than one step's space, so
+  // it must keep draining after the upstream ends.
+  override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    val out = target.asInstanceOf[Array[Byte]]
+    var produced: Int = 0
+    var run: Int = 1
+
+    while run > 0 && produced < targetSpace && !inflater.finished do
+      run =
+        try inflater.inflate(out, targetOffset + produced, targetSpace - produced)
+        catch case error: juz.DataFormatException => throw IllegalStateException(error)
+
+      produced += run
+
+    produced

--- a/lib/turbulence/src/jvm/turbulence.Gzip.scala
+++ b/lib/turbulence/src/jvm/turbulence.Gzip.scala
@@ -58,6 +58,7 @@ object Gzip:
 
         case _ =>
           out2.close()
+
           if out.size == 0 then LazyList()
           else LazyList(out.toByteArray().nn.immutable(using Unsafe))
 

--- a/lib/turbulence/src/jvm/turbulence.Gzip.scala
+++ b/lib/turbulence/src/jvm/turbulence.Gzip.scala
@@ -39,9 +39,22 @@ import anticipation.*
 import contingency.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 object Gzip:
   given compression: Gzip is Compression:
+    def compressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      Deflation(gzip = true, nowrap = true)
+
+    def decompressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      Inflation(gzip = true, nowrap = true)
+
     def compress(stream: LazyList[Data]): LazyList[Data] =
       val out = ji.ByteArrayOutputStream()
       val out2 = juz.GZIPOutputStream(out)

--- a/lib/turbulence/src/jvm/turbulence.Gzip.scala
+++ b/lib/turbulence/src/jvm/turbulence.Gzip.scala
@@ -58,7 +58,8 @@ object Gzip:
 
         case _ =>
           out2.close()
-          if out.size == 0 then LazyList() else LazyList(out.toByteArray().nn.immutable(using Unsafe))
+          if out.size == 0 then LazyList()
+          else LazyList(out.toByteArray().nn.immutable(using Unsafe))
 
       recur(stream)
 

--- a/lib/turbulence/src/jvm/turbulence.Zlib.scala
+++ b/lib/turbulence/src/jvm/turbulence.Zlib.scala
@@ -39,9 +39,22 @@ import anticipation.*
 import denominative.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 object Zlib:
   given compression: Zlib is Compression:
+    def compressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      Deflation(gzip = false, nowrap = false)
+
+    def decompressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      Inflation(gzip = false, nowrap = false)
+
     def compress(stream: LazyList[Data]): LazyList[Data] =
       val deflater = juz.Deflater()
       val buffer: Array[Byte] = new Array(4096)

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -584,6 +584,51 @@ object Tests extends Suite(m"Turbulence tests"):
           true
       . assert(identity)
 
+      val mixed: Data =
+        Data.fill(50000) { index => (index%251).toByte } ++ (t"repetition "*500).data
+
+      test(m"gzip duct roundtrips a byte stream"):
+        val gather = Gather2()
+        summon[Data is Source by Data over Credit].stream(mixed)
+        . compress[Gzip].decompress[Gzip].flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == mixed.to(List))
+
+      test(m"deflate duct roundtrips a byte stream"):
+        val gather = Gather2()
+        summon[Data is Source by Data over Credit].stream(mixed)
+        . compress[Deflate].decompress[Deflate].flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == mixed.to(List))
+
+      test(m"zlib duct roundtrips a byte stream"):
+        val gather = Gather2()
+        summon[Data is Source by Data over Credit].stream(mixed)
+        . compress[Zlib].decompress[Zlib].flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == mixed.to(List))
+
+      test(m"gzip duct output is genuine gzip"):
+        val gather = Gather2()
+        summon[Data is Source by Data over Credit].stream(mixed).compress[Gzip].flowTo(gather)
+        val stream = java.util.zip.GZIPInputStream(ji.ByteArrayInputStream(gather.data.mutable(using Unsafe)))
+        stream.readAllBytes().nn.to(List)
+      . assert(_ == mixed.to(List))
+
+      test(m"gzip duct decompresses JDK-produced gzip"):
+        val out = ji.ByteArrayOutputStream()
+        val zipped = java.util.zip.GZIPOutputStream(out)
+        zipped.write(mixed.mutable(using Unsafe))
+        zipped.close()
+        val gather = Gather2()
+
+        summon[LazyList[Data] is Source by Data over Credit]
+        . stream(out.toByteArray.nn.immutable(using Unsafe).grouped(7).to(LazyList))
+        . decompress[Gzip].flowTo(gather)
+
+        gather.data.to(List)
+      . assert(_ == mixed.to(List))
+
       test(m"cancelling a detached flow blocked on an empty conduit releases it"):
         supervise:
           val conduit = Conduit[Data]()

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -584,6 +584,30 @@ object Tests extends Suite(m"Turbulence tests"):
           true
       . assert(identity)
 
+      test(m"confluence merges all sources completely"):
+        supervise:
+          val sources = (1 to 4).map { index => Data.fill(1000)(_ => index.toByte) }
+          val merged = Confluence(sources.map { data =>
+              summon[Data is Source by Data over Credit].stream(data) }*)
+          val gather = Gather2()
+          merged.flowTo(gather)
+          gather.data.to(List).sorted
+      . assert(_ == (1 to 4).flatMap { index => List.fill(1000)(index.toByte) }.sorted.to(List))
+
+      test(m"manifold delivers the whole stream to every subscriber"):
+        supervise:
+          val source = summon[Data is Source by Data over Credit].stream(payload)
+          val subscribers = Manifold(source, 3)
+
+          val results = subscribers.map: stream =>
+            async:
+              val gather = Gather2()
+              stream.flowTo(gather)
+              gather.data.to(List)
+
+          results.map { task => task.await() }.to(List)
+      . assert(_ == List.fill(3)(payload.to(List)))
+
       val mixed: Data =
         Data.fill(50000) { index => (index%251).toByte } ++ (t"repetition "*500).data
 

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -39,6 +39,7 @@ import soundness.*
 import charEncoders.utf8Encoder, charDecoders.utf8Decoder, textSanitizers.strictSanitizer
 import threading.platformThreading
 import strategies.throwUnsafely
+import probates.panicProbate
 import errorDiagnostics.emptyDiagnostics
 
 import scala.collection.mutable as scm
@@ -559,3 +560,71 @@ object Tests extends Suite(m"Turbulence tests"):
         summon[Data is Source by Data over Credit].stream(payload).flowTo(sink.intake(store))
         store.buffer.length
       . assert(_ == payload.length)
+
+      test(m"a sink write failure raises StreamError"):
+        import unsafeExceptions.canThrowAny
+
+        val broken = new ji.OutputStream():
+          override def write(byte: Int): Unit = throw ji.IOException("cut")
+          override def write(array: Array[Byte] | Null, off: Int, len: Int): Unit =
+            throw ji.IOException("cut")
+
+        val sink = summon[ji.OutputStream is Sink by Data over Credit]
+
+        capture[StreamError]:
+          summon[Data is Source by Data over Credit].stream(payload).flowTo(sink.intake(broken))
+      . assert(_ == StreamError(0.b))
+
+      test(m"cancelling a blocked conduit writer releases it"):
+        supervise:
+          val conduit = Conduit[Data]()
+          val big = Data.fill(100000)(_.toByte)
+          val writer = async(conduit.put(big))
+          writer.cancel()
+          true
+      . assert(identity)
+
+      test(m"cancelling a detached flow blocked on an empty conduit releases it"):
+        supervise:
+          val conduit = Conduit[Data]()
+          val gather = Gather2()
+          val pump = conduit.stream.flow(gather)
+          pump.cancel()
+          true
+      . assert(identity)
+
+// A byte intake that gathers everything written to it, for exercising the
+// pump and cancellation paths.
+class Gather2() extends Intake[Data]:
+  type Transport = Credit
+
+  private val block: Int = 16
+  private val storage: addressable.Storage = addressable.allocate(block)
+  private val target: addressable.Target = addressable.blank(64)
+  private var mark1: Int = 0
+
+  def demand: Credit = Credit(Long.MaxValue)
+  protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
+  def mark: Int = mark1
+
+  def reserve(min: Int): Int =
+    val free = block - mark1
+
+    if free >= min then free else
+      drain()
+      block
+
+  def commit(count: Int): Unit =
+    mark1 += count
+    if mark1 == block then drain()
+
+  def finish(): Unit = drain()
+
+  def data: Data =
+    drain()
+    addressable.build(target)
+
+  private def drain(): Unit =
+    if mark1 > 0 then
+      addressable.cloneStorage(storage, 0, mark1)(target)
+      mark1 = 0

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package turbulence
 
+import java.io as ji
+
 import soundness.*
 
 import charEncoders.utf8Encoder, charDecoders.utf8Decoder, textSanitizers.strictSanitizer
@@ -489,3 +491,71 @@ object Tests extends Suite(m"Turbulence tests"):
       test(m"Empty stream yields empty result"):
         LazyList[Data]().framed[U32]().to(List)
       . assert(_ == Nil)
+
+    suite(m"Source and Sink tests"):
+      val payload: Data = Data.fill(10000)(_.toByte)
+
+      test(m"input stream source flows to output stream sink"):
+        val input = ji.ByteArrayInputStream(payload.mutable(using Unsafe))
+        val output = ji.ByteArrayOutputStream()
+        val source = summon[ji.ByteArrayInputStream is Source by Data over Credit]
+        val sink = summon[ji.ByteArrayOutputStream is Sink by Data over Credit]
+        source.stream(input).flowTo(sink.intake(output))
+        output.toByteArray.nn.to(List)
+      . assert(_ == payload.to(List))
+
+      test(m"in-memory data source flows to output stream sink"):
+        val output = ji.ByteArrayOutputStream()
+        val sink = summon[ji.ByteArrayOutputStream is Sink by Data over Credit]
+        summon[Data is Source by Data over Credit].stream(payload).flowTo(sink.intake(output))
+        output.toByteArray.nn.to(List)
+      . assert(_ == payload.to(List))
+
+      val original = t"The quick brown fox jumps over the lazy dog"*100
+
+      test(m"reader source delivers text across refills"):
+        val reader = ji.StringReader(original.s)
+        val source = summon[ji.StringReader is Source by Text over Credit]
+        val stream = source.stream(reader)
+        val builder = StringBuilder()
+
+        def recur(): Unit = stream.refill(Credit(64)) match
+          case count: Int =>
+            val window = unsafely(stream.window).asInstanceOf[Array[Char]]
+            builder.append(String(window, stream.start, count))
+            stream.skip(count)
+            recur()
+
+          case _ => ()
+
+        recur()
+        builder.toString.tt
+      . assert(_ == original)
+
+      test(m"lazyList view drains a stream as chunks"):
+        val stream = summon[Data is Source by Data over Credit].stream(payload)
+        stream.lazyList.map(_.to(List)).flatten.to(List)
+      . assert(_ == payload.to(List))
+
+      test(m"a Streamable instance is a Source through the bridge"):
+        val output = ji.ByteArrayOutputStream()
+        val sink = summon[ji.ByteArrayOutputStream is Sink by Data over Credit]
+        val source = summon[LazyList[Data] is Source by Data over Credit]
+        source.stream(LazyList(payload, payload)).flowTo(sink.intake(output))
+        output.toByteArray.nn.length
+      . assert(_ == payload.length*2)
+
+      test(m"a Writable instance is a Sink through the bridge"):
+        class Store():
+          val buffer: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
+
+        object Store:
+          given Store is Writable by Data = (store, stream) => stream.each: data =>
+            data.each: byte =>
+              store.buffer.append(byte)
+
+        val store = Store()
+        val sink = summon[Store is Sink by Data over Credit]
+        summon[Data is Source by Data over Credit].stream(payload).flowTo(sink.intake(store))
+        store.buffer.length
+      . assert(_ == payload.length)

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -512,7 +512,7 @@ object Xml extends Tag.Container
       type Result = HttpStreams.Content
 
       def genericize(xml: Xml): HttpStreams.Content =
-        (t"application/xml; charset=${encoder.encoding.name}", LazyList(xml.show.data))
+        (t"application/xml; charset=${encoder.encoding.name}", HttpStreams.Body(xml.show.data))
 
   given instantiable: (schema: XmlSchema) => Tactic[ParseError]
   =>  Xml is Instantiable across HttpRequests from Text =

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -1481,7 +1481,7 @@ object Yaml extends Yaml2, Dynamic:
 
       def genericize(value: Yaml): HttpStreams.Content =
         ( t"application/yaml; charset=${encoder.encoding.name}",
-          LazyList(Yaml.unseal(value).show.data) )
+          HttpStreams.Body(Yaml.unseal(value).show.data) )
 
   given instantiable: (Tactic[ParseError], PositionTracking)
   =>  Yaml is Instantiable across HttpRequests from Text =

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Flow,
+export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
     Regulation, Stream, Substrate, accepting, flowTo, locate, locateKey, through}
 

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,8 +32,8 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Flow, Format,
-    Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
+export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Flow,
+    Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
     Regulation, Stream, Substrate, accepting, flowTo, locate, locateKey, through}
 
 package parsing:

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,8 +32,9 @@
                                                                                                   */
 package soundness
 
-export zephyrine.{Addressable, Cursor, Datum, Format, Formatting, Lineation, ParseError,
-    PositionTracking, Producer, Positionable, locate, locateKey}
+export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Flow, Format,
+    Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
+    Regulation, Stream, Substrate, accepting, flowTo, locate, locateKey, through}
 
 package parsing:
   export zephyrine.parsing.trackPositions

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -49,6 +49,7 @@ object Addressable:
 
     val empty: Data = IArray.from(Nil)
 
+    inline def substrate: Substrate = Substrate.Bytes
     inline def blank(size: Int): ji.ByteArrayOutputStream = ji.ByteArrayOutputStream(size)
 
     inline def build(target: ji.ByteArrayOutputStream): Data =
@@ -109,6 +110,7 @@ object Addressable:
 
     val empty: Text = ""
 
+    inline def substrate: Substrate = Substrate.Chars
     inline def build(target: jl.StringBuilder): Text = target.toString.tt
     inline def blank(size: Int): jl.StringBuilder = jl.StringBuilder(size)
     inline def length(text: Text): Int = text.s.length
@@ -166,6 +168,10 @@ trait Addressable extends Typeclass, Operable, Targetable:
   type Storage
 
   def empty: Self
+
+  // How this medium's storage is physically represented, for `Buffering` to
+  // size stage buffers appropriately.
+  def substrate: Substrate
   // All operations are declared non-inline at the trait level so non-inline
   // call sites (e.g. inside `Cursor.forward`, or in parser plumbing that
   // wraps Cursor calls) can still dispatch through them. Concrete instances

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -35,6 +35,8 @@ package zephyrine
 import java.io as ji
 import java.lang as jl
 
+import scala.collection.mutable as scm
+
 import anticipation.*
 import denominative.*
 import prepositional.*
@@ -101,6 +103,87 @@ object Addressable:
     :   Unit =
 
       target.write(storage, off, len)
+
+
+  // Heap-object media: a chunk of records (parsed rows, JSON events) is an
+  // `IArray` of them, stored in an erased `Array[AnyRef]` — so credit is
+  // counted in records, and `Buffering` sizes these buffers by reference
+  // count (`Substrate.Boxes`), since their memory usage isn't
+  // deterministically bounded. Erasure means the medium's element type must
+  // be a reference type; the `IArray`s this instance materializes are backed
+  // by `Array[AnyRef]`, which is indistinguishable at erased use sites.
+  given boxed: [element <: AnyRef] => IArray[element] is Addressable:
+    type Operand = element
+    type Target = scm.ArrayBuffer[element]
+    type Storage = Array[AnyRef]
+
+    val empty: IArray[element] = IArray.empty[AnyRef].asInstanceOf[IArray[element]]
+
+    def substrate: Substrate = Substrate.Boxes
+    def blank(size: Int): scm.ArrayBuffer[element] = scm.ArrayBuffer[element]()
+
+    def build(target: scm.ArrayBuffer[element]): IArray[element] =
+      target.toArray[AnyRef].asInstanceOf[IArray[element]]
+
+    def length(block: IArray[element]): Int = block.length
+    def address(block: IArray[element], index: Ordinal): element = block(index.n0)
+
+    def grab(block: IArray[element], start: Ordinal, end: Ordinal): IArray[element] =
+      block.slice(start.n0, end.n0)
+
+    def clone(source: IArray[element], start: Ordinal, end: Ordinal)
+      ( target: scm.ArrayBuffer[element] )
+    :   Unit =
+
+      var index = start.n0
+
+      while index <= end.n0 do
+        target += source(index)
+        index += 1
+
+    def allocate(size: Int): Array[AnyRef] = new Array[AnyRef](size)
+    def storageSize(storage: Array[AnyRef]): Int = storage.length
+
+    def storageAddress(storage: Array[AnyRef], index: Int): element =
+      storage(index).asInstanceOf[element]
+
+    def storageUpdate(storage: Array[AnyRef], index: Int, operand: element): Unit =
+      storage(index) = operand
+
+    def append(target: scm.ArrayBuffer[element], operand: element): Unit = target += operand
+
+    def copyChunk
+      ( source:  IArray[element],
+       srcOff:  Int,
+       dest:    Array[AnyRef],
+       destOff: Int,
+       len:     Int )
+    :   Unit =
+
+      System.arraycopy(source.asInstanceOf[Array[AnyRef]], srcOff, dest, destOff, len)
+
+    def transfer
+      ( src:     Array[AnyRef],
+       srcOff:  Int,
+       dest:    Array[AnyRef],
+       destOff: Int,
+       len:     Int )
+    :   Unit = System.arraycopy(src, srcOff, dest, destOff, len)
+
+    def materialize(storage: Array[AnyRef], off: Int, len: Int): IArray[element] =
+      val array = new Array[AnyRef](len)
+      System.arraycopy(storage, off, array, 0, len)
+      array.asInstanceOf[IArray[element]]
+
+    def cloneStorage
+      (storage: Array[AnyRef], off: Int, len: Int)(target: scm.ArrayBuffer[element])
+    :   Unit =
+
+      var index = off
+
+      while index < off + len do
+        target += storage(index).asInstanceOf[element]
+        index += 1
 
 
   inline given text: Text is Addressable:

--- a/lib/zephyrine/src/core/zephyrine.Buffering.scala
+++ b/lib/zephyrine/src/core/zephyrine.Buffering.scala
@@ -32,77 +32,20 @@
                                                                                                   */
 package zephyrine
 
-import scala.quoted.*
+// Contextual configuration determining how streaming stages are instantiated
+// with buffers. `capacity` is consulted once per stage at construction time, so
+// an adaptive instance (e.g. one consulting available memory) sees each new
+// stage, but never resizes a live one. `window` is the number of blocks of
+// headroom a `Conduit` holds between its writer and reader threads.
+object Buffering:
+  given standard: Buffering:
+    def capacity(substrate: Substrate): Int = substrate match
+      case Substrate.Bytes => 4096
+      case Substrate.Chars => 2048
+      case Substrate.Boxes => 256
 
-import gigantism.*
-import rudiments.*
+    def window: Int = 4
 
-object internal:
-  def consume(cursor: Expr[Cursor[?]], text0: Expr[String], otherwise: Expr[Unit]): Macro[Unit] =
-    import quotes.reflect.*
-
-    val text = text0.valueOrAbort
-
-    def recur(index: Int, checks: Expr[Unit]): Expr[Unit] =
-      if index >= text.length then checks else
-        val char = text(index)
-
-        val checks2 =
-          ' {
-              $checks
-              $cursor.next()
-
-              $cursor.lay($otherwise): datum =>
-                if datum != ${Expr(char)} then $otherwise
-            }
-
-        recur(index + 1, checks2)
-
-    recur(0, '{()})
-
-  // Fine-grained backpressure demand: "I can accept `count` more operands". A
-  // count of elements of the medium's `Operand` type (bytes, chars or
-  // records), not a byte count, so its meaning changes across a `Duct` that
-  // changes medium; `Duct.translate` performs that conversion. Unboxed on the
-  // hot path.
-  opaque type Credit = Long
-
-  object Credit:
-    inline def apply(count: Long): Credit = count
-
-    extension (credit: Credit)
-      inline def count: Long = credit
-
-  opaque type Datum = Int
-
-  object Datum:
-    // Sentinel for an exhausted cursor. The only `Datum` not derivable from a
-    // byte or char.
-    val End: Datum = -1
-
-    // Lift an unsigned byte (`0..255` after `& 0xff`) into a `Datum`.
-    inline def apply(byte: Byte): Datum = byte & 0xff
-
-    // Lift a char into a `Datum`.
-    inline def apply(char: Char): Datum = char.toInt
-
-    // Construct from a raw `Int`. Caller is responsible for the value being a
-    // valid byte/char or `-1` — used by `Cursor.peek` to wrap an `Int` it has
-    // already validated.
-    private[zephyrine] inline def fromRaw(int: Int): Datum = int
-
-    inline given datumByte:  CanEqual[Datum, Byte]  = !!
-    inline given byteDatum:  CanEqual[Byte, Datum] = !!
-    inline given datumChar:  CanEqual[Datum, Char]  = !!
-    inline given charDatum:  CanEqual[Char, Datum] = !!
-    inline given datumDatum: CanEqual[Datum, Datum] = !!
-
-
-    extension (datum: Datum)
-      // The underlying `Int` representation. Use sparingly — anywhere it
-      // leaks the `Datum` distinction is lost.
-      inline def asInt: Int = datum
-
-      // `true` if the cursor that produced this `Datum` was exhausted.
-      inline def isEnd: Boolean = datum == Datum.End
-
+trait Buffering:
+  def capacity(substrate: Substrate): Int
+  def window: Int

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -1,0 +1,167 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package zephyrine
+
+import java.util.concurrent as juc
+import java.util.concurrent.atomic as juca
+
+import fulminate.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// The asynchronous boundary of a streaming pipeline: an `Intake` on its write
+// side and a `Stream` on its read side, with exactly one thread ever touching
+// each. Data crosses in blocks through a bounded queue, so a writer that
+// outpaces its reader parks in `reserve` — cross-thread backpressure — and
+// the free capacity is the credit this conduit reports as its `demand`. This
+// is the only synchronized component of a pipeline; every other stage is
+// single-owner mutable state on one side of a conduit or the other.
+//
+// A conduit is the generalization of `Producer.Channel`: block-granular
+// hand-off, but with element-granular credit, storage handed to the reader
+// without materializing an immutable chunk, and failure propagation — a
+// producer-side `fail` is rethrown from the reader's next `refill`.
+object Conduit:
+  private object End
+
+  private class Block(val storage: AnyRef, val size: Int)
+
+final class Conduit[medium]
+  (using val addressable0: medium is Addressable)(using buffering: Buffering)
+extends Intake[medium](using addressable0):
+  type Transport = Credit
+
+  private val block: Int = buffering.capacity(addressable0.substrate)
+  private val queue: juc.ArrayBlockingQueue[AnyRef] = juc.ArrayBlockingQueue(buffering.window)
+
+  private val written: juca.AtomicLong = juca.AtomicLong(0)
+  private val consumed: juca.AtomicLong = juca.AtomicLong(0)
+  @volatile private var error: Throwable | Null = null
+  @volatile private var closed: Boolean = false
+
+  private var current: addressable0.Storage = addressable0.allocate(block)
+  private var mark0: Int = 0
+
+  // Everything this conduit can hold: the queued blocks plus the block being
+  // written. `demand` is this allowance less what is currently buffered, so
+  // it reaches zero exactly when `reserve` would block.
+  private val allowance: Long = block.toLong * (buffering.window + 1)
+
+  def demand: Credit = Credit(allowance - (written.get - consumed.get))
+
+  protected def buffer0: AnyRef = current.asInstanceOf[AnyRef]
+  def mark: Int = mark0
+
+  def reserve(min: Int): Int =
+    val free = block - mark0
+
+    if free >= min then free else
+      publish()
+      block
+
+  def commit(count: Int): Unit =
+    mark0 += count
+    written.addAndGet(count)
+    if mark0 == block then publish()
+
+  override def flush(): Unit = if mark0 > 0 then publish()
+
+  def finish(): Unit =
+    flush()
+    queue.put(Conduit.End)
+
+  override def fail(error: Throwable): Unit =
+    this.error = error
+    queue.clear()
+    queue.put(Conduit.End)
+
+  private def publish(): Unit =
+    if mark0 > 0 then
+      if closed then
+        written.addAndGet(-mark0)
+        mark0 = 0
+      else
+        queue.put(Conduit.Block(current.asInstanceOf[AnyRef], mark0))
+        current = addressable0.allocate(block)
+        mark0 = 0
+
+  // The read side; single reader. `refill` parks (in `queue.take`) until the
+  // writer publishes a block or finishes.
+  val stream: Stream[medium] over Credit = new Stream[medium](using addressable0):
+    type Transport = Credit
+
+    private var storage: addressable0.Storage = addressable0.allocate(0)
+    private var start0: Int = 0
+    private var limit0: Int = 0
+    private var size: Int = 0
+    private var ended: Boolean = false
+
+    protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+    def start: Int = start0
+    def limit: Int = limit0
+
+    def skip(count: Int): Unit =
+      start0 += count
+      consumed.addAndGet(count)
+
+    def refill(demand: Credit): Optional[Int] =
+      if limit0 > start0 then limit0 - start0
+      else if ended then Unset
+      else
+        val granted = summon[Credit is Regulation].grant(demand)
+
+        if granted == 0 then 0
+        else if limit0 < size then
+          limit0 += (size - limit0).min(granted)
+          limit0 - start0
+        else
+          queue.take().nn match
+            case Conduit.End =>
+              ended = true
+              val error0 = error
+              if error0 == null then Unset else throw error0
+
+            case received: Conduit.Block =>
+              storage = received.storage.asInstanceOf[addressable0.Storage]
+              size = received.size
+              start0 = 0
+              limit0 = size.min(granted)
+              limit0
+
+            case _ =>
+              panic(m"unexpected value in conduit queue")
+
+    override def close(): Unit =
+      closed = true
+      queue.clear()

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -122,6 +122,32 @@ object Cursor:
         lineation0 )
 
 
+  // Build a Cursor over a pull endpoint: each load refills the stream with a
+  // block-sized credit (from the ambient `Buffering`) and materializes the
+  // delivered window as one chunk. The credit bounds how much any upstream
+  // stage produces per load, so memory stays bounded through a parse of an
+  // arbitrarily large input.
+  transparent inline def apply[data](stream: Stream[data] over Credit)
+    ( using addressable0: data is Addressable,
+            lineation0:   Lineation by addressable0.Operand,
+            buffering:    Buffering )
+  :   Cursor[data] =
+
+    val block: Int = buffering.capacity(addressable0.substrate)
+
+    new Cursor[data]
+      ( () =>
+          stream.refill(Credit(block)).let: count =>
+            val window = stream.window(using Unsafe).asInstanceOf[addressable0.Storage]
+            val chunk = addressable0.materialize(window, stream.start, count)
+            stream.skip(count)
+            chunk,
+        Unset,
+        DefaultCapacity,
+        addressable0,
+        lineation0 )
+
+
   // Backwards-compatible factory that adapts an Iterator to the loader API.
   // Lets the existing test suite cross-compile against Cursor.
   transparent inline def apply[data](iterator: Iterator[data])

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -94,8 +94,12 @@ abstract class Duct[in, out]
       targetSpace: Int )
   :   Duct.Progress
 
-  // Emit terminal state after the upstream ends (e.g. a compressor's tail).
-  // Called repeatedly until it returns `0`.
+  // Emit terminal state after the upstream ends: a compressor's tail, and —
+  // critically — any pending output the transformation retains internally
+  // beyond what `step` could deliver (a decompressor may hold far more
+  // undelivered output than one step's space). A duct whose state can retain
+  // output MUST override this; the first `0` it returns is taken as the end
+  // of the stream. Called repeatedly until it returns `0`.
   def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int = 0
 
   def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -32,77 +32,70 @@
                                                                                                   */
 package zephyrine
 
-import scala.quoted.*
+import prepositional.*
 
-import gigantism.*
-import rudiments.*
+// A synchronous transformation stage, attachable to either end of a pipeline:
+// `stream.through(duct)` yields a differently-typed `Stream`, and
+// `intake.accepting(duct)` yields a differently-typed `Intake` — the same
+// `Duct` instance serves both, since `translate` converts demand whichever
+// direction it is reported.
+//
+// `translate` is the demand-conversion hook: it maps downstream demand (in
+// `out` terms) to upstream demand (in `in` terms), e.g. a bytes-to-hex duct
+// maps a credit of 1024 chars to a credit of 512 bytes. Conversions must be
+// conservative bounds, not exact arithmetic: any surplus a stage produces is
+// retained in its buffer for the next transfer, which is what makes ducts
+// with unknowable ratios (compression) possible.
+//
+// `step` is a pure buffer-to-buffer transformation. Given at least one input
+// element and at least `quantum` elements of output space, it must consume or
+// produce at least one element; input that cannot yet be transformed (a
+// partial atom at the end of the offered input) must be consumed and carried
+// in the duct's internal state, never left unconsumed across steps. A duct is
+// single-owner mutable state: it belongs to the one thread driving its side
+// of the pipeline.
+object Duct:
+  // Unboxed (consumed, produced) pair returned by `step`.
+  object Progress:
+    inline def apply(consumed: Int, produced: Int): Progress =
+      (consumed.toLong << 32) | (produced.toLong & 0xffffffffL)
 
-object internal:
-  def consume(cursor: Expr[Cursor[?]], text0: Expr[String], otherwise: Expr[Unit]): Macro[Unit] =
-    import quotes.reflect.*
+    extension (progress: Progress)
+      inline def consumed: Int = (progress >> 32).toInt
+      inline def produced: Int = progress.toInt
 
-    val text = text0.valueOrAbort
+  opaque type Progress = Long
 
-    def recur(index: Int, checks: Expr[Unit]): Expr[Unit] =
-      if index >= text.length then checks else
-        val char = text(index)
+abstract class Duct[in, out]
+  ( using val input: in is Addressable, val output: out is Addressable ):
 
-        val checks2 =
-          ' {
-              $checks
-              $cursor.next()
+  type Transport
+  type Upstream
 
-              $cursor.lay($otherwise): datum =>
-                if datum != ${Expr(char)} then $otherwise
-            }
+  def regulation: Transport is Regulation
 
-        recur(index + 1, checks2)
+  // Convert downstream demand into the demand this duct presents upstream.
+  // Must not starve: whenever `demand` grants at least `quantum` elements, the
+  // translated demand must grant at least one, and unbounded demand values
+  // (`Long.MaxValue` credit) must be handled without arithmetic overflow —
+  // compute ceiling divisions as `n - n/2`, not `(n + 1)/2`.
+  def translate(demand: Transport): Upstream
 
-    recur(0, '{()})
+  // The minimum output space `step` needs to guarantee progress, e.g. `2` for
+  // a duct whose smallest output atom is two elements.
+  def quantum: Int = 1
 
-  // Fine-grained backpressure demand: "I can accept `count` more operands". A
-  // count of elements of the medium's `Operand` type (bytes, chars or
-  // records), not a byte count, so its meaning changes across a `Duct` that
-  // changes medium; `Duct.translate` performs that conversion. Unboxed on the
-  // hot path.
-  opaque type Credit = Long
+  def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress
 
-  object Credit:
-    inline def apply(count: Long): Credit = count
+  // Emit terminal state after the upstream ends (e.g. a compressor's tail).
+  // Called repeatedly until it returns `0`.
+  def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int = 0
 
-    extension (credit: Credit)
-      inline def count: Long = credit
-
-  opaque type Datum = Int
-
-  object Datum:
-    // Sentinel for an exhausted cursor. The only `Datum` not derivable from a
-    // byte or char.
-    val End: Datum = -1
-
-    // Lift an unsigned byte (`0..255` after `& 0xff`) into a `Datum`.
-    inline def apply(byte: Byte): Datum = byte & 0xff
-
-    // Lift a char into a `Datum`.
-    inline def apply(char: Char): Datum = char.toInt
-
-    // Construct from a raw `Int`. Caller is responsible for the value being a
-    // valid byte/char or `-1` — used by `Cursor.peek` to wrap an `Int` it has
-    // already validated.
-    private[zephyrine] inline def fromRaw(int: Int): Datum = int
-
-    inline given datumByte:  CanEqual[Datum, Byte]  = !!
-    inline given byteDatum:  CanEqual[Byte, Datum] = !!
-    inline given datumChar:  CanEqual[Datum, Char]  = !!
-    inline given charDatum:  CanEqual[Char, Datum] = !!
-    inline given datumDatum: CanEqual[Datum, Datum] = !!
-
-
-    extension (datum: Datum)
-      // The underlying `Int` representation. Use sparingly — anywhere it
-      // leaks the `Datum` distinction is lost.
-      inline def asInt: Int = datum
-
-      // `true` if the cursor that produced this `Datum` was exhausted.
-      inline def isEnd: Boolean = datum == Datum.End
-
+  def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -1,0 +1,231 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package zephyrine
+
+import java.nio as jn, jn.charset as jnc
+
+import anticipation.*
+import hieroglyph.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// Makes a stage-descriptor value — a character decoder, a compression
+// algorithm, a serialization alphabet — instantiable as a `Duct`, so it can
+// be applied directly with `stream.through(stage)` or
+// `intake.accepting(stage)`. Instances are typed
+// `X is Ductile by In to Out over Transport`, with `Upstream` (the demand
+// type the stage presents to its upstream) as a further member, `Credit` in
+// almost all cases. A `Duct` is trivially its own descriptor, so raw ducts
+// compose with the same `through`/`accepting` calls.
+object Ductile:
+  // The fully-determined type of a `Ductile` instance for `stage`, naming all
+  // five type members positionally.
+  type Of[stage, in, out, transport, upstream] =
+    (stage is Ductile by in to out over transport) { type Upstream = upstream }
+
+  given duct: [in, out, transport, upstream,
+        stage <: Duct[in, out] { type Transport = transport; type Upstream = upstream }]
+  =>  Of[stage, in, out, transport, upstream] =
+
+    new Ductile:
+      type Self = stage
+      type Operand = in
+      type Result = out
+      type Transport = transport
+      type Upstream = upstream
+
+      def duct(stage0: stage)(using Buffering)
+      :   Duct[in, out] { type Transport = transport; type Upstream = upstream } =
+
+        stage0
+
+  // Character decoding as a pipeline stage. Bytes are staged internally (so
+  // multi-byte characters split across refills are carried, and `step`
+  // always consumes what it is offered), and malformed input is substituted
+  // through the decoder's `TextSanitizer`, exactly as `CharDecoder.decoded`.
+  given charDecoder: Of[CharDecoder, Data, Text, Credit, Credit] =
+    new Ductile:
+      type Self = CharDecoder
+      type Operand = Data
+      type Result = Text
+      type Transport = Credit
+      type Upstream = Credit
+
+      def duct(stage: CharDecoder)(using buffering: Buffering)
+      :   Duct[Data, Text] { type Transport = Credit; type Upstream = Credit } =
+
+        new Duct[Data, Text]:
+          type Transport = Credit
+          type Upstream = Credit
+
+          private val decoder: jnc.CharsetDecoder = stage.encoding.charset.newDecoder().nn
+
+          private val staging: jn.ByteBuffer =
+            jn.ByteBuffer.allocate(buffering.capacity(Substrate.Bytes)).nn
+
+          private var total: Int = 0
+          private var ended: Boolean = false
+
+          def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+          // At most one output char per input byte, so char-credit is a
+          // sound byte-credit as it stands.
+          def translate(demand: Credit): Credit = demand
+
+          private def decode(out: jn.CharBuffer, endOfInput: Boolean): Unit =
+            val result = decoder.decode(staging, out, endOfInput).nn
+
+            if result.isMalformed then
+              stage.sanitizer.sanitize(total + staging.position, stage.encoding).let(out.put(_))
+              staging.position(staging.position + result.length)
+              decode(out, endOfInput)
+
+          def step
+            ( source: input.Storage,
+              sourceOffset: Int,
+              sourceLength: Int,
+              target: output.Storage,
+              targetOffset: Int,
+              targetSpace: Int )
+          :   Duct.Progress =
+
+            val bytes = source.asInstanceOf[Array[Byte]]
+            val chars = target.asInstanceOf[Array[Char]]
+            val copy = sourceLength.min(staging.remaining)
+            staging.put(bytes, sourceOffset, copy)
+            staging.flip()
+
+            val out = jn.CharBuffer.wrap(chars, targetOffset, targetSpace).nn
+            decode(out, false)
+            total += staging.position
+            staging.compact()
+
+            Duct.Progress(copy, out.position - targetOffset)
+
+          override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
+          :   Int =
+
+            if ended then 0 else
+              val chars = target.asInstanceOf[Array[Char]]
+              val out = jn.CharBuffer.wrap(chars, targetOffset, targetSpace).nn
+              staging.flip()
+              decode(out, true)
+              total += staging.position
+              staging.compact()
+
+              if decoder.flush(out).nn.isUnderflow then ended = true
+
+              out.position - targetOffset
+
+  // Character encoding as a pipeline stage. Malformed input (a split
+  // surrogate pair at end-of-stream) and unmappable characters are replaced,
+  // mirroring the replacement semantics of `CharEncoder.encoded`.
+  given charEncoder: Of[CharEncoder, Text, Data, Credit, Credit] =
+    new Ductile:
+      type Self = CharEncoder
+      type Operand = Text
+      type Result = Data
+      type Transport = Credit
+      type Upstream = Credit
+
+      def duct(stage: CharEncoder)(using buffering: Buffering)
+      :   Duct[Text, Data] { type Transport = Credit; type Upstream = Credit } =
+
+        new Duct[Text, Data]:
+          type Transport = Credit
+          type Upstream = Credit
+
+          private val encoder: jnc.CharsetEncoder =
+            stage.encoding.charset.newEncoder().nn
+            . onMalformedInput(jnc.CodingErrorAction.REPLACE).nn
+            . onUnmappableCharacter(jnc.CodingErrorAction.REPLACE).nn
+
+          private val worst: Int = encoder.maxBytesPerChar.toDouble.ceil.toInt.max(1)
+
+          private val staging: jn.CharBuffer =
+            jn.CharBuffer.allocate(buffering.capacity(Substrate.Chars)).nn
+
+          private var ended: Boolean = false
+
+          def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+          // A char yields at least one byte and at most `worst`; requesting
+          // the byte demand divided by the worst case can never overflow the
+          // downstream, and the floor of one prevents starvation.
+          def translate(demand: Credit): Credit = Credit((demand.count/worst).max(1))
+
+          override def quantum: Int = worst
+
+          def step
+            ( source: input.Storage,
+              sourceOffset: Int,
+              sourceLength: Int,
+              target: output.Storage,
+              targetOffset: Int,
+              targetSpace: Int )
+          :   Duct.Progress =
+
+            val chars = source.asInstanceOf[Array[Char]]
+            val bytes = target.asInstanceOf[Array[Byte]]
+            val copy = sourceLength.min(staging.remaining)
+            staging.put(chars, sourceOffset, copy)
+            staging.flip()
+
+            val out = jn.ByteBuffer.wrap(bytes, targetOffset, targetSpace).nn
+            encoder.encode(staging, out, false)
+            staging.compact()
+
+            Duct.Progress(copy, out.position - targetOffset)
+
+          override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
+          :   Int =
+
+            if ended then 0 else
+              val bytes = target.asInstanceOf[Array[Byte]]
+              val out = jn.ByteBuffer.wrap(bytes, targetOffset, targetSpace).nn
+              staging.flip()
+              encoder.encode(staging, out, true)
+              staging.compact()
+
+              if encoder.flush(out).nn.isUnderflow then ended = true
+
+              out.position - targetOffset
+
+trait Ductile extends Typeclass, Operable, Resultant:
+  type Transport
+  type Upstream
+
+  def duct(stage: Self)(using Buffering): Duct[Operand, Result] {
+    type Transport = Ductile.this.Transport
+    type Upstream = Ductile.this.Upstream }

--- a/lib/zephyrine/src/core/zephyrine.Flow.scala
+++ b/lib/zephyrine/src/core/zephyrine.Flow.scala
@@ -32,77 +32,8 @@
                                                                                                   */
 package zephyrine
 
-import scala.quoted.*
-
-import gigantism.*
-import rudiments.*
-
-object internal:
-  def consume(cursor: Expr[Cursor[?]], text0: Expr[String], otherwise: Expr[Unit]): Macro[Unit] =
-    import quotes.reflect.*
-
-    val text = text0.valueOrAbort
-
-    def recur(index: Int, checks: Expr[Unit]): Expr[Unit] =
-      if index >= text.length then checks else
-        val char = text(index)
-
-        val checks2 =
-          ' {
-              $checks
-              $cursor.next()
-
-              $cursor.lay($otherwise): datum =>
-                if datum != ${Expr(char)} then $otherwise
-            }
-
-        recur(index + 1, checks2)
-
-    recur(0, '{()})
-
-  // Fine-grained backpressure demand: "I can accept `count` more operands". A
-  // count of elements of the medium's `Operand` type (bytes, chars or
-  // records), not a byte count, so its meaning changes across a `Duct` that
-  // changes medium; `Duct.translate` performs that conversion. Unboxed on the
-  // hot path.
-  opaque type Credit = Long
-
-  object Credit:
-    inline def apply(count: Long): Credit = count
-
-    extension (credit: Credit)
-      inline def count: Long = credit
-
-  opaque type Datum = Int
-
-  object Datum:
-    // Sentinel for an exhausted cursor. The only `Datum` not derivable from a
-    // byte or char.
-    val End: Datum = -1
-
-    // Lift an unsigned byte (`0..255` after `& 0xff`) into a `Datum`.
-    inline def apply(byte: Byte): Datum = byte & 0xff
-
-    // Lift a char into a `Datum`.
-    inline def apply(char: Char): Datum = char.toInt
-
-    // Construct from a raw `Int`. Caller is responsible for the value being a
-    // valid byte/char or `-1` — used by `Cursor.peek` to wrap an `Int` it has
-    // already validated.
-    private[zephyrine] inline def fromRaw(int: Int): Datum = int
-
-    inline given datumByte:  CanEqual[Datum, Byte]  = !!
-    inline given byteDatum:  CanEqual[Byte, Datum] = !!
-    inline given datumChar:  CanEqual[Datum, Char]  = !!
-    inline given charDatum:  CanEqual[Char, Datum] = !!
-    inline given datumDatum: CanEqual[Datum, Datum] = !!
-
-
-    extension (datum: Datum)
-      // The underlying `Int` representation. Use sparingly — anywhere it
-      // leaks the `Datum` distinction is lost.
-      inline def asInt: Int = datum
-
-      // `true` if the cursor that produced this `Datum` was exhausted.
-      inline def isEnd: Boolean = datum == Datum.End
-
+// Coarse backpressure demand: a sink that cannot usefully count elements can
+// still ask its upstream to send freely, to pace itself between blocks
+// (`Measured`), or to stop producing until demand is polled again (`Halted`).
+enum Flow:
+  case Free, Measured, Halted

--- a/lib/zephyrine/src/core/zephyrine.Intake.scala
+++ b/lib/zephyrine/src/core/zephyrine.Intake.scala
@@ -32,77 +32,85 @@
                                                                                                   */
 package zephyrine
 
-import scala.quoted.*
-
-import gigantism.*
+import denominative.*
+import prepositional.*
 import rudiments.*
+import vacuous.*
 
-object internal:
-  def consume(cursor: Expr[Cursor[?]], text0: Expr[String], otherwise: Expr[Unit]): Macro[Unit] =
-    import quotes.reflect.*
+// The push endpoint of a streaming pipeline: a mutable buffer whose writable
+// window is exposed zero-copy to exactly one producer, and which reports its
+// current `demand` — the reactive message telling that producer how much it
+// can accept. An `Intake` is transformed into a differently-typed `Intake`
+// with `accepting`. `Intake` extends `Producer`, so producing code written
+// against `put`/`push` (serializers) drives a pipeline unchanged.
+//
+// The primitive protocol is `reserve`/`buffer`/`mark`/`commit`: a writer
+// reserves contiguous space, writes directly into the intake's storage at
+// `mark`, then commits. `put`, `push` and `absorb` are final loops over that
+// protocol, so implementations provide only the window and its lifecycle.
+trait Intake[medium](using val addressable: medium is Addressable) extends Producer[medium]:
+  type Operand = addressable.Operand
+  type Transport
 
-    val text = text0.valueOrAbort
+  // The current demand this intake reports to whoever writes to it. Computed
+  // on request; never cached by callers. Advisory for bounding upstream
+  // production — `reserve` is what actually blocks.
+  def demand: Transport
 
-    def recur(index: Int, checks: Expr[Unit]): Expr[Unit] =
-      if index >= text.length then checks else
-        val char = text(index)
+  // Ensure at least `min` elements of contiguous writable space, blocking if
+  // necessary, and return the available space. `min` must not exceed the
+  // intake's block size.
+  def reserve(min: Int): Int
 
-        val checks2 =
-          ' {
-              $checks
-              $cursor.next()
+  // Zero-copy view of this intake's buffer; elements from `mark` are writable
+  // up to the last `reserve`d space. Valid only until the next `commit`,
+  // `flush` or `finish` — single-owner discipline, as `Stream.window`.
+  // Implementations provide the untyped `buffer0`; since `Addressable`
+  // instances are unique per medium, the cast in `buffer` is sound.
+  final def buffer(using Unsafe): addressable.Storage =
+    buffer0.asInstanceOf[addressable.Storage]
 
-              $cursor.lay($otherwise): datum =>
-                if datum != ${Expr(char)} then $otherwise
-            }
+  protected def buffer0: AnyRef
+  def mark: Int
 
-        recur(index + 1, checks2)
+  // Declare `count` elements written at `mark`; may synchronously cascade
+  // them through downstream stages.
+  def commit(count: Int): Unit
 
-    recur(0, '{()})
+  // Propagate buffered data downstream now, without ending the stream.
+  def flush(): Unit = ()
 
-  // Fine-grained backpressure demand: "I can accept `count` more operands". A
-  // count of elements of the medium's `Operand` type (bytes, chars or
-  // records), not a byte count, so its meaning changes across a `Duct` that
-  // changes medium; `Duct.translate` performs that conversion. Unboxed on the
-  // hot path.
-  opaque type Credit = Long
+  // End-of-stream: flush, emit any terminal stage state, release downstream.
+  // Called exactly once.
+  def finish(): Unit
 
-  object Credit:
-    inline def apply(count: Long): Credit = count
+  // Abort: propagate failure downstream so stages can release resources. The
+  // error is rethrown to the reader at an asynchronous boundary.
+  def fail(error: Throwable): Unit = finish()
 
-    extension (credit: Credit)
-      inline def count: Long = credit
+  final def absorb(source: addressable.Storage, offset: Int, count: Int): Unit =
+    var done: Int = 0
 
-  opaque type Datum = Int
+    while done < count do
+      val free = reserve(1)
+      val size = free.min(count - done)
+      addressable.transfer(source, offset + done, buffer(using Unsafe), mark, size)
+      commit(size)
+      done += size
 
-  object Datum:
-    // Sentinel for an exhausted cursor. The only `Datum` not derivable from a
-    // byte or char.
-    val End: Datum = -1
+  final def put(source: medium): Unit = put(source, Prim, addressable.length(source))
 
-    // Lift an unsigned byte (`0..255` after `& 0xff`) into a `Datum`.
-    inline def apply(byte: Byte): Datum = byte & 0xff
+  final def put(source: medium, offset: Ordinal, size: Int): Unit =
+    var done: Int = 0
 
-    // Lift a char into a `Datum`.
-    inline def apply(char: Char): Datum = char.toInt
+    while done < size do
+      val free = reserve(1)
+      val count = free.min(size - done)
+      addressable.copyChunk(source, offset.n0 + done, buffer(using Unsafe), mark, count)
+      commit(count)
+      done += count
 
-    // Construct from a raw `Int`. Caller is responsible for the value being a
-    // valid byte/char or `-1` — used by `Cursor.peek` to wrap an `Int` it has
-    // already validated.
-    private[zephyrine] inline def fromRaw(int: Int): Datum = int
-
-    inline given datumByte:  CanEqual[Datum, Byte]  = !!
-    inline given byteDatum:  CanEqual[Byte, Datum] = !!
-    inline given datumChar:  CanEqual[Datum, Char]  = !!
-    inline given charDatum:  CanEqual[Char, Datum] = !!
-    inline given datumDatum: CanEqual[Datum, Datum] = !!
-
-
-    extension (datum: Datum)
-      // The underlying `Int` representation. Use sparingly — anywhere it
-      // leaks the `Datum` distinction is lost.
-      inline def asInt: Int = datum
-
-      // `true` if the cursor that produced this `Datum` was exhausted.
-      inline def isEnd: Boolean = datum == Datum.End
-
+  final def push(operand: Operand): Unit =
+    reserve(1)
+    addressable.storageUpdate(buffer(using Unsafe), mark, operand)
+    commit(1)

--- a/lib/zephyrine/src/core/zephyrine.Pace.scala
+++ b/lib/zephyrine/src/core/zephyrine.Pace.scala
@@ -35,5 +35,5 @@ package zephyrine
 // Coarse backpressure demand: a sink that cannot usefully count elements can
 // still ask its upstream to send freely, to pace itself between blocks
 // (`Measured`), or to stop producing until demand is polled again (`Halted`).
-enum Flow:
+enum Pace:
   case Free, Measured, Halted

--- a/lib/zephyrine/src/core/zephyrine.Regulation.scala
+++ b/lib/zephyrine/src/core/zephyrine.Regulation.scala
@@ -32,77 +32,45 @@
                                                                                                   */
 package zephyrine
 
-import scala.quoted.*
+import prepositional.*
 
-import gigantism.*
-import rudiments.*
+// Operations over a backpressure-demand type, the "reactive message" of a
+// streaming pipeline. Demand values do not travel as messages at runtime: a
+// stage computes its current demand on request, by converting its downstream's
+// demand (see `Duct.translate`), bottoming out in shared state at an
+// asynchronous boundary. `encode`/`decode` require every demand type to pack
+// into a `Long`, so that shared state is a single atomic value, whatever the
+// demand type.
+object Regulation:
+  given credit: Credit is Regulation:
+    def initial: Credit = Credit(Long.MaxValue)
+    def grant(demand: Credit): Int = demand.count.max(0L).min(Int.MaxValue).toInt
+    def spend(demand: Credit, count: Int): Credit = Credit(demand.count - count)
+    def measured(demand: Credit): Boolean = false
+    def encode(demand: Credit): Long = demand.count
+    def decode(bits: Long): Credit = Credit(bits)
 
-object internal:
-  def consume(cursor: Expr[Cursor[?]], text0: Expr[String], otherwise: Expr[Unit]): Macro[Unit] =
-    import quotes.reflect.*
+  given flow: Flow is Regulation:
+    def initial: Flow = Flow.Free
 
-    val text = text0.valueOrAbort
+    def grant(demand: Flow): Int = demand match
+      case Flow.Halted => 0
+      case _           => Int.MaxValue
 
-    def recur(index: Int, checks: Expr[Unit]): Expr[Unit] =
-      if index >= text.length then checks else
-        val char = text(index)
+    def spend(demand: Flow, count: Int): Flow = demand
+    def measured(demand: Flow): Boolean = demand == Flow.Measured
+    def encode(demand: Flow): Long = demand.ordinal
+    def decode(bits: Long): Flow = Flow.fromOrdinal(bits.toInt)
 
-        val checks2 =
-          ' {
-              $checks
-              $cursor.next()
+trait Regulation extends Typeclass:
+  def initial: Self
+  def grant(demand: Self): Int
+  def spend(demand: Self, count: Int): Self
 
-              $cursor.lay($otherwise): datum =>
-                if datum != ${Expr(char)} then $otherwise
-            }
+  // A `Measured` demand grants freely but asks the pump to pace itself (e.g.
+  // `relent()` or sleep between blocks); pacing is the pump's concern, not a
+  // grant-arithmetic one.
+  def measured(demand: Self): Boolean
 
-        recur(index + 1, checks2)
-
-    recur(0, '{()})
-
-  // Fine-grained backpressure demand: "I can accept `count` more operands". A
-  // count of elements of the medium's `Operand` type (bytes, chars or
-  // records), not a byte count, so its meaning changes across a `Duct` that
-  // changes medium; `Duct.translate` performs that conversion. Unboxed on the
-  // hot path.
-  opaque type Credit = Long
-
-  object Credit:
-    inline def apply(count: Long): Credit = count
-
-    extension (credit: Credit)
-      inline def count: Long = credit
-
-  opaque type Datum = Int
-
-  object Datum:
-    // Sentinel for an exhausted cursor. The only `Datum` not derivable from a
-    // byte or char.
-    val End: Datum = -1
-
-    // Lift an unsigned byte (`0..255` after `& 0xff`) into a `Datum`.
-    inline def apply(byte: Byte): Datum = byte & 0xff
-
-    // Lift a char into a `Datum`.
-    inline def apply(char: Char): Datum = char.toInt
-
-    // Construct from a raw `Int`. Caller is responsible for the value being a
-    // valid byte/char or `-1` — used by `Cursor.peek` to wrap an `Int` it has
-    // already validated.
-    private[zephyrine] inline def fromRaw(int: Int): Datum = int
-
-    inline given datumByte:  CanEqual[Datum, Byte]  = !!
-    inline given byteDatum:  CanEqual[Byte, Datum] = !!
-    inline given datumChar:  CanEqual[Datum, Char]  = !!
-    inline given charDatum:  CanEqual[Char, Datum] = !!
-    inline given datumDatum: CanEqual[Datum, Datum] = !!
-
-
-    extension (datum: Datum)
-      // The underlying `Int` representation. Use sparingly — anywhere it
-      // leaks the `Datum` distinction is lost.
-      inline def asInt: Int = datum
-
-      // `true` if the cursor that produced this `Datum` was exhausted.
-      inline def isEnd: Boolean = datum == Datum.End
-
+  def encode(demand: Self): Long
+  def decode(bits: Long): Self

--- a/lib/zephyrine/src/core/zephyrine.Regulation.scala
+++ b/lib/zephyrine/src/core/zephyrine.Regulation.scala
@@ -50,17 +50,17 @@ object Regulation:
     def encode(demand: Credit): Long = demand.count
     def decode(bits: Long): Credit = Credit(bits)
 
-  given flow: Flow is Regulation:
-    def initial: Flow = Flow.Free
+  given pace: Pace is Regulation:
+    def initial: Pace = Pace.Free
 
-    def grant(demand: Flow): Int = demand match
-      case Flow.Halted => 0
+    def grant(demand: Pace): Int = demand match
+      case Pace.Halted => 0
       case _           => Int.MaxValue
 
-    def spend(demand: Flow, count: Int): Flow = demand
-    def measured(demand: Flow): Boolean = demand == Flow.Measured
-    def encode(demand: Flow): Long = demand.ordinal
-    def decode(bits: Long): Flow = Flow.fromOrdinal(bits.toInt)
+    def spend(demand: Pace, count: Int): Pace = demand
+    def measured(demand: Pace): Boolean = demand == Pace.Measured
+    def encode(demand: Pace): Long = demand.ordinal
+    def decode(bits: Long): Pace = Pace.fromOrdinal(bits.toInt)
 
 trait Regulation extends Typeclass:
   def initial: Self

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -1,0 +1,154 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package zephyrine
+
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// The pull endpoint of a streaming pipeline: a mutable buffer whose readable
+// window is exposed zero-copy to exactly one consumer. Backpressure is
+// intrinsic to pulling — a consumer that does not call `refill` demands
+// nothing — and the `demand` argument of each `refill` call is the reactive
+// message bounding how much the upstream may produce to satisfy it. A `Stream`
+// is transformed into a differently-typed `Stream` with `through`, and
+// connected to an `Intake` with `flowTo`; a chain of `through`s involves no
+// threads and no synchronization, executing as nested calls on the consumer's
+// thread.
+object Stream:
+  // A single-chunk in-memory stream. The chunk is copied into fresh storage
+  // once, at construction, so the window can be exposed mutably.
+  def apply[medium](value: medium)(using addressable0: medium is Addressable)
+  :   Stream[medium] over Credit =
+
+    new Stream[medium]:
+      type Transport = Credit
+
+      private val size: Int = addressable0.length(value)
+      private val storage: addressable0.Storage = addressable0.allocate(size.max(1))
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var loaded: Boolean = false
+
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      def skip(count: Int): Unit = start0 += count
+
+      def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0 else
+          if !loaded then
+            addressable0.copyChunk(value, 0, storage, 0, size)
+            loaded = true
+
+          val granted = summon[Credit is Regulation].grant(demand)
+          val remaining = size - limit0
+
+          if remaining == 0 then Unset
+          else if granted == 0 then 0
+          else
+            limit0 += remaining.min(granted)
+            limit0 - start0
+
+  // Adapts a chunk iterator (the legacy interoperation shape) into a stream.
+  // Demand bounds only how much of each chunk is exposed per refill, not the
+  // iterator's own production, which is outside this stream's control.
+  def apply[medium](iterator: Iterator[medium])(using addressable0: medium is Addressable)
+  :   Stream[medium] over Credit =
+
+    new Stream[medium]:
+      type Transport = Credit
+
+      private var storage: addressable0.Storage = addressable0.allocate(0)
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var size: Int = 0
+
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      def skip(count: Int): Unit = start0 += count
+
+      def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0 else
+          val granted = summon[Credit is Regulation].grant(demand)
+
+          if granted == 0 then 0
+          else if limit0 < size then
+            limit0 += (size - limit0).min(granted)
+            limit0 - start0
+          else
+            def advance(): Optional[Int] =
+              if !iterator.hasNext then Unset else
+                val chunk = iterator.next()
+                size = addressable0.length(chunk)
+
+                if size == 0 then advance() else
+                  if addressable0.storageSize(storage) < size then
+                    storage = addressable0.allocate(size)
+
+                  addressable0.copyChunk(chunk, 0, storage, 0, size)
+                  start0 = 0
+                  limit0 = size.min(granted)
+                  limit0
+
+            advance()
+
+trait Stream[medium](using val addressable: medium is Addressable):
+  type Transport
+
+  // Ensure at least one element is readable (blocking if necessary),
+  // producing no more than `demand` permits, and return the number of
+  // readable elements, i.e. `limit - start`. Returns `0` only when `demand`
+  // grants nothing; returns `Unset` at end-of-stream. If unconsumed elements
+  // remain in the window, they are reported without producing more.
+  def refill(demand: Transport): Optional[Int]
+
+  // Zero-copy view of this stream's buffer; elements `start until limit` are
+  // readable. Valid only until the next `refill` or `close` — the same
+  // single-owner discipline as `Cursor.unsafeBuffer`, and the hook by which
+  // separation checking will later enforce it. Implementations provide the
+  // untyped `window0`; since `Addressable` instances are unique per medium,
+  // the cast in `window` is sound.
+  final def window(using Unsafe): addressable.Storage =
+    window0.asInstanceOf[addressable.Storage]
+
+  protected def window0: AnyRef
+  def start: Int
+  def limit: Int
+
+  // Consume `count` elements of the window without materializing them.
+  def skip(count: Int): Unit
+
+  // Release resources, propagating upstream through the whole chain.
+  def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Substrate.scala
+++ b/lib/zephyrine/src/core/zephyrine.Substrate.scala
@@ -32,77 +32,9 @@
                                                                                                   */
 package zephyrine
 
-import scala.quoted.*
-
-import gigantism.*
-import rudiments.*
-
-object internal:
-  def consume(cursor: Expr[Cursor[?]], text0: Expr[String], otherwise: Expr[Unit]): Macro[Unit] =
-    import quotes.reflect.*
-
-    val text = text0.valueOrAbort
-
-    def recur(index: Int, checks: Expr[Unit]): Expr[Unit] =
-      if index >= text.length then checks else
-        val char = text(index)
-
-        val checks2 =
-          ' {
-              $checks
-              $cursor.next()
-
-              $cursor.lay($otherwise): datum =>
-                if datum != ${Expr(char)} then $otherwise
-            }
-
-        recur(index + 1, checks2)
-
-    recur(0, '{()})
-
-  // Fine-grained backpressure demand: "I can accept `count` more operands". A
-  // count of elements of the medium's `Operand` type (bytes, chars or
-  // records), not a byte count, so its meaning changes across a `Duct` that
-  // changes medium; `Duct.translate` performs that conversion. Unboxed on the
-  // hot path.
-  opaque type Credit = Long
-
-  object Credit:
-    inline def apply(count: Long): Credit = count
-
-    extension (credit: Credit)
-      inline def count: Long = credit
-
-  opaque type Datum = Int
-
-  object Datum:
-    // Sentinel for an exhausted cursor. The only `Datum` not derivable from a
-    // byte or char.
-    val End: Datum = -1
-
-    // Lift an unsigned byte (`0..255` after `& 0xff`) into a `Datum`.
-    inline def apply(byte: Byte): Datum = byte & 0xff
-
-    // Lift a char into a `Datum`.
-    inline def apply(char: Char): Datum = char.toInt
-
-    // Construct from a raw `Int`. Caller is responsible for the value being a
-    // valid byte/char or `-1` — used by `Cursor.peek` to wrap an `Int` it has
-    // already validated.
-    private[zephyrine] inline def fromRaw(int: Int): Datum = int
-
-    inline given datumByte:  CanEqual[Datum, Byte]  = !!
-    inline given byteDatum:  CanEqual[Byte, Datum] = !!
-    inline given datumChar:  CanEqual[Datum, Char]  = !!
-    inline given charDatum:  CanEqual[Char, Datum] = !!
-    inline given datumDatum: CanEqual[Datum, Datum] = !!
-
-
-    extension (datum: Datum)
-      // The underlying `Int` representation. Use sparingly — anywhere it
-      // leaks the `Datum` distinction is lost.
-      inline def asInt: Int = datum
-
-      // `true` if the cursor that produced this `Datum` was exhausted.
-      inline def isEnd: Boolean = datum == Datum.End
-
+// The physical representation of a stage's buffer, used by `Buffering` to size
+// allocations: byte and char buffers have deterministic footprints, while
+// `Boxes` (heap-object buffers) are counted in references, so their memory
+// usage isn't deterministically bounded.
+enum Substrate:
+  case Bytes, Chars, Boxes

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -87,13 +87,17 @@ export Cursor.{Mark, Offset}
 
 extension [in, transport](stream: Stream[in] over transport)
   // Pull-composition: a differently-typed `Stream` whose refills translate
-  // demand through the duct and pull from this stream. Runs entirely on the
-  // consumer's thread.
-  def through[out](duct: Duct[in, out] { type Upstream = transport })
-    ( using buffering: Buffering )
-  :   Stream[out] over duct.Transport =
+  // demand through the stage and pull from this stream. Runs entirely on
+  // the consumer's thread. The stage may be a raw `Duct` or any descriptor
+  // value with a `Ductile` instance.
+  def through[stage](stage: stage)
+    ( using ductile: (stage is Ductile by in) { type Upstream = transport },
+            buffering: Buffering )
+  :   Stream[ductile.Result] over ductile.Transport =
 
-    new Stream[out](using duct.output):
+    val duct = ductile.duct(stage)
+
+    new Stream[ductile.Result](using duct.output):
       type Transport = duct.Transport
 
       private val capacity: Int =
@@ -127,17 +131,13 @@ extension [in, transport](stream: Stream[in] over transport)
                 if produced == 0 then flushed = true else limit0 += produced
               else
                 stream.refill(duct.translate(demand)) match
-                  case Unset =>
-                    ended = true
-
-                  // The downstream demand granted at least `quantum`, so a
-                  // starved upstream means the duct's `translate` violated
-                  // its contract; spinning here would livelock silently.
-                  case 0 =>
-                    panic(m"a duct translated a productive demand into one granting nothing")
-
                   case count: Int =>
-                    if count > 0 then
+                    // The downstream demand granted at least `quantum`, so a
+                    // starved upstream means the duct's `translate` violated
+                    // its contract; spinning here would livelock silently.
+                    if count == 0
+                    then panic(m"a duct translated a productive demand into one granting nothing")
+                    else
                       // `Addressable` instances are unique per medium, so the
                       // stream's storage and the duct's input storage
                       // coincide, even though their paths differ.
@@ -152,6 +152,9 @@ extension [in, transport](stream: Stream[in] over transport)
 
                       stream.skip(progress.consumed)
                       limit0 += progress.produced
+
+                  case _ =>
+                    ended = true
 
             if flushed && limit0 == start0 then Unset else limit0 - start0
 
@@ -186,14 +189,17 @@ extension [in, transport](stream: Stream[in] over transport)
 
 extension [out, transport](intake: Intake[out] over transport)
   // Push-composition: a differently-typed `Intake` which reports translated
-  // demand, and whose commits step synchronously through the duct into this
-  // intake's writable window. The same `Duct` serves `through` and
-  // `accepting`; only the attachment differs.
-  def accepting[in](duct: Duct[in, out] { type Transport = transport })
-    ( using buffering: Buffering )
-  :   Intake[in] over duct.Upstream =
+  // demand, and whose commits step synchronously through the stage into
+  // this intake's writable window. The same stage value serves `through`
+  // and `accepting`; only the attachment differs.
+  def accepting[stage](stage: stage)
+    ( using ductile: (stage is Ductile to out) { type Transport = transport },
+            buffering: Buffering )
+  :   Intake[ductile.Operand] over ductile.Upstream =
 
-    new Intake[in](using duct.input):
+    val duct = ductile.duct(stage)
+
+    new Intake[ductile.Operand](using duct.input):
       type Transport = duct.Upstream
 
       private val capacity: Int = buffering.capacity(duct.input.substrate)

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -32,9 +32,12 @@
                                                                                                   */
 package zephyrine
 
+import fulminate.*
+import prepositional.*
+import rudiments.*
 import vacuous.*
 
-export zephyrine.internal.Datum
+export zephyrine.internal.{Credit, Datum}
 
 extension [value](value: value)(using positionable: value is Positionable)
   // Locate the source `Position` of the node addressed by `path` within
@@ -81,3 +84,170 @@ package parsing:
   given trackPositions: PositionTracking = PositionTracking.On
 
 export Cursor.{Mark, Offset}
+
+extension [in, transport](stream: Stream[in] over transport)
+  // Pull-composition: a differently-typed `Stream` whose refills translate
+  // demand through the duct and pull from this stream. Runs entirely on the
+  // consumer's thread.
+  def through[out](duct: Duct[in, out] { type Upstream = transport })
+    ( using buffering: Buffering )
+  :   Stream[out] over duct.Transport =
+
+    new Stream[out](using duct.output):
+      type Transport = duct.Transport
+
+      private val capacity: Int =
+        buffering.capacity(duct.output.substrate).max(duct.quantum)
+
+      private val storage: duct.output.Storage = duct.output.allocate(capacity)
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var ended: Boolean = false
+      private var flushed: Boolean = false
+
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      def skip(count: Int): Unit = start0 += count
+
+      def refill(demand: duct.Transport): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if flushed then Unset
+        else
+          start0 = 0
+          limit0 = 0
+          val granted = duct.regulation.grant(demand)
+
+          if granted == 0 then 0 else
+            val space = capacity.min(granted.max(duct.quantum))
+
+            while limit0 == 0 && !flushed do
+              if ended then
+                val produced = duct.flush(storage, limit0, space - limit0)
+                if produced == 0 then flushed = true else limit0 += produced
+              else
+                stream.refill(duct.translate(demand)) match
+                  case Unset =>
+                    ended = true
+
+                  // The downstream demand granted at least `quantum`, so a
+                  // starved upstream means the duct's `translate` violated
+                  // its contract; spinning here would livelock silently.
+                  case 0 =>
+                    panic(m"a duct translated a productive demand into one granting nothing")
+
+                  case count: Int =>
+                    if count > 0 then
+                      // `Addressable` instances are unique per medium, so the
+                      // stream's storage and the duct's input storage
+                      // coincide, even though their paths differ.
+                      val progress =
+                        duct.step
+                          ( stream.window(using Unsafe).asInstanceOf[duct.input.Storage],
+                            stream.start,
+                            count,
+                            storage,
+                            limit0,
+                            space - limit0 )
+
+                      stream.skip(progress.consumed)
+                      limit0 += progress.produced
+
+            if flushed && limit0 == start0 then Unset else limit0 - start0
+
+      override def close(): Unit =
+        duct.close()
+        stream.close()
+
+  // The pump loop connecting a pull-chain to a push-chain, on the calling
+  // thread: poll the intake's demand, refill with it, transfer the window.
+  // This is the only place data crosses from the pull side to the push side
+  // of a pipeline.
+  def flowTo(intake: Intake[in] over transport): Unit =
+    def loop(): Unit =
+      stream.refill(intake.demand) match
+        case Unset =>
+          intake.finish()
+
+        case count: Int =>
+          if count > 0 then
+            intake.absorb
+              ( stream.window(using Unsafe).asInstanceOf[intake.addressable.Storage],
+                stream.start,
+                count )
+
+            stream.skip(count)
+          else
+            intake.reserve(1)
+
+          loop()
+
+    try loop() finally stream.close()
+
+extension [out, transport](intake: Intake[out] over transport)
+  // Push-composition: a differently-typed `Intake` which reports translated
+  // demand, and whose commits step synchronously through the duct into this
+  // intake's writable window. The same `Duct` serves `through` and
+  // `accepting`; only the attachment differs.
+  def accepting[in](duct: Duct[in, out] { type Transport = transport })
+    ( using buffering: Buffering )
+  :   Intake[in] over duct.Upstream =
+
+    new Intake[in](using duct.input):
+      type Transport = duct.Upstream
+
+      private val capacity: Int = buffering.capacity(duct.input.substrate)
+      private val storage: duct.input.Storage = duct.input.allocate(capacity)
+      private var mark0: Int = 0
+
+      def demand: duct.Upstream = duct.translate(intake.demand)
+      protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
+      def mark: Int = mark0
+
+      // `commit` always drains the whole buffer through the duct (partial
+      // atoms are carried in duct state, not here), so all space is free.
+      def reserve(min: Int): Int = capacity - mark0
+
+      def commit(count: Int): Unit =
+        mark0 += count
+        var offset: Int = 0
+
+        while offset < mark0 do
+          val free = intake.reserve(duct.quantum)
+
+          val progress =
+            duct.step
+              ( storage,
+                offset,
+                mark0 - offset,
+                intake.buffer(using Unsafe).asInstanceOf[duct.output.Storage],
+                intake.mark,
+                free )
+
+          intake.commit(progress.produced)
+          offset += progress.consumed
+
+        mark0 = 0
+
+      override def flush(): Unit = intake.flush()
+
+      def finish(): Unit =
+        var produced: Int = -1
+
+        while produced != 0 do
+          val free = intake.reserve(duct.quantum)
+
+          produced =
+            duct.flush
+              ( intake.buffer(using Unsafe).asInstanceOf[duct.output.Storage],
+                intake.mark,
+                free )
+
+          if produced > 0 then intake.commit(produced)
+
+        duct.close()
+        intake.finish()
+
+      override def fail(error: Throwable): Unit =
+        duct.close()
+        intake.fail(error)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -684,6 +684,53 @@ object Tests extends Suite(m"Zephyrine tests"):
         out
       . assert(_ == "abcd")
 
+      import charDecoders.utf8Decoder, charEncoders.utf8Encoder, textSanitizers.skipSanitizer
+
+      val exotic = t"héllo → 🎉 fin"
+
+      test(m"char decoder duct reassembles multi-byte characters split across refills"):
+        val chunks = exotic.s.getBytes("UTF-8").nn.toSeq.map { byte => IArray[Byte](byte) }
+        val stream = Stream(chunks.iterator).through(summon[CharDecoder])
+        val builder = StringBuilder()
+
+        def recur(): Unit = stream.refill(Credit(8)) match
+          case count: Int =>
+            val window = unsafely(stream.window).asInstanceOf[Array[Char]]
+            builder.append(String(window, stream.start, count))
+            stream.skip(count)
+            recur()
+
+          case _ => ()
+
+        recur()
+        builder.toString.tt
+      . assert(_ == exotic)
+
+      test(m"char encoder duct emits UTF-8 for supplementary characters"):
+        val gather = Gather()
+        Stream(exotic).through(summon[CharEncoder]).flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == exotic.s.getBytes("UTF-8").nn.to(List))
+
+      test(m"charset ducts roundtrip through both directions"):
+        val gather = Gather()
+        Stream(exotic).through(summon[CharEncoder]).flowTo(gather)
+        val decoded = Stream(gather.data).through(summon[CharDecoder])
+        val builder = StringBuilder()
+
+        def recur(): Unit = decoded.refill(Credit(4)) match
+          case count: Int =>
+            val window = unsafely(decoded.window).asInstanceOf[Array[Char]]
+            builder.append(String(window, decoded.start, count))
+            decoded.skip(count)
+            recur()
+
+          case _ => ()
+
+        recur()
+        builder.toString.tt
+      . assert(_ == exotic)
+
       test(m"flow grants nothing when halted"):
         val regulation = summon[Flow is Regulation]
 

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -673,6 +673,17 @@ object Tests extends Suite(m"Zephyrine tests"):
         regulation.decode(regulation.encode(Credit(3456))).count
       . assert(_ == 3456L)
 
+      test(m"cursor over a stream sees all elements across chunk boundaries"):
+        val cursor = Cursor[Text](Stream(Iterator(t"ab", t"cd")))
+        var out: String = ""
+
+        while !cursor.finished do
+          out += cursor.peek.asInt.toChar
+          cursor.next()
+
+        out
+      . assert(_ == "abcd")
+
       test(m"flow grants nothing when halted"):
         val regulation = summon[Flow is Regulation]
 

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -575,3 +575,228 @@ object Tests extends Suite(m"Zephyrine tests"):
           (inner, cursor.grab(outer, cursor.mark).s)
       . assert(_ == ((true, "a")))
 
+    suite(m"Streaming kernel tests"):
+      val small = IArray[Byte](1, 2, 3, 4, 5)
+
+      test(m"flowTo transfers a single-chunk stream"):
+        val gather = Gather()
+        Stream(bytes).flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == bytes.to(List))
+
+      test(m"iterator stream transfers all chunks in order"):
+        val gather = Gather()
+        Stream(Iterator(IArray[Byte](1, 2, 3), IArray[Byte](), IArray[Byte](4, 5))).flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == List[Byte](1, 2, 3, 4, 5))
+
+      test(m"through doubles each byte"):
+        val gather = Gather()
+        Stream(small).through(Doubler()).flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == small.to(List).flatMap { byte => List(byte, byte) })
+
+      test(m"a duct translates downstream demand for its upstream"):
+        val recorder = Recorder(Stream(small))
+        val gather = Gather()
+        gather.credit = 10
+        recorder.through(Doubler()).flowTo(gather)
+        recorder.demands.last
+      . assert(_ == 5L)
+
+      test(m"accepting reports translated demand"):
+        val gather = Gather()
+        gather.credit = 10
+        gather.accepting(Doubler()).demand.count
+      . assert(_ == 5L)
+
+      test(m"accepting transforms pushed data"):
+        val gather = Gather()
+        val intake = gather.accepting(Doubler())
+        intake.put(small)
+        intake.finish()
+        gather.data.to(List)
+      . assert(_ == small.to(List).flatMap { byte => List(byte, byte) })
+
+      test(m"duct flush emits terminal state on finish"):
+        val gather = Gather()
+        val intake = gather.accepting(Trailer())
+        intake.put(IArray[Byte](1, 2))
+        intake.finish()
+        gather.data.to(List)
+      . assert(_ == List[Byte](1, 2, 99))
+
+      test(m"duct flush emits terminal state at end of a pulled stream"):
+        val gather = Gather()
+        Stream(IArray[Byte](1, 2)).through(Trailer()).flowTo(gather)
+        gather.data.to(List)
+      . assert(_ == List[Byte](1, 2, 99))
+
+      test(m"conduit transfers data across threads"):
+        val conduit = Conduit[Data]()
+        val gather = Gather()
+        val task = async(conduit.stream.flowTo(gather))
+        conduit.put(bytes)
+        conduit.finish()
+        unsafely(task.await())
+        gather.data.to(List)
+      . assert(_ == bytes.to(List))
+
+      test(m"conduit demand reflects buffered data"):
+        val conduit = Conduit[Data]()
+        val before = conduit.demand.count
+        conduit.put(IArray[Byte](1, 2, 3))
+        val after = conduit.demand.count
+        before - after
+      . assert(_ == 3L)
+
+      test(m"conduit rethrows producer failure at the reader"):
+        val conduit = Conduit[Data]()
+        conduit.fail(RuntimeException("boom"))
+
+        try
+          conduit.stream.refill(Credit(1))
+          false
+        catch case _: RuntimeException => true
+      . assert(identity)
+
+      test(m"credit grant clamps to Int range and zero"):
+        val regulation = summon[Credit is Regulation]
+
+        ( regulation.grant(Credit(-5)),
+          regulation.grant(Credit(3)),
+          regulation.grant(Credit(Long.MaxValue)) )
+      . assert(_ == ((0, 3, Int.MaxValue)))
+
+      test(m"credit encode/decode roundtrip"):
+        val regulation = summon[Credit is Regulation]
+        regulation.decode(regulation.encode(Credit(3456))).count
+      . assert(_ == 3456L)
+
+      test(m"flow grants nothing when halted"):
+        val regulation = summon[Flow is Regulation]
+
+        ( regulation.grant(Flow.Halted),
+          regulation.grant(Flow.Free) > 0,
+          regulation.measured(Flow.Measured) )
+      . assert(_ == ((0, true, true)))
+
+
+// A byte intake that gathers everything written to it, with a configurable
+// reported demand, for asserting demand translation.
+class Gather() extends Intake[Data]:
+  type Transport = Credit
+
+  private val block: Int = 16
+  private val storage: addressable.Storage = addressable.allocate(block)
+  private val target: addressable.Target = addressable.blank(64)
+  private var mark1: Int = 0
+  var credit: Long = Long.MaxValue
+
+  def demand: Credit = Credit(credit)
+  protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
+  def mark: Int = mark1
+
+  def reserve(min: Int): Int =
+    val free = block - mark1
+
+    if free >= min then free else
+      drain()
+      block
+
+  def commit(count: Int): Unit =
+    mark1 += count
+    if mark1 == block then drain()
+
+  def finish(): Unit = drain()
+
+  def data: Data =
+    drain()
+    addressable.build(target)
+
+  private def drain(): Unit =
+    if mark1 > 0 then
+      addressable.cloneStorage(storage, 0, mark1)(target)
+      mark1 = 0
+
+// Doubles each byte, like hexadecimal serialization: 1024 elements of
+// downstream demand translate to 512 elements of upstream demand.
+class Doubler() extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+  // Ceiling division, written to avoid overflow when the demand is unbounded
+  // (`Long.MaxValue`).
+  def translate(demand: Credit): Credit = Credit(demand.count - demand.count/2)
+
+  override def quantum: Int = 2
+
+  def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    var consumed: Int = 0
+    var produced: Int = 0
+    val target2 = target.asInstanceOf[input.Storage]
+
+    while consumed < sourceLength && produced + 2 <= targetSpace do
+      val byte = input.storageAddress(source, sourceOffset + consumed)
+      input.storageUpdate(target2, targetOffset + produced, byte)
+      input.storageUpdate(target2, targetOffset + produced + 1, byte)
+      consumed += 1
+      produced += 2
+
+    Duct.Progress(consumed, produced)
+
+// The identity transformation, plus a single trailing `99` byte at
+// end-of-stream, exercising the `flush` path.
+class Trailer() extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private var emitted: Boolean = false
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    val count = sourceLength.min(targetSpace)
+    input.transfer(source, sourceOffset, target.asInstanceOf[input.Storage], targetOffset, count)
+
+    Duct.Progress(count, count)
+
+  override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    if emitted then 0 else
+      emitted = true
+      output.storageUpdate(target, targetOffset, 99.toByte.asInstanceOf[output.Operand])
+      1
+
+// Passes refills through unchanged, recording each demand it receives.
+class Recorder(underlying: Stream[Data] over Credit) extends Stream[Data]:
+  type Transport = Credit
+
+  var demands: List[Long] = Nil
+
+  def refill(demand: Credit): Optional[Int] =
+    demands ::= demand.count
+    underlying.refill(demand)
+
+  protected def window0: AnyRef = unsafely(underlying.window).asInstanceOf[AnyRef]
+  def start: Int = underlying.start
+  def limit: Int = underlying.limit
+  def skip(count: Int): Unit = underlying.skip(count)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -731,6 +731,27 @@ object Tests extends Suite(m"Zephyrine tests"):
         builder.toString.tt
       . assert(_ == exotic)
 
+      test(m"record streams carry heap objects with credit counted in records"):
+        val records = IArray.from((1 to 100).map { index => s"record-$index" })
+        val stream = Stream[IArray[String]](records)
+        var collected: List[String] = Nil
+
+        def recur(): Unit = stream.refill(Credit(7)) match
+          case count: Int =>
+            val window = unsafely(stream.window).asInstanceOf[Array[AnyRef]]
+
+            for index <- 0 until count
+            do collected = window(stream.start + index).asInstanceOf[String] :: collected
+
+            stream.skip(count)
+            recur()
+
+          case _ => ()
+
+        recur()
+        collected.reverse
+      . assert(_ == (1 to 100).map { index => s"record-$index" }.to(List))
+
       test(m"flow grants nothing when halted"):
         val regulation = summon[Pace is Regulation]
 

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -732,11 +732,11 @@ object Tests extends Suite(m"Zephyrine tests"):
       . assert(_ == exotic)
 
       test(m"flow grants nothing when halted"):
-        val regulation = summon[Flow is Regulation]
+        val regulation = summon[Pace is Regulation]
 
-        ( regulation.grant(Flow.Halted),
-          regulation.grant(Flow.Free) > 0,
-          regulation.measured(Flow.Measured) )
+        ( regulation.grant(Pace.Halted),
+          regulation.grant(Pace.Free) > 0,
+          regulation.measured(Pace.Measured) )
       . assert(_ == ((0, true, true)))
 
 


### PR DESCRIPTION
This PR introduces the streaming architecture designed for #1477: pull `Stream`s and push `Intake`s over mutable, single-owner buffer windows; synchronous `Duct` transformation stages with typed, per-stage backpressure-demand conversion; `Conduit` as the sole synchronized asynchronous boundary; and contextual `Buffering`. High-level `read`/`writeTo` call-sites are unchanged, now running on the new kernel via recomposed `Readable`/`Aggregable` and the new `Source`/`Sink` typeclasses, with transitional bridges from `Streamable`/`Writable` so downstream code migrates incrementally.

## Release notes

- **zephyrine** gains the streaming kernel: `Stream` (pull endpoint), `Intake` (push endpoint, a `Producer`), `Duct`/`Ductile` (transformation stages with a `translate` demand-conversion hook), `Conduit` (bounded SPSC asynchronous boundary), the `Regulation` typeclass with `Credit` and `Pace` demand types, and contextual `Buffering`. `Cursor` can be built directly over a `Stream`, so parsers pull with credit-bounded memory.
- **turbulence** gains `Source` and `Sink` (successors to `Streamable`/`Writable`, which remain as bridges), a recomposed `Readable`, pipeline composition (`through`, `accepting`, `flowTo`, `flow`), `Confluence`/`Manifold` for bounded fan-in/fan-out, and streaming compression: `stream.compress[Gzip]`/`decompress[Gzip]` (also `Deflate`, `Zlib`).
- Charset transcoding (hieroglyph) and base-N serialization (monotonous, via `Alphabet` values) are pipeline stages, e.g. `stream.through(alphabets.hex.upperCase)`; demand converts exactly (1024 hex chars ⇒ 512 bytes).
- **jacinta** and **honeycomb** parse natively from pull endpoints; coaxial's `Duplex` exposes `source`/`intake` socket endpoints.
- `HttpStreams.Content`'s body is now `HttpStreams.Body`, a minimal demand-aware pull protocol; a body is directly `read`-able.
- The logging interface `anticipation.Sink` is renamed `LogSink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)