### PR TITLE
Enforce separation checking module-wide in the first streaming consumers

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -130,6 +130,15 @@ object settings:
   def cc(options: Seq[String]): Seq[String] =
     options ++ Seq("-Ycc-new", "-language:experimental.captureChecking")
 
+  // Capture checking plus separation checking: `consume` linearity, hidden-set
+  // separation and `freeze` are only diagnosed in units compiled with this flag,
+  // so a module holding exclusive capabilities is not actually checked for
+  // single ownership until it routes through `sep`. Rolled out module-by-module
+  // like `cc`; the flag subsumes the per-file
+  // `import language.experimental.separationChecking`.
+  def sep(options: Seq[String]): Seq[String] =
+    cc(options) :+ "-language:experimental.separationChecking"
+
   // Override `-Xmax-inlines` to `limit`, replacing any existing setting rather
   // than appending a second one (which the compiler reports as "Option
   // -Xmax-inlines was updated"). The base stays 32 everywhere else.
@@ -814,7 +823,7 @@ object coaxial extends Library:
   object core extends Component(galilei.jvm, urticose.core, frontier.core):
     override def scalaJs = false // TCP sockets (`java.nio.channels`)
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core)
 
 object contextual extends Library:
@@ -1433,7 +1442,7 @@ object metamorphose extends Library:
 object monotonous extends Library:
   object core extends Component(gossamer.core, zephyrine.core):
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
@@ -1680,7 +1689,7 @@ object scintillate extends Library:
   object servlet extends Component(server):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
     def mvnDeps = Seq(mvn"jakarta.servlet:jakarta.servlet-api:6.0.0")
 
   object test extends Tests(server, servlet):
@@ -1811,7 +1820,7 @@ object tarantula extends Library:
 object telekinesis extends Library:
   object core extends Component(monotonous.core, legerdemain.core, turbulence.core):
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   // JVM-only transports split out of `core` so the platform-agnostic HTTP model and client can
   // cross-compile to Scala.js: the `java.net.http` `Http.Backend` (`httpBackends.virtualMachine`)
   // and the `coaxial` domain-socket client.

--- a/build.mill
+++ b/build.mill
@@ -1288,6 +1288,11 @@ object hellenism extends Library:
 object honeycomb extends Library:
   object core extends Component(panopticon.core, gesticulate.core, xylophone.core, urticose.url,
       nomenclature.core, hellenism.core):
+    // NOT capture-checked: the `e`-macro's quoted type patterns
+    // (`case Some('{$renderable: Renderable})`) fail to unify with
+    // capture-decorated `Expr` types under `-Ycc-new` (12 errors, all in the
+    // macro/quotes family). Re-attempt when the quote-pattern/CC interaction
+    // improves upstream; see rep/DECISIONS.md "Sepcheck rollout".
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
   object test extends Tests(core)

--- a/lib/coaxial/src/core/coaxial.Bindable.scala
+++ b/lib/coaxial/src/core/coaxial.Bindable.scala
@@ -172,8 +172,18 @@ object Bindable:
               jn.InetAddress.getByAddress(array).nn
 
             case ip: Ipv6 =>
-              val array =
-                IArray.from(ip.highBits.bits.bytes ++ ip.lowBits.bits.bytes).mutable(using Unsafe)
+              val array: Array[Byte]^ =
+                val high = ip.highBits.bits.bytes
+                val bytes = new Array[Byte](16)
+                var index = 0
+                while index < 8 do
+                  bytes(index) = high(index)
+                  index += 1
+                val low = ip.lowBits.bits.bytes
+                while index < 16 do
+                  bytes(index) = low(index - 8)
+                  index += 1
+                bytes
 
               jn.InetAddress.getByAddress(array).nn
 

--- a/lib/coaxial/src/core/coaxial.Duplex.scala
+++ b/lib/coaxial/src/core/coaxial.Duplex.scala
@@ -39,10 +39,29 @@ import java.nio.channels as jnc
 import anticipation.*
 import prepositional.*
 import rudiments.*
+import turbulence.Spool
 import vacuous.*
 import zephyrine.*
 
 object Duplex:
+  // An in-process connected pair: whatever one side sends, the other receives.
+  // Chunk boundaries are preserved (each send is memoized to one element), which
+  // in-memory protocol tests rely on. Ends when a side's `close` stops its
+  // outbound spool.
+  def pair(): (Duplex, Duplex) =
+    val leftToRight: Spool[Data] = Spool()
+    val rightToLeft: Spool[Data] = Spool()
+
+    def side(inbound: Spool[Data], outbound: Spool[Data]): Duplex = new Duplex:
+      def stream: LazyList[Data] = inbound.stream
+
+      def send(consume data: (Stream[Data] over Credit)^): Unit =
+        outbound.put(data.memoize)
+
+      def close(): Unit = outbound.stop()
+
+    (side(leftToRight, rightToLeft), side(rightToLeft, leftToRight))
+
   // Wraps a blocking `InputStream`/`OutputStream` pair — the shape a socket that has no
   // `SocketChannel` exposes (e.g. an `SSLSocket`). `shutdown` closes the underlying
   // resource. The read side blocks in `read` and copies each fill; EOF (`-1`) ends the
@@ -50,7 +69,10 @@ object Duplex:
   // `shutdown` is a pure function: its closures hold only untracked OS resources (like
   // `channel`'s socket), so the `Duplex` remains capture-free under capture checking.
   def streams(in: ji.InputStream, out: ji.OutputStream)(shutdown: () -> Unit): Duplex = new Duplex:
-    private val buffer = new Array[Byte](65536)
+    // Untracked: `stream` is called by a single reader (the Duplex contract), and
+    // each delivered chunk is copied out of the buffer by `take` before reuse.
+    @caps.unsafe.untrackedCaptures
+    private val buffer: Array[Byte] = new Array[Byte](65536)
 
     def stream: LazyList[Data] =
       def recur(): LazyList[Data] = in.read(buffer) match
@@ -59,7 +81,7 @@ object Duplex:
 
       recur()
 
-    def send(data: (Stream[Data] over Credit)^): Unit =
+    def send(consume data: (Stream[Data] over Credit)^): Unit =
       data.foreachWindow: (storage, start, count) =>
         out.write(storage.asInstanceOf[Array[Byte]], start, count)
         out.flush()
@@ -86,7 +108,7 @@ object Duplex:
 
       recur()
 
-    def send(data: (Stream[Data] over Credit)^): Unit =
+    def send(consume data: (Stream[Data] over Credit)^): Unit =
       data.foreachWindow: (storage, start, count) =>
         val out = ByteBuffer.wrap(storage.asInstanceOf[Array[Byte]], start, count).nn
         while out.hasRemaining do socketChannel.write(out)
@@ -104,7 +126,7 @@ object Duplex:
         private var limit0: Int = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage
+        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -141,7 +163,7 @@ object Duplex:
 // closes; `send` may be called many times and never half-closes the connection.
 trait Duplex:
   def stream: LazyList[Data]
-  def send(data: (Stream[Data] over Credit)^): Unit
+  def send(consume data: (Stream[Data] over Credit)^): Unit
   def close(): Unit
 
   // Pull endpoint over the read side. The default adapts the legacy
@@ -160,7 +182,7 @@ trait Duplex:
       private var mark0: Int = 0
 
       def demand: Credit = Credit(Long.MaxValue)
-      protected def buffer0: AnyRef = storage
+      protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
       def mark: Int = mark0
 
       update def reserve(min: Int): Int =

--- a/lib/coaxial/src/core/coaxial.Routable.scala
+++ b/lib/coaxial/src/core/coaxial.Routable.scala
@@ -57,7 +57,7 @@ object Routable:
 
       Connection(address, endpoint.port.number, socket)
 
-    def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit =
+    def transmit(connection: Connection, consume input: (Stream[Data] over Credit)^): Unit =
       // One `transmit` call carries one message, and UDP frames per datagram.
       val bytes = input.memoize
 
@@ -79,7 +79,7 @@ object Routable:
 
       Connection(port.number, socket)
 
-    def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit =
+    def transmit(connection: Connection, consume input: (Stream[Data] over Credit)^): Unit =
       // See `udpEndpoint`: one message, one datagram.
       val bytes = input.memoize
 
@@ -97,4 +97,4 @@ trait Routable extends Findable:
   type Connection
 
   def connect(endpoint: Self, interface: Optional[MacAddress]): Connection
-  def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit
+  def transmit(connection: Connection, consume input: (Stream[Data] over Credit)^): Unit

--- a/lib/coaxial/src/core/coaxial.Sender.scala
+++ b/lib/coaxial/src/core/coaxial.Sender.scala
@@ -40,5 +40,11 @@ import zephyrine.*
 // before the first inbound message arrives, or concurrently from another task — rather
 // than only in reply to one. Handed to the `interact` block of `exchange` on a
 // `Duplexable` transport, whose `transmit` is safe to call concurrently.
-class Sender[message: Transmissible as transmissible](post: ((Stream[Data] over Credit)^) => Unit):
+object Sender:
+  // A consuming postal target: a named SAM rather than a function type, because
+  // only a method parameter can be marked `consume`.
+  trait Post:
+    def apply(consume stream: (Stream[Data] over Credit)^): Unit
+
+class Sender[message: Transmissible as transmissible](post: Sender.Post^):
   def send(message: message): Unit = post(transmissible.serialize(message))

--- a/lib/coaxial/src/core/coaxial.Serviceable.scala
+++ b/lib/coaxial/src/core/coaxial.Serviceable.scala
@@ -65,7 +65,7 @@ object Serviceable:
 
       Connection(channel)
 
-    def transmit(connection: Connection, input: (Stream[Data] over Credit)^): Unit =
+    def transmit(connection: Connection, consume input: (Stream[Data] over Credit)^): Unit =
       input.foreachWindow: (storage, start, count) =>
         connection.channel.write(ByteBuffer.wrap(storage.asInstanceOf[Array[Byte]], start, count))
 
@@ -91,8 +91,8 @@ object Serviceable:
 
     def close(connection: Connection): Unit = connection.channel.close()
 
-  given tcpEndpoint: (Online, Tactic[StreamError], Every[SocketOption.Tcp])
-  =>  ( (Endpoint[TcpPort] is Serviceable)^ ) = new Serviceable:
+  given tcpEndpoint: Online => (tactic: Tactic[StreamError]) => (options: Every[SocketOption.Tcp])
+  =>  ( (Endpoint[TcpPort] is Serviceable)^{tactic} ) = new Serviceable:
     type Self = Endpoint[TcpPort]
     type Output = Data
     type Connection = jn.Socket
@@ -107,7 +107,7 @@ object Serviceable:
       configure(socket, summon[Every[SocketOption.Tcp]].values)
       socket
 
