### PR TITLE
Staged and Expr-composed direct parsers, tuned to 1.1x Jsoniter

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1669,6 +1669,30 @@ object polyvinyl extends Library:
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
 
+// Proof of concept: a typeclass whose methods are macro-time code generators
+// (`Expr` in, `Expr` out), with instances evaluated at expansion time — by
+// loading precompiled singletons through the macro classloader, or through an
+// in-macro `staging.Compiler`. The `leaves` component exists to give instance
+// objects a compilation phase strictly before the `test` use site.
+object prescience extends Library:
+  object core extends Component(prepositional.core, fulminate.core, gossamer.core):
+    override def scalaJs = false // compile-time instance evaluation via the macro classloader
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
+
+  object leaves extends Component(core):
+    override def scalaJs = false // exists only to precede `test` in compilation order
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+
+  object test extends Tests(leaves):
+    override def scalacOptions = Task:
+      super.scalacOptions()
+
 object prepositional extends Library:
   object core extends Component:
     override def scalacOptions = Task:
@@ -2213,8 +2237,8 @@ val allLibraries: Seq[Library] = Seq(
   kaleidoscope, larceny, legerdemain, locomotion, mandible, mercator, metamorphose,
   monotonous,
   mosquito, nomenclature, obligatory, octogenarian, orthodoxy, panopticon, parasite,
-  perihelion, phoenicia, plutocrat, polaris, polysyllabic, polyvinyl, prepositional, probably,
-  profanity,
+  perihelion, phoenicia, plutocrat, polaris, polysyllabic, polyvinyl, prepositional, prescience,
+  probably, profanity,
   proscenium, punctuation, quantitative, querencia, revolution, rudiments, savagery,
   scintillate, sedentary, serpentine, spectacular, stenography, stratiform, superlunary,
   surveillance, symbolism, synesthesia, tarantula, telekinesis, turbulence, typonym,

--- a/build.mill
+++ b/build.mill
@@ -71,7 +71,7 @@ object settings:
   // `3.9.0-RC1-propensive`. Override the coordinate with `SOUNDNESS_SCALA_VERSION` (e.g. the
   // 3.10.0 row is version "3.10.0-propensive").
   val scalaVersion = sys.env.getOrElse("SOUNDNESS_SCALA_VERSION", "3.9.0-RC1-propensive")
-  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC1-p2")
+  val scalaRelease = sys.env.getOrElse("SOUNDNESS_SCALA_RELEASE", "3.9.0-RC1-p3")
   // Empty by default → download `scalaRelease`. Set to a local `release` directory to use its
   // `release/lib` jars directly (fork-developer mode).
   val scalaHome = sys.env.getOrElse("SOUNDNESS_SCALA_HOME", "")

--- a/build.mill
+++ b/build.mill
@@ -943,8 +943,15 @@ object cosmopolite extends Library:
     override def enabled = false
 
 object crossparse extends Library:
-  object bench extends Benchmarks(jacinta.core, stratiform.core, xylophone.core, ypsiloid.core,
-      quantitative.units):
+  // The corpus's domain types, compiled one phase before the benchmarks so
+  // that `Json.Inlinable`'s expansion-time instance evaluation can load them
+  // (and resolve the companion `Inlinable` givens) at the bench's expansion.
+  object model extends Component(jacinta.staged, stratiform.core, xylophone.core, ypsiloid.core):
+    override def scalaJs = false // depends on jacinta.staged (compiler jars)
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+
+  object bench extends Benchmarks(model, quantitative.units):
     def mvnDeps = Seq(
       mvn"io.circe::circe-parser:0.14.13",
       mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.35.3",
@@ -1463,6 +1470,17 @@ object jacinta extends Library:
   object records extends Component(core, polyvinyl.core):
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+  // The Expr-level `Json.Inlinable` typeclass and its expansion-time instance
+  // evaluation (an in-macro staging compiler), kept out of `core` so jacinta
+  // users don't inherit the compiler jars unless they opt in.
+  object staged extends Component(core):
+    override def scalaJs = false // expansion-time instance evaluation via staging
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
   object test extends Tests(time, http, schema, records, sedentary.core, diuretic.core,
     galilei.jvm, octogenarian.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -208,6 +208,21 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
   // AST-only (YAML aliases require materialized subtrees).
   def decodeJsonDirect(): Orders = jsonData.read[Orders in Json]
   def decodeJsonAst(): Orders = jsonData.read[Json].as[Orders]
+
+  // The staged arm: monomorphic generated parsers for each record type,
+  // hoisted so the KeyTables and instance arrays are built once. The nested
+  // record types' staged givens are siblings, so each expansion finds them;
+  // `items` (a `List`) and `payment` (a sum) still cross runtime `Json.Field`
+  // seams — the current staged composition boundary.
+  object staged:
+    given lineItem: LineItem is Json.Parsable = Json.Parsable.staged
+    given customer: Customer is Json.Parsable = Json.Parsable.staged
+    given order: Order is Json.Parsable = Json.Parsable.staged
+    given orders: Orders is Json.Parsable = Json.Parsable.staged
+
+  def decodeJsonStaged(): Orders =
+    import staged.orders
+    jsonData.read[Orders in Json]
   def decodeTelDirect(): Orders = telData.read[Orders in Tel]
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
   def decodeXmlDirect(): Orders = xmlText.read[Orders in Xml]
@@ -270,6 +285,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     // The correctness gate: every arm must reproduce the original value
     // before anything is timed.
     assert(decodeJsonDirect() == corpus, "JSON direct decode disagrees with the corpus")
+    assert(decodeJsonStaged() == corpus, "JSON staged decode disagrees with the corpus")
     assert(decodeJsonAst() == corpus, "JSON AST decode disagrees with the corpus")
     assert(decodeTelDirect() == corpus, "TEL direct decode disagrees with the corpus")
     assert(decodeTelAst() == corpus, "TEL AST decode disagrees with the corpus")
@@ -287,6 +303,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     suite(m"Decode a ~10 KB order corpus to case classes"):
       bench(m"JSON direct")(target = 1*Second, baseline = Baseline(compare = Min)):
         '{ crossparse.Benchmarks.decodeJsonDirect() }
+
+      bench(m"JSON staged")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeJsonStaged() }
 
       bench(m"JSON via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsonAst() }
@@ -326,6 +345,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       profile(m"JSON direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsonDirect() }
+
+      profile(m"JSON staged")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeJsonStaged() }
 
       profile(m"Jsoniter direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsoniterDirect() }

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -69,56 +69,6 @@ import ypsiloid.formatting.blockYamlFormatting
 // member), so it must be imported by name.
 import ypsiloid.showable
 
-// The shared structure decoded by every format: varied primitive types, a
-// nested record, a sequence and a coproduct.
-enum Payment:
-  case Card(number: Text, expiry: Text, secure: Boolean)
-  case Transfer(iban: Text, reference: Long)
-
-object Payment:
-  // An XML sum nested inside a product cannot use xylophone's label-based
-  // default `Discriminable`: the product encoder relabels the variant
-  // element with the *field's* name, which destroys the discriminator. The
-  // variant rides in a `type` attribute instead — `<payment type="Card">` —
-  // mirroring the discriminator key the JSON and YAML corpora carry.
-  given xmlDiscriminable: Payment is Discriminable in Xml = new Discriminable:
-    type Self = Payment
-    type Form = Xml
-
-    def discriminate(xml: Xml): Optional[Text] = xml match
-      case Element(_, attributes, _)           => attributes.at(t"type")
-      case Fragment(Element(_, attributes, _)) => attributes.at(t"type")
-      case _                                   => Unset
-
-    def rewrite(kind: Text, xml: Xml): Xml = xml match
-      case Element(label, attributes, children) =>
-        Element(label, attributes.updated(t"type", kind), children)
-
-      case Fragment(Element(label, attributes, children)) =>
-        Element(label, attributes.updated(t"type", kind), children)
-
-      case other =>
-        other
-
-    def variant(xml: Xml): Xml = xml
-
-case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
-case class Customer(id: Long, name: Text, email: Text, region: Text)
-
-case class Order
-  ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
-    priority: Boolean, discount: Double )
-
-case class Orders(orders: List[Order])
-
-object Orders:
-  // Direct parsing is opt-in per format; only the top type needs a nominal
-  // instance — nested types resolve through each format's field fallback
-  // chain.
-  given jsonParsable: Orders is Json.Parsable = Json.Parsable.derived
-  given telParsable: Orders is Tel.Parsable = Tel.Parsable.derived
-  given xmlParsable: Orders is Xml.Parsable = Xml.Parsable.derived
-
 // Jsoniter/circe mirrors of the corpus structure, with `String` fields as
 // those libraries expect; the `kind` discriminator matches the JSON corpus.
 sealed trait JsoniterPayment derives io.circe.derivation.ConfiguredDecoder
@@ -233,8 +183,19 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     given xmlOrder: Order is Xml.Parsable = Xml.Parsable.staged
     given xmlOrders: Orders is Xml.Parsable = Xml.Parsable.staged
 
+    // The Inlinable-composed parser: the whole instance graph (records,
+    // collection loops, leaf parsers) resolves live inside an in-macro
+    // staging compiler — the model component's companion givens — and
+    // inlines into one flat parser. `payment` (a sum) has no Inlinable and
+    // splices a runtime call to the sibling staged sum given above.
+    given inlinedOrders: Orders is Json.Parsable = Inlinable.parsable[Orders]
+
   def decodeJsonStaged(): Orders =
     import staged.orders
+    jsonData.read[Orders in Json]
+
+  def decodeJsonInlined(): Orders =
+    import staged.inlinedOrders
     jsonData.read[Orders in Json]
 
   def decodeTelStaged(): Orders =
@@ -307,6 +268,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     // before anything is timed.
     assert(decodeJsonDirect() == corpus, "JSON direct decode disagrees with the corpus")
     assert(decodeJsonStaged() == corpus, "JSON staged decode disagrees with the corpus")
+    assert(decodeJsonInlined() == corpus, "JSON inlined decode disagrees with the corpus")
     assert(decodeJsonAst() == corpus, "JSON AST decode disagrees with the corpus")
     assert(decodeTelDirect() == corpus, "TEL direct decode disagrees with the corpus")
     assert(decodeTelStaged() == corpus, "TEL staged decode disagrees with the corpus")
@@ -329,6 +291,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       bench(m"JSON staged")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsonStaged() }
+
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeJsonInlined() }
 
       bench(m"JSON via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsonAst() }
@@ -383,6 +348,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       profile(m"JSON staged")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsonStaged() }
+
+      profile(m"JSON inlined")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeJsonInlined() }
 
       profile(m"Jsoniter direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsoniterDirect() }

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -225,6 +225,11 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     given telOrder: Order is Tel.Parsable = Tel.Parsable.staged
     given telOrders: Orders is Tel.Parsable = Tel.Parsable.staged
 
+    given xmlLineItem: LineItem is Xml.Parsable = Xml.Parsable.staged
+    given xmlCustomer: Customer is Xml.Parsable = Xml.Parsable.staged
+    given xmlOrder: Order is Xml.Parsable = Xml.Parsable.staged
+    given xmlOrders: Orders is Xml.Parsable = Xml.Parsable.staged
+
   def decodeJsonStaged(): Orders =
     import staged.orders
     jsonData.read[Orders in Json]
@@ -232,6 +237,10 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
   def decodeTelStaged(): Orders =
     import staged.telOrders
     telData.read[Orders in Tel]
+
+  def decodeXmlStaged(): Orders =
+    import staged.xmlOrders
+    xmlText.read[Orders in Xml]
   def decodeTelDirect(): Orders = telData.read[Orders in Tel]
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
   def decodeXmlDirect(): Orders = xmlText.read[Orders in Xml]
@@ -300,6 +309,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeTelStaged() == corpus, "TEL staged decode disagrees with the corpus")
     assert(decodeTelAst() == corpus, "TEL AST decode disagrees with the corpus")
     assert(decodeXmlDirect() == corpus, "XML direct decode disagrees with the corpus")
+    assert(decodeXmlStaged() == corpus, "XML staged decode disagrees with the corpus")
     assert(decodeXmlAst() == corpus, "XML AST decode disagrees with the corpus")
     assert(decodeYamlAst() == corpus, "YAML AST decode disagrees with the corpus")
 
@@ -332,6 +342,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
       bench(m"XML direct")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeXmlDirect() }
 
+      bench(m"XML staged")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeXmlStaged() }
+
       bench(m"XML via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeXmlAst() }
 
@@ -358,6 +371,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       profile(m"XML direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlDirect() }
+
+      profile(m"XML staged")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeXmlStaged() }
 
       profile(m"JSON direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsonDirect() }

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -217,6 +217,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
   object staged:
     given lineItem: LineItem is Json.Parsable = Json.Parsable.staged
     given customer: Customer is Json.Parsable = Json.Parsable.staged
+    given card: Payment.Card is Json.Parsable = Json.Parsable.staged
+    given transfer: Payment.Transfer is Json.Parsable = Json.Parsable.staged
+    given payment: Payment is Json.Parsable = Json.Parsable.staged
     given order: Order is Json.Parsable = Json.Parsable.staged
     given orders: Orders is Json.Parsable = Json.Parsable.staged
 

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -220,9 +220,18 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     given order: Order is Json.Parsable = Json.Parsable.staged
     given orders: Orders is Json.Parsable = Json.Parsable.staged
 
+    given telLineItem: LineItem is Tel.Parsable = Tel.Parsable.staged
+    given telCustomer: Customer is Tel.Parsable = Tel.Parsable.staged
+    given telOrder: Order is Tel.Parsable = Tel.Parsable.staged
+    given telOrders: Orders is Tel.Parsable = Tel.Parsable.staged
+
   def decodeJsonStaged(): Orders =
     import staged.orders
     jsonData.read[Orders in Json]
+
+  def decodeTelStaged(): Orders =
+    import staged.telOrders
+    telData.read[Orders in Tel]
   def decodeTelDirect(): Orders = telData.read[Orders in Tel]
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
   def decodeXmlDirect(): Orders = xmlText.read[Orders in Xml]
@@ -288,6 +297,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeJsonStaged() == corpus, "JSON staged decode disagrees with the corpus")
     assert(decodeJsonAst() == corpus, "JSON AST decode disagrees with the corpus")
     assert(decodeTelDirect() == corpus, "TEL direct decode disagrees with the corpus")
+    assert(decodeTelStaged() == corpus, "TEL staged decode disagrees with the corpus")
     assert(decodeTelAst() == corpus, "TEL AST decode disagrees with the corpus")
     assert(decodeXmlDirect() == corpus, "XML direct decode disagrees with the corpus")
     assert(decodeXmlAst() == corpus, "XML AST decode disagrees with the corpus")
@@ -312,6 +322,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       bench(m"TEL direct")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeTelDirect() }
+
+      bench(m"TEL staged")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeTelStaged() }
 
       bench(m"TEL via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeTelAst() }
@@ -339,6 +352,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     suite(m"Profile: direct-parser hotspots"):
       profile(m"TEL direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeTelDirect() }
+
+      profile(m"TEL staged")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeTelStaged() }
 
       profile(m"XML direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlDirect() }

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -282,6 +282,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeJsoniterAst() == jsoniterExpected, "Jsoniter AST decode disagrees")
 
     val bench = Bench()
+    val profile = Profile()
 
     suite(m"Decode a ~10 KB order corpus to case classes"):
       bench(m"JSON direct")(target = 1*Second, baseline = Baseline(compare = Min)):
@@ -312,3 +313,19 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       bench(m"Jsoniter via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsoniterAst() }
+
+    // Where the self-time actually goes in each direct arm — a JFR hotspot
+    // histogram per parser, coloured by package. Jsoniter direct is the
+    // reference. Longer targets so the sampler gathers enough execution samples.
+    suite(m"Profile: direct-parser hotspots"):
+      profile(m"TEL direct")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeTelDirect() }
+
+      profile(m"XML direct")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeXmlDirect() }
+
+      profile(m"JSON direct")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeJsonDirect() }
+
+      profile(m"Jsoniter direct")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeJsoniterDirect() }

--- a/lib/crossparse/src/model/crossparse.model.scala
+++ b/lib/crossparse/src/model/crossparse.model.scala
@@ -1,0 +1,112 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package crossparse
+
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import gossamer.*
+import jacinta.*
+import prepositional.*
+import rudiments.*
+import stratiform.*
+import vacuous.*
+import wisteria.*
+import xylophone.*
+
+// The discriminator key the JSON derivations read at this module's
+// derivation sites.
+import jacinta.discriminables.jsonByKindDiscriminable
+
+// The shared structure decoded by every format: varied primitive types, a
+// nested record, a sequence and a coproduct. Compiled one phase before the
+// benchmarks, so `Json.Inlinable`'s expansion-time instance evaluation can
+// load the types and resolve the companion `Inlinable` givens.
+enum Payment:
+  case Card(number: Text, expiry: Text, secure: Boolean)
+  case Transfer(iban: Text, reference: Long)
+
+object Payment:
+  // An XML sum nested inside a product cannot use xylophone's label-based
+  // default `Discriminable`: the product encoder relabels the variant
+  // element with the *field's* name, which destroys the discriminator. The
+  // variant rides in a `type` attribute instead — `<payment type="Card">` —
+  // mirroring the discriminator key the JSON and YAML corpora carry.
+  given xmlDiscriminable: Payment is Discriminable in Xml = new Discriminable:
+    type Self = Payment
+    type Form = Xml
+
+    def discriminate(xml: Xml): Optional[Text] = xml match
+      case Element(_, attributes, _)           => attributes.at(t"type")
+      case Fragment(Element(_, attributes, _)) => attributes.at(t"type")
+      case _                                   => Unset
+
+    def rewrite(kind: Text, xml: Xml): Xml = xml match
+      case Element(label, attributes, children) =>
+        Element(label, attributes.updated(t"type", kind), children)
+
+      case Fragment(Element(label, attributes, children)) =>
+        Element(label, attributes.updated(t"type", kind), children)
+
+      case other =>
+        other
+
+    def variant(xml: Xml): Xml = xml
+
+case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
+
+object LineItem:
+  given inlinable: (LineItem is Inlinable) = Inlinable.derived
+
+case class Customer(id: Long, name: Text, email: Text, region: Text)
+
+object Customer:
+  given inlinable: (Customer is Inlinable) = Inlinable.derived
+
+case class Order
+  ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
+    priority: Boolean, discount: Double )
+
+object Order:
+  given inlinable: (Order is Inlinable) = Inlinable.derived
+
+case class Orders(orders: List[Order])
+
+object Orders:
+  // Direct parsing is opt-in per format; only the top type needs a nominal
+  // instance — nested types resolve through each format's field fallback
+  // chain.
+  given jsonParsable: Orders is Json.Parsable = Json.Parsable.derived
+  given telParsable: Orders is Tel.Parsable = Tel.Parsable.derived
+  given xmlParsable: Orders is Xml.Parsable = Xml.Parsable.derived
+
+  given inlinable: (Orders is Inlinable) = Inlinable.derived

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -2375,7 +2375,104 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
       case value: Array[Double] @unchecked => value.asInstanceOf[Bcd].toLong.or(0L)
       case _                               => 0L // unreachable: only number forms are produced
 
+  // Buffer-local fast path for the overwhelmingly common double shape:
+  // optional sign, up to fifteen mantissa digits with one optional decimal
+  // point, an optional short exponent, closing inside the current window.
+  // The value is composed exactly as `parseNumber`'s in-Long path composes
+  // it — `mantissa.toDouble` scaled by `TenPow` within Clinger's exact range
+  // (mantissa < 2^53, |exp| <= 22) — so the fast path is bit-identical to
+  // the general path and bails out (a plain `pos` reset; nothing here
+  // refills) for everything else: a sixteenth digit, a leading zero before
+  // a digit, an out-of-range exponent, or the window's end.
   private[jacinta] update def directDouble()(using Tactic[ParseError]): Double =
+    skip()
+    val start = pos
+    val limit = bufEnd
+    var i = start
+    var negative = false
+
+    if i < limit && bytes(i) == Minus then
+      negative = true
+      i += 1
+
+    val digitsStart = i
+    var mantissa = 0L
+    var digits = 0
+    var decimalDigits = 0
+    var ok = i < limit
+
+    while i < limit && digits < 16 && bytes(i) >= Num0 && bytes(i) <= Num9 do
+      mantissa = mantissa*10 + (bytes(i) - Num0)
+      digits += 1
+      i += 1
+
+    val integerDigits = digits
+
+    // JSON forbids a leading zero before another digit, and requires at
+    // least one integer digit; the general path raises the exact error.
+    if integerDigits == 0 || digits >= 16 then ok = false
+    if integerDigits > 1 && bytes(digitsStart) == Num0 then ok = false
+
+    if ok && i < limit && bytes(i) == Period then
+      i += 1
+      val fractionStart = i
+
+      while i < limit && digits < 16 && bytes(i) >= Num0 && bytes(i) <= Num9 do
+        mantissa = mantissa*10 + (bytes(i) - Num0)
+        digits += 1
+        decimalDigits += 1
+        i += 1
+
+      if i == fractionStart || digits >= 16 then ok = false
+
+    var explicitExp = 0
+    var expSign = 1
+    var floating = decimalDigits > 0
+
+    if ok && i < limit && (bytes(i) == LowerE || bytes(i) == UpperE) then
+      floating = true
+      i += 1
+
+      if i < limit && (bytes(i) == Minus || bytes(i) == Plus) then
+        if bytes(i) == Minus then expSign = -1
+        i += 1
+
+      val expStart = i
+
+      while i < limit && explicitExp < 1000 && bytes(i) >= Num0 && bytes(i) <= Num9 do
+        explicitExp = explicitExp*10 + (bytes(i) - Num0)
+        i += 1
+
+      if i == expStart || explicitExp >= 1000 then ok = false
+
+    // The number must demonstrably end inside the window: at the window's
+    // edge more digits may follow in the next chunk.
+    if ok && i < limit then
+      val next = bytes(i)
+      if next >= Num0 && next <= Num9 then ok = false
+    else ok = false
+
+    if ok then
+      val totalExp = expSign*explicitExp - decimalDigits
+
+      if !floating then
+        pos = i
+        val signed = if negative then -mantissa else mantissa
+        return signed.toDouble
+      else if totalExp >= -22 && totalExp <= 22 then
+        pos = i
+
+        val mag =
+          if mantissa == 0L then 0.0
+          else if totalExp >= 0 then mantissa.toDouble * TenPow(totalExp)
+          else mantissa.toDouble / TenPow(-totalExp)
+
+        return if negative then -mag else mag
+
+    pos = start
+    directDoubleGeneral()
+
+  private update def directDoubleGeneral()(using Tactic[ParseError]): Double =
     val raw: Any = directNumber()
 
     raw.asMatchable match
@@ -2467,7 +2564,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     while
       i < limit && {
         val b = bytes(i)
-        b == Space || b == Tab || b == Newline || b == Return
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
       }
     do i += 1
 
@@ -2487,7 +2584,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
       while
         i < limit && {
           val b2 = bytes(i)
-          b2 == Space || b2 == Tab || b2 == Newline || b2 == Return
+          b2 <= Space && (b2 == Space || b2 == Tab || b2 == Newline || b2 == Return)
         }
       do i += 1
 
@@ -2496,44 +2593,44 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
 
     if b != Quote then return Int.MinValue
     val start = i + 1
-    var j = start
-    var scanning = true
 
-    while scanning && j <= limit - 8 do
-      val word: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], j)
-      val stops = stringStops(word)
+    // Fused scan-and-pack, as in `directKeyWordFast`: the words loaded to
+    // find the closing quote are the packed form. Window-edge keys take the
+    // general step.
+    if start + 8 > limit then return Int.MinValue
+    val word0: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start)
+    val stops0 = stringStops(word0)
+    var low = 0L
+    var high = 0L
+    var j = 0
 
-      if stops == 0L then j += 8
+    if stops0 != 0L then
+      val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
+      j = start + length
+      if bytes(j) != Quote || length == 0 then return Int.MinValue
+      low = word0 & ((1L << (length*8)) - 1)
+    else
+      if start + 16 > limit then return Int.MinValue
+      val word1: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start + 8)
+      val stops1 = stringStops(word1)
+      low = word0
+
+      if stops1 != 0L then
+        val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
+        j = start + 8 + length1
+        if bytes(j) != Quote then return Int.MinValue
+        if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
       else
-        j += java.lang.Long.numberOfTrailingZeros(stops) >> 3
-        scanning = false
+        j = start + 16
+        if j >= limit || bytes(j) != Quote then return Int.MinValue
+        high = word1
 
-    if scanning then while j < limit && StringScanContinue(bytes(j) & 0xFF) != 0 do j += 1
-
-    if j >= limit || bytes(j) != Quote || j == start || j - start > 16 then return Int.MinValue
-    val length = j - start
-
-    // Word loads instead of byte-by-byte packing; a short key's over-read is
-    // in bounds (the closing quote is at `j < limit`) and masked away.
-    val low =
-      if start + 8 <= limit then
-        val word: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start)
-        if length >= 8 then word else word & ((1L << (length*8)) - 1)
-      else packBytes(bytes, start, math.min(length, 8))
-
-    val high =
-      if length > 8 then
-        if start + 16 <= limit then
-          val word: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start + 8)
-          if length == 16 then word else word & ((1L << ((length - 8)*8)) - 1)
-        else packBytes(bytes, start + 8, length - 8)
-      else 0L
     var k = j + 1
 
     while
       k < limit && {
         val b3 = bytes(k)
-        b3 == Space || b3 == Tab || b3 == Newline || b3 == Return
+        b3 <= Space && (b3 == Space || b3 == Tab || b3 == Newline || b3 == Return)
       }
     do k += 1
 
@@ -2564,7 +2661,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     while
       i < limit && {
         val b = bytes(i)
-        b == Space || b == Tab || b == Newline || b == Return
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
       }
     do i += 1
 
@@ -2584,7 +2681,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
       while
         i < limit && {
           val b2 = bytes(i)
-          b2 == Space || b2 == Tab || b2 == Newline || b2 == Return
+          b2 <= Space && (b2 == Space || b2 == Tab || b2 == Newline || b2 == Return)
         }
       do i += 1
 
@@ -2593,43 +2690,47 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
 
     if b != Quote then return -2L
     val start = i + 1
-    var j = start
-    var scanning = true
 
-    while scanning && j <= limit - 8 do
-      val word: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], j)
-      val stops = stringStops(word)
+    // Fused scan-and-pack: the word loaded to find the key's closing quote
+    // *is* its packed form, so a short key costs one load and a 16-byte key
+    // two — where the two-pass shape re-loaded the same words to pack after
+    // scanning. A key at the window's edge takes the general step, exactly
+    // like an escaped or oversized one.
+    if start + 8 > limit then return -2L
+    val word0: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start)
+    val stops0 = stringStops(word0)
+    var low = 0L
+    var high = 0L
+    var j = 0
 
-      if stops == 0L then j += 8
+    if stops0 != 0L then
+      val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
+      j = start + length
+      if bytes(j) != Quote || length == 0 then return -2L
+      low = word0 & ((1L << (length*8)) - 1)
+    else
+      if start + 16 > limit then return -2L
+      val word1: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start + 8)
+      val stops1 = stringStops(word1)
+      low = word0
+
+      if stops1 != 0L then
+        val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
+        j = start + 8 + length1
+        if bytes(j) != Quote then return -2L
+        if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
       else
-        j += java.lang.Long.numberOfTrailingZeros(stops) >> 3
-        scanning = false
-
-    if scanning then while j < limit && StringScanContinue(bytes(j) & 0xFF) != 0 do j += 1
-
-    if j >= limit || bytes(j) != Quote || j == start || j - start > 16 then return -2L
-    val length = j - start
-
-    val low =
-      if start + 8 <= limit then
-        val word: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start)
-        if length >= 8 then word else word & ((1L << (length*8)) - 1)
-      else packBytes(bytes, start, math.min(length, 8))
-
-    val high =
-      if length > 8 then
-        if start + 16 <= limit then
-          val word: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start + 8)
-          if length == 16 then word else word & ((1L << ((length - 8)*8)) - 1)
-        else packBytes(bytes, start + 8, length - 8)
-      else 0L
+        // Exactly sixteen bytes, or too long for the fast path.
+        j = start + 16
+        if j >= limit || bytes(j) != Quote then return -2L
+        high = word1
 
     var k = j + 1
 
     while
       k < limit && {
         val b3 = bytes(k)
-        b3 == Space || b3 == Tab || b3 == Newline || b3 == Return
+        b3 <= Space && (b3 == Space || b3 == Tab || b3 == Newline || b3 == Return)
       }
     do k += 1
 
