### PR TITLE
Re-parent the streaming kernel as exclusive capabilities and retire the LazyList bridges

### DIFF
--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -94,9 +94,9 @@ object Api:
 
     val url = full.decode[HttpUrl]
 
-    val empty: () => (Stream[Data] over Credit)^ = () => Stream(Iterator.empty[Data])
+    val empty: Spring[Data] = () => Stream(Iterator.empty[Data])
 
-    val (contentType, body): (Optional[Text], () => (Stream[Data] over Credit)^) = request.body match
+    val (contentType, body): (Optional[Text], Spring[Data]) = request.body match
       case Api.Body.Empty       => (Unset, empty)
       case Api.Body.Json(value) => (t"application/json", () => Stream(value.show.data))
       case Api.Body.Xml(value)  => (t"application/xml", () => Stream(value.show.data))

--- a/lib/apoplexy/src/core/apoplexy.Api.scala
+++ b/lib/apoplexy/src/core/apoplexy.Api.scala
@@ -94,9 +94,9 @@ object Api:
 
     val url = full.decode[HttpUrl]
 
-    val empty: () => Stream[Data] over Credit = () => Stream(Iterator.empty[Data])
+    val empty: () => (Stream[Data] over Credit)^ = () => Stream(Iterator.empty[Data])
 
-    val (contentType, body): (Optional[Text], () => Stream[Data] over Credit) = request.body match
+    val (contentType, body): (Optional[Text], () => (Stream[Data] over Credit)^) = request.body match
       case Api.Body.Empty       => (Unset, empty)
       case Api.Body.Json(value) => (t"application/json", () => Stream(value.show.data))
       case Api.Body.Xml(value)  => (t"application/xml", () => Stream(value.show.data))

--- a/lib/apoplexy/src/core/apoplexy.Conformant.scala
+++ b/lib/apoplexy/src/core/apoplexy.Conformant.scala
@@ -43,7 +43,7 @@ import turbulence.*
 import xylophone.*
 
 import errorDiagnostics.emptyDiagnostics
-import zephyrine.ParseError
+import zephyrine.{ParseError, memoize}
 
 // Interprets an `Http.Response` as a value of `Self`, reading the body in the wire
 // format `Transport` (`jacinta.Json` or `xylophone.Xml`) the spec dictates.
@@ -67,7 +67,7 @@ trait LowPriorityConformant:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
         case JsonError(_)        => ApiError(ApiError.Reason.Malformed)
 
-      . protect(response.body.stream.read[Json].as[value])
+      . protect(response.body.stream.memoize.read[Json].as[value])
 
   // A 2xx XML body decoded to any XML-decodable type.
   given xmlDecodable: [value: Decodable in Xml]
@@ -79,7 +79,7 @@ trait LowPriorityConformant:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
         case _: XmlError         => ApiError(ApiError.Reason.Malformed)
 
-      . protect(summon[CharDecoder].decoded(response.body.stream).read[Xml].as[value])
+      . protect(summon[CharDecoder].decoded(response.body.stream.memoize).read[Xml].as[value])
 
 object Conformant extends LowPriorityConformant:
   // Raise `ApiError` unless the response status is in the 2xx range.
@@ -104,7 +104,7 @@ object Conformant extends LowPriorityConformant:
     mitigate:
       case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
 
-    . protect(response.body.stream.read[Json])
+    . protect(response.body.stream.memoize.read[Json])
 
   // The raw 2xx body as XML. The body bytes are decoded to `Text` (via the
   // `CharDecoder`) before xylophone parses them.
@@ -115,7 +115,7 @@ object Conformant extends LowPriorityConformant:
       mitigate:
         case ParseError(_, _, _) => ApiError(ApiError.Reason.Malformed)
 
-      . protect(summon[CharDecoder].decoded(response.body.stream).read[Xml])
+      . protect(summon[CharDecoder].decoded(response.body.stream.memoize).read[Xml])
 
 trait Conformant extends Typeclass, Transportive:
   def read(response: Http.Response): Self

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -60,7 +60,7 @@ class Recorder(canned: () => Http.Response) extends Http.Backend:
 
   def request
      ( url: Text, method: Http.Method, headers: List[Http.Header],
-        body: () => Stream[Data] over Credit )
+        body: () => (Stream[Data] over Credit)^ )
      ( using Tactic[ConnectError] )
   :   Http.Response =
     lastUrl = url

--- a/lib/apoplexy/src/test/apoplexy.ApiTests.scala
+++ b/lib/apoplexy/src/test/apoplexy.ApiTests.scala
@@ -60,14 +60,14 @@ class Recorder(canned: () => Http.Response) extends Http.Backend:
 
   def request
      ( url: Text, method: Http.Method, headers: List[Http.Header],
-        body: () => (Stream[Data] over Credit)^ )
+        body: Spring[Data]^ )
      ( using Tactic[ConnectError] )
   :   Http.Response =
     lastUrl = url
     lastMethod = method
     lastHeaders = headers
-    val chunks = body().lazyList.to(List)
-    lastBody = if chunks.isEmpty then Unset else chunks.head
+    val data = body().memoize
+    lastBody = if data.isEmpty then Unset else data
     canned()
 
 object ApiTests extends Suite(m"Api client tests"):

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -255,17 +255,17 @@ object Cbor extends Cbor2, Dynamic:
     // shortest of the 1/2/4/8-byte head encodings, floats are always emitted as 64-bit, and arrays
     // and maps are length-prefixed.
     given encodable: Ast is Encodable in Data = cbor =>
-      def u16(out: Producer.Bytes, value: Int): Unit =
+      def u16(out: (Producer.Bytes)^, value: Int): Unit =
         out.push(((value >>> 8) & 0xFF).toByte)
         out.push((value & 0xFF).toByte)
 
-      def u32(out: Producer.Bytes, value: Long): Unit =
+      def u32(out: (Producer.Bytes)^, value: Long): Unit =
         out.push(((value >>> 24) & 0xFF).toByte)
         out.push(((value >>> 16) & 0xFF).toByte)
         out.push(((value >>> 8) & 0xFF).toByte)
         out.push((value & 0xFF).toByte)
 
-      def u64(out: Producer.Bytes, value: Long): Unit =
+      def u64(out: (Producer.Bytes)^, value: Long): Unit =
         out.push(((value >>> 56) & 0xFF).toByte)
         out.push(((value >>> 48) & 0xFF).toByte)
         out.push(((value >>> 40) & 0xFF).toByte)
@@ -275,7 +275,7 @@ object Cbor extends Cbor2, Dynamic:
         out.push(((value >>> 8) & 0xFF).toByte)
         out.push((value & 0xFF).toByte)
 
-      def head(out: Producer.Bytes, major: Int, value: Long): Unit =
+      def head(out: (Producer.Bytes)^, major: Int, value: Long): Unit =
         val majorBits = major << 5
 
         if value < 0 then
@@ -296,7 +296,7 @@ object Cbor extends Cbor2, Dynamic:
           out.push((majorBits | 27).toByte)
           u64(out, value)
 
-      def write(out: Producer.Bytes, cbor: Cbor.Ast): Unit =
+      def write(out: (Producer.Bytes)^, cbor: Cbor.Ast): Unit =
         if cbor.isInteger then
           val long = cbor.asInstanceOf[Long]
 

--- a/lib/burdock/src/core/burdock.Repackager.scala
+++ b/lib/burdock/src/core/burdock.Repackager.scala
@@ -204,8 +204,8 @@ object Repackager:
             // are needed (to rewrite the manifest and read the hash list); read those two. Drop any
             // bundled `burdock/Bootstrap.class` (an app whose `Main-Class` is `burdock.Bootstrap`
             // bundles burdock) since the bootstrap is force-included below, avoiding a duplicate.
-            if name == manifestName then manifestData = entry.read[Data]
-            else if name == resource then depsData = entry.read[Data]
+            if name == manifestName then manifestData = entry.stream[Data].read[Data]
+            else if name == resource then depsData = entry.stream[Data].read[Data]
             else if name == bootstrapName then ()
             else ownBuilder += entry
 

--- a/lib/burdock/src/core/burdock_repackage.scala
+++ b/lib/burdock/src/core/burdock_repackage.scala
@@ -100,7 +100,7 @@ def repackage(): Unit = application(Nil):
 
       // The bootstrap loader cannot be downloaded — it does the downloading — so
       // its bytes are force-included from burdock's own (boot) JAR on the classpath.
-      val bootstrapClass: Data = (Classpath/"burdock"/"Bootstrap.class").read[Data]
+      val bootstrapClass: Data = (Classpath/"burdock"/"Bootstrap.class").stream[Data].read[Data]
 
       // Unpublished dependencies are reconstructed from the build-time hard-links in
       // `~/.cache/burdock/<sha256>.jar` (see `externalize`); published ones resolve via

--- a/lib/cacophony/src/core/cacophony.Audible.scala
+++ b/lib/cacophony/src/core/cacophony.Audible.scala
@@ -48,7 +48,7 @@ trait Audible extends Typeclass:
     def mediaType: MediaType
 
     def read[input: Streamable by Data](source: input): Audio in Self raises AudioError =
-      val rawBytes: Array[Byte] = source.read[Data].javaInputStream.readAllBytes.nn
+      val rawBytes: Array[Byte] = source.stream[Data].read[Data].javaInputStream.readAllBytes.nn
 
       val fileFormat: jss.AudioFileFormat =
         try jss.AudioSystem.getAudioFileFormat(ji.ByteArrayInputStream(rawBytes)).nn

--- a/lib/cacophony/src/core/cacophony.Audio.scala
+++ b/lib/cacophony/src/core/cacophony.Audio.scala
@@ -42,6 +42,7 @@ import quantitative.*
 import rudiments.*
 import symbolism.*
 import turbulence.*
+import zephyrine.Credit
 import vacuous.*
 
 object Audio:
@@ -106,11 +107,20 @@ object Audio:
   given streamable: [form: Audible] => (Audio in form) is Streamable by Data = audio =>
     writeAudio(audio, form.name)
 
+  given source: [form: Audible]
+  =>  (Audio in form) is Source by Data over Credit =
+    audio => zephyrine.Stream(writeAudio(audio, form.name).iterator)
+
 
   given streamableAcross: [form: Audible, layout]
   =>  (Audio in form across layout) is Streamable by Data =
 
     audio => writeAudio(audio, form.name)
+
+  given sourceAcross: [form: Audible, layout]
+  =>  (Audio in form across layout) is Source by Data over Credit =
+
+    audio => zephyrine.Stream(writeAudio(audio, form.name).iterator)
 
 
   given abstractable: [format: Audible] => (Audio in format) is Abstractable:

--- a/lib/cacophony/src/core/cacophony.Audio.scala
+++ b/lib/cacophony/src/core/cacophony.Audio.scala
@@ -46,7 +46,7 @@ import vacuous.*
 
 object Audio:
   def apply[streamable: Streamable by Data](input: streamable): Audio raises AudioError =
-    val rawBytes: Array[Byte] = input.read[Data].javaInputStream.readAllBytes.nn
+    val rawBytes: Array[Byte] = input.stream[Data].read[Data].javaInputStream.readAllBytes.nn
 
     val raw: jss.AudioInputStream =
       try jss.AudioSystem.getAudioInputStream(ji.ByteArrayInputStream(rawBytes)).nn
@@ -118,7 +118,7 @@ object Audio:
     type Result = HttpStreams.Content
 
     def genericize(audio: Audio in format): HttpStreams.Content =
-      (format.mediaType.basic, HttpStreams.Body(audio.read[LazyList[Data]].iterator))
+      (format.mediaType.basic, HttpStreams.Body(audio.stream[Data].iterator))
 
   given aggregable: [format: Audible as audible] => (tactic: Tactic[AudioError])
   =>  (((Audio in format) is Aggregable by Data)^{tactic}) =

--- a/lib/caduceus/src/core/caduceus.Sendable.scala
+++ b/lib/caduceus/src/core/caduceus.Sendable.scala
@@ -46,7 +46,7 @@ object Sendable:
   given htmlDoc: (dom: Dom, monitor: Monitor, probate: Probate)
   =>  ((Document[Html] is Sendable)^{monitor}) =
     html =>
-      Email(Map(), Email.Message(Email.Content(Email.Body.HtmlOnly(html.read[Text]))))
+      Email(Map(), Email.Message(Email.Content(Email.Body.HtmlOnly(html.stream[Text].read[Text]))))
 
   given email: Email is Sendable = identity(_)
 

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -103,7 +103,7 @@ object Sheet:
         type Operand = Text
 
         def aggregate(text: LazyList[Text]): Sheet = sheet(parse(text))
-        override def accept(stream: Stream[Text] over Credit): Sheet = sheet(parse(stream))
+        override def accept(consume stream: (Stream[Text] over Credit)^): Sheet = sheet(parse(stream))
 
         private def sheet(rows: LazyList[Dsv]): Sheet =
           if format.header then Sheet(rows, format, rows.prim.let(_.header))

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -103,7 +103,7 @@ object Sheet:
         type Operand = Text
 
         def aggregate(text: LazyList[Text]): Sheet = sheet(parse(text))
-        override def accept(consume stream: (Stream[Text] over Credit)^): Sheet = sheet(parse(stream))
+        override def accept(stream: (Stream[Text] over Credit)^): Sheet = sheet(parse(stream))
 
         private def sheet(rows: LazyList[Dsv]): Sheet =
           if format.header then Sheet(rows, format, rows.prim.let(_.header))
@@ -131,7 +131,7 @@ object Sheet:
 
 
   // Parse rows from a pull endpoint, one block-credit refill per chunk.
-  private def parse(stream: Stream[Text] over Credit)
+  private def parse(consume stream: (Stream[Text] over Credit)^)
     ( using format: DsvFormat, tactic: Tactic[DsvError], buffering: Buffering )
   :   LazyList[Dsv] =
 

--- a/lib/coaxial/src/core/coaxial.Control.scala
+++ b/lib/coaxial/src/core/coaxial.Control.scala
@@ -34,6 +34,7 @@ package coaxial
 
 import anticipation.*
 import vacuous.*
+import zephyrine.*
 
 object Control:
   sealed trait Interactive
@@ -43,7 +44,7 @@ object Control:
       ( message: transmissible, state: Optional[state] = Unset )
     :   Conclude[state] =
 
-      Conclude(transmissible.serialize(message).foldLeft(Data())(_ ++ _), state)
+      Conclude(transmissible.serialize(message).memoize, state)
 
   case object Terminate extends Control[Nothing]
 
@@ -54,7 +55,7 @@ object Control:
       ( message: transmissible, state: Optional[state] = Unset )
     :   Reply[state] =
 
-      Reply(transmissible.serialize(message).foldLeft(Data())(_ ++ _), state)
+      Reply(transmissible.serialize(message).memoize, state)
 
   case class Conclude[+state](message: Data, state: Optional[state]) extends Control[state]
 

--- a/lib/coaxial/src/core/coaxial.Duplex.scala
+++ b/lib/coaxial/src/core/coaxial.Duplex.scala
@@ -59,9 +59,9 @@ object Duplex:
 
       recur()
 
-    def send(data: LazyList[Data]): Unit =
-      data.each: bytes =>
-        out.write(bytes.mutable(using Unsafe))
+    def send(data: (Stream[Data] over Credit)^): Unit =
+      data.foreachWindow: (storage, start, count) =>
+        out.write(storage.asInstanceOf[Array[Byte]], start, count)
         out.flush()
 
     def close(): Unit = shutdown()
@@ -86,9 +86,9 @@ object Duplex:
 
       recur()
 
-    def send(data: LazyList[Data]): Unit =
-      data.each: bytes =>
-        val out = ByteBuffer.wrap(bytes.mutable(using Unsafe)).nn
+    def send(data: (Stream[Data] over Credit)^): Unit =
+      data.foreachWindow: (storage, start, count) =>
+        val out = ByteBuffer.wrap(storage.asInstanceOf[Array[Byte]], start, count).nn
         while out.hasRemaining do socketChannel.write(out)
 
     def close(): Unit = socketChannel.close()
@@ -141,7 +141,7 @@ object Duplex:
 // closes; `send` may be called many times and never half-closes the connection.
 trait Duplex:
   def stream: LazyList[Data]
-  def send(data: LazyList[Data]): Unit
+  def send(data: (Stream[Data] over Credit)^): Unit
   def close(): Unit
 
   // Pull endpoint over the read side. The default adapts the legacy
@@ -179,5 +179,5 @@ trait Duplex:
 
       private update def drain(): Unit =
         if mark0 > 0 then
-          send(LazyList(storage.slice(0, mark0).nn.immutable(using Unsafe)))
+          send(Stream(storage.slice(0, mark0).nn.immutable(using Unsafe)))
           mark0 = 0

--- a/lib/coaxial/src/core/coaxial.Duplex.scala
+++ b/lib/coaxial/src/core/coaxial.Duplex.scala
@@ -107,9 +107,9 @@ object Duplex:
         protected def window0: AnyRef = storage
         def start: Int = start0
         def limit: Int = limit0
-        def skip(count: Int): Unit = start0 += count
+        update def skip(count: Int): Unit = start0 += count
 
-        def refill(demand: Credit): Optional[Int] =
+        update def refill(demand: Credit): Optional[Int] =
           if limit0 > start0 then limit0 - start0
           else if ended then Unset
           else
@@ -163,21 +163,21 @@ trait Duplex:
       protected def buffer0: AnyRef = storage
       def mark: Int = mark0
 
-      def reserve(min: Int): Int =
+      update def reserve(min: Int): Int =
         val free = block - mark0
 
         if free >= min then free else
           drain()
           block
 
-      def commit(count: Int): Unit =
+      update def commit(count: Int): Unit =
         mark0 += count
         if mark0 == block then drain()
 
-      override def flush(): Unit = drain()
-      def finish(): Unit = drain()
+      override update def flush(): Unit = drain()
+      update def finish(): Unit = drain()
 
-      private def drain(): Unit =
+      private update def drain(): Unit =
         if mark0 > 0 then
           send(LazyList(storage.slice(0, mark0).nn.immutable(using Unsafe)))
           mark0 = 0

--- a/lib/coaxial/src/core/coaxial.Routable.scala
+++ b/lib/coaxial/src/core/coaxial.Routable.scala
@@ -37,8 +37,10 @@ import java.net as jn
 import anticipation.*
 import beneficence.*
 import gigantism.*
+import prepositional.*
 import rudiments.*
 import urticose.*
+import zephyrine.*
 import vacuous.*
 
 object Routable:
@@ -55,13 +57,15 @@ object Routable:
 
       Connection(address, endpoint.port.number, socket)
 
-    def transmit(connection: Connection, input: LazyList[Data]): Unit =
-      input.each: bytes =>
-        val packet =
-          jn.DatagramPacket
-            ( bytes.mutable(using Unsafe), bytes.length, connection.address, connection.port )
+    def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit =
+      // One `transmit` call carries one message, and UDP frames per datagram.
+      val bytes = input.memoize
 
-        connection.socket.send(packet)
+      val packet =
+        jn.DatagramPacket
+          ( bytes.mutable(using Unsafe), bytes.length, connection.address, connection.port )
+
+      connection.socket.send(packet)
 
   given udpPort: Every[SocketOption.Udp] => UdpPort is Routable:
     case class Connection(port: Int, socket: jn.DatagramSocket)
@@ -75,20 +79,22 @@ object Routable:
 
       Connection(port.number, socket)
 
-    def transmit(connection: Connection, input: LazyList[Data]): Unit =
-      input.each: bytes =>
-        val packet =
-          jn.DatagramPacket
-            ( bytes.mutable(using Unsafe),
-              bytes.length,
-              jn.InetAddress.getLocalHost.nn,
-              connection.port )
+    def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit =
+      // See `udpEndpoint`: one message, one datagram.
+      val bytes = input.memoize
 
-        connection.socket.send(packet)
+      val packet =
+        jn.DatagramPacket
+          ( bytes.mutable(using Unsafe),
+            bytes.length,
+            jn.InetAddress.getLocalHost.nn,
+            connection.port )
+
+      connection.socket.send(packet)
 
 trait Routable extends Findable:
   type Self
   type Connection
 
   def connect(endpoint: Self, interface: Optional[MacAddress]): Connection
-  def transmit(connection: Connection, input: LazyList[Data]): Unit
+  def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit

--- a/lib/coaxial/src/core/coaxial.Sender.scala
+++ b/lib/coaxial/src/core/coaxial.Sender.scala
@@ -34,10 +34,11 @@ package coaxial
 
 import anticipation.*
 import prepositional.*
+import zephyrine.*
 
 // A handle for sending messages over an open, full-duplex connection at any moment —
 // before the first inbound message arrives, or concurrently from another task — rather
 // than only in reply to one. Handed to the `interact` block of `exchange` on a
 // `Duplexable` transport, whose `transmit` is safe to call concurrently.
-class Sender[message: Transmissible as transmissible](post: LazyList[Data] => Unit):
+class Sender[message: Transmissible as transmissible](post: ((Stream[Data] over Credit)^) => Unit):
   def send(message: message): Unit = post(transmissible.serialize(message))

--- a/lib/coaxial/src/core/coaxial.Serviceable.scala
+++ b/lib/coaxial/src/core/coaxial.Serviceable.scala
@@ -40,10 +40,12 @@ import java.nio.file as jnf
 import anticipation.*
 import contingency.*
 import gigantism.*
+import prepositional.*
 import rudiments.*
 import turbulence.*
 import urticose.*
 import vacuous.*
+import zephyrine.*
 
 object Serviceable:
   given domainSocket: (Tactic[StreamError], Every[SocketOption.Domain])
@@ -63,9 +65,9 @@ object Serviceable:
 
       Connection(channel)
 
-    def transmit(connection: Connection, input: LazyList[Data]): Unit =
-      input.each: bytes =>
-        connection.channel.write(ByteBuffer.wrap(bytes.mutable(using Unsafe)))
+    def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit =
+      input.foreachWindow: (storage, start, count) =>
+        connection.channel.write(ByteBuffer.wrap(storage.asInstanceOf[Array[Byte]], start, count))
 
       connection.channel.shutdownOutput()
 
@@ -105,11 +107,11 @@ object Serviceable:
       configure(socket, summon[Every[SocketOption.Tcp]].values)
       socket
 
-    def transmit(socket: jn.Socket, input: LazyList[Data]): Unit =
+    def transmit(socket: jn.Socket, input: (Stream[Data] over Credit)^): Unit =
       val out = socket.getOutputStream.nn
 
-      input.each: bytes =>
-        out.write(bytes.mutable(using Unsafe))
+      input.foreachWindow: (storage, start, count) =>
+        out.write(storage.asInstanceOf[Array[Byte]], start, count)
         out.flush()
 
     def close(socket: jn.Socket): Unit = socket.close()
@@ -134,11 +136,11 @@ object Serviceable:
     def close(socket: jn.Socket): Unit = socket.close()
     def receive(socket: jn.Socket): LazyList[Data] = socket.getInputStream.nn.stream[Data]
 
-    def transmit(socket: jn.Socket, input: LazyList[Data]): Unit =
+    def transmit(socket: jn.Socket, input: (Stream[Data] over Credit)^): Unit =
       val out = socket.getOutputStream.nn
 
-      input.each: bytes =>
-        out.write(bytes.mutable(using Unsafe))
+      input.foreachWindow: (storage, start, count) =>
+        out.write(storage.asInstanceOf[Array[Byte]], start, count)
         out.flush()
 
 trait Serviceable extends Routable:

--- a/lib/coaxial/src/core/coaxial.Transmissible.scala
+++ b/lib/coaxial/src/core/coaxial.Transmissible.scala
@@ -36,19 +36,26 @@ import anticipation.*
 import gossamer.*
 import hieroglyph.*
 import prepositional.*
+import zephyrine.*
 
 object Transmissible:
-  given bytes: [bytes <: Data] => bytes is Transmissible = LazyList(_)
-  given stream: [stream <: LazyList[Data]] => stream is Transmissible = identity(_)
+  given bytes: [bytes <: Data] => bytes is Transmissible = Stream(_)
+
+  given stream: [stream <: LazyList[Data]] => stream is Transmissible = value =>
+    Stream(value.iterator)
 
   given text: [text <: Text] => CharEncoder => text is Transmissible =
-    text => LazyList(text.data)
+    text => Stream(text.data)
 
   given encoder: [message: Encodable in Text] => CharEncoder => message is Transmissible =
-    value => LazyList(value.encode.data)
+    value => Stream(value.encode.data)
 
+// One call to `serialize` yields the wire form of one message, as a fresh pull
+// endpoint. Transports with message framing (a UDP datagram, a WebSocket frame)
+// may therefore `memoize` the stream into a single framed unit; byte-stream
+// transports write it through the window, zero-copy.
 trait Transmissible extends Typeclass:
-  def serialize(message: Self): LazyList[Data]
+  def serialize(message: Self): (Stream[Data] over Credit)^
 
   def contramap[self2](lambda: self2 => Self): (self2 is Transmissible)^{this, lambda} =
     message => serialize(lambda(message))

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -43,6 +43,7 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import urticose.MacAddress
+import zephyrine.{Stream, Credit}
 import vacuous.*
 
 import Control.*
@@ -117,11 +118,11 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
         case Terminate        => state
 
         case Reply(message, state2) =>
-          serviceable.transmit(connection, LazyList(message))
+          serviceable.transmit(connection, Stream(message))
           recur(more, state2.or(state))
 
         case Conclude(message, state2) =>
-          serviceable.transmit(connection, LazyList(message))
+          serviceable.transmit(connection, Stream(message))
           state2.or(state)
 
     recur(serviceable.receive(connection), initialState).also(serviceable.close(connection))
@@ -153,11 +154,11 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
         case Terminate        => state
 
         case Reply(message, state2) =>
-          duplexable.transmit(connection, LazyList(message))
+          duplexable.transmit(connection, Stream(message))
           recur(more, state2.or(state))
 
         case Conclude(message, state2) =>
-          duplexable.transmit(connection, LazyList(message))
+          duplexable.transmit(connection, Stream(message))
           state2.or(state)
 
     recur(duplexable.receive(connection), initialState).also(duplexable.close(connection))

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -60,6 +60,7 @@ object Tests extends Suite(m"Coaxial tests"):
     def ascii(text: Text): Data = IArray.from(text.s.getBytes("US-ASCII").nn.to(List))
     def bytes(data: Data): List[Byte] = data.to(List)
     def joined(stream: LazyList[Data]): List[Byte] = stream.to(List).flatMap(_.to(List))
+    def drained(stream: zephyrine.Stream[Data] over Credit): List[Byte] = stream.memoize.to(List)
 
     suite(m"Duplex streaming endpoints"):
       supervise:
@@ -90,25 +91,25 @@ object Tests extends Suite(m"Coaxial tests"):
 
     suite(m"Transmissible serialization"):
       test(m"Data is transmitted as a single chunk"):
-        joined(summon[Data is Transmissible].serialize(ascii(t"abc")))
+        drained(summon[Data is Transmissible].serialize(ascii(t"abc")))
       . assert(_ == bytes(ascii(t"abc")))
 
       test(m"A LazyList[Data] is transmitted unchanged"):
         val stream = LazyList(ascii(t"ab"), ascii(t"cd"))
-        joined(summon[LazyList[Data] is Transmissible].serialize(stream))
+        drained(summon[LazyList[Data] is Transmissible].serialize(stream))
       . assert(_ == bytes(ascii(t"abcd")))
 
       test(m"Text is transmitted via its character encoding"):
-        joined(summon[Text is Transmissible].serialize(t"hello"))
+        drained(summon[Text is Transmissible].serialize(t"hello"))
       . assert(_ == bytes(ascii(t"hello")))
 
       test(m"An Encodable value is transmitted via its Text encoding"):
-        joined(summon[Port is Transmissible].serialize(Port.unsafe[Tcp](8080)))
+        drained(summon[Port is Transmissible].serialize(Port.unsafe[Tcp](8080)))
       . assert(_ == bytes(ascii(t"8080")))
 
       test(m"contramap adapts a Transmissible to a new source type"):
         val ints: Int is Transmissible = summon[Text is Transmissible].contramap[Int](_.show)
-        joined(ints.serialize(42))
+        drained(ints.serialize(42))
       . assert(_ == bytes(ascii(t"42")))
 
     suite(m"Ingressive deserialization"):
@@ -222,7 +223,7 @@ object Tests extends Suite(m"Coaxial tests"):
           // makes any type conform to `Unit`, the `Routable` overload is not
           // reachable by ascription, so its given is exercised directly here.
           val routable = summon[UdpPort is Routable]
-          routable.transmit(routable.connect(port, Unset), LazyList(ascii(t"ping")))
+          routable.transmit(routable.connect(port, Unset), zephyrine.Stream(ascii(t"ping")))
           received.await().also(server.stop())
         . assert(_ == t"ping")
 

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -268,7 +268,7 @@ object Tests extends Suite(m"Coaxial tests"):
             IArray.from(buffer.take(count.max(0)).to(List))
 
           val reply = socket.duplex: duplex =>
-            duplex.send(LazyList(ascii(t"ping")))
+            duplex.send(zephyrine.Stream(ascii(t"ping")))
             bytes(duplex.stream.head)
 
           reply.also(server.stop())

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -47,6 +47,7 @@ import rudiments.*
 import telekinesis.*
 import turbulence.*
 import vacuous.*
+import zephyrine.*
 
 import Http2.*
 
@@ -229,10 +230,9 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
 
     Log.fine(Http2Event.RequestSent(authority))
     val headerBlock = PseudoHeaders.request(request, scheme, authority)
-    val chunks = request.body().lazyList.to(List)
+    val data = request.body().memoize
 
-    val payload: Optional[Bytes] =
-      if chunks.isEmpty then Unset else chunks.foldLeft(IArray.empty[Byte])(_ ++ _)
+    val payload: Optional[Bytes] = if data.isEmpty then Unset else data
 
     val stream = this.request(headerBlock, payload)
     val responseHeaders = stream.headers.await()

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -179,10 +179,10 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
 
     . protect:
         val writer = daemon:
-          duplex.send(LazyList(connectionPreface))
+          duplex.send(zephyrine.Stream(connectionPreface))
 
           outbound.stream.each: frame =>
