### PR TITLE
Stream HTTP request bodies natively (#1477)

### DIFF
--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -46,9 +46,11 @@ import prepositional.*
 import rudiments.*
 import spectacular.*
 import telekinesis.*
+import turbulence.*
 import urticose.*
 import vacuous.*
 import xylophone.*
+import zephyrine.*
 
 object Api:
   // Root constructor: `Api(cp"/spec.json")` reads the spec resource's `Locus`,
@@ -92,12 +94,12 @@ object Api:
 
     val url = full.decode[HttpUrl]
 
-    val empty: () => LazyList[Data] = () => LazyList()
+    val empty: () => Stream[Data] over Credit = () => Stream(Iterator.empty[Data])
 
-    val (contentType, body): (Optional[Text], () => LazyList[Data]) = request.body match
+    val (contentType, body): (Optional[Text], () => Stream[Data] over Credit) = request.body match
       case Api.Body.Empty       => (Unset, empty)
-      case Api.Body.Json(value) => (t"application/json", () => LazyList(value.show.data))
-      case Api.Body.Xml(value)  => (t"application/xml", () => LazyList(value.show.data))
+      case Api.Body.Json(value) => (t"application/json", () => Stream(value.show.data))
+      case Api.Body.Xml(value)  => (t"application/xml", () => Stream(value.show.data))
 
     val contentTypeHeader: List[Http.Header] = contentType.lay(Nil): media =>
       List(Http.Header(t"content-type", media))

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -59,13 +59,14 @@ class Recorder(canned: () => Http.Response) extends Http.Backend:
   var lastHeaders: List[Http.Header]     = Nil
 
   def request
-     ( url: Text, method: Http.Method, headers: List[Http.Header], body: () => LazyList[Data] )
+     ( url: Text, method: Http.Method, headers: List[Http.Header],
+        body: () => Stream[Data] over Credit )
      ( using Tactic[ConnectError] )
   :   Http.Response =
     lastUrl = url
     lastMethod = method
     lastHeaders = headers
-    val chunks = body().to(List)
+    val chunks = body().lazyList.to(List)
     lastBody = if chunks.isEmpty then Unset else chunks.head
     canned()
 

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -229,7 +229,7 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
 
     Log.fine(Http2Event.RequestSent(authority))
     val headerBlock = PseudoHeaders.request(request, scheme, authority)
-    val chunks = request.body().to(List)
+    val chunks = request.body().lazyList.to(List)
 
     val payload: Optional[Bytes] =
       if chunks.isEmpty then Unset else chunks.foldLeft(IArray.empty[Byte])(_ ++ _)

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -277,7 +277,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
           connection.start()
 
           val request = Http.Request(Http.Post, 2.0, unsafely(t"unix".decode[Host]),
-              t"/echo.Service/Call", Nil, () => LazyList(ascii(t"ping")))
+              t"/echo.Service/Call", Nil, () => Stream(ascii(t"ping")))
 
           val (stream, response) = connection.fetch(request, t"http", t"unix")
           val bodyText = ascii(t"pong").to(List) == response.body.stream.reduce(_ ++ _).to(List)
@@ -309,7 +309,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
           val endpoint = Http2.Endpoint(Loopback(clientSide), t"unix")
 
           val request = Http.Request(Http.Get, 2.0, unsafely(t"unix".decode[Host]),
-              t"/echo.Service/Call", Nil, () => LazyList())
+              t"/echo.Service/Call", Nil, () => Stream(Iterator.empty[Data]))
 
           client.request(request, endpoint).status.code
       . assert(_ == 200)

--- a/lib/jacinta/src/http/jacinta_http.scala
+++ b/lib/jacinta/src/http/jacinta_http.scala
@@ -38,10 +38,11 @@ import gossamer.*
 import hieroglyph.*
 import spectacular.*
 import telekinesis.*
+import zephyrine.*
 
 package postables:
   given jsonPostable: (encoder: CharEncoder, formatting: Json.Formatting) => Json is Postable =
-    Postable(media"application/json"(charset = "UTF-8"), value => LazyList(value.show.data))
+    Postable(media"application/json"(charset = "UTF-8"), value => Stream(value.show.data))
 
 package servables:
   given jsonServable: (encoder: CharEncoder, formatting: Json.Formatting) => Json is Servable =

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -45,6 +45,7 @@ import telekinesis.*
 import turbulence.*
 import urticose.*
 import vacuous.*
