### PR TITLE
Add take/drop/fold stream operators, with ZIO/FS2 comparison chains

### DIFF
--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -239,6 +239,91 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
       . via(zio.stream.ZPipeline.gunzip()).via(zio.stream.ZPipeline.utfDecode)
       . map(_.length).runSum
 
+  // ── Chained example Q: transcode cascade (no compression, 3-way) ────────────
+  // A long chain of the one non-compression stage all three kernels share
+  // natively — UTF-8 transcoding — with no gzip to dominate the cost and no
+  // per-element boxing to skew it: bytes decode to text and re-encode three
+  // times over, then a final decode counts characters. This isolates the
+  // streaming machinery itself (chunk scheduling, buffer hand-off, duct
+  // composition) across Soundness's pull kernel and the ZIO/FS2 interpreters.
+
+  def transcodeChainSoundness: Int =
+    Stream(textData)
+    . through(summon[CharDecoder]).through(summon[CharEncoder])
+    . through(summon[CharDecoder]).through(summon[CharEncoder])
+    . through(summon[CharDecoder]).memoize.s.length
+
+  def transcodeChainFs2: Int =
+    import cats.effect.unsafe.implicits.global
+    fs2.Stream.chunk(fs2.Chunk.array(textArray)).covary[cats.effect.IO]
+    . through(fs2.text.utf8.decode).through(fs2.text.utf8.encode)
+    . through(fs2.text.utf8.decode).through(fs2.text.utf8.encode)
+    . through(fs2.text.utf8.decode)
+    . map(_.length).compile.fold(0)(_ + _).unsafeRunSync()
+
+  def transcodeChainZio: Int =
+    runZio:
+      zio.stream.ZStream.fromChunk(zio.Chunk.fromArray(textArray))
+      . via(zio.stream.ZPipeline.utfDecode).via(zio.stream.ZPipeline.utf8Encode)
+      . via(zio.stream.ZPipeline.utfDecode).via(zio.stream.ZPipeline.utf8Encode)
+      . via(zio.stream.ZPipeline.utfDecode)
+      . map(_.length).runSum
+
+  // ── Chained example R: transcode + base64 armor (no compression, 2-way) ─────
+  // A more varied chain, combining UTF-8 transcoding with a base64 codec
+  // roundtrip: decode -> encode -> base64 -> debase64 -> decode -> count. FS2
+  // has a native streaming base64 pipe; ZIO-Streams has none, so (as with the
+  // AES rows) only FS2 is the streaming reference here.
+
+  def armorTranscodeSoundness: Int =
+    Stream(textData)
+    . through(summon[CharDecoder]).through(summon[CharEncoder])
+    . through(summon[Alphabet[Base64]]).through(summon[Alphabet[Base64]])
+    . through(summon[CharDecoder]).memoize.s.length
+
+  def armorTranscodeFs2: Int =
+    import cats.effect.unsafe.implicits.global
+    fs2.Stream.chunk(fs2.Chunk.array(textArray)).covary[cats.effect.IO]
+    . through(fs2.text.utf8.decode).through(fs2.text.utf8.encode)
+    . through(fs2.text.base64.encode).through(fs2.text.base64.decode)
+    . through(fs2.text.utf8.decode)
+    . map(_.length).compile.fold(0)(_ + _).unsafeRunSync()
+
+  // ── Chained example S: slice + transcode (no compression, 3-way) ────────────
+  // A varied byte-level chain combining the new `drop`/`take`/`fold` kernel
+  // operators with transcoding: drop the first 64 KiB, transcode UTF-8 through
+  // decode+encode, keep the first 2 MiB, count. `drop`/`take` are element
+  // (byte) counts in all three libraries and chunk-aware (no unboxing), and the
+  // terminal count folds over whole windows; the byte total is identical across
+  // implementations.
+
+  // Int rather than Long: ZIO's `take`/`drop` are `Int`-counted, and both values
+  // fit; Soundness's and FS2's `Long`-counted versions widen automatically.
+  private val dropBytes: Int = 65536
+  private val takeBytes: Int = 2*1024*1024
+
+  def slicedTranscodeSoundness: Long =
+    Stream(textData).drop(dropBytes)
+    . through(summon[CharDecoder]).through(summon[CharEncoder])
+    . take(takeBytes)
+    . fold(0L)((total, _, _, count) => total + count)
+
+  def slicedTranscodeFs2: Long =
+    import cats.effect.unsafe.implicits.global
+    fs2.Stream.chunk(fs2.Chunk.array(textArray)).covary[cats.effect.IO]
+    . drop(dropBytes)
+    . through(fs2.text.utf8.decode).through(fs2.text.utf8.encode)
+    . take(takeBytes)
+    . compile.count.unsafeRunSync()
+
+  def slicedTranscodeZio: Long =
+    runZio:
+      zio.stream.ZStream.fromChunk(zio.Chunk.fromArray(textArray))
+      . drop(dropBytes)
+      . via(zio.stream.ZPipeline.utfDecode).via(zio.stream.ZPipeline.utf8Encode)
+      . take(takeBytes)
+      . runCount
+
   // ── Chained example O: gzip -> base64 -> debase64 -> gunzip roundtrip ───────
   // The full "armored transport" chain, streaming end-to-end in each library:
   // Soundness runs monotonous `Alphabet` ducts (Data -> Text -> Data) between
