### PR TITLE
Gate the Scala.js cross-build in the local CI attestation

### DIFF
--- a/etc/ci/attest.sh
+++ b/etc/ci/attest.sh
@@ -125,8 +125,13 @@ if [[ "${SOUNDNESS_CI_SKIP_BUILD:-0}" != "1" ]]; then
     # The reusable runner stubs are not stored in the repo or any JAR; build them into
     # `dist/runners` so the test suite (the `Enclave` rig and the ethereal/profanity tests)
     # can read them. They are not part of the Soundness (Mill) build.
+    # `soundness.all` is the JVM + WASI surface. `soundness.js` cross-compiles the
+    # whole Scala.js-capable surface under `-scalajs`, which the JVM pipeline can't
+    # catch — gating it here stops `main` from silently drifting into `-scalajs`-only
+    # capture-checking breakage (there are no JS tests to run; compiling is the check).
     make runners-build \
       && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.all.compile \
+      && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false soundness.js.compile \
       && CLAUDECODE=1 ./mill --no-daemon -j "$JOBS" --ticker false test.assembly \
       && CLAUDECODE=1 make ci
   ) 2>&1 | tee "$LOG"


### PR DESCRIPTION
The local CI attestation now cross-compiles the entire Scala.js-capable surface of Soundness under `-scalajs` as part of every `make attest`, so regressions that only manifest in the Scala.js capture-checking pipeline are caught at attestation time rather than slipping into `main` unnoticed.

Soundness compiles cleanly to Scala.js under capture checking, and the build now guarantees it stays that way: `make attest` runs `mill soundness.js.compile` alongside the JVM and WASI builds. Because the Scala.js and JVM capture-checking pipelines diverge, a handful of constructs that build fine on the JVM are rejected under `-scalajs` — gating the cross-build means such breakage surfaces immediately instead of silently reaching `main` (as it recently did when a purity change broke `spectacular` only under Scala.js). This is a compile-only check — there are no Scala.js test runs — and adds roughly two minutes to a clean attestation.
