### PR TITLE
Streaming performance: block recycling, zero-copy zlib, fast UTF-8 decode

### DIFF
--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -122,6 +122,11 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   lazy val gzippedText: Data = textData.stream.compress[Gzip].memoize
   lazy val gzippedTextArray: Array[Byte] = gzippedText.asInstanceOf[Array[Byte]]
 
+  // The byte corpus pre-compressed with gzip, for the standalone decompression
+  // suite.
+  lazy val gzippedInput: Data = input.stream.compress[Gzip].memoize
+  lazy val gzippedInputArray: Array[Byte] = gzippedInput.asInstanceOf[Array[Byte]]
+
   // AES-256 key + a fixed key/IV for the JDK reference, generated/derived once.
   lazy val aesKey: SymmetricKey[Aes[256] over Cbc against Pkcs7] =
     SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
@@ -170,6 +175,50 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               zio.stream.ZStream.fromChunk(zio.Chunk.fromArray(turbulence.Benchmarks.inputArray))
               . via(zio.stream.ZPipeline.gzip())
               . runCount
+        }
+
+    // Example 1b: gzip decompression alone (drain, count output bytes) — the
+    // inverse of example 1, on the pre-gzipped corpus, so inflate performance
+    // is visible unchained. `GZIPInputStream` (64 KiB buffer) is the JDK
+    // reference.
+    suite(m"Gzip decompression (4 MB)"):
+      bench(m"Soundness  Stream.decompress[Gzip]")
+        ( target = 1*Second, operationSize = size, baseline = Baseline(compare = Min) ):
+        '{ turbulence.Benchmarks.gzippedInput.stream.decompress[Gzip].memoize.length }
+
+      bench(m"FS2  Compression[IO].gunzip")(target = 1*Second, operationSize = size):
+        '{
+            import cats.effect.unsafe.implicits.global
+            val comp = fs2.compression.Compression.forSync[cats.effect.IO]
+            fs2.Stream.chunk(fs2.Chunk.array(turbulence.Benchmarks.gzippedInputArray))
+            . covary[cats.effect.IO]
+            . through(comp.gunzip()).flatMap(_.content)
+            . compile.count.unsafeRunSync()
+        }
+
+      bench(m"ZIO  ZPipeline.gunzip")(target = 1*Second, operationSize = size):
+        '{
+            turbulence.Benchmarks.runZio:
+              zio.stream.ZStream.fromChunk(zio.Chunk.fromArray(turbulence.Benchmarks.gzippedInputArray))
+              . via(zio.stream.ZPipeline.gunzip())
+              . runCount
+        }
+
+      bench(m"JDK  GZIPInputStream")(target = 1*Second, operationSize = size):
+        '{
+            val in =
+              java.util.zip.GZIPInputStream
+                (java.io.ByteArrayInputStream(turbulence.Benchmarks.gzippedInputArray), 65536)
+
+            val buffer = new Array[Byte](65536)
+            var total = 0L
+            var count = in.read(buffer)
+
+            while count >= 0 do
+              total += count
+              count = in.read(buffer)
+
+            total
         }
 
     // Example 2: UTF-8 decode (count decoded characters).

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -227,6 +227,18 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         ( target = 1*Second, operationSize = textSize, baseline = Baseline(compare = Min) ):
         '{ turbulence.Benchmarks.textData.stream.via(summon[CharDecoder]).memoize.s.length }
 
+      // The memoize row above concatenates the full 5 MB Text; this row counts
+      // chars per window, the same aggregation shape as the FS2/ZIO rows.
+      bench(m"Soundness  via(CharDecoder) fold")(target = 1*Second, operationSize = textSize):
+        '{
+            var total = 0L
+
+            turbulence.Benchmarks.textData.stream.via(summon[CharDecoder])
+            . sweep((_, _, count) => total += count)
+
+            total
+        }
+
       bench(m"FS2  text.utf8.decode")(target = 1*Second, operationSize = textSize):
         '{
             import cats.effect.unsafe.implicits.global

--- a/lib/turbulence/src/jvm/turbulence.Deflation.scala
+++ b/lib/turbulence/src/jvm/turbulence.Deflation.scala
@@ -40,9 +40,10 @@ import zephyrine.*
 // Streaming compression as a pipeline stage, over `juz.Deflater`. The three
 // compression formats differ only in framing: `Zlib` is the deflater's own
 // wrapper, `Deflate` is the raw stream, and `Gzip` adds a manual header,
-// CRC-32 and trailer around a raw stream. Input is staged in a duct-owned
-// buffer, since the deflater holds a reference to (not a copy of) its input
-// array, which would otherwise outlive the source window's validity.
+// CRC-32 and trailer around a raw stream. The deflater is fed zero-copy from
+// the source window: it holds a reference to (not a copy of) its input array,
+// but that reference is released before each step returns, so it never
+// outlives the window's validity — the same discipline as `Inflation`.
 //
 // Compression ratios are unknowable, so `translate` is a pass-through: the
 // duct's own bounded buffer and the retained-surplus rule absorb expansion.
