### PR TITLE
Hand off conduit data in transfer-sized blocks

### DIFF
--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -297,16 +297,17 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   // 64 KiB chunks on one thread/fiber, consume on another. Soundness `Conduit`
   // against the JDK `ArrayBlockingQueue`, FS2 `Channel` and ZIO `Queue`.
   //
-  // Two asymmetries dominate and are the point of the comparison:
-  //   * Soundness `Conduit` COPIES data into fixed kernel-block buffers (its
-  //     bounded-memory guarantee) and re-chunks the 64 KiB inputs to the block
-  //     size, so it performs many small copying hand-offs; the queues pass the
-  //     chunk REFERENCES with zero copy.
+  // Two asymmetries remain and are the point of the comparison:
+  //   * Soundness `Conduit` COPIES data into transfer blocks (its bounded-memory
+  //     guarantee), minted at up to `Buffering.transfer` elements to match bulk
+  //     `put`s, so the hand-off count tracks the input chunking; the reference
+  //     queues pass the chunk REFERENCES with zero copy. The residual gap over
+  //     the JDK reference is that one copy.
   //   * FS2/ZIO run the producer as a fiber; Soundness uses a virtual thread
   //     (the Loom analogue of a fiber) and the JDK reference a platform thread.
-  //     Switching Soundness between virtual and platform threads makes no
-  //     material difference here, which locates the gap in the copying data
-  //     path above, not the concurrency substrate. The same holds for the
+  //     Fiber wakeups on a shared worker pool cost less than a thread
+  //     park/unpark (~0.5 µs vs ~1.2 µs per hand-off), a fixed factor visible
+  //     in the reference rows themselves. The same holds for the
   //     `Confluence`/`Manifold` fan-in/fan-out primitives below.
 
   def conduitSoundness: Long =

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -63,7 +63,10 @@ object Confluence:
             probate:      Probate )
   :   (Stream[medium] over Credit)^ =
 
-    val block: Int = buffering.capacity(addressable0.substrate)
+    // Pumps pull boundary-transfer-sized credits, not staging-block-sized ones:
+    // every block crossing the queue costs a synchronized hand-off, so the
+    // transfer size bounds the hand-off count, not the cache footprint.
+    val block: Int = buffering.transfer(addressable0.substrate)
 
     val queue: juc.ArrayBlockingQueue[AnyRef] =
       juc.ArrayBlockingQueue(buffering.window.max(sources.length))

--- a/lib/turbulence/src/core/turbulence.Manifold.scala
+++ b/lib/turbulence/src/core/turbulence.Manifold.scala
@@ -58,7 +58,10 @@ object Manifold:
             probate:      Probate )
   :   IndexedSeq[(Stream[medium] over Credit)^] =
 
-    val block: Int = buffering.capacity(addressable0.substrate)
+    // The pump pulls boundary-transfer-sized credits, not staging-block-sized
+    // ones: every chunk is delivered to each subscriber through a synchronized
+    // hand-off, so the transfer size bounds the hand-off count.
+    val block: Int = buffering.transfer(addressable0.substrate)
 
     val queues: IndexedSeq[juc.ArrayBlockingQueue[AnyRef]] =
       IndexedSeq.fill(count)(juc.ArrayBlockingQueue[AnyRef](buffering.window))

--- a/lib/zephyrine/src/core/zephyrine.Buffering.scala
+++ b/lib/zephyrine/src/core/zephyrine.Buffering.scala
@@ -51,3 +51,10 @@ object Buffering:
 trait Buffering extends caps.Pure:
   def capacity(substrate: Substrate): Int
   def window: Int
+
+  // The preferred size of a block crossing an asynchronous boundary (a `Conduit`
+  // hand-off, or a fan-in/fan-out pump transfer). Staging buffers want to stay
+  // cache-resident, but every asynchronous block costs a synchronized queue
+  // transfer (with a likely park/unpark), so boundary blocks want to be much
+  // larger: the default is sixteen staging blocks.
+  def transfer(substrate: Substrate): Int = capacity(substrate)*16

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -35,7 +35,6 @@ package zephyrine
 import language.experimental.separationChecking
 
 import java.util.concurrent as juc
