### PR TITLE
Add a WASI HTTP client backend to telekinesis.wasi

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1515,6 +1515,12 @@ object telekinesis extends Library:
     override def scalaJs = false
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // A GET-only `Http.Backend` over `wasi:http/outgoing-handler`, materialized by xenophile's
+  // `invoke` at the downstream (Wasm-linked) summoning site. Target-neutral `.sjsir` here; only
+  // meaningful linked as a component.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, jvm)
 
 object turbulence extends Library:

--- a/lib/telekinesis/res/wasi/telekinesis/http.wit
+++ b/lib/telekinesis/res/wasi/telekinesis/http.wit
@@ -1,0 +1,61 @@
+// The subset of the WASI HTTP and I/O interfaces that telekinesis's Wasm backend uses: enough of
+// `wasi:http/types` to build an outgoing request and read its response, the `outgoing-handler`
+// that sends it, and the `wasi:io` pollable/stream resources the response flow passes through.
+// Field names, status codes and header values are written as their concrete types (`string`,
+// `u16`, `list<u8>`) — WIT type aliases are structural, so the canonical function types match the
+// host's. The `error-code` variant's cases are not enumerated here: its shape is derived from its
+// facade class; only its name and defining interface matter to this subset.
+
+package wasi:io@0.2.0;
+
+interface poll {
+  resource pollable {
+    block: func();
+  }
+}
+
+interface streams {
+  resource input-stream {
+    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+  }
+}
+
+package wasi:http@0.2.0;
+
+interface types {
+  variant error-code {}
+
+  resource request-options;
+
+  resource fields {
+    constructor();
+    append: func(name: string, value: list<u8>) -> result<_, header-error>;
+    entries: func() -> list<tuple<string, list<u8>>>;
+  }
+
+  resource outgoing-request {
+    constructor(headers: fields);
+    set-authority: func(authority: option<string>) -> result;
+    set-path-with-query: func(path-with-query: option<string>) -> result;
+  }
+
+  resource future-incoming-response {
+    subscribe: func() -> pollable;
+    get: func() -> option<result<result<incoming-response, error-code>>>;
+  }
+
+  resource incoming-response {
+    status: func() -> u16;
+    headers: func() -> fields;
+    consume: func() -> result<incoming-body>;
+  }
+
+  resource incoming-body {
+    %stream: func() -> result<input-stream>;
+  }
+}
+
+interface outgoing-handler {
+  handle: func(request: outgoing-request, options: option<request-options>)
+    -> result<future-incoming-response, error-code>;
+}

