### PR TITLE
Convert Coaxial's receive side to kernel pull endpoints

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -859,7 +859,7 @@ object cordillera extends Library:
         parasite.core, hypotenuse.core, gossamer.core, contingency.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())

--- a/lib/coaxial/src/core/coaxial.Connection.scala
+++ b/lib/coaxial/src/core/coaxial.Connection.scala
@@ -36,11 +36,15 @@ import java.io as ji
 
 import anticipation.*
 import contingency.*
+import prepositional.*
 import turbulence.*
+import zephyrine.*
 
 case class Connection
   ( private[coaxial] val in: ji.InputStream, private[coaxial] val out: ji.OutputStream ):
-  def stream(): LazyList[Data] raises StreamError = in.stream[Data]
+  // A fresh pull endpoint over the read side; single-use, like the connection.
+  def source()(using Buffering, Tactic[StreamError]): (Stream[Data] over Credit)^ =
+    summon[(ji.InputStream is Source by Data over Credit)^].stream(in)
   def reader: ji.InputStream = in
   def writer: ji.OutputStream = out
 

--- a/lib/coaxial/src/core/coaxial.Duplex.scala
+++ b/lib/coaxial/src/core/coaxial.Duplex.scala
@@ -53,7 +53,9 @@ object Duplex:
     val rightToLeft: Spool[Data] = Spool()
 
     def side(inbound: Spool[Data], outbound: Spool[Data]): Duplex = new Duplex:
-      def stream: LazyList[Data] = inbound.stream
+      // Each memoized send is exposed as one refill window, preserving the
+      // chunk boundaries the in-memory protocol tests rely on.
+      def source(using Buffering): (Stream[Data] over Credit)^ = Stream(inbound.stream.iterator)
 
       def send(consume data: (Stream[Data] over Credit)^): Unit =
         outbound.put(data.memoize)
@@ -69,17 +71,43 @@ object Duplex:
   // `shutdown` is a pure function: its closures hold only untracked OS resources (like
   // `channel`'s socket), so the `Duplex` remains capture-free under capture checking.
   def streams(in: ji.InputStream, out: ji.OutputStream)(shutdown: () -> Unit): Duplex = new Duplex:
-    // Untracked: `stream` is called by a single reader (the Duplex contract), and
-    // each delivered chunk is copied out of the buffer by `take` before reuse.
-    @caps.unsafe.untrackedCaptures
-    private val buffer: Array[Byte] = new Array[Byte](65536)
+    // Reads directly into the endpoint's own buffer; EOF (`-1`) ends the stream.
+    def source(using buffering: Buffering): (Stream[Data] over Credit)^ =
+      new Stream[Data]:
+        type Transport = Credit
 
-    def stream: LazyList[Data] =
-      def recur(): LazyList[Data] = in.read(buffer) match
-        case -1    => LazyList()
-        case count => buffer.take(count).immutable(using Unsafe) #:: recur()
+        private val capacity: Int = buffering.capacity(Substrate.Bytes)
+        private val storage: Array[Byte] = new Array[Byte](capacity)
+        private var start0: Int = 0
+        private var limit0: Int = 0
+        private var ended: Boolean = false
 
-      recur()
+        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+        def start: Int = start0
+        def limit: Int = limit0
+        update def skip(count: Int): Unit = start0 += count
+
+        update def refill(demand: Credit): Optional[Int] =
+          if limit0 > start0 then limit0 - start0
+          else if ended then Unset
+          else
+            val granted = summon[Credit is Regulation].grant(demand)
+
+            if granted == 0 then 0 else
+              start0 = 0
+              limit0 = 0
+
+              in.read(storage, 0, capacity.min(granted)) match
+                case -1 =>
+                  ended = true
+                  Unset
+
+                case 0 =>
+                  refill(demand)
+
+                case count =>
+                  limit0 = count
+                  count
 
     def send(consume data: (Stream[Data] over Credit)^): Unit =
       data.foreachWindow: (storage, start, count) =>
@@ -91,23 +119,6 @@ object Duplex:
   // Wraps a blocking `SocketChannel` (TCP or Unix-domain). The read side fills a
   // reusable buffer and blocks in `read`; EOF (`-1`) terminates the stream.
   def channel(socketChannel: jnc.SocketChannel): Duplex = new Duplex:
-    private val buffer = ByteBuffer.allocate(65536).nn
-
-    def stream: LazyList[Data] =
-      def recur(): LazyList[Data] =
-        buffer.clear()
-
-        socketChannel.read(buffer) match
-          case -1 => LazyList()
-
-          case _ =>
-            buffer.flip()
-            val array = new Array[Byte](buffer.remaining)
-            buffer.get(array)
-            array.immutable(using Unsafe) #:: recur()
-
-      recur()
-
     def send(consume data: (Stream[Data] over Credit)^): Unit =
       data.foreachWindow: (storage, start, count) =>
         val out = ByteBuffer.wrap(storage.asInstanceOf[Array[Byte]], start, count).nn
@@ -115,7 +126,8 @@ object Duplex:
 
     def close(): Unit = socketChannel.close()
 
-    override def source(using buffering: Buffering): Stream[Data] over Credit =
+    // Reads directly into the endpoint's buffer, allocation-free.
+    def source(using buffering: Buffering): (Stream[Data] over Credit)^ =
       new Stream[Data]:
         type Transport = Credit
 
@@ -162,14 +174,14 @@ object Duplex:
 // server-initiated frames concurrently. Reads block until data arrives or the peer
 // closes; `send` may be called many times and never half-closes the connection.
 trait Duplex:
-  def stream: LazyList[Data]
   def send(consume data: (Stream[Data] over Credit)^): Unit
   def close(): Unit
 
-  // Pull endpoint over the read side. The default adapts the legacy
-  // `stream`; `Duplex.channel` overrides it to read directly into the
-  // endpoint's buffer, allocation-free.
-  def source(using Buffering): Stream[Data] over Credit = Stream(stream.iterator)
+  // Pull endpoint over the read side: a fresh single-use endpoint whose refill
+  // blocks until data arrives or the peer closes. The `Duplex` contract is a
+  // single reader, so `source` should be opened once. The `^` is load-bearing:
+  // a bare stateful result reads as `.rd` at separation-checked use sites.
+  def source(using Buffering): (Stream[Data] over Credit)^
 
   // Push endpoint over the write side: repeatable, like `send`, and
   // `finish()` flushes without half-closing the connection.

--- a/lib/coaxial/src/core/coaxial.Serviceable.scala
+++ b/lib/coaxial/src/core/coaxial.Serviceable.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package coaxial
 
+import java.io as ji
 import java.net as jn
 import java.nio.ByteBuffer
 import java.nio.channels as jnc
@@ -48,8 +49,64 @@ import vacuous.*
 import zephyrine.*
 
 object Serviceable:
-  given domainSocket: (Tactic[StreamError], Every[SocketOption.Domain])
-  =>  ( (DomainSocket is Serviceable)^ ) = new Serviceable:
+  // A pull endpoint over a readable channel: refill reads directly into the
+  // endpoint's buffer, blocking until data arrives; EOF (`-1`) runs `onEnd` and
+  // terminates; an I/O failure aborts with the bytes read so far.
+  private def channelSource(channel: jnc.ReadableByteChannel)(onEnd: () -> Unit)
+    ( using buffering: Buffering, tactic: Tactic[StreamError] )
+  :   (Stream[Data] over Credit)^{tactic, caps.any} =
+
+    new Stream[Data]:
+      type Transport = Credit
+
+      private val capacity: Int = buffering.capacity(Substrate.Bytes)
+      private val storage: Array[Byte] = new Array[Byte](capacity)
+      private val wrapped: ByteBuffer = ByteBuffer.wrap(storage).nn
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var total: Long = 0
+      private var ended: Boolean = false
+
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      update def skip(count: Int): Unit = start0 += count
+
+      update def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if ended then Unset
+        else
+          val granted = summon[Credit is Regulation].grant(demand)
+
+          if granted == 0 then 0 else
+            start0 = 0
+            limit0 = 0
+            wrapped.clear()
+            wrapped.limit(capacity.min(granted))
+
+            try channel.read(wrapped) match
+              case -1 =>
+                ended = true
+                onEnd()
+                Unset
+
+              case 0 =>
+                refill(demand)
+
+              case count =>
+                total += count
+                limit0 = count
+                count
+
+            catch case error: ji.IOException =>
+              ended = true
+              // Pre-read into a local: `abort`'s capture-polymorphic argument may
+              // not hide this instance's state.
+              val sent: Long = total
+              abort(StreamError(sent.b))
+
+  given domainSocket: (tactic: Tactic[StreamError], options: Every[SocketOption.Domain])
+  =>  ( (DomainSocket is Serviceable)^{tactic, caps.any} ) = new Serviceable:
     type Self = DomainSocket
     type Output = Data
 
@@ -71,23 +128,8 @@ object Serviceable:
 
       connection.channel.shutdownOutput()
 
