### PR TITLE
Launder pure-typeclass SAM givens for the Scala.js pipeline

### DIFF
--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -499,7 +499,12 @@ object Cbor extends Cbor2, Dynamic:
       else
         origin
 
+  // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM
+  // pipeline — rejects the `Optic`'s capture of `filter.predicate` against the required
+  // pure `Optic` type. (Compiler divergence; see #1520 and `caesura`'s `rowFilter`.)
   given filterOptical: Filter[Cbor] is Optical from Cbor onto Cbor = filter =>
+    val predicate: Cbor -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+
     Optic: (origin, lambda) =>
       if origin.root.isArray then
         val n = origin.root.elements
@@ -510,7 +515,7 @@ object Cbor extends Cbor2, Dynamic:
 
           while i < n do
             val element = Cbor.ast(origin.root.element(i))
-            updated(i) = (if filter.predicate(element) then lambda(element) else element).root
+            updated(i) = (if predicate(element) then lambda(element) else element).root
             i += 1
 
           Cbor.Ast.array(updated.asInstanceOf[IArray[Any]])
@@ -611,22 +616,34 @@ object Cbor extends Cbor2, Dynamic:
   given listEncodable: [list <: List, element] => (encodable: => element is Encodable in Cbor)
   =>  list[element] is Encodable in Cbor =
 
-    caps.unsafe.unsafeAssumePure:
-      values => ast(Ast.array(IArray.from(values.map(encodable.encoded(_).root))))
+    // A pure thunk rather than a sealed lambda: under `-scalajs` the SAM expands to an
+    // anonymous class whose pure self-type may not capture the by-name parameter.
+    val enc: () -> (element is Encodable in Cbor) = caps.unsafe.unsafeAssumePure(() => encodable)
+
+    values => ast(Ast.array(caps.unsafe.unsafeAssumePure
+      (IArray.from(values.map(enc().encoded(_).root)))))
 
 
   given setEncodable: [set <: Set, element] => (encodable: => element is Encodable in Cbor)
   =>  set[element] is Encodable in Cbor =
 
-    caps.unsafe.unsafeAssumePure:
-      values => ast(Ast.array(IArray.from(values.map(encodable.encoded(_).root))))
+    // A pure thunk rather than a sealed lambda: under `-scalajs` the SAM expands to an
+    // anonymous class whose pure self-type may not capture the by-name parameter.
+    val enc: () -> (element is Encodable in Cbor) = caps.unsafe.unsafeAssumePure(() => encodable)
+
+    values => ast(Ast.array(caps.unsafe.unsafeAssumePure
+      (IArray.from(values.map(enc().encoded(_).root)))))
 
 
   given seriesEncodable: [series <: Series, element] => (encodable: => element is Encodable in Cbor)
   =>  series[element] is Encodable in Cbor =
 
-    caps.unsafe.unsafeAssumePure:
-      values => ast(Ast.array(IArray.from(values.map(encodable.encoded(_).root))))
+    // A pure thunk rather than a sealed lambda: under `-scalajs` the SAM expands to an
+    // anonymous class whose pure self-type may not capture the by-name parameter.
+    val enc: () -> (element is Encodable in Cbor) = caps.unsafe.unsafeAssumePure(() => encodable)
+
+    values => ast(Ast.array(caps.unsafe.unsafeAssumePure
+      (IArray.from(values.map(enc().encoded(_).root)))))
 
 
   given collectionDecodable: [collection <: Iterable, element]

--- a/lib/caesura/src/core/caesura.Spannable.scala
+++ b/lib/caesura/src/core/caesura.Spannable.scala
@@ -42,7 +42,12 @@ object Spannable extends ProductDerivable[Spannable]:
   inline def conjunction[derivation <: Product: ProductReflection]: derivation is Spannable =
     () => contexts[derivation](): [field] => context => context.spans().sum
 
-  given decoder: [decodable: Decodable in Text] => decodable is Spannable = () => IArray(1)
+  // The Scala.js pipeline treats arrays as mutable capabilities under separation checking, so
+  // this SAM's inferred `IArray[Int]` result is boxed to `^{any}` and fails to override the
+  // trait's pure `spans()`. The JVM pipeline accepts the direct form. (Compiler divergence; see
+  // #1520.)
+  given decoder: [decodable: Decodable in Text] => decodable is Spannable =
+    () => caps.unsafe.unsafeAssumePure(IArray(1))
 
   // An `Optional[T]` field spans exactly as many cells as its inner type: a present value
   // occupies the inner span, and an absent (trailing/missing) value leaves those cells empty.

