### PR TITLE
Stress tests: memory/scaling measurement type for Probably reports

### DIFF
--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -75,7 +75,7 @@ object Report:
   given detail: Inclusion[Report, Verdict.Detail] = _.addDetail(_, _)
 
   enum Status:
-    case Pass, Fail, Throws, CheckThrows, Mixed, Suite, Bench, AspirePass, AspireFail
+    case Pass, Fail, Throws, CheckThrows, Mixed, Suite, Bench, Stress, AspirePass, AspireFail
 
     private val nbsp = '\u00a0'
 
@@ -87,6 +87,7 @@ object Report:
       case Mixed       => e"${Bg(palette.mixed)}($Bold(${Fg(palette.black)}( ? )))"
       case Suite       => e"   "
       case Bench       => e"${Bg(palette.benchmark)}($Bold(${Fg(palette.black)}($nbsp*$nbsp)))"
+      case Stress      => e"${Bg(palette.benchmark)}($Bold(${Fg(palette.black)}($nbsp≈$nbsp)))"
       case AspirePass  => e"${Bg(palette.aspirePass)}($Bold(${Fg(palette.black)}( ↑ )))"
       case AspireFail  => e"${Bg(palette.aspireFail)}($Bold(${Fg(palette.black)}( ↓ )))"
 
@@ -98,6 +99,7 @@ object Report:
       case Mixed       => e"Mixed"
       case Suite       => e"Suite"
       case Bench       => e"Benchmark"
+      case Stress      => e"Stress"
       case AspirePass  => e"Aspire passed"
       case AspireFail  => e"Aspire failed"
 
@@ -142,6 +144,7 @@ final class Report(using Environment)(using palette: TestPalette):
     case Suite(suite: Optional[Testable], tests: TestsMap = TestsMap())
     case Test(test: TestId, verdicts: scm.ArrayBuffer[Verdict] = scm.ArrayBuffer())
     case Bench(test: TestId, benchmark: Benchmark)
+    case Strain(test: TestId, strain: probably.Strain)
 
     def summaries: List[Summary] = this match
       case Suite(suite, tests) =>
@@ -152,6 +155,9 @@ final class Report(using Environment)(using palette: TestPalette):
 
       case Bench(testId, bench@Benchmark(_, _, _, _, _, _, _, _, _, _, _)) =>
         List(Summary(Status.Bench, testId, 0, 0, 0, 0))
+
+      case Strain(testId, _) =>
+        List(Summary(Status.Stress, testId, 0, 0, 0, 0))
 
       case Test(testId, buffer) =>
         val status =
@@ -185,6 +191,10 @@ final class Report(using Environment)(using palette: TestPalette):
     val benchmarks = resolve(testId.suite).tests
     benchmarks.getOrElseUpdate(testId, ReportLine.Bench(testId, benchmark))
 
+  def addStrain(testId: TestId, strain: probably.Strain): Report = this.also:
+    val strains = resolve(testId.suite).tests
+    strains.getOrElseUpdate(testId, ReportLine.Strain(testId, strain))
+
   def addVerdict(testId: TestId, verdict: Verdict): Report = this.also:
     val tests = resolve(testId.suite).tests
 
@@ -199,6 +209,11 @@ final class Report(using Environment)(using palette: TestPalette):
     case ReportLine.Suite(_, tests)   => tests.list.flatMap: (_, line) => benches(line)
     case _                            => Nil
 
+  private def strains(line: ReportLine): Iterable[ReportLine.Strain] = line match
+    case strain@ReportLine.Strain(_, _) => Iterable(strain)
+    case ReportLine.Suite(_, tests)     => tests.list.flatMap: (_, line) => strains(line)
+    case _                              => Nil
+
   val unitsSeq: List[Teletype] =
     List(e"${Fg(palette.cold)}(µs)", e"${Fg(palette.warm)}(ms)", e"${Fg(palette.hot)}(s) ")
 
@@ -207,6 +222,18 @@ final class Report(using Environment)(using palette: TestPalette):
 
     case unit :: rest =>
       if n > 100000L then showTime(n/1000L, rest) else
