### PR TITLE
Match Stratiform's literal-atom closing delimiter to the opening line (TEL §15)

### DIFF
--- a/lib/stratiform/res/test/stratiform/corpus/neg/e113-source-after-literal.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/neg/e113-source-after-literal.tel
@@ -1,5 +1,5 @@
 code
       EOF
 literal content
-EOF
+      EOF
     source content

--- a/lib/stratiform/res/test/stratiform/corpus/neg/e114-duplicate-literal.check
+++ b/lib/stratiform/res/test/stratiform/corpus/neg/e114-duplicate-literal.check
@@ -24,16 +24,10 @@ Document {
                     remark: None,
                     children: [],
                 },
-                Compound {
-                    keyword: "END",
-                    atoms: [],
-                    remark: None,
-                    children: [],
-                },
             ],
             trailing_blank_lines: 1,
         },
     ],
 }
 errors:
-  E111 [25,31): Over-indentation
+  E111 [31,37): Over-indentation

--- a/lib/stratiform/res/test/stratiform/corpus/neg/e114-duplicate-literal.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/neg/e114-duplicate-literal.tel
@@ -1,7 +1,6 @@
 code
       EOF
 first
-EOF
+      EOF
       END
 second
-END

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-basic.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-basic.tel
@@ -3,4 +3,4 @@ code
 hello world
   indented
 trailing spaces
-EOF
+      EOF

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-cr-in-payload.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-cr-in-payload.tel
@@ -2,4 +2,4 @@ code
       END
 hello
 world
-END
+      END

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-cr-preserved.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-cr-preserved.tel
@@ -3,4 +3,4 @@ code
 first
 second
 third
-END
+      END

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-custom-delimiter.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-custom-delimiter.tel
@@ -1,4 +1,4 @@
 code
       ===
 content
-===
+      ===

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-delimiter-in-payload.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-delimiter-in-payload.tel
@@ -2,4 +2,4 @@ code
       END
 this END is not the closing delimiter
 because it's not on its own line
-END
+      END

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-delimiter-partial-match.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-delimiter-partial-match.tel
@@ -2,4 +2,4 @@ code
       EOF
 EOF is mentioned here
 not EOF alone
-EOF
+      EOF

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-empty-payload.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-empty-payload.tel
@@ -1,3 +1,3 @@
 code
       EOF
-EOF
+      EOF

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-flush-delimiter-in-payload.check
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-flush-delimiter-in-payload.check
@@ -11,8 +11,8 @@ Document {
                     keyword: "code",
                     atoms: [
                         Literal {
-                            delimiter: "EOF",
-                            text: "literal content",
+                            delimiter: "END",
+                            text: "END\nstill payload",
                         },
                     ],
                     remark: None,
@@ -23,5 +23,3 @@ Document {
         },
     ],
 }
-errors:
-  E111 [41,45): Over-indentation

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-flush-delimiter-in-payload.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-flush-delimiter-in-payload.tel
@@ -1,4 +1,5 @@
 code
       END
-hello   
+END
+still payload
       END

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-from-nested.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-from-nested.tel
@@ -2,4 +2,4 @@ parent
   child
         END
 literal content here
-END
+        END

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-multiline-payload.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-multiline-payload.tel
@@ -3,4 +3,4 @@ code
 line 1
 line 2
 line 3
----
+      ---

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-nested-compound.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-nested-compound.tel
@@ -3,5 +3,5 @@ parent
         EOF
 hello
 world
-EOF
+        EOF
   other

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-resumes-after-close.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-resumes-after-close.tel
@@ -1,5 +1,5 @@
 code
       EOF
 content
-EOF
+      EOF
 sibling

--- a/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-sigil-no-meaning.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/pos/literal-atom-sigil-no-meaning.tel
@@ -1,4 +1,4 @@
 code
       END
 # not a comment inside literal
-END
+      END

--- a/lib/stratiform/res/test/stratiform/corpus/stream/literal-contains-separator.tel
+++ b/lib/stratiform/res/test/stratiform/corpus/stream/literal-contains-separator.tel
@@ -5,5 +5,5 @@ code
       line one
 ##
       line three
-END
+      END
 after plain

--- a/lib/stratiform/src/core/stratiform.Mutation.scala
+++ b/lib/stratiform/src/core/stratiform.Mutation.scala
@@ -609,22 +609,26 @@ object Mutation:
       ok
 
   // §22.3 literal delimiter: the shortest run of `-`, starting from
-  // `initial`, that does not appear as a line of the value — so the value
-  // is literal-safe (§22.2) with respect to it.
+  // `initial`, that does not collide with a line of the value at any
+  // indentation — a position-independent sufficient check for §22.2
+  // literal-safety, since the actual serialization indent isn't known here.
   private def literalDelimiter(value: Text, initial: Text): Text =
     var delimiter = initial.s
