### PR TITLE
Support WIT variant arguments and request bodies in telekinesis.wasi

### DIFF
--- a/lib/telekinesis/res/wasi/telekinesis/http.wit
+++ b/lib/telekinesis/res/wasi/telekinesis/http.wit
@@ -18,12 +18,18 @@ interface streams {
   resource input-stream {
     blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
   }
+
+  resource output-stream {
+    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+  }
 }
 
 package wasi:http@0.2.0;
 
 interface types {
   variant error-code {}
+  variant method {}
+  variant scheme {}
 
   resource request-options;
 
@@ -35,8 +41,16 @@ interface types {
 
   resource outgoing-request {
     constructor(headers: fields);
+    set-method: func(method: method) -> result;
+    set-scheme: func(scheme: option<scheme>) -> result;
     set-authority: func(authority: option<string>) -> result;
     set-path-with-query: func(path-with-query: option<string>) -> result;
+    body: func() -> result<outgoing-body>;
+  }
+
+  resource outgoing-body {
+    write: func() -> result<output-stream>;
+    finish: static func(this: outgoing-body, trailers: option<fields>) -> result<_, error-code>;
   }
 
   resource future-incoming-response {

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -41,6 +41,7 @@ import hellenism.*
 import hypotenuse.*
 import prepositional.*
 import rudiments.*
+import spectacular.*
 import vacuous.*
 import soundness.{invoke, dispose}
 import xenophile.*
@@ -53,15 +54,12 @@ given wasiHttpApi: WasiHttpApi = Interface[Wit](cp"/telekinesis/http.wit")
 
 package httpBackends:
   // An `Http.Backend` over `wasi:http/outgoing-handler`: the request is assembled from
-  // `wasi:http/types` resources (`fields` for the headers, then an `outgoing-request`), handed to
-  // the host, and its response awaited through the pollable and read from the body's
+  // `wasi:http/types` resources (`fields` for the headers, then an `outgoing-request` with its
+  // method, scheme, authority and path, plus an `outgoing-body` when the method carries one),
+  // handed to the host, and its response awaited through the pollable and read from the body's
   // `input-stream`. `inline`, so the `invoke`s expand at the downstream summoning site: the Wasm
   // Component imports only materialize in code compiled for a Wasm target. Summoning it requires
   // `wasiHttpApi` (and this module's WIT resource) to be visible at that site.
-  //
-  // Only `GET` requests are supported so far: setting the method or scheme on an
-  // `outgoing-request` takes a WIT `variant` argument, which `invoke` cannot yet marshal, so the
-  // request is sent with its defaults (`GET`, and a scheme of the host's choosing).
   //
   // The per-site duplication the compiler warns about is the point: the instance must materialize
   // at the downstream summoning site, and a WASI-linked application summons it once.
@@ -75,13 +73,11 @@ package httpBackends:
       ( using Tactic[ConnectError] )
     :   Http.Response =
 
-      if method != Http.Get then abort(ConnectError(ConnectError.Reason.Unknown))
-
-      // The URL arrives fully resolved; split it into the authority and the path-with-query the
-      // `outgoing-request` setters take. (The scheme is currently left unset — see above.)
-      val afterScheme: Text = url.cut(t"://", 2) match
-        case List(_, rest) => rest
-        case _             => url
+      // The URL arrives fully resolved; split it into the scheme, authority and path-with-query
+      // the `outgoing-request` setters take.
+      val (scheme: Text, afterScheme: Text) = url.cut(t"://", 2) match
+        case List(scheme, rest) => (scheme, rest)
+        case _                  => (t"http", url)
 
       val (authority: Text, target: Text) = afterScheme.cut(t"/", 2) match
         case List(host, path) => (host, t"/$path")
@@ -108,17 +104,46 @@ package httpBackends:
       val requestHandle =
         outgoingRequest.constructor(fieldsHandle).invoke[WitHandle of "outgoing-request"]
 
-      // The setters take `option<string>`s; a plain `string` argument subsumes (and crosses the
-      // boundary wrapped as a present option).
+      // The method and scheme are WIT `variant` cases, selected by their lower-kebab-case names;
+      // the other setters take `option<string>`s, which a plain `string` argument subsumes (and
+      // crosses the boundary wrapped as a present option).
       val request: Foreign of "outgoing-request" from Wit = requestHandle
+      request.`set-method`(WitCase["method"](method.show.lower)).invoke[Unit]
+      request.`set-scheme`(WitCase["scheme"](scheme.lower)).invoke[Unit]
       request.`set-authority`(authority).invoke[Unit]
       request.`set-path-with-query`(target).invoke[Unit]
+
+      // A method that carries a payload streams it through the request's `outgoing-body`, which
+      // must then be `finish`ed (a static function) for the request to be complete.
+      val payload: LazyList[Data] = if method.payload then body() else LazyList()
+
+      val bodyHandles =
+        if payload.isEmpty then Unset else
+          val bodyHandle = request.body.invoke[WitHandle of "outgoing-body"]
+          val outgoingBody: Foreign of "outgoing-body" from Wit = bodyHandle
+          val writeHandle = outgoingBody.write.invoke[WitHandle of "output-stream"]
+          (bodyHandle, writeHandle)
 
       val outgoingHandler =
         Foreign["outgoing-handler", Wit].asInstanceOf[Foreign of "outgoing-handler" from Wit]
 
       val futureHandle =
         outgoingHandler.handle(requestHandle, Unset).invoke[WitHandle of "future-incoming-response"]
+
+      // The payload is written after the request is handed off (the host consumes it as it
+      // arrives) and before blocking on the response.
+      bodyHandles.let: (bodyHandle, writeHandle) =>
+        val outStream: Foreign of "output-stream" from Wit = writeHandle
+
+        payload.each: chunk =>
+          outStream.`blocking-write-and-flush`(chunk).invoke[Unit]
+
+        writeHandle.dispose()
+
+        val outgoingBody =
+          Foreign["outgoing-body", Wit].asInstanceOf[Foreign of "outgoing-body" from Wit]
+
+        outgoingBody.finish(bodyHandle, Unset).invoke[Unit]
 
       val future: Foreign of "future-incoming-response" from Wit = futureHandle
 

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -366,57 +366,85 @@ object WasmInvoke:
     if arity != argumentTerms.length then
       halt(m"xenophile: $owner.$function takes $arity parameters, not ${argumentTerms.length}")
 
+    // A payload-less `variant` case argument (a `WitCase of topic`): the facade case object,
+    // selected by name at runtime from the sealed facade trait's children. The case-object names
+    // are matched in their lower-kebab-case form (`DnsTimeout` matches `dns-timeout`).
+    def caseArgument(topic: Text, value: Term): (TypeRepr, Term) =
+      val facade = facadeOf(topic)
+      val selector = '{${value.asExprOf[Any]}.asInstanceOf[WitCase].name.s}.asTerm
+
+      val caseDefs: List[CaseDef] = facade.children.flatMap: child =>
+        if child.flags.is(Flags.Module) then
+          val name = child.name.tt.uncamel.kebab
+          List(CaseDef(Literal(StringConstant(name.s)), None, Ref(child.companionModule)))
+        else
+          List()
+
+      val missing =
+        CaseDef
+          ( Wildcard(), None,
+            '{throw new RuntimeException("xenophile: not a case of " + ${Expr(topic.s)})}.asTerm )
+
+      (facade.typeRef, Match(selector, caseDefs :+ missing))
+
     def encodedArgument(value: Term, parameter: Foreign.Type): (TypeRepr, Term) =
-      value.tpe.widen.dealias match
-      // A statically-absent argument (a bare `Unset` against an `option<T>` parameter, e.g. the
-      // `option<request-options>` of `wasi:http`'s `handle`) needs no payload codec at all.
-      case tpe if tpe =:= TypeRepr.of[Unset] =>
-        (optionClass.typeRef, '{java.util.Optional.empty[Any]().nn}.asTerm)
+      val (carrier, encoded, alreadyOption) = value.tpe.widen.dealias match
+        // A statically-absent argument (a bare `Unset` against an `option<T>` parameter, e.g. the
+        // `option<request-options>` of `wasi:http`'s `handle`) needs no payload codec at all.
+        case tpe if tpe =:= TypeRepr.of[Unset] =>
+          (optionClass.typeRef, '{java.util.Optional.empty[Any]().nn}.asTerm, true)
 
-      // A resource argument (a `WitHandle of topic`, e.g. the `fields` passed to
-      // `outgoing-request`'s constructor) crosses as its facade class, unwrapped to the raw
-      // handle.
-      case Refinement(base, "Topic", TypeBounds(_, ConstantType(StringConstant(topic))))
-      if base =:= TypeRepr.of[WitHandle] =>
-        val encoded = '{${value.asExprOf[Any]}.asInstanceOf[WitHandle].value}.asTerm
-        (facadeOf(topic.tt).typeRef, encoded)
+        // A resource argument (a `WitHandle of topic`, e.g. the `fields` passed to
+        // `outgoing-request`'s constructor) crosses as its facade class, unwrapped to the raw
+        // handle.
+        case Refinement(base, "Topic", TypeBounds(_, ConstantType(StringConstant(topic))))
+        if base =:= TypeRepr.of[WitHandle] =>
+          val encoded = '{${value.asExprOf[Any]}.asInstanceOf[WitHandle].value}.asTerm
+          (facadeOf(topic.tt).typeRef, encoded, false)
 
-      case OrType(left, right)
-      if left =:= TypeRepr.of[Unset] || right =:= TypeRepr.of[Unset] =>
-        val inner0 = if left =:= TypeRepr.of[Unset] then right else left
+        case Refinement(base, "Topic", TypeBounds(_, ConstantType(StringConstant(topic))))
+        if base =:= TypeRepr.of[WitCase] =>
+          val (carrier, encoded) = caseArgument(topic.tt, value)
+          (carrier, encoded, false)
 
-        inner0.asType.absolve match
-          case '[inner] =>
-            val encodable = Expr.summon[inner is Encodable in Wasm].getOrElse:
-              halt(m"xenophile: no way to pass a ${inner0.show} across a WIT boundary")
+        case OrType(left, right)
+        if left =:= TypeRepr.of[Unset] || right =:= TypeRepr.of[Unset] =>
+          val inner0 = if left =:= TypeRepr.of[Unset] then right else left
 
-            val optional = value.asExprOf[Optional[inner]]
+          inner0.asType.absolve match
+            case '[inner] =>
+              val encodable = Expr.summon[inner is Encodable in Wasm].getOrElse:
+                halt(m"xenophile: no way to pass a ${inner0.show} across a WIT boundary")
 
-            // `match`, not `let`/`lay`: `Optional`'s inline combinators crash `pickleQuotes`
-            // inside staged code.
-            val encoded =
-              '{  $optional match
-                    case Unset => java.util.Optional.empty[Any]().nn
+              val optional = value.asExprOf[Optional[inner]]
 
-                    case value =>
-                      java.util.Optional.of($encodable.encoded(value.asInstanceOf[inner]).value)
-                      . nn  }
+              // `match`, not `let`/`lay`: `Optional`'s inline combinators crash `pickleQuotes`
+              // inside staged code.
+              val encoded =
+                '{  $optional match
+                      case Unset => java.util.Optional.empty[Any]().nn
 
-            (optionClass.typeRef.appliedTo(List(carrierType(encodable))), encoded.asTerm)
+                      case value =>
+                        java.util.Optional.of($encodable.encoded(value.asInstanceOf[inner]).value)
+                        . nn  }
 
-      case other => other.asType.absolve match
-        case '[argument] =>
-          val encodable = Expr.summon[argument is Encodable in Wasm].getOrElse:
-            halt(m"xenophile: no way to pass a ${other.show} across a WIT boundary")
+              (optionClass.typeRef.appliedTo(List(carrierType(encodable))), encoded.asTerm, true)
 
-          val encoded = '{$encodable.encoded(${value.asExprOf[argument]}).value}.asTerm
+        case other => other.asType.absolve match
+          case '[argument] =>
+            val encodable = Expr.summon[argument is Encodable in Wasm].getOrElse:
+              halt(m"xenophile: no way to pass a ${other.show} across a WIT boundary")
 
-          // A plain (always-present) value against an `option<T>` parameter crosses as a present
-          // `java.util.Optional`, matching the parameter's descriptor.
-          if optionPayload(parameter).present then
-            val wrapped = '{java.util.Optional.of(${encoded.asExprOf[Any]}).nn}.asTerm
-            (optionClass.typeRef.appliedTo(List(carrierType(encodable))), wrapped)
-          else (carrierType(encodable), encoded)
+            val encoded = '{$encodable.encoded(${value.asExprOf[argument]}).value}.asTerm
+            (carrierType(encodable), encoded, false)
+
+      // A plain (always-present) value against an `option<T>` parameter crosses as a present
+      // `java.util.Optional`, matching the parameter's descriptor.
+      if optionPayload(parameter).present && !alreadyOption then
+        val wrapped = '{java.util.Optional.of(${encoded.asExprOf[Any]}).nn}.asTerm
+        (optionClass.typeRef.appliedTo(List(carrier)), wrapped)
+      else
+        (carrier, encoded)
 
     val argumentPairs: List[Term] =
       argumentTerms.zip(parameterTypes).flatMap: (argument, parameter) =>

--- a/lib/xenophile/src/wasm/xenophile.WitCase.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitCase.scala
@@ -30,23 +30,22 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Wasm, WasmInvoke, WitCase, WitHandle}
+import anticipation.*
+import prepositional.*
 
-// Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
-// call. Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
-// Plain `inline` (not `transparent`): the return type is fully determined by the type argument,
-// and non-transparency defers the macro when `invoke` appears inside another `inline` definition,
-// so a library can publish an inline given whose import call only materializes at the downstream
-// (Wasm-linked) call site — where `scala.scalajs.wit.witImportCall` is on the classpath.
-extension (foreign: xenophile.Foreign)
-  inline def invoke[result]: result =
-    ${xenophile.WasmInvoke.invoke[result]('foreign)}
+// A payload-less case of a WIT `variant` (or `enum`), named by its lower-kebab-case Scala-side
+// name (e.g. `get` or `dns-timeout`), for passing as an argument to a WIT function — such as the
+// `method` taken by `wasi:http`'s `outgoing-request.set-method`. The phantom `Topic` records the
+// variant type, so the value converts (via the `Interoperable` instance below) into an argument of
+// that foreign type; `invoke` selects the corresponding facade case object at runtime.
+object WitCase:
+  def apply[topic <: Label](name: Text): WitCase of topic =
+    new WitCase(name).asInstanceOf[WitCase of topic]
 
-// Releases a WIT resource handle, emitting its `[resource-drop]` Component Model import. Like
-// `invoke`, plain `inline` so the import materializes at the downstream (Wasm-linked) call site.
-extension (handle: xenophile.WitHandle)
-  inline def dispose(): Unit =
-    ${xenophile.WasmInvoke.dispose('handle)}
+  given interoperable: [topic <: Label]
+  =>  ( (WitCase of topic) is Interoperable in Wit of topic ) =
+    Interoperable()
+
+final class WitCase(val name: Text) extends Topical


### PR DESCRIPTION
The WASI HTTP backend now supports every HTTP method, HTTPS, and request payloads — completing the client that #1488 introduced as GET-only. Verified end-to-end under `wasmtime -S http`: an HTTPS GET of `https://example.com/` (status 200) and a POST to an echo service whose response contained the posted body.

## `WitCase`: variant arguments

A payload-less case of a WIT `variant` (or `enum`) can now be passed as an argument, named by its lower-kebab-case name:

```scala
request.`set-method`(WitCase["method"](t"post")).invoke[Unit]
request.`set-scheme`(WitCase["scheme"](t"https")).invoke[Unit]
```

`invoke` selects the corresponding facade case object at runtime from the variant's sealed facade trait. (Cases carrying payloads, like `method`'s `other(string)`, are not yet supported.) A `WitCase` against an `option<variant>` parameter is wrapped as a present option automatically, like any other plain argument.

## Request bodies

A method that carries a payload streams it through the request's `outgoing-body` resource (`body` → `write` → `blocking-write-and-flush` per chunk) and completes it with the static `finish` function — exercising static functions with resource-valued and absent-option arguments.

With these, `httpBackends.wasi` sets the method, scheme, authority and path on every request, so the full `fetch`/`submit` surface of telekinesis works from a Wasm Component.