### PR TITLE
Record-stream kernel additions: `records`, `delineate`, `streamOf` and `Relay`

### DIFF
--- a/lib/turbulence/src/core/soundness_turbulence_core.scala
+++ b/lib/turbulence/src/core/soundness_turbulence_core.scala
@@ -35,7 +35,7 @@ package soundness
 export
   turbulence
   . { Aggregable, chunked, cluster, compress, Compression, Compressor, decompress, deduplicate,
-      defer, discard, Document, Documentary, Eof, Err, In, inputStream,
+      defer, delineate, discard, Document, Documentary, Eof, Err, In, inputStream,
       Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
       multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, shred, Spool, spool,
       Confluence, Divergence, Readable, Sink, Source, Stdio, lazyList, Streamable, StreamError,

--- a/lib/turbulence/src/core/turbulence.LineSeparation.scala
+++ b/lib/turbulence/src/core/turbulence.LineSeparation.scala
@@ -32,8 +32,12 @@
                                                                                                   */
 package turbulence
 
+import java.lang as jl
+
 import anticipation.*
 import beneficence.*
+import prepositional.*
+import zephyrine.*
 
 object LineSeparation:
   inline def readByte
@@ -74,6 +78,204 @@ object LineSeparation:
       case Action.LfNl => put(10); mkNewline
       case Action.Skip => ()
 
+
+  // Line splitting as a pipeline stage: a `LineSeparation` policy value applies
+  // directly with `stream.via(policy)` (or the `.lines` combinators), yielding a
+  // record stream on the boxed medium — one `Text` per line, without its
+  // terminator. The duct dispatches through the same `Action` table as
+  // `readByte` above, so each packaged policy behaves identically to the legacy
+  // reader. A separator's first char at a window boundary is carried in
+  // `pending` (the two-char sequences resolve across windows); the incomplete
+  // final line is carried in `partial` and emitted by `flush`, so an input
+  // without a trailing separator still yields its last line, and an empty input
+  // yields no lines at all.
+  //
+  // A separator-free input grows `partial` without bound — the inherent
+  // exposure of any line reader; cap upstream if the input is adversarial.
+  given lines: Ductile.Of[LineSeparation, Text, IArray[Text], Credit, Credit] =
+    new Ductile:
+      type Self = LineSeparation
+      type Operand = Text
+      type Result = IArray[Text]
+      type Transport = Credit
+      type Upstream = Credit
+
+      def duct(consume stage: LineSeparation^)(using Buffering)
+      :   (Duct[Text, IArray[Text]] { type Transport = Credit; type Upstream = Credit })^ =
+
+        new Duct[Text, IArray[Text]]:
+          type Transport = Credit
+          type Upstream = Credit
+
+          // The incomplete current line, carried across steps.
+          private val partial: jl.StringBuilder = jl.StringBuilder(64)
+
+          // A separator's first char at a window boundary (10 or 13; 0 = none).
+          private var pending: Int = 0
+
+          // End-of-stream lines (the resolved `pending` may complete some, plus
+          // the final unterminated line), built once and drained by `flush`.
+          private var drained: Boolean = false
+          private var tail: List[Text] = Nil
+
+          def regulation: Credit is Regulation = summon[Credit is Regulation]
+
+          // One char completes at most one line, so line-credit is a sound
+          // char-credit as it stands; surplus consumption is carried in
+          // `partial`, per the conservative-bound contract.
+          def translate(demand: Credit): Credit = demand
+
+          // An `NlNl` action emits two lines at once.
+          override def quantum: Int = 2
+
+          // Completed lines from the most recent action, staged in fields (at
+          // most two — `NlNl`) rather than emitted through a callback: a
+          // closure's captures hide from subsequent statements under
+          // separation checking, so the caller drains these instead.
+          private var out0: Text = "".tt
+          private var out1: Text = "".tt
+          private var emitted: Int = 0
+
+          private update def newline(): Unit =
+            val line = partial.toString.tt
+            partial.setLength(0)
+            if emitted == 0 then out0 = line else out1 = line
+            emitted += 1
+
+          // Apply `action` to the current line state, staging completed lines.
+          private update def act(action: LineSeparation.Action): Unit = action match
+            case Action.Nl   => newline()
+            case Action.NlCr => newline(); partial.append('\r')
+            case Action.NlLf => newline(); partial.append('\n')
+            case Action.CrNl => partial.append('\r'); newline()
+            case Action.NlNl => newline(); newline()
+            case Action.Cr   => partial.append('\r')
+            case Action.Lf   => partial.append('\n')
+            case Action.LfNl => partial.append('\n'); newline()
+            case Action.Skip => ()
+
+          // Deliver the staged lines into the target window at `at`, returning
+          // how many were written. The caller guarantees two free slots.
+          private update def deliver(slots: Array[AnyRef]^, at: Int): Int =
+            var written: Int = 0
+
+            if emitted > 0 then
+              slots(at) = out0.asInstanceOf[AnyRef]
+              written = 1
+
+              if emitted == 2 then
+                slots(at + 1) = out1.asInstanceOf[AnyRef]
+                written = 2
+
+              emitted = 0
+
+            written
+
+          update def step
+            ( source: input.Storage,
+              sourceOffset: Int,
+              sourceLength: Int,
+              target: output.Storage,
+              targetOffset: Int,
+              targetSpace: Int )
+          :   Duct.Progress =
+
+            val chars = source.asInstanceOf[Array[Char]]
+            var consumed: Int = 0
+            var produced: Int = 0
+
+            // The guard reserves `quantum` slots so any action fits whole; a
+            // stop here with unconsumed input is a partial step, which the
+            // kernel handles (the produced window is delivered first).
+            while consumed < sourceLength && produced + 2 <= targetSpace do
+              if pending != 0 then
+                val first = pending
+                pending = 0
+                val char = chars(sourceOffset + consumed)
+
+                if first == 10 then
+                  if char == '\r' then { consumed += 1; act(stage.lfcr) }
+                  else act(stage.lf)
+                else
+                  if char == '\n' then { consumed += 1; act(stage.crlf) }
+                  else act(stage.cr)
+
+                produced += deliver(target.asInstanceOf[Array[AnyRef]^], targetOffset + produced)
+              else
+                val char = chars(sourceOffset + consumed)
+
+                if char == '\n' then
+                  consumed += 1
+
+                  if consumed < sourceLength then
+                    if chars(sourceOffset + consumed) == '\r'
+                    then { consumed += 1; act(stage.lfcr) }
+                    else act(stage.lf)
+
+                    produced +=
+                      deliver(target.asInstanceOf[Array[AnyRef]^], targetOffset + produced)
+                  else pending = 10
+                else if char == '\r' then
+                  consumed += 1
+
+                  if consumed < sourceLength then
+                    if chars(sourceOffset + consumed) == '\n'
+                    then { consumed += 1; act(stage.crlf) }
+                    else act(stage.cr)
+
+                    produced +=
+                      deliver(target.asInstanceOf[Array[AnyRef]^], targetOffset + produced)
+                  else pending = 13
+                else
+                  // Bulk-append the run of ordinary chars up to the next
+                  // separator (or the window's end).
+                  val start = sourceOffset + consumed
+                  val stop = sourceOffset + sourceLength
+                  var end = start
+
+                  while end < stop && { val c = chars(end); c != '\n' && c != '\r' } do end += 1
+
+                  partial.append(chars, start, end - start)
+                  consumed += end - start
+
+            Duct.Progress(consumed, produced)
+
+          override update def flush
+            ( target: output.Storage, targetOffset: Int, targetSpace: Int )
+          :   Int =
+
+            if !drained then
+              drained = true
+              var lines: List[Text] = Nil
+
+              // A dangling separator-initial char at end-of-stream resolves as
+              // its bare single-char sequence.
+              if pending == 10 then act(stage.lf)
+              else if pending == 13 then act(stage.cr)
+              pending = 0
+
+              if emitted > 0 then
+                lines ::= out0
+                if emitted == 2 then lines ::= out1
+                emitted = 0
+
+              // The final line, if the input didn't end with a separator.
+              if partial.length > 0 then
+                lines ::= partial.toString.tt
+                partial.setLength(0)
+
+              tail = lines.reverse
+
+            var count: Int = 0
+
+            while count < targetSpace && tail != Nil do
+              target.asInstanceOf[Array[AnyRef]^](targetOffset + count) =
+                tail.head.asInstanceOf[AnyRef]
+
+              tail = tail.tail
+              count += 1
+
+            count
 
   enum NewlineSeq:
     case Cr, Lf, CrLf, LfCr

--- a/lib/turbulence/src/core/turbulence.Relay.scala
+++ b/lib/turbulence/src/core/turbulence.Relay.scala
@@ -30,25 +30,93 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package turbulence
 
-export
-  turbulence
-  . { Aggregable, chunked, cluster, compress, Compression, Compressor, decompress, deduplicate,
-      defer, delineate, discard, Document, Documentary, Eof, Err, In, inputStream,
-      Io, Line, LineSeparation, load, Loadable, metronome, more, multiplex, Multiplexer,
-      multiplexer, Out, parallelMap, Pistol, Pulsar, rate, read, regulate, Relay, shred, Spool,
-      spool,
-      Confluence, Divergence, Readable, Sink, Source, Stdio, lazyList, Streamable, StreamError,
-      StreamOutputStream, strict, take, Tap, Writable, writeTo, framed, flow }
+import java.util.concurrent as juc
 
-package stdios:
-  export turbulence.stdios.{muteStdio, systemStdio, virtualMachineStdio}
+import vacuous.*
+import prepositional.*
+import zephyrine.*
 
-package lineSeparation:
-  export
-    turbulence.lineSeparation
-    . { adaptiveLinefeedLineSeparation, carriageReturnLineSeparation,
-        carriageReturnLinefeedLineSeparation, linefeedLineSeparation,
-        strictCarriageReturnLineSeparation, strictLinefeedsLineSeparation,
-        virtualMachineLineSeparation }
+// The push-side bridge from any number of producer threads to a pull endpoint
+// of record chunks: `Spool`'s kernel successor. Producers `put` records (an
+// unbounded MPSC queue insertion — producers never block on the reader), and
+// one of them eventually calls `stop`; the single reader owns `stream`, whose
+// refill blocks for the first record and then drains whatever else has already
+// arrived into the same window — records batch across the thread boundary
+// instead of paying one hand-off per element. (`Conduit` is the byte/char
+// counterpart: strictly SPSC and block-structured. A relay is for
+// many-producer, record-granularity traffic: events, notifications, messages.)
+object Relay:
+  private object Termination extends scala.caps.Pure
+
+class Relay[record]():
+  private val queue: juc.LinkedBlockingQueue[record | Relay.Termination.type] =
+    juc.LinkedBlockingQueue()
+
+  def put(record: record): Unit = queue.put(record)
+  def stop(): Unit = queue.put(Relay.Termination)
+
+  // The pull endpoint over this relay's records: single-owner, drained by one
+  // thread; create it once. Records arriving after `stop` are not delivered.
+  // The medium evidence resolves at the (concretely-typed) call site — the
+  // generic `Addressable.boxed` for ordinary reference-typed records.
+  @scala.annotation.nowarn("msg=match may not be exhaustive")
+  def stream(using addressable: IArray[record] is Addressable, buffering: Buffering)
+  :   (Stream[IArray[record]] over Credit)^ =
+
+    new Stream[IArray[record]](using addressable):
+      type Transport = Credit
+
+      private val capacity: Int = buffering.capacity(Substrate.Boxes)
+
+      // Untracked, cast-erased: reached only through this endpoint. All
+      // `Substrate.Boxes` media store records erased (`boxed`, `texts`), so
+      // the window storage is written directly.
+      @caps.unsafe.untrackedCaptures
+      private val storage: Array[AnyRef] =
+        new Array[AnyRef](capacity).asInstanceOf[Array[AnyRef]]
+
+      private var start0: Int = 0
+      private var limit0: Int = 0
+      private var ended: Boolean = false
+
+      protected def window0: AnyRef = storage.asInstanceOf[AnyRef]
+      def start: Int = start0
+      def limit: Int = limit0
+      update def skip(count: Int): Unit = start0 += count
+
+      update def refill(demand: Credit): Optional[Int] =
+        if limit0 > start0 then limit0 - start0
+        else if ended then Unset
+        else
+          val granted = summon[Credit is Regulation].grant(demand)
+
+          if granted == 0 then 0 else
+            start0 = 0
+            limit0 = 0
+            val space = capacity.min(granted)
+
+            queue.take().nn match
+              case Relay.Termination =>
+                ended = true
+                Unset
+
+              case first =>
+                storage.asInstanceOf[Array[AnyRef]^](0) = first.asInstanceOf[AnyRef]
+                limit0 = 1
+
+                // Opportunistic batching: whatever else has already arrived
+                // joins the same window, up to its space. A termination found
+                // mid-drain still delivers the batch; the next refill ends.
+                var draining = true
+
+                while draining && limit0 < space do queue.poll() match
+                  case null              => draining = false
+                  case Relay.Termination => ended = true
+                                            draining = false
+                  case record            => storage.asInstanceOf[Array[AnyRef]^](limit0) =
+                                              record.asInstanceOf[AnyRef]
+                                            limit0 += 1
+
+                limit0

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -41,6 +41,7 @@ import anticipation.*
 import capricious.*
 import contingency.*
 import denominative.*
+import hieroglyph.*
 import hypotenuse.*
 import parasite.*
 import prepositional.*
@@ -93,6 +94,28 @@ extension [medium, transport](consume stream: (Stream[medium] over transport)^)
     async:
       streamRef.asInstanceOf[(Stream[medium] over transport)^]
       . pump(intakeRef.asInstanceOf[(Intake[medium] over transport)^])
+
+extension (consume stream: (Stream[Text] over Credit)^)
+  // Split a character stream into a record stream of its lines (each `Text`,
+  // without its terminator), under the ambient `LineSeparation` policy. Drain
+  // with `.elements`/`.memoize`, or compose onward like any record stream.
+  // (Named to steer clear of gossamer's value-level `lines` — same-named
+  // extensions from different modules shadow, not overload, under the flat
+  // `soundness.*` re-export.)
+  def delineate(using lineSeparation: LineSeparation, buffering: Buffering)
+  :   (Stream[IArray[Text]] over Credit)^ =
+
+    stream.via(lineSeparation).asInstanceOf[(Stream[IArray[Text]] over Credit)^]
+
+extension (consume stream: (Stream[Data] over Credit)^)
+  // Split a byte stream into its lines: character decoding under the ambient
+  // `CharDecoder`, then line splitting as above.
+  @targetName("delineateData")
+  def delineate
+    ( using decoder: CharDecoder, lineSeparation: LineSeparation, buffering: Buffering )
+  :   (Stream[IArray[Text]] over Credit)^ =
+
+    stream.via(decoder).asInstanceOf[(Stream[Text] over Credit)^].delineate
 
 extension (consume stream: (Stream[Data] over Credit)^)
   def compress[format <: Compressor](using compression: format is Compression, buffering: Buffering)

--- a/lib/turbulence/src/core/turbulence_core.scala
+++ b/lib/turbulence/src/core/turbulence_core.scala
@@ -98,7 +98,7 @@ extension [medium, transport](consume stream: (Stream[medium] over transport)^)
 extension (consume stream: (Stream[Text] over Credit)^)
   // Split a character stream into a record stream of its lines (each `Text`,
   // without its terminator), under the ambient `LineSeparation` policy. Drain
-  // with `.elements`/`.memoize`, or compose onward like any record stream.
+  // with `.records`/`.memoize`, or compose onward like any record stream.
   // (Named to steer clear of gossamer's value-level `lines` — same-named
   // extensions from different modules shadow, not overload, under the flat
   // `soundness.*` re-export.)

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -414,6 +414,67 @@ object Tests extends Suite(m"Turbulence tests"):
         supervise(l1.multiplex(l2).filter(_%2 == 1))
       . assert(_ == l2)
 
+    suite(m"Relay tests"):
+      test(m"records put before draining arrive in order"):
+        val relay = Relay[Text]()
+        relay.put(t"one")
+        relay.put(t"two")
+        relay.put(t"three")
+        relay.stop()
+        relay.stream.elements.to(List)
+      . assert(_ == List(t"one", t"two", t"three"))
+
+      test(m"records already queued batch into one window"):
+        val relay = Relay[Text]()
+        relay.put(t"a")
+        relay.put(t"b")
+        relay.put(t"c")
+        relay.stop()
+        var windows: Int = 0
+
+        relay.stream.sweep: (storage, start, count) =>
+          windows += 1
+
+        windows
+      . assert(_ == 1)
+
+      test(m"an immediately-stopped relay yields no records"):
+        val relay = Relay[Text]()
+        relay.stop()
+        relay.stream.elements.to(List)
+      . assert(_ == List())
+
+      test(m"records after stop are not delivered"):
+        val relay = Relay[Text]()
+        relay.put(t"before")
+        relay.stop()
+        relay.put(t"after")
+        relay.stream.elements.to(List)
+      . assert(_ == List(t"before"))
+
+      test(m"the reader blocks for records from concurrent producers"):
+        supervise:
+          val relay = Relay[Text]()
+          val producers = (1 to 4).map: index =>
+            async:
+              for value <- 1 to 25 do relay.put(t"${index*100 + value}")
+
+          val reader = async(relay.stream.elements.to(Set))
+          producers.each(_.await())
+          relay.stop()
+          unsafely(reader.await())
+      . assert(_ == (for index <- 1 to 4; value <- 1 to 25 yield t"${index*100 + value}").to(Set))
+
+      test(m"per-producer order is preserved through the relay"):
+        supervise:
+          val relay = Relay[Text]()
+          val producer = async:
+            for value <- 1 to 100 do relay.put(t"$value")
+            relay.stop()
+
+          unsafely(async(relay.stream.elements.to(List)).await())
+      . assert(_ == (1 to 100).to(List).map { value => t"$value" })
+
     suite(m"Compression tests"):
       test(m"Compress a single block with GZip"):
         LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).compress[Gzip].to(List).map(_.to(List))

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -421,7 +421,7 @@ object Tests extends Suite(m"Turbulence tests"):
         relay.put(t"two")
         relay.put(t"three")
         relay.stop()
