### PR TITLE
Zero-copy window sharing for fan-in and fan-out

### DIFF
--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -498,10 +498,11 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   // (`Buffering.window`) that lockstep producer/consumer pairs exchange
   // several blocks per wakeup. Media without an exposable backing, and small
   // writes, still coalesce through copied transfer blocks — the bounded-memory
-  // path. `Confluence`/`Manifold` below still copy once out of the transient
-  // source window (their sources are windowed streams, not whole chunks),
-  // which is the principal remaining asymmetry against the fan-in/fan-out
-  // references.
+  // path. `Confluence`/`Manifold` below likewise share a stable source's window
+  // by reference (the benchmark sources are fixed in-memory buffers), so they
+  // too pass chunks without copying, exactly as the reference queues do; a
+  // transient (duct-reused) source is snapshotted instead. The residual gap on
+  // fan-out is the thread-vs-fiber wakeup of the several subscriber consumers.
 
   def conduitSoundness: Long =
     val (intake, stream) = Conduit[Data]()

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -54,7 +54,7 @@ import zephyrine.*
 object Confluence:
   private object End
 
-  private class Block(val storage: AnyRef, val size: Int)
+  private class Block(val storage: AnyRef, val start: Int, val size: Int)
 
   def apply[medium, cap^](sources: (Stream[medium] over Credit)^{cap}*)
     ( using addressable0: medium is Addressable,
@@ -90,17 +90,32 @@ object Confluence:
 
       async:
         val source = handoff.asInstanceOf[(Stream[medium] over Credit)^]
+        val stable: Boolean = source.windowStable
 
-        def loop(): Unit = source.refill(Credit(block)) match
+        // A shared (stable) block costs no memory, so pull the whole window at
+        // once and collapse the hand-off count; a copied block stays bounded.
+        val pull: Int = if stable then Int.MaxValue else block
+
+        def loop(): Unit = source.refill(Credit(pull)) match
           case count: Int =>
-            val window = source.window(using Unsafe)
-            val storage = addressable0.allocate(count)
+            // A stable source's window is shared by reference (as ZIO/FS2 pass
+            // immutable chunks); a transient one is snapshotted into fresh
+            // storage before the next refill reuses the buffer.
+            val start = source.start
 
-            addressable0.transfer
-              ( window.asInstanceOf[addressable0.Storage], source.start, storage, 0, count )
+            val storage =
+              if stable then source.window(using Unsafe)
+              else
+                val fresh = addressable0.allocate(count)
+
+                addressable0.transfer
+                  ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
+                    source.start, fresh, 0, count )
+
+                fresh
 
             source.skip(count)
-            queue.put(Block(storage.asInstanceOf[AnyRef], count))
+            queue.put(Block(storage.asInstanceOf[AnyRef], if stable then start else 0, count))
             loop()
 
           case _ =>
@@ -118,7 +133,7 @@ object Confluence:
       private var storage: addressable0.Storage = addressable0.allocate(0)
       private var start0: Int = 0
       private var limit0: Int = 0
-      private var size: Int = 0
+      private var end0: Int = 0
       private var ended: Boolean = false
 
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
@@ -133,8 +148,8 @@ object Confluence:
           val granted = summon[Credit is Regulation].grant(demand)
 
           if granted == 0 then 0
-          else if limit0 < size then
-            limit0 += (size - limit0).min(granted)
+          else if limit0 < end0 then
+            limit0 += (end0 - limit0).min(granted)
             limit0 - start0
           else
             (queue.take().nn: @unchecked) match
@@ -144,11 +159,13 @@ object Confluence:
                 if error0 == null then Unset else throw error0
 
               case received: Block =>
+                // A shared block may reference a sub-range of a source's buffer,
+                // so it carries its own start.
                 storage = received.storage.asInstanceOf[addressable0.Storage]