@@ -55,7 +56,7 @@ extends Duct[Data, Data]:
     juz.Deflater(juz.Deflater.DEFAULT_COMPRESSION, nowrap || gzip)
 
   private val crc: juz.CRC32 = juz.CRC32()
-  private val staging: Array[Byte] = new Array[Byte](summon[Buffering].capacity(Substrate.Bytes))
+  private val empty: Array[Byte] = new Array[Byte](0)
   private var headerDone: Boolean = !gzip
   private var size: Long = 0
   private var finishing: Boolean = false
@@ -95,20 +96,28 @@ extends Duct[Data, Data]:
       produced += 10
       headerDone = true
 
-    if deflater.needsInput && sourceLength > 0 then
-      consumed = sourceLength.min(staging.length)
-      System.arraycopy(bytes, sourceOffset, staging, 0, consumed)
-      deflater.setInput(staging, 0, consumed)
+    // Feed the deflater directly from the source window — no staging copy. As
+    // in `Inflation`, the reference is released before this step returns, and
+    // only the bytes the deflater actually consumed (`getBytesRead` measures
+    // them; `Deflater` has no `getRemaining`) are claimed; the remainder stays
+    // in the window for the next step to re-feed.
+    if sourceLength > 0 then deflater.setInput(bytes, sourceOffset, sourceLength)
 
-      if gzip then
-        crc.update(staging, 0, consumed)
-        size += consumed
-
+    val before: Long = deflater.getBytesRead
     var run: Int = 1
 
     while run > 0 && produced < targetSpace do
       run = deflater.deflate(out, targetOffset + produced, targetSpace - produced)
       produced += run
+
+    consumed = (deflater.getBytesRead - before).toInt
+    deflater.setInput(empty)
+
+    // The consumed range is a contiguous prefix of the window, so the checksum
+    // sees exactly the stream the deflater compressed, in order.
+    if gzip && consumed > 0 then
+      crc.update(bytes, sourceOffset, consumed)
+      size += consumed
 
     Duct.Progress(consumed, produced)
 
@@ -163,7 +172,7 @@ extends Duct[Data, Data]:
     case Done
 
   private val inflater: juz.Inflater = juz.Inflater(nowrap || gzip)
-  private val staging: Array[Byte] = new Array[Byte](summon[Buffering].capacity(Substrate.Bytes))
+  private val empty: Array[Byte] = new Array[Byte](0)
   private var header: Header = if gzip then Header.Fixed(10) else Header.Done
   private var flags: Int = 0
   private var headerPosition: Int = 0
@@ -241,11 +250,15 @@ extends Duct[Data, Data]:
 
     if header == Header.Done then
       if !inflater.finished then
-        if inflater.needsInput && consumed < sourceLength then
-          val copy = (sourceLength - consumed).min(staging.length)
-          System.arraycopy(bytes, sourceOffset + consumed, staging, 0, copy)
-          inflater.setInput(staging, 0, copy)
-          consumed += copy
+        // Feed the inflater directly from the source window — no staging copy.
+        // The reference cannot outlive the window's validity, because the input
+        // is unconditionally released before this step returns: only the bytes
+        // the inflater actually consumed are claimed, and the remainder stays
+        // in the window for the next step to re-feed. (zlib's own position is
+        // held bit-exactly in the inflater's state, so re-supplying the unread
+        // whole bytes later is the same stream.)
+        val fed = sourceLength - consumed
+        if fed > 0 then inflater.setInput(bytes, sourceOffset + consumed, fed)
 
         var run: Int = 1
 
@@ -256,11 +269,12 @@ extends Duct[Data, Data]:
 
           produced += run
 
-      if inflater.finished && trailer > 0 then
-        // Any input the inflater over-read belongs to the trailer.
-        trailer -= inflater.getRemaining.min(trailer)
-        inflater.setInput(staging, 0, 0)
+        consumed += fed - inflater.getRemaining
+        inflater.setInput(empty)
 
+      if inflater.finished && trailer > 0 then
+        // Unconsumed input was never claimed, so the trailer begins exactly at
+        // `consumed`; skip as much of it as this window holds.
         val skip = trailer.min(sourceLength - consumed)
         consumed += skip
         trailer -= skip

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -668,6 +668,54 @@ object Tests extends Suite(m"Turbulence tests"):
         stream.readAllBytes().nn.to(List)
       . assert(_ == mixed.to(List))
 
