### PR TITLE
Stress-test follow-ups: latency percentiles, scaling sweeps, constrained heaps

### DIFF
--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -342,6 +342,8 @@ final class Report(using Environment)(using palette: TestPalette):
           Column(e"Throughput", textAlign = TextAlignment.Right): s =>
             val tp = s.strain.throughput
             if tp == 0 then e"" else e"$tp op/s",
+          Column(e"p99", textAlign = TextAlignment.Right): s =>
+            s.strain.p99.lay(e"")(showTime(_)),
           Column(e"Alloc/op", textAlign = TextAlignment.Right): s =>
             showMemory(s.strain.allocationRate.toLong),
           Column(e"Peak", textAlign = TextAlignment.Right): s =>
@@ -799,15 +801,25 @@ final class Report(using Environment)(using palette: TestPalette):
           Column(e"$Bold(Throughput)", textAlign = TextAlignment.Right): s =>
             frequency(s.strain),
           Column(e"$Bold(Alloc·op¯¹)", textAlign = TextAlignment.Right): s =>
-            showMemory(s.strain.allocationRate.toLong),
-          Column(e"$Bold(Peak)", textAlign = TextAlignment.Right): s =>
-            showMemory(s.strain.peakHeap),
-          Column(e"$Bold(Retained)", textAlign = TextAlignment.Right): s =>
-            showMemory(s.strain.retained),
-          Column(e"$Bold(GC n)", textAlign = TextAlignment.Right): s =>
-            s.strain.gcCount,
-          Column(e"$Bold(GC t)", textAlign = TextAlignment.Right): s =>
-            showTime(s.strain.gcTime*1000000L)) :::
+            showMemory(s.strain.allocationRate.toLong)) :::
+          (
+          if rows.exists(_.strain.p50.present) then List(
+            Column(e"$Bold(p50)", textAlign = TextAlignment.Right):
+              (s: ReportLine.Strain) => s.strain.p50.lay(e"")(showTime(_)),
+            Column(e"$Bold(p99)", textAlign = TextAlignment.Right):
+              (s: ReportLine.Strain) => s.strain.p99.lay(e"")(showTime(_)),
+            Column(e"$Bold(p999)", textAlign = TextAlignment.Right):
+              (s: ReportLine.Strain) => s.strain.p999.lay(e"")(showTime(_)))
+          else Nil) :::
+          List(
+          Column(e"$Bold(Peak)", textAlign = TextAlignment.Right):
+            (s: ReportLine.Strain) => showMemory(s.strain.peakHeap),
+          Column(e"$Bold(Retained)", textAlign = TextAlignment.Right):
+            (s: ReportLine.Strain) => showMemory(s.strain.retained),
+          Column(e"$Bold(GC n)", textAlign = TextAlignment.Right):
+            (s: ReportLine.Strain) => e"${s.strain.gcCount}",
+          Column(e"$Bold(GC t)", textAlign = TextAlignment.Right):
+            (s: ReportLine.Strain) => showTime(s.strain.gcTime*1000000L)) :::
           comparisons.map: comparison =>
           import Baseline.*
           val baseline = comparison.strain.baseline.vouch

--- a/lib/probably/src/core/probably.Strain.scala
+++ b/lib/probably/src/core/probably.Strain.scala
@@ -46,7 +46,8 @@ object Strain:
 // `allocation` is the total heap allocation over the window; `peakHeap` the high-water mark of
 // the heap pools; `retained` the live set remaining after a post-run GC (bounded-memory designs
 // show a flat, small value here); `gcCount`/`gcTime` are the collector deltas over the window