-    def transmit(socket: jn.Socket, input: (Stream[Data] over Credit)^): Unit =
+    def transmit(socket: jn.Socket, consume input: (Stream[Data] over Credit)^): Unit =
       val out = socket.getOutputStream.nn
 
       input.foreachWindow: (storage, start, count) =>
@@ -117,8 +117,8 @@ object Serviceable:
     def close(socket: jn.Socket): Unit = socket.close()
     def receive(socket: jn.Socket): LazyList[Data] = socket.getInputStream.nn.stream[Data]
 
-  given tcpPort: (Tactic[StreamError], Every[SocketOption.Tcp])
-  =>  ( (TcpPort is Serviceable)^ ) = new Serviceable:
+  given tcpPort: (tactic: Tactic[StreamError]) => (options: Every[SocketOption.Tcp])
+  =>  ( (TcpPort is Serviceable)^{tactic} ) = new Serviceable:
     type Self = TcpPort
     type Output = Data
     type Connection = jn.Socket
@@ -136,7 +136,7 @@ object Serviceable:
     def close(socket: jn.Socket): Unit = socket.close()
     def receive(socket: jn.Socket): LazyList[Data] = socket.getInputStream.nn.stream[Data]
 
-    def transmit(socket: jn.Socket, input: (Stream[Data] over Credit)^): Unit =
+    def transmit(socket: jn.Socket, consume input: (Stream[Data] over Credit)^): Unit =
       val out = socket.getOutputStream.nn
 
       input.foreachWindow: (storage, start, count) =>

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -39,6 +39,7 @@ import java.util as ju
 import anticipation.*
 import contingency.*
 import parasite.*
+import prepositional.*
 import rudiments.*
 import spectacular.*
 import turbulence.*
@@ -94,7 +95,8 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
 // the evidence is an explicit capturing using-parameter rather than a context bound, which would
 // demand a pure instance.
 extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint is Serviceable)^)
-  def transmit[message: Transmissible](input: message): LazyList[Data] logs SocketEvent =
+  def transmit[message: Transmissible](input: message)(using SocketEvent is Loggable)
+  :   LazyList[Data] =
     val connection = serviceable.connect(endpoint, Unset)
     Log.fine(SocketEvent.Connected(endpoint.show))
 
@@ -107,7 +109,8 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
   // initiate; a `Duplexable` additionally offers `exchange`, which can also send proactively.
   def react[state](initialState: state)[message: Ingressive]
     ( handle: (state: state) ?=> message => Control[state] )
-  :   state logs SocketEvent =
+    ( using SocketEvent is Loggable )
+  :   state =
 
     val connection = serviceable.connect(endpoint, Unset)
     Log.fine(SocketEvent.Connected(endpoint.show))
@@ -141,12 +144,19 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
   def exchange[state](initialState: state)[message: {Ingressive, Transmissible}]
     ( handle: (state: state) ?=> message => Control[state] )
     ( interact: Sender[message]^ => Unit )
-  :   state logs SocketEvent =
+    ( using SocketEvent is Loggable )
+  :   state =
 
     val connection = duplexable.connect(endpoint, Unset)
     Log.fine(SocketEvent.Connected(endpoint.show))
 
-    interact(Sender[message](duplexable.transmit(connection, _)))
+    // A named `Post` rather than a lambda: forwarding to the consuming `transmit`
+    // requires a `consume` parameter, which only a method can declare.
+    interact:
+      Sender[message]:
+        new Sender.Post:
+          def apply(consume stream: (Stream[Data] over Credit)^): Unit =
+            duplexable.transmit(connection, stream)
 
     def recur(input: LazyList[Data], state: state): state = input.flow(state):
       handle(using state)(message.deserialize(next)) match
@@ -165,8 +175,9 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
 
 
 extension [endpoint: {Routable as routable, Showable}](endpoint: endpoint)
-  def transmit[transmissible: Transmissible](message: transmissible)(using Monitor)
-  :   Unit raises StreamError logs SocketEvent =
+  def transmit[transmissible: Transmissible](message: transmissible)
+    ( using Monitor, Tactic[StreamError], SocketEvent is Loggable )
+  :   Unit =
 
     Log.fine(SocketEvent.Connected(endpoint.show))
     routable.transmit(routable.connect(endpoint, Unset), transmissible.serialize(message))
@@ -180,10 +191,12 @@ extension [endpoint: {Connectable as connectable, Showable}](endpoint: endpoint)
   // connection is never half-closed. A long-lived connection that must outlive any
   // single block keeps `lambda` running (e.g. parked on its supervisor) until the
   // enclosing scope ends, at which point the loan closes the connection.
-  def duplex[result](lambda: Duplex => result): result logs SocketEvent = duplex(lambda)(Unset)
+  def duplex[result](lambda: Duplex => result)(using SocketEvent is Loggable): result =
+    duplex(lambda)(Unset)
 
   def duplex[result](lambda: Duplex => result)(interface: Optional[MacAddress])
-  :   result logs SocketEvent =
+    ( using SocketEvent is Loggable )
+  :   result =
 
     val connection = connectable.connect(endpoint, interface)
     Log.info(SocketEvent.Connected(endpoint.show))

--- a/lib/cordillera/src/core/cordillera.Http2.scala
+++ b/lib/cordillera/src/core/cordillera.Http2.scala
@@ -359,7 +359,7 @@ object Http2:
       new HttpClient:
         type Target = Endpoint[endpoint]
 
