### PR TITLE
Make errors pure so raising can never leak capabilities

### DIFF
--- a/lib/contingency/src/core/contingency.Accrual.scala
+++ b/lib/contingency/src/core/contingency.Accrual.scala
@@ -47,7 +47,7 @@ import fulminate.*
 object Accrual:
   // The `Tactic` injected into an `accrue` block: each covered error is folded into the accrual
   // rather than escaping; `accumulated`/`changed` report the result to `.protect`.
-  class AccrueTactic[error <: Exception, accrual <: Exception]
+  class AccrueTactic[error <: Hazard, accrual <: Hazard]
     ( initial: accrual, combine: (accrual, Exception) => accrual )
     ( using val diagnostics: Diagnostics )
   extends Tactic[error]:
@@ -67,7 +67,7 @@ object Accrual:
     def accumulated: accrual = ref.get().nn
     def changed: Boolean = ref.get().nn != initial
 
-  extension [accrual <: Exception, lambda[_]](inline accrual: Accrual[accrual, lambda])
+  extension [accrual <: Hazard, lambda[_]](inline accrual: Accrual[accrual, lambda])
     inline def protect[result](inline body: lambda[result])
       ( using outer: Tactic[accrual]^, diagnostics: Diagnostics )
     :   result =
@@ -82,7 +82,7 @@ object Accrual:
               'diagnostics )
         }
 
-class Accrual[accrual <: Exception, lambda[_]]
+class Accrual[accrual <: Hazard, lambda[_]]
   ( val handler: PartialFunction[Exception, Any],
     val initial: accrual,
     val combine: (accrual, Exception) => accrual )

--- a/lib/contingency/src/core/contingency.AmalgamateTactic.scala
+++ b/lib/contingency/src/core/contingency.AmalgamateTactic.scala
@@ -36,7 +36,7 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-class AmalgamateTactic[error <: Exception, success]
+class AmalgamateTactic[error <: Hazard, success]
   ( label: boundary.Label[success | error] )
   ( using Diagnostics )
 extends Tactic[error]:

--- a/lib/contingency/src/core/contingency.Attempt.scala
+++ b/lib/contingency/src/core/contingency.Attempt.scala
@@ -32,10 +32,12 @@
                                                                                                   */
 package contingency
 
+import fulminate.Hazard
+
 import language.experimental.pureFunctions
 
 
-enum Attempt[+success, +error <: Exception]:
+enum Attempt[+success, +error <: Hazard]:
   case Success(value: success)
   case Failure(value: error)
 
@@ -50,7 +52,7 @@ enum Attempt[+success, +error <: Exception]:
       case Success(success) => Success(lambda(success))
       case Failure(failure) => Failure(failure)
 
-  def handle(block: error ~> Exception): Attempt[success, Exception] =
+  def handle(block: error ~> Hazard): Attempt[success, Hazard] =
     this match
       case Success(value) => Success(value)
       case Failure(value) => Failure(if block.isDefinedAt(value) then block(value) else value)

--- a/lib/contingency/src/core/contingency.AttemptTactic.scala
+++ b/lib/contingency/src/core/contingency.AttemptTactic.scala
@@ -36,7 +36,7 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-class AttemptTactic[error <: Exception, success](label: boundary.Label[Attempt[success, error]])
+class AttemptTactic[error <: Hazard, success](label: boundary.Label[Attempt[success, error]])
   ( using Diagnostics )
 extends Tactic[error]:
   private given boundary.Label[Attempt[success, error]] = label

--- a/lib/contingency/src/core/contingency.Deferred.scala
+++ b/lib/contingency/src/core/contingency.Deferred.scala
@@ -32,9 +32,11 @@
                                                                                                   */
 package contingency
 
+import fulminate.Hazard
+
 import language.experimental.pureFunctions
 
 // Holds an unevaluated `Tactic[error] ?=> result` body; `apply()` re-evaluates it under whichever
 // `Tactic[error]` is in scope at the call, allowing late binding to different error handlers.
-final class Deferred[result, error <: Exception](body: Tactic[error]^ ?=> result):
+final class Deferred[result, error <: Hazard](body: Tactic[error]^ ?=> result):
   def apply()(using Tactic[error]^): result = body

--- a/lib/contingency/src/core/contingency.EitherTactic.scala
+++ b/lib/contingency/src/core/contingency.EitherTactic.scala
@@ -36,7 +36,7 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-class EitherTactic[error <: Exception, success](label: boundary.Label[Either[error, success]])
+class EitherTactic[error <: Hazard, success](label: boundary.Label[Either[error, success]])
   ( using Diagnostics )
 extends Tactic[error]:
   def diagnostics: Diagnostics = summon[Diagnostics]

--- a/lib/contingency/src/core/contingency.Emit.scala
+++ b/lib/contingency/src/core/contingency.Emit.scala
@@ -40,7 +40,7 @@ import fulminate.*
 object Emit:
   // Builds an `Emit` whose `record` simply runs `handler` as a side-effect at the emit point — the
   // basis of `handle`, where each covered error type gets an `Emit` backed by its case body.
-  def apply[error <: Exception](handler: error => Unit)(using diagnostics0: Diagnostics)
+  def apply[error <: Hazard](handler: error => Unit)(using diagnostics0: Diagnostics)
   :   Emit[error]^ =
 
     new Emit[error]:
@@ -60,12 +60,12 @@ object Emit:
 // flow into any scope. Combinators that retain the receiver and a user lambda — `contramap`,
 // `Emit.apply` — annotate their result with that capture set, exactly as `LzyList.map` returns
 // `^{xs, f}`.
-trait Emit[-error <: Exception] extends Findable, caps.ExclusiveCapability:
+trait Emit[-error <: Hazard] extends Findable, caps.ExclusiveCapability:
   private inline def emitter: this.type = this
   def diagnostics: Diagnostics
   def record(error: Diagnostics ?=> error): Unit
 
