### PR TITLE
Direct JSON parsing into values via a new Parsable typeclass

### DIFF
--- a/lib/distillate/src/core/distillate.Parsable.scala
+++ b/lib/distillate/src/core/distillate.Parsable.scala
@@ -30,9 +30,24 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package distillate
 
-export
-  distillate
-  . { As, as, Decodable, Decodable2, Enumerable, Extractable, Identifiable, Irrefutable,
-      NumberError, Parsable, Requirable }
+import prepositional.*
+
+// The streaming counterpart of `Decodable`: instead of receiving an
+// already-materialized `Form` value (a `Json`, an `Xml`), a `Parsable` instance
+// drives a format-specific token reader directly over the input, so composite
+// values are instantiated without an intermediate syntax tree. `Transport`
+// names the format (`value is Parsable over Json`); `Reader` is the format's
+// token-reader capability, fixed by each format's subtrait (Jacinta's
+// `Json.Parsable` sets `Reader = JsonReader`).
+//
+// The reader is an exclusive, stateful capability owned by the caller for the
+// duration of the call; nothing of it may be retained in `Self`. Parse errors
+// flow through the reader (which carries its own tactic) or through a
+// resolution-scoped `Tactic` captured at instance construction (codec-thunk
+// seal; see rep/DECISIONS.md), so `parse` itself needs no error vocabulary and
+// the generic trait needs no dependency on any parsing substrate.
+trait Parsable extends Typeclass, Transportive:
+  type Reader
+  def parse(reader: Reader^): Self

--- a/lib/jacinta/src/bench/jacinta.Benchmarks.scala
+++ b/lib/jacinta/src/bench/jacinta.Benchmarks.scala
@@ -40,6 +40,7 @@ import contingency.*, strategies.throwUnsafely
 import fulminate.*
 import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader
+import prepositional.*
 import probably.*
 import proscenium.*
 import quantitative.*
@@ -48,7 +49,21 @@ import sedentary.*
 import spectacular.*
 import symbolism.*
 import temporaryDirectories.systemTemporaryDirectory
+import turbulence.*
 import vacuous.*
+
+// Typed targets for the decode benchmarks (Example 4's shape). `BenchUsers`
+// opts in to direct parsing, so `read[BenchUsers in Json]` never builds the
+// AST that the `read[Json].as[BenchUsers]` arm materializes.
+case class BenchUser(id: Int, username: Text, email: Text, active: Boolean, role: Text)
+
+object BenchUser:
+  given parsable: BenchUser is Json.Parsable = Json.Parsable.derived
+
+case class BenchUsers(users: List[BenchUser])
+
+object BenchUsers:
+  given parsable: BenchUsers is Json.Parsable = Json.Parsable.derived
 
 object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
   sealed trait Information extends Dimension
@@ -79,6 +94,11 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
 
   def parseWithJackson(text: String): com.fasterxml.jackson.databind.JsonNode =
     jacksonMapper.readTree(text).nn
+
+  // The two decode arms: materialize the AST and walk it with `Decodable`,
+  // or parse tokens straight into the records with `Parsable`.
+  def decodeUsersAst(): BenchUsers = LazyList(jsonBytes4).read[Json].as[BenchUsers]
+  def decodeUsersDirect(): BenchUsers = LazyList(jsonBytes4).read[BenchUsers in Json]
 
   def run(): Unit =
     val bench = Bench()
@@ -181,6 +201,14 @@ object Benchmarks extends Suite(m"Jacinta JSON parser benchmarks"):
 
       bench(m"Parse file with Jackson")(target = 1*Second, operationSize = size4):
         '{ jacinta.Benchmarks.parseWithJackson(jacinta.Benchmarks.jsonText4) }
+
+    suite(m"Decode example 4 into records (100 user records)"):
+      bench(m"Decode via the Json AST")
+        ( target = 1*Second, operationSize = size4, baseline = Baseline(compare = Min) ):
+        '{ jacinta.Benchmarks.decodeUsersAst() }
+
+      bench(m"Decode directly with Parsable")(target = 1*Second, operationSize = size4):
+        '{ jacinta.Benchmarks.decodeUsersDirect() }
 
     suite(m"Parse example 5 (500 log entries)"):
       bench(m"Parse file with Merino")

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -129,7 +129,7 @@ private[jacinta] object Parser:
     new ThreadLocal[AnyRef]:
       override def initialValue(): AnyRef = (new Parser).asInstanceOf[AnyRef]
 
-  private def borrow(): Parser^ = pool.get.nn.asInstanceOf[Parser^]
+  private[jacinta] def borrow(): Parser^ = pool.get.nn.asInstanceOf[Parser^]
 
   def parse(source: Data, mode: NumberMode = NumberMode.Full): Raw raises ParseError =
     val parser = borrow()