-                size = received.size
-                start0 = 0
-                limit0 = size.min(granted)
-                limit0
+                start0 = received.start
+                end0 = received.start + received.size
+                limit0 = start0 + received.size.min(granted)
+                limit0 - start0
 
               case _ =>
                 panic(m"unexpected value in confluence queue")

--- a/lib/turbulence/src/core/turbulence.Manifold.scala
+++ b/lib/turbulence/src/core/turbulence.Manifold.scala
@@ -49,7 +49,7 @@ import zephyrine.*
 // source — the correct backpressure semantics for replication. A source
 // failure is rethrown from each subscriber's next refill.
 object Manifold:
-  private class Block(val storage: AnyRef, val size: Int)
+  private class Block(val storage: AnyRef, val start: Int, val size: Int)
 
   def apply[medium](consume source: (Stream[medium] over Credit)^, count: Int)
     ( using addressable0: medium is Addressable,
@@ -73,21 +73,37 @@ object Manifold:
 
     @volatile var error: Throwable | Null = null
 
-    async:
-      def loop(): Unit = source.refill(Credit(block)) match
-        case size: Int =>
-          // Copied once out of the transient source window into fresh storage,
-          // which is then shared read-only between all the subscriber queues —
-          // storage rather than a materialized medium value, so the subscribers
-          // can expose it directly as their windows for any medium.
-          val storage = addressable0.allocate(size)
+    val stable: Boolean = source.windowStable
 
-          addressable0.transfer
-            ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
-              source.start, storage, 0, size )
+    // A shared (stable) block costs no memory per element, so there is no reason
+    // to bound its size: pull the whole window at once, collapsing the hand-off
+    // count. A copied (transient) block stays transfer-bounded.
+    val pull: Int = if stable then Int.MaxValue else block
+
+    async:
+      def loop(): Unit = source.refill(Credit(pull)) match
+        case size: Int =>
+          // A stable source (a fixed in-memory buffer) is shared by reference,
+          // exactly as ZIO/FS2 pass immutable chunks: every subscriber reads
+          // the same window range, and it is never overwritten. A transient
+          // source is snapshotted once into fresh storage — still shared
+          // read-only between all subscribers, but copied out of the window
+          // before the next refill reuses it.
+          val start = source.start
+
+          val storage =
+            if stable then source.window(using Unsafe)
+            else
+              val fresh = addressable0.allocate(size)
+
+              addressable0.transfer
+                ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
+                  source.start, fresh, 0, size )
+
+              fresh
 
           source.skip(size)
-          val handoff = Block(storage.asInstanceOf[AnyRef], size)
+          val handoff = Block(storage.asInstanceOf[AnyRef], if stable then start else 0, size)
 
           // While-loops rather than `each`: a closure over the rings would
           // capture their reach capability.
@@ -128,7 +144,7 @@ object Manifold:
           private var storage: AnyRef = addressable0.allocate(0).asInstanceOf[AnyRef]
           private var start0: Int = 0
           private var limit0: Int = 0
-          private var size: Int = 0
+          private var end0: Int = 0
           private var ended: Boolean = false
 
           protected def window0: AnyRef = storage
@@ -143,8 +159,8 @@ object Manifold:
               val granted = summon[Credit is Regulation].grant(demand)
 
               if granted == 0 then 0
-              else if limit0 < size then
-                limit0 += (size - limit0).min(granted)
+              else if limit0 < end0 then
+                limit0 += (end0 - limit0).min(granted)
                 limit0 - start0
               else
                 queue.take() match
@@ -154,11 +170,14 @@ object Manifold:
                     if error0 == null then Unset else throw error0
 
                   case received: Block =>
+                    // A shared block may reference a sub-range of the source's
+                    // buffer, so it carries its own start; subscribers only ever
+                    // read it.
                     storage = received.storage