-        relay.stream.elements.to(List)
+        relay.stream.records.to(List)
       . assert(_ == List(t"one", t"two", t"three"))
 
       test(m"records already queued batch into one window"):
@@ -441,7 +441,7 @@ object Tests extends Suite(m"Turbulence tests"):
       test(m"an immediately-stopped relay yields no records"):
         val relay = Relay[Text]()
         relay.stop()
-        relay.stream.elements.to(List)
+        relay.stream.records.to(List)
       . assert(_ == List())
 
       test(m"records after stop are not delivered"):
@@ -449,7 +449,7 @@ object Tests extends Suite(m"Turbulence tests"):
         relay.put(t"before")
         relay.stop()
         relay.put(t"after")
-        relay.stream.elements.to(List)
+        relay.stream.records.to(List)
       . assert(_ == List(t"before"))
 
       test(m"the reader blocks for records from concurrent producers"):
@@ -459,7 +459,7 @@ object Tests extends Suite(m"Turbulence tests"):
             async:
               for value <- 1 to 25 do relay.put(t"${index*100 + value}")
 
-          val reader = async(relay.stream.elements.to(Set))
+          val reader = async(relay.stream.records.to(Set))
           producers.each(_.await())
           relay.stop()
           unsafely(reader.await())
@@ -472,7 +472,7 @@ object Tests extends Suite(m"Turbulence tests"):
             for value <- 1 to 100 do relay.put(t"$value")
             relay.stop()
 
