### PR TITLE
Repair mosquito and obligatory under the Scala.js capture-checking pipeline

### DIFF
--- a/lib/mosquito/src/core/mosquito.Matrix.scala
+++ b/lib/mosquito/src/core/mosquito.Matrix.scala
@@ -754,7 +754,20 @@ class Matrix[element, rows <: Int, columns <: Int]
   override def hashCode: Int =
     scala.util.hashing.MurmurHash3.arrayHash(elements.mutable(using Unsafe))
 
-  override def toString(): String = t"[${elements.inspect}]".s
+  // `elements.inspect` derives an `Inspectable` for `IArray[element]` element-wise; under capture
+  // checking in the Scala.js pipeline the derivation leaks the element's capture into the
+  // generated `text` override, so `toString` (debug output only) builds the string from the
+  // elements' own `toString`.
+  override def toString(): String =
+    val builder = StringBuilder("[")
+    var index = 0
+
+    while index < elements.length do
+      if index > 0 then builder.append(", ")
+      builder.append(elements(index).toString)
+      index += 1
+
+    builder.append("]").toString
 
 
   @targetName("scalarMul")

--- a/lib/obligatory/src/core/obligatory.CarriageReturn.scala
+++ b/lib/obligatory/src/core/obligatory.CarriageReturn.scala
@@ -40,15 +40,28 @@ import vacuous.*
 import zephyrine.*
 
 object CarriageReturn:
-  given framable: Text is Framable by CarriageReturn = input =>
-    val cursor = Cursor(input)
+  // An explicit `new Framable` rather than a SAM lambda: the Scala.js pipeline, computing the
+  // result's capture set, infers a self-referential union (`input | Framable{…}`) for the
+  // lambda's `this` and rejects it; a named instance gives `this` a concrete type. (Compiler
+  // divergence; the JVM pipeline accepts the lambda.)
+  given framable: (Text is Framable by CarriageReturn) = new Framable:
+    type Self = Text
+    type Operand = CarriageReturn
 
-    Framable.frames[Text]:
-      cursor.hold:
-        val start = cursor.mark
+    def frames(input: Iterator[Text]^): Iterator[Text]^{input, this} =
+      val cursor = Cursor(input)
 
-        if !cursor.finished && cursor.seek(Cr.toByte.asInstanceOf[cursor.addressable.Operand])
-        then cursor.grab(start, cursor.mark).also(cursor.next())
-        else if cursor.mark == start then Unset else cursor.grab(start, cursor.mark)
+      val framed =
+        Framable.frames[Text]:
+          cursor.hold:
+            val start = cursor.mark
+
+            if !cursor.finished && cursor.seek(Cr.toByte.asInstanceOf[cursor.addressable.Operand])
+            then cursor.grab(start, cursor.mark).also(cursor.next())
+            else if cursor.mark == start then Unset else cursor.grab(start, cursor.mark)
+
+      // The framed iterator captures `cursor`, which is built from (and so reaches) `input`; the
+      // relabel states that reachability, which the JS pipeline does not infer through the local.
+      framed.asInstanceOf[Iterator[Text]^{input, this}]
 
 sealed trait CarriageReturn

--- a/lib/obligatory/src/core/obligatory.ContentLength.scala
+++ b/lib/obligatory/src/core/obligatory.ContentLength.scala
@@ -47,71 +47,80 @@ object ContentLength:
   // framer would) coincides with bytes only for ASCII content and corrupts the stream on any
   // multi-byte UTF-8 body. Unrecognised headers are skipped rather than rejected, since clients
   // routinely send headers beyond `Content-Length` and `Content-Type`.
+  // An explicit `new Framable` rather than a SAM lambda, with the result relabelled to state
+  // that the framed iterator (capturing the local `cursor`, built from `input`) reaches
+  // `input` — the Scala.js pipeline infers neither the lambda's `this` nor the local's
+  // reachability. (Compiler divergence; the JVM pipeline accepts the lambda.)
   given framable: (tactic: Tactic[FrameError])