-            duplex.send(LazyList(frame.serialize))
+            duplex.send(zephyrine.Stream(frame.serialize))
 
         val reader = daemon:
           // A protocol error tears down just this connection; throw it to the enclosing

--- a/lib/cordillera/src/core/cordillera.PseudoHeaders.scala
+++ b/lib/cordillera/src/core/cordillera.PseudoHeaders.scala
@@ -82,4 +82,4 @@ object PseudoHeaders:
     val status: Http.Status =
       Http.Status.unapply(code).optional.lest(Http2Error(Reason.Protocol(t"missing :status")))
 
-    status(headers.to(List), Http.Body.Streaming(body))
+    status(headers.to(List), Http.Body.Flowing(() => zephyrine.Stream(body.iterator)))

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -280,7 +280,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
               t"/echo.Service/Call", Nil, () => Stream(ascii(t"ping")))
 
           val (stream, response) = connection.fetch(request, t"http", t"unix")
-          val bodyText = ascii(t"pong").to(List) == response.body.stream.reduce(_ ++ _).to(List)
+          val bodyText = ascii(t"pong").to(List) == response.body.stream.memoize.to(List)
           val statusCode = response.status.code
           val grpcStatus = stream.trailers.await().find(_.name == t"grpc-status").map(_.value)
           server.cancel()

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -225,7 +225,8 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
 
         def duplex(inbound: Spool[Data], outbound: Spool[Data]) = new Duplex:
           def stream: LazyList[Data] = inbound.stream
-          def send(data: LazyList[Data]): Unit = data.each(outbound.put)
+          def send(data: (zephyrine.Stream[Data] over Credit)^): Unit =
+            outbound.put(data.memoize)
           def close(): Unit = outbound.stop()
 
         (duplex(serverToClient, clientToServer), duplex(clientToServer, serverToClient))
@@ -237,7 +238,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
       // trailer. Returned as a Daemon so the caller can cancel it.
       def runServer(serverSide: Duplex)(using Monitor, Probate): Daemon = daemon:
         safely:
-          serverSide.send(LazyList(Frame.Settings(Nil, ack = false).serialize))
+          serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = false).serialize))
 
           // Skip the 24-byte client connection preface before frame-parsing.
           val raw = serverSide.stream.iterator
@@ -256,16 +257,16 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
             case Unset        => continue = false
             case f: Frame     => f match
               case Frame.Settings(_, false) =>
-                serverSide.send(LazyList(Frame.Settings(Nil, ack = true).serialize))
+                serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = true).serialize))
 
               case Frame.Headers(id, _, _, _) =>
                 val respHeaders = hpack.encode(List(HpackEntry(t":status", t"200"),
                     HpackEntry(t"content-type", t"application/grpc")))
 
                 val trailers = hpack.encode(List(HpackEntry(t"grpc-status", t"0")))
-                serverSide.send(LazyList(Frame.Headers(id, respHeaders, false, true).serialize))
-                serverSide.send(LazyList(Frame.Data(id, ascii(t"pong"), false).serialize))
-                serverSide.send(LazyList(Frame.Headers(id, trailers, true, true).serialize))
+                serverSide.send(zephyrine.Stream(Frame.Headers(id, respHeaders, false, true).serialize))
+                serverSide.send(zephyrine.Stream(Frame.Data(id, ascii(t"pong"), false).serialize))
+                serverSide.send(zephyrine.Stream(Frame.Headers(id, trailers, true, true).serialize))
 
               case _ => ()
 

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -164,7 +164,8 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
 
         def duplex(inbound: Spool[Data], outbound: Spool[Data]) = new Duplex:
           def stream: LazyList[Data] = inbound.stream
-          def send(data: LazyList[Data]): Unit = data.each(outbound.put)
+          def send(data: (zephyrine.Stream[Data] over Credit)^): Unit =
+            outbound.put(data.memoize)
           def close(): Unit = outbound.stop()
 
         (duplex(serverToClient, clientToServer), duplex(clientToServer, serverToClient))
@@ -177,7 +178,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
 
         daemon:
           safely:
-            serverSide.send(LazyList(Frame.Settings(Nil, ack = false).serialize))
+            serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = false).serialize))
             val raw = serverSide.stream.iterator
 
             val afterPreface: Iterator[Data] =
@@ -195,7 +196,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
 
               case f: Frame => f match
                 case Frame.Settings(_, false) =>
-                  serverSide.send(LazyList(Frame.Settings(Nil, ack = true).serialize))
+                  serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = true).serialize))
 
                 case Frame.Headers(id, block, _, _) =>
                   val fields = hpack.decode(block)
@@ -206,9 +207,9 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
                       HpackEntry(t"content-type", t"application/grpc")))
 
                   val trailer = hpack.encode(List(HpackEntry(t"grpc-status", t"0")))
-                  serverSide.send(LazyList(Frame.Headers(id, status, false, true).serialize))
-                  serverSide.send(LazyList(Frame.Data(id, body, false).serialize))
-                  serverSide.send(LazyList(Frame.Headers(id, trailer, true, true).serialize))
+                  serverSide.send(zephyrine.Stream(Frame.Headers(id, status, false, true).serialize))
+                  serverSide.send(zephyrine.Stream(Frame.Data(id, body, false).serialize))
+                  serverSide.send(zephyrine.Stream(Frame.Headers(id, trailer, true, true).serialize))
 
                 case _ => ()
 

--- a/lib/galilei/src/core/galilei.Handle.scala
+++ b/lib/galilei/src/core/galilei.Handle.scala
@@ -61,7 +61,7 @@ object Handle:
 // source/result types instead.
 class Handle
   ( val reader: () => LazyList[Data], val writer: LazyList[Data] => Unit )
-  ( val source: () => Stream[Data] over Credit = () => Stream(reader().iterator),
+  ( val source: () => (Stream[Data] over Credit)^ = () => Stream(reader().iterator),
     val intake: () => Intake[Data] over Credit =
       () => Sink.buffered((), (_, stream) => writer(stream)) )
 extends caps.ExclusiveCapability:

--- a/lib/gesticulate/src/core/gesticulate.Part.scala
+++ b/lib/gesticulate/src/core/gesticulate.Part.scala
@@ -35,10 +35,13 @@ package gesticulate
 import anticipation.*
 import prepositional.*
 import turbulence.*
+import zephyrine.Credit
 import vacuous.*
 
 object Part:
   given streamable: Part is Streamable by Data = _.body
+  given source: Part is Source by Data over Credit = part =>
+    zephyrine.Stream(part.body.iterator)
 
 case class Part
   ( disposition: Optional[Multipart.Disposition],

--- a/lib/graffiti/src/test/graffiti_test.scala
+++ b/lib/graffiti/src/test/graffiti_test.scala
@@ -251,6 +251,6 @@ object Tests extends Suite(m"Graffiti tests"):
       . assert(_.starts(t"text/html"))
 
       test(m"serving an archetype streams the full HTML document, with a doctype"):
-        supervise(Page(t"Demo", Nil).read[Text])
+        supervise(Page(t"Demo", Nil).stream[Text].read[Text])
       . assert: served =>
           served.contains(t"<!DOCTYPE html>") && served.contains(t"Hello, world!")

--- a/lib/hallucination/src/core/hallucination.Raster.scala
+++ b/lib/hallucination/src/core/hallucination.Raster.scala
@@ -54,7 +54,7 @@ object Raster:
     new Raster(image)
 
   def apply[streamable: Streamable by Data](input: streamable): Raster =
-    new Raster(ji.ImageIO.read(input.read[Data].javaInputStream).nn)
+    new Raster(ji.ImageIO.read(input.stream[Data].read[Data].javaInputStream).nn)
 
   def apply[form: Rasterizable as rasterizable](image: jai.BufferedImage): Raster in form =
     new Raster(image):
@@ -66,12 +66,20 @@ object Raster:
     out.close()
     out.stream
 
+  given source: [form: Rasterizable]
+  =>  (Raster in form) is Source by Data over zephyrine.Credit =
+    raster =>
+      val out = StreamOutputStream()
+      ji.ImageIO.write(raster.image, form.name.s, out)
+      out.close()
+      zephyrine.Stream(out.stream.iterator)
+
   given abstractable: [format: Rasterizable] => (Raster in format) is Abstractable:
     type Domain = HttpStreams
     type Result = HttpStreams.Content
 
     def genericize(image: Raster in format): HttpStreams.Content =
-      (format.mediaType.basic, HttpStreams.Body(image.read[LazyList[Data]].iterator))
+      (format.mediaType.basic, HttpStreams.Body(image.stream[Data].iterator))
 
   given graphical: Raster is Graphical:
     def pixel(raster: Raster, x: Int, y: Int): Chroma = raster(x, y)

--- a/lib/hallucination/src/core/hallucination.Rasterizable.scala
+++ b/lib/hallucination/src/core/hallucination.Rasterizable.scala
@@ -50,7 +50,7 @@ trait Rasterizable extends Typeclass:
 
     def read[input: Streamable by Data](inputType: input): Raster in Self raises RasterError =
       val reader: ji.ImageReader = ji.ImageIO.getImageReadersByFormatName(name.s).nn.next().nn
-      reader.setInput(ji.ImageIO.createImageInputStream(inputType.read[Data].javaInputStream).nn)
+      reader.setInput(ji.ImageIO.createImageInputStream(inputType.stream[Data].read[Data].javaInputStream).nn)
 
       val data = try reader.read(0).nn catch case _: ji.IIOException => abort(RasterError(this))
 

--- a/lib/hellenism/src/core/hellenism.Classpath.scala
+++ b/lib/hellenism/src/core/hellenism.Classpath.scala
@@ -43,6 +43,7 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 import turbulence.*
+import zephyrine.*
 import vacuous.*
 
 object Classpath extends Root(t""):
@@ -87,6 +88,17 @@ object Classpath extends Root(t""):
       given Tactic[StreamError] = strategies.throwUnsafely
 
       Streamable.inputStream.contramap: path =>
+        classloader.inputStream(path.encode)
+
+  given source: [path <: Path on Classpath] => Tactic[ClasspathError]
+  =>  ( classloader: Classloader, buffering: Buffering )
+  =>  path is Source by Data over Credit =
+
+    // See `streamable` above; laundered pure for the same reason.
+    caps.unsafe.unsafeAssumePure:
+      given Tactic[StreamError] = strategies.throwUnsafely
+
+      Source.inputStream.contramap: path =>
         classloader.inputStream(path.encode)
 
 

--- a/lib/hellenism/src/core/hellenism.Resource.scala
+++ b/lib/hellenism/src/core/hellenism.Resource.scala
@@ -39,6 +39,7 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 import turbulence.*
+import zephyrine.*
 import vacuous.*
 
 object Resource:
@@ -50,6 +51,16 @@ object Resource:
       given Tactic[StreamError | ClasspathError] = strategies.throwUnsafely
 
       Streamable.inputStream.contramap: resource =>
+        classloader.inputStream(resource.path.encode)
+
+  given source: [resource <: Resource]
+  =>  ( classloader: Classloader, buffering: Buffering )
+  =>  resource is Source by Data over Credit =
+    // See `streamable` above: unscoped throwing tactic + pure classloader; laundered pure.
+    caps.unsafe.unsafeAssumePure:
+      given Tactic[StreamError | ClasspathError] = strategies.throwUnsafely
+
+      Source.inputStream.contramap: resource =>
         classloader.inputStream(resource.path.encode)
 
   given nominable: [resource <: Resource] => resource is Nominable = _.path.descent.prim.or(t"/")

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -173,7 +173,7 @@ object Html extends Tag.Container
         val root = Tag.root(content.reify.map(_.tt).to(Set))
         HtmlParser.fromIterator(input.iterator, permissive = false).parseHtml(root).of[content]
 
-      override def accept(consume stream: (Stream[Text] over Credit)^): Html of content =
+      override def accept(stream: Stream[Text] over Credit): Html of content =
         val root = Tag.root(content.reify.map(_.tt).to(Set))
         HtmlParser.fromStream(stream, permissive = false).parseHtml(root).of[content]
 
@@ -189,7 +189,7 @@ object Html extends Tag.Container
         HtmlParser.fromIterator(input.iterator, permissive = false)
         . parseHtml(dom.generic, doctypes = false)
 
-      override def accept(consume stream: (Stream[Text] over Credit)^): Html =
+      override def accept(stream: Stream[Text] over Credit): Html =
         HtmlParser.fromStream(stream, permissive = false)
         . parseHtml(dom.generic, doctypes = false)
 
@@ -233,7 +233,7 @@ object Html extends Tag.Container
         lenient(Fragment().of[content]):
           HtmlParser.fromIterator(input.iterator, permissive = true).parseHtml(root).of[content]
 
-      override def accept(consume stream: (Stream[Text] over Credit)^): Html of content =
+      override def accept(stream: Stream[Text] over Credit): Html of content =
         given Tactic[ParseError] = lenientTactic
         val root = Tag.root(content.reify.map(_.tt).to(Set))
 
@@ -254,7 +254,7 @@ object Html extends Tag.Container
           HtmlParser.fromIterator(input.iterator, permissive = true)
           . parseHtml(dom.generic, doctypes = false)
 
-      override def accept(consume stream: (Stream[Text] over Credit)^): Html =
+      override def accept(stream: Stream[Text] over Credit): Html =
         given Tactic[ParseError] = lenientTactic
 
         lenient(Fragment()):

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -173,7 +173,7 @@ object Html extends Tag.Container
         val root = Tag.root(content.reify.map(_.tt).to(Set))
         HtmlParser.fromIterator(input.iterator, permissive = false).parseHtml(root).of[content]
 
-      override def accept(stream: Stream[Text] over Credit): Html of content =
+      override def accept(consume stream: (Stream[Text] over Credit)^): Html of content =
         val root = Tag.root(content.reify.map(_.tt).to(Set))
         HtmlParser.fromStream(stream, permissive = false).parseHtml(root).of[content]
 
@@ -189,7 +189,7 @@ object Html extends Tag.Container
         HtmlParser.fromIterator(input.iterator, permissive = false)
         . parseHtml(dom.generic, doctypes = false)
 
-      override def accept(stream: Stream[Text] over Credit): Html =
+      override def accept(consume stream: (Stream[Text] over Credit)^): Html =
         HtmlParser.fromStream(stream, permissive = false)
         . parseHtml(dom.generic, doctypes = false)
 
@@ -233,7 +233,7 @@ object Html extends Tag.Container
         lenient(Fragment().of[content]):
           HtmlParser.fromIterator(input.iterator, permissive = true).parseHtml(root).of[content]
 
-      override def accept(stream: Stream[Text] over Credit): Html of content =
+      override def accept(consume stream: (Stream[Text] over Credit)^): Html of content =
         given Tactic[ParseError] = lenientTactic
         val root = Tag.root(content.reify.map(_.tt).to(Set))
 
@@ -254,7 +254,7 @@ object Html extends Tag.Container
           HtmlParser.fromIterator(input.iterator, permissive = true)
           . parseHtml(dom.generic, doctypes = false)
 
-      override def accept(stream: Stream[Text] over Credit): Html =
+      override def accept(consume stream: (Stream[Text] over Credit)^): Html =
         given Tactic[ParseError] = lenientTactic
 
         lenient(Fragment()):

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -185,20 +185,24 @@ private[jacinta] object Parser:
     val raw = caps.unsafe.unsafeAssumePure(parser.parse())
     (raw, parser.rootIndex.nn)
 
-  def parse(input: Stream[Data] over Credit, mode: NumberMode): Raw raises ParseError =
+  def parse(consume input: (Stream[Data] over Credit)^, mode: NumberMode): Raw raises ParseError =
     val parser = borrow()
     parser.tracking = false
-    parser.resetStream(input)
+    // consume-to-consume forwarding is not admitted; the hop re-asserts the transfer
+    val moved: AnyRef = input.asInstanceOf[AnyRef]
+    parser.resetStream(moved.asInstanceOf[(Stream[Data] over Credit)^])
     parser.holes = false
     parser.numberMode = mode
     caps.unsafe.unsafeAssumePure(parser.parse())
 
-  def parseTracked(input: Stream[Data] over Credit, mode: NumberMode)
+  def parseTracked(consume input: (Stream[Data] over Credit)^, mode: NumberMode)
   :   (Raw, IArray[Int]) raises ParseError =
 
     val parser = borrow()
     parser.tracking = true
-    parser.resetStream(input)
+    // consume-to-consume forwarding is not admitted; the hop re-asserts the transfer
+    val moved: AnyRef = input.asInstanceOf[AnyRef]
+    parser.resetStream(moved.asInstanceOf[(Stream[Data] over Credit)^])
     parser.holes = false
     parser.numberMode = mode
     val raw = caps.unsafe.unsafeAssumePure(parser.parse())
@@ -315,7 +319,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     indexBufferId = -1
     rootIndex = null
 
-  update def resetStream(input: Stream[Data] over Credit): Unit =
+  update def resetStream(consume input: (Stream[Data] over Credit)^): Unit =
     if tracking then
       import zephyrine.lineation.linefeedByte
       val fresh = Cursor[Data](input)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1233,7 +1233,7 @@ object Json extends Json2, Dynamic:
         type Operand = Data
 
         def aggregate(bytes: LazyList[Data]): Json = readJson(bytes.iterator)
-        override def accept(stream: Stream[Data] over Credit): Json = readJson(stream)
+        override def accept(consume stream: (Stream[Data] over Credit)^): Json = readJson(stream)
 
 
   // Sealed like `aggregable` above.
@@ -1249,7 +1249,7 @@ object Json extends Json2, Dynamic:
         def aggregate(bytes: LazyList[Data]): value in Json =
           readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
 
-        override def accept(stream: Stream[Data] over Credit): value in Json =
+        override def accept(consume stream: (Stream[Data] over Credit)^): value in Json =
           readJson(stream).as[value].asInstanceOf[value in Json]
 
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -800,12 +800,12 @@ object Json extends Json2, Dynamic:
       val (raw, ints) = Parser.parseTracked(input, mode)
       (Json.Ast(raw), Json.PositionIndex(ints))
 
-    private[jacinta] def parse(input: Stream[Data] over Credit)(using mode: NumberMode)
+    private[jacinta] def parse(input: (Stream[Data] over Credit)^)(using mode: NumberMode)
     :   Json.Ast raises ParseError =
 
       Json.Ast(Parser.parse(input, mode))
 
-    private[jacinta] def parseTracked(input: Stream[Data] over Credit)(using mode: NumberMode)
+    private[jacinta] def parseTracked(input: (Stream[Data] over Credit)^)(using mode: NumberMode)
     :   (Json.Ast, Json.PositionIndex) raises ParseError =
 
       val (raw, ints) = Parser.parseTracked(input, mode)
@@ -848,7 +848,7 @@ object Json extends Json2, Dynamic:
 
   // As above, but pulling from a demand-aware stream rather than a chunk
   // iterator.
-  private def readJson(input: Stream[Data] over Credit)
+  private def readJson(input: (Stream[Data] over Credit)^)
     ( using Tactic[ParseError], PositionTracking )
   :   Json =
 
@@ -1233,7 +1233,7 @@ object Json extends Json2, Dynamic:
         type Operand = Data
 
         def aggregate(bytes: LazyList[Data]): Json = readJson(bytes.iterator)
-        override def accept(consume stream: (Stream[Data] over Credit)^): Json = readJson(stream)
+        override def accept(stream: (Stream[Data] over Credit)^): Json = readJson(stream)
 
 
   // Sealed like `aggregable` above.
@@ -1249,7 +1249,7 @@ object Json extends Json2, Dynamic:
         def aggregate(bytes: LazyList[Data]): value in Json =
           readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
 
-        override def accept(consume stream: (Stream[Data] over Credit)^): value in Json =
+        override def accept(stream: (Stream[Data] over Credit)^): value in Json =
           readJson(stream).as[value].asInstanceOf[value in Json]
 
 

--- a/lib/jacinta/src/core/jacinta.Ndjson.scala
+++ b/lib/jacinta/src/core/jacinta.Ndjson.scala
@@ -34,12 +34,13 @@ package jacinta
 
 import anticipation.*
 import contingency.*
+import hieroglyph.*
 import prepositional.*
 import turbulence.*
 import zephyrine.*
 
 object Ndjson:
-  def parse[source: Streamable by Line](value: source)(using Text is Streamable by Data)
+  def parse[source: Streamable by Line](value: source)(using CharEncoder)
   :   Ndjson raises ParseError =
 
     Ndjson(value.stream[Line].map { line => line.content.read[Json] })

--- a/lib/jacinta/src/core/jacinta_parser.scala
+++ b/lib/jacinta/src/core/jacinta_parser.scala
@@ -46,4 +46,4 @@ given parserAggregable: Tactic[ParseError] => Json.Ast is Aggregable by Data =
       type Operand = Data
 
       def aggregate(source: LazyList[Data]): Json.Ast = Json.Ast.parse(source.iterator)
-      override def accept(stream: Stream[Data] over Credit): Json.Ast = Json.Ast.parse(stream)
+      override def accept(consume stream: (Stream[Data] over Credit)^): Json.Ast = Json.Ast.parse(stream)

--- a/lib/jacinta/src/core/jacinta_parser.scala
+++ b/lib/jacinta/src/core/jacinta_parser.scala
@@ -46,4 +46,4 @@ given parserAggregable: Tactic[ParseError] => Json.Ast is Aggregable by Data =
       type Operand = Data
 
       def aggregate(source: LazyList[Data]): Json.Ast = Json.Ast.parse(source.iterator)
-      override def accept(consume stream: (Stream[Data] over Credit)^): Json.Ast = Json.Ast.parse(stream)
+      override def accept(stream: (Stream[Data] over Credit)^): Json.Ast = Json.Ast.parse(stream)

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -156,7 +156,7 @@ object Protobuf extends Protobuf2:
       . or(origin)
 
   // Synchronously assemble wire bytes by running `lambda` against a `ProtobufPrinter`.
-  private def printed(lambda: ProtobufPrinter => Unit): Data =
+  private def printed(lambda: ProtobufPrinter^ => Unit): Data =
     Producer.collect[Data](): producer =>
       lambda(ProtobufPrinter(producer))
 

--- a/lib/locomotion/src/core/locomotion.ProtobufPrinter.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufPrinter.scala
@@ -40,12 +40,14 @@ import zephyrine.*
 // length-delimited wire type). Drive it through `Protobuf.printed` (synchronous) or `Protobuf.emit`
 // (streaming).
 @unexported
-class ProtobufPrinter(out: Producer.Bytes):
-  def byte(value: Int): Unit = out.push(value.toByte)
+// Holds the exclusive producer it drives, so the printer is itself a stateful
+// capability with update-classified writes.
+class ProtobufPrinter(out: (Producer.Bytes)^) extends caps.ExclusiveCapability, caps.Stateful:
+  update def byte(value: Int): Unit = out.push(value.toByte)
 
-  def raw(data: Data): Unit = out.put(data)
+  update def raw(data: Data): Unit = out.put(data)
 
-  def varint(value: Long): Unit =
+  update def varint(value: Long): Unit =
     var rest = value
     var continue = true
 
@@ -57,23 +59,23 @@ class ProtobufPrinter(out: Producer.Bytes):
         byte(septet)
         continue = false
 
-  def fixed32(value: Int): Unit =
+  update def fixed32(value: Int): Unit =
     var i = 0
 
     while i < 4 do
       byte((value >>> (i*8)) & 0xff)
       i += 1
 
-  def fixed64(value: Long): Unit =
+  update def fixed64(value: Long): Unit =
     var i = 0
 
     while i < 8 do
       byte(((value >>> (i*8)) & 0xff).toInt)
       i += 1
 
-  def tag(number: Int, wireType: WireType): Unit = varint((number.toLong << 3) | wireType.id)
+  update def tag(number: Int, wireType: WireType): Unit = varint((number.toLong << 3) | wireType.id)
 
-  def field(number: Int, value: Protobuf): Unit = value match
+  update def field(number: Int, value: Protobuf): Unit = value match
     case Protobuf.Absent           => ()
     case Protobuf.Repeated(values) => values.foreach(field(number, _))
 

--- a/lib/monotonous/src/core/monotonous.Alphabet.scala
+++ b/lib/monotonous/src/core/monotonous.Alphabet.scala
@@ -66,14 +66,17 @@ object Alphabet:
       type Transport = Credit
       type Upstream = Credit
 
-      def duct(stage: Alphabet[encoding])(using Buffering)
-      :   Duct[Data, Text] { type Transport = Credit; type Upstream = Credit } =
+      def duct(consume stage: Alphabet[encoding]^)(using Buffering)
+      :   (Duct[Data, Text] { type Transport = Credit; type Upstream = Credit })^ =
+
+        // hoisted: a constructor may not read the consumed (exclusive) descriptor
+        val alphabet = caps.unsafe.unsafeAssumePure(stage)
 
         new Duct[Data, Text]:
           type Transport = Credit
           type Upstream = Credit
 
-          private val base: Int = bits(stage)
+          private val base: Int = bits(alphabet)
 
           // Serialized characters per group, for terminal padding.
           private val multiple: Int = 8/base.gcd(8)
@@ -88,7 +91,7 @@ object Alphabet:
           def translate(demand: Credit): Credit =
             Credit((demand.count.min(Long.MaxValue/8)*base/8).max(1))
 
-          def step
+          update def step
             ( source: input.Storage,
               sourceOffset: Int,
               sourceLength: Int,
@@ -107,7 +110,7 @@ object Alphabet:
               if accumulated >= base then
                 if produced < targetSpace then
                   chars(targetOffset + produced) =
-                    stage((accumulator >>> (accumulated - base)) & ((1 << base) - 1))
+                    alphabet((accumulator >>> (accumulated - base)) & ((1 << base) - 1))
 
                   produced += 1
                   accumulated -= base
@@ -123,7 +126,7 @@ object Alphabet:
 
             Duct.Progress(consumed, produced)
 
-          override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
+          override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
           :   Int =
 
             val chars = target.asInstanceOf[Array[Char]]
@@ -134,7 +137,7 @@ object Alphabet:
 
               if accumulated > 0 then
                 chars(targetOffset) =
-                  stage((accumulator << (base - accumulated)) & ((1 << base) - 1))
+                  alphabet((accumulator << (base - accumulated)) & ((1 << base) - 1))
 
                 produced = 1
                 accumulated = 0
@@ -142,7 +145,7 @@ object Alphabet:
 
             if stage.padding then
               while written%multiple != 0 && produced < targetSpace do
-                chars(targetOffset + produced) = stage(1 << base)
+                chars(targetOffset + produced) = alphabet(1 << base)
                 produced += 1
                 written += 1
 
@@ -160,18 +163,18 @@ object Alphabet:
       type Transport = Credit
       type Upstream = Credit
 
-      def duct(stage: Alphabet[encoding])(using Buffering)
-      :   Duct[Text, Data] { type Transport = Credit; type Upstream = Credit } =
+      def duct(consume stage: Alphabet[encoding]^)(using Buffering)
+      :   (Duct[Text, Data] { type Transport = Credit; type Upstream = Credit })^ =
 
-        // Sealed: the duct closes over the ambient `Buffering`, which is sizing policy
-        // only; the instance performs no effects beyond its own mutable buffers.
-        caps.unsafe.unsafeAssumePure:
-         new Duct[Text, Data]:
+        // hoisted: a constructor may not read the consumed (exclusive) descriptor
+        val alphabet = caps.unsafe.unsafeAssumePure(stage)
+
+        new Duct[Text, Data]:
           type Transport = Credit
           type Upstream = Credit
 
-          private val base: Int = bits(stage)
-          private val pad: Char = if stage.padding then stage(1 << base) else ' '
+          private val base: Int = bits(alphabet)
+          private val pad: Char = if stage.padding then alphabet(1 << base) else ' '
 
           private var accumulator: Int = 0
           private var accumulated: Int = 0
@@ -182,7 +185,7 @@ object Alphabet:
           def translate(demand: Credit): Credit =
             Credit((demand.count.min(Long.MaxValue/8)*8/base).max(1))
 
-          def step
+          update def step
             ( source: input.Storage,
               sourceOffset: Int,
               sourceLength: Int,

--- a/lib/monotonous/src/test/monotonous_test.scala
+++ b/lib/monotonous/src/test/monotonous_test.scala
@@ -212,7 +212,7 @@ object Tests extends Suite(m"Monotonous tests"):
 // Drains a duct-composed pull endpoint, for the streaming serialization
 // tests.
 object Drain:
-  def text(stream: Stream[Text] over Credit, credit: Int = 7): Text =
+  def text(stream: (Stream[Text] over Credit)^, credit: Int = 7): Text =
     val builder = StringBuilder()
 
     def recur(): Unit = stream.refill(Credit(credit)) match
@@ -227,7 +227,7 @@ object Drain:
     recur()
     builder.toString.tt
 
-  def data(stream: Stream[Data] over Credit, credit: Int = 7): Data =
+  def data(stream: (Stream[Data] over Credit)^, credit: Int = 7): Data =
     val target = java.io.ByteArrayOutputStream()
 
     def recur(): Unit = stream.refill(Credit(credit)) match

--- a/lib/nomenclature/src/lexicon/nomenclature.Vocabulary.scala
+++ b/lib/nomenclature/src/lexicon/nomenclature.Vocabulary.scala
@@ -49,7 +49,7 @@ object Vocabulary:
     new Vocabulary(load(adjectives), load(animals)).asInstanceOf[Vocabulary over transport]
 
   private def load[source: Streamable by Data](resource: source): List[Text] =
-    resource.read[Text].cut(t"\n").map(_.trim).filter(_ != t"")
+    resource.stream[Data].read[Text].cut(t"\n").map(_.trim).filter(_ != t"")
 
 class Vocabulary private (adjectives: List[Text], animals: List[Text]):
   type Transport

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -84,7 +84,7 @@ class GrpcChannel
         Http.Header(t"te", t"trailers") ::
         metadataHeaders
 
-    val body = () => Stream(GrpcFraming.encode(message))
+    val body: Spring[Data] = () => Stream(GrpcFraming.encode(message))
     Http.Request(Http.Post, 2.0, host, method.path, headers, body)
 
   // gRPC requires HTTP status 200; anything else is a transport-level failure.

--- a/lib/obligatory/src/json/obligatory.Sse.scala
+++ b/lib/obligatory/src/json/obligatory.Sse.scala
@@ -53,7 +53,7 @@ object Sse:
     import charEncoders.utf8Encoder
 
     Servable[LazyList[Sse]](_ => media"text/event-stream"): stream =>
-      Http.Body.Streaming(stream.map(_.encode.data))
+      Http.Body.Flowing(() => zephyrine.Stream(stream.map(_.encode.data).iterator))
 
   given framable: Text is Framable by Sse = input =>
     val cursor = Cursor(input)

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -156,7 +156,8 @@ object Tests extends Suite(m"Obligatory Tests"):
 
         def duplex(inbound: Spool[Data], outbound: Spool[Data]) = new Duplex:
           def stream: LazyList[Data] = inbound.stream
-          def send(data: LazyList[Data]): Unit = data.each(outbound.put)
+          def send(data: zephyrine.Stream[Data] over Credit): Unit =
+            outbound.put(data.memoize)
           def close(): Unit = outbound.stop()
 
         (duplex(serverToClient, clientToServer), duplex(clientToServer, serverToClient))
@@ -178,7 +179,7 @@ object Tests extends Suite(m"Obligatory Tests"):
 
         daemon:
           safely:
-            serverSide.send(LazyList(Frame.Settings(Nil, ack = false).serialize))
+            serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = false).serialize))
             val raw = serverSide.stream.iterator
 
             val afterPreface: Iterator[Data] =
@@ -196,11 +197,11 @@ object Tests extends Suite(m"Obligatory Tests"):
 
               case f: Frame => f match
                 case Frame.Settings(_, false) =>
-                  serverSide.send(LazyList(Frame.Settings(Nil, ack = true).serialize))
+                  serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = true).serialize))
 
                 case Frame.Headers(id, _, _, _) =>
                   responder(hpack, id).each: frame =>