@@ -1926,6 +1926,242 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
         case char                           => errorAt(Issue.SpuriousContent(char.toChar))
 
     result
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Direct-parsing rim (used by `JsonReader`). The token-level operations
+  // behind `Json.Parsable` instances: each consumes exactly one token (or one
+  // structural step) from the input, without building AST nodes for the values
+  // the caller reads directly. Container stepping (`directKey`,
+  // `directElement`) tracks a first-entry bit per nesting level so separator
+  // commas are enforced exactly as strictly as the AST parser's loops, and
+  // each error mirrors the `Issue` the corresponding AST loop would raise.
+
+  // Bit `level & 63` of `directMask(level >> 6)` is set once the container
+  // open at that nesting level has consumed its first entry (so a separator
+  // comma is required before the next). Exclusive scratch: reached only
+  // through this (exclusive) parser.
+  private var directDepth: Int = 0
+  private var directMask: Array[Long]^ = new Array[Long](1)
+
+  private update def directPush(): Unit =
+    val level = directDepth
+    val word = level >> 6
+
+    if directMask.length <= word then
+      val grown = new Array[Long](directMask.length*2)
+      System.arraycopy(directMask, 0, grown, 0, directMask.length)
+      directMask = grown
+
+    directMask(word) &= ~(1L << (level & 63))
+    directDepth = level + 1
+
+  private update def directSeen(): Boolean =
+    val level = directDepth - 1
+    (directMask(level >> 6) & (1L << (level & 63))) != 0
+
+  private update def directMark(): Unit =
+    val level = directDepth - 1
+    directMask(level >> 6) |= 1L << (level & 63)
+
+  private update def directPop(): Unit = directDepth -= 1
+
+  private[jacinta] update def directBegin()(using Tactic[ParseError]): Unit =
+    directDepth = 0
+    bom()
+    skip()
+    if !more then abort(ParseError(Json.Ast, Position(0, 0), Issue.EmptyInput))
+
+  // Trailing-content check, identical to the tail of `parse()`.
+  private[jacinta] update def directEnd()(using Tactic[ParseError]): Unit =
+    while more do
+      peek match
+        case Tab | Return | Newline | Space => advance()
+        case char                           => errorAt(Issue.SpuriousContent(char.toChar))
+
+  private[jacinta] update def directValue()(using Tactic[ParseError]): Raw =
+    skip()
+    parseValue()
+
+  // Structure-aware skip of one whole value. Parses and discards for now; a
+  // non-materializing scanner is a later optimization, invisible to callers.
+  private[jacinta] update def directSkipValue()(using Tactic[ParseError]): Unit =
+    skip()
+    parseValue()
+    ()
+
+  private[jacinta] update def directString()(using Tactic[ParseError]): String =
+    skip()
+    if must() == Quote then
+      advance()
+      parseString()
+    else errorAt(Issue.ExpectedString(peek.toChar))
+
+  private[jacinta] update def directBoolean()(using Tactic[ParseError]): Boolean =
+    skip()
+    must() match
+      case LowerT => parseTrue()
+      case LowerF => parseFalse()
+      case ch     => errorAt(Issue.ExpectedBoolean(ch.toChar))
+
+  private[jacinta] update def directNull()(using Tactic[ParseError]): Unit =
+    skip()
+    if must() == LowerN then { parseNull(); () } else errorAt(Issue.ExpectedNull)
+
+  // Non-consuming: is the next value a `null`? False at end of input (the
+  // subsequent read reports the missing value with its own expectation).
+  private[jacinta] update def directIsNull(): Boolean =
+    skip()
+    more && peek == LowerN
+
+  // One number token, in the same `Raw` forms the AST parser produces for a
+  // top-level number (`Long`, `Double` or `Bcd` under `bcdOnly = false`).
+  private update def directNumber()(using Tactic[ParseError]): Raw =
+    skip()
+    val ch = must()
+
+    if (ch & 0xF8) == Num0 || (ch & 0xFE) == 0x38 then
+      advance()
+      parseNumber(ch & 0x0F, false)
+    else if ch == Minus then
+      advance()
+      val digit = must()
+
+      if (digit & 0xF8) == Num0 || (digit & 0xFE) == 0x38 then
+        advance()
+        parseNumber(digit & 0x0F, true)
+      else errorAt(Issue.ExpectedDigit(digit.toChar))
+    else errorAt(Issue.ExpectedNumber(ch.toChar))
+
+  // The numeric coercions mirror the `Json.Ast` accessors (`long`, `double`,
+  // `bcd`) exactly, so a direct read of a number yields the same value the
+  // AST path would decode.
+  private[jacinta] update def directLong()(using Tactic[ParseError]): Long =
+    val raw: Any = directNumber()
+
+    raw.asMatchable match
+      case value: Long                     => value
+      case value: Double                   => value.toLong
+      case value: Int                      => Bcd.bcdIntToDouble(value).toLong
+      case value: Array[Double] @unchecked => value.asInstanceOf[Bcd].toLong.or(0L)
+      case _                               => 0L // unreachable: only number forms are produced
+
+  private[jacinta] update def directDouble()(using Tactic[ParseError]): Double =
+    val raw: Any = directNumber()
+
+    raw.asMatchable match
+      case value: Double                   => value
+      case value: Long                     => value.toDouble
+      case value: Int                      => Bcd.bcdIntToDouble(value)
+      case value: Array[Double] @unchecked => value.asInstanceOf[Bcd].toDouble
+      case _                               => 0.0 // unreachable: only number forms are produced
+
+  private[jacinta] update def directBcd()(using Tactic[ParseError]): Bcd =
+    val raw: Any = directNumber()
+
+    raw.asMatchable match
+      case value: Array[Double] @unchecked => value.asInstanceOf[Bcd]
+      case value: Long                     => caps.unsafe.unsafeAssumePure(Bcd(BigDecimal(value)))
+      case value: Double                   => caps.unsafe.unsafeAssumePure(Bcd(BigDecimal(value)))
+
+      case value: Int =>
+        caps.unsafe.unsafeAssumePure:
+          Bcd.fromString(Bcd.bcdIntText(value).stripPrefix("-"), value < 0)
+
+      case _ =>
+        caps.unsafe.unsafeAssumePure(Bcd(BigDecimal(0L))) // unreachable
+
+  private[jacinta] update def directOpenObject()(using Tactic[ParseError]): Unit =
+    skip()
+
+    if must() == OpenBrace then
+      advance()
+      directPush()
+    else errorAt(Issue.ExpectedObject(peek.toChar))
+
+  // The next key of the current object (consuming any separator comma, the
+  // key and its colon), or `null` after consuming the closing brace.
+  private[jacinta] update def directKey()(using Tactic[ParseError]): String | Null =
+    skip()
+
+    if directSeen() then
+      must() match
+        case CloseBrace =>
+          advance()
+          directPop()
+          null
+
+        case Comma =>
+          advance()
+          skip()
+
+          must() match
+            case Quote      => advance() yet directKeyTail()
+            case CloseBrace => errorAt(Issue.ExpectedSomeValue('}'))
+            case ch         => errorAt(Issue.ExpectedString(ch.toChar))
+
+        case ch => errorAt(Issue.UnexpectedChar(ch.toChar))
+    else
+      must() match
+        case CloseBrace =>
+          advance()
+          directPop()
+          null
+
+        case Quote =>
+          advance()
+          directMark()
+          directKeyTail()
+
+        case ch => errorAt(Issue.ExpectedString(ch.toChar))
+
+  // After the opening quote: the key itself and its trailing colon.
+  private update def directKeyTail()(using Tactic[ParseError]): String =
+    val key = parseObjectKey()
+    skip()
+
+    if must() == Colon then
+      advance()
+      key
+    else errorAt(Issue.ExpectedColon(peek.toChar))
+
+  private[jacinta] update def directOpenArray()(using Tactic[ParseError]): Unit =
+    skip()
+
+    if must() == OpenBracket then
+      advance()
+      directPush()
+    else errorAt(Issue.ExpectedArray(peek.toChar))
+
+  // True when another element follows (positioned at it, with any separator
+  // comma consumed); false after consuming the closing bracket.
+  private[jacinta] update def directElement()(using Tactic[ParseError]): Boolean =
+    skip()
+
+    if directSeen() then
+      must() match
+        case CloseBracket =>
+          advance()
+          directPop()
+          false
+
+        case Comma =>
+          advance()
+          true
+
+        case ch => errorAt(Issue.ExpectedSomeValue(ch.toChar))
+    else
+      must() match
+        case CloseBracket =>
+          advance()
+          directPop()
+          false
+
+        case _ =>
+          directMark()
+          true
+
+  private[jacinta] update def directFail(issue: Issue)(using Tactic[ParseError]): Nothing =
+    errorAt(issue)
 
 
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -133,6 +133,26 @@ trait Json2 extends Json3:
   =>  ((Bytes is Json.Decodable)^{tactic, caps.any}) =
     Json.Decodable(Morphology.Whole)(_.root.long.b)
 
+  // The AST-materializing read path: parse the whole input into a `Json`,
+  // then decode. Lives at this priority so `object Json`'s direct-parsing
+  // `aggregableParsed` wins whenever the value has a `Json.Parsable`; when it
+  // does not (all pre-`Parsable` code), this resolves exactly as before.
+  // Sealed like `Json.aggregable`; see the comment there.
+  given aggregableDirect: [value: distillate.Decodable in Json]
+  =>  (tactic: Tactic[ParseError], jsonTactic: Tactic[JsonError], tracking: PositionTracking)
+  =>  ((value in Json) is Aggregable by Data) =
+
+    caps.unsafe.unsafeAssumePure:
+      new Aggregable:
+        type Self = value in Json
+        type Operand = Data
+
+        def aggregate(bytes: LazyList[Data]): value in Json =
+          Json.readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
+
+        override def accept(stream: (Stream[Data] over Credit)^): value in Json =
+          Json.readJson(stream).as[value].asInstanceOf[value in Json]
+
   inline given decodable: [value] => value is Json.Decodable = summonFrom:
     // `Json` decodes to itself. Handled here (not as a separate carrier given) so it
     // does not compete — as a `Json.Decodable` subtype — with the plain
@@ -386,6 +406,39 @@ object Json extends Json2, Dynamic:
     type Form = Json
     def shape(): Morphology
 