--- a/lib/telekinesis/src/wasi/soundness_telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/soundness_telekinesis_wasi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export telekinesis.{WasiHttpApi, wasiHttpApi}
+
+package httpBackends:
+  export telekinesis.httpBackends.wasi

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -1,0 +1,170 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package telekinesis
+
+import scala.annotation.nowarn
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import hellenism.*
+import hypotenuse.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+import soundness.{invoke, dispose}
+import xenophile.*
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for module ids, resource methods and
+// parameter types.
+type WasiHttpApi = Interface in Wit at "/telekinesis/http.wit"
+given wasiHttpApi: WasiHttpApi = Interface[Wit](cp"/telekinesis/http.wit")
+
+package httpBackends:
+  // An `Http.Backend` over `wasi:http/outgoing-handler`: the request is assembled from
+  // `wasi:http/types` resources (`fields` for the headers, then an `outgoing-request`), handed to
+  // the host, and its response awaited through the pollable and read from the body's
+  // `input-stream`. `inline`, so the `invoke`s expand at the downstream summoning site: the Wasm
+  // Component imports only materialize in code compiled for a Wasm target. Summoning it requires
+  // `wasiHttpApi` (and this module's WIT resource) to be visible at that site.
+  //
+  // Only `GET` requests are supported so far: setting the method or scheme on an
+  // `outgoing-request` takes a WIT `variant` argument, which `invoke` cannot yet marshal, so the
+  // request is sent with its defaults (`GET`, and a scheme of the host's choosing).
+  //
+  // The per-site duplication the compiler warns about is the point: the instance must materialize
+  // at the downstream summoning site, and a WASI-linked application summons it once.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasi: Http.Backend = new Http.Backend:
+    def request
+      ( url:     Text,
+        method:  Http.Method,
+        headers: List[Http.Header],
+        body:    () => LazyList[Data] )
+      ( using Tactic[ConnectError] )
+    :   Http.Response =
+
+      if method != Http.Get then abort(ConnectError(ConnectError.Reason.Unknown))
+
+      // The URL arrives fully resolved; split it into the authority and the path-with-query the
+      // `outgoing-request` setters take. (The scheme is currently left unset — see above.)
+      val afterScheme: Text = url.cut(t"://", 2) match
+        case List(_, rest) => rest
+        case _             => url
+
+      val (authority: Text, target: Text) = afterScheme.cut(t"/", 2) match
+        case List(host, path) => (host, t"/$path")
+        case _                => (afterScheme, t"/")
+
+      def bytes(text: Text): Data = text.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+
+      // Request headers travel in a `fields` resource, whose ownership passes into the
+      // `outgoing-request`, whose ownership in turn passes into `handle` — so neither is
+      // explicitly dropped here.
+      val fieldsHandle = Foreign["fields", Wit].constructor.invoke[WitHandle of "fields"]
+      val fields: Foreign of "fields" from Wit = fieldsHandle
+
+      headers.each: header =>
+        fields.append(header.key, bytes(header.value)).invoke[Unit]
+
+      // Applied calls need stable receivers with visible `Origin`s, so the argument conversions
+      // can resolve their ecosystem; roots invoked with arguments are bound to `val`s first. (The
+      // cast supplies the refinement `Foreign.apply` would carry, whose transparent-inline
+      // expansion is deferred inside this `inline given`.)
+      val outgoingRequest =
+        Foreign["outgoing-request", Wit].asInstanceOf[Foreign of "outgoing-request" from Wit]
+
+      val requestHandle =
+        outgoingRequest.constructor(fieldsHandle).invoke[WitHandle of "outgoing-request"]
+
+      // The setters take `option<string>`s; a plain `string` argument subsumes (and crosses the
+      // boundary wrapped as a present option).
+      val request: Foreign of "outgoing-request" from Wit = requestHandle
+      request.`set-authority`(authority).invoke[Unit]
+      request.`set-path-with-query`(target).invoke[Unit]
+
+      val outgoingHandler =
+        Foreign["outgoing-handler", Wit].asInstanceOf[Foreign of "outgoing-handler" from Wit]
+
+      val futureHandle =
+        outgoingHandler.handle(requestHandle, Unset).invoke[WitHandle of "future-incoming-response"]
+
+      val future: Foreign of "future-incoming-response" from Wit = futureHandle
+
+      // The response arrives asynchronously: block on the future's pollable, after which `get`
+      // yields it (or an `error-code`, raised by the decoder).
+      val pollableHandle = future.subscribe.invoke[WitHandle of "pollable"]
+      val pollable: Foreign of "pollable" from Wit = pollableHandle
+      pollable.block.invoke[Unit]
+      pollableHandle.dispose()
+
+      val responseHandle =
+        try future.get.invoke[Optional[WitHandle of "incoming-response"]].or:
+          abort(ConnectError(ConnectError.Reason.Unknown))
+        catch case error: RuntimeException => abort(ConnectError(ConnectError.Reason.Unknown))
+
+      futureHandle.dispose()
+      val response: Foreign of "incoming-response" from Wit = responseHandle
+
+      val status: Http.Status = Http.Status.unapply(response.status.invoke[U16].int).getOrElse:
+        abort(ConnectError(ConnectError.Reason.Unknown))
+
+      val headersHandle = response.headers.invoke[WitHandle of "fields"]
+      val responseFields: Foreign of "fields" from Wit = headersHandle
+
+      val textHeaders: List[Http.Header] =
+        responseFields.entries.invoke[List[(Text, Data)]].map: (key, value) =>
+          Http.Header(key, value.utf8)
+
+      headersHandle.dispose()
+
+      // Read the body to exhaustion: `blocking-read`'s `Err(closed)` arm (raised by the decoder)
+      // is end-of-stream.
+      val bodyHandle = response.consume.invoke[WitHandle of "incoming-body"]
+      val incomingBody: Foreign of "incoming-body" from Wit = bodyHandle
+      val streamHandle = incomingBody.stream.invoke[WitHandle of "input-stream"]
+      val stream: Foreign of "input-stream" from Wit = streamHandle
+
+      var chunks: List[Data] = Nil
+
+      try
+        while true do
+          chunks = stream.`blocking-read`(U64(65536L.bits)).invoke[Data] :: chunks
+      catch case error: RuntimeException => ()
+
+      streamHandle.dispose()
+      bodyHandle.dispose()
+      responseHandle.dispose()
+
+      status(textHeaders, Http.Body.Streaming(chunks.reverse.to(LazyList)))

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -211,7 +211,9 @@ object Xenophile:
     val argTopic = refinements(argRepr).at(t"Topic").or:
       halt(m"xenophile: the foreign type of an argument to $method is not known")
 