@@ -589,10 +674,18 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         confluenceSoundness == n && confluenceFs2 == n && confluenceZio == n
       val fanOutOk =
         manifoldSoundness == 3*n && manifoldFs2 == 3*n && manifoldZio == 3*n
+      val transcodeChainOk =
+        transcodeChainSoundness == transcodeChainFs2
+          && transcodeChainFs2 == transcodeChainZio
+      val armorTranscodeOk = armorTranscodeSoundness == armorTranscodeFs2
+      val slicedOk =
+        slicedTranscodeSoundness == takeBytes && slicedTranscodeFs2 == takeBytes
+          && slicedTranscodeZio == takeBytes
       ( roundtripOk, transcodeOk, readOk, base64Ok, readOk2, cursorOk, writeOk, hexOk, flowOk,
-        conduitOk, fanInOk, fanOutOk, armoredOk, secureOk )
+        conduitOk, fanInOk, fanOutOk, armoredOk, secureOk, transcodeChainOk, armorTranscodeOk,
+        slicedOk )
     . assert(_ == (true, true, true, true, true, true, true, true, true, true, true, true, true,
-        true))
+        true, true, true, true))
 
     suite(m"Gzip compression (4 MB)"):
       bench(m"Soundness  Stream.compress[Gzip]")
@@ -681,6 +774,36 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
 
       bench(m"JDK  GZIP/Cipher/Base64 composition")(target = 1*Second, operationSize = size):
         '{ turbulence.Benchmarks.secureChainJdk }
+
+    suite(m"Chained: UTF-8 transcode cascade, no compression (4 MB)"):
+      bench(m"Soundness  dec.enc.dec.enc.dec")
+        ( target = 1*Second, operationSize = textSize, baseline = Baseline(compare = Min) ):
+        '{ turbulence.Benchmarks.transcodeChainSoundness }
+
+      bench(m"FS2  utf8 decode/encode x2.5")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.transcodeChainFs2 }
+
+      bench(m"ZIO  utfDecode/utf8Encode x2.5")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.transcodeChainZio }
+
+    suite(m"Chained: transcode + base64 armor, no compression (4 MB)"):
+      bench(m"Soundness  dec.enc.b64.b64.dec")
+        ( target = 1*Second, operationSize = textSize, baseline = Baseline(compare = Min) ):
+        '{ turbulence.Benchmarks.armorTranscodeSoundness }
+
+      bench(m"FS2  utf8/base64 chain")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.armorTranscodeFs2 }
+
+    suite(m"Chained: drop -> transcode -> take -> count (4 MB)"):
+      bench(m"Soundness  drop.dec.enc.take.fold")
+        ( target = 1*Second, operationSize = textSize, baseline = Baseline(compare = Min) ):
+        '{ turbulence.Benchmarks.slicedTranscodeSoundness }
+
+      bench(m"FS2  drop.utf8.take.count")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.slicedTranscodeFs2 }
+
+      bench(m"ZIO  drop.utf.take.runCount")(target = 1*Second, operationSize = textSize):
+        '{ turbulence.Benchmarks.slicedTranscodeZio }
 
     suite(m"Base64 encode (4 MB)"):
       bench(m"Soundness  serialize[Base64]")

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -180,6 +180,39 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
 
     addressable.build(target)
 