+        val sig = (n/1000L).show
+        val frac = (n%1000).show.pad(3, Rtl, '0')
+        e"${Fg(palette.foreground)}(${sig}.$frac) ${unit}"
+
+  val memoryUnitsSeq: List[Teletype] =
+    List(e"${Fg(palette.cold)}(kB)", e"${Fg(palette.warm)}(MB)", e"${Fg(palette.hot)}(GB)")
+
+  def showMemory(n: Long, units: List[Teletype] = memoryUnitsSeq): Teletype = units match
+    case Nil => n.show.teletype
+
+    case unit :: rest =>
+      if n > 100000L then showMemory(n/1000L, rest) else
         val sig = (n/1000L).show
         val frac = (n%1000).show.pad(3, Rtl, '0')
         e"${Fg(palette.foreground)}(${sig}.$frac) ${unit}"
@@ -235,7 +262,10 @@ final class Report(using Environment)(using palette: TestPalette):
     val columns: Int = safely(Environment.columns.as[Int]).or(120)
     val summaryLines = lines.summaries
     val totals = summaryLines.groupBy(_.status).view.mapValues(_.size).to(Map) - Status.Suite
-    val passed: Int = totals.getOrElse(Status.Pass, 0) + totals.getOrElse(Status.Bench, 0)
+    val passed: Int =
+      totals.getOrElse(Status.Pass, 0)
+      + totals.getOrElse(Status.Bench, 0)
+      + totals.getOrElse(Status.Stress, 0)
     val aspirePassed: Int = totals.getOrElse(Status.AspirePass, 0)
     val aspireFailed: Int = totals.getOrElse(Status.AspireFail, 0)
     val total: Int = totals.values.sum
@@ -258,6 +288,7 @@ final class Report(using Environment)(using palette: TestPalette):
       case Status.Mixed       => t"mixed"
       case Status.Suite       => t"suite"
       case Status.Bench       => t"bench"
+      case Status.Stress      => t"stress"
       case Status.AspirePass  => t"aspire-pass"
       case Status.AspireFail  => t"aspire-fail"
 
@@ -289,6 +320,38 @@ final class Report(using Environment)(using palette: TestPalette):
             if tp == 0 then e"" else e"$tp op/s" )
 
       . tabulate(benchmarks.sortBy(_.test.timestamp)).grid(columns).render
+      . each(Out.println(_))
+
+    val strainBySuite = strains(lines).to(List).groupBy(_.test.suite).to(List)
+      . sortBy(_(1).iterator.map(_.test.timestamp).min)
+
+    strainBySuite.each: (suite, rows) =>
+      val suiteName = suite.let(_.name.text).or(t"")
+      Out.println(t"")
+      if suiteName.length > 0 then Out.println(suiteName)
+
+      Scaffold[ReportLine.Strain]
+        ( Column(e"Hash"): s =>
+            e"${s.test.id}",
+          Column(e"Stress"): s =>
+            e"${s.test.name}",
+          Column(e"N", textAlign = TextAlignment.Right): s =>
+            e"${s.strain.concurrency}",
+          Column(e"Ops", textAlign = TextAlignment.Right): s =>
+            e"${s.strain.operations}",
+          Column(e"Throughput", textAlign = TextAlignment.Right): s =>
+            val tp = s.strain.throughput
+            if tp == 0 then e"" else e"$tp op/s",
+          Column(e"Alloc/op", textAlign = TextAlignment.Right): s =>
+            showMemory(s.strain.allocationRate.toLong),
+          Column(e"Peak", textAlign = TextAlignment.Right): s =>
+            showMemory(s.strain.peakHeap),
+          Column(e"Retained", textAlign = TextAlignment.Right): s =>
+            showMemory(s.strain.retained),
+          Column(e"GC", textAlign = TextAlignment.Right): s =>
+            e"${s.strain.gcCount}" )
+
+      . tabulate(rows.sortBy(_.test.timestamp)).grid(columns).render
       . each(Out.println(_))
 
     val failureStatuses: Set[Status] =
@@ -494,7 +557,10 @@ final class Report(using Environment)(using palette: TestPalette):
     def totals(tabulation: Boolean): Unit =
       if summaryLines.exists(_.count > 0) then
         val totals = summaryLines.groupBy(_.status).view.mapValues(_.size).to(Map) - Status.Suite
-        val passed: Int = totals.getOrElse(Status.Pass, 0) + totals.getOrElse(Status.Bench, 0)
+        val passed: Int =
+          totals.getOrElse(Status.Pass, 0)
+          + totals.getOrElse(Status.Bench, 0)
+          + totals.getOrElse(Status.Stress, 0)
         val aspirePassed: Int = totals.getOrElse(Status.AspirePass, 0)
         val aspireFailed: Int = totals.getOrElse(Status.AspireFail, 0)
         val total: Int = totals.values.sum