+  object Parsable:
+    def apply[value](shape0: => Morphology)(parser: (reader: JsonReader^) => value)
+    :   ((value is Json.Parsable)^{parser}) =
+      // Same shape-thunk laundering as `Encodable.apply`; see the comment there.
+      val shape1: () -> Morphology = caps.unsafe.unsafeAssumePure { () => shape0 }
+
+      new Json.Parsable:
+        type Self = value
+        def parse(reader: JsonReader^): value = parser(reader)
+        def shape(): Morphology = shape1()
+
+    // The universal bridge from the AST world: parse one whole value into a
+    // `Json` and decode it. Field types with only a `Decodable in Json` keep
+    // working through this, and it is the user's one-line escape hatch when a
+    // custom decoder must beat a derived direct parser.
+    def fromDecodable[value](decodable: (value is Json.Decodable)^)
+    :   ((value is Json.Parsable)^{decodable}) =
+
+      new Json.Parsable:
+        type Self = value
+        def parse(reader: JsonReader^): value = decodable.decoded(reader.value())
+        def shape(): Morphology = decodable.shape()
+
+  // The direct-parsing counterpart of `Json.Decodable`: consumes JSON tokens
+  // from a `JsonReader` instead of walking a materialized `Json`, so
+  // `read[value in Json]` can instantiate values without building the AST.
+  // Carries the same `Morphology` so a direct parser stays coherent with the
+  // schema machinery.
+  trait Parsable extends distillate.Parsable:
+    type Transport = Json
+    type Reader = JsonReader
+    def shape(): Morphology
+
   // All internal references in a `PositionIndex` are stored as offsets
   // relative to the start of the containing node descriptor, so any slice
   // extracted at a descriptor boundary is itself a valid `PositionIndex`.
@@ -448,6 +501,13 @@ object Json extends Json2, Dynamic:
       case MultipleDecimalPoints
       case ExpectedDigit(found: Char)
 
+      // Raised only on the direct-parsing path (`Json.Parsable`), where a
+      // typed reader knows which kind of value it expects next.
+      case ExpectedNumber(found: Char)
+      case ExpectedBoolean(found: Char)
+      case ExpectedObject(found: Char)
+      case ExpectedArray(found: Char)
+
       def describe: Message = this match
         case EmptyInput              => m"the input was empty"
         case UnexpectedChar(found)   => m"the character $found was not expected here"
@@ -465,6 +525,10 @@ object Json extends Json2, Dynamic:
         case NotEscaped(char)        => m"the character $char must be escaped with a backslash"
         case ExpectedDigit(found)    => m"a digit was expected but $found was found instead"
         case MultipleDecimalPoints   => m"a number cannot contain more than one decimal point"
+        case ExpectedNumber(found)   => m"a number was expected but $found was found instead"
+        case ExpectedBoolean(found)  => m"a boolean was expected but $found was found instead"
+        case ExpectedObject(found)   => m"an object was expected but $found was found instead"
+        case ExpectedArray(found)    => m"an array was expected but $found was found instead"
 
         case NumberHasLeadingZero =>
           m"a number cannot start with a zero except when followed by a decimal point"
@@ -850,7 +914,8 @@ object Json extends Json2, Dynamic:
   // positions are recorded and retained on the `Json` (locatable via
   // `Positionable`); when off, the throughput path is unchanged. This is the
   // single place the `read`/`load` givens branch on tracking.
-  private def readJson(input: Iterator[Data])(using Tactic[ParseError], PositionTracking): Json =
+  private[jacinta] def readJson(input: Iterator[Data])(using Tactic[ParseError], PositionTracking)
+  :   Json =
     summon[PositionTracking] match
       case PositionTracking.On =>
         val (ast, index) = Json.Ast.parseTracked(input)
@@ -865,7 +930,7 @@ object Json extends Json2, Dynamic:
   // non-consuming by overrides in modules outside separation checking, so the
   // stream crosses to the consuming parser as a neutral reference — each accept
   // call delivers a stream that is used exactly once, by construction.
-  private def readJson(input: (Stream[Data] over Credit)^)
+  private[jacinta] def readJson(input: (Stream[Data] over Credit)^)
     ( using Tactic[ParseError], PositionTracking )
   :   Json =
 
@@ -879,6 +944,45 @@ object Json extends Json2, Dynamic:
 
       case PositionTracking.Off =>
         Json(Json.Ast.parse(ref.asInstanceOf[(Stream[Data] over Credit)^]))
+
+  // Direct-parsing counterpart of `readJson`: drives a `Json.Parsable`
+  // instance over the input through a `JsonReader`, so no AST is built for
+  // the values the instance reads directly. Under `parsing.trackPositions`
+  // the parser's lineation is enabled so parse errors carry real source
+  // coordinates; there is no `PositionIndex` (nothing to index — the result
+  // is the caller's value, not a `Json`).
+  private def parseDirect[value]
+    ( input: Iterator[Data], parsable: (value is Json.Parsable)^ )
+    ( using tactic: Tactic[ParseError], tracking: PositionTracking, mode: NumberMode )
+  :   value =
+
+    val parser = Parser.borrow()
+    parser.tracking = tracking == PositionTracking.On
+    parser.resetIterator(input)
+    parser.holes = false
+    parser.numberMode = mode
+    parser.directBegin()
+    val result = parsable.parse(JsonReader(parser, tactic))
+    parser.directEnd()
+    result
+
+  // As above, but pulling from a demand-aware stream; see `readJson`'s note
+  // on the neutral-reference hop.
+  private def parseDirect[value]
+    ( input: (Stream[Data] over Credit)^, parsable: (value is Json.Parsable)^ )
+    ( using tactic: Tactic[ParseError], tracking: PositionTracking, mode: NumberMode )
+  :   value =
+
+    val ref: AnyRef = input.asInstanceOf[AnyRef]
+    val parser = Parser.borrow()
+    parser.tracking = tracking == PositionTracking.On
+    parser.resetStream(ref.asInstanceOf[(Stream[Data] over Credit)^])
+    parser.holes = false
+    parser.numberMode = mode
+    parser.directBegin()
+    val result = parsable.parse(JsonReader(parser, tactic))
+    parser.directEnd()
+    result
 
   // Canonical external accessor for the underlying AST. The `root`
   // method on `class Json` is package-private so that breaking through
@@ -1096,6 +1200,32 @@ object Json extends Json2, Dynamic:
         raise(JsonError(reason))
 
 
+  // Direct-parsing primitives. Genuinely pure — no tactic and no seal: all
+  // raising happens inside the `JsonReader`, through the tactic it carries.
+  given booleanParsable: Boolean is Json.Parsable =
+    Json.Parsable(Morphology.Bool)(_.boolean())
+
+  given doubleParsable: Double is Json.Parsable =
+    Json.Parsable(Morphology.Real)(_.double())
+
+  given floatParsable: Float is Json.Parsable =
+    Json.Parsable(Morphology.Real)(_.double().toFloat)
+
+  given longParsable: Long is Json.Parsable =
+    Json.Parsable(Morphology.Whole)(_.long())
+
+  given intParsable: Int is Json.Parsable =
+    Json.Parsable(Morphology.Whole)(_.long().toInt)
+
+  given textParsable: Text is Json.Parsable =
+    Json.Parsable(Morphology.Str)(_.string())
+
+  given stringParsable: String is Json.Parsable =
+    Json.Parsable(Morphology.Str)(_.string().s)
+
+  given jsonParsable: Json is Json.Parsable =
+    Json.Parsable(Morphology.Any)(_.value())
+
   given option: [value: Json.Decodable] => Tactic[JsonError]
   =>  Option[value] is Json.Decodable =
 
@@ -1299,9 +1429,14 @@ object Json extends Json2, Dynamic:
         override def accept(stream: (Stream[Data] over Credit)^): Json = readJson(stream)
 
 
-  // Sealed like `aggregable` above.
-  given aggregableDirect: [value: distillate.Decodable in Json]
-  =>  (tactic: Tactic[ParseError], jsonTactic: Tactic[JsonError], tracking: PositionTracking)
+  // Direct parsing: when the value knows how to consume JSON tokens itself,
+  // the AST is never materialized. Declared here (not in `Json2`, where the
+  // `Decodable`-based `aggregableDirect` lives) so it wins whenever a
+  // `Json.Parsable` exists, and is otherwise inapplicable — existing code
+  // resolves exactly as before. Sealed like `aggregable` above.
+  given aggregableParsed: [value]
+  =>  (parsable: (value is Json.Parsable)^)
+  =>  (tactic: Tactic[ParseError], tracking: PositionTracking)
   =>  ((value in Json) is Aggregable by Data) =
 
     caps.unsafe.unsafeAssumePure:
@@ -1310,10 +1445,10 @@ object Json extends Json2, Dynamic:
         type Operand = Data
 
         def aggregate(bytes: LazyList[Data]): value in Json =
-          readJson(bytes.iterator).as[value].asInstanceOf[value in Json]
+          parseDirect(bytes.iterator, parsable).asInstanceOf[value in Json]
 
         override def accept(stream: (Stream[Data] over Credit)^): value in Json =
-          readJson(stream).as[value].asInstanceOf[value in Json]
+          parseDirect(stream, parsable).asInstanceOf[value in Json]
 
 
   given showable: Formatting => Json is Showable = _.root.show

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -83,6 +83,35 @@ private[jacinta] trait JsonDecodable[T] extends Decodable:
 // `Json.Decodable`) so generic `as[T]` callers bounded on `Decodable in Json`
 // still resolve.
 trait Json3:
+  // The universal fallback for `Json.Field` — the typeclass the product
+  // derivation resolves per field — mirroring `Json2.decodable`'s dispatch
+  // order so a field's wire format is identical on both paths: an explicit
+  // (or derived) direct parser; a string codec; structural derivation; or
+  // the AST bridge over any remaining `Json.Decodable` (opaque leaf types
+  // like `Instant`). A case class with both a `Reflection` and a custom
+  // hand-written `Json.Decodable` derives here, diverging from its custom
+  // decoder — the documented remedy is one line:
+  // `given MyType is Json.Parsable = Json.Parsable.fromDecodable(...)`.
+  // Lowest priority so `Json2`'s element-wise field givens match collection
+  // types first (a `List`'s own `Mirror` would otherwise derive it as a
+  // sum).
+  inline given field: [value] => value is Json.Field = summonFrom:
+    case parsable: (`value` is Json.Parsable) =>
+      Json.Field(parsable)
+
+    case given (`value` is distillate.Decodable in Text) =>
+      // Laundered pure per the codec-thunk seal pattern: the parse lambda
+      // closes over the resolution-scoped text decodable.
+      caps.unsafe.unsafeAssumePure:
+        Json.Field(Json.Parsable(Morphology.Str)(_.string().as[value]))
+
+    case given Reflection[`value`] =>
+      Json.ParsableDerivation.derived
+
+    case given (`value` is Json.Decodable) =>
+      caps.unsafe.unsafeAssumePure:
+        Json.Field(Json.Parsable.fromDecodable(infer[`value` is Json.Decodable]))
+
   given decodableAtFocus: [value]
   =>  ( inner: (value is Decodable in Json)^ )
   =>  ((value is Decodable in Json at Json.Focus)^{inner, caps.any}) =
@@ -132,6 +161,43 @@ trait Json2 extends Json3:
   given bytes: (tactic: Tactic[JsonError])
   =>  ((Bytes is Json.Decodable)^{tactic, caps.any}) =
     Json.Decodable(Morphology.Whole)(_.root.long.b)
+
+  // Element-wise `Json.Field` instances resolved during derivation: the
+  // element's own parser comes from the fallback chain, so nested products
+  // still parse directly. This layer beats `Json3`'s fallback, so collection
+  // types never reach its `Reflection` case (a `List`'s own `Mirror` would
+  // otherwise derive it as a sum).
+  given fieldOptional: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  Tactic[JsonError]
+  =>  ( field: => (inner is Json.Field)^ )
+  =>  value is Json.Field =
+    Json.Field(Json.Parsable.optionality[inner, value](field))
+
+  given fieldOption: [value] => (field: => (value is Json.Field)^)
+  =>  Option[value] is Json.Field =
+    Json.Field(Json.Parsable.boxed(field))
+
+  given fieldArray: [collection <: Iterable, element]
+  =>  ( factory: Factory[element, collection[element]],
+        tactic:  Tactic[JsonError],
+        foci:    Foci[Json.Focus] )
+  =>  ( field: => (element is Json.Field)^ )
+  =>  collection[element] is Json.Field =
+    Json.Field(Json.Parsable.iterable[collection, element](field))
+
+  given fieldMap: [key: distillate.Decodable in Text, element]
+  =>  Tactic[JsonError]
+  =>  ( field: => (element is Json.Field)^ )
+  =>  Map[key, element] is Json.Field =
+    Json.Field(Json.Parsable.dictionary[key, element](field))
+
+  // The nominal counterpart of `fieldOptional`: an `Optional` reads
+  // directly only when its element has opted in.
+  given optionalParsable: [inner <: value, value >: Unset.type: Mandatable to inner]
+  =>  Tactic[JsonError]
+  =>  ( parsable: => (inner is Json.Parsable)^ )
+  =>  value is Json.Parsable =
+    Json.Parsable.optionality[inner, value](parsable)
 
   // The AST-materializing read path: parse the whole input into a `Json`,
   // then decode. Lives at this priority so `object Json`'s direct-parsing
@@ -277,6 +343,41 @@ trait Json2 extends Json3:
 
               delegate(discriminant): [variant <: derivation] =>
                 context => context.decoded(json)