-    if argTopic =:= paramTopic then '{$arg.expr}
+    // Subsumption, not equality: a `string` (or a bare `none`) argument satisfies an
+    // `option<string>` (`string|none`) parameter.
+    if argTopic <:< paramTopic then '{$arg.expr}
     else halt(m"xenophile: $method expects an argument of foreign type ${paramType.text}")
 
   def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -149,73 +149,117 @@ object WasmInvoke:
       facadeClass(definingModule(name).or(halt(m"xenophile: $name has no defining module")), name)
 
     // The requested result type determines both the WIT carrier the import returns (told to
-    // `witImportCall` as `classOf[Carrier]`) and how that carrier is decoded. `deriveResult`
-    // computes the pair; the carrier for a `list<tuple<…>>` mentions the scala-wasm `Tuple2` class,
-    // which is resolved (and only ever appears) in this downstream-expanded code. Two result shapes
-    // are handled here rather than in `deriveResult`, because they need the WIT prototype:
+    // `witImportCall` as `classOf[Carrier]`) and how that carrier is decoded. The derivation is
+    // driven by the WIT result type, recursing structurally so that wrapped shapes compose (the
+    // WASI HTTP response flow yields e.g. `option<result<result<incoming-response, error-code>>>`):
     //
-    //  -  A `WitHandle of topic` result is a WIT resource: its carrier is the resource's facade
-    //     class, and the raw handle is wrapped in a `WitHandle`.
-    //  -  A result against a WIT `result<…>` function crosses as a `scala.scalajs.wit.Result`
-    //     and is checked: an `Err` raises an exception; an `Ok` becomes `()` or its decoded
-    //     payload.
-    val (carrier, decode) = TypeRepr.of[result].dealias match
-      case Refinement(base, "Topic", TypeBounds(_, topic)) if base =:= TypeRepr.of[WitHandle] =>
-        prototype.result.absolve match
-          case Foreign.Type.Named(name) =>
-            val facade = facadeOf(name)
+    //  -  A WIT `result<…>` crosses as a `scala.scalajs.wit.Result` and is checked: an `Err`
+    //     raises an exception; an `Ok` becomes `()` or its recursively-decoded payload.
+    //  -  A WIT `option<T>` (read as `T | none`) crosses as a `java.util.Optional` and becomes
+    //     `Unset` or its recursively-decoded payload.
+    //  -  A named WIT type requested as a `WitHandle of topic` is a resource: its carrier is the
+    //     resource's facade class, and the raw handle is wrapped in a `WitHandle`.
+    //  -  Anything else is derived from the requested Scala type alone (`deriveResult`: leaf
+    //     codecs, pairs, lists of pairs), whose carrier for a `list<tuple<…>>` mentions the
+    //     scala-wasm `Tuple2` class — resolved (and only ever appearing) in this
+    //     downstream-expanded code.
+    val optionClass = Symbol.requiredClass("java.util.Optional")
 
-            val decode: Expr[Any] => Expr[Any] = call =>
-              val handle = '{new WitHandle($call)}.asTerm
-              TypeApply(Select.unique(handle, "asInstanceOf"), List(TypeTree.of[result]))
-                .asExprOf[Any]
+    // The payload type of an `option`, whichever way the dialect rendered it.
+    def optionPayload(witType: Foreign.Type): Optional[Foreign.Type] = witType match
+      case Foreign.Type.Union(List(inner, Foreign.Type.Named(none))) if none.s == "none" =>
+        inner
 
-            (facade.typeRef, decode)
-
-          case other =>
-            halt(m"xenophile: $owner.$function does not return a WIT resource")
+      case Foreign.Type.Applied(constructor, List(inner)) if constructor.s == "option" =>
+        inner
 
       case _ =>
