### PR TITLE
Wrapper and envelope sum encodings, with streaming-friendly dispatch

### DIFF
--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -1982,12 +1982,149 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     skip()
     parseValue()
 
-  // Structure-aware skip of one whole value. Parses and discards for now; a
-  // non-materializing scanner is a later optimization, invisible to callers.
+  // Structure-aware skip of one whole value: a validated scan that enforces
+  // the same grammar (and raises the same `Issue`s) as `parseValue`'s loops,
+  // but builds nothing — no AST nodes, no scratch buffers, no key strings.
   private[jacinta] update def directSkipValue()(using Tactic[ParseError]): Unit =
     skip()
-    parseValue()
-    ()
+    skipValue1()
+
+  // Positioned at the first byte of a value (no leading whitespace).
+  private update def skipValue1()(using Tactic[ParseError]): Unit =
+    val ch = must()
+
+    if (ch & 0xF8) == Num0 || (ch & 0xFE) == 0x38 then
+      advance()
+      parseNumber(ch & 0x0F, false)
+      ()
+    else
+      (ch: @switch) match
+        case Quote       => advance() yet skipString()
+        case OpenBracket => advance() yet skipArrayBody()
+        case LowerF      => parseFalse() yet ()
+        case LowerN      => parseNull() yet ()
+        case LowerT      => parseTrue() yet ()
+        case OpenBrace   => advance() yet skipObjectBody()
+
+        case Minus =>
+          advance()
+          val digit = must()
+
+          if (digit & 0xF8) == Num0 || (digit & 0xFE) == 0x38 then
+            advance()
+            parseNumber(digit & 0x0F, true)
+            ()
+          else errorAt(Issue.ExpectedDigit(digit.toChar))
+
+        case other => errorAt(Issue.ExpectedSomeValue(other.toChar))
+
+  // Mirrors `parseObject`'s loop structure and issues, without materializing
+  // keys or values.
+  private update def skipObjectBody()(using Tactic[ParseError]): Unit =
+    var continue = true
+    var first = true
+
+    while continue do
+      skip()
+
+      must() match
+        case Quote =>
+          advance()
+          skipString()
+          skip()
+
+          must() match
+            case Colon =>
+              advance()
+              skip()
+              skipValue1()
+              skip()
+
+              must() match
+                case Comma      => advance()
+                case CloseBrace => advance() yet { continue = false }
+                case ch         => errorAt(Issue.UnexpectedChar(ch.toChar))
+
+            case ch => errorAt(Issue.ExpectedColon(ch.toChar))
+
+        case CloseBrace =>
+          if !first then errorAt(Issue.ExpectedSomeValue('}'))
+          advance()
+          continue = false
+
+        case ch => errorAt(Issue.ExpectedString(ch.toChar))
+
+      first = false
+
+  // Mirrors `parseArray`'s loop structure and issues.
+  private update def skipArrayBody()(using Tactic[ParseError]): Unit =
+    var continue = true
+    var first = true
+
+    while continue do
+      skip()
+
+      must() match
+        case CloseBracket =>
+          if !first then errorAt(Issue.ExpectedSomeValue(']'))
+          advance()
+          continue = false
+
+        case _ =>
+          skipValue1()
+          skip()
+
+          must() match
+            case Comma        => advance()
+            case CloseBracket => advance() yet { continue = false }
+            case ch           => errorAt(Issue.ExpectedSomeValue(ch.toChar))
+
+      first = false
+
+  // Skips a string, validating escapes, hex digits and character legality
+  // exactly as `tail` does, without accumulating characters. Positioned
+  // after the opening quote; consumes the closing quote.
+  private update def skipString()(using Tactic[ParseError]): Unit =
+    var continue = true
+
+    while continue do
+      while more && StringScanContinue(peek & 0xFF) != 0 do advance()
+      if !more then errorAt(Issue.PrematureEnd)
+      val ch = peek
+
+      ch match
+        case Quote =>
+          advance()
+          continue = false
+
+        case Tab | Newline | Return =>
+          errorAt(Issue.InvalidWhitespace)
+
+        case Backslash =>
+          advance()
+          if !more then errorAt(Issue.PrematureEnd)
+
+          (peek: @switch) match
+            case Quote | Slash | Backslash | LowerB | LowerF | LowerN | LowerR | LowerT =>
+              advance()
+
+            case LowerU =>
+              parseUnicode()
+              advance()
+
+            case bad => errorAt(Issue.IncorrectEscape(bad.toChar))
+
+        case _ =>
+          if ch == 0 && holes then advance()
+          else ((ch >> 5): @switch) match
+            case 0                 => errorAt(Issue.NotEscaped(ch.toChar))
+            case 1 | 2 | 3 | 4 | 5 => advance()
+
+            case _ =>
+              if (ch & 0xE0) == 0xC0 then { next(); advance() }
+              else if (ch & 0xF0) == 0xE0 then { next(); next(); advance() }
+              else if (ch & 0xF8) == 0xF0 then { next(); next(); next(); advance() }
+              else advance()
 
   private[jacinta] update def directString()(using Tactic[ParseError]): String =
     skip()