@@ -569,7 +635,7 @@ final class Report(using Environment)(using palette: TestPalette):
         import Status.*
 
         val allStatuses =
-          List(Pass, Bench, AspirePass, Throws, Fail, AspireFail, Mixed, CheckThrows)
+          List(Pass, Bench, Stress, AspirePass, Throws, Fail, AspireFail, Mixed, CheckThrows)
 
         // Printed with index loops rather than `grouped(_).each`/`map` closures: a lambda whose
         // parameter is a `List` and whose body uses the `Stdio` capability leaks the list's reach
@@ -692,6 +758,87 @@ final class Report(using Environment)(using palette: TestPalette):
       )
 
       bench.tabulate(benchmarks.to(List).sortBy(-_.benchmark.throughput))
+      . grid(columns).render.each(Out.println(_))
+
+      if githubActions then GithubActions.endGroup()
+
+    strains(lines).groupBy(_.test.suite).each: (suite, rows) =>
+      val ribbon =
+        Ribbon
+          ( palette.subdue(palette.detail, 0.3),
+            palette.subdue(palette.detail, 0.6),
+            palette.subdue(palette.detail, 0.9) )
+
+      val suiteName = suite.let(_.name.teletype).or(e"")
+
+      if githubActions then
+        GithubActions.group(t"Stress: ${suite.let(_.name.text).or(t"")}")
+
+      Out.println:
+        ribbon.fill(e"${suite.lay(t"")(_.id.id)}", e"Stress", suiteName)
+
+      val comparisons: List[ReportLine.Strain] =
+        rows.filter(!_.strain.baseline.absent).to(List)
+
+      def frequency(strain: probably.Strain): Teletype =
+        if strain.throughput == 0 then e""
+        else
+          val tp = e"${Fg(palette.foreground)}(${strain.throughput})"
+          e"$tp ${Fg(palette.accented)}(op${Fg(palette.subdued)}(·)s¯¹)"
+
+      val strain: Scaffold[ReportLine.Strain, Teletype] = Scaffold[ReportLine.Strain](
+        (List(
+          Column(e"$Bold(Hash)"): s =>
+            e"${Fg(palette.informative)}(${s.test.id})",
+          Column(e"$Bold(Test)"): s =>
+            e"${s.test.name}",
+          Column(e"$Bold(N)", textAlign = TextAlignment.Right): s =>
+            s.strain.concurrency,
+          Column(e"$Bold(Ops)", textAlign = TextAlignment.Right): s =>
+            s.strain.operations,
+          Column(e"$Bold(Throughput)", textAlign = TextAlignment.Right): s =>
+            frequency(s.strain),
+          Column(e"$Bold(Alloc·op¯¹)", textAlign = TextAlignment.Right): s =>
+            showMemory(s.strain.allocationRate.toLong),
+          Column(e"$Bold(Peak)", textAlign = TextAlignment.Right): s =>
+            showMemory(s.strain.peakHeap),
+          Column(e"$Bold(Retained)", textAlign = TextAlignment.Right): s =>
+            showMemory(s.strain.retained),
+          Column(e"$Bold(GC n)", textAlign = TextAlignment.Right): s =>
+            s.strain.gcCount,
+          Column(e"$Bold(GC t)", textAlign = TextAlignment.Right): s =>
+            showTime(s.strain.gcTime*1000000L)) :::
+          comparisons.map: comparison =>
+          import Baseline.*
+          val baseline = comparison.strain.baseline.vouch
+
+          val title = e"$Bold(${Fg(palette.informative)}(${comparison.test.id}))"
+
+          // The relative column compares allocation per operation: the `Compare`/`Metric`
+          // axes of `Baseline` describe timing distributions and don't apply to memory.
+          Column(title, textAlign = TextAlignment.Right):
+            (row: ReportLine.Strain) =>
+              val value = baseline.mode match
+                case Arithmetic =>
+                  row.strain.allocationRate - comparison.strain.allocationRate
+
+                case Geometric =>
+                  if comparison.strain.allocationRate == 0.0 then 0.0
+                  else row.strain.allocationRate/comparison.strain.allocationRate
+
+              baseline.mode match
+                case Arithmetic =>
+                  if value == 0 then e"★"
+                  else if value < 0
+                  then e"${Fg(palette.accented)}(-)${showMemory((-value).toLong)}"
+                  else e"${Fg(palette.accented)}(+)${showMemory(value.toLong)}"
+
+                case Geometric =>
+                  if value == 1 then e"★" else e"${Fg(palette.foreground)}($value)"
+        )*
+      )
+
+      strain.tabulate(rows.to(List).sortBy(_.strain.allocationRate))
       . grid(columns).render.each(Out.println(_))
 
       if githubActions then GithubActions.endGroup()

