### PR TITLE
Track XML positions through `load` + `parsing.trackPositions`

### DIFF
--- a/lib/xylophone/src/bench/xylophone.Benchmarks.scala
+++ b/lib/xylophone/src/bench/xylophone.Benchmarks.scala
@@ -65,7 +65,9 @@ object Benchmarks extends Suite(m"Xylophone benchmarks"):
 
   def parseXylophone(text: Text): Document[Xml] = unsafely(text.load[Xml])
 
-  def parseXylophoneTracked(text: Text): Xml.Tracked = unsafely(Xml.parseTracked(text))
+  def parseXylophoneTracked(text: Text): Document[Xml] =
+    import zephyrine.parsing.trackPositions
+    unsafely(text.load[Xml])
 
   def parseScalaXml(text: String): scala.xml.Elem = scala.xml.XML.loadString(text)
 

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -587,9 +587,19 @@ object Xml extends Tag.Container
   // tracking `Lineation` in its cursor, parse, then bundle the resulting
   // `Xml` with the position index the parser emitted along the way.
   // `positionIndex` is `Unset` if the input contains no root element.
+  //
+  // Parse with `headers0 = true` so a leading `<?xml …?>` declaration is
+  // accepted (like `.load[Xml]`), then drop it: the position index is built
+  // from the root element alone, so the tracked value must have the same
+  // shape it would for header-less input, else `Tracked.walk` misaligns.
+  private def dropHeader(xml: Xml): Xml = xml match
+    case Fragment((_: Header), rest*) => if rest.length == 1 then rest.head else Fragment(rest*)
+    case _: Header                    => Fragment()
+    case other                        => other
+
   def parseTracked(text: Text)(using schema: XmlSchema, tactic: Tactic[ParseError]): Tracked =
     val parser = XmlParser.fromTextTracked(text)
-    val xml = parser.parseXml(headers0 = false)
+    val xml = dropHeader(parser.parseXml(headers0 = true))
     val index = parser.rootIndex
     Tracked(xml, PositionIndex(if index == null then IArray.empty[Int] else index))
 
@@ -598,7 +608,7 @@ object Xml extends Tag.Container
   :   Tracked =
 
     val parser = XmlParser.fromIteratorTracked(input)
-    val xml = parser.parseXml(headers0 = false)
+    val xml = dropHeader(parser.parseXml(headers0 = true))
     val index = parser.rootIndex
     Tracked(xml, PositionIndex(if index == null then IArray.empty[Int] else index))
 

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1474,18 +1474,25 @@ object Xml extends Tag.Container
           while more && peek != ';' do
             val c = peek
 
+            // Reuse the digit-value subtraction as its own range check: the
+            // difference, masked to 16 bits by `.toChar`, is in range iff small,
+            // so the value the decoder already needs doubles as the bounds test.
+            // The hex-letter subtraction is only computed when `c` isn't a digit.
+            val dec = (c - '0').toChar
+
             value =
-              if '0' <= c && c <= '9' then 16*value + (c - '0')
-              else if 'a' <= c && c <= 'f' then 16*value + (c - 87)
-              else if 'A' <= c && c <= 'F' then 16*value + (c - 55)
-              else fail(Issue.Unexpected(c))
+              if dec <= 9 then 16*value + dec
+              else
+                val hex = ((c | 0x20) - 'a').toChar
+                if hex <= 5 then 16*value + hex + 10 else fail(Issue.Unexpected(c))
 
             advance()
         else
           while more && peek != ';' do
             val c = peek
+            val dec = (c - '0').toChar
 
-            if '0' <= c && c <= '9' then value = 10*value + (c - '0')
+            if dec <= 9 then value = 10*value + dec
             else fail(Issue.Unexpected(c))
 
             advance()

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -561,56 +561,51 @@ object Xml extends Tag.Container
       XmlParser.fromIterator(input.iterator).parseXml(headers0 = false).as[value]
       . asInstanceOf[value in Xml]
 