+import zephyrine.*
 
 object GrpcChannel:
   // Open a channel to a cleartext-h2c endpoint, completing the HTTP/2 handshake. The
@@ -83,7 +84,7 @@ class GrpcChannel
         Http.Header(t"te", t"trailers") ::
         metadataHeaders
 
-    val body = () => LazyList(GrpcFraming.encode(message))
+    val body = () => Stream(GrpcFraming.encode(message))
     Http.Request(Http.Post, 2.0, host, method.path, headers, body)
 
   // gRPC requires HTTP status 200; anything else is a transport-level failure.

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -233,4 +233,4 @@ class Websocket[message, state]
         initial
 
     . protect:
-        loop(Reader(() => request.body(), channel).messages, initial)
+        loop(Reader(() => request.body().lazyList, channel).messages, initial)

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -215,7 +215,7 @@ given wsClient: ( Online,
               Http.Header(t"Upgrade", t"websocket"),
               Http.Header(t"Sec-WebSocket-Key", key),
               Http.Header(t"Sec-WebSocket-Version", t"13") ),
-          () => LazyList() )
+          () => Http.emptyBody() )
 
     duplex.send(Http.Request.serialize(request))
 

--- a/lib/scintillate/src/server/scintillate.Acceptable.scala
+++ b/lib/scintillate/src/server/scintillate.Acceptable.scala
@@ -59,7 +59,7 @@ object Acceptable:
           val boundary = contentType.at(t"boundary").or:
             abort(MultipartError(MultipartError.Reason.MediaType))
 
-          Multipart.parse(request.body(), boundary)
+          Multipart.parse(request.body().lazyList, boundary)
         else
           abort(MultipartError(MultipartError.Reason.MediaType))
 

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -89,7 +89,7 @@ object HttpConnection:
           version     = version,
           host        = host,
           target      = target,
-          body        = () => stream(),
+          body        = () => Stream(stream().iterator),
           textHeaders = headers )
 
     Log.fine(HttpServerEvent.Received(request))

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -178,7 +178,12 @@ extends RequestServable:
 
           val request =
             Http.Request
-              ( head.method, head.version, head.host, head.target, head.headers, () => body )
+              ( head.method,
+                head.version,
+                head.host,
+                head.target,
+                head.headers,
+                () => Stream(body.iterator) )
 
           var upgraded = false
           var keep = keepAlive(head)

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -73,7 +73,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
           version     = Http.Version.parse(request.getProtocol.nn.tt),
           host        = request.getServerName.nn.tt.decode[Hostname],
           target      = target,
-          body        = () => streamBody(request),
+          body        = () => Stream(streamBody(request).iterator),
           textHeaders = headers )
 
     def respond(response: Http.Response): Unit =

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -97,7 +97,7 @@ object Tests extends Suite(m"Scintillate tests"):
           val port = freePort()
 
           val server = SocketServer(port).handle:
-            Http.Response(Http.Ok)(request.body().read[Data].utf8)
+            Http.Response(Http.Ok)(request.body().lazyList.read[Data].utf8)
 
           val response =
             rawRequest(port, t"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello")
@@ -111,7 +111,7 @@ object Tests extends Suite(m"Scintillate tests"):
           val port = freePort()
 
           val server = SocketServer(port).handle:
-            Http.Response(Http.Ok)(request.body().read[Data].utf8)
+            Http.Response(Http.Ok)(request.body().lazyList.read[Data].utf8)
 
           val response =
             rawRequest
@@ -156,7 +156,7 @@ object Tests extends Suite(m"Scintillate tests"):
           // Echo upgrade: the response body is the post-handshake request stream,
           // piped straight back out with no HTTP framing.
           val server = SocketServer(port).handle:
-            Http.Response(Http.SwitchingProtocols)(Http.Body.Streaming(request.body()))
+            Http.Response(Http.SwitchingProtocols)(Http.Body.Flowing(() => request.body()))
 
           val response =
             rawRequest

--- a/lib/stratiform/src/http/stratiform_http.scala
+++ b/lib/stratiform/src/http/stratiform_http.scala
@@ -38,13 +38,14 @@ import gossamer.*
 import hieroglyph.*
 import spectacular.*
 import telekinesis.*
+import zephyrine.*
 
 private val telMediaType: MediaType =
   MediaType(Media.Group.Application, Media.Subtype.Vendor(t"tel"))
 
 package postables:
   given telPostable: (encoder: CharEncoder) => Tel is Postable =