-// (time in milliseconds).
+// (time in milliseconds). The optional `p50`/`p90`/`p99`/`p999` fields are per-operation
+// latency percentiles in nanoseconds, taken from a histogram accumulated across all workers.
 case class Strain
   ( concurrency: Int,
     operations:  Long,
@@ -56,7 +57,11 @@ case class Strain
     retained:    Long,
     gcCount:     Long,
     gcTime:      Long,
-    baseline:    Optional[Baseline] ):
+    baseline:    Optional[Baseline],
+    p50:         Optional[Long] = Unset,
+    p90:         Optional[Long] = Unset,
+    p99:         Optional[Long] = Unset,
+    p999:        Optional[Long] = Unset ):
 
   def throughput: Long = if nanoseconds == 0L then 0L else (operations*1e9/nanoseconds).toLong
 

--- a/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
+++ b/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
@@ -37,12 +37,14 @@ import anticipation.*
 import contingency.*
 import eucalyptus.*
 import galilei.*
+import gossamer.*
 import guillotine.*
 import inimitable.*
 import prepositional.*
 import rudiments.*
 import serpentine.*
 import urticose.*
+import vacuous.*
 
 import logging.silentLogging
 import workingDirectories.javaWorkingDirectory
@@ -50,20 +52,29 @@ import beneficence.*
 
 trait BenchmarkDevice extends Findable:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError
-  def invoke(path: Path on Linux, input: Text): Text raises BenchError
+
+  // `heap` overrides the measurement JVM's fixed heap size (both `-Xms` and `-Xmx`), in
+  // `-Xmx` syntax, e.g. `t"256m"`; when unset, the default of `1g` applies. Constrained-heap
+  // stress tests use this to demonstrate what a workload sustains in a small, pinned heap.
+  def invoke(path: Path on Linux, input: Text, heap: Optional[Text] = Unset)
+  :   Text raises BenchError
+
   def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError
 
 class NetworkDevice(user: Text, host: Hostname) extends BenchmarkDevice:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
     safely(sh"scp $path $user@$host:$uuid.jar".exec[Exit]()).lest(BenchError())
 