+
+  object ParsableDerivation extends Derivable[Json.Field]:
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   derivation is Json.Field =
+
+      // Like `DecodableDerivation.conjunction`: the capabilities are summoned
+      // at the derivation site and the instance is sealed per the codec-thunk
+      // pattern. A single `contexts` traversal collects, per field, its wire
+      // key (`@name`-aware), its parser (via the `Field` fallback chain) and
+      // its declared default; `Json.Parsable.product` owns the parse loop, so
+      // no per-field lambda ever closes over the reader.
+      caps.unsafe.unsafeAssumePure:
+        val reflection = infer[ProductReflection[derivation]]
+
+        Json.Parsable.product[derivation](
+          { () =>
+            val renames: Map[Text, Text] = relabelling[derivation, Json]
+
+            contexts[derivation]():
+              [field] => context =>
+                ( renames.at(label).or(label).s,
+                  context: Json.Parsing,
+                  default[Optional[field]]: Any )
+          },
+          values => Json.Parsable.assemble(reflection, values))
+          ( using infer[Foci[Json.Focus]], infer[Tactic[JsonError]] )
+
+    inline def disjunction[derivation: SumReflection]: derivation is Json.Field =
+      // A sum materializes one value's AST and dispatches through its
+      // decoder — the same discriminated-object handling as the AST path,
+      // byte for byte, honoring any custom `Json.Decodable` the sum has.
+      // Token-level sum parsing (discriminator scan-ahead with rewind) is a
+      // later optimization.
+      caps.unsafe.unsafeAssumePure:
+        Json.Field(Json.Parsable.fromDecodable(infer[derivation is Json.Decodable]))
 
   object EncodableDerivation extends Derivable[Json.Encodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
@@ -429,15 +530,275 @@ object Json extends Json2, Dynamic:
         def parse(reader: JsonReader^): value = decodable.decoded(reader.value())
         def shape(): Morphology = decodable.shape()
 
+        override def absent()(using Tactic[JsonError]): value =
+          decodable.decoded(Json.ast(Json.Ast(Unset)))
+
+    // The one-line opt-in to direct parsing for a structural type:
+    // `given MyType is Json.Parsable = Json.Parsable.derived` — a
+    // Wisteria-derived direct parser, wrapped as a *nominal* `Parsable` so
+    // it participates in the read trigger. Deliberately a method, not a
+    // blanket given: a type parses directly only once it has opted in.
+    inline def derived[value](using Reflection[value]): value is Json.Parsable =
+      fromField(ParsableDerivation.derivedOne[value])
+
+    def fromField[value](field0: (value is Json.Parsing)^)
+    :   ((value is Json.Parsable)^{field0}) =
+
+      new Json.Parsable:
+        type Self = value
+        def parse(reader: JsonReader^): value = field0.parse(reader)
+        def shape(): Morphology = field0.shape()
+        override def absent()(using Tactic[JsonError]): value = field0.absent()
+
+    // Shared element-wise implementations, used by the nominal
+    // `Json.Parsable` givens (elements must themselves be nominally
+    // `Parsable`, so the read trigger stays opt-in) and by the `Field`
+    // givens above (elements resolve through the fallback chain). Each is
+    // sealed per the codec-thunk pattern: a by-name parameter cannot be
+    // named in a capture set (see `Json2.optional`).
+    def optionality[inner <: value, value >: Unset.type]
+      ( field: => (inner is Json.Parsing)^ )
+      ( using tactic: Tactic[JsonError] )
+    :   value is Json.Parsable =
+
+      caps.unsafe.unsafeAssumePure:
+        new Json.Parsable:
+          type Self = value
+          def shape(): Morphology = Morphology.Opt(field.shape())
+
+          // A wire `null` reads as `Unset`, and so does an absent key: both
+          // mean "no value", exactly as the AST decoder's `optional`.
+          def parse(reader: JsonReader^): value =
+            if reader.hasNull then
+              reader.nullValue()
+              Unset
+            else field.parse(reader)
+
+          override def absent()(using Tactic[JsonError]): value = Unset
+
+    def boxed[value](field: => (value is Json.Parsing)^)
+    :   Option[value] is Json.Parsable =
+
+      caps.unsafe.unsafeAssumePure:
+        new Json.Parsable:
+          type Self = Option[value]
+          def shape(): Morphology = Morphology.Opt(field.shape())
+
+          // A present key always reads the value — a wire `null` flows to
+          // the element, preserving the AST decoder's `Option` asymmetry —
+          // while an absent key yields `None`.
+          def parse(reader: JsonReader^): Option[value] = Some(field.parse(reader))
+          override def absent()(using Tactic[JsonError]): Option[value] = None
+
+    def iterable[collection <: Iterable, element]
+      ( field: => (element is Json.Parsing)^ )
+      ( using factory: Factory[element, collection[element]],
+              tactic:  Tactic[JsonError],
+              foci:    Foci[Json.Focus] )
+    :   collection[element] is Json.Parsable =
+
+      caps.unsafe.unsafeAssumePure:
+        new Json.Parsable:
+          type Self = collection[element]
+          def shape(): Morphology = Morphology.Arr(field.shape())
+
+          def parse(reader: JsonReader^): collection[element] =
+            val builder = factory.newBuilder
+            reader.openArray()
+            var index = 0
+
+            while reader.element() do
+              builder += focus(descend(prior, index.toString.tt))(field.parse(reader))
+              index += 1
+
+            builder.result()
+
+    def dictionary[key: distillate.Decodable in Text, element]
+      ( field: => (element is Json.Parsing)^ )
+      ( using tactic: Tactic[JsonError] )
+    :   Map[key, element] is Json.Parsable =
+
+      caps.unsafe.unsafeAssumePure:
+        new Json.Parsable:
+          type Self = Map[key, element]
+          def shape(): Morphology = Morphology.Dict(Morphology.Str, field.shape())
+
+          def parse(reader: JsonReader^): Map[key, element] =
+            var entries = Map.empty[key, element]
+            reader.openObject()
+            var name: String | Null = reader.keyName()
+
+            while name != null do
+              entries = entries.updated(name.nn.tt.as[key], field.parse(reader))
+              name = reader.keyName()
+
+            entries
+
+    // The prior focus's pointer, extended by one step. Called inside
+    // `focus`'s transform context, so it only runs at error-registration
+    // time — the success path pays nothing.
+    private def descend(base0: Optional[Json.Focus], key: Text): Json.Focus =
+      val base = base0.let(_.pointer).or(JsonPointer())
+
+      val pointer =
+        JsonPointer
+          ( base.url,
+            Path[JsonPointer, JsonPointer.type, Tuple]
+              ( base.path.root, base.path.descent :+ key ) )
+
+      Json.Focus(pointer)
+
+    // Sentinel for the derived product parser's value buffer: a slot still
+    // `AbsentSlot` after the key loop had no key on the wire (`null`-checking
+    // would be unsound — `Optional` fields legitimately store a null-backed
+    // `Unset`, and a bitmask would cap the field count).
+    private[jacinta] val AbsentSlot: AnyRef = new Object
+
+    // Positional construction through the threaded `Mirror`, from the value
+    // buffer the parse loop filled. `fromProduct` is the only construction
+    // form that works for method-local and object-nested case classes; see
+    // the note on `ProductDerivation.build`.
+    def assemble[derivation <: Product]
+      ( reflection: ProductReflection[derivation], values: IArray[Any] )
+    :   derivation =
+
+      reflection.fromProduct(ArrayProduct(values))
+
+    private final class ArrayProduct(values: IArray[Any]) extends Product:
+      def canEqual(that: Any): Boolean = true
+      def productArity: Int = values.length
+      def productElement(index: Int): Any = values(index)
+
+    // The derived product parser's engine. `fields0` is an explicit thunk
+    // (nameable in the capture set, unlike a by-name) evaluated lazily, so
+    // recursive derivation can defer sibling resolution; it yields, per
+    // field, the wire key, the field's parser and its declared default (or
+    // `Unset`). The parse loop lives here, in an ordinary method body —
+    // no Wisteria per-field lambda ever closes over the reader, which is
+    // what lets the whole construction respect the checker.
+    def product[derivation]
+      ( fields0: () => IArray[(String, Json.Parsing, Any)],
+        make:    IArray[Any] -> derivation )
+      ( using foci: Foci[Json.Focus], tactic: Tactic[JsonError] )
+    :   ((derivation is Json.Field)^{fields0, tactic}) =
+
+      new Json.Field:
+        type Self = derivation
+
+        private lazy val fields: IArray[(String, Json.Parsing, Any)] = fields0()
+        private lazy val keys: IArray[String] = fields.map(_(0))
+
+        def shape(): Morphology =
+          val entries: List[(Text, Morphology)] =
+            fields.map { (key, parser, _) => (key.tt, parser.shape()) }.to(List)
+
+          Morphology.Obj
+            ( entries, entries.collect { case (key, shape) if !shape.optional => key } )
+
+        // Reference equality first: object keys of up to 16 bytes come out
+        // of the tokenizer's per-thread intern cache, so a steady-state
+        // lookup is a scan of pointer compares. The `equals` pass covers
+        // cache evictions, longer keys and escaped keys.
+        private def indexOf(key: String): Int =
+          val named = keys
+          val count = named.length
+          var index = 0
+
+          while index < count do
+            if named(index) eq key then return index
+            index += 1
+
+          index = 0
+
+          while index < count do
+            if named(index) == key then return index
+            index += 1
+
+          -1
+
+        def parse(reader: JsonReader^): derivation =
+          val entries = fields
+          val count = entries.length
+          val values = new Array[Any](count)
+          var index = 0
+
+          while index < count do
+            values(index) = AbsentSlot
+            index += 1
+
+          reader.openObject()
+          var key: String | Null = reader.keyName()
+
+          while key != null do
+            val found = indexOf(key.nn)
+
+            if found < 0 then reader.skipValue()
+            else values(found) =
+              focus(descend(prior, keys(found).tt))(entries(found)(1).parse(reader))
+
+            key = reader.keyName()
+
+          index = 0
+
+          while index < count do
+            if values(index).asInstanceOf[AnyRef] eq AbsentSlot then
+              val fallback = entries(index)(2).asInstanceOf[Optional[Any]]
+
+              values(index) =
+                if fallback.present then fallback
+                else focus(descend(prior, keys(index).tt))(entries(index)(1).absent())
+
+            index += 1
+
+          make(values.immutable(using Unsafe))
+
   // The direct-parsing counterpart of `Json.Decodable`: consumes JSON tokens
   // from a `JsonReader` instead of walking a materialized `Json`, so
   // `read[value in Json]` can instantiate values without building the AST.
   // Carries the same `Morphology` so a direct parser stays coherent with the
-  // schema machinery.
-  trait Parsable extends distillate.Parsable:
+  // schema machinery. `Parsable` is the opt-in surface: explicit instances,
+  // `Json.Parsable.derived`, and the read trigger. It has no blanket
+  // fallback given, so no read changes behavior until a type opts in; the
+  // fallback belongs to its operational sibling, `Json.Field`.
+  trait Parsable extends Parsing
+
+  // The shared substance of `Json.Parsable` and `Json.Field`. The two
+  // subtraits add nothing: they exist so that neither is a subtype of the
+  // other. A subtype relation in either direction would make one family's
+  // givens candidates for the other's queries — nominal instances would
+  // clash ambiguously with the field fallback, and Wisteria's codec probe
+  // would find a generic type's own `Parsable` given while deriving it, a
+  // lazy-val self-reference.
+  trait Parsing extends distillate.Parsable:
     type Transport = Json
     type Reader = JsonReader
     def shape(): Morphology
+
+    // What a field of this type yields when its key is absent from the
+    // object: an error unless overridden (`Unset` for `Optional`s, `None`
+    // for `Option`s; the bridge delegates to its decoder). A wire `null` is
+    // never routed here: the parse method consumes it itself.
+    def absent()(using Tactic[JsonError]): Self = abort(JsonError(Reason.Absent))
+
+  object Field:
+    // Adapts an opted-in nominal instance (or any other `Parsing`) for use
+    // as a field parser.
+    def apply[value](parsing: (value is Json.Parsing)^)
+    :   ((value is Json.Field)^{parsing}) =
+
+      new Json.Field:
+        type Self = value
+        def parse(reader: JsonReader^): value = parsing.parse(reader)
+        def shape(): Morphology = parsing.shape()
+        override def absent()(using Tactic[JsonError]): value = parsing.absent()
+
+  // The operational face of direct parsing: how a value is read from a
+  // `JsonReader`, whether directly or through the AST bridge. This is the
+  // typeclass the product derivation resolves per field: `Json2` carries its
+  // element-wise instances and `Json3` the universal fallback — declared as
+  // members of this companion (like `Json2.decodable`) so Wisteria's wrapper
+  // detection excludes the fallback during codec probing.
+  trait Field extends Parsing
 
   // All internal references in a `PositionIndex` are stored as offsets
   // relative to the start of the containing node descriptor, so any slice
@@ -1225,6 +1586,26 @@ object Json extends Json2, Dynamic:
 
   given jsonParsable: Json is Json.Parsable =
     Json.Parsable(Morphology.Any)(_.value())
+
+  // Nominal counterparts of the `Json.Field` element-wise givens:
+  // a collection reads directly only when its element type has opted in.
+  given optionParsable: [value] => (parsable: => (value is Json.Parsable)^)
+  =>  Option[value] is Json.Parsable =
+    Json.Parsable.boxed(parsable)
+
+  given arrayParsable: [collection <: Iterable, element]
+  =>  ( factory: Factory[element, collection[element]],
+        tactic:  Tactic[JsonError],
+        foci:    Foci[Json.Focus] )
+  =>  ( parsable: => (element is Json.Parsable)^ )
+  =>  collection[element] is Json.Parsable =
+    Json.Parsable.iterable[collection, element](parsable)
+
+  given mapParsable: [key: distillate.Decodable in Text, element]
+  =>  Tactic[JsonError]
+  =>  ( parsable: => (element is Json.Parsable)^ )
+  =>  Map[key, element] is Json.Parsable =
+    Json.Parsable.dictionary[key, element](parsable)
 
   given option: [value: Json.Decodable] => Tactic[JsonError]
   =>  Option[value] is Json.Decodable =

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -89,6 +89,11 @@ extends caps.ExclusiveCapability, caps.Stateful:
     case null        => Unset
     case key: String => key.tt
 
+  // As `key()`, but exposing the tokenizer's interned `String` (repeated keys
+  // return the same reference), so the derived product parser's key lookup is
+  // a reference-equality scan in the steady state.
+  private[jacinta] update def keyName(): String | Null = parser.directKey()(using tactic)
+
   update def openArray(): Unit = parser.directOpenArray()(using tactic)
   update def element(): Boolean = parser.directElement()(using tactic)
 

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -30,9 +30,74 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package jacinta
 
-export
-  distillate
-  . { As, as, Decodable, Decodable2, Enumerable, Extractable, Identifiable, Irrefutable,
-      NumberError, Parsable, Requirable }
+import anticipation.*
+import contingency.*
+import gossamer.*
+import vacuous.*
+import zephyrine.*
+
+object JsonReader:
+  // Only jacinta's read path (`Json.parseDirect`) constructs readers, so the
+  // parser-pool invariants (one exclusive `Parser` per thread) and the
+  // resolution scope of the carried tactic are preserved by construction. The
+  // wrapped capabilities travel as neutral carriers (the `FrameReader`
+  // pattern): the fields stay pure, and each accessor reasserts the type at
+  // the rim — the audited point.
+  private[jacinta] def apply(parser: Parser^, tactic: Tactic[ParseError]): JsonReader^ =
+    new JsonReader(parser.asInstanceOf[AnyRef], tactic.asInstanceOf[AnyRef])
+
+// The public, restricted rim of the JSON tokenizer, handed to `Json.Parsable`
+// instances so they can consume JSON tokens straight off the input without an
+// intermediate `Json.Ast`. Each method consumes exactly one token (or one
+// structural step), skipping any leading whitespace. The reader carries its
+// own `Tactic[ParseError]`, so instance `parse` bodies need no error
+// vocabulary: malformed input and mistyped values abort through the read
+// call's ambient tactic.
+//
+// An exclusive, stateful capability, like the parser it wraps: it is owned by
+// one `Json.Parsable.parse` call at a time, for the duration of that call,
+// and nothing of it may be retained afterwards.
+final class JsonReader private (parser0: AnyRef, tactic0: AnyRef)
+extends caps.ExclusiveCapability, caps.Stateful:
+  private inline def parser: Parser^ = parser0.asInstanceOf[Parser^]
+  private inline def tactic: Tactic[ParseError] = tactic0.asInstanceOf[Tactic[ParseError]]
+
+  // ── Scalars: one JSON value each. Numbers coerce exactly as the
+  // `Json.Ast` accessors do, so direct and AST reads yield equal values. ──
+  update def string(): Text = parser.directString()(using tactic).tt
+  update def boolean(): Boolean = parser.directBoolean()(using tactic)
+  update def long(): Long = parser.directLong()(using tactic)
+  update def int(): Int = parser.directLong()(using tactic).toInt
+  update def double(): Double = parser.directDouble()(using tactic)
+  update def bcd(): Bcd = parser.directBcd()(using tactic)
+
+  // ── Null handling: `hasNull` peeks without consuming, for optional
+  // wrappers that map a wire `null` to an absent value. ──
+  update def hasNull: Boolean = parser.directIsNull()
+  update def nullValue(): Unit = parser.directNull()(using tactic)
+
+  // ── Structure. After `openObject()`, `key()` yields each key in turn
+  // (consuming the separator and the colon) and `Unset` once the closing
+  // brace is consumed. After `openArray()`, `element()` is true while
+  // another element follows (positioned at it) and false once the closing
+  // bracket is consumed. ──
+  update def openObject(): Unit = parser.directOpenObject()(using tactic)
+
+  update def key(): Optional[Text] = parser.directKey()(using tactic) match
+    case null        => Unset
+    case key: String => key.tt
+
+  update def openArray(): Unit = parser.directOpenArray()(using tactic)
+  update def element(): Boolean = parser.directElement()(using tactic)
+
+  // ── The fallback seam: parse one whole value into an AST (for field types
+  // that only have a `Decodable in Json`), or skip one whole value (for
+  // unknown keys). ──
+  update def value(): Json = Json.ast(Json.Ast(parser.directValue()(using tactic)))
+  update def skipValue(): Unit = parser.directSkipValue()(using tactic)
+
+  // Abort through the reader's tactic, positioned at the current input
+  // offset — for leaf instances that reject a well-formed token's content.
+  update def fail(issue: Json.Ast.Issue): Nothing = parser.directFail(issue)(using tactic)

--- a/lib/jacinta/src/core/soundness_jacinta_core.scala
+++ b/lib/jacinta/src/core/soundness_jacinta_core.scala
@@ -35,7 +35,8 @@ package soundness
 export
   jacinta
   . { dynamicJsonAccess, DynamicJsonEnabler, j, jp, Json, Json2, jsonConversion, JsonError,
-      JsonPointer, JsonPointerError, JsonPrimitive, Ndjson, NumberMode, parserAggregable, showable }
+      JsonPointer, JsonPointerError, JsonPrimitive, JsonReader, Ndjson, NumberMode,
+      parserAggregable, showable }
 
 package formatting:
   export jacinta.formatting.{indentedJsonFormatting, compactJsonFormatting}

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -109,6 +109,7 @@ case class Boxed[value](value: value) derives CanEqual
 // Read by a hand-written `Json.Parsable` in the direct-parsing tests.
 case class DirectPoint(x: Int, y: Int) derives CanEqual
 
