### PR TITLE
Verify purity of Encodable, Abstractable and Transmissible instances

### DIFF
--- a/lib/anticipation/src/codec/anticipation.Encodable.scala
+++ b/lib/anticipation/src/codec/anticipation.Encodable.scala
@@ -51,13 +51,13 @@ object Encodable:
   given char: Char is Encodable in Text = _.toString.tt
   given string: String is Encodable in Text = _.tt
 
-trait Encodable extends Typeclass, Formal:
+trait Encodable extends Typeclass.Pure, Formal:
   private inline def encodable: this.type = this
   def encoded(value: Self): Form
 
   extension (value: Self) def encode: Form = encoded(value)
 
-  def contramap[self2](lambda: self2 => Self): (self2 is Encodable in Form)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Encodable in Form =
     new Encodable:
       type Self = self2
       type Form = encodable.Form

--- a/lib/anticipation/src/generic/anticipation.Abstractable.scala
+++ b/lib/anticipation/src/generic/anticipation.Abstractable.scala
@@ -34,11 +34,10 @@ package anticipation
 
 import prepositional.*
 
-trait Abstractable extends Typeclass, Resultant, Domainal:
+trait Abstractable extends Typeclass.Pure, Resultant, Domainal:
   def genericize(value: Self): Result
 
-  def contramap[self2](lambda: self2 => Self)
-  :   (self2 is Abstractable across Domain to Result)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Abstractable across Domain to Result =
     value => genericize(lambda(value))
 
   extension (value: Self) def generic: Result = genericize(value)

--- a/lib/coaxial/src/core/coaxial.Transmissible.scala
+++ b/lib/coaxial/src/core/coaxial.Transmissible.scala
@@ -54,8 +54,8 @@ object Transmissible:
 // endpoint. Transports with message framing (a UDP datagram, a WebSocket frame)
 // may therefore `memoize` the stream into a single framed unit; byte-stream
 // transports write it through the window, zero-copy.
-trait Transmissible extends Typeclass:
+trait Transmissible extends Typeclass.Pure:
   def serialize(message: Self): (Stream[Data] over Credit)^
 
-  def contramap[self2](lambda: self2 => Self): (self2 is Transmissible)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Transmissible =
     message => serialize(lambda(message))

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -346,7 +346,7 @@ object Json extends Json2, Dynamic:
 
   object Encodable:
     def apply[value](shape0: => Morphology)(lambda: (value -> Json)^)
-    :   ((value is Json.Encodable)^{lambda}) =
+    :   (value is Json.Encodable) =
 
       // The shape thunk may close over a `Tactic` when field/element codecs are summoned from
       // tactic-taking givens, but `shape()` only reads static metadata and never encodes or
@@ -354,9 +354,15 @@ object Json extends Json2, Dynamic:
       // pure. Invariant: a `shape()` implementation must never invoke its tactic.
       val shape1: () -> Morphology = caps.unsafe.unsafeAssumePure { () => shape0 }
 
+      // The encode lambda may capture the resolution-scoped tactic of field/element codecs,
+      // which shares this instance's given-resolution lifetime; `Json.Encodable` is a pure
+      // typeclass (via `anticipation.Encodable`), so the payload — not the instance — is
+      // sealed here, once, for every codec constructed through this factory.
+      val lambda1: value -> Json = caps.unsafe.unsafeAssumePure(lambda)
+
       new Json.Encodable:
         type Self = value
-        def encoded(value: value): Json = lambda(value)
+        def encoded(value: value): Json = lambda1(value)
         def shape(): Morphology = shape1()
 
   // A JSON encoder that also carries the format-neutral `Morphology` describing exactly

--- a/lib/nomenclature/src/lexicon/nomenclature.Moniker.scala
+++ b/lib/nomenclature/src/lexicon/nomenclature.Moniker.scala
@@ -49,8 +49,18 @@ object Moniker:
   extension (moniker: Moniker) def ordinal: Int = moniker
 
   given encodable: [transport] => (vocabulary: Vocabulary over transport, tactic: Tactic[MonikerError])
