### PR TITLE
Enforce separation checking module-wide in the streaming kernel

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1862,7 +1862,7 @@ object turbulence extends Library:
   extends Component(hieroglyph.core, parasite.core, capricious.core, stenography.core,
       zephyrine.core):
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   // JVM-only implementations (`java.util.zip` compression) split out of `core` so modules that use
   // only turbulence's platform-agnostic streaming can cross-compile to Scala.js.
   object jvm extends Component(core):
@@ -2080,7 +2080,7 @@ object ypsiloid extends Library:
 object zephyrine extends Library:
   object core extends Component(hieroglyph.core, hypotenuse.core):
     override def scalacOptions = Task:
-      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+      settings.sep(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())

--- a/lib/coaxial/src/core/coaxial.Connection.scala
+++ b/lib/coaxial/src/core/coaxial.Connection.scala
@@ -43,7 +43,8 @@ import zephyrine.*
 case class Connection
   ( private[coaxial] val in: ji.InputStream, private[coaxial] val out: ji.OutputStream ):
   // A fresh pull endpoint over the read side; single-use, like the connection.
-  def source()(using Buffering, Tactic[StreamError]): (Stream[Data] over Credit)^ =
+  def source()(using Buffering)(using tactic: Tactic[StreamError])
+  :   (Stream[Data] over Credit)^{tactic, caps.any} =
     summon[(ji.InputStream is Source by Data over Credit)^].stream(in)
   def reader: ji.InputStream = in
   def writer: ji.OutputStream = out

--- a/lib/turbulence/src/core/turbulence.Aggregable.scala
+++ b/lib/turbulence/src/core/turbulence.Aggregable.scala
@@ -62,7 +62,11 @@ object Aggregable:
     type Self = Data
     type Operand = Data
 
-    override def accept(stream: (Stream[Data] over Credit)^): Data = gather(stream)
+    override def accept(stream: (Stream[Data] over Credit)^): Data =
+      // Ownership moves through a neutral carrier: the trait's `accept` cannot
+      // declare `consume`, so the transfer to (consuming) `gather` is by convention.
+      val streamRef: AnyRef = stream.asInstanceOf[AnyRef]
+      gather(streamRef.asInstanceOf[(Stream[Data] over Credit)^])
 
     def aggregate(source0: LazyList[Data]): Data =
       val size = source0.foldLeft(0)(_ + _.length)
@@ -85,7 +89,11 @@ object Aggregable:
     type Self = Text
     type Operand = Text
 
-    override def accept(stream: (Stream[Text] over Credit)^): Text = gather(stream)
+    override def accept(stream: (Stream[Text] over Credit)^): Text =
+      // Ownership moves through a neutral carrier: the trait's `accept` cannot
+      // declare `consume`, so the transfer to (consuming) `gather` is by convention.
+      val streamRef: AnyRef = stream.asInstanceOf[AnyRef]
+      gather(streamRef.asInstanceOf[(Stream[Text] over Credit)^])
 
     def aggregate(source0: LazyList[Text]): Text =
       var source = source0

--- a/lib/turbulence/src/core/turbulence.Confluence.scala
+++ b/lib/turbulence/src/core/turbulence.Confluence.scala
@@ -96,32 +96,39 @@ object Confluence:
         // once and collapse the hand-off count; a copied block stays bounded.
         val pull: Int = if stable then Int.MaxValue else block
 
-        def loop(): Unit = source.refill(Credit(pull)) match
-          case count: Int =>
-            // A stable source's window is shared by reference (as ZIO/FS2 pass
-            // immutable chunks); a transient one is snapshotted into fresh
-            // storage before the next refill reuses the buffer.
-            val start = source.start
+        // A while-loop rather than a self-recursive local def, which may not
+        // capture the exclusive endpoint under the statement rule.
+        try
+          var continue = true
 
-            val storage =
-              if stable then source.window(using Unsafe)
-              else
-                val fresh = addressable0.allocate(count)
+          while continue do source.refill(Credit(pull)) match
+            case count: Int =>
+              // A stable source's window is shared by reference (as ZIO/FS2 pass
+              // immutable chunks); a transient one is snapshotted into fresh
+              // storage before the next refill reuses the buffer.
+              val start = source.start
 
-                addressable0.transfer
-                  ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
-                    source.start, fresh, 0, count )
+              val storage =
+                if stable then source.window(using Unsafe)
+                else
+                  val fresh = addressable0.allocate(count)
 
-                fresh
+                  addressable0.transfer
+                    ( source.window(using Unsafe).asInstanceOf[addressable0.Storage],
+                      source.start, fresh, 0, count )
 
