### PR TITLE
Split telekinesis into cross-platform core and JVM transport modules

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -288,7 +288,7 @@ object soundness extends ScalaModule:
   object web extends Bundle(archimedes.core, cacophony.core, cataclysm.core, coaxial.core, cosmopolite.core, gesticulate.core,
     honeycomb.core, urticose.core, urticose.url, hallucination.core, phoenicia.core,
     punctuation.core, savagery.core, scintillate.server, scintillate.servlet,
-    telekinesis.core, plutocrat.core, eucalyptus.gcp, punctuation.html, perihelion.core,
+    telekinesis.jvm, plutocrat.core, eucalyptus.gcp, punctuation.html, perihelion.core,
     legerdemain.core, caduceus.core, caduceus.resend, orthodoxy.core, jacinta.http, jacinta.schema,
     stratiform.http, obligatory.core, obligatory.json, synesthesia.core, apoplexy.core,
     cataclysm.html, querencia.core, cordillera.core, embarcadero.containerd, obligatory.grpc,
@@ -567,7 +567,7 @@ object burdock extends Library:
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object core
-      extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.core,
+      extends Component(zeppelin.core, exoskeleton.core, revolution.core, telekinesis.jvm,
                        gastronomy.core, jacinta.core, boot):
     override def scalaJs = false // packaging; depends on JVM-only `zeppelin`/`telekinesis`
     def compileMvnDeps = Seq(mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}")
@@ -586,7 +586,7 @@ object caduceus extends Library:
   object core extends Component(honeycomb.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object resend extends Component(core, telekinesis.core, jacinta.core):
+  object resend extends Component(core, telekinesis.jvm, jacinta.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -795,7 +795,7 @@ object polysyllabic extends Library:
   object bench extends Benchmarks(core, escritoire.core, hellenism.core, quantitative.units)
 
 object ethereal extends Library:
-  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.core, quantitative.units, telekinesis.core, urticose.url, gastronomy.core):
+  object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.core, quantitative.units, telekinesis.jvm, urticose.url, gastronomy.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -1113,7 +1113,7 @@ object jacinta extends Library:
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object schema extends Component(core, telekinesis.core):
+  object schema extends Component(core, telekinesis.jvm):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -1223,7 +1223,7 @@ object octogenarian extends Library:
   object test extends Tests(core)
 
 object orthodoxy extends Library:
-  object core extends Component(scintillate.server, jacinta.core):
+  object core extends Component(scintillate.server, jacinta.core, telekinesis.jvm):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -1498,18 +1498,24 @@ object synesthesia extends Library:
   object test extends Tests(core)
 
 object tarantula extends Library:
-  object core extends Component(jacinta.core, telekinesis.core, cataclysm.core, hallucination.core, diuretic.core, gastronomy.core):
+  object core extends Component(jacinta.core, telekinesis.jvm, cataclysm.core, hallucination.core, diuretic.core, gastronomy.core):
     override def scalaJs = false // browser automation; depends on JVM-only `hallucination`
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)
 
 object telekinesis extends Library:
-  object core extends Component(monotonous.core, coaxial.core, legerdemain.core, turbulence.core):
-    override def scalaJs = false // HTTP client (`java.net.http`, `coaxial`)
+  object core extends Component(monotonous.core, legerdemain.core, turbulence.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
-  object test extends Tests(core)
+  // JVM-only transports split out of `core` so the platform-agnostic HTTP model and client can
+  // cross-compile to Scala.js: the `java.net.http` `Http.Backend` (`httpBackends.virtualMachine`)
+  // and the `coaxial` domain-socket client.
+  object jvm extends Component(core, coaxial.core):
+    override def scalaJs = false
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  object test extends Tests(core, jvm)
 
 object turbulence extends Library:
   object core
@@ -1723,7 +1729,7 @@ object ziggurat extends Library:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object packager
       extends Component(core, guillotine.core, galilei.core, eucalyptus.core, ethereal.core,
-                       telekinesis.core):
+                       telekinesis.jvm):
     override def scalaJs = false // native packaging; `guillotine`/`galilei`/`ethereal` (JVM)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")

--- a/lib/burdock/src/core/burdock.DepsDev.scala
+++ b/lib/burdock/src/core/burdock.DepsDev.scala
@@ -45,6 +45,7 @@ import telekinesis.*
 import urticose.*
 import vacuous.*
 
+import httpBackends.virtualMachine
 import internetAccess.online
 
 // Resolves a dependency's content hash to its public download URL using Google's

--- a/lib/caduceus/src/resend/caduceus_core.scala
+++ b/lib/caduceus/src/resend/caduceus_core.scala
@@ -53,6 +53,7 @@ import charEncoders.utf8Encoder
 import environments.javaEnvironment
 import errorDiagnostics.stackTracesDiagnostics
 import formatting.compactJsonFormatting
+import httpBackends.virtualMachine
 import stdios.virtualMachineStdio
 import termcaps.environmentTermcap
 

--- a/lib/ethereal/src/core/ethereal.Runners.scala
+++ b/lib/ethereal/src/core/ethereal.Runners.scala
@@ -46,6 +46,7 @@ import vacuous.*
 
 import errorDiagnostics.emptyDiagnostics
 import gastronomy.*, providers.javaStdlibProvider
+import httpBackends.virtualMachine
 import internetAccess.online
 import monotonous.*, alphabets.hexLowerCase
 

--- a/lib/jacinta/src/schema/jacinta_schema.scala
+++ b/lib/jacinta/src/schema/jacinta_schema.scala
@@ -42,6 +42,8 @@ import urticose.*
 import vacuous.*
 import wisteria.*
 import zephyrine.*
+
+import httpBackends.virtualMachine
 import JsonError.Reason
 
 package jsonPointerRegistries:

--- a/lib/obligatory/src/json/obligatory.JsonRpc.scala
+++ b/lib/obligatory/src/json/obligatory.JsonRpc.scala
@@ -54,6 +54,8 @@ import urticose.*
 import vacuous.*
 import zephyrine.*
 
+import httpBackends.virtualMachine
+
 
 object JsonRpc:
   private val promises: scm.HashMap[Text | Int, Promise[Json]] = scm.HashMap()

--- a/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
@@ -51,6 +51,7 @@ import vacuous.*
 import zephyrine.*
 
 import errorDiagnostics.stackTracesDiagnostics
+import httpBackends.virtualMachine
 import queryParameters.arbitraryQueryParameter
 
 object Issuer:

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -217,7 +217,7 @@ given wsClient: ( Online,
               Http.Header(t"Sec-WebSocket-Version", t"13") ),
           () => LazyList() )
 