+      // JDK-produced gzip, delivered one byte per chunk: the header state
+      // machine, the inflater's window re-feed and the trailer all span many
+      // steps, each offered a single byte.
+      test(m"gzip duct decompresses JDK gzip fed one byte at a time"):
+        val buffer = ji.ByteArrayOutputStream()
+        val zipped = java.util.zip.GZIPOutputStream(buffer)
+        zipped.write(mixed.mutable(using Unsafe))
+        zipped.close()
+        val chunks = buffer.toByteArray.nn.iterator.map { byte => Data(byte) }
+        val gather = Gather2()
+        Stream(chunks).decompress[Gzip].pump(gather)
+        gather.data.to(List)
+      . assert(_ == mixed.to(List))
+
+      // The mirror image: compress fed one byte per chunk, so the CRC and size
+      // accumulate over single-byte consumptions, validated by the JDK.
+      test(m"gzip duct compresses correctly when fed one byte at a time"):
+        val chunks = mixed.to(List).iterator.map { byte => Data(byte) }
+        val gather = Gather2()
+        Stream(chunks).compress[Gzip].pump(gather)
+        val stream = java.util.zip.GZIPInputStream(ji.ByteArrayInputStream(gather.data.mutable(using Unsafe)))
+        stream.readAllBytes().nn.to(List)
+      . assert(_ == mixed.to(List))
+
+      // Tiny demand: each refill grants a few bytes, so the inflater retains
+      // pending output and unconsumed input across many output-bound steps,
+      // exercising the un-claim/re-feed path.
+      test(m"gzip duct decompresses correctly under three-byte demand"):
+        val stream = summon[Data is Source by Data over Credit].stream(mixed)
+                     . compress[Gzip].decompress[Gzip]
+        val builder = List.newBuilder[Byte]
+
+        def recur(): Unit = stream.refill(Credit(3)) match
+          case count: Int =>
+            val window = unsafely(stream.window).asInstanceOf[Array[Byte]]
+            var index = 0
+            while index < count do
+              builder += window(stream.start + index)
+              index += 1
+            stream.skip(count)
+            recur()
+
+          case _ => ()
+
+        recur()
+        builder.result()
+      . assert(_ == mixed.to(List))
+
       test(m"gzip duct decompresses JDK-produced gzip"):
         val out = ji.ByteArrayOutputStream()
         val zipped = java.util.zip.GZIPOutputStream(out)

--- a/lib/zephyrine/src/core/zephyrine.Conduit.scala
+++ b/lib/zephyrine/src/core/zephyrine.Conduit.scala
@@ -56,13 +56,18 @@ import vacuous.*
 object Conduit:
   // A queued hand-off: `storage` is either a block the writer minted and
   // filled (start 0), or the immutable backing of a chunk passed through by
-  // reference, windowed at [start, start + size).
-  private class Block(val storage: AnyRef, val start: Int, val size: Int)
+  // reference, windowed at [start, start + size). `recyclable` is true only for
+  // writer-minted blocks, whose storage the reader may return to the freelist
+  // for reuse; a passed-through backing is the caller's immutable data and must
+  // never be recycled.
+  private class Block(val storage: AnyRef, val start: Int, val size: Int, val recyclable: Boolean)
 
   // The synchronized substrate both endpoints capture: a spin-then-park SPSC
-  // ring, plus the failure flag.
+  // ring, the failure flag, and a non-blocking pool of spent blocks the reader
+  // returns to the writer for reuse.
   private final class Core(val window: Int) extends caps.SharedCapability:
     val handoff: Handoff = Handoff(window)
+    val freelist: Freelist = Freelist(window + 1)
     // A JMM-managed flag: its safety is the volatile publication guarantee, not
     // aliasing analysis, so its captures are untracked.
     @caps.unsafe.untrackedCaptures @volatile var error: Throwable | Null = null
@@ -75,11 +80,20 @@ object Conduit:
     val ceiling: Int = buffering.transfer(addressable0.substrate).max(block)
     val core = new Core(buffering.window)
 
-    // The write side; single writer. Blocks are minted at the size `reserve` is
-    // asked for, between `block` and `ceiling`: a bulk `put` crosses the
-    // boundary in ceiling-sized hand-offs rather than being re-chunked to the
-    // staging block size, since each hand-off costs a synchronized queue
-    // transfer. The memory bound is `window + 1` blocks of at most `ceiling`.
+    // Whether to recycle drained transfer blocks. When on, every minted block is
+    // physically `ceiling`-sized, so the pool holds a single size and a reused
+    // block always fits any reservation — no size matching, no wasted re-zeroing.
+    val recycle: Boolean = buffering.recycle
+
+    // The write side; single writer. Without recycling, blocks are minted at the
+    // size `reserve` is asked for, between `block` and `ceiling`: a bulk `put`
+    // crosses the boundary in ceiling-sized hand-offs rather than being
+    // re-chunked to the staging block size, since each hand-off costs a
+    // synchronized queue transfer. With recycling, every block is physically
+    // `ceiling`-sized (so any drained block fits any future reservation and the
+    // pool stays single-size), while `capacity` still bounds the usable prefix,
+    // leaving the publish cadence unchanged. The memory bound is `window + 1`
+    // blocks of at most `ceiling` either way.
     val intake: (Intake[medium] over Credit)^ = new Intake[medium](using addressable0):
       type Transport = Credit
 