-    Postable(telMediaType, value => LazyList(encoder.encoded(value.show)))
+    Postable(telMediaType, value => Stream(encoder.encoded(value.show)))
 
 package servables:
   given telServable: (encoder: CharEncoder) => Tel is Servable =

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -184,7 +184,7 @@ object Mcp:
                 ( mcpInterface.stream )
 
             case Http.Post =>
-              val input = request.body().read[Json]
+              val input = request.body().lazyList.read[Json]
 
               dispatch(input).let: json =>
                 import formatting.indentedJsonFormatting

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -226,7 +226,7 @@ object Http:
   object Request:
     given showable: Request is Showable = request =>
       val bodySample: Text =
-        try request.body().read[Data].utf8 catch
+        try request.body().lazyList.read[Data].utf8 catch
           case error: StreamError  => t"[-/-]"
 
       val headers: Text =
@@ -273,7 +273,7 @@ object Http:
         append(request.host.show)
         newline()
 
-        request.body() match
+        request.body().lazyList match
           case LazyList()     => append(t"Content-Length: 0")
           case LazyList(data) => append(t"Content-Length: ${data.length}")
           case _              => append(t"Transfer-Encoding: chunked")
@@ -287,7 +287,7 @@ object Http:
         newline()
         newline()
 
-      text.data #:: request.body()
+      text.data #:: request.body().lazyList
 
     case class Head
       ( method: Method, version: Version, host: Host, target: Text, headers: List[Header] )
@@ -378,7 +378,12 @@ object Http:
       val head = parseHead(cursor)
 
       Request
-        ( head.method, head.version, head.host, head.target, head.headers, () => cursor.remainder )
+        ( head.method,
+          head.version,
+          head.host,
+          head.target,
+          head.headers,
+          () => Stream(cursor.remainder.iterator) )
 
     // LazyList exactly `length` bytes of body off `cursor`, in buffer-sized
     // pieces, leaving it at the first byte after the body (the start of the next
@@ -479,13 +484,17 @@ object Http:
       case Body.Flowing(source)   => source().lazyList
 
 
+  // A request body with no bytes; each call constructs a fresh, already-empty
+  // pull endpoint, matching the re-materializable contract of `body` thunks.
+  def emptyBody(): Stream[Data] over Credit = Stream(Iterator.empty[Data])
+
   class Request
     ( val method:      Http.Method,
       val version:     Http.Version,
       val host:        Host,
       val target:      Text,
       val textHeaders: List[Http.Header],
-      val body:        () => LazyList[Data] ):
+      val body:        () => Stream[Data] over Credit ):
 
     inline def request: this.type = this
 
@@ -500,7 +509,7 @@ object Http:
     lazy val query: Query =
       contentType.let(_.base.show) match
         case t"application/x-www-form-urlencoded" =>
-          queryText.decode[Query] ++ body().read[Data].utf8.decode[Query]
+          queryText.decode[Query] ++ body().lazyList.read[Data].utf8.decode[Query]
 
         case _ =>
           queryText.decode[Query]
@@ -538,7 +547,7 @@ object Http:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => LazyList[Data] )
+        body:    () => Stream[Data] over Credit )
       ( using Tactic[ConnectError] )
     :   Http.Response
 

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -45,6 +45,7 @@ import prepositional.*
 import rudiments.*
 import spectacular.*
 import urticose.*
+import zephyrine.*
 
 object HttpClient:
   // Log a received response at a level reflecting its status: a server error is a `Fail`, a client
@@ -98,7 +99,8 @@ object HttpClient:
       val url = httpRequest.on(origin)
       Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-      def loop(uri: jn.URI, method: Http.Method, bodyFn: () => LazyList[Data], remaining: Int)
+      def loop(uri: jn.URI, method: Http.Method, bodyFn: () => Stream[Data] over Credit,
+          remaining: Int)
       :   Http.Response =
 
         val response = backend.request(uri.toString.tt, method, httpRequest.textHeaders, bodyFn)
@@ -117,8 +119,8 @@ object HttpClient:
               Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))
               val nextMethod = redirectMethod(code, method)
 
-              val nextBody: () => LazyList[Data] =
-                if nextMethod == method then bodyFn else () => LazyList()
+              val nextBody: () => Stream[Data] over Credit =
+                if nextMethod == method then bodyFn else () => Http.emptyBody()
 
               loop(nextUri, nextMethod, nextBody, remaining - 1)
 

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -48,32 +48,39 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import vacuous.*
+import zephyrine.*
 
 import alphabets.hexLowerCase
 
 object Postable:
-  def apply[response](mediaType0: MediaType, stream0: response => LazyList[Data])
+  // `stream0` must construct a fresh pull endpoint on each call: the request
+  // body may be materialized more than once — for a redirect that preserves
+  // the method, and independently by `preview` for logging — and a `Stream`,
+  // being a single-use mutable buffer, cannot be re-pulled.
+  def apply[response](mediaType0: MediaType, stream0: response => Stream[Data] over Credit)
   :   response is Postable =
 
     new Postable:
       type Self = response
       def mediaType(response: response): MediaType = mediaType0
-      def stream(response: response): LazyList[Data] = stream0(response)
+      def stream(response: response): Stream[Data] over Credit = stream0(response)
 
 
   given text: (encoder: CharEncoder) => Text is Postable =
-    Postable(media"text/plain", value => LazyList(IArray.from(value.data)))
+    Postable(media"text/plain", value => Stream(IArray.from(value.data)))
 
   given textStream: (encoder: CharEncoder) => LazyList[Text] is Postable =
-    Postable(media"application/octet-stream", _.map(_.data))
+    Postable(media"application/octet-stream", lazyList => Stream(lazyList.map(_.data).iterator))
 
-  given unit: Unit is Postable = Postable(media"text/plain", unit => LazyList())
-  given data: Data is Postable = Postable(media"application/octet-stream", LazyList(_))
-  given byteStream: LazyList[Data] is Postable = Postable(media"application/octet-stream", identity)
+  given unit: Unit is Postable = Postable(media"text/plain", _ => Stream(Iterator.empty[Data]))
+  given data: Data is Postable = Postable(media"application/octet-stream", Stream(_))
+
+  given byteStream: LazyList[Data] is Postable =
+    Postable(media"application/octet-stream", lazyList => Stream(lazyList.iterator))
 
   given query: Query is Postable =
     import charEncoders.utf8Encoder
-    Postable(media"application/x-www-form-urlencoded", query => LazyList(query.queryString.data))
+    Postable(media"application/x-www-form-urlencoded", query => Stream(query.queryString.data))
 
 
   given dataStream: [response: Abstractable across HttpStreams to HttpStreams.Content]
@@ -84,13 +91,13 @@ object Postable:
       type Self = response
 
       def mediaType(content: response): MediaType = content.generic(0).decode[MediaType]
-      def stream(content: response): LazyList[Data] = content.generic(1).lazyList
+      def stream(content: response): Stream[Data] over Credit = content.generic(1).stream
 
 trait Postable extends Typeclass:
   def mediaType(content: Self): MediaType
-  def stream(content: Self): LazyList[Data]
+  def stream(content: Self): Stream[Data] over Credit
 
-  def preview(value: Self): Text = stream(value).prim.lay(t""): data =>
+  def preview(value: Self): Text = stream(value).lazyList.prim.lay(t""): data =>
     val sample = data.take(1024)
     val string: Text = sample.serialize[Hex]
     if data.length > 128 then t"$string..." else string

--- a/lib/telekinesis/src/core/telekinesis.internal.scala
+++ b/lib/telekinesis/src/core/telekinesis.internal.scala
@@ -129,12 +129,17 @@ object internal:
             given payload is Postable = $postable
             given loggable0: HttpEvent is Loggable = $loggable
             val host: Host = $submit.host
-            val body = $postable.stream($payload)
             val path = $submit.originForm
             val contentType = Http.Header("content-type".tt, $postable.mediaType($payload).show)
 
             val request =
-              Http.Request($method, 1.1, host, path, contentType :: $headers.to(List), () => body)
+              Http.Request
+                ( $method,
+                  1.1,
+                  host,
+                  path,
+                  contentType :: $headers.to(List),
+                  () => $postable.stream($payload) )
 
             $client.request(request, $submit.target)
           }
@@ -163,7 +168,8 @@ object internal:
             val path = $fetch.originForm
 
             val request =
-              Http.Request($method, 1.1, $fetch.host, path, $headers.to(List), () => LazyList())
+              Http.Request
+                ( $method, 1.1, $fetch.host, path, $headers.to(List), () => Http.emptyBody() )
 
             $client.request(request, $fetch.target)
           }

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -45,7 +45,6 @@ import prepositional.*
 import rudiments.*
 import turbulence.*
 import urticose.*