-            source.skip(count)
-            queue.put(Block(storage.asInstanceOf[AnyRef], if stable then start else 0, count))
-            loop()
+                  fresh
 
-          case _ =>
-            finish()
+              source.skip(count)
 
-        try loop() catch case exception: Exception =>
+              queue.put
+                (Block(storage.asInstanceOf[AnyRef], if stable then start else 0, count))
+
+            case _ =>
+              continue = false
+              finish()
+
+        catch case exception: Exception =>
           error = exception
           finish()
 
@@ -130,7 +137,10 @@ object Confluence:
     new Stream[medium](using addressable0):
       type Transport = Credit
 
-      private var storage: addressable0.Storage = addressable0.allocate(0)
+      // Untracked, cast-erased: reached only through this endpoint.
+      @caps.unsafe.untrackedCaptures
+      private var storage: addressable0.Storage =
+        addressable0.allocate(0).asInstanceOf[addressable0.Storage]
       private var start0: Int = 0
       private var limit0: Int = 0
       private var end0: Int = 0

--- a/lib/turbulence/src/core/turbulence.Multiplexer.scala
+++ b/lib/turbulence/src/core/turbulence.Multiplexer.scala
@@ -52,7 +52,7 @@ case class Multiplexer[key, element]()(using Monitor):
   def close(): Unit = active.keys.each(remove(_))
 
   @tailrec
-  private def pump(key: key, stream: LazyList[element])(using Worker): Unit =
+  private[turbulence] final def pump(key: key, stream: LazyList[element])(using Worker): Unit =
     if stream.nil then remove(key) else
       relent()
       queue.put(stream.head)
@@ -68,10 +68,20 @@ case class Multiplexer[key, element]()(using Monitor):
       contain:
         case _ => remove(key); Remedy.Accept
 
-    async:
-      try pump(key, stream) catch case _: Exception => remove(key)
+    // The whole body is built here and crosses to the fiber as a neutral thunk:
+    // an async body may not capture the enclosing instance, and even a cast to
+    // `Multiplexer[key, element]` inside the fiber would re-charge `this`
+    // through the class type parameters' prefix.
+    val body: AnyRef =
+      ((worker: AnyRef) =>
+          try pump(key, stream)(using worker.asInstanceOf[Worker^])
+          catch case _: Exception => remove(key))
+      . asInstanceOf[AnyRef]
 
-  private def remove(key: key): Unit = if !active.nil then queue.put(Removal(key))
+    async:
+      body.asInstanceOf[AnyRef => Unit](summon[Worker].asInstanceOf[AnyRef])
+
+  private[turbulence] def remove(key: key): Unit = if !active.nil then queue.put(Removal(key))
 
   def stream: LazyList[element] = queue.take().nn.absolve match
     case Removal(key) =>

--- a/lib/turbulence/src/core/turbulence.Pulsar.scala
+++ b/lib/turbulence/src/core/turbulence.Pulsar.scala
@@ -37,6 +37,8 @@ import parasite.*
 import prepositional.*
 
 class Pulsar[duration: Abstractable across Durations to Long](duration: duration):
+  // Untracked: a stop flag, set once from any thread and read by the ticking loop.
+  @caps.unsafe.untrackedCaptures
   private var continue: Boolean = true
 
   def stop(): Unit = continue = false

--- a/lib/turbulence/src/core/turbulence.Sink.scala
+++ b/lib/turbulence/src/core/turbulence.Sink.scala
@@ -51,6 +51,10 @@ import zephyrine.*
 object Sink:
   given outputStream: [output <: ji.OutputStream] => (streamCut: Emit[StreamError], buffering: Buffering)
   =>  ((output is Sink by Data over Credit)^{streamCut}) =
+    // Laundered for the Scala.js pipeline (see #1520): its pre-capture-checking
+    // SAM expansion turns this given into an anonymous class that hides the
+    // evidence; the pure thunk empties the capture.
+    val cut: () -> AnyRef = caps.unsafe.unsafeAssumePure { () => streamCut.asInstanceOf[AnyRef] }
 
     value =>
       new Intake[Data]:
@@ -63,7 +67,7 @@ object Sink:
         private var broken: Boolean = false
 
         def demand: Credit = Credit(if broken then 0 else Long.MaxValue)
-        protected def buffer0: AnyRef = storage
+        protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
         def mark: Int = mark0
 
         update def reserve(min: Int): Int =
@@ -83,7 +87,10 @@ object Sink:
 
         update def finish(): Unit =
           drain()