-  =>  (((Moniker over transport) is Encodable in Text)^{tactic}) =
-    moniker => vocabulary.name(moniker.ordinal)
+  =>  (Moniker over transport) is Encodable in Text =
+    new Encodable:
+      type Self = Moniker over transport
+      type Form = Text
+
+      // `vocabulary.name` raises through the resolution-scoped tactic, which shares this
+      // instance's lifetime; contained in a single untracked field (see
+      // `prepositional.Typeclass.Pure`).
+      @caps.unsafe.untrackedCaptures
+      private val tactic0: Tactic[MonikerError] = tactic
+
+      def encoded(moniker: Self): Text = vocabulary.name(moniker.ordinal)(using tactic0)
 
   given decodable: [transport] => (vocabulary: Vocabulary over transport, tactic: Tactic[MonikerError])
   =>  (((Moniker over transport) is Decodable in Text)^{tactic}) =

--- a/lib/telekinesis/src/core/telekinesis.Postable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Postable.scala
@@ -57,7 +57,9 @@ object Postable:
   // `response => (Stream[Data] over Credit)^`: a lambda may not mint a fresh
   // scoped capability as its result, but a SAM's method may (see
   // `zephyrine.Spring`). Lambda call sites are unchanged by SAM conversion.
-  trait Streamer[content]:
+  // It is a capability class: a value constructed from capabilities is a
+  // capability (Jon, 2026-07-06; see rep/DECISIONS.md).
+  trait Streamer[content] extends caps.SharedCapability:
     def stream(content: content): (Stream[Data] over Credit)^
 
   // `stream0` must construct a fresh pull endpoint on each call: the request
@@ -67,15 +69,17 @@ object Postable:
   def apply[response](mediaType0: MediaType, stream0: Streamer[response]^)
   :   response is Postable =
 
-    // `Typeclass` instances are `Pure` by infrastructure, but the streaming lambda may capture
-    // capabilities with the same lifetime as this instance's given resolution; laundered pure —
-    // the jacinta codec-thunk seal pattern (see rep/DECISIONS.md).
-    val stream1: Streamer[response] = caps.unsafe.unsafeAssumePure(stream0)
-
     new Postable:
       type Self = response
+
+      // The streaming lambda may capture capabilities with the same lifetime as this
+      // instance's given resolution; contained in a single untracked field rather than
+      // sealing the whole value (see `prepositional.Typeclass.Pure`).
+      @caps.unsafe.untrackedCaptures
+      private val streamer: Streamer[response] = stream0
+
       def mediaType(response: response): MediaType = mediaType0
-      def stream(response: response): (Stream[Data] over Credit)^ = stream1.stream(response)
+      def stream(response: response): (Stream[Data] over Credit)^ = streamer.stream(response)
 
 
   given text: (encoder: CharEncoder) => Text is Postable =
@@ -100,15 +104,15 @@ object Postable:
   =>  ( tactic: Tactic[MediaTypeError] )
   =>  response is Postable =
 
-    // See `apply`: the instance's `mediaType` raises through the resolution-scoped tactic,
-    // which shares the instance's lifetime; the media-type decoder is resolved once under a
-    // laundered tactic so the instance stays pure, per the codec-thunk seal pattern.
-    val decoder: MediaType is Decodable in Text =
-      given Tactic[MediaTypeError] = caps.unsafe.unsafeAssumePure(tactic)
-      caps.unsafe.unsafeAssumePure(summon[(MediaType is Decodable in Text)^])
-
     new Postable:
       type Self = response
+
+      // The instance's `mediaType` raises through the resolution-scoped tactic, which
+      // shares the instance's lifetime; the tactic-capturing decoder is contained in a
+      // single untracked field (see `prepositional.Typeclass.Pure`).
+      @caps.unsafe.untrackedCaptures
+      private val decoder: MediaType is Decodable in Text =
+        summon[(MediaType is Decodable in Text)^]
 
       def mediaType(content: response): MediaType =
         content.generic(0).decode[MediaType](using decoder)

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -196,7 +196,9 @@ object Ductile:
       type Transport = Credit
       type Upstream = Credit
 
-      def duct(consume stage: CharEncoder^)(using buffering: Buffering)
+      // `CharEncoder` is pure (`Encodable` is `Typeclass.Pure`), so `Self^` collapses:
+      // the stage carries no capabilities to consume, only the encoding it names.
+      def duct(consume stage: CharEncoder)(using buffering: Buffering)
       :   Duct[Text, Data] { type Transport = Credit; type Upstream = Credit } =
 
         new Duct[Text, Data]:

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1450,6 +1450,52 @@ FUTURE LEGS: Postable/Transmissible (sealed constructors — need untracked-fiel
 conversion), Loadable/Computable/near-1-capture audits, converting codec-thunk
 whole-instance seals to untracked fields where traits stay tracked.
 