--- a/lib/caesura/src/core/caesura_core.scala
+++ b/lib/caesura/src/core/caesura_core.scala
@@ -86,7 +86,12 @@ given rowOptical: [element] => Ordinal is Optical from Sheet onto Dsv = ordinal 
 given rowEach: Each.type is Optical from Sheet onto Dsv = _ =>
   Optic: (origin, lambda) => origin.copy(rows = origin.rows.map(lambda))
 
+// The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM pipeline —
+// rejects the `Optic`'s capture of `filter.predicate` against the required pure `Optic` type.
+// (Compiler divergence; see #1520 and the identical laundering in `panopticon.Optical.filter`.)
 given rowFilter: Filter[Dsv] is Optical from Sheet onto Dsv = filter =>
+  val predicate: Dsv -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+
   Optic: (origin, lambda) =>
     origin.copy
-      ( rows = origin.rows.map { row => if filter.predicate(row) then lambda(row) else row } )
+      ( rows = origin.rows.map { row => if predicate(row) then lambda(row) else row } )

--- a/lib/chiaroscuro/src/core/chiaroscuro.Decomposition.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Decomposition.scala
@@ -46,6 +46,12 @@ object Decomposition:
   def apply(optional: Optional[Decomposition]): Decomposition = optional.or:
     Decomposition.Primitive(t"Unset", t"Unset", Unset)
 
+  // An explicit instance to avoid deriving `Inspectable[Decomposition]`, whose derived anon
+  // class the Scala.js pipeline rejects (the `text` parameter acquires a fresh capture var,
+  // unlike the JVM pipeline). Hand-written SAMs are unaffected. (Compiler divergence; see
+  // #1520 and the identical laundering in `yossarian`.)
+  given inspectable: Decomposition is Inspectable = _.text
+
 enum Decomposition:
   case Primitive(typeName: Text, value: Text, ref: Any)
   case Product(name: Text, values: Map[Text, Decomposition], ref: Any)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -1026,7 +1026,12 @@ object Json extends Json2, Dynamic:
       else
         origin
 
+  // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM
+  // pipeline — rejects the `Optic`'s capture of `filter.predicate` against the required
+  // pure `Optic` type. (Compiler divergence; see #1520 and `caesura`'s `rowFilter`.)
   given filterOptical: Filter[Json] is Optical from Json onto Json = filter =>
+    val predicate: Json -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+
     Optic: (origin, lambda) =>
       if origin.root.isArray then
         val n = origin.root.arrayLength
@@ -1037,7 +1042,7 @@ object Json extends Json2, Dynamic:
 
           while i < n do
             val element = Json.ast(origin.root.arrayElement(i))
-            updated(i) = (if filter.predicate(element) then lambda(element) else element).root
+            updated(i) = (if predicate(element) then lambda(element) else element).root
             i += 1
 
           Json.Ast.arr(updated.asInstanceOf[IArray[Any]])

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -80,8 +80,13 @@ trait Protobuf2:
   =>  ( encodable: => element is Encodable in Protobuf )
   =>  collection[element] is Encodable in Protobuf =
 
-    caps.unsafe.unsafeAssumePure: values =>
-      val occurrences = values.to(List).flatMap(encodable.encode(_).occurrences)
+    // A pure thunk rather than a sealed lambda: under `-scalajs` the SAM expands to an
+    // anonymous class whose pure self-type may not capture the by-name parameter.
+    val enc: () -> (element is Encodable in Protobuf) =
+      caps.unsafe.unsafeAssumePure(() => encodable)
+
+    values =>
+      val occurrences = values.to(List).flatMap(enc().encode(_).occurrences)
       if occurrences.isEmpty then Protobuf.Absent else Protobuf.Repeated(occurrences)
 
   given listDecodable: [collection <: Iterable, element]
@@ -318,7 +323,11 @@ object Protobuf extends Protobuf2:
   =>  ( encodable: => element is Encodable in Protobuf, packable: element is Packable )
   =>  collection[element] is Encodable in Protobuf =
 
-    caps.unsafe.unsafeAssumePure: values =>
+    // A pure thunk, as `listEncodable` above.
+    val enc: () -> (element is Encodable in Protobuf) =
+      caps.unsafe.unsafeAssumePure(() => encodable)
+
+    values =>
       val list = values.to(List)
 
       if list.isEmpty then Absent else
@@ -326,7 +335,7 @@ object Protobuf extends Protobuf2:
           var rest = list
 
           while rest.nonEmpty do
-            printer.raw(encodable.encode(rest.head).payload)
+            printer.raw(enc().encode(rest.head).payload)
             rest = rest.tail
 
         Wire(WireType.Len, bytes)