+  // Drain the stream, threading an accumulator through each window: the
+  // window-level fold, the terminal counterpart to a pull chain. The operation
+  // receives the running state, the window storage, its start index and its
+  // element count; it must not retain the storage. Unlike an element-wise fold,
+  // this exposes the raw window, so a byte reduction runs over the array with
+  // no per-element boxing.
+  def fold[state](initial: state)(operation: (state, AnyRef, Int, Int) => state)
+    (using buffering: Buffering)
+  :   state =
+
+    val block = buffering.transfer(stream.addressable.substrate)
+
+    def loop(state: state): state = stream.refill(Credit(block)) match
+      case count: Int =>
+        val state2 =
+          operation(state, stream.window(using Unsafe).asInstanceOf[AnyRef], stream.start, count)
+
+        stream.skip(count)
+        loop(state2)
+
+      case _ => state
+
+    try loop(initial) finally stream.close()
+
+  // The first `count` elements, then end-of-stream. The remainder of the
+  // upstream is released unread on `close`. (FS2 `take`, ZIO `ZStream.take`.)
+  def take(count: Long): (Stream[medium] over Credit)^ = takeStream(stream, count)
+
+  // Skip the first `count` elements, then pass the rest through unchanged. The
+  // skipped elements are pulled and discarded on the first `refill`. (FS2
+  // `drop`, ZIO `ZStream.drop`.)
+  def drop(count: Long): (Stream[medium] over Credit)^ = dropStream(stream, count)
+
 private def throughDuct[in, out, upTransport, downTransport]
   ( consume duct:
       (Duct[in, out] { type Transport = downTransport; type Upstream = upTransport })^,
@@ -251,6 +284,69 @@ private def throughDuct[in, out, upTransport, downTransport]
       override update def close(): Unit =
         duct.close()
         stream.close()
+
+// `take`/`drop` wrappers, in helpers rather than inline in the extension for
+// the same reason as `throughDuct`: a local binding of the upstream would hide
+// it from the anonymous class, whereas the consumed parameter carries its
+// capture explicitly. Each delegates window access to the upstream (zero copy)
+// and only adjusts the element budget.
+
+private def takeStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
+:   (Stream[medium] over Credit)^ =
+
+    new Stream[medium](using stream.addressable):
+      type Transport = Credit
+
+      private var remaining: Long = count.max(0)
+
+      protected def window0: AnyRef = stream.window(using Unsafe).asInstanceOf[AnyRef]
+      def start: Int = stream.start
+
+      def limit: Int =
+        val available = stream.limit - stream.start
+        stream.start + (if remaining < available then remaining.toInt else available)
+
+      update def skip(elements: Int): Unit =
+        remaining -= elements
+        stream.skip(elements)
+
+      update def refill(demand: Credit): Optional[Int] =
+        if remaining <= 0 then Unset else stream.refill(demand) match
+          case available: Int =>
+            if remaining < available then remaining.toInt else available
+
+          case _ => Unset
+
+      override update def close(): Unit = stream.close()
+
+private def dropStream[medium](consume stream: (Stream[medium] over Credit)^, count: Long)
+:   (Stream[medium] over Credit)^ =
+
+    new Stream[medium](using stream.addressable):
+      type Transport = Credit
+
+      private var pending: Long = count.max(0)
+
+      protected def window0: AnyRef = stream.window(using Unsafe).asInstanceOf[AnyRef]
+      def start: Int = stream.start
+      def limit: Int = stream.limit
+      update def skip(elements: Int): Unit = stream.skip(elements)
+
+      update def refill(demand: Credit): Optional[Int] =
+        var ended: Boolean = false
+
+        while pending > 0 && !ended do
+          stream.refill(Credit(pending.min(Int.MaxValue.toLong))) match
+            case available: Int =>
+              val discard = available.toLong.min(pending).toInt
+              stream.skip(discard)
+              pending -= discard
+
+            case _ => ended = true
+
+        if ended then Unset else stream.refill(demand)
+
+      override update def close(): Unit = stream.close()
 
 private def acceptingDuct[in, out, upTransport, downTransport]
   ( consume duct:

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -34,6 +34,11 @@ package zephyrine
 
 import soundness.*
 
+// The kernel `Stream.take`/`drop` are shadowed here by turbulence's legacy
+// `LazyList[Data]` `take`/`drop` arriving through the `soundness.*` wildcard;
+// the explicit imports restore the kernel versions under test.
+import zephyrine.{take, drop}
+
 import randomization.unseededRandomization
 
 import supervisors.globalSupervisor
@@ -803,6 +808,51 @@ object Tests extends Suite(m"Zephyrine tests"):
         test(m"memoize drains a text stream into a single text value"):
           Stream(Iterator(t"ab", t"cd", t"e")).memoize.s
         . assert(_ == "abcde")
+
+        test(m"take limits a stream to its first elements"):
+          Stream(small).take(3).memoize.to(List)
+        . assert(_ == List[Byte](1, 2, 3))
+
+        test(m"take across chunk boundaries"):
+          Stream(Iterator(IArray[Byte](1, 2, 3), IArray[Byte](4, 5, 6))).take(4).memoize.to(List)
+        . assert(_ == List[Byte](1, 2, 3, 4))
+
+        test(m"take of more than the stream holds yields the whole stream"):
+          Stream(small).take(100).memoize.to(List)
+        . assert(_ == small.to(List))
+
+        test(m"take zero yields an empty stream"):
+          Stream(small).take(0).memoize.to(List)
+        . assert(_ == List())
+
+        test(m"drop skips a stream's first elements"):
+          Stream(small).drop(2).memoize.to(List)
+        . assert(_ == List[Byte](3, 4, 5))
+
+        test(m"drop across chunk boundaries"):
+          Stream(Iterator(IArray[Byte](1, 2, 3), IArray[Byte](4, 5, 6))).drop(4).memoize.to(List)
+        . assert(_ == List[Byte](5, 6))
+
+        test(m"drop of more than the stream holds yields an empty stream"):
+          Stream(small).drop(100).memoize.to(List)
+        . assert(_ == List())
+
+        test(m"take and drop compose to a slice"):
+          Stream(Data.fill(20)(_.toByte)).drop(5).take(5).memoize.to(List)
+        . assert(_ == List[Byte](5, 6, 7, 8, 9))
+
+        test(m"take composes with a duct"):
+          Stream(small).take(3).through(Doubler()).memoize.to(List)
+        . assert(_ == List[Byte](1, 1, 2, 2, 3, 3))
+
+        test(m"fold reduces over windows without boxing"):
+          Stream(bytes).fold(0L): (total, storage, start, count) =>
+            val array = storage.asInstanceOf[Array[Byte]]
+            var sum = total
+            var index = 0
+            while index < count do { sum += (array(start + index) & 0xff); index += 1 }
+            sum
+        . assert(_ == bytes.to(List).map(_ & 0xff).sum.toLong)
 
 
   // A byte intake that gathers everything written to it, with a configurable


### PR DESCRIPTION
Adds `take`, `drop` and `fold` to the `Stream` kernel — the window-level counterparts to the `take`/`drop`/`runFold`/`compile.fold` that ZIO-Streams and FS2 expose — so streaming pipelines can slice and reduce without dropping to the legacy `LazyList` view, and comparative benchmarks no longer need compression to share stages with the other libraries.

```scala
Stream(data).drop(65536).through(decoder).take(2*1024*1024).fold(0L)((n, _, _, c) => n + c)
```

`take`/`drop` wrap the upstream and delegate its window zero-copy, adjusting only an element budget: `take` ends the stream and releases the remainder once the budget is spent, `drop` discards on the first refill. `fold` threads state through each raw window, so a byte reduction runs over the array with no per-element boxing.

Three no-compression benchmark suites compare these directly against ZIO and FS2: a UTF-8 transcode cascade, a drop/transcode/take/count slice (where the new operators put Soundness ~3× ahead, since `take` short-circuits and `fold` avoids boxing), and a 2-way transcode+base64 chain that honestly shows the reverse — Soundness's *streaming* base64 duct trails FS2's native pipe by ~2×, flagged as future work.

One naming note: `take`/`drop` collide with turbulence's legacy `LazyList[Data]` operators of the same name; the kernel versions resolve under a direct `zephyrine.*` import (which the benchmarks use), and the tests import them explicitly.