-import vacuous.*
 import zephyrine.*
 
 // Build the underlying Java client with redirect-following disabled — the
@@ -71,19 +70,16 @@ private def buildJavaRequest
   ( uri:         jn.URI,
     method:      Http.Method,
     textHeaders: List[Http.Header],
-    bodyFn:      () => LazyList[Data] )
+    bodyFn:      () => Stream[Data] over Credit )
 :   jnh.HttpRequest =
 
   val request: jnh.HttpRequest.Builder = jnh.HttpRequest.newBuilder().nn.uri(uri).nn
 
-  lazy val body = bodyFn() match
-    case LazyList() => jnh.HttpRequest.BodyPublishers.noBody.nn
-
-    case LazyList(bytes) =>
-      jnh.HttpRequest.BodyPublishers.ofByteArray(bytes.mutable(using Unsafe))
-
-    case stream =>
-      jnh.HttpRequest.BodyPublishers.ofInputStream: () => stream.inputStream
+  // The publisher pulls a fresh pull endpoint each time it is subscribed (the
+  // JDK may re-subscribe on retry), draining it lazily through an
+  // `InputStream` so the body is never held whole in memory.
+  lazy val body =
+    jnh.HttpRequest.BodyPublishers.ofInputStream { () => bodyFn().lazyList.inputStream }.nn
 
   method match
     case Http.Delete  => request.DELETE().nn
@@ -150,7 +146,7 @@ package httpBackends:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => LazyList[Data] )
+        body:    () => Stream[Data] over Credit )
       ( using Tactic[ConnectError] )
     :   Http.Response =
 

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -302,7 +302,7 @@ object Tests extends Suite(m"Telekinesis tests"):
             data.slice(offset, end) #:: go(end)
         go(0)
 
-      def bodyText(request: Http.Request): Text = request.body().read[Data].utf8
+      def bodyText(request: Http.Request): Text = request.body().lazyList.read[Data].utf8
 
       val blockSizes = List(1, 2, 3, 7, 13, 4096)
       val fixture = t"GET /path?q=1 HTTP/1.1\r\nHost: example.com\r\nX-Foo: bar\r\n\r\nbody"

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -42,9 +42,10 @@ import hypotenuse.*
 import prepositional.*
 import rudiments.*
 import spectacular.*
+import turbulence.*
 import vacuous.*
-import soundness.{invoke, dispose}
 import xenophile.*
+import zephyrine.*
 
 // The WIT definitions the navigation below is typechecked against, and which the `invoke`
 // materializer consults (at its downstream expansion site) for module ids, resource methods and
@@ -69,7 +70,7 @@ package httpBackends:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => LazyList[Data] )
+        body:    () => Stream[Data] over Credit )
       ( using Tactic[ConnectError] )
     :   Http.Response =
 
@@ -115,7 +116,7 @@ package httpBackends:
 
       // A method that carries a payload streams it through the request's `outgoing-body`, which
       // must then be `finish`ed (a static function) for the request to be complete.
-      val payload: LazyList[Data] = if method.payload then body() else LazyList()
+      val payload: LazyList[Data] = if method.payload then body().lazyList else LazyList()
 
       val bodyHandles =
         if payload.isEmpty then Unset else


### PR DESCRIPTION
Follow-up to #1490, converting the request-body path to the streaming kernel. The request body is now a re-materializable pull-endpoint thunk — `() => Stream[Data] over Credit` — threaded through `Postable`, `Http.Request.body`, `Http.Backend` and the redirect loop, replacing `() => LazyList[Data]`. This completes the client-side streaming story begun with response bodies in #1490.

## Release notes

- `Postable` instances produce a `Stream[Data] over Credit`, constructed fresh on each call since a request body may be materialized more than once — a method-preserving redirect re-sends it, and `preview` reads it independently for logging — and a `Stream`, being a single-use mutable buffer, cannot be re-pulled.
- The JDK client drains the body lazily through an `InputStream`, so it is never held whole in memory. Because a streamed body has no known length, small in-memory bodies are now framed with chunked transfer-encoding rather than a `Content-Length` header; standard servers accept both.
- The socket, WASI, gRPC (obligatory) and apoplexy transports and the server-side request parser adapt at their boundaries; `Http.Request.body` and `Http.Backend.request` now carry the streaming type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)