### PR TITLE
Serve HTTP from a WASM component, and bring the WASI modules into CI

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -386,12 +386,13 @@ object soundness extends Toolchain:
     hieroglyph.core, adversaria.core, turbulence.core, eucalyptus.core, gossamer.core,
     inimitable.core, iridescence.core, kaleidoscope.core, mercator.core, nomenclature.core,
     nomenclature.lexicon,
-    parasite.core, polysyllabic.core, rudiments.core, spectacular.core, symbolism.core,
+    parasite.core, parasite.jvm, polysyllabic.core, rudiments.core, spectacular.core, symbolism.core,
+    turbulence.jvm,
     prepositional.core, vacuous.core, wisteria.core, vicarious.core, serpentine.core,
     typonym.core, zephyrine.core, frontier.core, gigantism.core, stenography.core)
 
   object cli extends Bundle(burdock.boot, burdock.core, dendrology.tree, dendrology.dag,
-    exoskeleton.completions, escritoire.core, ethereal.core, galilei.jvm, eucalyptus.ansi,
+    exoskeleton.completions, escritoire.core, ethereal.core, galilei.core, galilei.jvm, eucalyptus.ansi,
     eucalyptus.syslog, guillotine.core, escapade.csi, escapade.core, imperial.core, profanity.core,
     surveillance.core, punctuation.ansi, hallucination.ansi, ziggurat.core, ziggurat.packager,
     ultimatum.core, xenophile.native, exoskeleton.args, exoskeleton.core)
@@ -415,7 +416,7 @@ object soundness extends Toolchain:
   object tool extends Bundle(anthology.core, decorum.plugin, harlequin.core, hellenism.core,
     hyperbole.core, octogenarian.core, revolution.core, umbrageous.plugin, anthology.java,
     harlequin.md, harlequin.ansi, austronesian.core, anthology.bundle, anthology.`scala`,
-    exegesis.core)
+    exegesis.core, hellenism.jvm)
 
   object web extends Bundle(archimedes.core, cacophony.core, cataclysm.core, coaxial.core, cosmopolite.core, gesticulate.core,
     honeycomb.core, urticose.core, urticose.url, hallucination.core, phoenicia.core,
@@ -424,9 +425,26 @@ object soundness extends Toolchain:
     legerdemain.core, caduceus.core, caduceus.resend, orthodoxy.core, jacinta.http, jacinta.schema,
     stratiform.http, obligatory.core, obligatory.json, synesthesia.core, apoplexy.core,
     cataclysm.html, querencia.core, cordillera.core, embarcadero.containerd, obligatory.grpc,
-    xenophile.core, xenophile.typescript, xenophile.webidl, xenophile.wit, graffiti.core)
+    xenophile.core, xenophile.js, xenophile.wasm, xenophile.typescript, xenophile.webidl,
+    xenophile.wit, telekinesis.core, graffiti.core)
 
-  object all extends Bundle(base, cli, data, sci, test, tool, web)
+  // The three platform aggregates. `jvm` is every JVM module (the group bundles); `wasi` is the
+  // WASI backends (compiled here as ordinary JVM, which typechecks their deferred `invoke`
+  // navigation — the guard that catches breakage like a streaming-kernel change); `js` is the
+  // Scala.js cross-build of every JS-capable component (including the `.wasi` modules' `.js`
+  // outputs). `all` spans the two JVM-classpath aggregates; the Scala.js surface is a distinct
+  // platform and is built through `js` alongside it (both are compiled by CI).
+  object jvm extends Bundle(base, cli, data, sci, test, tool, web)
+
+  object wasi extends Bundle(ambience.wasi, aviation.wasi, capricious.wasi, galilei.wasi,
+    telekinesis.wasi, turbulence.wasi)
+
+  object js extends ScalaJSModule, Toolchain:
+    def scalaVersion = settings.scalaVersion
+    def scalaJSVersion = settings.scalaJsVersion
+    override def moduleDeps = jsComponents
+
+  object all extends Bundle(jvm, wasi)
 
 object test extends Toolchain:
   def scalaVersion = settings.scalaVersion