-        prototype.result match
-          // A `result<…>` function crosses as a `scala.scalajs.wit.Result` and is checked: an
-          // `Err` raises an exception; an `Ok`'s payload — if the requested type is not `Unit` —
-          // is decoded exactly as if the function had returned the `ok` arm directly.
-          case Foreign.Type.Applied(constructor, _) if constructor.s == "result" =>
-            val resultClass = Symbol.requiredClass("scala.scalajs.wit.Result")
-            val okClass = Symbol.requiredClass("scala.scalajs.wit.Ok")
-            val okType = AppliedType(okClass.typeRef, List(TypeBounds.empty))
+        Unset
 
-            def isOk(outcome: Expr[Any]): Expr[Boolean] =
-              TypeApply(Select.unique(outcome.asTerm, "isInstanceOf"), List(Inferred(okType)))
-                .asExprOf[Boolean]
+    // The mandatory part of an `Optional[T]` (a plain `Unset | T` union).
+    def scalaPayload(scala: TypeRepr): Optional[TypeRepr] = scala.dealias match
+      case OrType(left, right) if left =:= TypeRepr.of[Unset]  => right
+      case OrType(left, right) if right =:= TypeRepr.of[Unset] => left
+      case _                                                   => Unset
 
-            def payload(outcome: Expr[Any]): Expr[Any] =
-              val cast =
-                TypeApply(Select.unique(outcome.asTerm, "asInstanceOf"), List(Inferred(okType)))
+    def isHandle(scala: TypeRepr): Boolean = scala.dealias match
+      case Refinement(base, "Topic", _) => base =:= TypeRepr.of[WitHandle]
+      case _                            => false
 
-              Select.unique(cast, "value").asExprOf[Any]
+    def handleDecode(name: Text, scala: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      val facade = facadeOf(name)
 
-            val decode: Expr[Any] => Expr[Any] =
-              if TypeRepr.of[result] =:= TypeRepr.of[Unit] then call =>
+      val decode: Expr[Any] => Expr[Any] = call => scala.asType.absolve match
+        case '[scala] =>
+          val handle = '{new WitHandle($call)}.asTerm
+          TypeApply(Select.unique(handle, "asInstanceOf"), List(TypeTree.of[scala])).asExprOf[Any]
+
+      (facade.typeRef, decode)
+
+    def decodeFor(witType: Foreign.Type, scala: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
+      witType match
+        case Foreign.Type.Applied(constructor, arguments) if constructor.s == "result" =>
+          val resultClass = Symbol.requiredClass("scala.scalajs.wit.Result")
+          val okClass = Symbol.requiredClass("scala.scalajs.wit.Ok")
+          val okType = AppliedType(okClass.typeRef, List(TypeBounds.empty))
+
+          def isOk(outcome: Expr[Any]): Expr[Boolean] =
+            TypeApply(Select.unique(outcome.asTerm, "isInstanceOf"), List(Inferred(okType)))
+              .asExprOf[Boolean]
+
+          def payload(outcome: Expr[Any]): Expr[Any] =
+            val cast =
+              TypeApply(Select.unique(outcome.asTerm, "asInstanceOf"), List(Inferred(okType)))
+
+            Select.unique(cast, "value").asExprOf[Any]
+
+          val decode: Expr[Any] => Expr[Any] =
+            if scala =:= TypeRepr.of[Unit] then call =>
+              '{  val outcome = $call
+
+                  if !${isOk('outcome)}
+                  then throw new RuntimeException("WIT import returned an error: " + outcome)  }
+            else
+              val (_, payloadDecode) = decodeFor(arguments.head, scala)
+
+              call =>
                 '{  val outcome = $call
 
-                    if !${isOk('outcome)}
-                    then throw new RuntimeException("WIT import returned an error: " + outcome)  }
-              else
-                val (_, payloadDecode) = deriveResult[result]
+                    if ${isOk('outcome)} then ${payloadDecode(payload('outcome))}
+                    else throw new RuntimeException("WIT import returned an error: " + outcome)  }
 
-                call =>
-                  '{  val outcome = $call
+          (resultClass.typeRef, decode)
 
-                      if ${isOk('outcome)} then ${payloadDecode(payload('outcome))}
-                      else throw new RuntimeException("WIT import returned an error: " + outcome)  }
+        case _ =>
+          val payloadWit = optionPayload(witType)
+          val payloadScala = scalaPayload(scala)
 
-            (resultClass.typeRef, decode)
+          if payloadWit.present && payloadScala.present then
+            val (innerCarrier, innerDecode) = decodeFor(payloadWit.vouch, payloadScala.vouch)
 