-  given loadable: (schema: XmlSchema) => (tactic: Tactic[ParseError])
+  // The single place `.load[Xml]` branches on position tracking. With
+  // `parsing.trackPositions` in scope the parser records source positions and the
+  // resulting `Document[Xml]` carries them in its `Header` metadata, locatable via
+  // `document.locate(path)`; otherwise the untracked throughput path is unchanged.
+  // `headers0 = true` accepts a leading `<?xml …?>` declaration, which is lifted
+  // into the metadata `Header` and dropped from the tree, so the tracked value has
+  // the same shape as a header-less load (keeping it aligned with the index, which
+  // is built from the root element alone).
+  given loadable: (schema: XmlSchema) => (tactic: Tactic[ParseError], tracking: PositionTracking)
   =>  ((Xml is Loadable by Text)^{tactic}) = stream =>
-    XmlParser.fromIterator(stream.iterator).parseXml(headers0 = true) match
+    val parser = tracking match
+      case PositionTracking.On  => XmlParser.fromIteratorTracked(stream.iterator)
+      case PositionTracking.Off => XmlParser.fromIterator(stream.iterator)
+
+    val parsed = parser.parseXml(headers0 = true)
+
+    val positionIndex: Optional[PositionIndex] = tracking match
+      case PositionTracking.On =>
+        val index = parser.rootIndex
+        PositionIndex(if index == null then IArray.empty[Int] else index)
+
+      case PositionTracking.Off =>
+        Unset
+
+    def withIndex(header: Header): Header = header.copy(positionIndex = positionIndex)
+
+    parsed match
       case Fragment((header: Header), rest*) =>
         if rest.nil then abort(ParseError(Xml, Position(1.u, 1.u), Issue.BadDocument))
-        else if rest.length == 1 then Document(rest.head, header)
-        else Document(Fragment(rest*), header)
+        else if rest.length == 1 then Document(rest.head, withIndex(header))
+        else Document(Fragment(rest*), withIndex(header))
 
       case _: Header =>
         abort(ParseError(Xml, Position(1.u, 1.u), Issue.BadDocument))
 
       case fragment: Fragment =>
-        Document(fragment, Xml.header)
+        Document(fragment, withIndex(Xml.header))
 
       case node: Node =>
-        Document(node, Xml.header)
+        Document(node, withIndex(Xml.header))
 
   // `^{monitor}` only: `Probate` is not capture-tracked (see rep/REVIEW.md).
   given streamable: (monitor: Monitor, probate: Probate)
   =>  ((Document[Xml] is Streamable by Text)^{monitor}) =
     emit(_).to(LazyList)
-
-  // Tracking-mode parse entry points. Build the parser with a line-feed
-  // tracking `Lineation` in its cursor, parse, then bundle the resulting
-  // `Xml` with the position index the parser emitted along the way.
-  // `positionIndex` is `Unset` if the input contains no root element.
-  //
-  // Parse with `headers0 = true` so a leading `<?xml …?>` declaration is
-  // accepted (like `.load[Xml]`), then drop it: the position index is built
-  // from the root element alone, so the tracked value must have the same
-  // shape it would for header-less input, else `Tracked.walk` misaligns.
-  private def dropHeader(xml: Xml): Xml = xml match
-    case Fragment((_: Header), rest*) => if rest.length == 1 then rest.head else Fragment(rest*)
-    case _: Header                    => Fragment()
-    case other                        => other
-
-  def parseTracked(text: Text)(using schema: XmlSchema, tactic: Tactic[ParseError]): Tracked =
-    val parser = XmlParser.fromTextTracked(text)
-    val xml = dropHeader(parser.parseXml(headers0 = true))
-    val index = parser.rootIndex
-    Tracked(xml, PositionIndex(if index == null then IArray.empty[Int] else index))
-
-  def parseTracked
-    (input: Iterator[Text])(using schema: XmlSchema, tactic: Tactic[ParseError])
-  :   Tracked =
-
-    val parser = XmlParser.fromIteratorTracked(input)
-    val xml = dropHeader(parser.parseXml(headers0 = true))
-    val index = parser.rootIndex
-    Tracked(xml, PositionIndex(if index == null then IArray.empty[Int] else index))
 
   def emit(document: Document[Xml])
     ( using formatting: Formatting, monitor: Monitor, probate: Probate )
