### PR TITLE
Parse Markdown incrementally from streams

### DIFF
--- a/lib/punctuation/src/core/punctuation.BlockParser.scala
+++ b/lib/punctuation/src/core/punctuation.BlockParser.scala
@@ -39,6 +39,7 @@ import denominative.*
 import fulminate.*
 import prepositional.*
 import vacuous.*
+import zephyrine.*
 
 // Pass 1: line-by-line dispatch over a stack of open block builders. The
 // algorithm follows CommonMark's "phase 1" (block parsing):
@@ -78,10 +79,38 @@ private[punctuation] final class BlockParser:
         pos = nlPos + 1
         lineNum += 1
 
+    finish()
+
+  // The streaming entry: lines are read incrementally off a cursor, so the
+  // input is consumed as it arrives and only the AST (plus each paragraph's
+  // deferred raw text) is retained. The direct `String` path above remains
+  // for materialized text, where the intrinsified scan wins; per-line
+  // behaviour is identical (`\n`-only splitting, `\r` retained).
+  def parse(cursor: Cursor[Text, {}]^): Markdown of Layout =
+    var lineNum = 0
+
+    while !cursor.finished do
+      val line = cursor.hold:
+        val start = cursor.mark
+
+        while !cursor.finished && !(cursor.peek == '\n') do cursor.next()
+
+        val line = cursor.grab(start, cursor.mark)
+        if !cursor.finished then cursor.next()
+        line
+
+      processLine(line, lineNum.z)
+      lineNum += 1
+
+    finish()
+
+  private def finish(): Markdown of Layout =
     closeAll()
 
     // Post-pass: with the link-reference table now fully populated, run the
-    // inline parser over each Paragraph/Heading's deferred raw text.
+    // inline parser over each Paragraph/Heading's deferred raw text. (This is
+    // why parsing cannot emit blocks as it goes: a link-reference definition
+    // may follow its uses, so no inline content is final until end of input.)
     val resolved = docBuilder.children.iterator.map(resolveInlines).toSeq
     Markdown(refs.all, resolved*)
 

--- a/lib/punctuation/src/core/punctuation.Markdown.scala
+++ b/lib/punctuation/src/core/punctuation.Markdown.scala
@@ -63,6 +63,23 @@ object Markdown:
 
   case class LinkRef(label: Text, title: Optional[Text], destination: Text)
 
+  // Markdown reads directly from any streaming source (`file.read[Markdown of
+  // Layout]`): parsing is total, so the given is unconditional, and the
+  // streaming `accept` path consumes its input incrementally.
+  given aggregable: (Markdown of Layout) is turbulence.Aggregable by Text =
+    new turbulence.Aggregable:
+      type Self = Markdown of Layout
+      type Operand = Text
+
+      def aggregate(stream: LazyList[Text]): Markdown of Layout = Parser.parse(stream.iterator)
+
+      override def accept(stream: (zephyrine.Stream[Text] over zephyrine.Credit)^)
+      :   Markdown of Layout =
+        // The non-consume `accept` crosses to the consuming factory as a
+        // neutral reference; each accept delivers a single-use stream.
+        Parser.parse:
+          stream.asInstanceOf[AnyRef].asInstanceOf[(zephyrine.Stream[Text] over zephyrine.Credit)^]
+
   // FIXME: This implementation needs to be cleaned up
   private def url(text: Text): Text =
     val builder = StringBuilder()

--- a/lib/punctuation/src/core/punctuation.Parser.scala
+++ b/lib/punctuation/src/core/punctuation.Parser.scala
@@ -34,9 +34,20 @@ package punctuation
 
 import anticipation.*
 import prepositional.*
+import zephyrine.*
 
 // Public entry point for the CommonMark parser. Returns a `Markdown of Layout`
 // directly built from Punctuation's own ADT, with full CommonMark spec
 // compliance (passes 578/578 spec tests).
 object Parser:
   def parse(text: Text): Markdown of Layout = BlockParser().parse(text)
+
+  // Streaming entries: the input is consumed incrementally (a fresh parser
+  // per stream), retaining only the AST and each paragraph's deferred raw
+  // text. The result is necessarily a whole tree: link-reference definitions
+  // may follow their uses, so nothing is final until end of input.
+  def parse(stream: (Stream[Text] over Credit)^)(using Buffering): Markdown of Layout =
+    BlockParser().parse(Cursor(stream))
+
+  def parse(iterator: Iterator[Text]^): Markdown of Layout =
+    BlockParser().parse(Cursor(iterator))

--- a/lib/punctuation/src/test/punctuation_test.scala
+++ b/lib/punctuation/src/test/punctuation_test.scala
@@ -63,6 +63,19 @@ object Tests extends Suite(m"Punctuation tests"):
                   Parser.parse(testcase.markdown).html.show
                 . assert(_ == html.show)
 
+                test(m"Commonmark test case ${testcase.example}, streamed in single chars"):
+                  Parser.parse(testcase.markdown.s.grouped(1).map(_.tt).stream).html.show
+                . assert(_ == html.show)
+
+    suite(m"Streaming reads"):
+      test(m"markdown reads from a fragmented stream through the Aggregable given"):
+        val md = t"# Title\n\nA [link][ref] here.\n\n[ref]: https://example.org\n"
+
+        summon[(Markdown of Layout) is Aggregable by Text]
+        . accept(md.s.grouped(3).map(_.tt).stream)
+        . children.length
+      . assert(_ == 2)
+
     suite(m"Serializer round-trip"):
       def roundTrip(markdown: Text): Markdown of Layout =
         Parser.parse(Parser.parse(markdown).show)


### PR DESCRIPTION
Markdown now parses incrementally from streaming sources: the CommonMark block parser reads lines off a cursor as input arrives, retaining only the AST, and a new `Aggregable` given makes Markdown readable through the uniform `.read` API.

The block parser previously required the whole document as a single `Text`. That path remains — its intrinsified line scan is fastest for materialized input — but a streaming entry now consumes a `Cursor[Text]` line by line with identical semantics, so parsing a large document from a file or network source no longer materializes it first:

```scala
file.read[Markdown of Layout]
```

The result is necessarily a whole tree: CommonMark link-reference definitions may follow their uses, so no inline content is final until end of input. Conformance is verified doubly — the full CommonMark spec suite now also runs through the streaming entry, delivered one character per chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)