-        def request(request: Http.Request, target: Endpoint[endpoint])
-        :   Http.Response logs HttpEvent =
+        def request(request: Http.Request, target: Endpoint[endpoint])(using HttpEvent is Loggable)
+        :   Http.Response =
 
           target.connect().fetch(request, t"http", target.authority)(1)

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -219,17 +219,7 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
 
       // An in-memory `Duplex` pair: bytes written to one side surface on the other's
       // stream. Backed by `Spool`s so reads block until data arrives, like a socket.
-      def pair(): (Duplex, Duplex) =
-        val clientToServer = Spool[Data]()
-        val serverToClient = Spool[Data]()
-
-        def duplex(inbound: Spool[Data], outbound: Spool[Data]) = new Duplex:
-          def stream: LazyList[Data] = inbound.stream
-          def send(data: (zephyrine.Stream[Data] over Credit)^): Unit =
-            outbound.put(data.memoize)
-          def close(): Unit = outbound.stop()
-
-        (duplex(serverToClient, clientToServer), duplex(clientToServer, serverToClient))
+      def pair(): (Duplex, Duplex) = Duplex.pair()
 
       // A minimal in-process HTTP/2 server on the given duplex side. It sends its own
       // SETTINGS (so the client's handshake completes), reads the client's preface +

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -158,17 +158,7 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       import threading.virtualThreading
       import probates.cancelProbate
 
-      def pair(): (Duplex, Duplex) =
-        val clientToServer = Spool[Data]()
-        val serverToClient = Spool[Data]()
-
-        def duplex(inbound: Spool[Data], outbound: Spool[Data]) = new Duplex:
-          def stream: LazyList[Data] = inbound.stream
-          def send(data: (zephyrine.Stream[Data] over Credit)^): Unit =
-            outbound.put(data.memoize)
-          def close(): Unit = outbound.stop()
-
-        (duplex(serverToClient, clientToServer), duplex(clientToServer, serverToClient))
+      def pair(): (Duplex, Duplex) = Duplex.pair()
 
       // A fake containerd: completes the HTTP/2 handshake, records the namespace header
       // from the request, and replies to the `Version` call with a framed response.

--- a/lib/gossamer/src/core/gossamer_core.scala
+++ b/lib/gossamer/src/core/gossamer_core.scala
@@ -80,7 +80,7 @@ inline def appendln[textual: Textual, value](using builder: Builder[textual] aka
 inline def builder[value](using value: value aka "builder"): value = value()
 
 extension (module: IArray.type)
-  def build[element: ClassTag](size: Int)(lambda: Array[element] => Unit): IArray[element] =
+  def build[element: ClassTag](size: Int)(lambda: Array[element]^ => Unit): IArray[element] =
     val array: Array[element] = new Array[element](size)
     lambda(array)
     array.immutable(using Unsafe)

--- a/lib/monotonous/src/core/monotonous.Alphabet.scala
+++ b/lib/monotonous/src/core/monotonous.Alphabet.scala
@@ -101,7 +101,8 @@ object Alphabet:
           :   Duct.Progress =
 
             val bytes = source.asInstanceOf[Array[Byte]]
-            val chars = target.asInstanceOf[Array[Char]]
+            // The stage's own buffer, asserted exclusive at the cast rim.
+            val chars: Array[Char]^ = target.asInstanceOf[Array[Char]^]
             var consumed: Int = 0
             var produced: Int = 0
             var continue: Boolean = true
@@ -129,7 +130,7 @@ object Alphabet:
           override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int)
           :   Int =
 
-            val chars = target.asInstanceOf[Array[Char]]
+            val chars: Array[Char]^ = target.asInstanceOf[Array[Char]^]
             var produced: Int = 0
 
             if !flushing then
@@ -151,11 +152,19 @@ object Alphabet:
 
             produced
 
-  given deserialization: [encoding <: Serialization] => Tactic[SerializationError]
+  given deserialization: [encoding <: Serialization] => (tactic: Tactic[SerializationError])
   =>  Ductile.Of[Alphabet[encoding], Text, Data, Credit, Credit] =
 
-    // Sealed: see `serialization` above.
+    // Sealed: see `serialization` above. The tactic is sealed here too — the duct
+    // raises through the given's resolution-scoped tactic, which shares the
+    // instance's lifetime (the codec-thunk seal pattern); a fresh duct result may
+    // hide only local state, not the enclosing given's parameter.
     caps.unsafe.unsafeAssumePure:
+     // The tactic crosses into the fresh duct as a neutral reference: the duct
+     // raises through the given's resolution-scoped tactic (the codec-thunk seal
+     // pattern), and a fresh result may hide only local state, so even a sealed
+     // capability-typed binding would trip the hiding rule.
+     val tacticRef: AnyRef = tactic.asInstanceOf[AnyRef]
      new Ductile:
       type Self = Alphabet[encoding]
       type Operand = Text
@@ -195,7 +204,8 @@ object Alphabet:
           :   Duct.Progress =
 
             val chars = source.asInstanceOf[Array[Char]]
-            val bytes = target.asInstanceOf[Array[Byte]]
+            // The stage's own buffer, asserted exclusive at the cast rim.
+            val bytes: Array[Byte]^ = target.asInstanceOf[Array[Byte]^]
             var consumed: Int = 0
             var produced: Int = 0
             var continue: Boolean = true