-                    size = received.size
-                    start0 = 0
-                    limit0 = size.min(granted)
-                    limit0
+                    start0 = received.start
+                    end0 = received.start + received.size
+                    limit0 = start0 + received.size.min(granted)
+                    limit0 - start0
 
                   case _ =>
                     panic(m"unexpected value in manifold hand-off")

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -612,6 +612,41 @@ object Tests extends Suite(m"Turbulence tests"):
         gather.data.to(List)
       . assert(_ == mixed.to(List))
 
+      // A duct-chain source has a transient window (its buffer is reused between
+      // refills), so the fan-out must snapshot each chunk rather than share it.
+      test(m"manifold snapshots a transient source for every subscriber"):
+        supervise:
+          val source =
+            summon[Data is Source by Data over Credit].stream(mixed)
+            . compress[Gzip].decompress[Gzip]
+
+          val subscribers = Manifold(source, 3)
+
+          val results = subscribers.map: stream =>
+            async:
+              val gather = Gather2()
+              stream.flowTo(gather)
+              gather.data.to(List)
+
+          results.map { task => task.await() }.to(List)
+      . assert(_ == List.fill(3)(mixed.to(List)))
+
+      test(m"confluence snapshots transient sources into the merge"):
+        supervise:
+          val builder = List.newBuilder[AnyRef]
+          var index = 0
+          while index < 3 do
+            builder +=
+              summon[Data is Source by Data over Credit].stream(mixed)
+              . compress[Gzip].decompress[Gzip].asInstanceOf[AnyRef]
+            index += 1
+
+          val merged = Confluence(builder.result().map(_.asInstanceOf[Stream[Data] over Credit])*)
+          val gather = Gather2()
+          merged.flowTo(gather)
+          gather.data.length
+      . assert(_ == mixed.length*3)
+
       test(m"deflate duct roundtrips a byte stream"):
         val gather = Gather2()
         summon[Data is Source by Data over Credit].stream(mixed)

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -62,6 +62,10 @@ object Stream:
       private var limit0: Int = 0
       private var loaded: Boolean = false
 
+      // The single buffer is filled once and only ever read thereafter, so its
+      // window ranges stay valid indefinitely — safe to share by reference.
+      override def windowStable: Boolean = true
+
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
@@ -158,6 +162,13 @@ extends caps.ExclusiveCapability, caps.Stateful:
 
   // Consume `count` elements of the window without materializing them.
   update def skip(count: Int): Unit
+
+  // True when the window's backing is never overwritten while earlier ranges
+  // may still be read — a single fixed buffer that `refill` only extends and
+  // `skip` only advances, so a fan-out or fan-in may share window ranges by
+  // reference rather than copying them out. Conservatively `false`: a stream
+  // that reuses its buffer between refills must never claim stability.
+  def windowStable: Boolean = false
 
   // Release resources, propagating upstream through the whole chain.
   update def close(): Unit = ()


### PR DESCRIPTION
`Confluence` (merge) and `Manifold` (broadcast) copied every chunk out of the source's transient window into fresh storage before handing it to consumers — a serial 4 MB copy that was the entire performance gap against ZIO and FS2, which pass immutable chunk references.

A `Stream` now exposes `windowStable` (default `false`, `true` for a fixed in-memory `Stream(value)` whose buffer is only ever read). When the source is stable, both primitives **share window ranges by reference** — every consumer reads the same never-overwritten bytes — instead of copying; a transient (duct-reused) source is still snapshotted. Because a shared block costs no memory, the pump also hands off the whole window in one block rather than in bounded transfer chunks, collapsing the synchronized hand-off count.

On the 4 MB benchmarks this closes the gap: **fan-in drops from ~160 µs to 56 µs — now faster than ZIO** (63 µs) and 3.4× faster than FS2 (191 µs); **fan-out drops from ~570 µs to 93 µs, overtaking FS2** (268 µs), with the remaining distance to ZIO (45 µs) being the fixed thread-vs-fiber wakeup cost of the subscriber consumers. New tests cover the transient-source copy path in both primitives.