+
 object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
     suite(m"Parsing tests"):
@@ -846,6 +847,141 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_.issue match
           case Json.Ast.Issue.PrematureEnd | Json.Ast.Issue.ExpectedTrue => true
           case _                                                         => false)
+
+    suite(m"Derived direct parsing tests"):
+      given Person is Json.Parsable = Json.Parsable.derived
+      given Band is Json.Parsable = Json.Parsable.derived
+      given WithDefault is Json.Parsable = Json.Parsable.derived
+      given Renamed is Json.Parsable = Json.Parsable.derived
+      given FooOption is Json.Parsable = Json.Parsable.derived
+      given FooOptional is Json.Parsable = Json.Parsable.derived
+      given Org is Json.Parsable = Json.Parsable.derived
+      given Tree is Json.Parsable = Json.Parsable.derived
+      given TreeOpt is Json.Parsable = Json.Parsable.derived
+      given Forest is Json.Parsable = Json.Parsable.derived
+      given Empty is Json.Parsable = Json.Parsable.derived
+      given NewBand is Json.Parsable = Json.Parsable.derived
+      given Status is Json.Parsable = Json.Parsable.derived
+      given Boxed[Int] is Json.Parsable = Json.Parsable.derived
+
+      // The acceptance criterion for derivation: the direct read must equal
+      // the AST-path read, for the same input.
+      inline def parity[value](json: Text)
+        ( using value is Json.Parsable, value is Json.Decodable )
+      :   Boolean =
+        json.read[value in Json] == json.read[Json].as[value]
+
+      test(m"Derive a direct product parser"):
+        t"""{"name": "Amy", "age": 50}""".read[Person in Json]
+      . assert(_ == Person(t"Amy", 50))
+
+      test(m"Derived parser accepts reordered fields"):
+        t"""{"age": 50, "name": "Amy"}""".read[Person in Json]
+      . assert(_ == Person(t"Amy", 50))
+
+      test(m"Derived parser skips unknown fields, including nested ones"):
+        t"""{"name": "Amy", "extra": {"deep": [1, {"x": null}]}, "age": 50}"""
+        . read[Person in Json]
+      . assert(_ == Person(t"Amy", 50))
+
+      test(m"Duplicate keys are last-wins, as on the AST path"):
+        parity[Person](t"""{"name": "Amy", "name": "Bea", "age": 50}""")
+      . assert(identity)
+
+      test(m"A missing field takes the declared default"):
+        t"""{"name": "Kid"}""".read[WithDefault in Json]
+      . assert(_ == WithDefault(t"Kid", 18))
+
+      test(m"A missing required field raises JsonError Absent"):
+        capture[JsonError](t"""{"age": 50}""".read[Person in Json])
+      . assert(_.reason match
+          case JsonError.Reason.Absent => true
+          case _                       => false)
+
+      test(m"@name renames apply to direct parsing"):
+        parity[Renamed](t"""{"first_name": "Jon", "yob": 1983}""")
+      . assert(identity)
+
+      test(m"An absent Option field is None"):
+        t"""{"x": 1}""".read[FooOption in Json]
+      . assert(_ == FooOption(1, None))
+
+      test(m"An Optional field reads null and absent as Unset, a value as itself"):
+        ( t"""{"x": 1}""".read[FooOptional in Json],
+          t"""{"x": 1, "y": null}""".read[FooOptional in Json],
+          t"""{"x": 1, "y": 2}""".read[FooOptional in Json] )
+      . assert(_ == (FooOptional(1, Unset), FooOptional(1, Unset), FooOptional(1, 2)))
+
+      test(m"Nested products and collections parse directly"):
+        val json = t"""{"name": "Acme", "leader":
+            {"name": "Bob", "age": 40, "roles": [{"name": "CEO"}, {"name": "CTO"}]}}"""
+
+        json.read[Org in Json]
+      . assert(_ == Org("Acme", Entity("Bob", 40, List(Role("CEO"), Role("CTO")))))
+
+      test(m"A full record round-trips equally on both paths"):
+        val json = t"""{"guitarists": [{"name": "John", "age": 40}, {"name": "George", "age":
+            58}], "drummer": {"name": "Ringo", "age": 82}, "bassist": {"name": "Paul", "age":
+            81}}"""
+
+        parity[Band](json)
+      . assert(identity)
+
+      test(m"Recursive types parse directly"):
+        parity[Tree](t"""{"value": "a", "children": [{"value": "b", "children": []}]}""")
+      . assert(identity)
+
+      test(m"Recursion through an Optional parses directly"):
+        parity[TreeOpt](t"""{"value": "a", "child": {"value": "b"}}""")
+      . assert(identity)
+
+      test(m"Recursion through a Map parses directly"):
+        parity[Forest](t"""{"trees": {"oak": {"value": "a", "children": []}}}""")
+      . assert(identity)
+
+      test(m"An empty case class parses from an object with spurious fields"):
+        t"""{"whatever": 42}""".read[Empty in Json]
+      . assert(_ == Empty())
+
+      test(m"A generic product parses directly"):
+        t"""{"value": 42}""".read[Boxed[Int] in Json]
+      . assert(_ == Boxed(42))
+
+      test(m"A sum dispatches by discriminator, anywhere in the object"):
+        parity[Status](t"""{"since": 2020, "kind": "ok"}""")
+      . assert(identity)
+
+      test(m"A collection of a derived sum parses equally on both paths"):
+        val json = t"""{"members": [{"person": {"name": "Paul", "age": 81}, "kind": "Bassist"},
+            {"person": {"name": "Ringo", "age": 82}, "kind": "Drummer"}]}"""
+
+        parity[NewBand](json)
+      . assert(identity)
+
+      test(m"A top-level collection of an opted-in element reads directly"):
+        t"""[{"name": "Amy", "age": 50}, {"name": "Bea", "age": 60}]"""
+        . read[List[Person] in Json]
+      . assert(_ == List(Person(t"Amy", 50), Person(t"Bea", 60)))
+
+      test(m"A mistyped directly-parsed field raises ParseError"):
+        // On the AST path this is a `JsonError`; token-level readers report
+        // type mismatches as parse errors, with source positions.
+        capture[ParseError](t"""{"name": "Amy", "age": "x"}""".read[Person in Json])
+      . assert(_.issue match
+          case Json.Ast.Issue.ExpectedNumber('"') => true
+          case _                                  => false)
+
+      test(m"A custom Decodable beats derivation via fromDecodable"):
+        // The documented escape hatch for a type whose hand-written decoder
+        // must win over structural derivation.
+        val decodable: Worker is Json.Decodable =
+          Json.Decodable(Morphology.Str): json =>
+            unsafely(Worker(json.root.string, 0))
+
+        given Worker is Json.Parsable = Json.Parsable.fromDecodable(decodable)
+
+        t"""\"Syd\"""".read[Worker in Json]
+      . assert(_ == Worker(t"Syd", 0))
 
     suite(m"Json error handling"):
       test(m"Decode wrong type raises JsonError NotType"):

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -106,6 +106,9 @@ case class TreeOpt(value: Text, child: Optional[TreeOpt]) derives CanEqual
 case class Forest(trees: Map[Text, Tree]) derives CanEqual
 case class Boxed[value](value: value) derives CanEqual
 
