### PR TITLE
Cross-format direct-parsing benchmarks, and XML collection codecs

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -942,6 +942,16 @@ object cosmopolite extends Library:
       settings.cc(super.scalacOptions())
     override def enabled = false
 
+object crossparse extends Library:
+  object bench extends Benchmarks(jacinta.core, stratiform.core, xylophone.core, ypsiloid.core,
+      quantitative.units):
+    def mvnDeps = Seq(
+      mvn"io.circe::circe-parser:0.14.13",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.35.3",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-circe:2.35.3",
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.35.3"
+    )
+
 object dendrology extends Library:
   object tree extends Component(gossamer.core):
     override def scalacOptions = Task:

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -1,0 +1,314 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package crossparse
+
+import ambience.*, environments.javaEnvironment, systems.javaSystem
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import distillate.*
+import fulminate.*
+import gossamer.*
+import hellenism.*, classloaders.threadContextClassloader
+import jacinta.*
+import prepositional.*
+import probably.*
+import proscenium.*
+import quantitative.*
+import rudiments.*
+import sedentary.*
+import spectacular.*
+import stratiform.*
+import symbolism.*
+import temporaryDirectories.systemTemporaryDirectory
+import turbulence.*
+import vacuous.*
+import wisteria.*
+import xylophone.*
+import ypsiloid.*
+
+// A discriminator key inside the value, mirroring the format tests: JSON
+// carries `"kind": …`, YAML carries `type: …`; TEL and XML need no import
+// (TEL keys the variant compound by name; XML uses the custom `Discriminable`
+// on `Payment`'s companion below).
+import jacinta.discriminables.jsonByKindDiscriminable
+import jacinta.formatting.compactJsonFormatting
+import ypsiloid.discriminables.yamlByTypeDiscriminable
+import ypsiloid.formatting.blockYamlFormatting
+
+// Ypsiloid's `Yaml is Showable` is a top-level given (not a companion
+// member), so it must be imported by name.
+import ypsiloid.showable
+
+// The shared structure decoded by every format: varied primitive types, a
+// nested record, a sequence and a coproduct.
+enum Payment:
+  case Card(number: Text, expiry: Text, secure: Boolean)
+  case Transfer(iban: Text, reference: Long)
+
+object Payment:
+  // An XML sum nested inside a product cannot use xylophone's label-based
+  // default `Discriminable`: the product encoder relabels the variant
+  // element with the *field's* name, which destroys the discriminator. The
+  // variant rides in a `type` attribute instead — `<payment type="Card">` —
+  // mirroring the discriminator key the JSON and YAML corpora carry.
+  given xmlDiscriminable: Payment is Discriminable in Xml = new Discriminable:
+    type Self = Payment
+    type Form = Xml
+
+    def discriminate(xml: Xml): Optional[Text] = xml match
+      case Element(_, attributes, _)           => attributes.at(t"type")
+      case Fragment(Element(_, attributes, _)) => attributes.at(t"type")
+      case _                                   => Unset
+
+    def rewrite(kind: Text, xml: Xml): Xml = xml match
+      case Element(label, attributes, children) =>
+        Element(label, attributes.updated(t"type", kind), children)
+
+      case Fragment(Element(label, attributes, children)) =>
+        Element(label, attributes.updated(t"type", kind), children)
+
+      case other =>
+        other
+
+    def variant(xml: Xml): Xml = xml
+
+case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
+case class Customer(id: Long, name: Text, email: Text, region: Text)
+
+case class Order
+  ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
+    priority: Boolean, discount: Double )
+
+case class Orders(orders: List[Order])
+
+object Orders:
+  // Direct parsing is opt-in per format; only the top type needs a nominal
+  // instance — nested types resolve through each format's field fallback
+  // chain.
+  given jsonParsable: Orders is Json.Parsable = Json.Parsable.derived
+  given telParsable: Orders is Tel.Parsable = Tel.Parsable.derived
+  given xmlParsable: Orders is Xml.Parsable = Xml.Parsable.derived
+
+// Jsoniter/circe mirrors of the corpus structure, with `String` fields as
+// those libraries expect; the `kind` discriminator matches the JSON corpus.
+sealed trait JsoniterPayment derives io.circe.derivation.ConfiguredDecoder
+
+object JsoniterPayment:
+  case class Card(number: String, expiry: String, secure: Boolean) extends JsoniterPayment
+  case class Transfer(iban: String, reference: Long) extends JsoniterPayment
+
+case class JsoniterLineItem
+  (sku: String, description: String, quantity: Int, price: Double, taxed: Boolean)
+derives io.circe.derivation.ConfiguredDecoder
+
+case class JsoniterCustomer(id: Long, name: String, email: String, region: String)
+derives io.circe.derivation.ConfiguredDecoder
+
+case class JsoniterOrder
+  ( reference: String, customer: JsoniterCustomer, items: List[JsoniterLineItem],
+    payment: JsoniterPayment, priority: Boolean, discount: Double )
+derives io.circe.derivation.ConfiguredDecoder
+
+case class JsoniterOrders(orders: List[JsoniterOrder])
+derives io.circe.derivation.ConfiguredDecoder
+
+// The circe derivation reads this at each `derives` site above.
+given io.circe.derivation.Configuration =
+  io.circe.derivation.Configuration.default.withDiscriminator("kind")
+
+object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
+  given decimalizer: Decimalizer = Decimalizer(2)
+  given device: BenchmarkDevice = LocalhostDevice
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  // ── The corpus ────────────────────────────────────────────────────────────
+  // One deterministic `Orders` value, sized so its JSON serialization is
+  // ~10 KB, then serialized once through each format's own encoder so that
+  // every arm decodes semantically identical data. Doubles are multiples of
+  // 0.25 (exactly representable) and `Text` values avoid spaces, so every
+  // format round-trips values byte-stably.
+  def lineItem(order: Int, item: Int): LineItem =
+    LineItem
+      ( sku         = t"SKU-$order-$item",
+        description = t"component-${(order*7 + item*3) % 20}-assembly",
+        quantity    = (order + item) % 9 + 1,
+        price       = ((order*13 + item*7) % 400).toDouble + 0.25*(item % 4),
+        taxed       = (order + item) % 2 == 0 )
+
+  def order(index: Int): Order =
+    val regions = List(t"north", t"south", t"east", t"west")
+
+    val payment: Payment =
+      if index % 2 == 0
+      then Payment.Card
+        ( number = t"4000-0000-0000-${1000 + index}",
+          expiry = t"20${26 + index % 4}-0${index % 9 + 1}",
+          secure = index % 3 == 0 )
+      else Payment.Transfer
+        ( iban      = t"GB${10 + index}BANK${700000 + index*13}",
+          reference = 500000L + index*37 )
+
+    Order
+      ( reference = t"ORD-2026-${1000 + index}",
+        customer  = Customer
+          ( id     = 10000L + index,
+            name   = t"customer-$index",
+            email  = t"user$index@example.com",
+            region = regions(index % 4) ),
+        items     = List.tabulate(6)(lineItem(index, _)),
+        payment   = payment,
+        priority  = index % 3 == 0,
+        discount  = 0.25*(index % 3) )
+
+  val corpus: Orders = Orders(List.tabulate(12)(order(_)))
+
+  lazy val jsonText: Text = corpus.in[Json].show
+  lazy val telText: Text = corpus.in[Tel].show
+  lazy val xmlText: Text = corpus.in[Xml].show
+  lazy val yamlText: Text = corpus.in[Yaml].show
+
+  lazy val jsonData: Data = jsonText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val telData: Data = telText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+
+  // ── The decode arms ───────────────────────────────────────────────────────
+  // Each format reads from its natural whole-input form — JSON and TEL from
+  // `Data`, XML and YAML from `Text` — with both of a format's arms reading
+  // the *same* input kind, so direct-versus-AST is a fair comparison within
+  // each format. YAML has no direct arm: ypsiloid's decoding is deliberately
+  // AST-only (YAML aliases require materialized subtrees).
+  def decodeJsonDirect(): Orders = jsonData.read[Orders in Json]
+  def decodeJsonAst(): Orders = jsonData.read[Json].as[Orders]
+  def decodeTelDirect(): Orders = telData.read[Orders in Tel]
+  def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
+  def decodeXmlDirect(): Orders = xmlText.read[Orders in Xml]
+  def decodeXmlAst(): Orders = xmlText.read[Xml].as[Orders]
+  def decodeYamlAst(): Orders = yamlText.read[Yaml].as[Orders]
+
+  // ── Jsoniter arms ─────────────────────────────────────────────────────────
+  // The external yardstick, decoding the same JSON corpus: direct with a
+  // macro-generated codec (configured for the corpus's `kind` discriminator),
+  // and via an AST — Jsoniter parsing into a circe `Json` tree, then a circe
+  // decoder walking it, the analog of the other formats' AST arms.
+  val jsoniterOrdersCodec
+  :   com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[JsoniterOrders] =
+    com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker.make
+      ( com.github.plokhotnyuk.jsoniter_scala.macros.CodecMakerConfig
+          . withDiscriminatorFieldName(Some("kind"))
+          // The corpus writes the discriminator last, as Jacinta does.
+          . withRequireDiscriminatorFirst(false) )
+
+  val circeAstCodec: com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec[io.circe.Json] =
+    com.github.plokhotnyuk.jsoniter_scala.circe.JsoniterScalaCodec.jsonCodec()
+
+  def decodeJsoniterDirect(): JsoniterOrders =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[JsoniterOrders]
+      ( jsonData.mutable(using Unsafe) )(using jsoniterOrdersCodec)
+
+  def decodeJsoniterAst(): JsoniterOrders =
+    val ast = com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[io.circe.Json]
+      ( jsonData.mutable(using Unsafe) )(using circeAstCodec)
+
+    summon[io.circe.Decoder[JsoniterOrders]].decodeJson(ast) match
+      case Right(orders) => orders
+      case Left(error)   => sys.error(error.getMessage.nn)
+
+  // The expected value for the Jsoniter correctness gate.
+  def jsoniterMirror(orders: Orders): JsoniterOrders =
+    JsoniterOrders
+      ( orders.orders.map { order =>
+          JsoniterOrder
+            ( order.reference.s,
+              JsoniterCustomer
+                ( order.customer.id, order.customer.name.s, order.customer.email.s,
+                  order.customer.region.s ),
+              order.items.map { item =>
+                JsoniterLineItem
+                  (item.sku.s, item.description.s, item.quantity, item.price, item.taxed) },
+              order.payment match
+                case Payment.Card(number, expiry, secure) =>
+                  JsoniterPayment.Card(number.s, expiry.s, secure)
+
+                case Payment.Transfer(iban, reference) =>
+                  JsoniterPayment.Transfer(iban.s, reference),
+              order.priority,
+              order.discount ) } )
+
+  def run(): Unit =
+    println(s"Corpus sizes (bytes): JSON=${jsonText.s.length} TEL=${telText.s.length} "
+        + s"XML=${xmlText.s.length} YAML=${yamlText.s.length}")
+
+    // The correctness gate: every arm must reproduce the original value
+    // before anything is timed.
+    assert(decodeJsonDirect() == corpus, "JSON direct decode disagrees with the corpus")
+    assert(decodeJsonAst() == corpus, "JSON AST decode disagrees with the corpus")
+    assert(decodeTelDirect() == corpus, "TEL direct decode disagrees with the corpus")
+    assert(decodeTelAst() == corpus, "TEL AST decode disagrees with the corpus")
+    assert(decodeXmlDirect() == corpus, "XML direct decode disagrees with the corpus")
+    assert(decodeXmlAst() == corpus, "XML AST decode disagrees with the corpus")
+    assert(decodeYamlAst() == corpus, "YAML AST decode disagrees with the corpus")
+
+    val jsoniterExpected = jsoniterMirror(corpus)
+    assert(decodeJsoniterDirect() == jsoniterExpected, "Jsoniter direct decode disagrees")
+    assert(decodeJsoniterAst() == jsoniterExpected, "Jsoniter AST decode disagrees")
+
+    val bench = Bench()
+
+    suite(m"Decode a ~10 KB order corpus to case classes"):
+      bench(m"JSON direct")(target = 1*Second, baseline = Baseline(compare = Min)):
+        '{ crossparse.Benchmarks.decodeJsonDirect() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeJsonAst() }
+
+      bench(m"TEL direct")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeTelDirect() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeTelAst() }
+
+      bench(m"XML direct")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeXmlDirect() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeXmlAst() }
+
+      // YAML decodes through the AST only: aliases require materialized
+      // subtrees, so ypsiloid deliberately has no direct path.
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeYamlAst() }
+
+      bench(m"Jsoniter direct")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeJsoniterDirect() }
+
+      bench(m"Jsoniter via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeJsoniterAst() }

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -37,6 +37,7 @@ import language.dynamics
 import java.lang as jl
 import java.util as ju
 
+import scala.collection.Factory
 import scala.collection.mutable as scm
 import scala.compiletime.*
 import scala.quoted.*
@@ -204,6 +205,92 @@ object Xml extends Tag.Container
       . or:
           raise(XmlError()) yet false
 
+  // The encoding counterpart of the `boolean` decodable above. The other
+  // primitives encode through the blanket `encodable`'s `Encodable in Text`
+  // branch, but no `Boolean is Encodable in Text` exists, so without this a
+  // `Boolean` field cannot be written at all despite reading fine.
+  given booleanEncodable: Boolean is Encodable in Xml =
+    value => TextNode(if value then t"true" else t"false")
+
+  // Marks a `Decodable in Xml` / `Encodable in Xml` as *repeatable* —
+  // xylophone's counterpart of stratiform's `Tel.Decodable.repeatable` flag.
+  // The wire form of a repeatable (collection) field is *all* the child
+  // elements sharing the field's name, one per collection element, rather
+  // than a single first-matching child. The `distillate` codec traits are
+  // format-neutral and cannot carry the flag themselves, so it rides on this
+  // mixin; a codec without the mixin is implicitly `repeatable = false`, and
+  // the collection codecs below mix it in with the flag left `true`.
+  trait Repeatable:
+    def repeatable: Boolean = true
+
+  // AST-path collection decoding: a field of type `List[value]` / `Set[value]`
+  // etc. decodes from *all* the child elements labelled with the field's name,
+  // in document order, each element decoding as one collection element. The
+  // product derivation (`buildWith`) recognises the `Repeatable` mixin and
+  // hands over a synthetic `Fragment` of the matching children — stratiform's
+  // synthetic-document idea. A lone `Element` decodes as a single-element
+  // collection (the shape `Xml#as` sees at a document root, where the parsed
+  // `Fragment(root)` wraps it).
+  given collectionDecodable: [collection <: Iterable, element]
+  =>  ( factory: Factory[element, collection[element]] )
+  =>  ( element0: => (element is Decodable in Xml)^ )
+  =>  collection[element] is Decodable in Xml =
+
+    // Sealed per the codec-thunk pattern: a by-name parameter cannot be
+    // named in a capture set, so the honest capture of `element0` cannot be
+    // expressed; see rep/DECISIONS.md.
+    caps.unsafe.unsafeAssumePure:
+      new distillate.Decodable with Repeatable:
+        type Self = collection[element]
+        type Form = Xml
+
+        def decoded(xml: Xml): collection[element] =
+          val builder = factory.newBuilder
+
+          xml match
+            case Fragment(nodes*) =>
+              // The synthetic wrapper (or the `Absent` sentinel, an empty
+              // `Fragment`): each element node is one collection element.
+              // Zero nodes build the empty collection — a missing repeated
+              // field is empty, never an error.
+              nodes.each:
+                case child: Element => builder += element0.decoded(child)
+                case _              => ()
+
+            case node: Node =>
+              builder += element0.decoded(node)
+
+          builder.result()
+
+  // The mirror of `collectionDecodable`: a collection encodes to a `Fragment`
+  // holding one node per element, which the product derivation (recognising
+  // the `Repeatable` mixin) flattens into repeated same-named children.
+  given collectionEncodable: [collection <: Iterable, element]
+  =>  ( encodable: => (element is Encodable in Xml)^ )
+  =>  collection[element] is Encodable in Xml =
+
+    // Sealed per the codec-thunk pattern, as in `collectionDecodable`.
+    caps.unsafe.unsafeAssumePure:
+      new anticipation.Encodable with Repeatable:
+        type Self = collection[element]
+        type Form = Xml
+
+        def encoded(values: collection[element]): Xml =
+          val nodes: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
+
+          values.each: value =>
+            encodable.encoded(value) match
+              case node: Node           => nodes += node
+              case Fragment(node: Node) => nodes += node
+
+              // A multi-node fragment (itself a repeated form — a nested
+              // collection) has no per-element XML shape; it nests under an
+              // unnamed element, relabelled by the enclosing product.
+              case Fragment(nested*) =>
+                nodes += Element(t"", Attributes.empty, IArray.from(nested))
+
+          Fragment(nodes.toSeq*)
+
   // Single entry-point for resolving `Decodable in Xml`. Prefers a textual
   // decoder when one exists (so any `Decodable in Text` value works as a
   // field type); otherwise falls back to Wisteria-derived case-class /
@@ -341,15 +428,39 @@ object Xml extends Tag.Container
               element.attributes.at(wireName).lay(default.or(context.decoded(Absent))): text =>
                 context.decoded(TextNode(text))
             else
-              children.get(wireName.s) match
-                case Some(child) => context.decoded(child)
-                // Missing field: fall back to the case-class declared
-                // default (Wisteria's `default`); if absent, hand the
-                // `Absent` sentinel to the field's decoder. Primitives
-                // detect it and `raise + continue`; nested conjunctions
-                // detect it and may further short-circuit via a
-                // user-supplied `Default[Nested]`.
-                case None        => default.or(context.decoded(Absent))
+              // The `AnyRef` cast (rather than `asMatchable`) sidesteps the
+              // capture-refined singleton type the checker would otherwise
+              // require of the scrutinee.
+              context.asInstanceOf[AnyRef] match
+                case marked: Repeatable if marked.repeatable =>
+                  // A repeatable (collection) field gathers *all* same-label
+                  // children, in document order, into a synthetic `Fragment`
+                  // for the collection decoder — stratiform's synthetic-
+                  // document idea. Zero matches decode the empty fragment
+                  // (an empty collection): the declared default is never
+                  // consulted, exactly as on the direct path.
+                  val gathered: scm.ArrayBuffer[Node] = scm.ArrayBuffer()
+                  var child = 0
+
+                  while child < element.children.length do
+                    element.children(child) match
+                      case node: Element => if node.label == wireName then gathered += node
+                      case _             => ()
+
+                    child += 1
+
+                  context.decoded(Fragment(gathered.toSeq*))
+
+                case _ =>
+                  children.get(wireName.s) match
+                    case Some(child) => context.decoded(child)
+                    // Missing field: fall back to the case-class declared
+                    // default (Wisteria's `default`); if absent, hand the
+                    // `Absent` sentinel to the field's decoder. Primitives
+                    // detect it and `raise + continue`; nested conjunctions
+                    // detect it and may further short-circuit via a
+                    // user-supplied `Default[Nested]`.
+                    case None        => default.or(context.decoded(Absent))
 
     // Sealed-trait disjunction picks a variant by element label. We screen
     // the discriminator against `variantLabels` *before* `delegate`-ing so
@@ -436,13 +547,34 @@ object Xml extends Tag.Container
           field =>
             val fieldLabel: Text = wisteria.label[Text]
             val wireName: Text = renames.at(fieldLabel).or(fieldLabel)
-            val encoded: Xml = contextual.encode(field)
+            val encoder: field is Encodable in Xml = wisteria.contextual
+            val encoded: Xml = encoder.encoded(field)
 
             // `@attribute` fields become attributes carrying the encoded leaf's
             // text; every other field becomes a child element via `wrap`.
             if attributeFields.contains(fieldLabel)
             then attributes += wireName -> textOf(encoded).or(t"")
-            else children += wrap(wireName, encoded)
+            else
+              // The `AnyRef` cast (rather than `asMatchable`) sidesteps the
+              // capture-refined singleton type the checker would otherwise
+              // require of the scrutinee.
+              encoder.asInstanceOf[AnyRef] match
+                case marked: Repeatable if marked.repeatable =>
+                  // A repeatable (collection) field encodes as repeated
+                  // child elements — one per collection element, each
+                  // relabelled with the field's wire name — the exact
+                  // inverse of the decoder gathering all same-label
+                  // children.
+                  encoded match
+                    case Fragment(nodes*) =>
+                      nodes.each: node =>
+                        children += wrap(wireName, node)
+
+                    case other =>
+                      children += wrap(wireName, other)
+
+                case _ =>
+                  children += wrap(wireName, encoded)
 
         Element
           ( typeName,
@@ -481,6 +613,11 @@ object Xml extends Tag.Container
     type Transport = Xml
     type Reader = XmlReader
 
+    // True for collection parsers: a repeated field, gathered occurrence by
+    // occurrence by the derived product parser — the direct counterpart of a
+    // `Repeatable`-marked `Decodable in Xml`.
+    def repeatable: Boolean = false
+
     // What a field of this type yields when no child element (or attribute)
     // carries its name — the direct counterpart of the AST derivation
     // handing the `Absent` sentinel to the field's decoder: an abort unless
@@ -515,15 +652,44 @@ object Xml extends Tag.Container
     def fromDecodable[value](decodable: (value is Decodable in Xml)^)
     :   ((value is Xml.Parsable)^{decodable}) =
 
-      new Xml.Parsable:
-        type Self = value
-        def parse(reader: XmlReader^): value = decodable.decoded(reader.element())
+      // The `AnyRef` cast (rather than `asMatchable`) sidesteps the capture-
+      // refined singleton type the checker would otherwise require of the
+      // scrutinee.
+      val repeated: Boolean = decodable.asInstanceOf[AnyRef] match
+        case marked: Repeatable => marked.repeatable
+        case _                  => false
 
-        override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): value =
-          decodable.decoded(Absent)
+      // A repeatable decoder (a custom collection) keeps its gathering
+      // semantics: each occurrence is materialized separately and the
+      // occurrences are decoded together as a synthetic fragment, exactly as
+      // the AST derivation hands them over.
+      if repeated then
+        new Xml.Parsable with Gathering:
+          type Self = value
+          override def repeatable: Boolean = true
+          def parse(reader: XmlReader^): value = decodable.decoded(reader.element())
 
-        override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): value =
-          decodable.decoded(TextNode(text))
+          override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): value =
+            decodable.decoded(Absent)
+
+          override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): value =
+            decodable.decoded(TextNode(text))
+
+          def parseElement(reader: XmlReader^): Any = reader.element()
+
+          def gathered(elements: List[Any]): value =
+            // `XmlReader.element()` materializes exactly one `Element`.
+            decodable.decoded(Fragment(elements.map(_.asInstanceOf[Node])*))
+      else
+        new Xml.Parsable:
+          type Self = value
+          def parse(reader: XmlReader^): value = decodable.decoded(reader.element())
+
+          override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): value =
+            decodable.decoded(Absent)
+
+          override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): value =
+            decodable.decoded(TextNode(text))
 
     // The one-line opt-in to direct parsing for a structural type:
     // `given MyType is Xml.Parsable = Xml.Parsable.derived` — a