-                    serverSide.send(LazyList(frame.serialize))
+                    serverSide.send(zephyrine.Stream(frame.serialize))
 
                 case _ => ()
 

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -74,94 +74,117 @@ enum Message:
     case Text(text)   => text.data
     case Binary(data) => data
 
-// The outgoing side of a connection: a thread-safe spool of encoded frames that
-// the server pumps to the socket as the `101` response body (mirroring Coaxial's
-// `Duplex.send`). The reader and the handler both enqueue here.
-class Channel()(using masking: Masking):
-  private val spool: Spool[Data] = Spool()
+// The outgoing side of a connection: a bounded, thread-safe conduit of encoded
+// frames that the server pumps to the socket as the `101` response body
+// (mirroring Coaxial's `Duplex.send`). The reader and the handler both enqueue
+// here, so a full queue backpressures every producer.
+class Channel()(using masking: Masking, buffering: Buffering):
+  // The endpoints are held at an AnyRef rim: capture sets do not ride fields of
+  // a shared front-end object. Each has one owner by construction: producers
+  // serialize through this object's lock, and the server or client pump is the
+  // single consumer of the reader endpoint.
+  private val endpoints: (AnyRef, AnyRef) =
+    val (intake, stream) = Conduit[Data]()
+    (intake.asInstanceOf[AnyRef], stream.asInstanceOf[AnyRef])
 
-  // Mask each frame once, here, on its way out: every element reaching the spool is
-  // already a complete, unmasked frame (a Reader auto-reply, a handler `Reply`, a
+  private def intake: (Intake[Data] over Credit)^ =
+    endpoints(0).asInstanceOf[(Intake[Data] over Credit)^]
+
+  // The single reader endpoint: consumed exactly once, by the pump that writes
+  // the upgraded connection's outgoing bytes.
+  private[perihelion] def stream: (Stream[Data] over Credit)^ =
+    endpoints(1).asInstanceOf[(Stream[Data] over Credit)^]
+
+  // Mask each frame once, here, on its way out: every frame reaching the conduit
+  // is already complete and unmasked (a Reader auto-reply, a handler `Reply`, a
   // `send`, or a `close`), so a client masks it and a server passes it through.
-  private[perihelion] def enqueue(frame: Data): Unit = spool.put(masking.outbound(frame))
-  private[perihelion] def stream: LazyList[Data] = spool.stream
+  private[perihelion] def enqueue(frame: Data): Unit = synchronized:
+    intake.put(masking.outbound(frame))
+    // Flushed per frame: the conduit otherwise buffers a full block before
+    // publishing, but an interactive protocol must deliver each frame promptly.
+    intake.flush()
 
   def send(message: Message): Unit logs WebsocketEvent =
     Log.fine(WebsocketEvent.Sent(message.bytes.length))
     // One message serializes to one complete frame; see `Transmissible`.
     enqueue(Message.transmissible.serialize(message).memoize)
 
-  def stop(): Unit = spool.stop()
+  def stop(): Unit = synchronized(intake.finish())
 
   def close(code: Int = 1000): Unit logs WebsocketEvent =
     Log.info(WebsocketEvent.Closed(code))
     enqueue(Frame.Close(code, Data()).encode)
-    spool.stop()
+    stop()
 
 // Reads client frames off the connection, reassembles fragmented messages,
 // answers Ping with Pong, and ends (stopping the outgoing side) when the peer
 // sends Close. Protocol violations raise `WebsocketError`.
 class Reader(body: Spring[Data]^, channel: Channel)(using Tactic[WebsocketError], Masking):
   def messages: LazyList[Message] =
-    val cursor = Cursor[Data](body())
+    // Deferred: constructing a stream-backed `Cursor` performs its first
+    // refill, which on a live connection blocks until bytes arrive. The
+    // cursor is created only when the first message is forced, so a server
+    // can send its `101` response (and a client its first frame) first.
+    LazyList.defer:
+      val cursor = Cursor[Data](body())
 
-    // Validate `data` as UTF-8. `whole` marks a complete message, where a
-    // trailing partial multi-byte sequence is an error; for a fragment prefix it
-    // is tolerated, since a code point may straddle a fragment boundary. Used
-    // incrementally so invalid bytes fail the connection at once (RFC 6455 §8.1),
-    // not only once the whole message is in.
-    def validUtf8(data: Data, whole: Boolean): Boolean =
-      val decoder = java.nio.charset.StandardCharsets.UTF_8.nn.newDecoder().nn
-      val in = java.nio.ByteBuffer.wrap(data.mutable(using Unsafe)).nn
-      val out = java.nio.CharBuffer.allocate(data.length + 1).nn
-      !decoder.decode(in, out, whole).nn.isError
+      // Validate `data` as UTF-8. `whole` marks a complete message, where a
+      // trailing partial multi-byte sequence is an error; for a fragment prefix it
+      // is tolerated, since a code point may straddle a fragment boundary. Used
+      // incrementally so invalid bytes fail the connection at once (RFC 6455 §8.1),
+      // not only once the whole message is in.
+      def validUtf8(data: Data, whole: Boolean): Boolean =
+        val decoder = java.nio.charset.StandardCharsets.UTF_8.nn.newDecoder().nn
+        val in = java.nio.ByteBuffer.wrap(data.mutable(using Unsafe)).nn
+        val out = java.nio.CharBuffer.allocate(data.length + 1).nn
+        !decoder.decode(in, out, whole).nn.isError
 
-    def emit(text: Boolean, data: Data): Message =
-      if text then Message.Text(data.utf8) else Message.Binary(data)
+      def emit(text: Boolean, data: Data): Message =
+        if text then Message.Text(data.utf8) else Message.Binary(data)
 
-    // Extend a (new or in-progress) message by `data`, validating a text message
-    // incrementally and emitting it once `fin` is seen.
-    def extend(text: Boolean, data: Data, fin: Boolean): LazyList[Message] =
-      if text && !validUtf8(data, fin)
-      then abort(WebsocketError(WebsocketError.Reason.InvalidText))
+      // Extend a (new or in-progress) message by `data`, validating a text message
+      // incrementally and emitting it once `fin` is seen.
+      def extend(text: Boolean, data: Data, fin: Boolean): LazyList[Message] =
+        if text && !validUtf8(data, fin)
+        then abort(WebsocketError(WebsocketError.Reason.InvalidText))
 
-      if fin then emit(text, data) #:: recur(Unset) else recur((text, data))
+        if fin then emit(text, data) #:: recur(Unset) else recur((text, data))
 
-    // A data frame arriving mid-message (a fragmented message is still open) is a
-    // protocol violation, as is a continuation with nothing to continue.
-    def started(fin: Boolean, text: Boolean, data: Data, partial: Optional[(Boolean, Data)])
-    :   LazyList[Message] =
+      // A data frame arriving mid-message (a fragmented message is still open) is a
+      // protocol violation, as is a continuation with nothing to continue.
+      def started(fin: Boolean, text: Boolean, data: Data, partial: Optional[(Boolean, Data)])
+      :   LazyList[Message] =
 
-      if partial.present then abort(WebsocketError(WebsocketError.Reason.BadFragmentation))
-      else extend(text, data, fin)
+        if partial.present then abort(WebsocketError(WebsocketError.Reason.BadFragmentation))
+        else extend(text, data, fin)
 
-    def recur(partial: Optional[(Boolean, Data)]): LazyList[Message] =
-      (Frame.parse(cursor): @unchecked) match
-        case Unset =>
-          LazyList()
+      def recur(partial: Optional[(Boolean, Data)]): LazyList[Message] =
+        (Frame.parse(cursor): @unchecked) match
+          case Unset =>
+            LazyList()
 
-        case Frame.Ping(data) =>
-          channel.enqueue(Frame.Pong(data).encode)
-          recur(partial)
+          case Frame.Ping(data) =>
+            channel.enqueue(Frame.Pong(data).encode)
+            recur(partial)
 
-        case Frame.Pong(_) =>
-          recur(partial)
+          case Frame.Pong(_) =>
+            recur(partial)
 
-        case Frame.Close(code, reason) =>
-          if !validUtf8(reason, true) then abort(WebsocketError(WebsocketError.Reason.InvalidText))
-          channel.enqueue(Frame.Close(if code == 1005 then 1000 else code, Data()).encode)
-          channel.stop()
-          LazyList()
+          case Frame.Close(code, reason) =>
+            if !validUtf8(reason, true) then abort(WebsocketError(WebsocketError.Reason.InvalidText))
+            channel.enqueue(Frame.Close(if code == 1005 then 1000 else code, Data()).encode)
+            channel.stop()
+            LazyList()
 
-        case Frame.Text(fin, data)   => started(fin, true, data, partial)
-        case Frame.Binary(fin, data) => started(fin, false, data, partial)
+          case Frame.Text(fin, data)   => started(fin, true, data, partial)
+          case Frame.Binary(fin, data) => started(fin, false, data, partial)
 
-        case Frame.Continuation(fin, data) =>
-          partial.lay(abort(WebsocketError(WebsocketError.Reason.BadFragmentation))):
-            (text, accumulated) =>
-              extend(text, accumulated ++ data, fin)
+          case Frame.Continuation(fin, data) =>
+            partial.lay(abort(WebsocketError(WebsocketError.Reason.BadFragmentation))):
+              (text, accumulated) =>
+                extend(text, accumulated ++ data, fin)
 
-    recur(Unset)
+      recur(Unset)
 
 object Websocket:
   val magic: Text = t"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
@@ -180,7 +203,9 @@ object Websocket:
           secWebsocketVersion = 13,
           connection          = t"Upgrade",
           upgrade             = t"websocket" )
-        ( Http.Body.Flowing(() => zephyrine.Stream(websocket.channel.stream.iterator)) )
+        // The channel's reader endpoint is a singleton: the upgrade body is
+        // materialized exactly once, by the server's response writer.
+        ( Http.Body.Flowing(() => websocket.channel.stream) )
 
 // The `Servable` carrier for a WebSocket handler. On serve it produces the `101`
 // handshake response whose body is the outgoing frame stream; the handler runs

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -58,8 +58,8 @@ object Message:
   // A `Message` serialises to a complete (unmasked) WebSocket frame, so it can
   // flow through Coaxial's `Control.Reply`/`Conclude` and be written verbatim.
   given transmissible: Message is Transmissible =
-    case Text(text)   => LazyList(Frame.Text(true, text.data).encode)
-    case Binary(data) => LazyList(Frame.Binary(true, data).encode)
+    case Text(text)   => zephyrine.Stream(Frame.Text(true, text.data).encode)
+    case Binary(data) => zephyrine.Stream(Frame.Binary(true, data).encode)
 
 // A complete WebSocket message: text frames are reassembled and UTF-8-decoded;
 // binary frames are reassembled as raw bytes. Control frames (Ping/Pong/Close)
@@ -88,7 +88,8 @@ class Channel()(using masking: Masking):
 
   def send(message: Message): Unit logs WebsocketEvent =
     Log.fine(WebsocketEvent.Sent(message.bytes.length))
-    Message.transmissible.serialize(message).each(enqueue(_))
+    // One message serializes to one complete frame; see `Transmissible`.
+    enqueue(Message.transmissible.serialize(message).memoize)
 
   def stop(): Unit = spool.stop()
 

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -100,9 +100,9 @@ class Channel()(using masking: Masking):
 // Reads client frames off the connection, reassembles fragmented messages,
 // answers Ping with Pong, and ends (stopping the outgoing side) when the peer
 // sends Close. Protocol violations raise `WebsocketError`.
-class Reader(body: () => LazyList[Data], channel: Channel)(using Tactic[WebsocketError], Masking):
+class Reader(body: Spring[Data]^, channel: Channel)(using Tactic[WebsocketError], Masking):
   def messages: LazyList[Message] =
-    val cursor = Cursor(body().filter(_.nonEmpty).iterator)
+    val cursor = Cursor[Data](body())
 
     // Validate `data` as UTF-8. `whole` marks a complete message, where a
     // trailing partial multi-byte sequence is an error; for a fragment prefix it
@@ -233,4 +233,4 @@ class Websocket[message, state]
         initial
 
     . protect:
-        loop(Reader(() => request.body().lazyList, channel).messages, initial)
+        loop(Reader(request.body, channel).messages, initial)

--- a/lib/perihelion/src/core/perihelion.Websocket.scala
+++ b/lib/perihelion/src/core/perihelion.Websocket.scala
@@ -180,7 +180,7 @@ object Websocket:
           secWebsocketVersion = 13,
           connection          = t"Upgrade",
           upgrade             = t"websocket" )
-        ( Http.Body.Streaming(websocket.channel.stream) )
+        ( Http.Body.Flowing(() => zephyrine.Stream(websocket.channel.stream.iterator)) )
 
 // The `Servable` carrier for a WebSocket handler. On serve it produces the `101`
 // handshake response whose body is the outgoing frame stream; the handler runs

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -224,7 +224,9 @@ given wsClient: ( online:            Online,
                 Http.Header(t"Sec-WebSocket-Version", t"13") ),
             () => Http.emptyBody() )
 
-      duplex.send(Http.Request.serialize(request))
+      // The handshake request is a single small chunk; `Duplex.send` still
+      // speaks LazyList until the receive side converts to kernel streams.
+      duplex.send(LazyList(Http.Request.serialize(request).memoize))
 
       // Read the response headers up to the CRLFCRLF terminator *without* over-reading:
       // `Http.Response.parse` on a live socket eagerly refills one chunk past the headers,

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -254,7 +254,7 @@ given wsClient: ( online:            Online,
 
     def receive(connection: WsConnection): LazyList[Data] =
       given Masking = connection.masking
-      Reader(() => connection.inbound, connection.channel).messages.map(_.bytes)
+      Reader(() => zephyrine.Stream(connection.inbound.iterator), connection.channel).messages.map(_.bytes)
 
     def transmit(connection: WsConnection, input: LazyList[Data]): Unit =
       input.each(connection.channel.enqueue(_))

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -45,6 +45,7 @@ import hieroglyph.*
 import monotonous.*
 import parasite.*
 import prepositional.*
+import zephyrine.memoize
 import rudiments.*
 import spectacular.*
 import telekinesis.*
@@ -103,7 +104,7 @@ given transmissible: [transport, value]
 =>  ( format: transport is Encodable in Text, codec: value is Encodable in transport )
 =>  CharEncoder
 =>  (value over transport) is Transmissible =
-  payload => LazyList(Frame.Text(true, format.encoded(codec.encoded(payload)).data).encode)
+  payload => zephyrine.Stream(Frame.Text(true, format.encoded(codec.encoded(payload)).data).encode)
 
 // The decode direction. The `Decodable in Text`/`in transport` instances are
 // `Tactic`-conditional and don't resolve as nested given constraints, so we
@@ -256,8 +257,10 @@ given wsClient: ( online:            Online,
       given Masking = connection.masking
       Reader(() => zephyrine.Stream(connection.inbound.iterator), connection.channel).messages.map(_.bytes)
 
-    def transmit(connection: WsConnection, input: LazyList[Data]): Unit =
-      input.each(connection.channel.enqueue(_))
+    def transmit(connection: WsConnection, input: (zephyrine.Stream[Data] over zephyrine.Credit)^): Unit =
+      // One `transmit` carries one message = one complete frame, masked at the
+      // `Channel` boundary; see `Transmissible`.
+      connection.channel.enqueue(input.memoize)
 
     def close(connection: WsConnection): Unit =
       given Masking = connection.masking

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -224,9 +224,7 @@ given wsClient: ( online:            Online,
                 Http.Header(t"Sec-WebSocket-Version", t"13") ),
             () => Http.emptyBody() )
 
-      // The handshake request is a single small chunk; `Duplex.send` still
-      // speaks LazyList until the receive side converts to kernel streams.
-      duplex.send(LazyList(Http.Request.serialize(request).memoize))
+      duplex.send(Http.Request.serialize(request))
 
       // Read the response headers up to the CRLFCRLF terminator *without* over-reading:
       // `Http.Response.parse` on a live socket eagerly refills one chunk past the headers,

--- a/lib/perihelion/src/test/perihelion.AutobahnClient.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnClient.scala
@@ -72,7 +72,7 @@ object AutobahnClient:
               safely(connection.channel.close(error.reason.closeCode))
 
           . protect:
-              Reader(() => connection.inbound, connection.channel).messages.each:
+              Reader(() => zephyrine.Stream(connection.inbound.iterator), connection.channel).messages.each:
                 consume(connection.channel)(_)
 
         finally

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -171,7 +171,7 @@ object Tests extends Suite(m"Perihelion tests"):
 
     def readMessages(frames: Array[Byte]*): List[perihelion.Message] =
       val stream = LazyList(frames*).map(_.immutable(using Unsafe))
-      Reader(() => stream, Channel()).messages.toList
+      Reader(() => zephyrine.Stream(stream.iterator), Channel()).messages.toList
 
     def texts(messages: List[perihelion.Message]): List[Text] = messages.map:
       case perihelion.Message.Text(text) => text

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -281,7 +281,7 @@ object Tests extends Suite(m"Perihelion tests"):
 
         // `outgoing` now yields a complete (unmasked) Text frame; the reader unframes it
         // before `incoming` decodes the JSON payload.
-        val frameBytes = outgoing.serialize(Ping(7).over[Json]).foldLeft(Data())(_ ++ _)
+        val frameBytes = outgoing.serialize(Ping(7).over[Json]).memoize
 
         val payload = Frame.parse(Cursor[Data](LazyList(frameBytes).iterator))(using Masking.Client()) match
           case Frame.Text(_, data) => data

--- a/lib/phoenicia/src/core/phoenicia.Ttf.scala
+++ b/lib/phoenicia/src/core/phoenicia.Ttf.scala
@@ -46,7 +46,7 @@ import vacuous.*
 
 object Ttf:
   def apply[source: Streamable by Data](source: source): Ttf =
-    val data = source.read[Data]
+    val data = source.stream[Data].read[Data]
     Ttf(data)
 
   enum PlatformId:

--- a/lib/punctuation/src/core/punctuation.Serializer.scala
+++ b/lib/punctuation/src/core/punctuation.Serializer.scala
@@ -59,7 +59,7 @@ private[punctuation] object Serializer:
           markdown.children,
           protectFirst = false )
 
-  private def writeDocument(writer: Writer, markdown: Markdown of Layout): Unit =
+  private def writeDocument(writer: Writer^, markdown: Markdown of Layout): Unit =
     var first = true
 
     markdown.children.each: node =>
@@ -69,7 +69,7 @@ private[punctuation] object Serializer:
 
     linkRefs(writer, markdown.linkRefs)
 
-  private def linkRefs(writer: Writer, refs: List[Markdown.LinkRef]): Unit =
+  private def linkRefs(writer: Writer^, refs: List[Markdown.LinkRef]): Unit =
     if !refs.nil then
       if writer.written && !writer.atLineStart then writer.newline()
 
@@ -308,7 +308,7 @@ private[punctuation] object Serializer:
 
   // Word-wrap a paragraph's inline content: textual nodes break at their spaces, inline constructs
   // are atomic. `protectFirst` backslash-escapes a leading block-start character.
-  private def flow(writer: Writer, children: Seq[Prose], protectFirst: Boolean): Unit =
+  private def flow(writer: Writer^, children: Seq[Prose], protectFirst: Boolean): Unit =
     if protectFirst then writer.protectNext()
 
     children.each:
@@ -319,7 +319,7 @@ private[punctuation] object Serializer:
 
     writer.endFlow()
 
-  private def layout(writer: Writer, node: Layout): Unit = node match
+  private def layout(writer: Writer^, node: Layout): Unit = node match
     case Layout.Heading(_, level, children*) =>
       writer.raw(t"#"*level)
       writer.raw(t" ")
@@ -377,7 +377,7 @@ private[punctuation] object Serializer:
         n += 1
 
   // Emit a list item: the first line carries the marker, subsequent lines the hanging indent.
-  private def listItem(writer: Writer, item: List[Layout], marker: Text, hanging: Text): Unit =
+  private def listItem(writer: Writer^, item: List[Layout], marker: Text, hanging: Text): Unit =
     if item.nil then writer.newline() else
       var first = true
 
@@ -390,7 +390,10 @@ private[punctuation] object Serializer:
   // A streaming sink for Markdown source. Block separation, indentation and the first-character
   // block-start escape are carried as state (no looking back at emitted output), and paragraph text
   // is word-wrapped at `width` (the default `Int.MaxValue` never wraps, preserving the AST).
-  class Writer(producer: Producer[Text], val width: Int):
+  // Holds the exclusive producer it drives, so the writer is itself a stateful
+  // capability with update-classified writes.
+  class Writer(producer: (Producer[Text])^, val width: Int)
+  extends caps.ExclusiveCapability, caps.Stateful:
     private var trailing = 0          // consecutive trailing newlines just emitted
     private var col = 0               // current column, for wrapping
     private var pendingSpaces = 0     // spaces buffered before the current word
@@ -398,10 +401,10 @@ private[punctuation] object Serializer:
     private var protect = false       // escape the next word's leading block-start char
     var written: Boolean = false
 
-    def atLineStart: Boolean = col == 0
+    update def atLineStart: Boolean = col == 0
 
     // Emit text verbatim (it may contain newlines), tracking the trailing-newline count and column.
-    def raw(text: Text): Unit =
+    update def raw(text: Text): Unit =
       val s = text.s
 
       if s.length > 0 then
@@ -422,14 +425,14 @@ private[punctuation] object Serializer:
           val lastNl = s.lastIndexOf('\n')
           col = if lastNl < 0 then col + s.length else s.length - lastNl - 1
 
-    def newline(): Unit =
+    update def newline(): Unit =
       producer.put(t"\n")
       written = true
       trailing += 1
       col = 0
 
     // Ensure blocks are separated by a blank line (two trailing newlines), once content exists.
-    def blankLine(): Unit =
+    update def blankLine(): Unit =
       if written then
         if trailing == 0 then
           newline()
@@ -437,9 +440,9 @@ private[punctuation] object Serializer:
         else if trailing == 1 then
           newline()
 
-    def protectNext(): Unit = protect = true
+    update def protectNext(): Unit = protect = true
 
-    def text(content: Text): Unit =
+    update def text(content: Text): Unit =
       val s = content.s
       var i = 0
 
@@ -452,14 +455,14 @@ private[punctuation] object Serializer:
 
         i += 1
 
-    def atom(content: Text): Unit = seg.add(content)
+    update def atom(content: Text): Unit = seg.add(content)
 
-    def soft(): Unit =
+    update def soft(): Unit =
       flushSeg()
       pendingSpaces = 0
       newline()
 
-    def hard(): Unit =
+    update def hard(): Unit =
       flushSeg()
       pendingSpaces = 0
       raw(t"\\")

--- a/lib/punctuation/src/core/punctuation.Serializer.scala
+++ b/lib/punctuation/src/core/punctuation.Serializer.scala
@@ -468,9 +468,9 @@ private[punctuation] object Serializer:
       raw(t"\\")
       newline()
 
-    def endFlow(): Unit = flushSeg()
+    update def endFlow(): Unit = flushSeg()
 
-    private def flushSeg(): Unit =
+    private update def flushSeg(): Unit =
       if seg.length > 0 then
         val word = seg.text
         seg.clear()

--- a/lib/revolution/src/core/revolution.Manifest.scala
+++ b/lib/revolution/src/core/revolution.Manifest.scala
@@ -45,7 +45,7 @@ import vacuous.*
 
 object Manifest:
   protected def parse[streamable: Streamable by Data](source: streamable): Manifest =
-    val java = juj.Manifest(source.read[LazyList[Data]].inputStream)
+    val java = juj.Manifest(source.stream[Data].inputStream)
 
     Manifest:
       java.getMainAttributes.nn.asScala.to(List).map: (key, value) =>

--- a/lib/scintillate/src/server/scintillate.Acceptable.scala
+++ b/lib/scintillate/src/server/scintillate.Acceptable.scala
@@ -41,6 +41,7 @@ import prepositional.*
 import rudiments.*
 import telekinesis.*
 import turbulence.*
+import zephyrine.*
 import vacuous.*
 
 import errorDiagnostics.stackTracesDiagnostics
@@ -59,7 +60,10 @@ object Acceptable:
           val boundary = contentType.at(t"boundary").or:
             abort(MultipartError(MultipartError.Reason.MediaType))
 
-          Multipart.parse(request.body().lazyList, boundary)
+          // Interim: `Multipart.parse` is still `Streamable`-typed; the whole body is
+          // materialized (as its parts already were). Cursor-based parsing comes with
+          // the Streamable-tail conversion (see rep/DECISIONS.md).
+          Multipart.parse(request.body().memoize, boundary)
         else
           abort(MultipartError(MultipartError.Reason.MediaType))
 

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -109,7 +109,6 @@ object HttpConnection:
       val length = if chunked then 0 else response.body match
         case Http.Body.Empty        => -1
         case Http.Body.Fixed(data)  => data.length
-        case Http.Body.Streaming(_) => 0
         case Http.Body.Flowing(_)   => 0
 
       exchange.sendResponseHeaders(response.status.code, length)
@@ -124,14 +123,6 @@ object HttpConnection:
             count += data.length
             responseBody.flush()
           catch case _: ji.IOException => abort(StreamError(count.b))
-
-        case Http.Body.Streaming(stream) =>
-          stream.foreach: block =>
-            try
-              responseBody.write(block.mutable(using Unsafe))
-              count += block.length
-              responseBody.flush()
-            catch case _: ji.IOException => abort(StreamError(count.b))
 
         case Http.Body.Flowing(source) =>
           val stream = source()

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -42,6 +42,7 @@ import denominative.*
 import gossamer.*
 import hieroglyph.charEncoders.asciiEncoder
 import parasite.*
+import prepositional.*
 import rudiments.*
 import telekinesis.*
 import turbulence.*
@@ -68,23 +69,26 @@ extends RequestServable:
 
   private val continueResponse: Data = t"HTTP/1.1 100 Continue\r\n\r\n".data
 
-  private def writeAll(out: ji.OutputStream, stream: LazyList[Data]): Unit raises StreamError =
+  private def writeAll(out: ji.OutputStream, stream: Stream[Data] over Credit)
+  :   Unit raises StreamError =
+
     var count: Int = 0
 
     // Consume the stream one block at a time and flush after each: a streaming
     // body (chunked response, SSE, or an upgraded WebSocket) may never end, so
     // its bytes must reach the client as they are produced rather than be forced
     // into memory or sit unflushed in the buffer.
-    def recur(stream: LazyList[Data]): Unit = stream.flow(()):
-      try
-        out.write(next.mutable(using Unsafe))
-        out.flush()
-        count += next.length
-      catch case _: ji.IOException => abort(StreamError(count.b))
+    var failed: Boolean = false
 
-      recur(more)
+    stream.foreachWindow: (storage, start, size) =>
+      if !failed then
+        try
+          out.write(storage.asInstanceOf[Array[Byte]], start, size)
+          out.flush()
+          count += size
+        catch case error: ji.IOException => failed = true
 
-    recur(stream)
+    if failed then abort(StreamError(count.b))
 
   // Frame the request body off the shared connection cursor: chunked decoding
   // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or empty
@@ -126,9 +130,8 @@ extends RequestServable:
       header.key.lower == t"expect" && header.value.lower.contains(t"100-continue")
 
   private def streaming(response: Http.Response): Boolean = response.body match
-    case Http.Body.Streaming(_) => true
-    case Http.Body.Flowing(_)   => true
-    case _                      => false
+    case Http.Body.Flowing(_) => true
+    case _                    => false
 
   // Map a request-parsing failure to the status the client should see.
   private def errorStatus(reason: HttpRequestError.Reason): Http.Status =
@@ -172,7 +175,7 @@ extends RequestServable:
           val upgrade = isUpgrade(head)
 
           // Tell a waiting client it may send the body before we read it.
-          if expectsContinue(head) then writeAll(out, LazyList(continueResponse))
+          if expectsContinue(head) then writeAll(out, Stream(continueResponse))
 
           val body = if upgrade then cursor.remainder else requestBody(cursor, head)
 

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -94,10 +94,6 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
         case Http.Body.Empty =>
           servletResponse.addHeader("content-length", "0")
 
-        case Http.Body.Streaming(stream) =>
-          servletResponse.addHeader("transfer-encoding", "chunked")
-          stream.map(_.mutable(using Unsafe)).each(out.write(_))
-
         case Http.Body.Flowing(source) =>
           servletResponse.addHeader("transfer-encoding", "chunked")
           val stream = source()

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -97,7 +97,7 @@ object Tests extends Suite(m"Scintillate tests"):
           val port = freePort()
 
           val server = SocketServer(port).handle:
-            Http.Response(Http.Ok)(request.body().lazyList.read[Data].utf8)
+            Http.Response(Http.Ok)(request.body().memoize.utf8)
 
           val response =
             rawRequest(port, t"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello")
@@ -111,7 +111,7 @@ object Tests extends Suite(m"Scintillate tests"):
           val port = freePort()
 
           val server = SocketServer(port).handle:
-            Http.Response(Http.Ok)(request.body().lazyList.read[Data].utf8)
+            Http.Response(Http.Ok)(request.body().memoize.utf8)
 
           val response =
             rawRequest

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -331,7 +331,7 @@ object Tests extends Suite(m"Scintillate tests"):
       . assert(_.contains(t"431"))
 
       test(m"A streaming response to HTTP/1.0 is close-delimited, not chunked"):
-        val body = Http.Body.Streaming(LazyList(t"Hello".data, t"World".data))
+        val body = Http.Body.Flowing(() => Stream(LazyList(t"Hello".data, t"World".data).iterator))
         inProcess(Http.Response(Http.Ok)(body), t"GET / HTTP/1.0\r\nHost: x\r\n\r\n")
 
       . assert: response =>

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1028,7 +1028,11 @@ object Tel extends Tel2:
 
           case _ => ()
 
-        compound.children.each(emitBlock(_, indent + 1, sigil))
+        // indexed: the foreach lambda would capture the exclusive producer transitively
+        var childIndex = 0
+        while childIndex < compound.children.length do
+          emitBlock(compound.children(childIndex), indent + 1, sigil)
+          childIndex += 1
 
       def emitBlock(block: Tel.Block, indent: Int, sigil: Char): Unit =
         val pad = "  "*indent

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -184,7 +184,7 @@ object Mcp:
                 ( mcpInterface.stream )
 
             case Http.Post =>
-              val input = request.body().lazyList.read[Json]
+              val input = request.body().memoize.read[Json]
 
               dispatch(input).let: json =>
                 import formatting.indentedJsonFormatting

--- a/lib/synesthesia/src/core/synesthesia.internal.scala
+++ b/lib/synesthesia/src/core/synesthesia.internal.scala
@@ -301,7 +301,7 @@ object internal:
                                     Mcp.TextResourceContents
                                       ( $uri,
                                         mimeType = t"text/html;profile=mcp-app", // FIXME
-                                        text = $value.read[Text] )
+                                        text = $value.stream[Text].read[Text] )
                                 }
 
                             case None => Expr.summon[result is Streamable by Data] match
@@ -312,7 +312,7 @@ object internal:
 
                                     Mcp.Contents:
                                       Mcp.BlobResourceContents
-                                        ( $uri, Unset, blob = $value.read[Data].serialize[Base64] )
+                                        ( $uri, Unset, blob = $value.stream[Data].read[Data].serialize[Base64] )
                                   }
 
                               case None => halt:

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -226,8 +226,10 @@ object Http:
   object Request:
     given showable: Request is Showable = request =>
       val bodySample: Text =
-        try request.body().lazyList.read[Data].utf8 catch
-          case error: StreamError  => t"[-/-]"
+        try
+          val stream = request.body()
+          stream.lazyList.read[Data].utf8
+        catch case error: StreamError  => t"[-/-]"
 
       val headers: Text =
         request.textHeaders.map: header =>
@@ -473,7 +475,7 @@ object Http:
 
   enum Body:
     case Streaming(data: LazyList[Data])
-    case Flowing(source: () => (Stream[Data] over Credit)^)
+    case Flowing(source: Spring[Data]^)
     case Fixed(data: Data)
     case Empty
 
@@ -488,7 +490,7 @@ object Http:
 
   // A request body with no bytes; each call constructs a fresh, already-empty
   // pull endpoint, matching the re-materializable contract of `body` thunks.
-  def emptyBody(): Stream[Data] over Credit = Stream(Iterator.empty[Data])
+  def emptyBody(): (Stream[Data] over Credit)^ = Stream(Iterator.empty[Data])
 
   class Request
     ( val method:      Http.Method,
@@ -496,7 +498,7 @@ object Http:
       val host:        Host,
       val target:      Text,
       val textHeaders: List[Http.Header],
-      val body:        () => (Stream[Data] over Credit)^ ):
+      val body:        Spring[Data]^ ):
 
     inline def request: this.type = this
 
@@ -552,7 +554,7 @@ object Http:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => (Stream[Data] over Credit)^ )
+        body:    Spring[Data]^ )
       ( using Tactic[ConnectError] )
     :   Http.Response
 

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -254,13 +254,40 @@ object Http:
       ).map { case (key, value) => t"$key = $value" }.join(t", ")
 
     // Serialize the request to its HTTP/1.1 wire form: the request line, `Host`
-    // and framing headers, then the header block and body. Used by transports
-    // that write directly to a socket (e.g. the `coaxial` domain-socket client
-    // in `telekinesis.jvm`, which wraps this in a `Transmissible`).
-    def serialize(request: Request): LazyList[Data] =
+    // and framing headers, then the header block and body, as a fresh pull
+    // endpoint. Used by transports that write directly to a socket (e.g. the
+    // `coaxial` domain-socket client in `telekinesis.jvm`, which wraps this in
+    // a `Transmissible`). The body is probed one block at a time: a body that
+    // ends within the first block is framed with `Content-Length`; anything
+    // longer streams with chunked transfer encoding.
+    def serialize(request: Request)(using buffering: Buffering)
+    :   (Stream[Data] over Credit)^ =
+
       import charEncoders.asciiEncoder
 
-      val text: Text = Text.build:
+      val endpoint = request.body()
+      val block = buffering.capacity(Substrate.Bytes)
+
+      // A zero count (an empty upstream chunk) is retried, never yielded: a
+      // zero-length frame would terminate chunked transfer encoding early.
+      def pull(): Optional[Data] = endpoint.refill(Credit(block)) match
+        case 0 => pull()
+
+        case count: Int =>
+          val chunk =
+            endpoint.addressable.materialize
+              ( endpoint.window(using Unsafe), endpoint.start, count )
+
+          endpoint.skip(count)
+          chunk
+
+        case _ =>
+          Unset
+
+      val first: Optional[Data] = pull()
+      val second: Optional[Data] = if first.absent then Unset else pull()
+
+      def head(framing: Text): Text = Text.build:
         def newline(): Unit = append(t"\r\n")
         append(request.method.show)
         append(t" ")
@@ -271,11 +298,7 @@ object Http:
         append(t"Host: ")
         append(request.host.show)
         newline()
-
-        request.body().lazyList match
-          case LazyList()     => append(t"Content-Length: 0")
-          case LazyList(data) => append(t"Content-Length: ${data.length}")
-          case _              => append(t"Transfer-Encoding: chunked")
+        append(framing)
 
         request.textHeaders.map: parameter =>
           newline()
@@ -286,7 +309,22 @@ object Http:
         newline()
         newline()
 
-      text.data #:: request.body().lazyList
+      def frame(data: Data): Iterator[Data] =
+        Iterator(t"${Integer.toHexString(data.length).nn.tt}\r\n".data, data, t"\r\n".data)
+
+      if second.absent then
+        val data = first.or(IArray.empty[Byte])
+        val text = head(t"Content-Length: ${data.length}")
+        Stream(if data.length == 0 then Iterator(text.data) else Iterator(text.data, data))
+      else
+        val text = head(t"Transfer-Encoding: chunked")
+
+        Stream
+          ( Iterator(text.data)
+            ++ frame(first.vouch)
+            ++ frame(second.vouch)
+            ++ Iterator.continually(pull()).takeWhile(_.present).flatMap { data => frame(data.vouch) }
+            ++ Iterator(t"0\r\n\r\n".data) )
 
     case class Head
       ( method: Method, version: Version, host: Host, target: Text, headers: List[Header] )
@@ -471,18 +509,16 @@ object Http:
       recur()
 
   enum Body:
-    case Streaming(data: LazyList[Data])
     case Flowing(source: Spring[Data]^)
     case Fixed(data: Data)
     case Empty
 
-    def stream: LazyList[Data] = this match
-      case Body.Fixed(data)       => LazyList(data)
-      case Body.Empty             => LazyList()
-      case Body.Streaming(stream) => stream
-      case Body.Flowing(source)   =>
-        val flowing = source()
-        flowing.lazyList
+    // A fresh pull endpoint over this body's content: mintable repeatedly for
+    // `Fixed`/`Empty`, and per the `Spring` contract for `Flowing`.
+    def stream: (Stream[Data] over Credit)^ = this match
+      case Body.Fixed(data)     => Stream(data)
+      case Body.Empty           => Stream(Iterator.empty[Data])
+      case Body.Flowing(source) => source()
 
 
   // A request body with no bytes; each call constructs a fresh, already-empty
@@ -584,7 +620,7 @@ object Http:
     given streamable: (tactic: Tactic[HttpError])
     =>  ((Response is Streamable by Data)^{tactic}) = response =>
       response.status.category match
-        case Http.Status.Category.Successful => response.body.stream
+        case Http.Status.Category.Successful => LazyList(response.body.stream.memoize)
 
         case _ =>
           abort(HttpError(response.status, response.textHeaders))
@@ -599,7 +635,8 @@ object Http:
     // `101` upgrades (where the caller pipes the post-handshake stream raw). The
     // inverse of `parse`.
     def serialize(response: Response, includeBody: Boolean = true, version: Version = 1.1)
-    :   LazyList[Data] =
+      ( using buffering: Buffering )
+    :   (Stream[Data] over Credit)^ =
 
       import charEncoders.asciiEncoder
 
@@ -627,7 +664,7 @@ object Http:
             val length = data.length.toString.tt
             (if hasContentLength then Nil else List(Header(t"content-length", length)), false)
 
-          case Body.Streaming(_) | Body.Flowing(_) =>
+          case Body.Flowing(_) =>
             if explicitChunked && chunkable then (Nil, true)
             else if hasContentLength then (Nil, false)
             else if chunkable then (List(Header(t"transfer-encoding", t"chunked")), true)
@@ -654,27 +691,47 @@ object Http:
 
         append(t"\r\n")
 
-      def chunkedFraming(stream: LazyList[Data]): LazyList[Data] = stream match
-        case block #:: tail =>
-          if block.length == 0 then chunkedFraming(tail) else
-            val size: Text = Integer.toHexString(block.length).nn.tt
-            t"$size\r\n".data #:: block #:: t"\r\n".data #:: chunkedFraming(tail)
+      // Materialize successive blocks off a pull endpoint as a chunk iterator.
+      def pulls(endpoint: (Stream[Data] over Credit)^): Iterator[Data]^{endpoint} =
+        val block = buffering.capacity(Substrate.Bytes)
 
-        case _ =>
-          LazyList(t"0\r\n\r\n".data)
+        Iterator.continually:
+          def pull(): Optional[Data] = endpoint.refill(Credit(block)) match
+            // See `Request.serialize`: empty chunks are retried, never framed.
+            case 0 => pull()
 
-      def bodyBytes: LazyList[Data] =
-        if !includeBody then LazyList() else if upgrade then response.body.stream
+            case count: Int =>
+              val chunk =
+                endpoint.addressable.materialize
+                  ( endpoint.window(using Unsafe), endpoint.start, count )
+
+              endpoint.skip(count)
+              chunk
+
+            case _ =>
+              Unset
+
+          pull()
+
+        . takeWhile(_.present).map(_.vouch)
+
+      def frame(data: Data): Iterator[Data] =
+        Iterator(t"${Integer.toHexString(data.length).nn.tt}\r\n".data, data, t"\r\n".data)
+
+      def bodyBytes: Iterator[Data]^ =
+        if !includeBody then Iterator.empty
+        else if upgrade then pulls(response.body.stream)
         else response.body match
-          case Body.Empty             => LazyList()
-          case Body.Fixed(data)       => LazyList(data)
-          case Body.Streaming(stream) => if chunked then chunkedFraming(stream) else stream
+          case Body.Empty       => Iterator.empty
+          case Body.Fixed(data) => Iterator(data)
 
           case Body.Flowing(source) =>
-            val stream = source().lazyList
-            if chunked then chunkedFraming(stream) else stream
+            if chunked then pulls(source()).flatMap(frame) ++ Iterator(t"0\r\n\r\n".data)
+            else pulls(source())
 
-      head.data #:: bodyBytes
+      // Hoisted: a by-name `++` operand may not mint a fresh capability.
+      val chunks = bodyBytes
+      Stream(Iterator(head.data) ++ chunks)
 
     def parse(stream: LazyList[Data]): Response raises HttpResponseError =
       val cursor = Cursor[Data](stream.filter(_.nonEmpty).iterator)
@@ -766,7 +823,11 @@ object Http:
 
       val headers = readHeaders(Nil)
 
-      val body = Http.Body.Streaming(cursor.remainder)
+      // Sealed: the cursor is single-owner and reachable only through its
+      // memoized `remainder`, so the spring is pure in effect; a capturing
+      // `Body` would cascade `^` through every `Response` value.
+      val spring: Spring[Data]^ = () => Stream(cursor.remainder.iterator)
+      val body = Http.Body.Flowing(caps.unsafe.unsafeAssumePure(spring))
 
       Response(version, status, headers.reverse, body)
 
@@ -782,7 +843,8 @@ object Http:
 
 
     def successBody: Optional[LazyList[Data]] =
-      if status.category != Http.Status.Category.Successful then Unset else body.stream
+      if status.category != Http.Status.Category.Successful then Unset
+      else LazyList(body.stream.memoize)
 
 
     def receive[body](using receivable: (body is Receivable)^): body =

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -481,7 +481,9 @@ object Http:
       case Body.Fixed(data)       => LazyList(data)
       case Body.Empty             => LazyList()
       case Body.Streaming(stream) => stream
-      case Body.Flowing(source)   => source().lazyList
+      case Body.Flowing(source)   =>
+        val flowing = source()
+        flowing.lazyList
 
 
   // A request body with no bytes; each call constructs a fresh, already-empty
@@ -511,7 +513,8 @@ object Http:
     lazy val query: Query =
       contentType.let(_.base.show) match
         case t"application/x-www-form-urlencoded" =>
-          queryText.decode[Query] ++ body().lazyList.read[Data].utf8.decode[Query]
+          val flowing = body()
+          queryText.decode[Query] ++ flowing.lazyList.read[Data].utf8.decode[Query]
 
         case _ =>
           queryText.decode[Query]

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -625,6 +625,14 @@ object Http:
         case _ =>
           abort(HttpError(response.status, response.textHeaders))
 
+    given source: (tactic: Tactic[HttpError])
+    =>  ((Response is Source by Data over Credit)^{tactic}) = response =>
+      response.status.category match
+        case Http.Status.Category.Successful => response.body.stream
+
+        case _ =>
+          abort(HttpError(response.status, response.textHeaders))
+
     private[Http] def response(status: Status, headers: List[Header], body: Body): Response =
       new Response(1.1, status, headers, body)
 

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -473,7 +473,7 @@ object Http:
 
   enum Body:
     case Streaming(data: LazyList[Data])
-    case Flowing(source: () => Stream[Data] over Credit)
+    case Flowing(source: () => (Stream[Data] over Credit)^)
     case Fixed(data: Data)
     case Empty
 
@@ -496,7 +496,7 @@ object Http:
       val host:        Host,
       val target:      Text,
       val textHeaders: List[Http.Header],
-      val body:        () => Stream[Data] over Credit ):
+      val body:        () => (Stream[Data] over Credit)^ ):
 
     inline def request: this.type = this
 
@@ -552,7 +552,7 @@ object Http:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => Stream[Data] over Credit )
+        body:    () => (Stream[Data] over Credit)^ )
       ( using Tactic[ConnectError] )
     :   Http.Response
 

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -226,10 +226,7 @@ object Http:
   object Request:
     given showable: Request is Showable = request =>
       val bodySample: Text =
-        try
-          val stream = request.body()
-          stream.lazyList.read[Data].utf8
-        catch case error: StreamError  => t"[-/-]"
+        try request.body().memoize.utf8 catch case error: StreamError  => t"[-/-]"
 
       val headers: Text =
         request.textHeaders.map: header =>
@@ -515,8 +512,7 @@ object Http:
     lazy val query: Query =
       contentType.let(_.base.show) match
         case t"application/x-www-form-urlencoded" =>
-          val flowing = body()
-          queryText.decode[Query] ++ flowing.lazyList.read[Data].utf8.decode[Query]
+          queryText.decode[Query] ++ body().memoize.utf8.decode[Query]
 
         case _ =>
           queryText.decode[Query]

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -112,7 +112,7 @@ object HttpClient:
 
             case Some(header) =>
               // Drain the discarded intermediate body to free its connection.
-              safely(response.body.stream.each { _ => () })
+              safely(response.body.stream.foreachWindow { (_, _, _) => () })
 
               val nextUri = uri.resolve(jn.URI.create(header.value.s).nn).nn
               Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -99,7 +99,7 @@ object HttpClient:
       val url = httpRequest.on(origin)
       Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-      def loop(uri: jn.URI, method: Http.Method, bodyFn: () => Stream[Data] over Credit,
+      def loop(uri: jn.URI, method: Http.Method, bodyFn: () => (Stream[Data] over Credit)^,
           remaining: Int)
       :   Http.Response =
 
@@ -119,7 +119,7 @@ object HttpClient:
               Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))
               val nextMethod = redirectMethod(code, method)
 
-              val nextBody: () => Stream[Data] over Credit =
+              val nextBody: () => (Stream[Data] over Credit)^ =
                 if nextMethod == method then bodyFn else () => Http.emptyBody()
 
               loop(nextUri, nextMethod, nextBody, remaining - 1)

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -99,8 +99,7 @@ object HttpClient:
       val url = httpRequest.on(origin)
       Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-      def loop(uri: jn.URI, method: Http.Method, bodyFn: () => (Stream[Data] over Credit)^,
-          remaining: Int)
+      def loop(uri: jn.URI, method: Http.Method, bodyFn: Spring[Data]^, remaining: Int)
       :   Http.Response =
 
         val response = backend.request(uri.toString.tt, method, httpRequest.textHeaders, bodyFn)
@@ -119,7 +118,7 @@ object HttpClient:
               Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))
               val nextMethod = redirectMethod(code, method)
 
-              val nextBody: () => (Stream[Data] over Credit)^ =
+              val nextBody: Spring[Data]^ =
                 if nextMethod == method then bodyFn else () => Http.emptyBody()
 
               loop(nextUri, nextMethod, nextBody, remaining - 1)

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -57,7 +57,7 @@ object Postable:
   // body may be materialized more than once — for a redirect that preserves
   // the method, and independently by `preview` for logging — and a `Stream`,
   // being a single-use mutable buffer, cannot be re-pulled.
-  def apply[response](mediaType0: MediaType, stream0: response => Stream[Data] over Credit)
+  def apply[response](mediaType0: MediaType, stream0: response => (Stream[Data] over Credit)^)
   :   response is Postable =
 
     // `Typeclass` instances are `Pure` by infrastructure, but the streaming lambda may capture

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -53,22 +53,29 @@ import zephyrine.*
 import alphabets.hexLowerCase
 
 object Postable:
+  // The streaming payload as a named SAM rather than the function type
+  // `response => (Stream[Data] over Credit)^`: a lambda may not mint a fresh
+  // scoped capability as its result, but a SAM's method may (see
+  // `zephyrine.Spring`). Lambda call sites are unchanged by SAM conversion.
+  trait Streamer[content]:
+    def stream(content: content): (Stream[Data] over Credit)^
+
   // `stream0` must construct a fresh pull endpoint on each call: the request
   // body may be materialized more than once — for a redirect that preserves
   // the method, and independently by `preview` for logging — and a `Stream`,
   // being a single-use mutable buffer, cannot be re-pulled.
-  def apply[response](mediaType0: MediaType, stream0: response => (Stream[Data] over Credit)^)
+  def apply[response](mediaType0: MediaType, stream0: Streamer[response]^)
   :   response is Postable =
 
     // `Typeclass` instances are `Pure` by infrastructure, but the streaming lambda may capture
     // capabilities with the same lifetime as this instance's given resolution; laundered pure —
     // the jacinta codec-thunk seal pattern (see rep/DECISIONS.md).
-    val stream1: response -> (Stream[Data] over Credit) = caps.unsafe.unsafeAssumePure(stream0)
+    val stream1: Streamer[response] = caps.unsafe.unsafeAssumePure(stream0)
 
     new Postable:
       type Self = response
       def mediaType(response: response): MediaType = mediaType0
-      def stream(response: response): Stream[Data] over Credit = stream1(response)
+      def stream(response: response): (Stream[Data] over Credit)^ = stream1.stream(response)
 
 
   given text: (encoder: CharEncoder) => Text is Postable =
@@ -104,11 +111,11 @@ object Postable:
 
       def mediaType(content: response): MediaType =
         content.generic(0).decode[MediaType](using decoder)
-      def stream(content: response): Stream[Data] over Credit = content.generic(1).stream
+      def stream(content: response): (Stream[Data] over Credit)^ = content.generic(1).stream
 
 trait Postable extends Typeclass:
   def mediaType(content: Self): MediaType
-  def stream(content: Self): Stream[Data] over Credit
+  def stream(content: Self): (Stream[Data] over Credit)^
 
   def preview(value: Self): Text = stream(value).lazyList.prim.lay(t""): data =>
     val sample = data.take(1024)

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -117,7 +117,19 @@ trait Postable extends Typeclass:
   def mediaType(content: Self): MediaType
   def stream(content: Self): (Stream[Data] over Credit)^
 
-  def preview(value: Self): Text = stream(value).lazyList.prim.lay(t""): data =>
-    val sample = data.take(1024)
-    val string: Text = sample.serialize[Hex]
-    if data.length > 128 then t"$string..." else string
+  // A sample of the body for logging: a single bounded refill, not a full drain —
+  // the body may be large, and `stream` mints a fresh endpoint anyway.
+  def preview(value: Self): Text =
+    val endpoint = stream(value)
+
+    try endpoint.refill(Credit(1024)) match
+      case count: Int =>
+        val sample =
+          endpoint.addressable.materialize
+            ( endpoint.window(using Unsafe), endpoint.start, count )
+
+        val string: Text = sample.serialize[Hex]
+        if count > 128 then t"$string..." else string
+
+      case _ => t""
+    finally endpoint.close()

--- a/lib/telekinesis/src/core/telekinesis.Servable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Servable.scala
@@ -55,7 +55,7 @@ object Servable:
     def serve(content: Content): Http.Response =
       val headers = List(Http.Header(t"content-type", content.media.show))
 
-      Http.Ok(headers, Http.Body.Streaming(content.stream))
+      Http.Ok(headers, Http.Body.Flowing(() => Stream(content.stream.iterator)))
 
 
   given bytes: [response: Abstractable across HttpStreams to HttpStreams.Content]
@@ -80,12 +80,12 @@ object Servable:
     case given (`media` is Streamable by Data) =>
       value =>
         val headers = List(Http.Header(t"content-type", media.mediaType(value).show))
-        Http.Ok(headers, Http.Body.Streaming(value.stream[Data]))
+        Http.Ok(headers, Http.Body.Flowing(() => Stream(value.stream[Data].iterator)))
 
     case given (`media` is Streamable by Text) =>
       value =>
         val headers = List(Http.Header(t"content-type", media.mediaType(value).show))
-        Http.Ok(headers, Http.Body.Streaming(value.stream[Data]))
+        Http.Ok(headers, Http.Body.Flowing(() => Stream(value.stream[Data].iterator)))
 
 trait Servable extends Typeclass:
   def serve(content: Self): Http.Response

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -70,7 +70,7 @@ private def buildJavaRequest
   ( uri:         jn.URI,
     method:      Http.Method,
     textHeaders: List[Http.Header],
-    bodyFn:      () => (Stream[Data] over Credit)^ )
+    bodyFn:      Spring[Data] )
 :   jnh.HttpRequest =
 
   val request: jnh.HttpRequest.Builder = jnh.HttpRequest.newBuilder().nn.uri(uri).nn
@@ -146,7 +146,7 @@ package httpBackends:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => (Stream[Data] over Credit)^ )
+        body:    Spring[Data] )
       ( using Tactic[ConnectError] )
     :   Http.Response =
 

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -153,7 +153,8 @@ package httpBackends:
       buildResponse(send(buildJavaRequest(jn.URI.create(url.s).nn, method, headers, body)))
 
 // A request is transmitted over a raw socket as its HTTP/1.1 wire form.
-given requestTransmissible: Http.Request is Transmissible = Http.Request.serialize(_)
+given requestTransmissible: Http.Request is Transmissible = request =>
+  zephyrine.Stream(Http.Request.serialize(request).iterator)
 
 // Fetch from a Unix domain socket, speaking HTTP/1.1 directly over the socket
 // (e.g. the Docker daemon's API). The request's `Host` is `localhost`.

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -153,8 +153,7 @@ package httpBackends:
       buildResponse(send(buildJavaRequest(jn.URI.create(url.s).nn, method, headers, body)))
 
 // A request is transmitted over a raw socket as its HTTP/1.1 wire form.
-given requestTransmissible: Http.Request is Transmissible = request =>
-  zephyrine.Stream(Http.Request.serialize(request).iterator)
+given requestTransmissible: Http.Request is Transmissible = Http.Request.serialize(_)
 
 // Fetch from a Unix domain socket, speaking HTTP/1.1 directly over the socket
 // (e.g. the Docker daemon's API). The request's `Host` is `localhost`.

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -70,7 +70,7 @@ private def buildJavaRequest
   ( uri:         jn.URI,
     method:      Http.Method,
     textHeaders: List[Http.Header],
-    bodyFn:      () => Stream[Data] over Credit )
+    bodyFn:      () => (Stream[Data] over Credit)^ )
 :   jnh.HttpRequest =
 
   val request: jnh.HttpRequest.Builder = jnh.HttpRequest.newBuilder().nn.uri(uri).nn
@@ -146,7 +146,7 @@ package httpBackends:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => Stream[Data] over Credit )
+        body:    () => (Stream[Data] over Credit)^ )
       ( using Tactic[ConnectError] )
     :   Http.Response =
 

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -79,7 +79,7 @@ private def buildJavaRequest
   // JDK may re-subscribe on retry), draining it lazily through an
   // `InputStream` so the body is never held whole in memory.
   lazy val body =
-    jnh.HttpRequest.BodyPublishers.ofInputStream { () => bodyFn().lazyList.inputStream }.nn
+    jnh.HttpRequest.BodyPublishers.ofInputStream { () => bodyFn().inputStream }.nn
 
   method match
     case Http.Delete  => request.DELETE().nn

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -302,7 +302,7 @@ object Tests extends Suite(m"Telekinesis tests"):
             data.slice(offset, end) #:: go(end)
         go(0)
 
-      def bodyText(request: Http.Request^): Text = request.body().lazyList.read[Data].utf8
+      def bodyText(request: Http.Request^): Text = request.body().memoize.utf8
 
       val blockSizes = List(1, 2, 3, 7, 13, 4096)
       val fixture = t"GET /path?q=1 HTTP/1.1\r\nHost: example.com\r\nX-Foo: bar\r\n\r\nbody"

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -117,7 +117,7 @@ object Tests extends Suite(m"Telekinesis tests"):
         go(0)
 
       def bodyText(response: Http.Response): Text =
-        response.body.stream.read[Data].utf8
+        response.body.stream.memoize.utf8
 
       val blockSizes = List(1, 2, 3, 7, 13, 4096)
 
@@ -427,10 +427,10 @@ object Tests extends Suite(m"Telekinesis tests"):
             data.slice(offset, end) #:: go(end)
         go(0)
 
-      def bodyText(response: Http.Response): Text = response.body.stream.read[Data].utf8
+      def bodyText(response: Http.Response): Text = response.body.stream.memoize.utf8
 
       def wire(response: Http.Response, includeBody: Boolean = true): Text =
-        Http.Response.serialize(response, includeBody).read[Data].utf8
+        Http.Response.serialize(response, includeBody).memoize.utf8
 
       val blockSizes = List(1, 2, 3, 7, 13, 4096)
 
@@ -458,7 +458,7 @@ object Tests extends Suite(m"Telekinesis tests"):
       . assert(_ == true)
 
       test(m"Streaming body is framed with chunked transfer-encoding"):
-        val body = Http.Body.Streaming(LazyList(t"Hello".data, t"World".data))
+        val body = Http.Body.Flowing(() => Stream(LazyList(t"Hello".data, t"World".data).iterator))
         wire(Http.Response(Http.Ok)(body))
 
       . assert: text =>
@@ -468,7 +468,7 @@ object Tests extends Suite(m"Telekinesis tests"):
           && text.ends(t"0\r\n\r\n")
 
       test(m"Streaming body skips zero-length blocks"):
-        val body = Http.Body.Streaming(LazyList(t"ab".data, t"".data, t"cd".data))
+        val body = Http.Body.Flowing(() => Stream(LazyList(t"ab".data, t"".data, t"cd".data).iterator))
         wire(Http.Response(Http.Ok)(body))
 
       . assert(_.contains(t"2\r\nab\r\n2\r\ncd\r\n"))

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -70,7 +70,7 @@ package httpBackends:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => Stream[Data] over Credit )
+        body:    () => (Stream[Data] over Credit)^ )
       ( using Tactic[ConnectError] )
     :   Http.Response =
 

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -116,7 +116,7 @@ package httpBackends:
 
       // A method that carries a payload streams it through the request's `outgoing-body`, which
       // must then be `finish`ed (a static function) for the request to be complete.
-      val payload: LazyList[Data] = if method.payload then body().lazyList else LazyList()
+      val payload: Data = if method.payload then body().memoize else IArray.empty[Byte]
 
       val bodyHandles =
         if payload.isEmpty then Unset else
@@ -136,8 +136,7 @@ package httpBackends:
       bodyHandles.let: (bodyHandle, writeHandle) =>
         val outStream: Foreign of "output-stream" from Wit = writeHandle
 
-        payload.each: chunk =>
-          outStream.`blocking-write-and-flush`(chunk).invoke[Unit]
+        outStream.`blocking-write-and-flush`(payload).invoke[Unit]
 
         writeHandle.dispose()
 

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -70,7 +70,7 @@ package httpBackends:
       ( url:     Text,
         method:  Http.Method,
         headers: List[Http.Header],
-        body:    () => (Stream[Data] over Credit)^ )
+        body:    Spring[Data] )
       ( using Tactic[ConnectError] )
     :   Http.Response =
 