-    def receive(connection: Connection): LazyList[Data] =
-      val buffer = ByteBuffer.allocate(512).nn
-
-      def recur(): LazyList[Data] =
-        connection.channel.read(buffer) match
-          case -1 =>
-            connection.channel.shutdownInput()
-            LazyList()
-
-          case n =>
-            buffer.flip()
-            val array = new Array[Byte](buffer.remaining)
-            buffer.get(array)
-            buffer.clear()
-            array.immutable(using Unsafe) #:: recur()
-
-      recur()
+    def receive(connection: Connection): (Stream[Data] over Credit)^{this, caps.any} =
+      channelSource(connection.channel)(() => connection.channel.shutdownInput())
 
     def close(connection: Connection): Unit = connection.channel.close()
 
@@ -115,7 +157,8 @@ object Serviceable:
         out.flush()
 
     def close(socket: jn.Socket): Unit = socket.close()
-    def receive(socket: jn.Socket): LazyList[Data] = socket.getInputStream.nn.stream[Data]
+    def receive(socket: jn.Socket): (Stream[Data] over Credit)^{this, caps.any} =
+      channelSource(jnc.Channels.newChannel(socket.getInputStream.nn).nn)(() => ())
 
   given tcpPort: (tactic: Tactic[StreamError]) => (options: Every[SocketOption.Tcp])
   =>  ( (TcpPort is Serviceable)^{tactic} ) = new Serviceable:
@@ -134,7 +177,8 @@ object Serviceable:
       socket
 
     def close(socket: jn.Socket): Unit = socket.close()
-    def receive(socket: jn.Socket): LazyList[Data] = socket.getInputStream.nn.stream[Data]
+    def receive(socket: jn.Socket): (Stream[Data] over Credit)^{this, caps.any} =
+      channelSource(jnc.Channels.newChannel(socket.getInputStream.nn).nn)(() => ())
 
     def transmit(socket: jn.Socket, consume input: (Stream[Data] over Credit)^): Unit =
       val out = socket.getOutputStream.nn
@@ -144,5 +188,8 @@ object Serviceable:
         out.flush()
 
 trait Serviceable extends Routable:
-  def receive(connection: Connection): LazyList[Data]
+  // A fresh pull endpoint over the connection's read side; single-use, like the
+  // connection itself. The endpoint may retain this instance's capabilities (a
+  // `Tactic[StreamError]`), so the result is instance-relative rather than fresh.
+  def receive(connection: Connection): (Stream[Data] over Credit)^{this, caps.any}
   def close(connection: Connection): Unit

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -44,7 +44,7 @@ import rudiments.*
 import spectacular.*
 import turbulence.*
 import urticose.MacAddress
-import zephyrine.{Stream, Credit}
+import zephyrine.{Stream, Credit, Buffering, Substrate}
 import vacuous.*
 
 import Control.*
@@ -96,7 +96,7 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
 // demand a pure instance.
 extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint is Serviceable)^)
   def transmit[message: Transmissible](input: message)(using SocketEvent is Loggable)
-  :   LazyList[Data] =
+  :   (Stream[Data] over Credit)^{serviceable, caps.any} =
     val connection = serviceable.connect(endpoint, Unset)
     Log.fine(SocketEvent.Connected(endpoint.show))
 
@@ -109,26 +109,45 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
   // initiate; a `Duplexable` additionally offers `exchange`, which can also send proactively.
   def react[state](initialState: state)[message: Ingressive]
     ( handle: (state: state) ?=> message => Control[state] )
-    ( using SocketEvent is Loggable )
+    ( using SocketEvent is Loggable )(using buffering: Buffering)
   :   state =
 
     val connection = serviceable.connect(endpoint, Unset)
     Log.fine(SocketEvent.Connected(endpoint.show))
 
-    def recur(input: LazyList[Data], state: state): state = input.flow(state):
-      handle(using state)(message.deserialize(next)) match
-        case Continue(state2) => recur(more, state2.or(state))
-        case Terminate        => state
+    // One refill window is one inbound message: chunk boundaries frame messages,
+    // exactly as each lazy-list element did. A while-loop rather than a
+    // self-recursive local def, which may not capture the exclusive endpoint.
+    try
+      val input = serviceable.receive(connection)
+      val demand = Credit(buffering.capacity(Substrate.Bytes))
+      var state = initialState
+      var done = false
 
-        case Reply(message, state2) =>
-          serviceable.transmit(connection, Stream(message))
-          recur(more, state2.or(state))
+      while !done do input.refill(demand) match
+        case count: Int =>
+          if count > 0 then
+            val data = input.addressable.materialize(input.window(using Unsafe), input.start, count)
+            input.skip(count)
 
-        case Conclude(message, state2) =>
-          serviceable.transmit(connection, Stream(message))
-          state2.or(state)
+            handle(using state)(message.deserialize(data)) match
+              case Continue(state2) => state = state2.or(state)
+              case Terminate        => done = true
 
-    recur(serviceable.receive(connection), initialState).also(serviceable.close(connection))
+              case Reply(message, state2) =>
+                serviceable.transmit(connection, Stream(message))
+                state = state2.or(state)
+
+              case Conclude(message, state2) =>
+                serviceable.transmit(connection, Stream(message))
+                state = state2.or(state)
+                done = true
+
+        case _ =>
+          done = true
+
+      state
+    finally serviceable.close(connection)
 
 
 // As for `Serviceable` above: `Duplexable` instances may be capabilities (a WebSocket client
@@ -144,7 +163,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
   def exchange[state](initialState: state)[message: {Ingressive, Transmissible}]
     ( handle: (state: state) ?=> message => Control[state] )
     ( interact: Sender[message]^ => Unit )
-    ( using SocketEvent is Loggable )
+    ( using SocketEvent is Loggable )(using buffering: Buffering)
   :   state =
 
     val connection = duplexable.connect(endpoint, Unset)
@@ -158,20 +177,37 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
           def apply(consume stream: (Stream[Data] over Credit)^): Unit =
             duplexable.transmit(connection, stream)
 
-    def recur(input: LazyList[Data], state: state): state = input.flow(state):
-      handle(using state)(message.deserialize(next)) match
-        case Continue(state2) => recur(more, state2.or(state))
-        case Terminate        => state
+    // As `react`: one refill window is one inbound message.
+    try
+      val input = duplexable.receive(connection)
+      val demand = Credit(buffering.capacity(Substrate.Bytes))
+      var state = initialState
+      var done = false
 
-        case Reply(message, state2) =>
-          duplexable.transmit(connection, Stream(message))
-          recur(more, state2.or(state))
+      while !done do input.refill(demand) match
+        case count: Int =>
+          if count > 0 then
+            val data = input.addressable.materialize(input.window(using Unsafe), input.start, count)
+            input.skip(count)
 
-        case Conclude(message, state2) =>
-          duplexable.transmit(connection, Stream(message))
-          state2.or(state)
+            handle(using state)(message.deserialize(data)) match
+              case Continue(state2) => state = state2.or(state)
+              case Terminate        => done = true
 
-    recur(duplexable.receive(connection), initialState).also(duplexable.close(connection))
+              case Reply(message, state2) =>
+                duplexable.transmit(connection, Stream(message))
+                state = state2.or(state)
+
+              case Conclude(message, state2) =>
+                duplexable.transmit(connection, Stream(message))
+                state = state2.or(state)
+                done = true
+
+        case _ =>
+          done = true
+
+      state
+    finally duplexable.close(connection)
 
 
 extension [endpoint: {Routable as routable, Showable}](endpoint: endpoint)

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -246,13 +246,13 @@ object Tests extends Suite(m"Coaxial tests"):
           val received: Promise[Text] = Promise()
 
           val server = socket.listen[Data]: connection =>
-            val request = IArray.from(joined(connection.stream()))
+            val request = connection.source().memoize
             received.fulfill(request.utf8)
             request
 
           // The ascription selects the `Serviceable` overload of `transmit`; the
           // client half-closes after sending, so the server reads to EOF.
-          val _: LazyList[Data] = socket.transmit(t"request")
+          val _: zephyrine.Stream[Data] over zephyrine.Credit = socket.transmit(t"request")
           received.await().also(server.stop())
         . assert(_ == t"request")
 
@@ -269,7 +269,12 @@ object Tests extends Suite(m"Coaxial tests"):
 
           val reply = socket.duplex: duplex =>
             duplex.send(zephyrine.Stream(ascii(t"ping")))
-            bytes(duplex.stream.head)
+
+            // One refill window is the server's single reply.
+            val source = duplex.source
+            val count = source.refill(zephyrine.Credit(64)).or(0)
+            val data = source.addressable.materialize(source.window(using Unsafe), source.start, count)
+            bytes(data)
 
           reply.also(server.stop())
         . assert(_ == bytes(ascii(t"ping")))

--- a/lib/cordillera/src/core/cordillera.ByteBuf.scala
+++ b/lib/cordillera/src/core/cordillera.ByteBuf.scala
@@ -33,76 +33,47 @@
 package cordillera
 
 import anticipation.{Data as Bytes, *}
-import contingency.*
-import rudiments.*
-import vacuous.*
 import prepositional.*
-import zephyrine.{Stream, Credit, Buffering, Substrate}
+import vacuous.*
+import rudiments.*
 