-import java.util.concurrent.atomic as juca
 
 import fulminate.*
 import prepositional.*
@@ -53,7 +52,7 @@ import vacuous.*
 // The two endpoints are separate exclusive capabilities: a single object owning both
 // sides could not give two threads separated exclusive access. They share a
 // `SharedCapability`-classified core — correctly exempt from separation checking, since
-// the core's guarantees come from the queue's happens-before and the atomics, not from
+// the core's guarantees come from the queue's happens-before and its volatile flags, not from
 // aliasing analysis. Capture sets are erased crossing the queue (it carries `AnyRef`);
 // single ownership of a published block is discharged on the writer's side before the
 // hand-off, and visibility is the queue's publication guarantee.
@@ -63,10 +62,8 @@ object Conduit:
   private class Block(val storage: AnyRef, val size: Int)
 
   // The synchronized substrate both endpoints capture.
-  private final class Core(window: Int) extends caps.SharedCapability:
+  private final class Core(val window: Int) extends caps.SharedCapability:
     val queue: juc.ArrayBlockingQueue[AnyRef] = juc.ArrayBlockingQueue(window)
-    val written: juca.AtomicLong = juca.AtomicLong(0)
-    val consumed: juca.AtomicLong = juca.AtomicLong(0)
     // JMM-managed flags: their safety is the volatile publication guarantee, not
     // aliasing analysis, so their captures are untracked.
     @caps.unsafe.untrackedCaptures @volatile var error: Throwable | Null = null
@@ -77,38 +74,44 @@ object Conduit:
   :   ((Intake[medium] over Credit)^, (Stream[medium] over Credit)^) =
 
     val block: Int = buffering.capacity(addressable0.substrate)
+    val ceiling: Int = buffering.transfer(addressable0.substrate).max(block)
     val core = new Core(buffering.window)
 
-    // Everything this conduit can hold: the queued blocks plus the block being
-    // written. `demand` is this allowance less what is currently buffered, so
-    // it reaches zero exactly when `reserve` would block.
-    val allowance: Long = block.toLong * (buffering.window + 1)
-
-    // The write side; single writer.
+    // The write side; single writer. Blocks are minted at the size `reserve` is
+    // asked for, between `block` and `ceiling`: a bulk `put` crosses the
+    // boundary in ceiling-sized hand-offs rather than being re-chunked to the
+    // staging block size, since each hand-off costs a synchronized queue
+    // transfer. The memory bound is `window + 1` blocks of at most `ceiling`.
     val intake: (Intake[medium] over Credit)^ = new Intake[medium](using addressable0):
       type Transport = Credit
 
       private var current: addressable0.Storage = addressable0.allocate(block)
+      private var capacity: Int = block
       private var mark0: Int = 0
 
-      def demand: Credit = Credit(allowance - (core.written.get - core.consumed.get))
+      // Advisory free space: block-sized credit for each free queue slot, plus
+      // the room left in the block being written. Zero exactly when `reserve`
+      // would park on a full queue.
+      def demand: Credit =
+        Credit((core.window - core.queue.size).toLong*block + (capacity - mark0))
 
       protected def buffer0: AnyRef = current.asInstanceOf[AnyRef]
       def mark: Int = mark0
 
       update def reserve(min: Int): Int =
-        val free = block - mark0
+        val free = capacity - mark0
 
-        if free >= min then free else
+        if free >= min.max(1) then free else
           publish()
-          block
+          capacity = min.min(ceiling).max(block)
+          current = addressable0.allocate(capacity)
+          capacity
 
       update def commit(count: Int): Unit =
         mark0 += count
-        core.written.addAndGet(count)
-        if mark0 == block then publish()
+        if mark0 == capacity then publish()
 
-      override update def flush(): Unit = if mark0 > 0 then publish()
+      override update def flush(): Unit = publish()
 
       update def finish(): Unit =
         flush()
@@ -119,15 +122,14 @@ object Conduit:
         core.queue.clear()
         core.queue.put(End)
 
+      // Hand the written block over (or discard it after close). The storage
+      // moves to the queue, so the capacity drops to zero and the next
+      // `reserve` mints a fresh block, sized to its request.
       private update def publish(): Unit =
         if mark0 > 0 then
