### PR TITLE
Repair the Scala.js cross-build under capture checking

### DIFF
--- a/lib/anticipation/src/log/anticipation.Loggable.scala
+++ b/lib/anticipation/src/log/anticipation.Loggable.scala
@@ -72,6 +72,10 @@ trait Loggable extends Typeclass:
     def log(level: Level, timestamp: Long, event: => Self): Unit
 
     // `^{lambda}` only: the compiler treats a bare `Loggable` receiver as untracked
-    // (empty capture set), so `this` is not a legal capture reference here.
+    // (empty capture set), so `this` is not a legal capture reference here. The laundering is
+    // for the Scala.js pipeline, which — unlike the JVM pipeline — insists the anonymous
+    // instance's base class is pure and rejects the capture of `lambda`; the result type still
+    // declares it. (Compiler divergence; the JVM pipeline accepts the direct form.)
     def contramap[self2](lambda: self2 => Self): (self2 is Loggable)^{lambda} =
-      (level, timestamp, event) => loggable.log(level, timestamp, lambda(event))
+      val lambda0: self2 -> Self = caps.unsafe.unsafeAssumePure(lambda)
+      (level, timestamp, event) => loggable.log(level, timestamp, lambda0(event))

--- a/lib/panopticon/src/core/panopticon.Optical.scala
+++ b/lib/panopticon/src/core/panopticon.Optical.scala
@@ -63,17 +63,24 @@ object Optical:
       Optic: (origin, lambda) =>
         origin.at(key).let(lambda).lay(origin)(origin.updated(key, _))
 
+  // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM pipeline —
+  // rejects the `Optic`'s capture of `filter.predicate` against the required pure `Optic` type.
+  // (Compiler divergence; the JVM pipeline accepts the direct form.)
   given filter: [key, element] => Filter[key] is Optical from Map[key, element] onto element =
     filter =>
+      val predicate: key -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+
       Optic: (origin, lambda) =>
         origin.map: (key, value) =>
-          if filter.predicate(key) then (key, lambda(value)) else (key, value)
+          if predicate(key) then (key, lambda(value)) else (key, value)
 
   given filter2: [element] => Filter[element] is Optical from List[element] onto element =
     filter =>
+      val predicate: element -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+
       Optic: (origin, lambda) =>
         origin.map: value =>
-          if filter.predicate(value) then lambda(value) else value
+          if predicate(value) then lambda(value) else value
 
 trait Optical:
   type Self

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -74,11 +74,17 @@ sealed trait Monitor extends Resultant, Findable, caps.ExclusiveCapability:
 
   protected[parasite] def workers: Set[Worker^{}] = workersRef.get().nn
 
+  // The casts are for the Scala.js pipeline, which infers the updated set's element type with
+  // the argument's reach capabilities attached (widening the worker's fields to `any`), where
+  // the JVM pipeline accepts the direct form. A cast, not an ascription, because no source-level
+  // type spells the pipeline's widened element type. (Compiler divergence.)
   protected[parasite] def addWorker(worker: Worker^): Unit =
-    workersRef.updateAndGet(_.nn + caps.unsafe.unsafeAssumePure(worker))
+    val worker0: Worker^{} = caps.unsafe.unsafeAssumePure(worker)
+    workersRef.updateAndGet(_.nn.incl(worker0).asInstanceOf[Set[Worker^{}]])
 
   protected[parasite] def remove(monitor: Worker^): Unit =
-    workersRef.updateAndGet(_.nn - caps.unsafe.unsafeAssumePure(monitor))
+    val monitor0: Worker^{} = caps.unsafe.unsafeAssumePure(monitor)
+    workersRef.updateAndGet(_.nn.excl(monitor0).asInstanceOf[Set[Worker^{}]])
 
   def name: Optional[Name[Async]]
   def chain: Optional[Chain]


### PR DESCRIPTION
The Scala.js compilation pipeline diverges from the JVM pipeline on several capture-checking judgements, breaking the JS cross-build (and hence `jsAll`) of three modules since capture checking was enabled. Each is laundered at the divergence, with a comment; the JVM pipeline accepts all three direct forms unchanged.

## Release notes

- `anticipation.Loggable.contramap` no longer fails the JS pipeline's rejection of `lambda`'s capture against the pure-treated `Loggable` base; the result type still declares the capture.
- panopticon's `filter` optics (`Map` and `List`) launder `filter.predicate` past the JS pipeline's requirement that the produced `Optic` be pure.
- parasite's `Monitor` worker registry updates no longer acquire the argument's reach capabilities in the JS pipeline's inferred set element type.

Two further modules (`mosquito.core`, `obligatory.core`) still fail the JS pipeline with distinct capture-checking flavours and are left for a compiler-side fix.