### PR TITLE
Enable capture checking for honeycomb

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1307,13 +1307,8 @@ object hellenism extends Library:
 object honeycomb extends Library:
   object core extends Component(panopticon.core, gesticulate.core, xylophone.core, urticose.url,
       nomenclature.core, hellenism.core):
-    // NOT capture-checked: the `e`-macro's quoted type patterns
-    // (`case Some('{$renderable: Renderable})`) fail to unify with
-    // capture-decorated `Expr` types under `-Ycc-new` (12 errors, all in the
-    // macro/quotes family). Re-attempt when the quote-pattern/CC interaction
-    // improves upstream; see rep/DECISIONS.md "Sepcheck rollout".
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core)
   object bench extends Benchmarks(core, quantitative.units):
     def mvnDeps = Seq(mvn"org.jsoup:jsoup:1.18.3")

--- a/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
+++ b/lib/honeycomb/src/core/honeycomb.Honeycomb.scala
@@ -309,7 +309,10 @@ object Honeycomb:
                 ConstantType(StringConstant(tag.s)).asType.absolve match
                   case '[tag] => Expr.summon[(? >: value) is Renderable in (? >: tag)] match
                     case Some('{$renderable: Renderable}) =>
-                      '{$renderable.render($expr)}
+                      // Widened eagerly: joining the branch types under capture
+                      // checking decorates the summoned evidence's skolem, which
+                      // then fails to unify (the macro only needs `Expr[Any]`).
+                      ('{$renderable.render($expr)}: Expr[Any])
 
                     case _ => halt:
                       m"""
@@ -321,7 +324,10 @@ object Honeycomb:
                 ConstantType(StringConstant(tag.s)).asType.absolve match
                   case '[tag] => Expr.summon[(? >: value) is Renderable in (? >: tag)] match
                     case Some('{$renderable: Renderable}) =>
-                      '{$renderable.render($expr)}
+                      // Widened eagerly: joining the branch types under capture
+                      // checking decorates the summoned evidence's skolem, which
+                      // then fails to unify (the macro only needs `Expr[Any]`).
+                      ('{$renderable.render($expr)}: Expr[Any])
 
                     case _ =>
                       Expr.summon[(? >: value) is Showable] match
@@ -348,11 +354,11 @@ object Honeycomb:
                 case None =>
                   halt(m"a ${TypeRepr.of[value is Showable].show} is required")
 
-              case Hole.Tagbody => Type.of[value] match
-                case '[Map[Text, Optional[Text]]] =>
-                  expr
-
-                case _ =>
+              case Hole.Tagbody =>
+                // A reflection-level test rather than a quoted type pattern
+                // (`case '[Map[Text, Optional[Text]]]`), which fails to unify
+                // against the capture-decorated scrutinee under capture checking.
+                if TypeRepr.of[value] <:< TypeRepr.of[Map[Text, Optional[Text]]] then expr else
                   halt:
                     m"""
                       only a ${TypeRepr.of[Map[Text, Optional[Text]]].show} can be applied in a tag

--- a/lib/honeycomb/src/core/honeycomb.Html.scala
+++ b/lib/honeycomb/src/core/honeycomb.Html.scala
@@ -160,10 +160,10 @@ object Html extends Tag.Container
 
 
   given strictAggregable: [content <: Label: Reifiable to List[String]]
-  =>  ( dom: Dom )
-  =>  Tactic[ParseError]
-  =>  NotGiven[Html.Recovery.Permissive]
-  =>  (Html of content) is Aggregable by Text =
+  =>  ( dom:    Dom,
+        tactic: Tactic[ParseError],
+        strict: NotGiven[Html.Recovery.Permissive] )
+  =>  (((Html of content) is Aggregable by Text)^{tactic, caps.any}) =
 
     new Aggregable:
       type Self = Html of content
@@ -173,14 +173,13 @@ object Html extends Tag.Container
         val root = Tag.root(content.reify.map(_.tt).to(Set))
         HtmlParser.fromIterator(input.iterator, permissive = false).parseHtml(root).of[content]
 
-      override def accept(stream: Stream[Text] over Credit): Html of content =
+      override def accept(stream: (Stream[Text] over Credit)^): Html of content =
         val root = Tag.root(content.reify.map(_.tt).to(Set))
         HtmlParser.fromStream(stream, permissive = false).parseHtml(root).of[content]
 
-  given strictAggregable2: (dom: Dom)
-  =>  Tactic[ParseError]
-  =>  NotGiven[Html.Recovery.Permissive]
-  =>  Html is Aggregable by Text =
+  given strictAggregable2: (dom: Dom, tactic: Tactic[ParseError])
+  =>  ( strict: NotGiven[Html.Recovery.Permissive] )
+  =>  ((Html is Aggregable by Text)^{tactic, caps.any}) =
     new Aggregable:
       type Self = Html
       type Operand = Text
@@ -189,14 +188,13 @@ object Html extends Tag.Container
         HtmlParser.fromIterator(input.iterator, permissive = false)
         . parseHtml(dom.generic, doctypes = false)
 
-      override def accept(stream: Stream[Text] over Credit): Html =
+      override def accept(stream: (Stream[Text] over Credit)^): Html =
         HtmlParser.fromStream(stream, permissive = false)
         . parseHtml(dom.generic, doctypes = false)
 
-  given strictLoadable: (dom: Dom)
-  =>  Tactic[ParseError]
-  =>  NotGiven[Html.Recovery.Permissive]
-  =>  Html is Loadable by Text = stream =>
+  given strictLoadable: (dom: Dom, tactic: Tactic[ParseError])
+  =>  ( strict: NotGiven[Html.Recovery.Permissive] )
+  =>  ((Html is Loadable by Text)^{tactic, caps.any}) = stream =>
     val root = Tag.root(Set(t"html"))
 
     HtmlParser.fromIterator(stream.iterator, permissive = false)
@@ -233,7 +231,7 @@ object Html extends Tag.Container
         lenient(Fragment().of[content]):
           HtmlParser.fromIterator(input.iterator, permissive = true).parseHtml(root).of[content]
 
-      override def accept(stream: Stream[Text] over Credit): Html of content =
+      override def accept(stream: (Stream[Text] over Credit)^): Html of content =
         given Tactic[ParseError] = lenientTactic
         val root = Tag.root(content.reify.map(_.tt).to(Set))
 
@@ -254,7 +252,7 @@ object Html extends Tag.Container
           HtmlParser.fromIterator(input.iterator, permissive = true)
           . parseHtml(dom.generic, doctypes = false)
 
-      override def accept(stream: Stream[Text] over Credit): Html =
+      override def accept(stream: (Stream[Text] over Credit)^): Html =
         given Tactic[ParseError] = lenientTactic
 
         lenient(Fragment()):
@@ -281,7 +279,8 @@ object Html extends Tag.Container
   // Streams a document's HTML source, using the document's own DOM and the indentation from the
   // contextual `Formatting`. The whole emission lives in this instance so `.stream` is the single
   // route to streamed HTML; the producing code runs on a separate fiber.
-  given streamable: (Monitor, Probate) => Document[Html] is Streamable by Text = document =>
+  given streamable: (monitor: Monitor, probate: Probate)
+  =>  ((Document[Html] is Streamable by Text)^{monitor, caps.any}) = document =>
     val formatting = summon[Formatting]
     val dom = document.metadata
     val producer = Producer[Text](4096)
@@ -303,7 +302,7 @@ object Html extends Tag.Container
 
   // HTML5 text-content escaping: `&`, `<` and `>`. Raw-text elements such as `script` and `style`
   // use `Mode.Raw` and are written verbatim by `writeHtml`.
-  private def writeEscapedText(producer: Producer[Text], text: Text): Unit =
+  private def writeEscapedText(producer: Producer[Text]^, text: Text): Unit =
     val source = text.s
     val length = source.length
     var start = 0
@@ -327,7 +326,7 @@ object Html extends Tag.Container
 
   // HTML5 escaping for a double-quoted attribute value: `&` and the `"` delimiter. `<` and `>` are
   // permitted literally in attribute values.
-  private def writeEscapedAttribute(producer: Producer[Text], text: Text): Unit =
+  private def writeEscapedAttribute(producer: Producer[Text]^, text: Text): Unit =
     val source = text.s
     val length = source.length
     var start = 0
@@ -352,7 +351,7 @@ object Html extends Tag.Container
   // `showable` so the two cannot drift. Void elements omit their close tag; raw-text elements
   // suppress escaping; whitespace-mode elements are indented when `block` is set.
   private def writeHtml
-    ( producer: Producer[Text],
+    ( producer: Producer[Text]^,
       dom:      Dom,
       node:     Html,
       indent:   Int,
@@ -384,15 +383,17 @@ object Html extends Tag.Container
         producer.put("<")
         producer.put(label)
 
-        if !attributes.nil then
-          attributes.each: (key, value) =>
-            producer.put(" ")
-            producer.put(key)
+        // No emptiness guard: `each` no-ops on an empty `Attributes`, and the
+        // inline `nil` extension fails to dealias the opaque through its
+        // capture-decorated pattern proxy under capture checking.
+        attributes.each: (key, value) =>
+          producer.put(" ")
+          producer.put(key)
 
-            value.let: value =>
-              producer.put("=\"")
-              writeEscapedAttribute(producer, value)
-              producer.put("\"")
+          value.let: value =>
+            producer.put("=\"")
+            writeEscapedAttribute(producer, value)
+            producer.put("\"")
 
         producer.put(">")
 
@@ -582,20 +583,24 @@ object Html extends Tag.Container
     // position — an O(buffer) cost paid only on the failure path.
 
     def fromText(text: Text, permissive: Boolean = false)(using Dom): HtmlParser =
-      new HtmlParser(Cursor[Text](text), permissive)
+      new HtmlParser(Cursor[Text](text).asInstanceOf[AnyRef], permissive)
 
     def fromIterator(input: Iterator[Text], permissive: Boolean = false)(using Dom): HtmlParser =
-      new HtmlParser(Cursor[Text](input), permissive)
+      new HtmlParser(Cursor[Text](input).asInstanceOf[AnyRef], permissive)
 
-    def fromStream(input: Stream[Text] over Credit, permissive: Boolean = false)(using Dom)
+    def fromStream(input: (Stream[Text] over Credit)^, permissive: Boolean = false)(using Dom)
     :   HtmlParser =
 
-      new HtmlParser(Cursor[Text](input), permissive)
+      new HtmlParser(Cursor[Text](input).asInstanceOf[AnyRef], permissive)
 
   private[honeycomb] final class HtmlParser
-    ( cursor:        Cursor[Text, ?],
+    ( cursor0:        AnyRef,
       val permissive: Boolean      = false )
     ( using dom: Dom ):
+    // A neutral carrier with an inline accessor (the `perihelion.Reader` pattern):
+    // the parser owns the cursor exclusively, but an exclusive-typed field would
+    // make the parser a capability and hide the cursor from its own methods.
+    private inline def cursor: Cursor[Text, ?]^ = cursor0.asInstanceOf[Cursor[Text, ?]^]
     private var heldToken: Cursor.Held | Null = null
 
     type Region = Cursor.Mark
@@ -682,7 +687,10 @@ object Html extends Tag.Container
       ( target: jl.StringBuilder )
     :   Unit =
 
-      cursor.clone(start, end)(target.asInstanceOf[cursor.addressable.Target])
+      // A stable binding: the inline `cursor` accessor is not a valid prefix for
+      // the path-dependent `addressable.Target`.
+      val cursor1: Cursor[Text, ?]^ = cursor
+      cursor1.clone(start, end)(target.asInstanceOf[cursor1.addressable.Target])
 
     protected def computePosition
       ( start: Optional[Cursor.Mark] = Unset,
@@ -725,6 +733,9 @@ object Html extends Tag.Container
 
     // Optional callback invoked for null-placeholder holes during macro
     // interpolation. Default no-op.
+    // Untracked: the macro-expansion callback is installed and invoked only within
+    // one `parseHtml` call.
+    @caps.unsafe.untrackedCaptures
     var callback: Optional[(Ordinal, Hole) => Unit] = Unset
 
     // Cursor-compat helpers so the algorithm body stays close to the
@@ -857,16 +868,26 @@ object Html extends Tag.Container
 
       def warn(issue: Issue): Unit = raise(ParseError(Html, currentPosition(), issue))
 
-      @tailrec
-      def skip(): Unit = let:
-        case ' ' | '\f' | '\n' | '\r' | '\t' => advance() yet skip()
-        case _                               => ()
+      // While-loops rather than `@tailrec` over the inline `let`/`lay`
+      // combinators: capture checking's beta-reduction of the inline lambdas
+      // leaves the recursive calls in non-tail position.
+      def skip(): Unit =
+        var continue = true
 
-      @tailrec
-      def whitespace(): Unit = lay(()):
-        case ' ' | '\f' | '\n' | '\r' | '\t' => advance() yet whitespace()
-        case '<'                             => ()
-        case char                            => fail(OnlyWhitespace(char))
+        while continue && more do peek match
+          case ' ' | '\f' | '\n' | '\r' | '\t' => advance()
+          case _                               => continue = false
+
+      def whitespace(): Unit =
+        var continue = true
+
+        while continue && more do peek match
+          case ' ' | '\f' | '\n' | '\r' | '\t' => advance()
+          case '<'                             => continue = false
+
+          case char =>
+            fail(OnlyWhitespace(char))
+            continue = false
 
       @tailrec
       def tagname(mark: Mark, node: Int): Tag =
@@ -1732,7 +1753,8 @@ object Html extends Tag.Container
   :   Html raises ParseError =
 
     val parser = HtmlParser.fromIterator(input, permissive = false)
-    parser.callback = callback
+    // Sealed into the untracked field: the callback lives only for this parse.
+    parser.callback = caps.unsafe.unsafeAssumePure(callback)
     parser.parseHtml(root, doctypes)
 
 sealed into trait Html extends Topical, Documentary, Formal:

--- a/lib/honeycomb/src/core/honeycomb.Tag.scala
+++ b/lib/honeycomb/src/core/honeycomb.Tag.scala
@@ -232,7 +232,11 @@ abstract class Tag
     val void:        Boolean                   = false,
     val transparent: Boolean                   = false,
     val boundary:    Boolean                   = false )
-extends Element(label, Attributes.from(presets), IArray(), foreign), Formal, Dynamic:
+// The empty-children `IArray()` is sealed: a fresh `IArray` in the parent
+// constructor call would otherwise decorate `Tag`'s self type, which must stay
+// pure like `Element`'s (the opaque-Array artifact).
+extends Element(label, Attributes.from(presets), caps.unsafe.unsafeAssumePure(IArray()), foreign),
+  Formal, Dynamic, caps.Pure:
   type Result <: Element
 
   // Pre-computed "is this a table-context tag" flag, evaluated once per Tag

--- a/lib/honeycomb/src/core/honeycomb.internal.scala
+++ b/lib/honeycomb/src/core/honeycomb.internal.scala
@@ -305,17 +305,20 @@ object internal:
       case Some(s: String) => s
       case _               => Unset
 
-    val perPart: IndexedSeq[((String, Int), Int => Int)] =
+    val perPart: IndexedSeq[((String, Int), Int -> Int)] =
       parts.zip(partOrigins).map: (part, origin) =>
         val (srcStart, _) = origin
 
-        val mapping: Int => Int = sourceContent.lay[Int => Int](identity(_)): content =>
-          if srcStart > 0 && srcStart < content.length then
-            val upper = (srcStart + part.length * 6 + 16).min(content.length)
-            val sourceText = content.substring(srcStart, upper).nn
-            Interpolation.buildMapping(sourceText, part)
-          else
-            (i: Int) => i
+        // Sealed: the mapping closes over only strings, but its inferred fresh
+        // capture would leak into the collected sequence.
+        val mapping: Int -> Int = caps.unsafe.unsafeAssumePure:
+          sourceContent.lay[Int => Int](identity(_)): content =>
+            if srcStart > 0 && srcStart < content.length then
+              val upper = (srcStart + part.length * 6 + 16).min(content.length)
+              val sourceText = content.substring(srcStart, upper).nn
+              Interpolation.buildMapping(sourceText, part)
+            else
+              (i: Int) => i
 
         ((part, srcStart), mapping)
 
@@ -400,7 +403,10 @@ object internal:
                 ConstantType(StringConstant(tag.s)).asType.absolve match
                   case '[tag] => Expr.summon[(? >: value) is Renderable in (? >: tag)] match
                     case Some('{$renderable: Renderable}) =>
-                      '{$renderable.render($expr)}
+                      // Widened eagerly: joining the branch types under capture
+                      // checking decorates the summoned evidence's skolem, which
+                      // then fails to unify (the macro only needs `Expr[Any]`).
+                      ('{$renderable.render($expr)}: Expr[Any])
 
                     case _ =>
                       halt
@@ -414,7 +420,10 @@ object internal:
                 ConstantType(StringConstant(tag.s)).asType.absolve match
                   case '[tag] => Expr.summon[(? >: value) is Renderable in (? >: tag)] match
                     case Some('{$renderable: Renderable}) =>
-                      '{$renderable.render($expr)}
+                      // Widened eagerly: joining the branch types under capture
+                      // checking decorates the summoned evidence's skolem, which
+                      // then fails to unify (the macro only needs `Expr[Any]`).
+                      ('{$renderable.render($expr)}: Expr[Any])
 
                     case _ =>
                       Expr.summon[(? >: value) is Showable] match
@@ -447,11 +456,11 @@ object internal:
                     ( m"a ${TypeRepr.of[value is Showable].show} is required",
                       expr.asTerm.underlyingArgument.pos )
 
-              case Hole.Tagbody => Type.of[value] match
-                case '[Map[Text, Optional[Text]]] =>
-                  expr
-
-                case _ =>
+              case Hole.Tagbody =>
+                // A reflection-level test rather than a quoted type pattern
+                // (`case '[Map[Text, Optional[Text]]]`), which fails to unify
+                // against the capture-decorated scrutinee under capture checking.
+                if TypeRepr.of[value] <:< TypeRepr.of[Map[Text, Optional[Text]]] then expr else
                   halt
                     ( m"""
                         only a ${TypeRepr.of[Map[Text, Optional[Text]]].show} can be applied in a
@@ -605,7 +614,10 @@ object internal:
   opaque type Attributes = IArray[String | Null]
 
   object Attributes:
-    val empty: Attributes = IArray.empty[String | Null]
+    // Sealed: fresh `IArray`s are immutable; fresh-ness is the opaque-Array
+    // artifact, which would otherwise decorate every constructed `Attributes`
+    // (and, through `Element`'s constructor, every `Tag`).
+    val empty: Attributes = caps.unsafe.unsafeAssumePure(IArray.empty[String | Null])
 
     def apply(pairs: (Text, Optional[Text])*): Attributes =
       if pairs.isEmpty then empty else
@@ -618,7 +630,8 @@ object internal:
           arr(i*2 + 1) = pair._2.lay(null: String | Null)(_.s)
           i += 1
 
-        arr.immutable(using Unsafe)
+        // Sealed: see `empty` — the opaque-Array artifact.
+        caps.unsafe.unsafeAssumePure(arr.immutable(using Unsafe))
 
     def from(map: Map[Text, Optional[Text]]): Attributes =
       if map.isEmpty then empty else
@@ -631,7 +644,8 @@ object internal:
           arr(i*2 + 1) = v.lay(null: String | Null)(_.s)
           i += 1
 
-        arr.immutable(using Unsafe)
+        // Sealed: see `empty` — the opaque-Array artifact.
+        caps.unsafe.unsafeAssumePure(arr.immutable(using Unsafe))
 
     // Construct an `Attributes` directly from an interleaved `IArray`. The
     // caller guarantees the array's length is even and that every key slot

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1564,3 +1564,41 @@ the RECEIVE side to kernel pull endpoints:
 - Tests: h2c fake servers skip the preface by consuming exactly 24 bytes off the
   endpoint; FrameReader then owns it. Suites green: coaxial, cordillera,
   obligatory, perihelion, scintillate.
+
+## Honeycomb capture checking (2026-07-12, branch honeycomb-cc)
+
+honeycomb.core — the last cc-excluded module — is now capture-checked. The "12
+macro-quote errors" that parked it decomposed into only SIX quote-family errors
+plus ordinary conversion work:
+
+Quote-family fixes (no compiler change needed):
+- `case Some('{$renderable: Renderable}) => '{$renderable.render($expr)}` — the
+  BRANCH JOIN decorates the summoned evidence's skolem with capture variables
+  (`Expr[Html{Topic = ?1.Form^'s}^'s]^'s`) which then fails to unify. FIX: widen
+  each branch eagerly (`('{...}: Expr[Any])`) so the join never sees the skolem —
+  the macro only needs `Expr[Any]`. (4 sites.)
+- `Type.of[value] match { case '[Map[Text, Optional[Text]]] => ... }` — a
+  BINDINGLESS type-quote pattern fails against the capture-decorated scrutinee
+  (`Expr[value^{}]^{}` mismatch). FIX: reflection-level
+  `TypeRepr.of[value] <:< TypeRepr.of[...]`. (2 sites.) A type pattern WITH
+  bindings would still be blocked — none needed here.
+
+Ordinary-CC recipes applied:
+- Tracked given results named their evidence (`^{tactic, caps.any}`) for the
+  Aggregable/Loadable/Streamable instances; `accept` override params need
+  explicit `^` (bare stateful param reads `.rd`).
+- HtmlParser holds its cursor via the perihelion-Reader AnyRef-carrier +
+  inline-accessor pattern; the macro callback var is `@untrackedCaptures` with
+  sealed assignment. NOTE: an inline accessor is NOT a valid prefix for
+  path-dependent types (`cursor.addressable.Target`) — bind a stable local.
+- IArray-opacity seals in `Attributes.empty/apply/from` — sealing at the OPAQUE
+  CONSTRUCTOR removes the artifact for every consumer, including `Tag`'s extends
+  clause (a fresh ctor argument decorates the subclass's SELF TYPE, breaking
+  "pure base class" conformance). An abstract class extending a pure class ALSO
+  needs explicit `caps.Pure` — its default self type is `{any}`.
+- Two `@tailrec` loops over inline `let`/`lay` combinators: CC's beta-reduction
+  leaves the recursive call non-tail → while-loops.
+- The `nil` inline extension on the opaque fails to dealias through a
+  capture-decorated pattern proxy — dropped a redundant emptiness guard.
+
+321 tests pass. Sepcheck for honeycomb.core NOT attempted (separate leg).


### PR DESCRIPTION
This lifts the last capture-checking exclusion in the codebase: `honeycomb.core` is now compiled with experimental capture checking. Of the twelve errors that had parked the module, only six were genuinely in the macro-quote family — four splice-branch types whose join decorated a summoned evidence's skolem with capture variables (fixed by widening each branch to `Expr[Any]` eagerly), and two bindingless quoted type patterns that fail to unify against capture-decorated scrutinees (replaced by reflection-level subtype tests). The remainder were ordinary conversion work: named capture evidence on the parsing typeclass instances, a neutral-carrier pattern for the HTML parser's cursor, immutability seals at the `Attributes` constructors, and while-loops where capture checking de-tails `@tailrec` recursion through inline combinators. No compiler changes were needed.

## Release notes

- The `honeycomb` module is now compiled with experimental capture checking, like the rest of Soundness.
- `Html`'s parsing (`Aggregable`, `Loadable`) and streaming (`Streamable`) instances now carry capture-tracked types naming the tactics and monitors they retain; resolution at call sites is unchanged.
- `HtmlParser.fromStream` takes its input endpoint with an explicit capture (`(Stream[Text] over Credit)^`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)