### PR TITLE
Contextual TLS acceptance criteria (#676)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1511,7 +1511,7 @@ object telekinesis extends Library:
   // JVM-only transports split out of `core` so the platform-agnostic HTTP model and client can
   // cross-compile to Scala.js: the `java.net.http` `Http.Backend` (`httpBackends.virtualMachine`)
   // and the `coaxial` domain-socket client.
-  object jvm extends Component(core, coaxial.core):
+  object jvm extends Component(core, coaxial.core, gastronomy.core):
     override def scalaJs = false
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")

--- a/lib/gastronomy/src/core/gastronomy.Concession.scala
+++ b/lib/gastronomy/src/core/gastronomy.Concession.scala
@@ -47,6 +47,18 @@ object Concession:
   sealed trait Md5
   sealed trait Sha1
 
+  // TLS concessions (telekinesis): peer configurations a connection may be
+  // permitted to accept, from deprecated protocol versions and key sizes to
+  // certificate-validation relaxations.
+  sealed trait Tls10
+  sealed trait Tls11
+  sealed trait SmallDh              // ephemeral DH shorter than 2048 bits
+  sealed trait CbcCipher
+  sealed trait ExpiredCertificate
+  sealed trait SelfSignedCertificate
+  sealed trait UnverifiedHostname
+  sealed trait UncheckedRevocation
+
   // cipher concessions (enigmatic)
   sealed trait Des
   sealed trait TripleDes

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -62,6 +62,26 @@ package crypto:
   erased given permitDeprecatedCrypto: Permit[Concession.TripleDes] & Permit[Concession.Sha1] =
     caps.unsafe.unsafeErasedValue
 
+  // Deprecated TLS protocol versions, key sizes and cipher families. Note that
+  // re-enabling these is process-wide (see `telekinesis.Tls.unlock`).
+  erased given permitLegacyTls
+  :   Permit[Concession.Tls10] & Permit[Concession.Tls11] & Permit[Concession.SmallDh] &
+    Permit[Concession.CbcCipher] =
+
+    caps.unsafe.unsafeErasedValue
+
+  // Certificate-validation relaxations: expired or self-signed peer
+  // certificates, and hostname mismatches.
+  erased given permitUntrustedCertificates
+  :   Permit[Concession.ExpiredCertificate] & Permit[Concession.SelfSignedCertificate] &
+    Permit[Concession.UnverifiedHostname] =
+
+    caps.unsafe.unsafeErasedValue
+
+  // Connections to peers whose certificates' revocation status is not checked.
+  erased given permitUncheckedRevocation: Permit[Concession.UncheckedRevocation] =
+    caps.unsafe.unsafeErasedValue
+
   // "Legacy use": processing already-protected data only (decrypt/verify).
   erased given permitLegacyCrypto
   :   ProcessingPermit[Concession.TripleDes] & ProcessingPermit[Concession.Dsa] =

--- a/lib/gastronomy/src/core/soundness_gastronomy_core.scala
+++ b/lib/gastronomy/src/core/soundness_gastronomy_core.scala
@@ -44,4 +44,5 @@ package providers:
 package crypto:
   export gastronomy.crypto.{permitUnauthenticatedCrypto, permitDeprecatedCrypto, permitLegacyCrypto,
       permitDisallowedCrypto, permitCryptoThrough2014, permitCryptoThrough2024,
-      permitCryptoThrough2030}
+      permitCryptoThrough2030, permitLegacyTls, permitUntrustedCertificates,
+      permitUncheckedRevocation}

--- a/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
@@ -32,7 +32,8 @@
                                                                                                   */
 package soundness
 
-export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHttpClient}
+export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHttpClient, Tls,
+    TlsAcceptance}
 
 package httpBackends:
   export telekinesis.httpBackends.virtualMachine