-  def invoke(path: Path on Linux, input: Text): Text raises BenchError =
+  def invoke(path: Path on Linux, input: Text, heap: Optional[Text] = Unset)
+  :   Text raises BenchError =
+    val size = heap.or(t"1g")
+
     val command =
       sh"""
         java
           -XX:+AlwaysPreTouch
-          -Xms1g
-          -Xmx1g
+          -Xms$size
+          -Xmx$size
           -XX:CICompilerCount=2
           -XX:+UseSerialGC
           -jar ${path.name}
@@ -79,8 +90,10 @@ class NetworkDevice(user: Text, host: Hostname) extends BenchmarkDevice:
 object LocalhostDevice extends BenchmarkDevice:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError = ()
 
-  def invoke(path: Path on Linux, input: Text): Text raises BenchError =
-    val opts = sh"-XX:+AlwaysPreTouch -Xms1g -Xmx1g -XX:CICompilerCount=2 -XX:+UseSerialGC"
+  def invoke(path: Path on Linux, input: Text, heap: Optional[Text] = Unset)
+  :   Text raises BenchError =
+    val size = heap.or(t"1g")
+    val opts = sh"-XX:+AlwaysPreTouch -Xms$size -Xmx$size -XX:CICompilerCount=2 -XX:+UseSerialGC"
     val cmd = sh"java $opts -jar $path $input"
     safely(cmd.exec[Text]()).lest(BenchError())
 

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -34,7 +34,6 @@ package sedentary
 
 import java.lang as jl
 
-import galilei.*
 import scala.quoted.*
 
 import ambience.*
@@ -43,6 +42,7 @@ import anticipation.*
 import contingency.*
 import digression.*
 import fulminate.*
+import galilei.*
 import gossamer.*
 import hellenism.*
 import inimitable.*
@@ -53,16 +53,25 @@ import probably.*
 import rudiments.*
 import serpentine.*
 import superlunary.*
-import symbolism.*
 import vacuous.*
 
 
 // A stress test: the memory/scaling counterpart of `Bench`. Where `Bench` times one operation
 // repeated serially on the calling thread, `Stress` runs the body concurrently on `concurrency`
-// platform threads for a fixed wall-clock window and measures memory behaviour over that window:
-// total allocation (hence allocation per operation), peak heap, the live set retained after a
-// post-run GC, and GC count/time. The results are reported as a `Strain` row in the report.
-case class Stress()(using Classloader, Environment)(using device: BenchmarkDevice) extends Rig:
+// platform threads for a fixed wall-clock window and measures memory behaviour over that
+// window: total allocation (hence allocation per operation), peak heap, the live set retained
+// after a post-run GC, GC count/time, and per-operation latency percentiles. Each measurement
+// is reported as a `Strain` row.
+//
+// Setting `sweep` turns the measurement into a scaling sweep: the window is run repeatedly with
+// the worker count doubling from `concurrency` (default 1) up to `sweep`, emitting one `Strain`
+// row per step, so the report shows throughput/latency/memory as curves against N. The sweep
+// stops early if a step ends in `OutOfMemoryError` or spends more than half its window in GC —
+// so in a constrained heap (the `heap` constructor parameter, e.g. `Stress(heap = t"128m")`)
+// the last emitted row is the maximum sustainable concurrency for that heap.
+case class Stress(heap: Optional[Text] = Unset)(using Classloader, Environment)
+  ( using device: BenchmarkDevice )
+extends Rig:
   type Result[output] = output
   type Form = Text
   type Target = Path on Linux
@@ -73,6 +82,7 @@ case class Stress()(using Classloader, Environment)(using device: BenchmarkDevic
     ( name: Message )
     ( target:      duration,
       concurrency: Optional[Int]      = Unset,
+      sweep:       Optional[Int]      = Unset,
       baseline:    Optional[Baseline] = Unset )
     ( body0: (References over Transport) ?=> Quotes ?=> Expr[Any] )
     ( using System, TemporaryDirectory, Stageable over Transport in Form )
@@ -82,9 +92,22 @@ case class Stress()(using Classloader, Environment)(using device: BenchmarkDevic
             codepoint: Codepoint )
   :   Unit raises CompilerError raises RemoteError =
 
-    val testId = TestId(name, suite, codepoint)
     val concurrency0: Optional[Int] = concurrency
-    val concurrency2: Int = concurrency0.or(1)
+    val start: Int = concurrency0.or(1)
+    val sweep0: Optional[Int] = sweep
+    val limit: Int = sweep0.or(start)
+    val sweeping: Boolean = sweep0.present
+
+    val steps: List[Int] =
+      val builder = List.newBuilder[Int]
+      var n = start
+
+      while n < limit do
+        builder += n
+        n *= 2
+
+      builder += limit
+      builder.result()
 
     val body: (References over Transport) ?=> Quotes ?=> Expr[List[Long]] =
       val target2: Expr[Long] = Expr(target.generic)
@@ -113,105 +136,191 @@ case class Stress()(using Classloader, Environment)(using device: BenchmarkDevic
             java.lang.management.ManagementFactory.getThreadMXBean.nn
             . asInstanceOf[com.sun.management.ThreadMXBean]
 
-          var i = 0
+          val results = scala.collection.mutable.ListBuffer[Long]()
+          val stepsIterator = ${Expr(steps)}.iterator
+          var stop = false
 
-          while i < pools.size do
-            val pool = pools.get(i).nn
-            if pool.getType == java.lang.management.MemoryType.HEAP then pool.resetPeakUsage()
-            i += 1
+          while stepsIterator.hasNext && !stop do
+            val n: Int = stepsIterator.next()
 
-          var gcCount = 0L
-          var gcTime = 0L
-          i = 0
+            // Preallocate every measurement structure before the allocation snapshot, so none
+            // of it pollutes the allocation-per-operation figure.
+            val ops = new Array[Long](n)
+            val histograms = new Array[Array[Long] | Null](n)
+            val threads = new Array[java.lang.Thread | Null](n)
+            val oom = new java.util.concurrent.atomic.AtomicBoolean(false)
+            var k = 0
 
-          while i < gcs.size do
-            val gc = gcs.get(i).nn
-            gcCount -= gc.getCollectionCount
-            gcTime -= gc.getCollectionTime
-            i += 1
+            while k < n do
+              histograms(k) = new Array[Long](1024)
+              k += 1
 
-          val allocated0 = threadMx.getTotalThreadAllocatedBytes
+            var i = 0
 
-          val n: Int = ${Expr(concurrency2)}
-          val ops = new Array[Long](n)
-          val threads = new Array[java.lang.Thread | Null](n)
-          val t0 = jl.System.nanoTime
-          val deadline = t0 + $target2
-          var k = 0
+            while i < pools.size do
+              val pool = pools.get(i).nn
+              if pool.getType == java.lang.management.MemoryType.HEAP then pool.resetPeakUsage()
+              i += 1
 
-          while k < n do
-            val slot = k
+            var gcCount = 0L
+            var gcTime = 0L
+            i = 0
 
-            val runnable: java.lang.Runnable = () =>
-              var count = 0L
+            while i < gcs.size do
+              val gc = gcs.get(i).nn
+              gcCount -= gc.getCollectionCount
+              gcTime -= gc.getCollectionTime
+              i += 1
 
-              while jl.System.nanoTime < deadline do
-                sink.lazySet($body0)
-                count += 1L
+            val allocated0 = threadMx.getTotalThreadAllocatedBytes
+            val t0 = jl.System.nanoTime
+            val deadline = t0 + $target2
+            k = 0
 
-              ops(slot) = count
+            while k < n do
+              val slot = k
 
-            val thread = new java.lang.Thread(runnable)
-            threads(k) = thread
-            thread.start()
-            k += 1
+              val runnable: java.lang.Runnable = () =>
+                try
+                  val histogram = histograms(slot).nn
+                  var count = 0L
+                  var before = jl.System.nanoTime
 
-          k = 0
+                  while before < deadline do
+                    sink.lazySet($body0)
+                    val after = jl.System.nanoTime
 
-          while k < n do
-            threads(k).nn.join()
-            k += 1
+                    // Log-linear bucketing with 16 sub-buckets per power of two, in the style
+                    // of HDR histograms: ~±3% quantisation in 8 KiB per worker.
+                    val time = if after > before then after - before else 1L
+                    val bits = 63 - java.lang.Long.numberOfLeadingZeros(time)
 
-          val elapsed = jl.System.nanoTime - t0
-          val allocated = threadMx.getTotalThreadAllocatedBytes - allocated0
+                    val index =
+                      if bits < 4 then time.toInt
+                      else (bits - 4)*16 + ((time >> (bits - 4)) & 15L).toInt + 16
 
-          var peak = 0L
-          i = 0
+                    histogram(if index > 1023 then 1023 else index) += 1L
+                    count += 1L
+                    before = after
 
-          while i < pools.size do
-            val pool = pools.get(i).nn
+                  ops(slot) = count
 
-            if pool.getType == java.lang.management.MemoryType.HEAP
-            then peak += pool.getPeakUsage.nn.getUsed
+                catch case error: java.lang.OutOfMemoryError => oom.set(true)
 
-            i += 1
+              val thread = new java.lang.Thread(runnable)
+              threads(k) = thread
+              thread.start()
+              k += 1
 
-          i = 0
+            k = 0
 
-          while i < gcs.size do
-            val gc = gcs.get(i).nn
-            gcCount += gc.getCollectionCount
-            gcTime += gc.getCollectionTime
-            i += 1
+            while k < n do
+              threads(k).nn.join()
+              k += 1
 
-          // Retained live set: collect, let the collector settle, then read the heap. A
-          // bounded-memory design shows a flat, small value here regardless of how much data
-          // flowed during the window.
-          sink.lazySet(null)
-          jl.System.gc()
-          java.lang.Thread.sleep(100L)
-          val retained = memory.getHeapMemoryUsage.nn.getUsed
+            val elapsed = jl.System.nanoTime - t0
+            val allocated = threadMx.getTotalThreadAllocatedBytes - allocated0
 
-          var total = 0L
-          k = 0
+            var peak = 0L
+            i = 0
 
-          while k < n do
-            total += ops(k)
-            k += 1
+            while i < pools.size do
+              val pool = pools.get(i).nn
+
+              if pool.getType == java.lang.management.MemoryType.HEAP
+              then peak += pool.getPeakUsage.nn.getUsed
+
+              i += 1
+
+            i = 0
+
+            while i < gcs.size do
+              val gc = gcs.get(i).nn
+              gcCount += gc.getCollectionCount
+              gcTime += gc.getCollectionTime
+              i += 1
+
+            // Retained live set: collect, let the collector settle, then read the heap. A
+            // bounded-memory design shows a flat, small value here regardless of how much
+            // data flowed during the window. The sink is cleared first so the last body
+            // result doesn't count as retained.
+            sink.lazySet(null)
+            jl.System.gc()
+            java.lang.Thread.sleep(100L)
+            val retained = memory.getHeapMemoryUsage.nn.getUsed
+
+            var total = 0L
+            k = 0
+
+            while k < n do
+              total += ops(k)
+              k += 1
+
+            // Merge the worker histograms and extract the latency percentiles.
+            val merged = new Array[Long](1024)
+            k = 0
+
+            while k < n do
+              val histogram = histograms(k).nn
+              i = 0
+
+              while i < 1024 do
+                merged(i) += histogram(i)
+                i += 1
+
+              k += 1
+
+            def percentile(fraction: Double): Long =
+              if total == 0L then 0L else
+                var remaining = (total*fraction).toLong + 1L
+                var index = 0
+
+                while index < 1024 && remaining > merged(index) do
+                  remaining -= merged(index)
+                  index += 1
+
+                if index >= 1024 then index = 1023
+
+                if index < 16 then index.toLong
+                else (16L + (index - 16)%16) << ((index - 16)/16)
+
+            // A step which ran out of memory is not reported, and ends the sweep; a step
+            // which spent more than half its window collecting garbage is reported, but
+            // larger worker counts aren't sustainable in this heap, so the sweep ends there.
+            if oom.get then stop = true else
+              results += n.toLong
+              results += total
+              results += elapsed
+              results += allocated
+              results += peak
+              results += retained
+              results += gcCount
+              results += gcTime
+              results += percentile(0.5)
+              results += percentile(0.9)
+              results += percentile(0.99)
+              results += percentile(0.999)
+
+              if gcTime*2000000L > elapsed then stop = true
 
           if jl.System.nanoTime < 0L then jl.System.err.nn.println(sink.get)
 
-          List(total, elapsed, allocated, peak, retained, gcCount, gcTime)
+          results.toList
         }
 
-    val results = dispatch(body)
+    dispatch(body).grouped(12).to(List).each: step =>
+      val n = step(0).toInt
 
-    val strain =
-      Strain
-        ( concurrency2, results(0), results(1), results(2), results(3), results(4), results(5),
-          results(6), baseline )
+      val testId =
+        if sweeping then TestId(m"$name (N = $n)", suite, codepoint)
+        else TestId(name, suite, codepoint)
 
-    inclusion.include(runner.report, testId, strain)
+      val strain =
+        Strain
+          ( n, step(1), step(2), step(3), step(4), step(5), step(6), step(7), baseline,
+            step(8), step(9), step(10), step(11) )
+
+      inclusion.include(runner.report, testId, strain)
 
 
   def stage(out: Path on Linux): Path on Linux = unsafely:
@@ -226,4 +335,5 @@ case class Stress()(using Classloader, Environment)(using device: BenchmarkDevic
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>
-      unsafely(device.invoke(stage.target, input))
+      unsafely(device.invoke(stage.target, input, heap))
+// x

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -153,6 +153,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
   def run(): Unit =
     val bench = Bench()
     val stress = Stress()
+    val constrained = Stress(heap = t"128m")
     val size = input.length*Byte
     val textSize = textData.length*Byte
 
@@ -880,6 +881,51 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
         }
 
       stress(m"ZIO  Queue.bounded")(target = 2*Second, concurrency = 16):
+        '{
+            turbulence.Benchmarks.runZio:
+              import zio.*, zio.stream.*
+              val source =
+                ZStream.fromIterable
+                  (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[Array[Byte]])))
+              for
+                queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
+                _     <- source.runIntoQueue(queue).fork
+                total <- ZStream.fromQueue(queue).flattenTake.runFold(0L)((acc, c) => acc + c.size)
+              yield total
+        }
+    // Example P: constrained-heap scaling sweep — the same hand-off pipeline in a
+    // pinned 128 MB heap, with the pipeline count doubling from 1 towards 64.
+    // Each step is reported as its own row, so the table reads as the
+    // throughput/latency/memory-vs-N curve, and the sweep stops at the largest N
+    // the heap sustains (OutOfMemoryError, or over half the window spent in GC) —
+    // the bounded-buffer design should sustain more pipelines in the same heap.
+    suite(m"Stress: constrained-heap scaling sweep (128 MB heap, N ≤ 64)"):
+      constrained(m"Soundness  Conduit")(target = 1*Second, sweep = 64):
+        '{
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.foreach(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep((_, _, count) => total += count)
+            producer.join()
+            total
+        }
+
+      constrained(m"FS2  Channel.bounded")(target = 1*Second, sweep = 64):
+        '{
+            import cats.effect.unsafe.implicits.global
+            import cats.effect.IO
+            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
+              val produce =
+                turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[Array[Byte]])).void
+                *> channel.close.void
+              produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
+            program.unsafeRunSync()
+        }
+
+      constrained(m"ZIO  Queue.bounded")(target = 1*Second, sweep = 64):
         '{
             turbulence.Benchmarks.runZio:
               import zio.*, zio.stream.*


### PR DESCRIPTION
Stress tests (#1542) gain the remaining measurement axes proposed in #1514. Every stress window now records per-operation latency percentiles (p50/p99/p999) alongside the memory profile; a `sweep` parameter re-runs the window with the worker count doubling up to a limit, emitting one row per step so the report reads as a throughput/latency/memory-versus-N curve; and the measurement JVM's heap can be pinned small, so a sweep discovers the maximum concurrency a workload sustains in a constrained heap. The streaming benchmarks gain a 128 MB-heap sweep of the cross-thread hand-off pipeline up to 64 concurrent pipelines.

## Release notes

Stress tests now measure per-operation **latency percentiles** in addition to the memory profile. Latencies are accumulated in HDR-style log-linear histograms (about ±3% quantisation, 8 KiB per worker, allocated before the measurement window so they don't pollute the allocation figures) and merged across workers; `Strain` rows gain `p50`/`p90`/`p99`/`p999` fields, and the report shows p50, p99 and p999 columns.

A stress test can also run as a **scaling sweep**:

```scala
val constrained = Stress(heap = t"128m")

suite(m"Constrained-heap sweep"):
  constrained(m"Conduit hand-off")(target = 1*Second, sweep = 64):
    '{ ... }
```

With `sweep` set, the window is run repeatedly with the worker count doubling from `concurrency` (default 1) up to `sweep`, and each step is reported as its own row — so the table reads as the throughput/latency/memory-vs-N curve. The sweep stops early if a step throws `OutOfMemoryError` or spends more than half its window in GC, so the last row shows the maximum sustainable concurrency.

The `heap` constructor parameter (in `-Xmx` syntax) pins the measurement JVM's heap — both `-Xms` and `-Xmx` — for the constrained-heap variant; unset, the established 1 GB default applies. `BenchmarkDevice.invoke` correspondingly accepts an optional heap size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