@@ -2254,6 +2391,58 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
         case _ =>
           directMark()
           true
+
+  // Reposition at a previously-taken mark. Only valid inside the `holding`
+  // block that produced the mark (which pins the buffer region).
+  private update def rewind(start: Cursor.Mark)(using held: Cursor.Held): Unit =
+    syncTo()
+
+    // Block-scoped like `begin`; the parser snapshot is refreshed afterwards.
+    locally:
+      val current = cursor
+      current.cue(start)
+
+    syncFrom()
+
+  // Scans the upcoming object for the given key and returns its string
+  // value, leaving the reader where it started (the `hold` pins the region
+  // so the whole object can be re-read afterwards). This is the dispatch
+  // primitive for an internal discriminator field that may appear anywhere
+  // in the object. `null` when the object ends without the key, or when its
+  // value is not a string — mirroring `discriminate`'s `Unset` on the AST
+  // path. Malformed content raises exactly as parsing it would.
+  private[jacinta] update def directDiscriminant(key: String)(using Tactic[ParseError])
+  :   String | Null =
+
+    skip()
+    val savedDepth = directDepth
+    var result: String | Null = null
+
+    holding:
+      val start = begin()
+
+      if must() != OpenBrace then errorAt(Issue.ExpectedObject(peek.toChar))
+      advance()
+      directPush()
+      var name: String | Null = directKey()
+
+      while name != null do
+        if key == name then
+          val raw: Any = directValue()
+
+          raw.asMatchable match
+            case tag: String => result = tag
+            case _           => ()
+
+          name = null
+        else
+          directSkipValue()
+          name = directKey()
+
+      rewind(start)
+
+    directDepth = savedDepth
+    result
 
   private[jacinta] update def directFail(issue: Issue)(using Tactic[ParseError]): Nothing =
     errorAt(issue)

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -325,6 +325,12 @@ trait Json2 extends Json3:
       // codec-carried shape is kept permissive (`Any`) because the only way to walk
       // the variants here (`delegate`) is `fallible` and would leak a
       // `Tactic[VariantError]` requirement onto every codec.
+      // The shape test happens once, outside the decode lambda: a reference
+      // to the shape class inside the nested context functions poisons
+      // their capture sets.
+      val fieldShaped: Boolean =
+        infer[derivation is Discriminable in Json].isInstanceOf[Json.DiscriminantField[?]]
+
       Json.Decodable(Morphology.Any):
         json =>
           provide[Tactic[JsonError]]:
@@ -341,8 +347,14 @@ trait Json2 extends Json3:
 
               val discriminant: Text = variantNames.getOrElse(wire, wire)
 
+              // The variant decodes the whole value for the internal-field
+              // shape (its tag is simply skipped as an unknown key — no need
+              // to rebuild the object without it), and the extracted payload
+              // for every other shape.
+              val payload = if fieldShaped then json else discriminable.variant(json)
+
               delegate(discriminant): [variant <: derivation] =>
-                context => context.decoded(json)
+                context => context.decoded(payload)
 
   object ParsableDerivation extends Derivable[Json.Field]:
     inline def conjunction[derivation <: Product: ProductReflection]