-  def contramap[error2 <: Exception](lambda: error2 => error)
+  def contramap[error2 <: Hazard](lambda: error2 => error)
   :   Emit[error2]^ =
 
     new Emit[error2]:

--- a/lib/contingency/src/core/contingency.Mitigable.scala
+++ b/lib/contingency/src/core/contingency.Mitigable.scala
@@ -32,8 +32,10 @@
                                                                                                   */
 package contingency
 
+import fulminate.Hazard
+
 trait Mitigable:
-  type Self <: Exception
-  type Result <: Exception
+  type Self <: Hazard
+  type Result <: Hazard
 
   def mitigate(tactic: Self): Result

--- a/lib/contingency/src/core/contingency.OptionalTactic.scala
+++ b/lib/contingency/src/core/contingency.OptionalTactic.scala
@@ -37,7 +37,7 @@ import language.experimental.pureFunctions
 import fulminate.*
 import vacuous.*
 
-class OptionalTactic[error <: Exception, success](label: boundary.Label[Optional[success]])
+class OptionalTactic[error <: Hazard, success](label: boundary.Label[Optional[success]])
 extends Tactic[error]:
   type Result = Optional[success]
   type Return = Optional[success]

--- a/lib/contingency/src/core/contingency.Recovery.scala
+++ b/lib/contingency/src/core/contingency.Recovery.scala
@@ -42,8 +42,15 @@ import fulminate.*
 // the protected block's result type. `recover { case FooError(n) => fallback }.protect { … }` runs
 // the block and, on the first covered error, escapes with the case body's value instead.
 object Recovery:
-  // A case body's recovered value, escaping the block via `boundary`.
-  final case class Escape[+result](value: result) extends Exception:
+  object Escape:
+    def apply[result](value: result): Escape[result] = new Escape(value.asInstanceOf[AnyRef])
+
+  // A case body's recovered value, escaping the block via `boundary`. Pure by an
+  // `AnyRef` rim: the payload never leaves a scope inside the exception — `record`
+  // unwraps it and escapes through the capture-checked `boundary.break` — so the
+  // briefcase carries it as a neutral reference between two frames of one call.
+  final class Escape[+result](private val value0: AnyRef) extends Exception, caps.Pure:
+    def value: result = value0.asInstanceOf[result]
     override def fillInStackTrace(): Throwable = this
 
   class EscapeTactic[result](label: boundary.Label[result]) extends Tactic[Escape[result]]:

--- a/lib/contingency/src/core/contingency.Tactic.scala
+++ b/lib/contingency/src/core/contingency.Tactic.scala
@@ -40,12 +40,12 @@ import fulminate.*
 // error` (`Tactic[error] ?=>`) is therefore the stronger obligation than `emits error`; code with a
 // `Tactic` can satisfy either, but a fire-and-forget context offering only an `Emit` cannot supply
 // the `abort` half. See [[Emit]].
-trait Tactic[-error <: Exception] extends Emit[error]:
+trait Tactic[-error <: Hazard] extends Emit[error]:
   private inline def tactic: this.type = this
   def abort(error: Diagnostics ?=> error): Nothing
   def certify(): Unit
 
-  override def contramap[error2 <: Exception](lambda: error2 => error)
+  override def contramap[error2 <: Hazard](lambda: error2 => error)
   :   Tactic[error2]^ =
 
     new Tactic[error2]:

--- a/lib/contingency/src/core/contingency.ThrowTactic.scala
+++ b/lib/contingency/src/core/contingency.ThrowTactic.scala
@@ -42,7 +42,7 @@ import fulminate.*
 // which really do capture their `Label`, remain scoped.
 // The `CanThrow` evidence lives on the `strategies` givens that mint throwing tactics, not on
 // the class: even an erased constructor parameter is a retained capture under capture checking.
-class ThrowTactic[error <: Exception, success]()
+class ThrowTactic[error <: Hazard, success]()
 extends Tactic[error], caps.Unscoped:
   def diagnostics: Diagnostics = Diagnostics.capture
 

--- a/lib/contingency/src/core/contingency.TrackTactic.scala
+++ b/lib/contingency/src/core/contingency.TrackTactic.scala
@@ -36,7 +36,7 @@ import language.experimental.pureFunctions
 
 import fulminate.*
 
-class TrackTactic[error <: Exception, accrual, result, supplement]
+class TrackTactic[error <: Hazard, accrual, result, supplement]
   ( label: boundary.Label[Option[result]], initial: accrual, foci: Foci[supplement] )
   ( using Diagnostics )
 extends Tactic[error]:

--- a/lib/contingency/src/core/contingency.Tracking.scala
+++ b/lib/contingency/src/core/contingency.Tracking.scala
@@ -37,7 +37,7 @@ import fulminate.*
 import vacuous.*
 
 object Tracking:
-  extension [accrual <: Exception, lambda[_], focus](inline track: Tracking[accrual, lambda, focus])
+  extension [accrual <: Hazard, lambda[_], focus](inline track: Tracking[accrual, lambda, focus])
     inline def protect[result](inline lambda: Foci[focus] ?=> lambda[result])
       ( using tactic: Tactic[accrual]^, diagnostics: Diagnostics )
     :   result =
@@ -47,6 +47,6 @@ object Tracking:
             ( 'track, 'lambda, 'tactic, 'diagnostics )
         }
 
-class Tracking[accrual <: Exception, lambda[_], focus]
+class Tracking[accrual <: Hazard, lambda[_], focus]
   ( val initial: accrual,
     val lambda:  (Optional[focus] aka "prior", accrual aka "accrual") ?=> Exception ~> accrual )

