### PR TITLE
Add a WASI sockets backend for coaxial via structured WIT arguments

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -488,8 +488,8 @@ object soundness extends Toolchain:
   // platform and is built through `js` alongside it (both are compiled by CI).
   object jvm extends Bundle(base, cli, data, sci, test, tool, web)
 
-  object wasi extends Bundle(ambience.wasi, aviation.wasi, capricious.wasi, galilei.wasi,
-    telekinesis.wasi, turbulence.wasi)
+  object wasi extends Bundle(ambience.wasi, aviation.wasi, capricious.wasi, coaxial.wasi,
+    galilei.wasi, telekinesis.wasi, turbulence.wasi)
 
   object js extends ScalaJSModule, Toolchain:
     def scalaVersion = settings.scalaVersion
@@ -899,6 +899,11 @@ object coaxial extends Library:
   // supply their own backend.
   object jvm extends Component(core):
     override def scalaJs = false
+    override def scalacOptions = Task:
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+  // A `SocketBackend` over `wasi:sockets` (TCP only; WASI has no Unix-domain sockets), materialized
+  // by xenophile's `invoke` at the downstream Wasm-linked summoning site.
+  object wasi extends Component(core, xenophile.wasm, xenophile.wit):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core, jvm)

--- a/lib/coaxial/res/wasi/coaxial/sockets.wit
+++ b/lib/coaxial/res/wasi/coaxial/sockets.wit
@@ -1,0 +1,65 @@
+// The subset of the WASI sockets and I/O interfaces that coaxial's Wasm backend uses. As in
+// galilei's `filesystem.wit`, the named types (`error-code`, `ip-socket-address`,
+// `ip-address-family`, `shutdown-type`) are declared with empty bodies: their shapes are derived
+// from their facade classes, and only their names and defining interface matter to this subset.
+// The socket-address records `ipv4`/`ipv6` wrap are likewise supplied by the facades — coaxial
+// builds them through `WitVariant`, so they need no structural declaration here.
+
+package wasi:io@0.2.0;
+
+interface poll {
+  resource pollable {
+    block: func();
+  }
+}
+
+interface streams {
+  resource input-stream {
+    blocking-read: func(len: u64) -> result<list<u8>, stream-error>;
+  }
+
+  resource output-stream {
+    blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
+  }
+}
+
+package wasi:sockets@0.2.0;
+
+interface network {
+  resource network {}
+  variant error-code {}
+  variant ip-address-family {}
+  variant ip-socket-address {}
+}
+
+interface instance-network {
+  instance-network: func() -> network;
+}
+
+interface tcp-create-socket {
+  create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+}
+
+interface tcp {
+  variant shutdown-type {}
+
+  resource tcp-socket {
+    start-bind: func(network: borrow<network>, local-address: ip-socket-address)
+      -> result<_, error-code>;
+
+    finish-bind: func() -> result<_, error-code>;
+
+    start-connect: func(network: borrow<network>, remote-address: ip-socket-address)
+      -> result<_, error-code>;
+
+    finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+
+    start-listen: func() -> result<_, error-code>;
+    finish-listen: func() -> result<_, error-code>;
+
+    accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
+
+    subscribe: func() -> pollable;
+    shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
+  }
+}