--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -39,7 +39,7 @@ export
       Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
       multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool,
       Confluence, Manifold, Readable, Sink, Source, Stdio, stream, Streamable, StreamError,
-      StreamOutputStream, strict, take, Tap, Writable, writeTo, framed, flow, lazyList }
+      StreamOutputStream, strict, take, Tap, Writable, writeTo, framed, flow }
 
 package stdios:
   export turbulence.stdios.{muteStdio, systemStdio, virtualMachineStdio}

--- a/lib/turbulence/src/core/turbulence.Aggregable.scala
+++ b/lib/turbulence/src/core/turbulence.Aggregable.scala
@@ -62,7 +62,7 @@ object Aggregable:
     type Self = Data
     type Operand = Data
 
-    override def accept(consume stream: (Stream[Data] over Credit)^): Data = gather(stream)
+    override def accept(stream: (Stream[Data] over Credit)^): Data = gather(stream)
 
     def aggregate(source0: LazyList[Data]): Data =
       val size = source0.foldLeft(0)(_ + _.length)
@@ -85,7 +85,7 @@ object Aggregable:
     type Self = Text
     type Operand = Text
 
-    override def accept(consume stream: (Stream[Text] over Credit)^): Text = gather(stream)
+    override def accept(stream: (Stream[Text] over Credit)^): Text = gather(stream)
 
     def aggregate(source0: LazyList[Text]): Text =
       var source = source0
@@ -113,7 +113,7 @@ trait Aggregable extends Typeclass, Operable:
   // Consume a pull endpoint. The default materializes one chunk per refill
   // and delegates to the legacy `aggregate`; instances override it to build
   // directly from the stream's windows.
-  def accept(consume stream: (Stream[Operand] over Credit)^): Self =
+  def accept(stream: (Stream[Operand] over Credit)^): Self =
     def recur(): LazyList[Operand] =
       stream.refill(Credit(Long.MaxValue)) match
         case count: Int =>

--- a/lib/turbulence/src/core/turbulence.Aggregable.scala
+++ b/lib/turbulence/src/core/turbulence.Aggregable.scala
@@ -44,7 +44,7 @@ import zephyrine.*
 object Aggregable:
   // Drain a pull endpoint into the medium's builder: one copy per window,
   // no intermediate chunks. The native `accept` for whole-value aggregation.
-  private def gather[medium](stream: Stream[medium] over Credit): medium =
+  private def gather[medium](consume stream: (Stream[medium] over Credit)^): medium =
     val target = stream.addressable.blank(4096)
 
     def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
@@ -62,7 +62,7 @@ object Aggregable:
     type Self = Data
     type Operand = Data
 
-    override def accept(stream: Stream[Data] over Credit): Data = gather(stream)
+    override def accept(consume stream: (Stream[Data] over Credit)^): Data = gather(stream)
 
     def aggregate(source0: LazyList[Data]): Data =
       val size = source0.foldLeft(0)(_ + _.length)
@@ -85,7 +85,7 @@ object Aggregable:
     type Self = Text
     type Operand = Text
 
-    override def accept(stream: Stream[Text] over Credit): Text = gather(stream)
+    override def accept(consume stream: (Stream[Text] over Credit)^): Text = gather(stream)
 
     def aggregate(source0: LazyList[Text]): Text =
       var source = source0
@@ -113,7 +113,7 @@ trait Aggregable extends Typeclass, Operable:
   // Consume a pull endpoint. The default materializes one chunk per refill
   // and delegates to the legacy `aggregate`; instances override it to build
   // directly from the stream's windows.
-  def accept(stream: Stream[Operand] over Credit): Self =
+  def accept(consume stream: (Stream[Operand] over Credit)^): Self =
     def recur(): LazyList[Operand] =
       stream.refill(Credit(Long.MaxValue)) match
         case count: Int =>

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -56,12 +56,12 @@ object Confluence:
 
   private class Block(val storage: AnyRef, val size: Int)
 
-  def apply[medium](sources: Stream[medium] over Credit*)
+  def apply[medium, cap^](sources: (Stream[medium] over Credit)^{cap}*)
     ( using addressable0: medium is Addressable,
             buffering:    Buffering,
             monitor:      Monitor,
             probate:      Probate )
-  :   Stream[medium] over Credit =
+  :   (Stream[medium] over Credit)^ =
 
     val block: Int = buffering.capacity(addressable0.substrate)
 
@@ -73,8 +73,21 @@ object Confluence:
 
     def finish(): Unit = if remaining.decrementAndGet == 0 then queue.put(End)
 
-    sources.each: source =>
+    // Indexed iteration: capture sets do not ride standard-collection elements, so each
+    // source is re-asserted exclusive at its fiber rim — one consuming fiber per source
+    // by construction.
+    var index = 0
+
+    // A while-loop rather than a for-comprehension: the desugared foreach closure would
+    // capture the sources' reach capability. Each element crosses to its fiber as a
+    // neutral carrier and is re-asserted exclusive inside: one consuming fiber per
+    // source by construction.
+    while index < sources.length do
+      val handoff: AnyRef = sources(index).asInstanceOf[AnyRef]
+
       async:
+        val source = handoff.asInstanceOf[(Stream[medium] over Credit)^]
+
         def loop(): Unit = source.refill(Credit(block)) match
           case count: Int =>
             val window = source.window(using Unsafe)
@@ -94,6 +107,8 @@ object Confluence:
           error = exception
           finish()
 
+      index += 1
+
     new Stream[medium](using addressable0):
       type Transport = Credit
 
@@ -106,9 +121,9 @@ object Confluence:
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
-      def skip(count: Int): Unit = start0 += count
+      update def skip(count: Int): Unit = start0 += count
 
-      def refill(demand: Credit): Optional[Int] =
+      update def refill(demand: Credit): Optional[Int] =
         if limit0 > start0 then limit0 - start0
         else if ended then Unset
         else

--- a/lib/turbulence/src/core/turbulence.Manifold.scala
+++ b/lib/turbulence/src/core/turbulence.Manifold.scala
@@ -51,12 +51,12 @@ import zephyrine.*
 object Manifold:
   private object End
 
-  def apply[medium](source: Stream[medium] over Credit, count: Int)
+  def apply[medium](consume source: (Stream[medium] over Credit)^, count: Int)
     ( using addressable0: medium is Addressable,
             buffering:    Buffering,
             monitor:      Monitor,
             probate:      Probate )
-  :   IndexedSeq[Stream[medium] over Credit] =
+  :   IndexedSeq[(Stream[medium] over Credit)^] =
 
     val block: Int = buffering.capacity(addressable0.substrate)
 
@@ -85,43 +85,58 @@ object Manifold:
         error = exception
         queues.each(_.put(End))
 
-    queues.map: queue =>
-      new Stream[medium](using addressable0):
-        type Transport = Credit
+    // The subscribers are typed exclusive element-wise at the collection rim: capture
+    // sets do not ride standard-collection elements, and each queue feeds exactly one
+    // subscriber by construction.
+    locally:
+      val subscribers = queues.map: queue =>
+        sealSubscriber(new Stream[medium](using addressable0):
+          type Transport = Credit
 
-        // The shared chunk is immutable; subscribers only read the window,
-        // so exposing its backing array directly is safe and copy-free.
-        private var storage: AnyRef = addressable0.allocate(0).asInstanceOf[AnyRef]
-        private var start0: Int = 0
-        private var limit0: Int = 0
-        private var size: Int = 0
-        private var ended: Boolean = false
+          // The shared chunk is immutable; subscribers only read the window,
+          // so exposing its backing array directly is safe and copy-free.
+          private var storage: AnyRef = addressable0.allocate(0).asInstanceOf[AnyRef]
+          private var start0: Int = 0
+          private var limit0: Int = 0
+          private var size: Int = 0
+          private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage
-        def start: Int = start0
-        def limit: Int = limit0
-        def skip(count: Int): Unit = start0 += count
+          protected def window0: AnyRef = storage
+          def start: Int = start0
+          def limit: Int = limit0
+          update def skip(count: Int): Unit = start0 += count
 
-        def refill(demand: Credit): Optional[Int] =
-          if limit0 > start0 then limit0 - start0
-          else if ended then Unset
-          else
-            val granted = summon[Credit is Regulation].grant(demand)
-
-            if granted == 0 then 0
-            else if limit0 < size then
-              limit0 += (size - limit0).min(granted)
-              limit0 - start0
+          update def refill(demand: Credit): Optional[Int] =
+            if limit0 > start0 then limit0 - start0
+            else if ended then Unset
             else
-              (queue.take().nn: @unchecked) match
-                case End =>
-                  ended = true
-                  val error0 = error
-                  if error0 == null then Unset else throw error0
+              val granted = summon[Credit is Regulation].grant(demand)
 
-                case chunk =>
-                  storage = chunk
-                  size = addressable0.length(chunk.asInstanceOf[medium])
-                  start0 = 0
-                  limit0 = size.min(granted)
-                  limit0
+              if granted == 0 then 0
+              else if limit0 < size then
+                limit0 += (size - limit0).min(granted)
+                limit0 - start0
+              else
+                (queue.take().nn: @unchecked) match
+                  case End =>
+                    ended = true
+                    val error0 = error
+                    if error0 == null then Unset else throw error0
+
+                  case chunk =>
+                    storage = chunk
+                    size = addressable0.length(chunk.asInstanceOf[medium])
+                    start0 = 0
+                    limit0 = size.min(granted)
+                    limit0
+        )
+
+      subscribers.asInstanceOf[IndexedSeq[(Stream[medium] over Credit)^]]
+
+  // Bridges a fresh subscriber into a collection element: capture sets do not ride
+  // standard-collection elements, so the exclusivity is re-asserted element-wise in the
+  // declared result type.
+  private def sealSubscriber[medium]
+    ( stream: (Stream[medium] over Credit)^ )
+  :   AnyRef =
+    stream.asInstanceOf[AnyRef]

--- a/lib/turbulence/src/core/turbulence.Sink.scala
+++ b/lib/turbulence/src/core/turbulence.Sink.scala
@@ -66,26 +66,26 @@ object Sink extends Sink2:
         protected def buffer0: AnyRef = storage
         def mark: Int = mark0
 
-        def reserve(min: Int): Int =
+        update def reserve(min: Int): Int =
           val free = block - mark0
 
           if free >= min then free else
             drain()
             block
 
-        def commit(count: Int): Unit =
+        update def commit(count: Int): Unit =
           mark0 += count
           if mark0 == block then drain()
 
-        override def flush(): Unit =
+        override update def flush(): Unit =
           drain()
           try value.flush() catch case _: ji.IOException => ()
 
-        def finish(): Unit =
+        update def finish(): Unit =
           drain()
           try value.close() catch case _: ji.IOException => raise(StreamError(total.b))
 
-        private def drain(): Unit =
+        private update def drain(): Unit =
           if mark0 > 0 && !broken then
             try
               value.write(storage, 0, mark0)
@@ -114,24 +114,24 @@ object Sink extends Sink2:
         protected def buffer0: AnyRef = storage
         def mark: Int = mark0
 
-        def reserve(min: Int): Int =
+        update def reserve(min: Int): Int =
           val free = block - mark0
 
           if free >= min then free else
             drain()
             block
 
-        def commit(count: Int): Unit =
+        update def commit(count: Int): Unit =
           mark0 += count
           if mark0 == block then drain()
 
-        override def flush(): Unit = drain()
+        override update def flush(): Unit = drain()
 
-        def finish(): Unit =
+        update def finish(): Unit =
           drain()
           try value.close() catch case _: Exception => raise(StreamError(total.b))
 
-        private def drain(): Unit =
+        private update def drain(): Unit =
           if mark0 > 0 && !broken then
             val buffer = jn.ByteBuffer.wrap(storage, 0, mark0).nn
 
@@ -154,7 +154,7 @@ object Sink extends Sink2:
   def buffered[target, medium]
     ( target: target, write: (target, LazyList[medium]) => Unit )
     ( using addressable0: medium is Addressable )
-  :   (Intake[medium] over Credit)^{write} =
+  :   (Intake[medium] over Credit)^{write, caps.any} =
 
     new Intake[medium]:
       type Transport = Credit
@@ -168,22 +168,22 @@ object Sink extends Sink2:
       protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
       def mark: Int = mark0
 
-      def reserve(min: Int): Int =
+      update def reserve(min: Int): Int =
         val free = block - mark0
 
         if free >= min then free else
           drain()
           block
 
-      def commit(count: Int): Unit =
+      update def commit(count: Int): Unit =
         mark0 += count
         if mark0 == block then drain()
 
-      def finish(): Unit =
+      update def finish(): Unit =
         drain()
         write(target, chunks.reverse.to(LazyList))
 
-      private def drain(): Unit =
+      private update def drain(): Unit =
         if mark0 > 0 then
           chunks ::= addressable0.materialize(storage, 0, mark0)
           mark0 = 0
@@ -206,7 +206,7 @@ trait Sink2:
 
 trait Sink extends Typeclass, Operable:
   type Transport
-  def intake(target: Self): Intake[Operand] over Transport
+  def intake(target: Self): (Intake[Operand] over Transport)^
 
   def contramap[self2](lambda: self2 => Self)
   :   (self2 is Sink by Operand over Transport)^{this, lambda} =

--- a/lib/turbulence/src/core/turbulence.Sink.scala
+++ b/lib/turbulence/src/core/turbulence.Sink.scala
@@ -48,7 +48,7 @@ import zephyrine.*
 // a typed `StreamError` through an `Emit` captured by the given — a writer
 // only reports a cut, never aborts. `finish` closes the underlying resource,
 // matching `Writable`'s end-of-stream behaviour.
-object Sink extends Sink2:
+object Sink:
   given outputStream: [output <: ji.OutputStream] => (streamCut: Emit[StreamError], buffering: Buffering)
   =>  ((output is Sink by Data over Credit)^{streamCut}) =
 
@@ -188,21 +188,6 @@ object Sink extends Sink2:
           chunks ::= addressable0.materialize(storage, 0, mark0)
           mark0 = 0
 
-// Transitional: any `Writable` instance over a buffer-backed medium is a
-// `Sink`, at lower priority than the native instances above. Since `Writable`
-// consumes its entire `LazyList` in one call (closing the target at its end),
-// this bridge must accumulate everything written and deliver it at `finish` —
-// memory is unbounded, so native `Sink` instances should replace it.
-trait Sink2:
-  given writableData: [target] => (writable: (target is Writable by Data)^)
-  =>  ((target is Sink by Data over Credit)^{writable}) =
-
-    Sink.buffered(_, writable.write)
-
-  given writableText: [target] => (writable: (target is Writable by Text)^)
-  =>  ((target is Sink by Text over Credit)^{writable}) =
-
-    Sink.buffered(_, writable.write)
 
 trait Sink extends Typeclass, Operable:
   type Transport

--- a/lib/turbulence/src/core/turbulence.Source.scala
+++ b/lib/turbulence/src/core/turbulence.Source.scala
@@ -47,7 +47,7 @@ import zephyrine.*
 // instead of a `LazyList`. Sources needing buffers or error contexts capture
 // them as contextual values of the given (`Buffering`, `Tactic[StreamError]`),
 // so the typeclass itself remains a single abstract method.
-object Source extends Source2:
+object Source:
   given bytes: Data is Source by Data over Credit = Stream(_)
   given text: [textual <: Text] => textual is Source by Text over Credit = value => Stream(value)
 
@@ -180,20 +180,6 @@ object Source extends Source2:
         ended = true
         try input.close() catch case _: Exception => ()
 
-// Transitional: any `Streamable` instance over a buffer-backed medium is a
-// `Source`, at lower priority than the native instances above, so downstream
-// code migrates without ceremony. Production of the underlying `LazyList` is
-// not demand-controlled.
-trait Source2:
-  given streamableData: [value] => (streamable: (value is Streamable by Data)^)
-  =>  ((value is Source by Data over Credit)^{streamable}) =
-
-    source => Stream(streamable.stream(source).iterator)
-
-  given streamableText: [value] => (streamable: (value is Streamable by Text)^)
-  =>  ((value is Source by Text over Credit)^{streamable}) =
-
-    source => Stream(streamable.stream(source).iterator)
 
 trait Source extends Typeclass, Operable:
   type Transport

--- a/lib/turbulence/src/core/turbulence.Source.scala
+++ b/lib/turbulence/src/core/turbulence.Source.scala
@@ -90,9 +90,9 @@ object Source extends Source2:
         protected def window0: AnyRef = storage
         def start: Int = start0
         def limit: Int = limit0
-        def skip(count: Int): Unit = start0 += count
+        update def skip(count: Int): Unit = start0 += count
 
-        def refill(demand: Credit): Optional[Int] =
+        update def refill(demand: Credit): Optional[Int] =
           if limit0 > start0 then limit0 - start0
           else if ended then Unset
           else
@@ -118,7 +118,7 @@ object Source extends Source2:
                 try value.close() catch case _: Exception => ()
                 abort(StreamError(total.b))
 
-        override def close(): Unit =
+        override update def close(): Unit =
           ended = true
           try value.close() catch case _: Exception => ()
 
@@ -127,7 +127,7 @@ object Source extends Source2:
   // time.
   private def stream(input: jn.channels.ReadableByteChannel)
     ( using tactic: Tactic[StreamError], buffering: Buffering )
-  :   (Stream[Data] over Credit)^{tactic} =
+  :   (Stream[Data] over Credit)^{tactic, caps.any} =
 
     new Stream[Data]:
       type Transport = Credit
@@ -143,9 +143,9 @@ object Source extends Source2:
       protected def window0: AnyRef = storage
       def start: Int = start0
       def limit: Int = limit0
-      def skip(count: Int): Unit = start0 += count
+      update def skip(count: Int): Unit = start0 += count
 
-      def refill(demand: Credit): Optional[Int] =
+      update def refill(demand: Credit): Optional[Int] =
         if limit0 > start0 then limit0 - start0
         else if ended then Unset
         else
@@ -176,7 +176,7 @@ object Source extends Source2:
               try input.close() catch case _: Exception => ()
               abort(StreamError(total.b))
 
-      override def close(): Unit =
+      override update def close(): Unit =
         ended = true
         try input.close() catch case _: Exception => ()
 
@@ -197,7 +197,7 @@ trait Source2:
 
 trait Source extends Typeclass, Operable:
   type Transport
-  def stream(value: Self): Stream[Operand] over Transport
+  def stream(value: Self): (Stream[Operand] over Transport)^
 
   def contramap[self2](lambda: self2 => Self)
   :   (self2 is Source by Operand over Transport)^{this, lambda} =

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package turbulence
 
+import language.experimental.separationChecking
+
 import language.adhocExtensions
 
 import java.io as ji
@@ -77,26 +79,26 @@ extension [value: Streamable by Text](value: value)
   :   Document[result] =
     loadable.load(value.stream[Text])
 
-extension [medium, transport](stream: Stream[medium] over transport)
+extension [medium, transport](consume stream: (Stream[medium] over transport)^)
   // The detached pump: `flowTo` on its own parasite task, for fire-and-forget
   // transfers and genuinely concurrent pipeline halves. This is the "one
   // pumping thread" of a pipeline with an asynchronous boundary.
-  def flow(intake: Intake[medium] over transport)(using Monitor, Probate): Task[Unit] =
+  def flow(consume intake: (Intake[medium] over transport)^)(using Monitor, Probate): Task[Unit] =
     async(stream.flowTo(intake))
 
-extension (stream: Stream[Data] over Credit)
+extension (consume stream: (Stream[Data] over Credit)^)
   def compress[format <: Compressor](using compression: format is Compression, buffering: Buffering)
-  :   Stream[Data] over Credit =
+  :   (Stream[Data] over Credit)^ =
 
     stream.through(compression.compressor())
 
   def decompress[format <: Compressor]
     ( using compression: format is Compression, buffering: Buffering )
-  :   Stream[Data] over Credit =
+  :   (Stream[Data] over Credit)^ =
 
     stream.through(compression.decompressor())
 
-extension [medium](stream: Stream[medium] over Credit)
+extension [medium](consume stream: (Stream[medium] over Credit)^)
   // Legacy view: drain a pull endpoint as a lazy list of materialized chunks,
   // pulling one block per forced cell. For consumers not yet converted to the
   // streaming kernel; conversion holds only one block at a time, but the
@@ -117,10 +119,10 @@ extension [medium](stream: Stream[medium] over Credit)
 
     LazyList.defer(recur())
 
-extension (stream: Stream[Data] over Credit)
+extension (consume stream: (Stream[Data] over Credit)^)
   // Adapt a pull endpoint to the HTTP-body interchange protocol: each `next`
   // refills with `limit` credit and materializes the delivered window.
-  def httpBody: HttpStreams.Body = limit =>
+  def httpBody: HttpStreams.Body^ = limit =>
     stream.refill(Credit(limit)) match
       case count: Int =>
         val take = count.min(limit)
@@ -134,7 +136,7 @@ extension (stream: Stream[Data] over Credit)
 extension (body: HttpStreams.Body)
   // View an HTTP-body interchange value as a pull endpoint, one chunk per
   // block-sized request.
-  def stream(using buffering: Buffering): Stream[Data] over Credit =
+  def stream(using buffering: Buffering): (Stream[Data] over Credit)^ =
     new Stream[Data]:
       type Transport = Credit
 
@@ -148,9 +150,9 @@ extension (body: HttpStreams.Body)
       protected def window0: AnyRef = chunk.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
-      def skip(count: Int): Unit = start0 += count
+      update def skip(count: Int): Unit = start0 += count
 
-      def refill(demand: Credit): Optional[Int] =
+      update def refill(demand: Credit): Optional[Int] =
         if limit0 > start0 then limit0 - start0
         else if ended then Unset
         else
@@ -372,7 +374,11 @@ extension (stream: LazyList[Data])
     def recur(stream: LazyList[Data], count: Bytes): LazyList[Data] = stream.flow(LazyList()):
       if next.bytes < count
       then recur(more, count - next.bytes)
-      else next.drop(count.long.toInt) #:: more
+      else
+        // hoisted: a fresh array built inside `#::`'s by-name operand (which would
+        // capture the enclosing context) could not escape it
+        val head: Data = next.drop(count.long.toInt).asInstanceOf[Data]
+        head #:: more
 
     recur(stream, bytes)
 
@@ -407,7 +413,7 @@ extension (stream: LazyList[Data])
 
         case _ =>
           if destPos == 0 then LazyList()
-          else LazyList(dest.slice(0, destPos).immutable(using Unsafe))
+          else LazyList(dest.slice(0, destPos).immutable(using Unsafe).asInstanceOf[Data])
 
     recur(stream, 0, newArray(), 0)
 

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -84,7 +84,15 @@ extension [medium, transport](consume stream: (Stream[medium] over transport)^)
   // transfers and genuinely concurrent pipeline halves. This is the "one
   // pumping thread" of a pipeline with an asynchronous boundary.
   def flow(consume intake: (Intake[medium] over transport)^)(using Monitor, Probate): Task[Unit] =
-    async(stream.flowTo(intake))
+    // Both endpoints move onto the pump fiber as neutral carriers (a consume parameter
+    // cannot be consumed from inside the spawned closure); single ownership transfers
+    // with the spawn.
+    val streamRef: AnyRef = stream.asInstanceOf[AnyRef]
+    val intakeRef: AnyRef = intake.asInstanceOf[AnyRef]
+
+    async:
+      streamRef.asInstanceOf[(Stream[medium] over transport)^]
+      . flowTo(intakeRef.asInstanceOf[(Intake[medium] over transport)^])
 
 extension (consume stream: (Stream[Data] over Credit)^)
   def compress[format <: Compressor](using compression: format is Compression, buffering: Buffering)
@@ -141,7 +149,7 @@ extension (body: HttpStreams.Body)
       type Transport = Credit
 
       private val block: Int = buffering.capacity(Substrate.Bytes)
-      private var chunk: Data = IArray.empty[Byte]
+      private var chunk: Data = IArray.empty[Byte].asInstanceOf[Data]
       private var start0: Int = 0
       private var limit0: Int = 0
       private var ended: Boolean = false
@@ -197,6 +205,35 @@ package stdios:
         ji.FileInputStream(ji.FileDescriptor.in),
         termcap )
 
+package lineSeparation:
+  given carriageReturnLineSeparation
+  :   LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Skip, Action.Nl, Action.Nl)
+
+  given strictCarriageReturnLineSeparation
+  :   LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Lf, Action.NlLf, Action.LfNl)
+
+  given linefeedLineSeparation
+  :   LineSeparation(NewlineSeq.Lf, Action.Skip, Action.Nl, Action.Nl, Action.Nl)
+
+  given strictLinefeedsLineSeparation
+  :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Lf, Action.NlLf, Action.LfNl)
+
+  given carriageReturnLinefeedLineSeparation
+  :   LineSeparation(NewlineSeq.CrLf, Action.Skip, Action.Lf, Action.Nl, Action.LfNl)
+
+  given adaptiveLinefeedLineSeparation
+  :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Nl, Action.Nl, Action.Nl)
+
+  given virtualMachineLineSeparation: LineSeparation = jl.System.lineSeparator.nn match
+    case "\r\n"    => carriageReturnLinefeedLineSeparation
+    case "\r"      => carriageReturnLineSeparation
+    case "\n"      => linefeedLineSeparation
+    case _: String => adaptiveLinefeedLineSeparation
+
+def spool[item](using erased void: Void)[result](lambda: Spool[item] => result): result =
+  val spool: Spool[item] = Spool()
+  try lambda(spool) finally spool.stop()
+
 extension [element](stream: LazyList[element])
   def deduplicate: LazyList[element] =
     def recur(last: element, stream: LazyList[element]): LazyList[element] =
@@ -219,23 +256,6 @@ extension [element](stream: LazyList[element])
 
 
   def strict: LazyList[element] = stream.length yet stream
-
-  def rate
-    [ generic: {Abstractable across Durations to Long, Instantiable across Durations from Long} ]
-    ( duration: generic )
-    ( using Monitor )
-  :   LazyList[element] raises AsyncError =
-
-    def recur(stream: LazyList[element], last: Long): LazyList[element] =
-      stream.flow(LazyList()):
-        val duration2 =
-          generic(duration.generic - (jl.System.currentTimeMillis - last)*1_000_000L)
-
-        if duration2.generic > 0 then snooze(duration2)
-        stream
-
-    async(recur(stream, jl.System.currentTimeMillis)).await()
-
 
   def multiplex(that: LazyList[element])(using Monitor): LazyList[element] =
     LazyList.multiplex(stream, that)
@@ -308,36 +328,11 @@ extension [element](stream: LazyList[element])
 
     out.stream
 
-package lineSeparation:
-  given carriageReturnLineSeparation
-  :   LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Skip, Action.Nl, Action.Nl)
-
-  given strictCarriageReturnLineSeparation
-  :   LineSeparation(NewlineSeq.Cr, Action.Nl, Action.Lf, Action.NlLf, Action.LfNl)
-
-  given linefeedLineSeparation
-  :   LineSeparation(NewlineSeq.Lf, Action.Skip, Action.Nl, Action.Nl, Action.Nl)
-
-  given strictLinefeedsLineSeparation
-  :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Lf, Action.NlLf, Action.LfNl)
-
-  given carriageReturnLinefeedLineSeparation
-  :   LineSeparation(NewlineSeq.CrLf, Action.Skip, Action.Lf, Action.Nl, Action.LfNl)
-
-  given adaptiveLinefeedLineSeparation
-  :   LineSeparation(NewlineSeq.Lf, Action.Nl, Action.Nl, Action.Nl, Action.Nl)
-
-  given virtualMachineLineSeparation: LineSeparation = jl.System.lineSeparator.nn match
-    case "\r\n"    => carriageReturnLinefeedLineSeparation
-    case "\r"      => carriageReturnLineSeparation
-    case "\n"      => linefeedLineSeparation
-    case _: String => adaptiveLinefeedLineSeparation
-
 extension (obj: LazyList.type)
   def multiplex[element](streams: LazyList[element]*)(using Monitor): LazyList[element] =
     multiplexer(streams*).stream
 
-  def multiplexer[element](streams: LazyList[element]*)(using Monitor): Multiplexer[Any, element]^ =
+  def multiplexer[element](streams: LazyList[element]*)(using monitor: Monitor): Multiplexer[Any, element]^{monitor} =
     Multiplexer[Any, element]().tap: multiplexer =>
       streams.zipWithIndex.each: (stream, index) =>
         multiplexer.add(index, stream)
@@ -391,9 +386,9 @@ extension (stream: LazyList[Data])
   def shred(mean: Double, variance: Double)(using Random): LazyList[Data] =
     given gamma: Distribution = Gamma.approximate(mean, variance)
 
-    def newArray(): Array[Byte] = new Array[Byte](arbitrary[Double]().toInt.max(1))
+    def newArray(): Array[Byte]^ = new Array[Byte](arbitrary[Double]().toInt.max(1))
 
-    def recur(stream: LazyList[Data], sourcePos: Int, dest: Array[Byte], destPos: Int)
+    def recur(stream: LazyList[Data], sourcePos: Int, dest: Array[Byte]^, destPos: Int)
     :   LazyList[Data] =
 
       stream match
@@ -413,15 +408,19 @@ extension (stream: LazyList[Data])
 
         case _ =>
           if destPos == 0 then LazyList()
-          else LazyList(dest.slice(0, destPos).immutable(using Unsafe).asInstanceOf[Data])
+          else
+            // arraycopy, not `.slice`: the ArrayOps conversion demands a pure array
+            val out = new Array[Byte](destPos)
+            jl.System.arraycopy(dest, 0, out, 0, destPos)
+            LazyList(out.immutable(using Unsafe).asInstanceOf[Data])
 
     recur(stream, 0, newArray(), 0)
 
   def chunked(size: Int, zeroPadding: Boolean = false): LazyList[Data] =
-    def newArray(): Array[Byte] = new Array[Byte](size)
+    def newArray(): Array[Byte]^ = new Array[Byte](size)
 
 
-    def recur(stream: LazyList[Data], sourcePos: Int, dest: Array[Byte], destPos: Int)
+    def recur(stream: LazyList[Data], sourcePos: Int, dest: Array[Byte]^, destPos: Int)
     :   LazyList[Data] =
 
       stream match