@@ -539,10 +705,68 @@ object Xml extends Tag.Container
       new Xml.Parsable:
         type Self = value
         def parse(reader: XmlReader^): value = field0.parse(reader)
+        override def repeatable: Boolean = field0.repeatable
         override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): value = field0.absent()
 
         override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): value =
           field0.attribute(text)
+
+    // The element-wise hooks of a repeatable (collection) parser. The
+    // derived product parser gathers each same-label occurrence through
+    // `parseElement` and builds the collection once the element's children
+    // end — the direct counterpart of the AST derivation collecting all
+    // matching children into a synthetic `Fragment` for the collection
+    // decoder. The self type is capturing so implementing instances may
+    // capture their element parser or decoder, like any other `Parsing`
+    // instance.
+    private[xylophone] trait Gathering:
+      self: Xml.Parsing^ =>
+      def parseElement(reader: XmlReader^): Any
+      def gathered(elements: List[Any]): Self
+
+    // Shared collection implementation, backing the `fieldCollection` given
+    // (elements resolve through the field fallback chain, so nested products
+    // still parse directly). Sealed per the codec-thunk pattern: a by-name
+    // parameter cannot be named in a capture set.
+    def iterable[collection <: Iterable, element]
+      ( field: => (element is Xml.Parsing)^ )
+      ( using factory: Factory[element, collection[element]] )
+    :   collection[element] is Xml.Parsable =
+
+      caps.unsafe.unsafeAssumePure:
+        new Xml.Parsable with Gathering:
+          type Self = collection[element]
+          override def repeatable: Boolean = true
+
+          def parseElement(reader: XmlReader^): Any = field.parse(reader)
+
+          def gathered(elements: List[Any]): collection[element] =
+            val builder = factory.newBuilder
+            elements.each: item => builder += item.asInstanceOf[element]
+            builder.result()
+
+          // A single element read as a collection: one element — the AST
+          // collection decoder's behavior when handed a lone element (a
+          // whole-document read of a collection value).
+          def parse(reader: XmlReader^): collection[element] =
+            val builder = factory.newBuilder
+            builder += field.parse(reader)
+            builder.result()
+
+          // A missing collection field is the empty collection on both
+          // paths (the AST decoder receives an empty synthetic fragment);
+          // the engine routes repeatable fields through `gathered`, so this
+          // covers only the wrong-shape and root fallbacks.
+          override def absent()(using Tactic[XmlError], Foci[Xml.Focus])
+          :   collection[element] =
+
+            factory.newBuilder.result()
+
+    // Field instances travel wrapped in the `Field.Adapter`; the engine
+    // looks through it for repeatability and the element-wise hooks.
+    private def unwrap(parsing: Xml.Parsing): Xml.Parsing = parsing match
+      case adapter: Xml.Field.Adapter[?] => adapter.source
+      case other                         => other
 
     // Sentinel for the derived product parser's value buffer: a slot still
     // `AbsentSlot` after the child loop had no matching element