@@ -217,7 +227,9 @@ object Alphabet:
                 // accumulated before them are alignment filler.
                 if stage.padding && char == pad then accumulated = 0
                 else
-                  accumulator = (accumulator << base) | stage.invert(position, char)
+                  accumulator = (accumulator << base)
+                    | stage.invert(position, char)
+                        (using tacticRef.asInstanceOf[Tactic[SerializationError]])
                   accumulated += base
 
                 position += 1
@@ -235,4 +247,6 @@ case class Alphabet[encoding <: Serialization]
   def invert(position: Int, char: Char): Int raises SerializationError =
     inverse.getOrElse(char, abort(SerializationError(position, char)))
 
-  lazy val inverse: Map[Char, Int] = tolerance ++ chars.chars.zipWithIndex.to(Map)
+  // Sealed: an `IArray` zip is immutable; fresh-ness is the opaque-Array artifact.
+  lazy val inverse: Map[Char, Int] =
+    tolerance ++ caps.unsafe.unsafeAssumePure(chars.chars.zipWithIndex).to(Map)

--- a/lib/monotonous/src/core/monotonous.Deserializable.scala
+++ b/lib/monotonous/src/core/monotonous.Deserializable.scala
@@ -94,9 +94,10 @@ trait Deserializable extends Findable:
   def deserialize(previous: Text, current: Text, index0: Int, last: Boolean)
   :   Data raises SerializationError
 
-  def deserialize(value: Text): Data raises SerializationError = deserialize(t"", value, 0, true)
+  def deserialize(value: Text)(using Tactic[SerializationError]): Data =
+    deserialize(t"", value, 0, true)
 
-  def deserialize(stream: LazyList[Text]): LazyList[Data] raises SerializationError =
+  def deserialize(stream: LazyList[Text])(using Tactic[SerializationError]): LazyList[Data] =
     def recur(stream: LazyList[Text], previous: Text, carry: Int): LazyList[Data] = stream match
       case head #:: tail =>
         val carry2 = (carry + head.length)%atomicity

--- a/lib/monotonous/src/core/monotonous.Serializable.scala
+++ b/lib/monotonous/src/core/monotonous.Serializable.scala
@@ -53,19 +53,30 @@ object Serializable:
 
         val array = new Array[Char](length)
 
-          def recur(current: Int = 0, next: Int = 0, index: Int = 0, loaded: Int = 0): Unit =
-            if index < length then
-              if loaded < bits then
-                if next < bytes.length then
-                  recur((current << 8) | (bytes(next) & 0xff), next + 1, index, loaded + 8)
-                else
-                  array(index) = alphabet((current << (bits - loaded)) & mask)
-                  ((index + 1) until length).each: i => array(i) = alphabet(1 << bits)
-              else
-                array(index) = alphabet((current >>> (loaded - bits)) & mask)
-                recur(current, next, index + 1, loaded - bits)
+        // A while-loop rather than a recursive def: a closure over the exclusive
+        // array would hide it from the statements that follow.
+        var current = 0
+        var next = 0
+        var index = 0
+        var loaded = 0
 
-          recur()
+        while index < length do
+          if loaded < bits then
+            if next < bytes.length then
+              current = (current << 8) | (bytes(next) & 0xff)
+              next += 1
+              loaded += 8
+            else
+              array(index) = alphabet((current << (bits - loaded)) & mask)
+              var filler = index + 1
+              while filler < length do
+                array(filler) = alphabet(1 << bits)
+                filler += 1
+              index = length
+          else
+            array(index) = alphabet((current >>> (loaded - bits)) & mask)
+            index += 1
+            loaded -= bits
 
         Text(array.immutable(using Unsafe))
 

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -150,17 +150,7 @@ object Tests extends Suite(m"Obligatory Tests"):
       import probates.cancelProbate
       import errorDiagnostics.stackTracesDiagnostics
 