--- a/lib/coaxial/res/wasi/coaxial/sockets.wit
+++ b/lib/coaxial/res/wasi/coaxial/sockets.wit
@@ -26,7 +26,7 @@ interface streams {
 package wasi:sockets@0.2.0;
 
 interface network {
-  resource network {}
+  resource network;
   variant error-code {}
   variant ip-address-family {}
   variant ip-socket-address {}
@@ -44,12 +44,12 @@ interface tcp {
   variant shutdown-type {}
 
   resource tcp-socket {
-    start-bind: func(network: borrow<network>, local-address: ip-socket-address)
+    start-bind: func(network: network, local-address: ip-socket-address)
       -> result<_, error-code>;
 
     finish-bind: func() -> result<_, error-code>;
 
-    start-connect: func(network: borrow<network>, remote-address: ip-socket-address)
+    start-connect: func(network: network, remote-address: ip-socket-address)
       -> result<_, error-code>;
 
     finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;

--- a/lib/coaxial/src/wasi/coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/coaxial_wasi.scala
@@ -117,10 +117,8 @@ package socketBackends:
         val (input, output) =
           socket.`finish-connect`.invoke[(WitHandle of "input-stream", WitHandle of "output-stream")]
 
-        net.dispose()
         WasiExchange(input, output, socketHandle)
       catch case error: WitError =>
-        net.dispose()
         socketHandle.dispose()
         abort(ConnectionError(ConnectionError.Reason.Accept))
 
@@ -161,7 +159,8 @@ package socketBackends:
               val stream: Foreign of "input-stream" from Wit = inputHandle
 
               try
-                val data = stream.`blocking-read`(U64(capacity.min(granted).toLong.bits)).invoke[Data]
+                val want = if capacity < granted then capacity else granted
+                val data = stream.`blocking-read`(U64(want.toLong.bits)).invoke[Data]
                 chunk = data.mutable(using Unsafe)
                 start0 = 0
                 limit0 = chunk.length
@@ -206,7 +205,6 @@ package socketBackends:
         socket.`finish-bind`.invoke[Unit]
         socket.`start-listen`.invoke[Unit]
         socket.`finish-listen`.invoke[Unit]
-        net.dispose()
         socketHandle
 
     def listenDomain(address: DomainSocket, options: List[SocketOption]): WitHandle of "tcp-socket" =

--- a/lib/coaxial/src/wasi/coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/coaxial_wasi.scala
@@ -1,0 +1,286 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package coaxial
+
+import scala.annotation.nowarn
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import gigantism.*
+import gossamer.*
+import hellenism.*
+import hypotenuse.*
+import prepositional.*
+import rudiments.*
+import spectacular.*
+import turbulence.*
+import urticose.*
+import vacuous.*
+import zephyrine.*
+import soundness.{invoke, dispose}
+import xenophile.*
+
+// The WIT definitions the navigation below is typechecked against, and which the `invoke`
+// materializer consults (at its downstream expansion site) for module ids, resource methods and
+// parameter types.
+type WasiSocketsApi = Interface in Wit at "/coaxial/sockets.wit"
+given wasiSocketsApi: WasiSocketsApi = Interface[Wit](cp"/coaxial/sockets.wit")
+
+// The handles a connected TCP socket threads back to the backend: the readable and writable halves
+// of the connection, and the socket itself (kept so it can be shut down and dropped).
+private case class WasiExchange
+  ( input:  WitHandle of "input-stream",
+    output: WitHandle of "output-stream",
+    socket: WitHandle of "tcp-socket" )
+
+package socketBackends:
+  // A `SocketBackend` over `wasi:sockets`. WASI sockets are capability-based (the host grants
+  // network access with `wasmtime run -S inherit-network`) and asynchronous: `start-connect` /
+  // `accept` are driven to completion by blocking on the socket's `pollable`. Only TCP is
+  // supported — WASI has no Unix-domain sockets (those operations raise), and UDP is not yet
+  // wired. `inline`, so the `invoke`s expand at the downstream summoning site, where the WASI
+  // facades are on the classpath.
+  @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
+  inline given wasi: SocketBackend = new SocketBackend:
+    type ServerSocket = WitHandle of "tcp-socket"
+    type DatagramSocket = Unit
+    type Exchange = WasiExchange
+    type Courier = Unit
+
+    // The shared `wasi:sockets` default network, opened once per operation and dropped after use.
+    private def network(): WitHandle of "network" =
+      Foreign["instance-network", Wit].`instance-network`.invoke[WitHandle of "network"]
+
+    // Builds an `ip-socket-address` from a dotted-quad host and port. Only IPv4 literals are
+    // handled; a host that is not a literal address (needing DNS) raises.
+    private def address(host: Text, port: Int) =
+      val ip: Ipv4 = unsafely(host.as[Ipv4])
+
+      val octets =
+        ( U8(ip.byte0.toByte.bits), U8(ip.byte1.toByte.bits),
+          U8(ip.byte2.toByte.bits), U8(ip.byte3.toByte.bits) )
+
+      WitVariant["ip-socket-address", "ipv4"]((U16(port.toShort.bits), octets))
+
+    // Creates a fresh IPv4 TCP socket. The interface root is bound to a `val` (with the refinement
+    // `Foreign.apply`'s deferred inline expansion would otherwise leave implicit) so the
+    // `ip-address-family` argument conversion can resolve its ecosystem.
+    private def createSocket(): WitHandle of "tcp-socket" =
+      val factory =
+        Foreign["tcp-create-socket", Wit].asInstanceOf[Foreign of "tcp-create-socket" from Wit]
+
+      factory.`create-tcp-socket`(WitCase["ip-address-family"]("ipv4"))
+      . invoke[WitHandle of "tcp-socket"]
+
+    // Opens a TCP connection to `host:port` and drives `start-connect` to completion, blocking on
+    // the socket's pollable. Returns the connection's stream halves and the socket handle.
+    private def connect(host: Text, port: Int)(using Tactic[ConnectionError]): WasiExchange =
+      val net = network()
+      val socketHandle = createSocket()
+      val socket: Foreign of "tcp-socket" from Wit = socketHandle
+
+      try
+        socket.`start-connect`(net, address(host, port)).invoke[Unit]
+        await(socketHandle)
+
+        val (input, output) =
+          socket.`finish-connect`.invoke[(WitHandle of "input-stream", WitHandle of "output-stream")]
+
+        net.dispose()
+        WasiExchange(input, output, socketHandle)
+      catch case error: WitError =>
+        net.dispose()
+        socketHandle.dispose()
+        abort(ConnectionError(ConnectionError.Reason.Accept))
+
+    // Blocks until the socket is ready for the next step of a `start-`/`finish-` operation.
+    private def await(socketHandle: WitHandle of "tcp-socket"): Unit =
+      val socket: Foreign of "tcp-socket" from Wit = socketHandle
+      val pollableHandle = socket.subscribe.invoke[WitHandle of "pollable"]
+      val pollable: Foreign of "pollable" from Wit = pollableHandle
+      pollable.block.invoke[Unit]
+      pollableHandle.dispose()
+
+    // A pull endpoint over a WASI `input-stream`: each refill is one `blocking-read`, whose result
+    // becomes the window; the peer closing the stream surfaces as a `WitError`, which ends it.
+    private def readStream(inputHandle: WitHandle of "input-stream")(using buffering: Buffering)
+    :   (Stream[Data] over Credit)^{caps.any} =
+
+      new Stream[Data]:
+        type Transport = Credit
+
+        private val capacity: Int = buffering.capacity(Substrate.Bytes)
+        private var chunk: Array[Byte] = new Array[Byte](0)
+        private var start0: Int = 0
+        private var limit0: Int = 0
+        private var ended: Boolean = false
+
+        protected def window0: AnyRef = chunk.asInstanceOf[AnyRef]
+        def start: Int = start0
+        def limit: Int = limit0
+        update def skip(count: Int): Unit = start0 += count
+
+        update def refill(demand: Credit): Optional[Int] =
+          if limit0 > start0 then limit0 - start0
+          else if ended then Unset
+          else
+            val granted = summon[Credit is Regulation].grant(demand)
+
+            if granted == 0 then 0 else
+              val stream: Foreign of "input-stream" from Wit = inputHandle
+
+              try
+                val data = stream.`blocking-read`(U64(capacity.min(granted).toLong.bits)).invoke[Data]
+                chunk = data.mutable(using Unsafe)
+                start0 = 0
+                limit0 = chunk.length
+                if limit0 == 0 then refill(demand) else limit0
+              catch case error: WitError =>
+                ended = true
+                Unset
+
+    // Writes a whole pull-stream to a WASI `output-stream`, one `blocking-write-and-flush` per
+    // window.
+    private def drain(outputHandle: WitHandle of "output-stream", input: (Stream[Data] over Credit)^)
+    :   Unit =
+
+      val stream: Foreign of "output-stream" from Wit = outputHandle
+
+      input.sweep: (storage, start, count) =>
+        val slice = storage.asInstanceOf[Array[Byte]].slice(start, start + count).nn
+        stream.`blocking-write-and-flush`(slice.immutable(using Unsafe)).invoke[Unit]
+
+    // Presents a connected socket's stream halves as a `Duplex`: `source` reads, `send` writes,
+    // `close` drops both streams and the socket.
+    private def duplexOf(exchange: WasiExchange): Duplex = new Duplex:
+      def source(using Buffering): (Stream[Data] over Credit)^ =
+        readStream(exchange.input)
+
+      def send(consume data: (Stream[Data] over Credit)^): Unit = drain(exchange.output, data)
+
+      def close(): Unit =
+        exchange.input.dispose()
+        exchange.output.dispose()
+        exchange.socket.dispose()
+
+    //── Stream server (TCP; Unix-domain unsupported) ─────────────────────────────────────────────
+    def listenTcp(port: TcpPort, interface: Optional[MacAddress], options: List[SocketOption])
+    :   WitHandle of "tcp-socket" =
+
+      unsafely:
+        val net = network()
+        val socketHandle = createSocket()
+        val socket: Foreign of "tcp-socket" from Wit = socketHandle
+        socket.`start-bind`(net, address(t"0.0.0.0", port.number)).invoke[Unit]
+        socket.`finish-bind`.invoke[Unit]
+        socket.`start-listen`.invoke[Unit]
+        socket.`finish-listen`.invoke[Unit]
+        net.dispose()
+        socketHandle
+
+    def listenDomain(address: DomainSocket, options: List[SocketOption]): WitHandle of "tcp-socket" =
+      unsafely(abort(ConnectionError(ConnectionError.Reason.Accept)))
+
+    def accept(socketHandle: WitHandle of "tcp-socket"): Duplex raises ConnectionError =
+      val socket: Foreign of "tcp-socket" from Wit = socketHandle
+
+      try
+        await(socketHandle)
+
+        val (client, input, output) =
+          socket.accept.invoke
+            [(WitHandle of "tcp-socket", WitHandle of "input-stream", WitHandle of "output-stream")]
+
+        duplexOf(WasiExchange(input, output, client))
+      catch case error: WitError => abort(ConnectionError(ConnectionError.Reason.Accept))
+
+    def shutdown(socketHandle: WitHandle of "tcp-socket"): Unit = socketHandle.dispose()
+
+    //── Datagram server (unsupported on WASI for now) ────────────────────────────────────────────
+    def listenUdp(port: UdpPort, interface: Optional[MacAddress], options: List[SocketOption]): Unit =
+      ()
+
+    def receive(socket: Unit): Packet raises ConnectionError =
+      abort(ConnectionError(ConnectionError.Reason.Accept))
+
+    def reply(socket: Unit, sender: Ipv4 | Ipv6, port: UdpPort, data: Data)
+    :   Unit raises ConnectionError =
+      abort(ConnectionError(ConnectionError.Reason.Transmit))
+
+    def unbind(socket: Unit): Unit = ()
+
+    //── Request/response exchange (TCP; Unix-domain unsupported) ──────────────────────────────────
+    def dialTcp
+      ( endpoint: Endpoint[TcpPort], interface: Optional[MacAddress], options: List[SocketOption] )
+    :   WasiExchange =
+      unsafely(connect(endpoint.remote, endpoint.port.number))
+
+    def dialTcpPort(port: TcpPort, interface: Optional[MacAddress], options: List[SocketOption])
+    :   WasiExchange =
+      unsafely(connect(t"127.0.0.1", port.number))
+
+    def dialDomain(address: DomainSocket, options: List[SocketOption]): WasiExchange =
+      unsafely(abort(ConnectionError(ConnectionError.Reason.Accept)))
+
+    def request(exchange: WasiExchange, input: (Stream[Data] over Credit)^): Unit =
+      drain(exchange.output, input)
+      exchange.output.dispose()
+
+    def response(exchange: WasiExchange)(using Buffering, Tactic[StreamError])
+    :   (Stream[Data] over Credit)^{caps.any} =
+      readStream(exchange.input)
+
+    def hangUp(exchange: WasiExchange): Unit =
+      exchange.input.dispose()
+      exchange.socket.dispose()
+
+    //── Persistent duplex client (TCP; Unix-domain unsupported) ───────────────────────────────────
+    def duplexTcp
+      ( endpoint: Endpoint[TcpPort], interface: Optional[MacAddress], options: List[SocketOption] )
+    :   Duplex =
+      duplexOf(unsafely(connect(endpoint.remote, endpoint.port.number)))
+
+    def duplexDomain(address: DomainSocket, options: List[SocketOption]): Duplex =
+      duplexOf(unsafely(abort(ConnectionError(ConnectionError.Reason.Accept))))
+
+    //── Fire-and-forget datagram courier (unsupported on WASI for now) ────────────────────────────
+    def routeUdp
+      ( endpoint: Endpoint[UdpPort], interface: Optional[MacAddress], options: List[SocketOption] )
+    :   Unit =
+      ()
+
+    def routeUdpPort(port: UdpPort, interface: Optional[MacAddress], options: List[SocketOption]): Unit =
+      ()
+
+    def dispatch(courier: Unit, input: (Stream[Data] over Credit)^): Unit = ()

--- a/lib/coaxial/src/wasi/soundness_coaxial_wasi.scala
+++ b/lib/coaxial/src/wasi/soundness_coaxial_wasi.scala
@@ -1,0 +1,38 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package soundness
+
+export coaxial.{WasiSocketsApi, wasiSocketsApi}
+
+package socketBackends:
+  export coaxial.socketBackends.wasi

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -512,12 +512,94 @@ object WasmInvoke:
 
       (facade.typeRef, Match(selector, caseDefs :+ missing))
 
+    // The base class a (possibly multiply-)refined type refines, and the constant string / aliased
+    // type a named refinement member is set to — used to read `WitVariant`'s `Topic`/`Case`/
+    // `Payload` phantom members regardless of the order the compiler nests them.
+    def refinementBase(tpe: TypeRepr): TypeRepr = tpe match
+      case Refinement(parent, _, _) => refinementBase(parent)
+      case other                    => other
+
+    def refinedString(tpe: TypeRepr, name: String): Optional[Text] = tpe match
+      case Refinement(_, `name`, TypeBounds(_, ConstantType(StringConstant(text)))) =>
+        text.tt
+
+      case Refinement(parent, _, _) =>
+        refinedString(parent, name)
+
+      case _ =>
+        Unset
+
+    val witVariantClass = Symbol.requiredClass("xenophile.WitVariant")
+    val witRecordAnnotation = Symbol.requiredClass("scala.scalajs.wit.annotation.WitRecord")
+
+    // Constructs a scala-wasm facade value of WIT type `target` from a Scala `value`, recursing
+    // structurally: a scala-wasm `TupleN` and a `@WitRecord` class are each built element-wise via
+    // their companion `apply` (a record shares the tuple ABI, so its fields map to the Scala
+    // tuple's positionally); a leaf is encoded through its `Encodable in Wasm` codec, whose carrier
+    // is the facade field's type (the `scala.scalajs.wit.unsigned` types are aliases of the boxed
+    // primitives). The facade classes are resolved here, downstream, so they never appear in this
+    // module's own compilation.
+    def buildFacade(target: TypeRepr, value: Term): Term =
+      val symbol = target.typeSymbol
+
+      if symbol.fullName.startsWith("scala.scalajs.wit.Tuple") then
+        val elements = target.typeArgs
+        val applier = Select.unique(Ref(symbol.companionModule), "apply")
+
+        val built = elements.zipWithIndex.map: (element, index) =>
+          buildFacade(element, Select.unique(value, "_" + (index + 1).toString))
+
+        Apply(TypeApply(applier, elements.map(Inferred(_))), built)
+
+      else if symbol.hasAnnotation(witRecordAnnotation) then
+        val fields = symbol.declaredFields
+
+        val built = fields.zipWithIndex.map: (field, index) =>
+          buildFacade(target.memberType(field), Select.unique(value, "_" + (index + 1).toString))
+
+        Apply(Select.unique(Ref(symbol.companionModule), "apply"), built)
+
+      else
+        value.tpe.widen.dealias.asType.absolve match
+          case '[leaf] =>
+            val encodable = Expr.summon[leaf is Encodable in Wasm].getOrElse:
+              halt(m"xenophile: no `Encodable in Wasm` to build a WIT payload of ${value.tpe.show}")
+
+            '{$encodable.encoded(${value.asExprOf[leaf]}).value}.asTerm
+
+    // A payload-carrying `variant` case argument (a `WitVariant`): the facade case class named by
+    // `caseName` (fixed at compile time, so no runtime dispatch), constructed with its record/
+    // tuple/primitive payload built from the `WitVariant`'s payload — cast back to the Scala type
+    // `payloadType` the phantom `Payload` carried — and encoded element-wise.
+    def variantArgument(topic: Text, caseName: Text, payloadType: TypeRepr, value: Term)
+    :   (TypeRepr, Term) =
+
+      val facade = facadeOf(topic)
+
+      val child = facade.children.find(_.name.tt.uncamel.kebab == caseName).getOrElse:
+        halt(m"xenophile: the variant $topic has no case $caseName")
+
+      val valueField = child.declaredFields.headOption.getOrElse:
+        halt(m"xenophile: the variant case $topic.$caseName carries no payload")
+
+      val caseValueType = child.typeRef.memberType(valueField)
+
+      val castPayload =
+        TypeApply
+          ( Select.unique
+              ( '{${value.asExprOf[Any]}.asInstanceOf[WitVariant[Any]].payload}.asTerm,
+                "asInstanceOf" ),
+            List(Inferred(payloadType)) )
+
+      val built = buildFacade(caseValueType, castPayload)
+      (facade.typeRef, Apply(Select.unique(Ref(child.companionModule), "apply"), List(built)))
+
     def encodedArgument(value: Term, parameter: Foreign.Type): (TypeRepr, Term) =
       val (carrier, encoded, alreadyOption) = value.tpe.widen.dealias match
         // A `tuple<…>` (or a record, whose ABI it shares) argument with a matching Scala tuple:
         // element-wise recursion, constructed as the scala-wasm `TupleN` of the element carriers —
-        // the mirror of the decode path. `WitCase` payloads and nested `option<T>`/`result` elements
-        // are handled by the per-element recursion into `encodedArgument`.
+        // the mirror of the decode path. Nested tuples, `option<T>` and `WitCase` elements are
+        // handled by the per-element recursion into `encodedArgument`.
         case valueType
         if parameterTuple(parameter).let { es => isTuple(valueType, es.length) }.or(false) =>
           val elements = parameterTuple(parameter).vouch
@@ -534,7 +616,10 @@ object WasmInvoke:
 
           val encodedElements = encodedBuffer.result()
           val carriers = encodedElements.map(_(0))
-          val tupleClass = Symbol.requiredClass("scala.scalajs.wit.Tuple" + elements.length.toString)
+
+          val tupleClass =
+            Symbol.requiredClass("scala.scalajs.wit.Tuple" + elements.length.toString)
+
           val tupleCarrier = tupleClass.typeRef.appliedTo(carriers)
 
           val constructed =
@@ -562,6 +647,16 @@ object WasmInvoke:
         case Refinement(base, "Topic", TypeBounds(_, ConstantType(StringConstant(topic))))
         if base =:= TypeRepr.of[WitCase] =>
           val (carrier, encoded) = caseArgument(topic.tt, value)
+          (carrier, encoded, false)
+
+        // A payload-carrying `variant` case argument (a `WitVariant`, e.g. the `ip-socket-address`
+        // passed to `start-connect`): read its `Topic`/`Case` phantom members and payload type
+        // argument, and build the named facade case around its payload.
+        case tpe if refinementBase(tpe).typeSymbol == witVariantClass =>
+          val topic = refinedString(tpe, "Topic").or(halt(m"xenophile: WitVariant has no Topic"))
+          val caseName = refinedString(tpe, "Case").or(halt(m"xenophile: WitVariant has no Case"))
+          val payloadType = refinementBase(tpe).typeArgs.head
+          val (carrier, encoded) = variantArgument(topic, caseName, payloadType, value)
           (carrier, encoded, false)
 
         case OrType(left, right)

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -515,11 +515,15 @@ object WasmInvoke:
     // The base class a (possibly multiply-)refined type refines, and the constant string / aliased
     // type a named refinement member is set to — used to read `WitVariant`'s `Topic`/`Case`/
     // `Payload` phantom members regardless of the order the compiler nests them.
-    def refinementBase(tpe: TypeRepr): TypeRepr = tpe match
+    // `.dealias` at each step because the phantom members are carried through `of` — a type alias
+    // (`X of topic` = `of[X, topic]` = `X { type Topic = topic }`) — so a `WitVariant` argument
+    // reads as `of[WitVariant[payload], topic] { type Case = … }`, whose base and `Topic` member are
+    // hidden inside the unexpanded `of` until dealiased.
+    def refinementBase(tpe: TypeRepr): TypeRepr = tpe.dealias match
       case Refinement(parent, _, _) => refinementBase(parent)
       case other                    => other
 
-    def refinedString(tpe: TypeRepr, name: String): Optional[Text] = tpe match
+    def refinedString(tpe: TypeRepr, name: String): Optional[Text] = tpe.dealias match
       case Refinement(_, `name`, TypeBounds(_, ConstantType(StringConstant(text)))) =>
         text.tt
 
@@ -552,9 +556,12 @@ object WasmInvoke:
         Apply(TypeApply(applier, elements.map(Inferred(_))), built)
 
       else if symbol.hasAnnotation(witRecordAnnotation) then
-        val fields = symbol.declaredFields
+        // Constructor-parameter order, not `declaredFields` (which does not preserve it), so the
+        // record's fields line up with the Scala tuple's positions and the companion `apply`.
+        val params = symbol.primaryConstructor.paramSymss.flatten.filter(!_.isType)
 
-        val built = fields.zipWithIndex.map: (field, index) =>
+        val built = params.zipWithIndex.map: (param, index) =>
+          val field = symbol.declaredField(param.name)
           buildFacade(target.memberType(field), Select.unique(value, "_" + (index + 1).toString))
 
         Apply(Select.unique(Ref(symbol.companionModule), "apply"), built)
@@ -565,7 +572,10 @@ object WasmInvoke:
             val encodable = Expr.summon[leaf is Encodable in Wasm].getOrElse:
               halt(m"xenophile: no `Encodable in Wasm` to build a WIT payload of ${value.tpe.show}")
 
-            '{$encodable.encoded(${value.asExprOf[leaf]}).value}.asTerm
+            // `Wasm#value` is `Any`; cast it to the facade field's carrier type (`target`) so it
+            // conforms to the record/tuple `apply`'s parameter.
+            val encoded = '{$encodable.encoded(${value.asExprOf[leaf]}).value}.asTerm
+            TypeApply(Select.unique(encoded, "asInstanceOf"), List(Inferred(target)))
 
     // A payload-carrying `variant` case argument (a `WitVariant`): the facade case class named by
     // `caseName` (fixed at compile time, so no runtime dispatch), constructed with its record/

--- a/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
+++ b/lib/xenophile/src/wasm/xenophile.WasmInvoke.scala
@@ -199,6 +199,12 @@ object WasmInvoke:
       case _ =>
         false
 
+    // The element WIT types of a `tuple<…>` parameter (a WIT record, whose ABI it shares, may be
+    // declared as its structural tuple), or `Unset` for any other parameter shape.
+    def parameterTuple(parameter: Foreign.Type): Optional[List[Foreign.Type]] = parameter match
+      case Foreign.Type.Applied(constructor, elements) if constructor.s == "tuple" => elements
+      case _                                                                       => Unset
+
     val listClass = Symbol.requiredClass("scala.collection.immutable.List")
 
     def isList(scala: TypeRepr): Boolean = scala.dealias match
@@ -508,6 +514,38 @@ object WasmInvoke:
 
     def encodedArgument(value: Term, parameter: Foreign.Type): (TypeRepr, Term) =
       val (carrier, encoded, alreadyOption) = value.tpe.widen.dealias match
+        // A `tuple<…>` (or a record, whose ABI it shares) argument with a matching Scala tuple:
+        // element-wise recursion, constructed as the scala-wasm `TupleN` of the element carriers —
+        // the mirror of the decode path. `WitCase` payloads and nested `option<T>`/`result` elements
+        // are handled by the per-element recursion into `encodedArgument`.
+        case valueType
+        if parameterTuple(parameter).let { es => isTuple(valueType, es.length) }.or(false) =>
+          val elements = parameterTuple(parameter).vouch
+
+          // Explicit loop, not a mapping lambda: minted quote capabilities must not leak into a
+          // closure's capture set (macro-under-cc precedent, rep/DECISIONS.md).
+          val encodedBuffer = List.newBuilder[(TypeRepr, Term)]
+          val indexed = elements.iterator.zipWithIndex
+
+          while indexed.hasNext do
+            val (element, index) = indexed.next()
+            val field = Select.unique(value, "_" + (index + 1).toString)
+            encodedBuffer += encodedArgument(field, element)
+
+          val encodedElements = encodedBuffer.result()
+          val carriers = encodedElements.map(_(0))
+          val tupleClass = Symbol.requiredClass("scala.scalajs.wit.Tuple" + elements.length.toString)
+          val tupleCarrier = tupleClass.typeRef.appliedTo(carriers)
+
+          val constructed =
+            Apply
+              ( TypeApply
+                  ( Select.unique(Ref(tupleClass.companionModule), "apply"),
+                    carriers.map(Inferred(_)) ),
+                encodedElements.map(_(1)) )
+
+          (tupleCarrier, constructed, false)
+
         // A statically-absent argument (a bare `Unset` against an `option<T>` parameter, e.g. the
         // `option<request-options>` of `wasi:http`'s `handle`) needs no payload codec at all.
         case tpe if tpe =:= TypeRepr.of[Unset] =>

--- a/lib/xenophile/src/wasm/xenophile.WitVariant.scala
+++ b/lib/xenophile/src/wasm/xenophile.WitVariant.scala
@@ -30,23 +30,37 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package xenophile
 
-export xenophile.{Wasm, WasmInvoke, WitCase, WitError, WitHandle, WitVariant}
+import prepositional.*
 
-// Materializes a fully-applied WIT `Foreign` invocation into a real Wasm Component Model import
-// call. Must be applied directly to an inline navigation chain — e.g.
-// `Foreign["random", Wit].\`get-random-u64\`().invoke[U64]` — not to a value bound to a `val`.
-// Plain `inline` (not `transparent`): the return type is fully determined by the type argument,
-// and non-transparency defers the macro when `invoke` appears inside another `inline` definition,
-// so a library can publish an inline given whose import call only materializes at the downstream
-// (Wasm-linked) call site — where `scala.scalajs.wit.witImportCall` is on the classpath.
-extension (foreign: xenophile.Foreign)
-  inline def invoke[result]: result =
-    ${xenophile.WasmInvoke.invoke[result]('foreign)}
+// A payload-carrying case of a WIT `variant`, for passing as an argument to a WIT function — such
+// as the `ip-socket-address` (an `ipv4`/`ipv6` case wrapping a socket-address record) taken by
+// `wasi:sockets`'s `start-connect`. The phantom `Topic` records the variant type and `Case` the
+// selected case (both lower-kebab-case names, given as literal type arguments), while `Payload`
+// preserves the argument's Scala type so `invoke` can encode it; the case must be a compile-time
+// literal because the payload type differs per case, so the facade case is built with no runtime
+// dispatch. `WitCase` is the payload-less counterpart.
+//
+// Written `WitVariant["ip-socket-address", "ipv4"](payload)`: the topic and case are explicit type
+// arguments, the payload is inferred. At the downstream Wasm-link site `invoke` resolves the
+// variant's facade, selects the named case, and constructs it — building any nested record/tuple
+// payload from `payload` element-wise.
+object WitVariant:
+  transparent inline def apply[topic <: Label, name <: Label]: Applier[topic, name] =
+    Applier()
 
-// Releases a WIT resource handle, emitting its `[resource-drop]` Component Model import. Like
-// `invoke`, plain `inline` so the import materializes at the downstream (Wasm-linked) call site.
-extension (handle: xenophile.WitHandle)
-  inline def dispose(): Unit =
-    ${xenophile.WasmInvoke.dispose('handle)}
+  // The topic and case are fixed by the type arguments above; this second application infers the
+  // payload's Scala type (which a single explicit type-argument list could not do alongside them).
+  // `invoke` reads the payload type from the `WitVariant`'s type argument and the topic and case
+  // from its phantom `Topic`/`Case` members.
+  class Applier[topic <: Label, name <: Label]():
+    transparent inline def apply[payload](payload: payload)
+    :   (WitVariant[payload] of topic) { type Case = name } =
+      new WitVariant(payload).asInstanceOf[(WitVariant[payload] of topic) { type Case = name }]
+
+  given interoperable: [topic <: Label, name <: Label, payload]
+  =>  ((WitVariant[payload] of topic) { type Case = name } is Interoperable in Wit of topic) =
+    Interoperable()
+
+final class WitVariant[payload](val payload: payload) extends Topical

--- a/lib/xenophile/src/wit/xenophile.WitDialect.scala
+++ b/lib/xenophile/src/wit/xenophile.WitDialect.scala
@@ -183,11 +183,15 @@ object WitDialect extends Dialect:
     :   (Map[Text, Map[Text, Prototype]], Map[Text, Foreign.Type], List[String]) =
 
       todo match
+        // Merge, rather than overwrite: a resource or variant sharing the interface's own name
+        // (e.g. the `network` resource in `interface network`) has already recorded its module
+        // under this key, which a plain overwrite with the interface's (possibly empty) functions
+        // would discard.
         case "}" :: rest =>
-          (types.updated(name, functions), typedefs, rest)
+          (types.updated(name, types.at(name).lay(functions)(_ ++ functions)), typedefs, rest)
 
         case Nil =>
-          (types.updated(name, functions), typedefs, Nil)
+          (types.updated(name, types.at(name).lay(functions)(_ ++ functions)), typedefs, Nil)
 
         case "record" :: record :: "{" :: rest =>
           val (fields, after) = recordFields(rest, ListMap())


### PR DESCRIPTION
This adds `coaxial.wasi`, a `SocketBackend` implemented over `wasi:sockets`, so coaxial's TCP client and server API works inside a Wasm component under WASI. Landing it meant teaching xenophile's WIT `invoke` machinery to pass structured arguments across the boundary — tuples, records, and payload-carrying variants — which the `ip-socket-address` variant and its wrapped socket-address records depend on, and fixing a xenophile WIT-parser bug where a resource sharing its interface's name (such as `wasi:sockets`' `network`) had its module silently discarded.

### Structured WIT arguments in xenophile

`invoke` can now pass tuple and record arguments to WIT functions, encoding each field through its `Encodable in Wasm` instance in primary-constructor order. Payload-carrying variant cases are built with the new `WitVariant` constructor:

```scala
WitVariant["ip-socket-address", "ipv4"]((U16(port.toShort.bits), octets))
```

### `coaxial.wasi`

Importing the backend makes coaxial's socket API available in a WASI component:

```scala
import coaxial.*, coaxial.socketBackends.wasi

val exchange = summon[SocketBackend].dialTcp(endpoint, Unset, Nil)
```

The backend drives `create-tcp-socket` / `start-connect` / `pollable.block` / `finish-connect` and exposes the connection through coaxial's usual `Duplex` streaming interface. UDP and Unix-domain sockets are not part of this WASI subset and raise.

### Status

The WASI modules are compile-gated in CI, like `galilei.wasi` and `telekinesis.wasi`, and this branch is green through the full attest build. Running a fully linked component under wasmtime is blocked only by a separate scala-wasm runtime-helper gap (`scala/runtime/BoxesRunTime$` for big-tuple `equals`/`hashCode`), tracked independently of this change.