-import Http2.Frame
-import Http2Error.Reason
-
-// Pulls whole HTTP/2 frames from a connection's pull endpoint, whose bytes arrive
-// in arbitrary chunks (a socket). Buffers leftover bytes between reads and blocks
-// (by refilling the endpoint) until a full frame — its 9-byte header plus declared
-// payload — is available. Returns `Unset` at end of stream. The reader consumes the
-// endpoint: it is the connection's single reader.
-object FrameReader:
-  // Only a method may declare `consume`: the factory takes ownership of the
-  // endpoint and moves it into the reader as a neutral carrier.
-  def apply(consume input: (Stream[Bytes] over Credit)^)(using Buffering): FrameReader^ =
-    new FrameReader(input.asInstanceOf[AnyRef])
-
-// An exclusive, stateful capability, like a parser: it owns the connection's read
-// endpoint and its own reassembly buffer.
-class FrameReader private (input0: AnyRef)(using buffering: Buffering)
+// A minimal growable byte buffer, classified as an exclusive, stateful capability:
+// the separation checker rejects `scala.collection.mutable.ArrayBuilder` mutation
+// outside a `uses`-clause scope, so the HTTP/2 wire encoders append through this
+// instead. `data` copies out, so the internal storage never escapes.
+private[cordillera] class ByteBuf(initial: Int = 32)
 extends caps.ExclusiveCapability, caps.Stateful:
-  private inline def input: (Stream[Bytes] over Credit)^ =
-    input0.asInstanceOf[(Stream[Bytes] over Credit)^]
-
-  private val demand: Credit = Credit(buffering.capacity(Substrate.Bytes))
-
-  // Untracked: the reassembly buffer is reached only through this (exclusive)
-  // reader, and every `slice` copies out of it.
+  // Untracked: reached only through this (exclusive) buffer, and `data` copies out.
   @caps.unsafe.untrackedCaptures
-  private var buffer: Array[Byte] = new Array(0)
-  private var pos: Int = 0
+  private var storage: Array[Byte] = new Array[Byte](initial.max(8))
+  private var size0: Int = 0
 
-  // Ensure at least `n` unread bytes are buffered; false if the stream ends first.
-  private update def ensure(n: Int): Boolean =
-    var ended = false
+  // An exclusive view for writes: the untracked field reads as read-only.
+  private inline def target: Array[Byte]^ = storage.asInstanceOf[Array[Byte]^]
 
-    while buffer.length - pos < n && !ended do input.refill(demand) match
-      case count: Int =>
-        if count > 0 then
-          val remaining = buffer.length - pos
-          val grown = new Array[Byte](remaining + count)
-          System.arraycopy(buffer, pos, grown, 0, remaining)
-          System.arraycopy(input.window(using Unsafe), input.start, grown, remaining, count)
-          input.skip(count)
-          // The cast erases the fresh array's capture: it is confined to this
-          // (exclusive) reader from here on.
-          buffer = grown.asInstanceOf[Array[Byte]]
-          pos = 0
+  def size: Int = size0
 
-      case _ =>
-        ended = true
+  private update def ensure(extra: Int): Unit =
+    if size0 + extra > storage.length then
+      var capacity = storage.length*2
+      while size0 + extra > capacity do capacity *= 2
+      val grown = new Array[Byte](capacity)
+      System.arraycopy(storage, 0, grown, 0, size0)
+      // The cast erases the fresh array's capture: it is confined to this buffer.
+      storage = grown.asInstanceOf[Array[Byte]]
 
-    buffer.length - pos >= n
+  update def add(byte: Byte): Unit =
+    ensure(1)
+    target(size0) = byte
+    size0 += 1
 
-  private update def slice(n: Int): Bytes =
-    val out = new Array[Byte](n)
-    System.arraycopy(buffer, pos, out, 0, n)
-    pos += n
-    out.immutable(using Unsafe)
+  update def addAll(bytes: Bytes): Unit =
+    ensure(bytes.length)
+    System.arraycopy(bytes.mutable(using Unsafe), 0, target, size0, bytes.length)
+    size0 += bytes.length
 
-  // Read the next frame, or `Unset` at clean end of stream. The tactic is a plain
-  // using-parameter: a context-function result may not hide `this`.
-  update def next()(using Tactic[Http2Error]): Optional[Frame] =
-    if !ensure(9) then Unset else
-      val header = slice(9)
-      val length = Frame.uint24(header, 0)
-      if !ensure(length) then abort(Http2Error(Reason.Truncated))
-      // Sealed: a fresh `IArray` is immutable; fresh-ness is the opaque-Array artifact.
-      val whole: Bytes = caps.unsafe.unsafeAssumePure(header ++ slice(length))
-      Frame.decode(whole, 0)(0)
+  def data: Bytes =
+    val out = new Array[Byte](size0)
+    System.arraycopy(storage, 0, out, 0, size0)
+    // Sealed: a fresh copy no alias can reach is immutable.
+    caps.unsafe.unsafeAssumePure(out.immutable(using Unsafe))

--- a/lib/cordillera/src/core/cordillera.Hpack.scala
+++ b/lib/cordillera/src/core/cordillera.Hpack.scala
@@ -46,6 +46,53 @@ import Http2Error.Reason
 // owns one direction's dynamic table; a connection keeps one for decoding inbound
 // header blocks and one for encoding outbound ones, since the tables evolve
 // independently as fields are added.
+object Hpack:
+  // Builder mutation lives here rather than in class methods, which would force a
+  // `uses` clause onto the class itself.
+  private[cordillera] def encodeEntries(headers: List[HpackEntry], table: HpackTable): Data =
+    val buf: ByteBuf^ = ByteBuf()
+
+    // A while-loop rather than `each`: the closure may not capture the exclusive buffer.
+    var rest = headers
+
+    while !rest.isEmpty do
+      val header = rest.head
+      writeInteger(buf, 0x40, 6, 0)
+      writeString(buf, header.name)
+      writeString(buf, header.value)
+      table.add(header)
+      rest = rest.tail
+
+    buf.data
+
+  // Writes `value` into the low `prefix` bits of `first` (its high bits preserved),
+  // with continuation bytes as needed.
+  private def writeInteger(buf: ByteBuf^, first: Int, prefix: Int, value: Int): Unit =
+    val mask = (1 << prefix) - 1
+
+    if value < mask then buf.add((first | value).toByte) else
+      buf.add((first | mask).toByte)
+      var rest = value - mask
+
+      while rest >= 0x80 do
+        buf.add(((rest & 0x7f) | 0x80).toByte)
+        rest >>>= 7
+
+      buf.add(rest.toByte)
+
+  private def writeString(buf: ByteBuf^, text: Text): Unit =
+    // Sealed: fresh `IArray`s are immutable; the opaque-Array artifact.
+    val raw: Data = caps.unsafe.unsafeAssumePure(text.s.getBytes("US-ASCII").nn.immutable(using Unsafe))
+    val huffed: Data = caps.unsafe.unsafeAssumePure(Huffman.encode(raw))
+
+    // Use whichever encoding is shorter (RFC permits either); flag Huffman in bit 7.
+    if huffed.length < raw.length then
+      writeInteger(buf, 0x80, 7, huffed.length)
+      buf.addAll(huffed)
+    else
+      writeInteger(buf, 0, 7, raw.length)
+      buf.addAll(raw)
+
 class Hpack(maxTableSize: Int = 4096):
   private val table = HpackTable(maxTableSize)
 
@@ -75,23 +122,6 @@ class Hpack(maxTableSize: Int = 4096):
 
       (result, pos)
 
-  // Writes `value` into the low `prefix` bits of `first` (its high bits preserved),
-  // with continuation bytes as needed.
-  private def writeInteger(builder: scm.ArrayBuilder[Byte], first: Int, prefix: Int, value: Int)
-  :   Unit =
-
-    val mask = (1 << prefix) - 1
-
-    if value < mask then builder.addOne((first | value).toByte) else
-      builder.addOne((first | mask).toByte)
-      var rest = value - mask
-
-      while rest >= 0x80 do
-        builder.addOne(((rest & 0x7f) | 0x80).toByte)
-        rest >>>= 7
-
-      builder.addOne(rest.toByte)
-
   // ─── string literal (RFC 7541 §5.2) ───────────────────────────────────────
   //
   // A length-prefixed octet sequence; the prefix's high bit flags Huffman coding.
@@ -99,22 +129,11 @@ class Hpack(maxTableSize: Int = 4096):
     val huffman = (data(offset) & 0x80) != 0
     val (length, start) = readInteger(data, offset, 7)
     if start + length > data.length then abort(Http2Error(Reason.Truncated))
-    val raw = data.slice(start, start + length)
-    val decoded = if huffman then Huffman.decode(raw) else raw
+    // Sealed: fresh `IArray`s are immutable; fresh-ness is the opaque-Array artifact.
+    val raw: Data = caps.unsafe.unsafeAssumePure(data.slice(start, start + length))
+    val decoded: Data = if huffman then caps.unsafe.unsafeAssumePure(Huffman.decode(raw)) else raw
 
     (decoded.utf8, start + length)