-          case _ =>
-            if TypeRepr.of[result] =:= TypeRepr.of[Unit]
-            then halt(m"xenophile: `invoke[Unit]` requires a WIT `result<…>` function")
-            else deriveResult[result]
+            // `java.util.Optional` is nameable here, so ordinary quotes suffice; an absent
+            // value becomes `Unset`.
+            val decode: Expr[Any] => Expr[Any] = call =>
+              '{  val option = $call.asInstanceOf[java.util.Optional[Any]]
+                  if option.isPresent then ${innerDecode('{option.get})} else Unset  }
+
+            (optionClass.typeRef.appliedTo(List(innerCarrier)), decode)
+          else
+            witType match
+              case Foreign.Type.Named(name) if isHandle(scala) =>
+                handleDecode(name, scala)
+
+              // A genuinely void function (`block: func()`): nothing to check or decode.
+              case Foreign.Type.Named(name) if name.s == "unit" && scala =:= TypeRepr.of[Unit] =>
+                (TypeRepr.of[Unit], call => '{val _ = $call})
+
+              case _ =>
+                if scala =:= TypeRepr.of[Unit]
+                then halt(m"xenophile: `invoke[Unit]` requires a WIT `result<…>` or void function")
+                else scala.asType.absolve match
+                  case '[scala] => deriveResult[scala]
+
+    val (carrier, decode) = decodeFor(prototype.result, TypeRepr.of[result].dealias)
 
     // Emit `<decode>(witImportCall(module, function, classOf[Carrier]))`. The import call is built
     // by looking up `witImportCall` in the *downstream* classpath (the scala-wasm library), so this
@@ -244,6 +288,9 @@ object WasmInvoke:
           "string")
 
     def descriptor(witType: Foreign.Type): Term = witType match
+      case Foreign.Type.Named(name) if name.s == "unit" || name.s == "_" =>
+        marker("witUnit")
+
       case Foreign.Type.Named(name) if primitives(name.s) =>
         Apply(marker("witPrim"), List(Literal(StringConstant(name.s))))
 
@@ -308,18 +355,79 @@ object WasmInvoke:
         List(Literal(ClassOfConstant(facade.typeRef)), handle.asTerm)
 
     // Each declared argument crosses the boundary through its `Encodable in Wasm` codec, passed as
-    // a `(classOf[Carrier], encoded)` pair.
-    val argumentPairs: List[Term] = argumentTerms.flatMap: argument =>
-      val value = convertedValue(argument)
+    // a `(witParam(classOf[Carrier], <descriptor>), encoded)` pair: the carrier class gives the
+    // IR-level type the argument is lowered as, and the structured descriptor the exact WIT type
+    // (which `classOf` alone erases, e.g. `option<string>`'s payload). An `Optional[T]` argument
+    // (WIT `option<T>`) crosses as a `java.util.Optional` of `T`'s carrier.
+    val parameterTypes: List[Foreign.Type] = prototype.parameters.or(Nil)
 
-      value.tpe.widen.asType.absolve match
+    val arity = parameterTypes.length
+
+    if arity != argumentTerms.length then
+      halt(m"xenophile: $owner.$function takes $arity parameters, not ${argumentTerms.length}")
+
+    def encodedArgument(value: Term, parameter: Foreign.Type): (TypeRepr, Term) =
+      value.tpe.widen.dealias match
+      // A statically-absent argument (a bare `Unset` against an `option<T>` parameter, e.g. the
+      // `option<request-options>` of `wasi:http`'s `handle`) needs no payload codec at all.
+      case tpe if tpe =:= TypeRepr.of[Unset] =>
+        (optionClass.typeRef, '{java.util.Optional.empty[Any]().nn}.asTerm)
+
+      // A resource argument (a `WitHandle of topic`, e.g. the `fields` passed to
+      // `outgoing-request`'s constructor) crosses as its facade class, unwrapped to the raw
+      // handle.
+      case Refinement(base, "Topic", TypeBounds(_, ConstantType(StringConstant(topic))))
+      if base =:= TypeRepr.of[WitHandle] =>
+        val encoded = '{${value.asExprOf[Any]}.asInstanceOf[WitHandle].value}.asTerm
+        (facadeOf(topic.tt).typeRef, encoded)
+
+      case OrType(left, right)
+      if left =:= TypeRepr.of[Unset] || right =:= TypeRepr.of[Unset] =>
+        val inner0 = if left =:= TypeRepr.of[Unset] then right else left
+
+        inner0.asType.absolve match
+          case '[inner] =>
+            val encodable = Expr.summon[inner is Encodable in Wasm].getOrElse:
+              halt(m"xenophile: no way to pass a ${inner0.show} across a WIT boundary")
+
+            val optional = value.asExprOf[Optional[inner]]
+
+            // `match`, not `let`/`lay`: `Optional`'s inline combinators crash `pickleQuotes`
+            // inside staged code.
+            val encoded =
+              '{  $optional match
+                    case Unset => java.util.Optional.empty[Any]().nn
+
+                    case value =>
+                      java.util.Optional.of($encodable.encoded(value.asInstanceOf[inner]).value)
+                      . nn  }
+
+            (optionClass.typeRef.appliedTo(List(carrierType(encodable))), encoded.asTerm)
+
+      case other => other.asType.absolve match
         case '[argument] =>
           val encodable = Expr.summon[argument is Encodable in Wasm].getOrElse:
-            halt(m"xenophile: no way to pass a ${value.tpe.widen.show} across a WIT boundary")
+            halt(m"xenophile: no way to pass a ${other.show} across a WIT boundary")
 
           val encoded = '{$encodable.encoded(${value.asExprOf[argument]}).value}.asTerm
 
-          List(Literal(ClassOfConstant(carrierType(encodable))), encoded)
+          // A plain (always-present) value against an `option<T>` parameter crosses as a present
+          // `java.util.Optional`, matching the parameter's descriptor.
+          if optionPayload(parameter).present then
+            val wrapped = '{java.util.Optional.of(${encoded.asExprOf[Any]}).nn}.asTerm
+            (optionClass.typeRef.appliedTo(List(carrierType(encodable))), wrapped)
+          else (carrierType(encodable), encoded)
+
+    val argumentPairs: List[Term] =
+      argumentTerms.zip(parameterTypes).flatMap: (argument, parameter) =>
+        val (carrierRepr, encoded) = encodedArgument(convertedValue(argument), parameter)
+
+        val slot =
+          Apply
+            ( marker("witParam"),
+              List(Literal(ClassOfConstant(carrierRepr)), descriptor(parameter)) )
+
+        List(slot, encoded)
 
     val varargs =
       Typed

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -78,6 +78,9 @@ object WitDialect extends Dialect:
         if char == '/' && next == '/' then recur(skipLine(index), "", flushed)
         else if char == '/' && next == '*' then recur(skipBlock(index + 2), "", flushed)
         else if char == '-' && next == '>' then recur(index + 2, "", "->" :: flushed)
+        // `%` escapes an identifier that collides with a WIT keyword (`%stream`); the name
+        // itself is the unescaped form.
+        else if char == '%' then recur(index + 1, current, tokens)
         else if ident(char) then recur(index + 1, current + char, tokens)
         else if char.isWhitespace then recur(index + 1, "", flushed)
         else recur(index + 1, "", char.toString :: flushed)
@@ -94,13 +97,23 @@ object WitDialect extends Dialect:
       if name == "option" then args match
         case inner :: Nil => (Foreign.Type.Union(List(inner, Foreign.Type.Named(t"none"))), after)
         case _            => (Foreign.Type.Applied(t"option", args), after)
+      else if name == "result" then (result(args), after)
       else (Foreign.Type.Applied(name.tt, args), after)
+
+    case "result" :: rest =>
+      (result(Nil), rest)
 
     case name :: rest =>
       (Foreign.Type.Named(name.tt), rest)
 
     case Nil =>
       (Foreign.Type.Named(t""), Nil)
+
+  // A `result` type always carries exactly two arms: `result` and `result<T>` pad the missing
+  // `ok`/`err` arm(s) with `_`, so consumers see one uniform shape.
+  private def result(args: List[Foreign.Type]): Foreign.Type =
+    val unit = Foreign.Type.Named(t"_")
+    Foreign.Type.Applied(t"result", (args ++ List(unit, unit)).take(2))
 
   private def typeArguments(tokens: List[String], acc: List[Foreign.Type])
   :   (List[Foreign.Type], List[String]) =
@@ -194,8 +207,12 @@ object WitDialect extends Dialect:
 
           recur(after, functions, types, typedefs.updated(alias.tt, Foreign.Type.Named(topic)))
 
+        // A variant (or a bodyless resource) has no navigable members, but must still record
+        // which module defines it, so functions in *other* interfaces that mention it (e.g. in a
+        // `result` error arm) resolve its facade class through `definingModule`: a single
+        // unnameable member carries the module.
         case "variant" :: variant :: "{" :: rest =>
-          val updated = types.updated(variant.tt, ListMap[Text, Prototype]())
+          val updated = types.updated(variant.tt, declaration(variant.tt, module))
           recur(skipBraces(rest, 1), functions, updated, typedefs)
 
         case "resource" :: resource :: "{" :: rest =>
@@ -203,7 +220,8 @@ object WitDialect extends Dialect:
           recur(after, functions, types.updated(resource.tt, methods), typedefs)
 
         case "resource" :: resource :: ";" :: rest =>
-          recur(rest, functions, types.updated(resource.tt, ListMap()), typedefs)
+          val updated = types.updated(resource.tt, declaration(resource.tt, module))
+          recur(rest, functions, updated, typedefs)
 
         case "use" :: rest =>
           recur(skipTo(rest, t";"), functions, types, typedefs)
@@ -255,7 +273,8 @@ object WitDialect extends Dialect:
       case "constructor" :: "(" :: rest =>
         val (parameters, after) = params(rest, Nil)
         val signature = Prototype(parameters, Foreign.Type.Named(resource), module, resource, true)
-        resourceBody(skipTo(after, t";"), resource, module, methods.updated(t"constructor", signature))
+        val updated = methods.updated(t"constructor", signature)
+        resourceBody(skipTo(after, t";"), resource, module, updated)
 
       case method :: ":" :: "static" :: "func" :: "(" :: rest =>
         val (parameters, after) = params(rest, Nil)
@@ -279,6 +298,10 @@ object WitDialect extends Dialect:
 
       case _ :: rest =>
         resourceBody(rest, resource, module, methods)
+
+  // The pseudo-member recording, for a memberless type declaration, the module that defines it.
+  private def declaration(name: Text, module: Optional[Text]): Map[Text, Prototype] =
+    ListMap(t"" -> Prototype(Unset, Foreign.Type.Named(name), module))
 
   private def recordFields(tokens: List[String], acc: Map[Text, Prototype])
   :   (Map[Text, Prototype], List[String]) =


### PR DESCRIPTION
A new `telekinesis.wasi` module provides a GET-only `Http.Backend` over `wasi:http/outgoing-handler`, so applications linked as Wasm Components can make real HTTP requests through the host. Verified end-to-end under `wasmtime -S http`: a component fetched `http://example.com/` and read the status, all response headers and the full body. Getting there required several new rungs in xenophile's `invoke` machinery (paired with a forked-compiler change carrying exact WIT parameter types across erasure).

## `httpBackends.wasi`

On a Wasm target, summon the WASI HTTP transport with:
```scala
import telekinesis.wasiHttpApi
import httpBackends.wasi

url"http://example.com/".fetch()
```
The backend assembles the request from `wasi:http/types` resources (a `fields` for the headers, then an `outgoing-request`), hands it to `outgoing-handler.handle`, blocks on the response future's `pollable`, and reads the body from the response's `input-stream`. Requests are currently sent with the host's default method and scheme (i.e. `GET`, plain HTTP): setting either takes a WIT `variant` argument, which `invoke` cannot yet marshal.

## `invoke` machinery

- **Structured parameter types**: every argument now crosses the boundary with its exact WIT type as a structured descriptor (`witParam`), so parameters like `option<string>` — whose payload `classOf` erases — work.
- **Recursive result decoding**: derivation is driven by the WIT result type, so wrapped shapes compose; the WASI response flow's `option<result<result<incoming-response, error-code>>>` decodes directly into an `Optional[WitHandle of "incoming-response"]`.
- **New argument forms**: WIT resources (a `WitHandle` passed by handle, e.g. to a constructor), `Optional[T]` and absent (`Unset`) values, and plain values against `option<T>` parameters (auto-wrapped as present options). Argument type-checking now uses subsumption, so a `string` satisfies an `option<string>`.
- **Void functions**: `invoke[Unit]` accepts genuinely void WIT functions (e.g. `pollable.block`), not only `result<…>`-returning ones.
- The WIT dialect normalizes `result` types to two arms, records the defining module of `variant` and bodyless `resource` declarations (so types referenced across interfaces resolve their facades), and reads `%`-escaped names.