### PR TITLE
Rename three colliding soundness names: Transmitter, Trust, enumerate

### DIFF
--- a/lib/anamnesis/src/core/anamnesis_core.scala
+++ b/lib/anamnesis/src/core/anamnesis_core.scala
@@ -38,7 +38,7 @@ import prepositional.*
 infix type -< [left, right] = Database.Relation[left, right]
 infix type >- [left, right] = Database.Relation[right, left]
 
-def every[entity <: Entity: Listable]: Iterable[Reference[entity]] = entity.list(_ => true)
+def enumerate[entity <: Entity: Listable]: Iterable[Reference[entity]] = entity.list(_ => true)
 
 extension [left](using db: Database)(left: Ref of left in db.type)
   inline def unassign[right](right: Ref of right in db.type)(using db.Has[left -< right])

--- a/lib/anamnesis/src/core/soundness_anamnesis_core.scala
+++ b/lib/anamnesis/src/core/soundness_anamnesis_core.scala
@@ -32,5 +32,5 @@
                                                                                                   */
 package soundness
 
-export anamnesis.{Database, DataError, Entity, every, Listable, Referenceable, assign, lookup,
+export anamnesis.{Database, DataError, Entity, enumerate, Listable, Referenceable, assign, lookup,
     reference, store, unassign}

--- a/lib/coaxial/src/core/coaxial.Duplexable.scala
+++ b/lib/coaxial/src/core/coaxial.Duplexable.scala
@@ -36,6 +36,6 @@ package coaxial
 // called repeatedly, and concurrently with `receive` and with itself, without ever
 // half-closing the connection. Only such a transport can send *proactively* — before
 // the first inbound message, or from another task — so `exchange` (which hands the caller
-// a `Sender`) is offered only for a `Duplexable`, while a request/response `Serviceable`
+// a `Transmitter`) is offered only for a `Duplexable`, while a request/response `Serviceable`
 // (which may shut its output down after transmitting) has only the reactive `react`.
 trait Duplexable extends Serviceable

--- a/lib/coaxial/src/core/coaxial.Transmitter.scala
+++ b/lib/coaxial/src/core/coaxial.Transmitter.scala
@@ -40,11 +40,11 @@ import zephyrine.*
 // before the first inbound message arrives, or concurrently from another task — rather
 // than only in reply to one. Handed to the `interact` block of `exchange` on a
 // `Duplexable` transport, whose `transmit` is safe to call concurrently.
-object Sender:
+object Transmitter:
   // A consuming postal target: a named SAM rather than a function type, because
   // only a method parameter can be marked `consume`.
   trait Post:
     def apply(consume stream: (Stream[Data] over Credit)^): Unit
 
-class Sender[message: Transmissible as transmissible](post: Sender.Post^):
+class Transmitter[message: Transmissible as transmissible](post: Transmitter.Post^):
   def send(message: message): Unit = post(transmissible.serialize(message))

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -151,7 +151,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
 // retains a `Monitor` and its tactics), so the evidence is a capturing using-parameter.
 extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint is Duplexable)^)
   // A full-duplex exchange: as soon as the connection opens — before the `handle` loop
-  // begins — `interact` is handed a `Sender`, so a client can send *proactively* (send
+  // begins — `interact` is handed a `Transmitter`, so a client can send *proactively* (send
   // first, or push from a task it spawns), concurrently with the reactive `handle` loop
   // (which still replies via `Control`). `handle` precedes `interact` so the message type
   // is fixed by the (annotated) handler. Available only for a `Duplexable` transport,
@@ -159,7 +159,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
   // only the reactive `react`.
   def exchange[state](initialState: state)[message: {Ingressive, Transmissible}]
     ( handle: (state: state) ?=> message => Control[state] )
-    ( interact: Sender[message]^ => Unit )
+    ( interact: Transmitter[message]^ => Unit )
     ( using SocketEvent is Loggable )(using buffering: Buffering)
   :   state =
 
@@ -169,8 +169,8 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
     // A named `Post` rather than a lambda: forwarding to the consuming `transmit`
     // requires a `consume` parameter, which only a method can declare.
     interact:
-      Sender[message]:
-        new Sender.Post:
+      Transmitter[message]:
+        new Transmitter.Post:
           def apply(consume stream: (Stream[Data] over Credit)^): Unit =
             duplexable.transmit(connection, stream)
 

--- a/lib/coaxial/src/core/soundness_coaxial_core.scala
+++ b/lib/coaxial/src/core/soundness_coaxial_core.scala
@@ -36,7 +36,7 @@ export
   coaxial
   . { Bindable, BindError, Connectable, ConnectionError, Control, DomainSocket,
       DomainSocketEndpoint, duplex, Duplex, Duplexable, exchange, Ingressive, listen, Packet,
-      react, Routable, Sender, Serviceable, SocketBackend, SocketEvent,
+      react, Routable, Transmitter, Serviceable, SocketBackend, SocketEvent,
       SocketOption, SocketService, Transmissible, transmit, UdpResponse }
 
 package socketOptions:

--- a/lib/gastronomy/src/core/gastronomy_core.scala
+++ b/lib/gastronomy/src/core/gastronomy_core.scala
@@ -63,7 +63,7 @@ package crypto:
     caps.unsafe.unsafeErasedValue
 
   // Deprecated TLS protocol versions, key sizes and cipher families. Note that
-  // re-enabling these is process-wide (see `telekinesis.Tls.unlock`).
+  // re-enabling these is process-wide (see `telekinesis.Trust.unlock`).
   erased given permitLegacyTls
   :   Permit[Concession.Tls10] & Permit[Concession.Tls11] & Permit[Concession.SmallDh] &
     Permit[Concession.CbcCipher] =

--- a/lib/legerdemain/src/core/legerdemain.Elicitable.scala
+++ b/lib/legerdemain/src/core/legerdemain.Elicitable.scala
@@ -71,7 +71,7 @@ object Elicitable extends Elicitable2:
     def input(ref: Reference[entity]): Text = ref.encode
 
     def widget(id: Text, label: Text, value: Text): Dropdown =
-      val items = every[entity].map { item => item.encode -> item().show }.to(List)
+      val items = enumerate[entity].map { item => item.encode -> item().show }.to(List)
       Dropdown(id, items, value)
 
 trait Elicitable extends Typeclass, Operable:

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -176,7 +176,7 @@ private def readHandshake(input: (zephyrine.Stream[Data] over zephyrine.Credit)^
 // own client loop: `url.react(initialState) { message => … }`, symmetric with the
 // server's `webSocket(initial) { … }`. It is a `Duplexable` (not merely a `Serviceable`)
 // because its `transmit` spools through a thread-safe `Channel`, so Coaxial's `exchange`
-// (the `Sender`-carrying, full-duplex counterpart of `react`) also works — a client can
+// (the `Transmitter`-carrying, full-duplex counterpart of `react`) also works — a client can
 // send proactively (`url.exchange(state) { reply => … } { sender => sender.send(request) }`),
 // not only in reply. `connect` opens the TCP connection and performs the RFC 6455 handshake;
 // `receive` runs the shared `Reader` (Ping/Pong and Close handled there) and yields one

--- a/lib/perihelion/src/test/perihelion.Test.scala
+++ b/lib/perihelion/src/test/perihelion.Test.scala
@@ -414,7 +414,7 @@ object Tests extends Suite(m"Perihelion tests"):
 
         . assert(_ == 7)
 
-        // The full-duplex `exchange` gives the caller a `Sender` before the loop, so
+        // The full-duplex `exchange` gives the caller a `Transmitter` before the loop, so
         // the client speaks first: it sends `Ping(7)`, the server replies `Ping(8)`.
         test(m"A client sends proactively, then reacts to the reply"):
           val port = freePort()

--- a/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
+++ b/lib/telekinesis/src/jvm/soundness_telekinesis_jvm.scala
@@ -32,7 +32,7 @@
                                                                                                   */
 package soundness
 
-export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHttpClient, Tls,
+export telekinesis.{requestTransmissible, domainSocketFetchable, domainSocketHttpClient, Trust,
     TlsAcceptance}
 
 package httpBackends:

--- a/lib/telekinesis/src/jvm/telekinesis.Trust.scala
+++ b/lib/telekinesis/src/jvm/telekinesis.Trust.scala
@@ -59,8 +59,8 @@ import vacuous.*
 // algorithm constraints as purely additional to the process-wide
 // `jdk.tls.disabledAlgorithms` security property, so those relaxations can
 // only be unlocked process-wide, once, before JSSE initializes — see
-// `Tls.unlock`.
-object Tls:
+// `Trust.unlock`.
+object Trust:
   enum Version:
     case Tls12, Tls13
     case Tls10, Tls11
@@ -74,16 +74,7 @@ object Tls:
   enum Revocation:
     case Required, SoftFail, Unchecked
 
-  object Trust:
-    val Strict: Trust = Trust()
-
-  // Which certificate chains to trust beyond an intact, current chain to a
-  // platform anchor.
-  case class Trust
-    ( expired:    Boolean = false,
-      selfSigned: Boolean = false,
-      hostname:   Boolean = true,
-      anchors:    List[jsc.X509Certificate] = Nil )
+  val Strict: Trust = Trust()
 
   // Process-wide re-enablement of deprecated protocol versions and key sizes.
   // Must run before any JSSE machinery is initialized; later calls have no
@@ -101,6 +92,14 @@ object Tls:
       !versions.exists(_.id.s == entry)
 
     js.Security.setProperty("jdk.tls.disabledAlgorithms", String.join(", ", retained*))
+
+// Which certificate chains to trust beyond an intact, current chain to a
+// platform anchor.
+case class Trust
+  ( expired:    Boolean = false,
+    selfSigned: Boolean = false,
+    hostname:   Boolean = true,
+    anchors:    List[jsc.X509Certificate] = Nil )
 
 // The runtime acceptance value, resolved contextually wherever a TLS
 // connection is made. The companion default is strict; relaxed instances are
@@ -176,11 +175,11 @@ object TlsAcceptance:
             acceptance.trust.expired
 
           case jsc.CertPathValidatorException.BasicReason.REVOKED =>
-            acceptance.revocation != Tls.Revocation.Required
+            acceptance.revocation != Trust.Revocation.Required
 
           case jsc.CertPathValidatorException.BasicReason.UNDETERMINED_REVOCATION_STATUS =>
-            acceptance.revocation == Tls.Revocation.Unchecked ||
-              acceptance.revocation == Tls.Revocation.SoftFail
+            acceptance.revocation == Trust.Revocation.Unchecked ||
+              acceptance.revocation == Trust.Revocation.SoftFail
 
           case _ =>
             tolerable(error.getCause)
@@ -255,9 +254,9 @@ object TlsAcceptance:
         attempt(platform.checkServerTrusted(chain, authType, engine))
 
 case class TlsAcceptance
-  ( versions:   List[Tls.Version] = Nil, // Nil selects the platform default set
-    trust:      Tls.Trust = Tls.Trust.Strict,
-    revocation: Tls.Revocation = Tls.Revocation.SoftFail ):
+  ( versions:   List[Trust.Version] = Nil, // Nil selects the platform default set
+    trust:      Trust = Trust.Strict,
+    revocation: Trust.Revocation = Trust.Revocation.SoftFail ):
 
   def permitExpired(using erased permit: Permit[Concession.ExpiredCertificate]): TlsAcceptance =
     copy(trust = trust.copy(expired = true))
@@ -268,10 +267,10 @@ case class TlsAcceptance
   def permitHostnameMismatch(using erased permit: Permit[Concession.UnverifiedHostname]): TlsAcceptance =
     copy(trust = trust.copy(hostname = false))
 
-  def requireRevocationChecks: TlsAcceptance = copy(revocation = Tls.Revocation.Required)
+  def requireRevocationChecks: TlsAcceptance = copy(revocation = Trust.Revocation.Required)
 
   def permitRevoked(using erased permit: Permit[Concession.UncheckedRevocation]): TlsAcceptance =
-    copy(revocation = Tls.Revocation.Unchecked)
+    copy(revocation = Trust.Revocation.Unchecked)
 
   def trusting(anchors: List[jsc.X509Certificate]): TlsAcceptance =
     copy(trust = trust.copy(anchors = anchors))

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -622,7 +622,7 @@ object Tests extends Suite(m"Telekinesis tests"):
       . assert(identity)
 
       test(m"protocol restriction is applied to parameters"):
-        val acceptance = TlsAcceptance(versions = List(Tls.Version.Tls13))
+        val acceptance = TlsAcceptance(versions = List(Trust.Version.Tls13))
         val (_, parameters) = acceptance.materialize()
         parameters.getProtocols.nn.to(List).map(_.nn.tt)
       . assert(_ == List(t"TLSv1.3"))


### PR DESCRIPTION
Three unrelated definitions each shared a name with another module at the top level of the `soundness` package, so `import soundness.*` while depending on both was ambiguous. Each is renamed on the side where a distinctive name fits more naturally, clearing every remaining genuine same-namespace collision in `soundness`.

## Release notes

**Breaking:** three public names in `soundness` are renamed.

- **coaxial** `Sender[message]` → **`Transmitter[message]`** — the socket message-sender, now aligned with coaxial's `Transmissible` typeclass. Frees `Sender` for caduceus's email type.
- **telekinesis** `Tls` → **`Trust`** — the HTTP TLS-acceptance namespace. Its certificate-trust config is promoted to the top-level `Trust` type, with `Version`/`Revocation`/`unlock`/`Strict` on its companion (`Trust.Version`, `Trust.unlock`, …). Frees `Tls` for coaxial's socket TLS-connection type.
- **anamnesis** `every[Entity]` → **`enumerate[Entity]`** — lists all entities of a type. Keeps gigantism's metaprogramming `every`.

```scala
// before → after
coaxial.Sender[Msg]          → coaxial.Transmitter[Msg]
telekinesis.Tls.Version.Tls13 → telekinesis.Trust.Version.Tls13
anamnesis.every[Person]      → anamnesis.enumerate[Person]
```

The only shared names now remaining in `soundness` are intentional (`in`/`to`/`from`/`at`/`via` type-operator + extension pairs), benign extension overloads, redundant same-symbol re-exports, and the harmless type/term `index`.