-
-  private def writeString(builder: scm.ArrayBuilder[Byte], text: Text): Unit =
-    val raw = text.s.getBytes("US-ASCII").nn.immutable(using Unsafe)
-    val huffed = Huffman.encode(raw)
-
-    // Use whichever encoding is shorter (RFC permits either); flag Huffman in bit 7.
-    if huffed.length < raw.length then
-      writeInteger(builder, 0x80, 7, huffed.length)
-      builder.addAll(huffed.mutable(using Unsafe))
-    else
-      writeInteger(builder, 0, 7, raw.length)
-      builder.addAll(raw.mutable(using Unsafe))
 
   // ─── decode a complete header block ────────────────────────────────────────
 
@@ -167,13 +186,6 @@ class Hpack(maxTableSize: Int = 4096):
   // literal (Huffman-or-raw) name and value. Correct and interoperable; does not
   // yet exploit static-table name matches. Pseudo-headers must already be ordered
   // ahead of regular headers by the caller (RFC 7540 §8.1.2.1).
-  def encode(headers: List[HpackEntry]): Data =
-    val builder = scm.ArrayBuilder.make[Byte]
-
-    headers.each: header =>
-      writeInteger(builder, 0x40, 6, 0)
-      writeString(builder, header.name)
-      writeString(builder, header.value)
-      table.add(header)
-
-    builder.result().immutable(using Unsafe)
+  // Delegates to the companion: builder mutation inside a class method would
+  // force a `uses` clause onto the class itself.
+  def encode(headers: List[HpackEntry]): Data = Hpack.encodeEntries(headers, table)

--- a/lib/cordillera/src/core/cordillera.HpackTable.scala
+++ b/lib/cordillera/src/core/cordillera.HpackTable.scala
@@ -45,7 +45,8 @@ case class HpackEntry(name: Text, value: Text):
 
 object HpackTable:
   // The 61-entry static table (RFC 7541, Appendix A). Index 1 is element 0 here.
-  val static: IArray[HpackEntry] = IArray[HpackEntry](
+  // Sealed: a fresh `IArray` is immutable; fresh-ness is the opaque-Array artifact.
+  val static: IArray[HpackEntry] = caps.unsafe.unsafeAssumePure(IArray[HpackEntry](
     HpackEntry(t":authority", t""),
     HpackEntry(t":method", t"GET"),
     HpackEntry(t":method", t"POST"),
@@ -106,15 +107,20 @@ object HpackTable:
     HpackEntry(t"user-agent", t""),
     HpackEntry(t"vary", t""),
     HpackEntry(t"via", t""),
-    HpackEntry(t"www-authenticate", t"") )
+    HpackEntry(t"www-authenticate", t"") ))
 
 // The HPACK dynamic table: a FIFO of recently-seen header fields, bounded by a
 // byte-size limit, with oldest-first eviction. Combined with the static table it
 // forms the HPACK address space: index 1..61 is static; 62.. is the dynamic table,
 // most-recently-inserted first (RFC 7541 §2.3.3).
 class HpackTable(initialMaxSize: Int = 4096):
-  private val entries = scm.ArrayDeque.empty[HpackEntry]
+  // Untracked: the dynamic table is confined to its owning `Hpack` codec, which
+  // is itself confined to one connection's reader or writer daemon.
+  @caps.unsafe.untrackedCaptures
+  private val entries: scm.ArrayDeque[HpackEntry] = scm.ArrayDeque.empty[HpackEntry]
+  @caps.unsafe.untrackedCaptures
   private var maxSize: Int = initialMaxSize
+  @caps.unsafe.untrackedCaptures
   private var currentSize: Int = 0
 
   def size: Int = currentSize

--- a/lib/cordillera/src/core/cordillera.Http2.scala
+++ b/lib/cordillera/src/core/cordillera.Http2.scala
@@ -139,16 +139,16 @@ object Http2:
       ((data(offset).toLong & 0xff) << 24) | ((data(offset + 1).toLong & 0xff) << 16) |
         ((data(offset + 2).toLong & 0xff) << 8) | (data(offset + 3).toLong & 0xff)
 
-    private def writeUint24(builder: scm.ArrayBuilder[Byte], value: Int): Unit =
-      builder.addOne(((value >>> 16) & 0xff).toByte)
-      builder.addOne(((value >>> 8) & 0xff).toByte)
-      builder.addOne((value & 0xff).toByte)
+    private def writeUint24(buf: ByteBuf^, value: Int): Unit =
+      buf.add(((value >>> 16) & 0xff).toByte)
+      buf.add(((value >>> 8) & 0xff).toByte)
+      buf.add((value & 0xff).toByte)
 
-    private def writeUint32(builder: scm.ArrayBuilder[Byte], value: Long): Unit =
-      builder.addOne(((value >>> 24) & 0xff).toByte)
-      builder.addOne(((value >>> 16) & 0xff).toByte)
-      builder.addOne(((value >>> 8) & 0xff).toByte)
-      builder.addOne((value & 0xff).toByte)
+    private def writeUint32(buf: ByteBuf^, value: Long): Unit =
+      buf.add(((value >>> 24) & 0xff).toByte)
+      buf.add(((value >>> 16) & 0xff).toByte)
+      buf.add(((value >>> 8) & 0xff).toByte)
+      buf.add((value & 0xff).toByte)
 
     // Decodes a single frame from `data` starting at `offset`; returns the frame and
     // the offset just past it. `data` must already contain the whole frame.
@@ -162,7 +162,8 @@ object Http2:
       val end = start + length
 
       if end > data.length then abort(Http2Error(Reason.Truncated))
-      val body = data.slice(start, end)
+      // Sealed: a fresh `IArray` slice is immutable; the opaque-Array artifact.
+      val body: anticipation.Data = caps.unsafe.unsafeAssumePure(data.slice(start, end))
 
       val frame = FrameType.fromId(typeId).lest(Http2Error(Reason.BadFrameType(typeId))) match
         case FrameType.Data =>
@@ -172,9 +173,10 @@ object Http2:
           val unpadded = stripPadding(body, flags)
           // A PRIORITY prefix (5 bytes: 4-byte dependency + 1-byte weight) precedes
           // the header block when the PRIORITY flag is set; skip it.
-          val block =
+          // Sealed: a fresh `IArray` slice is immutable; the opaque-Array artifact.
+          val block: anticipation.Data =
             if Flags.set(flags, Flags.Priority)
-            then unpadded.slice(5, unpadded.length)
+            then caps.unsafe.unsafeAssumePure(unpadded.slice(5, unpadded.length))
             else unpadded
 
           Frame.Headers
@@ -197,7 +199,11 @@ object Http2:
 
         case FrameType.GoAway =>
           val lastStreamId = (uint32(body, 0) & 0x7fffffffL).toInt
-          Frame.GoAway(lastStreamId, uint32(body, 4), body.slice(8, body.length))
+          Frame.GoAway
+            ( lastStreamId,
+              uint32(body, 4),
+              // Sealed: the opaque-Array artifact.
+              caps.unsafe.unsafeAssumePure(body.slice(8, body.length)) )
 
         case FrameType.WindowUpdate =>
           Frame.WindowUpdate(streamId, (uint32(body, 0) & 0x7fffffffL).toInt)
@@ -211,7 +217,8 @@ object Http2:
         if payload.length < 1 then abort(Http2Error(Reason.Truncated))
         val padLength = payload(0) & 0xff
         if 1 + padLength > payload.length then abort(Http2Error(Reason.Protocol(t"bad padding")))
-        payload.slice(1, payload.length - padLength)
+        // Sealed: the opaque-Array artifact.
+        caps.unsafe.unsafeAssumePure(payload.slice(1, payload.length - padLength))
 
     private def decodeSettings(payload: Bytes): List[Setting] raises Http2Error =
       if payload.length%6 != 0 then abort(Http2Error(Reason.Protocol(t"bad SETTINGS length")))
@@ -245,10 +252,20 @@ object Http2:
       case Frame.Ping(_, ack)                   => if ack then Flags.Ack else 0
       case _                                    => 0
 
-    private def frameBuilder(lambda: scm.ArrayBuilder[Byte] => Unit): Bytes =
-      val builder = scm.ArrayBuilder.make[Byte]
-      lambda(builder)
-      builder.result().immutable(using Unsafe)
+    private def frameBuilder(lambda: ByteBuf^ => Unit): Bytes =
+      val buf: ByteBuf^ = ByteBuf()
+      lambda(buf)
+      buf.data
+
+    private[cordillera] def serializeFrame(frame: Frame): Bytes =
+      val body = payload(frame)
+      val buf: ByteBuf^ = ByteBuf(9 + body.length)
+      writeUint24(buf, body.length)
+      buf.add(frameType(frame).id.toByte)
+      buf.add(frameFlags(frame).toByte)
+      writeUint32(buf, frame.stream.toLong & 0x7fffffffL)
+      buf.addAll(body)
+      buf.data
 
     private def payload(frame: Frame): Bytes = frame match
       case Frame.Headers(_, block, _, _)   => block
@@ -261,17 +278,23 @@ object Http2:
         frameBuilder(writeUint32(_, increment.toLong & 0x7fffffffL))
 
       case Frame.Settings(settings, _) =>