+// Read by a hand-written `Json.Parsable` in the direct-parsing tests.
+case class DirectPoint(x: Int, y: Int) derives CanEqual
+
 object Tests extends Suite(m"Jacinta Tests"):
   def run(): Unit =
     suite(m"Parsing tests"):
@@ -767,6 +770,82 @@ object Tests extends Suite(m"Jacinta Tests"):
       test(m"primitive of null is Null"):
         Json.unseal(t"null".read[Json]).primitive
       . assert(_ == JsonPrimitive.Null)
+
+    suite(m"Direct parsing tests"):
+      test(m"Read an Int directly"):
+        t"42".read[Int in Json]
+      . assert(_ == 42)
+
+      test(m"Read a Long directly"):
+        t"1234567890123".read[Long in Json]
+      . assert(_ == 1234567890123L)
+
+      test(m"Read a Double directly"):
+        t"3.1415926".read[Double in Json]
+      . assert(_ == 3.1415926)
+
+      test(m"Read a Boolean directly"):
+        t"true".read[Boolean in Json]
+      . assert(identity)
+
+      test(m"Read a Text directly"):
+        t"\"hello world\"".read[Text in Json]
+      . assert(_ == t"hello world")
+
+      test(m"Read a string with escapes directly"):
+        t"\"a\\nb\\u0041\"".read[Text in Json]
+      . assert(_ == t"a\nbA")
+
+      test(m"Read with surrounding whitespace"):
+        t"  42  ".read[Int in Json]
+      . assert(_ == 42)
+
+      test(m"Direct number coercion matches the AST path"):
+        t"3.9".read[Long in Json]
+      . assert(_ == 3L)
+
+      test(m"Read a Json value through the direct path"):
+        t"""{"a": 1}""".read[Json in Json].as[Json]
+      . assert: json =>
+          import dynamicJsonAccess.enabled
+          unsafely(json.a.as[Int]) == 1
+
+      test(m"A hand-written Parsable reads an object without an AST"):
+        given DirectPoint is Json.Parsable = Json.Parsable(Morphology.Any): reader =>
+          reader.openObject()
+          var x = 0
+          var y = 0
+
+          while
+            reader.key().lay(false): key =>
+              if key == t"x" then x = reader.int()
+              else if key == t"y" then y = reader.int()
+              else reader.skipValue()
+              true
+          do ()
+
+          DirectPoint(x, y)
+
+        t"""{"y": 3, "unknown": [1, {"a": false}], "x": 2}""".read[DirectPoint in Json]
+      . assert(_ == DirectPoint(2, 3))
+
+      test(m"Trailing content after a direct read raises ParseError"):
+        capture[ParseError](t"42 true".read[Int in Json])
+      . assert(_.issue match
+          case Json.Ast.Issue.SpuriousContent(_) => true
+          case _                                 => false)
+
+      test(m"Type mismatch on a direct read raises ParseError"):
+        capture[ParseError](t"\"abc\"".read[Int in Json])
+      . assert(_.issue match
+          case Json.Ast.Issue.ExpectedNumber('"') => true
+          case _                                  => false)
+
+      test(m"Malformed JSON on a direct read raises ParseError"):
+        capture[ParseError](t"tru".read[Boolean in Json])
+      . assert(_.issue match
+          case Json.Ast.Issue.PrematureEnd | Json.Ast.Issue.ExpectedTrue => true
+          case _                                                         => false)
 
     suite(m"Json error handling"):
       test(m"Decode wrong type raises JsonError NotType"):

