### PR TITLE
Carry surrogate pairs across chunk boundaries when encoding streams

### DIFF
--- a/lib/hieroglyph/src/core/hieroglyph.CharEncoder.scala
+++ b/lib/hieroglyph/src/core/hieroglyph.CharEncoder.scala
@@ -36,6 +36,7 @@ import java.nio as jn, jn.charset as jnc
 
 import anticipation.*
 import beneficence.*
+import denominative.*
 import rudiments.*
 import vacuous.*
 
@@ -51,4 +52,47 @@ extends Encodable, Findable:
   type Form = Data
 
   def encoded(text: Text): Data = text.s.getBytes(encoding.name.s).nn.immutable(using Unsafe)
-  def encoded(stream: LazyList[Text]): LazyList[Data] = stream.map(encode)
+
+  // Chunk boundaries are not character boundaries: a surrogate pair may be
+  // split across two chunks, so encoding each chunk independently (as this
+  // method formerly did) corrupts any astral character on a boundary. Chars
+  // stage through a `CharBuffer` — the mirror of `CharDecoder.decoded` — so
+  // pairs carry whole across chunks; malformed and unmappable input is
+  // replaced, matching `getBytes` on the whole-value path above.
+  def encoded(stream: LazyList[Text]): LazyList[Data] =
+    val encoder =
+      encoding.charset.newEncoder().nn
+      . onMalformedInput(jnc.CodingErrorAction.REPLACE).nn
+      . onUnmappableCharacter(jnc.CodingErrorAction.REPLACE).nn
+
+    val in = jn.CharBuffer.allocate(4096).nn
+    val out = jn.ByteBuffer.allocate(4096).nn
+
+    def recur(todo: LazyList[Text], offset: Int = 0): LazyList[Data] =
+      val count = in.remaining
+
+      if !todo.nil then
+        in.put(todo.head.s, offset, offset + count.min(todo.head.s.length - offset))
+
+      in.flip()
+      val status = encoder.encode(in, out, todo.nil).nn
+
+      // An overflowed final round loops to drain; `flush` (significant only
+      // for stateful charsets) happens on the true final round.
+      if todo.nil && !status.isOverflow then encoder.flush(out)
+
+      out.flip()
+      val array = new Array[Byte](out.remaining)
+      out.get(array)
+      val data: Data = array.immutable(using Unsafe)
+      out.clear()
+      in.compact()
+
+      def continue =
+        if todo.nil && !status.isOverflow then LazyList()
+        else if !todo.nil && count >= todo.head.s.length - offset then recur(todo.tail, 0)
+        else recur(todo, offset + count)
+
+      if data.length == 0 then continue else data #:: continue
+
+    recur(stream)

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -95,6 +95,25 @@ object Tests extends Suite(m"Turbulence tests"):
           result.s
         . assert(_ == string.s)
 
+      test(m"a surrogate pair split across chunks encodes correctly"):
+        val gothic = t"𐍈"
+        val high = gothic.s.charAt(0).toString.tt
+        val low = gothic.s.charAt(1).toString.tt
+
+        summon[CharEncoder].encoded(LazyList(t"a", high, low, t"b"))
+        . to(List).reduce(_ ++ _).to(List)
+      . assert(_ == t"a𐍈b".in[Data].to(List))
+
+      test(m"per-char-chunk streams roundtrip through encode and decode"):
+        val string = "aë€𐍈z"
+
+        val chunks =
+          (0 until string.length).map { index => string.charAt(index).toString.tt }.to(LazyList)
+
+        summon[CharDecoder].decoded(summon[CharEncoder].encoded(chunks))
+        . to(List).map(_.s).mkString
+      . assert(_ == "aë€𐍈z")
+
     val qbf = t"The quick brown fox\njumps over the lazy dog"
     val qbfData = qbf.in[Data]
 


### PR DESCRIPTION
A correctness fix for streamed character encoding: an astral character whose surrogate pair straddled a chunk boundary previously encoded as two replacement characters, because each chunk was encoded independently.

`CharEncoder.encoded(stream: LazyList[Text])` now stages characters through a `CharBuffer` — the mirror of `CharDecoder.decoded`'s staging loop — so surrogate pairs carry whole across chunk boundaries, whatever the chunking. Malformed and unmappable input is replaced, matching `getBytes` on the whole-value path, and `flush` runs at end-of-input for stateful charsets. Whole-value encoding is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)