-        frameBuilder: builder =>
-          settings.each: setting =>
-            builder.addOne(((setting.id >>> 8) & 0xff).toByte)
-            builder.addOne((setting.id & 0xff).toByte)
-            writeUint32(builder, setting.value)
+        frameBuilder: buf =>
+          // A while-loop rather than `each`: the closure may not capture the
+          // exclusive buffer.
+          var rest = settings
+
+          while !rest.isEmpty do
+            val setting = rest.head
+            buf.add(((setting.id >>> 8) & 0xff).toByte)
+            buf.add((setting.id & 0xff).toByte)
+            writeUint32(buf, setting.value)
+            rest = rest.tail
 
       case Frame.GoAway(lastStreamId, errorCode, debug) =>
-        frameBuilder: builder =>
-          writeUint32(builder, lastStreamId.toLong & 0x7fffffffL)
-          writeUint32(builder, errorCode)
-          builder.addAll(debug.mutable(using Unsafe))
+        frameBuilder: buf =>
+          writeUint32(buf, lastStreamId.toLong & 0x7fffffffL)
+          writeUint32(buf, errorCode)
+          buf.addAll(debug)
 
   // An HTTP/2 frame (RFC 7540 §6): a 9-byte header — 24-bit length, 8-bit type, 8-bit
   // flags, 1 reserved bit + 31-bit stream id — followed by a type-specific payload.
@@ -311,15 +334,9 @@ object Http2:
       case WindowUpdate(id, _)    => id
 
     // Serialise the frame, including its 9-byte header.
-    def serialize: Bytes =
-      val body = Frame.payload(this)
-      val builder = scm.ArrayBuilder.make[Byte]
-      Frame.writeUint24(builder, body.length)
-      builder.addOne(Frame.frameType(this).id.toByte)
-      builder.addOne(Frame.frameFlags(this).toByte)
-      Frame.writeUint32(builder, stream.toLong & 0x7fffffffL)
-      builder.addAll(body.mutable(using Unsafe))
-      builder.result().immutable(using Unsafe)
+    // Delegates to the companion: builder mutation inside an enum-class method
+    // would force a `uses` clause onto the class itself.
+    def serialize: Bytes = Frame.serializeFrame(this)
 
   // A cleartext-h2c endpoint: a connectable address plus the `:authority` to send.
   // Used as the `Target` of the HTTP/2 `HttpClient` given, distinct from the
@@ -332,20 +349,26 @@ object Http2:
     // parked until the scope is torn down — so the response bodies it streams lazily
     // stay readable for the scope's lifetime instead of being closed per request.
     // Returns once the HTTP/2 handshake has completed.
-    def connect()(using Monitor, Probate): Http2Connection raises AsyncError =
-      val ready: Promise[Http2Connection] = Promise()
+    // Named using-parameters, de-sugared from `raises`: the result retains the
+    // connection's capabilities, so it must name its evidence rather than hide it.
+    def connect()(using monitor: Monitor, probate: Probate, asyncError: Tactic[AsyncError])
+    :   Http2Connection^{monitor, caps.any} =
+
+      // A neutral carrier: the connection (a capability) crosses the daemon and the
+      // promise as an `AnyRef`.
+      val ready: Promise[AnyRef] = Promise()
 
       daemon:
         try
           endpoint.duplex: duplex =>
             val connection = Http2Connection(duplex)
             connection.start()
-            ready.offer(connection)
+            ready.offer(connection.asInstanceOf[AnyRef])
             Promise[Unit]().await()
 
         finally if !ready.ready then ready.cancel()
 
-      ready.await()
+      ready.await().asInstanceOf[Http2Connection^{monitor, caps.any}]
 
   // An `HttpClient` that speaks HTTP/2 (prior-knowledge h2c) to an `Http2.Endpoint`.
   // It captures the ambient `Monitor`/`Probate` from this given's context — the
@@ -353,8 +376,12 @@ object Http2:
   // summoned inside a `supervise` scope. A fresh connection is opened per request for
   // now; pooling is a later refinement.
   object Client:
-    given http2: [endpoint] => (Monitor, Probate, Tactic[Http2Error], Tactic[AsyncError])
-    =>  HttpClient onto Endpoint[endpoint] =
+    given http2: [endpoint]
+    =>  ( monitor:    Monitor,
+          probate:    Probate,
+          http2Error: Tactic[Http2Error],
+          asyncError: Tactic[AsyncError] )
+    =>  ((HttpClient onto Endpoint[endpoint])^{monitor, http2Error, asyncError, caps.any}) =
 
       new HttpClient:
         type Target = Endpoint[endpoint]

--- a/lib/cordillera/src/core/cordillera.Http2Connection.scala
+++ b/lib/cordillera/src/core/cordillera.Http2Connection.scala
@@ -62,6 +62,63 @@ object Http2Connection:
       ( Setting(SettingId.EnablePush.id, 0),
         Setting(SettingId.InitialWindowSize.id, 0x7fffffff) )
 
+  // Dispatch one decoded frame. Lives on the companion — taking the connection as a
+  // plain parameter — so the reader daemon's body stays free of `this` captures.
+  // The tactic is a plain using-parameter: a context-function result may not hide it.
+  private def dispatch(conn: Http2Connection, frame: Frame, decoder: Hpack)
+    ( using Tactic[Http2Error] )
+  :   Boolean =
+    frame match
+      case Frame.Settings(_, ack) =>
+        if !ack then
+          conn.send(Frame.Settings(Nil, ack = true))
+          conn.started.offer(())
+
+        true
+
+      case Frame.Ping(opaque, ack) =>
+        if !ack then conn.send(Frame.Ping(opaque, ack = true))
+        true
+
+      case Frame.GoAway(lastStreamId, _, _) =>
+        Log.warn(Http2Event.GoAway(lastStreamId))
+        false
+
+      case Frame.Headers(id, block, endStream, _) =>
+        conn.streams.get(id).foreach: stream =>
+          stream.acceptHeaders(decoder.decode(block))
+
+          if endStream then
+            stream.end()
+            conn.streams.remove(id)
+
+        true
+
+      case Frame.Data(id, payload, endStream) =>
+        conn.streams.get(id).foreach: stream =>
+          stream.acceptData(payload)
+          // Replenish the peer's flow-control window for what we consumed.
+          if payload.length > 0 then
+            conn.send(Frame.WindowUpdate(0, payload.length))
+            conn.send(Frame.WindowUpdate(id, payload.length))
+
+          if endStream then
+            stream.end()
+            conn.streams.remove(id)
+
+        true
+
+      case Frame.RstStream(id, _) =>
+        conn.streams.get(id).foreach: stream =>
+          stream.end()
+          conn.streams.remove(id)
+
+        true
+
+      case Frame.WindowUpdate(_, _) | Frame.Continuation(_, _, _) =>
+        true
+
+
 // One outbound request stream's receive side: a promise for its response header
 // block (resolved on the first HEADERS frame), a spool feeding the response body
 // (fed by DATA frames), and a promise for trailers (resolved on a second, end-stream
@@ -71,6 +128,8 @@ class Http2Stream(val id: Int):
   val headers: Promise[List[HpackEntry]] = Promise()
   val trailers: Promise[List[HpackEntry]] = Promise()
   val body: Spool[Bytes] = Spool()
+  // Untracked: written only by the connection's single reader daemon.
+  @caps.unsafe.untrackedCaptures
   private var headersSeen: Boolean = false
 
   // Record an incoming HEADERS block: the first becomes the response headers, a
@@ -105,58 +164,6 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
 
   private def send(frame: Frame): Unit = outbound.put(frame)
 
-  // Dispatch one decoded frame. Separated out so the read loop's `Tactic[Http2Error]`
-  // (for HPACK decoding) is supplied in one place.
-  private def dispatch(frame: Frame, decoder: Hpack): Boolean raises Http2Error =
-    frame match
-      case Frame.Settings(_, ack) =>
-        if !ack then
-          send(Frame.Settings(Nil, ack = true))
-          started.offer(())
-
-        true
-
-      case Frame.Ping(opaque, ack) =>
-        if !ack then send(Frame.Ping(opaque, ack = true))
-        true
-
-      case Frame.GoAway(lastStreamId, _, _) =>
-        Log.warn(Http2Event.GoAway(lastStreamId))
-        false
-
-      case Frame.Headers(id, block, endStream, _) =>
-        streams.get(id).foreach: stream =>
-          stream.acceptHeaders(decoder.decode(block))
-
-          if endStream then
-            stream.end()
-            streams.remove(id)
-
-        true
-
-      case Frame.Data(id, payload, endStream) =>
-        streams.get(id).foreach: stream =>
-          stream.acceptData(payload)
-          // Replenish the peer's flow-control window for what we consumed.
-          if payload.length > 0 then
-            send(Frame.WindowUpdate(0, payload.length))
-            send(Frame.WindowUpdate(id, payload.length))
-
-          if endStream then
-            stream.end()
-            streams.remove(id)
-
-        true
-
-      case Frame.RstStream(id, _) =>
-        streams.get(id).foreach: stream =>
-          stream.end()
-          streams.remove(id)
-
-        true
-
-      case Frame.WindowUpdate(_, _) | Frame.Continuation(_, _, _) =>
-        true
 
   // Tear the connection down after an unrecoverable reader/writer failure: unblock a
   // pending handshake, end every open stream so awaiters of its headers/body/trailers