-    duplex.send(Http.Request.transmissible.serialize(request))
+    duplex.send(Http.Request.serialize(request))
 
     // Read the response headers up to the CRLFCRLF terminator *without* over-reading:
     // `Http.Response.parse` on a live socket eagerly refills one chunk past the headers,

--- a/lib/tarantula/src/core/tarantula.WebDriver.scala
+++ b/lib/tarantula/src/core/tarantula.WebDriver.scala
@@ -48,6 +48,7 @@ import telekinesis.*
 import turbulence.*
 import urticose.*
 
+import httpBackends.virtualMachine
 import strategies.throwUnsafely
 
 case class WebDriver(server: Navigator#Server):

--- a/lib/telekinesis/src/core/telekinesis.Fetchable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Fetchable.scala
@@ -33,7 +33,6 @@
 package telekinesis
 
 import anticipation.*
-import coaxial.*
 import fulminate.*
 import prepositional.*
 import urticose.*
@@ -50,15 +49,6 @@ object Fetchable:
 
       def hostname(httpUrl: url): Host = httpUrl.host.or:
         panic(m"The HTTP URL does not have a hostname")
-
-  given unixSocket: DomainSocketEndpoint is Fetchable onto DomainSocket =
-    new Fetchable:
-      type Self = DomainSocketEndpoint
-      type Target = DomainSocket
-
-      def target(endpoint: DomainSocketEndpoint): DomainSocket = endpoint.socket
-      def text(endpoint: DomainSocketEndpoint): Text = endpoint.path
-      def hostname(endpoint: DomainSocketEndpoint): Host = Localhost
 
 trait Fetchable extends Typeclass, Targetable:
   def target(value: Self): Target

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -35,7 +35,6 @@ package telekinesis
 import language.dynamics
 
 import anticipation.*
-import coaxial.*
 import contingency.*
 import denominative.*
 import distillate.*
@@ -255,7 +254,11 @@ object Http:
         t"params"   -> params
       ).map { case (key, value) => t"$key = $value" }.join(t", ")
 