@@ -652,29 +876,64 @@ object Xml extends Tag.Container
           while label.present do
             val found = indexOf(label.vouch)
 
-            // Unknown children are skipped, and a duplicate child keeps the
-            // first occurrence — the AST derivation's `HashMap` inserts only
-            // when the label is not yet present.
-            if found < 0 || !(values(found).asInstanceOf[AnyRef] eq AbsentSlot)
-            then reader.skipElement()
-            else values(found) =
-              if focused
-              then focus(descend(prior, keys(found).tt))(entries(found)(1).parse(reader))
-              else entries(found)(1).parse(reader)
+            if found < 0 then reader.skipElement()
+            else Xml.Parsable.unwrap(entries(found)(1)) match
+              case gathering: Gathering if entries(found)(1).repeatable =>
+                // Every occurrence of a repeatable field accumulates, in
+                // document order — the AST derivation's gather-all
+                // semantics.
+                val buffer = values(found) match
+                  case buffer: scm.ListBuffer[?] => buffer.asInstanceOf[scm.ListBuffer[Any]]
+
+                  case _ =>
+                    val buffer = scm.ListBuffer.empty[Any]
+                    values(found) = buffer
+                    buffer
+
+                buffer +=
+                  ( if focused
+                    then focus(descend(prior, keys(found).tt))(gathering.parseElement(reader))
+                    else gathering.parseElement(reader) )
+
+              case _ =>
+                // Unknown children are skipped, and a duplicate child keeps
+                // the first occurrence — the AST derivation's `HashMap`
+                // inserts only when the label is not yet present.
+                if !(values(found).asInstanceOf[AnyRef] eq AbsentSlot)
+                then reader.skipElement()
+                else values(found) =
+                  if focused
+                  then focus(descend(prior, keys(found).tt))(entries(found)(1).parse(reader))
+                  else entries(found)(1).parse(reader)
 
             label = reader.nextChild()
 
           index = 0
 
           while index < count do