@@ -178,29 +185,41 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
       case _ => tearDown(); Remedy.Accept
 
     . protect:
-        val writer = daemon:
-          duplex.send(zephyrine.Stream(connectionPreface))
+        // Everything the fibers touch is bound to locals (or neutral carriers)
+        // before they spawn: a daemon body may not capture the instance under
+        // construction, and its context function must stay pure.
+        val duplex0: Duplex = duplex
+        val outbound0: Spool[Frame] = outbound
+        val self: AnyRef = this.asInstanceOf[AnyRef]
 
-          outbound.stream.each: frame =>
-            duplex.send(zephyrine.Stream(frame.serialize))
+        val writer = daemon:
+          duplex0.send(zephyrine.Stream(connectionPreface))
+
+          outbound0.stream.each: frame =>
+            duplex0.send(zephyrine.Stream(frame.serialize))
+
+        val frameReaderRef: AnyRef = FrameReader(duplex0.source).asInstanceOf[AnyRef]
 
         val reader = daemon:
           // A protocol error tears down just this connection; throw it to the enclosing
           // `contain`, which runs `tearDown()` and stops the reader.
           given Tactic[Http2Error] = AsyncTactic()
 
-          val frameReader = FrameReader(duplex.stream.iterator)
+          val frameReader = frameReaderRef.asInstanceOf[FrameReader^]
           val decoder = Hpack()
           var continue = true
 
           while continue do (frameReader.next(): @unchecked) match
             case Unset        => continue = false
-            case frame: Frame => continue = dispatch(frame, decoder)
+            case frame: Frame =>
+              continue = dispatch(self.asInstanceOf[Http2Connection], frame, decoder)
 
         (writer, reader)
 
   // Perform the connection handshake: emit our SETTINGS and await the peer's.
-  def start(): Unit raises AsyncError =
+  // Plain using-parameters, de-sugared from `raises`: a context-function result may
+  // not hide `this`.
+  def start()(using Tactic[AsyncError]): Unit =
     send(Frame.Settings(initialSettings, ack = false))
     started.await()
 
@@ -226,7 +245,8 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
   // pseudo-headers the request type doesn't carry. Trailers (e.g. gRPC status) are
   // available afterwards via `stream.trailers`.
   def fetch(request: Http.Request, scheme: Text, authority: Text)
-  :   (Http2Stream, Http.Response) raises Http2Error raises AsyncError =
+    ( using Tactic[Http2Error], Tactic[AsyncError] )
+  :   (Http2Stream, Http.Response) =
 
     Log.fine(Http2Event.RequestSent(authority))
     val headerBlock = PseudoHeaders.request(request, scheme, authority)
@@ -240,7 +260,8 @@ class Http2Connection(duplex: Duplex)(using Monitor, Probate):
     (stream, PseudoHeaders.response(responseHeaders, stream.body.stream))
 
   def close(): Unit =
-    send(Frame.GoAway(0, ErrorCode.NoError.code, IArray.empty[Byte]))
+    // Sealed: a fresh empty `IArray` is immutable; the opaque-Array artifact.
+    send(Frame.GoAway(0, ErrorCode.NoError.code, caps.unsafe.unsafeAssumePure(IArray.empty[Byte])))
     outbound.stop()
     reader.cancel()
     writer.cancel()

--- a/lib/cordillera/src/core/cordillera.Huffman.scala
+++ b/lib/cordillera/src/core/cordillera.Huffman.scala
@@ -45,7 +45,8 @@ import Http2Error.Reason
 // byte values plus the EOS symbol (index 256), the right-aligned code and its bit
 // length. Codes are most-significant-bit first.
 object Huffman:
-  private val codes: IArray[Int] = IArray[Int](
+  // Sealed: a fresh `IArray` is immutable; fresh-ness is the opaque-Array artifact.
+  private val codes: IArray[Int] = caps.unsafe.unsafeAssumePure(IArray[Int](
     0x1ff8, 0x7fffd8, 0xfffffe2, 0xfffffe3, 0xfffffe4, 0xfffffe5, 0xfffffe6, 0xfffffe7,
     0xfffffe8, 0xffffea, 0x3ffffffc, 0xfffffe9, 0xfffffea, 0x3ffffffd, 0xfffffeb, 0xfffffec,
     0xfffffed, 0xfffffee, 0xfffffef, 0xffffff0, 0xffffff1, 0xffffff2, 0x3ffffffe, 0xffffff3,
@@ -78,9 +79,10 @@ object Huffman:
     0x3fffea, 0x3fffeb, 0x1ffffee, 0x1ffffef, 0xfffff4, 0xfffff5, 0x3ffffea, 0x7ffff4,
     0x3ffffeb, 0x7ffffe6, 0x3ffffec, 0x3ffffed, 0x7ffffe7, 0x7ffffe8, 0x7ffffe9, 0x7ffffea,
     0x7ffffeb, 0xffffffe, 0x7ffffec, 0x7ffffed, 0x7ffffee, 0x7ffffef, 0x7fffff0, 0x3ffffee,
-    0x3fffffff )
+    0x3fffffff ))
 
-  private val lengths: IArray[Int] = IArray[Int](
+  // Sealed: the opaque-Array artifact, as `codes` above.
+  private val lengths: IArray[Int] = caps.unsafe.unsafeAssumePure(IArray[Int](
     13, 23, 28, 28, 28, 28, 28, 28,
     28, 24, 30, 28, 28, 30, 28, 28,
     28, 28, 28, 28, 28, 28, 30, 28,
@@ -113,12 +115,12 @@ object Huffman:
     22, 22, 25, 25, 24, 24, 26, 23,
     26, 27, 26, 26, 27, 27, 27, 27,
     27, 28, 27, 27, 27, 27, 27, 26,
-    30 )
+    30 ))
 
   // Encodes bytes with the HPACK Huffman code, padding the final byte with 1-bits
   // (the most-significant bits of the EOS symbol), per RFC 7541 §5.2.
   def encode(data: Data): Data =
-    val builder = scm.ArrayBuilder.make[Byte]
+    val buf: ByteBuf^ = ByteBuf()
     var bitBuffer = 0L
     var bitCount = 0
     var i = 0
@@ -132,20 +134,21 @@ object Huffman:
 
       while bitCount >= 8 do
         bitCount -= 8
-        builder.addOne(((bitBuffer >>> bitCount) & 0xff).toByte)
+        buf.add(((bitBuffer >>> bitCount) & 0xff).toByte)
 
       i += 1
 
     if bitCount > 0 then
       val pad = 8 - bitCount
-      builder.addOne((((bitBuffer << pad) | ((1L << pad) - 1)) & 0xff).toByte)
+      buf.add((((bitBuffer << pad) | ((1L << pad) - 1)) & 0xff).toByte)
 
-    builder.result().immutable(using Unsafe)
+    buf.data
 
   // Decodes an HPACK Huffman string. Walks the code bit-by-bit against the table;
   // the trailing padding (all 1-bits, fewer than 8) is accepted and discarded.
-  def decode(data: Data): Data raises Http2Error =
-    val builder = scm.ArrayBuilder.make[Byte]
+  // The tactic is a plain using-parameter, de-sugared from `raises`.
+  def decode(data: Data)(using Tactic[Http2Error]): Data =
+    val buf: ByteBuf^ = ByteBuf()
     var current = 0
     var bits = 0
     var matched = false
@@ -164,7 +167,7 @@ object Huffman:
 
         while symbol < 256 && !matched do
           if lengths(symbol) == bits && codes(symbol) == current then
-            builder.addOne(symbol.toByte)
+            buf.add(symbol.toByte)
             current = 0
             bits = 0
             matched = true
@@ -179,4 +182,4 @@ object Huffman:
     // Any leftover bits must be the EOS padding: all ones, fewer than 8 bits.
     if bits >= 8 || (current != ((1 << bits) - 1)) then abort(Http2Error(Reason.BadHuffman))
 
-    builder.result().immutable(using Unsafe)
+    buf.data

--- a/lib/cordillera/src/test/cordillera_test.scala
+++ b/lib/cordillera/src/test/cordillera_test.scala
@@ -230,16 +230,22 @@ object Tests extends Suite(m"Cordillera HTTP/2 Tests"):
         safely:
           serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = false).serialize))
 
-          // Skip the 24-byte client connection preface before frame-parsing.
-          val raw = serverSide.stream.iterator
+          // Skip the 24-byte client connection preface before frame-parsing: consume
+          // exactly the preface; anything after it stays in the endpoint's window.
+          val source = serverSide.source
+          var skipped = 0
 
-          val afterPreface: Iterator[Data] =
-            var buffered = IArray.empty[Byte]
-            while buffered.length < 24 && raw.hasNext do buffered = buffered ++ raw.next()
-            val leftover = buffered.drop(24)
-            (if leftover.isEmpty then Iterator.empty else Iterator(leftover)) ++ raw
+          while skipped < 24 do source.refill(zephyrine.Credit(4096)) match
+            case count: Int =>
+              if count > 0 then
+                val take = count.min(24 - skipped)
+                source.skip(take)
+                skipped += take
 