@@ -468,7 +486,8 @@ object groupCheck extends Module:
       case c: (Component | BareComponent) => c.moduleSegments.render
     .toSet
     val groupBundles = Seq(soundness.base, soundness.cli, soundness.data,
-                           soundness.sci, soundness.test, soundness.tool, soundness.web)
+                           soundness.sci, soundness.test, soundness.tool, soundness.web,
+                           soundness.wasi)
     val coveredComponents = groupBundles.flatMap(_.moduleDeps.map(_.moduleSegments.render)).toSet
 
     val problems = scala.collection.mutable.Buffer.empty[String]
@@ -2114,18 +2133,13 @@ val allLibraries: Seq[Library] = Seq(
   yossarian, ypsiloid, zephyrine, zeppelin, ziggurat
 )
 
-// Every Scala.js-capable component's `js` cross-module. Compiling `jsAll` cross-compiles the whole
-// JS-capable surface of the build (`./mill jsAll.compile`); JVM-only modules opt out with
-// `override def scalaJs = false` and are skipped here.
+// Every Scala.js-capable component's `js` cross-module — the module deps of `soundness.js`.
+// Compiling `soundness.js` cross-compiles the whole JS-capable surface of the build; JVM-only
+// modules opt out with `override def scalaJs = false` and are skipped here.
 val jsComponents: Seq[ScalaJSModule] =
   allLibraries.flatMap(_.moduleDirectChildren).collect:
     case component: Component if component.scalaJs     => component.js
     case component: BareComponent if component.scalaJs => component.js
-
-object jsAll extends ScalaJSModule, Toolchain:
-  def scalaVersion = settings.scalaVersion
-  def scalaJSVersion = settings.scalaJsVersion
-  override def moduleDeps = jsComponents
 
 // A tiny Scala.js app whose `fastLinkJS` actually LINKS a representative slice of
 // the JS-capable modules, so the linker reports any reachable reference to a