--- a/lib/spectacular/src/core/spectacular.Inspectable.scala
+++ b/lib/spectacular/src/core/spectacular.Inspectable.scala
@@ -105,81 +105,102 @@ object Inspectable extends Inspectable2:
       else String.format("\\u%04x", Integer.valueOf(char.toInt)).nn.tt
 
   // The collection instances below retain their by-name element instance, which shares each
-  // instance's given-resolution lifetime, so they are laundered pure rather than making every
-  // Inspectable a capability (the codec-thunk seal pattern; see rep/DECISIONS.md).
+  // instance's given-resolution lifetime. The by-name is bound as a *pure thunk* before the
+  // SAM body: under `-scalajs` the SAM expands to an anonymous class before capture checking,
+  // and the pure self-type of an `Inspectable` (a `Typeclass.Pure`) forbids it from capturing
+  // the by-name parameter directly — a seal on the lambda cannot reach that self-type check.
+  // The thunk keeps resolution lazy, which recursive derivations depend on (the codec-thunk
+  // seal pattern; see rep/DECISIONS.md).
   given set: [element] => (inspectable: => element is Inspectable) => Set[element] is Inspectable =
-    caps.unsafe.unsafeAssumePure(_.map(inspectable.text(_)).mkString("{", ", ", "}").tt)
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
+    _.map(insp().text(_)).mkString("{", ", ", "}").tt
 
   given map: [key, value]
   =>  ( inspectableKey: => key is Inspectable, inspectableValue: => value is Inspectable )
   =>  Map[key, value] is Inspectable =
 
-    caps.unsafe.unsafeAssumePure: entries =>
-        entries.map: (key, value) =>
-          inspectableKey.text(key).s+" → "+inspectableValue.text(value).s
+    val inspKey: () -> (key is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectableKey)
 
-        . mkString("{", ", ", "}").tt
+    val inspValue: () -> (value is Inspectable) =
+      caps.unsafe.unsafeAssumePure(() => inspectableValue)
+
+    entries =>
+      entries.map: (key, value) =>
+        inspKey().text(key).s+" → "+inspValue().text(value).s
+
+      . mkString("{", ", ", "}").tt
 
 
   given series: [element] => (inspectable: => element is Inspectable)
   =>  Series[element] is Inspectable =
 
-    caps.unsafe.unsafeAssumePure(_.map(inspectable.text(_)).mkString("⟨ ", " ", " ⟩").tt)
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
+    _.map(insp().text(_)).mkString("⟨ ", " ", " ⟩").tt
 
 
   given indexedSeq: [element] => (inspectable: => element is Inspectable)
   =>  IndexedSeq[element] is Inspectable =
-    caps.unsafe.unsafeAssumePure(_.map(inspectable.text(_)).mkString("⟨ ", " ", " ⟩ᵢ").tt)
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
+    _.map(insp().text(_)).mkString("⟨ ", " ", " ⟩ᵢ").tt
 
 
   given list: [element] => (inspectable: => element is Inspectable)
   =>  List[element] is Inspectable =
 
-    caps.unsafe.unsafeAssumePure(_.map(inspectable.text(_)).mkString("[", ", ", "]").tt)
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
+    _.map(insp().text(_)).mkString("[", ", ", "]").tt
 
 
   given array: [element] => (inspectable: => element is Inspectable)
   =>  Array[element] is Inspectable =
 
-    caps.unsafe.unsafeAssumePure: array =>
-        array.iterator.zipWithIndex.map: (value, index) =>
-          val subscript = index.toString.map { digit => (digit + 8272).toChar }.mkString
-          (subscript+inspectable.text(value).s).tt
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
 
-        . mkString("⦋"+arrayPrefix(array.toString), "∣", "⦌").tt
+    array =>
+      array.iterator.zipWithIndex.map: (value, index) =>
+        val subscript = index.toString.map { digit => (digit + 8272).toChar }.mkString
+        (subscript+insp().text(value).s).tt
+
+      . mkString("⦋"+arrayPrefix(array.toString), "∣", "⦌").tt
 
 
   given arraySeq: [element] => (inspectable: => element is Inspectable)
   =>  scm.ArraySeq[element] is Inspectable =
-    caps.unsafe.unsafeAssumePure: array =>
-        array.zipWithIndex.map: (value, index) =>
-          val subscript = index.toString.map { digit => (digit + 8272).toChar }.mkString
-          (subscript+inspectable.text(value).s).tt
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
 
