### PR TITLE
Extend separation checking to the jacinta satellite modules

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1376,15 +1376,15 @@ object jacinta extends Library:
       settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object time extends Component(core, aviation.core):
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object http extends Component(core, telekinesis.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object schema extends Component(core, telekinesis.jvm):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object records extends Component(core, polyvinyl.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")

--- a/lib/jacinta/src/schema/jacinta.JsonSchema.scala
+++ b/lib/jacinta/src/schema/jacinta.JsonSchema.scala
@@ -177,7 +177,10 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
     Json.Encodable(Morphology.Any):
       case JsonSchema.Ref(pointer, _, _) =>
         val ref = summon[JsonPointer is Encodable in Text].encoded(pointer).s
-        Json.ast(Json.Ast.obj(IArray("$ref"), IArray(Json.Ast(ref))))
+        // Sealed: fresh `IArray`s are immutable; fresh-ness is the opaque-Array artifact.
+        Json.ast(Json.Ast.obj
+          ( caps.unsafe.unsafeAssumePure(IArray("$ref")),
+            caps.unsafe.unsafeAssumePure(IArray(Json.Ast(ref))) ))
 
       case other =>
         derivedEncodable.encoded(other)
@@ -186,87 +189,118 @@ object JsonSchema extends Derivable[Schematic over JsonSchema]:
   // the *value* of its `type` field (and may carry none, for `$ref`), which the
   // `type`-as-Scala-subtype derivation cannot model. Decoding by hand also
   // keeps the recursion on nested schemas pointed back at this same given.
-  given decodable: (Tactic[JsonError], Tactic[JsonPointerError])
+  given decodable: (jsonError: Tactic[JsonError], pointerError: Tactic[JsonPointerError])
   =>  JsonSchema is Json.Decodable =
     // The decoder closes over the two resolution-scoped tactics (and, through the nested-
     // schema recursion, over itself), which share the instance's given-resolution lifetime;
     // the whole instance is laundered pure per the codec-thunk seal pattern (see
-    // rep/DECISIONS.md). The local primitive codecs below re-expose the (sealed-pure)
-    // primitives at a higher priority so the `optional`/`array`/`map` givens' pure by-name
-    // inner codecs (their thunks must remain pure to be expressible inside staged quotes)
-    // resolve without consulting the enclosing tactics.
+    // rep/DECISIONS.md).
     caps.unsafe.unsafeAssumePure:
-      Json.Decodable(Morphology.Any): json =>
-        given textDecodable: (Text is Json.Decodable) = Json.text
-        given intDecodable: (Int is Json.Decodable) = Json.int
+      Json.Decodable(Morphology.Any)(decodeSchema(_))
 
-        given doubleDecodable: (Double is Json.Decodable) = Json.double
+  // The body of `decodable`, named so the nested-schema recursion below can rebuild its
+  // own element codecs explicitly. The local primitive codecs re-expose the (sealed-pure)
+  // primitives at a higher priority so the `optional`/`array`/`map` givens' pure by-name
+  // inner codecs (their thunks must remain pure to be expressible inside staged quotes)
+  // resolve without consulting the enclosing tactics.
+  private def decodeSchema(json: Json)
+    ( using jsonError: Tactic[JsonError], pointerError: Tactic[JsonPointerError] )
+  :   JsonSchema =
+    given textDecodable: (Text is Json.Decodable) = Json.text
+    given intDecodable: (Int is Json.Decodable) = Json.int
 
-        given booleanDecodable: (scala.Boolean is Json.Decodable) = Json.boolean
+    given doubleDecodable: (Double is Json.Decodable) = Json.double
 
-        def field[value](name: Text)(using decodable: value is Json.Decodable)
-        :   Optional[value] =
-          json(name).as[Optional[value]]
+    given booleanDecodable: (scala.Boolean is Json.Decodable) = Json.boolean
 
-        val reference = json("$ref".tt)
+    def field[value](name: Text)(using decodable: value is Json.Decodable)
+    :   Optional[value] =
+      json(name).as[Optional[value]]
 
-        if !reference.root.isAbsent
-        then JsonSchema.Ref(reference.as[JsonPointer], field[Text](t"description"))
-        else field[Text](t"type") match
-          case t"array" =>
-            JsonSchema.Array
-              ( field[Text](t"description"),
-                field[JsonSchema](t"items"),
-                field[Int](t"minItems"),
-                field[Int](t"maxItems"),
-                false,
-                field[Int](t"maxContains"),
-                field[Int](t"minContains") )
+    val reference = json("$ref".tt)
 
-          case t"string" =>
-            JsonSchema.String
-              ( field[Text](t"description"),
-                field[Int](t"minLength"),
-                field[Int](t"maxLength"),
-                field[Text](t"pattern"),
-                field[JsonSchema.Format](t"format"),
-                false )
+    if !reference.root.isAbsent
+    then JsonSchema.Ref(reference.as[JsonPointer], field[Text](t"description"))
+    else field[Text](t"type") match
+      case t"array" =>
+        JsonSchema.Array
+          ( field[Text](t"description"),
+            field[JsonSchema](t"items"),
+            field[Int](t"minItems"),
+            field[Int](t"maxItems"),
+            false,
+            field[Int](t"maxContains"),
+            field[Int](t"minContains") )
 
-          case t"number" =>
-            JsonSchema.Number
-              ( field[Text](t"description"),
-                field[Double](t"multipleOf"),
-                field[Double](t"maximum"),
-                field[Double](t"minimum"),
-                field[Double](t"exclusiveMinimum"),
-                field[Double](t"exclusiveMaximum"),
-                false )
+      case t"string" =>
+        JsonSchema.String
+          ( field[Text](t"description"),
+            field[Int](t"minLength"),
+            field[Int](t"maxLength"),
+            field[Text](t"pattern"),
+            field[JsonSchema.Format](t"format"),
+            false )
 
-          case t"integer" =>
-            JsonSchema.Integer
-              ( field[Text](t"description"),
-                field[Int](t"maximum"),
-                field[Int](t"minimum"),
-                field[Int](t"exclusiveMinimum"),
-                field[Int](t"exclusiveMaximum"),
-                false )
+      case t"number" =>
+        JsonSchema.Number
+          ( field[Text](t"description"),
+            field[Double](t"multipleOf"),
+            field[Double](t"maximum"),
+            field[Double](t"minimum"),
+            field[Double](t"exclusiveMinimum"),
+            field[Double](t"exclusiveMaximum"),
+            false )
 
-          case t"boolean" =>
-            JsonSchema.Boolean(field[Text](t"description"), false)
+      case t"integer" =>
+        JsonSchema.Integer
+          ( field[Text](t"description"),
+            field[Int](t"maximum"),
+            field[Int](t"minimum"),
+            field[Int](t"exclusiveMinimum"),
+            field[Int](t"exclusiveMaximum"),
+            false )
 
-          case t"null" =>
-            JsonSchema.Null(field[Text](t"description"), false)
+      case t"boolean" =>
+        JsonSchema.Boolean(field[Text](t"description"), false)
 
-          case _ =>
-            // `object`, or an untyped schema (treated as an object).
-            JsonSchema.Object
-              ( field[Text](t"description"),
-                field[Map[Text, JsonSchema]](t"properties").or(Map()),
-                false,
-                field[List[Text]](t"required"),
-                field[List[Json]](t"enum"),
-                json(t"additionalProperties").as[Optional[scala.Boolean]].or(false),
-                field[List[JsonSchema]](t"oneOf") )
+      case t"null" =>
+        JsonSchema.Null(field[Text](t"description"), false)
+
+      case _ =>
+        // `object`, or an untyped schema (treated as an object). The collection reads
+        // take their element codecs explicitly, as sealed-pure vals: resolved
+        // implicitly, the synthesized by-name codec thunks re-evaluate tactic-capturing
+        // given expansions at the application, aliasing the collection givens'
+        // capture-polymorphic tactic parameter — a separation failure. A reference to a
+        // pure local val carries no hidden set. The seals are consistent with (and no
+        // stronger than) the enclosing whole-instance seal on `decodable`.
+        val self: JsonSchema is Json.Decodable =
+          caps.unsafe.unsafeAssumePure(Json.Decodable(Morphology.Any)(decodeSchema(_)))
+
+        // A plain val, not the `textDecodable` given alias: a given alias re-evaluates
+        // its (tactic-applying) right-hand side inside the synthesized thunk.
+        val textDecodable0: Text is Json.Decodable = textDecodable
+
+        val textList: List[Text] is Json.Decodable =
+          caps.unsafe.unsafeAssumePure
+            (Json.array[List, Text](using summon, jsonError, summon)(using textDecodable0))
+
+        val schemaList: List[JsonSchema] is Json.Decodable =
+          caps.unsafe.unsafeAssumePure
+            (Json.array[List, JsonSchema](using summon, jsonError, summon)(using self))
+
+        val schemaMap: Map[Text, JsonSchema] is Json.Decodable =
+          caps.unsafe.unsafeAssumePure
+            (Json.map[Text, JsonSchema](using self)(using summon, jsonError))
+
+        JsonSchema.Object
+          ( field[Text](t"description"),
+            field[Map[Text, JsonSchema]](t"properties")(using schemaMap).or(Map()),
+            false,
+            field[List[Text]](t"required")(using textList),
+            field[List[Json]](t"enum"),
+            field[scala.Boolean](t"additionalProperties").or(false),
+            field[List[JsonSchema]](t"oneOf")(using schemaList) )
 
   given discriminatedUnion: JsonSchema is Discriminable:
     type Form = Json

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1449,3 +1449,34 @@ field is the pattern.
 FUTURE LEGS: Postable/Transmissible (sealed constructors — need untracked-field
 conversion), Loadable/Computable/near-1-capture audits, converting codec-thunk
 whole-instance seals to untracked fields where traits stay tracked.
+
+## Sepcheck rollout leg 3: jacinta satellites (2026-07-12, branch jacinta-satellites-sepcheck)
+
+jacinta.time and jacinta.http flipped to `settings.sep` with NO source changes —
+the derived-given separation failures that parked them have evaporated (the
+typeclass-purity flips and Json.Encodable payload-seal conversion removed the
+tracked instances they tripped on).
+
+jacinta.schema needed one file (JsonSchema.scala):
+- Two `IArray(...)` seals (the opacity artifact) in the `$ref` encoder.
+- THE REAL FINDING — collection-codec aliasing at use sites: `field[List[Text]]`/
+  `field[Map[Text, JsonSchema]]` applications of the `array`/`map` givens fail
+  separation: the capture-polymorphic `Tactic^` formal hides the passed tactic,
+  and the SYNTHESIZED by-name element-codec thunk *re-evaluates* tactic-applying
+  given expansions inside the thunk (even `unsafeAssumePure`-sealed ones — the
+  seal launders the capture set, not the hidden set), overlapping the same
+  tactic. TWO sub-findings:
+  * A local `given x: T = tacticTakingExpr` ALIAS also re-evaluates its RHS
+    inside the thunk (def semantics) — the thunk captures the tactic even when
+    the alias is annotated pure. Bind a plain `val` instead.
+  * References to pure local VALS carry no hidden set, so the recipe is: bind
+    every element codec (including the recursive self-codec) as a sealed-pure
+    local val and pass it EXPLICITLY (`field[...](...)(using theVal)`), which
+    both bypasses resolution and empties the thunk's captures.
+- The decode body moved from the given's lambda to a named private
+  `decodeSchema` so the self-codec can be rebuilt explicitly for recursion.
+- `field[List[Json]](t"enum")` never failed — its element codec is the pure
+  identity — which is what isolated the diagnosis.
+
+Laundering the tactic (`given Tactic = unsafeAssumePure(tactic)`) does NOT fix
+the aliasing: the local is still a capability value passed through two channels.


### PR DESCRIPTION
With jacinta.core already separation-checked, this extends `settings.sep` to jacinta.time, jacinta.http and jacinta.schema. The first two needed no source changes; jacinta.schema's hand-written `JsonSchema` decoder now binds its collection element codecs as sealed-pure local vals passed explicitly, since implicit resolution re-evaluates tactic-capturing codec expansions inside the synthesized by-name thunks, which the separation checker correctly rejects as aliasing.

## Release notes

- The `jacinta.time`, `jacinta.http` and `jacinta.schema` modules are now compiled with experimental separation checking, extending the guarantees already enforced in `jacinta.core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)