-      def pair(): (Duplex, Duplex) =
-        val clientToServer = Spool[Data]()
-        val serverToClient = Spool[Data]()
-
-        def duplex(inbound: Spool[Data], outbound: Spool[Data]) = new Duplex:
-          def stream: LazyList[Data] = inbound.stream
-          def send(data: zephyrine.Stream[Data] over Credit): Unit =
-            outbound.put(data.memoize)
-          def close(): Unit = outbound.stop()
-
-        (duplex(serverToClient, clientToServer), duplex(clientToServer, serverToClient))
+      def pair(): (Duplex, Duplex) = Duplex.pair()
 
       def okHeaders(hpack: Hpack, id: Int): Frame =
         val block = hpack.encode(List(HpackEntry(t":status", t"200"),

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -32,6 +32,8 @@
                                                                                                   */
 package perihelion
 
+import language.experimental.separationChecking
+
 import java.security.SecureRandom
 
 import anticipation.*
@@ -258,7 +260,10 @@ given wsClient: ( online:            Online,
       given Masking = connection.masking
       Reader(() => zephyrine.Stream(connection.inbound.iterator), connection.channel).messages.map(_.bytes)
 
-    def transmit(connection: WsConnection, input: (zephyrine.Stream[Data] over zephyrine.Credit)^): Unit =
+    def transmit
+      ( connection: WsConnection,
+        consume input: (zephyrine.Stream[Data] over zephyrine.Credit)^ )
+    :   Unit =
       // One `transmit` carries one message = one complete frame, masked at the
       // `Channel` boundary; see `Transmissible`.
       connection.channel.enqueue(input.memoize)

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -98,16 +98,17 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
           servletResponse.addHeader("transfer-encoding", "chunked")
           val stream = source()
 
-          def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
+          // A while-loop rather than a recursive def: a def capturing the
+          // locally bound exclusive stream may not call itself.
+          var draining = true
+
+          while draining do stream.refill(Credit(Long.MaxValue)) match
             case count: Int =>
               out.write(stream.window(using Unsafe).asInstanceOf[Array[Byte]], stream.start, count)
               out.flush()
               stream.skip(count)
-              recur()
 
-            case _ => ()
-
-          recur()
+            case _ => draining = false
 
       out.close()
 

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -269,20 +269,30 @@ object Http:
       val block = buffering.capacity(Substrate.Bytes)
 
       // A zero count (an empty upstream chunk) is retried, never yielded: a
-      // zero-length frame would terminate chunked transfer encoding early.
-      def pull(): Optional[Data] = endpoint.refill(Credit(block)) match
-        case 0 => pull()
+      // zero-length frame would terminate chunked transfer encoding early. A
+      // while-loop rather than self-recursion: a def capturing the exclusive
+      // endpoint may not call itself under the statement rule.
+      def pull(): Optional[Data] =
+        var result: Optional[Data] = Unset
+        var continue = true
 
-        case count: Int =>
-          val chunk =
-            endpoint.addressable.materialize
-              ( endpoint.window(using Unsafe), endpoint.start, count )
+        while continue do
+          endpoint.refill(Credit(block)) match
+            case 0 => ()
 
-          endpoint.skip(count)
-          chunk
+            case count: Int =>
+              result =
+                endpoint.addressable.materialize
+                  ( endpoint.window(using Unsafe), endpoint.start, count )
 
-        case _ =>
-          Unset
+              endpoint.skip(count)
+              continue = false
+
+            case _ =>
+              result = Unset
+              continue = false
+
+        result
 
       val first: Optional[Data] = pull()
       val second: Optional[Data] = if first.absent then Unset else pull()
@@ -342,7 +352,8 @@ object Http:
     // unbounded amount) — the scan aborts mid-token once the cap is crossed.
     def parseHead
       ( cursor: Cursor[Data, {}]^, maxRequestLine: Int = 8192, maxHeaders: Int = 65536 )
-    :   Head raises HttpRequestError =
+      ( using Tactic[HttpRequestError] )
+    :   Head =
 
       import HttpRequestError.Reason
 
@@ -704,22 +715,28 @@ object Http:
         val block = buffering.capacity(Substrate.Bytes)
 
         Iterator.continually:
-          def pull(): Optional[Data] = endpoint.refill(Credit(block)) match
-            // See `Request.serialize`: empty chunks are retried, never framed.
-            case 0 => pull()
+          // See `Request.serialize`: empty chunks are retried, never framed, and
+          // the retry is a loop, not self-recursion.
+          var result: Optional[Data] = Unset
+          var continue = true
 
-            case count: Int =>
-              val chunk =
-                endpoint.addressable.materialize
-                  ( endpoint.window(using Unsafe), endpoint.start, count )
+          while continue do
+            endpoint.refill(Credit(block)) match
+              case 0 => ()
 
-              endpoint.skip(count)
-              chunk
+              case count: Int =>
+                result =
+                  endpoint.addressable.materialize
+                    ( endpoint.window(using Unsafe), endpoint.start, count )
 
-            case _ =>
-              Unset
+                endpoint.skip(count)
+                continue = false
 
-          pull()
+              case _ =>
+                result = Unset
+                continue = false
+
+          result
 
         . takeWhile(_.present).map(_.vouch)
 
@@ -803,11 +820,16 @@ object Http:
       cursor.next()
       cursor.expect('\n')(expected('\n'))
 
-      def readHeaders(headers: List[Http.Header]): List[Http.Header] =
+      // A while-loop rather than a recursive def: a def capturing the locally
+      // bound exclusive cursor may not call itself under the statement rule.
+      var headers: List[Http.Header] = Nil
+      var reading = true
+
+      while reading do
         if cursor.peek == '\r' then
           cursor.next()
           cursor.expect('\n')(expected('\n'))
-          headers
+          reading = false
 
         else
           val header: Text = cursor.hold:
@@ -827,9 +849,7 @@ object Http:
 
           cursor.next()
           cursor.expect('\n')(expected('\n'))
-          readHeaders(Http.Header(header, value) :: headers)
-
-      val headers = readHeaders(Nil)
+          headers = Http.Header(header, value) :: headers
 
       // Sealed: the cursor is single-owner and reachable only through its
       // memoized `remainder`, so the spring is pure in effect; a capturing

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -69,65 +69,76 @@ object HttpClient:
     case 301 | 302 | 303 | 307 | 308 => true
     case _                           => false
 
-  given httpStrict: Tactic[ConnectError]
+  given httpStrict: (tactic: Tactic[ConnectError])
   =>  Online
   =>  Redirects.Disabled
   =>  ( backend: Http.Backend )
-  =>  HttpClient:
-    type Target = Origin["http" | "https"]
+  =>  ( (HttpClient { type Target = Origin["http" | "https"] })^{tactic, caps.any} ) =
+    new HttpClient:
+      type Target = Origin["http" | "https"]
 
-    def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
-    :   Http.Response logs HttpEvent =
+      def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
+        ( using HttpEvent is Loggable )
+      :   Http.Response =
 
-      val url = httpRequest.on(origin)
-      Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
+        val url = httpRequest.on(origin)
+        Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-      logResponse:
-        backend.request(url.show, httpRequest.method, httpRequest.textHeaders, httpRequest.body)
+        logResponse:
+          backend.request(url.show, httpRequest.method, httpRequest.textHeaders, httpRequest.body)
 
-  given http: Tactic[ConnectError]
+  given http: (tactic: Tactic[ConnectError])
   =>  Online
   =>  NotGiven[Redirects.Disabled]
   =>  ( redirection: HttpRedirection )
   =>  ( backend: Http.Backend )
-  =>  HttpClient:
-    type Target = Origin["http" | "https"]
+  =>  ( (HttpClient { type Target = Origin["http" | "https"] })^{tactic, caps.any} ) =
+    new HttpClient:
+      type Target = Origin["http" | "https"]
 
-    def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
-    :   Http.Response logs HttpEvent =
-
-      val url = httpRequest.on(origin)
-      Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
-
-      def loop(uri: jn.URI, method: Http.Method, bodyFn: Spring[Data]^, remaining: Int)
+      def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
+        ( using HttpEvent is Loggable )
       :   Http.Response =
 
-        val response = backend.request(uri.toString.tt, method, httpRequest.textHeaders, bodyFn)
-        val code = response.status.code
+        val url = httpRequest.on(origin)
+        Log.info(HttpEvent.Send(httpRequest.method, url, httpRequest.textHeaders))
 
-        if !isRedirect(code) || remaining <= 0 then response else
-          response.textHeaders.find(_.key.lower == t"location") match
-            case None =>
-              response
+        // The spring crosses the recursion as a neutral reference: a
+        // capability-typed binding of a parameter would hide it from the
+        // recursive call under the statement rule.
+        def loop(uri: jn.URI, method: Http.Method, bodyRef: AnyRef, remaining: Int)
+        :   Http.Response =
 
-            case Some(header) =>
-              // Drain the discarded intermediate body to free its connection.
-              safely(response.body.stream.foreachWindow { (_, _, _) => () })
+          val bodyFn = bodyRef.asInstanceOf[Spring[Data]^]
+          val response = backend.request(uri.toString.tt, method, httpRequest.textHeaders, bodyFn)
+          val code = response.status.code
 
-              val nextUri = uri.resolve(jn.URI.create(header.value.s).nn).nn
-              Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))
-              val nextMethod = redirectMethod(code, method)
+          if !isRedirect(code) || remaining <= 0 then response else
+            response.textHeaders.find(_.key.lower == t"location") match
+              case None =>
+                response
 
-              val nextBody: Spring[Data]^ =
-                if nextMethod == method then bodyFn else () => Http.emptyBody()
+              case Some(header) =>
+                // Drain the discarded intermediate body to free its connection.
+                safely(response.body.stream.foreachWindow { (_, _, _) => () })
 
-              loop(nextUri, nextMethod, nextBody, remaining - 1)
+                val nextUri = uri.resolve(jn.URI.create(header.value.s).nn).nn
+                Log.fine(HttpEvent.Redirect(uri.toString.tt, nextUri.toString.tt))
+                val nextMethod = redirectMethod(code, method)
 
-      logResponse:
-        loop(jn.URI.create(url.show.s).nn, httpRequest.method, httpRequest.body, redirection.value)
+                val nextBody: AnyRef =
+                  if nextMethod == method then bodyRef else
+                    val empty: Spring[Data] = () => Http.emptyBody()
+                    empty.asInstanceOf[AnyRef]
+
+                loop(nextUri, nextMethod, nextBody, remaining - 1)
+
+        logResponse:
+          loop(jn.URI.create(url.show.s).nn, httpRequest.method,
+              httpRequest.body.asInstanceOf[AnyRef], redirection.value)
 
 // An `HttpClient` is a capability: its instances are constructed from other capabilities (a
 // `Tactic`, an `Online` token, a backend) which they retain — a given that takes capabilities
 // as parameters produces a capability (Jon, 2026-07-06; see rep/DECISIONS.md).
 trait HttpClient extends Targetable, caps.ExclusiveCapability:
-  def request(request: Http.Request, target: Target): Http.Response logs HttpEvent
+  def request(request: Http.Request, target: Target)(using HttpEvent is Loggable): Http.Response

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -79,7 +79,8 @@ object Postable:
 
 
   given text: (encoder: CharEncoder) => Text is Postable =
-    Postable(media"text/plain", value => Stream(IArray.from(value.data)))
+    // Sealed: a fresh `IArray` is immutable; fresh-ness is the opaque-Array artifact.
+    Postable(media"text/plain", value => Stream(caps.unsafe.unsafeAssumePure(IArray.from(value.data))))
 
   given textStream: (encoder: CharEncoder) => LazyList[Text] is Postable =
     Postable(media"application/octet-stream", lazyList => Stream(lazyList.map(_.data).iterator))

--- a/lib/telekinesis/src/core/telekinesis_core2.scala
+++ b/lib/telekinesis/src/core/telekinesis_core2.scala
@@ -53,8 +53,8 @@ class Orchestrate[value: Encodable in Query, result](initial: Optional[value] = 
 extends caps.ExclusiveCapability:
   def otherwise(validate: (query: Query) ?=> Validation)(using Formulation, value is Formulaic)
     ( using decodable: Tactic[Hazard] ?=> value is Decodable in Query )
-    ( using request: Http.Request )
-  :   result raises QueryError =
+    ( using request: Http.Request, tactic: Tactic[QueryError] )
+  :   result =
 
     request.method match
       case Http.Post =>
@@ -69,6 +69,6 @@ extends caps.ExclusiveCapability:
 
 def orchestrate[value: Encodable in Query](initial: Optional[value] = Unset)[result]
   ( render: (form: Text => Html of Flow) ?=> (value: Optional[value]) => result )
-:   Orchestrate[value, result] =
+:   Orchestrate[value, result]^{render, caps.any} =
 
   new Orchestrate[value, result](initial)(render(using _))

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -170,5 +170,6 @@ given domainSocketHttpClient: Tactic[StreamError] => HttpClient onto DomainSocke
   new HttpClient:
     type Target = DomainSocket
 
-    def request(request: Http.Request, socket: DomainSocket): Http.Response logs HttpEvent =
+    def request(request: Http.Request, socket: DomainSocket)(using HttpEvent is Loggable)
+    :   Http.Response =
       unsafely(Http.Response.parse(socket.transmit(request)))

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1386,3 +1386,10 @@ keep per-file separationChecking imports; the rollout targets CONSUMER modules
 (which hold capabilities but never implement storage). Also: IArray fresh-ness
 under sepcheck is an opacity artifact (`caps.freeze` accepts `Mutable | Array[?]`
 and cannot see through the opaque type) — upstream stdlib-annotation gap.
+
+honeycomb.core's missing settings.cc is DELIBERATE, now documented in build.mill:
+flipping it yields 12 errors, all in the macro-quote/CC unification family
+(quoted type patterns `'{$renderable: Renderable}` and `'[Map[Text, ...]]`
+against capture-decorated Expr types, plus Aggregable given results capturing
+anonymous evidence). Needs a dedicated leg (possibly fork work on quote-pattern
+capture unification); parked with a pointer.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1369,3 +1369,20 @@ capture-checked boundary.break. throwUnsafely: ThrowTactic[Hazard, success].
 Sweep fallout was small: 13 bounds outside contingency (parasite/zephyrine/
 obligatory), 7 Tactic[Exception]→Tactic[Hazard] sites, one raw test exception
 (zephyrine Mismatch → Error). Suites green incl. contingency 91/parasite 148.
+
+## Sepcheck rollout (2026-07-11, branch sepcheck-rollout)
+
+`settings.sep` added to build.mill (cc + separationChecking, module-level).
+MODULE-WIDE SEP ON ZEPHYRINE IS BLOCKED BY P5: flagging the module pulls
+Addressable.scala (deliberately the unchecked interior) into sepcheck. New P5
+data from the attempt: ANNOTATED abstract members DO work — `def allocate(size:
+Int): Storage^` and `storage: Storage^`/`Storage^{caps.any.rd}` params override
+concrete Array signatures cleanly (the probe only tried bare members). What
+remains blocked is the FIELD layer: honest fresh `allocate` means kernel classes
+need `Storage^` fields, and abstract exclusive fields cannot be reassigned
+(Conduit.publish's `current = allocate(block)`). Fix requires per-medium Storage
+concretization or an upstream/fork primitive. Until then zephyrine/turbulence
+keep per-file separationChecking imports; the rollout targets CONSUMER modules
+(which hold capabilities but never implement storage). Also: IArray fresh-ness
+under sepcheck is an opacity artifact (`caps.freeze` accepts `Mutable | Array[?]`
+and cannot see through the opaque type) — upstream stdlib-annotation gap.


### PR DESCRIPTION
Separation checking is now enforced module-wide in the first tier of streaming consumers — coaxial, monotonous, scintillate's server and telekinesis — via a new `settings.sep` build option. Until now, `consume` linearity and hidden-set separation were only diagnosed in the eleven kernel files carrying a per-file language import; a module holding exclusive streams could double-consume them without complaint. The rollout makes the kernel's single-ownership discipline a checked property where those capabilities actually live, and the compiler's diagnostics drove honest annotations throughout the transport layer.

## Release notes

- The socket transports declare their linearity: `Duplex.send`, `Routable.transmit` and `Serviceable.transmit` take `consume` streams, so sending a stream twice is a compile error in separation-checked code.
- `Sender` posts through a named `Sender.Post` SAM (a lambda cannot declare a `consume` parameter).
- `Duplex.pair()` constructs an in-process connected pair — the transport that the HTTP/2, gRPC and registry test suites previously hand-rolled.
- Methods returning `result raises E` or `result logs E` where the receiver or a parameter is a capability now take the equivalent `using` parameter instead: a context-function result may not hide a capability. This changes `HttpClient.request` (now `(using HttpEvent is Loggable)`), `Http.Request.parseHead`, coaxial's `transmit`/`react`/`exchange`/`duplex` and monotonous's `deserialize`.
- Capability-given results name what they retain: `(Endpoint[TcpPort] is Serviceable)^{tactic}`, `HttpClient^{tactic, caps.any}`, `Orchestrate[value, result]^{render, caps.any}`.
- honeycomb.core's absence from capture checking is now documented in the build (12 macro-quote/CC unification errors block it), and the zephyrine kernel itself keeps per-file flags: module-wide separation checking there is blocked by the abstract-`Storage` field limit, recorded with new probe data in `rep/DECISIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