-          unsafely(async(relay.stream.elements.to(List)).await())
+          unsafely(async(relay.stream.records.to(List)).await())
       . assert(_ == (1 to 100).to(List).map { value => t"$value" })
 
     suite(m"Compression tests"):
@@ -560,8 +560,8 @@ object Tests extends Suite(m"Turbulence tests"):
       // Split whole, or fragmented into `chunk`-char pieces — the fragmented
       // rows exercise separator sequences spanning window boundaries.
       def splitLines(input: Text, chunk: Int)(using LineSeparation): List[Text] =
-        if chunk == 0 then input.stream.delineate.elements.to(List)
-        else input.s.grouped(chunk).map(_.tt).stream.delineate.elements.to(List)
+        if chunk == 0 then input.stream.delineate.records.to(List)
+        else input.s.grouped(chunk).map(_.tt).stream.delineate.records.to(List)
 
       def check(policy: Text, cases: List[(Text, List[Text])])(using LineSeparation): Unit =
         for fragment <- List(0, 1, 3) do
@@ -642,17 +642,17 @@ object Tests extends Suite(m"Turbulence tests"):
         import lineSeparation.adaptiveLinefeedLineSeparation
 
         test(m"lines splits a byte stream through the character decoder"):
-          t"first\nsecond\r\nthird".in[Data].stream.delineate.elements.to(List)
+          t"first\nsecond\r\nthird".in[Data].stream.delineate.records.to(List)
         . assert(_ == List(t"first", t"second", t"third"))
 
         test(m"a line spanning many windows is reassembled"):
           val long = Text(String(Array.fill(10000)('x')))
           val input = long + t"\ny"