--- a/lib/contingency/src/core/contingency.UncheckedTactic.scala
+++ b/lib/contingency/src/core/contingency.UncheckedTactic.scala
@@ -40,7 +40,7 @@ import fulminate.*
 // (an erased obligation carried by `strategies.uncheckedErrors`, not retained here: even an erased
 // constructor parameter is a capture under capture checking). `caps.Unscoped`, like `ThrowTactic`:
 // it captures no scoped capability, so it may satisfy a `raises` requirement at any level.
-class UncheckedTactic[error <: Exception]() extends Tactic[error], caps.Unscoped:
+class UncheckedTactic[error <: Hazard]() extends Tactic[error], caps.Unscoped:
   given diagnostics: Diagnostics = errorDiagnostics.stackTracesDiagnostics
 
   def record(error: Diagnostics ?=> error): Unit =
@@ -56,7 +56,7 @@ class UncheckedTactic[error <: Exception]() extends Tactic[error], caps.Unscoped
 // A tactic that terminates the process with the error's exit status, for errors marked `Fatal`.
 // The `Fatal` evidence is an ordinary (untracked) typeclass instance, so retaining it does not
 // conflict with the `caps.Unscoped` classification.
-class FatalTactic[exception <: Exception]()(using fatal: exception is Fatal)
+class FatalTactic[exception <: Hazard]()(using fatal: exception is Fatal)
 extends Tactic[exception], caps.Unscoped:
   given diagnostics: Diagnostics = errorDiagnostics.stackTracesDiagnostics
 

--- a/lib/contingency/src/core/contingency.Validate.scala
+++ b/lib/contingency/src/core/contingency.Validate.scala
@@ -37,7 +37,7 @@ import fulminate.*
 import vacuous.*
 
 object Validate:
-  extension [accrual <: Exception, lambda[_],
+  extension [accrual <: Hazard, lambda[_],
     focus](inline validate: Validate[accrual, lambda, focus])
 
     inline def protect(inline lambda: Foci[focus] ?=> lambda[Any])(using diagnostics: Diagnostics)

--- a/lib/contingency/src/core/contingency.internal.scala
+++ b/lib/contingency/src/core/contingency.internal.scala
@@ -154,7 +154,7 @@ object internal:
       case other                              => List(other)
 
 
-  def track[accrual <: Exception: Type, focus: Type]
+  def track[accrual <: Hazard: Type, focus: Type]
     ( accrual: Expr[accrual],
       handler: Expr[(Optional[focus] aka "prior", accrual aka "accrual") ?=> Exception ~> accrual] )
   :   Macro[Tracking[accrual, ?, focus]] =
@@ -204,7 +204,7 @@ object internal:
           }
 
 
-  def trackWithin[accrual <: Exception: Type, context[_]: Type, result: Type, focus: Type]
+  def trackWithin[accrual <: Hazard: Type, context[_]: Type, result: Type, focus: Type]
     ( track:       Expr[Tracking[accrual, context, focus]],
       lambda:      Expr[Foci[focus] ?=> context[result]],
       tactic:      Expr[Tactic[accrual]],
@@ -255,7 +255,7 @@ object internal:
       }
 
 
-  def validateWithin[accrual <: Exception: Type, context[_]: Type, focus: Type]
+  def validateWithin[accrual <: Hazard: Type, context[_]: Type, focus: Type]
     ( validate:    Expr[Validate[accrual, context, focus]],
       lambda:      Expr[Foci[focus] ?=> context[Any]],
       diagnostics: Expr[Diagnostics] )
@@ -327,7 +327,7 @@ object internal:
       case '[type typeLambda[_]; typeLambda] => '{Mitigation[typeLambda]($handler)}
 
 
-  def accrueBuild[accrual <: Exception: Type]
+  def accrueBuild[accrual <: Hazard: Type]
     ( initial: Expr[accrual],
       combine: Expr[(accrual, Exception) => accrual],
       handler: Expr[PartialFunction[Exception, Any]] )
@@ -370,7 +370,7 @@ object internal:
 
         mapping[Exception](matches).keys.map: errorType =>
           errorType.typeRef.asType.absolve match
-            case '[type errorType <: Exception; errorType] =>
+            case '[type errorType <: Hazard; errorType] =>
               val handler = '{(error: errorType) => $partialFunction(error)}
               '{Emit($handler)(using $diagnostics)}.asTerm
 
@@ -394,7 +394,7 @@ object internal:
 
         mapping[Exception](matches).values.map: errorType =>
           errorType.typeRef.asType.absolve match
-            case '[type errorType <: Exception; errorType] =>
+            case '[type errorType <: Hazard; errorType] =>
               Expr.summon[Tactic[errorType]] match
                 case Some(errorTactic) =>
                   '{$errorTactic.contramap($partialFunction(_).asInstanceOf[errorType])}.asTerm
@@ -452,7 +452,7 @@ object internal:
       }
 
 