@@ -441,8 +440,12 @@ extension (stream: LazyList[Data])
 
         case _ =>
           if destPos == 0 then LazyList()
-          else LazyList:
-            (if zeroPadding then dest else dest.slice(0, destPos)).immutable(using Unsafe)
+          else
+            // arraycopy, not `.slice`: the ArrayOps conversion demands a pure array
+            val length = if zeroPadding then dest.length else destPos
+            val out = new Array[Byte](length)
+            jl.System.arraycopy(dest, 0, out, 0, length)
+            LazyList(out.immutable(using Unsafe).asInstanceOf[Data])
 
 
     recur(stream, 0, newArray(), 0)
@@ -450,15 +453,18 @@ extension (stream: LazyList[Data])
   def take(bytes: Bytes): LazyList[Data] =
     def recur(stream: LazyList[Data], count: Bytes): LazyList[Data] =
       stream.flow(LazyList()):
-        if next.bytes < count then next #:: recur(more, count - next.bytes)
-        else LazyList(next.take(count.long.toInt))
+        if next.bytes < count then
+          val head: Data = next
+          head #:: recur(more, count - next.bytes)
+        else LazyList(next.take(count.long.toInt).asInstanceOf[Data])
 
     recur(stream, bytes)
 
   def inputStream: ji.InputStream = new ji.InputStream:
-    private var current: LazyList[Data] = stream
-    private var offset: Int = 0
-    private var focus: Data = IArray.empty[Byte]
+    // A JDK adapter, not a capability class: its staging slots are untracked.
+    @caps.unsafe.untrackedCaptures private var current: LazyList[Data] = stream
+    @caps.unsafe.untrackedCaptures private var offset: Int = 0
+    @caps.unsafe.untrackedCaptures private var focus: Data = IArray.empty[Byte].asInstanceOf[Data]
 
     override def available(): Int =
       val diff = focus.length - offset
@@ -483,7 +489,3 @@ extension (stream: LazyList[Data])
           if count > 0 then jl.System.arraycopy(focus, offset, array, arrayOffset, count)
           offset += count
           count
-
-def spool[item](using erased void: Void)[result](lambda: Spool[item] => result): result =
-  val spool: Spool[item] = Spool()
-  try lambda(spool) finally spool.stop()

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -131,6 +131,51 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
     caps.unsafe.unsafeAssumePure(LazyList.defer(recur()))
 
 extension (consume stream: (Stream[Data] over Credit)^)
+  // View a pull endpoint as a `java.io.InputStream` for handing to JDK APIs:
+  // each `read` pulls through the window (one block of credit at a time) and
+  // never materializes a chunk; `close` closes the endpoint. The kernel-native
+  // replacement for `lazyList.inputStream`.
+  def inputStream(using buffering: Buffering): ji.InputStream^ =
+    val block = buffering.capacity(Substrate.Bytes)
+
+    new ji.InputStream:
+      // A JDK class cannot extend `Stateful`; the flag is this adapter's only state.
+      @caps.unsafe.untrackedCaptures
+      private var ended: Boolean = false
+
+      // The count of bytes now readable in the window: refills (skipping
+      // zero-credit grants) until data arrives or the stream ends.
+      private def ensure(): Int =
+        if ended then -1 else stream.refill(Credit(block)) match
+          case count: Int => if count == 0 then ensure() else count
+          case _          =>
+            ended = true
+            stream.close()
+            -1
+
+      override def read(): Int =
+        val available = ensure()
+
+        if available < 0 then -1 else
+          val byte = stream.window(using Unsafe).asInstanceOf[Array[Byte]](stream.start) & 0xff
+          stream.skip(1)
+          byte
+
+      override def read(target: Array[Byte] | Null, offset: Int, length: Int): Int =
+        if length == 0 then 0 else
+          val available = ensure()
+
+          if available < 0 then -1 else
+            val take = available.min(length)
+            System.arraycopy(stream.window(using Unsafe), stream.start, target, offset, take)
+            stream.skip(take)
+            take
+
+      override def close(): Unit = if !ended then
+        ended = true
+        stream.close()
+
+extension (consume stream: (Stream[Data] over Credit)^)
   // Adapt a pull endpoint to the HTTP-body interchange protocol: each `next`
   // refills with `limit` credit and materializes the delivered window.
   def httpBody: HttpStreams.Body^ = limit =>

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -106,30 +106,6 @@ extension (consume stream: (Stream[Data] over Credit)^)
 
     stream.through(compression.decompressor())
 
-extension [medium](consume stream: (Stream[medium] over Credit)^)
-  // Legacy view: drain a pull endpoint as a lazy list of materialized chunks,
-  // pulling one block per forced cell. For consumers not yet converted to the
-  // streaming kernel; conversion holds only one block at a time, but the
-  // resulting cells are immutable and GC-managed like any lazy list.
-  def lazyList(using buffering: Buffering): LazyList[medium] =
-    val block = buffering.capacity(stream.addressable.substrate)
-
-    def recur(): LazyList[medium] =
-      stream.refill(Credit(block)) match
-        case Unset =>
-          LazyList()
-
-        case count: Int =>
-          val window = stream.window(using Unsafe)
-          val chunk = stream.addressable.materialize(window, stream.start, count)
-          stream.skip(count)
-          chunk #:: recur()
-
-    // The transitional bridge: a LazyList is pure, so it cannot carry the consumed
-    // stream's capture — the well-known confinement gap that motivated the capability
-    // kernel. Sealed here, at the single bridge point (scheduled for removal).
-    caps.unsafe.unsafeAssumePure(LazyList.defer(recur()))
-
 extension (consume stream: (Stream[Data] over Credit)^)
   // View a pull endpoint as a `java.io.InputStream` for handing to JDK APIs:
   // each `read` pulls through the window (one block of credit at a time) and
@@ -226,18 +202,6 @@ extension (body: HttpStreams.Body)
                 limit0 = data.length
                 if limit0 == 0 then refill(demand) else limit0
 
-  // Legacy view of an HTTP body as a lazy list of chunks.
-  def lazyList(using buffering: Buffering): LazyList[Data] =
-    val block = buffering.capacity(Substrate.Bytes)
-
-    def recur(): LazyList[Data] = body.next(block) match
-      case null       => LazyList()
-      case data: Data => data #:: recur()
-
-    // The transitional bridge: a LazyList is pure, so it cannot carry the consumed
-    // stream's capture — the well-known confinement gap that motivated the capability
-    // kernel. Sealed here, at the single bridge point (scheduled for removal).
-    caps.unsafe.unsafeAssumePure(LazyList.defer(recur()))
 
 package stdios:
   given muteStdio: Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -125,7 +125,10 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
           stream.skip(count)
           chunk #:: recur()
 
-    LazyList.defer(recur())
+    // The transitional bridge: a LazyList is pure, so it cannot carry the consumed
+    // stream's capture — the well-known confinement gap that motivated the capability
+    // kernel. Sealed here, at the single bridge point (scheduled for removal).
+    caps.unsafe.unsafeAssumePure(LazyList.defer(recur()))
 
 extension (consume stream: (Stream[Data] over Credit)^)
   // Adapt a pull endpoint to the HTTP-body interchange protocol: each `next`
@@ -186,7 +189,10 @@ extension (body: HttpStreams.Body)
       case null       => LazyList()
       case data: Data => data #:: recur()
 
-    LazyList.defer(recur())
+    // The transitional bridge: a LazyList is pure, so it cannot carry the consumed
+    // stream's capture — the well-known confinement gap that motivated the capability
+    // kernel. Sealed here, at the single bridge point (scheduled for removal).
+    caps.unsafe.unsafeAssumePure(LazyList.defer(recur()))
 
 package stdios:
   given muteStdio: Stdio = Stdio(null, null, null, termcapDefinitions.basicTermcap)

--- a/lib/turbulence/src/core/turbulence_lazylist.scala
+++ b/lib/turbulence/src/core/turbulence_lazylist.scala
@@ -1,0 +1,73 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+// LazyList streaming utilities: the transitional view layer over the lazy-list
+// representation. Deliberately NOT separation-checked — this unit predates the
+// capability kernel and is scheduled for removal with the LazyList bridges.
+
+import language.adhocExtensions
+
+import java.io as ji
+import java.lang as jl
+
+import anticipation.*
+import contingency.*
+import denominative.*
+import hypotenuse.*
+import parasite.*
+import prepositional.*
+import rudiments.*
+import symbolism.*
+import vacuous.*
+import zephyrine.*
+
+import abstractables.instantAbstractable
+import probates.awaitProbate
+
+extension [element](stream: LazyList[element])
+  def rate
+    [ generic: {Abstractable across Durations to Long, Instantiable across Durations from Long} ]
+    ( duration: generic )
+    ( using Monitor )
+  :   LazyList[element] raises AsyncError =
+
+    def recur(stream: LazyList[element], last: Long): LazyList[element] =
+      stream.flow(LazyList()):
+        val duration2 =
+          generic(duration.generic - (jl.System.currentTimeMillis - last)*1_000_000L)
+
+        if duration2.generic > 0 then snooze(duration2)
+        stream
+
+    async(recur(stream, jl.System.currentTimeMillis)).await()

--- a/lib/turbulence/src/jvm/turbulence.Deflation.scala
+++ b/lib/turbulence/src/jvm/turbulence.Deflation.scala
@@ -67,7 +67,7 @@ extends Duct[Data, Data]:
   // The gzip header (10 bytes) must fit in one step's output space.
   override def quantum: Int = if gzip then 10 else 1
 
-  private def header(target: Array[Byte], offset: Int): Unit =
+  private update def header(target: Array[Byte], offset: Int): Unit =
     target(offset) = 0x1f
     target(offset + 1) = 0x8b.toByte
     target(offset + 2) = 8
@@ -76,7 +76,7 @@ extends Duct[Data, Data]:
 
     target(offset + 9) = -1
 
-  def step
+  update def step
     ( source: input.Storage,
       sourceOffset: Int,
       sourceLength: Int,
@@ -112,7 +112,7 @@ extends Duct[Data, Data]:
 
     Duct.Progress(consumed, produced)
 
-  override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
     val out = target.asInstanceOf[Array[Byte]]
     var produced: Int = 0
 
@@ -173,7 +173,7 @@ extends Duct[Data, Data]:
   def translate(demand: Credit): Credit = demand
 
   // Consume one header byte, returning the successor state.
-  private def advance(byte: Int, position: Int): Header = header match
+  private update def advance(byte: Int, position: Int): Header = header match
     case Header.Fixed(remaining) =>
       if position == 3 then flags = byte
 
@@ -206,21 +206,21 @@ extends Duct[Data, Data]:
     case Header.Done =>
       Header.Done
 
-  private def afterExtra: Header =
+  private update def afterExtra: Header =
     if (flags & 8) != 0 then Header.Name
     else if (flags & 16) != 0 then Header.Comment
     else if (flags & 2) != 0 then Header.Checksum(2)
     else Header.Done
 
-  private def afterName: Header =
+  private update def afterName: Header =
     if (flags & 16) != 0 then Header.Comment
     else if (flags & 2) != 0 then Header.Checksum(2)
     else Header.Done
 
-  private def afterComment: Header =
+  private update def afterComment: Header =
     if (flags & 2) != 0 then Header.Checksum(2) else Header.Done
 
-  def step
+  update def step
     ( source: input.Storage,
       sourceOffset: Int,
       sourceLength: Int,

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -99,18 +99,20 @@ object Tests extends Suite(m"Turbulence tests"):
     val qbfData = qbf.data
 
     object Ref:
-      given Ref is Streamable by Text = ref => LazyList(t"abc", t"def")
-      given Ref is Streamable by Data = ref => LazyList(t"abc".data, t"def".data)
+      given textSource: Ref is Source by Text over Credit =
+        ref => Stream(LazyList(t"abc", t"def").iterator)
+      given dataSource: Ref is Source by Data over Credit =
+        ref => Stream(LazyList(t"abc".data, t"def".data).iterator)
 
     case class Ref()
 
     object Ref2:
-      given Ref2 is Streamable by Text = ref => LazyList(t"abc", t"def")
+      given Ref2 is Source by Text over Credit = ref => Stream(LazyList(t"abc", t"def").iterator)
 
     case class Ref2()
 
     object Ref3:
-      given Ref3 is Streamable by Data = ref => LazyList(t"abc".data, t"def".data)
+      given Ref3 is Source by Data over Credit = ref => Stream(LazyList(t"abc".data, t"def".data).iterator)
 
     case class Ref3()
 
@@ -127,23 +129,23 @@ object Tests extends Suite(m"Turbulence tests"):
         qbf.read[Text].s
       . assert(_ == qbf.s)
 
-      test(m"Read type as Text with Text and Byte Streamable"):
+      test(m"Read type as Text with Text and Byte Source"):
         Ref().read[Text].s
       . assert(_ == t"abcdef".s)
 
-      test(m"Read type as Data with Text and Byte Streamable"):
+      test(m"Read type as Data with Text and Byte Source"):
         Ref().read[Data].to(List)
       . assert(_ == t"abcdef".data.to(List))
 
-      test(m"Read some type as Text with only Text Streamable instance"):
+      test(m"Read some type as Text with only Text Source instance"):
         Ref2().read[Text].s
       . assert(_ == t"abcdef".s)
 
-      test(m"Read some type as Data with only Text Streamable instance"):
+      test(m"Read some type as Data with only Text Source instance"):
         Ref2().read[Data].to(List)
       . assert(_ == t"abcdef".data.to(List))
 
-      test(m"Read some type as Text with only Data Streamable instance"):
+      test(m"Read some type as Text with only Data Source instance"):
         Ref3().read[Text].s
       . assert(_ == t"abcdef".s)
 
@@ -533,33 +535,18 @@ object Tests extends Suite(m"Turbulence tests"):
         builder.toString.tt
       . assert(_ == original)
 
-      test(m"lazyList view drains a stream as chunks"):
+      test(m"memoize view drains a stream as one value"):
         val stream = summon[Data is Source by Data over Credit].stream(payload)
-        stream.lazyList.map(_.to(List)).flatten.to(List)
+        stream.memoize.to(List)
       . assert(_ == payload.to(List))
 
-      test(m"a Streamable instance is a Source through the bridge"):
+      test(m"a LazyList is a Source through its native instance"):
         val output = ji.ByteArrayOutputStream()
         val sink = summon[ji.ByteArrayOutputStream is Sink by Data over Credit]
         val source = summon[LazyList[Data] is Source by Data over Credit]
         source.stream(LazyList(payload, payload)).flowTo(sink.intake(output))
         output.toByteArray.nn.length
       . assert(_ == payload.length*2)
-
-      test(m"a Writable instance is a Sink through the bridge"):
-        class Store():
-          val buffer: scm.ArrayBuffer[Byte] = scm.ArrayBuffer()
-
-        object Store:
-          given Store is Writable by Data = (store, stream) => stream.each: data =>
-            data.each: byte =>
-              store.buffer.append(byte)
-
-        val store = Store()
-        val sink = summon[Store is Sink by Data over Credit]
-        summon[Data is Source by Data over Credit].stream(payload).flowTo(sink.intake(store))
-        store.buffer.length
-      . assert(_ == payload.length)
 
       test(m"a sink write failure raises StreamError"):
         import unsafeExceptions.canThrowAny

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -577,9 +577,9 @@ object Tests extends Suite(m"Turbulence tests"):
 
       test(m"cancelling a blocked conduit writer releases it"):
         supervise:
-          val conduit = Conduit[Data]()
+          val (intake, stream) = Conduit[Data]()
           val big = Data.fill(100000)(_.toByte)
-          val writer = async(conduit.put(big))
+          val writer = async(intake.put(big))
           writer.cancel()
           true
       . assert(identity)
@@ -587,8 +587,15 @@ object Tests extends Suite(m"Turbulence tests"):
       test(m"confluence merges all sources completely"):
         supervise:
           val sources = (1 to 4).map { index => Data.fill(1000)(_ => index.toByte) }
-          val merged = Confluence(sources.map { data =>
-              summon[Data is Source by Data over Credit].stream(data) }*)
+          // built in a while-loop: fresh endpoints cannot leave a `map` lambda
+          val builder = List.newBuilder[AnyRef]
+          var index = 0
+          while index < sources.length do
+            builder += summon[Data is Source by Data over Credit].stream(sources(index)).asInstanceOf[AnyRef]
+            index += 1
+          val endpoints = builder.result()
+
+          val merged = Confluence(endpoints.map(_.asInstanceOf[Stream[Data] over Credit])*)
           val gather = Gather2()
           merged.flowTo(gather)
           gather.data.to(List).sorted
@@ -655,9 +662,9 @@ object Tests extends Suite(m"Turbulence tests"):
 
       test(m"cancelling a detached flow blocked on an empty conduit releases it"):
         supervise:
-          val conduit = Conduit[Data]()
+          val (intake, stream) = Conduit[Data]()
           val gather = Gather2()
-          val pump = conduit.stream.flow(gather)
+          val pump = stream.flow(gather)
           pump.cancel()
           true
       . assert(identity)
@@ -676,24 +683,24 @@ class Gather2() extends Intake[Data]:
   protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
   def mark: Int = mark1
 
-  def reserve(min: Int): Int =
+  update def reserve(min: Int): Int =
     val free = block - mark1
 
     if free >= min then free else
       drain()
       block
 
-  def commit(count: Int): Unit =
+  update def commit(count: Int): Unit =
     mark1 += count
     if mark1 == block then drain()
 
-  def finish(): Unit = drain()
+  update def finish(): Unit = drain()
 
-  def data: Data =
+  update def data: Data =
     drain()
     addressable.build(target)
 
-  private def drain(): Unit =
+  private update def drain(): Unit =
     if mark1 > 0 then
       addressable.cloneStorage(storage, 0, mark1)(target)
       mark1 = 0

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -620,7 +620,7 @@ object Xml extends Tag.Container
     producer.iterator
 
   private def writeDocument
-    ( producer: Producer[Text], formatting: Formatting, document: Document[Xml] )
+    ( producer: (Producer[Text])^, formatting: Formatting, document: Document[Xml] )
   :   Unit =
 
     writeXml(producer, formatting, document.metadata, 0)
@@ -631,7 +631,7 @@ object Xml extends Tag.Container
   // Escape text content so the result is well-formed and round-trips exactly. `&` and `<` must be
   // escaped; `>` is escaped too so the `]]>` sequence can never appear; and a carriage return is
   // written as a character reference so XML line-ending normalization cannot rewrite it to `\n`.
-  private def writeEscapedText(producer: Producer[Text], text: Text): Unit =
+  private def writeEscapedText(producer: (Producer[Text])^, text: Text): Unit =
     val source = text.s
     val length = source.length
     var start = 0
@@ -657,7 +657,7 @@ object Xml extends Tag.Container
   // Escape an attribute value delimited by double quotes. Besides the text escapes, the delimiter
   // and the whitespace characters tab, line feed and carriage return become character references,
   // since attribute-value normalization would otherwise collapse literal whitespace to spaces.
-  private def writeEscapedAttribute(producer: Producer[Text], text: Text): Unit =
+  private def writeEscapedAttribute(producer: (Producer[Text])^, text: Text): Unit =
     val source = text.s
     val length = source.length
     var start = 0
@@ -687,7 +687,7 @@ object Xml extends Tag.Container
   // `showable` through a synchronous one, so the two never drift. When the `Formatting` carries
   // an `indent`, element-only content is laid out one child per indented line; an element that
   // contains any character data is kept inline so its text is never altered.
-  private def writeXml(producer: Producer[Text], formatting: Formatting, node: Xml, depth: Int)
+  private def writeXml(producer: (Producer[Text])^, formatting: Formatting, node: Xml, depth: Int)
   :   Unit =
 
     node match
@@ -772,7 +772,7 @@ object Xml extends Tag.Container
     case _           => false
 
   // In indented mode, emit a newline followed by `depth` indent units.
-  private def newline(producer: Producer[Text], formatting: Formatting, depth: Int): Unit =
+  private def newline(producer: (Producer[Text])^, formatting: Formatting, depth: Int): Unit =
     formatting.indent.let: unit =>
       producer.put("\n")
       var i = 0

--- a/lib/xylophone/src/test/xylophone_test.scala
+++ b/lib/xylophone/src/test/xylophone_test.scala
@@ -77,7 +77,7 @@ object Tests extends Suite(m"Xylophone tests"):
 
       test(m"Serialize document"):
         supervise:
-          unsafely(t"""<?xml  version="1.0"?><message>hello world</message>""".load[Xml].read[Text])
+          unsafely(t"""<?xml  version="1.0"?><message>hello world</message>""".load[Xml].stream[Text].read[Text])
       . assert(_ == t"""<?xml version="1.0"?><message>hello world</message>""")
 
     suite(m"`in Xml` decoder shorthand"):

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package soundness
 
+import language.experimental.separationChecking
+
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
     Regulation, Stream, Substrate, flowTo, locate, locateKey}
@@ -39,25 +41,25 @@ export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, 
 // Hand-written forwarders: the synthesized export forwarders for these dependent-typed
 // extensions lose the `ductile.Result`/`ductile.Operand` path refinements under capture
 // checking and fail to retypecheck.
-extension [in, transport](stream: Stream[in] over transport)
-  def through[stage](stage: stage)
+extension [in, transport](consume stream: (Stream[in] over transport)^)
+  def through[stage](consume stage: stage^)
     ( using ductile: (stage is Ductile by in) { type Upstream = transport },
             buffering: Buffering )
-  :   Stream[ductile.Result] over ductile.Transport =
+  :   (Stream[ductile.Result] over ductile.Transport)^ =
     // The call's dependent result widens to a `Ductile{...}#Result` projection rather than
     // narrowing back to this forwarder's `ductile.Result`; the value is returned unchanged,
     // so the cast only restores the dependent typing the export forwarder would have lost.
     zephyrine.through[in, transport](stream)[stage](stage)(using ductile, buffering)
-    . asInstanceOf[Stream[ductile.Result] over ductile.Transport]
+    . asInstanceOf[(Stream[ductile.Result] over ductile.Transport)^]
 
-extension [out, transport](intake: Intake[out] over transport)
-  def accepting[stage](stage: stage)
+extension [out, transport](consume intake: (Intake[out] over transport)^)
+  def accepting[stage](consume stage: stage^)
     ( using ductile: (stage is Ductile to out) { type Transport = transport },
             buffering: Buffering )
-  :   Intake[ductile.Operand] over ductile.Upstream =
+  :   (Intake[ductile.Operand] over ductile.Upstream)^ =
     // See `through` above.
     zephyrine.accepting[out, transport](intake)[stage](stage)(using ductile, buffering)
-    . asInstanceOf[Intake[ductile.Operand] over ductile.Upstream]
+    . asInstanceOf[(Intake[ductile.Operand] over ductile.Upstream)^]
 
 package parsing:
   export zephyrine.parsing.trackPositions

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -36,7 +36,7 @@ import language.experimental.separationChecking
 
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
-    Regulation, Stream, Substrate, flowTo, locate, locateKey}
+    Regulation, Spring, Stream, Substrate, flowTo, foreachWindow, locate, locateKey, memoize}
 
 // Hand-written forwarders: the synthesized export forwarders for these dependent-typed
 // extensions lose the `ductile.Result`/`ductile.Operand` path refinements under capture

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import java.util.concurrent as juc
 import java.util.concurrent.atomic as juca
 
@@ -40,128 +42,143 @@ import prepositional.*
 import rudiments.*
 import vacuous.*
 
-// The asynchronous boundary of a streaming pipeline: an `Intake` on its write
-// side and a `Stream` on its read side, with exactly one thread ever touching
-// each. Data crosses in blocks through a bounded queue, so a writer that
-// outpaces its reader parks in `reserve` — cross-thread backpressure — and
-// the free capacity is the credit this conduit reports as its `demand`. This
-// is the only synchronized component of a pipeline; every other stage is
-// single-owner mutable state on one side of a conduit or the other.
+// The asynchronous boundary of a streaming pipeline: a factory yielding an `Intake` for
+// the writing thread and a `Stream` for the reading thread, with exactly one thread ever
+// touching each. Data crosses in blocks through a bounded queue, so a writer that
+// outpaces its reader parks in `reserve` — cross-thread backpressure — and the free
+// capacity is the credit the intake reports as its `demand`. This is the only
+// synchronized component of a pipeline; every other stage is single-owner mutable state
+// on one side of a conduit or the other.
 //
-// A conduit is the generalization of `Producer.Channel`: block-granular
-// hand-off, but with element-granular credit, storage handed to the reader
-// without materializing an immutable chunk, and failure propagation — a
-// producer-side `fail` is rethrown from the reader's next `refill`.
+// The two endpoints are separate exclusive capabilities: a single object owning both
+// sides could not give two threads separated exclusive access. They share a
+// `SharedCapability`-classified core — correctly exempt from separation checking, since
+// the core's guarantees come from the queue's happens-before and the atomics, not from
+// aliasing analysis. Capture sets are erased crossing the queue (it carries `AnyRef`);
+// single ownership of a published block is discharged on the writer's side before the
+// hand-off, and visibility is the queue's publication guarantee.
 object Conduit:
   private object End
 
   private class Block(val storage: AnyRef, val size: Int)
 
-final class Conduit[medium]
-  (using val addressable0: medium is Addressable)(using buffering: Buffering)
-extends Intake[medium](using addressable0):
-  type Transport = Credit
+  // The synchronized substrate both endpoints capture.
+  private final class Core(window: Int) extends caps.SharedCapability:
+    val queue: juc.ArrayBlockingQueue[AnyRef] = juc.ArrayBlockingQueue(window)
+    val written: juca.AtomicLong = juca.AtomicLong(0)
+    val consumed: juca.AtomicLong = juca.AtomicLong(0)
+    // JMM-managed flags: their safety is the volatile publication guarantee, not
+    // aliasing analysis, so their captures are untracked.
+    @caps.unsafe.untrackedCaptures @volatile var error: Throwable | Null = null
+    @caps.unsafe.untrackedCaptures @volatile var closed: Boolean = false
 
-  private val block: Int = buffering.capacity(addressable0.substrate)
-  private val queue: juc.ArrayBlockingQueue[AnyRef] = juc.ArrayBlockingQueue(buffering.window)
+  def apply[medium]()
+    ( using addressable0: medium is Addressable )(using buffering: Buffering)
+  :   ((Intake[medium] over Credit)^, (Stream[medium] over Credit)^) =
 
-  private val written: juca.AtomicLong = juca.AtomicLong(0)
-  private val consumed: juca.AtomicLong = juca.AtomicLong(0)
-  @volatile private var error: Throwable | Null = null
-  @volatile private var closed: Boolean = false
+    val block: Int = buffering.capacity(addressable0.substrate)
+    val core = new Core(buffering.window)
 
-  private var current: addressable0.Storage = addressable0.allocate(block)
-  private var mark0: Int = 0
+    // Everything this conduit can hold: the queued blocks plus the block being
+    // written. `demand` is this allowance less what is currently buffered, so
+    // it reaches zero exactly when `reserve` would block.
+    val allowance: Long = block.toLong * (buffering.window + 1)
 
-  // Everything this conduit can hold: the queued blocks plus the block being
-  // written. `demand` is this allowance less what is currently buffered, so
-  // it reaches zero exactly when `reserve` would block.
-  private val allowance: Long = block.toLong * (buffering.window + 1)
+    // The write side; single writer.
+    val intake: (Intake[medium] over Credit)^ = new Intake[medium](using addressable0):
+      type Transport = Credit
 
-  def demand: Credit = Credit(allowance - (written.get - consumed.get))
+      private var current: addressable0.Storage = addressable0.allocate(block)
+      private var mark0: Int = 0
 
-  protected def buffer0: AnyRef = current.asInstanceOf[AnyRef]
-  def mark: Int = mark0
+      def demand: Credit = Credit(allowance - (core.written.get - core.consumed.get))
 
-  def reserve(min: Int): Int =
-    val free = block - mark0
+      protected def buffer0: AnyRef = current.asInstanceOf[AnyRef]
+      def mark: Int = mark0
 
-    if free >= min then free else
-      publish()
-      block
+      update def reserve(min: Int): Int =
+        val free = block - mark0
 
-  def commit(count: Int): Unit =
-    mark0 += count
-    written.addAndGet(count)
-    if mark0 == block then publish()
+        if free >= min then free else
+          publish()
+          block
 
-  override def flush(): Unit = if mark0 > 0 then publish()
+      update def commit(count: Int): Unit =
+        mark0 += count
+        core.written.addAndGet(count)
+        if mark0 == block then publish()
 
-  def finish(): Unit =
-    flush()
-    queue.put(Conduit.End)
+      override update def flush(): Unit = if mark0 > 0 then publish()
 
-  override def fail(error: Throwable): Unit =
-    this.error = error
-    queue.clear()
-    queue.put(Conduit.End)
+      update def finish(): Unit =
+        flush()
+        core.queue.put(End)
 
-  private def publish(): Unit =
-    if mark0 > 0 then
-      if closed then
-        written.addAndGet(-mark0)
-        mark0 = 0
-      else
-        queue.put(Conduit.Block(current.asInstanceOf[AnyRef], mark0))
-        current = addressable0.allocate(block)
-        mark0 = 0
+      override update def fail(error: Throwable): Unit =
+        core.error = error
+        core.queue.clear()
+        core.queue.put(End)
 
-  // The read side; single reader. `refill` parks (in `queue.take`) until the
-  // writer publishes a block or finishes.
-  val stream: Stream[medium] over Credit = new Stream[medium](using addressable0):
-    type Transport = Credit
+      private update def publish(): Unit =
+        if mark0 > 0 then
+          if core.closed then
+            core.written.addAndGet(-mark0)
+            mark0 = 0
+          else
+            core.queue.put(Block(current.asInstanceOf[AnyRef], mark0))
+            current = addressable0.allocate(block)
+            mark0 = 0
 
-    private var storage: addressable0.Storage = addressable0.allocate(0)
-    private var start0: Int = 0
-    private var limit0: Int = 0
-    private var size: Int = 0
-    private var ended: Boolean = false
+    // The read side; single reader. `refill` parks (in `queue.take`) until the
+    // writer publishes a block or finishes.
+    val stream: (Stream[medium] over Credit)^ = new Stream[medium](using addressable0):
+      type Transport = Credit
 