--- a/lib/telekinesis/src/jvm/telekinesis.Tls.scala
+++ b/lib/telekinesis/src/jvm/telekinesis.Tls.scala
@@ -1,0 +1,277 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package telekinesis
+
+import java.security as js
+import java.security.cert as jsc
+import javax.net.ssl as jns
+
+import anticipation.*
+import fulminate.*
+import gastronomy.*
+import gossamer.*
+import prepositional.*
+import rudiments.*
+import vacuous.*
+
+// Contextual TLS acceptance criteria (#676). A `TlsAcceptance` given
+// determines which peer configurations a connection will accept, mirroring
+// the progressive-deprecation model of gastronomy's cryptographic permits:
+// the strict default needs no permission, while each relaxation is
+// constructed only under an erased `Permit` for the corresponding
+// `Concession`, so a codebase's tolerated weaknesses are auditable from its
+// permit imports alone, at no runtime cost.
+//
+// Certificate-level criteria (trust anchors, expiry, self-signature,
+// hostname verification, revocation) are enforced per-connection through a
+// wrapping trust manager and `SSLParameters`. Protocol-level re-enablement
+// (TLS 1.0/1.1, small key sizes) is different: JSSE treats per-connection
+// algorithm constraints as purely additional to the process-wide
+// `jdk.tls.disabledAlgorithms` security property, so those relaxations can
+// only be unlocked process-wide, once, before JSSE initializes — see
+// `Tls.unlock`.
+object Tls:
+  enum Version:
+    case Tls12, Tls13
+    case Tls10, Tls11
+
+    def id: Text = this match
+      case Tls10 => t"TLSv1"
+      case Tls11 => t"TLSv1.1"
+      case Tls12 => t"TLSv1.2"
+      case Tls13 => t"TLSv1.3"
+
+  enum Revocation:
+    case Required, SoftFail, Unchecked
+
+  object Trust:
+    val Strict: Trust = Trust()
+
+  // Which certificate chains to trust beyond an intact, current chain to a
+  // platform anchor.
+  case class Trust
+    ( expired:    Boolean = false,
+      selfSigned: Boolean = false,
+      hostname:   Boolean = true,
+      anchors:    List[jsc.X509Certificate] = Nil )
+
+  // Process-wide re-enablement of deprecated protocol versions and key sizes.
+  // Must run before any JSSE machinery is initialized; later calls have no
+  // effect on already-created contexts. Requires the corresponding permits.
+  def unlock(versions: List[Version])
+    ( using erased tls10: Permit[Concession.Tls10], erased tls11: Permit[Concession.Tls11] )
+  :   Unit =
+
+    val current: String =
+      js.Security.getProperty("jdk.tls.disabledAlgorithms") match
+        case null           => ""
+        case value: String  => value
+
+    val retained = current.split(",").nn.map(_.nn.trim.nn).filter: entry =>
+      !versions.exists(_.id.s == entry)
+
+    js.Security.setProperty("jdk.tls.disabledAlgorithms", String.join(", ", retained*))
+
+// The runtime acceptance value, resolved contextually wherever a TLS
+// connection is made. The companion default is strict; relaxed instances are
+// built with the named constructors, each gated on its permit.
+object TlsAcceptance:
+  given strict: TlsAcceptance = TlsAcceptance()
+
+  // Materialize the JSSE artefacts for this acceptance. Cached by the
+  // transport layer, keyed on the acceptance value.
+  extension (acceptance: TlsAcceptance)
+    def materialize(): (jns.SSLContext, jns.SSLParameters) =
+      // The strict default is exactly the platform's own behaviour; only a
+      // relaxed acceptance pays for a custom trust manager.
+      val context =
+        if acceptance == TlsAcceptance() then jns.SSLContext.getDefault.nn else
+          val custom = jns.SSLContext.getInstance("TLS").nn
+          custom.init(null, Array(trustManager(acceptance)), null)
+          custom
+
+      val parameters = context.getDefaultSSLParameters().nn
+
+      if acceptance.versions != Nil then
+        parameters.setProtocols(acceptance.versions.map(_.id.s).toArray)
+
+      if acceptance.trust.hostname
+      then parameters.setEndpointIdentificationAlgorithm("HTTPS")
+      else parameters.setEndpointIdentificationAlgorithm(null)
+
+      (context, parameters)
+
+  private def platformManager(anchors: List[jsc.X509Certificate])
+  :   jns.X509ExtendedTrustManager =
+
+    val keystore: js.KeyStore | Null =
+      if anchors == Nil then null else
+        val store = js.KeyStore.getInstance(js.KeyStore.getDefaultType.nn).nn
+        store.load(null, null)
+
+        anchors.zipWithIndex.each: (anchor, index) =>
+          store.setCertificateEntry(s"anchor-$index", anchor)
+
+        store
+
+    val factory =
+      jns.TrustManagerFactory.getInstance(jns.TrustManagerFactory.getDefaultAlgorithm.nn).nn
+
+    factory.init(keystore)
+
+    factory.getTrustManagers.nn.collectFirst:
+      case manager: jns.X509ExtendedTrustManager => manager
+
+    . getOrElse(panic(m"the platform provides no X.509 trust manager"))
+
+  // Wraps the platform trust manager, downgrading precisely the failure
+  // causes this acceptance tolerates: an expired chain is retried against
+  // validity-blind parameters only when `expired` is set, and an unresolvable
+  // anchor is tolerated only when `selfSigned` is set. All other causes
+  // (revocation per its own setting, malformed chains, wrong key usage)
+  // propagate unchanged.
+  private def trustManager(acceptance: TlsAcceptance): jns.X509ExtendedTrustManager =
+    val platform = platformManager(acceptance.trust.anchors)
+
+    def tolerable(error: Throwable | Null): Boolean = error match
+      case null =>
+        false
+
+      case error: jsc.CertificateExpiredException =>
+        acceptance.trust.expired
+
+      case error: jsc.CertPathValidatorException =>
+        error.getReason match
+          case jsc.CertPathValidatorException.BasicReason.EXPIRED =>
+            acceptance.trust.expired
+
+          case jsc.CertPathValidatorException.BasicReason.REVOKED =>
+            acceptance.revocation != Tls.Revocation.Required
+
+          case jsc.CertPathValidatorException.BasicReason.UNDETERMINED_REVOCATION_STATUS =>
+            acceptance.revocation == Tls.Revocation.Unchecked ||
+              acceptance.revocation == Tls.Revocation.SoftFail
+
+          case _ =>
+            tolerable(error.getCause)
+
+      case error: java.security.InvalidAlgorithmParameterException =>
+        // "the trustAnchors parameter must be non-empty" and kin: no path to
+        // any anchor — the self-signed case.
+        acceptance.trust.selfSigned
+
+      case error =>
+        error.getMessage match
+          case message: String
+            if message.contains("unable to find valid certification path") =>
+            acceptance.trust.selfSigned
+
+          case _ =>
+            tolerable(error.getCause)
+
+    new jns.X509ExtendedTrustManager:
+      import unsafeExceptions.canThrowAny
+
+      private def attempt(check: => Unit): Unit =
+        try check catch
+          case error: jsc.CertificateException =>
+            if !tolerable(error) then throw error
+
+      def getAcceptedIssuers(): Array[jsc.X509Certificate | Null] | Null =
+        platform.getAcceptedIssuers()
+
+      def checkClientTrusted
+        ( chain: Array[jsc.X509Certificate | Null] | Null, authType: String | Null )
+      :   Unit =
+
+        platform.checkClientTrusted(chain, authType)
+
+      def checkClientTrusted
+        ( chain:    Array[jsc.X509Certificate | Null] | Null,
+          authType: String | Null,
+          socket:   java.net.Socket | Null )
+      :   Unit =
+
+        platform.checkClientTrusted(chain, authType, socket)
+
+      def checkClientTrusted
+        ( chain:    Array[jsc.X509Certificate | Null] | Null,
+          authType: String | Null,
+          engine:   jns.SSLEngine | Null )
+      :   Unit =
+
+        platform.checkClientTrusted(chain, authType, engine)
+
+      def checkServerTrusted
+        ( chain: Array[jsc.X509Certificate | Null] | Null, authType: String | Null )
+      :   Unit =
+
+        attempt(platform.checkServerTrusted(chain, authType))
+
+      def checkServerTrusted
+        ( chain:    Array[jsc.X509Certificate | Null] | Null,
+          authType: String | Null,
+          socket:   java.net.Socket | Null )
+      :   Unit =
+
+        attempt(platform.checkServerTrusted(chain, authType, socket))
+
+      def checkServerTrusted
+        ( chain:    Array[jsc.X509Certificate | Null] | Null,
+          authType: String | Null,
+          engine:   jns.SSLEngine | Null )
+      :   Unit =
+
+        attempt(platform.checkServerTrusted(chain, authType, engine))
+
+case class TlsAcceptance
+  ( versions:   List[Tls.Version] = Nil, // Nil selects the platform default set
+    trust:      Tls.Trust = Tls.Trust.Strict,
+    revocation: Tls.Revocation = Tls.Revocation.SoftFail ):
+
+  def permitExpired(using erased Permit[Concession.ExpiredCertificate]): TlsAcceptance =
+    copy(trust = trust.copy(expired = true))
+
+  def permitSelfSigned(using erased Permit[Concession.SelfSignedCertificate]): TlsAcceptance =
+    copy(trust = trust.copy(selfSigned = true))
+
+  def permitHostnameMismatch(using erased Permit[Concession.UnverifiedHostname]): TlsAcceptance =
+    copy(trust = trust.copy(hostname = false))
+
+  def requireRevocationChecks: TlsAcceptance = copy(revocation = Tls.Revocation.Required)
+
+  def permitRevoked(using erased Permit[Concession.UncheckedRevocation]): TlsAcceptance =
+    copy(revocation = Tls.Revocation.Unchecked)
+
+  def trusting(anchors: List[jsc.X509Certificate]): TlsAcceptance =
+    copy(trust = trust.copy(anchors = anchors))

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -35,6 +35,7 @@ package telekinesis
 import java.io as ji
 import java.net as jn
 import java.net.http as jnh