-  =>  ((Data is Framable by ContentLength)^{tactic}) = input =>
-    val cursor = Cursor(input)
+  =>  ( (Data is Framable by ContentLength)^{tactic} ) = new Framable:
+    type Self = Data
+    type Operand = ContentLength
 
-    val cr: Byte = 13
-    val lf: Byte = 10
-    val colon: Byte = 58
-    val space: Byte = 32
+    def frames(input: Iterator[Data]^): Iterator[Data]^{input, this} =
+      val cursor = Cursor(input)
 
-    def fail(): Nothing = abort(FrameError(FrameError.Reason.ShortRead))
-    def lower(byte: Byte): Byte = if byte >= 65 && byte <= 90 then (byte + 32).toByte else byte
+      val cr: Byte = 13
+      val lf: Byte = 10
+      val colon: Byte = 58
+      val space: Byte = 32
 
-    val name: Text = t"content-length"
+      def fail(): Nothing = abort(FrameError(FrameError.Reason.ShortRead))
+      def lower(byte: Byte): Byte = if byte >= 65 && byte <= 90 then (byte + 32).toByte else byte
 
-    def frame(): Optional[Data] =
-      if cursor.finished then Unset else
-        var length: Int = -1
-        var blank = false
+      val name: Text = t"content-length"
 
-        while !blank do
-          if cursor.finished then fail()
+      def frame(): Optional[Data] =
+        if cursor.finished then Unset else
+          var length: Int = -1
+          var blank = false
 
-          if cursor.datum(using Unsafe) == cr then
-            cursor.next()
-            if cursor.finished || cursor.datum(using Unsafe) != lf then fail()
-            cursor.next()
-            blank = true
-          else
-            var matches = true
-            var index = 0
+          while !blank do
+            if cursor.finished then fail()
 
-            while !cursor.finished && cursor.datum(using Unsafe) != colon do
-              val byte = lower(cursor.datum(using Unsafe).asInstanceOf[Byte])
-              if index >= name.length || byte != name.s.charAt(index).toByte then matches = false
-              index += 1
+            if cursor.datum(using Unsafe) == cr then
+              cursor.next()
+              if cursor.finished || cursor.datum(using Unsafe) != lf then fail()
+              cursor.next()
+              blank = true
+            else
+              var matches = true
+              var index = 0
+
+              while !cursor.finished && cursor.datum(using Unsafe) != colon do
+                val byte = lower(cursor.datum(using Unsafe).asInstanceOf[Byte])
+                if index >= name.length || byte != name.s.charAt(index).toByte then matches = false
+                index += 1
+                cursor.next()
+
+              if index != name.length then matches = false
+              if cursor.finished then fail()
               cursor.next()
 
-            if index != name.length then matches = false
-            if cursor.finished then fail()
-            cursor.next()
+              while !cursor.finished && cursor.datum(using Unsafe) == space do cursor.next()
 
-            while !cursor.finished && cursor.datum(using Unsafe) == space do cursor.next()
+              var value = 0
+              var digits = false
 
-            var value = 0
-            var digits = false
+              while !cursor.finished && cursor.datum(using Unsafe) != cr do
+                val byte = cursor.datum(using Unsafe).asInstanceOf[Byte]
 
-            while !cursor.finished && cursor.datum(using Unsafe) != cr do
-              val byte = cursor.datum(using Unsafe).asInstanceOf[Byte]
+                if matches && byte >= 48 && byte <= 57 then
+                  value = value*10 + (byte - 48)
+                  digits = true
 
-              if matches && byte >= 48 && byte <= 57 then
-                value = value*10 + (byte - 48)
-                digits = true
+                cursor.next()
 
+              if cursor.finished then fail()
+              cursor.next()
+              if cursor.finished || cursor.datum(using Unsafe) != lf then fail()
               cursor.next()
 