-            if values(index).asInstanceOf[AnyRef] eq AbsentSlot then
-              val declared = entries(index)(2).asInstanceOf[Optional[Any]]
+            Xml.Parsable.unwrap(entries(index)(1)) match
+              case gathering: Gathering if entries(index)(1).repeatable =>
+                // A repeatable field never consults the declared default:
+                // zero occurrences build the empty collection, exactly as
+                // the AST derivation decodes an empty synthetic fragment.
+                val elements: List[Any] = values(index) match
+                  case buffer: scm.ListBuffer[?] => buffer.toList
+                  case _                         => Nil
 
-              values(index) =
-                if declared.present then declared
-                else if focused
-                then focus(descend(prior, keys(index).tt))(entries(index)(1).absent())
-                else entries(index)(1).absent()
+                values(index) =
+                  if focused
+                  then focus(descend(prior, keys(index).tt))(gathering.gathered(elements))
+                  else gathering.gathered(elements)
+
+              case _ =>
+                if values(index).asInstanceOf[AnyRef] eq AbsentSlot then
+                  val declared = entries(index)(2).asInstanceOf[Optional[Any]]
+
+                  values(index) =
+                    if declared.present then declared
+                    else if focused
+                    then focus(descend(prior, keys(index).tt))(entries(index)(1).absent())
+                    else entries(index)(1).absent()
 
             index += 1
 