-    protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
-    def start: Int = start0
-    def limit: Int = limit0
+      private var storage: addressable0.Storage = addressable0.allocate(0)
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var size: Int = 0
+      private var ended: Boolean = false
 
-    def skip(count: Int): Unit =
-      start0 += count
-      consumed.addAndGet(count)
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
 
-    def refill(demand: Credit): Optional[Int] =
-      if limit0 > start0 then limit0 - start0
-      else if ended then Unset
-      else
-        val granted = summon[Credit is Regulation].grant(demand)
+      update def skip(count: Int): Unit =
+        start0 += count
+        core.consumed.addAndGet(count)
 
-        if granted == 0 then 0
-        else if limit0 < size then
-          limit0 += (size - limit0).min(granted)
-          limit0 - start0
+      update def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if ended then Unset
         else
-          (queue.take().nn: @unchecked) match
-            case Conduit.End =>
-              ended = true
-              val error0 = error
-              if error0 == null then Unset else throw error0
+          val granted = summon[Credit is Regulation].grant(demand)
 
-            case received: Conduit.Block =>
-              storage = received.storage.asInstanceOf[addressable0.Storage]
-              size = received.size
-              start0 = 0
-              limit0 = size.min(granted)
-              limit0
+          if granted == 0 then 0
+          else if limit0 < size then
+            limit0 += (size - limit0).min(granted)
+            limit0 - start0
+          else
+            (core.queue.take().nn: @unchecked) match
+              case End =>
+                ended = true
+                val error0 = core.error
+                if error0 == null then Unset else throw error0
 
-            case _ =>
-              panic(m"unexpected value in conduit queue")
+              case received: Block =>
+                // Single-ownership transfer: the writer never touches a published
+                // block again (proven on its side by the fresh re-mint in `publish`).
+                storage = received.storage.asInstanceOf[addressable0.Storage]
+                size = received.size
+                start0 = 0
+                limit0 = size.min(granted)
+                limit0
 
-    override def close(): Unit =
-      closed = true
-      queue.clear()
+              case _ =>
+                panic(m"unexpected value in conduit queue")
+
+      override update def close(): Unit =
+        core.closed = true
+        core.queue.clear()
+
+    (intake, stream)

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -154,7 +154,7 @@ object Cursor:
   // memory stays bounded through a parse of an arbitrarily large input. The window is
   // read and skipped within the fill, before the stream can refill again — the borrow
   // discipline `Stream.window` documents, applied at the one place a cursor touches it.
-  def apply[data](stream: Stream[data] over Credit)
+  def apply[data](consume stream: (Stream[data] over Credit)^)
     ( using addressable0: data is Addressable,
             lineation0:   Lineation by addressable0.Operand,
             buffering:    Buffering )
@@ -170,16 +170,25 @@ object Cursor:
         DefaultCapacity,
         addressable0,
         lineation0,
-        new Filler[addressable0.Storage]:
-          val block: Int = buffering.capacity(addressable0.substrate)
+        // Sealed like the loader: the filler captures the adopted stream (consumed by
+        // this factory — sole ownership), and Cursor's Unscoped classification cannot
+        // hold a non-Unscoped capture.
+        locally:
+          val filler = new Filler[addressable0.Storage]:
+            val block: Int = buffering.capacity(addressable0.substrate)
 
-          def fill(storage: addressable0.Storage, offset: Int, space: Int): Int =
-            stream.refill(Credit(space.min(block))).lay(-1): count =>
-              val copied = count.min(space)
-              val window = stream.window(using Unsafe).asInstanceOf[addressable0.Storage]
-              addressable0.transfer(window, stream.start, storage, offset, copied)
-              stream.skip(copied)
-              copied )
+            def fill(storage: addressable0.Storage, offset: Int, space: Int): Int =
+              stream.refill(Credit(space.min(block))).lay(-1): count =>
+                val copied = count.min(space)
+                val window = stream.window(using Unsafe).asInstanceOf[addressable0.Storage]
+                addressable0.transfer(window, stream.start, storage, offset, copied)
+                stream.skip(copied)
+                copied
+
+          // Sealed like the loader: the filler captures the adopted stream (consumed by
+          // this factory — sole ownership), and Cursor's Unscoped classification cannot
+          // hold a non-Unscoped capture.
+          caps.unsafe.unsafeAssumePure(filler) )
 
     cursor
 

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import prepositional.*
 
 // A synchronous transformation stage, attachable to either end of a pipeline:
@@ -66,8 +68,12 @@ object Duct:
 
   opaque type Progress = Long
 
+// A duct is single-owner mutable state (compressors, partial atoms), so it is a stateful
+// capability: `step`/`flush`/`close` mutate it and require exclusive access, while
+// `translate`/`quantum`/`regulation` are pure queries.
 abstract class Duct[in, out]
-  ( using val input: in is Addressable, val output: out is Addressable ):
+  ( using val input: in is Addressable, val output: out is Addressable )
+extends caps.ExclusiveCapability, caps.Stateful:
 
   type Transport
   type Upstream
@@ -85,7 +91,7 @@ abstract class Duct[in, out]
   // a duct whose smallest output atom is two elements.
   def quantum: Int = 1
 
-  def step
+  update def step
     ( source: input.Storage,
       sourceOffset: Int,
       sourceLength: Int,
@@ -100,6 +106,6 @@ abstract class Duct[in, out]
   // undelivered output than one step's space). A duct whose state can retain
   // output MUST override this; the first `0` it returns is taken as the end
   // of the stream. Called repeatedly until it returns `0`.
-  def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int = 0
+  update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int = 0
 
-  def close(): Unit = ()
+  update def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import java.nio as jn, jn.charset as jnc
 
 import anticipation.*
@@ -55,20 +57,30 @@ object Ductile:
     (stage is Ductile by in to out over transport) { type Upstream = upstream }
 
   given duct: [in, out, transport, upstream,
-        stage <: Duct[in, out] { type Transport = transport; type Upstream = upstream }]
+        stage <: (Duct[in, out] { type Transport = transport; type Upstream = upstream })^]
   =>  Of[stage, in, out, transport, upstream] =
 
-    new Ductile:
+    // The identity instance: the cast bridges the capture-decorated inferred member types
+    // against the declared alias (bare `stage` under a stateful bound reads as `.rd`).
+    (new Ductile:
       type Self = stage
       type Operand = in
       type Result = out
       type Transport = transport
       type Upstream = upstream
 
-      def duct(stage0: stage)(using Buffering)
-      :   Duct[in, out] { type Transport = transport; type Upstream = upstream } =
+      def duct(consume stage0: stage^)(using Buffering)
+      :   (Duct[in, out] { type Transport = transport; type Upstream = upstream })^ =
 
-        stage0
+        // consumed pass-through: ownership moves from caller to result (the admission
+        // gap for direct returns is bridged by the erasure cast)
+        stage0.asInstanceOf[(Duct[in, out] { type Transport = transport; type Upstream = upstream })^]
+    ).asInstanceOf[Ductile {
+      type Self = stage^{caps.any.rd}
+      type Operand = in
+      type Result = out
+      type Transport = transport
+      type Upstream = upstream }]
 
   // Character decoding as a pipeline stage. Bytes are staged internally (so
   // multi-byte characters split across refills are carried, and `step`
@@ -82,7 +94,7 @@ object Ductile:
       type Transport = Credit
       type Upstream = Credit
 
-      def duct(stage: CharDecoder)(using buffering: Buffering)
+      def duct(consume stage: CharDecoder^)(using buffering: Buffering)
       :   Duct[Data, Text] { type Transport = Credit; type Upstream = Credit } =
 
         new Duct[Data, Text]:
@@ -103,7 +115,7 @@ object Ductile:
           // sound byte-credit as it stands.
           def translate(demand: Credit): Credit = demand
 
-          private def decode(out: jn.CharBuffer, endOfInput: Boolean): Unit =
+          private update def decode(out: jn.CharBuffer, endOfInput: Boolean): Unit =
             val result = decoder.decode(staging, out, endOfInput).nn
 
             if result.isMalformed then
@@ -111,7 +123,7 @@ object Ductile:
               staging.position(staging.position + result.length)
               decode(out, endOfInput)
 