@@ -371,13 +383,93 @@ trait Json2 extends Json3:
           ( using infer[Foci[Json.Focus]], infer[Tactic[JsonError]] )
 
     inline def disjunction[derivation: SumReflection]: derivation is Json.Field =
-      // A sum materializes one value's AST and dispatches through its
-      // decoder — the same discriminated-object handling as the AST path,
-      // byte for byte, honoring any custom `Json.Decodable` the sum has.
-      // Token-level sum parsing (discriminator scan-ahead with rewind) is a
-      // later optimization.
+      // Dispatch strategy by wire shape: a wrapper's tag is its first token,
+      // so it streams with no lookahead at all; an envelope and an internal
+      // field locate the tag with a bounded scan-ahead (`discriminant`
+      // skips values without materializing them, then rewinds), after which
+      // the chosen variant parses directly from the tokens. Any custom
+      // `Discriminable` falls back to materializing one value's AST and
+      // dispatching through the decoder. Sealed per the codec-thunk
+      // pattern: each instance captures resolution-scoped tactics.
       caps.unsafe.unsafeAssumePure:
-        Json.Field(Json.Parsable.fromDecodable(infer[derivation is Json.Decodable]))
+        infer[derivation is Discriminable in Json] match
+          case fielded: Json.DiscriminantField[?] =>
+            new Json.Field:
+              type Self = derivation
+              def shape(): Morphology = Morphology.Any
+
+              def parse(reader: JsonReader^): derivation =
+                provide[Tactic[JsonError]]:
+                  provide[Tactic[VariantError]]:
+                    val variantNames: Map[Text, Text] =
+                      variantRelabelling[derivation, Json].map: (variant, wire) =>
+                        wire -> variant
+
+                    val wire: Text = reader.discriminant(fielded.field).or:
+                      abort(JsonError(Reason.Absent))
+
+                    // The variant re-reads the whole object, skipping the
+                    // tag as an unknown key.
+                    delegate(variantNames.getOrElse(wire, wire)):
+                      [variant <: derivation] => context => context.parse(reader)
+
+          case wrapper: Json.DiscriminantWrapper[?] =>
+            new Json.Field:
+              type Self = derivation
+              def shape(): Morphology = Morphology.Any
+
+              def parse(reader: JsonReader^): derivation =
+                provide[Tactic[JsonError]]:
+                  provide[Tactic[VariantError]]:
+                    val variantNames: Map[Text, Text] =
+                      variantRelabelling[derivation, Json].map: (variant, wire) =>
+                        wire -> variant
+
+                    reader.openObject()
+                    val wire: Text = reader.key().or(abort(JsonError(Reason.Absent)))
+
+                    val result =
+                      delegate(variantNames.getOrElse(wire, wire)):
+                        [variant <: derivation] => context => context.parse(reader)
+
+                    // A wrapper is a single-key object; anything more means
+                    // no tag is identifiable, as on the AST path.
+                    if !reader.key().absent then abort(JsonError(Reason.Absent))
+                    result
+
+          case envelope: Json.DiscriminantEnvelope[?] =>
+            new Json.Field:
+              type Self = derivation
+              def shape(): Morphology = Morphology.Any
+
+              def parse(reader: JsonReader^): derivation =
+                provide[Tactic[JsonError]]:
+                  provide[Tactic[VariantError]]:
+                    val variantNames: Map[Text, Text] =
+                      variantRelabelling[derivation, Json].map: (variant, wire) =>
+                        wire -> variant
+
+                    val wire: Text = reader.discriminant(envelope.tagField).or:
+                      abort(JsonError(Reason.Absent))
+
+                    val name = variantNames.getOrElse(wire, wire)
+                    reader.openObject()
+                    var result: Optional[derivation] = Unset
+                    var continue = true
+
+                    while continue do
+                      val key = reader.key()
+
+                      if key.absent then continue = false
+                      else if key.or(t"") == envelope.valueField && result.absent then
+                        result = delegate(name):
+                          [variant <: derivation] => context => context.parse(reader)
+                      else reader.skipValue()
+
+                    result.or(abort(JsonError(Reason.Absent)))
+
+          case other =>
+            Json.Field(Json.Parsable.fromDecodable(infer[derivation is Json.Decodable]))
 
   object EncodableDerivation extends Derivable[Json.Encodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
@@ -1913,10 +2005,24 @@ object Json extends Json2, Dynamic:
     val values: IArray[Json.Ast] = IArray.from(elements.map(_(1).root)).asInstanceOf[IArray[Json.Ast]]
     Json(Json.Ast.obj(keys, values.asInstanceOf[IArray[Any]]))
 
-  def discriminatedUnion[value](label: Text): value is Discriminable in Json = new Discriminable:
+  def discriminatedUnion[value](label: Text): value is Discriminable in Json =
+    DiscriminantField(label)
+
+  // The three standard shapes a discriminated sum takes on the wire. Each is
+  // a NAMED class so both derivations can recognize the shape: the AST
+  // decoder knows whether to decode the whole value or the variant payload,
+  // and the direct parser picks the most streaming-friendly token-level
+  // dispatch for each — a wrapper's tag is always its first token, an
+  // envelope's usually is, and an internal field needs a bounded scan-ahead.
+  // Any other (custom) `Discriminable` still works through the AST bridge.
+
+  // `{"radius": 1.0, "type": "Circle"}` — the tag is a field of the
+  // variant's own object, under `label`.
+  class DiscriminantField[value](label: Text) extends Discriminable:
     type Form = Json
     type Self = value
 
+    private[jacinta] def field: Text = label
     protected def key: String = label.s
 
     import dynamicJsonAccess.enabled
@@ -1927,6 +2033,39 @@ object Json extends Json2, Dynamic:
     // invariant `Self` bound cannot absorb.
     def discriminate(json: Json): Optional[Text] = safely(json.selectField(key).root.string)
     def variant(json: Json): Json = unsafely(json.updateDynamic(key)(Unset))
+
+  // `{"Circle": {"radius": 1.0}}` — a single-key object whose key is the
+  // tag and whose value is the variant's payload.
+  class DiscriminantWrapper[value]() extends Discriminable:
+    type Form = Json
+    type Self = value
+
+    def rewrite(kind: Text, json: Json): Json =
+      Json.ast(Json.Ast.obj(IArray(kind.s), IArray(json.root)))
+
+    def discriminate(json: Json): Optional[Text] =
+      if json.root.isObject && json.root.objectSize == 1
+      then json.root.objectKey(0).tt
+      else Unset
+
+    def variant(json: Json): Json = Json.ast(json.root.objectValue(0))
+
+  // `{"type": "Circle", "value": {"radius": 1.0}}` — the tag and the
+  // variant's payload are adjacent fields of an enclosing object.
+  class DiscriminantEnvelope[value](tagLabel: Text, valueLabel: Text) extends Discriminable:
+    type Form = Json
+    type Self = value
+
+    private[jacinta] def tagField: Text = tagLabel
+    private[jacinta] def valueField: Text = valueLabel
+
+    def rewrite(kind: Text, json: Json): Json =
+      Json.ast(Json.Ast.obj(IArray(tagLabel.s, valueLabel.s), IArray(kind.s, json.root)))
+
+    def discriminate(json: Json): Optional[Text] =
+      safely(json.selectField(tagLabel.s).root.string)
+
+    def variant(json: Json): Json = json.selectField(valueLabel.s)
 
 class Json(rootValue: Any, positions: Optional[Json.PositionIndex] = Unset)
 extends Dynamic, Topical, Original derives CanEqual:

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -103,6 +103,15 @@ extends caps.ExclusiveCapability, caps.Stateful:
   update def value(): Json = Json.ast(Json.Ast(parser.directValue()(using tactic)))
   update def skipValue(): Unit = parser.directSkipValue()(using tactic)
 
+  // Scans the upcoming object for the given key and returns its string
+  // value, leaving the reader where it started — the dispatch primitive for
+  // an internal discriminator field that may appear anywhere in the object.
+  // `Unset` when the object has no such key or its value is not a string.
+  update def discriminant(key: Text): Optional[Text] =
+    parser.directDiscriminant(key.s)(using tactic) match
+      case null        => Unset
+      case tag: String => tag.tt
+
   // Abort through the reader's tactic, positioned at the current input
   // offset — for leaf instances that reject a well-formed token's content.
   update def fail(issue: Json.Ast.Issue): Nothing = parser.directFail(issue)(using tactic)

--- a/lib/jacinta/src/core/jacinta_core.scala
+++ b/lib/jacinta/src/core/jacinta_core.scala
@@ -229,6 +229,15 @@ package discriminables:
   given jsonByKindDiscriminable: [value] => value is Discriminable in Json =
     Json.discriminatedUnion[value]("kind")
 
+  // `{"Circle": {"radius": 1.0}}` — the streaming-friendliest shape: the
+  // tag is always the first token of the value.
+  given jsonWrapperDiscriminable: [value] => value is Discriminable in Json =
+    Json.DiscriminantWrapper[value]()
+
+  // `{"type": "Circle", "value": {"radius": 1.0}}`
+  given jsonEnvelopeDiscriminable: [value] => value is Discriminable in Json =
+    Json.DiscriminantEnvelope[value]("type", "value")
+
 
 package numberModes:
   given fullNumberMode:   NumberMode = NumberMode.Full

--- a/lib/jacinta/src/core/soundness_jacinta_core.scala
+++ b/lib/jacinta/src/core/soundness_jacinta_core.scala
@@ -47,3 +47,5 @@ package numberModes:
 package discriminables:
   export jacinta.discriminables.jsonByTypeDiscriminable
   export jacinta.discriminables.jsonByKindDiscriminable
+  export jacinta.discriminables.jsonWrapperDiscriminable
+  export jacinta.discriminables.jsonEnvelopeDiscriminable

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -990,6 +990,17 @@ object Tests extends Suite(m"Jacinta Tests"):
         t"""{"name": "Amy", "age": -3}""".read[Person in Json]
       . assert(_ == Person(t"Amy", -3))
 
+      test(m"Malformed content inside a skipped field raises ParseError"):
+        capture[ParseError](t"""{"name": "Amy", "junk": {"x": }, "age": 50}""".read[Person in Json])
+      . assert(_.issue match
+          case Json.Ast.Issue.ExpectedSomeValue(_) => true
+          case _                                   => false)
+
+      test(m"Deeply nested skipped values are scanned correctly"):
+        t"""{"junk": [[[{"a": [1, {"b": "x\\n"}, null, true]}]]], "name": "Amy", "age": 50}"""
+        . read[Person in Json]
+      . assert(_ == Person(t"Amy", 50))
+
       test(m"A custom Decodable beats derivation via fromDecodable"):
         // The documented escape hatch for a type whose hand-written decoder
         // must win over structural derivation.
@@ -1001,6 +1012,81 @@ object Tests extends Suite(m"Jacinta Tests"):
 
         t"""\"Syd\"""".read[Worker in Json]
       . assert(_ == Worker(t"Syd", 0))
+
+    suite(m"Sum encoding tests"):
+      test(m"Wrapper encoding writes a single-key object"):
+        given Shape is Discriminable in Json = Json.DiscriminantWrapper()
+        (Shape.Circle(1.0): Shape).in[Json].show
+      . assert(_ == t"""{"Circle":{"radius":1.0}}""")
+
+      test(m"Wrapper encoding decodes via the AST"):
+        given Shape is Discriminable in Json = Json.DiscriminantWrapper()
+        t"""{"Circle": {"radius": 2.5}}""".read[Json].as[Shape]
+      . assert(_ == Shape.Circle(2.5))
+
+      test(m"Wrapper encoding parses directly"):
+        given Shape is Discriminable in Json = Json.DiscriminantWrapper()
+        given Shape is Json.Parsable = Json.Parsable.derived
+        t"""{"Circle": {"radius": 2.5}}""".read[Shape in Json]
+      . assert(_ == Shape.Circle(2.5))
+
+      test(m"A multi-key wrapper raises JsonError Absent on both paths"):
+        given Shape is Discriminable in Json = Json.DiscriminantWrapper()
+        given Shape is Json.Parsable = Json.Parsable.derived
+        val json = t"""{"Circle": {"radius": 1.0}, "junk": 1}"""
+
+        ( capture[JsonError](json.read[Shape in Json]).reason,
+          capture[JsonError](json.read[Json].as[Shape]).reason )
+      . assert(_ == (JsonError.Reason.Absent, JsonError.Reason.Absent))
+
+      test(m"Envelope encoding writes tag and value fields"):
+        given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"value")
+        (Shape.Square(2.0): Shape).in[Json].show
+      . assert(_ == t"""{"type":"Square","value":{"side":2.0}}""")
+
+      test(m"Envelope encoding decodes via the AST"):
+        given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"value")
+        t"""{"type": "Square", "value": {"side": 3.0}}""".read[Json].as[Shape]
+      . assert(_ == Shape.Square(3.0))
+
+      test(m"Envelope encoding parses directly, tag first"):
+        given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"value")
+        given Shape is Json.Parsable = Json.Parsable.derived
+        t"""{"type": "Square", "value": {"side": 3.0}}""".read[Shape in Json]
+      . assert(_ == Shape.Square(3.0))
+
+      test(m"Envelope encoding parses directly, tag last"):
+        given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"value")
+        given Shape is Json.Parsable = Json.Parsable.derived
+        t"""{"value": {"side": 3.0}, "type": "Square"}""".read[Shape in Json]
+      . assert(_ == Shape.Square(3.0))
+
+      test(m"Envelope encoding decodes via the AST, tag last"):
+        given Shape is Discriminable in Json = Json.DiscriminantEnvelope(t"type", t"value")
+        t"""{"value": {"side": 3.0}, "type": "Square"}""".read[Json].as[Shape]
+      . assert(_ == Shape.Square(3.0))
+
+      test(m"An internal-field sum parses directly with the tag anywhere"):
+        given Status is Json.Parsable = Json.Parsable.derived
+        t"""{"since": 2020, "kind": "ok"}""".read[Status in Json]
+      . assert(_ == Status.Active(2020))
+
+      test(m"An internal-field sum with a missing tag raises Absent directly"):
+        given Status is Json.Parsable = Json.Parsable.derived
+        capture[JsonError](t"""{"since": 2020}""".read[Status in Json]).reason
+      . assert(_ == JsonError.Reason.Absent)
+
+      test(m"A custom Discriminable falls back to the AST bridge"):
+        given Shape is Discriminable in Json = new Discriminable:
+          type Form = Json
+          type Self = Shape
+          def rewrite(kind: Text, json: Json): Json = Json.DiscriminantWrapper[Shape]().rewrite(kind, json)
+          def discriminate(json: Json): Optional[Text] = Json.DiscriminantWrapper[Shape]().discriminate(json)
+          def variant(json: Json): Json = Json.DiscriminantWrapper[Shape]().variant(json)
+
+        given Shape is Json.Parsable = Json.Parsable.derived
+        t"""{"Circle": {"radius": 4.5}}""".read[Shape in Json]
+      . assert(_ == Shape.Circle(4.5))
 
     suite(m"Json error handling"):
       test(m"Decode wrong type raises JsonError NotType"):