-          input.s.grouped(7).map(_.tt).stream.delineate.elements.to(List)
+          input.s.grouped(7).map(_.tt).stream.delineate.records.to(List)
         . assert(_ == List(Text(String(Array.fill(10000)('x'))), t"y"))
 
         test(m"lines of an empty byte stream is empty"):
-          Iterator.empty[Data].stream.delineate.elements.to(List)
+          Iterator.empty[Data].stream.delineate.records.to(List)
         . assert(_ == List())
 
     suite(m"Source and Sink tests"):

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -495,6 +495,105 @@ object Tests extends Suite(m"Turbulence tests"):
         LazyList[Data]().framed[U32]().to(List)
       . assert(_ == Nil)
 
+    suite(m"Line splitting"):
+      // Split whole, or fragmented into `chunk`-char pieces — the fragmented
+      // rows exercise separator sequences spanning window boundaries.
+      def splitLines(input: Text, chunk: Int)(using LineSeparation): List[Text] =
+        if chunk == 0 then input.stream.delineate.elements.to(List)
+        else input.s.grouped(chunk).map(_.tt).stream.delineate.elements.to(List)
+
+      def check(policy: Text, cases: List[(Text, List[Text])])(using LineSeparation): Unit =
+        for fragment <- List(0, 1, 3) do
+          cases.zipWithIndex.each: (row, index) =>
+            test(m"$policy, case $index, chunk size $fragment"):
+              splitLines(row(0), fragment)
+            . assert(_ == row(1))
+
+      suite(m"adaptive linefeeds"):
+        import lineSeparation.adaptiveLinefeedLineSeparation
+
+        check(t"adaptive", List(
+          (t"", List()),
+          (t"a", List(t"a")),
+          (t"a\nb", List(t"a", t"b")),
+          (t"a\nb\n", List(t"a", t"b")),
+          (t"a\rb", List(t"a", t"b")),
+          (t"a\r\nb", List(t"a", t"b")),
+          (t"a\n\rb", List(t"a", t"b")),
+          (t"a\n\nb", List(t"a", t"", t"b")),
+          (t"a\r", List(t"a")),
+          (t"\n", List(t"")),
+          (t"one two\nthree four\r\nfive", List(t"one two", t"three four", t"five"))))
+
+      suite(m"linefeeds"):
+        import lineSeparation.linefeedLineSeparation
+
+        check(t"linefeed", List(
+          (t"a\nb", List(t"a", t"b")),
+          (t"a\rb", List(t"ab")),
+          (t"a\r\nb", List(t"a", t"b")),
+          (t"a\n\rb", List(t"a", t"b")),
+          (t"a\r", List(t"a"))))
+
+      suite(m"strict linefeeds"):
+        import lineSeparation.strictLinefeedsLineSeparation
+
+        // NOTE: the packaged policy's action table is (cr = Nl, lf = Lf, ...) —
+        // identical to strictCarriageReturn's, which looks inverted for a
+        // "linefeeds" policy, but the duct must match the table as it stands.
+        check(t"strict linefeed", List(
+          (t"a\nb", List(t"a\nb")),
+          (t"a\rb", List(t"a", t"b")),
+          (t"a\r\nb", List(t"a", t"\nb")),
+          (t"a\n\rb", List(t"a\n", t"b"))))
+
+      suite(m"carriage returns"):
+        import lineSeparation.carriageReturnLineSeparation
+
+        check(t"carriage return", List(
+          (t"a\rb", List(t"a", t"b")),
+          (t"a\nb", List(t"ab")),
+          (t"a\r\nb", List(t"a", t"b")),
+          (t"a\n\rb", List(t"a", t"b")),
+          (t"a\r", List(t"a"))))
+
+      suite(m"strict carriage returns"):
+        import lineSeparation.strictCarriageReturnLineSeparation
+
+        check(t"strict carriage return", List(
+          (t"a\rb", List(t"a", t"b")),
+          (t"a\nb", List(t"a\nb")),
+          (t"a\r\nb", List(t"a", t"\nb")),
+          (t"a\n\rb", List(t"a\n", t"b"))))
+
+      suite(m"carriage return linefeeds"):
+        import lineSeparation.carriageReturnLinefeedLineSeparation
+
+        check(t"crlf", List(
+          (t"a\r\nb", List(t"a", t"b")),
+          (t"a\nb", List(t"a\nb")),
+          (t"a\rb", List(t"ab")),
+          (t"a\n\rb", List(t"a\n", t"b")),
+          (t"a\r\n", List(t"a")),
+          (t"a\r", List(t"a"))))
+
+      suite(m"byte streams and long lines"):
+        import lineSeparation.adaptiveLinefeedLineSeparation
+
+        test(m"lines splits a byte stream through the character decoder"):
+          t"first\nsecond\r\nthird".in[Data].stream.delineate.elements.to(List)
+        . assert(_ == List(t"first", t"second", t"third"))
+
+        test(m"a line spanning many windows is reassembled"):
+          val long = Text(String(Array.fill(10000)('x')))
+          val input = long + t"\ny"
+          input.s.grouped(7).map(_.tt).stream.delineate.elements.to(List)
+        . assert(_ == List(Text(String(Array.fill(10000)('x'))), t"y"))
+
+        test(m"lines of an empty byte stream is empty"):
+          Iterator.empty[Data].stream.delineate.elements.to(List)
+        . assert(_ == List())
+
     suite(m"Source and Sink tests"):
       val payload: Data = Data.fill(10000)(_.toByte)
 

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -34,7 +34,7 @@ package soundness
 
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
-    Records, Regulation, Spring, Stream, Substrate, elements, locate, locateKey, memoize, pump,
+    Records, records, Regulation, Spring, Stream, Substrate, locate, locateKey, memoize, pump,
     stream, streamOf, sweep, toLazyList}
 
 // Hand-written forwarders: the synthesized export forwarders for these dependent-typed