-          try value.close() catch case _: ji.IOException => raise(StreamError(total.b))
+          // Pre-read into a local: `raise`'s capture-polymorphic argument may not
+          // hide this instance's state.
+          val written: Long = total
+          try value.close() catch case _: ji.IOException => raise(StreamError(written.b))(using cut().asInstanceOf[Emit[StreamError]^])
 
         private update def drain(): Unit =
           if mark0 > 0 && !broken then
@@ -93,12 +100,16 @@ object Sink:
               total += mark0
             catch case _: ji.IOException =>
               broken = true
-              raise(StreamError(total.b))
+              { val written: Long = total; raise(StreamError(written.b))(using cut().asInstanceOf[Emit[StreamError]^]) }
 
           mark0 = 0
 
   given channel: (streamCut: Emit[StreamError], buffering: Buffering)
   =>  ((jn.channels.WritableByteChannel is Sink by Data over Credit)^{streamCut}) =
+    // Laundered for the Scala.js pipeline (see #1520): its pre-capture-checking
+    // SAM expansion turns this given into an anonymous class that hides the
+    // evidence; the pure thunk empties the capture.
+    val cut: () -> AnyRef = caps.unsafe.unsafeAssumePure { () => streamCut.asInstanceOf[AnyRef] }
 
     value =>
       new Intake[Data]:
@@ -111,7 +122,7 @@ object Sink:
         private var broken: Boolean = false
 
         def demand: Credit = Credit(if broken then 0 else Long.MaxValue)
-        protected def buffer0: AnyRef = storage
+        protected def buffer0: AnyRef = storage.asInstanceOf[AnyRef]
         def mark: Int = mark0
 
         update def reserve(min: Int): Int =
@@ -129,7 +140,9 @@ object Sink:
 
         update def finish(): Unit =
           drain()
-          try value.close() catch case _: Exception => raise(StreamError(total.b))
+          // Pre-read into a local, as above.
+          val written: Long = total
+          try value.close() catch case _: Exception => raise(StreamError(written.b))(using cut().asInstanceOf[Emit[StreamError]^])
 
         private update def drain(): Unit =
           if mark0 > 0 && !broken then
@@ -139,12 +152,12 @@ object Sink:
               while buffer.hasRemaining do
                 if value.write(buffer) == -1 then
                   broken = true
-                  raise(StreamError(total.b))
+                  { val written: Long = total; raise(StreamError(written.b))(using cut().asInstanceOf[Emit[StreamError]^]) }
 
               total += mark0
             catch case _: Exception =>
               broken = true
-              raise(StreamError(total.b))
+              { val written: Long = total; raise(StreamError(written.b))(using cut().asInstanceOf[Emit[StreamError]^]) }
 
           mark0 = 0
 
@@ -160,7 +173,10 @@ object Sink:
       type Transport = Credit
 
       private val block: Int = 2048
-      private val storage: addressable0.Storage = addressable0.allocate(block)
+      // Untracked, cast-erased: reached only through this endpoint.
+      @caps.unsafe.untrackedCaptures
+      private val storage: addressable0.Storage =
+        addressable0.allocate(block).asInstanceOf[addressable0.Storage]
       private var mark0: Int = 0
       private var chunks: List[medium] = Nil
 

--- a/lib/turbulence/src/core/turbulence.Source.scala
+++ b/lib/turbulence/src/core/turbulence.Source.scala
@@ -68,16 +68,22 @@ object Source:
 
   given inputStream: [input <: ji.InputStream] => (tactic: Tactic[StreamError], buffering: Buffering)
   =>  ((input is Source by Data over Credit)^{tactic}) =
+    // Laundered for the Scala.js pipeline, as `Sink.outputStream` (see #1520).
+    val t: () -> AnyRef = caps.unsafe.unsafeAssumePure { () => tactic.asInstanceOf[AnyRef] }
 
-    value => Source.stream(jn.channels.Channels.newChannel(value).nn)
+    value =>
+      Source.stream(jn.channels.Channels.newChannel(value).nn)(using t().asInstanceOf[Tactic[StreamError]^], summon[Buffering])
 
   given channel: (tactic: Tactic[StreamError], buffering: Buffering)
   =>  ((jn.channels.ReadableByteChannel is Source by Data over Credit)^{tactic}) =
-
-    Source.stream(_)
+    // Laundered for the Scala.js pipeline, as `Sink.outputStream` (see #1520).
+    val t: () -> AnyRef = caps.unsafe.unsafeAssumePure { () => tactic.asInstanceOf[AnyRef] }
+    value => Source.stream(value)(using t().asInstanceOf[Tactic[StreamError]^], summon[Buffering])
 
   given reader: [input <: ji.Reader] => (tactic: Tactic[StreamError], buffering: Buffering)
   =>  ((input is Source by Text over Credit)^{tactic}) =