@@ -2770,7 +2871,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     while
       i < limit && {
         val b = bytes(i)
-        b == Space || b == Tab || b == Newline || b == Return
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
       }
     do i += 1
 

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -2625,7 +2625,7 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
     if stops0 != 0L then
       val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
       j = start + length
-      if bytes(j) != Quote || length == 0 then return Int.MinValue
+      if ((word0 >>> (length*8)) & 0xFFL) != Quote || length == 0 then return Int.MinValue
       low = word0 & ((1L << (length*8)) - 1)
     else
       if start + 16 > limit then return Int.MinValue
@@ -2636,7 +2636,7 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
       if stops1 != 0L then
         val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
         j = start + 8 + length1
-        if bytes(j) != Quote then return Int.MinValue
+        if ((word1 >>> (length1*8)) & 0xFFL) != Quote then return Int.MinValue
         if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
       else
         j = start + 16
@@ -2724,7 +2724,9 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
     if stops0 != 0L then
       val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
       j = start + length
-      if bytes(j) != Quote || length == 0 then return -2L
+      // The stop byte is already in the loaded word: verify it there rather
+      // than through a bounds-checked array read.
+      if ((word0 >>> (length*8)) & 0xFFL) != Quote || length == 0 then return -2L
       low = word0 & ((1L << (length*8)) - 1)
     else
       if start + 16 > limit then return -2L
@@ -2735,7 +2737,7 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
       if stops1 != 0L then
         val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
         j = start + 8 + length1
-        if bytes(j) != Quote then return -2L
+        if ((word1 >>> (length1*8)) & 0xFFL) != Quote then return -2L
         if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
       else
         // Exactly sixteen bytes, or too long for the fast path.
@@ -2802,7 +2804,9 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
     if stops0 != 0L then
       val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
       j = start + length
-      if bytes(j) != Quote || length == 0 then return -2L
+      // The stop byte is already in the loaded word: verify it there rather
+      // than through a bounds-checked array read.
+      if ((word0 >>> (length*8)) & 0xFFL) != Quote || length == 0 then return -2L
       low = word0 & ((1L << (length*8)) - 1)
     else
       if start + 16 > limit then return -2L
@@ -2813,7 +2817,7 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
       if stops1 != 0L then
         val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
         j = start + 8 + length1
-        if bytes(j) != Quote then return -2L
+        if ((word1 >>> (length1*8)) & 0xFFL) != Quote then return -2L
         if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
       else
         // Exactly sixteen bytes, or too long for the fast path.
@@ -2887,7 +2891,9 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
     if stops0 != 0L then
       val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
       j = start + length
-      if bytes(j) != Quote || length == 0 then return -2L
+      // The stop byte is already in the loaded word: verify it there rather
+      // than through a bounds-checked array read.
+      if ((word0 >>> (length*8)) & 0xFFL) != Quote || length == 0 then return -2L
       low = word0 & ((1L << (length*8)) - 1)
     else
       if start + 16 > limit then return -2L
@@ -2898,7 +2904,7 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
       if stops1 != 0L then
         val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
         j = start + 8 + length1
-        if bytes(j) != Quote then return -2L
+        if ((word1 >>> (length1*8)) & 0xFFL) != Quote then return -2L
         if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
       else
         // Exactly sixteen bytes, or too long for the fast path.
@@ -3070,6 +3076,61 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
       else
         directMark()
         pos = i
+        return true
+
+    directElementGeneral()
+
+  // The split element protocol for generated collection loops that know
+  // which step is first: `directElementFirst` expects a value or the closing
+  // bracket and marks the depth; `directElementNext` expects a comma or the
+  // closing bracket and consults no per-element state. Fallbacks preserve
+  // `directElement`'s exact semantics.
+  update def directElementFirst()(using Tactic[ParseError]): Boolean =
+    val limit = bufEnd
+    var i = pos
+
+    while
+      i < limit && {
+        val b = bytes(i)
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
+      }
+    do i += 1
+
+    if i < limit then
+      val b = bytes(i)
+
+      if b == CloseBracket then
+        pos = i + 1
+        directPop()
+        return false
+
+      directMark()
+      pos = i
+      return true
+
+    directElementGeneral()
+
+  update def directElementNext()(using Tactic[ParseError]): Boolean =
+    val limit = bufEnd
+    var i = pos
+
+    while
+      i < limit && {
+        val b = bytes(i)
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
+      }
+    do i += 1
+
+    if i < limit then
+      val b = bytes(i)
+
+      if b == CloseBracket then
+        pos = i + 1
+        directPop()
+        return false
+
+      if b == Comma then
+        pos = i + 1
         return true
 
     directElementGeneral()

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -243,7 +243,9 @@ private[jacinta] object Parser:
 // the per-thread pool), with every state-mutating method classified `update`. This unit
 // is separation-checked; consumers (capture-checked only) interact through the exclusive
 // reference the pool hands out.
-private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.Stateful:
+// EXPERIMENT(cc-bypass): temporarily public so staged-generated code can be
+// measured calling the parser directly, without the JsonReader rim.
+final class Parser extends caps.ExclusiveCapability, caps.Stateful:
   import scala.annotation.switch
   import scala.collection.mutable.ArrayBuffer
   import Json.Ast.AsciiByte.*
@@ -2110,7 +2112,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
   // Structure-aware skip of one whole value: a validated scan that enforces
   // the same grammar (and raises the same `Issue`s) as `parseValue`'s loops,
   // but builds nothing — no AST nodes, no scratch buffers, no key strings.
-  private[jacinta] update def directSkipValue()(using Tactic[ParseError]): Unit =
+  update def directSkipValue()(using Tactic[ParseError]): Unit =
     skip()
     skipValue1()
 
@@ -2267,7 +2269,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
               else if (ch & 0xF8) == 0xF0 then { next(); next(); next(); advance() }
               else advance()
 
-  private[jacinta] update def directString()(using Tactic[ParseError]): String =
+  update def directString()(using Tactic[ParseError]): String =
     skip()
     if must() == Quote then
       advance()
@@ -2299,7 +2301,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
       else parseString()
     else errorAt(Issue.ExpectedString(peek.toChar))
 
-  private[jacinta] update def directBoolean()(using Tactic[ParseError]): Boolean =
+  update def directBoolean()(using Tactic[ParseError]): Boolean =
     skip()
     must() match
       case LowerT => parseTrue()
@@ -2343,7 +2345,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
   // fractions and exponents, a 19th digit, a leading zero (which must
   // raise), and numbers touching the window's end (more digits may follow
   // in the next chunk).
-  private[jacinta] update def directLong()(using Tactic[ParseError]): Long =
+  update def directLong()(using Tactic[ParseError]): Long =
     skip()
     val start = pos
     val limit = bufEnd
@@ -2398,7 +2400,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
   // the general path and bails out (a plain `pos` reset; nothing here
   // refills) for everything else: a sixteenth digit, a leading zero before
   // a digit, an out-of-range exponent, or the window's end.
-  private[jacinta] update def directDouble()(using Tactic[ParseError]): Double =
+  update def directDouble()(using Tactic[ParseError]): Double =
     skip()
     val start = pos
     val limit = bufEnd
@@ -2511,7 +2513,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
       case _ =>
         caps.unsafe.unsafeAssumePure(Bcd(BigDecimal(0L))) // unreachable
 
-  private[jacinta] update def directOpenObject()(using Tactic[ParseError]): Unit =
+  update def directOpenObject()(using Tactic[ParseError]): Unit =
     skip()
 
     if must() == OpenBrace then
@@ -2657,7 +2659,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
   // High word of the key most recently scanned by `directKeyWordFast`.
   private var directKeyHigh: Long = 0L
 
-  private[jacinta] update def directKeyWordHigh: Long = directKeyHigh
+  update def directKeyWordHigh: Long = directKeyHigh
 
   // As `directKeyIndexFast`, but exposing the key's packed form instead of
   // resolving it against a table, so generated (staged) parsers can compare
@@ -2761,7 +2763,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
   // consults no per-key state at all. Both preserve `directKeyWordFast`'s
   // exact sentinels and fallback discipline, so an opaque outcome still
   // resolves through the general, state-aware step.
-  private[jacinta] update def directKeyWordFirst(): Long =
+  update def directKeyWordFirst(): Long =
     val limit = bufEnd
     var i = pos
 
@@ -2833,7 +2835,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     directKeyHigh = high
     low
 
-  private[jacinta] update def directKeyWordNext(): Long =
+  update def directKeyWordNext(): Long =
     val limit = bufEnd
     var i = pos
 
@@ -3029,7 +3031,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
         out
     else parseObjectKey()
 
-  private[jacinta] update def directOpenArray()(using Tactic[ParseError]): Unit =
+  update def directOpenArray()(using Tactic[ParseError]): Unit =
     skip()
 
     if must() == OpenBracket then
@@ -3039,7 +3041,7 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
 
   // True when another element follows (positioned at it, with any separator
   // comma consumed); false after consuming the closing bracket.
-  private[jacinta] update def directElement()(using Tactic[ParseError]): Boolean =
+  update def directElement()(using Tactic[ParseError]): Boolean =
     // Buffer-local fast path, mirroring `directKeyIndexFast`.
     val limit = bufEnd
     var i = pos

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -243,8 +243,10 @@ private[jacinta] object Parser:
 // the per-thread pool), with every state-mutating method classified `update`. This unit
 // is separation-checked; consumers (capture-checked only) interact through the exclusive
 // reference the pool hands out.
-// EXPERIMENT(cc-bypass): temporarily public so staged-generated code can be
-// measured calling the parser directly, without the JsonReader rim.
+// Public as a type — generated parsers hold a `Parser` in a local and read
+// through its direct rim — but acquiring the instance behind a live read is
+// sealed inside `JsonReader.rawParser`, which only jacinta's own generated
+// splices can reach; the pool and every reset entry point remain private.
 final class Parser extends caps.ExclusiveCapability, caps.Stateful:
   import scala.annotation.switch
   import scala.collection.mutable.ArrayBuffer

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -738,7 +738,9 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     while
       more && {
         val ch = peek
-        ch == Space || ch == Tab || ch == Newline || ch == Return
+        // One comparison for the common non-whitespace byte; the full test
+        // only for bytes at or below the space character.
+        ch <= Space && (ch == Space || ch == Tab || ch == Newline || ch == Return)
       }
     do advance()
 
@@ -2052,27 +2054,39 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
   // comma is required before the next). Exclusive scratch: reached only
   // through this (exclusive) parser.
   private var directDepth: Int = 0
+  private var directMask0: Long = 0L
   private var directMask: Array[Long]^ = new Array[Long](1)
 
+  // Depths zero to sixty-three — all realistic JSON — keep their seen-bits
+  // in a single `Long` field, so the per-key `directSeen` test is two
+  // register operations; the array carries deeper nesting only.
   private update def directPush(): Unit =
     val level = directDepth
-    val word = level >> 6
 
-    if directMask.length <= word then
-      val grown = new Array[Long](directMask.length*2)
-      System.arraycopy(directMask, 0, grown, 0, directMask.length)
-      directMask = grown
+    if level < 64 then directMask0 &= ~(1L << level)
+    else
+      val word = (level - 64) >> 6
 
-    directMask(word) &= ~(1L << (level & 63))
+      if directMask.length <= word then
+        val grown = new Array[Long](directMask.length*2)
+        System.arraycopy(directMask, 0, grown, 0, directMask.length)
+        directMask = grown
+
+      directMask(word) &= ~(1L << ((level - 64) & 63))
+
     directDepth = level + 1
 
   private update def directSeen(): Boolean =
     val level = directDepth - 1
-    (directMask(level >> 6) & (1L << (level & 63))) != 0
+
+    if level < 64 then (directMask0 & (1L << level)) != 0
+    else (directMask((level - 64) >> 6) & (1L << ((level - 64) & 63))) != 0
 
   private update def directMark(): Unit =
     val level = directDepth - 1
-    directMask(level >> 6) |= 1L << (level & 63)
+
+    if level < 64 then directMask0 |= 1L << level
+    else directMask((level - 64) >> 6) |= 1L << ((level - 64) & 63)
 
   private update def directPop(): Unit = directDepth -= 1
 
@@ -2737,6 +2751,168 @@ private[jacinta] final class Parser extends caps.ExclusiveCapability, caps.State
     if k >= limit || bytes(k) != Colon then return -2L
 
     if !seen then directMark()
+    pos = k + 1
+    directKeyHigh = high
+    low
+
+  // The split key protocol for generated parsers whose loop statically
+  // knows which step is first: `directKeyWordFirst` expects no separator and
+  // marks the depth's seen-bit; `directKeyWordNext` expects a comma and
+  // consults no per-key state at all. Both preserve `directKeyWordFast`'s
+  // exact sentinels and fallback discipline, so an opaque outcome still
+  // resolves through the general, state-aware step.
+  private[jacinta] update def directKeyWordFirst(): Long =
+    val limit = bufEnd
+    var i = pos
+
+    while
+      i < limit && {
+        val b = bytes(i)
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
+      }
+    do i += 1
+
+    if i >= limit then return -2L
+    val b = bytes(i)
+
+    if b == CloseBrace then
+      pos = i + 1
+      directPop()
+      return -1L
+
+    if b != Quote then return -2L
+    val start = i + 1
+
+    // Fused scan-and-pack: the word loaded to find the key's closing quote
+    // *is* its packed form, so a short key costs one load and a 16-byte key
+    // two — where the two-pass shape re-loaded the same words to pack after
+    // scanning. A key at the window's edge takes the general step, exactly
+    // like an escaped or oversized one.
+    if start + 8 > limit then return -2L
+    val word0: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start)
+    val stops0 = stringStops(word0)
+    var low = 0L
+    var high = 0L
+    var j = 0
+
+    if stops0 != 0L then
+      val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
+      j = start + length
+      if bytes(j) != Quote || length == 0 then return -2L
+      low = word0 & ((1L << (length*8)) - 1)
+    else
+      if start + 16 > limit then return -2L
+      val word1: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start + 8)
+      val stops1 = stringStops(word1)
+      low = word0
+
+      if stops1 != 0L then
+        val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
+        j = start + 8 + length1
+        if bytes(j) != Quote then return -2L
+        if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
+      else
+        // Exactly sixteen bytes, or too long for the fast path.
+        j = start + 16
+        if j >= limit || bytes(j) != Quote then return -2L
+        high = word1
+
+    var k = j + 1
+
+    while
+      k < limit && {
+        val b3 = bytes(k)
+        b3 <= Space && (b3 == Space || b3 == Tab || b3 == Newline || b3 == Return)
+      }
+    do k += 1
+
+    if k >= limit || bytes(k) != Colon then return -2L
+
+    directMark()
+    pos = k + 1
+    directKeyHigh = high
+    low
+
+  private[jacinta] update def directKeyWordNext(): Long =
+    val limit = bufEnd
+    var i = pos
+
+    while
+      i < limit && {
+        val b = bytes(i)
+        b <= Space && (b == Space || b == Tab || b == Newline || b == Return)
+      }
+    do i += 1
+
+    if i >= limit then return -2L
+    var b = bytes(i)
+
+    if b == CloseBrace then
+      pos = i + 1
+      directPop()
+      return -1L
+
+    if b != Comma then return -2L
+    i += 1
+
+    while
+      i < limit && {
+        val b2 = bytes(i)
+        b2 <= Space && (b2 == Space || b2 == Tab || b2 == Newline || b2 == Return)
+      }
+    do i += 1
+
+    if i >= limit then return -2L
+    b = bytes(i)
+
+    if b != Quote then return -2L
+    val start = i + 1
+
+    // Fused scan-and-pack: the word loaded to find the key's closing quote
+    // *is* its packed form, so a short key costs one load and a 16-byte key
+    // two — where the two-pass shape re-loaded the same words to pack after
+    // scanning. A key at the window's edge takes the general step, exactly
+    // like an escaped or oversized one.
+    if start + 8 > limit then return -2L
+    val word0: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start)
+    val stops0 = stringStops(word0)
+    var low = 0L
+    var high = 0L
+    var j = 0
+
+    if stops0 != 0L then
+      val length = java.lang.Long.numberOfTrailingZeros(stops0) >> 3
+      j = start + length
+      if bytes(j) != Quote || length == 0 then return -2L
+      low = word0 & ((1L << (length*8)) - 1)
+    else
+      if start + 16 > limit then return -2L
+      val word1: Long = WordAccess.get(bytes.asInstanceOf[Array[Byte]], start + 8)
+      val stops1 = stringStops(word1)
+      low = word0
+
+      if stops1 != 0L then
+        val length1 = java.lang.Long.numberOfTrailingZeros(stops1) >> 3
+        j = start + 8 + length1
+        if bytes(j) != Quote then return -2L
+        if length1 > 0 then high = word1 & ((1L << (length1*8)) - 1)
+      else
+        // Exactly sixteen bytes, or too long for the fast path.
+        j = start + 16
+        if j >= limit || bytes(j) != Quote then return -2L
+        high = word1
+
+    var k = j + 1
+
+    while
+      k < limit && {
+        val b3 = bytes(k)
+        b3 <= Space && (b3 == Space || b3 == Tab || b3 == Newline || b3 == Return)
+      }
+    do k += 1
+
+    if k >= limit || bytes(k) != Colon then return -2L
+
     pos = k + 1
     directKeyHigh = high
     low

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -628,12 +628,39 @@ object Json extends Json2, Dynamic:
     inline def derived[value](using Reflection[value]): value is Json.Parsable =
       fromField(ParsableDerivation.derivedOne[value])
 
-    // Generates a monomorphic parser for a case class at compile time — the
-    // staged counterpart of `derived`, with identical semantics but no
-    // interpretive machinery at runtime. Sums, method-local classes and
-    // curried case classes stay on `derived`.
-    inline def staged[value]: value is Json.Parsable =
+    // Generates a monomorphic parser at compile time — the staged
+    // counterpart of `derived`, with identical semantics but no interpretive
+    // machinery at runtime. A case class parses through typed local slots
+    // and packed-literal key dispatch; a sealed sum (whose `Discriminable`
+    // must be a field-discriminated shape, like `jsonByKindDiscriminable`)
+    // dispatches its scan-ahead tag through a monomorphic comparison chain
+    // into per-variant `Json.Field` instances. Method-local classes,
+    // curried case classes, singleton variants and generic sums stay on
+    // `derived`.
+    inline def staged[value]: value is Json.Parsable = summonFrom:
+      case given SumReflection[`value`] => stagedSum[value]
+      case _                            => stagedProduct[value]
+
+    private inline def stagedProduct[value]: value is Json.Parsable =
       ${ jacinta.internal.stagedParsable[value]('{ relabelling[value, Json] }) }
+
+    private inline def stagedSum[value]: value is Json.Parsable =
+      ${ jacinta.internal.stagedSum[value]('{ variantRelabelling[value, Json] }) }
+
+    // The scan-ahead tag field of a field-discriminated sum, for staged
+    // parsers, which dispatch on it monomorphically. The other shapes have
+    // no equivalent single step, so a staged sum whose `Discriminable` is
+    // not a `DiscriminantField` fails fast at instance construction. Public
+    // because staged parsers are generated into user modules.
+    def discriminantField(discriminable: Discriminable in Json): Text =
+      discriminable match
+        case fielded: Json.DiscriminantField[?] => fielded.field
+
+        case other =>
+          panic
+            (m"""staged sum parsing requires a field-discriminated sum (a `DiscriminantField`
+                 `Discriminable`, like `jsonByKindDiscriminable`); other shapes use
+                 `Json.Parsable.derived`""")
 
     def fromField[value](field0: (value is Json.Parsing)^)
     :   ((value is Json.Parsable)^{field0}) =

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -392,6 +392,13 @@ trait Json2 extends Json3:
       // dispatching through the decoder. Sealed per the codec-thunk
       // pattern: each instance captures resolution-scoped tactics.
       caps.unsafe.unsafeAssumePure:
+        // Wire tag → variant label, a per-derivation constant: built once
+        // here rather than on every `parse` call, whose profile it dominated
+        // (map building plus generic-equality lookups, per occurrence).
+        val variantNames: Map[Text, Text] =
+          variantRelabelling[derivation, Json].map: (variant, wire) =>
+            wire -> variant
+
         infer[derivation is Discriminable in Json] match
           case fielded: Json.DiscriminantField[?] =>
             new Json.Field:
@@ -401,10 +408,6 @@ trait Json2 extends Json3:
               def parse(reader: JsonReader^): derivation =
                 provide[Tactic[JsonError]]:
                   provide[Tactic[VariantError]]:
-                    val variantNames: Map[Text, Text] =
-                      variantRelabelling[derivation, Json].map: (variant, wire) =>
-                        wire -> variant
-
                     val wire: Text = reader.discriminant(fielded.field).or:
                       abort(JsonError(Reason.Absent))
 
@@ -421,10 +424,6 @@ trait Json2 extends Json3:
               def parse(reader: JsonReader^): derivation =
                 provide[Tactic[JsonError]]:
                   provide[Tactic[VariantError]]:
-                    val variantNames: Map[Text, Text] =
-                      variantRelabelling[derivation, Json].map: (variant, wire) =>
-                        wire -> variant
-
                     reader.openObject()
                     val wire: Text = reader.key().or(abort(JsonError(Reason.Absent)))
 
@@ -445,10 +444,6 @@ trait Json2 extends Json3:
               def parse(reader: JsonReader^): derivation =
                 provide[Tactic[JsonError]]:
                   provide[Tactic[VariantError]]:
-                    val variantNames: Map[Text, Text] =
-                      variantRelabelling[derivation, Json].map: (variant, wire) =>
-                        wire -> variant
-
                     val wire: Text = reader.discriminant(envelope.tagField).or:
                       abort(JsonError(Reason.Absent))
 

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -67,6 +67,12 @@ object JsonReader:
 final class JsonReader private (parser0: AnyRef, tactic0: AnyRef)
 extends caps.ExclusiveCapability, caps.Stateful:
   private inline def parser: Parser^ = parser0.asInstanceOf[Parser^]
+
+  // EXPERIMENT(cc-bypass): the wrapped capabilities as neutral carriers, so
+  // staged-generated code (in unchecked modules) can bind the parser once
+  // per record and bypass this rim — measuring what the rim costs.
+  def rawParser: AnyRef = parser0
+  def rawTactic: AnyRef = tactic0
   private inline def tactic: Tactic[ParseError] = tactic0.asInstanceOf[Tactic[ParseError]]
 
   // ── Scalars: one JSON value each. Numbers coerce exactly as the

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -116,6 +116,12 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // instead, which consumes it generally.
   update def keyWord(): Long = parser.directKeyWordFast()
 
+  // The split protocol for generated parsers whose loop statically knows
+  // which step is first — the steady-state step consults no per-key state.
+  update def keyWordFirst(): Long = parser.directKeyWordFirst()
+
+  update def keyWordNext(): Long = parser.directKeyWordNext()
+
   update def keyWordHigh: Long = parser.directKeyWordHigh
 
   update def openArray(): Unit = parser.directOpenArray()(using tactic)

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -68,11 +68,14 @@ final class JsonReader private (parser0: AnyRef, tactic0: AnyRef)
 extends caps.ExclusiveCapability, caps.Stateful:
   private inline def parser: Parser^ = parser0.asInstanceOf[Parser^]
 
-  // EXPERIMENT(cc-bypass): the wrapped capabilities as neutral carriers, so
-  // staged-generated code (in unchecked modules) can bind the parser once
-  // per record and bypass this rim — measuring what the rim costs.
-  def rawParser: AnyRef = parser0
-  def rawTactic: AnyRef = tactic0
+  // The sealed conduit for generated parsers: package-private, so the only
+  // path to the wrapped capabilities from outside jacinta is through the
+  // accessor the compiler synthesizes for jacinta's own macro-generated
+  // splices — hand-written code cannot name it. Generated code binds the
+  // parser once per record and reads through `Parser`'s direct rim without
+  // this class's per-token forwarders (measured at ~3% of a parse).
+  private[jacinta] def rawParser: AnyRef = parser0
+  private[jacinta] def rawTactic: AnyRef = tactic0
   private inline def tactic: Tactic[ParseError] = tactic0.asInstanceOf[Tactic[ParseError]]
 
   // ── Scalars: one JSON value each. Numbers coerce exactly as the

--- a/lib/jacinta/src/core/jacinta.JsonReader.scala
+++ b/lib/jacinta/src/core/jacinta.JsonReader.scala
@@ -80,11 +80,11 @@ extends caps.ExclusiveCapability, caps.Stateful:
 
   // ── Scalars: one JSON value each. Numbers coerce exactly as the
   // `Json.Ast` accessors do, so direct and AST reads yield equal values. ──
-  update def string(): Text = parser.directString()(using tactic).tt
-  update def boolean(): Boolean = parser.directBoolean()(using tactic)
-  update def long(): Long = parser.directLong()(using tactic)
-  update def int(): Int = parser.directLong()(using tactic).toInt
-  update def double(): Double = parser.directDouble()(using tactic)
+  inline update def string(): Text = parser.directString()(using tactic).tt
+  inline update def boolean(): Boolean = parser.directBoolean()(using tactic)
+  inline update def long(): Long = parser.directLong()(using tactic)
+  inline update def int(): Int = parser.directLong()(using tactic).toInt
+  inline update def double(): Double = parser.directDouble()(using tactic)
   update def bcd(): Bcd = parser.directBcd()(using tactic)
 
   // ── Null handling: `hasNull` peeks without consuming, for optional
@@ -97,7 +97,7 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // brace is consumed. After `openArray()`, `element()` is true while
   // another element follows (positioned at it) and false once the closing
   // bracket is consumed. ──
-  update def openObject(): Unit = parser.directOpenObject()(using tactic)
+  inline update def openObject(): Unit = parser.directOpenObject()(using tactic)
 
   update def key(): Optional[Text] = parser.directKey()(using tactic) match
     case null        => Unset
@@ -127,20 +127,20 @@ extends caps.ExclusiveCapability, caps.Stateful:
 
   // The split protocol for generated parsers whose loop statically knows
   // which step is first — the steady-state step consults no per-key state.
-  update def keyWordFirst(): Long = parser.directKeyWordFirst()
+  inline update def keyWordFirst(): Long = parser.directKeyWordFirst()
 
-  update def keyWordNext(): Long = parser.directKeyWordNext()
+  inline update def keyWordNext(): Long = parser.directKeyWordNext()
 
-  update def keyWordHigh: Long = parser.directKeyWordHigh
+  inline update def keyWordHigh: Long = parser.directKeyWordHigh
 
-  update def openArray(): Unit = parser.directOpenArray()(using tactic)
-  update def element(): Boolean = parser.directElement()(using tactic)
+  inline update def openArray(): Unit = parser.directOpenArray()(using tactic)
+  inline update def element(): Boolean = parser.directElement()(using tactic)
 
   // ── The fallback seam: parse one whole value into an AST (for field types
   // that only have a `Decodable in Json`), or skip one whole value (for
   // unknown keys). ──
   update def value(): Json = Json.ast(Json.Ast(parser.directValue()(using tactic)))
-  update def skipValue(): Unit = parser.directSkipValue()(using tactic)
+  inline update def skipValue(): Unit = parser.directSkipValue()(using tactic)
 
   // Scans the upcoming object for the given key and returns its string
   // value, leaving the reader where it started — the dispatch primitive for

--- a/lib/jacinta/src/core/jacinta.internal.scala
+++ b/lib/jacinta/src/core/jacinta.internal.scala
@@ -46,6 +46,7 @@ import gossamer.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+import wisteria.{Discriminable, VariantError}
 import zephyrine.*
 
 object internal:
@@ -1664,4 +1665,118 @@ object internal:
                 ( '{reader}, '{foci}, '{tactic}, '{keys}, '{table}, '{instances},
                   '{fallbacks} )
             }
+    }
+
+  // Generates a monomorphic `Json.Parsable` for a sealed sum with a
+  // field-discriminated wire shape: the tag is located with `discriminant`'s
+  // bounded scan-ahead (which rewinds), dispatched through a chain of
+  // monomorphic string comparisons against the wire variant names (renames
+  // applied once, at instance construction), and the chosen variant parses
+  // the whole object directly through its `Json.Field` instance (summoned at
+  // expansion, so a sibling staged given composes) — no per-occurrence map
+  // building, no generic-equality dispatch, no `delegate` fold. A missing
+  // tag and an unknown tag raise exactly as `ParsableDerivation.disjunction`
+  // does: `JsonError(Absent)` and wisteria's `VariantError`, each through
+  // the same deferred `provide` summons the derived engine uses.
+  def stagedSum[value: Type](renames: Expr[Map[Text, Text]])(using Quotes)
+  :   Expr[value is Json.Parsable] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[value].dealias
+
+    val classSymbol = tpe.classSymbol.getOrElse:
+      report.errorAndAbort("jacinta: staged sum parsing requires a sealed trait or enum")
+
+    tpe match
+      case AppliedType(_, _) =>
+        report.errorAndAbort
+          ("jacinta: staged parsing does not support generic sums; use `Json.Parsable.derived`")
+
+      case _ =>
+        ()
+
+    val children = classSymbol.children
+
+    if children.isEmpty then
+      report.errorAndAbort("jacinta: staged sum parsing requires at least one variant")
+
+    if !children.forall { child => child.isClassDef && child.flags.is(Flags.Case) } then
+      report.errorAndAbort
+        ("jacinta: staged sum parsing requires every variant to be a case class; singleton "+
+          "variants use `Json.Parsable.derived`")
+
+    val variantTypes: List[TypeRepr] = children.map(_.typeRef)
+    val variantNames: List[String] = children.map(_.name)
+    val arity = children.length
+
+    def summonVariant(index: Int): Expr[Json.Field] =
+      variantTypes(index).asType match
+        case '[variantType] =>
+          Expr.summon[variantType is Json.Field].getOrElse:
+            report.errorAndAbort
+              (s"jacinta: no Json.Field instance for variant ${variantNames(index)}: "+
+                variantTypes(index).show)
+
+    val discriminableExpr: Expr[value is Discriminable in Json] =
+      Expr.summon[value is Discriminable in Json].getOrElse:
+        report.errorAndAbort
+          ("jacinta: staged sum parsing needs a contextual `Discriminable in Json`, like "+
+            "`jacinta.discriminables.jsonByKindDiscriminable`")
+
+    val nameExprs = variantNames.map { name => Expr(name) }
+    val variantExprs = List.range(0, arity).map(summonVariant)
+
+    // The dispatch chain: one monomorphic comparison per variant, ending in
+    // the derived engine's unknown-variant raise.
+    def dispatch
+      ( index:        Int,
+        reader:       Expr[JsonReader],
+        wire:         Expr[Text],
+        wireString:   Expr[String],
+        variants:     Expr[IArray[Json.Field]],
+        wireVariants: Expr[IArray[String]] )
+    :   Expr[value] =
+
+      if index == arity then
+        '{
+          provide[Tactic[VariantError]]:
+            abort(VariantError[value]($wire))
+        }
+      else variantTypes(index).asType match
+        case '[type variantType <: value; variantType] =>
+          '{
+            if $wireVariants(${Expr(index)}) == $wireString then
+              $variants(${Expr(index)}).asInstanceOf[variantType is Json.Field].parse($reader)
+            else ${ dispatch(index + 1, reader, wire, wireString, variants, wireVariants) }
+          }
+
+    '{
+      // Sealed per the codec-thunk pattern, like the derived instances: the
+      // variant instances may capture resolution-scoped tactics. The variant
+      // array is a single lazy val, so recursive references stay deferred.
+      caps.unsafe.unsafeAssumePure:
+        val discriminable: value is Discriminable in Json = $discriminableExpr
+        val tagField: Text = Json.Parsable.discriminantField(discriminable)
+
+        val wireVariants: IArray[String] =
+          Json.Parsable.wireKeys(IArray[String](${Varargs(nameExprs)}*), $renames)
+
+        lazy val variants: IArray[Json.Field] = IArray(${Varargs(variantExprs)}*)
+
+        new Json.Parsable:
+          type Self = value
+          def shape(): Morphology = Morphology.Any
+
+          def parse(reader: JsonReader^): value =
+            provide[Tactic[JsonError]]:
+              val wire: Text = reader.discriminant(tagField).or:
+                abort(JsonError(JsonError.Reason.Absent))
+
+              val wireString: String = wire.s
+
+              ${
+                dispatch
+                  ( 0, '{reader}, '{wire}, '{wireString}, '{variants}, '{wireVariants} )
+              }
     }

--- a/lib/jacinta/src/staged/jacinta.Inlinable.scala
+++ b/lib/jacinta/src/staged/jacinta.Inlinable.scala
@@ -1,0 +1,136 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+
+// The Expr-level counterpart of `Json.Parsable`: a typeclass whose methods
+// are macro-time code generators. An instance receives an `Expr` of the
+// reader and returns an `Expr` of the decoded value, which the deriving
+// macro splices directly into its generated parser — so an instance
+// contributes *inlined* code, with no runtime dispatch, no instance arrays
+// and no adapter hops between composed parsers.
+//
+// Instances are ordinary runtime values: code generation is deferred to the
+// `parse` call, which receives the `Quotes` and the `Type` of `Self`, so
+// `derived` needs no macro of its own. At a `Json.Inlinable.parsable[T]`
+// expansion, the instance behind each summoned given is obtained *live* by
+// running the implicit search inside an in-macro staging compiler (the
+// prescience mechanism), which composes conditional instances — a collection
+// of a custom element, for example — through ordinary given resolution. The
+// constraint this inherits: an instance (and its type) must be compiled in
+// an earlier run than the expansion; same-run instances degrade to a spliced
+// runtime call through `Json.Field`.
+trait Inlinable extends Typeclass:
+  def parse(reader: Expr[JsonReader])(using Quotes, Type[Self]): Expr[Self]
+
+  // What a field of this type yields when its key is absent from the object,
+  // mirroring the runtime instances: an abort unless overridden.
+  def absent(tactic: Expr[Tactic[JsonError]])(using Quotes, Type[Self]): Expr[Self] =
+    '{ Json.Parsable.missing[Self]()(using $tactic) }
+
+object Inlinable:
+  // Generates a monomorphic `Json.Parsable` for a case class at compile
+  // time, like `Json.Parsable.staged`, but composed through `Inlinable`
+  // instances: nested records, collection loops and custom leaf parsers all
+  // inline into one flat parser.
+  inline def parsable[value]: value is Json.Parsable =
+    ${ jacinta.stagedInternal.inlinableParsable[value] }
+
+  // The structural instance for a case class: reflects `Self` when invoked
+  // (no macro — `Type[Self]` arrives with the call).
+  def derived[product]: product is Inlinable = ProductInlinable[product]()
+
+  private[jacinta] final class ProductInlinable[product]() extends Inlinable:
+    type Self = product
+
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[product]): Expr[product] =
+      stagedInternal.productBody[product](reader)
+
+  private[jacinta] final class IterableInlinable[element](element0: element is Inlinable)
+  extends Inlinable:
+    type Self = Iterable[element]
+
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      stagedInternal.iterableBody[Iterable[element]](reader, element0)
+
+  // ── Instances ──────────────────────────────────────────────────────────
+  // The leaf generators mirror `Json.Parsable.staged`'s builtin arms; the
+  // conditional collection instance composes through given resolution when
+  // the graph is resolved inside the staging compiler.
+
+  given int: (Int is Inlinable) = new Inlinable:
+    type Self = Int
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Int]): Expr[Int] =
+      '{ $reader.long().toInt }
+
+  given long: (Long is Inlinable) = new Inlinable:
+    type Self = Long
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Long]): Expr[Long] =
+      '{ $reader.long() }
+
+  given double: (Double is Inlinable) = new Inlinable:
+    type Self = Double
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Double]): Expr[Double] =
+      '{ $reader.double() }
+
+  given float: (Float is Inlinable) = new Inlinable:
+    type Self = Float
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Float]): Expr[Float] =
+      '{ $reader.double().toFloat }
+
+  given boolean: (Boolean is Inlinable) = new Inlinable:
+    type Self = Boolean
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Boolean]): Expr[Boolean] =
+      '{ $reader.boolean() }
+
+  given text: (Text is Inlinable) = new Inlinable:
+    type Self = Text
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[Text]): Expr[Text] =
+      '{ $reader.string() }
+
+  given string: (String is Inlinable) = new Inlinable:
+    type Self = String
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[String]): Expr[String] =
+      '{ $reader.string().s }
+
+  given iterable: [collection <: Iterable, element]
+  =>  (element0: element is Inlinable)
+  =>  (collection[element] is Inlinable) =
+    IterableInlinable[element](element0).asInstanceOf[collection[element] is Inlinable]

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -466,55 +466,92 @@ object stagedInternal:
           Some('{ $parser.directString()(using $ptactic) })
         else None
 
-      // Per-field parse and absent expressions, through the ladder.
-      def fieldExprs(index: Int): (Expr[Any], Expr[Any]) =
+      // The absent expression per field, through the ladder.
+      def fieldAbsent(index: Int): Expr[Any] =
         fieldTypes(index).asType match
           case '[fieldType] =>
-            builtinDirect(fieldTypes(index)) match
-              case Some(direct) =>
-                return (direct, '{ Json.Parsable.missing[fieldType]()(using $tactic) })
-
-              case None =>
-                ()
-
-            resolve[fieldType](cache) match
+            if builtinDirect(fieldTypes(index)).isDefined then
+              '{ Json.Parsable.missing[fieldType]()(using $tactic) }
+            else resolve[fieldType](cache) match
               case Some(instance0) =>
-                val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
-                (nested[fieldType](instance, reader), instance.absent(tactic))
+                instance0.asInstanceOf[Inlinable { type Self = fieldType }].absent(tactic)
 
               case None =>
-                // A nominal `Parsable` (a staged sum, a custom instance) is
-                // called directly, skipping the `Field.Adapter` the fallback
-                // chain would otherwise construct per occurrence.
-                ( '{ stagedInternal.fieldSeam[fieldType]($reader) },
-                  '{
-                    scala.compiletime.summonInline[fieldType is Json.Field]
-                    . absent()(using $tactic)
-                  } )
+                '{
+                  scala.compiletime.summonInline[fieldType is Json.Field]
+                  . absent()(using $tactic)
+                }
 