--- a/lib/zephyrine/src/core/soundness_zephyrine_core.scala
+++ b/lib/zephyrine/src/core/soundness_zephyrine_core.scala
@@ -34,7 +34,8 @@ package soundness
 
 export zephyrine.{Addressable, Buffering, Conduit, Credit, Cursor, Datum, Duct, Ductile, Pace,
     Format, Formatting, Intake, Lineation, ParseError, PositionTracking, Producer, Positionable,
-    Regulation, Spring, Stream, Substrate, locate, locateKey, memoize, pump, stream, sweep}
+    Records, Regulation, Spring, Stream, Substrate, elements, locate, locateKey, memoize, pump,
+    stream, streamOf, sweep, toLazyList}
 
 // Hand-written forwarders: the synthesized export forwarders for these dependent-typed
 // extensions lose the `ductile.Result`/`ductile.Operand` path refinements under capture

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -36,6 +36,7 @@ import java.io as ji
 import java.lang as jl
 
 import scala.collection.mutable as scm
+import scala.reflect.ClassTag
 
 import anticipation.*
 import denominative.*
@@ -113,20 +114,22 @@ object Addressable:
   // counted in records, and `Buffering` sizes these buffers by reference
   // count (`Substrate.Boxes`), since their memory usage isn't
   // deterministically bounded. Erasure means the medium's element type must
-  // be a reference type; the `IArray`s this instance materializes are backed
-  // by `Array[AnyRef]`, which is indistinguishable at erased use sites.
-  given boxed: [element <: AnyRef] => IArray[element] is Addressable:
+  // be a reference type, and the `IArray`s this instance MATERIALIZES must be
+  // genuine `element[]`s (an `IArray[element]` value checkcasts to one at any
+  // concretely-typed use site) — hence the `ClassTag`; only the working
+  // storage is an erased `Array[AnyRef]`.
+  given boxed: [element <: AnyRef: ClassTag] => IArray[element] is Addressable:
     type Operand = element
     type Target = scm.ArrayBuffer[element]
     type Storage = Array[AnyRef]
 
-    val empty: IArray[element] = IArray.empty[AnyRef].asInstanceOf[IArray[element]]
+    val empty: IArray[element] = IArray.empty[element]
 
     def substrate: Substrate = Substrate.Boxes
     def blank(size: Int): scm.ArrayBuffer[element] = scm.ArrayBuffer[element]()
 
     def build(target: scm.ArrayBuffer[element]): IArray[element] =
-      target.toArray[AnyRef].asInstanceOf[IArray[element]]
+      target.toArray[element].immutable(using Unsafe)
 
     def length(block: IArray[element]): Int = block.length
     def address(block: IArray[element], index: Ordinal): element = block(index.n0)
@@ -174,9 +177,9 @@ object Addressable:
     :   Unit = System.arraycopy(src, srcOff, dest, destOff, len)
 
     def materialize(storage: Array[AnyRef], off: Int, len: Int): IArray[element] =
-      val array = new Array[AnyRef](len)
+      val array = new Array[element](len)
       System.arraycopy(storage, off, array, 0, len)
-      array.asInstanceOf[IArray[element]]
+      array.immutable(using Unsafe)
 
     def cloneStorage
       (storage: Array[AnyRef], off: Int, len: Int)(target: scm.ArrayBuffer[element])

--- a/lib/zephyrine/src/core/zephyrine.Addressable.scala
+++ b/lib/zephyrine/src/core/zephyrine.Addressable.scala
@@ -189,6 +189,97 @@ object Addressable:
         index += 1
 
 