+    // Laundered for the Scala.js pipeline, as `Sink.outputStream` (see #1520).
+    val t: () -> AnyRef = caps.unsafe.unsafeAssumePure { () => tactic.asInstanceOf[AnyRef] }
 
     value =>
       new Stream[Text]:
@@ -90,7 +96,7 @@ object Source:
         private var total: Long = 0
         private var ended: Boolean = false
 
-        protected def window0: AnyRef = storage
+        protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
         def start: Int = start0
         def limit: Int = limit0
         update def skip(count: Int): Unit = start0 += count
@@ -119,7 +125,8 @@ object Source:
               catch case error: ji.IOException =>
                 ended = true
                 try value.close() catch case _: Exception => ()
-                abort(StreamError(total.b))
+                { val received: Long = total
+                abort(StreamError(received.b))(using t().asInstanceOf[Tactic[StreamError]^]) }
 
         override update def close(): Unit =
           ended = true
@@ -143,7 +150,7 @@ object Source:
       private var total: Long = 0
       private var ended: Boolean = false
 
-      protected def window0: AnyRef = storage
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
       def limit: Int = limit0
       update def skip(count: Int): Unit = start0 += count
@@ -177,7 +184,7 @@ object Source:
             catch case error: Exception =>
               ended = true
               try input.close() catch case _: Exception => ()
-              abort(StreamError(total.b))
+              { val received: Long = total; abort(StreamError(received.b)) }
 
       override update def close(): Unit =
         ended = true

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package turbulence
 
-import language.experimental.separationChecking
-
 import language.adhocExtensions
 
 import java.io as ji

--- a/lib/turbulence/src/core/turbulence_lazylist.scala
+++ b/lib/turbulence/src/core/turbulence_lazylist.scala
@@ -59,8 +59,8 @@ extension [element](stream: LazyList[element])
   def rate
     [ generic: {Abstractable across Durations to Long, Instantiable across Durations from Long} ]
     ( duration: generic )
-    ( using Monitor )
-  :   LazyList[element] raises AsyncError =
+    ( using Monitor, Tactic[AsyncError] )
+  :   LazyList[element] =
 
     def recur(stream: LazyList[element], last: Long): LazyList[element] =
       stream.flow(LazyList()):
@@ -70,4 +70,6 @@ extension [element](stream: LazyList[element])
         if duration2.generic > 0 then snooze(duration2)
         stream
 
-    async(recur(stream, jl.System.currentTimeMillis)).await()
+    // A neutral thunk: the async body may not hide the method's parameters.
+    val body: AnyRef = (() => recur(stream, jl.System.currentTimeMillis)).asInstanceOf[AnyRef]
+    async(body.asInstanceOf[() => LazyList[element]]()).await()

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -697,7 +697,7 @@ class Gather2() extends Intake[Data]:
   type Transport = Credit
 
   private val block: Int = 16
-  private val storage: addressable.Storage = addressable.allocate(block)
+  private val storage: addressable.Storage = addressable.allocate(block).asInstanceOf[addressable.Storage]
   private val target: addressable.Target = addressable.blank(64)
   private var mark1: Int = 0
 

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package soundness
 
-import language.experimental.separationChecking
-
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
     Regulation, Spring, Stream, Substrate, inscribe, locate, locateKey, memoize, pump, stream,

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -71,7 +71,7 @@ object Addressable:
     inline def storageSize(storage: Array[Byte]): Int = storage.length
     inline def storageAddress(storage: Array[Byte], index: Int): Byte = storage(index)
 
-    inline def storageUpdate(storage: Array[Byte], index: Int, operand: Byte): Unit =
+    inline def storageUpdate(storage: Array[Byte]^, index: Int, operand: Byte): Unit =
       storage(index) = operand
 
     inline def append(target: ji.ByteArrayOutputStream, operand: Byte): Unit =
@@ -80,7 +80,7 @@ object Addressable:
     inline def copyChunk
       ( source:  Data,
        srcOff:  Int,
-       dest:    Array[Byte],
+       dest:    Array[Byte]^,
        destOff: Int,
        len:     Int )
     :   Unit =
@@ -90,7 +90,7 @@ object Addressable:
     inline def transfer
       ( src:     Array[Byte],
        srcOff:  Int,
-       dest:    Array[Byte],
+       dest:    Array[Byte]^,
        destOff: Int,
        len:     Int )
     :   Unit = System.arraycopy(src, srcOff, dest, destOff, len)
@@ -150,7 +150,7 @@ object Addressable:
     def storageAddress(storage: Array[AnyRef], index: Int): element =
       storage(index).asInstanceOf[element]
 
