### PR TITLE
Rename aviation's timeline Posix to Unix to free soundness.Posix

### DIFF
--- a/lib/aviation/src/core/aviation.Chronometry.scala
+++ b/lib/aviation/src/core/aviation.Chronometry.scala
@@ -38,14 +38,14 @@ import prepositional.*
 // counts on, expressed as a conversion to and from TAI (International Atomic Time) — the one
 // strictly-linear scale, counting every SI second with no discontinuities. Conversions between any
 // two chronometries compose through TAI. Each chronometry is a distinct marker type (`Tai`,
-// `Posix`, …); the phantom `X` in `Instant over X` tags an instant with its chronometry at the type
+// `Unix`, …); the phantom `X` in `Instant over X` tags an instant with its chronometry at the type
 // level, so instants on different timelines never mix without an explicit `.over[…]` conversion.
 //
 // (v1 works in milliseconds; sub-millisecond timelines such as `Monotonic` or nanosecond clocks are
 // a later extension, where the conversion's working unit becomes part of the chronometry.)
 object Chronometry:
   // The default chronometry for instants that don't state one — selected by importing one of the
-  // `chronometries.*` givens (e.g. `import chronometries.posix`). It names the marker type so a
+  // `chronometries.*` givens (e.g. `import chronometries.unix`). It names the marker type so a
   // constructed `Instant` takes that chronometry at the type level.
   trait Ambient:
     type Transport
@@ -59,7 +59,7 @@ object Chronometry:
   // Unix/POSIX time: leap seconds aren't counted, so the offset from TAI grows by one second at
   // each leap. `fromTai` is the (table-driven) inverse; a TAI value inside an inserted leap second
   // has no Unix preimage and maps to the following second by convention.
-  given posix: Posix is Chronometry:
+  given unix: Unix is Chronometry:
     def toTai(value: Long): Long = LeapSeconds.tai(value)
     def fromTai(tai: Long): Long = LeapSeconds.untai(tai)
 

--- a/lib/aviation/src/core/aviation.Clock.scala
+++ b/lib/aviation/src/core/aviation.Clock.scala
@@ -36,16 +36,16 @@ import beneficence.*
 import prepositional.*
 import symbolism.*
 
-// A `Clock` reads the wall clock, which is Unix/POSIX time, so it produces `Instant over Posix`.
+// A `Clock` reads the wall clock, which is Unix/POSIX time, so it produces `Instant over Unix`.
 object Clock:
   given current: Clock:
-    def apply(): Instant over Posix = Instant.of[Posix](System.currentTimeMillis)
+    def apply(): Instant over Unix = Instant.of[Unix](System.currentTimeMillis)
 
-  def fixed(instant: Instant over Posix): Clock = new Clock():
-    def apply(): Instant over Posix = instant
+  def fixed(instant: Instant over Unix): Clock = new Clock():
+    def apply(): Instant over Unix = instant
 
   def offset(diff: into[Duration]): Clock = new Clock():
-    def apply(): Instant over Posix = Instant.of[Posix](System.currentTimeMillis) + diff
+    def apply(): Instant over Unix = Instant.of[Unix](System.currentTimeMillis) + diff
 
 abstract class Clock() extends Findable:
-  def apply(): Instant over Posix
+  def apply(): Instant over Unix

--- a/lib/aviation/src/core/aviation.GapPolicy.scala
+++ b/lib/aviation/src/core/aviation.GapPolicy.scala
@@ -50,4 +50,4 @@ object GapPolicy:
   given pushForward: GapPolicy = (forward, _) => forward
 
 trait GapPolicy:
-  def resolve(forward: Instant over Posix, backward: Instant over Posix): Instant over Posix
+  def resolve(forward: Instant over Unix, backward: Instant over Unix): Instant over Unix

--- a/lib/aviation/src/core/aviation.Iso8601.scala
+++ b/lib/aviation/src/core/aviation.Iso8601.scala
@@ -63,7 +63,7 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
   import Issue.*
 
-  def parse(text: Text): Instant over Posix raises TimeError =
+  def parse(text: Text): Instant over Unix raises TimeError =
     import calendars.gregorianCalendar
 
     given Timezone = tz"UTC"
@@ -144,14 +144,14 @@ object Iso8601 extends Date.Format(t"ISO 8601"):
 
     // A `:60` second is a leap second; on the (leap-free) Unix line it collapses onto the next
     // second (`23:59:60` ≡ the following `00:00:00`), so store `:59` and add one second.
-    def clockInstant(hour: Int, minute: Int, second: Int): Instant over Posix =
+    def clockInstant(hour: Int, minute: Int, second: Int): Instant over Unix =
       if second == 60 then
         Clockface(Base24(hour), Base60(minute), Base60(59)).on(date).instant +
           Quantity[Seconds[1]](1.0)
       else
         Clockface(Base24(hour), Base60(minute), Base60(second)).on(date).instant
 
-    val instant: Instant over Posix = next() match
+    val instant: Instant over Unix = next() match
       case '\u0000' => Clockface(Base24(0), Base60(0), Base60(0)).on(date).instant
 
       case 'T' =>

--- a/lib/aviation/src/core/aviation.Moment.scala
+++ b/lib/aviation/src/core/aviation.Moment.scala
@@ -49,7 +49,7 @@ object Moment:
   // Moments order by their grounded instant (so a `Second`-occurrence overlap sorts after the
   // `First`, and zones are compared on absolute time), hence the `RomanCalendar`/`GapPolicy` need.
   given orderable: (RomanCalendar, GapPolicy) => Moment is Orderable =
-    summon[(Instant over Posix) is Orderable].contramap(_.instant)
+    summon[(Instant over Unix) is Orderable].contramap(_.instant)
 
   given ordering: (RomanCalendar, GapPolicy) => Ordering[Moment] = Ordering.by(_.instant.long)
 