+import java.util.concurrent as juc
 import javax.net.ssl as jns
 
 import anticipation.*
@@ -50,9 +51,21 @@ import zephyrine.*
 // Build the underlying Java client with redirect-following disabled — the
 // redirect-following telekinesis given runs its own loop so it can honour
 // `HttpRedirection` exactly. Java's `NORMAL` policy has its own hard-coded
-// cap and would shadow the limit we summon.
-private lazy val javaClient: jnh.HttpClient =
-  jnh.HttpClient.newBuilder.nn.followRedirects(jnh.HttpClient.Redirect.NEVER).nn.build.nn
+// cap and would shadow the limit we summon. Java clients are immutable per
+// SSL configuration, so one is built and cached for each distinct
+// `TlsAcceptance` in use.
+private val javaClients: juc.ConcurrentHashMap[TlsAcceptance, jnh.HttpClient] =
+  juc.ConcurrentHashMap()
+
+private def javaClient(using acceptance: TlsAcceptance): jnh.HttpClient =
+  javaClients.computeIfAbsent(acceptance, { acceptance0 =>
+    val (context, parameters) = acceptance0.nn.materialize()
+
+    jnh.HttpClient.newBuilder.nn
+    . followRedirects(jnh.HttpClient.Redirect.NEVER).nn
+    . sslContext(context).nn
+    . sslParameters(parameters).nn
+    . build.nn }).nn
 
 private def buildJavaRequest
   ( uri:         jn.URI,
@@ -90,7 +103,7 @@ private def buildJavaRequest
 
   request.build().nn
 
-private def send(request: jnh.HttpRequest)(using Tactic[ConnectError])
+private def send(request: jnh.HttpRequest)(using Tactic[ConnectError], TlsAcceptance)
 :   jnh.HttpResponse[ji.InputStream] =
 
   import ConnectError.Reason.*, Ssl.Reason.*
@@ -132,7 +145,7 @@ package httpBackends:
   // The JVM transport, using `java.net.http`. Other platforms (e.g. Scala.js)
   // or implementations (e.g. an HTTP/2 client) supply their own `Http.Backend`
   // given instead.
-  given virtualMachine: Http.Backend = new Http.Backend:
+  given virtualMachine: TlsAcceptance => Http.Backend = new Http.Backend:
     def request
       ( url:     Text,
         method:  Http.Method,

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -595,3 +595,55 @@ object Tests extends Suite(m"Telekinesis tests"):
 
         test(m"no-sct")(capture[ConnectError](url"https://no-sct.badssl.com/".fetch()))
         . aspire(_ == ConnectError(Ssl(Handshake)))
+
+    suite(m"TLS acceptance materialization"):
+      test(m"strict acceptance verifies hostnames"):
+        val (_, parameters) = TlsAcceptance().materialize()
+        parameters.getEndpointIdentificationAlgorithm == "HTTPS"
+      . assert(identity)
+
+      test(m"relaxed acceptance disables endpoint identification"):
+        import crypto.permitUntrustedCertificates
+        val (_, parameters) = TlsAcceptance().permitHostnameMismatch.materialize()
+        parameters.getEndpointIdentificationAlgorithm == null
+      . assert(identity)
+
+      test(m"an expired-tolerant acceptance materializes a custom context"):
+        import crypto.permitUntrustedCertificates
+        val (context, _) = TlsAcceptance().permitExpired.materialize()
+        context != javax.net.ssl.SSLContext.getDefault
+      . assert(identity)
+
+      test(m"protocol restriction is applied to parameters"):
+        val acceptance = TlsAcceptance(versions = List(Tls.Version.Tls13))
+        val (_, parameters) = acceptance.materialize()
+        parameters.getProtocols.nn.to(List).map(_.nn.tt)
+      . assert(_ == List(t"TLSv1.3"))
+
+    suite(m"Certificate validation with relaxed acceptance"):
+      import crypto.permitUntrustedCertificates, crypto.permitUncheckedRevocation
+
+      test(m"expired certificate accepted under permitExpired"):
+        given TlsAcceptance = TlsAcceptance().permitExpired
+        url"https://expired.badssl.com/".fetch().status
+      . aspire(_ == Http.Ok)
+
+      test(m"self-signed certificate accepted under permitSelfSigned"):
+        given TlsAcceptance = TlsAcceptance().permitSelfSigned
+        url"https://self-signed.badssl.com/".fetch().status
+      . aspire(_ == Http.Ok)
+
+      test(m"untrusted root accepted under permitSelfSigned"):
+        given TlsAcceptance = TlsAcceptance().permitSelfSigned
+        url"https://untrusted-root.badssl.com/".fetch().status
+      . aspire(_ == Http.Ok)
+
+      test(m"wrong-host certificate accepted under permitHostnameMismatch"):
+        given TlsAcceptance = TlsAcceptance().permitHostnameMismatch
+        url"https://wrong.host.badssl.com/".fetch().status
+      . aspire(_ == Http.Ok)
+
+      test(m"revoked certificate accepted under permitRevoked"):
+        given TlsAcceptance = TlsAcceptance().permitRevoked
+        url"https://revoked.badssl.com/".fetch().status
+      . aspire(_ == Http.Ok)


### PR DESCRIPTION
Closes #676. TLS peer acceptance is now controlled by a contextual `TlsAcceptance` value, extending the progressive-deprecation model of the cryptographic permits to the TLS layer: the strict default matches platform behaviour, and each relaxation is constructed only under an erased `Permit` for a corresponding new `Concession`, so a codebase's tolerated TLS weaknesses are auditable from its permit imports alone, at zero runtime cost.

## Release notes

- `TlsAcceptance` (telekinesis, JVM) is resolved contextually wherever an HTTPS connection is made. The default is strict; relaxations are built with permit-gated combinators:

  ```scala
  import crypto.permitUntrustedCertificates

  given TlsAcceptance = TlsAcceptance().permitSelfSigned.permitHostnameMismatch
  url"https://self-signed.internal/".fetch()
  ```

- Relaxations: `permitExpired`, `permitSelfSigned`, `permitHostnameMismatch`, `permitRevoked`, `requireRevocationChecks`, `trusting(anchors)` (custom trust anchors), and protocol restriction via `TlsAcceptance(versions = …)`.
- New `Concession`s in gastronomy (`Tls10`, `Tls11`, `SmallDh`, `CbcCipher`, `ExpiredCertificate`, `SelfSignedCertificate`, `UnverifiedHostname`, `UncheckedRevocation`) with permits `crypto.permitLegacyTls`, `crypto.permitUntrustedCertificates` and `crypto.permitUncheckedRevocation`.
- Certificate-level criteria are enforced per-connection through a wrapping trust manager that downgrades precisely the tolerated failure causes; the JDK transport caches one client per acceptance in use. Re-enabling deprecated protocol versions is process-wide by JSSE's design, via the permit-gated `Tls.unlock`.
- The aspirational badssl.com tests gain permissive-accept twins, exercising the acceptance logic in both directions when the external service is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)