### PR TITLE
SLO-constrained capacity search for stress tests

### DIFF
--- a/lib/probably/src/core/probably.Report.scala
+++ b/lib/probably/src/core/probably.Report.scala
@@ -344,6 +344,9 @@ final class Report(using Environment)(using palette: TestPalette):
             if tp == 0 then e"" else e"$tp op/s",
           Column(e"p99", textAlign = TextAlignment.Right): s =>
             s.strain.p99.lay(e"")(showTime(_)),
+          Column(e"SLO", textAlign = TextAlignment.Right): s =>
+            s.strain.compliance.lay(e""): compliance =>
+              e"${compliance*100}%",
           Column(e"Alloc/op", textAlign = TextAlignment.Right): s =>
             showMemory(s.strain.allocationRate.toLong),
           Column(e"Peak", textAlign = TextAlignment.Right): s =>
@@ -810,6 +813,12 @@ final class Report(using Environment)(using palette: TestPalette):
               (s: ReportLine.Strain) => s.strain.p99.lay(e"")(showTime(_)),
             Column(e"$Bold(p999)", textAlign = TextAlignment.Right):
               (s: ReportLine.Strain) => s.strain.p999.lay(e"")(showTime(_)))
+          else Nil) :::
+          (
+          if rows.exists(_.strain.compliance.present) then List(
+            Column(e"$Bold(SLO)", textAlign = TextAlignment.Right):
+              (s: ReportLine.Strain) => s.strain.compliance.lay(e""): compliance =>
+                e"${Fg(palette.foreground)}(${compliance*100})%")
           else Nil) :::
           List(
           Column(e"$Bold(Peak)", textAlign = TextAlignment.Right):

--- a/lib/probably/src/core/probably.Strain.scala
+++ b/lib/probably/src/core/probably.Strain.scala
@@ -48,6 +48,9 @@ object Strain:
 // show a flat, small value here); `gcCount`/`gcTime` are the collector deltas over the window
 // (time in milliseconds). The optional `p50`/`p90`/`p99`/`p999` fields are per-operation
 // latency percentiles in nanoseconds, taken from a histogram accumulated across all workers.
+// In a capacity search, `compliance` is the measured fraction of operations completing
+// within the latency threshold, and `sustained` marks the winning row: the highest
+// concurrency whose (extended) window still met the compliance target.
 case class Strain
   ( concurrency: Int,
     operations:  Long,
@@ -58,10 +61,12 @@ case class Strain
     gcCount:     Long,
     gcTime:      Long,
     baseline:    Optional[Baseline],
-    p50:         Optional[Long] = Unset,
-    p90:         Optional[Long] = Unset,
-    p99:         Optional[Long] = Unset,
-    p999:        Optional[Long] = Unset ):
+    p50:         Optional[Long]   = Unset,
+    p90:         Optional[Long]   = Unset,
+    p99:         Optional[Long]   = Unset,
+    p999:        Optional[Long]   = Unset,
+    compliance:  Optional[Double] = Unset,
+    sustained:   Boolean          = false ):
 
   def throughput: Long = if nanoseconds == 0L then 0L else (operations*1e9/nanoseconds).toLong
 

--- a/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
+++ b/lib/sedentary/src/core/sedentary.BenchmarkDevice.scala
@@ -56,7 +56,16 @@ trait BenchmarkDevice extends Findable:
   // `heap` overrides the measurement JVM's fixed heap size (both `-Xms` and `-Xmx`), in
   // `-Xmx` syntax, e.g. `t"256m"`; when unset, the default of `1g` applies. Constrained-heap
   // stress tests use this to demonstrate what a workload sustains in a small, pinned heap.
-  def invoke(path: Path on Linux, input: Text, heap: Optional[Text] = Unset)
+  //
+  // `cpus` limits the measurement JVM to that many processors. Everywhere it sets
+  // `-XX:ActiveProcessorCount`, which sizes GC/JIT threads and every pool derived from
+  // `Runtime.availableProcessors`; on a Linux device the process is additionally pinned to
+  // that many cores with `taskset`. Note that without OS-level pinning (macOS localhost),
+  // raw platform threads still schedule across all cores, so the limit is advisory there —
+  // for hard CPU isolation, run against a Linux `NetworkDevice`.
+  def invoke
+    ( path: Path on Linux, input: Text, heap: Optional[Text] = Unset,
+      cpus: Optional[Int] = Unset )
   :   Text raises BenchError
 
   def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError
@@ -65,18 +74,29 @@ class NetworkDevice(user: Text, host: Hostname) extends BenchmarkDevice:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError =
     safely(sh"scp $path $user@$host:$uuid.jar".exec[Exit]()).lest(BenchError())
 
-  def invoke(path: Path on Linux, input: Text, heap: Optional[Text] = Unset)
+  def invoke
+    ( path: Path on Linux, input: Text, heap: Optional[Text] = Unset,
+      cpus: Optional[Int] = Unset )
   :   Text raises BenchError =
+
     val size = heap.or(t"1g")
+
+    val pin = cpus.lay(List[Text]()): n =>
+      List(t"taskset", t"-c", t"0-${n - 1}")
+
+    val processors = cpus.lay(List[Text]()): n =>
+      List(t"-XX:ActiveProcessorCount=$n")
 
     val command =
       sh"""
+        $pin
         java
           -XX:+AlwaysPreTouch
           -Xms$size
           -Xmx$size
           -XX:CICompilerCount=2
           -XX:+UseSerialGC
+          $processors
           -jar ${path.name}
           '$input'
           2> /dev/null
@@ -90,11 +110,18 @@ class NetworkDevice(user: Text, host: Hostname) extends BenchmarkDevice:
 object LocalhostDevice extends BenchmarkDevice:
   def deploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError = ()
 
-  def invoke(path: Path on Linux, input: Text, heap: Optional[Text] = Unset)
+  def invoke
+    ( path: Path on Linux, input: Text, heap: Optional[Text] = Unset,
+      cpus: Optional[Int] = Unset )
   :   Text raises BenchError =
+
     val size = heap.or(t"1g")
+
+    val processors = cpus.lay(List[Text]()): n =>
+      List(t"-XX:ActiveProcessorCount=$n")
+
     val opts = sh"-XX:+AlwaysPreTouch -Xms$size -Xmx$size -XX:CICompilerCount=2 -XX:+UseSerialGC"
-    val cmd = sh"java $opts -jar $path $input"
+    val cmd = sh"java $opts $processors -jar $path $input"
     safely(cmd.exec[Text]()).lest(BenchError())
 
   def undeploy(path: Path on Linux, uuid: Uuid): Unit raises BenchError = ()

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -69,7 +69,20 @@ import vacuous.*
 // stops early if a step ends in `OutOfMemoryError` or spends more than half its window in GC —
 // so in a constrained heap (the `heap` constructor parameter, e.g. `Stress(heap = t"128m")`)
 // the last emitted row is the maximum sustainable concurrency for that heap.
-case class Stress(heap: Optional[Text] = Unset)(using Classloader, Environment)
+//
+// Setting `threshold` and `compliance` together turns the run into a capacity search: find
+// the maximum sustained throughput such that at least `compliance` percent of operations
+// complete within `threshold`. The search grows the worker count from `concurrency` while
+// each window meets the target (up to `sweep`, default 1024), binary-searches the boundary
+// to ~12% resolution, then confirms the winner over a window three times longer; the
+// confirmed row is flagged `sustained` and its throughput is the headline number. This is a
+// closed-loop search — operation latency includes queuing inside the body's own pipeline —
+// which honestly answers "how many concurrent pipelines, each completing promptly?".
+//
+// `cpus` limits the measurement JVM's processors (see `BenchmarkDevice.invoke` for the
+// pinning caveat), and `heap` its memory, so the search runs under pinned resources.
+case class Stress(heap: Optional[Text] = Unset, cpus: Optional[Int] = Unset)
+  ( using Classloader, Environment )
   ( using device: BenchmarkDevice )
 extends Rig:
   type Result[output] = output
@@ -83,6 +96,8 @@ extends Rig:
     ( target:      duration,
       concurrency: Optional[Int]      = Unset,
       sweep:       Optional[Int]      = Unset,
+      threshold:   Optional[duration] = Unset,
+      compliance:  Optional[Int]      = Unset,
       baseline:    Optional[Baseline] = Unset )
     ( body0: (References over Transport) ?=> Quotes ?=> Expr[Any] )
     ( using System, TemporaryDirectory, Stageable over Transport in Form )
@@ -94,20 +109,32 @@ extends Rig:
 
     val concurrency0: Optional[Int] = concurrency
     val start: Int = concurrency0.or(1)
+    val threshold0: Optional[Long] = threshold.let(_.generic)
+    val compliance0: Optional[Int] = compliance
+
+    if threshold0.present != compliance0.present
+    then panic(m"a capacity search needs both `threshold` and `compliance`, or neither")
+
+    val searching: Boolean = threshold0.present
     val sweep0: Optional[Int] = sweep
-    val limit: Int = sweep0.or(start)
-    val sweeping: Boolean = sweep0.present
+    val limit: Int = sweep0.or(if searching then 1024 else start)
+    val sweeping: Boolean = sweep0.present || searching
 
-    val steps: List[Int] =
-      val builder = List.newBuilder[Int]
-      var n = start
+    // The threshold's histogram bucket index, computed with the same log-linear formula the
+    // workers use; operations in buckets strictly below it completed within the threshold
+    // (conservative to within the histogram's ~±3% quantisation). -1 disables the check.
+    val thresholdIndex: Int = threshold0.lay(-1): nanos =>
+      val time = if nanos < 1L then 1L else nanos
+      val bits = 63 - jl.Long.numberOfLeadingZeros(time)
 
-      while n < limit do
-        builder += n
-        n *= 2
+      val index =
+        if bits < 4 then time.toInt
+        else (bits - 4)*16 + ((time >> (bits - 4)) & 15L).toInt + 16
 
-      builder += limit
-      builder.result()
+      if index > 1023 then 1023 else index
+
+    // The compliance target in basis points, e.g. 95% -> 9500.
+    val complianceBp: Long = compliance0.lay(-1L)(_*100L)
 
     val body: (References over Transport) ?=> Quotes ?=> Expr[List[Long]] =
       val target2: Expr[Long] = Expr(target.generic)
@@ -137,11 +164,24 @@ extends Rig:
             . asInstanceOf[com.sun.management.ThreadMXBean]
 
           val results = scala.collection.mutable.ListBuffer[Long]()
-          val stepsIterator = ${Expr(steps)}.iterator
-          var stop = false
+          val startN: Int = ${Expr(start)}
+          val capN: Int = ${Expr(limit)}
+          val thresholdIndex2: Int = ${Expr(thresholdIndex)}
+          val targetBp: Long = ${Expr(complianceBp)}
+          val slo = thresholdIndex2 >= 0
 
-          while stepsIterator.hasNext && !stop do
-            val n: Int = stepsIterator.next()
+          // Phases: 0 = growth (doubling; the whole run when there is no SLO), 1 = binary
+          // refinement of the compliant/non-compliant boundary, 2 = confirmation of the
+          // candidate over a 3x window, 9 = done.
+          var phase = 0
+          var currentN = startN
+          var low = 0
+          var high = 0
+          var confirmations = 0
+
+          while phase != 9 do
+            val n: Int = currentN
+            val window: Long = if phase == 2 then $target2*3L else $target2
 
             // Preallocate every measurement structure before the allocation snapshot, so none
             // of it pollutes the allocation-per-operation figure.
@@ -174,7 +214,7 @@ extends Rig:
 
             val allocated0 = threadMx.getTotalThreadAllocatedBytes
             val t0 = jl.System.nanoTime
-            val deadline = t0 + $target2
+            val deadline = t0 + window
             k = 0
 
             while k < n do
@@ -284,10 +324,26 @@ extends Rig:
                 if index < 16 then index.toLong
                 else (16L + (index - 16)%16) << ((index - 16)/16)
 
-            // A step which ran out of memory is not reported, and ends the sweep; a step
-            // which spent more than half its window collecting garbage is reported, but
-            // larger worker counts aren't sustainable in this heap, so the sweep ends there.
-            if oom.get then stop = true else
+            // Compliant fraction in basis points: operations in buckets strictly below the
+            // threshold's bucket completed within the threshold. -1 when there is no SLO.
+            val compliantBp: Long =
+              if !slo || total == 0L then -1L else
+                var below = 0L
+                var b = 0
+
+                while b < thresholdIndex2 do
+                  below += merged(b)
+                  b += 1
+
+                below*10000L/total
+
+            val thrash = gcTime*2000000L > elapsed
+            val ok = !oom.get && !thrash && (!slo || compliantBp >= targetBp)
+            val sustained = slo && phase == 2 && ok
+
+            // A step which ran out of memory is not reported; every other window is,
+            // including a failing confirmation — it is still a valid measurement at that N.
+            if !oom.get then
               results += n.toLong
               results += total
               results += elapsed
@@ -300,25 +356,67 @@ extends Rig:
               results += percentile(0.9)
               results += percentile(0.99)
               results += percentile(0.999)
+              results += compliantBp
+              results += (if sustained then 1L else 0L)
 
-              if gcTime*2000000L > elapsed then stop = true
+            if !slo then
+              // Plain sweep: keep doubling until the cap; stop on memory exhaustion or a
+              // window that spent more than half its time collecting garbage.
+              if oom.get || thrash || n >= capN then phase = 9
+              else currentN = if n >= capN/2 then capN else n*2
+            else if phase == 0 then
+              // Growth: double while compliant. The first failure brackets the boundary; a
+              // failure on the very first window means nothing is sustainable.
+              if ok then
+                low = n
+
+                if n >= capN then phase = 2
+                else currentN = if n >= capN/2 then capN else n*2
+              else if low == 0 then
+                phase = 9
+              else
+                high = n
+                phase = 1
+                currentN = low + (high - low)/2
+            else if phase == 1 then
+              // Refinement: binary-search between the largest compliant and the smallest
+              // failing worker count, to ~12% resolution.
+              if ok then low = n else high = n
+
+              if high - low <= (if low > 8 then low/8 else 1) then
+                phase = 2
+                currentN = low
+              else
+                currentN = low + (high - low)/2
+            else
+              // Confirmation: the candidate must also survive a window three times longer.
+              // On failure, step the candidate down ~12% and try again, a few times.
+              if ok then
+                phase = 9
+              else
+                confirmations += 1
+                currentN = n - (if n > 8 then n/8 else 1)
+                if confirmations >= 3 || currentN < startN then phase = 9
 
           if jl.System.nanoTime < 0L then jl.System.err.nn.println(sink.get)
 
           results.toList
         }
 
-    dispatch(body).grouped(12).to(List).each: step =>
+    dispatch(body).grouped(14).to(List).each: step =>
       val n = step(0).toInt
+      val compliance2: Optional[Double] = if step(12) < 0L then Unset else step(12)/10000.0
+      val sustained: Boolean = step(13) == 1L
 
       val testId =
-        if sweeping then TestId(m"$name (N = $n)", suite, codepoint)
+        if sustained then TestId(m"$name (sustained, N = $n)", suite, codepoint)
+        else if sweeping then TestId(m"$name (N = $n)", suite, codepoint)
         else TestId(name, suite, codepoint)
 
       val strain =
         Strain
           ( n, step(1), step(2), step(3), step(4), step(5), step(6), step(7), baseline,
-            step(8), step(9), step(10), step(11) )
+            step(8), step(9), step(10), step(11), compliance2, sustained )
 
       inclusion.include(runner.report, testId, strain)
 
@@ -335,5 +433,4 @@ extends Rig:
 
   protected def invoke[output](stage: Stage[output, Text, Path on Linux]): output =
     stage.remote: input =>
-      unsafely(device.invoke(stage.target, input, heap))
-// x
+      unsafely(device.invoke(stage.target, input, heap, cpus))

--- a/lib/turbulence/src/bench/turbulence.Benchmarks.scala
+++ b/lib/turbulence/src/bench/turbulence.Benchmarks.scala
@@ -154,6 +154,7 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
     val bench = Bench()
     val stress = Stress()
     val constrained = Stress(heap = t"128m")
+    val gated = Stress(heap = t"2g", cpus = 4)
     val size = input.length*Byte
     val textSize = textData.length*Byte
 
@@ -1006,4 +1007,55 @@ object Benchmarks extends Suite(m"Streaming benchmarks: Soundness vs ZIO / FS2 /
             turbulence.Benchmarks.runZio:
               zio.stream.ZStream.fromChunk(zio.Chunk.fromArray(turbulence.Benchmarks.textArray))
               . via(zio.stream.ZPipeline.utfDecode).map(_.length).runSum
+        }
+
+    // Example S: SLO-constrained capacity search — the maximum sustained hand-off
+    // throughput such that 99% of operations complete within 5 ms, in a 2 GB heap
+    // on 4 CPUs (advisory on macOS; see `BenchmarkDevice.invoke`). The search
+    // doubles the pipeline count while each window meets the target,
+    // binary-searches the compliant/non-compliant boundary to ~12% resolution,
+    // then confirms the winner over a window three times longer. The probes form
+    // the curve; the `(sustained, N = …)` row is the answer: each library's
+    // maximum sustained ops/sec under identical constraints.
+    suite(m"Stress: capacity search (99% ≤ 5 ms, 2 GB heap, 4 CPUs)"):
+      gated(m"Soundness  Conduit")
+        ( target = 1*Second, threshold = 5*Milli(Second), compliance = 99 ):
+        '{
+            val (intake, stream) = Conduit[Data]()
+            val producer = Thread.ofVirtual.start(() =>
+              turbulence.Benchmarks.inputChunks.foreach(intake.put)
+              intake.finish())
+            var total = 0L
+            stream.sweep((_, _, count) => total += count)
+            producer.join()
+            total
+        }
+
+      gated(m"FS2  Channel.bounded")
+        ( target = 1*Second, threshold = 5*Milli(Second), compliance = 99 ):
+        '{
+            import cats.effect.unsafe.implicits.global
+            import cats.effect.IO
+            val program = fs2.concurrent.Channel.bounded[IO, fs2.Chunk[Byte]](8).flatMap: channel =>
+              val produce =
+                turbulence.Benchmarks.inputChunks.foldLeft(IO.unit): (io, chunk) =>
+                  io *> channel.send(fs2.Chunk.array(chunk.asInstanceOf[Array[Byte]])).void
+                *> channel.close.void
+              produce.start *> channel.stream.compile.fold(0L)((acc, chunk) => acc + chunk.size)
+            program.unsafeRunSync()
+        }
+
+      gated(m"ZIO  Queue.bounded")
+        ( target = 1*Second, threshold = 5*Milli(Second), compliance = 99 ):
+        '{
+            turbulence.Benchmarks.runZio:
+              import zio.*, zio.stream.*
+              val source =
+                ZStream.fromIterable
+                  (turbulence.Benchmarks.inputChunks.map(c => Chunk.fromArray(c.asInstanceOf[Array[Byte]])))
+              for
+                queue <- Queue.bounded[Take[Nothing, Chunk[Byte]]](8)
+                _     <- source.runIntoQueue(queue).fork
+                total <- ZStream.fromQueue(queue).flattenTake.runFold(0L)((acc, c) => acc + c.size)
+              yield total
         }


### PR DESCRIPTION
Stress tests can now answer the capacity question directly: *what is the maximum sustained throughput such that a given percentage of operations complete within a given time, under pinned CPU and memory limits?* Setting `threshold` and `compliance` on a stress test turns it into an adaptive search over concurrency — growing, binary-searching the compliant boundary, and confirming the winner over an extended window — and `cpus` joins `heap` for pinning the measurement JVM's resources. The streaming benchmarks gain a capacity-search suite comparing Soundness, FS2 and ZIO under identical constraints.

## Release notes

A stress test becomes a **capacity search** when both `threshold` and `compliance` are set:

```scala
val gated = Stress(heap = t"2g", cpus = 4)

suite(m"Capacity"):
  gated(m"Conduit hand-off")
    ( target = 1*Second, threshold = 5*Milli(Second), compliance = 99 ):
    '{ ... }
```

The search finds the *maximum sustained throughput such that at least `compliance` percent of operations complete within `threshold`*: the worker count doubles from `concurrency` (default 1) while each window meets the target — compliance is measured from the latency histograms the harness already collects — then the compliant/non-compliant boundary is binary-searched to ~12% resolution, and the winning concurrency must also survive a window three times longer than `target`; a failed confirmation steps the candidate down and retries. Every probed window appears as a row in the report, so the table reads as the throughput/latency/memory-vs-N curve, with a new **SLO** column showing each window's measured compliance; the confirmed winner is flagged `(sustained, N = …)`, and its throughput is the headline number. `sweep` caps the search (default 1024). This is a closed-loop search: operation latency includes queuing inside the body's own pipeline, which honestly answers "how many concurrent pipelines, each completing promptly?"

The new `cpus` constructor parameter limits the measurement JVM's processors, complementing `heap`: it always sets `-XX:ActiveProcessorCount` (sizing GC/JIT threads and everything derived from `availableProcessors`), and on Linux `NetworkDevice`s the process is additionally pinned with `taskset`. Without OS-level pinning (macOS localhost), the limit is advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