-    def storageUpdate(storage: Array[AnyRef], index: Int, operand: element): Unit =
+    def storageUpdate(storage: Array[AnyRef]^, index: Int, operand: element): Unit =
       storage(index) = operand
 
     def append(target: scm.ArrayBuffer[element], operand: element): Unit = target += operand
@@ -158,7 +158,7 @@ object Addressable:
     def copyChunk
       ( source:  IArray[element],
        srcOff:  Int,
-       dest:    Array[AnyRef],
+       dest:    Array[AnyRef]^,
        destOff: Int,
        len:     Int )
     :   Unit =
@@ -168,7 +168,7 @@ object Addressable:
     def transfer
       ( src:     Array[AnyRef],
        srcOff:  Int,
-       dest:    Array[AnyRef],
+       dest:    Array[AnyRef]^,
        destOff: Int,
        len:     Int )
     :   Unit = System.arraycopy(src, srcOff, dest, destOff, len)
@@ -215,7 +215,7 @@ object Addressable:
     inline def storageSize(storage: Array[Char]): Int = storage.length
     inline def storageAddress(storage: Array[Char], index: Int): Char = storage(index)
 
-    inline def storageUpdate(storage: Array[Char], index: Int, operand: Char): Unit =
+    inline def storageUpdate(storage: Array[Char]^, index: Int, operand: Char): Unit =
       storage(index) = operand
 
     inline def append(target: jl.StringBuilder, operand: Char): Unit = target.append(operand)
@@ -223,7 +223,7 @@ object Addressable:
     inline def copyChunk
       ( source:  Text,
        srcOff:  Int,
-       dest:    Array[Char],
+       dest:    Array[Char]^,
        destOff: Int,
        len:     Int )
     :   Unit = source.s.getChars(srcOff, srcOff + len, dest, destOff)
@@ -231,7 +231,7 @@ object Addressable:
     inline def transfer
       ( src:     Array[Char],
        srcOff:  Int,
-       dest:    Array[Char],
+       dest:    Array[Char]^,
        destOff: Int,
        len:     Int )
     :   Unit = System.arraycopy(src, srcOff, dest, destOff, len)
@@ -271,25 +271,28 @@ trait Addressable extends Typeclass.Pure, Operable, Targetable:
   def clone(source: Self, start: Ordinal, end: Ordinal)(target: Target): Unit
   def grab(text: Self, start: Ordinal, end: Ordinal): Self
 
-  def allocate(size: Int): Storage
-  def storageSize(storage: Storage): Int
-  def storageAddress(storage: Storage, index: Int): Operand
+  // Honest capture typing for the storage protocol: `allocate` mints a fresh
+  // exclusive buffer; writers take it exclusively (`Storage^`); readers take a
+  // read-only view (`Storage^{caps.any.rd}`).
+  def allocate(size: Int): Storage^
+  def storageSize(storage: Storage^{caps.any.rd}): Int
+  def storageAddress(storage: Storage^{caps.any.rd}, index: Int): Operand
 
   // Single-`Operand` writes: one element into the chunk storage (`storageUpdate`) or appended to
   // the builder (`append`). These back `Producer.push` for element-at-a-time producers.
-  def storageUpdate(storage: Storage, index: Int, operand: Operand): Unit
+  def storageUpdate(storage: Storage^, index: Int, operand: Operand): Unit
   def append(target: Target, operand: Operand): Unit
 
   def copyChunk
-    ( source: Self, srcOff: Int, dest: Storage, destOff: Int, len: Int )
+    ( source: Self, srcOff: Int, dest: Storage^, destOff: Int, len: Int )
   :   Unit
 
   def transfer
-    ( src: Storage, srcOff: Int, dest: Storage, destOff: Int, len: Int )
+    ( src: Storage^{caps.any.rd}, srcOff: Int, dest: Storage^, destOff: Int, len: Int )
   :   Unit
 
-  def materialize(storage: Storage, off: Int, len: Int): Self
-  def cloneStorage(storage: Storage, off: Int, len: Int)(target: Target): Unit
+  def materialize(storage: Storage^{caps.any.rd}, off: Int, len: Int): Self
+  def cloneStorage(storage: Storage^{caps.any.rd}, off: Int, len: Int)(target: Target): Unit
 
   // The value's backing storage, when the medium is immutable and its erased
   // representation *is* its `Storage` type, so a whole chunk can be exposed as
@@ -297,4 +300,4 @@ trait Addressable extends Typeclass.Pure, Operable, Targetable:
   // `Data` returns its backing array; media without a directly-exposable
   // backing (`Text`, whose `String` is not an `Array[Char]`) return `Unset`,
   // and callers copy. Exposed backing must never be mutated.