--- a/lib/probably/src/core/probably.Strain.scala
+++ b/lib/probably/src/core/probably.Strain.scala
@@ -30,17 +30,35 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package probably
 
-export
-  probably
-  . { !==, +/-, ===, Arithmetic, Autopsy, Baseline, Benchmark, Cadential, Checkable, Ci, debug,
-      Geometric, GithubActions, Harness, Inclusion, Max, Mean, Min, Report, Reporter, Runner,
-      Strain, suite, Temporal, Test, test, Testable, TestId, TestPalette, Tolerance, Trial, Verdict,
-      ± }
+import anticipation.*
+import vacuous.*
 
-package harnesses:
-  export probably.harnesses.threadLocal
+object Strain:
+  given inclusion: Inclusion[Report, Strain]:
+    def include(report: Report, testId: TestId, strain: Strain): Report =
+      report.addStrain(testId, strain)
 
-package autopsies:
-  export probably.autopsies.{contrastExpectations, none}
+// The measured response to a stress test — the memory/scaling counterpart of `Benchmark`.
+// `concurrency` workers ran a body repeatedly
+// for a fixed wall-clock window of `nanoseconds`, completing `operations` operations in total.
+// `allocation` is the total heap allocation over the window; `peakHeap` the high-water mark of
+// the heap pools; `retained` the live set remaining after a post-run GC (bounded-memory designs
+// show a flat, small value here); `gcCount`/`gcTime` are the collector deltas over the window
+// (time in milliseconds).
+case class Strain
+  ( concurrency: Int,
+    operations:  Long,
+    nanoseconds: Long,
+    allocation:  Long,
+    peakHeap:    Long,
+    retained:    Long,
+    gcCount:     Long,
+    gcTime:      Long,
+    baseline:    Optional[Baseline] ):
+
+  def throughput: Long = if nanoseconds == 0L then 0L else (operations*1e9/nanoseconds).toLong
+
+  def allocationRate: Double =
+    if operations == 0L then 0.0 else allocation.toDouble/operations

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -1,0 +1,229 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package sedentary
+
+import java.lang as jl
+
+import galilei.*
+import scala.quoted.*
+
+import ambience.*
+import anthology.*
+import anticipation.*
+import contingency.*
+import digression.*
+import fulminate.*
+import gossamer.*
+import hellenism.*
+import inimitable.*
+import jacinta.*
+import nomenclature.*
+import prepositional.*
+import probably.*
+import rudiments.*
+import serpentine.*
+import superlunary.*
+import symbolism.*
+import vacuous.*
+
+
+// A stress test: the memory/scaling counterpart of `Bench`. Where `Bench` times one operation
+// repeated serially on the calling thread, `Stress` runs the body concurrently on `concurrency`
+// platform threads for a fixed wall-clock window and measures memory behaviour over that window:
+// total allocation (hence allocation per operation), peak heap, the live set retained after a
+// post-run GC, and GC count/time. The results are reported as a `Strain` row in the report.
+case class Stress()(using Classloader, Environment)(using device: BenchmarkDevice) extends Rig:
+  type Result[output] = output
+  type Form = Text
+  type Target = Path on Linux
+  type Transport = Json
+
+
+  inline def apply[duration: Abstractable across Durations to Long, report]
+    ( name: Message )
+    ( target:      duration,
+      concurrency: Optional[Int]      = Unset,
+      baseline:    Optional[Baseline] = Unset )
+    ( body0: (References over Transport) ?=> Quotes ?=> Expr[Any] )
+    ( using System, TemporaryDirectory, Stageable over Transport in Form )
+    ( using runner:    Runner[report],
+            inclusion: Inclusion[report, Strain],
+            suite:     Testable,
+            codepoint: Codepoint )
+  :   Unit raises CompilerError raises RemoteError =
+
+    val testId = TestId(name, suite, codepoint)
+    val concurrency0: Optional[Int] = concurrency
+    val concurrency2: Int = concurrency0.or(1)
+
+    val body: (References over Transport) ?=> Quotes ?=> Expr[List[Long]] =
+      val target2: Expr[Long] = Expr(target.generic)
+      ' {
+          // Blackhole sink, exactly as in `Bench`: each body result is written here via
+          // lazySet so that the JIT cannot prove the body's value is unused and elide it. The
+          // never-true read at the end forces the AtomicReference to escape, preventing
+          // escape-analysis from scalarising the writes away.
+          val sink = new java.util.concurrent.atomic.AtomicReference[Any](null)
+
+          // Run 10 times initially as untimed, single-threaded warmup
+          var w = 0
+
+          while w < 10 do
+            sink.lazySet($body0)
+            w += 1
+
+          val pools = java.lang.management.ManagementFactory.getMemoryPoolMXBeans.nn
+          val gcs = java.lang.management.ManagementFactory.getGarbageCollectorMXBeans.nn
+          val memory = java.lang.management.ManagementFactory.getMemoryMXBean.nn
+
+          // `getTotalThreadAllocatedBytes` (JDK 21+) accumulates over terminated threads too,
+          // and virtual-thread allocation is attributed to its carrier platform thread, so
+          // bodies which spawn their own workers are still accounted for.
+          val threadMx =
+            java.lang.management.ManagementFactory.getThreadMXBean.nn
+            . asInstanceOf[com.sun.management.ThreadMXBean]
+
+          var i = 0
+
+          while i < pools.size do
+            val pool = pools.get(i).nn
+            if pool.getType == java.lang.management.MemoryType.HEAP then pool.resetPeakUsage()
+            i += 1
+
+          var gcCount = 0L
+          var gcTime = 0L
+          i = 0
+
+          while i < gcs.size do
+            val gc = gcs.get(i).nn
+            gcCount -= gc.getCollectionCount
+            gcTime -= gc.getCollectionTime
+            i += 1
+
+          val allocated0 = threadMx.getTotalThreadAllocatedBytes
+
+          val n: Int = ${Expr(concurrency2)}
+          val ops = new Array[Long](n)
+          val threads = new Array[java.lang.Thread | Null](n)
+          val t0 = jl.System.nanoTime
+          val deadline = t0 + $target2
+          var k = 0
+
+          while k < n do
+            val slot = k
+
+            val runnable: java.lang.Runnable = () =>
+              var count = 0L
+
+              while jl.System.nanoTime < deadline do
+                sink.lazySet($body0)
+                count += 1L
+
+              ops(slot) = count
+
+            val thread = new java.lang.Thread(runnable)
+            threads(k) = thread
+            thread.start()
+            k += 1
+
+          k = 0
+
+          while k < n do
+            threads(k).nn.join()
+            k += 1
+
+          val elapsed = jl.System.nanoTime - t0
+          val allocated = threadMx.getTotalThreadAllocatedBytes - allocated0
+
+          var peak = 0L
+          i = 0
+
+          while i < pools.size do
+            val pool = pools.get(i).nn
+
+            if pool.getType == java.lang.management.MemoryType.HEAP
+            then peak += pool.getPeakUsage.nn.getUsed
+
+            i += 1
+
+          i = 0
+
+          while i < gcs.size do
+            val gc = gcs.get(i).nn
+            gcCount += gc.getCollectionCount
+            gcTime += gc.getCollectionTime
+            i += 1
+
+          // Retained live set: collect, let the collector settle, then read the heap. A
+          // bounded-memory design shows a flat, small value here regardless of how much data
+          // flowed during the window.
+          sink.lazySet(null)
+          jl.System.gc()
+          java.lang.Thread.sleep(100L)
+          val retained = memory.getHeapMemoryUsage.nn.getUsed
+
+          var total = 0L
+          k = 0
+
+          while k < n do
+            total += ops(k)
+            k += 1
+
+          if jl.System.nanoTime < 0L then jl.System.err.nn.println(sink.get)
+
+          List(total, elapsed, allocated, peak, retained, gcCount, gcTime)
+        }
+
+    val results = dispatch(body)
+
+    val strain =
+      Strain
+        ( concurrency2, results(0), results(1), results(2), results(3), results(4), results(5),
+          results(6), baseline )
+
+    inclusion.include(runner.report, testId, strain)
+
+
+  def stage(out: Path on Linux): Path on Linux = unsafely:
+    val uuid = Uuid()
+    val name = t"$uuid.jar"
+    val jarfile = out.peer(name)
+    Bundler.bundle(out, jarfile, fqcn"superlunary.Executor")
+    device.deploy(jarfile, uuid)
+    jarfile
+
+  protected val scalac: Scalac[3.7] = Scalac(List(scalacOptions.experimental))
+
+  protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
+    stage.remote: input =>
+      unsafely(device.invoke(stage.target, input))