-      val fieldCode: List[(Expr[Any], Expr[Any])] = List.range(0, arity).map(fieldExprs)
+      val fieldCode: List[(Expr[Any], Expr[Any])] = List.range(0, arity).map: index =>
+        (Expr(0), fieldAbsent(index))
 
-      // Each field's read is generated once, as a local def both key steps'
-      // arms call — the arms themselves are regenerated per step (trees may
-      // not be shared), but stay one call each.
+      // Per field, up to three local defs, shaped for the JIT: a nested
+      // body (generated exactly once and *called* from both branches), a
+      // cold def holding the focusing machinery, and the hot `readField`,
+      // which shrinks to a flag test and a call — small enough that the
+      // key-step arms always inline it.
       val readDefs = List.range(0, arity).map: index =>
         Symbol.newMethod
           ( owner, "readField"+index,
             MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
 
-      val readDefDefs = List.range(0, arity).map: index =>
-        val rhs: Term =
-          fieldTypes(index).asType match
-            case '[fieldType] =>
-              val raw = fieldCode(index)(0).asExprOf[fieldType]
+      val slowDefs = List.range(0, arity).map: index =>
+        Symbol.newMethod
+          ( owner, "readFieldSlow"+index,
+            MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
 
+      val readDefDefs: List[Statement] = List.range(0, arity).flatMap: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            def rawParse(): Expr[fieldType] =
+              builtinDirect(fieldTypes(index)) match
+                case Some(direct) =>
+                  direct.asExprOf[fieldType]
+
+                case None =>
+                  resolve[fieldType](cache) match
+                    case Some(instance0) =>
+                      instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+                      . parse(reader)
+
+                    case None =>
+                      '{ stagedInternal.fieldSeam[fieldType]($reader) }
+
+            val builtin = builtinDirect(fieldTypes(index)).isDefined
+
+            // Non-builtin bodies are potentially large: emit once as a def
+            // and call it from both temperature branches.
+            val nestedDef: Option[(Symbol, Statement)] =
+              if builtin then None else
+                val symbol =
+                  Symbol.newMethod
+                    ( owner, "readNested"+index,
+                      MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
+
+                val rhs = rawParse().asTerm.changeOwner(symbol)
+                Some((symbol, DefDef(symbol, _ => Some(rhs))))
+
+            def call(symbol: Symbol): Expr[fieldType] =
+              Apply(Ref(symbol), Nil).asExprOf[fieldType]
+
+            def hot(): Expr[fieldType] =
+              nestedDef match
+                case Some((symbol, _)) => call(symbol)
+                case None              => rawParse()
+
+            val slowRhs: Term =
               '{
-                if $focused then
-                  Json.Parsable.focusing($foci, ${Expr(fieldNames(index))}.tt)($raw)
-                else $raw
-              }.asTerm
+                Json.Parsable.focusing($foci, ${Expr(fieldNames(index))}.tt)(${ hot() })
+              }.asTerm.changeOwner(slowDefs(index))
 
-        DefDef(readDefs(index), _ => Some(rhs.changeOwner(readDefs(index))))
+            val readRhs: Term =
+              '{ if $focused then ${ call(slowDefs(index)) } else ${ hot() } }
+              . asTerm.changeOwner(readDefs(index))
+
+            nestedDef.map(_(1)).toList
+              ::: List
+                    ( DefDef(slowDefs(index), _ => Some(slowRhs)),
+                      DefDef(readDefs(index), _ => Some(readRhs)) )
 
       def arms: List[CaseDef] = List.range(0, arity).map: index =>
         val rhs =

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -39,6 +39,7 @@ import anticipation.*
 import contingency.*
 import prepositional.*
 import vacuous.*
+import zephyrine.*
 
 // The machinery behind `Json.Inlinable`: expansion-time instance resolution
 // (through an in-macro staging compiler), the structural generators for
@@ -340,10 +341,12 @@ object stagedInternal:
               val builder = factory.newBuilder
               val foci = infer[Foci[Json.Focus]]
               val focused = foci.active
-              $reader.openArray()
+              val parser = $reader.rawParser.asInstanceOf[Parser]
+              val ptactic = $reader.rawTactic.asInstanceOf[Tactic[ParseError]]
+              parser.directOpenArray()(using ptactic)
               var index = 0
 
-              while $reader.element() do
+              while parser.directElement()(using ptactic) do
                 builder +=
                   ( if focused then
                       Json.Parsable.focusing(foci, index.toString.tt)(parseElement())
@@ -418,7 +421,9 @@ object stagedInternal:
     def body
       ( foci:    Expr[Foci[Json.Focus]],
         focused: Expr[Boolean],
-        tactic:  Expr[Tactic[JsonError]] )
+        tactic:  Expr[Tactic[JsonError]],
+        parser:  Expr[Parser],
+        ptactic: Expr[Tactic[ParseError]] )
     :   Expr[product] =
 
       val owner = Symbol.spliceOwner
@@ -446,10 +451,32 @@ object stagedInternal:
 
       val unit = Literal(UnitConstant())
 
+      // EXPERIMENT(cc-bypass): builtins read straight off the parser bound
+      // once per record, skipping the JsonReader rim entirely.
+      def builtinDirect(tpe: TypeRepr): Option[Expr[Any]] =
+        if tpe =:= TypeRepr.of[Int] then Some('{ $parser.directLong()(using $ptactic).toInt })
+        else if tpe =:= TypeRepr.of[Long] then Some('{ $parser.directLong()(using $ptactic) })
+        else if tpe =:= TypeRepr.of[Double] then
+          Some('{ $parser.directDouble()(using $ptactic) })
+        else if tpe =:= TypeRepr.of[Boolean] then
+          Some('{ $parser.directBoolean()(using $ptactic) })
+        else if tpe =:= TypeRepr.of[Text] then
+          Some('{ $parser.directString()(using $ptactic).tt })
+        else if tpe =:= TypeRepr.of[String] then
+          Some('{ $parser.directString()(using $ptactic) })
+        else None
+
       // Per-field parse and absent expressions, through the ladder.
       def fieldExprs(index: Int): (Expr[Any], Expr[Any]) =
         fieldTypes(index).asType match
           case '[fieldType] =>
+            builtinDirect(fieldTypes(index)) match
+              case Some(direct) =>
+                return (direct, '{ Json.Parsable.missing[fieldType]()(using $tactic) })
+
+              case None =>
+                ()
+
             resolve[fieldType](cache) match
               case Some(instance0) =>
                 val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
@@ -499,7 +526,8 @@ object stagedInternal:
 
         CaseDef(Literal(IntConstant(index)), None, rhs)
 
-      def fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipValue() }.asTerm)
+      def fallthrough =
+        CaseDef(Wildcard(), None, '{ $parser.directSkipValue()(using $ptactic) }.asTerm)
 
       val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
 
@@ -551,7 +579,7 @@ object stagedInternal:
             ( '{ $wordRef == JsonReader.KeyOpaque }.asTerm,
               opaque.asTerm,
               Block
-                ( List(ValDef(high, Some('{ $reader.keyWordHigh }.asTerm))),
+                ( List(ValDef(high, Some('{ $parser.directKeyWordHigh }.asTerm))),
                   packedChainOver(wordRef, highRef)(0) ) )
 
         Block
@@ -571,10 +599,10 @@ object stagedInternal:
       val loop: List[Statement] =
         readDefDefs :::
           List
-            ( '{ $reader.openObject() }.asTerm,
+            ( '{ $parser.directOpenObject()(using $ptactic) }.asTerm,
               ValDef(run, Some(Literal(BooleanConstant(true)))),
-              step('{ $reader.keyWordFirst() }),
-              While(Ref(run), step('{ $reader.keyWordNext() })) )
+              step('{ $parser.directKeyWordFirst() }),
+              While(Ref(run), step('{ $parser.directKeyWordNext() })) )
 
       val absents: List[Term] = List.range(0, arity).map: index =>
         fieldTypes(index).asType match
@@ -604,7 +632,9 @@ object stagedInternal:
       val foci = infer[Foci[Json.Focus]]
       val focused = foci.active
       val tactic = infer[Tactic[JsonError]]
-      ${ body('foci, 'focused, 'tactic) }
+      val parser = $reader.rawParser.asInstanceOf[Parser]
+      val ptactic = $reader.rawTactic.asInstanceOf[Tactic[ParseError]]
+      ${ body('foci, 'focused, 'tactic, 'parser, 'ptactic) }
     }
 
   // ── The entry macro ────────────────────────────────────────────────────

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -45,6 +45,16 @@ import vacuous.*
 // products and collections, and the `Inlinable.parsable` entry macro.
 object stagedInternal:
 
+  // The runtime seam for a field type without an `Inlinable`: a nominal
+  // `Parsable` (a staged sum, a custom instance) is called directly,
+  // skipping the `Field.Adapter` the fallback chain would otherwise
+  // construct per occurrence. An inline method because `summonFrom` may
+  // only live in one; it expands where the generated parser is spliced.
+  inline def fieldSeam[fieldType](reader: JsonReader): fieldType =
+    scala.compiletime.summonFrom:
+      case parsable: (`fieldType` is Json.Parsable) => parsable.parse(reader)
+      case _ => scala.compiletime.summonInline[fieldType is Json.Field].parse(reader)
+
   // ── Expansion-time environment ─────────────────────────────────────────
 
   private def macroClassloader: ClassLoader =
@@ -406,8 +416,9 @@ object stagedInternal:
     val packedNames: List[Option[(Long, Long)]] = List.range(0, arity).map(packedName)
 
     def body
-      ( foci:   Expr[Foci[Json.Focus]],
-        tactic: Expr[Tactic[JsonError]] )
+      ( foci:    Expr[Foci[Json.Focus]],
+        focused: Expr[Boolean],
+        tactic:  Expr[Tactic[JsonError]] )
     :   Expr[product] =
 
       val owner = Symbol.spliceOwner
@@ -445,9 +456,10 @@ object stagedInternal:
                 (nested[fieldType](instance, reader), instance.absent(tactic))
 
               case None =>
-                ( '{
-                    scala.compiletime.summonInline[fieldType is Json.Field].parse($reader)
-                  },
+                // A nominal `Parsable` (a staged sum, a custom instance) is
+                // called directly, skipping the `Field.Adapter` the fallback
+                // chain would otherwise construct per occurrence.
+                ( '{ stagedInternal.fieldSeam[fieldType]($reader) },
                   '{
                     scala.compiletime.summonInline[fieldType is Json.Field]
                     . absent()(using $tactic)
@@ -456,14 +468,15 @@ object stagedInternal:
       val fieldCode: List[(Expr[Any], Expr[Any])] = List.range(0, arity).map(fieldExprs)
 
       val arms = List.range(0, arity).map: index =>
-        val keyText: Expr[Text] = '{ ${Expr(fieldNames(index))}.tt }
-
         val read: Term =
           fieldTypes(index).asType match
             case '[fieldType] =>
+              val raw = fieldCode(index)(0).asExprOf[fieldType]
+
               '{
-                Json.Parsable.focusing($foci, $keyText)
-                  (${ fieldCode(index)(0).asExprOf[fieldType] })
+                if $focused then
+                  Json.Parsable.focusing($foci, ${Expr(fieldNames(index))}.tt)($raw)
+                else $raw
               }.asTerm
 
         val rhs =
@@ -566,8 +579,9 @@ object stagedInternal:
 
     '{
       val foci = infer[Foci[Json.Focus]]
+      val focused = foci.active
       val tactic = infer[Tactic[JsonError]]
-      ${ body('foci, 'tactic) }
+      ${ body('foci, 'focused, 'tactic) }
     }
 
   // ── The entry macro ────────────────────────────────────────────────────

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -345,14 +345,16 @@ object stagedInternal:
               val ptactic = $reader.rawTactic.asInstanceOf[Tactic[ParseError]]
               parser.directOpenArray()(using ptactic)
               var index = 0
+              var continue = parser.directElementFirst()(using ptactic)
 
-              while parser.directElement()(using ptactic) do
+              while continue do
                 builder +=
                   ( if focused then
                       Json.Parsable.focusing(foci, index.toString.tt)(parseElement())
                     else parseElement() )
 
                 index += 1
+                continue = parser.directElementNext()(using ptactic)
 
               builder.result()
             }
@@ -619,6 +621,13 @@ object stagedInternal:
                 ( List(ValDef(high, Some('{ $parser.directKeyWordHigh }.asTerm))),
                   packedChainOver(wordRef, highRef)(0) ) )
 
+        // The refill-revealed close brace (-2) is one more dispatch case
+        // rather than a comparison ahead of every dispatch.
+        val ended =
+          CaseDef
+            ( Literal(IntConstant(-2)), None,
+              Assign(Ref(run), Literal(BooleanConstant(false))) )
+
         Block
           ( List(ValDef(word, Some(wordStep.asTerm))),
             If
@@ -626,10 +635,7 @@ object stagedInternal:
                 Assign(Ref(run), Literal(BooleanConstant(false))),
                 Block
                   ( List(ValDef(found, Some(resolveStep))),
-                    If
-                      ( '{ ${Ref(found).asExprOf[Int]} == -2 }.asTerm,
-                        Assign(Ref(run), Literal(BooleanConstant(false))),
-                        Match(Ref(found), arms :+ fallthrough) ) ) ) )
+                    Match(Ref(found), arms ::: List(ended, fallthrough)) ) ) )
 
       // The first key step is unrolled ahead of the loop, so the steady-state
       // step consults no per-key seen/comma state.

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -467,8 +467,16 @@ object stagedInternal:
 
       val fieldCode: List[(Expr[Any], Expr[Any])] = List.range(0, arity).map(fieldExprs)
 
-      val arms = List.range(0, arity).map: index =>
-        val read: Term =
+      // Each field's read is generated once, as a local def both key steps'
+      // arms call — the arms themselves are regenerated per step (trees may
+      // not be shared), but stay one call each.
+      val readDefs = List.range(0, arity).map: index =>
+        Symbol.newMethod
+          ( owner, "readField"+index,
+            MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
+
+      val readDefDefs = List.range(0, arity).map: index =>
+        val rhs: Term =
           fieldTypes(index).asType match
             case '[fieldType] =>
               val raw = fieldCode(index)(0).asExprOf[fieldType]
@@ -479,37 +487,32 @@ object stagedInternal:
                 else $raw
               }.asTerm
 
+        DefDef(readDefs(index), _ => Some(rhs.changeOwner(readDefs(index))))
+
+      def arms: List[CaseDef] = List.range(0, arity).map: index =>
         val rhs =
           Block
             ( List
-                ( Assign(Ref(slots(index)), read),
+                ( Assign(Ref(slots(index)), Apply(Ref(readDefs(index)), Nil)),
                   Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
               unit )
 
         CaseDef(Literal(IntConstant(index)), None, rhs)
 
-      val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipValue() }.asTerm)
+      def fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipValue() }.asTerm)
 
       val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
-      val word = Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
-      val high = Symbol.newVal(owner, "high", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
 
-      val found =
-        Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
-
-      val wordRef = Ref(word).asExprOf[Long]
-      val highRef = Ref(high).asExprOf[Long]
-
-      def packedChain(index: Int): Term =
+      def packedChainOver(wordRef: Expr[Long], highRef: Expr[Long])(index: Int): Term =
         if index == arity then Literal(IntConstant(-1))
         else packedNames(index) match
-          case None => packedChain(index + 1)
+          case None => packedChainOver(wordRef, highRef)(index + 1)
 
           case Some((low, highWord)) =>
             If
               ( '{ $wordRef == ${Expr(low)} && $highRef == ${Expr(highWord)} }.asTerm,
                 Literal(IntConstant(index)),
-                packedChain(index + 1) )
+                packedChainOver(wordRef, highRef)(index + 1) )
 
       def namedChain(name: Expr[String], index: Int): Expr[Int] =
         if index == arity then Expr(-1)
@@ -519,24 +522,40 @@ object stagedInternal:
             else ${ namedChain(name, index + 1) }
           }
 
-      // An opaque key (window edge, escapes, oversized) resolves through the
-      // generally-consumed interned name; `null` there is a close brace that
-      // became visible only after a refill.
-      val opaque: Expr[Int] =
-        '{
-          val name = $reader.keyName()
-          if name == null then -2 else ${ namedChain('{name.nn}, 0) }
-        }
+      // One key step: fresh symbols and arm trees per instantiation (trees
+      // may not be shared between the unrolled first step and the loop).
+      def step(wordStep: Expr[Long]): Term =
+        val word =
+          Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
 
-      val resolveStep: Term =
-        If
-          ( '{ $wordRef == JsonReader.KeyOpaque }.asTerm,
-            opaque.asTerm,
-            Block(List(ValDef(high, Some('{ $reader.keyWordHigh }.asTerm))), packedChain(0)) )
+        val high =
+          Symbol.newVal(owner, "high", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
 
-      val step: Term =
+        val found =
+          Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+
+        val wordRef = Ref(word).asExprOf[Long]
+        val highRef = Ref(high).asExprOf[Long]
+
+        // An opaque key (window edge, escapes, oversized) resolves through
+        // the generally-consumed interned name; `null` there is a close
+        // brace that became visible only after a refill.
+        val opaque: Expr[Int] =
+          '{
+            val name = $reader.keyName()
+            if name == null then -2 else ${ namedChain('{name.nn}, 0) }
+          }
+
+        val resolveStep: Term =
+          If
+            ( '{ $wordRef == JsonReader.KeyOpaque }.asTerm,
+              opaque.asTerm,
+              Block
+                ( List(ValDef(high, Some('{ $reader.keyWordHigh }.asTerm))),
+                  packedChainOver(wordRef, highRef)(0) ) )
+
         Block
-          ( List(ValDef(word, Some('{ $reader.keyWord() }.asTerm))),
+          ( List(ValDef(word, Some(wordStep.asTerm))),
             If
               ( '{ $wordRef == JsonReader.KeyEnd }.asTerm,
                 Assign(Ref(run), Literal(BooleanConstant(false))),
@@ -547,11 +566,15 @@ object stagedInternal:
                         Assign(Ref(run), Literal(BooleanConstant(false))),
                         Match(Ref(found), arms :+ fallthrough) ) ) ) )
 
+      // The first key step is unrolled ahead of the loop, so the steady-state
+      // step consults no per-key seen/comma state.
       val loop: List[Statement] =
-        List
-          ( '{ $reader.openObject() }.asTerm,
-            ValDef(run, Some(Literal(BooleanConstant(true)))),
-            While(Ref(run), step) )
+        readDefDefs :::
+          List
+            ( '{ $reader.openObject() }.asTerm,
+              ValDef(run, Some(Literal(BooleanConstant(true)))),
+              step('{ $reader.keyWordFirst() }),
+              While(Ref(run), step('{ $reader.keyWordNext() })) )
 
       val absents: List[Term] = List.range(0, arity).map: index =>
         fieldTypes(index).asType match

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -1,0 +1,594 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package jacinta
+
+import scala.collection.mutable as scm
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+import vacuous.*
+
+// The machinery behind `Json.Inlinable`: expansion-time instance resolution
+// (through an in-macro staging compiler), the structural generators for
+// products and collections, and the `Inlinable.parsable` entry macro.
+object stagedInternal:
+
+  // ── Expansion-time environment ─────────────────────────────────────────
+
+  private def macroClassloader: ClassLoader =
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // A symbol defined in the compilation run in progress has no trustworthy
+  // classfile (none on a clean build; a stale one from the previous compile
+  // on an incremental build), so instance evaluation must refuse it and the
+  // caller degrade to a runtime seam.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+
+    val full =
+      dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
+
+  // ── Type transport into the staging context ────────────────────────────
+  // The outer macro's `Type` cannot cross into the inner compiler, so a type
+  // travels as a tree of `java.lang.Class`es and is rebuilt inside with
+  // `TypeRepr.typeConstructorOf`. This restricts instance evaluation to
+  // class-shaped types (plain classes and applications of them) — opaque
+  // and structural types degrade to a runtime seam.
+
+  private case class TypeShape(clazz: Class[?], arguments: List[TypeShape])
+
+  private val primitiveClasses: Map[String, Class[?]] =
+    Map
+      ( "scala.Int"     -> classOf[Int],
+        "scala.Long"    -> classOf[Long],
+        "scala.Double"  -> classOf[Double],
+        "scala.Float"   -> classOf[Float],
+        "scala.Boolean" -> classOf[Boolean],
+        "scala.Short"   -> classOf[Short],
+        "scala.Byte"    -> classOf[Byte],
+        "scala.Char"    -> classOf[Char],
+        "scala.Unit"    -> classOf[Unit] )
+
+  // The binary name of a class symbol: package segments joined with dots,
+  // enclosing type segments with dollars.
+  private def binaryName(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+
+    def build(symbol: Symbol): String =
+      val owner = symbol.owner
+
+      if owner.isPackageDef then
+        val prefix = owner.fullName
+        if prefix == "<empty>" then symbol.name else prefix+"."+symbol.name
+      else
+        val ownerName = build(if owner.isClassDef then owner else owner.owner)
+        ownerName+"$"+symbol.name
+
+    build(symbol)
+
+  private def shapeOf(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[TypeShape] =
+    import quotes.reflect.*
+
+    def classFor(tpe: TypeRepr): Option[Class[?]] =
+      tpe.classSymbol.flatMap: symbol =>
+        if definedInCurrentRun(symbol) then None
+        else primitiveClasses.get(symbol.fullName).orElse:
+          try Some(Class.forName(binaryName(symbol), false, macroClassloader).nn)
+          catch
+            case _: ReflectiveOperationException => None
+            case _: LinkageError                 => None
+
+    tpe.dealias match
+      case AppliedType(constructor, arguments) =>
+        for
+          clazz <- classFor(constructor)
+          shapes <- arguments.foldRight(Option(List.empty[TypeShape])): (argument, list) =>
+                      list.flatMap { tail => shapeOf(argument).map(_ :: tail) }
+        yield TypeShape(clazz, shapes)
+
+      case other =>
+        classFor(other).map(TypeShape(_, Nil))
+
+  // ── Instance evaluation: the staging summon ────────────────────────────
+  // One fresh compiler per summon, over the macro classloader with the
+  // current output directory excluded from its classpath. The summon is
+  // embedded in the compiled snippet (`summonInline`), so it resolves during
+  // the inner compiler's inlining phase, composing conditional instances —
+  // the whole instance graph arrives live in one run.
+  private def summonViaStaging[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[field]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val target =
+            r2.Refinement
+              ( r2.TypeRepr.of[Inlinable], "Self",
+                r2.TypeBounds(rebuild(shape), rebuild(shape)) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+
+        result match
+          case instance: Inlinable =>
+            report.info
+              (s"jacinta: staged summon for ${TypeRepr.of[field].show} took ${duration}ms")
+
+            Some(instance)
+
+          case _ =>
+            None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The resolution ladder ──────────────────────────────────────────────
+  // builtin → staged summon → structural collection/product → (caller's)
+  // runtime seam. The cache spans one entry expansion, so a type's staging
+  // summon runs at most once however often it recurs in the graph.
+
+  private type Cache = scm.HashMap[String, Option[Inlinable]]
+
+  private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    builtinFor(tpe).orElse:
+      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+
+  // Composition points become local defs rather than textual inlining: a
+  // fully-flattened parser exceeds HotSpot's huge-method bytecode limit and
+  // runs interpreted (measured: ~6x slower than the staged parser). A local
+  // def keeps each generated method JIT-compilable while the call stays
+  // monomorphic and direct. Leaf generators stay inline.
+  private def nested[fieldType: Type]
+    (instance: Inlinable { type Self = fieldType }, reader: Expr[JsonReader])
+    (using Quotes)
+  :   Expr[fieldType] =
+
+    instance match
+      case _: Inlinable.ProductInlinable[?] | _: Inlinable.IterableInlinable[?] =>
+        '{
+          def parseNested(): fieldType = ${ instance.parse(reader) }
+          parseNested()
+        }
+
+      case _ =>
+        instance.parse(reader)
+
+  private def builtinFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Inlinable] =
+    import quotes.reflect.*
+
+    if tpe =:= TypeRepr.of[Int] then Some(Inlinable.int)
+    else if tpe =:= TypeRepr.of[Long] then Some(Inlinable.long)
+    else if tpe =:= TypeRepr.of[Double] then Some(Inlinable.double)
+    else if tpe =:= TypeRepr.of[Float] then Some(Inlinable.float)
+    else if tpe =:= TypeRepr.of[Boolean] then Some(Inlinable.boolean)
+    else if tpe =:= TypeRepr.of[Text] then Some(Inlinable.text)
+    else if tpe =:= TypeRepr.of[String] then Some(Inlinable.string)
+    else None
+
+  private def structuralFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            resolve[element](cache).map: instance =>
+              Inlinable.IterableInlinable[element]
+                (instance.asInstanceOf[element is Inlinable])
+
+      case _ =>
+        None
+    else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
+    else None
+
+  private def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr): Boolean =
+    import quotes.reflect.*
+
+    tpe.classSymbol.exists: classSymbol =>
+      classSymbol.flags.is(Flags.Case)
+      && !classSymbol.owner.isTerm
+      && (tpe match { case AppliedType(_, _) => false case _ => true })
+      && classSymbol.primaryConstructor.paramSymss
+         . filterNot(_.exists(_.isTypeParam)).length == 1
+      && !hasRenames(classSymbol)
+
+  // `@name` renames resolve through inline machinery the structural
+  // generator does not replicate; annotated records stay on `staged`.
+  private def hasRenames(using Quotes)(classSymbol: quotes.reflect.Symbol): Boolean =
+    import quotes.reflect.*
+
+    val annotated =
+      classSymbol.primaryConstructor.paramSymss.flatten.filterNot(_.isTypeParam)
+        . flatMap(_.annotations)
+      ++ classSymbol.caseFields.flatMap(_.annotations)
+
+    annotated.exists { annotation => annotation.tpe <:< TypeRepr.of[adversaria.name[?]] }
+
+  // ── The collection generator ───────────────────────────────────────────
+  // Mirrors `Json.Parsable.iterable` exactly: openArray, per-element loop,
+  // per-index focusing when the read site's `Foci` is active — with the
+  // element's generated code inlined into the loop.
+  private[jacinta] def iterableBody[collection: Type]
+    (reader: Expr[JsonReader], element0: Inlinable)
+    (using Quotes)
+  :   Expr[collection] =
+
+    import quotes.reflect.*
+
+    TypeRepr.of[collection].dealias match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            val instance = element0.asInstanceOf[Inlinable { type Self = element }]
+
+            '{
+              def parseElement(): element = ${ instance.parse(reader) }
+              val factory = infer[scala.collection.Factory[element, collection]]
+              val builder = factory.newBuilder
+              val foci = infer[Foci[Json.Focus]]
+              val focused = foci.active
+              $reader.openArray()
+              var index = 0
+
+              while $reader.element() do
+                builder +=
+                  ( if focused then
+                      Json.Parsable.focusing(foci, index.toString.tt)(parseElement())
+                    else parseElement() )
+
+                index += 1
+
+              builder.result()
+            }
+
+      case _ =>
+        report.errorAndAbort
+          ("jacinta: an inlinable collection requires an applied collection type")
+
+  // ── The product generator ──────────────────────────────────────────────
+  // Self-contained monomorphic product parsing, mirroring the staged
+  // parser's semantics: typed local slots and seen flags, literal
+  // packed-word key dispatch (an opaque key resolves through the interned
+  // name against literal strings; unknown keys are skipped), first
+  // occurrence read per key with focus bookkeeping, declared defaults then
+  // absent semantics for missing fields, direct construction. Unlike the
+  // staged parser there is no KeyTable and no instances array: every field
+  // is either inlined through its `Inlinable` code or spliced as a
+  // `summonInline`d `Json.Field` runtime call.
+  private[jacinta] def productBody[product: Type](reader: Expr[JsonReader])(using Quotes)
+  :   Expr[product] =
+
+    productBody[product](reader, scm.HashMap())
+
+  private def productBody[product: Type](reader: Expr[JsonReader], cache: Cache)(using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+
+    if !productSupported(tpe) then
+      report.errorAndAbort
+        (s"jacinta: ${tpe.show} is not an inlinable product (a non-generic, top-level or "+
+          "object-nested case class with a single parameter list and no `@name` renames); "+
+          "use `Json.Parsable.staged` or `derived`")
+
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    def packedName(index: Int): Option[(Long, Long)] =
+      val name = fieldNames(index)
+      val length = name.length
+
+      val packs = length > 0 && length <= 16 &&
+        name.forall { char => char >= ' ' && char < 127 }
+
+      if !packs then None else
+        var low = 0L
+        var high = 0L
+        var position = 0
+
+        while position < length do
+          val byte = name.charAt(position).toLong & 0xFF
+          if position < 8 then low |= byte << (position*8)
+          else high |= byte << ((position - 8)*8)
+          position += 1
+
+        Some((low, high))
+
+    val packedNames: List[Option[(Long, Long)]] = List.range(0, arity).map(packedName)
+
+    def body
+      ( foci:   Expr[Foci[Json.Focus]],
+        tactic: Expr[Tactic[JsonError]] )
+    :   Expr[product] =
+
+      val owner = Symbol.spliceOwner
+
+      val slots = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+      val seens = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      def zero(fieldType: TypeRepr): Term =
+        if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+        else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+        else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+        else if fieldType =:= TypeRepr.of[Float] then Literal(FloatConstant(0.0f))
+        else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+        else fieldType.asType match
+          case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+      val slotDefs = List.range(0, arity).map: index =>
+        ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+      val seenDefs = List.range(0, arity).map: index =>
+        ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val unit = Literal(UnitConstant())
+
+      // Per-field parse and absent expressions, through the ladder.
+      def fieldExprs(index: Int): (Expr[Any], Expr[Any]) =
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            resolve[fieldType](cache) match
+              case Some(instance0) =>
+                val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+                (nested[fieldType](instance, reader), instance.absent(tactic))
+
+              case None =>
+                ( '{
+                    scala.compiletime.summonInline[fieldType is Json.Field].parse($reader)
+                  },
+                  '{
+                    scala.compiletime.summonInline[fieldType is Json.Field]
+                    . absent()(using $tactic)
+                  } )
+
+      val fieldCode: List[(Expr[Any], Expr[Any])] = List.range(0, arity).map(fieldExprs)
+
+      val arms = List.range(0, arity).map: index =>
+        val keyText: Expr[Text] = '{ ${Expr(fieldNames(index))}.tt }
+
+        val read: Term =
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              '{
+                Json.Parsable.focusing($foci, $keyText)
+                  (${ fieldCode(index)(0).asExprOf[fieldType] })
+              }.asTerm
+
+        val rhs =
+          Block
+            ( List
+                ( Assign(Ref(slots(index)), read),
+                  Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+              unit )
+
+        CaseDef(Literal(IntConstant(index)), None, rhs)
+
+      val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipValue() }.asTerm)
+
+      val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+      val word = Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+      val high = Symbol.newVal(owner, "high", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+
+      val found =
+        Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+
+      val wordRef = Ref(word).asExprOf[Long]
+      val highRef = Ref(high).asExprOf[Long]
+
+      def packedChain(index: Int): Term =
+        if index == arity then Literal(IntConstant(-1))
+        else packedNames(index) match
+          case None => packedChain(index + 1)
+
+          case Some((low, highWord)) =>
+            If
+              ( '{ $wordRef == ${Expr(low)} && $highRef == ${Expr(highWord)} }.asTerm,
+                Literal(IntConstant(index)),
+                packedChain(index + 1) )
+
+      def namedChain(name: Expr[String], index: Int): Expr[Int] =
+        if index == arity then Expr(-1)
+        else
+          '{
+            if ${Expr(fieldNames(index))} == $name then ${Expr(index)}
+            else ${ namedChain(name, index + 1) }
+          }
+
+      // An opaque key (window edge, escapes, oversized) resolves through the
+      // generally-consumed interned name; `null` there is a close brace that
+      // became visible only after a refill.
+      val opaque: Expr[Int] =
+        '{
+          val name = $reader.keyName()
+          if name == null then -2 else ${ namedChain('{name.nn}, 0) }
+        }
+
+      val resolveStep: Term =
+        If
+          ( '{ $wordRef == JsonReader.KeyOpaque }.asTerm,
+            opaque.asTerm,
+            Block(List(ValDef(high, Some('{ $reader.keyWordHigh }.asTerm))), packedChain(0)) )
+
+      val step: Term =
+        Block
+          ( List(ValDef(word, Some('{ $reader.keyWord() }.asTerm))),
+            If
+              ( '{ $wordRef == JsonReader.KeyEnd }.asTerm,
+                Assign(Ref(run), Literal(BooleanConstant(false))),
+                Block
+                  ( List(ValDef(found, Some(resolveStep))),
+                    If
+                      ( '{ ${Ref(found).asExprOf[Int]} == -2 }.asTerm,
+                        Assign(Ref(run), Literal(BooleanConstant(false))),
+                        Match(Ref(found), arms :+ fallthrough) ) ) ) )
+
+      val loop: List[Statement] =
+        List
+          ( '{ $reader.openObject() }.asTerm,
+            ValDef(run, Some(Literal(BooleanConstant(true)))),
+            While(Ref(run), step) )
+
+      val absents: List[Term] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val keyText: Expr[Text] = '{ ${Expr(fieldNames(index))}.tt }
+
+            val resolveAbsent: Term =
+              Assign
+                ( Ref(slots(index)),
+                  '{
+                    val declared =
+                      wisteria.internal.default[product, fieldType](${Expr(index)})
+
+                    if !declared.absent then declared.asInstanceOf[fieldType]
+                    else Json.Parsable.focusing($foci, $keyText)
+                      (${ fieldCode(index)(1).asExprOf[fieldType] })
+                  }.asTerm )
+
+            If('{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm, resolveAbsent, unit)
+
+      val construct: Term =
+        Apply(Select(New(Inferred(tpe)), ctor), slots.map { slot => Ref(slot) })
+
+      Block(slotDefs ::: seenDefs ::: loop ::: absents, construct).asExprOf[product]
+
+    '{
+      val foci = infer[Foci[Json.Focus]]
+      val tactic = infer[Tactic[JsonError]]
+      ${ body('foci, 'tactic) }
+    }
+
+  // ── The entry macro ────────────────────────────────────────────────────
+  def inlinableParsable[value: Type](using Quotes): Expr[value is Json.Parsable] =
+    import quotes.reflect.*
+
+    val cache: Cache = scm.HashMap()
+
+    val root: Inlinable = resolve[value](cache).getOrElse:
+      report.errorAndAbort
+        (s"jacinta: no Inlinable instance for ${TypeRepr.of[value].show}, and it is not an "+
+          "inlinable product; use `Json.Parsable.staged` or `derived`")
+
+    val instance = root.asInstanceOf[Inlinable { type Self = value }]
+
+    '{
+      // Sealed per the codec-thunk pattern, like the staged instances: the
+      // generated body resolves its capabilities where it is spliced.
+      caps.unsafe.unsafeAssumePure:
+        new Json.Parsable:
+          type Self = value
+          def shape(): Morphology = Morphology.Any
+          def parse(reader: JsonReader): value = ${ instance.parse('{reader}) }
+    }

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1077,6 +1077,39 @@ object Tests extends Suite(m"Jacinta Tests"):
           case Json.Ast.Issue.ExpectedNumber('"') => true
           case _                                  => false)
 
+      test(m"A staged sum parser dispatches on the discriminator field"):
+        given Shape.Circle is Json.Parsable = Json.Parsable.staged
+        given Shape.Square is Json.Parsable = Json.Parsable.staged
+        given Shape is Json.Parsable = Json.Parsable.staged
+
+        ( t"""{"radius": 2.5, "kind": "Circle"}""".read[Shape in Json],
+          t"""{"kind": "Square", "side": 3.0}""".read[Shape in Json] )
+      . assert(_ == (Shape.Circle(2.5), Shape.Square(3.0)))
+
+      test(m"A staged sum parser agrees with the AST path"):
+        given Shape.Circle is Json.Parsable = Json.Parsable.staged
+        given Shape.Square is Json.Parsable = Json.Parsable.staged
+        given Shape is Json.Parsable = Json.Parsable.staged
+        agree[Shape](t"""{"radius": 2.5, "kind": "Circle"}""")
+      . assert(identity)
+
+      test(m"A staged sum parser raises Absent for a missing discriminator"):
+        given Shape is Json.Parsable = Json.Parsable.staged
+        capture[JsonError](t"""{"radius": 2.5}""".read[Shape in Json]).reason
+      . assert(_ == JsonError.Reason.Absent)
+
+      test(m"A staged sum parser raises VariantError for an unknown tag"):
+        given Shape is Json.Parsable = Json.Parsable.staged
+        capture[VariantError](t"""{"radius": 2.5, "kind": "Blob"}""".read[Shape in Json])
+        . inputLabel
+      . assert(_ == t"Blob")
+
+      test(m"A staged sum parser honors variant renames"):
+        given Status.Active is Json.Parsable = Json.Parsable.staged
+        given Status is Json.Parsable = Json.Parsable.staged
+        t"""{"since": 3, "kind": "ok"}""".read[Status in Json]
+      . assert(_ == Status.Active(3))
+
     suite(m"Sum encoding tests"):
       test(m"Wrapper encoding writes a single-key object"):
         given Shape is Discriminable in Json = Json.DiscriminantWrapper()

--- a/lib/prescience/src/core/prescience.Inlinable.scala
+++ b/lib/prescience/src/core/prescience.Inlinable.scala
@@ -1,0 +1,57 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package prescience
+
+import scala.quoted.*
+
+import prepositional.*
+
+// Proof of concept: a typeclass whose primary method is a macro-time code
+// generator — it receives an `Expr` of the input and returns an `Expr` of the
+// decoded value, which a deriving macro splices directly into its generated
+// code, so a hand-written instance contributes *inlined* code rather than a
+// runtime call.
+//
+// The deriving macro cannot call `read` on an `Expr` of an instance: it needs
+// the live instance at expansion time. `prescience.internal.evaluate` obtains
+// it for instances that resolve to a static path (a singleton, or a
+// parameterless member of one) compiled in an earlier run — the same
+// evaluation the compiler's own splice interpreter performs for macro
+// implementations — and `prescience.internal.summonStaged` obtains it for any
+// instance re-summonable from implicit scope, by running the implicit search
+// inside a fresh `staging.Compiler`. When neither applies (a local or
+// same-run instance), the deriving macro splices a call to the runtime
+// sibling `readRuntime` instead.
+trait Inlinable extends Typeclass:
+  def read(input: Expr[String])(using Quotes): Expr[Self]
+  def readRuntime(input: String): Self

--- a/lib/prescience/src/core/prescience.Prescience.scala
+++ b/lib/prescience/src/core/prescience.Prescience.scala
@@ -1,0 +1,48 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package prescience
+
+object Prescience:
+  // Derives a reader for a case class from a comma-separated line (a toy wire
+  // format: the mechanism, not the format, is the point). Each field type's
+  // `Inlinable` instance is resolved at expansion time; statically-evaluable
+  // instances contribute generated code, anything else a runtime call.
+  inline def read[value](input: String): value =
+    ${ prescience.internal.readStaged[value]('input, '{false}) }
+
+  // As `read`, but instances beyond the static subset are obtained by running
+  // the implicit search inside an in-macro `staging.Compiler` — expensive (a
+  // full compiler run per instance, reported via an info diagnostic) but able
+  // to evaluate conditional and derived givens at expansion time.
+  inline def readStaging[value](input: String): value =
+    ${ prescience.internal.readStaged[value]('input, '{true}) }

--- a/lib/prescience/src/core/prescience.internal.scala
+++ b/lib/prescience/src/core/prescience.internal.scala
@@ -1,0 +1,226 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package prescience
+
+import scala.quoted.*
+
+import prepositional.*
+
+object internal:
+
+  // ── Tier A: static-path instance evaluation ───────────────────────────────
+  // Obtains the live value behind a summoned instance `Expr` when — and only
+  // when — its tree is a reference to a precompiled static object, or a
+  // parameterless member of one. This mirrors what the compiler's own splice
+  // interpreter does to run a macro implementation (`Interpreter.loadModule`
+  // reads `MODULE$` through the macro classloader and invokes methods on it
+  // reflectively), applied to a summoned given instead of the splice entry
+  // point. The load and the cast are sound because the instance's class and
+  // this macro's classes come from the same classloader.
+  //
+  // Anything else — a conditional given (an `Apply`), a lexically-scoped or
+  // same-run instance (whose classfile does not exist yet) — yields `None`,
+  // and the caller degrades to the next tier.
+  private[prescience] def evaluate(using Quotes)(term: quotes.reflect.Term): Option[AnyRef] =
+    import quotes.reflect.*
+
+    def loadModule(binaryName: String): Option[AnyRef] =
+      try
+        val loaded = Class.forName(binaryName, true, macroClassloader).nn
+        Option(loaded.getField("MODULE$").nn.get(null))
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+
+    def invokeMember(target: AnyRef, name: String): Option[AnyRef] =
+      try
+        val method = target.getClass.nn.getMethods.nn.find: method =>
+          method.nn.getName == name && method.nn.getParameterCount == 0
+
+        method.flatMap { method => Option(method.nn.invoke(target)) }
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+
+    def moduleBinaryName(symbol: Symbol): String =
+      val name = symbol.fullName
+      if name.endsWith("$") then name else name+"$"
+
+    def eval(term: Term): Option[AnyRef] = term match
+      case Inlined(_, Nil, inner) => eval(inner)
+      case Typed(inner, _)        => eval(inner)
+      case Block(Nil, inner)      => eval(inner)
+
+      case Select(qualifier, name) =>
+        if term.symbol.flags.is(Flags.Module) then loadModule(moduleBinaryName(term.symbol))
+        else eval(qualifier).flatMap(invokeMember(_, name))
+
+      case ref: Ref =>
+        val symbol = ref.symbol
+
+        if symbol.flags.is(Flags.Module) then loadModule(moduleBinaryName(symbol))
+        else if symbol.owner.flags.is(Flags.Module) then
+          loadModule(moduleBinaryName(symbol.owner)).flatMap(invokeMember(_, symbol.name))
+        else None
+
+      case _ =>
+        None
+
+    eval(term)
+
+  private def macroClassloader: ClassLoader =
+    // The Splicer installs the macro classloader as the thread context
+    // classloader for the duration of the expansion.
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  // ── Tier B: implicit search under an in-macro staging compiler ────────────
+  // Evaluates any instance that implicit search can resolve from *global*
+  // scope (companions and package-level givens on the classpath): a fresh
+  // `staging.Compiler` is constructed over the macro classloader — fresh, so
+  // its nested-`run` guard cannot trip — and the search runs inside
+  // `staging.run`, whose result is the live instance. The outer macro's
+  // `Type` cannot cross into the inner context, so the field type travels by
+  // `java.lang.Class`, rebuilt inside via `TypeRepr.typeConstructorOf` —
+  // which restricts this tier to non-generic class types. Lexically-scoped
+  // givens at the use site are invisible to the inner search, and each call
+  // costs a full (in-memory) compiler run.
+  private[prescience] def summonStaged[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    TypeRepr.of[field].classSymbol.flatMap: classSymbol =>
+      try
+        val clazz = Class.forName(classSymbol.fullName, false, macroClassloader).nn
+        // The repo compiles under experimental language features, so its
+        // symbols are `@experimental`-tagged; the inner compiler must opt in
+        // to reference them.
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make(None, List("-experimental"))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          val fieldType = r2.TypeRepr.typeConstructorOf(clazz)
+
+          val target =
+            r2.Refinement
+              (r2.TypeRepr.of[Inlinable], "Self", r2.TypeBounds(fieldType, fieldType))
+
+          // The summon is embedded in the snippet rather than performed here
+          // eagerly: the run's expression builder executes post-typer (phase
+          // `quotedFrontend`), where a failing implicit search asserts, while
+          // an embedded `summonInline` resolves during the inner compiler's
+          // own inlining phase — an ordinary search context.
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+        report.info(s"prescience: staged summon for ${classSymbol.fullName} took ${duration}ms")
+
+        result match
+          case instance: Inlinable => Some(instance)
+          case _                   => None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The deriving macro ─────────────────────────────────────────────────────
+  // One flat reader per case class: the input splits once, and each field's
+  // code comes from its `Inlinable` instance — inlined when the instance is
+  // evaluable at expansion time (tier A, then optionally tier B), a spliced
+  // runtime call otherwise.
+  def readStaged[value: Type](input: Expr[String], staging: Expr[Boolean])(using Quotes)
+  :   Expr[value] =
+
+    import quotes.reflect.*
+
+    val useStaging: Boolean = staging.valueOrAbort
+    val tpe = TypeRepr.of[value].dealias
+
+    val classSymbol = tpe.classSymbol.getOrElse:
+      report.errorAndAbort("prescience: reading requires a case class")
+
+    if !classSymbol.flags.is(Flags.Case) then
+      report.errorAndAbort("prescience: reading requires a case class")
+
+    tpe match
+      case AppliedType(_, _) =>
+        report.errorAndAbort("prescience: generic case classes are out of scope for the PoC")
+
+      case _ =>
+        ()
+
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    def readField(index: Int, parts: Expr[Array[String]]): Term =
+      fieldTypes(index).asType match
+        case '[fieldType] =>
+          val fieldExpr: Expr[String] = '{ $parts(${Expr(index)}) }
+
+          val instanceExpr: Expr[fieldType is Inlinable] =
+            Expr.summon[fieldType is Inlinable].getOrElse:
+              report.errorAndAbort
+                (s"prescience: no Inlinable instance for field ${fields(index).name}: "+
+                  fieldTypes(index).show)
+
+          def runtimeCall: Term = '{ $instanceExpr.readRuntime($fieldExpr) }.asTerm
+
+          evaluate(instanceExpr.asTerm) match
+            case Some(instance) =>
+              instance.asInstanceOf[Inlinable].read(fieldExpr).asExprOf[fieldType].asTerm
+
+            case None =>
+              if useStaging then
+                summonStaged[fieldType] match
+                  case Some(instance) => instance.read(fieldExpr).asExprOf[fieldType].asTerm
+                  case None           => runtimeCall
+              else runtimeCall
+
+    def construct(parts: Expr[Array[String]]): Expr[value] =
+      Apply(Select(New(Inferred(tpe)), ctor), List.range(0, arity).map(readField(_, parts)))
+      . asExprOf[value]
+
+    '{
+      val parts: Array[String] = $input.split(",").nn.map(_.nn)
+      ${ construct('parts) }
+    }

--- a/lib/prescience/src/core/prescience.internal.scala
+++ b/lib/prescience/src/core/prescience.internal.scala
@@ -81,14 +81,17 @@ object internal:
       case Typed(inner, _)        => eval(inner)
       case Block(Nil, inner)      => eval(inner)
 
-      case Select(qualifier, name) =>
-        if term.symbol.flags.is(Flags.Module) then loadModule(moduleBinaryName(term.symbol))
+      case select @ Select(qualifier, name) =>
+        if definedInCurrentRun(select.symbol) then None
+        else if select.symbol.flags.is(Flags.Module) then
+          loadModule(moduleBinaryName(select.symbol))
         else eval(qualifier).flatMap(invokeMember(_, name))
 
       case ref: Ref =>
         val symbol = ref.symbol
 
-        if symbol.flags.is(Flags.Module) then loadModule(moduleBinaryName(symbol))
+        if definedInCurrentRun(symbol) then None
+        else if symbol.flags.is(Flags.Module) then loadModule(moduleBinaryName(symbol))
         else if symbol.owner.flags.is(Flags.Module) then
           loadModule(moduleBinaryName(symbol.owner)).flatMap(invokeMember(_, symbol.name))
         else None
@@ -103,6 +106,64 @@ object internal:
     // classloader for the duration of the expansion.
     val contextual = Thread.currentThread.nn.getContextClassLoader
     if contextual != null then contextual else getClass.getClassLoader.nn
+
+  // The current compilation's output directory, through the compiler's own
+  // context (reachable because `scala3-compiler` is on this module's
+  // classpath). `None` when the output is virtual or the internals shift.
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // Whether a symbol's definition belongs to the compilation run in
+  // progress: its classfile either does not exist yet or — worse — exists
+  // stale from a previous incremental compile, so neither evaluation tier
+  // may touch it and the caller must degrade to the runtime tier.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  // The macro classpath minus the current output directory, so the staging
+  // tier's inner compiler can never resolve a same-run definition against a
+  // stale classfile.
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+    val full = dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
 
   // ── Tier B: implicit search under an in-macro staging compiler ────────────
   // Evaluates any instance that implicit search can resolve from *global*
@@ -120,13 +181,21 @@ object internal:
     import scala.quoted.staging
 
     TypeRepr.of[field].classSymbol.flatMap: classSymbol =>
-      try
+      if definedInCurrentRun(classSymbol) then None else try
         val clazz = Class.forName(classSymbol.fullName, false, macroClassloader).nn
-        // The repo compiles under experimental language features, so its
-        // symbols are `@experimental`-tagged; the inner compiler must opt in
-        // to reference them.
+
+        // The compiled snippet lands in a real directory, and the inner
+        // compiler's classpath excludes the current output directory, so a
+        // same-run instance can never resolve against a stale classfile from
+        // a previous incremental compile. `-experimental` because the repo
+        // compiles under experimental language features, so its symbols are
+        // `@experimental`-tagged.
+        val outputDir: String =
+          java.nio.file.Files.createTempDirectory("prescience").nn.toString
+
         given settings: staging.Compiler.Settings =
-          staging.Compiler.Settings.make(None, List("-experimental"))
+          staging.Compiler.Settings.make
+            (Some(outputDir), List("-experimental", "-classpath", innerClasspath))
 
         given staging.Compiler = staging.Compiler.make(macroClassloader)
         val started = System.nanoTime
@@ -149,10 +218,29 @@ object internal:
           target.asType match
             case '[target] => '{ scala.compiletime.summonInline[target] }
 
-        val duration = (System.nanoTime - started)/1000000L
-        report.info(s"prescience: staged summon for ${classSymbol.fullName} took ${duration}ms")
+        // The snippet's classes are now ordinary files in `outputDir`; a new
+        // classloader over that directory (parented by the macro classloader,
+        // which supplies the instance's own classes) can reconstruct the
+        // instance independently of `staging.run`'s internal loader — the
+        // basis for caching a compiled summon across expansions.
+        val reloaded: Any =
+          try
+            val url = java.io.File(outputDir).toURI.nn.toURL.nn
+            val loader = java.net.URLClassLoader(Array(url), macroClassloader)
+            val generated = loader.loadClass("Generated$Code$From$Quoted").nn
+            val instance = generated.getConstructor().nn.newInstance()
+            generated.getMethod("apply").nn.invoke(instance)
+          catch
+            case _: ReflectiveOperationException => result
+            case _: LinkageError                 => result
 
-        result match
+        val duration = (System.nanoTime - started)/1000000L
+
+        report.info
+          (s"prescience: staged summon for ${classSymbol.fullName} took ${duration}ms; "+
+            s"classes in $outputDir")
+
+        reloaded match
           case instance: Inlinable => Some(instance)
           case _                   => None
       catch

--- a/lib/prescience/src/leaves/prescience.inlinables.scala
+++ b/lib/prescience/src/leaves/prescience.inlinables.scala
@@ -1,0 +1,87 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package prescience
+
+import scala.quoted.*
+
+// The tier-A subjects: static singletons compiled in this component, one
+// phase before the `test` use site, so the deriving macro can load them
+// through the macro classloader at expansion time. Their runtime siblings
+// throw, so a test that silently fell back to the runtime tier fails loudly —
+// the passing tests *prove* the generated code came from `read`.
+object IntInlinable extends Inlinable:
+  type Self = Int
+  def read(input: Expr[String])(using Quotes): Expr[Int] =
+    '{ java.lang.Integer.parseInt($input.trim.nn) }
+
+  def readRuntime(input: String): Int =
+    throw AssertionError("prescience: runtime tier invoked for a static instance")
+
+object StringInlinable extends Inlinable:
+  type Self = String
+  def read(input: Expr[String])(using Quotes): Expr[String] = input
+
+  def readRuntime(input: String): String =
+    throw AssertionError("prescience: runtime tier invoked for a static instance")
+
+object BooleanInlinable extends Inlinable:
+  type Self = Boolean
+  def read(input: Expr[String])(using Quotes): Expr[Boolean] =
+    '{ java.lang.Boolean.parseBoolean($input.trim.nn) }
+
+  def readRuntime(input: String): Boolean =
+    throw AssertionError("prescience: runtime tier invoked for a static instance")
+
+// Given aliases as members of a static object: the member-access path of the
+// evaluator (load the module, invoke the parameterless accessor).
+object inlinables:
+  given int: (Int is Inlinable) = IntInlinable
+  given string: (String is Inlinable) = StringInlinable
+  given boolean: (Boolean is Inlinable) = BooleanInlinable
+
+// The tier-B subject: its given is conditional, so the summoned tree is an
+// application — not a static path — and tier A cannot evaluate it. The inner
+// implicit search of the staging tier resolves and *runs* it, yielding a live
+// instance at expansion time; the throwing runtime sibling again proves that
+// a passing test inlined at compile time.
+case class Celsius(degrees: Int)
+
+object Celsius:
+  given inlinable: (dummy: DummyImplicit) => (Celsius is Inlinable) = new Inlinable:
+    type Self = Celsius
+
+    def read(input: Expr[String])(using Quotes): Expr[Celsius] =
+      '{ Celsius(java.lang.Integer.parseInt($input.trim.nn)) }
+
+    def readRuntime(input: String): Celsius =
+      throw AssertionError("prescience: runtime tier invoked for a staging-tier instance")

--- a/lib/prescience/src/test/prescience_test.scala
+++ b/lib/prescience/src/test/prescience_test.scala
@@ -45,14 +45,15 @@ case class Reading(celsius: Celsius, station: String)
 
 // A same-compilation-run counterpart of `Celsius`: its conditional companion
 // given has the shape the staging tier evaluates, but it is compiled in the
-// same run as its use site. The PoC's decisive finding: which tier serves it
-// is NONDETERMINISTIC — on a clean build no classfile exists, so the macro
-// degrades to the runtime tier, but on an incremental rebuild the module's
-// output directory (on the macro classpath) still holds the previous
-// compile's classfile, and the staging tier loads it — potentially STALE
-// bytecode if the instance was edited in this very run. So neither tier
-// soundly escapes the earlier-compilation requirement; its runtime sibling
-// is therefore real, and the test asserts only the value.
+// same run as its use site, so no trustworthy classfile exists at expansion
+// time (an incremental rebuild leaves a STALE one from the previous compile
+// in the output directory, which sits on the macro classpath). Both tiers
+// therefore refuse same-run definitions outright — the evaluator through a
+// current-run symbol check, the staging tier by that check plus excluding
+// the output directory from its inner classpath — and the macro
+// deterministically degrades to the runtime tier, whose sibling here is
+// real so the observable behavior is identical on clean and incremental
+// builds.
 case class Fahrenheit(degrees: Int)
 case class Sample(fahrenheit: Fahrenheit)
 
@@ -105,9 +106,9 @@ object Tests extends Suite(m"Prescience tests"):
         Prescience.readStaging[Reading]("21,Kew")
       . assert(_ == Reading(Celsius(21), "Kew"))
 
-      test(m"A same-run instance decodes, whichever tier serves it"):
-        // Clean build: runtime tier (no classfile yet). Incremental rebuild:
-        // the staging tier resolves it from the PREVIOUS compile's classfile
-        // in the output directory — the staleness hazard documented above.
+      test(m"A same-run instance deterministically takes the runtime tier"):
+        // Would be nondeterministic without the same-run guards (see the
+        // comment on `Fahrenheit`); with them, clean and incremental builds
+        // agree: the runtime tier serves it.
         Prescience.readStaging[Sample]("70")
       . assert(_ == Sample(Fahrenheit(70)))

--- a/lib/prescience/src/test/prescience_test.scala
+++ b/lib/prescience/src/test/prescience_test.scala
@@ -43,6 +43,29 @@ case class Order(id: Int, name: String, active: Boolean)
 case class Rank(value: Int)
 case class Reading(celsius: Celsius, station: String)
 
+// A same-compilation-run counterpart of `Celsius`: its conditional companion
+// given has the shape the staging tier evaluates, but it is compiled in the
+// same run as its use site. The PoC's decisive finding: which tier serves it
+// is NONDETERMINISTIC — on a clean build no classfile exists, so the macro
+// degrades to the runtime tier, but on an incremental rebuild the module's
+// output directory (on the macro classpath) still holds the previous
+// compile's classfile, and the staging tier loads it — potentially STALE
+// bytecode if the instance was edited in this very run. So neither tier
+// soundly escapes the earlier-compilation requirement; its runtime sibling
+// is therefore real, and the test asserts only the value.
+case class Fahrenheit(degrees: Int)
+case class Sample(fahrenheit: Fahrenheit)
+
+object Fahrenheit:
+  given inlinable: (dummy: DummyImplicit) => (Fahrenheit is Inlinable) = new Inlinable:
+    type Self = Fahrenheit
+
+    def read(input: Expr[String])(using Quotes): Expr[Fahrenheit] =
+      '{ Fahrenheit(java.lang.Integer.parseInt($input.trim.nn)) }
+
+    def readRuntime(input: String): Fahrenheit =
+      Fahrenheit(java.lang.Integer.parseInt(input.trim.nn))
+
 object Tests extends Suite(m"Prescience tests"):
   def run(): Unit =
     suite(m"Tier A: static instances evaluated at expansion time"):
@@ -81,3 +104,10 @@ object Tests extends Suite(m"Prescience tests"):
         // sibling throws, so this passing proves it did.
         Prescience.readStaging[Reading]("21,Kew")
       . assert(_ == Reading(Celsius(21), "Kew"))
+
+      test(m"A same-run instance decodes, whichever tier serves it"):
+        // Clean build: runtime tier (no classfile yet). Incremental rebuild:
+        // the staging tier resolves it from the PREVIOUS compile's classfile
+        // in the output directory — the staleness hazard documented above.
+        Prescience.readStaging[Sample]("70")
+      . assert(_ == Sample(Fahrenheit(70)))

--- a/lib/prescience/src/test/prescience_test.scala
+++ b/lib/prescience/src/test/prescience_test.scala
@@ -1,0 +1,83 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package prescience
+
+import scala.quoted.*
+
+import soundness.*
+
+import prescience.inlinables.{int, string, boolean}
+
+case class Point(x: Int, y: Int)
+case class Order(id: Int, name: String, active: Boolean)
+case class Rank(value: Int)
+case class Reading(celsius: Celsius, station: String)
+
+object Tests extends Suite(m"Prescience tests"):
+  def run(): Unit =
+    suite(m"Tier A: static instances evaluated at expansion time"):
+      // The leaf instances' runtime siblings throw, so these passing at all
+      // proves every field was generated by the instances' `read` methods at
+      // compile time.
+      test(m"A two-field record reads through inlined instance code"):
+        Prescience.read[Point]("3,4")
+      . assert(_ == Point(3, 4))
+
+      test(m"Mixed field types each inline their own instance's code"):
+        Prescience.read[Order]("7,widget,true")
+      . assert(_ == Order(7, "widget", true))
+
+    suite(m"Runtime fallback: same-run and lexical instances degrade"):
+      test(m"A lexically-scoped instance routes through the runtime sibling"):
+        // Defined in the compilation run that expands the macro, so its class
+        // cannot be loaded at expansion time; the macro splices a call to
+        // `readRuntime` instead of failing.
+        given rank: (Rank is Inlinable) = new Inlinable:
+          type Self = Rank
+
+          def read(input: Expr[String])(using Quotes): Expr[Rank] =
+            '{ Rank(java.lang.Integer.parseInt($input.trim.nn)) }
+
+          def readRuntime(input: String): Rank =
+            Rank(java.lang.Integer.parseInt(input.trim.nn))
+
+        Prescience.read[Rank]("42")
+      . assert(_ == Rank(42))
+
+    suite(m"Tier B: staging evaluates a conditional given at expansion time"):
+      test(m"A non-static instance inlines through the staging summon"):
+        // `Celsius`'s given is conditional (not a static path), so only the
+        // staging tier can evaluate it at expansion time — and its runtime
+        // sibling throws, so this passing proves it did.
+        Prescience.readStaging[Reading]("21,Kew")
+      . assert(_ == Reading(Celsius(21), "Kew"))

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1947,6 +1947,15 @@ object Tel extends Tel2:
     private var arenaPos:      Int = 0
     private var inFlightStart: Int = -1
 
+    // Direct-primary-atom capture: when `directPrimaryOnly` is set (by
+    // `directAtomText`), `commit()` materializes the first inline atom's text
+    // straight into `directPrimaryText` and allocates no `Tel.Atom.Inline` at
+    // all — a scalar leaf then costs exactly its one value `String`. The text
+    // is decoded on capture (not deferred) because a later atom on the same
+    // line may grow the arena and move the bytes.
+    private var directPrimaryOnly: Boolean       = false
+    private var directPrimaryText: String | Null = null
+
     private inline def beginInFlightAtom(): Unit = inFlightStart = arenaPos
 
     private inline def endInFlightAtom(): Int =
@@ -3770,7 +3779,14 @@ object Tel extends Tel2:
         if atomOpen then
           val off = arenaInFlightOffset
           val len = endInFlightAtom()
-          pushAtom(Tel.Atom.Inline.fromArena(atomArena, off, len, precedingSpaces))
+
+          if directPrimaryOnly then
+            // Keep only the first inline atom's text; later atoms are consumed
+            // but neither materialized nor allocated.
+            if directPrimaryText == null then
+              directPrimaryText = new String(atomArena, off, len, StandardCharsets.UTF_8)
+          else pushAtom(Tel.Atom.Inline.fromArena(atomArena, off, len, precedingSpaces))
+
           atomOpen = false
 
       var stopped = false
@@ -4110,39 +4126,33 @@ object Tel extends Tel2:
     // `Tel#primaryAtom`, where a source/literal atom never supplies the
     // primary text. Backs the primitive parsers.
     //
-    // Unlike `directCompound`, this does not materialize a `Tel.Compound`,
-    // its `IArray[Atom]` (`takeAtoms`) or its children: it reads the inline
-    // atoms into scratch, pulls the first one's text, rewinds the scratch
-    // index without copying, and consumes (discarding) the source/literal
-    // continuation and child subtree so the reader still lands on the next
-    // sibling. For a scalar leaf that is one `String` allocation and nothing
-    // more — the direct path made genuinely direct.
+    // Unlike `directCompound`, this materializes no `Tel.Compound`, no
+    // `IArray[Atom]` (`takeAtoms`) and — via `directPrimaryOnly` — not even an
+    // `Tel.Atom.Inline`: `parseCompoundLineRest` decodes the first inline
+    // atom's text straight into `directPrimaryText`, and the source/literal
+    // continuation and child subtree are consumed (discarded) so the reader
+    // still lands on the next sibling. For a scalar leaf that is exactly one
+    // value `String` and nothing else — the direct path made genuinely direct.
     private[stratiform] def directAtomText(): Optional[Text] raises TelError =
       val spaces = directEntrySpaces
       val indent = directEntryIndent
       val tabulated = directTabulation.present
-      val atomsStart = atomScratchIx
-      parseCompoundLineRest(directEntryLine)
+
+      directPrimaryText = null
+      directPrimaryOnly = true
+      try parseCompoundLineRest(directEntryLine) finally directPrimaryOnly = false
+
+      // The primary text is the first inline atom's, decoded on capture; a
+      // source/literal atom never supplies it.
+      val captured = directPrimaryText
+      val result: Optional[Text] = if captured == null then Unset else Optional(Text(captured))
+
       prevContentLeadingSpaces = spaces
       prevLineWasBoundary = false
       fillHead()
 
       val extraAtom: Optional[Tel.Atom] =
         if tabulated then Unset else parseSourceOrLiteralAtomIfPresent(spaces)
-
-      // The primary text is the first inline atom's; a source/literal atom
-      // never supplies it, so `extraAtom` is only consumed, not inspected.
-      var result: Optional[Text] = Unset
-      var index = atomsStart
-
-      while index < atomScratchIx do
-        scratchAtoms(index) match
-          case inline: Tel.Atom.Inline => if result.absent then result = Optional(inline.text)
-          case _                       => ()
-
-        index += 1
-
-      atomScratchIx = atomsStart
 
       // Mirror `directCompound`: children are parsed (and here discarded) only
       // when no source/literal atom and no tabulation intervened; otherwise a

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1369,24 +1369,57 @@ object Tel extends Tel2:
   given stringParsable: String is Tel.Parsable =
     primitiveParsable(Morphology.Str, t"String", ""): atom => atom.s
 
+  // Distinguish the two ways a byte-parsed primitive can be `Unset`: a missing
+  // atom raises `Absent`, a present-but-unparseable one raises
+  // `NotScalar(text, expected)` with the offending atom's text — exactly the
+  // `primitiveFault` split the AST path performs, so the two paths' errors agree.
+  private def byteScalarFault[value](reader: TelReader^, expected: Text, sentinel: value): value =
+    if reader.primaryPresent
+    then reader.fault(TelError.Reason.NotScalar(reader.primaryText.or(t""), expected)) yet sentinel
+    else reader.fault(TelError.Reason.Absent) yet sentinel
+
+  // `Int`/`Long`/`Boolean` read their value straight from the atom's arena
+  // bytes (`reader.int()`/`long()`/`boolean()`), so a valid scalar never
+  // materializes the value `String` that `atom()` would — only a rejected one
+  // does, for its error. `Double` keeps the text path: replicating
+  // `Double.parseDouble`'s grammar in bytes buys little (doubles are the
+  // rarest leaf and the format is broad).
   given intParsable: Int is Tel.Parsable =
-    primitiveParsable(Morphology.Whole, t"Int", 0): atom =>
-      try atom.s.toInt catch case _: NumberFormatException => Unset
+    new Tel.Parsable:
+      type Self = Int
+      def shape(): Morphology = Morphology.Whole
+
+      def parse(reader: TelReader^, indent: Int): Int =
+        reader.int().lay(byteScalarFault(reader, t"Int", 0))(identity)
+
+      override def absent()(using Tactic[TelError]): Int =
+        raise(TelError(TelError.Reason.Absent)) yet 0
 
   given longParsable: Long is Tel.Parsable =
-    primitiveParsable(Morphology.Whole, t"Long", 0L): atom =>
-      try atom.s.toLong catch case _: NumberFormatException => Unset
+    new Tel.Parsable:
+      type Self = Long
+      def shape(): Morphology = Morphology.Whole
+
+      def parse(reader: TelReader^, indent: Int): Long =
+        reader.long().lay(byteScalarFault(reader, t"Long", 0L))(identity)
+
+      override def absent()(using Tactic[TelError]): Long =
+        raise(TelError(TelError.Reason.Absent)) yet 0L
 
   given doubleParsable: Double is Tel.Parsable =
     primitiveParsable(Morphology.Real, t"Double", 0.0): atom =>
       try atom.s.toDouble catch case _: NumberFormatException => Unset
 
   given booleanParsable: Boolean is Tel.Parsable =
-    primitiveParsable(Morphology.Bool, t"Boolean", false): atom =>
-      atom.s match
-        case "true"  => true
-        case "false" => false
-        case _       => Unset
+    new Tel.Parsable:
+      type Self = Boolean
+      def shape(): Morphology = Morphology.Bool
+
+      def parse(reader: TelReader^, indent: Int): Boolean =
+        reader.boolean().lay(byteScalarFault(reader, t"Boolean", false))(identity)
+
+      override def absent()(using Tactic[TelError]): Boolean =
+        raise(TelError(TelError.Reason.Absent)) yet false
 
   // `Tel` reads itself directly through the AST bridge — the direct
   // counterpart of `telDecodable`.
@@ -1947,14 +1980,58 @@ object Tel extends Tel2:
     private var arenaPos:      Int = 0
     private var inFlightStart: Int = -1
 
-    // Direct-primary-atom capture: when `directPrimaryOnly` is set (by
-    // `directAtomText`), `commit()` materializes the first inline atom's text
-    // straight into `directPrimaryText` and allocates no `Tel.Atom.Inline` at
-    // all — a scalar leaf then costs exactly its one value `String`. The text
-    // is decoded on capture (not deferred) because a later atom on the same
-    // line may grow the arena and move the bytes.
-    private var directPrimaryOnly: Boolean       = false
-    private var directPrimaryText: String | Null = null
+    // Direct-primary-atom capture: when `directPrimaryOnly` is set (by the
+    // primitive readers), `commit()` consumes the first inline atom's bytes
+    // straight into the mode-appropriate slot and allocates no `Tel.Atom.Inline`
+    // at all. Numeric modes parse the value out of the arena bytes with no
+    // `String` at all; only the `Text` mode materializes one. The value is
+    // captured on commit (not deferred) because a later atom on the same line
+    // may grow the arena and move the bytes.
+    private inline val PrimaryText = 0
+    private inline val PrimaryLong = 1
+    private inline val PrimaryBoolean = 2
+    private inline val PrimaryInt = 3
+
+    private var directPrimaryOnly:    Boolean       = false
+    private var directPrimaryMode:    Int           = PrimaryText
+    private[stratiform] var directPrimaryPresent: Boolean       = false
+    private var directPrimaryOk:      Boolean       = false
+    private[stratiform] var directPrimaryText:    String | Null = null
+    private var directPrimaryLongVal: Long          = 0L
+    private var directPrimaryBoolVal: Boolean       = false
+
+    // Parse `atomArena[off until off+len]` as a base-10 integer with exactly
+    // `java.lang.Long.parseLong`'s acceptance (optional single leading `+`/`-`,
+    // then ASCII digits, in `Long` range) — accumulating as a negative so
+    // `Long.MinValue` is representable. Sets `directPrimaryLongVal` and returns
+    // whether the slice parsed; on `false` the caller reproduces the AST path's
+    // `NumberFormatException => Unset`, so semantics match byte-for-byte.
+    private def parseArenaLong(off: Int, len: Int): Boolean =
+      if len == 0 then false else
+        var i = 0
+        var negative = false
+        val first = atomArena(off)
+
+        if first == '-'.toByte then { negative = true; i = 1 }
+        else if first == '+'.toByte then i = 1
+
+        if i == len then false else
+          var result = 0L
+          val limit = if negative then Long.MinValue else -Long.MaxValue
+          val multMin = limit / 10L
+          var ok = true
+
+          while ok && i < len do
+            val digit = atomArena(off + i) - '0'.toByte
+
+            if digit < 0 || digit > 9 || result < multMin then ok = false
+            else
+              result *= 10L
+              if result < limit + digit then ok = false
+              else { result -= digit; i += 1 }
+
+          if ok then directPrimaryLongVal = if negative then result else -result
+          ok
 
     private inline def beginInFlightAtom(): Unit = inFlightStart = arenaPos
 
@@ -3781,10 +3858,45 @@ object Tel extends Tel2:
           val len = endInFlightAtom()
 
           if directPrimaryOnly then
-            // Keep only the first inline atom's text; later atoms are consumed
-            // but neither materialized nor allocated.
-            if directPrimaryText == null then
-              directPrimaryText = new String(atomArena, off, len, StandardCharsets.UTF_8)
+            // Consume only the first inline atom, in the reader's requested mode;
+            // later atoms on the line are consumed but neither parsed nor allocated.
+            if !directPrimaryPresent then
+              directPrimaryPresent = true
+
+              directPrimaryMode match
+                case PrimaryLong =>
+                  directPrimaryOk = parseArenaLong(off, len)
+                  // Only a rejected value needs its text — for the `NotScalar`
+                  // error, byte-for-byte with the AST path. The happy path
+                  // allocates no `String`.
+                  if !directPrimaryOk then
+                    directPrimaryText = new String(atomArena, off, len, StandardCharsets.UTF_8)
+
+                case PrimaryInt =>
+                  // As `PrimaryLong`, but an out-of-`Int`-range (yet valid Long)
+                  // value is also a `NotScalar`, exactly as `_.toInt` throws —
+                  // so it too captures its text.
+                  directPrimaryOk =
+                    parseArenaLong(off, len)
+                    && directPrimaryLongVal >= Int.MinValue && directPrimaryLongVal <= Int.MaxValue
+
+                  if !directPrimaryOk then
+                    directPrimaryText = new String(atomArena, off, len, StandardCharsets.UTF_8)
+
+                case PrimaryBoolean =>
+                  if len == 4 && atomArena(off) == 't'.toByte && atomArena(off + 1) == 'r'.toByte
+                    && atomArena(off + 2) == 'u'.toByte && atomArena(off + 3) == 'e'.toByte
+                  then { directPrimaryBoolVal = true; directPrimaryOk = true }
+                  else if len == 5 && atomArena(off) == 'f'.toByte
+                    && atomArena(off + 1) == 'a'.toByte && atomArena(off + 2) == 'l'.toByte
+                    && atomArena(off + 3) == 's'.toByte && atomArena(off + 4) == 'e'.toByte
+                  then { directPrimaryBoolVal = false; directPrimaryOk = true }
+                  else
+                    directPrimaryOk = false
+                    directPrimaryText = new String(atomArena, off, len, StandardCharsets.UTF_8)
+
+                case _ =>
+                  directPrimaryText = new String(atomArena, off, len, StandardCharsets.UTF_8)
           else pushAtom(Tel.Atom.Inline.fromArena(atomArena, off, len, precedingSpaces))
 
           atomOpen = false
@@ -4121,31 +4233,24 @@ object Tel extends Tel2:
       val atoms = takeAtoms(atomScratchIx - atomsStart)
       Tel.Compound(keyword, atoms, remark, children)
 
-    // The entry's primary atom, consuming the whole entry: the first inline
-    // atom's text, or Unset when the line carries none — mirroring
-    // `Tel#primaryAtom`, where a source/literal atom never supplies the
-    // primary text. Backs the primitive parsers.
-    //
-    // Unlike `directCompound`, this materializes no `Tel.Compound`, no
-    // `IArray[Atom]` (`takeAtoms`) and — via `directPrimaryOnly` — not even an
-    // `Tel.Atom.Inline`: `parseCompoundLineRest` decodes the first inline
-    // atom's text straight into `directPrimaryText`, and the source/literal
-    // continuation and child subtree are consumed (discarded) so the reader
-    // still lands on the next sibling. For a scalar leaf that is exactly one
-    // value `String` and nothing else — the direct path made genuinely direct.
-    private[stratiform] def directAtomText(): Optional[Text] raises TelError =
+    // Consume the whole entry in the given primary-capture `mode`, leaving the
+    // captured value in the mode's slot (`directPrimaryText` /
+    // `directPrimaryLongVal` / `directPrimaryBoolVal`, with `directPrimaryPresent`
+    // and `directPrimaryOk`). Materializes no `Tel.Compound`, no `IArray[Atom]`
+    // (`takeAtoms`) and no `Tel.Atom.Inline`: the first inline atom is consumed
+    // straight into the slot, and the source/literal continuation and child
+    // subtree are consumed (discarded) so the reader lands on the next sibling.
+    private def consumeDirectEntry(mode: Int): Unit raises TelError =
       val spaces = directEntrySpaces
       val indent = directEntryIndent
       val tabulated = directTabulation.present
 
+      directPrimaryMode = mode
+      directPrimaryPresent = false
+      directPrimaryOk = false
       directPrimaryText = null
       directPrimaryOnly = true
       try parseCompoundLineRest(directEntryLine) finally directPrimaryOnly = false
-
-      // The primary text is the first inline atom's, decoded on capture; a
-      // source/literal atom never supplies it.
-      val captured = directPrimaryText
-      val result: Optional[Text] = if captured == null then Unset else Optional(Text(captured))
 
       prevContentLeadingSpaces = spaces
       prevLineWasBoundary = false
@@ -4161,7 +4266,31 @@ object Tel extends Tel2:
       else if !head.eof && !head.separator && !head.blank && head.indentLevels > indent
       then errorAt(directOverIndentReason, head.startLine, 1)
 
-      result
+    // The entry's primary atom as text — the first inline atom's, or Unset when
+    // the line carries none (a source/literal atom never supplies it), mirroring
+    // `Tel#primaryAtom`. Backs the `Text`/text-codec primitive readers.
+    private[stratiform] def directAtomText(): Optional[Text] raises TelError =
+      consumeDirectEntry(PrimaryText)
+      val captured = directPrimaryText
+      if captured == null then Unset else Optional(Text(captured))
+
+    // The entry's primary atom parsed straight from its bytes as an integer, or
+    // Unset for a missing / non-integer atom — the `Int`/`Long` readers, saving
+    // the value `String` the `Text` path would materialize only to re-scan.
+    private[stratiform] def directAtomLong(): Optional[Long] raises TelError =
+      consumeDirectEntry(PrimaryLong)
+      if directPrimaryPresent && directPrimaryOk then Optional(directPrimaryLongVal) else Unset
+
+    // As `directAtomLong`, additionally requiring the value to fit `Int`.
+    private[stratiform] def directAtomInt(): Optional[Int] raises TelError =
+      consumeDirectEntry(PrimaryInt)
+      if directPrimaryPresent && directPrimaryOk then Optional(directPrimaryLongVal.toInt) else Unset
+
+    // The entry's primary atom parsed straight from its bytes as a boolean, or
+    // Unset for a missing atom or anything but `true` / `false`.
+    private[stratiform] def directAtomBoolean(): Optional[Boolean] raises TelError =
+      consumeDirectEntry(PrimaryBoolean)
+      if directPrimaryPresent && directPrimaryOk then Optional(directPrimaryBoolVal) else Unset
 
     // Consume the rest of the entry's own line (atoms, remark) and any
     // source/literal continuation, but not its child lines — the step before

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -234,6 +234,18 @@ object Tel extends Tel2:
     inline def derived[value](using Reflection[value]): value is Tel.Parsable =
       fromField(ParsableDerivation.derivedOne[value])
 
+    // The staged counterpart of `derived`: a macro-generated monomorphic
+    // parser whose field values live in typed locals, whose keywords dispatch
+    // through packed-`Long` literal comparisons, and whose record is built by
+    // a direct constructor call — no `Array[Any]` buffer, no `Mirror`, no
+    // per-field boxing. Semantics (wire keywords, gathering, first-match-wins
+    // duplicates, defaults, absents, error foci) mirror `derived` exactly;
+    // the generated instance's `shape()` is `Morphology.Any`. Requires a
+    // top-level or object-nested case class with a single parameter list —
+    // sums, method-local classes and other shapes use `derived`.
+    inline def staged[value]: value is Tel.Parsable =
+      ${ stratiform.internal.stagedParsable[value]('{ adversaria.relabelling[value, Tel] }) }
+
     def fromField[value](field0: (value is Tel.Parsing)^)
     :   ((value is Tel.Parsable)^{field0}) =
 
@@ -356,6 +368,65 @@ object Tel extends Tel2:
     // per-field focus.
     private def descend(base0: Optional[Tel.Focus], keyword: Text): Tel.Focus =
       Tel.Focus(base0.let(_.pointer).or(TelPath.Root).prepend(keyword))
+
+    // Support points for staged parsers, which are generated into user
+    // modules and so may only reference public members.
+
+    // The wire keywords of a product's fields: `@name` renames applied
+    // verbatim, camel→kebab otherwise — the same mapping as the derivations.
+    def wireKeywords(names: IArray[String], renames: Map[Text, Text]): IArray[String] =
+      names.map { name => renames.at(name.tt).or(camelToKebab(name)).s }
+
+    // A required primitive field whose keyword never arrived: the primitives'
+    // `absent()` semantics — raise and continue with the sentinel.
+    def missing[value](sentinel: value)(using Tactic[TelError]): value =
+      raise(TelError(TelError.Reason.Absent)) yet sentinel
+
+    // A present entry whose atom was missing or unparseable: the byte-parsed
+    // primitives' fault split — a missing atom is `Absent`, a
+    // present-but-unparseable one `NotScalar` with the offending atom's text.
+    def scalarFault[value](reader: TelReader^, expected: Text, sentinel: value): value =
+      if reader.primaryPresent
+      then
+        reader.fault(TelError.Reason.NotScalar(reader.primaryText.or(t""), expected))
+        sentinel
+      else reader.fault(TelError.Reason.Absent) yet sentinel
+
+    // Focus bookkeeping for one field read, compiled away when the ambient
+    // `Foci` is the inert default — the same short-circuit as the derived
+    // parser's loop.
+    inline def focusing[result](foci: Foci[Tel.Focus], keyword: Text)(inline block: => result)
+    :   result =
+      if foci.active then focus(using foci)(descend(prior, keyword))(block) else block
+
+    // Linear keyword dispatch for the general step — an unpackable wire
+    // keyword, or any keyword of a `@name`-annotated record.
+    def keywordIndex(keys: IArray[String], keyword: Text): Int =
+      val count = keys.length
+      val name: String = keyword.s
+      var index = 0
+
+      while index < count do
+        if keys(index) == name then return index
+        index += 1
+
+      -1
+
+    // The repeatable-field hooks, looking through the `Field.Adapter` — for
+    // staged parsers, which cannot name the private `Gathering` trait. A
+    // field gathers only when its (unwrapped) instance is a repeatable
+    // `Gathering`, exactly the derived engine's test.
+    def repeats(parsing: Tel.Parsing): Boolean =
+      val actual = unwrap(parsing)
+      actual.repeatable && actual.isInstanceOf[Gathering]
+
+    def parseElement(parsing: Tel.Parsing, reader: TelReader^, indent: Int): Any =
+      (unwrap(parsing): @unchecked) match
+        case gathering: Gathering => gathering.parseElement(reader, indent)
+
+    def gathered[value](parsing: Tel.Parsing, elements: List[Any]): value =
+      (unwrap(parsing): @unchecked) match
+        case gathering: Gathering => gathering.gathered(elements).asInstanceOf[value]
 
     // Field instances travel wrapped in the `Field.Adapter`; the engine
     // looks through it for repeatability and element hooks.
@@ -1369,16 +1440,13 @@ object Tel extends Tel2:
   given stringParsable: String is Tel.Parsable =
     primitiveParsable(Morphology.Str, t"String", ""): atom => atom.s
 
-  // Distinguish the two ways a byte-parsed primitive can be `Unset`: a missing
-  // atom raises `Absent`, a present-but-unparseable one raises
-  // `NotScalar(text, expected)` with the offending atom's text — exactly the
-  // `primitiveFault` split the AST path performs, so the two paths' errors agree.
-  private def byteScalarFault[value](reader: TelReader^, expected: Text, sentinel: value): value =
-    if reader.primaryPresent
-    then reader.fault(TelError.Reason.NotScalar(reader.primaryText.or(t""), expected)) yet sentinel
-    else reader.fault(TelError.Reason.Absent) yet sentinel
-
-  // `Int`/`Long`/`Boolean` read their value straight from the atom's arena
+  // `Int`/`Long`/`Boolean` distinguish the two ways a byte-parsed primitive
+  // can be `Unset` through `Parsable.scalarFault`: a missing atom raises
+  // `Absent`, a present-but-unparseable one raises `NotScalar(text, expected)`
+  // with the offending atom's text — exactly the `primitiveFault` split the
+  // AST path performs, so the two paths' errors agree.
+  //
+  // They read their value straight from the atom's arena
   // bytes (`reader.int()`/`long()`/`boolean()`), so a valid scalar never
   // materializes the value `String` that `atom()` would — only a rejected one
   // does, for its error. `Double` keeps the text path: replicating
@@ -1390,7 +1458,7 @@ object Tel extends Tel2:
       def shape(): Morphology = Morphology.Whole
 
       def parse(reader: TelReader^, indent: Int): Int =
-        reader.int().lay(byteScalarFault(reader, t"Int", 0))(identity)
+        reader.int().lay(Parsable.scalarFault(reader, t"Int", 0))(identity)
 
       override def absent()(using Tactic[TelError]): Int =
         raise(TelError(TelError.Reason.Absent)) yet 0
@@ -1401,7 +1469,7 @@ object Tel extends Tel2:
       def shape(): Morphology = Morphology.Whole
 
       def parse(reader: TelReader^, indent: Int): Long =
-        reader.long().lay(byteScalarFault(reader, t"Long", 0L))(identity)
+        reader.long().lay(Parsable.scalarFault(reader, t"Long", 0L))(identity)
 
       override def absent()(using Tactic[TelError]): Long =
         raise(TelError(TelError.Reason.Absent)) yet 0L
@@ -1416,7 +1484,7 @@ object Tel extends Tel2:
       def shape(): Morphology = Morphology.Bool
 
       def parse(reader: TelReader^, indent: Int): Boolean =
-        reader.boolean().lay(byteScalarFault(reader, t"Boolean", false))(identity)
+        reader.boolean().lay(Parsable.scalarFault(reader, t"Boolean", false))(identity)
 
       override def absent()(using Tactic[TelError]): Boolean =
         raise(TelError(TelError.Reason.Absent)) yet false
@@ -4024,6 +4092,10 @@ object Tel extends Tel2:
         pos == bufEnd && more
       do ()
 
+      directKeywordLow = low
+      directKeywordHigh = high
+      directKeywordLen = len
+
       if len == 0 then t""
       else if len > 8 then
         Text(sliceText(startMark))
@@ -4072,6 +4144,13 @@ object Tel extends Tel2:
     private var directEntryIndent:  Int = 0
     private var directEntryLine:    Int = 1
     private var directEntryKeyword: Text = t""
+
+    // Fingerprint of the keyword most recently read by `readKeyword` — the
+    // packed words it computes anyway for the intern cache (low = bytes 0–3,
+    // high = bytes 4–7, LSB-first), and the keyword's byte length.
+    private var directKeywordLow:  Long = 0L
+    private var directKeywordHigh: Long = 0L
+    private var directKeywordLen:  Int = 0
 
     // The tabulation header governing subsequent rows at the same indent, and
     // the classification of the most recent group of consumed lines — the
@@ -4196,6 +4275,41 @@ object Tel extends Tel2:
           done = true
 
       result
+
+    // The keyword most recently stepped to, as interned text — behind
+    // `TelReader.keywordText`, for staged parsers whose packed step reported
+    // the keyword opaque.
+    private[stratiform] def directKeywordText: Text = directEntryKeyword
+
+    // As `directKeyword`, but returning the keyword in packed form for staged
+    // parsers that compare keywords against literal constants: the keyword's
+    // bytes 0–7, LSB-first (`TelReader.KeywordEnd` once the entry region
+    // ends, or `TelReader.KeywordOpaque` for a keyword that cannot pack —
+    // empty, longer than eight bytes, or carrying bytes outside printable
+    // ASCII, whose packed form could alias a shorter keyword's or a
+    // sentinel). An opaque keyword is still consumed: `directKeywordText`
+    // identifies it for the caller's general dispatch.
+    private[stratiform] def directKeywordWord(indent: Int): Long raises TelError =
+      if directKeyword(indent) == null then TelReader.KeywordEnd
+      else
+        val len = directKeywordLen
+
+        if len < 1 || len > 8 then TelReader.KeywordOpaque
+        else
+          val packed = (directKeywordLow & 0xFFFFFFFFL) | (directKeywordHigh << 32)
+
+          // SWAR printability test on the first `len` bytes: the tail is
+          // filled with a printable byte so only real content can trip the
+          // below-0x21, DEL or high-bit conditions.
+          val tail = if len == 8 then 0L else -1L << (len*8)
+          val filled = packed | (tail & 0x2121212121212121L)
+          val below = (filled - 0x2121212121212121L) & ~filled & 0x8080808080808080L
+          val del = { val x = filled ^ 0x7F7F7F7F7F7F7F7FL
+                      (x - 0x0101010101010101L) & ~x & 0x8080808080808080L }
+
+          if (below | del | (packed & 0x8080808080808080L)) != 0L
+          then TelReader.KeywordOpaque
+          else packed
 
     // Consume the current entry in full — line remainder, source/literal
     // continuation, and children — materializing it as the single compound

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -4109,16 +4109,49 @@ object Tel extends Tel2:
     // atom's text, or Unset when the line carries none — mirroring
     // `Tel#primaryAtom`, where a source/literal atom never supplies the
     // primary text. Backs the primitive parsers.
+    //
+    // Unlike `directCompound`, this does not materialize a `Tel.Compound`,
+    // its `IArray[Atom]` (`takeAtoms`) or its children: it reads the inline
+    // atoms into scratch, pulls the first one's text, rewinds the scratch
+    // index without copying, and consumes (discarding) the source/literal
+    // continuation and child subtree so the reader still lands on the next
+    // sibling. For a scalar leaf that is one `String` allocation and nothing
+    // more — the direct path made genuinely direct.
     private[stratiform] def directAtomText(): Optional[Text] raises TelError =
-      val compound = directCompound(directEntryIndent)
-      var index = 0
+      val spaces = directEntrySpaces
+      val indent = directEntryIndent
+      val tabulated = directTabulation.present
+      val atomsStart = atomScratchIx
+      parseCompoundLineRest(directEntryLine)
+      prevContentLeadingSpaces = spaces
+      prevLineWasBoundary = false
+      fillHead()
 
-      while index < compound.atoms.length do
-        compound.atoms(index) match
-          case atom: Tel.Atom.Inline => return Optional(atom.text)
-          case _                     => index += 1
+      val extraAtom: Optional[Tel.Atom] =
+        if tabulated then Unset else parseSourceOrLiteralAtomIfPresent(spaces)
 
-      Unset
+      // The primary text is the first inline atom's; a source/literal atom
+      // never supplies it, so `extraAtom` is only consumed, not inspected.
+      var result: Optional[Text] = Unset
+      var index = atomsStart
+
+      while index < atomScratchIx do
+        scratchAtoms(index) match
+          case inline: Tel.Atom.Inline => if result.absent then result = Optional(inline.text)
+          case _                       => ()
+
+        index += 1
+
+      atomScratchIx = atomsStart
+
+      // Mirror `directCompound`: children are parsed (and here discarded) only
+      // when no source/literal atom and no tabulation intervened; otherwise a
+      // following deeper line is over-indented and fails with the same reason.
+      if !tabulated && extraAtom.absent then parseChildren(indent)
+      else if !head.eof && !head.separator && !head.blank && head.indentLevels > indent
+      then errorAt(directOverIndentReason, head.startLine, 1)
+
+      result
 
     // Consume the rest of the entry's own line (atoms, remark) and any
     // source/literal continuation, but not its child lines — the step before

--- a/lib/stratiform/src/core/stratiform.TelReader.scala
+++ b/lib/stratiform/src/core/stratiform.TelReader.scala
@@ -37,6 +37,11 @@ import contingency.*
 import vacuous.*
 
 object TelReader:
+  // Sentinels of `keywordWord()`; impossible as packed keywords, whose bytes
+  // are all printable ASCII.
+  inline final val KeywordEnd = -1L
+  inline final val KeywordOpaque = -2L
+
   // Only stratiform's read path (`Tel.parseDirect`) constructs readers, so
   // the parser-pool invariants (one exclusive `Parser` per thread) and the
   // resolution scope of the carried tactic are preserved by construction.
@@ -72,6 +77,20 @@ extends caps.ExclusiveCapability, caps.Stateful:
   update def keyword(indent: Int): Optional[Text] =
     val next = parser.directKeyword(indent)(using errorTactic)
     if next == null then Unset else next.nn
+
+  // The next keyword step in packed form, for parsers that compare keywords
+  // against literal constants (staged parsers compile wire keywords to
+  // immediates): the keyword's bytes packed LSB-first (at most eight
+  // printable-ASCII bytes), `KeywordEnd` once the entry region ends, or
+  // `KeywordOpaque` for a keyword that cannot pack — the keyword is still
+  // consumed, and `keywordText` identifies it for a general dispatch. Public
+  // because staged parsers are generated into user modules.
+  update def keywordWord(indent: Int): Long =
+    parser.directKeywordWord(indent)(using errorTactic)
+
+  // The keyword most recently stepped to — the `KeywordOpaque` complement of
+  // `keywordWord`.
+  update def keywordText: Text = parser.directKeywordText
 
   // Peeks (without consuming) whether the entry has substance — an inline
   // atom or a child compound — the AST `optionalDecodable`'s emptiness test,

--- a/lib/stratiform/src/core/stratiform.TelReader.scala
+++ b/lib/stratiform/src/core/stratiform.TelReader.scala
@@ -87,6 +87,23 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // primitive parsers.
   update def atom(): Optional[Text] = parser.directAtomText()(using errorTactic)
 
+  // The entry's primary atom parsed straight from its arena bytes as an
+  // integer / boolean, or `Unset` for a missing or wrong-shaped atom — the
+  // number/boolean readers, saving the value `String` the `atom()` path would
+  // materialize only for the primitive to re-scan. After an `Unset`,
+  // `primaryPresent` says whether an atom was there (missing → `Absent`,
+  // present-but-unparseable → `NotScalar`) and `primaryText` gives that atom's
+  // text for the error, matching the AST path byte-for-byte.
+  update def int(): Optional[Int] = parser.directAtomInt()(using errorTactic)
+  update def long(): Optional[Long] = parser.directAtomLong()(using errorTactic)
+  update def boolean(): Optional[Boolean] = parser.directAtomBoolean()(using errorTactic)
+
+  update def primaryPresent: Boolean = parser.directPrimaryPresent
+
+  update def primaryText: Optional[Text] =
+    val text = parser.directPrimaryText
+    if text == null then Unset else Optional(Text(text))
+
   // Consumes only the entry's own line (and any source/literal
   // continuation), leaving its children for the caller to parse one level
   // deeper — the step before a nested record's field loop.

--- a/lib/stratiform/src/core/stratiform.internal.scala
+++ b/lib/stratiform/src/core/stratiform.internal.scala
@@ -38,6 +38,7 @@ import anticipation.*
 import contingency.*
 import fulminate.*
 import gigantism.*
+import gossamer.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -456,3 +457,420 @@ object internal:
           local += Tel.scalar(Text(s.substring(pos, end).nn))
           out ++= local
           true
+
+  // ── Staged parser generation ──────────────────────────────────────────────
+  // Generates a monomorphic `Tel.Parsable` for a case class: field values
+  // live in typed locals, keywords dispatch through packed-`Long` literal
+  // comparisons (with a linear text step for unpackable keywords), builtin
+  // primitives read inline off the reader, and the record is built by a
+  // direct constructor call — no `Array[Any]` buffer, no `Mirror`, no
+  // per-field boxing. Field types beyond the builtins resolve through
+  // `Tel.Field` instances (summoned at expansion, initialized lazily so
+  // recursive references stay deferred), so semantics — wire keywords,
+  // gathering of repeatable fields, first-match-wins duplicates, defaults,
+  // absents, error foci — are identical to `ParsableDerivation`. The body is
+  // assembled from reflection trees with only small, immediately-scoped
+  // quotes: chained quotes carrying `Type` bindings through closures are
+  // unpicklable.
+
+  private enum StagedKind:
+    case IntK, LongK, BooleanK, TextK, StringK, InstanceK
+
+  def stagedParsable[value: Type](renames: Expr[Map[Text, Text]])(using Quotes)
+  :   Expr[value is Tel.Parsable] =
+
+    import quotes.reflect.*
+    import StagedKind.*
+
+    val tpe = TypeRepr.of[value].dealias
+
+    val classSymbol = tpe.classSymbol.getOrElse:
+      report.errorAndAbort("stratiform: staged parsing requires a case class")
+
+    if !classSymbol.flags.is(Flags.Case) then
+      report.errorAndAbort
+        ("stratiform: staged parsing requires a case class; sums and other types use "+
+          "`Tel.Parsable.derived`")
+
+    if classSymbol.owner.isTerm then
+      report.errorAndAbort
+        ("stratiform: staged parsing requires a top-level or object-nested case class; "+
+          "method-local classes use `Tel.Parsable.derived`")
+
+    val ctor = classSymbol.primaryConstructor
+
+    if ctor.paramSymss.filterNot(_.exists(_.isTypeParam)).length != 1 then
+      report.errorAndAbort
+        ("stratiform: staged parsing requires a single parameter list; use "+
+          "`Tel.Parsable.derived`")
+
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    def kindOf(fieldType: TypeRepr): StagedKind =
+      if fieldType =:= TypeRepr.of[Int] then IntK
+      else if fieldType =:= TypeRepr.of[Long] then LongK
+      else if fieldType =:= TypeRepr.of[Boolean] then BooleanK
+      else if fieldType =:= TypeRepr.of[Text] then TextK
+      else if fieldType =:= TypeRepr.of[String] then StringK
+      else InstanceK
+
+    val kinds: List[StagedKind] = fieldTypes.map(kindOf)
+
+    // Keywords compile to literal packed-word comparisons when no `@name`
+    // annotation can rename them (renames resolve at runtime, so annotated
+    // classes keep the linear text step for every keyword). The literals use
+    // the same camel→kebab mapping `Tel.Parsable.wireKeywords` applies at
+    // runtime. A wire keyword that cannot pack (longer than eight bytes)
+    // still parses: it always arrives as `KeywordOpaque` and takes the
+    // general text step, which matches all fields by string.
+    val literalKeys: Boolean =
+      val annotated = ctor.paramSymss.flatten.filterNot(_.isTypeParam).flatMap(_.annotations)
+        ++ fields.flatMap(_.annotations)
+
+      !annotated.exists { annotation =>
+        annotation.tpe <:< TypeRepr.of[adversaria.name[?]] }
+
+    val wireNames: List[String] = fieldNames.map { name => Tel.camelToKebab(name).s }
+
+    def packedKeyword(index: Int): Option[Long] =
+      val name = wireNames(index)
+      val length = name.length
+
+      val packs = length > 0 && length <= 8 &&
+        name.forall { char => char >= '!' && char <= '~' }
+
+      if !packs then None else
+        var word = 0L
+        var position = 0
+
+        while position < length do
+          word |= (name.charAt(position).toLong & 0xFF) << (position*8)
+          position += 1
+
+        Some(word)
+
+    val packedKeywords: List[Option[Long]] = List.range(0, arity).map(packedKeyword)
+
+    def summonField(index: Int): Expr[Tel.Field | Null] =
+      if kinds(index) != InstanceK then '{null}
+      else fieldTypes(index).asType match
+        case '[fieldType] =>
+          Expr.summon[fieldType is Tel.Field].getOrElse:
+            report.errorAndAbort
+              (s"stratiform: no Tel.Field instance for field ${fieldNames(index)}: "+
+                fieldTypes(index).show)
+
+    def declaredDefault(index: Int): Expr[Any] = fieldTypes(index).asType match
+      case '[fieldType] =>
+        '{ wisteria.internal.default[value, fieldType](${Expr(index)}): Any }
+
+    def zero(fieldType: TypeRepr): Term =
+      if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+      else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+      else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+      else fieldType.asType match
+        case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+    def body
+      ( reader:      Expr[TelReader],
+        indent:      Expr[Int],
+        foci:        Expr[Foci[Tel.Focus]],
+        tactic:      Expr[Tactic[TelError]],
+        keys:        Expr[IArray[String]],
+        instances:   Expr[IArray[Tel.Field | Null]],
+        repeatables: Expr[IArray[Boolean]],
+        fallbacks:   Expr[IArray[Any]] )
+    :   Expr[value] =
+
+      val owner = Symbol.spliceOwner
+      val bufferType = TypeRepr.of[scala.collection.mutable.ListBuffer[Any] | Null]
+
+      val slots = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+      val seens = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      // Occurrence buffers for the fields that may gather (repeatable
+      // instances), allocated lazily on the first occurrence.
+      val buffers: List[Option[Symbol]] = List.range(0, arity).map: index =>
+        if kinds(index) != InstanceK then None else
+          Some(Symbol.newVal(owner, "gather"+index, bufferType, Flags.Mutable, Symbol.noSymbol))
+
+      val slotDefs = List.range(0, arity).map: index =>
+        ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+      val seenDefs = List.range(0, arity).map: index =>
+        ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val bufferDefs = List.range(0, arity).flatMap: index =>
+        buffers(index).map: symbol =>
+          ValDef(symbol, Some('{ null }.asTerm))
+
+      val unit = Literal(UnitConstant())
+
+      // One dispatch arm per field: read the value (with focus bookkeeping),
+      // honoring the derived engine's semantics — a repeatable field gathers
+      // every occurrence, a non-repeatable one keeps its first and skips the
+      // rest.
+      val arms = List.range(0, arity).map: index =>
+        val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+
+        def firstWins(read: Term): Term =
+          If
+            ( Ref(seens(index)),
+              '{ $reader.skipEntry($indent) }.asTerm,
+              Block
+                ( List
+                    ( Assign(Ref(slots(index)), read),
+                      Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                  unit ) )
+
+        val rhs: Term = fieldTypes(index).asType match
+          case '[fieldType] =>
+            kinds(index) match
+              case IntK =>
+                firstWins:
+                  '{
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $reader.int().lay(Tel.Parsable.scalarFault($reader, t"Int", 0))(identity)
+                  }.asTerm
+
+              case LongK =>
+                firstWins:
+                  '{
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $reader.long().lay(Tel.Parsable.scalarFault($reader, t"Long", 0L))(identity)
+                  }.asTerm
+
+              case BooleanK =>
+                firstWins:
+                  '{
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $reader.boolean()
+                      . lay(Tel.Parsable.scalarFault($reader, t"Boolean", false))(identity)
+                  }.asTerm
+
+              case TextK =>
+                firstWins:
+                  '{
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $reader.atom()
+                      . lay { $reader.fault(TelError.Reason.Absent); t"" } (identity)
+                  }.asTerm
+
+              case StringK =>
+                firstWins:
+                  '{
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $reader.atom()
+                      . lay { $reader.fault(TelError.Reason.Absent); "" } { atom => atom.s }
+                  }.asTerm
+
+              case InstanceK =>
+                val bufferRef = Ref(buffers(index).get)
+
+                val bufferExpr =
+                  bufferRef.asExprOf[scala.collection.mutable.ListBuffer[Any] | Null]
+
+                val ensure: Term =
+                  If
+                    ( '{ $bufferExpr == null }.asTerm,
+                      Assign
+                        ( bufferRef,
+                          '{ scala.collection.mutable.ListBuffer.empty[Any] }.asTerm ),
+                      unit )
+
+                val append: Term =
+                  '{
+                    $bufferExpr.asInstanceOf[scala.collection.mutable.ListBuffer[Any]].addOne
+                      ( Tel.Parsable.focusing($foci, $keyText):
+                          Tel.Parsable.parseElement
+                            ( $instances(${Expr(index)}).asInstanceOf[Tel.Parsing],
+                              $reader,
+                              $indent ) )
+                  }.asTerm
+
+                val read: Term =
+                  '{
+                    Tel.Parsable.focusing($foci, $keyText):
+                      $instances(${Expr(index)}).asInstanceOf[fieldType is Tel.Field]
+                      . parse($reader, $indent)
+                  }.asTerm
+
+                If
+                  ( '{ $repeatables(${Expr(index)}) }.asTerm,
+                    Block(List(ensure, append), unit),
+                    firstWins(read) )
+
+        CaseDef(Literal(IntConstant(index)), None, rhs)
+
+      val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipEntry($indent) }.asTerm)
+
+      // The keyword loop. With literal keywords, each step compares the
+      // packed word against the wire keywords as immediate constants,
+      // resolving an opaque keyword through the linear text step; otherwise
+      // (runtime renames) every keyword resolves through the text step.
+      val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+      val word = Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+      val found = Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+      val wordRef = Ref(word).asExprOf[Long]
+
+      def chain(index: Int): Term =
+        if index == arity then Literal(IntConstant(-1))
+        else packedKeywords(index) match
+          case None => chain(index + 1)
+
+          case Some(packed) =>
+            If
+              ( '{ $wordRef == ${Expr(packed)} }.asTerm,
+                Literal(IntConstant(index)),
+                chain(index + 1) )
+
+      val textStep: Term = '{ Tel.Parsable.keywordIndex($keys, $reader.keywordText) }.asTerm
+
+      val resolve: Term =
+        if literalKeys then
+          If('{ $wordRef == TelReader.KeywordOpaque }.asTerm, textStep, chain(0))
+        else textStep
+
+      val step: Term =
+        Block
+          ( List(ValDef(word, Some('{ $reader.keywordWord($indent) }.asTerm))),
+            If
+              ( '{ $wordRef == TelReader.KeywordEnd }.asTerm,
+                Assign(Ref(run), Literal(BooleanConstant(false))),
+                Block
+                  ( List(ValDef(found, Some(resolve))),
+                    Match(Ref(found), arms :+ fallthrough) ) ) )
+
+      val loop: List[Statement] =
+        List(ValDef(run, Some(Literal(BooleanConstant(true)))), While(Ref(run), step))
+
+      // Fields whose keywords never arrived — and repeatable fields, whose
+      // collection is always built from the gathered occurrences (zero
+      // occurrences build the empty collection; a repeatable field never
+      // consults the declared default), exactly as the derived engine does.
+      val absents: List[Term] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+
+            val onAbsent: Expr[fieldType] = kinds(index) match
+              case InstanceK =>
+                '{
+                  $instances(${Expr(index)}).asInstanceOf[fieldType is Tel.Field]
+                  . absent()(using $tactic)
+                }
+
+              case IntK     => '{ Tel.Parsable.missing[Int](0)(using $tactic) }.asExprOf[fieldType]
+              case LongK    => '{ Tel.Parsable.missing[Long](0L)(using $tactic) }.asExprOf[fieldType]
+              case TextK    => '{ Tel.Parsable.missing[Text](t"")(using $tactic) }.asExprOf[fieldType]
+              case StringK  => '{ Tel.Parsable.missing[String]("")(using $tactic) }.asExprOf[fieldType]
+
+              case BooleanK =>
+                '{ Tel.Parsable.missing[Boolean](false)(using $tactic) }.asExprOf[fieldType]
+
+            val resolveAbsent: Term =
+              Assign
+                ( Ref(slots(index)),
+                  '{
+                    val declared = $fallbacks(${Expr(index)}).asInstanceOf[Optional[fieldType]]
+
+                    if !declared.absent then declared.asInstanceOf[fieldType]
+                    else Tel.Parsable.focusing($foci, $keyText)($onAbsent)
+                  }.asTerm )
+
+            val whenUnseen: Term =
+              If('{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm, resolveAbsent, unit)
+
+            kinds(index) match
+              case InstanceK =>
+                val bufferExpr =
+                  Ref(buffers(index).get)
+                  . asExprOf[scala.collection.mutable.ListBuffer[Any] | Null]
+
+                val gatherFinish: Term =
+                  Assign
+                    ( Ref(slots(index)),
+                      '{
+                        Tel.Parsable.focusing($foci, $keyText):
+                          Tel.Parsable.gathered[fieldType]
+                            ( $instances(${Expr(index)}).asInstanceOf[Tel.Parsing],
+                              $bufferExpr match
+                                case null   => Nil
+                                case buffer => buffer.toList )
+                      }.asTerm )
+
+                If('{ $repeatables(${Expr(index)}) }.asTerm, gatherFinish, whenUnseen)
+
+              case _ =>
+                whenUnseen
+
+      val construct: Term =
+        val typeArguments = tpe match
+          case AppliedType(_, arguments) => arguments
+          case _                         => Nil
+
+        val newTerm = Select(New(Inferred(tpe)), ctor)
+
+        val applied =
+          if typeArguments.isEmpty then newTerm
+          else TypeApply(newTerm, typeArguments.map { argument => Inferred(argument) })
+
+        Apply(applied, slots.map { slot => Ref(slot) })
+
+      Block(slotDefs ::: seenDefs ::: bufferDefs ::: loop ::: absents, construct)
+      . asExprOf[value]
+
+    def summonOrAbort[required: Type](role: String): Expr[required] =
+      Expr.summon[required].getOrElse:
+        report.errorAndAbort(s"stratiform: staged parsing needs a contextual $role")
+
+    val fociExpr = summonOrAbort[Foci[Tel.Focus]]("Foci[Tel.Focus]")
+    val tacticExpr = summonOrAbort[Tactic[TelError]]("Tactic[TelError]")
+    val nameExprs = fieldNames.map { name => Expr(name) }
+    val instanceExprs = List.range(0, arity).map(summonField)
+    val fallbackExprs = List.range(0, arity).map(declaredDefault)
+
+    '{
+      // Sealed per the codec-thunk pattern, like the derived instances: the
+      // generated parser captures the resolution-scoped tactic and foci.
+      // The instance and default arrays are single lazy vals, so recursive
+      // self-references stay deferred until the first parse.
+      caps.unsafe.unsafeAssumePure:
+        val foci: Foci[Tel.Focus] = $fociExpr
+        val tactic: Tactic[TelError] = $tacticExpr
+
+        val keys: IArray[String] =
+          Tel.Parsable.wireKeywords(IArray[String](${Varargs(nameExprs)}*), $renames)
+
+        lazy val instances: IArray[Tel.Field | Null] = IArray(${Varargs(instanceExprs)}*)
+
+        lazy val repeatables: IArray[Boolean] =
+          instances.map { instance => instance != null && Tel.Parsable.repeats(instance) }
+
+        lazy val fallbacks: IArray[Any] = IArray[Any](${Varargs(fallbackExprs)}*)
+
+        new Tel.Parsable:
+          type Self = value
+          def shape(): Morphology = Morphology.Any
+
+          def parse(reader: TelReader^, indent: Int): value =
+            reader.finishLine()
+            ${
+              body
+                ( '{reader}, '{indent + 1}, '{foci}, '{tactic}, '{keys}, '{instances},
+                  '{repeatables}, '{fallbacks} )
+            }
+
+          override def parse(reader: TelReader^): value =
+            ${
+              body
+                ( '{reader}, '{0}, '{foci}, '{tactic}, '{keys}, '{instances},
+                  '{repeatables}, '{fallbacks} )
+            }
+    }

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -419,6 +419,98 @@ object Tests extends Suite(m"Stratiform Tests"):
         (doc.read[Tests.Crew in Tel], parity[Tests.Crew](doc))
       . assert(_ == (Tests.Crew(Tests.Worker(t"Syd", 0), 3), true))
 
+    suite(m"Staged direct parsing tests"):
+      given Tests.Person is Tel.Parsable = Tel.Parsable.staged
+      given Tests.Team is Tel.Parsable = Tel.Parsable.staged
+      given Tests.Renamed is Tel.Parsable = Tel.Parsable.staged
+      given Tests.WithDefault is Tel.Parsable = Tel.Parsable.staged
+      given Tests.KebabRecord is Tel.Parsable = Tel.Parsable.staged
+      given Tests.Company is Tel.Parsable = Tel.Parsable.staged
+      given Tests.OptField is Tel.Parsable = Tel.Parsable.staged
+      given Tests.Tree is Tel.Parsable = Tel.Parsable.staged
+      given Tests.TreeOpt is Tel.Parsable = Tel.Parsable.staged
+
+      // The acceptance criterion for staged generation: the staged read must
+      // equal the AST-path read, for the same input.
+      inline def parity[value](tel: Text)(using value is Tel.Parsable, value is Tel.Decodable)
+      :   Boolean =
+        tel.read[value in Tel] == tel.read[Tel].as[value]
+
+      test(m"A staged parser reads a simple record"):
+        t"name Alice\nage 30\n".read[Tests.Person in Tel]
+      . assert(_ == Tests.Person(t"Alice", 30))
+
+      test(m"A staged parser accepts reordered fields, equally on both paths"):
+        parity[Tests.Person](t"age 30\nname Alice\n")
+      . assert(identity)
+
+      test(m"Staged field names map to kebab-case keywords"):
+        t"first-name Jo\nshoe-size 9\n".read[Tests.KebabRecord in Tel]
+      . assert(_ == Tests.KebabRecord(t"Jo", 9))
+
+      test(m"@name renames apply to staged parsing"):
+        parity[Tests.Renamed](t"full_name Jon\nyob 1983\n")
+      . assert(identity)
+
+      test(m"A staged parser takes declared defaults"):
+        t"name Kid\n".read[Tests.WithDefault in Tel]
+      . assert(_ == Tests.WithDefault(t"Kid", 18))
+
+      test(m"A staged parser raises TelError Absent for missing required fields"):
+        capture[TelError](t"age 30\n".read[Tests.Person in Tel]).reason
+      . assert(_ == TelError.Reason.Absent)
+
+      test(m"A staged parser gathers a repeatable field's scattered occurrences"):
+        val doc = t"members\n  name Amy\n  age 1\nname Alpha\nmembers\n  name Bea\n  age 2\n"
+        (doc.read[Tests.Team in Tel], parity[Tests.Team](doc))
+      . assert(_ == (Tests.Team(t"Alpha", List(Tests.Person(t"Amy", 1), Tests.Person(t"Bea", 2))),
+          true))
+
+      test(m"A staged parser keeps the first match of a duplicate keyword"):
+        val doc = t"name Amy\nname Bea\nage 50\n"
+        (doc.read[Tests.Person in Tel], parity[Tests.Person](doc))
+      . assert(_ == (Tests.Person(t"Amy", 50), true))
+
+      test(m"Nested records parse through sibling staged instances"):
+        val doc = t"title Acme\nboss\n  name Bob\n  age 40\n"
+        (doc.read[Tests.Company in Tel], parity[Tests.Company](doc))
+      . assert(_ == (Tests.Company(t"Acme", Tests.Person(t"Bob", 40)), true))
+
+      test(m"A staged parser reads absent and present Optional fields"):
+        ( t"x 1\n".read[Tests.OptField in Tel],
+          t"x 1\nnote hello\n".read[Tests.OptField in Tel] )
+      . assert(_ == (Tests.OptField(1, Unset), Tests.OptField(1, t"hello")))
+
+      test(m"A staged parser skips unknown keywords with their subtrees"):
+        t"name Amy\nextra one two\n  deep 1\n  deeper\n    x 9\nage 50\n"
+        . read[Tests.Person in Tel]
+      . assert(_ == Tests.Person(t"Amy", 50))
+
+      test(m"Comments and blank lines are transparent to a staged parser"):
+        parity[Tests.Person](t"# leading\nname Amy\n\n# interlude\nage 50\n")
+      . assert(identity)
+
+      test(m"Recursive types parse through a staged instance"):
+        val doc = t"value a\nchildren\n  value b\nchildren\n  value c\n"
+        (doc.read[Tests.Tree in Tel], parity[Tests.Tree](doc))
+      . assert(_ == (Tests.Tree(t"a", List(Tests.Tree(t"b", Nil), Tests.Tree(t"c", Nil))), true))
+
+      test(m"Recursion through an Optional parses through a staged instance"):
+        val doc = t"value a\nchild\n  value b\n"
+        (doc.read[Tests.TreeOpt in Tel], parity[Tests.TreeOpt](doc))
+      . assert(_ == (Tests.TreeOpt(t"a", Tests.TreeOpt(t"b", Unset)), true))
+
+      test(m"A top-level collection reads staged elements"):
+        val doc = t"p\n  name Amy\n  age 1\nq\n  name Bea\n  age 2\n"
+        (doc.read[List[Tests.Person] in Tel], parity[List[Tests.Person]](doc))
+      . assert(_ == (List(Tests.Person(t"Amy", 1), Tests.Person(t"Bea", 2)), true))
+
+      test(m"A keyword longer than eight bytes dispatches through the text step"):
+        // `first-name` cannot pack into a single word, so it exercises the
+        // `KeywordOpaque` fallback; `shoe-size` stays on the packed chain.
+        parity[Tests.KebabRecord](t"shoe-size 9\nfirst-name Jo\n")
+      . assert(identity)
+
     suite(m"tel\"…\" interpolator"):
       test(m"simple literal"):
         val parsed = tel"hello"

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -699,6 +699,18 @@ object Xml extends Tag.Container
     inline def derived[value](using Reflection[value]): value is Xml.Parsable =
       fromField(ParsableDerivation.derivedOne[value])
 
+    // The staged counterpart of `derived`: a macro-generated monomorphic
+    // parser whose field values live in typed locals, whose child elements
+    // dispatch through packed-`Long` literal comparisons, and whose record
+    // is built by a direct constructor call — no `Array[Any]` buffer, no
+    // `Mirror`, no per-field boxing. Semantics (wire names, `@attribute`
+    // fields, gathering, first-match-wins duplicates, defaults, absents,
+    // error foci) mirror `derived` exactly. Requires a top-level or
+    // object-nested case class with a single parameter list — sums,
+    // method-local classes and other shapes use `derived`.
+    inline def staged[value]: value is Xml.Parsable =
+      ${ xylophone.internal.stagedParsable[value]('{ adversaria.relabelling[value, Xml] }) }
+
     def fromField[value](field0: (value is Xml.Parsing)^)
     :   ((value is Xml.Parsable)^{field0}) =
 
@@ -793,6 +805,56 @@ object Xml extends Tag.Container
     // per-field focus (`base.prepend(wireName, 1)`).
     private def descend(base0: Optional[Xml.Focus], name: Text): Xml.Focus =
       Xml.Focus(base0.let(_.path).or(XPath()).prepend(name, 1))
+
+    // Support points for staged parsers, which are generated into user
+    // modules and so may only reference public members.
+
+    // The wire names of a product's fields, `@name` renames applied.
+    def wireNames(names: IArray[String], renames: Map[Text, Text]): IArray[String] =
+      names.map { name => renames.at(name.tt).or(name.tt).s }
+
+    // A required primitive field whose name never arrived: the primitives'
+    // `absent()` semantics — raise and continue with the sentinel.
+    def missing[value](sentinel: value)(using Tactic[XmlError]): value =
+      raise(XmlError()) yet sentinel
+
+    // Focus bookkeeping for one field read, compiled away when the read
+    // site's `Foci` is the inert default — the same short-circuit as the
+    // derived parser's loop.
+    inline def focusing[result](foci: Foci[Xml.Focus], name: Text)(inline block: => result)
+    :   result =
+      if foci.active then focus(using foci)(descend(prior, name))(block) else block
+
+    // Linear child dispatch for the general step — an unpackable child name,
+    // or any child of a `@name`-annotated record. An `@attribute` field
+    // never matches a child element, exactly as the derived engine's
+    // `indexOf` skips them.
+    def childIndex(keys: IArray[String], attributes: IArray[Boolean], label: Text): Int =
+      val count = keys.length
+      val name: String = label.s
+      var index = 0
+
+      while index < count do
+        if !attributes(index) && keys(index) == name then return index
+        index += 1
+
+      -1
+
+    // The repeatable-field hooks, looking through the `Field.Adapter` — for
+    // staged parsers, which cannot name the private `Gathering` trait. A
+    // field gathers only when its (unwrapped) instance is a repeatable
+    // `Gathering`, exactly the derived engine's test.
+    def repeats(parsing: Xml.Parsing): Boolean =
+      val actual = unwrap(parsing)
+      actual.repeatable && actual.isInstanceOf[Gathering]
+
+    def parseElement(parsing: Xml.Parsing, reader: XmlReader^): Any =
+      (unwrap(parsing): @unchecked) match
+        case gathering: Gathering => gathering.parseElement(reader)
+
+    def gathered[value](parsing: Xml.Parsing, elements: List[Any]): value =
+      (unwrap(parsing): @unchecked) match
+        case gathering: Gathering => gathering.gathered(elements).asInstanceOf[value]
 
     // The derived product parser's engine. `fields0` is an explicit thunk
     // (nameable in the capture set, unlike a by-name) evaluated lazily, so
@@ -1912,6 +1974,13 @@ object Xml extends Tag.Container
     private val tagCacheLow:  Array[Long]        = new Array(TagCacheSize)
     private val tagCacheHigh: Array[Long]        = new Array(TagCacheSize)
 
+    // Fingerprint of the name most recently read by `readName` — the packed
+    // words it computes anyway for the tag cache, and whether they identify
+    // the name losslessly (ASCII, at most `TagCacheMaxChars` chars).
+    private var nameLow:      Long = 0L
+    private var nameHigh:     Long = 0L
+    private var namePackable: Boolean = false
+
     private inline def getNodeBuffer(): scala.collection.mutable.ArrayBuffer[Node] =
       nodeBufferId += 1
 
@@ -2206,6 +2275,10 @@ object Xml extends Tag.Container
 
         len += 1
         advance()
+
+      nameLow = packedLow
+      nameHigh = packedHigh
+      namePackable = ascii && len <= TagCacheMaxChars
 
       if !ascii || len > TagCacheMaxChars then slice(start)
       else
@@ -3149,6 +3222,14 @@ object Xml extends Tag.Container
     private var directAttributes1: Attributes = Attributes.empty
     private var directEmpty: Boolean = false
 
+    // The most recently opened child's name fingerprint (snapshotted in
+    // `directOpen` before `readAttributes` clobbers `readName`'s), and the
+    // child's interned name for the `NameOpaque` general dispatch.
+    private var directChildLow:      Long = 0L
+    private var directChildHigh:     Long = 0L
+    private var directChildPackable: Boolean = false
+    private var directChildName:     Text = t""
+
     private inline def directPop(): Text = directNames.remove(directNames.length - 1)
 
     // Establishes the cursor hold for a whole direct-parsing session,
@@ -3208,6 +3289,9 @@ object Xml extends Tag.Container
     // duplicate attributes) is identical to `readElement`'s.
     private def directOpen()(using Tactic[ParseError]): Text =
       val name = readName()
+      directChildLow = nameLow
+      directChildHigh = nameHigh
+      directChildPackable = namePackable
       directAttributes1 = readAttributes(name)
       if !more then fail(Issue.ExpectedMore)
 
@@ -3297,6 +3381,24 @@ object Xml extends Tag.Container
             readText(parent)
 
         result
+
+    // As `directNextChild`, but returning the child's name in packed form
+    // for staged parsers that compare names against literal constants: the
+    // packed low word (its high word from `directChildWordHigh`),
+    // `XmlReader.NameEnd` once the close tag is consumed, or
+    // `XmlReader.NameOpaque` when the name cannot pack (non-ASCII, or longer
+    // than sixteen chars) — the child is still opened, and
+    // `directChildLabel` identifies it for the general dispatch.
+    private[xylophone] def directNextChildWord()(using Tactic[ParseError]): Long =
+      val name = directNextChild()
+
+      if name == null then XmlReader.NameEnd
+      else
+        directChildName = name.nn
+        if !directChildPackable then XmlReader.NameOpaque else directChildLow
+
+    private[xylophone] def directChildWordHigh: Long = directChildHigh
+    private[xylophone] def directChildLabel: Text = directChildName
 
     // The current element's text content, consumed together with its close
     // tag: the text when the content is exactly one text run (or empty), or

--- a/lib/xylophone/src/core/xylophone.XmlReader.scala
+++ b/lib/xylophone/src/core/xylophone.XmlReader.scala
@@ -38,6 +38,11 @@ import vacuous.*
 import zephyrine.*
 
 object XmlReader:
+  // Sentinels of `childWord()`; impossible as packed names, whose chars are
+  // all 7-bit ASCII.
+  inline final val NameEnd = -1L
+  inline final val NameOpaque = -2L
+
   // Only xylophone's read path (`Xml.parseDirect`) constructs readers, so the
   // exclusivity of the wrapped parser and the resolution scope of the carried
   // capabilities are preserved by construction. The wrapped capabilities
@@ -82,10 +87,13 @@ extends caps.ExclusiveCapability, caps.Stateful:
   private[xylophone] inline def parseTactic: Tactic[ParseError] =
     tactic0.asInstanceOf[Tactic[ParseError]]
 
-  private[xylophone] inline def errorTactic: Tactic[XmlError] =
+  // The read-site capabilities, public because staged parsers — generated
+  // into user modules — bind them once per record for focus bookkeeping and
+  // absent-field raising, exactly as the derived engine does.
+  inline def errorTactic: Tactic[XmlError] =
     xmlTactic0.asInstanceOf[Tactic[XmlError]]
 
-  private[xylophone] inline def foci: Foci[Xml.Focus] = foci0.asInstanceOf[Foci[Xml.Focus]]
+  inline def foci: Foci[Xml.Focus] = foci0.asInstanceOf[Foci[Xml.Focus]]
 
   // The attributes of the just-opened element, valid until the next element
   // is opened. The derived product parser reads them before its child loop,
@@ -100,6 +108,19 @@ extends caps.ExclusiveCapability, caps.Stateful:
   update def nextChild(): Optional[Text] =
     val name = parser.directNextChild()(using parseTactic)
     if name == null then Unset else name.nn
+
+  // The next child step in packed form, for parsers that compare names
+  // against literal constants (staged parsers compile field names to
+  // immediates): the packed low word of the child's name (its high word from
+  // `childWordHigh`), `NameEnd` once the close tag is consumed, or
+  // `NameOpaque` when the name cannot pack — the child is still opened, and
+  // `childLabel` identifies it for a general dispatch. Public because staged
+  // parsers are generated into user modules.
+  update def childWord(): Long = parser.directNextChildWord()(using parseTactic)
+
+  update def childWordHigh: Long = parser.directChildWordHigh
+
+  update def childLabel: Text = parser.directChildLabel
 
   // The current element's text content, consumed together with its close
   // tag: `Unset` when the content is not exactly one text run (mirroring

--- a/lib/xylophone/src/core/xylophone.internal.scala
+++ b/lib/xylophone/src/core/xylophone.internal.scala
@@ -829,6 +829,21 @@ object internal:
 
         throw new NoSuchElementException(s"key not found: $key")
 
+      // `at` without the `Indexable` detour, whose resolution is ambiguous
+      // against the `IArray` instance under the opaque bound — used by
+      // staged parsers' generated `@attribute` steps.
+      def fetch(key: Text): Optional[Text] =
+        val a = storage(attrs)
+        val keyStr: String = key.s
+        val n = a.length
+        var i = 0
+
+        while i < n do
+          if a(i) == keyStr then return a(i + 1).asInstanceOf[Text]
+          i += 2
+
+        Unset
+
       def contains(key: Text): Boolean =
         val a = storage(attrs)
         val keyStr: String = key.s
@@ -1064,3 +1079,586 @@ object internal:
           i += 2
 
         h
+
+  // ── Staged parser generation ──────────────────────────────────────────────
+  // Generates a monomorphic `Xml.Parsable` for a case class: field values
+  // live in typed locals, child elements dispatch through packed-`Long`
+  // literal comparisons (with a linear text step for unpackable names),
+  // builtin primitives read through direct static calls, `@attribute` fields
+  // fill from the open tag before the child loop, and the record is built by
+  // a direct constructor call — no `Array[Any]` buffer, no `Mirror`, no
+  // per-field boxing. Field types beyond the builtins resolve through
+  // `Xml.Field` instances (summoned at expansion, initialized lazily so
+  // recursive references stay deferred), so semantics — wire names,
+  // gathering of repeatable fields, first-match-wins duplicates, defaults,
+  // absents, error foci — are identical to `ParsableDerivation`. Like the
+  // derived engine (and unlike jacinta's staged parser), no `Tactic` or
+  // `Foci` is captured at expansion: both come from the reader at the read
+  // site. The body is assembled from reflection trees with only small,
+  // immediately-scoped quotes: chained quotes carrying `Type` bindings
+  // through closures are unpicklable.
+
+  private enum StagedKind:
+    case IntK, LongK, DoubleK, FloatK, BooleanK, TextK, StringK, InstanceK
+
+  def stagedParsable[value: Type](renames: Expr[Map[Text, Text]])(using Quotes)
+  :   Expr[value is Xml.Parsable] =
+
+    import quotes.reflect.*
+    import StagedKind.*
+
+    val tpe = TypeRepr.of[value].dealias
+
+    val classSymbol = tpe.classSymbol.getOrElse:
+      report.errorAndAbort("xylophone: staged parsing requires a case class")
+
+    if !classSymbol.flags.is(Flags.Case) then
+      report.errorAndAbort
+        ("xylophone: staged parsing requires a case class; sums and other types use "+
+          "`Xml.Parsable.derived`")
+
+    if classSymbol.owner.isTerm then
+      report.errorAndAbort
+        ("xylophone: staged parsing requires a top-level or object-nested case class; "+
+          "method-local classes use `Xml.Parsable.derived`")
+
+    val ctor = classSymbol.primaryConstructor
+
+    if ctor.paramSymss.filterNot(_.exists(_.isTypeParam)).length != 1 then
+      report.errorAndAbort
+        ("xylophone: staged parsing requires a single parameter list; use "+
+          "`Xml.Parsable.derived`")
+
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    def kindOf(fieldType: TypeRepr): StagedKind =
+      if fieldType =:= TypeRepr.of[Int] then IntK
+      else if fieldType =:= TypeRepr.of[Long] then LongK
+      else if fieldType =:= TypeRepr.of[Double] then DoubleK
+      else if fieldType =:= TypeRepr.of[Float] then FloatK
+      else if fieldType =:= TypeRepr.of[Boolean] then BooleanK
+      else if fieldType =:= TypeRepr.of[Text] then TextK
+      else if fieldType =:= TypeRepr.of[String] then StringK
+      else InstanceK
+
+    val kinds: List[StagedKind] = fieldTypes.map(kindOf)
+
+    def annotationsOf(index: Int): List[Term] =
+      val params = ctor.paramSymss.flatten.filterNot(_.isTypeParam)
+      params(index).annotations ++ fields(index).annotations
+
+    // `@attribute` fields fill from the open tag and never match a child.
+    val attrFlags: List[Boolean] = List.range(0, arity).map: index =>
+      annotationsOf(index).exists { annotation => annotation.tpe <:< TypeRepr.of[Xml.attribute] }
+
+    // Names compile to literal packed-word comparisons when no `@name`
+    // annotation can rename them (renames resolve at runtime, so annotated
+    // classes keep the linear text step for every child). A field name that
+    // cannot pack still parses: it always arrives as `NameOpaque` and takes
+    // the general text step, which matches all fields by string.
+    val literalKeys: Boolean =
+      !List.range(0, arity).exists: index =>
+        annotationsOf(index).exists { annotation =>
+          annotation.tpe <:< TypeRepr.of[adversaria.name[?]] }
+
+    def packedName(index: Int): Option[(Long, Long)] =
+      val name = fieldNames(index)
+      val length = name.length
+
+      val packs = length > 0 && length <= 16 &&
+        name.forall { char => char >= '!' && char < 127 }
+
+      if !packs then None else
+        var low = 0L
+        var high = 0L
+        var position = 0
+
+        while position < length do
+          val byte = name.charAt(position).toLong & 0xFF
+          if position < 8 then low |= byte << (position*8)
+          else high |= byte << ((position - 8)*8)
+          position += 1
+
+        Some((low, high))
+
+    val packedNames: List[Option[(Long, Long)]] = List.range(0, arity).map(packedName)
+
+    def summonField(index: Int): Expr[Xml.Field | Null] =
+      if kinds(index) != InstanceK then '{null}
+      else fieldTypes(index).asType match
+        case '[fieldType] =>
+          Expr.summon[fieldType is Xml.Field].getOrElse:
+            report.errorAndAbort
+              (s"xylophone: no Xml.Field instance for field ${fieldNames(index)}: "+
+                fieldTypes(index).show)
+
+    def declaredDefault(index: Int): Expr[Any] = fieldTypes(index).asType match
+      case '[fieldType] =>
+        '{ wisteria.internal.default[value, fieldType](${Expr(index)}): Any }
+
+    def zero(fieldType: TypeRepr): Term =
+      if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+      else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+      else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+      else if fieldType =:= TypeRepr.of[Float] then Literal(FloatConstant(0.0f))
+      else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+      else fieldType.asType match
+        case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+    def construct(arguments: List[Term]): Term =
+      val typeArguments = tpe match
+        case AppliedType(_, applied) => applied
+        case _                       => Nil
+
+      val newTerm = Select(New(Inferred(tpe)), ctor)
+
+      val applied =
+        if typeArguments.isEmpty then newTerm
+        else TypeApply(newTerm, typeArguments.map { argument => Inferred(argument) })
+
+      Apply(applied, arguments)
+
+    def body
+      ( reader:      Expr[XmlReader],
+        keys:        Expr[IArray[String]],
+        attrs:       Expr[IArray[Boolean]],
+        instances:   Expr[IArray[Xml.Field | Null]],
+        repeatables: Expr[IArray[Boolean]],
+        fallbacks:   Expr[IArray[Any]] )
+    :   Expr[value] =
+
+      val owner = Symbol.spliceOwner
+      val bufferType = TypeRepr.of[scala.collection.mutable.ListBuffer[Any] | Null]
+
+      // The read-site capabilities, bound once per record.
+      val fociSymbol =
+        Symbol.newVal(owner, "foci", TypeRepr.of[Foci[Xml.Focus]], Flags.EmptyFlags,
+          Symbol.noSymbol)
+
+      val tacticSymbol =
+        Symbol.newVal(owner, "tactic", TypeRepr.of[Tactic[XmlError]], Flags.EmptyFlags,
+          Symbol.noSymbol)
+
+      val fociDef = ValDef(fociSymbol, Some('{ $reader.foci }.asTerm))
+      val tacticDef = ValDef(tacticSymbol, Some('{ $reader.errorTactic }.asTerm))
+      val foci = Ref(fociSymbol).asExprOf[Foci[Xml.Focus]]
+      val tactic = Ref(tacticSymbol).asExprOf[Tactic[XmlError]]
+
+      val slots = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+      val seens = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      // Occurrence buffers for the fields that may gather (repeatable
+      // instances), allocated lazily on the first occurrence.
+      val buffers: List[Option[Symbol]] = List.range(0, arity).map: index =>
+        if kinds(index) != InstanceK then None else
+          Some(Symbol.newVal(owner, "gather"+index, bufferType, Flags.Mutable, Symbol.noSymbol))
+
+      val slotDefs = List.range(0, arity).map: index =>
+        ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+      val seenDefs = List.range(0, arity).map: index =>
+        ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val bufferDefs = List.range(0, arity).flatMap: index =>
+        buffers(index).map: symbol =>
+          ValDef(symbol, Some('{ null }.asTerm))
+
+      val unit = Literal(UnitConstant())
+
+      // `@attribute` fields first: they are available from the element's
+      // open tag, before any child is consumed.
+      val attributesSymbol =
+        Symbol.newVal(owner, "attributes", TypeRepr.of[Attributes], Flags.EmptyFlags,
+          Symbol.noSymbol)
+
+      val attributesDef = ValDef(attributesSymbol, Some('{ $reader.attributes() }.asTerm))
+      val attributes = Ref(attributesSymbol).asExprOf[Attributes]
+
+      val attributeSteps: List[Term] = List.range(0, arity).flatMap: index =>
+        if !attrFlags(index) then None else fieldTypes(index).asType match
+          case '[fieldType] =>
+            val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+
+            val valueSymbol =
+              Symbol.newVal(owner, "attr"+index, TypeRepr.of[Optional[Text]], Flags.EmptyFlags,
+                Symbol.noSymbol)
+
+            val valueDef =
+              ValDef(valueSymbol, Some('{ Attributes.fetch($attributes)($keyText) }.asTerm))
+
+            val valueRef = Ref(valueSymbol).asExprOf[Optional[Text]]
+
+            val read: Expr[fieldType] = kinds(index) match
+              case IntK     => '{ Xml.intParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
+                               . asExprOf[fieldType]
+              case LongK    => '{ Xml.longParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
+                               . asExprOf[fieldType]
+              case DoubleK  => '{ Xml.doubleParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
+                               . asExprOf[fieldType]
+              case FloatK   => '{ Xml.floatParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
+                               . asExprOf[fieldType]
+              case BooleanK => '{ Xml.booleanParsable.attribute($valueRef.vouch)(using $tactic, $foci) }
+                               . asExprOf[fieldType]
+              case TextK    => '{ $valueRef.vouch }.asExprOf[fieldType]
+              case StringK  => '{ $valueRef.vouch.s }.asExprOf[fieldType]
+
+              case InstanceK =>
+                '{
+                  $instances(${Expr(index)}).asInstanceOf[fieldType is Xml.Field]
+                  . attribute($valueRef.vouch)(using $tactic, $foci)
+                }
+
+            val focused: Term =
+              '{ Xml.Parsable.focusing($foci, $keyText)($read) }.asTerm
+
+            Some:
+              Block
+                ( List(valueDef),
+                  If
+                    ( '{ $valueRef.present }.asTerm,
+                      Block
+                        ( List
+                            ( Assign(Ref(slots(index)), focused),
+                              Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                          unit ),
+                      unit ) )
+
+      // One dispatch arm per child-matching field: read the value (with
+      // focus bookkeeping), honoring the derived engine's semantics — a
+      // repeatable field gathers every occurrence, a non-repeatable one
+      // keeps its first and skips the rest.
+      val arms = List.range(0, arity).map: index =>
+        val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+
+        def firstWins(read: Term): Term =
+          If
+            ( Ref(seens(index)),
+              '{ $reader.skipElement() }.asTerm,
+              Block
+                ( List
+                    ( Assign(Ref(slots(index)), read),
+                      Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                  unit ) )
+
+        val rhs: Term = fieldTypes(index).asType match
+          case '[fieldType] =>
+            kinds(index) match
+              case IntK =>
+                firstWins:
+                  '{ Xml.Parsable.focusing($foci, $keyText)(Xml.intParsable.parse($reader)) }
+                  . asTerm
+
+              case LongK =>
+                firstWins:
+                  '{ Xml.Parsable.focusing($foci, $keyText)(Xml.longParsable.parse($reader)) }
+                  . asTerm
+
+              case DoubleK =>
+                firstWins:
+                  '{ Xml.Parsable.focusing($foci, $keyText)(Xml.doubleParsable.parse($reader)) }
+                  . asTerm
+
+              case FloatK =>
+                firstWins:
+                  '{ Xml.Parsable.focusing($foci, $keyText)(Xml.floatParsable.parse($reader)) }
+                  . asTerm
+
+              case BooleanK =>
+                firstWins:
+                  '{ Xml.Parsable.focusing($foci, $keyText)(Xml.booleanParsable.parse($reader)) }
+                  . asTerm
+
+              case TextK =>
+                firstWins:
+                  '{
+                    Xml.Parsable.focusing($foci, $keyText):
+                      $reader.text().or { $reader.fault(); t"" }
+                  }.asTerm
+
+              case StringK =>
+                firstWins:
+                  '{
+                    Xml.Parsable.focusing($foci, $keyText):
+                      ($reader.text().or { $reader.fault(); t"" }).s
+                  }.asTerm
+
+              case InstanceK =>
+                val bufferRef = Ref(buffers(index).get)
+
+                val bufferExpr =
+                  bufferRef.asExprOf[scala.collection.mutable.ListBuffer[Any] | Null]
+
+                val ensure: Term =
+                  If
+                    ( '{ $bufferExpr == null }.asTerm,
+                      Assign
+                        ( bufferRef,
+                          '{ scala.collection.mutable.ListBuffer.empty[Any] }.asTerm ),
+                      unit )
+
+                val append: Term =
+                  '{
+                    $bufferExpr.asInstanceOf[scala.collection.mutable.ListBuffer[Any]].addOne
+                      ( Xml.Parsable.focusing($foci, $keyText):
+                          Xml.Parsable.parseElement
+                            ( $instances(${Expr(index)}).asInstanceOf[Xml.Parsing], $reader ) )
+                  }.asTerm
+
+                val read: Term =
+                  '{
+                    Xml.Parsable.focusing($foci, $keyText):
+                      $instances(${Expr(index)}).asInstanceOf[fieldType is Xml.Field]
+                      . parse($reader)
+                  }.asTerm
+
+                If
+                  ( '{ $repeatables(${Expr(index)}) }.asTerm,
+                    Block(List(ensure, append), unit),
+                    firstWins(read) )
+
+        CaseDef(Literal(IntConstant(index)), None, rhs)
+
+      val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipElement() }.asTerm)
+
+      // The child loop. With literal names, each step compares the packed
+      // words against the field names as immediate constants, resolving an
+      // opaque name through the linear text step; otherwise (runtime
+      // renames) every child resolves through the text step.
+      val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+      val word = Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+      val high = Symbol.newVal(owner, "high", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+      val found = Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+      val wordRef = Ref(word).asExprOf[Long]
+      val highRef = Ref(high).asExprOf[Long]
+
+      def chain(index: Int): Term =
+        if index == arity then Literal(IntConstant(-1))
+        else if attrFlags(index) then chain(index + 1)
+        else packedNames(index) match
+          case None => chain(index + 1)
+
+          case Some((low, highWord)) =>
+            If
+              ( '{ $wordRef == ${Expr(low)} && $highRef == ${Expr(highWord)} }.asTerm,
+                Literal(IntConstant(index)),
+                chain(index + 1) )
+
+      val textStep: Term =
+        '{ Xml.Parsable.childIndex($keys, $attrs, $reader.childLabel) }.asTerm
+
+      val resolve: Term =
+        if literalKeys then
+          If
+            ( '{ $wordRef == XmlReader.NameOpaque }.asTerm,
+              textStep,
+              Block(List(ValDef(high, Some('{ $reader.childWordHigh }.asTerm))), chain(0)) )
+        else textStep
+
+      val step: Term =
+        Block
+          ( List(ValDef(word, Some('{ $reader.childWord() }.asTerm))),
+            If
+              ( '{ $wordRef == XmlReader.NameEnd }.asTerm,
+                Assign(Ref(run), Literal(BooleanConstant(false))),
+                Block
+                  ( List(ValDef(found, Some(resolve))),
+                    Match(Ref(found), arms :+ fallthrough) ) ) )
+
+      val loop: List[Statement] =
+        List(ValDef(run, Some(Literal(BooleanConstant(true)))), While(Ref(run), step))
+
+      // Fields whose names never arrived — and repeatable fields, whose
+      // collection is always built from the gathered occurrences (zero
+      // occurrences build the empty collection; a repeatable field never
+      // consults the declared default), exactly as the derived engine does.
+      val absents: List[Term] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+
+            val onAbsent: Expr[fieldType] = kinds(index) match
+              case InstanceK =>
+                '{
+                  $instances(${Expr(index)}).asInstanceOf[fieldType is Xml.Field]
+                  . absent()(using $tactic, $foci)
+                }
+
+              case IntK     => '{ Xml.Parsable.missing[Int](0)(using $tactic) }
+                               . asExprOf[fieldType]
+              case LongK    => '{ Xml.Parsable.missing[Long](0L)(using $tactic) }
+                               . asExprOf[fieldType]
+              case DoubleK  => '{ Xml.Parsable.missing[Double](0.0)(using $tactic) }
+                               . asExprOf[fieldType]
+              case FloatK   => '{ Xml.Parsable.missing[Float](0.0f)(using $tactic) }
+                               . asExprOf[fieldType]
+              case BooleanK => '{ Xml.Parsable.missing[Boolean](false)(using $tactic) }
+                               . asExprOf[fieldType]
+              case TextK    => '{ Xml.Parsable.missing[Text](t"")(using $tactic) }
+                               . asExprOf[fieldType]
+              case StringK  => '{ Xml.Parsable.missing[String]("")(using $tactic) }
+                               . asExprOf[fieldType]
+
+            val resolveAbsent: Term =
+              Assign
+                ( Ref(slots(index)),
+                  '{
+                    val declared = $fallbacks(${Expr(index)}).asInstanceOf[Optional[fieldType]]
+
+                    if !declared.absent then declared.asInstanceOf[fieldType]
+                    else Xml.Parsable.focusing($foci, $keyText)($onAbsent)
+                  }.asTerm )
+
+            val whenUnseen: Term =
+              If('{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm, resolveAbsent, unit)
+
+            kinds(index) match
+              case InstanceK =>
+                val bufferExpr =
+                  Ref(buffers(index).get)
+                  . asExprOf[scala.collection.mutable.ListBuffer[Any] | Null]
+
+                val gatherFinish: Term =
+                  Assign
+                    ( Ref(slots(index)),
+                      '{
+                        Xml.Parsable.focusing($foci, $keyText):
+                          Xml.Parsable.gathered[fieldType]
+                            ( $instances(${Expr(index)}).asInstanceOf[Xml.Parsing],
+                              $bufferExpr match
+                                case null   => Nil
+                                case buffer => buffer.toList )
+                      }.asTerm )
+
+                If('{ $repeatables(${Expr(index)}) }.asTerm, gatherFinish, whenUnseen)
+
+              case _ =>
+                whenUnseen
+
+      Block
+        ( fociDef :: tacticDef :: slotDefs ::: seenDefs ::: bufferDefs
+            ::: (attributesDef :: attributeSteps)
+            ::: loop
+            ::: absents,
+          construct(slots.map { slot => Ref(slot) }) )
+      . asExprOf[value]
+
+    // The absent-build: what a missing (or wrong-shape) occurrence of this
+    // record yields when no user-supplied `Default` collapses it — every
+    // sub-field takes its declared default or raises at its own focus,
+    // mirroring the derived engine's `absentBuild`.
+    def absentBody(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      ( keys:        Expr[IArray[String]],
+        instances:   Expr[IArray[Xml.Field | Null]],
+        repeatables: Expr[IArray[Boolean]],
+        fallbacks:   Expr[IArray[Any]] )
+    :   Expr[value] =
+
+      val arguments: List[Term] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val keyText: Expr[Text] = '{ $keys(${Expr(index)}).tt }
+
+            val onAbsent: Expr[fieldType] = kinds(index) match
+              case InstanceK =>
+                '{
+                  $instances(${Expr(index)}).asInstanceOf[fieldType is Xml.Field]
+                  . absent()(using $tactic, $foci)
+                }
+
+              case IntK     => '{ Xml.Parsable.missing[Int](0)(using $tactic) }
+                               . asExprOf[fieldType]
+              case LongK    => '{ Xml.Parsable.missing[Long](0L)(using $tactic) }
+                               . asExprOf[fieldType]
+              case DoubleK  => '{ Xml.Parsable.missing[Double](0.0)(using $tactic) }
+                               . asExprOf[fieldType]
+              case FloatK   => '{ Xml.Parsable.missing[Float](0.0f)(using $tactic) }
+                               . asExprOf[fieldType]
+              case BooleanK => '{ Xml.Parsable.missing[Boolean](false)(using $tactic) }
+                               . asExprOf[fieldType]
+              case TextK    => '{ Xml.Parsable.missing[Text](t"")(using $tactic) }
+                               . asExprOf[fieldType]
+              case StringK  => '{ Xml.Parsable.missing[String]("")(using $tactic) }
+                               . asExprOf[fieldType]
+
+            val declared: Expr[fieldType] =
+              '{
+                val declared = $fallbacks(${Expr(index)}).asInstanceOf[Optional[fieldType]]
+
+                if !declared.absent then declared.asInstanceOf[fieldType]
+                else Xml.Parsable.focusing($foci, $keyText)($onAbsent)
+              }
+
+            val argument: Expr[fieldType] = kinds(index) match
+              case InstanceK =>
+                '{
+                  if $repeatables(${Expr(index)}) then
+                    Xml.Parsable.focusing($foci, $keyText):
+                      Xml.Parsable.gathered[fieldType]
+                        ( $instances(${Expr(index)}).asInstanceOf[Xml.Parsing], Nil )
+                  else $declared
+                }
+
+              case _ =>
+                declared
+
+            argument.asTerm
+
+      construct(arguments).asExprOf[value]
+
+    val nameExprs = fieldNames.map { name => Expr(name) }
+    val attrExprs = attrFlags.map { flag => Expr(flag) }
+    val instanceExprs = List.range(0, arity).map(summonField)
+    val fallbackExprs = List.range(0, arity).map(declaredDefault)
+
+    // A user-supplied `Default[value]` collapses a missing nested value to a
+    // single error, exactly as the derived engine's `fallback` does.
+    val defaultExpr: Expr[Optional[() => value]] =
+      Expr.summon[Default[value]] match
+        case Some(default) => '{ Optional({ () => $default() }: () => value) }
+        case None          => '{ Unset }
+
+    '{
+      // Sealed per the codec-thunk pattern, like the derived instances: the
+      // field parsers the instance array resolves may capture resolution-
+      // scoped capabilities (the AST bridge does). The instance and default
+      // arrays are single lazy vals, so recursive self-references stay
+      // deferred until the first parse.
+      caps.unsafe.unsafeAssumePure:
+        val keys: IArray[String] =
+          Xml.Parsable.wireNames(IArray[String](${Varargs(nameExprs)}*), $renames)
+
+        val attrs: IArray[Boolean] = IArray[Boolean](${Varargs(attrExprs)}*)
+
+        lazy val instances: IArray[Xml.Field | Null] = IArray(${Varargs(instanceExprs)}*)
+
+        lazy val repeatables: IArray[Boolean] =
+          instances.map { instance => instance != null && Xml.Parsable.repeats(instance) }
+
+        lazy val fallbacks: IArray[Any] = IArray[Any](${Varargs(fallbackExprs)}*)
+        val fallback: Optional[() => value] = $defaultExpr
+
+        new Xml.Parsable:
+          type Self = value
+
+          def parse(reader: XmlReader^): value =
+            ${
+              body
+                ( '{reader}, '{keys}, '{attrs}, '{instances}, '{repeatables}, '{fallbacks} )
+            }
+
+          override def absent()(using tactic: Tactic[XmlError], foci: Foci[Xml.Focus]): value =
+            raise(XmlError())
+
+            fallback.lay
+              ( ${
+                  absentBody('{tactic}, '{foci})
+                    ('{keys}, '{instances}, '{repeatables}, '{fallbacks})
+                } )
+              { instantiate => instantiate() }
+    }

--- a/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
+++ b/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
@@ -345,3 +345,110 @@ object DirectParsingTests extends Suite(m"Xylophone direct parsing tests"):
           issue match
             case Xml.Issue.Incomplete(t"root") => true
             case _                             => false
+
+    suite(m"Staged direct parsing"):
+      given PWorker is Xml.Parsable = Xml.Parsable.staged
+      given PFirm is Xml.Parsable = Xml.Parsable.staged
+      given PBook is Xml.Parsable = Xml.Parsable.staged
+      given PTagged is Xml.Parsable = Xml.Parsable.staged
+      given PLabelled is Xml.Parsable = Xml.Parsable.staged
+      given PDefaulted is Xml.Parsable = Xml.Parsable.staged
+      given PReading is Xml.Parsable = Xml.Parsable.staged
+      given PPlaylist is Xml.Parsable = Xml.Parsable.staged
+      given PTeam is Xml.Parsable = Xml.Parsable.staged
+
+      test(m"A staged parser reads a simple record"):
+        t"<root><name>Alice</name><age>30</age></root>".read[PWorker in Xml]
+      . assert(_ == PWorker(t"Alice", 30))
+
+      test(m"A staged parser accepts reordered fields, equally on both paths"):
+        parity[PWorker](t"<root><age>21</age><name>Bob</name></root>")
+      . assert(identity)
+
+      test(m"Nested records parse through sibling staged instances"):
+        val input = t"<root><title>Acme</title><boss><name>Carol</name><age>40</age></boss></root>"
+        (input.read[PFirm in Xml], parity[PFirm](input))
+      . assert(_ == (PFirm(t"Acme", PWorker(t"Carol", 40)), true))
+
+      test(m"A staged parser skips unknown children with their subtrees"):
+        t"""<root><name>Amy</name>
+              <extra a="1"><deep><x/>text</deep><more/></extra>
+              <age>50</age></root>""".read[PWorker in Xml]
+      . assert(_ == PWorker(t"Amy", 50))
+
+      test(m"A staged parser keeps the first occurrence of a duplicate child"):
+        val input = t"<root><name>Amy</name><name>Bea</name><age>3</age></root>"
+        (input.read[PWorker in Xml], parity[PWorker](input))
+      . assert(_ == (PWorker(t"Amy", 3), true))
+
+      test(m"A staged parser takes declared defaults"):
+        t"<root><name>Kid</name></root>".read[PDefaulted in Xml]
+      . assert(_ == PDefaulted(t"Kid", 18))
+
+      test(m"An @attribute field reads from the attribute in a staged parser"):
+        val input = t"""<PBook isbn="0441013597"><title>Dune</title></PBook>"""
+        (input.read[PBook in Xml], parity[PBook](input))
+      . assert(_ == (PBook(t"Dune", t"0441013597"), true))
+
+      test(m"A staged @name-renamed @attribute field reads from the renamed attribute"):
+        val input = t"""<x ISBN="99"><title>T</title></x>"""
+        (input.read[PTagged in Xml], parity[PTagged](input))
+      . assert(_ == (PTagged(t"99", t"T"), true))
+
+      test(m"A staged child sharing an @attribute field's name is skipped"):
+        val input = t"""<x isbn="1"><isbn>2</isbn><title>T</title></x>"""
+        (input.read[PBook in Xml], parity[PBook](input))
+      . assert(_ == (PBook(t"T", t"1"), true))
+
+      test(m"@name[Xml] renames an element field in a staged parser"):
+        val input = t"<x><Title>Dune</Title><pages>412</pages></x>"
+        (input.read[PLabelled in Xml], parity[PLabelled](input))
+      . assert(_ == (PLabelled(t"Dune", 412), true))
+
+      test(m"Repeated elements gather in document order in a staged parser"):
+        val input = t"<root><songs>A</songs><name>Mix</name><songs>B</songs></root>"
+        (input.read[PPlaylist in Xml], parity[PPlaylist](input))
+      . assert(_ == (PPlaylist(t"Mix", List(t"A", t"B")), true))
+
+      test(m"No matching children decode as the empty list in a staged parser"):
+        val input = t"<root><name>Mix</name></root>"
+        (input.read[PPlaylist in Xml], parity[PPlaylist](input))
+      . assert(_ == (PPlaylist(t"Mix", Nil), true))
+
+      test(m"Record elements in lists parse through staged element instances"):
+        val input = t"""<root><name>A</name>
+              <members><name>X</name><age>1</age></members>
+              <members><name>Y</name><age>2</age></members></root>"""
+        (input.read[PTeam in Xml], parity[PTeam](input))
+      . assert(_ == (PTeam(t"A", List(PWorker(t"X", 1), PWorker(t"Y", 2))), true))
+
+      test(m"A bridged custom-Decodable field parses in a staged parser"):
+        val input = t"<r><temp>21</temp><station>Kew</station></r>"
+        (input.read[PReading in Xml], parity[PReading](input))
+      . assert(_ == (PReading(PTemperature(21), t"Kew"), true))
+
+      test(m"A staged missing field accrues the same focus as the AST path"):
+        val input = t"<root><name>Alice</name></root>"
+        ( issues(input.read[PWorker in Xml]),
+          issues(input.read[Xml].as[PWorker]) )
+      . assert { (staged, ast) => staged == ast && staged == Set("/age[1]") }
+
+      test(m"A staged wrong-type primitive accrues the same focus as the AST path"):
+        val input = t"<root><name>Alice</name><age>old</age></root>"
+        ( issues(input.read[PWorker in Xml]),
+          issues(input.read[Xml].as[PWorker]) )
+      . assert { (staged, ast) => staged == ast && staged == Set("/age[1]") }
+
+      test(m"A staged missing nested product expands per sub-field, as on the AST path"):
+        val input = t"<root><title>Acme</title></root>"
+        ( issues(input.read[PFirm in Xml]),
+          issues(input.read[Xml].as[PFirm]) )
+      . assert: (staged, ast) =>
+          staged == ast &&
+            staged == Set("/boss[1]", "/boss[1]/name[1]", "/boss[1]/age[1]")
+
+      test(m"An empty root element accrues every staged field, as on the AST path"):
+        val input = t"<root/>"
+        ( issues(input.read[PWorker in Xml]),
+          issues(input.read[Xml].as[PWorker]) )
+      . assert { (staged, ast) => staged == ast && staged == Set("/name[1]", "/age[1]") }


### PR DESCRIPTION
Extends direct (AST-free) parsing with compile-time code generation across all three structured formats, culminating in an Expr-level typeclass whose instances are evaluated live at macro-expansion time, and a tuning campaign that brings JSON decoding from 19.7µs to 8.5µs on the ~10KB cross-format corpus — 1.1× Jsoniter — while TEL improves from 53µs to 36µs and XML from 44µs to 33µs. The generated parsers preserve the derived engines' semantics exactly (wire keys, gathering, first-match-wins, defaults, error foci, accrual), verified by parity suites in each format, and the capability discipline is preserved end-to-end: the parser conduit is sealed so only jacinta's own generated splices can reach it, and the newly-released p3 toolchain's inline-update receiver fix lets the reader rim's hot methods be zero-cost inline forwarders under full capture checking.

## Release notes

### Staged parsers for TEL and XML

Case classes can now opt into macro-generated monomorphic parsing in stratiform and xylophone, mirroring jacinta's staged parsers: typed local slots, packed-`Long` keyword or tag-name dispatch, and direct construction — no `Array[Any]`, no `Mirror`, no per-field boxing.

```scala
given Order is Tel.Parsable = Tel.Parsable.staged
given Order is Xml.Parsable = Xml.Parsable.staged
```

XML staged parsers support `@attribute` fields, `Default`-collapsed absents, and read-site foci, exactly like `derived`.

### Staged JSON sums

`Json.Parsable.staged` now accepts sealed sums with a field-discriminated shape (such as `jsonByKindDiscriminable`): the tag is located with a bounded scan-ahead and dispatched through monomorphic comparisons into per-variant parsers.

### `Inlinable`: Expr-level parser composition

A new `jacinta.staged` component provides `Inlinable`, a typeclass whose `parse` method is a macro-time code generator. At an `Inlinable.parsable[T]` expansion, the instance graph — nested records, collection loops, custom leaf parsers — is resolved *live* inside an in-macro staging compiler and composed into one flat parser with no adapter hops or instance arrays:

```scala
given Orders is Json.Parsable = Inlinable.parsable[Orders]
```

Instances must be compiled in an earlier run than the expansion (a separate module); same-run instances degrade safely to runtime seams. The `prescience` library documents the underlying mechanism as a standalone proof of concept.

### Parser performance

The shared JSON tokenizer gains a buffer-local `Double` fast path (bit-identical to the general path), fused scan-and-pack key steps, split first/next key and element protocols for generated parsers, and single-comparison whitespace gates. All decoding paths benefit: direct, staged, and Expr-composed.

### Toolchain

The default toolchain is now `3.9.0-RC1-p3` (with matching `3.8.4-p3` and `3.10.0-dev-p3` releases), which adds the inline-update receiver fix: update methods are callable through `inline` forwarders on exclusive receivers, enabling zero-cost capability rims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)