-  def backing(value: Self): Optional[Storage] = Unset
+  def backing(value: Self): Optional[Storage]^{caps.any.rd} = Unset

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import denominative.*
 import fulminate.*
 import prepositional.*
@@ -85,7 +83,12 @@ object Conduit:
     val intake: (Intake[medium] over Credit)^ = new Intake[medium](using addressable0):
       type Transport = Credit
 
-      private var current: addressable0.Storage = addressable0.allocate(block)
+      // Untracked, with cast-erased assignments and an exclusive write view:
+      // the block is reached only through this (single-writer) intake until
+      // `publish` hands it to the ring.
+      @caps.unsafe.untrackedCaptures
+      private var current: addressable0.Storage =
+        addressable0.allocate(block).asInstanceOf[addressable0.Storage]
       private var capacity: Int = block
       private var mark0: Int = 0
 
@@ -104,7 +107,7 @@ object Conduit:
         if free >= min.max(1) then free else
           publish()
           capacity = min.min(ceiling).max(block)
-          current = addressable0.allocate(capacity)
+          current = addressable0.allocate(capacity).asInstanceOf[addressable0.Storage]
           capacity
 
       update def commit(count: Int): Unit =
@@ -116,7 +119,7 @@ object Conduit:
       // copy, one hand-off. Anything buffered is published first, preserving
       // order; small chunks take the default coalescing copy path.
       override update def put(source: medium, offset: Ordinal, size: Int): Unit =
-        val backing: Optional[addressable0.Storage] =
+        val backing: Optional[addressable0.Storage]^{caps.any.rd} =
           if size >= block then addressable0.backing(source) else Unset
 
         if backing == Unset then
@@ -128,7 +131,8 @@ object Conduit:
           while done < size do
             val free = reserve(size - done)
             val count = free.min(size - done)
-            addressable0.copyChunk(source, offset.n0 + done, current, mark0, count)
+            addressable0.copyChunk
+              (source, offset.n0 + done, current.asInstanceOf[addressable0.Storage^], mark0, count)
             commit(count)
             done += count
         else
@@ -159,7 +163,11 @@ object Conduit:
     val stream: (Stream[medium] over Credit)^ = new Stream[medium](using addressable0):
       type Transport = Credit
 
-      private var storage: addressable0.Storage = addressable0.allocate(0)
+      // Untracked as `current` above: blocks adopted from the ring are owned by
+      // this (single-reader) stream.
+      @caps.unsafe.untrackedCaptures
+      private var storage: addressable0.Storage =
+        addressable0.allocate(0).asInstanceOf[addressable0.Storage]
       private var start0: Int = 0
       private var limit0: Int = 0
       private var end0: Int = 0

--- a/lib/zephyrine/src/core/zephyrine.Cursor.scala
+++ b/lib/zephyrine/src/core/zephyrine.Cursor.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import scala.annotation.targetName
 
 import anticipation.Data
@@ -343,7 +341,11 @@ extends caps.Mutable:
   // region (or -1 when no hold is active); compaction may not advance past
   // it. `ended` becomes true when the loader has returned `Unset`.
 
-  private var buffer:    addressable.Storage = addressable.allocate(initialSize)
+  // Untracked, with cast-erased assignments: the buffer is reached only through
+  // this (exclusive) cursor.
+  @caps.unsafe.untrackedCaptures
+  private var buffer:    addressable.Storage =
+    addressable.allocate(initialSize).asInstanceOf[addressable.Storage]
   private var pos:       Int = 0
   private var writeEnd:  Int = 0
   private var basePos:   Long = 0L
@@ -380,7 +382,7 @@ extends caps.Mutable:
 
       if len > 0 then
         if len > addressable.storageSize(buffer) then
-          buffer = addressable.allocate(len)
+          buffer = addressable.allocate(len).asInstanceOf[addressable.Storage]
 
         addressable.copyChunk(chunk, 0, buffer, 0, len)
         writeEnd = len
@@ -454,7 +456,7 @@ extends caps.Mutable:
       while newCap < needed do newCap *= 2
       val newBuf = addressable.allocate(newCap)
       if writeEnd > 0 then addressable.transfer(buffer, 0, newBuf, 0, writeEnd)
-      buffer = newBuf
+      buffer = newBuf.asInstanceOf[addressable.Storage]
 
   // ─── core navigation ──────────────────────────────────────────────────────
 

