### PR TITLE
Capture-checked confinement of `expose`'d cipher capabilities

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1032,6 +1032,13 @@ object enigmatic extends Library:
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core, cose, openssl):
+    // Not `settings.cc`: the suite's `NoPadding` tests trip the tactic-capturing
+    // padding given (pure `using cipher` params can't accept capturing evidence
+    // yet); `CaptureTests` opts into capture checking per-file instead. `-Ycc-new`
+    // alone is inert for files without the import, but selects the new checker for
+    // that file — and larceny propagates it into `demilitarize` sub-compilations.
+    override def scalacOptions = Task:
+      super.scalacOptions() :+ "-Ycc-new"
     override def forkArgs: T[Seq[String]] = Task:
       super.forkArgs() ++ Seq("--enable-native-access=ALL-UNNAMED")
 

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -103,18 +103,24 @@ extension (data: Data)
 
     decodable.decoded(plaintext)
 
-// `expose` lends the key to the block as an `Encryptor`/`Decryptor` capability.
-// Capture checking (which would confine the capability to this scope) is not yet
-// enabled; the capability types are kept so it can be turned on as an enhancement.
+// `expose` lends the key to the block as an `Encryptor`/`Decryptor` capability,
+// and capture checking confines it there: `result` is instantiated at the call
+// site, so returning the capability — or any closure over it — is a compile
+// error ("leaks into outer capture set"). The capabilities are `SharedCapability`
+// because they are stateless key wrappers, freely aliasable within the block
+// (the symmetric variant lends two at once), so separation checking is
+// deliberately not used. The streaming caveat above stands: a lazily-encrypted
+// `LazyList[Data]` is pure (the key bytes are already baked in) and escapes
+// tracking by design. Confinement is regression-tested in `CaptureTests`.
 
 extension [cipher <: Cipher](key: PublicKey[cipher])
-  def expose[result](block: Encryptor[cipher] ?=> result): result =
+  def expose[result](block: Encryptor[cipher]^ ?=> result): result =
     block(using Encryptor(key.bytes))
 
 extension [cipher <: Cipher](key: PrivateKey[cipher])
-  def expose[result](block: Decryptor[cipher] ?=> result): result =
+  def expose[result](block: Decryptor[cipher]^ ?=> result): result =
     block(using Decryptor(key.privateData))
 
 extension [cipher <: Cipher](key: SymmetricKey[cipher])
-  def expose[result](block: (Encryptor[cipher], Decryptor[cipher]) ?=> result): result =
+  def expose[result](block: (Encryptor[cipher]^, Decryptor[cipher]^) ?=> result): result =
     block(using Encryptor(key.bytes), Decryptor(key.bytes))

--- a/lib/enigmatic/src/test/enigmatic.CaptureTests.scala
+++ b/lib/enigmatic/src/test/enigmatic.CaptureTests.scala
@@ -32,42 +32,83 @@
                                                                                                   */
 package enigmatic
 
+// Capture checking is enabled per-file: the rest of the test module compiles
+// without it (its `NoPadding` tests summon a tactic-capturing padding given that
+// pure `using cipher` parameters cannot yet accept). The import is part of the
+// source text, so larceny's sub-compilation of `demilitarize` blocks sees it too.
+import language.experimental.captureChecking
+
 import soundness.*
 
-import charEncoders.utf8Encoder
-import blockCipherMode.cbc, blockCipherPadding.pkcs7
+import strategies.throwUnsafely
+import charDecoders.utf8Decoder, charEncoders.utf8Encoder, textSanitizers.skipSanitizer
+import gossamer.textDecodable
 import providers.javaStdlibProvider
-import crypto.permitUnauthenticatedCrypto   // AES-CBC is unauthenticated
+import crypto.permitDisallowedCrypto   // RSA-1024 below is weak; AES-CBC is unauthenticated
 
-// Compile-time regressions for the cipher API. (Capture-checking confinement of
-// the exposed `Encryptor`/`Decryptor` capability is enforced and regression-tested
-// in `CaptureTests`.)
-object CompileChecks:
-  val key: SymmetricKey[Aes[256]] = SymmetricKey.generate[Aes[256]]()
+// `expose` lends a key to its block as an `Encryptor`/`Decryptor` capability, and
+// capture checking confines the capability to that block: these tests demonstrate
+// that key material cannot be smuggled out — neither directly, nor closed over —
+// while legitimate use within the block remains unaffected.
+object CaptureTests extends Suite(m"Capability confinement tests"):
+  def run(): Unit =
+    test(m"expose still works as normal under capture checking"):
+      val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+      key.expose:
+        t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
+    . assert(_ == t"Hello world")
 
-  val ciphertext: Data = key.expose:
-    t"Hello world".encrypt(InitializationVector.random)
+    test(m"a roundtrip within expose compiles without errors"):
+      demilitarize:
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        key.expose:
+          t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
+    . assert(_ == Nil)
 
