### PR TITLE
Add a WASI filesystem backend to galilei.wasi

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -964,6 +964,12 @@ object galilei extends Library:
     override def scalaJs = false
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // A `FilesystemBackend` over `wasi:filesystem`, materialized by xenophile's `invoke` at the
+  // downstream (Wasm-linked) summoning site. Target-neutral `.sjsir` here; only meaningful linked
+  // as a component.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core, jvm)
 
 object gastronomy extends Library:

--- a/lib/galilei/res/wasi/galilei/filesystem.wit
+++ b/lib/galilei/res/wasi/galilei/filesystem.wit
@@ -1,0 +1,66 @@
+// The subset of the WASI filesystem and I/O interfaces that galilei's Wasm backend uses. Records,
+// enums and flags are written as their ABI-equivalent structural types — `descriptor-stat` as a
+// tuple (with `descriptor-type` as `u8` and `datetime` as `tuple<u64, u32>`), and the flags types
+// as `u32` — since the canonical ABI lowers each pair identically. The `error-code` and
+// `new-timestamp` variants' cases are not enumerated here: their shapes are derived from their
+// facade classes; only their names and defining interface matter to this subset.
+
+package wasi:io@0.2.0;
+
+interface streams {
+  resource input-stream {
+    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+  }
+
+  resource output-stream {
+    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+  }
+}
+
+package wasi:filesystem@0.2.0;
+
+interface types {
+  variant error-code {}
+  variant new-timestamp {}
+
+  resource directory-entry-stream {
+    read-directory-entry: func() -> result<option<tuple<u8, string>>, error-code>;
+  }
+
+  resource descriptor {
+    read-via-stream: func(offset: u64) -> result<input-stream, error-code>;
+    write-via-stream: func(offset: u64) -> result<output-stream, error-code>;
+    append-via-stream: func() -> result<output-stream, error-code>;
+
+    read-directory: func() -> result<directory-entry-stream, error-code>;
+
+    stat: func()
+      -> result<tuple<u8, u64, u64, option<tuple<u64, u32>>, option<tuple<u64, u32>>,
+         option<tuple<u64, u32>>>, error-code>;
+
+    stat-at: func(path-flags: u32, path: string)
+      -> result<tuple<u8, u64, u64, option<tuple<u64, u32>>, option<tuple<u64, u32>>,
+         option<tuple<u64, u32>>>, error-code>;
+
+    set-times-at: func(path-flags: u32, path: string, data-access-timestamp: new-timestamp,
+      data-modification-timestamp: new-timestamp) -> result<_, error-code>;
+
+    open-at: func(path-flags: u32, path: string, open-flags: u32, flags: u32)
+      -> result<descriptor, error-code>;
+
+    create-directory-at: func(path: string) -> result<_, error-code>;
+    unlink-file-at: func(path: string) -> result<_, error-code>;
+    remove-directory-at: func(path: string) -> result<_, error-code>;
+    symlink-at: func(old-path: string, new-path: string) -> result<_, error-code>;
+
+    link-at: func(old-path-flags: u32, old-path: string, new-descriptor: descriptor,
+      new-path: string) -> result<_, error-code>;
+
+    rename-at: func(old-path: string, new-descriptor: descriptor, new-path: string)
+      -> result<_, error-code>;
+  }
+}
+
+interface preopens {
+  get-directories: func() -> list<tuple<descriptor, string>>;
+}