--- a/lib/sedentary/src/core/soundness_sedentary_core.scala
+++ b/lib/sedentary/src/core/soundness_sedentary_core.scala
@@ -33,4 +33,4 @@
 package soundness
 
 export sedentary.{Bench, BenchError, BenchmarkDevice, LocalhostDevice, NetworkDevice,
-    OperationSize}
+    OperationSize, Stress}

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -152,6 +152,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
 
   def run(): Unit =
     val bench = Bench()
+    val stress = Stress()
     val size = input.length*Byte
     val textSize = textData.length*Byte
 
@@ -845,4 +846,49 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
               ZIO.scoped:
                 ZStream.fromChunk(Chunk.fromArray(turbulence.Benchmarks.inputArray)).broadcast(3, 16).flatMap: streams =>
                   ZIO.foreachPar(streams)(_.runCount).map(_.sum)
+        }
+
+    // Example O: stress rows — the memory profile of the cross-thread hand-off
+    // pipeline from Example L, run as 16 concurrent pipelines for a fixed
+    // wall-clock window. The throughput rows above measure speed; these measure
+    // the axis the bounded-buffer design targets: allocation per pipeline, peak
+    // heap, and a retained live set that stays flat under concurrency.
+    suite(m"Stress: cross-thread hand-off memory (4 MB in 64 KiB chunks, N=16)"):
+      stress(m"Soundness  Conduit")(target = 2*Second, concurrency = 16, baseline = Baseline()):
+        '{
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.foreach(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep((_, _, count) => total += count)
+            producer.join()
+            total
+        }
+
+      stress(m"FS2  Channel.bounded")(target = 2*Second, concurrency = 16):
+        '{
+            import cats.effect.unsafe.implicits.global
+            import cats.effect.IO
+            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
+              val produce =
+                turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[Array[Byte]])).void
+                *> channel.close.void
+              produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
+            program.unsafeRunSync()
+        }
+
+      stress(m"ZIO  Queue.bounded")(target = 2*Second, concurrency = 16):
+        '{
+            turbulence.Benchmarks.runZio:
+              import zio.*, zio.stream.*
+              val source =
+                ZStream.fromIterable
+                  (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[Array[Byte]])))
+              for
+                queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
+                _     <- source.runIntoQueue(queue).fork
+                total <- ZStream.fromQueue(queue).flattenTake.runFold(0L)((acc, c) => acc + c.size)
+              yield total
         }