@@ -727,7 +722,7 @@ object Xml extends Tag.Container
 
         producer.put("?>")
 
-      case Header(version, encoding, standalone) =>
+      case Header(version, encoding, standalone, _) =>
         producer.put("<?xml version=\"")
         producer.put(version)
         producer.put("\"")
@@ -891,7 +886,7 @@ object Xml extends Tag.Container
   // relative to the start of the containing element descriptor, so any
   // slice extracted at a descriptor boundary is itself a valid
   // `PositionIndex`. See `XmlParser` (tracking mode) for the layout and
-  // `Xml.Tracked#locate` for the navigation algorithm.
+  // `Xml.Locator#walk` for the navigation algorithm.
   opaque type PositionIndex = IArray[Int]
 
   object PositionIndex:
@@ -902,21 +897,24 @@ object Xml extends Tag.Container
 
   // Focus value tracked by Xylophone's path-aware decoders / encoders.
   // `path` is the XPath to the current node; `position` is the source
-  // line/column/length, populated when the root `Xml` was produced by
-  // `parseTracked` and `Unset` otherwise.
+  // line/column/length, populated when the document was loaded with
+  // `parsing.trackPositions` in scope and `Unset` otherwise.
   case class Focus(path: XPath, position: Optional[Xml.Position] = Unset)
   derives CanEqual:
 
-    def withPosition(tracked: Tracked): Focus =
-      copy(position = tracked.locate(path))
+    def withPosition(document: Document[Xml]): Focus =
+      copy(position = document.locate(path))
 
-  object Tracked:
+  // Walks a `Document[Xml]`'s position index (held in its `Header` metadata)
+  // to resolve an `XPath` to a source `Position`; see the descriptor-layout
+  // comment on `PositionIndex` below.
+  private object Locator:
     // `XPath.path.descent` is stored leaf-first (Serpentine's `/`
     // prepends), so the walker iterates it in reverse to descend
     // root-to-leaf. The XPath convention is `/foo/bar/@attr`, so the
     // first element step names the *root* element itself (no descent
     // into children) and subsequent steps descend.