--- a/lib/galilei/src/wasi/galilei_wasi.scala
+++ b/lib/galilei/src/wasi/galilei_wasi.scala
@@ -1,0 +1,403 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package galilei
+
+import scala.annotation.nowarn
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import hellenism.*
+import hypotenuse.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import vacuous.*
+import soundness.{invoke, dispose}
+import xenophile.*
+
+import IoError.{Operation, Reason}
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for module ids, resource methods and
+// parameter types.
+type WasiFilesystemApi = Interface in Wit at "/galilei/filesystem.wit"
+given wasiFilesystemApi: WasiFilesystemApi = Interface[Wit](cp"/galilei/filesystem.wit")
+
+package filesystemBackends:
+  // A `FilesystemBackend` over `wasi:filesystem`. WASI filesystems are capability-based: the host
+  // grants access as *preopened directory descriptors* (`wasmtime run --dir …`), and every
+  // operation resolves its path against the preopen with the longest matching prefix — a path
+  // outside every preopen raises `PermissionDenied`, which is the capability model speaking.
+  // `inline`, so the `invoke`s expand at the downstream summoning site: the Wasm Component
+  // imports only materialize in code compiled for a Wasm target. Summoning it requires
+  // `wasiFilesystemApi` (and this module's WIT resource) to be visible at that site.
+  //
+  // WASI error codes are recovered from the `WitError` raised by `invoke`'s decoder and mapped
+  // onto `IoError.Reason` — so a quota failure reports `QuotaExceeded`, not a generic error.
+  //
+  // The per-site duplication the compiler warns about is the point: the instance must
+  // materialize at the downstream summoning site, and a WASI-linked application summons it once.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasi: [plane: Filesystem] => FilesystemBackend on plane =
+    new FilesystemBackend:
+      type Plane = plane
+
+      private def reason(error: WitError): Reason = error.name.s match
+        case "no-entry"                                    => Reason.Nonexistent
+        case "exist"                                       => Reason.AlreadyExists
+        case "not-directory"                               => Reason.IsNotDirectory
+        case "is-directory"                                => Reason.IsDirectory
+        case "not-empty"                                   => Reason.DirectoryNotEmpty
+        case "access" | "not-permitted"                    => Reason.PermissionDenied
+        case "loop"                                        => Reason.Cycle
+        case "cross-device"                                => Reason.NotSameVolume
+        case "busy" | "would-block" | "text-file-busy"     => Reason.Busy
+        case "read-only"                                   => Reason.ReadOnly
+        case "too-many-links"                              => Reason.TooManyLinks
+        case "name-too-long"                               => Reason.NameTooLong
+        case "quota"                                       => Reason.QuotaExceeded
+        case "insufficient-space"                          => Reason.StorageFull
+        case "illegal-byte-sequence"                       => Reason.InvalidData
+        case "interrupted"                                 => Reason.Interrupted
+        case "io"                                          => Reason.Physical
+        case _                                             => Reason.Unsupported
+
+      private def protect[result](path: Path on Plane, operation: Operation)(block: => result)
+        ( using Tactic[IoError] )
+      :   result =
+
+        try block catch case error: WitError => abort(IoError(path, operation, reason(error)))
+
+      // The preopened directory granted by the host that covers `path` — by longest prefix —
+      // paired with the path's remainder, relative to it (WASI paths are preopen-relative and
+      // never begin with `/`).
+      private def resolve(path: Path on Plane, operation: Operation)(using Tactic[IoError])
+      :   (WitHandle of "descriptor", Text) =
+
+        val target: Text = Path.encodable.encode(path)
+
+        val preopens =
+          Foreign["preopens", Wit].`get-directories`
+          . invoke[List[(WitHandle of "descriptor", Text)]]
+
+        def covers(preopen: Text): Boolean =
+          target == preopen || preopen == t"/" || target.starts(t"$preopen/")
+
+        val covering = preopens.filter: entry =>
+          covers(entry(1))
+
+        if covering.isEmpty then
+          preopens.each(_(0).dispose())
+          abort(IoError(path, operation, Reason.PermissionDenied))
+        else
+          val (descriptor, prefix) = covering.maxBy(_(1).length)
+
+          preopens.each: entry =>
+            if entry(0) != descriptor then entry(0).dispose()
+
+          val remainder =
+            if target == prefix then t"."
+            else if prefix == t"/" then target.keep(target.length - 1, Rtl)
+            else target.keep(target.length - prefix.length - 1, Rtl)
+
+          (descriptor, remainder)
+
+      private def follow(dereference: Boolean): U32 = U32(if dereference then 1.bits else 0.bits)
+
+      // The `descriptor-stat` record's fields, as its ABI-equivalent tuple: type, link count,
+      // size, and the access/modification/status-change timestamps.
+      private type StatFields =
+        (U8, U64, U64, Optional[(U64, U32)], Optional[(U64, U32)], Optional[(U64, U32)])
+
+      private def statOf
+        ( descriptor: WitHandle of "descriptor", relative: Text, dereference: Boolean )
+      :   Stat =
+
+        val directory: Foreign of "descriptor" from Wit = descriptor
+
+        val fields = directory.`stat-at`(follow(dereference), relative).invoke[StatFields]
+
+        // `descriptor-type`'s cases, by declaration order: unknown, block-device,
+        // character-device, directory, fifo, symbolic-link, regular-file, socket.
+        val entry: Entry = fields(0).byte.toInt match
+          case 1 => BlockDevice
+          case 2 => CharDevice
+          case 3 => Directory
+          case 4 => Fifo
+          case 5 => Symlink
+          case 7 => Socket
+          case _ => File
+
+        def millis(time: Optional[(U64, U32)]): Optional[Long] =
+          time.let: time =>
+            time(0).bits.s64.long*1000L + time(1).bits.s32.int/1000000L
+
+        Stat
+          ( entry,
+            fields(2).bits.s64.long,
+            millis(fields(4)).or(0L),
+            millis(fields(3)).or(0L),
+            Unset )
+
+      def stat(path: Path on Plane, dereference: Boolean)(using Tactic[IoError]): Stat =
+        protect(path, Operation.Metadata):
+          val (descriptor, relative) = resolve(path, Operation.Metadata)
+          try statOf(descriptor, relative, dereference) finally descriptor.dispose()
+
+      def exists(path: Path on Plane, dereference: Boolean): Boolean =
+        import strategies.throwUnsafely
+
+        try
+          stat(path, dereference) yet true
+        catch case error: Exception => false
+
+      def children(path: Path on Plane)(using Tactic[IoError]): LazyList[Text] =
+        protect(path, Operation.Read):
+          val (descriptor, relative) = resolve(path, Operation.Read)
+          val directory: Foreign of "descriptor" from Wit = descriptor
+
+          try
+            val listing =
+              directory.`open-at`(follow(true), relative, U32(2.bits), U32(1.bits))
+              . invoke[WitHandle of "descriptor"]
+
+            val target: Foreign of "descriptor" from Wit = listing
+
+            try
+              val streamHandle =
+                target.`read-directory`.invoke[WitHandle of "directory-entry-stream"]
+
+              val stream: Foreign of "directory-entry-stream" from Wit = streamHandle
+
+              var names: List[Text] = Nil
+              var done: Boolean = false
+
+              while !done do
+                val entry = stream.`read-directory-entry`.invoke[Optional[(U8, Text)]]
+                if entry.absent then done = true else names = entry.vouch(1) :: names
+
+              streamHandle.dispose()
+              names.reverse.to(LazyList)
+            finally listing.dispose()
+          finally descriptor.dispose()
+
+      private def act(path: Path on Plane, operation: Operation)
+        ( block: (Foreign of "descriptor" from Wit, Text) => Unit )
+        ( using Tactic[IoError] )
+      :   Unit =
+
+        protect(path, operation):
+          val (descriptor, relative) = resolve(path, operation)
+          val directory: Foreign of "descriptor" from Wit = descriptor
+
+          try block(directory, relative) finally descriptor.dispose()
+
+      def createDirectory(path: Path on Plane)(using Tactic[IoError]): Unit =
+        act(path, Operation.Create): (directory, relative) =>
+          directory.`create-directory-at`(relative).invoke[Unit]
+
+      def createFile(path: Path on Plane)(using Tactic[IoError]): Unit =
+        act(path, Operation.Create): (directory, relative) =>
+          // open-flags: create (1) | exclusive (4); descriptor-flags: write (2)
+          val created =
+            directory.`open-at`(follow(true), relative, U32(5.bits), U32(2.bits))
+            . invoke[WitHandle of "descriptor"]
+
+          created.dispose()
+
+      def createFifo(path: Path on Plane)(using Tactic[IoError]): Unit =
+        abort(IoError(path, Operation.Create, Reason.Unsupported))
+
+      def delete(path: Path on Plane)(using Tactic[IoError]): Unit =
+        act(path, Operation.Delete): (directory, relative) =>
+          val directoryEntry =
+            try statOf(resolve(path, Operation.Delete)(0), relative, false).entry == Directory
+            catch case error: WitError => false
+
+          if directoryEntry then directory.`remove-directory-at`(relative).invoke[Unit]
+          else directory.`unlink-file-at`(relative).invoke[Unit]
+
+      def deleteIfExists(path: Path on Plane)(using Tactic[IoError]): Unit =
+        if exists(path, false) then delete(path)
+
+      def symlink(link: Path on Plane, target: Path on Plane)(using Tactic[IoError]): Unit =
+        act(link, Operation.Create): (directory, relative) =>
+          directory.`symlink-at`(Path.encodable.encode(target), relative).invoke[Unit]
+
+      def hardLink(link: Path on Plane, target: Path on Plane)(using Tactic[IoError]): Unit =
+        protect(link, Operation.Create):
+          val (source, sourceRelative) = resolve(target, Operation.Create)
+          val directory: Foreign of "descriptor" from Wit = source
+
+          try
+            val (destination, linkRelative) = resolve(link, Operation.Create)
+
+            try
+              directory.`link-at`(follow(false), sourceRelative, destination, linkRelative)
+              . invoke[Unit]
+            finally destination.dispose()
+          finally source.dispose()
+
+      def copy(source: Path on Plane, destination: Path on Plane, dereference: Boolean)
+        ( using Tactic[IoError] )
+      :   Unit =
+
+        val content = open(source, List(OpenFlag.Read))(_.reader())
+        val flags = List(OpenFlag.Write, OpenFlag.Create, OpenFlag.Truncate)
+
+        open(destination, flags): handle =>
+          handle.writer(content)
+
+      def move
+        ( source:      Path on Plane,
+          destination: Path on Plane,
+          atomic:      Boolean,
+          dereference: Boolean )
+        ( using Tactic[IoError] )
+      :   Unit =
+
+        protect(source, Operation.Move):
+          val (from, fromRelative) = resolve(source, Operation.Move)
+          val directory: Foreign of "descriptor" from Wit = from
+
+          try
+            val (to, toRelative) = resolve(destination, Operation.Move)
+
+            try directory.`rename-at`(fromRelative, to, toRelative).invoke[Unit]
+            finally to.dispose()
+          finally from.dispose()
+
+      def touch(path: Path on Plane)(using Tactic[IoError]): Unit =
+        act(path, Operation.Metadata): (directory, relative) =>
+          directory.`set-times-at`
+            ( follow(true),
+              relative,
+              WitCase["new-timestamp"](t"now"),
+              WitCase["new-timestamp"](t"now") )
+
+          . invoke[Unit]
+
+      def hidden(path: Path on Plane)(using Tactic[IoError]): Boolean =
+        path.descent.prim.let(_.starts(t".")).or(false)
+
+      def volume(path: Path on Plane)(using Tactic[IoError]): Volume =
+        abort(IoError(path, Operation.Metadata, Reason.Unsupported))
+
+      def hardLinkCount(path: Path on Plane, dereference: Boolean)(using Tactic[IoError]): Int =
+        stat2(path, dereference)
+
+      private def stat2(path: Path on Plane, dereference: Boolean)(using Tactic[IoError]): Int =
+        protect(path, Operation.Metadata):
+          val (descriptor, relative) = resolve(path, Operation.Metadata)
+          val directory: Foreign of "descriptor" from Wit = descriptor
+
+          try
+            val fields = directory.`stat-at`(follow(dereference), relative).invoke[StatFields]
+            fields(1).bits.s64.long.toInt
+          finally descriptor.dispose()
+
+      // WASI has no per-path permission query or `chmod`: readability and writability are
+      // capability-scoped (a path is accessible exactly if a preopen covers it), so existence is
+      // the best answer available; updates are honestly unsupported.
+      def attribute(path: Path on Plane, attribute: FilesystemBackend.Attribute): Boolean =
+        attribute match
+          case FilesystemBackend.Attribute.Executable => false
+          case _                                      => exists(path, true)
+
+      def update(path: Path on Plane, attribute: FilesystemBackend.Attribute, value: Boolean)
+        ( using Tactic[IoError] )
+      :   Unit =
+
+        abort(IoError(path, Operation.Metadata, Reason.Unsupported))
+
+      def open[result](path: Path on Plane, flags: List[OpenFlag])(lambda: Handle => result)
+        ( using Tactic[IoError] )
+      :   result =
+
+        protect(path, Operation.Open):
+          val (descriptor, relative) = resolve(path, Operation.Open)
+          val directory: Foreign of "descriptor" from Wit = descriptor
+
+          // open-flags: create (1) | exclusive (4) | truncate (8); descriptor-flags: read (1) |
+          // write (2).
+          val create = if flags.contains(OpenFlag.Create) then 1 else 0
+          val exclusive = if flags.contains(OpenFlag.Exclusive) then 4 else 0
+          val truncate = if flags.contains(OpenFlag.Truncate) then 8 else 0
+          val openFlags = create | exclusive | truncate
+
+          val writing = flags.contains(OpenFlag.Write) || flags.contains(OpenFlag.Append)
+
+          val descriptorFlags =
+            (if flags.contains(OpenFlag.Read) then 1 else 0) | (if writing then 2 else 0)
+
+          val pathFlags = follow(!flags.contains(OpenFlag.NoFollow))
+
+          try
+            val opened =
+              directory
+              . `open-at`(pathFlags, relative, U32(openFlags.bits), U32(descriptorFlags.bits))
+              . invoke[WitHandle of "descriptor"]
+
+            val target: Foreign of "descriptor" from Wit = opened
+
+            def read(): LazyList[Data] =
+              val streamHandle =
+                target.`read-via-stream`(U64(0L.bits)).invoke[WitHandle of "input-stream"]
+
+              val stream: Foreign of "input-stream" from Wit = streamHandle
+              var chunks: List[Data] = Nil
+
+              try
+                while true do
+                  chunks = stream.`blocking-read`(U64(65536L.bits)).invoke[Data] :: chunks
+              catch case error: WitError => ()
+
+              streamHandle.dispose()
+              chunks.reverse.to(LazyList)
+
+            def write(data: LazyList[Data]): Unit =
+              val streamHandle =
+                if flags.contains(OpenFlag.Append)
+                then target.`append-via-stream`.invoke[WitHandle of "output-stream"]
+                else target.`write-via-stream`(U64(0L.bits)).invoke[WitHandle of "output-stream"]
+
+              val stream: Foreign of "output-stream" from Wit = streamHandle
+
+              data.each: chunk =>
+                stream.`blocking-write-and-flush`(chunk).invoke[Unit]
+
+              streamHandle.dispose()
+
+            try lambda(Handle(() => read(), write(_))()) finally opened.dispose()
+          finally descriptor.dispose()