### PR DESCRIPTION
Probably reports gain a third kind of row alongside pass/fail tests and `Bench` throughput benchmarks: *stress tests*, which run a staged body concurrently for a fixed wall-clock window and measure memory behaviour — the axis a bounded-buffer streaming design is built to win at. The new `sedentary.Stress` rig reports allocation per operation, peak heap, post-GC retained live set and GC pressure as a `Strain` row in the report table, and the streaming benchmark suite gains a first set of stress rows contrasting `Conduit` hand-off with FS2 and ZIO at sixteen concurrent pipelines.

## Release notes

A new kind of measurement, the *stress test*, can now be included in test reports, complementing pass/fail tests and `Bench` microbenchmarks. Where `Bench` times one operation repeated serially on a single thread, `Stress` runs the body on `concurrency` platform threads for a fixed wall-clock window and profiles memory over that window:

```scala
val stress = Stress()

suite(m"Pipeline memory"):
  stress(m"Conduit hand-off")(target = 2*Second, concurrency = 16, baseline = Baseline()):
    '{ // staged body, exactly as in Bench
       ... }
```

Each stress test appears in the report as a `Strain` row showing the operation count and throughput, **allocation per operation** (measured with the JDK's thread-allocation counters, so allocation on worker threads spawned by the body is included), **peak heap**, the **retained live set** after a post-run GC (flat and small for a bounded-memory design, however much data flowed), and GC count/time. As with benchmarks, a `baseline` may be nominated: other rows in the suite then gain a relative column comparing allocation per operation.

The measurement runs in the same staged, isolated JVM as `Bench` (via `superlunary`), after an untimed warm-up, with the same blackhole protection against dead-code elimination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