### PR DESCRIPTION
Discriminated sums can now be encoded in any of the three standard JSON shapes, and direct parsing dispatches each at the token level using the most streaming-friendly strategy its shape allows. Previously only one shape existed — a discriminator field inside the variant's own object — and it always dispatched by materializing the value's AST.

The shapes are named `Discriminable` classes, selectable with a given (importable or scoped per call site):

```scala
import discriminables.jsonByKindDiscriminable   // {"radius": 1.0, "kind": "Circle"}
import discriminables.jsonWrapperDiscriminable  // {"Circle": {"radius": 1.0}}
import discriminables.jsonEnvelopeDiscriminable // {"type": "Circle", "value": {"radius": 1.0}}
```

Encoding, AST decoding and direct parsing all honor the chosen shape. On the direct path, a wrapper's tag is always its first token, so it streams with no lookahead; envelopes and internal fields locate their tag with a bounded scan-ahead and rewind — exposed as `reader.discriminant(key)` for hand-written parsers — after which the chosen variant parses straight from the token stream. A custom `Discriminable` still works, through the AST bridge.

Skipping a value (unknown keys, and the scan-ahead above) is now a validated structural scan: it enforces exactly the grammar that parsing would, and raises the same errors, but allocates nothing — no AST nodes, no scratch buffers, no key strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