-  def accrueBody[accrual <: Exception: Type, context[_]: Type, result: Type]
+  def accrueBody[accrual <: Hazard: Type, context[_]: Type, result: Type]
     ( w:           Expr[Any],
       initial:     Expr[accrual],
       combine:     Expr[(accrual, Exception) => accrual],
@@ -472,8 +472,8 @@ object internal:
         halt(114, m"argument to `accrue` should be a partial function implemented as match cases")
 
     ' {
-        val acc: Accrual.AccrueTactic[Exception, accrual] =
-          Accrual.AccrueTactic[Exception, accrual]($initial, $combine)(using $diagnostics)
+        val acc: Accrual.AccrueTactic[Hazard, accrual] =
+          Accrual.AccrueTactic[Hazard, accrual]($initial, $combine)(using $diagnostics)
 
         val outcome: Either[accrual, result] =
           try Right:

--- a/lib/contingency/src/core/contingency_core.scala
+++ b/lib/contingency/src/core/contingency_core.scala
@@ -44,14 +44,14 @@ import prepositional.*
 import vacuous.*
 
 package strategies:
-  given throwUnsafely: [success] => (ThrowTactic[Exception, success]^) =
+  given throwUnsafely: [success] => (ThrowTactic[Hazard, success]^) =
     ThrowTactic()
 
-  given throwSafely: [error <: Exception: CanThrow, success] => (ThrowTactic[error, success]^) =
+  given throwSafely: [error <: Hazard: CanThrow, success] => (ThrowTactic[error, success]^) =
     ThrowTactic()
 
 
-  given mitigation: [error <: Exception, error2 <: Exception: Mitigable to error]
+  given mitigation: [error <: Hazard, error2 <: Hazard: Mitigable to error]
   =>  (tactic: Tactic[error]^)
   =>  ( Tactic[error2]^ ) =
 
@@ -61,17 +61,17 @@ package strategies:
   // Like `ThrowTactic`, these ambient strategies are `caps.Unscoped`: they capture no scoped
   // capability (they throw or terminate in place), so a use-site instantiation may flow into the
   // `raises` existential of a non-inline method result.
-  given fatalErrors: [exception <: Exception: Fatal] => (FatalTactic[exception]^) = FatalTactic()
+  given fatalErrors: [exception <: Hazard: Fatal] => (FatalTactic[exception]^) = FatalTactic()
 
-  given uncheckedErrors: [error <: Exception] => (erased unchecked: error is Unchecked)
+  given uncheckedErrors: [error <: Hazard] => (erased unchecked: error is Unchecked)
   =>  ( UncheckedTactic[error]^ ) =
 
     UncheckedTactic()
 
-def certify[error <: Exception](using tactic: Tactic[error]^)(): Unit = tactic.certify()
+def certify[error <: Hazard](using tactic: Tactic[error]^)(): Unit = tactic.certify()
 
 
-def raise[exception <: Exception]
+def raise[exception <: Hazard]
   ( error: Diagnostics ?=> exception )
   ( using emitter: Emit[exception]^ )
 :   Unit =
@@ -79,7 +79,7 @@ def raise[exception <: Exception]
   emitter.record(error)
 
 
-def abort[success, exception <: Exception](error: Diagnostics ?=> exception)
+def abort[success, exception <: Hazard](error: Diagnostics ?=> exception)
   ( using tactic: Tactic[exception]^ )
 :   Nothing =
 
@@ -92,7 +92,7 @@ def abort[success, exception <: Exception](error: Diagnostics ?=> exception)
 // that arrow's capture set cannot be reconciled with the block's expected type (the tactic is
 // created inside `safely`, after the block value). Collapsing the layers makes the block's result
 // the plain `success` value, which retains nothing.
-def safely[error <: Exception](using erased void: Void)[success]
+def safely[error <: Hazard](using erased void: Void)[success]
   ( block: (Diagnostics, OptionalTactic[error, success]^, CanThrow[Exception]) ?=> success )
 :   Optional[success] =
 
@@ -101,7 +101,7 @@ def safely[error <: Exception](using erased void: Void)[success]
   catch case error: Exception => Unset
 
 
-def unsafely[error <: Exception](using erased void: Void)[success]
+def unsafely[error <: Hazard](using erased void: Void)[success]
   ( block: (Unsafe, ThrowTactic[error, success]^, CanThrow[Exception]) ?=> success )
 :   success =
 
@@ -120,14 +120,14 @@ def unsafely[error <: Exception](using erased void: Void)[success]
       throw error
 
 
-def throwErrors[error <: Exception](using CanThrow[error])[success]
+def throwErrors[error <: Hazard](using CanThrow[error])[success]
   ( block: ThrowTactic[error, success]^ ?=> success )
 :   success =
 
   block(using ThrowTactic())
 
 
-def capture[error <: Exception: ClassTag](using erased void: Void)[success]
+def capture[error <: Hazard: ClassTag](using erased void: Void)[success]
   ( block: Tactic[error]^ ?=> success )
   ( using Tactic[ExpectationError[success]]^, Diagnostics )
 :   error =
@@ -145,7 +145,7 @@ def capture[error <: Exception: ClassTag](using erased void: Void)[success]
     case exception: Throwable => throw exception
 
 
-def attempt[error <: Exception](using erased void: Void)[success]
+def attempt[error <: Hazard](using erased void: Void)[success]
   ( block: AttemptTactic[error, success]^ ?=> success )
   ( using Diagnostics )
 :   Attempt[success, error] =
@@ -154,7 +154,7 @@ def attempt[error <: Exception](using erased void: Void)[success]
     Attempt.Success(block(using AttemptTactic(label)))
 
 
-def amalgamate[error <: Exception](using erased void: Void)[success]
+def amalgamate[error <: Hazard](using erased void: Void)[success]
   ( block: AmalgamateTactic[error, success]^ ?=> success )
   ( using Diagnostics )
 :   success | error =
@@ -172,7 +172,7 @@ def abortive[error <: Error](using Quotes)[success]
   block
 
 
-infix type raises [success, error <: Exception] = Tactic[error]^ ?=> success
+infix type raises [success, error <: Hazard] = Tactic[error]^ ?=> success
 
 // `raising` cannot replace `raises` until a Scala 3 compiler bug is fixed: when this match type
 // appears in a method's return type and reduces to a context function, PostTyper attaches
@@ -189,7 +189,7 @@ infix type raising[success, errors] = errors match
   case left *: right   => Tactic[left] ?=> raising[success, right]
   case _               => Tactic[errors] ?=> success
 
-infix type mitigates [error <: Exception, error2 <: Exception] =
+infix type mitigates [error <: Hazard, error2 <: Hazard] =
   error2 is Mitigable to error
 
 infix type tracks [result, focus] = Foci[focus] ?=> result
@@ -209,7 +209,7 @@ inline def focus[focus, result](using foci: Foci[focus])
 inline def accrual[value](using value: value aka "accrual"): value = value()
 
 
-transparent inline def track[focus](using erased void: Void)[accrual <: Exception](accrual: accrual)
+transparent inline def track[focus](using erased void: Void)[accrual <: Hazard](accrual: accrual)
   ( inline block: (Optional[focus] aka "prior", accrual aka "accrual") ?=> Exception ~> accrual )
 :   Tracking[accrual, ?, focus] =
 
@@ -224,7 +224,7 @@ transparent inline def validate[focus](using erased void: Void)[accrual](accrual
 
 
 extension [element](sequence: Iterable[element])
-  transparent inline def survive[result](using erased void: Void)[error <: Exception]
+  transparent inline def survive[result](using erased void: Void)[error <: Hazard]
     ( lambda
     : (OptionalTactic[error, result], Diagnostics, CanThrow[Exception]) ?=> element => result )
   :   Iterable[result] =
@@ -233,11 +233,11 @@ extension [element](sequence: Iterable[element])
 
 
 extension [value](optional: Optional[value])
-  def lest[success, error <: Exception](error: Diagnostics ?=> error)(using Tactic[error]^): value =
+  def lest[success, error <: Hazard](error: Diagnostics ?=> error)(using Tactic[error]^): value =
     optional.or(abort(error))
 
 
-  def dare[error <: Exception](using erased void: Void)[success]
+  def dare[error <: Hazard](using erased void: Void)[success]
     ( block
     : (Diagnostics, OptionalTactic[error, success]^, CanThrow[Exception]) ?=> value => success )
   :   Optional[success] =
@@ -247,7 +247,7 @@ extension [value](optional: Optional[value])
     catch case error: Exception => Unset
 
 
-def defer[result, error <: Exception](body: Tactic[error]^ ?=> result)
+def defer[result, error <: Hazard](body: Tactic[error]^ ?=> result)
 :   Deferred[result, error]^{body} =
 
   Deferred(body)
@@ -261,7 +261,7 @@ transparent inline def mitigate(inline handler: PartialFunction[Exception, Any])
   ${contingency.internal.mitigateBuild('handler)}
 
 
-transparent inline def accrue[accrual <: Exception](initial: accrual)
+transparent inline def accrue[accrual <: Hazard](initial: accrual)
   ( combine: (accrual, Exception) => accrual )
   ( inline handler: PartialFunction[Exception, Any] )
 :   Accrual[accrual, ?] =

--- a/lib/distillate/src/core/distillate.Extractable.scala
+++ b/lib/distillate/src/core/distillate.Extractable.scala
@@ -37,12 +37,13 @@ import scala.reflect.*
 
 import anticipation.*
 import contingency.*
+import fulminate.Hazard
 import prepositional.*
 import vacuous.*
 
 object Extractable:
   given decodable: [text <: Text, result]
-  =>  ( decodable: Tactic[Exception]^ ?=> result is Decodable in Text )
+  =>  ( decodable: Tactic[Hazard]^ ?=> result is Decodable in Text )
   =>  text is Extractable to result =
 
     // Laundered pure: the retained context function shares the instance's given-resolution

--- a/lib/distillate/src/core/distillate.Requirable.scala
+++ b/lib/distillate/src/core/distillate.Requirable.scala
@@ -34,11 +34,12 @@ package distillate
 
 import anticipation.*
 import contingency.*
+import fulminate.Hazard
 import prepositional.*
 import vacuous.*
 
 object Requirable:
-  given decodable: [value] => (decodable: Tactic[Exception]^ ?=> value is Decodable in Text)
+  given decodable: [value] => (decodable: Tactic[Hazard]^ ?=> value is Decodable in Text)
   =>  value is Requirable =
 
     // The `Decodable` is resolved against `throwUnsafely` (a label-free tactic) rather than the

--- a/lib/fulminate/src/core/fulminate.Error.scala
+++ b/lib/fulminate/src/core/fulminate.Error.scala
@@ -34,6 +34,12 @@ package fulminate
 
 import anticipation.*
 
+// The domain of raisable values: any pure exception. `Error` is pure by
+// inheritance, so every Soundness error is a `Hazard`; a JDK exception must be
+// wrapped in an `Error` (e.g. by `Error(throwable)`) to be raised, since
+// purity cannot be established for arbitrary `Throwable` subclasses.
+type Hazard = Exception & caps.Pure
+
 object Error:
   def apply(throwable: Throwable): Error = throwable match
     case error: Error         => error
@@ -42,7 +48,12 @@ object Error:
 transparent abstract class Error(val d: Int, val e: Int)
   ( val message: Message, private val cause: Throwable | Null )
   ( using val diagnostics: Diagnostics )
-extends Exception(message.text.s, cause, false, diagnostics.captureStack):
+// `caps.Pure`: an error may never hold a live capability. `throw` is the one
+// channel capture checking cannot see (an exception caught outside a scope
+// arrives with its captures erased), so purity here guarantees that no error —
+// raised, recorded, aborted or thrown — can smuggle a capability out of the
+// scope that confines it.
+extends Exception(message.text.s, cause, false, diagnostics.captureStack), caps.Pure:
   this: Error =>
 
   def this(d: Int, e: Int)(message: Message)(using Diagnostics) =

--- a/lib/fulminate/src/core/soundness_fulminate_core.scala
+++ b/lib/fulminate/src/core/soundness_fulminate_core.scala
@@ -34,7 +34,8 @@ package soundness
 
 export
   fulminate
-  . { Clarification, Communicable, communicate, Diagnostics, Error, EscapeError, halt, m, Message,
+  . { Clarification, Communicable, communicate, Diagnostics, Error, EscapeError, halt, Hazard, m,
+      Message,
       Panic, panic, TextEscapes, UncheckedError, warn }
 
 package errorDiagnostics:

--- a/lib/obligatory/src/grpc/obligatory.grpcInternal.scala
+++ b/lib/obligatory/src/grpc/obligatory.grpcInternal.scala
@@ -92,7 +92,7 @@ object grpcInternal:
 
           // The call's error capabilities are captured from the `remote` call site, so
           // the derived methods can have the interface's plain (raises-free) signatures.
-          def tactic[error <: Exception: Type]: Expr[Tactic[error]] =
+          def tactic[error <: Hazard: Type]: Expr[Tactic[error]] =
             Expr.summon[Tactic[error]].getOrElse:
               halt(m"a contextual ${TypeRepr.of[Tactic[error]].show} instance is required")
 

--- a/lib/parasite/src/core/parasite.AsyncTactic.scala
+++ b/lib/parasite/src/core/parasite.AsyncTactic.scala
@@ -44,7 +44,7 @@ import unsafeExceptions.canThrowAny
 // `boundary.Label`, so it is safe to invoke on the forked worker thread: both `record` and `abort`
 // simply throw the pure error. The worker's `try`/`catch` then stores it as `Fulfillment.Failed`,
 // whence it is delivered — still typed — at the join (`Task#await`) or to the trap (`Probate`).
-class AsyncTactic[error <: Exception]() extends Tactic[error]:
+class AsyncTactic[error <: Hazard]() extends Tactic[error]:
   def diagnostics: Diagnostics = Diagnostics.capture
   def record(error: Diagnostics ?=> error): Unit = throw error(using diagnostics)
   def abort(error: Diagnostics ?=> error): Nothing = throw error(using diagnostics)

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -248,13 +248,13 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
   // `Tactic[error | AsyncError]`. `error` is reconstructed by an unchecked cast that is sound for
   // any failure raised through the body's `AsyncTactic` (the only typed-error path); a genuinely
   // unchecked throwable from the body flows through as the raw `join` would have rethrown it.
-  def deliver[error <: Exception]()(using Tactic[error | AsyncError]^): Result =
+  def deliver[error <: Hazard]()(using Tactic[error | AsyncError]^): Result =
     promise.attend()
     thread.join()
     fulfilment()
 
 
-  def deliver[error <: Exception, abstractable: Abstractable across Durations to Long]
+  def deliver[error <: Hazard, abstractable: Abstractable across Durations to Long]
     ( duration: abstractable )
     ( using Tactic[error | AsyncError]^ )
   :   Result =
@@ -265,7 +265,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
     fulfilment()
 
 
-  private def fulfilment[error <: Exception]()(using Tactic[error | AsyncError]^): Result =
+  private def fulfilment[error <: Hazard]()(using Tactic[error | AsyncError]^): Result =
     state.updateAndGet:
       case Completed(duration, result) => Delivered(duration, result)
       case Delivered(duration, result) => Delivered(duration, result)
@@ -316,7 +316,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
       // installed nearby. This runs before the promise is settled below, so anything attending the
       // worker observes completion only once the trap has run. An error no trap accepts becomes an
       // `escalation`: rethrown after settling, reaching this thread's uncaught-exception handler
-      // (`Fault`, or the JVM default), so that it is never silently dropped.
+      // (`Hazard`, or the JVM default), so that it is never silently dropped.
       def remedy(error: Error): Optional[Throwable] = probate.trap(this, error) match
         case Remedy.Accept          => Unset
         case Remedy.Reject          => error

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -37,6 +37,7 @@ import language.experimental.pureFunctions
 
 import anticipation.*
 import contingency.*
+import fulminate.Hazard
 import digression.*
 import mercator.*
 import nomenclature.*
@@ -44,7 +45,7 @@ import prepositional.*
 import vacuous.*
 
 object Task:
-  def apply[result, error <: Exception](evaluate: Worker => result, name: Optional[Name[Async]])
+  def apply[result, error <: Hazard](evaluate: Worker => result, name: Optional[Name[Async]])
     ( using monitor: Monitor^, codepoint: Codepoint, probate: Probate^ )
   :   Task[result] { type Error = error } =
 
@@ -106,7 +107,7 @@ object Task:
 // `await`, where it is delivered through the caller's in-scope `Tactic`. `AsyncError` (cancellation
 // or timeout) is always a possible outcome, so it is added at the `await` site, not the member.
 trait Task[+result]:
-  type Error <: Exception
+  type Error <: Hazard
 
   def ready: Boolean
   def attend(): Unit

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -88,7 +88,7 @@ transparent inline def monitor: Monitor^ = infer[Monitor^]
 // over an outer one. So, like `async`, the daemon supplies its own label-free `AsyncTactic` rather
 // than letting the body capture an ambient `Emit`; a raised error fails the worker and reaches the
 // nearest `contain`/`Probate`.
-def daemon[error <: Exception](using Codepoint)
+def daemon[error <: Hazard](using Codepoint)
   ( evaluate: (Worker, Tactic[error]) ?->{} Unit )
   ( using Monitor^, Probate^ )
 :   Daemon =
@@ -115,7 +115,7 @@ def contain(handler: PartialFunction[Error, Remedy]^)(using outer: Probate^): Co
 // the side-effect obligation `Emit[error] ?=> X` — the weaker sibling of `raises error`
 // (`Tactic[error] ?=>`). The `Task` branch reduces to a refinement, not a context function, so it
 // avoids the match-type-in-return-position erasure crash documented on `raising`.
-infix type emits[left, error <: Exception] = left match
+infix type emits[left, error <: Hazard] = left match
   case Task[?] => left { type Error <: error }
   case _       => Emit[error] ?=> left
 
@@ -124,7 +124,7 @@ infix type emits[left, error <: Exception] = left match
 // `raises`, and carried in the task's `Error` member so it can be delivered, still typed, at the
 // join. The body is evaluated with an `AsyncTactic[error]` that records a raised error as the
 // worker's `Failed` outcome instead of trying to break a stack-confined `boundary` across threads.
-def async[result, error <: Exception](using Codepoint)
+def async[result, error <: Hazard](using Codepoint)
   ( evaluate: (Worker, Tactic[error]) ?=> result )
   ( using monitor: Monitor^, probate: Probate^ )
 :   Task[result] emits (error | AsyncError) =
@@ -133,7 +133,7 @@ def async[result, error <: Exception](using Codepoint)
   Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = Unset)
 
 
-def task[result, error <: Exception](using Codepoint)(name: Name[Async])
+def task[result, error <: Hazard](using Codepoint)(name: Name[Async])
   ( evaluate: (Worker, Tactic[error]) ?=> result )
   ( using monitor: Monitor^, probate: Probate^ )
 :   Task[result] emits (error | AsyncError) =

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -37,6 +37,7 @@ import java.security.SecureRandom
 import anticipation.*
 import coaxial.*
 import contingency.*
+import fulminate.Hazard
 import distillate.*
 import gastronomy.*
 import gigantism.*
@@ -108,11 +109,11 @@ given transmissible: [transport, value]
 
 // The decode direction. The `Decodable in Text`/`in transport` instances are
 // `Tactic`-conditional and don't resolve as nested given constraints, so we
-// require a `Tactic[Exception]` directly (satisfied by `strategies.throwUnsafely`;
+// require a `Tactic[Hazard]` directly (satisfied by `strategies.throwUnsafely`;
 // `Tactic` is contravariant) and summon them in the body, where it is in scope.
 given ingressive: [transport, value]
 =>  ( format: transport is Decodable in Text, codec: value is Decodable in transport )
-=>  ( CharDecoder, Tactic[Exception] )
+=>  ( CharDecoder, Tactic[Hazard] )
 =>  (value over transport) is Ingressive =
   bytes => codec.decoded(format.decoded(bytes.text)).over[transport]
 

--- a/lib/telekinesis/src/core/telekinesis.Submission.scala
+++ b/lib/telekinesis/src/core/telekinesis.Submission.scala
@@ -34,6 +34,7 @@ package telekinesis
 
 import anticipation.*
 import contingency.*
+import fulminate.Hazard
 import distillate.*
 import honeycomb.*
 import legerdemain.*
@@ -45,11 +46,11 @@ import doms.html.whatwg, whatwg.*
 case class Submission[value](query: Optional[Query]):
   def fresh: Boolean = query.absent
 
-  def optional(using Tactic[Exception] ?=> value is Decodable in Query): Optional[value] =
+  def optional(using Tactic[Hazard] ?=> value is Decodable in Query): Optional[value] =
     safely(query.let(_.decode[value]))
 
   def submitted: Boolean = query.present
-  def valid(using Tactic[Exception] ?=> value is Decodable in Query): Boolean = optional.present
+  def valid(using Tactic[Hazard] ?=> value is Decodable in Query): Boolean = optional.present
   def value(using value is Decodable in Query): Optional[value] = query.let(_.decode[value])
 
 

--- a/lib/telekinesis/src/core/telekinesis_core2.scala
+++ b/lib/telekinesis/src/core/telekinesis_core2.scala
@@ -36,6 +36,7 @@ import language.dynamics
 
 import anticipation.*
 import contingency.*
+import fulminate.Hazard
 import distillate.*
 import honeycomb.*
 import legerdemain.*
@@ -51,7 +52,7 @@ class Orchestrate[value: Encodable in Query, result](initial: Optional[value] = 
   ( process: (form: Text => Html of Flow) => Optional[value] ->{form, caps.any} result )
 extends caps.ExclusiveCapability:
   def otherwise(validate: (query: Query) ?=> Validation)(using Formulation, value is Formulaic)
-    ( using decodable: Tactic[Exception] ?=> value is Decodable in Query )
+    ( using decodable: Tactic[Hazard] ?=> value is Decodable in Query )
     ( using request: Http.Request )
   :   result raises QueryError =
 

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -40,7 +40,7 @@ import anticipation.Data
 import anticipation.Text
 import contingency.*
 import denominative.*
-import fulminate.Diagnostics
+import fulminate.{Diagnostics, Hazard}
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -256,7 +256,7 @@ object Cursor:
   // compiles to a single primitive `int == int`.
   extension [cap^](cursor: Cursor[Data, cap])
     @targetName("expectByte")
-    inline def expect[error <: Exception](target: Char)
+    inline def expect[error <: Hazard](target: Char)
       ( inline failure: Diagnostics ?=> error )
       ( using Tactic[error] )
     :   Unit =
@@ -265,7 +265,7 @@ object Cursor:
 
   extension [cap^](cursor: Cursor[Text, cap])
     @targetName("expectChar")
-    inline def expect[error <: Exception](target: Char)
+    inline def expect[error <: Hazard](target: Char)
       ( inline failure: Diagnostics ?=> error )
       ( using Tactic[error] )
     :   Unit =

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -527,7 +527,7 @@ object Tests extends Suite(m"Zephyrine tests"):
 
       suite(m"expect tests"):
         import strategies.throwUnsafely
-        case class Mismatch() extends Exception
+        case class Mismatch()(using Diagnostics) extends Error(m"mismatch")
 
         test(m"Cursor[Data].expect matching advances past the target"):
           val cursor = Cursor[Data](Iterator(Data('a'.toByte, 'b'.toByte)))

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1347,3 +1347,25 @@ embarcadero duplex fixture) — per-module clean compile loops are the only
 locally trustworthy approximation, and even they missed embarcadero once.
 escritoire.test is pre-existing broken on main and outside the attest suite.
 PR next: title/body awaiting Jon.
+
+## Pure errors: Hazard = Exception & caps.Pure (2026-07-11, branch pure-errors)
+
+Jon's directive: values passed to record/raise MUST be pure, so errors can never
+smuggle capabilities out of scopes through `throw` — the one channel capture
+checking cannot see. P13 probes (both rows green) established that `caps.Pure`
+enforcement is REAL: a Pure subclass with a capability field is rejected with
+E223 ("not included in the allowed capture set {} of the self type").
+
+Design: `fulminate.Error extends caps.Pure` (every Soundness error is pure by
+inheritance), and `fulminate.Hazard = Exception & caps.Pure` names the raisable
+domain — the bound on Tactic/Emit/raise/abort/lest/Attempt/raises and every
+tactic class ("Fault" was taken by parasite's uncaught-task pair). JDK
+exceptions must be wrapped (`Error(throwable)`) to be raised. Macro internals:
+caseDefs/mapping (handler ANALYSIS on PartialFunction[Exception, _]) keep
+Exception bounds; tactic-CONSTRUCTING sites use Hazard. Recovery.Escape (the
+recover-value briefcase) is pure via an AnyRef rim — its payload never leaves a
+scope inside the exception; record unwraps it and escapes through the
+capture-checked boundary.break. throwUnsafely: ThrowTactic[Hazard, success].
+Sweep fallout was small: 13 bounds outside contingency (parasite/zephyrine/
+obligatory), 7 Tactic[Exception]→Tactic[Hazard] sites, one raw test exception
+(zephyrine Mismatch → Error). Suites green incl. contingency 91/parasite 148.

--- a/rep/sepcheck-probes/p13-pure-error-field.neg.scala
+++ b/rep/sepcheck-probes/p13-pure-error-field.neg.scala
@@ -1,0 +1,14 @@
+// P13 (neg twin 1): the load-bearing enforcement test. A Pure subclass may not
+// hold a capability-typed field: if the compiler admitted this, `throw` would
+// remain a capability-exfiltration channel and Error-purity would be mere
+// documentation.
+//EXPECT: (non-pure|impure|Pure|pure)
+import language.experimental.captureChecking
+
+class Stream extends caps.ExclusiveCapability, caps.Stateful:
+  private var n: Int = 0
+  update def refill(): Int = { n += 1; n }
+
+transparent abstract class Error(val message: String) extends Exception(message), caps.Pure
+
+class SneakyError(val stream: Stream^) extends Error("smuggling")

--- a/rep/sepcheck-probes/p13-pure-error.pos.scala
+++ b/rep/sepcheck-probes/p13-pure-error.pos.scala
@@ -1,0 +1,22 @@
+// P13: a Pure error hierarchy. `Error extends caps.Pure` makes every subtype's
+// values pure, so an exception can never carry a live capability out of a scope
+// through `throw`/`raise` — the one channel capture checking cannot see.
+// Verifies: (a) a Pure error subtype with pure fields compiles and is raisable
+// through a purity-bounded entry point; (b) generic payloads of pure types work.
+import language.experimental.captureChecking
+
+transparent abstract class Error(val message: String) extends Exception(message), caps.Pure
+
+class ParseError(line: Int, char: Char) extends Error(s"parse error at $line")
+class AggregateError[error <: Error](val errors: List[error])
+extends Error(s"${errors.length} errors")
+
+trait Tactic[-error <: Exception]:
+  def abort(error: error): Nothing
+
+def raise[error <: Exception & caps.Pure](error: error)(using tactic: Tactic[error]): Nothing =
+  tactic.abort(error)
+
+def use(using Tactic[ParseError], Tactic[AggregateError[ParseError]]): Int =
+  if math.abs(-1) > 0 then raise(ParseError(1, 'x'))
+  else raise(AggregateError(List(ParseError(2, 'y'))))

--- a/rep/sepcheck-probes/p13-pure-raise.neg.scala
+++ b/rep/sepcheck-probes/p13-pure-raise.neg.scala
@@ -1,0 +1,20 @@
+// P13 (neg twin 2): a purity-bounded raise rejects a capability-carrying
+// exception type even when the hierarchy is not Pure — the entry-point
+// requirement stands on its own.
+//EXPECT: (does not conform|bounds|Pure)
+import language.experimental.captureChecking
+
+class Stream extends caps.ExclusiveCapability, caps.Stateful:
+  private var n: Int = 0
+  update def refill(): Int = { n += 1; n }
+
+class LeakyException(val stream: Stream^) extends Exception("leak")
+
+trait Tactic[-error <: Exception]:
+  def abort(error: error): Nothing
+
+def raise[error <: Exception & caps.Pure](error: error)(using tactic: Tactic[error]): Nothing =
+  tactic.abort(error)
+
+def use(stream: Stream^)(using Tactic[Exception & caps.Pure]): Int =
+  raise(LeakyException(stream))


### PR DESCRIPTION
Errors are now pure: `fulminate.Error` extends `caps.Pure`, so no error subtype may hold a live capability, and the new `Hazard` type bounds everything that can be recorded or raised. This closes the one channel capture checking cannot see — `throw` erases capture information at the JVM boundary, so an exception caught outside a scope was previously a working capability exfiltrator. Now an error declaring a capability field is rejected at its definition, and anything reaching `record`/`raise`/`abort` is pure by construction.

## Release notes

- `fulminate.Error` extends `caps.Pure`: an error type may only hold pure data. Declaring an error with a capability-typed field is now a compile error, so no raised, recorded, aborted or thrown Soundness error can smuggle a capability out of the scope that confines it.
- `fulminate.Hazard` names the domain of raisable values: `Exception & caps.Pure`. Every Soundness error is a `Hazard` by inheritance; a JDK exception must be wrapped in an `Error` (for example with `Error(throwable)`) to be raised.
- `Tactic`, `Emit`, `raise`, `abort`, `lest`, `Attempt`, `raises` and the tactic strategies are all bounded by `Hazard` instead of `Exception`. Existing code raising Soundness errors compiles unchanged; only code that raised raw JDK exceptions needs to wrap them.
- `strategies.throwUnsafely` is now a `ThrowTactic[Hazard, success]`, and generic error-typed APIs across parasite (`Task`, `async`, `daemon`, `emits`), zephyrine (`Cursor.expect`) and distillate adopt the `Hazard` bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