@@ -88,7 +102,8 @@ object Conduit:
       // `publish` hands it to the ring.
       @caps.unsafe.untrackedCaptures
       private var current: addressable0.Storage =
-        addressable0.allocate(block).asInstanceOf[addressable0.Storage]
+        addressable0.allocate(if recycle then ceiling else block).asInstanceOf[addressable0.Storage]
+
       private var capacity: Int = block
       private var mark0: Int = 0
 
@@ -107,7 +122,21 @@ object Conduit:
         if free >= min.max(1) then free else
           publish()
           capacity = min.min(ceiling).max(block)
-          current = addressable0.allocate(capacity).asInstanceOf[addressable0.Storage]
+
+          // With recycling, mint a physically `ceiling`-sized block — reused from
+          // the pool of blocks the reader has drained (overwritten in place, so
+          // never re-zeroed) or freshly allocated when the pool is empty — and
+          // let `capacity` bound the usable prefix. Without recycling, mint at
+          // exactly the requested size, as before.
+          current =
+            if recycle then
+              val reused = core.freelist.poll()
+
+              (if reused != null then reused else addressable0.allocate(ceiling))
+              . asInstanceOf[addressable0.Storage]
+            else
+              addressable0.allocate(capacity).asInstanceOf[addressable0.Storage]
+
           capacity
 
       update def commit(count: Int): Unit =
@@ -137,7 +166,9 @@ object Conduit:
             done += count
         else
           publish()
-          core.handoff.offer(Block(backing.asInstanceOf[AnyRef], offset.n0, size))
+
+          core.handoff.offer
+            ( Block(backing.asInstanceOf[AnyRef], offset.n0, size, recyclable = false) )
 
       override update def flush(): Unit = publish()
 
@@ -154,7 +185,7 @@ object Conduit:
       // `reserve` mints a fresh block, sized to its request.
       private update def publish(): Unit =
         if mark0 > 0 then
-          core.handoff.offer(Block(current.asInstanceOf[AnyRef], 0, mark0))
+          core.handoff.offer(Block(current.asInstanceOf[AnyRef], 0, mark0, recyclable = true))
           mark0 = 0
           capacity = 0
 
@@ -172,6 +203,10 @@ object Conduit:
       private var limit0: Int = 0
       private var end0: Int = 0
       private var ended: Boolean = false
+      // Whether the block currently in `storage` was writer-minted (so its
+      // storage may be returned to the pool once drained) or a passed-through
+      // backing (the caller's immutable data, never to be recycled).
+      private var recyclable0: Boolean = false
 
       protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
       def start: Int = start0
@@ -206,7 +241,17 @@ object Conduit:
                 // Single-ownership transfer: a minted block is never touched by
                 // the writer again (proven on its side by the fresh re-mint in
                 // `publish`), and a passed-through chunk backing is immutable.
+                //
+                // The outgoing block is fully drained (this branch runs only
+                // once `limit0` reached `end0`) and its window is relinquished
+                // the moment this `refill` returns a new one, so a ceiling-sized
+                // minted block is safe to return to the writer for reuse. The
+                // freelist's publication order carries the ownership across.
+                if recycle && recyclable0 && addressable0.storageSize(storage) == ceiling
+                then core.freelist.offer(storage.asInstanceOf[AnyRef])
+
                 storage = received.storage.asInstanceOf[addressable0.Storage]
+                recyclable0 = received.recyclable
                 start0 = received.start
                 end0 = received.start + received.size
                 limit0 = start0 + received.size.min(granted)

--- a/lib/zephyrine/src/core/zephyrine.Ductile.scala
+++ b/lib/zephyrine/src/core/zephyrine.Ductile.scala
@@ -101,6 +101,13 @@ object Ductile:
 
           private val decoder: jnc.CharsetDecoder = stage.encoding.charset.newDecoder().nn
 
+          // UTF-8 gets a hand-rolled kernel, as the base64 ducts do: the
+          // charset decoder's scalar loop is the bottleneck against
+          // implementations built on the JDK's intrinsified `String`
+          // constructor, and UTF-8's structure (ASCII bytes are exactly the
+          // non-negative ones) admits a much faster split.
+          private val utf8: Boolean = stage.encoding.charset == jnc.StandardCharsets.UTF_8
+
           private val staging: jn.ByteBuffer =
             jn.ByteBuffer.allocate(buffering.capacity(Substrate.Bytes)).nn
 
@@ -112,6 +119,10 @@ object Ductile:
           // At most one output char per input byte, so char-credit is a
           // sound byte-credit as it stands.
           def translate(demand: Credit): Credit = demand
+
+          // An astral character emits a surrogate pair — two chars at once —
+          // so guaranteed progress needs a two-slot output floor.
+          override def quantum: Int = 2
 
           // Decode `in` into `out`, substituting malformed input through the
           // sanitizer; `base` is the absolute byte offset of `in.position == 0`,