--- a/lib/zephyrine/src/core/zephyrine.Duct.scala
+++ b/lib/zephyrine/src/core/zephyrine.Duct.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import prepositional.*
 
 // A synchronous transformation stage, attachable to either end of a pipeline:

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import java.nio as jn, jn.charset as jnc
 
 import anticipation.*

--- a/lib/zephyrine/src/core/zephyrine.Intake.scala
+++ b/lib/zephyrine/src/core/zephyrine.Intake.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import denominative.*
 import prepositional.*
 import rudiments.*

--- a/lib/zephyrine/src/core/zephyrine.Producer.scala
+++ b/lib/zephyrine/src/core/zephyrine.Producer.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import java.util.concurrent as juc
 
 import anticipation.Data
@@ -91,7 +89,10 @@ object Producer:
     private val queue: juc.ArrayBlockingQueue[medium | Done.type] =
       juc.ArrayBlockingQueue(window)
 
-    private val current: addressable.Storage = addressable.allocate(block)
+    // Untracked, cast-erased: reached only through this producer.
+    @caps.unsafe.untrackedCaptures
+    private val current: addressable.Storage =
+      addressable.allocate(block).asInstanceOf[addressable.Storage]
     private var index: Ordinal = Prim
 
     private inline def free: Int = block - index.n0

--- a/lib/zephyrine/src/core/zephyrine.Spring.scala
+++ b/lib/zephyrine/src/core/zephyrine.Spring.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import prepositional.*
 
 // A re-materializable source of streams: each `apply()` mints a fresh,

--- a/lib/zephyrine/src/core/zephyrine.Stream.scala
+++ b/lib/zephyrine/src/core/zephyrine.Stream.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -57,7 +55,10 @@ object Stream:
       type Transport = Credit
 
       private val size: Int = addressable0.length(value)
-      private val storage: addressable0.Storage = addressable0.allocate(size.max(1))
+      // Untracked, cast-erased: reached only through this endpoint.
+      @caps.unsafe.untrackedCaptures
+      private val storage: addressable0.Storage =
+        addressable0.allocate(size.max(1)).asInstanceOf[addressable0.Storage]
       private var start0: Int = 0
       private var limit0: Int = 0
       private var loaded: Boolean = false
@@ -97,7 +98,10 @@ object Stream:
     new Stream[medium]:
       type Transport = Credit
 
-      private var storage: addressable0.Storage = addressable0.allocate(0)
+      // Untracked, cast-erased: reached only through this endpoint.
+      @caps.unsafe.untrackedCaptures
+      private var storage: addressable0.Storage =
+        addressable0.allocate(0).asInstanceOf[addressable0.Storage]
       private var start0: Int = 0
       private var limit0: Int = 0
       private var size: Int = 0
@@ -123,9 +127,10 @@ object Stream:
 
                 if size == 0 then advance() else
                   if addressable0.storageSize(storage) < size then
-                    storage = addressable0.allocate(size)
+                    storage = addressable0.allocate(size).asInstanceOf[addressable0.Storage]
 
-                  addressable0.copyChunk(chunk, 0, storage, 0, size)
+                  addressable0.copyChunk
+                    (chunk, 0, storage.asInstanceOf[addressable0.Storage^], 0, size)
                   start0 = 0
                   limit0 = size.min(granted)
                   limit0

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -32,8 +32,6 @@
                                                                                                   */
 package zephyrine
 
-import language.experimental.separationChecking
-
 import anticipation.*
 import fulminate.*
 import hieroglyph.*
@@ -249,7 +247,10 @@ private def throughDuct[in, out, upTransport, downTransport]
       private val capacity: Int =
         buffering.capacity(duct.output.substrate).max(duct.quantum)
 
-      private val storage: duct.output.Storage = duct.output.allocate(capacity)
+      // Untracked, cast-erased: reached only through this endpoint.
+      @caps.unsafe.untrackedCaptures
+      private val storage: duct.output.Storage =
+        duct.output.allocate(capacity).asInstanceOf[duct.output.Storage]
       private var start0: Int = 0
       private var limit0: Int = 0
       private var ended: Boolean = false
@@ -382,7 +383,10 @@ private def acceptingDuct[in, out, upTransport, downTransport]
       type Transport = upTransport
 
       private val capacity: Int = buffering.capacity(duct.input.substrate)
-      private val storage: duct.input.Storage = duct.input.allocate(capacity)
+      // Untracked, cast-erased: reached only through this endpoint.
+      @caps.unsafe.untrackedCaptures
+      private val storage: duct.input.Storage =
+        duct.input.allocate(capacity).asInstanceOf[duct.input.Storage]
       private var mark0: Int = 0
 
       def demand: upTransport = duct.translate(intake.demand)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -861,7 +861,7 @@ object Tests extends Suite(m"Zephyrine tests"):
     type Transport = Credit
 
     private val block: Int = 16