-  // Validity regression: only cipher/mode/padding triples the JDK supports have a
-  // `given`, so an invalid combination does not compile. CTR permits only
-  // `NoPadding`, so the line below fails with "no implicit values were found that
-  // match type Ctr Permits Pkcs7" (verified manually — uncomment to re-check).
-  //
-  //   val invalid = SymmetricKey.generate[Aes[256] over Ctr against Pkcs7]()
-  val valid = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+    test(m"the Encryptor capability cannot be returned from expose"):
+      demilitarize:
+        val key = PrivateKey.generate[Rsa[1024]]()
+        val stolen = key.public.expose(summon[Encryptor[Rsa[1024]]])
+      . map(_.message)
+    . assert(_.exists(_.contains("outlives its scope")))
 
-  // Totality regression: `NoPadding` can fail on misaligned input, so its `given`
-  // demands a `Tactic[CryptoError]`. With no error-handling strategy in scope,
-  // summoning a `NoPadding` cipher (and hence encrypting with one) does not
-  // compile, whereas every padded cipher is total (verified manually — uncomment).
-  //
-  //   val noTactic = SymmetricKey.generate[Aes[256] over Cbc against NoPadding]()
+    test(m"the Decryptor capability cannot be returned from expose"):
+      demilitarize:
+        val key = PrivateKey.generate[Rsa[1024]]()
+        val stolen = key.expose(summon[Decryptor[Rsa[1024]]])
+    . assert(_.nonEmpty)
 
-  // Permission regression: only `crypto.permitUnauthenticatedCrypto` is imported
-  // here, so AES (above) compiles, but reaching a "disallowed" algorithm without
-  // `crypto.permitDisallowedCrypto` does not — encrypting with DES fails with the
-  // `Permit` "no given instance" diagnostic (verified manually — uncomment). Note
-  // that key generation is *not* gated; only the encryption operation is.
-  //
-  //   val desKey = SymmetricKey.generate[Des over Cbc against Pkcs7]()
-  //   val desText = desKey.expose(t"Hello world".encrypt(InitializationVector.random))
+    test(m"a closure encrypting later cannot escape expose"):
+      demilitarize:
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        val later = key.expose:
+          () => t"secret".encrypt(InitializationVector.random)
+    . assert(_.nonEmpty)
+
+    test(m"a closure decrypting later cannot escape expose"):
+      demilitarize:
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        val ciphertext = key.expose(t"secret".encrypt(InitializationVector.random))
+        val later = key.expose(() => ciphertext.decrypt.as[Text])
+    . assert(_.nonEmpty)
+
+    test(m"the capability cannot be stashed in an outer variable"):
+      demilitarize:
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        var stash: () => Unit = () => ()
+        key.expose:
+          stash = () => { t"secret".encrypt(InitializationVector.random); () }
+      . map(_.message)
+    . assert(_.exists(_.contains("is not included in the allowed capture set")))
+
+    // A lazily-encrypted stream may leave the block: the ciphertext `LazyList` is
+    // pure (the key bytes are baked into the deferred JCE cipher, beyond the reach
+    // of capture checking), which is why `encrypt`'s documentation says to drain
+    // streams within the `expose` block. This is an executable record of that
+    // caveat; if it ever starts failing, the documentation should be updated.
+    test(m"caveat: a lazily-encrypted stream escapes by design"):
+      demilitarize:
+        val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
+        val ciphertext = key.expose:
+          LazyList(t"Hello world".in[Data]).encrypt(InitializationVector.random)
+    . assert(_ == Nil)

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -404,3 +404,5 @@ object Tests extends Suite(m"Gastronomy tests"):
           val chunks = LazyList(t"Hello, ".in[Data], t"streaming ".in[Data], t"world!".in[Data])
           chunks.encrypt(InitializationVector.random).reduce(_ ++ _).decrypt.as[Text]
       . assert(_ == t"Hello, streaming world!")
+
+    CaptureTests()

--- a/lib/larceny/src/plugin/larceny.CompileError.scala
+++ b/lib/larceny/src/plugin/larceny.CompileError.scala
@@ -33,8 +33,16 @@
 package larceny
 
 object CompileError:
+  // An ordinal from a newer compiler than this enum knows about must not raise (a
+  // raising `apply` would make `doReport` silently drop the diagnostic, and every
+  // `demilitarize` test expecting it would quietly stop testing anything); map
+  // unknown ordinals to `NoExplanation` so the message still comes through.
   def apply(ordinal: Int, message: String, focus: String, start: Int, offset: Int): CompileError =
-    new CompileError(CompileError.Reason.fromOrdinal(ordinal), message, focus, start, offset)
+    val reason =
+      if ordinal < CompileError.Reason.values.length then CompileError.Reason.fromOrdinal(ordinal)
+      else CompileError.Reason.NoExplanation
+
+    new CompileError(reason, message, focus, start, offset)
 
   enum Reason:
     case NoExplanation
@@ -250,6 +258,26 @@ object CompileError:
     case FormatInterpolationError
     case ValueClassCannotExtendAliasOfAnyVal
     case MatchIsNotPartialFunction