+  // Chunks of `Text` records (lines, tokens): `Text` is opaquely
+  // `String & caps.Pure`, not `<: AnyRef`, so the generic `boxed` instance
+  // above does not admit it, and it gets the same treatment spelled out. The
+  // element bound on `boxed` is load-bearing (it keeps `IArray[Byte]` — the
+  // transparent `Data` alias — from resolving ambiguously), so it cannot
+  // simply be relaxed.
+  given texts: IArray[Text] is Addressable:
+    type Operand = Text
+    type Target = scm.ArrayBuffer[Text]
+    type Storage = Array[AnyRef]
+
+    // `IArray[Text]` erases to `String[]` (unlike `boxed`'s `Object[]`, whose
+    // element type is generic), so materialized chunks must really be
+    // `String[]`s; the storage stays `Array[AnyRef]`, which `String[]` enters
+    // covariantly.
+    val empty: IArray[Text] = new Array[String](0).asInstanceOf[IArray[Text]]
+
+    def substrate: Substrate = Substrate.Boxes
+    def blank(size: Int): scm.ArrayBuffer[Text] = scm.ArrayBuffer[Text]()
+
+    def build(target: scm.ArrayBuffer[Text]): IArray[Text] =
+      val array = new Array[String](target.length)
+      var index = 0
+
+      while index < target.length do
+        array(index) = target(index).s
+        index += 1
+
+      array.asInstanceOf[IArray[Text]]
+
+    def length(block: IArray[Text]): Int = block.length
+    def address(block: IArray[Text], index: Ordinal): Text = block(index.n0)
+
+    def grab(block: IArray[Text], start: Ordinal, end: Ordinal): IArray[Text] =
+      block.slice(start.n0, end.n0)
+
+    def clone(source: IArray[Text], start: Ordinal, end: Ordinal)
+      ( target: scm.ArrayBuffer[Text] )
+    :   Unit =
+
+      var index = start.n0
+
+      while index <= end.n0 do
+        target += source(index)
+        index += 1
+
+    def allocate(size: Int): Array[AnyRef] = new Array[AnyRef](size)
+    def storageSize(storage: Array[AnyRef]): Int = storage.length
+
+    def storageAddress(storage: Array[AnyRef], index: Int): Text =
+      storage(index).asInstanceOf[Text]
+
+    def storageUpdate(storage: Array[AnyRef]^, index: Int, operand: Text): Unit =
+      storage(index) = operand.asInstanceOf[AnyRef]
+
+    def append(target: scm.ArrayBuffer[Text], operand: Text): Unit = target += operand
+
+    def copyChunk
+      ( source:  IArray[Text],
+       srcOff:  Int,
+       dest:    Array[AnyRef]^,
+       destOff: Int,
+       len:     Int )
+    :   Unit =
+
+      System.arraycopy(source.asInstanceOf[Array[AnyRef]], srcOff, dest, destOff, len)
+
+    def transfer
+      ( src:     Array[AnyRef],
+       srcOff:  Int,
+       dest:    Array[AnyRef]^,
+       destOff: Int,
+       len:     Int )
+    :   Unit = System.arraycopy(src, srcOff, dest, destOff, len)
+
+    def materialize(storage: Array[AnyRef], off: Int, len: Int): IArray[Text] =
+      val array = new Array[String](len)
+      System.arraycopy(storage, off, array, 0, len)
+      array.asInstanceOf[IArray[Text]]
+
+    def cloneStorage
+      (storage: Array[AnyRef], off: Int, len: Int)(target: scm.ArrayBuffer[Text])
+    :   Unit =
+
+      var index = off
+
+      while index < off + len do
+        target += storage(index).asInstanceOf[Text]
+        index += 1
+
+
   inline given text: Text is Addressable:
     type Operand = Char
     type Target = jl.StringBuilder

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -266,7 +266,7 @@ extension [record](consume stream: (Stream[IArray[record]] over Credit)^)
   // (or close the stream by other means) to release the upstream. Per-record
   // combinators come free from the `Iterator` interface (and rudiments' `each`);
   // window-level access for hot loops is `sweep`/`fold` above.
-  def elements(using Buffering): Iterator[record]^ = recordIterator(stream)
+  def records(using Buffering): Iterator[record]^ = recordIterator(stream)
 
 // A pull endpoint lending a bounded view of a cursor: the next `length` elements
 // (or all remaining, if `Unset`), exposed zero-copy — the cursor's own buffer

--- a/lib/zephyrine/src/core/zephyrine_core.scala
+++ b/lib/zephyrine/src/core/zephyrine_core.scala
@@ -95,6 +95,17 @@ package parsing:
 
 export Cursor.{Mark, Offset}
 
+// A stream of parsed records: each window is an `IArray` chunk of them (the boxed
+// medium), so credit counts records and `Buffering` sizes stage buffers by
+// reference count. Records are immutable values, so they cross stage and thread
+// boundaries by reference; a record must not itself hold a live endpoint. This
+// alias is the conventional shape for record-granularity streaming (rows, events,
+// frames, messages) between the windowed media (`Data`, `Text`) and materialized
+// collections. The record type is unbounded here — the `Addressable` given that
+// admits a record type governs at stream construction — but it must erase to a
+// reference type.
+type Records[record] = Stream[IArray[record]] over Credit
+
 extension [in, transport](consume stream: (Stream[in] over transport)^)
   // Pull-composition: a differently-typed `Stream` whose refills translate
   // demand through the stage and pull from this stream. Runs entirely on
@@ -222,6 +233,149 @@ extension [medium](consume stream: (Stream[medium] over Credit)^)
   // skipped elements are pulled and discarded on the first `refill`. (FS2
   // `drop`, ZIO `ZStream.drop`.)
   def drop(count: Long): (Stream[medium] over Credit)^ = dropStream(stream, count)