-            if cursor.finished then fail()
-            cursor.next()
-            if cursor.finished || cursor.datum(using Unsafe) != lf then fail()
-            cursor.next()
+              if matches && digits then length = value
 
-            if matches && digits then length = value
+          if length < 0 then abort(FrameError(FrameError.Reason.MalformedLength))
+          cursor.take(fail())(length)
 
-        if length < 0 then abort(FrameError(FrameError.Reason.MalformedLength))
-        cursor.take(fail())(length)
-
-    Framable.frames[Data](frame())
+      val framed = Framable.frames[Data](frame())
+      framed.asInstanceOf[Iterator[Data]^{input, this}]
 
 sealed trait ContentLength

--- a/lib/obligatory/src/core/obligatory.CrLf.scala
+++ b/lib/obligatory/src/core/obligatory.CrLf.scala
@@ -41,20 +41,32 @@ import vacuous.*
 import zephyrine.*
 
 object CrLf:
+  // An explicit `new Framable` rather than a SAM lambda, with the result relabelled to state that
+  // the framed iterator (capturing the local `cursor`, built from `input`) reaches `input` — the
+  // Scala.js pipeline infers neither the lambda's `this` nor the local's reachability. (Compiler
+  // divergence; the JVM pipeline accepts the lambda.)
   given framable: (tactic: Tactic[FrameError])
-  =>  ((Text is Framable by CrLf)^{tactic}) = input =>
-    val cursor = Cursor(input)
+  =>  ( (Text is Framable by CrLf)^{tactic} ) = new Framable:
+    type Self = Text
+    type Operand = CrLf
 
-    Framable.frames[Text]:
-      cursor.hold:
-        val start = cursor.mark
+    def frames(input: Iterator[Text]^): Iterator[Text]^{input, this} =
+      val cursor = Cursor(input)
 
-        if !cursor.finished && cursor.seek(Cr.toByte.asInstanceOf[cursor.addressable.Operand])
-        then cursor.grab(start, cursor.mark).also:
-          cursor.next()
+      val framed =
+        Framable.frames[Text]:
+          cursor.hold:
+            val start = cursor.mark
 
-          if !cursor.lay(false)(_ == Lf) then abort(FrameError(FrameError.Reason.MissingLineFeed))
-          else cursor.next()
-        else if cursor.mark == start then Unset else cursor.grab(start, cursor.mark)
+            if !cursor.finished && cursor.seek(Cr.toByte.asInstanceOf[cursor.addressable.Operand])
+            then cursor.grab(start, cursor.mark).also:
+              cursor.next()
+
+              if !cursor.lay(false)(_ == Lf)
+              then abort(FrameError(FrameError.Reason.MissingLineFeed))
+              else cursor.next()
+            else if cursor.mark == start then Unset else cursor.grab(start, cursor.mark)
+
+      framed.asInstanceOf[Iterator[Text]^{input, this}]
 
 sealed trait CrLf

--- a/lib/obligatory/src/core/obligatory.LengthPrefix.scala
+++ b/lib/obligatory/src/core/obligatory.LengthPrefix.scala
@@ -39,29 +39,38 @@ import vacuous.*
 import zephyrine.*
 
 object LengthPrefix:
+  // See `CarriageReturn.framable`: explicit `new` (the Scala.js pipeline mis-infers the SAM
+  // lambda's `this`) plus a relabel of the local cursor's reachability of `input`.
   given framable: (tactic: Tactic[FrameError])
-  =>  ((Data is Framable by LengthPrefix)^{tactic}) = input =>
-    def fail() = abort(FrameError(FrameError.Reason.ShortRead))
+  =>  ( (Data is Framable by LengthPrefix)^{tactic} ) = new Framable:
+    type Self = Data
+    type Operand = LengthPrefix
 
-    val cursor = Cursor(input)
+    def frames(input: Iterator[Data]^): Iterator[Data]^{input, this} =
+      def fail() = abort(FrameError(FrameError.Reason.ShortRead))
 