-          if core.closed then
-            core.written.addAndGet(-mark0)
-            mark0 = 0
-          else
-            core.queue.put(Block(current.asInstanceOf[AnyRef], mark0))
-            current = addressable0.allocate(block)
-            mark0 = 0
+          if !core.closed then core.queue.put(Block(current.asInstanceOf[AnyRef], mark0))
+          mark0 = 0
+          capacity = 0
 
     // The read side; single reader. `refill` parks (in `queue.take`) until the
     // writer publishes a block or finishes.
@@ -144,9 +146,7 @@ object Conduit:
       def start: Int = start0
       def limit: Int = limit0
 
-      update def skip(count: Int): Unit =
-        start0 += count
-        core.consumed.addAndGet(count)
+      update def skip(count: Int): Unit = start0 += count
 
       update def refill(demand: Credit): Optional[Int] =
         if limit0 > start0 then limit0 - start0

--- a/lib/zephyrine/src/core/zephyrine.Intake.scala
+++ b/lib/zephyrine/src/core/zephyrine.Intake.scala
@@ -61,9 +61,13 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
   // production — `reserve` is what actually blocks.
   def demand: Transport
 
-  // Ensure at least `min` elements of contiguous writable space, blocking if
-  // necessary, and return the available space. `min` must not exceed the
-  // intake's block size.
+  // Ensure contiguous writable space, blocking if necessary, and return the
+  // available space, always at least one element. `min` is a request: an
+  // implementation may return less than was asked for (writers loop over
+  // `reserve`/`commit`, so a short reservation only means another iteration),
+  // but may also use a large request as a sizing hint — a `Conduit` mints a
+  // correspondingly larger transfer block, so bulk writes cross the
+  // asynchronous boundary in fewer synchronized hand-offs.
   update def reserve(min: Int): Int
 
   // Zero-copy view of this intake's buffer; elements from `mark` are writable
@@ -96,7 +100,7 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
     var done: Int = 0
 
     while done < count do
-      val free = reserve(1)
+      val free = reserve(count - done)
       val size = free.min(count - done)
       addressable.transfer(source, offset + done, buffer(using Unsafe), mark, size)
       commit(size)
@@ -108,7 +112,7 @@ trait Intake[medium](using val addressable: medium is Addressable) extends Produ
     var done: Int = 0
 
     while done < size do
-      val free = reserve(1)
+      val free = reserve(size - done)
       val count = free.min(size - done)
       addressable.copyChunk(source, offset.n0 + done, buffer(using Unsafe), mark, count)
       commit(count)


### PR DESCRIPTION
Makes the asynchronous streaming boundaries — `Conduit`, and the `Confluence`/`Manifold` fan-in/fan-out primitives — move data in larger, transfer-sized blocks. Previously they re-chunked bulk data to the 4 KiB staging-block size, so a large stream crossed as hundreds of synchronized queue hand-offs; benchmarking showed each hand-off costs the same as a plain `ArrayBlockingQueue` transfer (~1–2 µs), just paid sixteen times more often than necessary. Cross-thread hand-off of 4 MB drops from 2.0 ms to 0.14 ms, fan-in from 3.4 ms to 0.31 ms, and fan-out from 5.9 ms to 0.76 ms — from 30–80× slower than FS2/ZIO to the same order of magnitude, with the residual being the one copy that Soundness's bounded-memory guarantee requires.

`Buffering` gains a `transfer` size — the preferred size of a block crossing an asynchronous boundary — defaulting to sixteen staging blocks (64 KiB for byte streams):

```scala
trait Buffering:
  def capacity(substrate: Substrate): Int
  def window: Int
  def transfer(substrate: Substrate): Int = capacity(substrate)*16
```

`Intake.reserve(min)` now treats `min` as a sizing request: `put` and `absorb` pass the full remaining size, and a `Conduit` mints its next block at that size (capped at `transfer`), so bulk writes cross the boundary in a few large hand-offs rather than many small ones. Existing `Intake` implementations are unaffected — they already treat `min` as advisory. The memory bound keeps its form: `window + 1` blocks in flight, now of at most the transfer size.

No API is removed; custom `Buffering` instances pick up the `transfer` default automatically.