+
+  // The legacy view: a lazy `LazyList` of one materialized chunk per refill,
+  // strictly demand-driven — construction pulls nothing, and each forced cell
+  // pulls at most one refill (the deferral `Cursor.remainder` documents). This
+  // is the audited bridge for consumers not yet converted to the kernel:
+  // `LazyList` is pure, so it cannot carry the endpoint capability its cells
+  // close over, and the ownership discipline is suspended beyond this point —
+  // implicit memoization retains every forced chunk. Prefer the kernel
+  // terminals above; never introduce new bridges elsewhere.
+  def toLazyList(using buffering: Buffering): LazyList[medium] =
+    val block = buffering.transfer(stream.addressable.substrate)
+
+    def recur(): LazyList[medium] = stream.refill(Credit(block)) match
+      case count: Int =>
+        val chunk =
+          stream.addressable.materialize(stream.window(using Unsafe), stream.start, count)
+
+        stream.skip(count)
+        chunk #:: recur()
+
+      case _ =>
+        stream.close()
+        LazyList.empty
+
+    LazyList.empty.lazyAppendedAll(recur())
+
+extension [record](consume stream: (Stream[IArray[record]] over Credit)^)
+  // Element-wise access to a stream of records: a single-consumer iterator over
+  // the records of successive windows, in order. The iterator owns the endpoint:
+  // it closes the stream when it reports exhaustion, so a consumer must drain it
+  // (or close the stream by other means) to release the upstream. Per-record
+  // combinators come free from the `Iterator` interface (and rudiments' `each`);
+  // window-level access for hot loops is `sweep`/`fold` above.
+  def elements(using Buffering): Iterator[record]^ = recordIterator(stream)
+
+// A pull endpoint lending a bounded view of a cursor: the next `length` elements
+// (or all remaining, if `Unset`), exposed zero-copy — the cursor's own buffer
+// backs each window, and skipping the stream advances the cursor. The cursor is
+// LENT, not consumed: closing this stream leaves it open, positioned at the
+// boundary, and the caller resumes it there. This is the shape of a delimited
+// payload inside a longer parse: an HTTP body before the next pipelined request,
+// an archive entry before the next header, a multipart part before the next
+// boundary.
+//
+// While the lent stream is live, the caller must not touch the cursor: the
+// aliasing is deliberate, and the result's capture of the cursor is what the
+// checker has to reason about it — temporal validity is not fully expressible,
+// so this factory is an audited point. Bulk skips bypass lineation, so lend only
+// cursors whose position tracking is inactive (the default for protocol and
+// binary parsing).
+def streamOf[data](cursor: Cursor[data, {}]^, length: Optional[Long] = Unset)
+:   (Stream[data] over Credit)^{cursor, caps.any} =
+
+    new Stream[data](using cursor.addressable):
+      type Transport = Credit
+
+      private var remaining: Long = length.or(Long.MaxValue)
+
+      // A snapshot of the cursor's buffer state, taken by `refill`: only update
+      // methods may access the exclusive cursor, so the read-only accessors
+      // below serve the snapshot. The buffer reference is cast-erased and never
+      // exposed before the first refill (hence the pure placeholder initial).
+      private var storage: AnyRef = ""
+      private var start0: Int = 0
+      private var limit0: Int = 0
+
+      protected def window0: AnyRef = storage
+      def start: Int = start0
+      def limit: Int = limit0
+
+      update def skip(count: Int): Unit =
+        remaining -= count
+        start0 += count
+        cursor.unsafeAdvanceBy(count)(using Unsafe)
+
+      // Demand does not bound exposure: the cursor refills by its own bounded
+      // block, which is what bounds memory (as the iterator factory on
+      // `Stream`'s companion notes of its chunks). An unconsumed window is
+      // reported, not extended: `cursor.more` short-circuits while buffered
+      // elements remain, so re-snapshotting it is free.
+      update def refill(demand: Credit): Optional[Int] =
+        if remaining <= 0 then Unset
+        else if cursor.more then
+          storage = cursor.unsafeBuffer(using Unsafe).asInstanceOf[AnyRef]
+          start0 = cursor.unsafePos(using Unsafe)
+          val available = cursor.unsafeWriteEnd(using Unsafe) - start0
+          val readable = if remaining < available then remaining.toInt else available
+          limit0 = start0 + readable
+          readable
+        else Unset
+
+      // Deliberately not overridden: `close()` must leave the lent cursor open
+      // for the caller to resume.
+
+private def recordIterator[record]
+  ( consume stream: (Stream[IArray[record]] over Credit)^ )
+  ( using buffering: Buffering )
+:   Iterator[record]^ =
+
+    new Iterator[record]:
+      private val block: Int = buffering.transfer(Substrate.Boxes)
+
+      // The current window: records `index until limit` of `storage` are
+      // unread; `consumed` is skipped lazily, just before the next refill, per
+      // the refill contract (an unskipped window is reported, not extended).
+      // A stdlib class cannot extend `Stateful`, so its state is untracked
+      // (the `inputStream` adapter's precedent).
+      @caps.unsafe.untrackedCaptures
+      private var storage: Array[AnyRef] = new Array[AnyRef](0)
+      @caps.unsafe.untrackedCaptures
+      private var index: Int = 0
+      @caps.unsafe.untrackedCaptures
+      private var limit: Int = 0
+      @caps.unsafe.untrackedCaptures
+      private var consumed: Int = 0
+      @caps.unsafe.untrackedCaptures
+      private var done: Boolean = false
+
+      def hasNext: Boolean = index < limit || (!done && replenish())
+
+      private def replenish(): Boolean =
+        if consumed > 0 then
+          stream.skip(consumed)
+          consumed = 0
+
+        stream.refill(Credit(block)) match
+          case count: Int =>
+            storage = stream.window(using Unsafe).asInstanceOf[Array[AnyRef]]
+            index = stream.start
+            limit = stream.start + count
+            consumed = count
+            index < limit
+
+          case _ =>
+            done = true
+            stream.close()
+            false
+
+      def next(): record =
+        if !hasNext then panic(m"the record stream is exhausted")
+        val result = storage(index).asInstanceOf[record]
+        index += 1
+        result
 
 private def throughDuct[in, out, upTransport, downTransport]
   ( consume duct:

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -909,6 +909,79 @@ object Tests extends Suite(m"Zephyrine tests"):
             sum
         . assert(_ == bytes.to(List).map(_ & 0xff).sum.toLong)
 
+        test(m"toLazyList yields the stream's chunks in order"):
+          Stream(Iterator(IArray[Byte](1, 2, 3), IArray[Byte](4, 5))).toLazyList.to(List)
+          . map(_.to(List))
+        . assert(_ == List(List[Byte](1, 2, 3), List[Byte](4, 5)))
+
+        test(m"toLazyList of an empty stream is empty"):
+          Iterator.empty[Data].stream.toLazyList.to(List)
+        . assert(_ == List())
+
+        test(m"toLazyList construction pulls nothing"):
+          var pulled: Int = 0
+          val chunks = Iterator(IArray[Byte](1.toByte), IArray[Byte](2.toByte)).map { chunk => pulled += 1; chunk }
+          val list = chunks.stream.toLazyList
+          pulled
+        . assert(_ == 0)
+
+        test(m"toLazyList pulls chunks only as cells are forced"):
+          var pulled: Int = 0
+          val chunks = Iterator(IArray[Byte](1.toByte), IArray[Byte](2.toByte)).map { chunk => pulled += 1; chunk }
+          val list = chunks.stream.toLazyList
+          list.head
+          pulled
+        . assert(_ == 1)
+
+        test(m"toLazyList reassembles a transformed pipeline"):
+          val text = Stream(Iterator(IArray[Byte](104, 105))).via(summon[CharDecoder]).toLazyList
+          text.to(List).map(_.s).mkString
+        . assert(_ == "hi")
+
+        test(m"elements iterates records across chunks in order"):
+          Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3)))).elements.to(List)
+        . assert(_ == List(Row(1), Row(2), Row(3)))
+
+        test(m"elements of an empty record stream is empty"):
+          Iterator.empty[IArray[Row]].stream.elements.to(List)
+        . assert(_ == List())
+
+        test(m"elements composes with take"):
+          Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3), Row(4)))).take(3).elements
+          . to(List)
+        . assert(_ == List(Row(1), Row(2), Row(3)))
+
+        test(m"streamOf lends a bounded sub-stream of a cursor"):
+          val cursor = Cursor(Data.fill(10)(_.toByte))
+          streamOf(cursor, 4).memoize.to(List)
+        . assert(_ == List[Byte](0, 1, 2, 3))
+
+        test(m"the lent cursor resumes at the boundary"):
+          val cursor = Cursor(Data.fill(10)(_.toByte))
+          streamOf(cursor, 4).memoize
+          cursor.remainder.to(List).flatMap(_.to(List))
+        . assert(_ == List[Byte](4, 5, 6, 7, 8, 9))
+
+        test(m"streamOf without a length lends the whole remainder"):
+          val cursor = Cursor(Data.fill(6)(_.toByte))
+          streamOf(cursor).memoize.to(List)
+        . assert(_ == List[Byte](0, 1, 2, 3, 4, 5))
+
+        test(m"streamOf spans cursor refills"):
+          val cursor = Cursor(Iterator(IArray[Byte](0, 1, 2), IArray[Byte](3, 4, 5), IArray[Byte](6.toByte)))
+          streamOf(cursor, 5).memoize.to(List)
+        . assert(_ == List[Byte](0, 1, 2, 3, 4))
+
+        test(m"a lent sub-stream and the resumed cursor partition the input"):
+          val cursor = Cursor(Iterator(IArray[Byte](0, 1, 2), IArray[Byte](3, 4, 5), IArray[Byte](6.toByte)))
+          val lent = streamOf(cursor, 5).memoize.to(List)
+          val rest = cursor.remainder.to(List).flatMap(_.to(List))
+          (lent, rest)
+        . assert(_ == (List[Byte](0, 1, 2, 3, 4), List[Byte](5, 6)))
+
+
+  // A reference-typed record for the boxed-medium (record stream) tests.
+  case class Row(id: Int)
 
   // A byte intake that gathers everything written to it, with a configurable
   // reported demand, for asserting demand translation.

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -946,6 +946,11 @@ object Tests extends Suite(m"Zephyrine tests"):
           Iterator.empty[IArray[Row]].stream.elements.to(List)
         . assert(_ == List())
 