-    def length: Optional[Int] =
-      cursor.lay(Unset): byte0 =>
-        cursor.next()
+      val cursor = Cursor(input)
 
-        cursor.lay(fail()): byte1 =>
+      def length: Optional[Int] =
+        cursor.lay(Unset): byte0 =>
           cursor.next()
 
-          cursor.lay(fail()): byte2 =>
+          cursor.lay(fail()): byte1 =>
             cursor.next()
 
-            cursor.lay(fail()): byte3 =>
+            cursor.lay(fail()): byte2 =>
               cursor.next()
-              byte0.asInstanceOf[Byte] << 24 | byte1.asInstanceOf[Byte] << 16
-                | byte2.asInstanceOf[Byte] << 8 | byte3.asInstanceOf[Byte]
 
-    Framable.frames[Data]:
-      length.let: length =>
-        cursor.take(fail())(length)
+              cursor.lay(fail()): byte3 =>
+                cursor.next()
+                byte0.asInstanceOf[Byte] << 24 | byte1.asInstanceOf[Byte] << 16 |
+                  byte2.asInstanceOf[Byte] << 8 | byte3.asInstanceOf[Byte]
+
+      val framed =
+        Framable.frames[Data]:
+          length.let: length =>
+            cursor.take(fail())(length)
+
+      framed.asInstanceOf[Iterator[Data]^{input, this}]
 
 sealed trait LengthPrefix

--- a/lib/obligatory/src/core/obligatory.Linefeed.scala
+++ b/lib/obligatory/src/core/obligatory.Linefeed.scala
@@ -40,15 +40,24 @@ import vacuous.*
 import zephyrine.*
 
 object Linefeed:
-  given framable: Text is Framable by Linefeed = input =>
-    val cursor = Cursor(input)
+  // See `CarriageReturn.framable`: explicit `new` (the Scala.js pipeline mis-infers the SAM
+  // lambda's `this`) plus a relabel of the local cursor's reachability of `input`.
+  given framable: (Text is Framable by Linefeed) = new Framable:
+    type Self = Text
+    type Operand = Linefeed
 
-    Framable.frames[Text]:
-      cursor.hold:
-        val start = cursor.mark
+    def frames(input: Iterator[Text]^): Iterator[Text]^{input, this} =
+      val cursor = Cursor(input)
 
-        if !cursor.finished && cursor.seek(Lf.toByte.asInstanceOf[cursor.addressable.Operand])
-        then cursor.grab(start, cursor.mark).also(cursor.next())
-        else if cursor.mark == start then Unset else cursor.grab(start, cursor.mark)
+      val framed =
+        Framable.frames[Text]:
+          cursor.hold:
+            val start = cursor.mark
+
+            if !cursor.finished && cursor.seek(Lf.toByte.asInstanceOf[cursor.addressable.Operand])
+            then cursor.grab(start, cursor.mark).also(cursor.next())
+            else if cursor.mark == start then Unset else cursor.grab(start, cursor.mark)
+
+      framed.asInstanceOf[Iterator[Text]^{input, this}]
 
 sealed trait Linefeed


### PR DESCRIPTION
Two more modules whose Scala.js cross-build the capture-checking migration broke — the JVM pipeline accepts both direct forms. Part of bringing `soundness.js` back to green (a longer effort tracked separately; the underlying cause is a compiler pipeline divergence, not the source).

## Release notes

- `mosquito.Matrix.toString` no longer derives an `Inspectable` for `IArray[element]` (whose generated `text` override leaked the element's capture in the JS pipeline); its debug output is built from the elements' own `toString`.
- obligatory's five `Framable` instances (`CarriageReturn`, `CrLf`, `ContentLength`, `LengthPrefix`, `Linefeed`) are now explicit `new Framable` instances rather than SAM lambdas, with the framed iterator's reachability of its input relabelled — the JS pipeline mis-inferred the lambda's captured `this` as a self-referential union.