--- a/lib/telekinesis/res/wasi/telekinesis/http.wit
+++ b/lib/telekinesis/res/wasi/telekinesis/http.wit
@@ -67,6 +67,24 @@ interface types {
   resource incoming-body {
     %stream: func() -> result<input-stream>;
   }
+
+  resource incoming-request {
+    method: func() -> method;
+    path-with-query: func() -> option<string>;
+    authority: func() -> option<string>;
+    headers: func() -> fields;
+    consume: func() -> result<incoming-body>;
+  }
+
+  resource outgoing-response {
+    constructor(headers: fields);
+    set-status-code: func(status-code: u16) -> result;
+    body: func() -> result<outgoing-body>;
+  }
+
+  resource response-outparam {
+    set: static func(param: response-outparam, response: result<outgoing-response, error-code>);
+  }
 }
 
 interface outgoing-handler {

--- a/lib/telekinesis/src/wasi/telekinesis_wasi.scala
+++ b/lib/telekinesis/src/wasi/telekinesis_wasi.scala
@@ -44,6 +44,9 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import vacuous.*
+import distillate.*
+import soundness.{invoke, dispose}
+import urticose.*
 import xenophile.*
 import zephyrine.*
 
@@ -178,7 +181,7 @@ package httpBackends:
       // is end-of-stream.
       val bodyHandle = response.consume.invoke[WitHandle of "incoming-body"]
       val incomingBody: Foreign of "incoming-body" from Wit = bodyHandle
-      val streamHandle = incomingBody.stream.invoke[WitHandle of "input-stream"]
+      val streamHandle = incomingBody.selectDynamic("stream").invoke[WitHandle of "input-stream"]
       val stream: Foreign of "input-stream" from Wit = streamHandle
 
       var chunks: List[Data] = Nil
@@ -192,4 +195,114 @@ package httpBackends:
       bodyHandle.dispose()
       responseHandle.dispose()
 
-      status(textHeaders, Http.Body.Streaming(chunks.reverse.to(LazyList)))
+      val content: Data = chunks.reverse.foldLeft(IArray.empty[Byte])(_ ++ _)
+      status(textHeaders, Http.Body.Fixed(content))
+
+// Serves HTTP from a Wasm Component: the bridge from `wasi:http/incoming-handler`'s exported
+// `handle` function to a Soundness handler. The application supplies a small `@WitExport` shim
+// (the one piece that must exist, annotated, in the Wasm-compiled application itself) which
+// passes the two facade instances through untyped — they are Wasm-only classes this module never
+// names — and everything else happens here: unmarshalling the request, dispatching to the
+// handler, marshalling the response, and setting the outparam. `inline`, so the `invoke`s expand
+// at the downstream summoning site, exactly as for the backends above.
+object WasiHttpServer:
+  inline def handle(request: Any, responseOut: Any)
+    ( inline handler: Http.Request => Http.Response )
+  :   Unit =
+
+    def bytes(text: Text): Data = text.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+
+    val requestHandle = new WitHandle(request).asInstanceOf[WitHandle of "incoming-request"]
+    val incoming: Foreign of "incoming-request" from Wit = requestHandle
+
+    val method: Http.Method =
+      unsafely(incoming.method.invoke[WitCase of "method"].name.upper.decode[Http.Method])
+
+    val target: Text = incoming.`path-with-query`.invoke[Optional[Text]].or(t"/")
+
+    val headersHandle = incoming.headers.invoke[WitHandle of "fields"]
+    val requestFields: Foreign of "fields" from Wit = headersHandle
+
+    val textHeaders: List[Http.Header] =
+      requestFields.entries.invoke[List[(Text, Data)]].map: (key, value) =>
+        Http.Header(key, value.utf8)
+
+    headersHandle.dispose()
+
+    val bodyHandle = incoming.consume.invoke[WitHandle of "incoming-body"]
+    val incomingBody: Foreign of "incoming-body" from Wit = bodyHandle
+    val streamHandle = incomingBody.selectDynamic("stream").invoke[WitHandle of "input-stream"]
+    val inputStream: Foreign of "input-stream" from Wit = streamHandle
+
+    var chunks: List[Data] = Nil
+
+    try
+      while true do
+        chunks = inputStream.`blocking-read`(U64(65536L.bits)).invoke[Data] :: chunks
+    catch case error: WitError => ()
+
+    streamHandle.dispose()
+    bodyHandle.dispose()
+    requestHandle.dispose()
+
+    val content: Data = chunks.reverse.foldLeft(IArray.empty[Byte])(_ ++ _)
+
+    // The request's host is the server's own; a component behind `wasi:http` is not addressed by
+    // hostname, so `Localhost` stands in (and avoids parsing the authority, which would reach the
+    // wasm javalib's trapping regex engine).
+    val httpRequest =
+      Http.Request
+        ( method,
+          1.1,
+          Localhost,
+          target,
+          textHeaders,
+          () => Stream(Iterator(content)) )
+
+    val response = handler(httpRequest)
+
+    // The response's headers travel in a `fields` whose ownership passes into the
+    // `outgoing-response`, whose ownership passes into `set` — so neither is dropped here.
+    val fieldsHandle = Foreign["fields", Wit].constructor.invoke[WitHandle of "fields"]
+    val fields: Foreign of "fields" from Wit = fieldsHandle
+
+    response.textHeaders.each: header =>
+      fields.append(header.key, bytes(header.value)).invoke[Unit]
+
+    val outgoingResponse =
+      Foreign["outgoing-response", Wit].asInstanceOf[Foreign of "outgoing-response" from Wit]
+
+    val responseHandle =
+      outgoingResponse.constructor(fieldsHandle).invoke[WitHandle of "outgoing-response"]
+
+    val outgoing: Foreign of "outgoing-response" from Wit = responseHandle
+    outgoing.`set-status-code`(U16(response.status.code.toShort.bits)).invoke[Unit]
+
+    val outBodyHandle = outgoing.body.invoke[WitHandle of "outgoing-body"]
+
+    // The outparam is set before the body is written, so the host can stream the response; the
+    // response's ownership passes into `set` (wrapped as the `ok` arm of its `result` parameter).
+    val outparamHandle = new WitHandle(responseOut).asInstanceOf[WitHandle of "response-outparam"]
+
+    val responseOutparam =
+      Foreign["response-outparam", Wit].asInstanceOf[Foreign of "response-outparam" from Wit]
+
+    responseOutparam.set(outparamHandle, responseHandle).invoke[Unit]
+
+    val payload: Data = response.body match
+      case Http.Body.Fixed(data) => data
+      case Http.Body.Empty       => IArray.empty[Byte]
+      case body                  => body.stream.memoize
+
+    val outBody: Foreign of "outgoing-body" from Wit = outBodyHandle
+
+    if !payload.isEmpty then
+      val writeHandle = outBody.write.invoke[WitHandle of "output-stream"]
+      val outputStream: Foreign of "output-stream" from Wit = writeHandle
+      outputStream.`blocking-write-and-flush`(payload).invoke[Unit]
+      writeHandle.dispose()
+
+    val outgoingBody =
+      Foreign["outgoing-body", Wit].asInstanceOf[Foreign of "outgoing-body" from Wit]
+
+    outgoingBody.finish(outBodyHandle, Unset).invoke[Unit]

--- a/lib/xenophile/src/core/xenophile.internal.scala
+++ b/lib/xenophile/src/core/xenophile.internal.scala
@@ -211,9 +211,16 @@ object Xenophile:
     val argTopic = refinements(argRepr).at(t"Topic").or:
       halt(m"xenophile: the foreign type of an argument to $method is not known")
 
+    // The `ok` arm topic of a `result<ok, err>` parameter, if it is one — so a value of that arm's
+    // foreign type satisfies the parameter (the terminal materializer wraps it as an `Ok`), used
+    // for `wasi:http`'s `response-outparam.set(result<outgoing-response, error-code>)`.
+    val okArm: Optional[TypeRepr] = paramType match
+      case Foreign.Type.Applied(constructor, ok :: _) if constructor.s == "result" => reprOf(ok)
+      case _                                                                       => Unset
+
     // Subsumption, not equality: a `string` (or a bare `none`) argument satisfies an
-    // `option<string>` (`string|none`) parameter.
-    if argTopic <:< paramTopic then '{$arg.expr}
+    // `option<string>` (`string|none`) parameter, and an `ok`-arm value a `result<…>` parameter.
+    if argTopic <:< paramTopic || okArm.lay(false)(argTopic <:< _) then '{$arg.expr}
     else halt(m"xenophile: $method expects an argument of foreign type ${paramType.text}")
 
   def select(self: Expr[Foreign], field: Expr[String]): Macro[Foreign] =

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -188,6 +188,10 @@ object WasmInvoke:
       case Refinement(base, "Topic", _) => base =:= TypeRepr.of[WitHandle]
       case _                            => false
 
+    def isCase(scala: TypeRepr): Boolean = scala.dealias match
+      case Refinement(base, "Topic", _) => base =:= TypeRepr.of[WitCase]
+      case _                            => false
+
     def isTuple(scala: TypeRepr, arity: Int): Boolean = scala.dealias match
       case AppliedType(tuple, arguments) =>
         tuple.typeSymbol == defn.TupleClass(arity) && arguments.length == arity
@@ -348,6 +352,21 @@ object WasmInvoke:
             witType match
               case Foreign.Type.Named(name) if isHandle(scala) =>
                 handleDecode(name, scala)
+
+              // A variant (or enum) result requested as a `WitCase of topic`: the facade case
+              // object arrives, and its lower-kebab-case name is recovered at runtime.
+              // Payload-carrying cases lose their payload.
+              case Foreign.Type.Named(name) if isCase(scala) =>
+                val facade = facadeOf(name)
+
+                val decode: Expr[Any] => Expr[Any] = call => scala.asType.absolve match
+                  case '[scala] =>
+                    val witCase = '{new WitCase(WitCase.caseName($call))}.asTerm
+
+                    TypeApply(Select.unique(witCase, "asInstanceOf"), List(TypeTree.of[scala]))
+                    . asExprOf[Any]
+
+                (facade.typeRef, decode)
 
               // A genuinely void function (`block: func()`): nothing to check or decode.
               case Foreign.Type.Named(name) if name.s == "unit" && scala =:= TypeRepr.of[Unit] =>
@@ -539,12 +558,28 @@ object WasmInvoke:
             (carrierType(encodable), encoded, false)
 
       // A plain (always-present) value against an `option<T>` parameter crosses as a present
-      // `java.util.Optional`, matching the parameter's descriptor.
+      // `java.util.Optional`, and one against a `result<T, E>` parameter as an `Ok` (used by
+      // `wasi:http`'s `response-outparam.set`), matching the parameter's descriptor.
       if optionPayload(parameter).present && !alreadyOption then
         val wrapped = '{java.util.Optional.of(${encoded.asExprOf[Any]}).nn}.asTerm
         (optionClass.typeRef.appliedTo(List(carrier)), wrapped)
       else
-        (carrier, encoded)
+        parameter match
+          case Foreign.Type.Applied(constructor, _) if constructor.s == "result" =>
+            val okClass = Symbol.requiredClass("scala.scalajs.wit.Ok")
+            val resultClass = Symbol.requiredClass("scala.scalajs.wit.Result")
+
+            val wrapped =
+              Apply
+                ( TypeApply
+                    ( Select(New(Inferred(okClass.typeRef)), okClass.primaryConstructor),
+                      List(TypeTree.of[Any]) ),
+                  List(encoded) )
+
+            (resultClass.typeRef, wrapped)
+
+          case _ =>
+            (carrier, encoded)
 
     val argumentPairs: List[Term] =
       argumentTerms.zip(parameterTypes).flatMap: (argument, parameter) =>

--- a/lib/xenophile/src/wasm/xenophile.WitCase.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitCase.scala
@@ -33,6 +33,7 @@
 package xenophile
 
 import anticipation.*
+import gossamer.*
 import prepositional.*
 
 // A payload-less case of a WIT `variant` (or `enum`), named by its lower-kebab-case Scala-side
@@ -43,6 +44,13 @@ import prepositional.*
 object WitCase:
   def apply[topic <: Label](name: Text): WitCase of topic =
     new WitCase(name).asInstanceOf[WitCase of topic]
+
+  // The case's lower-kebab-case name, recovered from a facade case object's class (the same
+  // spelling `apply` accepts, and the same derivation as `WitError.name`).
+  def caseName(value: Any): Text =
+    val simple = value.getClass.getSimpleName.nn.tt
+    val stripped = if simple.ends(t"$$") then simple.skip(1, Rtl) else simple
+    stripped.uncamel.kebab
 
   given interoperable: [topic <: Label]
   =>  ( (WitCase of topic) is Interoperable in Wit of topic ) =


### PR DESCRIPTION
A Soundness component can now serve HTTP: `telekinesis.wasi` gains `WasiHttpServer`, bridging `wasi:http/incoming-handler` to an ordinary `Http.Request => Http.Response` handler, verified end-to-end under `wasmtime serve`. Alongside it, the build is reorganised into three platform aggregates so that the WASI backends are compiled by CI — closing the gap that had let a merged change silently break `telekinesis.wasi`.

## `WasiHttpServer` — HTTP from a component

An application supplies one small annotated shim (the only piece that must live, annotated, in the Wasm-compiled application), and everything else is handled by the module:
```scala
@WitImplementation
object Main extends IncomingHandler:
  import telekinesis.wasiHttpApi

  @WitExport("wasi:http/incoming-handler@0.2.0", "handle")
  def handle(request: IncomingRequest, responseOut: ResponseOutparam): Unit =
    WasiHttpServer.handle(request, responseOut): request =>
      Http.Response(Http.Ok)(t"Hello from ${request.method} ${request.target}\n")
```
`WasiHttpServer.handle` unmarshals the `incoming-request` into an `Http.Request`, dispatches to the handler, and marshals the `Http.Response` back through `outgoing-response` and the `response-outparam`. This is the export direction of the Component Model — the counterpart to the import-based backends. It needed three additions to xenophile's `invoke`: reading a `variant` case back as a result (the request method), and passing a value as the `ok` arm of a `result<T, E>` argument (`response-outparam.set`), with the matching subsumption in the argument-type check.

## Platform aggregates and WASI in CI

The build now exposes three aggregates — `soundness.jvm` (the JVM modules), `soundness.js` (the Scala.js cross-build), and `soundness.wasi` (the WASI backends) — and `soundness.all` spans the JVM and WASI aggregates. CI now compiles the WASI modules, which typechecks their deferred `invoke` navigation; this repairs `telekinesis.wasi`, whose client backend had been silently broken (it was not previously compiled by any CI target).