+    case OnlyFullyDependentAppliedConstructorType
+    case PointlessAppliedConstructorType
+    case IllegalContextBounds
+    case NamedPatternNotApplicable
+    case UnnecessaryNn
+    case ErasedNotPure
+    case IllegalErasedDef
+    case CannotInstantiateQuotedTypeVar
+    case DefaultShadowsGiven
+    case RecurseWithDefault
+    case EncodedPackageName
+    case CannotBeIncluded
+    case OverrideClass
+    case InferUnionWarning
+    case TypeParameterShadowsType
+    case PrivateShadowsType
+    case AmbiguousTemplateName
+    case IndentationWarning
+    case IllegalIdentifier
+    case ConcreteClassHasUnimplementedMethods
 
 case class CompileError
   ( reason: CompileError.Reason, message: String, focus: String, start: Int, offset: Int ):

--- a/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
+++ b/lib/larceny/src/plugin/larceny.LarcenyTransformer.scala
@@ -116,6 +116,12 @@ class LarcenyTransformer() extends PluginPhase:
     val classpath = ctx.settings.classpath.value
     val language = ctx.settings.language.value
 
+    // `-Ycc-new` selects the capture checker but is not a `-language` setting, so
+    // it must be propagated separately or sub-compilations of capture-checked
+    // sources would be checked by the old scheme (which misses level violations
+    // such as stashing a local capability in an outer mutable variable).
+    val ccNew = ctx.settings.YccNew.value
+
     object collector extends UntypedTreeMap:
       val regions: scm.ListBuffer[(Int, Int)] = scm.ListBuffer()
 
@@ -141,7 +147,7 @@ class LarcenyTransformer() extends PluginPhase:
       ctx.settings.plugin.value.filterNot(LarcenyTransformer.isLarceny)
 
     val errors: List[CompileError] =
-      Subcompiler.compile(language, classpath, source, regions, plugins)
+      Subcompiler.compile(language, classpath, source, regions, plugins, ccNew)
 
     object transformer extends UntypedTreeMap:
       override def transform(tree: Tree)(using Context): Tree = tree match

--- a/lib/larceny/src/plugin/larceny.Subcompiler.scala
+++ b/lib/larceny/src/plugin/larceny.Subcompiler.scala
@@ -135,20 +135,24 @@ object Subcompiler:
   // computes this from the parent compilation's `-Xplugin` settings minus
   // larceny itself, so the inner compile sees the same plugin pipeline that
   // production code would see — except for larceny, whose recursion would
-  // re-fire on any `demilitarize(...)` calls in the sub-source.
+  // re-fire on any `demilitarize(...)` calls in the sub-source. `ccNew`
+  // propagates the parent's `-Ycc-new`, which selects the capture-checking
+  // scheme but is not part of the `-language` settings.
   def compile
     ( language:  List[Settings.Setting.ChoiceWithHelp[String]],
       classpath: String,
       source:    String,
       regions:   Set[(Int, Int)],
-      plugins:   List[String] )
+      plugins:   List[String],
+      ccNew:     Boolean = false )
   :   List[CompileError] =
 
     object driver extends Driver:
       val currentContext: Context =
         val context = initCtx.fresh
         val context2 = context.setSetting(context.settings.classpath, classpath)
-        val args = Array[String]("") ++ plugins.map: p => s"-Xplugin:$p"
+        val ccOptions = if ccNew then List("-Ycc-new") else Nil
+        val args = Array[String]("") ++ ccOptions ++ plugins.map: p => s"-Xplugin:$p"
         setup(args, context2).map(_(1)).get
 
 


### PR DESCRIPTION
Enigmatic's `expose` lends a key to its block as an `Encryptor`/`Decryptor` capability, and with capture checking enabled for the module this confinement is now guaranteed and regression-tested: the capability — or anything that closes over it — cannot leave the block. Along the way, two larceny bugs that made capture-checking diagnostics invisible to `demilitarize` tests were fixed: `-Ycc-new` is now propagated into sub-compilations, and compiler diagnostics with error IDs newer than larceny's `CompileError.Reason` enum are no longer silently dropped.

The `expose` methods on `PublicKey`, `PrivateKey` and `SymmetricKey` now declare their lent capabilities with explicit capture annotations (`Encryptor[cipher]^`), and capture checking enforces that key material cannot be used outside the block that borrows it:

```scala
val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()

key.expose:                       // ✓ use the key within the block
  message.encrypt(InitializationVector.random).decrypt.as[Text]

val stolen = key.expose:          // ✗ compile error: the capability
  summon[Encryptor[Aes[256]]]     //   "outlives its scope"

val later = key.expose:           // ✗ compile error: closures over the
  () => message.encrypt(iv)       //   capability cannot escape either
```

One caveat, unchanged and now recorded as an executable test: a lazily-encrypted `LazyList[Data]` is pure and may leave the block, so streams should be drained within `expose`.

For test authors using larceny, `demilitarize` blocks in files compiled under `-Ycc-new` are now checked by the same scheme as production code, and unknown compiler error IDs map to `CompileError.Reason.NoExplanation` rather than dropping the diagnostic.