--- a/lib/galilei/src/wasi/soundness_galilei_wasi.scala
+++ b/lib/galilei/src/wasi/soundness_galilei_wasi.scala
@@ -32,21 +32,7 @@
                                                                                                   */
 package soundness
 
-export xenophile.{Wasm, WasmInvoke, WitCase, WitError, WitHandle}
+export galilei.{WasiFilesystemApi, wasiFilesystemApi}
 
-// Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
-// call. Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
-// Plain `inline` (not `transparent`): the return type is fully determined by the type argument,
-// and non-transparency defers the macro when `invoke` appears inside another `inline` definition,
-// so a library can publish an inline given whose import call only materializes at the downstream
-// (Wasm-linked) call site — where `scala.scalajs.wit.witImportCall` is on the classpath.
-extension (foreign: xenophile.Foreign)
-  inline def invoke[result]: result =
-    ${xenophile.WasmInvoke.invoke[result]('foreign)}
-
-// Releases a WIT resource handle, emitting its `[resource-drop]` Component Model import. Like
-// `invoke`, plain `inline` so the import materializes at the downstream (Wasm-linked) call site.
-extension (handle: xenophile.WitHandle)
-  inline def dispose(): Unit =
-    ${xenophile.WasmInvoke.dispose('handle)}
+package filesystemBackends:
+  export galilei.filesystemBackends.wasi

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -159,10 +159,12 @@ object WasmInvoke:
     //     `Unset` or its recursively-decoded payload.
     //  -  A named WIT type requested as a `WitHandle of topic` is a resource: its carrier is the
     //     resource's facade class, and the raw handle is wrapped in a `WitHandle`.
-    //  -  Anything else is derived from the requested Scala type alone (`deriveResult`: leaf
-    //     codecs, pairs, lists of pairs), whose carrier for a `list<tuple<…>>` mentions the
-    //     scala-wasm `Tuple2` class — resolved (and only ever appearing) in this
-    //     downstream-expanded code.
+    //  -  A WIT `tuple<…>` (or a record, which shares its ABI) crosses as the scala-wasm `TupleN`
+    //     of its recursively-derived element carriers and becomes the corresponding Scala tuple;
+    //     a `list<T>` crosses as an `Array` of `T`'s carrier and becomes a `List`. The scala-wasm
+    //     class names are resolved here, downstream, so they never appear in this module's own
+    //     compilation.
+    //  -  Anything else is a leaf, derived from the requested Scala type's codec (`deriveResult`).
     val optionClass = Symbol.requiredClass("java.util.Optional")
 
     // The payload type of an `option`, whichever way the dialect rendered it.
@@ -186,6 +188,19 @@ object WasmInvoke:
       case Refinement(base, "Topic", _) => base =:= TypeRepr.of[WitHandle]
       case _                            => false
 
+    def isTuple(scala: TypeRepr, arity: Int): Boolean = scala.dealias match
+      case AppliedType(tuple, arguments) =>
+        tuple.typeSymbol == defn.TupleClass(arity) && arguments.length == arity
+
+      case _ =>
+        false
+
+    val listClass = Symbol.requiredClass("scala.collection.immutable.List")
+
+    def isList(scala: TypeRepr): Boolean = scala.dealias match
+      case AppliedType(list, List(_)) => list.typeSymbol == listClass
+      case _                          => false
+
     def handleDecode(name: Text, scala: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
       val facade = facadeOf(name)
 
@@ -207,28 +222,89 @@ object WasmInvoke:
             TypeApply(Select.unique(outcome.asTerm, "isInstanceOf"), List(Inferred(okType)))
               .asExprOf[Boolean]
 
-          def payload(outcome: Expr[Any]): Expr[Any] =
+          val errClass = Symbol.requiredClass("scala.scalajs.wit.Err")
+          val errType = AppliedType(errClass.typeRef, List(TypeBounds.empty))
+
+          def payload(outcome: Expr[Any], tpe: TypeRepr): Expr[Any] =
             val cast =
-              TypeApply(Select.unique(outcome.asTerm, "asInstanceOf"), List(Inferred(okType)))
+              TypeApply(Select.unique(outcome.asTerm, "asInstanceOf"), List(Inferred(tpe)))
 
             Select.unique(cast, "value").asExprOf[Any]
+
+          // An `Err` raises a `WitError` carrying the error value (e.g. an `error-code` case), so
+          // callers can recover which failure occurred (`WitError.name`) and translate it.
+          def raiseError(outcome: Expr[Any]): Expr[Nothing] =
+            '{throw new WitError(${payload(outcome, errType)})}
 
           val decode: Expr[Any] => Expr[Any] =
             if scala =:= TypeRepr.of[Unit] then call =>
               '{  val outcome = $call
-
-                  if !${isOk('outcome)}
-                  then throw new RuntimeException("WIT import returned an error: " + outcome)  }
+                  if !${isOk('outcome)} then ${raiseError('outcome)}  }
             else
               val (_, payloadDecode) = decodeFor(arguments.head, scala)
 
               call =>
                 '{  val outcome = $call
 
-                    if ${isOk('outcome)} then ${payloadDecode(payload('outcome))}
-                    else throw new RuntimeException("WIT import returned an error: " + outcome)  }
+                    if ${isOk('outcome)} then ${payloadDecode(payload('outcome, okType))}
+                    else ${raiseError('outcome)}  }
 
           (resultClass.typeRef, decode)
+
+        // A `tuple<…>` (or a record, whose ABI it shares) with the matching Scala tuple type:
+        // element-wise recursion, carried as the scala-wasm `TupleN` of the element carriers.
+        case Foreign.Type.Applied(constructor, elements)
+        if constructor.s == "tuple" && isTuple(scala, elements.length) =>
+          val fields = scala.dealias.typeArgs
+          val derived = elements.zip(fields).map(decodeFor(_, _))
+          val carriers = derived.map(_(0))
+
+          val tupleClass =
+            Symbol.requiredClass("scala.scalajs.wit.Tuple" + elements.length.toString)
+
+          val tupleCarrier = tupleClass.typeRef.appliedTo(carriers)
+          val scalaTuple = defn.TupleClass(elements.length).companionModule
+
+          val decode: Expr[Any] => Expr[Any] = call =>
+            val cast =
+              TypeApply(Select.unique(call.asTerm, "asInstanceOf"), List(Inferred(tupleCarrier)))
+
+            val decoded = derived.zipWithIndex.map: (derivation, index) =>
+              derivation(1)(Select.unique(cast, "_" + (index + 1).toString).asExprOf[Any]).asTerm
+
+            val applied =
+              Apply
+                ( TypeApply
+                    ( Select.unique(Ref(scalaTuple), "apply"),
+                      fields.map { field => Inferred(field) } ),
+                  decoded )
+
+            applied.asExprOf[Any]
+
+          (tupleCarrier, decode)
+
+        // A `list<T>` with a Scala `List[T]`: carried as an `Array` of `T`'s carrier, decoded
+        // element-wise (reflectively, since the element carrier may not be nameable here).
+        case Foreign.Type.Applied(constructor, List(element))
+        if constructor.s == "list" && isList(scala) =>
+          val elementType = scala.dealias.typeArgs.head
+          val (elementCarrier, elementDecode) = decodeFor(element, elementType)
+          val arrayCarrier = defn.ArrayClass.typeRef.appliedTo(elementCarrier)
+
+          val decode: Expr[Any] => Expr[Any] = call =>
+            val method = MethodType(List("element"))(_ => List(TypeRepr.of[Any]), _ => elementType)
+
+            val mapper = Lambda(Symbol.spliceOwner, method,
+                (_, parameters) => elementDecode(parameters.head.asInstanceOf[Term].asExprOf[Any])
+                  . asTerm)
+
+            val elements = '{$call.asInstanceOf[Array[Any]]}
+            val wrapped = '{_root_.scala.collection.immutable.ArraySeq.unsafeWrapArray($elements)}
+
+            val mapped = Select.overloaded(wrapped.asTerm, "map", List(elementType), List(mapper))
+            Select.unique(mapped, "toList").asExprOf[Any]
+
+          (arrayCarrier, decode)
 
         case _ =>
           val payloadWit = optionPayload(witType)
@@ -536,110 +612,19 @@ object WasmInvoke:
 
     Symbol.requiredClass(s"scala.scalajs.$namespace.$path.$className")
 
-  // The WIT carrier a result type crosses the boundary as, paired with a function decoding that
-  // carrier (an `Any`, the erased `witImportCall` result) back to the result. A leaf type uses its
-  // `Decodable in Wasm` codec directly; a `List[(A, B)]` is a `list<tuple<Ac, Bc>>`, carried as an
-  // `Array[scala.scalajs.wit.Tuple2[Ac, Bc]]` and decoded element-wise.
+  // The WIT carrier a leaf result type crosses the boundary as, paired with a function decoding
+  // that carrier (an `Any`, the erased `witImportCall` result) back to the result, using its
+  // `Decodable in Wasm` codec. Structured shapes (tuples, lists, options, results, resources) are
+  // derived recursively — and WIT-driven — by `decodeFor` in `invoke`; this is its base case.
   private def deriveResult[result: Type](using quotes: Quotes)
   :   (quotes.reflect.TypeRepr, Expr[Any] => Expr[Any]) =
 
     import quotes.reflect.*
 
-    def leaf(tpe: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
-      tpe.asType.absolve match
-        case '[leafType] =>
-          val decodable = Expr.summon[leafType is Decodable in Wasm].getOrElse:
-            halt(m"xenophile: no way to read a ${tpe.show} from a WIT boundary")
+    val decodable = Expr.summon[result is Decodable in Wasm].getOrElse:
+      halt(m"xenophile: no way to read a ${TypeRepr.of[result].show} from a WIT boundary")
 
-          (carrierType(decodable), call => '{$decodable.decoded(Wasm($call))})
-
-    val listClass = Symbol.requiredClass("scala.collection.immutable.List")
-
-    // The carrier and a decode for a single `tuple<Lc, Rc>` (Scala `(L, R)`): scala-wasm's `Tuple2`
-    // (whose name is resolved here, downstream, so it never appears in `xenophile.wasm`'s own
-    // scala-wasm-free compilation), and a `Term => Term` reading `_1`/`_2` off a raw `Tuple2` term.
-    // A WIT `record` of two fields shares a `tuple`'s ABI, so this also serves a two-field record.
-    def pairCodec(leftType: TypeRepr, rightType: TypeRepr)
-    :   (TypeRepr, TypeRepr, Term => Term) =
-
-      leftType.asType.absolve match case '[left] => rightType.asType.absolve match
-        case '[right] =>
-          val (leftCarrier, leftDecode) = leaf(leftType)
-          val (rightCarrier, rightDecode) = leaf(rightType)
-          val witTuple2 = Symbol.requiredClass("scala.scalajs.wit.Tuple2")
-          val tupleCarrier = witTuple2.typeRef.appliedTo(List(leftCarrier, rightCarrier))
-          val pairType = TypeRepr.of[(left, right)]
-
-          val decodeTuple: Term => Term = raw =>
-            val tuple = TypeApply(Select.unique(raw, "asInstanceOf"), List(Inferred(tupleCarrier)))
-            val leftValue = leftDecode(Select.unique(tuple, "_1").asExprOf[Any])
-            val rightValue = rightDecode(Select.unique(tuple, "_2").asExprOf[Any])
-            '{(${leftValue.asExprOf[left]}, ${rightValue.asExprOf[right]})}.asTerm
-
-          (tupleCarrier, pairType, decodeTuple)
-
-    // A bare `tuple<A, B>` (Scala `(A, B)`).
-    def pairOf(leftType: TypeRepr, rightType: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
-      val (tupleCarrier, _, decodeTuple) = pairCodec(leftType, rightType)
-      (tupleCarrier, call => decodeTuple(call.asTerm).asExprOf[Any])
-
-    // A `list<tuple<Ac, Bc>>` (Scala `List[(A, B)]`).
-    def listOfPairs(leftType: TypeRepr, rightType: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
-      val (tupleCarrier, pairType, decodeTuple) = pairCodec(leftType, rightType)
-      val arrayCarrier = defn.ArrayClass.typeRef.appliedTo(tupleCarrier)
-
-      val decode: Expr[Any] => Expr[Any] = call =>
-        // A reflective `map` because the element type (`Tuple2`) is not nameable in this module.
-        val method = MethodType(List("tuple"))(_ => List(TypeRepr.of[Any]), _ => pairType)
-
-        val mapper = Lambda(Symbol.spliceOwner, method,
-            (_, params) => decodeTuple(params.head.asInstanceOf[Term]))
-
-        val wrapped =
-          '{scala.collection.immutable.ArraySeq.unsafeWrapArray($call.asInstanceOf[Array[Any]])}
-
-        val mapped = Select.overloaded(wrapped.asTerm, "map", List(pairType), List(mapper))
-        Select.unique(mapped, "toList").asExprOf[Any]
-
-      (arrayCarrier, decode)
-
-    val optionClass = Symbol.requiredClass("java.util.Optional")
-
-    // An `option<T>` (Scala `Optional[T]` = `Unset | T`), carried as a `java.util.Optional[Tc]`.
-    def optionOf(inner: TypeRepr): (TypeRepr, Expr[Any] => Expr[Any]) =
-      val (innerCarrier, innerDecode) = leaf(inner)
-      val carrier = optionClass.typeRef.appliedTo(List(innerCarrier))
-
-      // `java.util.Optional` is nameable here, so ordinary quotes suffice (no reflective decode);
-      // an absent value becomes `Unset`.
-      val decode: Expr[Any] => Expr[Any] = call =>
-        '{  val option = $call.asInstanceOf[java.util.Optional[Any]]
-            if option.isPresent then ${innerDecode('{option.get})} else Unset  }
-
-      (carrier, decode)
-
-    TypeRepr.of[result].dealias match
-      case OrType(left, right) if left =:= TypeRepr.of[Unset] =>
-        optionOf(right)
-
-      case OrType(left, right) if right =:= TypeRepr.of[Unset] =>
-        optionOf(left)
-
-      case AppliedType(tuple, List(leftType, rightType))
-      if tuple.typeSymbol == defn.TupleClass(2) =>
-        pairOf(leftType, rightType)
-
-      case AppliedType(list, List(element)) if list.typeSymbol == listClass =>
-        element.dealias match
-          case AppliedType(tuple, List(leftType, rightType))
-          if tuple.typeSymbol == defn.TupleClass(2) =>
-            listOfPairs(leftType, rightType)
-
-          case _ =>
-            leaf(TypeRepr.of[result])
-
-      case _ =>
-        leaf(TypeRepr.of[result])
+    (carrierType(decodable), call => '{$decodable.decoded(Wasm($call))})
 
   // The `Carrier` type of a summoned `Encodable`/`Decodable in Wasm` codec, read from the `Carrier`
   // refinement member of the codec's (precise) type.

--- a/lib/xenophile/src/wasm/xenophile.WitError.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitError.scala
@@ -30,23 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Wasm, WasmInvoke, WitCase, WitError, WitHandle}
+import anticipation.*
+import gossamer.*
 
-// Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
-// call. Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
-// Plain `inline` (not `transparent`): the return type is fully determined by the type argument,
-// and non-transparency defers the macro when `invoke` appears inside another `inline` definition,
-// so a library can publish an inline given whose import call only materializes at the downstream
-// (Wasm-linked) call site — where `scala.scalajs.wit.witImportCall` is on the classpath.
-extension (foreign: xenophile.Foreign)
-  inline def invoke[result]: result =
-    ${xenophile.WasmInvoke.invoke[result]('foreign)}
+// The `err` arm of a WIT `result<…>`, raised by `invoke`'s decoder. The error value (e.g. a case
+// of `wasi:filesystem`'s `error-code`) is held untyped, so this module never names its
+// (Wasm-only) class; `name` recovers which case it is — the case's lower-kebab-case name, as a
+// `WitCase` would spell it — so callers can translate failures into their own error vocabulary.
+class WitError(val value: Any) extends RuntimeException:
+  def name: Text =
+    val simple = value.getClass.getSimpleName.nn.tt
+    val stripped = if simple.ends(t"$$") then simple.skip(1, Rtl) else simple
+    stripped.uncamel.kebab
 
-// Releases a WIT resource handle, emitting its `[resource-drop]` Component Model import. Like
-// `invoke`, plain `inline` so the import materializes at the downstream (Wasm-linked) call site.
-extension (handle: xenophile.WitHandle)
-  inline def dispose(): Unit =
-    ${xenophile.WasmInvoke.dispose('handle)}
+  override def getMessage: String = "WIT import returned an error: " + name.s


### PR DESCRIPTION
A new `galilei.wasi` module implements `FilesystemBackend` (introduced in the previous PR) over `wasi:filesystem`, so applications linked as Wasm Components get real filesystem access through the host's preopened directories. Verified end-to-end under `wasmtime run --dir`: mkdir, streaming writes and reads, `stat`, directory listing, hard-link counts and deletion — with a missing entry reported as `Nonexistent` and a path outside every preopen as `PermissionDenied`, the capability model speaking directly through `IoError`.

## `filesystemBackends.wasi`

On a Wasm target, summon the WASI filesystem with:
```scala
import galilei.wasiFilesystemApi
import filesystemBackends.wasi
```
Every operation resolves its path against the preopen with the longest matching prefix. WASI error codes are recovered and mapped onto `IoError.Reason` (19 distinct translations), and what WASIp2 genuinely cannot do — fifos, chmod, volume metadata — raises `Unsupported` rather than approximating.

## `invoke` machinery

- **Recursive tuple and list decoding**: a WIT `tuple<…>` of any arity (or a record, which shares its ABI) decodes element-wise into the matching Scala tuple, and `list<T>` into a `List[T]`, with full recursion — `wasi:filesystem`'s `descriptor-stat` (six fields, nested `option<datetime>`s) and `preopens`' `list<tuple<descriptor, string>>` (a tuple containing a *resource*) both decode directly. This replaces the previous two-field-only special cases.
- **Typed WIT errors**: a `result<…>`'s `Err` arm now raises `WitError`, which carries the error value and recovers its case name (`no-entry`, `quota`, …), so backends can translate failures into their own error vocabulary instead of receiving an opaque exception.

No compiler-fork changes were needed.
