### PR TITLE
Introduce Typeclass.Pure for compiler-verified pure typeclass instances

### DIFF
--- a/lib/anticipation/src/log/anticipation.Transcribable.scala
+++ b/lib/anticipation/src/log/anticipation.Transcribable.scala
@@ -34,9 +34,9 @@ package anticipation
 
 import prepositional.*
 
-trait Transcribable extends Typeclass, Resultant:
+trait Transcribable extends Typeclass.Pure, Resultant:
   def skip(value: Self): Boolean = false
   def record(value: Self): Result
 
-  def contramap[self2](lambda: self2 => Self): (self2 is Transcribable to Result)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Transcribable to Result =
     value => record(lambda(value))

--- a/lib/anticipation/src/path/anticipation.Nominable.scala
+++ b/lib/anticipation/src/path/anticipation.Nominable.scala
@@ -34,5 +34,5 @@ package anticipation
 
 import prepositional.*
 
-trait Nominable extends Typeclass:
+trait Nominable extends Typeclass.Pure:
   def name(value: Self): Text

--- a/lib/escapade/src/core/escapade.Teletypeable.scala
+++ b/lib/escapade/src/core/escapade.Teletypeable.scala
@@ -197,8 +197,8 @@ object Teletypeable:
     Teletype.styled[String]
       (throwable.getClass.getName.nn.show.cut(t".").last.s)(_.copy(fg = Chroma(0xdc133b)))
 
-trait Teletypeable extends Typeclass:
+trait Teletypeable extends Typeclass.Pure:
   def teletype(value: Self): Teletype
 
-  def contramap[self2](lambda: self2 => Self): (self2 is Teletypeable)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Teletypeable =
     value => teletype(lambda(value))

--- a/lib/fulminate/src/core/fulminate.Communicable.scala
+++ b/lib/fulminate/src/core/fulminate.Communicable.scala
@@ -68,5 +68,5 @@ trait Communicable extends Transcribable:
   def message(value: Self): Message
   def record(value: Self): Message = message(value)
 
-  override def contramap[self](lambda: self => Self): (self is Communicable)^{this, lambda} =
+  override def contramap[self](lambda: self -> Self): self is Communicable =
     value => message(lambda(value))

--- a/lib/gastronomy/src/core/gastronomy.Digestible.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestible.scala
@@ -136,7 +136,7 @@ object Digestible extends Derivable[Digestible]:
   given encodable: [value: Encodable in Data] => value is Digestible =
     bytes.contramap(value.encode)
 
-trait Digestible extends Typeclass:
+trait Digestible extends Typeclass.Pure:
   digestible: Digestible =>
 
     def digest(digestion: Digestion, value: Self): Unit