-        . mkString("⦋"+arrayPrefix(array.toString), "∣", "⦌ₛ").tt
+    array =>
+      array.zipWithIndex.map: (value, index) =>
+        val subscript = index.toString.map { digit => (digit + 8272).toChar }.mkString
+        (subscript+insp().text(value).s).tt
+
+      . mkString("⦋"+arrayPrefix(array.toString), "∣", "⦌ₛ").tt
 
   given stream: [element] => (inspectable: => element is Inspectable)
   =>  LazyList[element] is Inspectable =
 
-    caps.unsafe.unsafeAssumePure: stream =>
-        def recur(stream: LazyList[element], todo: Int): Text =
-          if todo <= 0 then "..?".tt
-          else if stream.toString == "LazyList(<not computed>)" then "∿∿∿".tt
-          else if stream.nil then "⯁ ".tt
-          else (inspectable.text(stream.head).s+" ⋰ "+recur(stream.tail, todo - 1)).tt
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
 
-        recur(stream, 3)
+    stream =>
+      def recur(stream: LazyList[element], todo: Int): Text =
+        if todo <= 0 then "..?".tt
+        else if stream.toString == "LazyList(<not computed>)" then "∿∿∿".tt
+        else if stream.nil then "⯁ ".tt
+        else (insp().text(stream.head).s+" ⋰ "+recur(stream.tail, todo - 1)).tt
+
+      recur(stream, 3)
 
 
   given iarray: [element] => (inspectable: => element is Inspectable)
   =>  IArray[element] is Inspectable =
 