-    given transmissible: Request is Transmissible = request =>
+    // Serialize the request to its HTTP/1.1 wire form: the request line, `Host`
+    // and framing headers, then the header block and body. Used by transports
+    // that write directly to a socket (e.g. the `coaxial` domain-socket client
+    // in `telekinesis.jvm`, which wraps this in a `Transmissible`).
+    def serialize(request: Request): LazyList[Data] =
       import charEncoders.asciiEncoder
 
       val text: Text = Text.build:
@@ -273,7 +276,7 @@ object Http:
         request.body() match
           case LazyList()     => append(t"Content-Length: 0")
           case LazyList(data) => append(t"Content-Length: ${data.length}")
-          case _            => append(t"Transfer-Encoding: chunked")
+          case _              => append(t"Transfer-Encoding: chunked")
 
         request.textHeaders.map: parameter =>
           newline()
@@ -524,16 +527,10 @@ object Http:
   // The swappable transport that physically sends a single request and returns
   // its response. The URL is fully resolved (passed as `Text`) so non-JVM
   // backends can parse it themselves; redirects are handled by `HttpClient`, not
-  // the backend. The JVM default (using `java.net.http`) is provided in
-  // `HttpClient`; other platforms or implementations (e.g. HTTP/2) supply their
-  // own given.
-  object Backend:
-    // The default transport. telekinesis is currently JVM-only, so this
-    // delegates to the `java.net.http` client; when the module is split for
-    // other platforms this default moves to a platform-specific source. A
-    // user-supplied `Http.Backend` given in scope overrides it.
-    given default: Backend = HttpClient.javaBackend
-
+  // the backend. Backends are platform-specific, so each is summoned by an
+  // explicit import: `httpBackends.virtualMachine` (`java.net.http`, in
+  // `telekinesis.jvm`) on the JVM; other platforms or implementations (e.g.
+  // HTTP/2) supply their own given.
   trait Backend:
     def request
       ( url:     Text,

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -34,23 +34,17 @@ package telekinesis
 
 import language.dynamics
 
-import java.io as ji
 import java.net as jn
-import java.net.http as jnh
-import javax.net.ssl as jns
 
 import scala.util.NotGiven
 
 import anticipation.*
-import coaxial.*
 import contingency.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
-import turbulence.*
 import urticose.*
-import vacuous.*
 
 object HttpClient:
   // Log a received response at a level reflecting its status: a server error is a `Fail`, a client
@@ -63,90 +57,6 @@ object HttpClient:
 
     response
 
-  // Build the underlying Java client with redirect-following disabled — the
-  // redirect-following telekinesis given runs its own loop so it can honour
-  // `HttpRedirection` exactly. Java's `NORMAL` policy has its own hard-coded
-  // cap and would shadow the limit we summon.
-  private lazy val client: jnh.HttpClient =
-    jnh.HttpClient.newBuilder.nn.followRedirects(jnh.HttpClient.Redirect.NEVER).nn.build.nn
-
-  given domainSocket: Tactic[StreamError] => HttpClient onto DomainSocket = new HttpClient:
-    type Target = DomainSocket
-
-    def request(request: Http.Request, socket: DomainSocket): Http.Response logs HttpEvent =
-
-      unsafely(Http.Response.parse(socket.transmit(request)))
-
-  private def buildJavaRequest
-    ( uri:         jn.URI,
-      method:      Http.Method,
-      textHeaders: List[Http.Header],
-      bodyFn:      () => LazyList[Data] )
-  :   jnh.HttpRequest =
-
-    val request: jnh.HttpRequest.Builder = jnh.HttpRequest.newBuilder().nn.uri(uri).nn
-
-    lazy val body = bodyFn() match
-      case LazyList() => jnh.HttpRequest.BodyPublishers.noBody.nn
-
-      case LazyList(bytes) =>
-        jnh.HttpRequest.BodyPublishers.ofByteArray(bytes.mutable(using Unsafe))
-
-      case stream =>
-        jnh.HttpRequest.BodyPublishers.ofInputStream: () => stream.inputStream
-
-    method match
-      case Http.Delete  => request.DELETE().nn
-      case Http.Get     => request.GET().nn
-      case Http.Post    => request.POST(body).nn
-      case Http.Put     => request.PUT(body).nn
-      case Http.Connect => request.method("CONNECT", body).nn
-      case Http.Head    => request.method("HEAD", body).nn
-      case Http.Options => request.method("OPTIONS", body).nn
-      case Http.Patch   => request.method("PATCH", body).nn
-      case Http.Trace   => request.method("TRACE", body).nn
-
-    request.header("User-Agent", "internal/1.0.0")
-
-    textHeaders.each:
-      case Http.Header(key, value) => request.header(key.s, value.s)
-
-    request.build().nn
-
-  private def send(request: jnh.HttpRequest)(using Tactic[ConnectError])
-  :   jnh.HttpResponse[ji.InputStream] =
-
-    import ConnectError.Reason.*, Ssl.Reason.*
-
-    try client.send(request, jnh.HttpResponse.BodyHandlers.ofInputStream()).nn catch
-      case error: jns.SSLHandshakeException       => abort(ConnectError(Ssl(Handshake)))
-      case error: jns.SSLProtocolException        => abort(ConnectError(Ssl(Protocol)))
-      case error: jns.SSLPeerUnverifiedException  => abort(ConnectError(Ssl(Peer)))
-      case error: jns.SSLKeyException             => abort(ConnectError(Ssl(Key)))
-      case error: jn.UnknownHostException         => abort(ConnectError(Dns))
-      case error: jnh.HttpConnectTimeoutException => abort(ConnectError(Timeout))
-
-      case error: jn.ConnectException =>
-        error.getMessage() match
-          case "Connection refused"                    => abort(ConnectError(Refused))
-          case "Connection timed out"                  => abort(ConnectError(Timeout))
-          case "HTTP connect timed out"                => abort(ConnectError(Timeout))
-          case error                                   => abort(ConnectError(Unknown))
-
-      case error: ji.IOException =>
-        abort(ConnectError(Unknown))
-
-  private def buildResponse(response: jnh.HttpResponse[ji.InputStream])(using Tactic[ConnectError])
-  :   Http.Response =
-
-    val status: Http.Status = Http.Status.unapply(response.statusCode()).getOrElse:
-      abort(ConnectError(ConnectError.Reason.Unknown))
-
-    val headers: List[Http.Header] = response.headers.nn.map().nn.asScala.to(List).flatMap:
-      (key, values) => values.asScala.map: value => Http.Header(key.tt, value.tt)
-
-    status(headers, Http.Body.Streaming(unsafely(response.body().nn.stream[Data])))
-
   // 301/302/303 historically downgrade the method to GET and drop the body;
   // 307/308 preserve both. Matches Java's `Redirect.NORMAL` and the WHATWG
   // fetch spec.
@@ -157,20 +67,6 @@ object HttpClient:
   private def isRedirect(code: Int): Boolean = code match
     case 301 | 302 | 303 | 307 | 308 => true
     case _                           => false
-
-  // The JVM default transport, using `java.net.http`. Other platforms (e.g.
-  // Scala.js) or implementations (e.g. an HTTP/2 client) supply their own
-  // `Http.Backend` given instead.
-  val javaBackend: Http.Backend = new Http.Backend:
-    def request
-      ( url:     Text,
-        method:  Http.Method,
-        headers: List[Http.Header],
-        body:    () => LazyList[Data] )
-      ( using Tactic[ConnectError] )
-    :   Http.Response =
-
-      buildResponse(send(buildJavaRequest(jn.URI.create(url.s).nn, method, headers, body)))
 
   given httpStrict: Tactic[ConnectError]
   =>  Online

--- a/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
@@ -30,88 +30,9 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package telekinesis
+package soundness
 
-import anticipation.*
-import distillate.*
-import fulminate.*
-import gossamer.*
-import inimitable.*
-import prepositional.*
-import rudiments.*
-import spectacular.*
-import symbolism.*
-import urticose.*
-import vacuous.*
+export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHttpClient}
 