@@ -703,13 +962,22 @@ object Xml extends Tag.Container
           var index = 0
 
           while index < count do
-            val declared = entries(index)(2).asInstanceOf[Optional[Any]]
+            values(index) = Xml.Parsable.unwrap(entries(index)(1)) match
+              // A repeatable field builds the empty collection, exactly as
+              // the AST derivation's wrong-shape fallback gathers zero
+              // children — the declared default is never consulted.
+              case gathering: Gathering if entries(index)(1).repeatable =>
+                if focused
+                then focus(descend(prior, keys(index).tt))(gathering.gathered(Nil))
+                else gathering.gathered(Nil)
 
-            values(index) =
-              if declared.present then declared
-              else if focused
-              then focus(descend(prior, keys(index).tt))(entries(index)(1).absent())
-              else entries(index)(1).absent()
+              case _ =>
+                val declared = entries(index)(2).asInstanceOf[Optional[Any]]
+
+                if declared.present then declared
+                else if focused
+                then focus(descend(prior, keys(index).tt))(entries(index)(1).absent())
+                else entries(index)(1).absent()
 
             index += 1
 
@@ -736,6 +1004,7 @@ object Xml extends Tag.Container
         source0.asInstanceOf[value is Xml.Parsing]
 
       def parse(reader: XmlReader^): value = source.parse(reader)