-    caps.unsafe.unsafeAssumePure: iarray =>
-        iarray.zipWithIndex.map: (value, index) =>
-          val subscript = index.toString.map { digit => (digit + 8272).toChar }.mkString
-          subscript+inspectable.text(value).s.tt
+    val insp: () -> (element is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
 
-        . mkString(arrayPrefix(iarray.toString)+"⁅", "╱", "⁆").tt
+    iarray =>
+      iarray.zipWithIndex.map: (value, index) =>
+        val subscript = index.toString.map { digit => (digit + 8272).toChar }.mkString
+        subscript+insp().text(value).s.tt
+
+      . mkString(arrayPrefix(iarray.toString)+"⁅", "╱", "⁆").tt
 
 
   private def arrayPrefix(string: String): String =
@@ -201,11 +222,14 @@ object Inspectable extends Inspectable2:
 
     arrayType+dimension//+renderBraille(string.split("@").nn(1).nn)
 
-  // Laundered pure like the collection instances above; see that comment.
+  // A pure thunk like the collection instances above; see that comment.
   given option: [value] => (inspectable: => value is Inspectable) => Option[value] is Inspectable =
-    caps.unsafe.unsafeAssumePure:
+    val insp: () -> (value is Inspectable) = caps.unsafe.unsafeAssumePure(() => inspectable)
+
+    {
       case None        => "None".tt
-      case Some(value) => s"Some(${inspectable.text(value).s})".tt
+      case Some(value) => s"Some(${insp().text(value).s})".tt
+    }
 
   given none: None.type is Inspectable = none => "None".tt
 

--- a/lib/yossarian/src/core/yossarian.internal.scala
+++ b/lib/yossarian/src/core/yossarian.internal.scala
@@ -184,6 +184,11 @@ object internal:
     val Foreground = Bits(40, 0x000000ffffffffffL)
     val Background = Bits(16, 0xffffff000000ffffL)
 
+    // An explicit instance to avoid deriving `Inspectable[Chroma]`, whose derived anon class the
+    // Scala.js pipeline rejects (the `text` parameter acquires a fresh capture var, unlike the JVM
+    // pipeline). Hand-written SAMs like this one are unaffected. (Compiler divergence; see #1520.)
+    given chromaInspectable: Chroma is Inspectable = _.underlying.inspect
+
     given inspectable: Style is Inspectable = style =>
       Map
         ( t"Bo" -> Bit.Bold(style),

--- a/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
+++ b/lib/ypsiloid/src/core/ypsiloid.Yaml.scala
@@ -1160,7 +1160,12 @@ object Yaml extends Yaml2, Dynamic:
       else
         origin
 
+  // The `predicate` laundering is for the Scala.js pipeline, which — unlike the JVM
+  // pipeline — rejects the `Optic`'s capture of `filter.predicate` against the required
+  // pure `Optic` type. (Compiler divergence; see #1520 and `caesura`'s `rowFilter`.)
   given filterOptical: Filter[Yaml] is Optical from Yaml onto Yaml = filter =>
+    val predicate: Yaml -> Boolean = caps.unsafe.unsafeAssumePure(filter.predicate)
+
     Optic: (origin, lambda) =>
       if origin.root.isArray then
         val n = origin.root.arrayLength
@@ -1171,7 +1176,7 @@ object Yaml extends Yaml2, Dynamic:
 
           while i < n do
             val element = Yaml.ast(origin.root.arrayElement(i))
-            updated(i) = (if filter.predicate(element) then lambda(element) else element).root
+            updated(i) = (if predicate(element) then lambda(element) else element).root
             i += 1
 
           Yaml.Ast.seqFromAnyArray(updated)
@@ -1369,9 +1374,12 @@ object Yaml extends Yaml2, Dynamic:
   given iterableEncodable: [collection <: Iterable, element]
   =>  ( encodable: => element is Encodable in Yaml )
   =>  collection[element] is Encodable in Yaml =
-    // By-name element codec; laundered pure (the codec-thunk seal).
-    caps.unsafe.unsafeAssumePure: values =>
-      val items = IArray.from(values.map(encodable.encode(_).root))
+    // A pure thunk rather than a sealed lambda: under `-scalajs` the SAM expands to an
+    // anonymous class whose pure self-type may not capture the by-name parameter.
+    val enc: () -> (element is Encodable in Yaml) = caps.unsafe.unsafeAssumePure(() => encodable)
+
+    values =>
+      val items = caps.unsafe.unsafeAssumePure(IArray.from(values.map(enc().encode(_).root)))
       Yaml.ast(Yaml.Ast.Sequence(items))
 
 

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1638,3 +1638,28 @@ Other recipes:
 - RUNTIME LESSON (tests caught it): `.asInstanceOf[List[...]]` on a fresh
   IArray-backed flatMap result CRASHES at macro expansion — cast to the true
   erased shape (`IArray[Expr[Node]]`) and `.to(List)` after.
+
+## Scala.js pipeline: pure-typeclass SAM launders (2026-07-12, branch pure-typeclass-js-launder)
+
+`soundness.js` compiles fully for the first time since the Typeclass.Pure flips.
+Root cause (per issue #1520): under `-scalajs`, ExpandSAMs runs BEFORE capture
+checking and SJSPlatform.isSam rejects arbitrary traits, so SAM givens become
+anonymous classes whose PURE self-types (Typeclass.Pure) may not capture what the
+JVM pipeline's closures may. Three recurring shapes, all laundered:
+
+1. BY-NAME element codecs in collection givens → bind a PURE THUNK before the SAM
+   body: `val enc: () -> (element is Encodable in X) = unsafeAssumePure(() => encodable)`
+   then `enc().…` inside. Keeps laziness (recursive derivation!); the anon class
+   captures a pure value. Applied: spectacular.Inspectable (10 givens), locomotion
+   (2), breviloquence (3), ypsiloid (1). [Pattern verified by the handover session.]
+2. `Filter[X] is Optical` givens → `val predicate: X -> Boolean =
+   unsafeAssumePure(filter.predicate)` before the Optic. Applied: jacinta,
+   breviloquence, ypsiloid (mirrors caesura's rowFilter and panopticon).
+3. DERIVED Inspectable instances whose anon-class `text` param acquires a fresh
+   capture var → hand-written explicit given (chiaroscuro.Decomposition, mirrors
+   yossarian.Chroma).
+
+Also cherry-picked the (previously unpushed) caesura+yossarian launder commit.
+The clean long-term fix is compiler #1520 (run ExpandSAMs after CC), which
+deletes ALL of this; soundness.js is still not CI-gated, so main can regress
+silently until then.


### PR DESCRIPTION
`soundness.js` compiles fully again. The `Typeclass.Pure` flips (#1512 and successors) broke around twenty by-name-capturing collection givens under `-scalajs`, where SAMs expand to anonymous classes *before* capture checking runs, and a pure typeclass's self-type rejects captures that the JVM pipeline's closures permit. Three recurring shapes are laundered, all tracked for deletion under the compiler fix proposed in #1520 (running `ExpandSAMs` after capture checking): by-name element codecs are bound as pure thunks before each SAM body — preserving the laziness that recursive derivation depends on — in spectacular, locomotion, breviloquence and ypsiloid; `Filter` optics launder their predicates in jacinta, breviloquence and ypsiloid (mirroring caesura and panopticon); and `chiaroscuro.Decomposition` gets a hand-written `Inspectable` in place of derivation. This also incorporates the previously unpushed caesura/yossarian launders.

## Release notes

- The Scala.js build (`soundness.js`) compiles again across all 183 cross-built modules; no JVM-facing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)