-    private def walk
+    private[xylophone] def walk
       ( xml:      Xml,
         data:     IArray[Int],
         offset:   Int,
@@ -1018,8 +1016,9 @@ object Xml extends Tag.Container
 
       found
 
-  // Wraps a parsed `Xml` with a parallel position index produced by
-  // `parseTracked`. Untracked parses keep returning bare `Xml`.
+  // The position index is produced when a document is loaded with
+  // `parsing.trackPositions` in scope, and held in the `Document[Xml]`'s
+  // `Header` metadata; untracked loads carry `Unset`.
   //
   // Element descriptor layout:
   //
@@ -1034,23 +1033,38 @@ object Xml extends Tag.Container
   // All offsets are relative to the start of the containing element
   // descriptor; any slice at a descriptor boundary is itself a valid
   // `PositionIndex`.
-  case class Tracked(value: Xml, positionIndex: PositionIndex):
-    def locate(path: XPath): Optional[Xml.Position] =
-      Tracked.walk(value, positionIndex.ints, 0, path.path.descent.toIndexedSeq, 0)
 
-    // Decode like `Xml#as` but also populate `position` on every
-    // accumulated `Xml.Focus` by looking up its XPath against this
-    // tracked root's position index. Outside `validate[Xml.Focus]` the
-    // ambient `Foci` is a no-op and `supplement` does nothing, so this
-    // call stays cost-free.
-    def as[result: Decodable in Xml]: result tracks Xml.Focus =
-      val decoded = value match
+  // Resolves an `XPath` to the source `Position` recorded in a tracked
+  // `Document[Xml]`'s `PositionIndex`. Exposed uniformly as
+  // `document.locate(path)` through zephyrine's `Positionable`; returns `Unset`
+  // for a document loaded without `parsing.trackPositions`.
+  given positionable: Document[Xml] is Positionable by XPath to Xml.Position =
+    new Positionable:
+      type Self    = Document[Xml]
+      type Operand = XPath
+      type Result  = Xml.Position
+
+      def locate(document: Document[Xml], path: XPath): Optional[Xml.Position] =
+        document.metadata.positionIndex.let: index =>
+          Locator.walk(document.root, index.ints, 0, path.path.descent.toIndexedSeq, 0)
+
+      // XML has no distinct key positions, so there is nothing to locate by key.
+      def locateKey(document: Document[Xml], path: XPath): Optional[Xml.Position] = Unset
+
+  // Decode a tracked `Document[Xml]` like `Xml#as`, but also populate `position`
+  // on every accumulated `Xml.Focus` by looking its XPath up against the document's
+  // position index. Named `asTracked` rather than `as` because `as` is a generic
+  // decoder extension (and clashes with import-renaming syntax); outside
+  // `validate[Xml.Focus]` the ambient `Foci` is a no-op, so this stays cost-free
+  // and yields `Unset` positions for an untracked document.
+  extension (document: Document[Xml])
+    def asTracked[result: Decodable in Xml]: result tracks Xml.Focus =
+      val decoded = document.root match
         case Fragment(inner) => result.decoded(inner)
         case xml: Xml        => result.decoded(xml)
 
       val foci = summon[Foci[Xml.Focus]]
-      val tracked = this
-      foci.supplement(foci.length, _.let(_.withPosition(tracked)).vouch)
+      foci.supplement(foci.length, _.let(_.withPosition(document)).vouch)
       decoded
 
   enum Hole:
@@ -1236,7 +1250,7 @@ object Xml extends Tag.Container
     // hold attribute descriptors back-to-back and their end positions
     // within `attrDescs`. `childDescs` and `childEnds` hold child element
     // descriptors / their end positions the same way. See the layout
-    // comment on `Xml.Tracked`.
+    // comment on `Xml.PositionIndex`.
     private def emitElementDescriptor
       ( out:         scala.collection.mutable.ArrayBuffer[Int],
         attrDescs:   scala.collection.mutable.ArrayBuffer[Int],
@@ -2397,8 +2411,8 @@ sealed into trait Xml extends Dynamic, Topical, Documentary, Formal:
   // via the `decodable` summonFrom (textual decoder, else Wisteria
   // derivation). Errors registered inside the decoder carry `Xml.Focus`
   // values describing the XPath of the failing field. Position information
-  // stays `Unset`; use `Xml.Tracked#as` against a `parseTracked` root if
-  // you also want source line / column.
+  // stays `Unset`; decode a `Document[Xml]` loaded with `parsing.trackPositions`
+  // in scope (`document.as[T]`) if you also want source line / column.
   def as[result: Decodable in Xml]: result tracks Xml.Focus = this match
     case Fragment(value) => result.decoded(value)
     case xml: Xml        => result.decoded(xml)
@@ -2540,7 +2554,17 @@ case class Fragment(nodes: Node*) extends Xml:
     case node: Xml         => nodes.length == 1 && nodes(0) == node
     case _                 => false
 
-case class Header(version: Text, encoding: Optional[Text], standalone: Optional[Boolean])
+// The `positionIndex` rides in the document `Metadata` (a `Document[Xml]`'s
+// `metadata` is its `Header`), carrying the position index produced when the
+// document was loaded with `parsing.trackPositions` in scope. It is deliberately
+// excluded from `equals`/`hashCode`/serialization: it is parse provenance, not
+// part of the document's identity, so a tracked and an untracked load of the same
+// source compare equal.
+case class Header
+    ( version:       Text,
+      encoding:      Optional[Text],
+      standalone:    Optional[Boolean],
+      positionIndex: Optional[Xml.PositionIndex] = Unset )
 extends Node:
   override def hashCode: Int =
     ((version.hashCode*31 + encoding.hashCode)*31 + standalone.hashCode)*31 + 0x48646572
@@ -2548,7 +2572,7 @@ extends Node:
   override def equals(that: Any): Boolean = that match
     case Fragment(header: Header) => equals(header)
 
-    case Header(version0, encoding0, standalone0) =>
+    case Header(version0, encoding0, standalone0, _) =>
       version0 == version && encoding0 == encoding && standalone0 == standalone
 
     case _ =>

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -593,7 +593,7 @@ object internal:
       def serialize(xml: Xml): Seq[Expr[Node]] = xml match
         case Fragment(children*) => children.flatMap(serialize(_))
 
-        case Header(version, encoding, standalone) =>
+        case Header(version, encoding, standalone, _) =>
           val encoding2: Expr[Optional[Text]] =
             if encoding == Unset then '{Unset} else Expr(encoding.asInstanceOf[Text])
 

--- a/lib/xylophone/src/test/xylophone.DecoderTests.scala
+++ b/lib/xylophone/src/test/xylophone.DecoderTests.scala
@@ -36,6 +36,7 @@ import soundness.*
 
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
+import parsing.trackPositions
 
 case class DPerson(name: Text, age: Int, email: Text) derives CanEqual
 case class DContact(person: DPerson, company: Text) derives CanEqual
@@ -231,8 +232,8 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
           Tagged(items :+ (focus, line, column))
 
       inline def validateWithPositions[result]
-        ( tracked: Xml.Tracked )
-        ( inline decode: Xml.Tracked => result raises XmlError tracks Xml.Focus )
+        ( document: Document[Xml] )
+        ( inline decode: Document[Xml] => result raises XmlError tracks Xml.Focus )
       :   List[(Text, Optional[Int], Optional[Int])] =
         Validate[Tagged, [r] =>> r raises XmlError, Xml.Focus]
           ( Tagged(),
@@ -241,12 +242,12 @@ object DecoderTests extends Suite(m"Xylophone case-class decoder tests"):
                 accrual + ( prior.let(_.path.encode).or(t"#"),
                             position.let(_.line.n1),
                             position.let(_.column.n1) ) } )
-        . protect(decode(tracked)).items
+        . protect(decode(document)).items
 
       test(m"Missing-field error on a tracked Xml reports the parent's position"):
         val source = t"<root>\n  <name>Alice</name>\n  <age>30</age>\n</root>"
-        val tracked = Xml.parseTracked(source)
-        val results = validateWithPositions(tracked)(_.as[DPerson])
+        val tracked = source.load[Xml]
+        val results = validateWithPositions(tracked)(_.asTracked[DPerson])
         results.find(_(0) == t"/email[1]").map(_(1))
       . assert(_ == Some(Unset))
 

--- a/lib/xylophone/src/test/xylophone.PositionTests.scala
+++ b/lib/xylophone/src/test/xylophone.PositionTests.scala
@@ -35,6 +35,7 @@ package xylophone
 import soundness.*
 
 import strategies.throwUnsafely
+import parsing.trackPositions
 
 object PositionTests extends Suite(m"Xylophone position-index tests"):
 
@@ -45,100 +46,105 @@ object PositionTests extends Suite(m"Xylophone position-index tests"):
   def run(): Unit =
     given XmlSchema = XmlSchema.Freeform
 
-    suite(m"Single-element parseTracked"):
+    // `import parsing.trackPositions` (above) turns on position tracking, so a
+    // plain `.load[Xml]` records source positions on the `Document[Xml]`;
+    // `document.locate(path)` then resolves an `XPath` to its `Position`.
+    def trackedDoc(source: Text): Document[Xml] = source.load[Xml]
+
+    suite(m"Single-element tracked load"):
       test(m"Root element line"):
-        val tracked = Xml.parseTracked(t"<root/>")
+        val tracked = trackedDoc(t"<root/>")
         line(tracked.locate(XPath().element(t"root", 1)))
       . assert(_ == 1)
 
       test(m"Root element column"):
-        val tracked = Xml.parseTracked(t"<root/>")
+        val tracked = trackedDoc(t"<root/>")
         col(tracked.locate(XPath().element(t"root", 1)))
       . assert(_ == 1)
 
       test(m"Root element source length spans the open / close"):
-        val tracked = Xml.parseTracked(t"<root>hello</root>")
+        val tracked = trackedDoc(t"<root>hello</root>")
         len(tracked.locate(XPath().element(t"root", 1)))
       . assert(_ == 18)
 
     suite(m"Nested elements"):
       test(m"Single nested child line"):
-        val tracked = Xml.parseTracked(t"<root><child/></root>")
+        val tracked = trackedDoc(t"<root><child/></root>")
         line(tracked.locate(XPath().element(t"root", 1).element(t"child", 1)))
       . assert(_ == 1)
 
       test(m"Single nested child column"):
-        val tracked = Xml.parseTracked(t"<root><child/></root>")
+        val tracked = trackedDoc(t"<root><child/></root>")
         col(tracked.locate(XPath().element(t"root", 1).element(t"child", 1)))
       . assert(_ == 7)
 
       test(m"Second child with same name uses [2]"):
-        val tracked = Xml.parseTracked(t"<root><x/><x/></root>")
+        val tracked = trackedDoc(t"<root><x/><x/></root>")
         col(tracked.locate(XPath().element(t"root", 1).element(t"x", 2)))
       . assert(_ == 11)
 
       test(m"Missing child returns Unset"):
-        val tracked = Xml.parseTracked(t"<root><a/></root>")
+        val tracked = trackedDoc(t"<root><a/></root>")
         tracked.locate(XPath().element(t"root", 1).element(t"missing", 1))
       . assert(_ == Unset)
 
     suite(m"Leading XML declaration"):
       test(m"Declaration does not prevent tracked parsing"):
-        val tracked = Xml.parseTracked(t"""<?xml version="1.0"?><root/>""")
+        val tracked = trackedDoc(t"""<?xml version="1.0"?><root/>""")
         tracked.locate(XPath().element(t"root", 1)) != Unset
       . assert(_ == true)
 
       test(m"Root column accounts for the declaration prefix"):
-        val tracked = Xml.parseTracked(t"""<?xml version="1.0"?><root/>""")
+        val tracked = trackedDoc(t"""<?xml version="1.0"?><root/>""")
         col(tracked.locate(XPath().element(t"root", 1)))
       . assert(_ == 22)
 
       test(m"Declaration on its own line, root on the next"):
-        val tracked = Xml.parseTracked(t"<?xml version=\"1.0\"?>\n<root>hello</root>")
+        val tracked = trackedDoc(t"<?xml version=\"1.0\"?>\n<root>hello</root>")
         line(tracked.locate(XPath().element(t"root", 1)))
       . assert(_ == 2)
 
     suite(m"Attributes"):
       test(m"Single attribute column"):
-        val tracked = Xml.parseTracked(t"""<root name="x"/>""")
+        val tracked = trackedDoc(t"""<root name="x"/>""")
         col(tracked.locate(XPath().element(t"root", 1).attribute(t"name")))
       . assert(_ == 7)
 
       test(m"Attribute length spans name='value'"):
-        val tracked = Xml.parseTracked(t"""<root name="alice"/>""")
+        val tracked = trackedDoc(t"""<root name="alice"/>""")
         len(tracked.locate(XPath().element(t"root", 1).attribute(t"name")))
       . assert(_ == 12)
 
       test(m"Second attribute column"):
-        val tracked = Xml.parseTracked(t"""<root a="1" b="2"/>""")
+        val tracked = trackedDoc(t"""<root a="1" b="2"/>""")
         col(tracked.locate(XPath().element(t"root", 1).attribute(t"b")))
       . assert(_ == 13)
 
       test(m"Missing attribute returns Unset"):
-        val tracked = Xml.parseTracked(t"""<root a="1"/>""")
+        val tracked = trackedDoc(t"""<root a="1"/>""")
         tracked.locate(XPath().element(t"root", 1).attribute(t"missing"))
       . assert(_ == Unset)
 
     suite(m"Multi-line input"):
       test(m"Second-line child is on line 2"):
         val source = t"<root>\n  <child/>\n</root>"
-        val tracked = Xml.parseTracked(source)
+        val tracked = trackedDoc(source)
         line(tracked.locate(XPath().element(t"root", 1).element(t"child", 1)))
       . assert(_ == 2)
 
       test(m"Second-line child column reflects indent"):
         val source = t"<root>\n  <child/>\n</root>"
-        val tracked = Xml.parseTracked(source)
+        val tracked = trackedDoc(source)
         col(tracked.locate(XPath().element(t"root", 1).element(t"child", 1)))
       . assert(_ == 3)
 
     suite(m"Mixed content"):
       test(m"Text between elements doesn't break child indexing"):
-        val tracked = Xml.parseTracked(t"<root>hi<a/>bye<b/>!</root>")
+        val tracked = trackedDoc(t"<root>hi<a/>bye<b/>!</root>")
         col(tracked.locate(XPath().element(t"root", 1).element(t"b", 1)))
       . assert(_ == 16)
 
       test(m"Comment between elements doesn't break child indexing"):
-        val tracked = Xml.parseTracked(t"<root><a/><!-- x --><b/></root>")
+        val tracked = trackedDoc(t"<root><a/><!-- x --><b/></root>")
         col(tracked.locate(XPath().element(t"root", 1).element(t"b", 1)))
       . assert(_ == 21)

--- a/lib/xylophone/src/test/xylophone.PositionTests.scala
+++ b/lib/xylophone/src/test/xylophone.PositionTests.scala
@@ -82,6 +82,22 @@ object PositionTests extends Suite(m"Xylophone position-index tests"):
         tracked.locate(XPath().element(t"root", 1).element(t"missing", 1))
       . assert(_ == Unset)
 
+    suite(m"Leading XML declaration"):
+      test(m"Declaration does not prevent tracked parsing"):
+        val tracked = Xml.parseTracked(t"""<?xml version="1.0"?><root/>""")
+        tracked.locate(XPath().element(t"root", 1)) != Unset
+      . assert(_ == true)
+
+      test(m"Root column accounts for the declaration prefix"):
+        val tracked = Xml.parseTracked(t"""<?xml version="1.0"?><root/>""")
+        col(tracked.locate(XPath().element(t"root", 1)))
+      . assert(_ == 22)
+
+      test(m"Declaration on its own line, root on the next"):
+        val tracked = Xml.parseTracked(t"<?xml version=\"1.0\"?>\n<root>hello</root>")
+        line(tracked.locate(XPath().element(t"root", 1)))
+      . assert(_ == 2)
+
     suite(m"Attributes"):
       test(m"Single attribute column"):
         val tracked = Xml.parseTracked(t"""<root name="x"/>""")


### PR DESCRIPTION
Xylophone's XML position tracking now follows the same contextual-toggle convention as `jacinta` and `stratiform`: bringing `parsing.trackPositions` into scope makes an ordinary `source.load[Xml]` record source positions on the resulting `Document[Xml]`, retrievable with `document.locate(xpath)`. The bespoke `Xml.parseTracked` entry point and `Xml.Tracked` wrapper are removed. As a minor internal change, the parser's numeric character-reference decoder now reuses the digit-value subtraction as its own range check.

### Position tracking via `load` + `parsing.trackPositions`

Recording source positions is now a contextual toggle on the ordinary load path rather than a separate method:

```scala
import parsing.trackPositions

val doc = source.load[Xml]                        // Document[Xml] carrying positions
val pos = doc.locate(XPath().element(t"item", 1)) // Optional[Xml.Position]
```

Without `parsing.trackPositions` in scope, `.load[Xml]` parses exactly as before and carries no index (zero overhead). The position index rides in the document's `Header` metadata, so the plain `Xml` value is unchanged. A leading `<?xml …?>` declaration is handled on the tracked path too (lifted into the metadata), matching the untracked load.

**Breaking:** `Xml.parseTracked` and `Xml.Tracked` are removed. Replace `Xml.parseTracked(src).locate(path)` with `src.load[Xml].locate(path)` under `import parsing.trackPositions`. Position-aware decoding moves from `tracked.as[T]` to `document.asTracked[T]`.

### Internal: character-reference decoding

Decoding `&#…;` / `&#x…;` entity references reuses the digit-value subtraction as its in-range test instead of a separate comparison chain. No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