--- a/lib/gesticulate/src/core/gesticulate.Media.scala
+++ b/lib/gesticulate/src/core/gesticulate.Media.scala
@@ -142,5 +142,5 @@ object Media:
   final private val specials: Set[Char] =
     Set('(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '+')
 
-trait Media extends Typeclass:
+trait Media extends Typeclass.Pure:
   extension (value: Self) def mediaType: MediaType

--- a/lib/gossamer/src/core/gossamer.Textual.scala
+++ b/lib/gossamer/src/core/gossamer.Textual.scala
@@ -80,7 +80,7 @@ object Textual:
     def builder(size: Optional[Int]): Builder[Text] = TextBuilder(size)
     def size(text: Self): Int = text.length
 
-trait Textual extends Typeclass, Countable, Segmentable, Zeroic, Indexable:
+trait Textual extends Typeclass.Pure, Countable, Segmentable, Zeroic, Indexable:
   type Operand = Ordinal
   type Result
   type Show[value]

--- a/lib/hieroglyph/src/core/hieroglyph.Measurable.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.Measurable.scala
@@ -39,5 +39,5 @@ object Measurable:
   given general: (measurable: Char is Measurable) => Text is Measurable =
     _.s.toCharArray.nn.iterator.map(measurable.width(_)).sum
 
-trait Measurable extends Typeclass:
+trait Measurable extends Typeclass.Pure:
   def width(text: Self): Int

--- a/lib/prepositional/src/core/prepositional.Typeclass.scala
+++ b/lib/prepositional/src/core/prepositional.Typeclass.scala
@@ -43,3 +43,16 @@ import beneficence.Findable
 // instances, and the constructing capabilities for the rest, which declare it explicitly.
 trait Typeclass extends Findable:
   type Self
+
+object Typeclass:
+  // The checked-pure subset: a typeclass whose instances hold only data and
+  // logic, never a capability. The compiler enforces it — an instance whose
+  // body references a capability is rejected at its definition — so purity
+  // here is a verified fact, not an assertion. Typeclasses whose instances
+  // legitimately retain capabilities (a `Tactic`, a backend, an encoder that
+  // writes) stay on plain `Typeclass`, with captures tracked explicitly per
+  // the design note above. A pure typeclass instance that must nonetheless
+  // hold a resolution-scoped capability names it in a single
+  // `@caps.unsafe.untrackedCaptures` field — a narrower, greppable assertion
+  // than sealing the whole instance.
+  trait Pure extends Typeclass, caps.Pure

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -226,6 +226,6 @@ trait Inspectable2:
     case given Reflection[`value`] => Inspectable.Derivation.derived[value]
     case _                         => value => ("“"+value+"”").tt
 
-trait Inspectable extends Typeclass:
+trait Inspectable extends Typeclass.Pure:
   def text(value: Self): Text
-  def contramap[self2](lambda: self2 => Self): (self2 is Inspectable)^{this, lambda} = value => text(lambda(value))
+  def contramap[self2](lambda: self2 -> Self): self2 is Inspectable = value => text(lambda(value))

--- a/lib/spectacular/src/core/spectacular.Showable.scala
+++ b/lib/spectacular/src/core/spectacular.Showable.scala
@@ -106,9 +106,9 @@ object Showable:
     stack.cause.lay(root): cause =>
       s"$root\ncaused by:\n$cause".tt
 
-trait Showable extends Typeclass, Communicable:
+trait Showable extends Communicable:
   def text(value: Self): Text
   def message(value: Self): Message = Message(text(value))
 
-  override def contramap[self2](lambda: self2 => Self): (self2 is Showable)^{this, lambda} =
+  override def contramap[self2](lambda: self2 -> Self): self2 is Showable =
     value => text(lambda(value))

--- a/lib/xylophone/src/core/xylophone.Renderable.scala
+++ b/lib/xylophone/src/core/xylophone.Renderable.scala
@@ -35,5 +35,5 @@ package xylophone
 import prepositional.*
 
 @unexported
-trait Renderable extends Typeclass, Formal:
+trait Renderable extends Typeclass.Pure, Formal:
   def render(value: Self): Xml of Form

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -243,7 +243,7 @@ object Addressable:
       target.append(storage, off, len)
 
 
-trait Addressable extends Typeclass, Operable, Targetable:
+trait Addressable extends Typeclass.Pure, Operable, Targetable:
   // Mutable backing storage for `Cursor`'s single-buffer model. For `Data`,
   // this is `Array[Byte]`; for `Text`, `Array[Char]`. Hot-path reads in
   // `Cursor.peek` / `Cursor.datum` go through `storageAddress` and lower

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -259,7 +259,7 @@ object Ductile:
 
               out.position - targetOffset
 
-trait Ductile extends Typeclass, Operable, Resultant:
+trait Ductile extends Typeclass.Pure, Operable, Resultant:
   type Transport
   type Upstream
 

--- a/lib/zephyrine/src/core/zephyrine.Regulation.scala
+++ b/lib/zephyrine/src/core/zephyrine.Regulation.scala
@@ -62,7 +62,7 @@ object Regulation:
     def encode(demand: Pace): Long = demand.ordinal
     def decode(bits: Long): Pace = Pace.fromOrdinal(bits.toInt)
 
-trait Regulation extends Typeclass:
+trait Regulation extends Typeclass.Pure:
   def initial: Self
   def grant(demand: Self): Int
   def spend(demand: Self, count: Int): Self

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1422,3 +1422,30 @@ are rejected — cast the pair whole to (AnyRef, AnyRef). ~20 IArray-opacity
 seals added: FORK-FIX CANDIDATE — stdlib IArray ops (from/slice/take/drop/
 ++/zipWithIndex/tabulate/updated) should return pure results, eliminating this
 entire seal class.
+
+## Typeclass purity campaign, leg 1 (2026-07-12, branch typeclass-purity)
+
+Jon's 2026-07-06 decision STANDS: Typeclass in general stays a plain tracked
+class (Decodable has 61 honestly-tracked `^{tactic}` instances, Instantiable 36,
+Aggregable 24, Writable 19 — flipping those to Pure would convert honest
+tracking into assertions). The campaign is the SPLIT: `Typeclass.Pure`
+(prepositional) = the checked-pure subset, enforced by the compiler (P14
+probes, both rows: capability capture in a Pure instance = E223 at definition).
+
+FLIPPED (zero capturing instances, purity now compiler-verified everywhere):
+Transcribable → Communicable → Showable; Inspectable; Addressable; Ductile;
+Regulation; Textual; Nominable; Teletypeable; Media; Digestible; Renderable;
+Measurable. Total fallout: FIVE contramap signatures purified
+(`self2 => Self` → `self2 -> Self`, capture-set results dropped) — nothing
+else in 127 modules. Every Showable/Textual/Addressable/... given is now a
+verified-pure value; a future capability-capturing instance is a compile error.
+
+PATTERN for pure typeclasses that must hold a resolution-scoped capability
+(P14 pos probe): a single `@caps.unsafe.untrackedCaptures` field — narrower and
+greppable vs sealing the whole instance. NOTE (P14): a SEALED capability-class
+value still cannot sit in a Pure class (the monotonous finding); the untracked
+field is the pattern.
+
+FUTURE LEGS: Postable/Transmissible (sealed constructors — need untracked-field
+conversion), Loadable/Computable/near-1-capture audits, converting codec-thunk
+whole-instance seals to untracked fields where traits stay tracked.

--- a/rep/sepcheck-probes/p14-pure-typeclass-capture.neg.scala
+++ b/rep/sepcheck-probes/p14-pure-typeclass-capture.neg.scala
@@ -1,0 +1,25 @@
+// P14 (neg twin): a `Typeclass.Pure` instance that captures a capability is
+// rejected at its definition — the enforcement that turns the codec-thunk
+// convention into a checked fact.
+//EXPECT: (allowed capture set|Pure|pure)
+import language.experimental.captureChecking
+
+trait Tactic[E] extends caps.ExclusiveCapability:
+  def abort(error: E): Nothing
+
+trait Typeclass:
+  type Self
+
+object Typeclass:
+  trait Pure extends Typeclass, caps.Pure
+
+trait Decodable extends Typeclass.Pure:
+  type Form
+  def decoded(value: Form): Self
+
+def make(using tactic: Tactic[String]): Decodable { type Self = Int; type Form = String } =
+  new Decodable:
+    type Self = Int
+    type Form = String
+    def decoded(value: String): Int =
+      if value.isEmpty then tactic.abort("empty") else value.length

--- a/rep/sepcheck-probes/p14-pure-typeclass.pos.scala
+++ b/rep/sepcheck-probes/p14-pure-typeclass.pos.scala
@@ -1,0 +1,39 @@
+// P14: the checked-pure typeclass subset. `Typeclass.Pure` instances may hold
+// only pure state; a given constructed under a resolution-scoped capability
+// seals the CAPABILITY (one uniform, documented pattern) and then constructs
+// purely — the instance itself is compiler-verified capability-free, unlike
+// the old whole-instance seal, which was an unchecked assertion.
+import language.experimental.captureChecking
+
+trait Tactic[E] extends caps.ExclusiveCapability:
+  def abort(error: E): Nothing
+
+trait Typeclass:
+  type Self
+
+object Typeclass:
+  trait Pure extends Typeclass, caps.Pure
+
+trait Decodable extends Typeclass.Pure:
+  type Form
+  def decoded(value: Form): Self
+
+// (a) a plain pure instance
+class TextDecoder extends Decodable:
+  type Self = Int
+  type Form = String
+  def decoded(value: String): Int = value.length
+
+// (c) the untracked-field pattern: a capturing codec given names exactly the
+// capability it retains, with an annotation at the field — the rest of the
+// instance stays compiler-checked pure.
+def make(using tactic: Tactic[String]): Decodable { type Self = Int; type Form = String } =
+  new Decodable:
+    type Self = Int
+    type Form = String
+
+    @caps.unsafe.untrackedCaptures
+    private val tactic0: Tactic[String] = tactic
+
+    def decoded(value: String): Int =
+      if value.isEmpty then tactic0.abort("empty") else value.length


### PR DESCRIPTION
Typeclass instances split into two checked worlds. The existing design stands: a `Typeclass` in general tracks the capabilities its instances retain, explicitly and honestly. `Typeclass.Pure` is the new checked subset for typeclasses whose instances hold only data and logic — and the compiler now enforces that, rejecting any instance that captures a capability at its definition. Purity for these typeclasses was previously a convention; it is now a verified fact at all of their instances across the codebase.

## Release notes

- `prepositional.Typeclass.Pure` marks a typeclass as having compiler-verified pure instances. Fourteen typeclasses adopt it: `Transcribable`, `Communicable`, `Showable`, `Inspectable`, `Addressable`, `Ductile`, `Regulation`, `Textual`, `Nominable`, `Teletypeable`, `Media`, `Digestible`, `Renderable` and `Measurable`.
- Their `contramap` methods take pure functions (`self2 -> Self`) and return plain pure instances — the only signature change the flip required anywhere.
- A pure typeclass instance that must retain a resolution-scoped capability declares it in a single `@caps.unsafe.untrackedCaptures` field: a narrower, greppable assertion than sealing a whole instance, with the rest of the instance still checked.
- Capability-carrying typeclasses (`Decodable`, `Instantiable`, `Aggregable`, `Writable`, `Readable`, `Source`, `Sink`, …) are deliberately untouched: their instances' captures remain explicitly tracked, per the design note on `Typeclass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