--- a/lib/jacinta/src/time/jacinta_time.scala
+++ b/lib/jacinta/src/time/jacinta_time.scala
@@ -57,3 +57,13 @@ package decodables:
   =>  Duration is Json.Decodable =
     caps.unsafe.unsafeAssumePure:
       Json.Decodable(Morphology.Whole): json => Duration(json.root.long)
+
+package parsables:
+  // Direct-parsing counterparts: the epoch number is read straight off the
+  // token stream, with no intermediate AST node or string. Genuinely pure —
+  // raising happens inside the `JsonReader`, through the tactic it carries.
+  given instantJsonParsable: (Instant over Posix) is Json.Parsable =
+    Json.Parsable(Morphology.Whole): reader => Instant.of[Posix](reader.long())
+
+  given durationJsonParsable: Duration is Json.Parsable =
+    Json.Parsable(Morphology.Whole): reader => Duration(reader.long())

--- a/lib/jacinta/src/time/soundness_jacinta_time.scala
+++ b/lib/jacinta/src/time/soundness_jacinta_time.scala
@@ -39,3 +39,7 @@ package encodables:
 package decodables:
   export jacinta.decodables.instantJsonDecodable
   export jacinta.decodables.durationJsonDecodable
+
+package parsables:
+  export jacinta.parsables.instantJsonParsable
+  export jacinta.parsables.durationJsonParsable


### PR DESCRIPTION
Reading a typed value from a JSON source previously always materialized the complete `Json` AST and then decoded it, allocating a full tree of nodes that was discarded immediately. A new `Parsable` typeclass lets a type opt in to consuming JSON tokens directly off the byte stream — in the style of Jsoniter — so `source.read[MyType in Json]` instantiates case classes with no intermediate AST, decoding a typical record corpus 2.4× faster. Types that have not opted in are entirely unaffected.

`distillate` gains the format-agnostic `Parsable` typeclass: a value is `Parsable over Json` when it can read itself from that format's token reader. For JSON, the reader is the new `JsonReader`, a restricted rim over Jacinta's tokenizer with methods for scalars (`long()`, `string()`, `boolean()`, …), structure (`openObject()`, `key()`, `openArray()`, `element()`), null handling, and two escape hatches: `value()` (parse one value into a `Json`) and `skipValue()`.

A case class opts in with one line, and `read[T in Json]` then parses it directly, with every behavioral detail of the AST path preserved: reordered and unknown keys, `@name` renames, defaults, last-wins duplicates, `null`-versus-absent semantics for `Option` and `Optional` fields, and discriminated sums:

```scala
case class Person(name: Text, age: Int)
given Person is Json.Parsable = Json.Parsable.derived

data.read[List[Person] in Json]  // no Json.Ast is built
```

Hand-written instances integrate custom types at the token level — `jacinta.time` now provides `import parsables.instantJsonParsable`, reading an epoch timestamp with no intermediate node — and any field type without a `Parsable` falls back automatically to its existing `Decodable in Json`, so everything keeps working:

```scala
given Instant over Posix is Json.Parsable =
  Json.Parsable(Morphology.Whole): reader => Instant.of[Posix](reader.long())
```

If a type has both a hand-written `Json.Decodable` and a derivable structure, derivation would win on the direct path; restore the custom format with `Json.Parsable.fromDecodable(myDecodable)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