-object Cookie:
-  // For some reason it seems necessary to use `DummyImplicit` instead of `Void` here
-  def apply[value: {Encodable in Text, Decodable in Text}](using DummyImplicit)
-    [ duration: Abstractable across Durations to Long ]
-    ( name:     Text,
-      domain:   Optional[Hostname] = Unset,
-      expiry:   Optional[duration] = Unset,
-      secure:   Boolean            = false,
-      httpOnly: Boolean            = false,
-      path:     Optional[Text]     = Unset ) =
-
-    new Cookie[value](name, domain, expiry.let(_.generic/1_000_000L), secure, httpOnly, path)
-
-
-  object Value:
-    given showable: Value is Showable = cookie =>
-      List
-        ( t"${cookie.name}=${cookie.value}",
-          cookie.expiry.let { expiry => t"Max-Age=$expiry" },
-          cookie.domain.let { domain => t"Domain=$domain" },
-          cookie.path.let { path => t"Path=$path" },
-          if cookie.secure then t"Secure" else Unset,
-          if cookie.httpOnly then t"HttpOnly" else Unset )
-
-      . compact.join(t"; ")
-
-    given encodable: Cookie.Value is Encodable in Http.Header = cookie =>
-      Http.Header("Set-Cookie", cookie.show)
-
-    given addable: Http.Response is Addable by Cookie.Value to Http.Response =
-      Addable: (response, cookie) =>
-        val header = Http.Header(t"set-cookie", cookie.show)
-        response.status(header :: response.textHeaders, response.body)
-
-    given decodable: List[Cookie.Value] is Decodable in Text = value =>
-      value.cut(t"; ").flatMap:
-        _.cut(t"=", 2) match
-          case List(key, value) => List(Cookie.Value(key.urlDecode, value.urlDecode))
-          case _                => Nil
-
-  case class Value
-    ( name:     Text,
-      value:    Text,
-      domain:   Optional[Text] = Unset,
-      path:     Optional[Text] = Unset,
-      expiry:   Optional[Long] = Unset,
-      secure:   Boolean        = false,
-      httpOnly: Boolean        = false )
-
-  extension (cookie: Cookie[Session])
-    def session(lambda: Session ?=> Http.Response)(using Http.Request): Http.Response =
-      val session = cookie().or(Session(Uuid().show))
-      lambda(using session) + cookie(session)
-
-case class Cookie[value: {Encodable in Text, Decodable in Text}]
-  ( name:     Text,
-    domain:   Optional[Hostname],
-    expiry:   Optional[Long],
-    secure:   Boolean,
-    httpOnly: Boolean,
-    path:     Optional[Text] ):
-
-  def apply(value: value): Cookie.Value =
-    Cookie.Value(name, value.encode, domain.let(_.show), path, expiry.let(_/1000), secure, httpOnly)
-
-  inline def apply()(using Http.Request): Optional[value] =
-    summon[Http.Request].textCookies.at(name).let(_.decode)
-
-  object Session:
-    def unapply(using request: Http.Request)[result](lambda: value ?=> result): Option[result] =
-      request.textCookies.at(name).let(_.decode).letGiven(lambda).option
+package httpBackends:
+  export telekinesis.httpBackends.virtualMachine

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -1,0 +1,160 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package telekinesis
+
+import java.io as ji
+import java.net as jn
+import java.net.http as jnh
+import javax.net.ssl as jns
+
+import anticipation.*
+import coaxial.*
+import contingency.*
+import prepositional.*
+import rudiments.*
+import turbulence.*
+import urticose.*
+import vacuous.*
+
+// Build the underlying Java client with redirect-following disabled — the
+// redirect-following telekinesis given runs its own loop so it can honour
+// `HttpRedirection` exactly. Java's `NORMAL` policy has its own hard-coded
+// cap and would shadow the limit we summon.
+private lazy val javaClient: jnh.HttpClient =
+  jnh.HttpClient.newBuilder.nn.followRedirects(jnh.HttpClient.Redirect.NEVER).nn.build.nn
+
+private def buildJavaRequest
+  ( uri:         jn.URI,
+    method:      Http.Method,
+    textHeaders: List[Http.Header],
+    bodyFn:      () => LazyList[Data] )
+:   jnh.HttpRequest =
+
+  val request: jnh.HttpRequest.Builder = jnh.HttpRequest.newBuilder().nn.uri(uri).nn
+
+  lazy val body = bodyFn() match
+    case LazyList() => jnh.HttpRequest.BodyPublishers.noBody.nn
+
+    case LazyList(bytes) =>
+      jnh.HttpRequest.BodyPublishers.ofByteArray(bytes.mutable(using Unsafe))
+
+    case stream =>
+      jnh.HttpRequest.BodyPublishers.ofInputStream: () => stream.inputStream
+
+  method match
+    case Http.Delete  => request.DELETE().nn
+    case Http.Get     => request.GET().nn
+    case Http.Post    => request.POST(body).nn
+    case Http.Put     => request.PUT(body).nn
+    case Http.Connect => request.method("CONNECT", body).nn
+    case Http.Head    => request.method("HEAD", body).nn
+    case Http.Options => request.method("OPTIONS", body).nn
+    case Http.Patch   => request.method("PATCH", body).nn
+    case Http.Trace   => request.method("TRACE", body).nn
+
+  request.header("User-Agent", "internal/1.0.0")
+
+  textHeaders.each:
+    case Http.Header(key, value) => request.header(key.s, value.s)
+
+  request.build().nn
+
+private def send(request: jnh.HttpRequest)(using Tactic[ConnectError])
+:   jnh.HttpResponse[ji.InputStream] =
+
+  import ConnectError.Reason.*, Ssl.Reason.*
+
+  try javaClient.send(request, jnh.HttpResponse.BodyHandlers.ofInputStream()).nn catch
+    case error: jns.SSLHandshakeException       => abort(ConnectError(Ssl(Handshake)))
+    case error: jns.SSLProtocolException        => abort(ConnectError(Ssl(Protocol)))
+    case error: jns.SSLPeerUnverifiedException  => abort(ConnectError(Ssl(Peer)))
+    case error: jns.SSLKeyException             => abort(ConnectError(Ssl(Key)))
+    case error: jn.UnknownHostException         => abort(ConnectError(Dns))
+    case error: jnh.HttpConnectTimeoutException => abort(ConnectError(Timeout))
+
+    case error: jn.ConnectException =>
+      error.getMessage() match
+        case "Connection refused"                    => abort(ConnectError(Refused))
+        case "Connection timed out"                  => abort(ConnectError(Timeout))
+        case "HTTP connect timed out"                => abort(ConnectError(Timeout))
+        case error                                   => abort(ConnectError(Unknown))
+
+    case error: ji.IOException =>
+      abort(ConnectError(Unknown))
+
+private def buildResponse(response: jnh.HttpResponse[ji.InputStream])(using Tactic[ConnectError])
+:   Http.Response =
+
+  val status: Http.Status = Http.Status.unapply(response.statusCode()).getOrElse:
+    abort(ConnectError(ConnectError.Reason.Unknown))
+
+  val headers: List[Http.Header] = response.headers.nn.map().nn.asScala.to(List).flatMap:
+    (key, values) => values.asScala.map: value => Http.Header(key.tt, value.tt)
+
+  status(headers, Http.Body.Streaming(unsafely(response.body().nn.stream[Data])))
+
+package httpBackends:
+  // The JVM transport, using `java.net.http`. Other platforms (e.g. Scala.js)
+  // or implementations (e.g. an HTTP/2 client) supply their own `Http.Backend`
+  // given instead.
+  given virtualMachine: Http.Backend = new Http.Backend:
+    def request
+      ( url:     Text,
+        method:  Http.Method,
+        headers: List[Http.Header],
+        body:    () => LazyList[Data] )
+      ( using Tactic[ConnectError] )
+    :   Http.Response =
+
+      buildResponse(send(buildJavaRequest(jn.URI.create(url.s).nn, method, headers, body)))
+
+// A request is transmitted over a raw socket as its HTTP/1.1 wire form.
+given requestTransmissible: Http.Request is Transmissible = Http.Request.serialize(_)
+
+// Fetch from a Unix domain socket, speaking HTTP/1.1 directly over the socket
+// (e.g. the Docker daemon's API). The request's `Host` is `localhost`.
+given domainSocketFetchable: DomainSocketEndpoint is Fetchable onto DomainSocket =
+  new Fetchable:
+    type Self = DomainSocketEndpoint
+    type Target = DomainSocket
+
+    def target(endpoint: DomainSocketEndpoint): DomainSocket = endpoint.socket
+    def text(endpoint: DomainSocketEndpoint): Text = endpoint.path
+    def hostname(endpoint: DomainSocketEndpoint): Host = Localhost
+
+given domainSocketHttpClient: Tactic[StreamError] => HttpClient onto DomainSocket =
+  new HttpClient:
+    type Target = DomainSocket
+
+    def request(request: Http.Request, socket: DomainSocket): Http.Response logs HttpEvent =
+      unsafely(Http.Response.parse(socket.transmit(request)))

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -44,6 +44,7 @@ case class Person(name: Text, address: Address)
 
 object Tests extends Suite(m"Telekinesis tests"):
   def run(): Unit =