+      override def repeatable: Boolean = source.repeatable
 
       override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): value = source.absent()
 
@@ -800,6 +1069,19 @@ object Xml extends Tag.Container
       case "true"  => true
       case "false" => false
       case _       => Unset
+
+  // Element-wise `Xml.Field` for collections, resolved during derivation:
+  // the element's own parser comes from the fallback chain, so nested
+  // products still parse directly. Declared here (not in `Xml3`) so it beats
+  // the fallback, and collection types never reach its `Reflection` case (a
+  // `List`'s own `Mirror` would otherwise derive it as a sum). The instance
+  // is repeatable: the product engine gathers every same-label occurrence,
+  // exactly as the AST derivation collects all matching children.
+  given fieldCollection: [collection <: Iterable, element]
+  =>  ( factory: Factory[element, collection[element]] )
+  =>  ( field: => (element is Xml.Field)^ )
+  =>  collection[element] is Xml.Field =
+    Xml.Field(Xml.Parsable.iterable[collection, element](field))
 
   // The direct read of a field type carried by a plain text codec — the
   // direct counterpart of the `decodable` blanket's `Decodable in Text`

--- a/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
+++ b/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
@@ -56,6 +56,12 @@ case class PTemperature(celsius: Int) derives CanEqual
 case class PBoxed[value](value: value) derives CanEqual
 case class PReading(temp: PTemperature, station: Text) derives CanEqual
 