-          val reader = FrameReader(afterPreface)
+            case _ =>
+              skipped = 24
+
+          val reader = FrameReader(source)
           val hpack = Hpack()
           var continue = true
 

--- a/lib/embarcadero/src/containerd/embarcadero.Containerd.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.Containerd.scala
@@ -76,15 +76,17 @@ object Containerd:
   // Must be called inside a `supervise` scope (the connection runs background daemons).
   def apply[endpoint]
     ( endpoint: Http2.Endpoint[endpoint], namespace: Text )
-    ( using Monitor, Probate )
-  :   Containerd raises AsyncError =
+    ( using monitor: Monitor, probate: Probate, asyncError: Tactic[AsyncError] )
+  :   Containerd^{monitor, caps.any} =
 
     val metadata = Grpc.Metadata(List(t"containerd-namespace" -> namespace))
     Containerd(GrpcChannel(endpoint, metadata))
 
 // A connected containerd client. Each method maps to one gRPC call over the shared
 // channel; the namespace travels in the channel's default metadata.
-case class Containerd(channel: GrpcChannel):
+// The client retains its channel — a capability holding the ambient `Monitor` — so
+// a client is itself a capability.
+case class Containerd(channel: GrpcChannel^):
   // The daemon's version and build revision (`containerd.services.version.v1.Version`).
   def version()
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -169,15 +169,22 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
         daemon:
           safely:
             serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = false).serialize))
-            val raw = serverSide.stream.iterator
+            // Skip the 24-byte client connection preface: consume exactly the
+            // preface; anything after it stays in the endpoint's window.
+            val source = serverSide.source
+            var skipped = 0
 
-            val afterPreface: Iterator[Data] =
-              var buffered = IArray.empty[Byte]
-              while buffered.length < 24 && raw.hasNext do buffered = buffered ++ raw.next()
-              val leftover = buffered.drop(24)
-              (if leftover.isEmpty then Iterator.empty else Iterator(leftover)) ++ raw
+            while skipped < 24 do source.refill(zephyrine.Credit(4096)) match
+              case count: Int =>
+                if count > 0 then
+                  val take = count.min(24 - skipped)
+                  source.skip(take)
+                  skipped += take
 
-            val reader = FrameReader(afterPreface)
+              case _ =>
+                skipped = 24
+
+            val reader = FrameReader(source)
             val hpack = Hpack()
             var continue = true
 

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -53,8 +53,8 @@ object GrpcChannel:
   // must be called inside a `supervise` scope.
   def apply[endpoint]
     ( endpoint: Http2.Endpoint[endpoint], defaults: Grpc.Metadata = Grpc.Metadata() )
-    ( using Monitor, Probate )
-  :   GrpcChannel raises AsyncError =
+    ( using monitor: Monitor, probate: Probate, asyncError: Tactic[AsyncError] )
+  :   GrpcChannel^{monitor, caps.any} =
 
     new GrpcChannel(endpoint.connect(), endpoint.authority, defaults)
 
@@ -64,8 +64,10 @@ object GrpcChannel:
 // `grpc-status` trailer. v1 supports unary and server-streaming calls; the request
 // is always a single message, so client-streaming and bidirectional streaming wait
 // on a `cordillera` enhancement.
+// The channel retains its connection — a capability holding the ambient `Monitor` —
+// so a channel is itself a capability.
 class GrpcChannel
-  ( connection: Http2Connection, authority: Text, defaults: Grpc.Metadata = Grpc.Metadata() ):
+  ( connection: Http2Connection^, authority: Text, defaults: Grpc.Metadata = Grpc.Metadata() ):
   // The `:authority` pseudo-header is supplied to `fetch` separately; the request's
   // `Host` is unused by the HTTP/2 transport, so the hostname is parsed leniently.
   private val host: Host = unsafely(authority.cut(t":").prim.or(authority).decode[Host])

--- a/lib/obligatory/src/test/obligatory_test.scala
+++ b/lib/obligatory/src/test/obligatory_test.scala
@@ -170,15 +170,22 @@ object Tests extends Suite(m"Obligatory Tests"):
         daemon:
           safely:
             serverSide.send(zephyrine.Stream(Frame.Settings(Nil, ack = false).serialize))
-            val raw = serverSide.stream.iterator
+            // Skip the 24-byte client connection preface: consume exactly the
+            // preface; anything after it stays in the endpoint's window.
+            val source = serverSide.source
+            var skipped = 0
 
-            val afterPreface: Iterator[Data] =
-              var buffered = IArray.empty[Byte]
-              while buffered.length < 24 && raw.hasNext do buffered = buffered ++ raw.next()
-              val leftover = buffered.drop(24)
-              (if leftover.isEmpty then Iterator.empty else Iterator(leftover)) ++ raw
+            while skipped < 24 do source.refill(zephyrine.Credit(4096)) match
+              case count: Int =>
+                if count > 0 then
+                  val take = count.min(24 - skipped)
+                  source.skip(take)
+                  skipped += take
 
-            val reader = FrameReader(afterPreface)
+              case _ =>
+                skipped = 24
+
+            val reader = FrameReader(source)
             val hpack = Hpack()
             var continue = true
 

--- a/lib/perihelion/src/core/perihelion.WsConnection.scala
+++ b/lib/perihelion/src/core/perihelion.WsConnection.scala
@@ -45,5 +45,7 @@ class WsConnection
   ( private[perihelion] val duplex:  Duplex,
     private[perihelion] val channel: Channel,
     private[perihelion] val masking: Masking,
-    private[perihelion] val inbound: LazyList[Data],
+    // The connection's pull endpoint (a neutral `AnyRef` carrier for the exclusive
+    // `Stream[Data] over Credit`), already advanced past the `101` handshake.
+    private[perihelion] val inbound: AnyRef,
     private[perihelion] val pump:    Daemon )

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -130,11 +130,15 @@ extension [self](value: self)
 // hostname verification by default).
 type WsUrl = Url["ws" | "wss"]
 
-// Split a byte stream at the first CRLFCRLF: returns the header block (up to and
-// including the terminator) and the remaining stream (the trailing bytes of the chunk
-// that completed it, then the untouched rest). Consumes only as many chunks as needed
-// to see the terminator, so it never reads past the `101` into a not-yet-sent frame.
-private def readHandshake(chunks: LazyList[Data], acc: Data): (Data, LazyList[Data]) =
+// Reads the handshake header block — up to and including the CRLFCRLF terminator —
+// from the connection's pull endpoint, consuming *exactly* the header bytes: anything
+// after the terminator stays unread in the endpoint's window, so this never reads past
+// the `101` into a not-yet-sent frame, and the endpoint continues with the first frame
+// bytes. On EOF before the terminator, returns whatever arrived.
+private def readHandshake(input: (zephyrine.Stream[Data] over zephyrine.Credit)^)
+  ( using buffering: zephyrine.Buffering )
+:   Data =
+
   def crlfCrlf(data: Data): Int =
     def matches(i: Int): Boolean =
       data(i) == 13 && data(i + 1) == 10 && data(i + 2) == 13 && data(i + 3) == 10