+        test(m"memoize materializes a record stream into one IArray"):
+          val rows: IArray[Row] = Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3)))).memoize
+          rows.to(List)
+        . assert(_ == List(Row(1), Row(2), Row(3)))
+
         test(m"elements composes with take"):
           Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3), Row(4)))).take(3).elements
           . to(List)

--- a/lib/zephyrine/src/test/zephyrine_test.scala
+++ b/lib/zephyrine/src/test/zephyrine_test.scala
@@ -938,12 +938,12 @@ object Tests extends Suite(m"Zephyrine tests"):
           text.to(List).map(_.s).mkString
         . assert(_ == "hi")
 
-        test(m"elements iterates records across chunks in order"):
-          Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3)))).elements.to(List)
+        test(m"records iterates across chunks in order"):
+          Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3)))).records.to(List)
         . assert(_ == List(Row(1), Row(2), Row(3)))
 
-        test(m"elements of an empty record stream is empty"):
-          Iterator.empty[IArray[Row]].stream.elements.to(List)
+        test(m"records of an empty record stream is empty"):
+          Iterator.empty[IArray[Row]].stream.records.to(List)
         . assert(_ == List())
 
         test(m"memoize materializes a record stream into one IArray"):
@@ -951,8 +951,8 @@ object Tests extends Suite(m"Zephyrine tests"):
           rows.to(List)
         . assert(_ == List(Row(1), Row(2), Row(3)))
 
-        test(m"elements composes with take"):
-          Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3), Row(4)))).take(3).elements
+        test(m"records composes with take"):
+          Stream(Iterator(IArray(Row(1), Row(2)), IArray(Row(3), Row(4)))).take(3).records
           . to(List)
         . assert(_ == List(Row(1), Row(2), Row(3)))
 


### PR DESCRIPTION
The streaming kernel gains first-class support for record-granularity streams — chunks of parsed values on the boxed medium — with terminals to iterate them, a line-splitting duct as the first record-emitting stage, a bounded lending sub-stream over a cursor, an audited `LazyList` bridge for unconverted consumers, and `Relay`, the kernel successor to `Spool`.

Streams of *records* — parsed rows, events, messages — now have a conventional shape in the streaming kernel: `Stream[IArray[record]] over Credit` (aliased as `Records[record]`), where each window is a chunk of records and credit counts records. New operations support it:

- `stream.records` drains a record stream as a single-owner `Iterator`.
- `stream.delineate` splits a `Stream[Text]` (or a `Stream[Data]`, decoding through the UTF-8 kernel first) into a record stream of its lines, under the ambient `LineSeparation` policy — the first record-emitting `Duct`:

  ```scala
  file.stream.delineate.records.each: line =>
    process(line)
  ```

- `streamOf(cursor, length)` lends a bounded, zero-copy pull endpoint over the next `length` elements of a `Cursor`, after which the cursor resumes at the boundary — the shape of a delimited payload: an HTTP body before the next pipelined request, an archive entry, a multipart part.
- `stream.toLazyList` is the audited bridge for consumers not yet converted to the kernel: strictly demand-driven, one materialized chunk per refill, nothing pulled until forced.
- `Relay[record]` succeeds `Spool` as the push-side bridge from many producer threads to a single pull endpoint: producers `put` records and `stop`; the reader's refill batches everything already arrived into one window instead of paying one hand-off per element.

`IArray[Text]` gains its own `Addressable` instance (`Text` chunks erase to `String[]`), and the generic boxed record medium now requires a `ClassTag`, fixing materialization of concretely-typed record chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)