+// Collection fixtures: a `List` field decodes from *all* same-label children,
+// in document order — one with a leaf-element list, one with a nested-record
+// list.
+case class PPlaylist(name: Text, songs: List[Text]) derives CanEqual
+case class PTeam(name: Text, members: List[PWorker]) derives CanEqual
+
 case class PIssues(items: List[(Text, XmlError)] = Nil)(using Diagnostics)
 extends Error(m"${items.length} XML decoding issues"):
   def +(focus: Text, error: XmlError): PIssues = PIssues(items :+ (focus, error))
@@ -104,6 +110,8 @@ object DirectParsingTests extends Suite(m"Xylophone direct parsing tests"):
     given PTemperature is Xml.Parsable =
       Xml.Parsable.fromDecodable(summon[PTemperature is Decodable in Xml])
     given PReading is Xml.Parsable = Xml.Parsable.derived
+    given PPlaylist is Xml.Parsable = Xml.Parsable.derived
+    given PTeam is Xml.Parsable = Xml.Parsable.derived
 
     // The acceptance criterion: the direct read must equal the AST-path
     // read (parse to an `Xml` tree, then decode), for the same input.
@@ -232,6 +240,43 @@ object DirectParsingTests extends Suite(m"Xylophone direct parsing tests"):
         capture[XmlError](t"<Triangle><foo>1</foo></Triangle>".read[PShape in Xml])
         true
       . assert(identity)