+    import httpBackends.virtualMachine
     import internetAccess.online
 
     suite(m"Response construction tests"):

--- a/lib/ziggurat/src/packager/ziggurat.Packager.scala
+++ b/lib/ziggurat/src/packager/ziggurat.Packager.scala
@@ -58,6 +58,7 @@ import filesystemOptions.overwritePreexisting.enabled
 import filesystemOptions.readAccess.enabled
 import filesystemOptions.writeAccess.enabled
 import gastronomy.*, providers.javaStdlibProvider
+import httpBackends.virtualMachine
 import internetAccess.online
 import monotonous.*, alphabets.hexLowerCase
 


### PR DESCRIPTION
The telekinesis HTTP model and client machinery now cross-compile to Scala.js, with the JVM-specific transports split into a new `telekinesis.jvm` module. This follows the same pattern as `turbulence.jvm`, and prepares for a `telekinesis.wasi` backend over `wasi:http`.

## HTTP backends are now explicit imports

The `java.net.http`-based transport is no longer an ambient default: it is summoned with,
```scala
import httpBackends.virtualMachine
```
in the same style as `internetAccess.online`. Code which fetches over HTTP or HTTPS on the JVM should add this import (and depend on `telekinesis.jvm`):
```scala
import httpBackends.virtualMachine
import internetAccess.online

url"https://example.com/".fetch()
```
Other platforms will supply their own `Http.Backend` given under the same `httpBackends` namespace.

## Domain-socket HTTP moves to `telekinesis.jvm`

The `coaxial`-based Unix domain-socket client (used, for example, to speak to the Docker daemon) now lives in `telekinesis.jvm` as top-level givens (`domainSocketHttpClient`, `domainSocketFetchable`, `requestTransmissible`), since `coaxial` is JVM-only.

## `Http.Request.serialize`

A request's HTTP/1.1 wire form is available directly as `Http.Request.serialize(request)` (platform-neutral); the `Transmissible` instance in `telekinesis.jvm` delegates to it.