-          def step
+          update def step
             ( source: input.Storage,
               sourceOffset: Int,
               sourceLength: Int,
@@ -133,7 +145,7 @@ object Ductile:
 
             Duct.Progress(copy, out.position - targetOffset)
 
-          override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
+          override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
           :   Int =
 
             if ended then 0 else
@@ -159,7 +171,7 @@ object Ductile:
       type Transport = Credit
       type Upstream = Credit
 
-      def duct(stage: CharEncoder)(using buffering: Buffering)
+      def duct(consume stage: CharEncoder^)(using buffering: Buffering)
       :   Duct[Text, Data] { type Transport = Credit; type Upstream = Credit } =
 
         new Duct[Text, Data]:
@@ -208,7 +220,7 @@ object Ductile:
 
             Duct.Progress(copy, out.position - targetOffset)
 
-          override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
+          override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
           :   Int =
 
             if ended then 0 else
@@ -226,6 +238,6 @@ trait Ductile extends Typeclass, Operable, Resultant:
   type Transport
   type Upstream
 
-  def duct(stage: Self)(using Buffering): Duct[Operand, Result] {
+  def duct(consume stage: Self^)(using Buffering): (Duct[Operand, Result] {
     type Transport = Ductile.this.Transport
-    type Upstream = Ductile.this.Upstream }
+    type Upstream = Ductile.this.Upstream })^

--- a/lib/zephyrine/src/core/zephyrine.Intake.scala
+++ b/lib/zephyrine/src/core/zephyrine.Intake.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import denominative.*
 import prepositional.*
 import rudiments.*
@@ -48,6 +50,8 @@ import vacuous.*
 // reserves contiguous space, writes directly into the intake's storage at
 // `mark`, then commits. `put`, `push` and `absorb` are final loops over that
 // protocol, so implementations provide only the window and its lifecycle.
+// The intake inherits Producer's capability classification: writes require an exclusive
+// reference; `demand` and `mark` are read-only queries.
 trait Intake[medium](using val addressable: medium is Addressable) extends Producer[medium]:
   type Operand = addressable.Operand
   type Transport
@@ -60,7 +64,7 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
   // Ensure at least `min` elements of contiguous writable space, blocking if
   // necessary, and return the available space. `min` must not exceed the
   // intake's block size.
-  def reserve(min: Int): Int
+  update def reserve(min: Int): Int
 
   // Zero-copy view of this intake's buffer; elements from `mark` are writable
   // up to the last `reserve`d space. Valid only until the next `commit`,
@@ -75,20 +79,20 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
 
   // Declare `count` elements written at `mark`; may synchronously cascade
   // them through downstream stages.
-  def commit(count: Int): Unit
+  update def commit(count: Int): Unit
 
   // Propagate buffered data downstream now, without ending the stream.
-  def flush(): Unit = ()
+  update def flush(): Unit = ()
 
   // End-of-stream: flush, emit any terminal stage state, release downstream.
   // Called exactly once.
-  def finish(): Unit
+  update def finish(): Unit
 
   // Abort: propagate failure downstream so stages can release resources. The
   // error is rethrown to the reader at an asynchronous boundary.
-  def fail(error: Throwable): Unit = finish()
+  update def fail(error: Throwable): Unit = finish()
 
-  final def absorb(source: addressable.Storage, offset: Int, count: Int): Unit =
+  final update def absorb(source: addressable.Storage, offset: Int, count: Int): Unit =
     var done: Int = 0
 
     while done < count do
@@ -98,9 +102,9 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
       commit(size)
       done += size
 
-  final def put(source: medium): Unit = put(source, Prim, addressable.length(source))
+  final update def put(source: medium): Unit = put(source, Prim, addressable.length(source))
 
-  final def put(source: medium, offset: Ordinal, size: Int): Unit =
+  final update def put(source: medium, offset: Ordinal, size: Int): Unit =
     var done: Int = 0
 
     while done < size do
@@ -110,7 +114,7 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
       commit(count)
       done += count
 
-  final def push(operand: Operand): Unit =
+  final update def push(operand: Operand): Unit =
     reserve(1)
     addressable.storageUpdate(buffer(using Unsafe), mark, operand)
     commit(1)

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import java.util.concurrent as juc
 
 import anticipation.Data
@@ -94,14 +96,14 @@ object Producer:
 
     private inline def free: Int = block - index.n0
 
-    private inline def publish(): Unit =
+    private inline update def publish(): Unit =
       if index != Prim then
         queue.put(addressable.materialize(current, 0, index.n0))
         index = Prim
 
-    def put(source: medium): Unit = put(source, Prim, addressable.length(source))
+    update def put(source: medium): Unit = put(source, Prim, addressable.length(source))
 
-    def put(source: medium, offset: Ordinal, size: Int): Unit =
+    update def put(source: medium, offset: Ordinal, size: Int): Unit =
       var done = 0
 
       while size - done > free do
@@ -115,29 +117,37 @@ object Producer:
 
       if free == 0 then publish()
 
-    def push(operand: Operand): Unit =
+    update def push(operand: Operand): Unit =
       addressable.storageUpdate(current, index.n0, operand)
       index = (index.n0 + 1).z
       if free == 0 then publish()
 
-    def finish(): Unit =
+    update def finish(): Unit =
       publish()
       queue.put(Done)
 
-    lazy val iterator: Iterator[medium] = new Iterator[medium]:
+    // The reader-side view: like a conduit's stream endpoint, it is owned by the
+    // consuming thread and mediated by the queue's happens-before; the seal is that rim.
+    lazy val iterator: Iterator[medium] = caps.unsafe.unsafeAssumePure(new Iterator[medium]:
+      // The iterator is the reader-side view of the channel (non-Stateful by design:
+      // scala.Iterator's methods cannot be update methods); its staging slot is untracked.
+      @caps.unsafe.untrackedCaptures
       private var ready: medium | Done.type = Done
 
       def hasNext: Boolean =
         ready = queue.take().nn
         ready != Done
 
-      def next(): medium = ready.asInstanceOf[medium]
+      def next(): medium = ready.asInstanceOf[medium])
 
 
-trait Producer[medium]:
+// A producer is a stateful capability: writing requires an exclusive reference, and the
+// root classification here lets `Intake` (and every other implementation) mark its
+// writes as update methods.
+trait Producer[medium] extends caps.ExclusiveCapability, caps.Stateful:
   type Operand
-  def put(source: medium): Unit
-  def put(source: medium, offset: Ordinal, size: Int): Unit
+  update def put(source: medium): Unit
+  update def put(source: medium, offset: Ordinal, size: Int): Unit
 
   // Write a single element: a `Char` for `Producer[Text]`, a `Byte` for `Producer[Data]`.
-  def push(operand: Operand): Unit
+  update def push(operand: Operand): Unit

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -54,14 +54,14 @@ object Producer:
   // Streaming: chunks are queued (with backpressure) and drained through `iterator`. The producing
   // code must run on a separate fiber, since `put` blocks once the window is full.
   def apply[medium](block: Int = 4096, window: Int = 2)(using addr: medium is Addressable)
-  :   Channel[medium] { type Operand = addr.Operand } =
+  :   (Channel[medium] { type Operand = addr.Operand })^ =
 
     Channel(block, window)(using addr)
 
   // Synchronous: run `body`, accumulating directly into a builder, and return the whole value. No
   // concurrency, no chunk buffer, and none of the streaming path's single-thread deadlock risk.
   def collect[medium](using addressable: medium is Addressable)(hint: Int = 4096)
-    ( body: (Producer[medium] { type Operand = addressable.Operand }) => Unit )
+    ( body: ((Producer[medium] { type Operand = addressable.Operand })^) => Unit )
   :   medium =
 
     val target = addressable.blank(hint)

--- a/lib/zephyrine/src/core/zephyrine.Spring.scala
+++ b/lib/zephyrine/src/core/zephyrine.Spring.scala
@@ -30,46 +30,19 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package galilei
+package zephyrine
 
-import anticipation.*
-import contingency.*
+import language.experimental.separationChecking
+
 import prepositional.*
-import turbulence.*
-import zephyrine.*
 
-object Handle:
-  // Polymorphic over the handle's (scoped, capturing) singleton type: `Openable.open`
-  // hands the lambda a capability-refined `Handle^{...}`, and a `Self = Handle` instance
-  // would not be summonable for it under capture checking.
-  given streamable: [handle <: Handle^] => Tactic[StreamError]
-  =>  handle is Streamable by Data = _.reader()
-
-  given writable: [handle <: Handle^] => Emit[StreamError]
-  =>  handle is Writable by Data = _.writer(_)
-
-  given source: [handle <: Handle^] => handle is Source by Data over Credit = _.source()
-  given sink: [handle <: Handle^] => handle is Sink by Data over Credit = _.intake()
-
-// The native `source`/`intake` endpoints default to bridging the legacy
-// `reader`/`writer`; `Openable` supplies channel-native endpoints, so file
-// I/O reads and writes directly through the streaming kernel's buffers.
-// A scoped capability: its `read`/`write` operations are direct methods as well as
-// `Streamable`/`Writable` typeclass givens, because summoning a typeclass on a *scoped*
-// capability's refined type can fail under capture checking (given resolution widens the
-// scoped capture to `{any}`); the direct methods summon typeclasses on the (non-scoped)
-// source/result types instead.
-class Handle
-  ( val reader: () => LazyList[Data], val writer: LazyList[Data] => Unit )
-  ( val source: Spring[Data]^ = () => Stream(reader().iterator),
-    val intake: () => Intake[Data] over Credit =
-      () => Sink.buffered((), (_, stream) => writer(stream)) )
-extends caps.ExclusiveCapability:
-
-  def write[source: Streamable by Data as streamable](source: source): Unit =
-    writer(streamable.stream(source))
-
-  def stream: LazyList[Data] = reader()
-
-  def read[result](using readable: (LazyList[Data] is Readable to result)^): result =
-    readable.read(reader())
+// A re-materializable source of streams: each `apply()` mints a fresh,
+// exclusive pull endpoint over the same content. This is a named trait rather
+// than the function type `() => (Stream[medium] over Credit)^` because
+// `Stream` is a scoped capability: a lambda may not mint a fresh scoped
+// capability as its result (the closure's fresh is not visible from the
+// function type's result capture at the binder's level), but a method may —
+// its result is re-leveled at each call site. Being a SAM trait, `Spring`
+// is still constructed from plain lambdas: `() => Stream(...)`.
+trait Spring[medium]:
+  def apply(): (Stream[medium] over Credit)^

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -63,9 +65,9 @@ object Stream:
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
-      def skip(count: Int): Unit = start0 += count
+      update def skip(count: Int): Unit = start0 += count
 
-      def refill(demand: Credit): Optional[Int] =
+      update def refill(demand: Credit): Optional[Int] =
         if limit0 > start0 then limit0 - start0 else
           if !loaded then
             addressable0.copyChunk(value, 0, storage, 0, size)
@@ -97,9 +99,9 @@ object Stream:
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
-      def skip(count: Int): Unit = start0 += count
+      update def skip(count: Int): Unit = start0 += count
 
-      def refill(demand: Credit): Optional[Int] =
+      update def refill(demand: Credit): Optional[Int] =
         if limit0 > start0 then limit0 - start0 else
           val granted = summon[Credit is Regulation].grant(demand)
 
@@ -124,7 +126,12 @@ object Stream:
 
             advance()
 
-trait Stream[medium](using val addressable: medium is Addressable):
+// A stream is a stateful capability: a bare `Stream` reference is read-only, and the
+// exclusive `Stream[...]^` that factories return is required to refill, skip or close.
+// `ExclusiveCapability, Stateful` rather than `Mutable`, so implementations may freely
+// capture their sources (iterators, queues, sockets), which are not Unscoped.
+trait Stream[medium](using val addressable: medium is Addressable)
+extends caps.ExclusiveCapability, caps.Stateful:
   type Transport
 
   // Ensure at least one element is readable (blocking if necessary),
@@ -132,7 +139,7 @@ trait Stream[medium](using val addressable: medium is Addressable):
   // readable elements, i.e. `limit - start`. Returns `0` only when `demand`
   // grants nothing; returns `Unset` at end-of-stream. If unconsumed elements
   // remain in the window, they are reported without producing more.
-  def refill(demand: Transport): Optional[Int]
+  update def refill(demand: Transport): Optional[Int]
 
   // Zero-copy view of this stream's buffer; elements `start until limit` are
   // readable. Valid only until the next `refill` or `close` — the same
@@ -148,7 +155,7 @@ trait Stream[medium](using val addressable: medium is Addressable):
   def limit: Int
 
   // Consume `count` elements of the window without materializing them.
-  def skip(count: Int): Unit
+  update def skip(count: Int): Unit
 
   // Release resources, propagating upstream through the whole chain.
-  def close(): Unit = ()
+  update def close(): Unit = ()

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -51,7 +51,7 @@ object Stream:
   // A single-chunk in-memory stream. The chunk is copied into fresh storage
   // once, at construction, so the window can be exposed mutably.
   def apply[medium](value: medium)(using addressable0: medium is Addressable)
-  :   Stream[medium] over Credit =
+  :   (Stream[medium] over Credit)^ =
 
     new Stream[medium]:
       type Transport = Credit
@@ -86,7 +86,7 @@ object Stream:
   // Demand bounds only how much of each chunk is exposed per refill, not the
   // iterator's own production, which is outside this stream's control.
   def apply[medium](iterator: Iterator[medium])(using addressable0: medium is Addressable)
-  :   Stream[medium] over Credit =
+  :   (Stream[medium] over Credit)^ =
 
     new Stream[medium]:
       type Transport = Credit

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -84,9 +84,11 @@ object Stream:
 
   // Adapts a chunk iterator (the legacy interoperation shape) into a stream.
   // Demand bounds only how much of each chunk is exposed per refill, not the
-  // iterator's own production, which is outside this stream's control.
-  def apply[medium](iterator: Iterator[medium])(using addressable0: medium is Addressable)
-  :   (Stream[medium] over Credit)^ =
+  // iterator's own production, which is outside this stream's control. The
+  // iterator may itself capture capabilities (e.g. pull from another
+  // endpoint), which the stream then retains alongside its own fresh state.
+  def apply[medium](iterator: Iterator[medium]^)(using addressable0: medium is Addressable)
+  :   (Stream[medium] over Credit)^{iterator, caps.any} =
 
     new Stream[medium]:
       type Transport = Credit

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -143,6 +143,41 @@ extension [out, transport](consume intake: (Intake[out] over transport)^)
       (ductile.duct(stage), intake)
 
 
+// ─── terminal operations and explicit replay ───────────────────────────────────────────
+//
+// The safe front-end replacing the LazyList views: pipeline stages compose with the
+// consume-typed `through`, and these terminal operations drain an exclusive endpoint
+// without exposing its window — each borrow is read, used and skipped before the next
+// refill. `memoize` is the explicit replacement for LazyList's implicit caching: it
+// drains the stream once into an immutable value, which may then be shared freely.
+
+extension [medium](consume stream: (Stream[medium] over Credit)^)
+  // Drain the stream, applying `operation` to each successive window. The lambda
+  // receives the storage, start index and element count; it must not retain the storage.
+  def foreachWindow(operation: (AnyRef, Int, Int) => Unit)(using buffering: Buffering): Unit =
+    val block = buffering.capacity(stream.addressable.substrate)
+
+    def loop(): Unit = stream.refill(Credit(block)) match
+      case count: Int =>
+        operation(stream.window(using Unsafe).asInstanceOf[AnyRef], stream.start, count)
+        stream.skip(count)
+        loop()
+
+      case _ => ()
+
+    try loop() finally stream.close()
+
+  // Drain the stream into a single immutable value: the explicit, bounded replacement
+  // for a LazyList's implicit memoization. The result is frozen and freely shareable.
+  def memoize(using buffering: Buffering): medium =
+    val addressable = stream.addressable
+    val target = addressable.blank(buffering.capacity(addressable.substrate))
+
+    foreachWindow: (storage, start, count) =>
+      addressable.cloneStorage(storage.asInstanceOf[addressable.Storage], start, count)(target)
+
+    addressable.build(target)
+
 private def throughDuct[in, out, upTransport, downTransport]
   ( consume duct:
       (Duct[in, out] { type Transport = downTransport; type Upstream = upTransport })^,

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package zephyrine
 
+import language.experimental.separationChecking
+
 import fulminate.*
 import prepositional.*
 import rudiments.*
@@ -85,20 +87,71 @@ package parsing:
 
 export Cursor.{Mark, Offset}
 
-extension [in, transport](stream: Stream[in] over transport)
+extension [in, transport](consume stream: (Stream[in] over transport)^)
   // Pull-composition: a differently-typed `Stream` whose refills translate
   // demand through the stage and pull from this stream. Runs entirely on
   // the consumer's thread. The stage may be a raw `Duct` or any descriptor
   // value with a `Ductile` instance.
-  def through[stage](stage: stage)
+  def through[stage](consume stage: stage^)
     ( using ductile: (stage is Ductile by in) { type Upstream = transport },
             buffering: Buffering )
-  :   Stream[ductile.Result] over ductile.Transport =
+  :   (Stream[ductile.Result] over ductile.Transport)^ =
 
-    val duct = ductile.duct(stage)
+    // Constructed in a helper: a local binding of the fresh duct would hide it from the
+    // anonymous class that wraps it (the statement rule); consume parameters carry
+    // explicit capture sets and hide nothing.
+    throughDuct[in, ductile.Result, transport, ductile.Transport]
+      (ductile.duct(stage), stream)
 
-    new Stream[ductile.Result](using duct.output):
-      type Transport = duct.Transport
+  // The pump loop connecting a pull-chain to a push-chain, on the calling
+  // thread: poll the intake's demand, refill with it, transfer the window.
+  // This is the only place data crosses from the pull side to the push side
+  // of a pipeline.
+  def flowTo(consume intake: (Intake[in] over transport)^): Unit =
+    def loop(): Unit =
+      stream.refill(intake.demand) match
+        case Unset =>
+          intake.finish()
+
+        case count: Int =>
+          if count > 0 then
+            intake.absorb
+              ( stream.window(using Unsafe).asInstanceOf[intake.addressable.Storage],
+                stream.start,
+                count )
+
+            stream.skip(count)
+          else
+            intake.reserve(1)
+
+          loop()
+
+    try loop() finally stream.close()
+
+extension [out, transport](consume intake: (Intake[out] over transport)^)
+  // Push-composition: a differently-typed `Intake` which reports translated
+  // demand, and whose commits step synchronously through the stage into
+  // this intake's writable window. The same stage value serves `through`
+  // and `accepting`; only the attachment differs.
+  def accepting[stage](consume stage: stage^)
+    ( using ductile: (stage is Ductile to out) { type Transport = transport },
+            buffering: Buffering )
+  :   (Intake[ductile.Operand] over ductile.Upstream)^ =
+
+    // See `throughDuct` above.
+    acceptingDuct[ductile.Operand, out, ductile.Upstream, transport]
+      (ductile.duct(stage), intake)
+
+
+private def throughDuct[in, out, upTransport, downTransport]
+  ( consume duct:
+      (Duct[in, out] { type Transport = downTransport; type Upstream = upTransport })^,
+    consume stream: (Stream[in] over upTransport)^ )
+  ( using buffering: Buffering )
+:   (Stream[out] over downTransport)^ =
+
+    new Stream[out](using duct.output):
+      type Transport = downTransport
 
       private val capacity: Int =
         buffering.capacity(duct.output.substrate).max(duct.quantum)
@@ -112,9 +165,9 @@ extension [in, transport](stream: Stream[in] over transport)
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
-      def skip(count: Int): Unit = start0 += count
+      update def skip(count: Int): Unit = start0 += count
 
-      def refill(demand: duct.Transport): Optional[Int] =
+      update def refill(demand: downTransport): Optional[Int] =
         if limit0 > start0 then limit0 - start0
         else if flushed then Unset
         else
@@ -158,63 +211,33 @@ extension [in, transport](stream: Stream[in] over transport)
 
             if flushed && limit0 == start0 then Unset else limit0 - start0
 
-      override def close(): Unit =
+      override update def close(): Unit =
         duct.close()
         stream.close()
 
-  // The pump loop connecting a pull-chain to a push-chain, on the calling
-  // thread: poll the intake's demand, refill with it, transfer the window.
-  // This is the only place data crosses from the pull side to the push side
-  // of a pipeline.
-  def flowTo(intake: Intake[in] over transport): Unit =
-    def loop(): Unit =
-      stream.refill(intake.demand) match
-        case Unset =>
-          intake.finish()
+private def acceptingDuct[in, out, upTransport, downTransport]
+  ( consume duct:
+      (Duct[in, out] { type Transport = downTransport; type Upstream = upTransport })^,
+    consume intake: (Intake[out] over downTransport)^ )
+  ( using buffering: Buffering )
+:   (Intake[in] over upTransport)^ =
 
-        case count: Int =>
-          if count > 0 then
-            intake.absorb
-              ( stream.window(using Unsafe).asInstanceOf[intake.addressable.Storage],
-                stream.start,
-                count )
-
-            stream.skip(count)
-          else
-            intake.reserve(1)
-
-          loop()
-
-    try loop() finally stream.close()
-
-extension [out, transport](intake: Intake[out] over transport)
-  // Push-composition: a differently-typed `Intake` which reports translated
-  // demand, and whose commits step synchronously through the stage into
-  // this intake's writable window. The same stage value serves `through`
-  // and `accepting`; only the attachment differs.
-  def accepting[stage](stage: stage)
-    ( using ductile: (stage is Ductile to out) { type Transport = transport },
-            buffering: Buffering )
-  :   Intake[ductile.Operand] over ductile.Upstream =
-
-    val duct = ductile.duct(stage)
-
-    new Intake[ductile.Operand](using duct.input):
-      type Transport = duct.Upstream
+    new Intake[in](using duct.input):
+      type Transport = upTransport
 
       private val capacity: Int = buffering.capacity(duct.input.substrate)
       private val storage: duct.input.Storage = duct.input.allocate(capacity)
       private var mark0: Int = 0
 
-      def demand: duct.Upstream = duct.translate(intake.demand)
+      def demand: upTransport = duct.translate(intake.demand)
       protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
       def mark: Int = mark0
 
       // `commit` always drains the whole buffer through the duct (partial
       // atoms are carried in duct state, not here), so all space is free.
-      def reserve(min: Int): Int = capacity - mark0
+      update def reserve(min: Int): Int = capacity - mark0
 
-      def commit(count: Int): Unit =
+      update def commit(count: Int): Unit =
         mark0 += count
         var offset: Int = 0
 
@@ -235,9 +258,9 @@ extension [out, transport](intake: Intake[out] over transport)
 
         mark0 = 0
 
-      override def flush(): Unit = intake.flush()
+      override update def flush(): Unit = intake.flush()
 
-      def finish(): Unit =
+      update def finish(): Unit =
         var produced: Int = -1
 
         while produced != 0 do
@@ -254,6 +277,6 @@ extension [out, transport](intake: Intake[out] over transport)
         duct.close()
         intake.finish()
 
-      override def fail(error: Throwable): Unit =
+      override update def fail(error: Throwable): Unit =
         duct.close()
         intake.fail(error)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -637,29 +637,29 @@ object Tests extends Suite(m"Zephyrine tests"):
         . assert(_ == List[Byte](1, 2, 99))
 
         test(m"conduit transfers data across threads"):
-          val conduit = Conduit[Data]()
+          val (intake, stream) = Conduit[Data]()
           val gather = Gather()
-          val task = async(conduit.stream.flowTo(gather))
-          conduit.put(bytes)
-          conduit.finish()
+          val task = async(stream.flowTo(gather))
+          intake.put(bytes)
+          intake.finish()
           unsafely(task.await())
           gather.data.to(List)
         . assert(_ == bytes.to(List))
 
         test(m"conduit demand reflects buffered data"):
-          val conduit = Conduit[Data]()
-          val before = conduit.demand.count
-          conduit.put(IArray[Byte](1, 2, 3))
-          val after = conduit.demand.count
+          val (intake, stream) = Conduit[Data]()
+          val before = intake.demand.count
+          intake.put(IArray[Byte](1, 2, 3))
+          val after = intake.demand.count
           before - after
         . assert(_ == 3L)
 
         test(m"conduit rethrows producer failure at the reader"):
-          val conduit = Conduit[Data]()
-          conduit.fail(RuntimeException("boom"))
+          val (intake, stream) = Conduit[Data]()
+          intake.fail(RuntimeException("boom"))
 
           try
-            conduit.stream.refill(Credit(1))
+            stream.refill(Credit(1))
             false
           catch case _: RuntimeException => true
         . assert(identity)
@@ -780,24 +780,24 @@ object Tests extends Suite(m"Zephyrine tests"):
     protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
     def mark: Int = mark1
 
-    def reserve(min: Int): Int =
+    update def reserve(min: Int): Int =
       val free = block - mark1
 
       if free >= min then free else
         drain()
         block
 
-    def commit(count: Int): Unit =
+    update def commit(count: Int): Unit =
       mark1 += count
       if mark1 == block then drain()
 
-    def finish(): Unit = drain()
+    update def finish(): Unit = drain()
 
-    def data: Data =
+    update def data: Data =
       drain()
       addressable.build(target)
 
-    private def drain(): Unit =
+    private update def drain(): Unit =
       if mark1 > 0 then
         addressable.cloneStorage(storage, 0, mark1)(target)
         mark1 = 0
@@ -849,7 +849,7 @@ object Tests extends Suite(m"Zephyrine tests"):
     def regulation: Credit is Regulation = summon[Credit is Regulation]
     def translate(demand: Credit): Credit = demand
 
-    def step
+    update def step
       ( source: input.Storage,
         sourceOffset: Int,
         sourceLength: Int,
@@ -863,23 +863,32 @@ object Tests extends Suite(m"Zephyrine tests"):
 
       Duct.Progress(count, count)
 
-    override def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
       if emitted then 0 else
         emitted = true
         output.storageUpdate(target, targetOffset, 99.toByte.asInstanceOf[output.Operand])
         1
 
   // Passes refills through unchanged, recording each demand it receives.
-  class Recorder(underlying: Stream[Data] over Credit) extends Stream[Data]:
+  class Recorder(consume underlying0: (Stream[Data] over Credit)^) extends Stream[Data]:
     type Transport = Credit
+
+    // The adopted stream is held through a neutral carrier: Stream is deliberately not
+    // Unscoped, so an exclusive field would be read-only; the accessor re-asserts the
+    // ownership this wrapper took at construction.
+    private val held: AnyRef = underlying0.asInstanceOf[AnyRef]
+    private def underlying: (Stream[Data] over Credit)^ =
+      held.asInstanceOf[(Stream[Data] over Credit)^]
 
     var demands: List[Long] = Nil
 
-    def refill(demand: Credit): Optional[Int] =
+    update def refill(demand: Credit): Optional[Int] =
       demands ::= demand.count
       underlying.refill(demand)
 
-    protected def window0: AnyRef = unsafely(underlying.window).asInstanceOf[AnyRef]
+    protected def window0: AnyRef =
+      val current = underlying
+      unsafely(current.window).asInstanceOf[AnyRef]
     def start: Int = underlying.start
     def limit: Int = underlying.limit
-    def skip(count: Int): Unit = underlying.skip(count)
+    update def skip(count: Int): Unit = underlying.skip(count)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -764,6 +764,33 @@ object Tests extends Suite(m"Zephyrine tests"):
             regulation.measured(Pace.Measured) )
         . assert(_ == ((0, true, true)))
 
+        test(m"foreachWindow visits every element in order across chunks"):
+          var collected: List[Byte] = Nil
+
+          Stream(Iterator(IArray[Byte](1, 2, 3), IArray[Byte](), IArray[Byte](4, 5)))
+          . foreachWindow: (storage, start, count) =>
+              val bytes = storage.asInstanceOf[Array[Byte]]
+              for index <- 0 until count do collected = bytes(start + index) :: collected
+
+          collected.reverse
+        . assert(_ == List[Byte](1, 2, 3, 4, 5))
+
+        test(m"memoize drains a byte stream into a single immutable value"):
+          Stream(Iterator(IArray[Byte](1, 2, 3), IArray[Byte](4, 5))).memoize.to(List)
+        . assert(_ == List[Byte](1, 2, 3, 4, 5))
+
+        test(m"memoize of an empty stream yields an empty value"):
+          Stream(Iterator.empty[Data]).memoize.to(List)
+        . assert(_ == List())
+
+        test(m"memoize reassembles a transformed pipeline"):
+          Stream(small).through(Doubler()).memoize.to(List)
+        . assert(_ == small.to(List).flatMap { byte => List(byte, byte) })
+
+        test(m"memoize drains a text stream into a single text value"):
+          Stream(Iterator(t"ab", t"cd", t"e")).memoize.s
+        . assert(_ == "abcde")
+
 
   // A byte intake that gathers everything written to it, with a configurable
   // reported demand, for asserting demand translation.

--- a/lib/zeppelin/src/core/zeppelin.Zip.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zip.scala
@@ -44,6 +44,7 @@ import prepositional.*
 import rudiments.*
 import serpentine.*
 import turbulence.*
+import zephyrine.*
 import vacuous.*
 
 object Zip:
@@ -144,6 +145,7 @@ object Zip:
           directory, comment)
 
     given streamable: Entry is Streamable by Data = _.contents
+    given source: Entry is Source by Data over Credit = entry => Stream(entry.contents.iterator)
 
   case class Entry
     ( ref:              Path on Zip,

--- a/lib/zeppelin/src/core/zeppelin.Zipfile.scala
+++ b/lib/zeppelin/src/core/zeppelin.Zipfile.scala
@@ -51,6 +51,7 @@ import rudiments.*
 import serpentine.*
 import spectacular.*
 import turbulence.*
+import zephyrine.*
 import vacuous.*
 
 object Zipfile:
@@ -58,6 +59,8 @@ object Zipfile:
   private val u16Max: Int  = 0xffff
 
   given streamable: Zipfile is Streamable by Data = _.serialize
+  given source: Zipfile is Source by Data over Credit = zipfile =>
+    Stream(zipfile.serialize.iterator)
 
   def write[path: Abstractable across Paths to Text]
     (path: path, prefix: Optional[Data] = Unset)(entries: Iterable[Zip.Entry])

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1265,3 +1265,36 @@ the `Showable` given hoists `val stream = request.body()` before `.lazyList`;
 `Http.emptyBody(): (Stream[Data] over Credit)^`. Ascribe vals holding SAM lambdas
 (`val body: Spring[Data] = () => ...`) or the val infers the raw function type
 and fails at use (obligatory.GrpcChannel).
+
+## LazyList-bridge removal: stage map (2026-07-11, in progress)
+
+DONE (committed 72ecfb4aaa, 34aac9e368): all whole-body `.lazyList.read[...]`
+reads → `memoize` (Http Showable/query, synesthesia dispatch, cordillera h2
+payload, wasi payload, telekinesis/scintillate/apoplexy tests); Postable.preview
+= one bounded refill + materialize (no full drain); apoplexy test Recorder takes
+`Spring[Data]^`; Spring/memoize/foreachWindow added to soundness umbrella exports
+(consume-extension export forwarders work — flowTo precedent; only dependent-
+typed ones need hand-written forwarders).
+
+REMAINING (each is a real refactor; convert one, compile, test, commit):
+1. `Http.Request.serialize` + `Response` wire form (Http.scala ~278/292/678):
+   return LazyList[Data] built from `request.body().lazyList` — the wire form
+   should become kernel-native (Stream^ or write-to-Intake); consumed by coaxial
+   Transmissible + jvm socket path. Content-Length probe forces ≤2 cells today.
+2. `Http.Body`: the `Streaming(LazyList[Data])` arm and `def stream: LazyList`
+   go away entirely once no consumer needs them (Flowing(Spring) is the native
+   arm; scintillate/perihelion/cordillera pattern-match Body cases).
+3. telekinesis_jvm:82 `bodyFn().lazyList.inputStream`: needs a kernel-native
+   `Stream[Data]^ → java.io.InputStream` adapter (read() pulls via
+   refill/window/skip) — natural home turbulence, next to httpBody.
+4. scintillate.Acceptable:62 `Multipart.parse(request.body().lazyList, _)`:
+   convert Multipart to cursor/stream parsing.
+5. perihelion.Websocket:236 `Reader(() => request.body().lazyList, channel)`.
+6. Source2.streamableData/Text + Sink2.writableData/Text (transitional givens
+   deriving Source from Streamable / Sink from Writable, turbulence.Source
+   .scala:183 / Sink.scala:191): delete once modules summon native instances —
+   this is the real "Streamable in 44 files" tail; measure per-module fallout.
+7. Delete both `lazyList` defs in turbulence_core (114, 185) + the bridge tests
+   (turbulence_test:538 "lazyList view drains", "Streamable instance is a
+   Source through the bridge"); then sweep any `Http.Body.Streaming` stragglers.
+Then dual gates: make attest (3.9) + 3.10 clean gate.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1334,3 +1334,16 @@ hallucination Raster; generic Streamable read-sites route via stream[Data] +
 the native LazyList Source. Receivable/successBody still LazyList-shaped via
 memoize — the remaining Streamable-tail (with Multipart cursor parsing and
 Duplex.stream receive side) is follow-up work, not bridge-blocking.
+
+## DUAL GATES GREEN (2026-07-11, @635fdc5546)
+
+attest (3.9 row): 7905 passed / 0 failed; attestation note pushed
+(refs/notes/ci-attestation @b2811a90f3). 3.10 row: clean-gate compile in
+cc-review (mill clean first — zinc false-greens bit three times today), 10457
+tasks green, only the benign aggregate finalMainClass non-task. Attest caught
+what per-module AND batched clean sweeps missed (monotonous read-only params,
+xylophone/graffiti Document reads, cacophony/gesticulate missing native Source,
+embarcadero duplex fixture) — per-module clean compile loops are the only
+locally trustworthy approximation, and even they missed embarcadero once.
+escritoire.test is pre-existing broken on main and outside the attest suite.
+PR next: title/body awaiting Jon.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1307,3 +1307,30 @@ checking." Execution order (bottom-up, compiling commits): coaxial
 Transmissible/transmit layer -> Http wire form (serialize/Response/Body) ->
 perihelion Channel -> scintillate/servlet/cordillera knock-ons -> delete
 lazyList defs + Source2/Sink2 + bridge tests -> dual gates.
+
+## Coaxial kernel-stream redesign executed (2026-07-11, commits c7c25a1903..4f22574f93)
+
+Jon's decisions delivered: Transmissible.serialize returns `(Stream[Data] over
+Credit)^` (one call = one message's wire form; framed transports memoize to one
+unit — UDP datagram, WS frame — byte transports foreachWindow zero-copy);
+Duplex.send takes a kernel stream; Http wire form kernel-native (Request
+probe-one-block for Content-Length vs chunked, empty chunks RETRIED never
+framed; Response framed via chunk iterators; Body.Streaming arm DELETED —
+Flowing(Spring) is the only streaming arm; Body.stream mints a kernel stream);
+websocket Channel is Conduit-backed (bounded => real backpressure; enqueue is
+synchronized multi-producer and FLUSHES per frame — the conduit otherwise
+buffers a block and interactive protocols deadlock; found via jcmd thread-dump);
+Reader.messages defers cursor construction (stream-backed Cursor refills
+EAGERLY at <init> — blocks on live sockets before the 101 goes out; the
+documented cursor-eager-refill gotcha). Stream.apply(iterator) now takes
+`Iterator[medium]^` returning `^{iterator, caps.any}` (iterator-backed streams
+retain their iterator's captures). Response keeps a PURE `body: Body` field —
+a Body^ field cascades ^ through copy/updateDynamic/read(this); the one
+capturing constructor (Response.parse's cursor spring) is sealed with the
+single-owner justification. BRIDGES DELETED: both lazyList views + Source2/
+Sink2; native Source instances added for hellenism Resource + classpath Path,
+Http.Response (raises HttpError on non-2xx), zeppelin Entry/Zipfile,
+hallucination Raster; generic Streamable read-sites route via stream[Data] +
+the native LazyList Source. Receivable/successBody still LazyList-shaped via
+memoize — the remaining Streamable-tail (with Multipart cursor parsing and
+Duplex.stream receive side) is follow-up work, not bridge-blocking.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1297,3 +1297,13 @@ committed 1157194e4b):
 4. Delete both `lazyList` defs in turbulence_core + bridge tests
    (turbulence_test:538 + "Streamable instance is a Source through the bridge").
 Then dual gates: make attest (3.9) + 3.10 clean gate.
+
+## Jon's design decisions for the wire-form finale (2026-07-11)
+
+Verbatim intent: the websocket Channel SHOULD be Conduit-backed, and
+Transmissible.serialize SHOULD return a `Stream^`. "Coaxial's design should be
+adapted to take full advantage of our new mutable streams and separation
+checking." Execution order (bottom-up, compiling commits): coaxial
+Transmissible/transmit layer -> Http wire form (serialize/Response/Body) ->
+perihelion Channel -> scintillate/servlet/cordillera knock-ons -> delete
+lazyList defs + Source2/Sink2 + bridge tests -> dual gates.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1237,3 +1237,31 @@ consume-to-consume argument forwarding is NOT admitted (neutral-carrier hop);
 `lazyList` seals INSIDE its definition (LazyList is pure — cannot carry the consumed
 stream's capture; `^` on LazyList is a case-2 error); enum payloads holding stream
 thunks type them `() => (Stream[...])^`.
+
+## Spring: fresh scoped results must come from methods, not lambdas (2026-07-11)
+
+Root cause of the telekinesis tail (P12, `p12-thunk-fresh-*.scala`): `Stream` is a
+SCOPED exclusive capability (ExclusiveCapability + Stateful, deliberately not
+Unscoped), and a lambda may not mint a fresh scoped capability as its result — the
+closure's per-call fresh is level-bound to the closure and "not visible from" the
+function type's existential result capture at the binder. So the thunk type
+`() => (Stream[Data] over Credit)^` is UNCONSTRUCTIBLE from any lambda that creates
+a stream (worked for Cursor earlier only because Cursor extends Mutable = Unscoped,
+which waives the level check). This is the level discipline working as designed —
+the same rule that rejects a `Stream^` escaping its scope — NOT a compiler bug.
+
+The legitimate fix: a named SAM trait whose METHOD returns the fresh stream — method
+results are re-leveled at each call site. `zephyrine.Spring[medium]`
+(`def apply(): (Stream[medium] over Credit)^`) replaced the thunk type everywhere
+(telekinesis Request.body / Body.Flowing / Http.Backend / HttpClient, galilei
+Handle.source, apoplexy, obligatory); `Postable.Streamer[content]` is the 1-arg
+analogue (`def stream(content): (Stream[Data] over Credit)^`) for Postable.apply's
+payload parameter. SAM conversion keeps every `() => Stream(...)` construction site
+compiling unchanged; `request.body()` call syntax unchanged via `apply`. In non-CC
+units (telekinesis.jvm/.wasi, like honeycomb.core) write bare `Spring[Data]`.
+
+Also fixed alongside: `Postable.stream`'s result was bare (= read-only) — now `^`;
+the `Showable` given hoists `val stream = request.body()` before `.lazyList`;
+`Http.emptyBody(): (Stream[Data] over Credit)^`. Ascribe vals holding SAM lambdas
+(`val body: Spring[Data] = () => ...`) or the val infers the raw function type
+and fails at use (obligatory.GrpcChannel).

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1276,25 +1276,24 @@ payload, wasi payload, telekinesis/scintillate/apoplexy tests); Postable.preview
 (consume-extension export forwarders work — flowTo precedent; only dependent-
 typed ones need hand-written forwarders).
 
-REMAINING (each is a real refactor; convert one, compile, test, commit):
-1. `Http.Request.serialize` + `Response` wire form (Http.scala ~278/292/678):
-   return LazyList[Data] built from `request.body().lazyList` — the wire form
-   should become kernel-native (Stream^ or write-to-Intake); consumed by coaxial
-   Transmissible + jvm socket path. Content-Length probe forces ≤2 cells today.
-2. `Http.Body`: the `Streaming(LazyList[Data])` arm and `def stream: LazyList`
-   go away entirely once no consumer needs them (Flowing(Spring) is the native
-   arm; scintillate/perihelion/cordillera pattern-match Body cases).
-3. telekinesis_jvm:82 `bodyFn().lazyList.inputStream`: needs a kernel-native
-   `Stream[Data]^ → java.io.InputStream` adapter (read() pulls via
-   refill/window/skip) — natural home turbulence, next to httpBody.
-4. scintillate.Acceptable:62 `Multipart.parse(request.body().lazyList, _)`:
-   convert Multipart to cursor/stream parsing.
-5. perihelion.Websocket:236 `Reader(() => request.body().lazyList, channel)`.
-6. Source2.streamableData/Text + Sink2.writableData/Text (transitional givens
-   deriving Source from Streamable / Sink from Writable, turbulence.Source
-   .scala:183 / Sink.scala:191): delete once modules summon native instances —
-   this is the real "Streamable in 44 files" tail; measure per-module fallout.
-7. Delete both `lazyList` defs in turbulence_core (114, 185) + the bridge tests
-   (turbulence_test:538 "lazyList view drains", "Streamable instance is a
-   Source through the bridge"); then sweep any `Http.Body.Streaming` stragglers.
+REMAINING (2026-07-11 end of leg; items 3,4,5 of the original list DONE —
+inputStream adapter committed 71aa56e032, websocket Reader + Multipart interim
+committed 1157194e4b):
+1. The Http wire-form cluster (the finale; single refactor): `Request.serialize`
+   (Http.scala ~275/289) and the Response wire form (~674) build LazyList[Data]
+   from `body().lazyList`; `Body.stream` (~485) is the LazyList accessor. The
+   Content-Length-vs-chunked probe pattern-matches the LazyList (forces <=2
+   cells); a kernel-native version pulls one block: stream ended -> fixed
+   length, else chunked with pulled block + remainder. But serialize RETURNING
+   LazyList inherently needs the seal - the honest fix changes serialize to
+   return (Stream[Data] over Credit)^ (or write to an Intake), which changes
+   coaxial Transmissible + scintillate/servlet/cordillera Body.stream callers,
+   and removes the Body.Streaming(LazyList) arm. Possibly worth Jon input on
+   the Transmissible shape.
+2. Multipart.parse cursor conversion (drops the interim memoize in
+   scintillate.Acceptable) - part of the Streamable tail.
+3. Source2.streamableData/Text + Sink2.writableData/Text transitional givens:
+   delete once modules summon native instances (the 44-file Streamable tail).
+4. Delete both `lazyList` defs in turbulence_core + bridge tests
+   (turbulence_test:538 + "Streamable instance is a Source through the bridge").
 Then dual gates: make attest (3.9) + 3.10 clean gate.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1217,3 +1217,23 @@ coaxial/galilei/hieroglyph/scintillate/telekinesis sweeps (same recipes), Phase 
 (borrow-based foreach/fold + freeze-based memoize on Stream^; combinators exist via the
 consume-typed through), full gates. LazyList-bridge REMOVAL deliberately deferred: needs
 Jon's API review (public break).
+
+## Phase 4/5 sweep: repo compiles except telekinesis (2026-07-11, sepcheck-kernel)
+
+Full `soundness.all` is green EXCEPT telekinesis.core (three small error classes left):
+1. `Request is Showable` given: lambda param needs the Request refinement ascription
+   (the class type now carries the body-thunk refinement).
+2. `() => Stream(cursor.remainder.iterator)` at Http.scala:386: fresh-in-thunk-result
+   admission ("any not visible from any² in method parse") — p11-family; likely needs a
+   named helper returning the thunk, or a rim.
+3. `Http.emptyBody()` result is bare (read-only) — needs `(Stream[Data] over Credit)^`.
+Then: apoplexy/scintillate knock-ons from the thunk-type sweep (`=> (Stream[Data] over
+Credit)^` swept across galilei/telekinesis/apoplexy), test suites, Phase 5 tests,
+LazyList-bridge removal (Jon approved; NOT yet started — Streamable in 44 files), gates.
+
+This leg's recipes: Producer factory results exclusive; serializer helpers take
+`Writer^`/`ProtobufPrinter^` (capability wrapper classes over their producers);
+consume-to-consume argument forwarding is NOT admitted (neutral-carrier hop);
+`lazyList` seals INSIDE its definition (LazyList is pure — cannot carry the consumed
+stream's capture; `^` on LazyList is a case-2 error); enum payloads holding stream
+thunks type them `() => (Stream[...])^`.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1188,3 +1188,32 @@ compiles all test sources together, where the implicit scope evidently differs. 
 regression from this branch or from fork fix #11 (which is thereby exonerated of
 CC-only-unit effects). Left as-is; flagged for a separate look at the per-module/umbrella
 implicit-scope divergence.
+
+## Phase 4 in flight: kernel re-parented and Conduit split (2026-07-11, branch sepcheck-kernel)
+
+zephyrine.core GREEN with the full Phase-4 kernel: Producer/Stream/Intake/Duct extend
+`ExclusiveCapability, Stateful` (capture-friendly — NOT Mutable: implementations capture
+iterators/queues/sockets) with honest update classification; Conduit is now a FACTORY
+returning `((Intake[medium] over Credit)^, (Stream[medium] over Credit)^)` over a private
+`SharedCapability` core (queue/atomics; volatiles untracked — JMM-managed);
+through/flowTo/accepting are consume-typed (Phase 5's pipeline semantics), with
+construction hoisted into `throughDuct`/`acceptingDuct` helpers whose consume PARAMETERS
+carry explicit sets — a local binding of the fresh duct would hide it from the anonymous
+class that wraps it (the statement rule); Ductile's `duct` takes `consume stage: Self^`.
+
+New workarounds proven this leg:
+- Overriding/implementing an update method requires RESTATING `update`.
+- Fresh stateful instances capturing evidence type as `^{evidence, caps.any}` results
+  (naming the evidence; hiding only their own state) — Sink.buffered, Source.stream.
+- Varargs of capabilities: follow the compiler's hint — capture-polymorphic
+  `[cap^](sources: (Stream[...])^{cap}*)` fixed Confluence's reach-leak; while-loops
+  instead of for-comprehensions (the desugared foreach closure captures the reach).
+- Collection/fiber rims carry `AnyRef` (the Conduit-queue precedent): Manifold's
+  subscribers and Confluence's per-fiber hand-offs.
+
+REMAINING for the next leg: ~10 errors in turbulence_core.scala (legacy LazyList-view
+sections: freeze-casts + flow sites), then zephyrine tests (Conduit pair destructure),
+coaxial/galilei/hieroglyph/scintillate/telekinesis sweeps (same recipes), Phase 5 surface
+(borrow-based foreach/fold + freeze-based memoize on Stream^; combinators exist via the
+consume-typed through), full gates. LazyList-bridge REMOVAL deliberately deferred: needs
+Jon's API review (public break).

--- a/rep/sepcheck-probes/p12-thunk-fresh-lambda.neg.scala
+++ b/rep/sepcheck-probes/p12-thunk-fresh-lambda.neg.scala
@@ -1,0 +1,22 @@
+// P12 (neg twin): a lambda whose body mints a fresh SCOPED capability cannot have
+// the function type `() => Stream^` — the closure's per-call fresh is level-bound to
+// the closure and is not visible from the binder's existential result capture. This
+// is the level discipline for scoped capabilities, not a bug: an Unscoped (Mutable)
+// class compiles in this position. The named-SAM shape (.pos twin) is the fix.
+//EXPECT: cannot flow into capture set
+//EXPECT: not visible from
+import language.experimental.captureChecking
+
+class Stream extends caps.ExclusiveCapability, caps.Stateful:
+  private var n: Int = 0
+  update def refill(): Int = { n += 1; n }
+
+def freshStream(): Stream^ = new Stream
+
+def request(flag: Boolean, body: () => Stream^): Int =
+  def loop(fn: () => Stream^, remaining: Int): Int =
+    if remaining <= 0 then 0 else
+      val nextBody: () => Stream^ =
+        if flag then fn else () => freshStream()
+      loop(nextBody, remaining - 1)
+  loop(body, 3)

--- a/rep/sepcheck-probes/p12-thunk-fresh-result.pos.scala
+++ b/rep/sepcheck-probes/p12-thunk-fresh-result.pos.scala
@@ -1,0 +1,34 @@
+// P12: promising a fresh SCOPED stateful result per call.
+// A lambda may not mint a fresh scoped capability as its result (see the .neg twin:
+// the closure's fresh is not visible from the function type's result capture at the
+// binder's level), but a METHOD may — its result is re-leveled at each call site.
+// So a named SAM trait admits everything the function type `() => Stream^` rejects,
+// while lambda construction sites still compile via SAM conversion.
+// This is the `zephyrine.Spring` / `Postable.Streamer` shape.
+import language.experimental.captureChecking
+
+class Stream extends caps.ExclusiveCapability, caps.Stateful:
+  private var n: Int = 0
+  update def refill(): Int = { n += 1; n }
+
+def freshStream(): Stream^ = new Stream
+
+trait BodySource:
+  def apply(): Stream^
+
+object Probe:
+  // SAM conversion from a lambda
+  val sam: BodySource = () => freshStream()
+
+  // anonymous class
+  val anon: BodySource = new BodySource:
+    def apply(): Stream^ = freshStream()
+
+  // each call yields a usable exclusive stream, at the caller's level
+  def use(flag: Boolean, body: BodySource): Int =
+    def loop(fn: BodySource, remaining: Int): Int =
+      if remaining <= 0 then 0 else
+        val next: BodySource = if flag then fn else sam
+        val s: Stream^ = next()
+        s.refill() + loop(next, remaining - 1)
+    loop(body, 3)


### PR DESCRIPTION
The zephyrine streaming kernel's endpoint types — `Stream`, `Intake`, `Duct` and `Producer` — are now scoped, stateful capabilities under separation checking, making single ownership of their mutable buffers a compile-time property rather than a convention. On top of that kernel, the LazyList views that bridged the old streaming world are deleted: coaxial, telekinesis, perihelion and every downstream consumer speak kernel streams natively.

## Release notes

- `Stream`, `Intake`, `Duct` and `Producer` are exclusive, stateful capabilities: their mutating operations are `update` methods, callable only through an exclusive (`^`) reference, and pipeline composition (`through`, `flowTo`, `accepting`) consumes its operands, so using an endpoint after piping it is now a compile error.
- `Conduit` is now a factory returning its two endpoints — `(Intake^, Stream^)` — since one object cannot soundly give two threads exclusive access.
- New terminal operations drain a stream without exposing its window: `foreachWindow` applies an operation to each successive window, and `memoize` materializes the stream into a single immutable, shareable value — the explicit replacement for a LazyList's implicit caching. A kernel-native `inputStream` view adapts a byte stream to JDK APIs.
- `zephyrine.Spring[medium]` names the "fresh stream per call" contract: a SAM trait whose method mints a new pull endpoint, used for HTTP bodies (`Http.Request.body`, `Http.Body.Flowing`), `galilei.Handle`, and anywhere a re-materializable stream is needed. Lambdas convert to it directly: `Http.Body.Flowing(() => Stream(data))`.
- `coaxial.Transmissible.serialize` returns a kernel stream: one call yields one message's wire form, so framed transports (UDP datagrams, WebSocket frames) memoize it into a single unit while byte-stream transports write through the window, zero-copy. `Duplex.send` likewise consumes a kernel stream.
- The HTTP wire form is kernel-native: `Http.Request.serialize` probes the body one block at a time to choose between `Content-Length` and chunked transfer encoding, and `Http.Body.Streaming(LazyList)` is gone — `Body.stream` mints a kernel stream.
- The websocket `Channel` is backed by a bounded `Conduit` instead of an unbounded spool, so a slow peer backpressures every producer; frames flush individually for prompt delivery.
- The transitional LazyList bridges are deleted: the `lazyList` views and the implicit derivation of `Source` from `Streamable` (and `Sink` from `Writable`). Types that relied on the derivation gained native `Source` instances: classpath `Resource` and `Path`, `Http.Response` (raising `HttpError` on non-2xx), `Zip.Entry`, `Zipfile`, `Raster`, `Audio` and multipart `Part`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