@@ -86,7 +86,7 @@ case class Moment
     leap:       Leap       = Leap.None ):
 
   // A `Moment` grounds to the Unix/POSIX timeline (`java.time` works in epoch milliseconds).
-  def instant(using calendar: RomanCalendar, gap: GapPolicy): Instant over Posix =
+  def instant(using calendar: RomanCalendar, gap: GapPolicy): Instant over Unix =
     val ldt =
       jt.LocalDateTime.of
         ( date.year(),
@@ -99,8 +99,8 @@ case class Moment
 
     val rules = jt.ZoneId.of(timezone.name.s).nn.getRules.nn
 
-    def at(offset: jt.ZoneOffset): Instant over Posix =
-      Instant.of[Posix](ldt.toInstant(offset).nn.toEpochMilli)
+    def at(offset: jt.ZoneOffset): Instant over Unix =
+      Instant.of[Unix](ldt.toInstant(offset).nn.toEpochMilli)
 
     val base =
       rules.getTransition(ldt) match
@@ -121,7 +121,7 @@ case class Moment
     // second's instant, so grounding it advances by one second.
     leap match
       case Leap.None     => base
-      case Leap.Inserted => Instant.of[Posix](base.long + 1000L)
+      case Leap.Inserted => Instant.of[Unix](base.long + 1000L)
 
   // The absolute SI instant on the atomic (TAI) timeline. For an inserted leap second the TAI value
   // is exactly one SI second before the following second's.

--- a/lib/aviation/src/core/aviation.Resolution.scala
+++ b/lib/aviation/src/core/aviation.Resolution.scala
@@ -35,12 +35,12 @@ package aviation
 import prepositional.*
 
 // How many nanoseconds one unit of an `Instant over X`'s underlying `Long` represents. Millisecond
-// timelines (`Posix`, `Tai`) tick every 1_000_000 ns; `Monotonic` (a `System.nanoTime` reading)
+// timelines (`Unix`, `Tai`) tick every 1_000_000 ns; `Monotonic` (a `System.nanoTime` reading)
 // ticks every nanosecond. Instant arithmetic uses this to convert between a `Duration` (in seconds)
 // and the timeline's own ticks, so adding "one second" advances the right number of ticks whatever
 // the resolution.
 object Resolution:
-  given posix: Posix is Resolution:
+  given unix: Unix is Resolution:
     def nanos: Long = 1_000_000L
 
   given tai: Tai is Resolution:

--- a/lib/aviation/src/core/aviation.Rfc1123.scala
+++ b/lib/aviation/src/core/aviation.Rfc1123.scala
@@ -56,7 +56,7 @@ object Rfc1123 extends Date.Format(t"RFC 1123"):
     case Expect(char: Char)
     case Digit
 
-  def parse(text: Text): Instant over Posix raises TimeError =
+  def parse(text: Text): Instant over Unix raises TimeError =
     import Rfc1123.Issue.*
     import Weekday.*
 

--- a/lib/aviation/src/core/aviation.Timespan.scala
+++ b/lib/aviation/src/core/aviation.Timespan.scala
@@ -300,7 +300,7 @@ object Timespan:
 
       val advanced = summon[LeapMode] match
         case LeapMode.Lenient => zoned.instant + seconds
-        case LeapMode.Exact   => (zoned.instant.over[Tai] + seconds).over[Posix]
+        case LeapMode.Exact   => (zoned.instant.over[Tai] + seconds).over[Unix]
 
       advanced.in(moment.timezone)
 

--- a/lib/aviation/src/core/aviation.protointernal.scala
+++ b/lib/aviation/src/core/aviation.protointernal.scala
@@ -45,7 +45,7 @@ import symbolism.*
 object protointernal:
   // An `Instant` is an absolute point in time, stored as a `Long` whose interpretation — which
   // timeline it counts on (Unix/POSIX, TAI, …) — is the phantom `Transport` set by `over`. So
-  // `Instant over Posix` and `Instant over Tai` are distinct types over the same grid; a
+  // `Instant over Unix` and `Instant over Tai` are distinct types over the same grid; a
   // `Chronometry` given converts between them (through TAI). The unrefined `Instant` is abstract in
   // its chronometry and is rarely used directly.
   opaque type Instant = Long
@@ -78,7 +78,7 @@ object protointernal:
     def Max[transport]: Instant over transport = Long.MaxValue.asInstanceOf[Instant over transport]
 
     // Construct in an explicit chronometry from its raw tick value (grounding code uses
-    // `Instant.of[Posix]` with epoch milliseconds; `monotonic` uses `Instant.of[Monotonic]` with
+    // `Instant.of[Unix]` with epoch milliseconds; `monotonic` uses `Instant.of[Monotonic]` with
     // nanoseconds).
     def of[transport](ticks: Long): Instant over transport =
       ticks.asInstanceOf[Instant over transport]
@@ -119,7 +119,7 @@ object protointernal:
 
 
     // Arithmetic converts a `Duration` (seconds) to the timeline's own ticks via its `Resolution`,
-    // so it works whatever the resolution (milliseconds for `Posix`/`Tai`, nanoseconds for
+    // so it works whatever the resolution (milliseconds for `Unix`/`Tai`, nanoseconds for
     // `Monotonic`).
     private def ticks(seconds: Double, resolution: Long): Long =
       (seconds*1_000_000_000.0/resolution).toLong
@@ -158,7 +158,7 @@ object protointernal:
       Period(instant, that)
 
     infix def in (using RomanCalendar, transport is Chronometry)(timezone: Timezone): Moment =
-      val unix = instant.over[Posix].long
+      val unix = instant.over[Unix].long
       val zone = jt.ZoneId.of(timezone.name.s).nn
       val zonedTime = jt.Instant.ofEpochMilli(unix).nn.atZone(zone).nn
 

--- a/lib/aviation/src/core/aviation.timestampInternal.scala
+++ b/lib/aviation/src/core/aviation.timestampInternal.scala
@@ -355,7 +355,7 @@ object timestampInternal:
     // Grounding goes through `Moment`, the single civil↔absolute bridge, so a `Timestamp` honours
     // the same `GapPolicy` as a `Moment` (a bare wall-clock time carries no overlap selector, so it
     // grounds at the earlier offset — `Occurrence.First`).
-    def instant(using Timezone, RomanCalendar, GapPolicy): Instant over Posix =
+    def instant(using Timezone, RomanCalendar, GapPolicy): Instant over Unix =
       timestamp.in(summon[Timezone]).instant
 
   // Comparisons are defined on `Timestamp` (the whole grid is monotonic); `Date`, being a

--- a/lib/aviation/src/core/aviation_core.scala
+++ b/lib/aviation/src/core/aviation_core.scala
@@ -78,19 +78,19 @@ trait Minute
 trait Second
 
 // Phantom chronometry markers for `Instant over <chronometry>` (the `Transport` type member): which
-// timeline an instant's `Long` counts on. `Tai` is atomic time; `Posix` is leap-free Unix time;
+// timeline an instant's `Long` counts on. `Tai` is atomic time; `Unix` is leap-free Unix time;
 // `Monotonic` is a `System.nanoTime` reading (nanosecond resolution, arbitrary origin). `Tai` and
-// `Posix` have a `Chronometry` (so they ground/convert); `Monotonic` does not — with no fixed
+// `Unix` have a `Chronometry` (so they ground/convert); `Monotonic` does not — with no fixed
 // relation to wall-clock time it only measures elapsed time. Purely type-level tags.
 trait Tai
-trait Posix
+trait Unix
 trait Monotonic
 
 package instantDecodables:
-  given iso8601InstantDecodable: Tactic[TimeError] => (Instant over Posix) is Decodable in Text =
+  given iso8601InstantDecodable: Tactic[TimeError] => (Instant over Unix) is Decodable in Text =
     Iso8601.parse(_)
 
-  given rfc1123InstantDecodable: Tactic[TimeError] => (Instant over Posix) is Decodable in Text =
+  given rfc1123InstantDecodable: Tactic[TimeError] => (Instant over Unix) is Decodable in Text =
     Rfc1123.parse(_)
 
 package dateFormats:
@@ -460,10 +460,10 @@ package calendars:
 // The default interpretation of an `Instant`'s `Long` (used by `Instant(…)`, decoding, etc.).
 // Import one of these to choose the timeline bare instants count on; convert with `.over[…]`.
 package chronometries:
-  given posix: (Chronometry.Ambient { type Transport = Posix }) =
+  given unix: (Chronometry.Ambient { type Transport = Unix }) =
     new Chronometry.Ambient:
-      type Transport = Posix
-      def chronometry: Posix is Chronometry = Chronometry.posix
+      type Transport = Unix
+      def chronometry: Unix is Chronometry = Chronometry.unix
 
   given atomic: (Chronometry.Ambient { type Transport = Tai }) =
     new Chronometry.Ambient:
@@ -501,7 +501,7 @@ package monthEnds:
     def resolve(using calendar: Calendar)(year: Year, month: calendar.Mensual, day: Int): Date =
       abort(TimeError(_.Invalid(year(), calendar.monthOrdinal(year, month) + 1, day, calendar)))
 
-def now()(using clock: Clock): Instant over Posix = clock()
+def now()(using clock: Clock): Instant over Unix = clock()
 
 // A reading of the monotonic system clock, for measuring elapsed time. It has an arbitrary origin,
 // so it can only be compared/subtracted with other `Monotonic` readings, never grounded to a

--- a/lib/aviation/src/core/soundness_aviation_core.scala
+++ b/lib/aviation/src/core/soundness_aviation_core.scala
@@ -45,7 +45,7 @@ export
       Meridiem, Minute, Moment, Mon, monotonic, Monotonic, MonotonicClock, Month, Months,
       Monthstamp, Nov, now,
       Occurrence, Oct, OffsetCalendar, OrdinalCalendar, Period, PersianCalendar, PersianMonth, pm,
-      following, occurrences, Posix, rec, Recurrence, RecurrenceError, recInterpolator,
+      following, occurrences, Unix, rec, Recurrence, RecurrenceError, recInterpolator,
       RecurrenceLiteral, RecurrenceSet, Recurrent, Regime, Resolution, Rfc1123, RomanCalendar,
       Rrule, RruleError, Tai, until, WeekdayOrdinal, within,
       Sat, Sep, Sun, Thu, TimeError, TimeEvent, TimeFormat, TimeNumerics,
@@ -72,7 +72,7 @@ package leapModes:
   export aviation.leapModes.exact
 
 package chronometries:
-  export aviation.chronometries.{posix, atomic}
+  export aviation.chronometries.{unix, atomic}
 
 package dateFormats:
   export aviation.dateFormats.{americanDateFormat, europeanDateFormat, iso8601DateFormat,

--- a/lib/aviation/src/test/aviation_test.scala
+++ b/lib/aviation/src/test/aviation_test.scala
@@ -37,7 +37,7 @@ import soundness.*
 import strategies.throwUnsafely
 import errorDiagnostics.stackTracesDiagnostics
 import abstractables.instantAbstractable
-import chronometries.posix
+import chronometries.unix
 
 object Tests extends Suite(m"Aviation Tests"):
   def run(): Unit =
@@ -374,205 +374,205 @@ object Tests extends Suite(m"Aviation Tests"):
       suite(m"ISO 8601"):
         import instantDecodables.iso8601InstantDecodable
         test(m"with Z suffix (UTC)"):
-          t"1994-11-06T08:49:37Z".as[Instant over Posix]
+          t"1994-11-06T08:49:37Z".as[Instant over Unix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with positive timezone offset"):
-          t"1994-11-06T09:49:37+01:00".as[Instant over Posix]
+          t"1994-11-06T09:49:37+01:00".as[Instant over Unix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with negative timezone offset"):
-          t"1994-11-06T03:49:37-05:00".as[Instant over Posix]
+          t"1994-11-06T03:49:37-05:00".as[Instant over Unix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with fractional seconds (.123)"):
-          t"2020-02-29T12:34:56.123Z".as[Instant over Posix]
+          t"2020-02-29T12:34:56.123Z".as[Instant over Unix]
         . assert(_ == Instant(1582979696123L))
 
         test(m"with nanosecond precision (.123456789)"):
-          t"2020-02-29T12:34:56.123456789Z".as[Instant over Posix]
+          t"2020-02-29T12:34:56.123456789Z".as[Instant over Unix]
         . assert(_ == Instant(1582979696123L))
 
         test(m"date-only format (midnight UTC)"):
-          t"2020-12-31".as[Instant over Posix]
+          t"2020-12-31".as[Instant over Unix]
         . assert(_ == Instant(1609372800000L))
 
         test(m"ISO 8601 leap second accepted as next second"):
-          t"2016-12-31T23:59:60Z".as[Instant over Posix]
+          t"2016-12-31T23:59:60Z".as[Instant over Unix]
         . assert(_ == Instant(1483228800000L))
 
         test(m"Month-only format"):
-          t"2012-11".as[Instant over Posix]
+          t"2012-11".as[Instant over Unix]
         . assert(_ == Instant(1351728000000L))
 
         test(m"ISO 8601 with timezone offset and fractional seconds"):
-          t"2023-03-25T10:15:30.456+02:00".as[Instant over Posix]
+          t"2023-03-25T10:15:30.456+02:00".as[Instant over Unix]
         . assert(_ == Instant(1679732130456L))
 
         test(m"Calendar date, full time, Z"):
-          t"2023-05-28T14:30:59Z".as[Instant over Posix]
+          t"2023-05-28T14:30:59Z".as[Instant over Unix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Calendar date, basic format, full time, Z"):
-          t"20230528T143059Z".as[Instant over Posix]
+          t"20230528T143059Z".as[Instant over Unix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Calendar date, full time, offset +00:00"):
-          t"2023-05-28T14:30:59+00:00".as[Instant over Posix]
+          t"2023-05-28T14:30:59+00:00".as[Instant over Unix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Calendar date, full time, offset +02:00"):
-          t"2023-05-28T14:30:59+02:00".as[Instant over Posix]
+          t"2023-05-28T14:30:59+02:00".as[Instant over Unix]
         . assert(_ == Instant(1685277059000L))
 
         test(m"Calendar date, full time, offset -05:00"):
-          t"2023-05-28T14:30:59-05:00".as[Instant over Posix]
+          t"2023-05-28T14:30:59-05:00".as[Instant over Unix]
         . assert(_ == Instant(1685302259000L))
 
         test(m"Calendar date, fractional seconds, Z"):
-          t"2023-05-28T14:30:59.123Z".as[Instant over Posix]
+          t"2023-05-28T14:30:59.123Z".as[Instant over Unix]
         . assert(_ == Instant(1685284259123L))
 
         test(m"Calendar date, comma as decimal separator, Z"):
-          t"2023-05-28T14:30:59,123Z".as[Instant over Posix]
+          t"2023-05-28T14:30:59,123Z".as[Instant over Unix]
         . assert(_ == Instant(1685284259123L))
 
         test(m"Calendar date, hours and minutes, Z"):
-          t"2023-05-28T14:30Z".as[Instant over Posix]
+          t"2023-05-28T14:30Z".as[Instant over Unix]
         . assert(_ == Instant(1685284200000L))
 
         test(m"Calendar date, hour only, Z"):
-          t"2023-05-28T14Z".as[Instant over Posix]
+          t"2023-05-28T14Z".as[Instant over Unix]
         . assert(_ == Instant(1685282400000L))
 
         test(m"Week date, Sunday of week 21, full time, Z"):
-          t"2023-W21-7T14:30:59Z".as[Instant over Posix]
+          t"2023-W21-7T14:30:59Z".as[Instant over Unix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Week date, Monday of week 21, full time, Z"):
-          t"2023-W21-1T14:30:59Z".as[Instant over Posix]
+          t"2023-W21-1T14:30:59Z".as[Instant over Unix]
         . assert(_ == Instant(1684765859000L))
 
         test(m"Week date, basic format, Sunday of week 21, full time, Z"):
-          t"2023W217T143059Z".as[Instant over Posix]
+          t"2023W217T143059Z".as[Instant over Unix]
         . assert(_ == Instant(1685284259000L))
 
         test(m"Start of UNIX epoch"):
-          t"1970-01-01T00:00:00Z".as[Instant over Posix]
+          t"1970-01-01T00:00:00Z".as[Instant over Unix]
         . assert(_ == Instant(0L))
 
         test(m"Leap day 2020"):
-          t"2020-02-29T12:00:00Z".as[Instant over Posix]
+          t"2020-02-29T12:00:00Z".as[Instant over Unix]
         . assert(_ == Instant(1582977600000L))
 
         test(m"End of 1999"):
-          t"1999-12-31T23:59:59Z".as[Instant over Posix]
+          t"1999-12-31T23:59:59Z".as[Instant over Unix]
         . assert(_ == Instant(946684799000L))
 
         test(m"Start of 2000"):
-          t"2000-01-01T00:00:00Z".as[Instant over Posix]
+          t"2000-01-01T00:00:00Z".as[Instant over Unix]
         . assert(_ == Instant(946684800000L))
 
         test(m"Far future 2199"):
-          t"2199-12-31T23:59:59Z".as[Instant over Posix]
+          t"2199-12-31T23:59:59Z".as[Instant over Unix]
         . assert(_ == Instant(7258118399000L))
 
         test(m"Far past 1800"):
-          t"1800-01-01T00:00:00Z".as[Instant over Posix]
+          t"1800-01-01T00:00:00Z".as[Instant over Unix]
         . assert(_ == Instant(-5364662400000L))
 
         test(m"Middle of the day"):
-          t"2023-06-15T12:00:00Z".as[Instant over Posix]
+          t"2023-06-15T12:00:00Z".as[Instant over Unix]
         . assert(_ == Instant(1686830400000L))
 
         test(m"New Year 2023"):
-          t"2023-01-01T00:00:00Z".as[Instant over Posix]
+          t"2023-01-01T00:00:00Z".as[Instant over Unix]
         . assert(_ == Instant(1672531200000L))
 
         test(m"DST change irrelevant (UTC)"):
-          t"2021-03-28T01:30:00Z".as[Instant over Posix]
+          t"2021-03-28T01:30:00Z".as[Instant over Unix]
         . assert(_ == Instant(1616895000000L))
 
         test(m"Millisecond rounding test"):
-          t"2022-11-15T23:59:59Z".as[Instant over Posix]
+          t"2022-11-15T23:59:59Z".as[Instant over Unix]
         . assert(_ == Instant(1668556799000L))
 
       suite(m"RFC 1123"):
         import instantDecodables.rfc1123InstantDecodable
         test(m"basic with GMT timezone"):
-          t"Sun, 06 Nov 1994 08:49:37 GMT".as[Instant over Posix]
+          t"Sun, 06 Nov 1994 08:49:37 GMT".as[Instant over Unix]
         . assert(_ == Instant(784111777000L))
 
         test(m"with unusual day of week (consistency check)"):
-          t"Tue, 01 Jan 2019 00:00:00 GMT".as[Instant over Posix]
+          t"Tue, 01 Jan 2019 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1546300800000L))
 
         test(m"Standard RFC1123 date with full weekday and month names"):
-          t"Sun, 06 Nov 1994 08:49:37 GMT".as[Instant over Posix]
+          t"Sun, 06 Nov 1994 08:49:37 GMT".as[Instant over Unix]
         . assert(_ == Instant(784111777000L))
 
         test(m"Leap day in a leap year"):
-          t"Mon, 29 Feb 2016 12:00:00 GMT".as[Instant over Posix]
+          t"Mon, 29 Feb 2016 12:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1456747200000L))
 
         test(m"Epoch start date"):
-          t"Thu, 01 Jan 1970 00:00:00 GMT".as[Instant over Posix]
+          t"Thu, 01 Jan 1970 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(0L))
 
         test(m"Last second before Y2K"):
-          t"Fri, 31 Dec 1999 23:59:59 GMT".as[Instant over Posix]
+          t"Fri, 31 Dec 1999 23:59:59 GMT".as[Instant over Unix]
         . assert(_ == Instant(946684799000L))
 
         test(m"First second of Y2K"):
-          t"Sat, 01 Jan 2000 00:00:00 GMT".as[Instant over Posix]
+          t"Sat, 01 Jan 2000 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(946684800000L))
 
         test(m"Date with single-digit day"):
-          capture(t"Wed, 3 Jul 2002 17:45:00 GMT".as[Instant over Posix])
+          capture(t"Wed, 3 Jul 2002 17:45:00 GMT".as[Instant over Unix])
         . assert(_ == TimeError(_.Format(t"Wed, 3 Jul 2002 17:45:00 GMT", Rfc1123, Prim + 6)(Rfc1123.Issue.Digit)))
 
         test(m"Date with single-digit hour, minute, and second"):
-          t"Tue, 02 Mar 2021 07:08:09 GMT".as[Instant over Posix]
+          t"Tue, 02 Mar 2021 07:08:09 GMT".as[Instant over Unix]
         . assert(_ == Instant(1614668889000L))
 
         test(m"Date with correct day of week (Monday)"):
-          t"Mon, 15 Aug 2022 18:30:00 GMT".as[Instant over Posix]
+          t"Mon, 15 Aug 2022 18:30:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1660588200000L))
 
         test(m"Incorrect weekday (should be Sunday, not Monday)"):
-          t"Mon, 31 Dec 2006 23:59:59 GMT".as[Instant over Posix]
+          t"Mon, 31 Dec 2006 23:59:59 GMT".as[Instant over Unix]
         . assert(_ == Instant(1167609599000L))
 
         test(m"Date around DST end (should be in UTC, so no DST effect)"):
-          t"Sun, 01 Nov 2020 01:30:00 GMT".as[Instant over Posix]
+          t"Sun, 01 Nov 2020 01:30:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1604194200000L))
 
         test(m"Far future date (2100)"):
-          t"Fri, 01 Jan 2100 00:00:00 GMT".as[Instant over Posix]
+          t"Fri, 01 Jan 2100 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(4102444800000L))
 
         test(m"Far past date (1900)"):
-          t"Mon, 01 Jan 1900 00:00:00 GMT".as[Instant over Posix]
+          t"Mon, 01 Jan 1900 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(-2208988800000L))
 
         test(m"Time with 2-digit hour 23"):
-          t"Wed, 08 Sep 2021 23:00:00 GMT".as[Instant over Posix]
+          t"Wed, 08 Sep 2021 23:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1631142000000L))
 
         test(m"Midday exactly (12:00:00)"):
-          t"Sat, 25 Dec 2021 12:00:00 GMT".as[Instant over Posix]
+          t"Sat, 25 Dec 2021 12:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1640433600000L))
 
         test(m"New Year's Eve (2022)"):
-          t"Sat, 31 Dec 2022 23:59:59 GMT".as[Instant over Posix]
+          t"Sat, 31 Dec 2022 23:59:59 GMT".as[Instant over Unix]
         . assert(_ == Instant(1672531199000L))
 
         test(m"Short month name test (Jan)"):
-          t"Sun, 01 Jan 2023 00:00:00 GMT".as[Instant over Posix]
+          t"Sun, 01 Jan 2023 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1672531200000L))
 
         test(m"Minimum valid time (00:00:00)"):
-          t"Sun, 10 Oct 2021 00:00:00 GMT".as[Instant over Posix]
+          t"Sun, 10 Oct 2021 00:00:00 GMT".as[Instant over Unix]
         . assert(_ == Instant(1633824000000L))
 
       suite(m"Working days tests"):
@@ -1399,22 +1399,22 @@ object Tests extends Suite(m"Aviation Tests"):
       import instantDecodables.iso8601InstantDecodable
 
       test(m"Non-digit at year start raises"):
-        capture(t"abcd-01-01".as[Instant over Posix])
+        capture(t"abcd-01-01".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
       test(m"Truncated year raises"):
-        capture(t"20".as[Instant over Posix])
+        capture(t"20".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
       test(m"Trailing junk after seconds raises"):
-        capture(t"2024-01-01T12:00:00garbage".as[Instant over Posix])
+        capture(t"2024-01-01T12:00:00garbage".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
       test(m"Bad week-date letter raises"):
-        capture(t"2024-X21-1".as[Instant over Posix])
+        capture(t"2024-X21-1".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
@@ -1422,22 +1422,22 @@ object Tests extends Suite(m"Aviation Tests"):
       import instantDecodables.rfc1123InstantDecodable
 
       test(m"Lowercase day name raises"):
-        capture(t"sun, 06 Nov 1994 08:49:37 GMT".as[Instant over Posix])
+        capture(t"sun, 06 Nov 1994 08:49:37 GMT".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
       test(m"Wrong month abbreviation raises"):
-        capture(t"Sun, 06 Jux 1994 08:49:37 GMT".as[Instant over Posix])
+        capture(t"Sun, 06 Jux 1994 08:49:37 GMT".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
       test(m"Missing trailing GMT raises"):
-        capture(t"Sun, 06 Nov 1994 08:49:37".as[Instant over Posix])
+        capture(t"Sun, 06 Nov 1994 08:49:37".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
       test(m"Truncated input raises"):
-        capture(t"Sun, ".as[Instant over Posix])
+        capture(t"Sun, ".as[Instant over Unix])
       . matches:
           case _: TimeError =>
 
@@ -1759,7 +1759,7 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"A POSIX instant round-trips through TAI"):
         val instant = Instant(newYear)
-        instant.over[Tai].over[Posix] == instant
+        instant.over[Tai].over[Unix] == instant
       . assert(_ == true)
 
       test(m"Subtracting instants on different timelines is a compile error"):
@@ -1992,7 +1992,7 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_ == List(2024-Jan-1, 2024-Jan-2, 2024-Jan-3))
 
     suite(m"Monotonic clock"):
-      test(m"A Posix instant ticks in milliseconds"):
+      test(m"A Unix instant ticks in milliseconds"):
         (Instant(0L) + 1*Second).long
       . assert(_ == 1000L)
 
@@ -2370,22 +2370,22 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_ == Timestamp(1970-Jan-1, Clockface(0, 0, 0)))
 
       test(m"Same instant in London during winter is GMT (offset 0)"):
-        val winter = t"2024-01-15T12:00:00Z".as[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
+        val winter = t"2024-01-15T12:00:00Z".as[Instant over Unix](using instantDecodables.iso8601InstantDecodable)
         winter.in(tz"Europe/London").time.hour
       . assert(_ == 12)
 
       test(m"Same instant in London during summer is BST (offset +1)"):
-        val summer = t"2024-07-15T12:00:00Z".as[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
+        val summer = t"2024-07-15T12:00:00Z".as[Instant over Unix](using instantDecodables.iso8601InstantDecodable)
         summer.in(tz"Europe/London").time.hour
       . assert(_ == 13)
 
       test(m"New York winter offset (UTC-5)"):
-        val winter = t"2024-01-15T12:00:00Z".as[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
+        val winter = t"2024-01-15T12:00:00Z".as[Instant over Unix](using instantDecodables.iso8601InstantDecodable)
         winter.in(tz"America/New_York").time.hour
       . assert(_ == 7)
 
       test(m"New York summer offset (UTC-4)"):
-        val summer = t"2024-07-15T12:00:00Z".as[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
+        val summer = t"2024-07-15T12:00:00Z".as[Instant over Unix](using instantDecodables.iso8601InstantDecodable)
         summer.in(tz"America/New_York").time.hour
       . assert(_ == 8)
 
@@ -2408,31 +2408,31 @@ object Tests extends Suite(m"Aviation Tests"):
         import gapPolicies.pushBackward
         given Timezone = tz"Europe/London"
         val grounded = Timestamp(2024-Mar-31, Clockface(1, 30, 0)).instant
-        grounded == t"2024-03-31T00:30:00Z".as[Instant over Posix]
+        grounded == t"2024-03-31T00:30:00Z".as[Instant over Unix]
       . assert(_ == true)
 
       // On 2024-10-27 London clocks go back at 02:00 BST, so 01:30 local occurs twice: first at
       // 00:30 UTC (BST), then again at 01:30 UTC (GMT).
       test(m"DST fall-back: earlier overlap occurrence round-trips through London"):
         import instantDecodables.iso8601InstantDecodable
-        val earlier = t"2024-10-27T00:30:00Z".as[Instant over Posix]
+        val earlier = t"2024-10-27T00:30:00Z".as[Instant over Unix]
         earlier.in(tz"Europe/London").instant == earlier
       . assert(_ == true)
 
       test(m"DST fall-back: later overlap occurrence round-trips through London"):
         import instantDecodables.iso8601InstantDecodable
-        val later = t"2024-10-27T01:30:00Z".as[Instant over Posix]
+        val later = t"2024-10-27T01:30:00Z".as[Instant over Unix]
         later.in(tz"Europe/London").instant == later
       . assert(_ == true)
 
       test(m"DST fall-back: later overlap occurrence is flagged Second"):
         import instantDecodables.iso8601InstantDecodable
-        t"2024-10-27T01:30:00Z".as[Instant over Posix].in(tz"Europe/London").occurrence
+        t"2024-10-27T01:30:00Z".as[Instant over Unix].in(tz"Europe/London").occurrence
       . assert(_ == Occurrence.Second)
 
       test(m"DST fall-back: earlier overlap occurrence is flagged First"):
         import instantDecodables.iso8601InstantDecodable
-        t"2024-10-27T00:30:00Z".as[Instant over Posix].in(tz"Europe/London").occurrence
+        t"2024-10-27T00:30:00Z".as[Instant over Unix].in(tz"Europe/London").occurrence
       . assert(_ == Occurrence.First)
 
       test(m"The two overlap occurrences ground one hour apart"):
@@ -2447,14 +2447,14 @@ object Tests extends Suite(m"Aviation Tests"):
       test(m"Spring-forward gap pushes forward by default"):
         import instantDecodables.iso8601InstantDecodable
         val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
-        grounded == t"2024-03-31T01:30:00Z".as[Instant over Posix]
+        grounded == t"2024-03-31T01:30:00Z".as[Instant over Unix]
       . assert(_ == true)
 
       test(m"Spring-forward gap can push backward"):
         import instantDecodables.iso8601InstantDecodable
         import gapPolicies.pushBackward
         val grounded = Moment(2024-Mar-31, Clockface(1, 30, 0), tz"Europe/London").instant
-        grounded == t"2024-03-31T00:30:00Z".as[Instant over Posix]
+        grounded == t"2024-03-31T00:30:00Z".as[Instant over Unix]
       . assert(_ == true)
 
       test(m"Spring-forward gap can be rejected"):
@@ -2589,18 +2589,18 @@ object Tests extends Suite(m"Aviation Tests"):
       . assert(_ == 12_000L)
 
       test(m"Instant in 2017 has +37 offset"):
-        val later = t"2017-06-15T00:00:00Z".as[Instant over Posix](using instantDecodables.iso8601InstantDecodable)
+        val later = t"2017-06-15T00:00:00Z".as[Instant over Unix](using instantDecodables.iso8601InstantDecodable)
         LeapSeconds.tai(later.long) - later.long
       . assert(_ == 37_000L)
 
       test(m"Instant.over[Tai] counts leap seconds"):
-        val later = t"2017-06-15T00:00:00Z".as[Instant over Posix]
+        val later = t"2017-06-15T00:00:00Z".as[Instant over Unix]
         later.over[Tai].long - later.long
       . assert(_ == 37_000L)
 
       test(m"An instant round-trips through TAI and back to POSIX"):
-        val instant = t"2017-06-15T00:00:00Z".as[Instant over Posix]
-        instant.over[Tai].over[Posix] == instant
+        val instant = t"2017-06-15T00:00:00Z".as[Instant over Unix]
+        instant.over[Tai].over[Unix] == instant
       . assert(_ == true)
 
       test(m"unsmearTai inverts smearTai across a leap window"):
@@ -2610,7 +2610,7 @@ object Tests extends Suite(m"Aviation Tests"):
 
       test(m"An inserted leap second grounds to the following second"):
         val leapMoment = Moment(2016-Dec-31, Clockface(23, 59, 59), tz"UTC", leap = Leap.Inserted)
-        leapMoment.instant == t"2017-01-01T00:00:00Z".as[Instant over Posix]
+        leapMoment.instant == t"2017-01-01T00:00:00Z".as[Instant over Unix]
       . assert(_ == true)
 
       test(m"An inserted leap second's TAI is one second before the following second"):

--- a/lib/aviation/src/wasi/aviation_wasi.scala
+++ b/lib/aviation/src/wasi/aviation_wasi.scala
@@ -62,6 +62,6 @@ package clocks:
   // boundary as a `(seconds: U64, nanoseconds: U32)` pair, converted to POSIX millisecond ticks.
   @nowarn("msg=New anonymous class definition will be duplicated at each inline site")
   inline given wasiClock: Clock = new Clock:
-    def apply(): Instant over Posix =
+    def apply(): Instant over Unix =
       val (seconds, nanoseconds) = Foreign["wall-clock", Wit].`now`.invoke[(U64, U32)]
-      Instant.of[Posix](seconds.bits.s64.long*1000 + nanoseconds.bits.s32.int/1000000)
+      Instant.of[Unix](seconds.bits.s64.long*1000 + nanoseconds.bits.s32.int/1000000)

--- a/lib/embarcadero/src/test/embarcadero_test.scala
+++ b/lib/embarcadero/src/test/embarcadero_test.scala
@@ -372,11 +372,11 @@ object Tests extends Suite(m"Embarcadero OCI Tests"):
       // millis; Aviation's own `Instant` abstractable/instantiable instances are found
       // via its companion, so `embarcadero` needs no dependency on Aviation.
       import abstractables.instantAbstractable
-      import chronometries.posix
+      import chronometries.unix
       val moment = Instant(1_700_000_001_000L)
 
       test(m"a Container timestamp round-trips and converts to an Aviation Instant"):
         val container = Container(t"svc", createdAt = embarcadero.Timestamp.of(moment))
         val restored = LazyList(container.in[Protobuf].encode).read[Container in Protobuf]
-        restored.createdAt.instant[Instant over Posix]
+        restored.createdAt.instant[Instant over Unix]
       . assert(_ == moment)

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1221,7 +1221,7 @@ object Tests extends Suite(m"Jacinta Tests"):
       import decodables.instantJsonDecodable
       import decodables.durationJsonDecodable
       import aviation.*
-      import chronometries.posix
+      import chronometries.unix
       import abstractables.instantAbstractable
 
       test(m"Encode an Instant as a Long"):
@@ -1229,11 +1229,11 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == t"1700000000000")
 
       test(m"Decode an Instant from a Long"):
-        t"1700000000000".read[Json].as[Instant over Posix].long
+        t"1700000000000".read[Json].as[Instant over Unix].long
       . assert(_ == 1700000000000L)
 
       test(m"Round-trip an Instant"):
-        Instant(1234567890L).in[Json].as[Instant over Posix].long
+        Instant(1234567890L).in[Json].as[Instant over Unix].long
       . assert(_ == 1234567890L)
 
       test(m"Encode a Duration as a Long of milliseconds"):

--- a/lib/jacinta/src/time/jacinta_time.scala
+++ b/lib/jacinta/src/time/jacinta_time.scala
@@ -38,7 +38,7 @@ import contingency.*
 import prepositional.*
 
 package encodables:
-  given instantJsonEncodable: (Instant over Posix) is Json.Encodable =
+  given instantJsonEncodable: (Instant over Unix) is Json.Encodable =
     Json.Encodable(() => Morphology.Whole): instant => Json(instant.long)
 
   given durationJsonEncodable: Duration is Json.Encodable =
@@ -48,10 +48,10 @@ package decodables:
   // Laundered pure like jacinta's primitive codecs (codec-thunk seal): as derived-product
   // field codecs these are summoned against pure expected types.
   given instantJsonDecodable: (tactic: Tactic[JsonError])
-  =>  (Instant over Posix) is Json.Decodable =
+  =>  (Instant over Unix) is Json.Decodable =
     caps.unsafe.unsafeAssumePure:
       Json.Decodable(Morphology.Whole): json =>
-        Instant.of[Posix](json.root.long)
+        Instant.of[Unix](json.root.long)
 
   given durationJsonDecodable: (tactic: Tactic[JsonError])
   =>  Duration is Json.Decodable =
@@ -62,8 +62,8 @@ package parsables:
   // Direct-parsing counterparts: the epoch number is read straight off the
   // token stream, with no intermediate AST node or string. Genuinely pure —
   // raising happens inside the `JsonReader`, through the tactic it carries.
-  given instantJsonParsable: (Instant over Posix) is Json.Parsable =
-    Json.Parsable(Morphology.Whole): reader => Instant.of[Posix](reader.long())
+  given instantJsonParsable: (Instant over Unix) is Json.Parsable =
+    Json.Parsable(Morphology.Whole): reader => Instant.of[Unix](reader.long())
 
   given durationJsonParsable: Duration is Json.Parsable =
     Json.Parsable(Morphology.Whole): reader => Duration(reader.long())

--- a/lib/stratiform/src/time/stratiform_time.scala
+++ b/lib/stratiform/src/time/stratiform_time.scala
@@ -43,7 +43,7 @@ import prepositional.*
 // clash with project-wide default encodings.
 
 package encodables:
-  given instantTelEncodable: (Instant over Posix) is Tel.Encodable =
+  given instantTelEncodable: (Instant over Unix) is Tel.Encodable =
     Tel.Encodable(() => Morphology.Whole): instant => Tel.scalar(instant.long.toString.tt)
 
   given durationTelEncodable: Duration is Tel.Encodable =
@@ -52,9 +52,9 @@ package encodables:
 
 package decodables:
   given instantTelDecodable: (tactic: Tactic[TelError])
-  =>  (((Instant over Posix) is Tel.Decodable)^{tactic}) =
+  =>  (((Instant over Unix) is Tel.Decodable)^{tactic}) =
     Tel.Decodable(() => Morphology.Whole): tel =>
-      try Instant.of[Posix](tel.primaryAtom.s.toLong)
+      try Instant.of[Unix](tel.primaryAtom.s.toLong)
       catch case _: NumberFormatException => abort(TelError(TelError.Reason.BadVersion))
 
   given durationTelDecodable: (tactic: Tactic[TelError])


### PR DESCRIPTION
Two unrelated types were both re-exported into the top-level `soundness` package as `Posix`: galilei's filesystem-platform trait (whose `name` is "POSIX", extended by `Linux`/`MacOs`) and aviation's phantom time-timeline marker for `Instant over Posix`. Under `import soundness.*` these collided into an ambiguous `Posix`. Since the filesystem type is genuinely POSIX, aviation's timeline marker — already documented in its own source as "leap-free Unix time" — is renamed to `Unix`, and the matching `chronometries.posix` given becomes `chronometries.unix`. `soundness.Posix` now resolves uniquely to the filesystem platform.

## Release notes

**Breaking:** The aviation timeline marker `Posix` is renamed to `Unix`, resolving a name clash with galilei's filesystem `Posix` under `import soundness.*`.

- `Instant over Posix` → `Instant over Unix`
- `import chronometries.posix` → `import chronometries.unix`

```scala
// Before
val now: Instant over Posix = Clock().apply()
import chronometries.posix

// After
val now: Instant over Unix = Clock().apply()
import chronometries.unix
```

`soundness.Posix` now refers unambiguously to the galilei filesystem platform.