### PR TITLE
Make WitError a fulminate Error

### DIFF
--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -157,7 +157,7 @@ package httpBackends:
       val responseHandle =
         try future.get.invoke[Optional[WitHandle of "incoming-response"]].or:
           abort(ConnectError(ConnectError.Reason.Unknown))
-        catch case error: RuntimeException => abort(ConnectError(ConnectError.Reason.Unknown))
+        catch case error: WitError => abort(ConnectError(ConnectError.Reason.Unknown))
 
       futureHandle.dispose()
       val response: Foreign of "incoming-response" from Wit = responseHandle
@@ -186,7 +186,7 @@ package httpBackends:
       try
         while true do
           chunks = stream.`blocking-read`(U64(65536L.bits)).invoke[Data] :: chunks
-      catch case error: RuntimeException => ()
+      catch case error: WitError => ()
 
       streamHandle.dispose()
       bodyHandle.dispose()

--- a/lib/turbulence/src/wasi/turbulence_wasi.scala
+++ b/lib/turbulence/src/wasi/turbulence_wasi.scala
@@ -102,7 +102,7 @@ package stdios:
               index += 1
 
             if data.length == 0 then -1 else data.length
-          catch case error: RuntimeException => -1
+          catch case error: WitError => -1
           finally handle.dispose()
 
     def bytes(text: Text): Data = text.s.getBytes("UTF-8").nn.immutable(using Unsafe)

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -232,9 +232,12 @@ object WasmInvoke:
             Select.unique(cast, "value").asExprOf[Any]
 
           // An `Err` raises a `WitError` carrying the error value (e.g. an `error-code` case), so
-          // callers can recover which failure occurred (`WitError.name`) and translate it.
+          // callers can recover which failure occurred (`WitError.name`) and translate it. The
+          // `canThrowAny` import supplies the `CanThrow` capability a checked `throw` needs in
+          // the expansion.
           def raiseError(outcome: Expr[Any]): Expr[Nothing] =
-            '{throw new WitError(${payload(outcome, errType)})}
+            '{  import _root_.scala.unsafeExceptions.canThrowAny
+                throw new WitError(${payload(outcome, errType)})  }
 
           val decode: Expr[Any] => Expr[Any] =
             if scala =:= TypeRepr.of[Unit] then call =>

--- a/lib/xenophile/src/wasm/xenophile.WitError.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitError.scala
@@ -33,16 +33,24 @@
 package xenophile
 
 import anticipation.*
+import fulminate.*
 import gossamer.*
+
+object WitError:
+  // The failing case's lower-kebab-case name (as a `WitCase` would spell it), recovered from the
+  // error value's class.
+  private def nameOf(value: Any): Text =
+    val simple = value.getClass.getSimpleName.nn.tt
+    val stripped = if simple.ends(t"$$") then simple.skip(1, Rtl) else simple
+    stripped.uncamel.kebab
 
 // The `err` arm of a WIT `result<…>`, raised by `invoke`'s decoder. The error value (e.g. a case
 // of `wasi:filesystem`'s `error-code`) is held untyped, so this module never names its
 // (Wasm-only) class; `name` recovers which case it is — the case's lower-kebab-case name, as a
 // `WitCase` would spell it — so callers can translate failures into their own error vocabulary.
-class WitError(val value: Any) extends RuntimeException:
-  def name: Text =
-    val simple = value.getClass.getSimpleName.nn.tt
-    val stripped = if simple.ends(t"$$") then simple.skip(1, Rtl) else simple
-    stripped.uncamel.kebab
+// Raised from generated code, where no `Diagnostics` can be summoned, so it supplies its own.
+case class WitError(value: Any)
+extends Error(m"the WIT import returned the error ${WitError.nameOf(value)}")
+  ( using errorDiagnostics.emptyDiagnostics ):
 
-  override def getMessage: String = "WIT import returned an error: " + name.s
+  def name: Text = WitError.nameOf(value)


### PR DESCRIPTION
The `err` arm of a WIT `result<…>`, raised by xenophile's `invoke` decoder, is now a `fulminate.Error` like every other Soundness error — and hence pure, and a `Hazard`. Previously it was a bare `RuntimeException`.

## Release notes

- `xenophile.WitError` extends `fulminate.Error`, carrying the message `the WIT import returned the error <name>`, where `name` is the failing case's lower-kebab-case name (e.g. `no-entry`), as before. It supplies its own (empty) `Diagnostics`, since it is raised from generated code where none can be summoned.
- The generated `throw` imports `canThrowAny` for the `CanThrow` capability a checked exception requires.
- The WASI backends catch `WitError` specifically rather than `RuntimeException`, so an internal invariant failure in generated code can no longer masquerade as end-of-stream or a connection failure.