+## Typeclass purity campaign, leg 2 (2026-07-12, branch typeclass-purity-2)
+
+FLIPPED (zero capturing instances remained after the sepcheck rollout):
+Encodable, Abstractable, Transmissible. Contramaps purified as in leg 1.
+Fallout beyond contramaps, all mechanical:
+- `CharEncoder extends Encodable` → CharEncoder is now a PURE TYPE. The
+  zephyrine `Ductile.charEncoder` stage signature drops its `^` (`consume
+  stage: CharEncoder` — a pure stage carries nothing to consume; the duct
+  builds its own jnc encoder from the named encoding). Overriding
+  `duct(consume stage: Self^)` with a pure `Self` collapses `Self^` fine.
+- `nomenclature.Moniker.encodable` was the one remaining honestly-tracked
+  `^{tactic}` Encodable given → converted to the untracked-field pattern.
+- `Json.Encodable.apply` returned `(value is Json.Encodable)^{lambda}` —
+  illegal on a Pure trait. Converted to sealing exactly the payload lambda
+  (`val lambda1: value -> Json = unsafeAssumePure(lambda)`) once in the
+  factory, for every codec built through it.
+
+POSTABLE (untracked-field conversion done): the two whole-value seals in
+`telekinesis.Postable` are gone. `Postable.Streamer` is now
+`caps.SharedCapability` — a value constructed from capabilities is a
+capability (Jon, 2026-07-06) — which is what lets a bare-typed
+`@untrackedCaptures` field hold it under sepcheck. Two field-typing findings
+under SEP modules (telekinesis.core):
+- `@untrackedCaptures` field typed `T^{outerParam}` still fails CC ("cannot
+  flow into {}"): naming the capability in the field TYPE re-introduces the
+  dependency. The field must be typed BARE.
+- A bare field of a NON-capability type cannot take a `^`-typed value (root
+  `any` cannot flow), and typing the field `T^` trips the sep hiding rule
+  ("hides non-local parameter"). So the untracked-field pattern only types
+  under sepcheck when the payload is a CAPABILITY CLASS (bare type carries
+  the implicit capture). Function-typed payloads need a payload seal (or an
+  AnyRef rim) instead.
+
+AUDITED, STAY TRACKED (flipping would convert honest tracking to assertion):
+Servable (`^{mediaType, lambda}` constructor), Sendable (`^{monitor}` given),
+Openable (`FileOpenable^` capturing six filesystem givens), Computable (7),
+Receivable (6), Serviceable (4), and the 1-capture tail (Loggable, Printable,
+Randomizable, ... — each capture is genuine).
+
+SEAL NARROWING: assessed — the remaining codec-thunk seals on tracked traits
+(jacinta/ypsiloid/breviloquence/locomotion `optional`/`list*` givens) are
+lambda-SAM seals: the assertion already lands on exactly the closure, so
+there is no narrower untracked-field form for them. Making those givens
+honestly tracked (`^{tactic, caps.any}` results) is the remaining design
+question, deferred (resolution ripple; needs its own probe).
+
 ## Sepcheck rollout leg 3: jacinta satellites (2026-07-12, branch jacinta-satellites-sepcheck)
 
 jacinta.time and jacinta.http flipped to `settings.sep` with NO source changes —


### PR DESCRIPTION
This continues the `Typeclass.Pure` campaign (#1512): `Encodable`, `Abstractable` and `Transmissible` — which now have no capability-capturing instances — become compiler-verified pure typeclasses, and `telekinesis.Postable` replaces its whole-value `unsafeAssumePure` seals with the narrower single-untracked-field pattern, classifying `Postable.Streamer` as a `SharedCapability`.

## Release notes

- `Encodable`, `Abstractable` and `Transmissible` instances are now compiler-verified pure: an instance that captures a capability is rejected at its definition. Their `contramap` methods accordingly take pure lambdas (`self2 -> Self`).
- `CharEncoder` is consequently a pure type; contexts which previously wrote `CharEncoder^` should drop the capture set.
- `Postable.Streamer` is now a `caps.SharedCapability`, and `Json.Encodable`'s factory returns an untracked (pure) instance; call sites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)