@@ -144,18 +148,29 @@ private def readHandshake(chunks: LazyList[Data], acc: Data): (Data, LazyList[Da
 
     recur(0)
 
-  val marker = crlfCrlf(acc)
+  val demand = zephyrine.Credit(buffering.capacity(zephyrine.Substrate.Bytes))
+  var acc: Data = Data()
+  var result: Optional[Data] = Unset
 
-  if marker >= 0 then
-    // Sealed: see `Frame.closeData` — the opaque-Array artifact.
-    val leftover: Data = caps.unsafe.unsafeAssumePure(acc.drop(marker + 4))
-    val head: Data = caps.unsafe.unsafeAssumePure(acc.take(marker + 4))
-    (head, if leftover.length > 0 then leftover #:: chunks else chunks)
-  else if chunks.isEmpty then
-    (acc, LazyList())
-  else
-    // Sealed: see `Frame.closeData` — the opaque-Array artifact.
-    readHandshake(chunks.tail, caps.unsafe.unsafeAssumePure(acc ++ chunks.head))
+  while result.absent do input.refill(demand) match
+    case count: Int =>
+      if count > 0 then
+        val window = input.addressable.materialize(input.window(using Unsafe), input.start, count)
+        // Sealed: see `Frame.closeData` — the opaque-Array artifact.
+        val acc2: Data = caps.unsafe.unsafeAssumePure(acc ++ window)
+        val marker = crlfCrlf(acc2)
+
+        if marker >= 0 then
+          input.skip(marker + 4 - acc.length)
+          result = caps.unsafe.unsafeAssumePure(acc2.take(marker + 4))
+        else
+          input.skip(count)
+          acc = acc2
+
+    case _ =>
+      result = acc
+
+  result.vouch
 
 // Makes a `WsUrl` a Coaxial client transport, so a WebSocket client is just Coaxial's
 // own client loop: `url.react(initialState) { message => … }`, symmetric with the
@@ -235,7 +250,14 @@ given wsClient: ( online:            Online,
       // which would block here, since a server that only sends the `101` has no frame to
       // send until we do. So split the header block off the stream and parse just that
       // finite slice; anything after the terminator is the first inbound frame bytes.
-      val (headerBytes, inbound) = readHandshake(duplex.stream, Data())
+      // A neutral reference: the endpoint is read here (for the handshake) and then
+      // stored on the connection for the frame reader; a capability-typed binding
+      // would be hidden from the later use by the statement rule.
+      val inboundRef: AnyRef = duplex.source.asInstanceOf[AnyRef]
+
+      val headerBytes =
+        readHandshake(inboundRef.asInstanceOf[(zephyrine.Stream[Data] over zephyrine.Credit)^])
+
       val response: Http.Response = Http.Response.parse(LazyList(headerBytes))
 
       if response.status != Http.SwitchingProtocols then
@@ -255,11 +277,20 @@ given wsClient: ( online:            Online,
       // reader (`receive`, over `inbound`) share the connection.
       val pump: Daemon = daemon(duplex.send(channel.stream))
 
-      WsConnection(duplex, channel, masking, inbound, pump)
+      WsConnection(duplex, channel, masking, inboundRef, pump)
 
-    def receive(connection: WsConnection): LazyList[Data] =
+    def receive(connection: WsConnection)
+    :   (zephyrine.Stream[Data] over zephyrine.Credit)^{this, caps.any} =
       given Masking = connection.masking
-      Reader(() => zephyrine.Stream(connection.inbound.iterator), connection.channel).messages.map(_.bytes)
+
+      val messages =
+        Reader
+          ( () => connection.inbound.asInstanceOf[(zephyrine.Stream[Data] over zephyrine.Credit)^],
+            connection.channel )
+        . messages.map(_.bytes)
+
+      // One reassembled message per refill window: chunk boundaries frame messages.
+      zephyrine.Stream(messages.iterator)
 
     def transmit
       ( connection: WsConnection,

--- a/lib/perihelion/src/test/perihelion.AutobahnClient.scala
+++ b/lib/perihelion/src/test/perihelion.AutobahnClient.scala
@@ -72,7 +72,12 @@ object AutobahnClient:
               safely(connection.channel.close(error.reason.closeCode))
 
           . protect:
-              Reader(() => zephyrine.Stream(connection.inbound.iterator), connection.channel).messages.each:
+              Reader
+                ( () =>
+                    connection.inbound
+                    . asInstanceOf[zephyrine.Stream[Data] over zephyrine.Credit],
+                  connection.channel )
+              . messages.each:
                 consume(connection.channel)(_)
 
         finally

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -759,7 +759,19 @@ object Http:
       Stream(Iterator(head.data) ++ chunks)
 
     def parse(stream: LazyList[Data]): Response raises HttpResponseError =
-      val cursor = Cursor[Data](stream.filter(_.nonEmpty).iterator)
+      parseCursor(Cursor[Data](stream.filter(_.nonEmpty).iterator))
+
+    // The endpoint form: the response is parsed straight off the connection's pull
+    // endpoint, with no lazy-list view. The tactic is a plain using-parameter: a
+    // context-function result may not hide the consumed endpoint.
+    def parse(consume input: (Stream[Data] over Credit)^)(using Tactic[HttpResponseError])
+    :   Response =
+
+      parseCursor(Cursor[Data](input))
+
+    private def parseCursor(consume cursor: Cursor[Data, {}]^)(using Tactic[HttpResponseError])
+    :   Response =
+      
 
       inline def expected(char: Char): Diagnostics ?=> HttpResponseError =
         HttpResponseError(HttpResponseError.Reason.Expectation(char, cursor.peek.asInt.toChar))

--- a/lib/telekinesis/src/jvm/telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/telekinesis_jvm.scala
@@ -172,4 +172,8 @@ given domainSocketHttpClient: Tactic[StreamError] => HttpClient onto DomainSocke
 
     def request(request: Http.Request, socket: DomainSocket)(using HttpEvent is Loggable)
     :   Http.Response =
-      unsafely(Http.Response.parse(socket.transmit(request)))
+      unsafely:
+        // Typed binding: `transmit` and `parse` are both overloaded (lazy-list and
+        // endpoint forms), so the expected type picks the endpoint pair.
+        val input: zephyrine.Stream[Data] over zephyrine.Credit = socket.transmit(request)
+        Http.Response.parse(input)

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1526,3 +1526,41 @@ jacinta.schema needed one file (JsonSchema.scala):
 
 Laundering the tactic (`given Tactic = unsafeAssumePure(tactic)`) does NOT fix
 the aliasing: the local is still a capability value passed through two channels.
+
+## Coaxial receive side + cordillera sepcheck (2026-07-12, branch coaxial-receive)
+
+Branch merges Jon's `coaxial-react-exchange` rename (react/exchange), then converts
+the RECEIVE side to kernel pull endpoints:
+- `Duplex.stream: LazyList[Data]` DELETED; `source(using Buffering): (Stream[Data]
+  over Credit)^` is the sole read endpoint (`^` LOAD-BEARING: a bare stateful result
+  reads as `.rd` at sep use sites — silently poisons downstream).
+- `Serviceable.receive` returns `(Stream[Data] over Credit)^{this, caps.any}` —
+  INSTANCE-RELATIVE, not fresh: overriding a `^` (fresh) trait result with
+  `^{tactic, caps.any}` is an override error; `{this, caps.any}` admits
+  instance-retained capabilities in both trait and impls.
+- `react`/`exchange`: while-loops over refill windows; ONE WINDOW = ONE MESSAGE
+  (chunk-boundary framing preserved: pair() memoizes each send to one window;
+  perihelion's Duplexable receive wraps reassembled messages one-per-window).
+- Websocket handshake (`readHandshake`) reads the endpoint directly, consuming
+  EXACTLY through CRLFCRLF — trailing bytes stay in the window; no leftover-prepend.
+- `Http.Response.parse` gains an endpoint overload; body refactored to
+  `parseCursor(consume cursor)`. Overload pairs (transmit×2, parse×2) can turn
+  formerly-inferred call sites AMBIGUOUS — disambiguate with a typed binding.
+- cordillera.core: NEVER ACTUALLY CC'd (leg-2 note overstated; even #1498 left it
+  bare) — now sep module-wide. New recipes:
+  * `scm.ArrayBuilder` mutation under sep demands `uses any.rd` at ANY enclosing
+    scope (object-level too) → `cordillera.ByteBuf`: a private exclusive+stateful
+    growable buffer (untracked storage + exclusive-cast write view).
+  * A daemon body must be a PURE context function: bind fields to locals and `this`
+    to an AnyRef rim before `daemon:`; a method called as
+    `ref.asInstanceOf[C].method(...)` still charges `C.this` when the method is
+    CLASS-private — relocate it to the COMPANION taking the instance as a plain
+    parameter (companion sees privates; no this-charge).
+  * `consume` params are METHOD-only: a consuming class constructor = private ctor
+    (AnyRef carrier) + companion `apply(consume ...)` factory (FrameReader).
+- GrpcChannel/Containerd become honestly tracked (`^{monitor, caps.any}` results,
+  `GrpcChannel^`/`Http2Connection^` ctor params): a client retaining a connection
+  retaining a Monitor is a capability.
+- Tests: h2c fake servers skip the preface by consuming exactly 24 bytes off the
+  endpoint; FrameReader then owns it. Suites green: coaxial, cordillera,
+  obligatory, perihelion, scintillate.


### PR DESCRIPTION
With the send side already Conduit-backed, this converts Coaxial's receive side to the reactive streaming kernel and retires its remaining `LazyList` views. `Duplex.source` becomes the sole read endpoint (with allocation-free native implementations for socket channels and blocking streams), `Serviceable.receive` returns a fresh pull endpoint per connection, and `react`/`exchange` drive while-loops over refill windows — one window per message, preserving chunk-boundary framing. The WebSocket handshake now consumes exactly the header bytes off the endpoint, and `Http.Response` can be parsed straight from a connection's endpoint. Along the way, `cordillera.core` — which had never actually been capture-checked — is now separation-checked module-wide, with its HTTP/2 wire encoders rewritten onto an exclusive byte buffer, and `GrpcChannel`/`Containerd` become honestly tracked capabilities. This also incorporates the `coaxial-react-exchange` rename branch (whose renames turned out to already be on main).

## Release notes

- `Duplex.stream` and `Serviceable.receive`'s `LazyList[Data]` results are replaced by kernel pull endpoints (`Stream[Data] over Credit`): call `duplex.source` to read, or use the `react`/`exchange` loops as before — their signatures are unchanged apart from an ambient `Buffering`.
- `Http.Response.parse` accepts a connection endpoint directly, in addition to the existing `LazyList[Data]` form.
- `cordillera` (HTTP/2) is now compiled with experimental separation checking, and its `FrameReader` reads a connection's endpoint directly.
- `GrpcChannel` and `Containerd` values now carry capture-tracked types reflecting the background daemons they retain, so they must be used within the `supervise` scope that created them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)