+
+    suite(m"Collections"):
+      test(m"Contiguous repeated elements gather in order, equally on both paths"):
+        val input = t"<root><name>Mix</name><songs>A</songs><songs>B</songs><songs>C</songs></root>"
+        (input.read[PPlaylist in Xml], parity[PPlaylist](input))
+      . assert(_ == (PPlaylist(t"Mix", List(t"A", t"B", t"C")), true))
+
+      test(m"Non-contiguous repeated elements still gather in document order"):
+        val input = t"<root><songs>A</songs><name>Mix</name><songs>B</songs></root>"
+        (input.read[PPlaylist in Xml], parity[PPlaylist](input))
+      . assert(_ == (PPlaylist(t"Mix", List(t"A", t"B")), true))
+
+      test(m"No matching children decode as the empty list on both paths"):
+        val input = t"<root><name>Mix</name></root>"
+        (input.read[PPlaylist in Xml], parity[PPlaylist](input))
+      . assert(_ == (PPlaylist(t"Mix", Nil), true))
+
+      test(m"Nested record elements in lists decode equally on both paths"):
+        val input = t"""<root>
+                          <name>Reds</name>
+                          <members><name>Ann</name><age>1</age></members>
+                          <extra>skipme</extra>
+                          <members><name>Bob</name><age>2</age></members>
+                        </root>"""
+        (input.read[PTeam in Xml], parity[PTeam](input))
+      . assert(_ == (PTeam(t"Reds", List(PWorker(t"Ann", 1), PWorker(t"Bob", 2))), true))
+
+      test(m"A list round-trips through the encoder, equally on both paths"):
+        val team = PTeam(t"Blues", List(PWorker(t"Cyd", 3), PWorker(t"Dee", 4)))
+        val input = team.in[Xml].show
+        (input.read[PTeam in Xml], parity[PTeam](input))
+      . assert(_ == (PTeam(t"Blues", List(PWorker(t"Cyd", 3), PWorker(t"Dee", 4))), true))
+
+      test(m"An empty list encodes to no children and round-trips"):
+        val input = PPlaylist(t"Quiet", Nil).in[Xml].show
+        (input.read[PPlaylist in Xml], parity[PPlaylist](input))
+      . assert(_ == (PPlaylist(t"Quiet", Nil), true))
 
     suite(m"Custom-Decodable bridge"):
       test(m"A type with only a custom Decodable reads through the bridge"):


### PR DESCRIPTION
A new standalone benchmark module, `crossparse.bench`, measures what direct-to-case-class parsing is worth in each format, on identical data. One deterministic order corpus — nested products, a list of line items, a payment coproduct, and a mix of `Text`, `Int`, `Long`, `Double` and `Boolean` fields, sized to ~10KB of JSON — is serialized through each format's own encoder, and every decode arm must reproduce the original value exactly before anything is timed. It runs alone with `mill crossparse.bench.run` and reports reads per second:

| Format | Direct | Via AST |
|--|--|--|
| JSON | 48,083 op/s | 22,608 op/s |
| TEL | 17,928 op/s | 10,861 op/s |
| XML | 22,648 op/s | 9,963 op/s |
| YAML | — | 12,903 op/s |
| Jsoniter | 131,669 op/s | 32,336 op/s |

Direct parsing decodes 1.7–2.3× more documents per second than the AST paths across JSON, TEL and XML. YAML has only a tree arm, since ypsiloid's decoding is deliberately AST-based (aliases require materialized subtrees), and Jsoniter serves as the external yardstick — its macro codec directly, and via a circe AST as the analog of the other tree arms. The corpus also puts the next optimization target on record: it is `Double`-heavy, and floating-point values still take the general number path.

Enabling the corpus in XML surfaced a real gap, now fixed: xylophone had no collection codecs at all, so a `List` field failed to derive on either path. A collection field now decodes from all same-label child elements in document order and encodes as repeated elements, on both the tree and direct paths, pinned to each other by parity tests; `Boolean` also gains its missing XML encodable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