-    while appearsAsLine(value.s, delimiter) do delimiter = delimiter+"-"
+    while collidesWithDelimiterLine(value.s, delimiter) do delimiter = delimiter+"-"
     Text(delimiter)
 
-  // True if `line` occurs as a whole LF-delimited line of `s`.
-  private def appearsAsLine(s: String, line: String): Boolean =
+  // True if `s` contains a line consisting of zero-or-more spaces followed
+  // exactly by `delimiter`.
+  private def collidesWithDelimiterLine(s: String, delimiter: String): Boolean =
     var start = 0
     var found = false
 
     while !found && start <= s.length do
       val nl = s.indexOf('\n', start)
       val end = if nl < 0 then s.length else nl
-      if s.substring(start, end).nn == line then found = true
+      var i = start
+      while i < end && s.charAt(i) == ' ' do i += 1
+      if s.substring(i, end).nn == delimiter then found = true
       start = if nl < 0 then s.length + 1 else nl + 1
 
     found

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1043,7 +1043,8 @@ object Tel extends Tel2:
               if nl < 0 then start = sourceText.length + 1 else start = nl + 1
 
           case Tel.Atom.Literal(delimiter, text) =>
-            out("  "*(indent + 3) + delimiter.s)
+            val delimiterLine = "  "*(indent + 3) + delimiter.s
+            out(delimiterLine)
             val payload = text.s
             var start = 0
 
@@ -1053,7 +1054,7 @@ object Tel extends Tel2:
               out(payload.substring(start, end))
               if nl < 0 then start = payload.length + 1 else start = nl + 1
 
-            out(delimiter.s)
+            out(delimiterLine)
 
           case _ => ()
 
@@ -3163,8 +3164,8 @@ object Tel extends Tel2:
 
     // Cursor is at the first content byte of the opening line (the delimiter
     // text). The delimiter is the rest of the opening line. The payload is
-    // everything between the next LF and the first line whose content equals
-    // the delimiter (at column 0 / flush left).
+    // everything between the next LF and the first line whose content is
+    // byte-identical to the opening delimiter line (indentation included).
     private def parseLiteralAtom(literalIndent: Int): Tel.Atom.Literal raises TelError =
       val openingLine = head.startLine
       // Read the delimiter — opening line, terminated by LF or CR per the
@@ -3181,6 +3182,7 @@ object Tel extends Tel2:
         consumeLineEnding()
         d
 
+      val closingLine = (" "*literalIndent)+delimiter
       sb.setLength(0)
       var done = false
 
@@ -3207,7 +3209,7 @@ object Tel extends Tel2:
             if raw.length > 0 && raw.charAt(raw.length - 1) == '\r'
             then raw.substring(0, raw.length - 1)
             else raw
-          if line == delimiter then
+          if line == closingLine then
             // Closing delimiter — the LF *before* the closing delimiter is the
             // delimiter's leading separator, not part of the payload. Strip the
             // trailing '\n' we appended for the previous payload line (if any),

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -1035,7 +1035,7 @@ object Tests extends Suite(m"Stratiform Tests"):
 
       test(m"UpdateAtom never downgrades a literal atom to inline (§22.3)"):
         // A literal atom updated to an inline-safe value stays literal.
-        val tel    = doc("note\n      ===\nnow literal\n===\n")
+        val tel    = doc("note\n      ===\nnow literal\n      ===\n")
         val ptr    = Tel.Pointer.of(t"note")
         val result = Mutation(tel, Mutation.Op.UpdateAtom(ptr, 0, t"now simple"))
         result.childCompounds.head.atoms.head match


### PR DESCRIPTION
Stratiform's parser, serializer, and mutation logic implemented the old TEL §15 rule for literal atom closing delimiters — a bare delimiter at column zero. The spec now requires the closing delimiter line to be byte-identical to the opening delimiter line, including indentation, so this updates all three components plus the test corpus to match.

- The parser now matches a literal atom's closing line against the opening line's exact indentation and delimiter text, rather than requiring the delimiter flush-left at column zero.
- The serializer emits the closing delimiter line identically to the opening one.
- Mutation's delimiter-collision check (used when escalating a value to a literal atom) now checks for a delimiter line at *any* indentation, not just column zero — the conservative, position-independent form of the new invariant.

```tel
foo
  bar
        ---
This is literal content as a parameter to `bar`.
        ---
```

A payload line that happens to be a bare delimiter at some other indentation (e.g. a flush-left `---` inside embedded Markdown) is now ordinary payload content and no longer terminates the atom.