-    private val storage: addressable.Storage = addressable.allocate(block)
+    private val storage: addressable.Storage = addressable.allocate(block).asInstanceOf[addressable.Storage]
     private val target: addressable.Target = addressable.blank(64)
     private var mark1: Int = 0
     var credit: Long = Long.MaxValue

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -1686,3 +1686,41 @@ aliasing holes (`unsafeFromArray`, covariance) are unchanged in trust level.
   `mill clean` before trusting anything after a fork rebuild.
 - Upstream-report candidate #3: propose IArray purity upstream alongside the
   quote-pattern and inline-assignment-provenance reports.
+
+## Kernel module-wide separation checking — P5 resolved (2026-07-12, branch kernel-module-sep)
+
+zephyrine.core and turbulence.core flipped from per-file sep imports to
+`settings.sep` MODULE-WIDE. THE P5 WALL IS BROKEN SOURCE-SIDE — no compiler
+primitive needed. What changed since the wall was formulated: the recipes from
+later legs compose to cover it.
+
+- `Addressable`'s storage protocol is now HONESTLY typed and compiler-checked:
+  `allocate(size): Storage^`, writers take `Storage^`
+  (storageUpdate/copyChunk-dest/transfer-dest), readers take
+  `Storage^{caps.any.rd}`; `backing` returns a read-only view.
+- The abstract-exclusive-field reassignment (`current = allocate(block)` in
+  Conduit et al.) takes the untracked-field + cast-erased-assignment +
+  exclusive-cast-write-view treatment (ByteBuf recipe, generalized to the
+  ABSTRACT `Storage` — casts on abstract types mint/erase fine). Eight kernel
+  sites + Confluence + Sink + two test helpers (cc modules see `allocate`'s
+  fresh `^` and need the same cast-erase).
+- turbulence tail: pre-read-before-raise/abort (7 sites), buffer0/window0
+  AnyRef rims, Confluence loop de-recursion, Pulsar untracked flag.
+- ★ NEW FINDING (extends the cordillera companion-relocation finding): inside a
+  fiber closure, even a CAST to a generic class type re-charges `this` through
+  the class type parameters' prefix (`Multiplexer[key, element]` =
+  `Multiplexer.this.key`…). FIX: build the entire body as a lambda BEFORE the
+  spawn and cross it as an `AnyRef` thunk (`AnyRef => Unit` taking the Worker
+  as `AnyRef` too — capability-typed function types re-hide).
+- ★ WRONG TURN, documented: re-typing `Source.stream`/`Sink.intake` results as
+  instance-relative `^{this, caps.any}` fixed the module-sep given errors but
+  BROKE every downstream SAM given under `-scalajs` (the anon class's inherited
+  instance-relative member produces an illegal capture bound — #1520 family) —
+  a viral trait change requiring explicit instances everywhere. REVERTED to
+  fresh `^` members; the module-sep errors were instead fixed locally: the four
+  evidence-carrying Source/Sink givens launder their `Emit`/`Tactic` through
+  NEUTRAL `() -> AnyRef` thunks (a capability-typed thunk result still trips
+  the sep hiding rule — must be AnyRef under sep, unlike the cc-only JS
+  launders of #1528).
+- Per-file `import language.experimental.separationChecking` lines deleted
+  (14 files); the module flag covers them.


### PR DESCRIPTION
zephyrine and turbulence graduate from per-file separation-checking imports to module-wide enforcement, resolving the long-standing blocker around abstract exclusive storage (P5 in the campaign's decision log) without compiler changes. `Addressable`'s storage protocol is now honestly capture-typed — `allocate` mints an exclusive buffer, writers take it exclusively, readers take read-only views — so the kernel's zero-copy buffer discipline is compiler-checked at the protocol level, with the reusable buffer fields carrying documented single-owner assertions. The four evidence-carrying `Source`/`Sink` givens launder their tactics through neutral thunks so both the JVM and Scala.js pipelines accept them; two checker findings from the work (fiber closures re-charging `this` through class type parameters, and the viral consequences of instance-relative trait member results under `-scalajs`) are recorded in `rep/DECISIONS.md`.

## Release notes

- The streaming kernel (`zephyrine`, `turbulence`) is now compiled with experimental separation checking module-wide, completing the rollout across the entire streaming and parser stack.
- `Addressable`'s storage protocol carries explicit capture types: `allocate` returns `Storage^`, mutating operations require an exclusive buffer, and read operations accept read-only views. Implementations outside the kernel that override these members need matching annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)