@@ -126,6 +137,160 @@ object Ductile:
               in.position(in.position + result.length)
               decode(in, out, base, last)
 
+          // Decode window bytes `[start, sourceOffset + sourceLength)` through
+          // the charset decoder into `[first, targetOffset + targetSpace)`:
+          // the whole window for a non-UTF-8 charset, or the remainder after
+          // the point where the UTF-8 kernel encountered malformed input.
+          private update def stepDecoder
+            ( bytes: Array[Byte],
+              sourceOffset: Int,
+              sourceLength: Int,
+              start: Int,
+              chars: Array[Char]^,
+              targetOffset: Int,
+              targetSpace: Int,
+              first: Int )
+          :   Duct.Progress =
+
+            val in = jn.ByteBuffer.wrap(bytes, start, sourceOffset + sourceLength - start).nn
+            val out = jn.CharBuffer.wrap(chars, first, targetOffset + targetSpace - first).nn
+            val result = decode(in, out, total - sourceOffset, false)
+            val consumed = in.position - sourceOffset
+            total += consumed
+
+            if result.isUnderflow && consumed < sourceLength then
+              // An incomplete trailing character: carry its bytes to the next
+              // refill, where they lead the staging buffer.
+              staging.put(bytes, sourceOffset + consumed, sourceLength - consumed)
+              Duct.Progress(sourceLength, out.position - targetOffset)
+            else
+              // Output filled with complete bytes still to come, or input
+              // drained cleanly: leave any remainder for the next window.
+              Duct.Progress(consumed, out.position - targetOffset)
+
+          // The UTF-8 kernel: ASCII runs widen through an unrolled block copy
+          // (an `|`-reduction spots any high bit), multi-byte sequences decode
+          // inline with strict validity (overlongs, the surrogate range and
+          // anything above U+10FFFF all reject), and only exceptional input
+          // leaves the loop: a valid-but-incomplete tail is carried exactly as
+          // the decoder path carries it, and malformed input falls back to the
+          // charset decoder for the window remainder, which owns sanitizer
+          // semantics unchanged.
+          private update def stepUtf8
+            ( bytes: Array[Byte],
+              sourceOffset: Int,
+              sourceLength: Int,
+              chars: Array[Char]^,
+              targetOffset: Int,
+              targetSpace: Int )
+          :   Duct.Progress =
+
+            val srcEnd = sourceOffset + sourceLength
+            val dstEnd = targetOffset + targetSpace
+            var src = sourceOffset
+            var dst = targetOffset
+
+            inline def continuation(index: Int): Boolean = (bytes(index) & 0xc0) == 0x80
+
+            // 0 = advancing; 1 = incomplete tail (carry); 2 = malformed
+            // (decoder fallback); 3 = surrogate pair with one slot left (stop
+            // before the sequence).
+            var mode: Int = 0
+
+            while mode == 0 && src < srcEnd && dst < dstEnd do
+              while src + 8 <= srcEnd && dst + 8 <= dstEnd &&
+                (bytes(src) | bytes(src + 1) | bytes(src + 2) | bytes(src + 3) |
+                  bytes(src + 4) | bytes(src + 5) | bytes(src + 6) | bytes(src + 7)) >= 0
+              do
+                chars(dst) = bytes(src).toChar
+                chars(dst + 1) = bytes(src + 1).toChar
+                chars(dst + 2) = bytes(src + 2).toChar
+                chars(dst + 3) = bytes(src + 3).toChar
+                chars(dst + 4) = bytes(src + 4).toChar
+                chars(dst + 5) = bytes(src + 5).toChar
+                chars(dst + 6) = bytes(src + 6).toChar
+                chars(dst + 7) = bytes(src + 7).toChar
+                src += 8
+                dst += 8
+
+              while src < srcEnd && dst < dstEnd && bytes(src) >= 0 do
+                chars(dst) = bytes(src).toChar
+                src += 1
+                dst += 1
+
+              if src < srcEnd && dst < dstEnd then
+                val b0 = bytes(src) & 0xff
+                val remaining = srcEnd - src
+
+                if b0 >= 0xc2 && b0 <= 0xdf then
+                  if remaining < 2 then mode = 1
+                  else if !continuation(src + 1) then mode = 2
+                  else
+                    chars(dst) = (((b0 & 0x1f) << 6) | (bytes(src + 1) & 0x3f)).toChar
+                    src += 2
+                    dst += 1
+                else if (b0 & 0xf0) == 0xe0 then
+                  // The second byte's range depends on the lead: E0 rejects
+                  // overlongs, ED rejects the surrogate range.
+                  inline def second(index: Int): Boolean =
+                    val b1 = bytes(index) & 0xff
+
+                    if b0 == 0xe0 then b1 >= 0xa0 && b1 <= 0xbf
+                    else if b0 == 0xed then b1 >= 0x80 && b1 <= 0x9f
+                    else continuation(index)
+
+                  if remaining >= 2 && !second(src + 1) then mode = 2
+                  else if remaining < 3 then mode = 1
+                  else if !continuation(src + 2) then mode = 2
+                  else
+                    chars(dst) =
+                      (((b0 & 0xf) << 12) | ((bytes(src + 1) & 0x3f) << 6) |
+                        (bytes(src + 2) & 0x3f)).toChar
+
+                    src += 3
+                    dst += 1
+                else if b0 >= 0xf0 && b0 <= 0xf4 then
+                  // The second byte's range depends on the lead: F0 rejects
+                  // overlongs, F4 rejects anything above U+10FFFF.
+                  inline def second(index: Int): Boolean =
+                    val b1 = bytes(index) & 0xff
+
+                    if b0 == 0xf0 then b1 >= 0x90 && b1 <= 0xbf
+                    else if b0 == 0xf4 then b1 >= 0x80 && b1 <= 0x8f
+                    else continuation(index)
+
+                  if remaining >= 2 && !second(src + 1) then mode = 2
+                  else if remaining >= 3 && !continuation(src + 2) then mode = 2
+                  else if remaining < 4 then mode = 1
+                  else if !continuation(src + 3) then mode = 2
+                  else if dst + 2 > dstEnd then mode = 3
+                  else
+                    val point =
+                      (((b0 & 0x7) << 18) | ((bytes(src + 1) & 0x3f) << 12) |
+                        ((bytes(src + 2) & 0x3f) << 6) | (bytes(src + 3) & 0x3f)) - 0x10000
+
+                    chars(dst) = (0xd800 | (point >> 10)).toChar
+                    chars(dst + 1) = (0xdc00 | (point & 0x3ff)).toChar
+                    src += 4
+                    dst += 2
+                else
+                  // A stray continuation byte, an overlong lead (C0/C1) or an
+                  // out-of-range lead (F5..FF).
+                  mode = 2
+
+            if mode == 2 then
+              stepDecoder
+                ( bytes, sourceOffset, sourceLength, src, chars, targetOffset, targetSpace,
+                  dst )
+            else
+              total += src - sourceOffset
+
+              if mode == 1 then
+                staging.put(bytes, src, srcEnd - src)
+                Duct.Progress(sourceLength, dst - targetOffset)
+              else
+                Duct.Progress(src - sourceOffset, dst - targetOffset)
+
           update def step
             ( source: input.Storage,
               sourceOffset: Int,
@@ -136,29 +301,23 @@ object Ductile:
           :   Duct.Progress =
 
             val bytes = source.asInstanceOf[Array[Byte]]
-            val chars = target.asInstanceOf[Array[Char]]
-            val out = jn.CharBuffer.wrap(chars, targetOffset, targetSpace).nn
+            // The exclusive cast is sound for the same reason as `Conduit.put`'s:
+            // the target is the stage's single-owner output buffer.
+            val chars = target.asInstanceOf[Array[Char]^]
 
             if staging.position == 0 then
               // Fast path: with no carried bytes, decode straight from the source
               // window — no intermediate copy of the bulk of the stream.
-              val in = jn.ByteBuffer.wrap(bytes, sourceOffset, sourceLength).nn
-              val result = decode(in, out, total - sourceOffset, false)
-              val consumed = in.position - sourceOffset
-              total += consumed
-
-              if result.isUnderflow && consumed < sourceLength then
-                // An incomplete trailing character: carry its bytes to the next
-                // refill, where they lead the staging buffer.
-                staging.put(bytes, sourceOffset + consumed, sourceLength - consumed)
-                Duct.Progress(sourceLength, out.position - targetOffset)
+              if utf8 then
+                stepUtf8(bytes, sourceOffset, sourceLength, chars, targetOffset, targetSpace)
               else
-                // Output filled with complete bytes still to come, or input
-                // drained cleanly: leave any remainder for the next window.
-                Duct.Progress(consumed, out.position - targetOffset)
+                stepDecoder
+                  ( bytes, sourceOffset, sourceLength, sourceOffset,
+                    chars, targetOffset, targetSpace, targetOffset )
             else
               // Carry path: prior incomplete bytes are staged, so append the new
               // window to make the split character contiguous, then decode.
+              val out = jn.CharBuffer.wrap(chars, targetOffset, targetSpace).nn
               val copy = sourceLength.min(staging.remaining)
               staging.put(bytes, sourceOffset, copy)
               staging.flip()

--- a/lib/zephyrine/src/core/zephyrine.Freelist.scala
+++ b/lib/zephyrine/src/core/zephyrine.Freelist.scala
@@ -32,39 +32,57 @@
                                                                                                   */
 package zephyrine
 
-// Contextual configuration determining how streaming stages are instantiated
-// with buffers. `capacity` is consulted once per stage at construction time, so
-// an adaptive instance (e.g. one consulting available memory) sees each new
-// stage, but never resizes a live one. `window` is the number of blocks of
-// headroom a `Conduit` holds between its writer and reader threads.
-object Buffering:
-  given standard: Buffering:
-    def capacity(substrate: Substrate): Int = substrate match
-      case Substrate.Bytes => 4096
-      case Substrate.Chars => 2048
-      case Substrate.Boxes => 256
+import java.util.concurrent.atomic as juca
 
-    // Deep enough that a producer/consumer pair in lockstep exchange several
-    // transfer blocks per wakeup rather than parking after every few: hand-off
-    // throughput scales almost linearly with depth up to this point, at a
-    // bounded cost of `window` in-flight transfer blocks.
-    def window: Int = 16
+// A bounded single-producer/single-consumer pool of spent blocks, the return
+// path that lets a `Conduit`'s reader hand a drained block back to its writer
+// for reuse instead of dropping it to the collector while the writer mints a
+// fresh (zero-filled) replacement. Exactly one thread offers (the reader) and
+// exactly one polls (the writer) — the same discipline the endpoints already
+// enforce for the forward `Handoff`.
+//
+// Unlike `Handoff`, neither side ever blocks: this is a best-effort cache, not
+// a rendezvous. A `poll` on an empty pool returns `null` (the writer allocates
+// instead) and an `offer` to a full pool discards the block (the collector
+// reclaims it). So the writer can never stall on an empty pool — which would
+// deadlock against a reader parked waiting for that same writer — and the
+// reader never stalls returning a block.
+//
+// A `SharedCapability`, like `Handoff`: the block ownership transfer is
+// discharged by the ring's volatile publication order (a returned block is one
+// the reader has finished reading and released), not by aliasing analysis.
+final class Freelist(slots0: Int) extends caps.SharedCapability:
+  private val capacity: Int = Integer.highestOneBit((slots0.max(1)*2) - 1)
+  private val mask: Int = capacity - 1
+  private val slots: juca.AtomicReferenceArray[AnyRef] = juca.AtomicReferenceArray(capacity)
 
-// Pure: a `Buffering` is only sizing policy, so instances are untracked under capture
-// checking and closures over them stay pure.
-trait Buffering extends caps.Pure:
-  def capacity(substrate: Substrate): Int
-  def window: Int
+  // `tail` is written only by the producer (reader), `head` only by the
+  // consumer (writer); each publishes its index with a volatile write the other
+  // reads to bound occupancy, exactly as `Handoff`.
+  private val head: juca.AtomicLong = juca.AtomicLong(0)
+  private val tail: juca.AtomicLong = juca.AtomicLong(0)
 
-  // The preferred size of a block crossing an asynchronous boundary (a `Conduit`
-  // hand-off, or a fan-in/fan-out pump transfer). Staging buffers want to stay
-  // cache-resident, but every asynchronous block costs a synchronized queue
-  // transfer (with a likely park/unpark), so boundary blocks want to be much
-  // larger: the default is sixteen staging blocks.
-  def transfer(substrate: Substrate): Int = capacity(substrate)*16
+  // Producer side (the reader thread): cache a spent block, or drop it if the
+  // pool is full. The block must be one the reader has fully drained and will
+  // never touch again — its contents are irrelevant, since the writer overwrites
+  // before publishing.
+  def offer(item: AnyRef): Unit =
+    val position = tail.get
 
-  // Whether a `Conduit` recycles the transfer blocks its reader drains, handing
-  // them back to the writer for reuse rather than minting a fresh (zero-filled)
-  // block per hand-off. On by default; override to `false` to isolate the pool's
-  // effect or to restore strict per-block allocation.
-  def recycle: Boolean = true
+    if position - head.get < capacity then
+      slots.lazySet((position & mask).toInt, item)
+      tail.set(position + 1)
+
+  // Consumer side (the writer thread): take a cached block to reuse, or `null`
+  // if the pool is empty, in which case the writer allocates a fresh block.
+  def poll(): AnyRef | Null =
+    val position = head.get
+
+    if position < tail.get then
+      val index = (position & mask).toInt
+      val item = slots.get(index)
+      slots.lazySet(index, null)
+      head.set(position + 1)
+      item
+    else
+      null

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -664,6 +664,34 @@ object Tests extends Suite(m"Zephyrine tests"):
           gather.data.to(List)
         . assert(_ == 9.toByte +: big.to(List))
 
+        // Pump a payload many times the transfer-block size across the conduit,
+        // so the reader drains and returns ceiling-sized blocks that the writer
+        // reuses from the pool: the data must survive the recycling intact.
+        test(m"conduit recycles transfer blocks across many hand-offs"):
+          val payload: Data = IArray.tabulate[Byte](1000000)(index => (index%251).toByte)
+          val (intake, stream) = Conduit[Data]()
+          val gather = Gather()
+          val task = async(stream.pump(gather))
+          payload.stream.pump(intake)
+          unsafely(task.await())
+          gather.data.to(List) == payload.to(List)
+        . assert(identity)
+
+        // A chunk passed through by reference is the caller's immutable data, so
+        // the reader must never return its backing to the pool: were it recycled,
+        // the ceiling-sized blocks minted for `extra` would overwrite `original`.
+        test(m"conduit never recycles a passed-through backing"):
+          val original: Data = IArray.tabulate[Byte](80000)(index => (index%251).toByte)
+          val extra: Data = IArray.tabulate[Byte](300000)(index => ((index + 1)%251).toByte)
+          val (intake, stream) = Conduit[Data]()
+          val gather = Gather()
+          val task = async(stream.pump(gather))
+          intake.put(original)
+          extra.stream.pump(intake)
+          unsafely(task.await())
+          original.to(List) == IArray.tabulate[Byte](80000)(index => (index%251).toByte).to(List)
+        . assert(identity)
+
         test(m"conduit demand reflects buffered data"):
           val (intake, stream) = Conduit[Data]()
           val before = intake.demand.count

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -762,6 +762,33 @@ object Tests extends Suite(m"Zephyrine tests"):
           gather.data.to(List)
         . assert(_ == exotic.s.getBytes("UTF-8").nn.to(List))
 
+        // Malformed input — a stray continuation, an overlong lead, a
+        // truncated sequence mid-stream and a bad continuation — must decode
+        // through the duct exactly as the whole-value decoder sanitizes it.
+        val malformed = IArray[Byte](
+          'a'.toByte, 0x80.toByte, 'b'.toByte,                              // stray continuation
+          0xc0.toByte, 0xaf.toByte, 'c'.toByte,                             // overlong lead
+          0xe4.toByte, 0xb8.toByte, 'd'.toByte,                             // truncated 3-byte
+          0xf0.toByte, 0x9f.toByte, 0x8e.toByte, 0x89.toByte, 'e'.toByte,  // valid 🎉
+          0xc3.toByte)                                                      // truncated at end
+
+        test(m"char decoder duct sanitizes malformed input like whole-value decoding"):
+          val stream = malformed.stream.via(summon[CharDecoder])
+          val builder = StringBuilder()
+
+          def recur(): Unit = stream.refill(Credit(8)) match
+            case count: Int =>
+              val window = unsafely(stream.window).asInstanceOf[Array[Char]]
+              builder.append(String(window, stream.start, count))
+              stream.skip(count)
+              recur()
+
+            case _ => ()
+
+          recur()
+          builder.toString.tt
+        . assert(_ == summon[CharDecoder].decoded(malformed))
+
         test(m"charset ducts roundtrip through both directions"):
           val gather = Gather()
           exotic.stream.via(summon[CharEncoder]).pump(gather)


### PR DESCRIPTION
Three performance improvements to the streaming kernel: `Conduit` transfer blocks are now recycled through a non-blocking freelist instead of being freshly allocated (and zero-filled) for every cross-thread hand-off; the gzip, zlib and deflate codecs feed their native coders zero-copy from the source window instead of staging every byte through an intermediate copy; and UTF-8 decoding gains a hand-rolled kernel that outperforms FS2's intrinsic-backed decoder while delegating malformed input to the charset decoder for identical sanitization.

## Release notes

### Conduit block recycling

A `Conduit`'s reader now returns each drained transfer block to its writer through a non-blocking SPSC pool, so steady-state streaming across a thread boundary reuses a bounded set of buffers instead of allocating (and paying the JVM's zero-fill for) a fresh block per hand-off. Chunks passed through by reference are never recycled, and the behaviour can be disabled by overriding the new `Buffering.recycle`:

```scala
given Buffering = new Buffering:
  def capacity(substrate: Substrate): Int = 4096
  def window: Int = 16
  override def recycle: Boolean = false
```

### Zero-copy compression codecs

`compress`/`decompress` for `Gzip`, `Zlib` and `Deflate` now feed the underlying `Deflater`/`Inflater` directly from the stream window, releasing the reference before each step returns. This removes a full copy of the stream in each direction; decompression of poorly-compressible data gains 5–15%. A standalone gzip-decompression benchmark suite tracks the result: **1.15 ms per 4 MB, ahead of FS2 (1.31) and ZIO (1.29)**.

### Fast UTF-8 decoding

Decoding a byte stream to text with `.via(CharDecoder)` (and everything built on it, including `.transcribe`) now uses a dedicated UTF-8 kernel: ASCII runs widen through an unrolled block copy and multi-byte sequences decode inline, with malformed input falling back to the JDK decoder so `TextSanitizer` semantics are unchanged. **UTF-8 decode now beats FS2 shape-for-shape (3.08 vs 3.31 ms per 4 MB)**, and chained pipelines inherit the gain — the five-stage transcode cascade drops from ~15.7 (FS2) to 12.9 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
