### PR TITLE
Inlined Expr-composed parsers for TEL and XML

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -944,10 +944,11 @@ object cosmopolite extends Library:
 
 object crossparse extends Library:
   // The corpus's domain types, compiled one phase before the benchmarks so
-  // that `Json.Inlinable`'s expansion-time instance evaluation can load them
-  // (and resolve the companion `Inlinable` givens) at the bench's expansion.
-  object model extends Component(jacinta.staged, stratiform.core, xylophone.core, ypsiloid.core):
-    override def scalaJs = false // depends on jacinta.staged (compiler jars)
+  // that each format's `Inlinable` expansion-time instance evaluation can
+  // load them (and resolve the companion `Inlinable` givens) at the bench's
+  // expansion.
+  object model extends Component(jacinta.staged, stratiform.staged, xylophone.staged, ypsiloid.core):
+    override def scalaJs = false // depends on the staged components (compiler jars)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
 
@@ -1891,6 +1892,17 @@ object stratiform extends Library:
   object records extends Component(core, polyvinyl.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+  // The Expr-level `Inlinable` typeclass and its expansion-time instance
+  // evaluation (an in-macro staging compiler), kept out of `core` so
+  // stratiform users don't inherit the compiler jars unless they opt in.
+  object staged extends Component(core):
+    override def scalaJs = false // expansion-time instance evaluation via staging
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
   object time extends Component(core, aviation.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
@@ -2158,6 +2170,17 @@ object xylophone extends Library:
   object core extends Component(zephyrine.core, adversaria.core, typonym.core, urticose.core, wisteria.core, panopticon.core, turbulence.core, serpentine.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+  // The Expr-level `Inlinable` typeclass and its expansion-time instance
+  // evaluation (an in-macro staging compiler), kept out of `core` so
+  // xylophone users don't inherit the compiler jars unless they opt in.
+  object staged extends Component(core):
+    override def scalaJs = false // expansion-time instance evaluation via staging
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
   object test extends Tests(core)
   object bench extends Benchmarks(core, quantitative.units, hellenism.core):
     def mvnDeps = Seq(mvn"org.scala-lang.modules::scala-xml:2.4.0")

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -151,82 +151,45 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
   lazy val telData: Data = telText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
 
   // ── The decode arms ───────────────────────────────────────────────────────
-  // Each format reads from its natural whole-input form — JSON and TEL from
-  // `Data`, XML and YAML from `Text` — with both of a format's arms reading
-  // the *same* input kind, so direct-versus-AST is a fair comparison within
-  // each format. YAML has no direct arm: ypsiloid's decoding is deliberately
-  // AST-only (YAML aliases require materialized subtrees).
-  def decodeJsonDirect(): Orders = jsonData.read[Orders in Json]
+  // Each format is measured two ways: through its materialized AST, and
+  // through its inlined parser — the Expr-composed, monomorphic decoder each
+  // format's `Inlinable.parsable` generates. Both of a format's arms read
+  // the *same* input kind (JSON and TEL from `Data`, XML and YAML from
+  // `Text`), so AST-versus-inlined is a fair comparison within each format.
+  // YAML has no inlined arm: ypsiloid's decoding is deliberately AST-only
+  // (YAML aliases require materialized subtrees).
   def decodeJsonAst(): Orders = jsonData.read[Json].as[Orders]
 
-  // The staged arm: monomorphic generated parsers for each record type,
-  // hoisted so the KeyTables and instance arrays are built once. The nested
-  // record types' staged givens are siblings, so each expansion finds them;
-  // `items` (a `List`) and `payment` (a sum) still cross runtime `Json.Field`
-  // seams — the current staged composition boundary.
-  object staged:
-    given lineItem: LineItem is Json.Parsable = Json.Parsable.staged
-    given customer: Customer is Json.Parsable = Json.Parsable.staged
+  object inlined:
+    // The JSON sum bridge: `payment` has no `Inlinable`, so the inlined
+    // parser binds this sibling staged sum through its runtime seam; the
+    // variant instances are its staged siblings.
     given card: Payment.Card is Json.Parsable = Json.Parsable.staged
     given transfer: Payment.Transfer is Json.Parsable = Json.Parsable.staged
     given payment: Payment is Json.Parsable = Json.Parsable.staged
-    given order: Order is Json.Parsable = Json.Parsable.staged
-    given orders: Orders is Json.Parsable = Json.Parsable.staged
-
-    given telLineItem: LineItem is Tel.Parsable = Tel.Parsable.staged
-    given telCustomer: Customer is Tel.Parsable = Tel.Parsable.staged
-    given telOrder: Order is Tel.Parsable = Tel.Parsable.staged
-    given telOrders: Orders is Tel.Parsable = Tel.Parsable.staged
-
-    given xmlLineItem: LineItem is Xml.Parsable = Xml.Parsable.staged
-    given xmlCustomer: Customer is Xml.Parsable = Xml.Parsable.staged
-    given xmlOrder: Order is Xml.Parsable = Xml.Parsable.staged
-    given xmlOrders: Orders is Xml.Parsable = Xml.Parsable.staged
-
-    // The nominal direct parsers for the sum: TEL and XML have no staged
-    // sum generation, so `payment` crosses each inlined parser's runtime
-    // seam — these sibling given vals make that seam a value reference (one
-    // Wisteria derivation per instance, not per parse), the same role the
-    // staged JSON sum given plays for the JSON inlined arm.
-    given telPayment: Payment is Tel.Parsable = Tel.Parsable.derived
-    given xmlPayment: Payment is Xml.Parsable = Xml.Parsable.derived
 
     // The Inlinable-composed parsers: the whole instance graph (records,
-    // collection gathering, leaf parsers) resolves live inside an in-macro
-    // staging compiler — the model component's companion givens — and
-    // inlines into one flat parser per format. `payment` (a sum) has no
-    // Inlinable and binds the sibling nominal instance above through the
-    // runtime seam.
+    // collection gathering, leaf parsers — and, for TEL and XML, the sum
+    // itself) resolves live inside an in-macro staging compiler — the model
+    // component's companion givens — and inlines into one flat parser per
+    // format.
     given inlinedOrders: Orders is Json.Parsable = jacinta.Inlinable.parsable[Orders]
     given inlinedTelOrders: Orders is Tel.Parsable = stratiform.Inlinable.parsable[Orders]
     given inlinedXmlOrders: Orders is Xml.Parsable = xylophone.Inlinable.parsable[Orders]
 
-  def decodeJsonStaged(): Orders =
-    import staged.orders
-    jsonData.read[Orders in Json]
-
   def decodeJsonInlined(): Orders =
-    import staged.inlinedOrders
+    import inlined.inlinedOrders
     jsonData.read[Orders in Json]
-
-  def decodeTelStaged(): Orders =
-    import staged.telOrders
-    telData.read[Orders in Tel]
 
   def decodeTelInlined(): Orders =
-    import staged.inlinedTelOrders
+    import inlined.inlinedTelOrders
     telData.read[Orders in Tel]
 
-  def decodeXmlStaged(): Orders =
-    import staged.xmlOrders
+  def decodeXmlInlined(): Orders =
+    import inlined.inlinedXmlOrders
     xmlText.read[Orders in Xml]
 
-  def decodeXmlInlined(): Orders =
-    import staged.inlinedXmlOrders
-    xmlText.read[Orders in Xml]
-  def decodeTelDirect(): Orders = telData.read[Orders in Tel]
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
-  def decodeXmlDirect(): Orders = xmlText.read[Orders in Xml]
   def decodeXmlAst(): Orders = xmlText.read[Xml].as[Orders]
   def decodeYamlAst(): Orders = yamlText.read[Yaml].as[Orders]
 
@@ -285,16 +248,10 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
     // The correctness gate: every arm must reproduce the original value
     // before anything is timed.
-    assert(decodeJsonDirect() == corpus, "JSON direct decode disagrees with the corpus")
-    assert(decodeJsonStaged() == corpus, "JSON staged decode disagrees with the corpus")
     assert(decodeJsonInlined() == corpus, "JSON inlined decode disagrees with the corpus")
     assert(decodeJsonAst() == corpus, "JSON AST decode disagrees with the corpus")
-    assert(decodeTelDirect() == corpus, "TEL direct decode disagrees with the corpus")
-    assert(decodeTelStaged() == corpus, "TEL staged decode disagrees with the corpus")
     assert(decodeTelInlined() == corpus, "TEL inlined decode disagrees with the corpus")
     assert(decodeTelAst() == corpus, "TEL AST decode disagrees with the corpus")
-    assert(decodeXmlDirect() == corpus, "XML direct decode disagrees with the corpus")
-    assert(decodeXmlStaged() == corpus, "XML staged decode disagrees with the corpus")
     assert(decodeXmlInlined() == corpus, "XML inlined decode disagrees with the corpus")
     assert(decodeXmlAst() == corpus, "XML AST decode disagrees with the corpus")
     assert(decodeYamlAst() == corpus, "YAML AST decode disagrees with the corpus")
@@ -307,35 +264,20 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     val profile = Profile()
 
     suite(m"Decode a ~10 KB order corpus to case classes"):
-      bench(m"JSON direct")(target = 1*Second, baseline = Baseline(compare = Min)):
-        '{ crossparse.Benchmarks.decodeJsonDirect() }
-
-      bench(m"JSON staged")(target = 1*Second):
-        '{ crossparse.Benchmarks.decodeJsonStaged() }
-
-      bench(m"JSON inlined")(target = 1*Second):
+      // The suite's first row absorbs the JVM's compile ramp, so it warms
+      // longer than the rest.
+      bench(m"JSON inlined")
+        (target = 1*Second, warmups = 15, baseline = Baseline(compare = Min)):
         '{ crossparse.Benchmarks.decodeJsonInlined() }
 
       bench(m"JSON via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsonAst() }
-
-      bench(m"TEL direct")(target = 1*Second):
-        '{ crossparse.Benchmarks.decodeTelDirect() }
-
-      bench(m"TEL staged")(target = 1*Second):
-        '{ crossparse.Benchmarks.decodeTelStaged() }
 
       bench(m"TEL inlined")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeTelInlined() }
 
       bench(m"TEL via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeTelAst() }
-
-      bench(m"XML direct")(target = 1*Second):
-        '{ crossparse.Benchmarks.decodeXmlDirect() }
-
-      bench(m"XML staged")(target = 1*Second):
-        '{ crossparse.Benchmarks.decodeXmlStaged() }
 
       bench(m"XML inlined")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeXmlInlined() }
@@ -344,7 +286,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
         '{ crossparse.Benchmarks.decodeXmlAst() }
 
       // YAML decodes through the AST only: aliases require materialized
-      // subtrees, so ypsiloid deliberately has no direct path.
+      // subtrees, so ypsiloid deliberately has no inlined path.
       bench(m"YAML via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeYamlAst() }
 
@@ -354,33 +296,15 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
       bench(m"Jsoniter via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsoniterAst() }
 
-    // Where the self-time actually goes in each direct arm — a JFR hotspot
+    // Where the self-time actually goes in each inlined arm — a JFR hotspot
     // histogram per parser, coloured by package. Jsoniter direct is the
     // reference. Longer targets so the sampler gathers enough execution samples.
-    suite(m"Profile: direct-parser hotspots"):
-      profile(m"TEL direct")(target = 5*Second):
-        '{ crossparse.Benchmarks.decodeTelDirect() }
-
-      profile(m"TEL staged")(target = 5*Second):
-        '{ crossparse.Benchmarks.decodeTelStaged() }
-
+    suite(m"Profile: inlined-parser hotspots"):
       profile(m"TEL inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeTelInlined() }
 
-      profile(m"XML direct")(target = 5*Second):
-        '{ crossparse.Benchmarks.decodeXmlDirect() }
-
-      profile(m"XML staged")(target = 5*Second):
-        '{ crossparse.Benchmarks.decodeXmlStaged() }
-
       profile(m"XML inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlInlined() }
-
-      profile(m"JSON direct")(target = 5*Second):
-        '{ crossparse.Benchmarks.decodeJsonDirect() }
-
-      profile(m"JSON staged")(target = 5*Second):
-        '{ crossparse.Benchmarks.decodeJsonStaged() }
 
       profile(m"JSON inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsonInlined() }

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -183,12 +183,23 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     given xmlOrder: Order is Xml.Parsable = Xml.Parsable.staged
     given xmlOrders: Orders is Xml.Parsable = Xml.Parsable.staged
 
-    // The Inlinable-composed parser: the whole instance graph (records,
-    // collection loops, leaf parsers) resolves live inside an in-macro
+    // The nominal direct parsers for the sum: TEL and XML have no staged
+    // sum generation, so `payment` crosses each inlined parser's runtime
+    // seam — these sibling given vals make that seam a value reference (one
+    // Wisteria derivation per instance, not per parse), the same role the
+    // staged JSON sum given plays for the JSON inlined arm.
+    given telPayment: Payment is Tel.Parsable = Tel.Parsable.derived
+    given xmlPayment: Payment is Xml.Parsable = Xml.Parsable.derived
+
+    // The Inlinable-composed parsers: the whole instance graph (records,
+    // collection gathering, leaf parsers) resolves live inside an in-macro
     // staging compiler — the model component's companion givens — and
-    // inlines into one flat parser. `payment` (a sum) has no Inlinable and
-    // splices a runtime call to the sibling staged sum given above.
-    given inlinedOrders: Orders is Json.Parsable = Inlinable.parsable[Orders]
+    // inlines into one flat parser per format. `payment` (a sum) has no
+    // Inlinable and binds the sibling nominal instance above through the
+    // runtime seam.
+    given inlinedOrders: Orders is Json.Parsable = jacinta.Inlinable.parsable[Orders]
+    given inlinedTelOrders: Orders is Tel.Parsable = stratiform.Inlinable.parsable[Orders]
+    given inlinedXmlOrders: Orders is Xml.Parsable = xylophone.Inlinable.parsable[Orders]
 
   def decodeJsonStaged(): Orders =
     import staged.orders
@@ -202,8 +213,16 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     import staged.telOrders
     telData.read[Orders in Tel]
 
+  def decodeTelInlined(): Orders =
+    import staged.inlinedTelOrders
+    telData.read[Orders in Tel]
+
   def decodeXmlStaged(): Orders =
     import staged.xmlOrders
+    xmlText.read[Orders in Xml]
+
+  def decodeXmlInlined(): Orders =
+    import staged.inlinedXmlOrders
     xmlText.read[Orders in Xml]
   def decodeTelDirect(): Orders = telData.read[Orders in Tel]
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
@@ -272,9 +291,11 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeJsonAst() == corpus, "JSON AST decode disagrees with the corpus")
     assert(decodeTelDirect() == corpus, "TEL direct decode disagrees with the corpus")
     assert(decodeTelStaged() == corpus, "TEL staged decode disagrees with the corpus")
+    assert(decodeTelInlined() == corpus, "TEL inlined decode disagrees with the corpus")
     assert(decodeTelAst() == corpus, "TEL AST decode disagrees with the corpus")
     assert(decodeXmlDirect() == corpus, "XML direct decode disagrees with the corpus")
     assert(decodeXmlStaged() == corpus, "XML staged decode disagrees with the corpus")
+    assert(decodeXmlInlined() == corpus, "XML inlined decode disagrees with the corpus")
     assert(decodeXmlAst() == corpus, "XML AST decode disagrees with the corpus")
     assert(decodeYamlAst() == corpus, "YAML AST decode disagrees with the corpus")
 
@@ -304,6 +325,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
       bench(m"TEL staged")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeTelStaged() }
 
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeTelInlined() }
+
       bench(m"TEL via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeTelAst() }
 
@@ -312,6 +336,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       bench(m"XML staged")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeXmlStaged() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeXmlInlined() }
 
       bench(m"XML via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeXmlAst() }
@@ -337,11 +364,17 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
       profile(m"TEL staged")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeTelStaged() }
 
+      profile(m"TEL inlined")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeTelInlined() }
+
       profile(m"XML direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlDirect() }
 
       profile(m"XML staged")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlStaged() }
+
+      profile(m"XML inlined")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeXmlInlined() }
 
       profile(m"JSON direct")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeJsonDirect() }

--- a/lib/crossparse/src/model/crossparse.model.scala
+++ b/lib/crossparse/src/model/crossparse.model.scala
@@ -84,20 +84,29 @@ object Payment:
 
 case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
 
+// The per-format `Inlinable` givens are qualified: each format's staged
+// component declares its own `Inlinable`, and this module imports all three
+// packages.
 object LineItem:
-  given inlinable: (LineItem is Inlinable) = Inlinable.derived
+  given jsonInlinable: (LineItem is jacinta.Inlinable) = jacinta.Inlinable.derived
+  given telInlinable: (LineItem is stratiform.Inlinable) = stratiform.Inlinable.derived
+  given xmlInlinable: (LineItem is xylophone.Inlinable) = xylophone.Inlinable.derived
 
 case class Customer(id: Long, name: Text, email: Text, region: Text)
 
 object Customer:
-  given inlinable: (Customer is Inlinable) = Inlinable.derived
+  given jsonInlinable: (Customer is jacinta.Inlinable) = jacinta.Inlinable.derived
+  given telInlinable: (Customer is stratiform.Inlinable) = stratiform.Inlinable.derived
+  given xmlInlinable: (Customer is xylophone.Inlinable) = xylophone.Inlinable.derived
 
 case class Order
   ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
     priority: Boolean, discount: Double )
 
 object Order:
-  given inlinable: (Order is Inlinable) = Inlinable.derived
+  given jsonInlinable: (Order is jacinta.Inlinable) = jacinta.Inlinable.derived
+  given telInlinable: (Order is stratiform.Inlinable) = stratiform.Inlinable.derived
+  given xmlInlinable: (Order is xylophone.Inlinable) = xylophone.Inlinable.derived
 
 case class Orders(orders: List[Order])
 
@@ -109,4 +118,6 @@ object Orders:
   given telParsable: Orders is Tel.Parsable = Tel.Parsable.derived
   given xmlParsable: Orders is Xml.Parsable = Xml.Parsable.derived
 
-  given inlinable: (Orders is Inlinable) = Inlinable.derived
+  given jsonInlinable: (Orders is jacinta.Inlinable) = jacinta.Inlinable.derived
+  given telInlinable: (Orders is stratiform.Inlinable) = stratiform.Inlinable.derived
+  given xmlInlinable: (Orders is xylophone.Inlinable) = xylophone.Inlinable.derived

--- a/lib/crossparse/src/model/crossparse.model.scala
+++ b/lib/crossparse/src/model/crossparse.model.scala
@@ -60,27 +60,10 @@ object Payment:
   // default `Discriminable`: the product encoder relabels the variant
   // element with the *field's* name, which destroys the discriminator. The
   // variant rides in a `type` attribute instead — `<payment type="Card">` —
-  // mirroring the discriminator key the JSON and YAML corpora carry.
-  given xmlDiscriminable: Payment is Discriminable in Xml = new Discriminable:
-    type Self = Payment
-    type Form = Xml
-
-    def discriminate(xml: Xml): Optional[Text] = xml match
-      case Element(_, attributes, _)           => attributes.at(t"type")
-      case Fragment(Element(_, attributes, _)) => attributes.at(t"type")
-      case _                                   => Unset
-
-    def rewrite(kind: Text, xml: Xml): Xml = xml match
-      case Element(label, attributes, children) =>
-        Element(label, attributes.updated(t"type", kind), children)
-
-      case Fragment(Element(label, attributes, children)) =>
-        Element(label, attributes.updated(t"type", kind), children)
-
-      case other =>
-        other
-
-    def variant(xml: Xml): Xml = xml
+  // mirroring the discriminator key the JSON and YAML corpora carry. The
+  // named `DiscriminantAttribute` shape also lets the inlined XML parser
+  // dispatch on the attribute straight off the open tag.
+  given xmlDiscriminable: Payment is Discriminable in Xml = Xml.DiscriminantAttribute(t"type")
 
 case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
 

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1871,6 +1871,11 @@ object Tel extends Tel2:
       p.reset(Cursor[Data](input), Unset)
       p.documentStream(first = true)
 
+    // The shared empty-children array: `IArray.empty[Tel.Block]` builds a
+    // fresh zero-length array through a reflective `ClassTag` on every call,
+    // and `parseChildren` returns it once per leaf entry.
+    private val EmptyBlocks: IArray[Tel.Block] = IArray.empty[Tel.Block]
+
     private final val SP: Byte = 0x20
     private final val LF: Byte = 0x0A
     private final val CR: Byte = 0x0D
@@ -1918,6 +1923,27 @@ object Tel extends Tel2:
     // Per-lane "does this byte equal the target?" mask.
     private inline def matchByte(v: Long, replicated: Long): Long =
       haszero(v ^ replicated)
+
+    // A compound-line scan's stop bytes — space, LF, CR — in one mask; zero
+    // means all eight bytes are keyword or atom content. Little-endian
+    // (`longView`), so `numberOfTrailingZeros(mask) >> 3` is the offset of
+    // the first stop byte.
+    private inline def contentStops(word: Long): Long =
+      matchByte(word, SpRepl) | matchByte(word, LfRepl) | matchByte(word, CrRepl)
+
+    // The packed-keyword printability test: true when the first `len` bytes
+    // of `packed` are all printable ASCII (0x21–0x7E), so the packed form
+    // cannot alias a shorter keyword's or a sentinel. The tail is filled
+    // with a printable byte so only real content can trip the below-0x21,
+    // DEL or high-bit conditions.
+    private inline def printableWord(packed: Long, len: Int): Boolean =
+      val tail = if len == 8 then 0L else -1L << (len*8)
+      val filled = packed | (tail & 0x2121212121212121L)
+      val below = (filled - 0x2121212121212121L) & ~filled & HighBitsMask
+      val del = { val x = filled ^ 0x7F7F7F7F7F7F7F7FL
+                  (x - OnesMask) & ~x & HighBitsMask }
+
+      (below | del | (packed & HighBitsMask)) == 0L
 
     // Carries the look-ahead state for the next unconsumed line. Parsed once
     // by `fillHead`, then consulted by recursive-descent functions to decide
@@ -2074,11 +2100,6 @@ object Tel extends Tel2:
     private inline val PrimaryLong = 1
     private inline val PrimaryBoolean = 2
     private inline val PrimaryInt = 3
-
-    // `true` and `false` packed LSB-first, for the leaf fast path's boolean
-    // comparison.
-    private inline val TrueWord = 0x65757274L
-    private inline val FalseWord = 0x65736C6166L
 
     private var directPrimaryOnly:    Boolean       = false
     private var directPrimaryMode:    Int           = PrimaryText
@@ -2261,7 +2282,7 @@ object Tel extends Tel2:
         result.asInstanceOf[IArray[Tel.Compound]]
 
     private inline def takeBlocks(count: Int): IArray[Tel.Block] =
-      if count == 0 then IArray.empty[Tel.Block]
+      if count == 0 then EmptyBlocks
       else
         val result = new Array[Tel.Block](count)
         System.arraycopy(scratchBlocks, blockScratchIx - count, result, 0, count)
@@ -2826,6 +2847,23 @@ object Tel extends Tel2:
     private inline def countLeadingSpaces(): Int =
       var count = 0
 
+      // A word at a time while the window allows: indent runs are short, so
+      // one load usually decides.
+      while pos + 8 <= bufEnd && {
+        val nonSpace =
+          ~Parser.matchByte(Parser.longView(bytes, pos), Parser.SpRepl) & Parser.HighBitsMask
+
+        if nonSpace == 0L then
+          pos += 8
+          count += 8
+          true
+        else
+          val run = java.lang.Long.numberOfTrailingZeros(nonSpace) >> 3
+          pos += run
+          count += run
+          false
+      } do ()
+
       while more && peek == SP do
         advance()
         count += 1
@@ -3172,7 +3210,7 @@ object Tel extends Tel2:
       val expected = parentIndent + 1
 
       if head.eof || head.separator || head.indentLevels < expected
-      then IArray.empty[Tel.Block]
+      then EmptyBlocks
       else
         val start = blockScratchIx
 
@@ -3310,7 +3348,7 @@ object Tel extends Tel2:
 
             val children =
               if extraAtom.absent && tabulation.absent then parseChildren(indent)
-              else IArray.empty[Tel.Block]
+              else EmptyBlocks
 
             val atoms = takeAtoms(atomScratchIx - atomsStart)
             pushCompound(Tel.Compound(compoundKeyword, atoms, compoundRemark, children))
@@ -4160,6 +4198,46 @@ object Tel extends Tel2:
     // keyword's or a sentinel — is sliced eagerly, exactly as `readKeyword`
     // would, and reported `KeywordOpaque`.
     private def readKeywordFast()(using Tactic[TelError]): Unit =
+      // Fused scan-and-pack: the word loaded to find the keyword's end *is*
+      // its packed form, so a packable keyword costs one load. A keyword at
+      // the window's edge, longer than eight bytes or carrying unpackable
+      // bytes takes the per-byte slow path.
+      var slow = true
+
+      if pos + 8 <= bufEnd then
+        val word: Long = Parser.longView(bytes, pos)
+        val stops = Parser.contentStops(word)
+
+        if stops != 0L then
+          val len = java.lang.Long.numberOfTrailingZeros(stops) >> 3
+
+          if len >= 1 then
+            val packed = word & ((1L << (len*8)) - 1L)
+
+            if Parser.printableWord(packed, len) then
+              directKeywordLow = packed & 0xFFFFFFFFL
+              directKeywordHigh = packed >>> 32
+              directKeywordLen = len
+              directKeywordPacked = packed
+              directEntryKeywordLazy = true
+              pos += len
+              slow = false
+        else if pos + 8 < bufEnd then
+          // No stop in the first eight bytes: exactly eight, or oversized.
+          val b8 = bytes(pos + 8)
+
+          if (b8 == SP || b8 == LF || b8 == CR) && Parser.printableWord(word, 8) then
+            directKeywordLow = word & 0xFFFFFFFFL
+            directKeywordHigh = word >>> 32
+            directKeywordLen = 8
+            directKeywordPacked = word
+            directEntryKeywordLazy = true
+            pos += 8
+            slow = false
+
+      if slow then readKeywordSlow()
+
+    private def readKeywordSlow()(using Tactic[TelError]): Unit =
       val startMark = beginMark()
       var low:  Long = 0L
       var high: Long = 0L
@@ -4186,21 +4264,7 @@ object Tel extends Tel2:
 
       val packed = (low & 0xFFFFFFFFL) | (high << 32)
 
-      // SWAR printability test on the first `len` bytes, with the tail
-      // filled printable so only real content can trip the below-0x21, DEL
-      // or high-bit conditions (see `directKeywordWord`'s former test).
-      val printable =
-        len >= 1 && len <= 8 && {
-          val tail = if len == 8 then 0L else -1L << (len*8)
-          val filled = packed | (tail & 0x2121212121212121L)
-          val below = (filled - 0x2121212121212121L) & ~filled & 0x8080808080808080L
-          val del = { val x = filled ^ 0x7F7F7F7F7F7F7F7FL
-                      (x - 0x0101010101010101L) & ~x & 0x8080808080808080L }
-
-          (below | del | (packed & 0x8080808080808080L)) == 0L
-        }
-
-      if printable then
+      if len >= 1 && len <= 8 && Parser.printableWord(packed, len) then
         directKeywordPacked = packed
         directEntryKeywordLazy = true
       else
@@ -4366,7 +4430,10 @@ object Tel extends Tel2:
           done = true
         else if head.indentLevels > indent then
           errorAt(directOverIndentReason, head.startLine, 1)
-        else if isCommentBody() then
+        // Both comment and tabulation lines open with the sigil, so a
+        // compound line — the overwhelmingly common step — skips both
+        // classifiers (and their hold ceremony) on one byte test.
+        else if more && peek == sigil && isCommentBody() then
           // §9 E109 check, exactly as `parseBlock` performs it before
           // consuming a comment line.
           if !prevLineWasBoundary && prevContentLeadingSpaces >= 0 &&
@@ -4379,7 +4446,7 @@ object Tel extends Tel2:
           prevLineWasBoundary = true
           hasConsumedNonBlankLine = true
           fillHead()
-        else if isTabulationBody() then
+        else if more && peek == sigil && isTabulationBody() then
           val leadingSpaces = head.leadingSpaces
           directTabulation = Optional(parseTabulationLine())
           directGroup = DirectTabulationHeader
@@ -4476,7 +4543,7 @@ object Tel extends Tel2:
 
       val children: IArray[Tel.Block] =
         if !tabulated && extraAtom.absent then parseChildren(indent)
-        else IArray.empty[Tel.Block]
+        else EmptyBlocks
 
       // When children were not parsed (extra atom or tabulated row), a
       // following deeper line is over-indented — the enclosing AST loop
@@ -4495,7 +4562,7 @@ object Tel extends Tel2:
     // (`takeAtoms`) and no `Tel.Atom.Inline`: the first inline atom is consumed
     // straight into the slot, and the source/literal continuation and child
     // subtree are consumed (discarded) so the reader lands on the next sibling.
-    private def consumeDirectEntry(mode: Int)(using Tactic[TelError]): Unit =
+    private inline def consumeDirectEntry(inline mode: Int)(using Tactic[TelError]): Unit =
       val spaces = directEntrySpaces
       val indent = directEntryIndent
       val tabulated = directTabulation.present
@@ -4533,7 +4600,10 @@ object Tel extends Tel2:
     // eighteen digits); any other line shape rewinds to the line's remainder
     // and takes the general path, so the two routes agree by construction.
     // Returns whether the line was consumed.
-    private def directLeafLine(mode: Int)(using Tactic[TelError]): Boolean = inHold:
+    // Inline with an inline `mode`, so each primitive reader expands its own
+    // mode-specialized copy — the dead mode arms fold away and the hot
+    // methods stay small enough to inline predictably.
+    private inline def directLeafLine(inline mode: Int)(using Tactic[TelError]): Boolean = inHold:
       val entry = beginMark()
 
       if !more then false
@@ -4558,92 +4628,115 @@ object Tel extends Tel2:
             false
           else
             val atomStart = beginMark()
-            var word = 0L
-            var value = 0L
-            var digits = 0
-            var len = 0
-            var neg = false
-            var numeric = true
+            val startPos = pos
 
-            while
-              while pos < bufEnd && bytes(pos) != SP && bytes(pos) != LF && bytes(pos) != CR do
-                val b = bytes(pos)
+            // Find the atom's end within the buffered window, a word at a
+            // time; the window's edge (a refill would be needed) takes the
+            // general path.
+            var endPos = -1
+            var scan = pos
 
-                if len < 8 then word |= (b & 0xFF).toLong << (len*8)
+            while endPos < 0 && scan + 8 <= bufEnd do
+              val word: Long = Parser.longView(bytes, scan)
+              val stops = Parser.contentStops(word)
 
-                if b >= '0'.toByte && b <= '9'.toByte then
-                  // Eighteen digits can never overflow; longer runs are
-                  // `parseArenaLong`'s to judge.
-                  if digits >= 18 then numeric = false else
-                    value = value*10L + (b - '0'.toByte)
-                    digits += 1
-                else if b == '-'.toByte && len == 0 then neg = true
-                else numeric = false
+              if stops != 0L
+              then endPos = scan + (java.lang.Long.numberOfTrailingZeros(stops) >> 3)
+              else scan += 8
 
-                len += 1
-                pos += 1
-
-              pos == bufEnd && more
-            do ()
-
-            if more && peek == SP then
-              // More atoms, a remark or a trailing space follow: general.
+            if endPos < 0 then
               rewindTo(entry)
               false
             else
-              // A single-atom line: capture the primary in the requested
-              // mode, then consume the ending — `parseCompoundLineRest`'s
-              // exit, with no trailing space possible (the atom's last byte
-              // precedes the ending).
-              inline def finish(): Boolean =
-                consumeLineEnding()
-                compoundLineRemark = Unset
-                true
+              pos = endPos
 
-              mode match
-                case PrimaryLong | PrimaryInt =>
-                  if numeric && digits > 0 && digits + (if neg then 1 else 0) == len then
-                    val signed = if neg then -value else value
+              if peek == SP then
+                // More atoms, a remark or a trailing space follow: general.
+                rewindTo(entry)
+                false
+              else
+                // A single-atom line, wholly in the window: capture the
+                // primary in the requested mode, then consume the ending —
+                // `parseCompoundLineRest`'s exit, with no trailing space
+                // possible (the atom's last byte precedes the ending).
+                val len = endPos - startPos
 
+                def finish(): Boolean =
+                  consumeLineEnding()
+                  compoundLineRemark = Unset
+                  true
+
+                mode match
+                  case PrimaryLong | PrimaryInt =>
+                    var index = startPos
+                    var neg = false
+
+                    if bytes(index) == '-'.toByte then
+                      neg = true
+                      index += 1
+
+                    // Eighteen digits can never overflow; anything else —
+                    // `+`, nineteen digits, non-digits — is
+                    // `parseArenaLong`'s to judge, on the general path.
+                    val digits = endPos - index
+                    var ok = digits >= 1 && digits <= 18
+                    var value = 0L
+
+                    while ok && index < endPos do
+                      val digit = bytes(index) - '0'.toByte
+                      if digit < 0 || digit > 9 then ok = false else
+                        value = value*10L + digit
+                        index += 1
+
+                    if ok then
+                      val signed = if neg then -value else value
+
+                      directPrimaryPresent = true
+
+                      if mode == PrimaryInt
+                        && (signed < Int.MinValue.toLong || signed > Int.MaxValue.toLong)
+                      then
+                        // In `Long` range but not `Int`: `NotScalar`, with
+                        // the atom's text for the error.
+                        directPrimaryOk = false
+                        directPrimaryText = sliceText(atomStart)
+                      else
+                        directPrimaryOk = true
+                        directPrimaryLongVal = signed
+
+                      finish()
+                    else
+                      rewindTo(entry)
+                      false
+
+                  case PrimaryBoolean =>
                     directPrimaryPresent = true
 
-                    if mode == PrimaryInt
-                      && (signed < Int.MinValue.toLong || signed > Int.MaxValue.toLong)
+                    if len == 4 && bytes(startPos) == 't'.toByte
+                      && bytes(startPos + 1) == 'r'.toByte
+                      && bytes(startPos + 2) == 'u'.toByte
+                      && bytes(startPos + 3) == 'e'.toByte
                     then
-                      // In `Long` range but not `Int`: `NotScalar`, with the
-                      // atom's text for the error.
+                      directPrimaryOk = true
+                      directPrimaryBoolVal = true
+                    else if len == 5 && bytes(startPos) == 'f'.toByte
+                      && bytes(startPos + 1) == 'a'.toByte
+                      && bytes(startPos + 2) == 'l'.toByte
+                      && bytes(startPos + 3) == 's'.toByte
+                      && bytes(startPos + 4) == 'e'.toByte
+                    then
+                      directPrimaryOk = true
+                      directPrimaryBoolVal = false
+                    else
                       directPrimaryOk = false
                       directPrimaryText = sliceText(atomStart)
-                    else
-                      directPrimaryOk = true
-                      directPrimaryLongVal = signed
 
                     finish()
-                  else
-                    // An exotic spelling (`+`, nineteen digits, non-digits):
-                    // `parseArenaLong` decides, on the general path.
-                    rewindTo(entry)
-                    false
 
-                case PrimaryBoolean =>
-                  directPrimaryPresent = true
-
-                  if len == 4 && word == TrueWord then
-                    directPrimaryOk = true
-                    directPrimaryBoolVal = true
-                  else if len == 5 && word == FalseWord then
-                    directPrimaryOk = true
-                    directPrimaryBoolVal = false
-                  else
-                    directPrimaryOk = false
+                  case _ =>
+                    directPrimaryPresent = true
                     directPrimaryText = sliceText(atomStart)
-
-                  finish()
-
-                case _ =>
-                  directPrimaryPresent = true
-                  directPrimaryText = sliceText(atomStart)
-                  finish()
+                    finish()
 
     // The entry's primary atom as text — the first inline atom's, or Unset when
     // the line carries none (a source/literal atom never supplies it), mirroring

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -1368,14 +1368,19 @@ object Tel extends Tel2:
   // Concatenate the chunks of a `LazyList[Data]` source into a single byte array.
   private[stratiform] def concatenate(source: LazyList[Data]): Data =
     import denominative.nil
-    var acc    = IArray.empty[Byte]
-    var stream = source
 
-    while !stream.nil do
-      acc = acc ++ stream.head
-      stream = stream.tail
+    // A single in-memory block — the common case — is returned as-is
+    // rather than copied into a fresh array (jacinta's single-chunk fast
+    // path; the copy dominated the entry cost of fast direct reads).
+    if !source.nil && source.tail.nil then source.head else
+      var acc    = IArray.empty[Byte]
+      var stream = source
 
-    acc
+      while !stream.nil do
+        acc = acc ++ stream.head
+        stream = stream.tail
+
+      acc
 
   // `bytes.read[Tel]` for any LazyList[Data] source: concatenates the
   // chunks and parses the result. The metadata (interpreter directive,
@@ -1395,6 +1400,16 @@ object Tel extends Tel2:
   =>  ( tactic: Tactic[TelError] )
   =>  ( ((value in Tel) is Aggregable by Data)^{parsable, tactic} ) =
     source => parseDirect(concatenate(source), parsable).asInstanceOf[value in Tel]
+
+  // Whole-`Data` direct read: when the entire content is already in hand,
+  // parse it in place rather than wrapping it in a one-element stream —
+  // jacinta's `readableParsed` precedent. Concrete in `Data`, so it beats
+  // the composed pipeline by specificity.
+  given readableParsed: [value]
+  =>  ( parsable: (value is Tel.Parsable)^ )
+  =>  ( tactic: Tactic[TelError] )
+  =>  ( (Data is Readable to (value in Tel))^{parsable, tactic} ) =
+    data => parseDirect(data, parsable).asInstanceOf[value in Tel]
 
   // Direct-parsing counterpart of `parse`: drives a `Tel.Parsable` instance
   // over the input through a `TelReader`, so no document AST is built for the

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -2075,6 +2075,11 @@ object Tel extends Tel2:
     private inline val PrimaryBoolean = 2
     private inline val PrimaryInt = 3
 
+    // `true` and `false` packed LSB-first, for the leaf fast path's boolean
+    // comparison.
+    private inline val TrueWord = 0x65757274L
+    private inline val FalseWord = 0x65736C6166L
+
     private var directPrimaryOnly:    Boolean       = false
     private var directPrimaryMode:    Int           = PrimaryText
     private[stratiform] var directPrimaryPresent: Boolean       = false
@@ -2506,6 +2511,13 @@ object Tel extends Tel2:
         val arr = storage.asInstanceOf[Array[Byte]]
         if len <= 0 then "" else new String(arr, off, len, StandardCharsets.UTF_8)
 
+    // Rewind to a held mark — the bail of a speculative fast scan (the
+    // `directEntrySubstance` idiom).
+    private def rewindTo(mark: Cursor.Mark): Unit =
+      syncTo()
+      cursor.cue(mark)
+      syncFrom()
+
     // ── Reset (per-thread reuse) ──────────────────────────────────────────────
     //
     // Re-initialise the parser for a new parse. Called by the cached factory
@@ -2826,7 +2838,7 @@ object Tel extends Tel2:
     // the document — used by consumeTrailingBlanksFor to count the virtual
     // empty trailing line that Parser surfaces when its lines array ends
     // with a sentinel empty entry.
-    private def consumeLineEnding(): Unit raises TelError =
+    private def consumeLineEnding()(using Tactic[TelError]): Unit =
       if !more then ()
       else if peek == LF then
         // §19.5 CollapseLineEndings: accept the inconsistent ending and carry on.
@@ -3108,7 +3120,7 @@ object Tel extends Tel2:
     // intermediate `consumeLineEnding` (which calls `peekNext` → `ensureLookahead`,
     // a mark-using lookahead) and `recoverOddIndent` (which calls `peekKeyword`,
     // also mark-using) execute inside an active `cursor.hold` scope.
-    private def fillHead(): Unit raises TelError = inHold:
+    private def fillHead()(using Tactic[TelError]): Unit = inHold:
       head.startLine = lineNo
       head.separator = false
 
@@ -3923,7 +3935,7 @@ object Tel extends Tel2:
     // the line ending. Factored out of `parseCompoundLine` so the direct
     // parsing rim, which reads the keyword itself (`directKeyword`), can
     // consume the rest of the line through the same scan.
-    private def parseCompoundLineRest(lineNumber: Int): Unit raises TelError = inHold:
+    private def parseCompoundLineRest(lineNumber: Int)(using Tactic[TelError]): Unit = inHold:
       var remark: Optional[Text] = Unset
       // Read atom bytes directly into the parser's atom-bytes arena. With
       // narrow holds, parseCompoundLine's hold has holdStart > 0, so refills
@@ -4086,7 +4098,7 @@ object Tel extends Tel2:
     // runs has `holdStart > 0`, so a refill inside the loop can compact the
     // buffer and shift live content toward index 0 — the absolute-position
     // mark survives that, a buffer-offset would not.
-    private def readKeyword(): Text raises TelError =
+    private def readKeyword()(using Tactic[TelError]): Text =
       val startMark = beginMark()
       var low:  Long = 0L
       var high: Long = 0L
@@ -4138,6 +4150,108 @@ object Tel extends Tel2:
         if result != null then Text(result)
         else Text(sliceText(startMark))
 
+    // As `readKeyword`, but for the packed-dispatch step: the keyword is
+    // *not* interned or sliced when it packs — the fingerprint the scan
+    // computes anyway is the whole result (`directKeywordPacked`), and its
+    // text materializes only if `directKeywordText` is later consulted (an
+    // opaque general dispatch, an unknown sum variant, an error). A keyword
+    // that cannot pack — empty, longer than eight bytes, or carrying bytes
+    // outside printable ASCII, whose packed form could alias a shorter
+    // keyword's or a sentinel — is sliced eagerly, exactly as `readKeyword`
+    // would, and reported `KeywordOpaque`.
+    private def readKeywordFast()(using Tactic[TelError]): Unit =
+      val startMark = beginMark()
+      var low:  Long = 0L
+      var high: Long = 0L
+      var len = 0
+
+      while
+        while pos < bufEnd && bytes(pos) != SP && bytes(pos) != LF && bytes(pos) != CR do
+          val b = bytes(pos)
+
+          if len < 4 then
+            low |= (b & 0xff).toLong << (len * 8)
+          else if len < 8 then
+            high |= (b & 0xff).toLong << ((len - 4) * 8)
+
+          len += 1
+          pos += 1
+
+        pos == bufEnd && more
+      do ()
+
+      directKeywordLow = low
+      directKeywordHigh = high
+      directKeywordLen = len
+
+      val packed = (low & 0xFFFFFFFFL) | (high << 32)
+
+      // SWAR printability test on the first `len` bytes, with the tail
+      // filled printable so only real content can trip the below-0x21, DEL
+      // or high-bit conditions (see `directKeywordWord`'s former test).
+      val printable =
+        len >= 1 && len <= 8 && {
+          val tail = if len == 8 then 0L else -1L << (len*8)
+          val filled = packed | (tail & 0x2121212121212121L)
+          val below = (filled - 0x2121212121212121L) & ~filled & 0x8080808080808080L
+          val del = { val x = filled ^ 0x7F7F7F7F7F7F7F7FL
+                      (x - 0x0101010101010101L) & ~x & 0x8080808080808080L }
+
+          (below | del | (packed & 0x8080808080808080L)) == 0L
+        }
+
+      if printable then
+        directKeywordPacked = packed
+        directEntryKeywordLazy = true
+      else
+        directKeywordPacked = TelReader.KeywordOpaque
+        directEntryKeywordLazy = false
+        directEntryKeyword = if len == 0 then t"" else Text(sliceText(startMark))
+
+    // The lazily-materialized text of a fast-stepped keyword: rebuilt from
+    // the fingerprint (byte-exact — the packed bytes are printable ASCII)
+    // through the intern cache, so repeated requests share one `String`.
+    private def internFingerprint(): Text =
+      val low = directKeywordLow
+      val high = directKeywordHigh
+      val hash = ((low ^ (low >>> 32)) ^ (high ^ (high >>> 17))).toInt
+      var slot = hash & 0x3F
+      var probes = 0
+      var result: String = null
+
+      while result == null && probes < 4 do
+        val existing = keyCache(slot)
+
+        if existing == null then
+          val s = fingerprintString()
+          keyCache(slot) = s
+          keyCacheLow(slot) = low
+          keyCacheHigh(slot) = high
+          result = s
+        else if keyCacheLow(slot) == low && keyCacheHigh(slot) == high then
+          result = existing
+        else
+          slot = (slot + 1) & 0x3F
+          probes += 1
+
+      if result == null then result = fingerprintString()
+      Text(result)
+
+    private def fingerprintString(): String =
+      val len = directKeywordLen
+      val chars = new Array[Char](len)
+      var index = 0
+
+      while index < len do
+        val byte =
+          if index < 4 then (directKeywordLow >>> (index*8)) & 0xFF
+          else (directKeywordHigh >>> ((index - 4)*8)) & 0xFF
+
+        chars(index) = byte.toChar
+        index += 1
+
+      new String(chars)
+
     // ── Direct parsing rim ───────────────────────────────────────────────────
     //
     // The token-level surface behind `TelReader`, letting a `Tel.Parsable`
@@ -4167,6 +4281,12 @@ object Tel extends Tel2:
     private var directKeywordHigh: Long = 0L
     private var directKeywordLen:  Int = 0
 
+    // The fast step's result — the keyword's packed bytes, or
+    // `TelReader.KeywordOpaque` — and whether `directEntryKeyword` is stale,
+    // its text pending lazy materialization from the fingerprint.
+    private var directKeywordPacked:    Long = 0L
+    private var directEntryKeywordLazy: Boolean = false
+
     // The tabulation header governing subsequent rows at the same indent, and
     // the classification of the most recent group of consumed lines — the
     // direct-path stand-in for `parseChildren`'s "last block", from which the
@@ -4192,7 +4312,7 @@ object Tel extends Tel2:
     // directive, pragma, and margin determination, leaving `head` parked on
     // the first content line (or EOF). The direct driver runs this before
     // handing the reader to a `Tel.Parsable`.
-    private[stratiform] def directProlog(): Unit raises TelError =
+    private[stratiform] def directProlog()(using Tactic[TelError]): Unit =
       syncFrom()
       checkBom()
       val directive = parseInterpreterDirective()
@@ -4217,8 +4337,17 @@ object Tel extends Tel2:
     // record. On a compound line, consumes the keyword (leaving the parser
     // mid-line, right after it) and records the entry state for the
     // per-entry consumers.
-    private[stratiform] def directKeyword(indent: Int): Text | Null raises TelError =
-      var result: Text | Null = null
+    private[stratiform] def directKeyword(indent: Int)(using Tactic[TelError]): Text | Null =
+      if directKeywordAdvance(indent, textual = true) then directEntryKeyword else null
+
+    // The step's shared line-classification loop. With `textual = true` the
+    // keyword is read interned (`readKeyword`); otherwise through the
+    // pack-only fast scan (`readKeywordFast`), whose text materializes only
+    // on demand. Returns whether an entry was found (false once the entry
+    // region ends).
+    private def directKeywordAdvance(indent: Int, textual: Boolean)(using Tactic[TelError])
+    :   Boolean =
+      var result = false
       var done = false
 
       while !done do
@@ -4268,33 +4397,48 @@ object Tel extends Tel2:
           directEntryIndent = head.indentLevels
           directEntryLine = head.startLine
 
-          val keyword = inHold:
+          inHold:
             val mayBeMisplacedPragma = head.leadingSpaces == 0 && hasConsumedNonBlankLine
-            val keyword = readKeyword()
 
-            // E102 / §19.5 RestartFromPragma, as in `parseCompoundLine`.
-            if mayBeMisplacedPragma && keyword == t"tel" then
-              recoverAt(Reason.PragmaNotFirst, directEntryLine, 1)(())
+            if textual then
+              val keyword = readKeyword()
+
+              // E102 / §19.5 RestartFromPragma, as in `parseCompoundLine`.
+              if mayBeMisplacedPragma && keyword == t"tel" then
+                recoverAt(Reason.PragmaNotFirst, directEntryLine, 1)(())
+
+              directEntryKeyword = keyword
+              directEntryKeywordLazy = false
+            else
+              readKeywordFast()
+
+              // The same E102 check against the packed form of `tel`.
+              if mayBeMisplacedPragma && directKeywordLen == 3
+                && directKeywordLow == 0x6C6574L
+              then recoverAt(Reason.PragmaNotFirst, directEntryLine, 1)(())
 
             hasConsumedNonBlankLine = true
-            keyword
-
-          directEntryKeyword = keyword
 
           directGroup =
             if directGroup == DirectTabulationHeader || directGroup == DirectTabulationRows
             then DirectTabulationRows
             else DirectCompound
 
-          result = keyword
+          result = true
           done = true
 
       result
 
     // The keyword most recently stepped to, as interned text — behind
     // `TelReader.keywordText`, for staged parsers whose packed step reported
-    // the keyword opaque.
-    private[stratiform] def directKeywordText: Text = directEntryKeyword
+    // the keyword opaque (and for errors and the AST bridge). A fast-stepped
+    // keyword materializes here, lazily, from its fingerprint.
+    private[stratiform] def directKeywordText: Text =
+      if directEntryKeywordLazy then
+        directEntryKeyword = internFingerprint()
+        directEntryKeywordLazy = false
+
+      directEntryKeyword
 
     // As `directKeyword`, but returning the keyword in packed form for staged
     // parsers that compare keywords against literal constants: the keyword's
@@ -4304,35 +4448,17 @@ object Tel extends Tel2:
     // ASCII, whose packed form could alias a shorter keyword's or a
     // sentinel). An opaque keyword is still consumed: `directKeywordText`
     // identifies it for the caller's general dispatch.
-    private[stratiform] def directKeywordWord(indent: Int): Long raises TelError =
-      if directKeyword(indent) == null then TelReader.KeywordEnd
-      else
-        val len = directKeywordLen
-
-        if len < 1 || len > 8 then TelReader.KeywordOpaque
-        else
-          val packed = (directKeywordLow & 0xFFFFFFFFL) | (directKeywordHigh << 32)
-
-          // SWAR printability test on the first `len` bytes: the tail is
-          // filled with a printable byte so only real content can trip the
-          // below-0x21, DEL or high-bit conditions.
-          val tail = if len == 8 then 0L else -1L << (len*8)
-          val filled = packed | (tail & 0x2121212121212121L)
-          val below = (filled - 0x2121212121212121L) & ~filled & 0x8080808080808080L
-          val del = { val x = filled ^ 0x7F7F7F7F7F7F7F7FL
-                      (x - 0x0101010101010101L) & ~x & 0x8080808080808080L }
-
-          if (below | del | (packed & 0x8080808080808080L)) != 0L
-          then TelReader.KeywordOpaque
-          else packed
+    private[stratiform] def directKeywordWord(indent: Int)(using Tactic[TelError]): Long =
+      if !directKeywordAdvance(indent, textual = false) then TelReader.KeywordEnd
+      else directKeywordPacked
 
     // Consume the current entry in full — line remainder, source/literal
     // continuation, and children — materializing it as the single compound
     // the AST path would have built. The direct seam for every consumer that
     // needs AST-identical semantics.
-    private def directCompound(indent: Int): Tel.Compound raises TelError =
+    private def directCompound(indent: Int)(using Tactic[TelError]): Tel.Compound =
       val spaces = directEntrySpaces
-      val keyword = directEntryKeyword
+      val keyword = directKeywordText
       val tabulated = directTabulation.present
       val atomsStart = atomScratchIx
       parseCompoundLineRest(directEntryLine)
@@ -4369,7 +4495,7 @@ object Tel extends Tel2:
     // (`takeAtoms`) and no `Tel.Atom.Inline`: the first inline atom is consumed
     // straight into the slot, and the source/literal continuation and child
     // subtree are consumed (discarded) so the reader lands on the next sibling.
-    private def consumeDirectEntry(mode: Int): Unit raises TelError =
+    private def consumeDirectEntry(mode: Int)(using Tactic[TelError]): Unit =
       val spaces = directEntrySpaces
       val indent = directEntryIndent
       val tabulated = directTabulation.present
@@ -4378,8 +4504,10 @@ object Tel extends Tel2:
       directPrimaryPresent = false
       directPrimaryOk = false
       directPrimaryText = null
-      directPrimaryOnly = true
-      try parseCompoundLineRest(directEntryLine) finally directPrimaryOnly = false
+
+      if !directLeafLine(mode) then
+        directPrimaryOnly = true
+        try parseCompoundLineRest(directEntryLine) finally directPrimaryOnly = false
 
       prevContentLeadingSpaces = spaces
       prevLineWasBoundary = false
@@ -4395,10 +4523,132 @@ object Tel extends Tel2:
       else if !head.eof && !head.separator && !head.blank && head.indentLevels > indent
       then errorAt(directOverIndentReason, head.startLine, 1)
 
+    // The leaf fast path, entered with the cursor right after the keyword:
+    // handles the dominant data shapes — a bare `keyword` line, and
+    // `keyword value` with a single inline atom, no remark, no hard spaces
+    // and no trailing space — parsing (or slicing) the value straight from
+    // the cursor buffer, with no arena copy and no `parseCompoundLineRest`
+    // scan. The numeric capture accepts only spellings whose parse is
+    // provably identical to `parseArenaLong`'s (an optional `-` and one to
+    // eighteen digits); any other line shape rewinds to the line's remainder
+    // and takes the general path, so the two routes agree by construction.
+    // Returns whether the line was consumed.
+    private def directLeafLine(mode: Int)(using Tactic[TelError]): Boolean = inHold:
+      val entry = beginMark()
+
+      if !more then false
+      else if peek == LF || peek == CR then
+        // A bare keyword line: no inline atoms.
+        consumeLineEnding()
+        compoundLineRemark = Unset
+        true
+      else if peek != SP then false
+      else
+        advance()
+
+        if !more then { rewindTo(entry); false }
+        else
+          val b1 = peek
+
+          // A second space (hard-space mode), a sigil (a remark, or an atom
+          // opening with one) or a line ending (a trailing space) all take
+          // the general path.
+          if b1 == SP || b1 == LF || b1 == CR || b1 == sigil then
+            rewindTo(entry)
+            false
+          else
+            val atomStart = beginMark()
+            var word = 0L
+            var value = 0L
+            var digits = 0
+            var len = 0
+            var neg = false
+            var numeric = true
+
+            while
+              while pos < bufEnd && bytes(pos) != SP && bytes(pos) != LF && bytes(pos) != CR do
+                val b = bytes(pos)
+
+                if len < 8 then word |= (b & 0xFF).toLong << (len*8)
+
+                if b >= '0'.toByte && b <= '9'.toByte then
+                  // Eighteen digits can never overflow; longer runs are
+                  // `parseArenaLong`'s to judge.
+                  if digits >= 18 then numeric = false else
+                    value = value*10L + (b - '0'.toByte)
+                    digits += 1
+                else if b == '-'.toByte && len == 0 then neg = true
+                else numeric = false
+
+                len += 1
+                pos += 1
+
+              pos == bufEnd && more
+            do ()
+
+            if more && peek == SP then
+              // More atoms, a remark or a trailing space follow: general.
+              rewindTo(entry)
+              false
+            else
+              // A single-atom line: capture the primary in the requested
+              // mode, then consume the ending — `parseCompoundLineRest`'s
+              // exit, with no trailing space possible (the atom's last byte
+              // precedes the ending).
+              inline def finish(): Boolean =
+                consumeLineEnding()
+                compoundLineRemark = Unset
+                true
+
+              mode match
+                case PrimaryLong | PrimaryInt =>
+                  if numeric && digits > 0 && digits + (if neg then 1 else 0) == len then
+                    val signed = if neg then -value else value
+
+                    directPrimaryPresent = true
+
+                    if mode == PrimaryInt
+                      && (signed < Int.MinValue.toLong || signed > Int.MaxValue.toLong)
+                    then
+                      // In `Long` range but not `Int`: `NotScalar`, with the
+                      // atom's text for the error.
+                      directPrimaryOk = false
+                      directPrimaryText = sliceText(atomStart)
+                    else
+                      directPrimaryOk = true
+                      directPrimaryLongVal = signed
+
+                    finish()
+                  else
+                    // An exotic spelling (`+`, nineteen digits, non-digits):
+                    // `parseArenaLong` decides, on the general path.
+                    rewindTo(entry)
+                    false
+
+                case PrimaryBoolean =>
+                  directPrimaryPresent = true
+
+                  if len == 4 && word == TrueWord then
+                    directPrimaryOk = true
+                    directPrimaryBoolVal = true
+                  else if len == 5 && word == FalseWord then
+                    directPrimaryOk = true
+                    directPrimaryBoolVal = false
+                  else
+                    directPrimaryOk = false
+                    directPrimaryText = sliceText(atomStart)
+
+                  finish()
+
+                case _ =>
+                  directPrimaryPresent = true
+                  directPrimaryText = sliceText(atomStart)
+                  finish()
+
     // The entry's primary atom as text — the first inline atom's, or Unset when
     // the line carries none (a source/literal atom never supplies it), mirroring
     // `Tel#primaryAtom`. Backs the `Text`/text-codec primitive readers.
-    private[stratiform] def directAtomText(): Optional[Text] raises TelError =
+    private[stratiform] def directAtomText()(using Tactic[TelError]): Optional[Text] =
       consumeDirectEntry(PrimaryText)
       val captured = directPrimaryText
       if captured == null then Unset else Optional(Text(captured))
@@ -4406,31 +4656,41 @@ object Tel extends Tel2:
     // The entry's primary atom parsed straight from its bytes as an integer, or
     // Unset for a missing / non-integer atom — the `Int`/`Long` readers, saving
     // the value `String` the `Text` path would materialize only to re-scan.
-    private[stratiform] def directAtomLong(): Optional[Long] raises TelError =
+    private[stratiform] def directAtomLong()(using Tactic[TelError]): Optional[Long] =
       consumeDirectEntry(PrimaryLong)
       if directPrimaryPresent && directPrimaryOk then Optional(directPrimaryLongVal) else Unset
 
     // As `directAtomLong`, additionally requiring the value to fit `Int`.
-    private[stratiform] def directAtomInt(): Optional[Int] raises TelError =
+    private[stratiform] def directAtomInt()(using Tactic[TelError]): Optional[Int] =
       consumeDirectEntry(PrimaryInt)
       if directPrimaryPresent && directPrimaryOk then Optional(directPrimaryLongVal.toInt) else Unset
 
     // The entry's primary atom parsed straight from its bytes as a boolean, or
     // Unset for a missing atom or anything but `true` / `false`.
-    private[stratiform] def directAtomBoolean(): Optional[Boolean] raises TelError =
+    private[stratiform] def directAtomBoolean()(using Tactic[TelError]): Optional[Boolean] =
       consumeDirectEntry(PrimaryBoolean)
       if directPrimaryPresent && directPrimaryOk then Optional(directPrimaryBoolVal) else Unset
 
     // Consume the rest of the entry's own line (atoms, remark) and any
     // source/literal continuation, but not its child lines — the step before
     // a nested record parses those children one level deeper.
-    private[stratiform] def directFinishLine(): Unit raises TelError =
+    private[stratiform] def directFinishLine()(using Tactic[TelError]): Unit =
       val spaces = directEntrySpaces
       val indent = directEntryIndent
       val tabulated = directTabulation.present
-      val atomsStart = atomScratchIx
-      parseCompoundLineRest(directEntryLine)
-      atomScratchIx = atomsStart
+
+      // A record entry is usually a bare `keyword` line: nothing to scan.
+      val bare = inHold:
+        if more && (peek == LF || peek == CR) then
+          consumeLineEnding()
+          compoundLineRemark = Unset
+          true
+        else false
+
+      if !bare then
+        val atomsStart = atomScratchIx
+        parseCompoundLineRest(directEntryLine)
+        atomScratchIx = atomsStart
       prevContentLeadingSpaces = spaces
       prevLineWasBoundary = false
       fillHead()
@@ -4448,17 +4708,17 @@ object Tel extends Tel2:
     // Skip the whole entry — line remainder, continuation and subtree —
     // discarding it. Used for unknown keywords and duplicate non-repeatable
     // fields (where the AST's `field()` keeps the first match).
-    private[stratiform] def directSkipEntry(indent: Int): Unit raises TelError =
+    private[stratiform] def directSkipEntry(indent: Int)(using Tactic[TelError]): Unit =
       directCompound(indent)
 
     // Materialize this one entry as a `Tel` — the AST bridge for field types
     // that only carry a `Tel.Decodable`.
-    private[stratiform] def directValue(indent: Int): Tel raises TelError =
+    private[stratiform] def directValue(indent: Int)(using Tactic[TelError]): Tel =
       Tel.make(directCompound(indent))
 
     // Materialize everything that remains as a document-rooted `Tel` — the
     // AST bridge for a whole-input read of a `Decodable`-only type.
-    private[stratiform] def directDocument(): Tel raises TelError =
+    private[stratiform] def directDocument()(using Tactic[TelError]): Tel =
       Tel.make(Tel.Document(Unset, Unset, lineEndings, parseChildren(-1)))
 
     // Peek whether the current entry has substance — an inline atom on its
@@ -4467,7 +4727,7 @@ object Tel extends Tel2:
     // atom and contributes none). The entry is parsed in full under a mark
     // and then rewound, restoring every piece of parser state the parse
     // touched, so the caller can still consume the entry either way.
-    private[stratiform] def directEntrySubstance(): Boolean raises TelError = inHold:
+    private[stratiform] def directEntrySubstance()(using Tactic[TelError]): Boolean = inHold:
       val mk = beginMark()
 
       val savedHead = (head.leadingSpaces, head.indentLevels, head.blank, head.eof,

--- a/lib/stratiform/src/core/stratiform.Tel2.scala
+++ b/lib/stratiform/src/core/stratiform.Tel2.scala
@@ -278,16 +278,19 @@ trait Tel2 extends Tel3:
       // (`delegate`) is `fallible` and would leak a `Tactic[VariantError]` requirement
       // onto every codec; the precise select schema comes from the standalone
       // `Schematic` / `Tels.tels`.
+      // Kebab keyword → variant label (the label `delegate` dispatches on), a
+      // per-derivation constant: built once here rather than on every decode
+      // call, whose profile it dominated (map building plus generic-equality
+      // lookups, per occurrence) — jacinta's map hoist.
+      val labels: Map[Text, Text] =
+        variantLabels.map: label => Tel.camelToKebab(label.s) -> label
+        . to(Map)
+
       Tel.Decodable(() => Morphology.Any):
         telVal =>
           provide[Foci[Tel.Focus]]:
             provide[Tactic[TelError]]:
               provide[Tactic[VariantError]]:
-                // Map the variant's kebab keyword back to the label `delegate` dispatches on.
-                val labels: Map[Text, Text] =
-                  variantLabels.map: label => Tel.camelToKebab(label.s) -> label
-                  . to(Map)
-
                 val variant: Tel = Tel.make(telVal.childCompounds.head)
                 val variantKeyword: Text = labels.getOrElse(variant.keyword, variant.keyword)
 

--- a/lib/stratiform/src/core/stratiform.TelReader.scala
+++ b/lib/stratiform/src/core/stratiform.TelReader.scala
@@ -74,9 +74,15 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // The next entry's keyword at exactly `indent`, with the reader left
   // positioned right after it, or `Unset` once the entry region ends (a
   // shallower line, a document separator, or the end of the input).
-  update def keyword(indent: Int): Optional[Text] =
-    val next = parser.directKeyword(indent)(using errorTactic)
-    if next == null then Unset else next.nn
+  // The quote-free forwarders are `inline` (enabled by the parser rim's
+  // `(using Tactic)` conventions and the toolchain's inline-update receiver
+  // fix); methods that appear inside stratiform's macro quotes stay
+  // non-inline — the spliced reader there is capture-erased, and an inline
+  // update method requires an exclusive receiver.
+  inline update def keyword(indent: Int): Optional[Text] =
+    parser.directKeyword(indent)(using errorTactic) match
+      case null       => Unset
+      case next: Text => next
 
   // The next keyword step in packed form, for parsers that compare keywords
   // against literal constants (staged parsers compile wire keywords to
@@ -95,7 +101,8 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // Peeks (without consuming) whether the entry has substance — an inline
   // atom or a child compound — the AST `optionalDecodable`'s emptiness test,
   // for optional wrappers that map a bare keyword to an absent value.
-  update def hasSubstance: Boolean = parser.directEntrySubstance()(using errorTactic)
+  inline update def hasSubstance: Boolean =
+    parser.directEntrySubstance()(using errorTactic)
 
   // ── Entry consumers: each takes the whole entry (line remainder,
   // source/literal continuation and child subtree), so the reader is left
@@ -135,9 +142,10 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // ── The fallback seam: materialize one entry (or the whole remaining
   // document) as a `Tel`, for field types that only have a
   // `Tel.Decodable`. ──
-  update def value(indent: Int): Tel = parser.directValue(indent)(using errorTactic)
+  inline update def value(indent: Int): Tel = parser.directValue(indent)(using errorTactic)
 
-  private[stratiform] update def document(): Tel = parser.directDocument()(using errorTactic)
+  private[stratiform] inline update def document(): Tel =
+    parser.directDocument()(using errorTactic)
 
   // Raise through the reader's tactic — for leaf instances that reject a
   // well-formed entry's content, continuing with a sentinel under an

--- a/lib/stratiform/src/staged/stratiform.Inlinable.scala
+++ b/lib/stratiform/src/staged/stratiform.Inlinable.scala
@@ -1,0 +1,194 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The Expr-level counterpart of `Tel.Parsable`: a typeclass whose methods
+// are macro-time code generators, following jacinta's `Inlinable` exactly.
+// An instance receives an `Expr` of the reader (and, because a TEL value is
+// an *entry* whose extent depends on its indent, an `Expr` of the current
+// indent) and returns an `Expr` of the decoded value, which the deriving
+// macro splices directly into its generated parser — so an instance
+// contributes *inlined* code, with no runtime dispatch, no instance arrays
+// and no adapter hops between composed parsers.
+//
+// Instances are ordinary runtime values: code generation is deferred to the
+// `parse` call, which receives the `Quotes` and the `Type` of `Self`, so
+// `derived` needs no macro of its own. At a `Inlinable.parsable[T]`
+// expansion, the instance behind each summoned given is obtained *live* by
+// running the implicit search inside an in-macro staging compiler (the
+// prescience mechanism), which composes conditional instances — a collection
+// of a custom element, for example — through ordinary given resolution. The
+// constraint this inherits: an instance (and its type) must be compiled in
+// an earlier run than the expansion; same-run instances degrade to a spliced
+// runtime call through `Tel.Field`.
+trait Inlinable extends Typeclass:
+  def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Self]): Expr[Self]
+
+  // What a field of this type yields when its keyword never arrives,
+  // mirroring the runtime instances: an abort unless overridden (the
+  // primitive instances raise and continue with a sentinel).
+  def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Self]): Expr[Self] =
+    '{ abort(TelError(TelError.Reason.Absent))(using $tactic) }
+
+object Inlinable:
+  // Generates a monomorphic `Tel.Parsable` for a case class at compile
+  // time, like `Tel.Parsable.staged`, but composed through `Inlinable`
+  // instances: nested records, collection gathering and custom leaf parsers
+  // all inline into one flat parser.
+  inline def parsable[value]: value is Tel.Parsable =
+    ${ stratiform.stagedInternal.inlinableParsable[value] }
+
+  // The structural instance for a case class: reflects `Self` when invoked
+  // (no macro — `Type[Self]` arrives with the call).
+  def derived[product]: product is Inlinable = ProductInlinable[product]()
+
+  private[stratiform] final class ProductInlinable[product]() extends Inlinable:
+    type Self = product
+
+    // A record field's value is its children, one level deeper than its own
+    // entry line — the derived engine's `parse(reader, indent)`.
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[product])
+    :   Expr[product] =
+
+      '{
+        $reader.finishLine()
+        val indent1 = $indent + 1
+        ${ stagedInternal.productFields[product](reader, 'indent1) }
+      }
+
+  private[stratiform] final class IterableInlinable[element](val element0: element is Inlinable)
+  extends Inlinable:
+    type Self = Iterable[element]
+
+    // A single entry read as a collection: one element — the runtime
+    // `Tel.Parsable.iterable`'s behavior when handed a lone compound. In
+    // *field* position the deriving generator never calls this: it gathers
+    // each occurrence of the keyword through the element's own generator.
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      stagedInternal.iterableBody[Iterable[element]](reader, indent, element0)
+
+  // ── Instances ──────────────────────────────────────────────────────────
+  // The leaf generators mirror the primitive `Tel.Parsable` instances
+  // exactly — including the `Absent`/`NotScalar` fault split — so direct,
+  // staged and inlined reads yield equal values and equal errors. `Double`
+  // keeps the text path, like `doubleParsable`.
+
+  given int: (Int is Inlinable) = new Inlinable:
+    type Self = Int
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Int]): Expr[Int] =
+      '{ $reader.int().lay(Tel.Parsable.scalarFault($reader, t"Int", 0)) { value => value } }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Int]): Expr[Int] =
+      '{ Tel.Parsable.missing[Int](0)(using $tactic) }
+
+  given long: (Long is Inlinable) = new Inlinable:
+    type Self = Long
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Long]): Expr[Long] =
+      '{ $reader.long().lay(Tel.Parsable.scalarFault($reader, t"Long", 0L)) { value => value } }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Long]): Expr[Long] =
+      '{ Tel.Parsable.missing[Long](0L)(using $tactic) }
+
+  given boolean: (Boolean is Inlinable) = new Inlinable:
+    type Self = Boolean
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Boolean])
+    :   Expr[Boolean] =
+
+      '{
+        $reader.boolean().lay(Tel.Parsable.scalarFault($reader, t"Boolean", false)):
+          value => value
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Boolean])
+    :   Expr[Boolean] =
+
+      '{ Tel.Parsable.missing[Boolean](false)(using $tactic) }
+
+  given double: (Double is Inlinable) = new Inlinable:
+    type Self = Double
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Double])
+    :   Expr[Double] =
+
+      '{
+        $reader.atom().lay({ $reader.fault(TelError.Reason.Absent); 0.0 }): atom =>
+          try java.lang.Double.parseDouble(atom.s)
+          catch case _: NumberFormatException =>
+            $reader.fault(TelError.Reason.NotScalar(atom, t"Double"))
+            0.0
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Double])
+    :   Expr[Double] =
+
+      '{ Tel.Parsable.missing[Double](0.0)(using $tactic) }
+
+  given text: (Text is Inlinable) = new Inlinable:
+    type Self = Text
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[Text]): Expr[Text] =
+      '{ $reader.atom().lay({ $reader.fault(TelError.Reason.Absent); t"" }) { atom => atom } }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Text]): Expr[Text] =
+      '{ Tel.Parsable.missing[Text](t"")(using $tactic) }
+
+  given string: (String is Inlinable) = new Inlinable:
+    type Self = String
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[String])
+    :   Expr[String] =
+
+      '{ $reader.atom().lay({ $reader.fault(TelError.Reason.Absent); "" }) { atom => atom.s } }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[String])
+    :   Expr[String] =
+
+      '{ Tel.Parsable.missing[String]("")(using $tactic) }
+
+  given iterable: [collection <: Iterable, element]
+  =>  (element0: element is Inlinable)
+  =>  (collection[element] is Inlinable) =
+    IterableInlinable[element](element0).asInstanceOf[collection[element] is Inlinable]

--- a/lib/stratiform/src/staged/stratiform.Inlinable.scala
+++ b/lib/stratiform/src/staged/stratiform.Inlinable.scala
@@ -94,6 +94,17 @@ object Inlinable:
         ${ stagedInternal.productFields[product](reader, 'indent1) }
       }
 
+  // The structural instance for a sealed sum whose variants are all
+  // inlinable case classes: the wire form is a single child compound keyed
+  // by the variant's kebab-cased name (the AST disjunction's form), so the
+  // generated code dispatches on that keyword and parses the chosen variant
+  // in place — no document AST, no `delegate`.
+  private[stratiform] final class SumInlinable[sum]() extends Inlinable:
+    type Self = sum
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[sum]): Expr[sum] =
+      stagedInternal.sumBody[sum](reader, indent)
+
   private[stratiform] final class IterableInlinable[element](val element0: element is Inlinable)
   extends Inlinable:
     type Self = Iterable[element]

--- a/lib/stratiform/src/staged/stratiform.stagedInternal.scala
+++ b/lib/stratiform/src/staged/stratiform.stagedInternal.scala
@@ -279,7 +279,43 @@ object stagedInternal:
       case _ =>
         None
     else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
-    else None
+    else sumFor[field](cache)
+
+  // A sealed sum qualifies when every variant is itself an inlinable case
+  // class (resolved through the ladder, so custom variant instances
+  // compose); anything else — singleton variants, `@name` renames, an
+  // unresolvable variant — degrades to the runtime seam, preserving the
+  // derived semantics exactly.
+  private def sumFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    sumVariants(quotes.reflect.TypeRepr.of[field].dealias).flatMap: variants =>
+      val resolvable = variants.forall: (_, variantType) =>
+        variantType.asType match
+          case '[variantType] => resolve[variantType](cache).isDefined
+
+      if resolvable then Some(Inlinable.SumInlinable[field]()) else None
+
+  // The variants of a stageable sealed sum: `(label, type)` per variant, or
+  // `None` when the shape is unsupported.
+  private def sumVariants(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[List[(String, quotes.reflect.TypeRepr)]] =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.flatMap: classSymbol =>
+      val applied = tpe match
+        case AppliedType(_, _) => true
+        case _                 => false
+
+      val children = classSymbol.children
+
+      val supported =
+        !applied
+        && classSymbol.flags.is(Flags.Sealed)
+        && children.nonEmpty
+        && children.forall: child =>
+             child.isClassDef && child.flags.is(Flags.Case) && !hasRenames(child)
+
+      if supported then Some(children.map { child => (child.name, child.typeRef) }) else None
 
   private[stratiform] def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr)
   :   Boolean =
@@ -293,6 +329,25 @@ object stagedInternal:
       && classSymbol.primaryConstructor.paramSymss
          . filterNot(_.exists(_.isTypeParam)).length == 1
       && !hasRenames(classSymbol)
+
+  // A wire keyword's packed form (at most eight printable-ASCII bytes,
+  // LSB-first, the same packing as `TelReader.keywordWord`), or `None` when
+  // it cannot pack.
+  private def packedTelKeyword(name: String): Option[Long] =
+    val length = name.length
+
+    val packs = length > 0 && length <= 8 &&
+      name.forall { char => char >= '!' && char <= '~' }
+
+    if !packs then None else
+      var word = 0L
+      var position = 0
+
+      while position < length do
+        word |= (name.charAt(position).toLong & 0xFF) << (position*8)
+        position += 1
+
+      Some(word)
 
   // `@name` renames resolve through inline machinery the structural
   // generator does not replicate; annotated records stay on `staged`.
@@ -423,24 +478,8 @@ object stagedInternal:
     // that cannot pack (longer than eight bytes) always arrives as
     // `KeywordOpaque` and resolves through the literal text step, which
     // matches all fields by string.
-    def packedKeyword(index: Int): Option[Long] =
-      val name = wireNames(index)
-      val length = name.length
-
-      val packs = length > 0 && length <= 8 &&
-        name.forall { char => char >= '!' && char <= '~' }
-
-      if !packs then None else
-        var word = 0L
-        var position = 0
-
-        while position < length do
-          word |= (name.charAt(position).toLong & 0xFF) << (position*8)
-          position += 1
-
-        Some(word)
-
-    val packedKeywords: List[Option[Long]] = List.range(0, arity).map(packedKeyword)
+    val packedKeywords: List[Option[Long]] =
+      List.range(0, arity).map { index => packedTelKeyword(wireNames(index)) }
 
     val owner = Symbol.spliceOwner
     val unit = Literal(UnitConstant())
@@ -803,6 +842,90 @@ object stagedInternal:
       ( slotDefs ::: seenDefs ::: gatherDefs ::: seamDefs ::: nestedDefs ::: loop ::: absents,
         construct )
     . asExprOf[product]
+
+  // ── The sum generator ──────────────────────────────────────────────────
+  // A sum's wire form is a single child compound keyed by the variant's
+  // kebab-cased name (the AST disjunction's form): consume the entry line,
+  // dispatch on the child's keyword — packed-word comparisons with a text
+  // step for opaque keywords — and parse the chosen variant in place. Extra
+  // entries after the variant are skipped (the AST path reads only the
+  // first child compound); an unknown keyword aborts through the splice
+  // site's `Tactic[VariantError]`, exactly as `delegate` does.
+  private[stratiform] def sumBody[sum: Type](reader: Expr[TelReader], indent: Expr[Int])
+    (using Quotes)
+  :   Expr[sum] =
+
+    sumBody[sum](reader, indent, scm.HashMap())
+
+  private def sumBody[sum: Type](reader: Expr[TelReader], indent: Expr[Int], cache: Cache)
+    (using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    val variants = sumVariants(TypeRepr.of[sum].dealias).getOrElse:
+      report.errorAndAbort
+        (s"stratiform: ${TypeRepr.of[sum].show} is not an inlinable sum (a non-generic sealed "+
+          "type whose variants are all case classes without `@name` renames)")
+
+    val arity = variants.length
+    val wireNames: List[String] = variants.map { (name, _) => Tel.camelToKebab(name).s }
+
+    def dispatch
+      ( index:   Int,
+        word:    Expr[Long],
+        indent1: Expr[Int] )
+    :   Expr[sum] =
+
+      if index == arity then
+        '{
+          provide[Tactic[wisteria.VariantError]]:
+            abort(wisteria.VariantError[sum]($reader.keywordText))
+        }
+      else variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"stratiform: no Inlinable for variant ${variants(index)(0)}")
+          . asInstanceOf[Inlinable { type Self = variantType }]
+
+          val name = wireNames(index)
+
+          val condition: Expr[Boolean] = packedTelKeyword(name) match
+            case Some(packed) =>
+              '{
+                $word == ${Expr(packed)}
+                || ($word == TelReader.KeywordOpaque && $reader.keywordText.s == ${Expr(name)})
+              }
+
+            case None =>
+              '{ $word == TelReader.KeywordOpaque && $reader.keywordText.s == ${Expr(name)} }
+
+          '{
+            if $condition then
+              def parseVariant(): variantType = ${ instance.parse(reader, indent1) }
+              parseVariant()
+            else ${ dispatch(index + 1, word, indent1) }
+          }
+
+    '{
+      val tactic = infer[Tactic[TelError]]
+      $reader.finishLine()
+      val indent1 = $indent + 1
+      val word = $reader.keywordWord(indent1)
+
+      if word == TelReader.KeywordEnd
+      then abort(TelError(TelError.Reason.Absent))(using tactic)
+      else
+        val result: sum = ${ dispatch(0, 'word, 'indent1) }
+        var next = $reader.keywordWord(indent1)
+
+        while next != TelReader.KeywordEnd do
+          $reader.skipEntry(indent1)
+          next = $reader.keywordWord(indent1)
+
+        result
+    }
 
   // ── The entry macro ────────────────────────────────────────────────────
   def inlinableParsable[value: Type](using Quotes): Expr[value is Tel.Parsable] =

--- a/lib/stratiform/src/staged/stratiform.stagedInternal.scala
+++ b/lib/stratiform/src/staged/stratiform.stagedInternal.scala
@@ -1,0 +1,834 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.collection.mutable as scm
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import gigantism.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The machinery behind `stratiform.Inlinable`: expansion-time instance
+// resolution (through an in-macro staging compiler), the structural
+// generators for products and collections, and the `Inlinable.parsable`
+// entry macro — jacinta's `stagedInternal`, transposed to TEL's entry-based
+// reading (an indent travels with the reader) and to the derived engine's
+// gathering semantics for repeatable fields.
+object stagedInternal:
+
+  // The runtime seam for a field type without an `Inlinable`: the field's
+  // `Tel.Parsing` instance, preferring a nominal `Parsable` in scope (a
+  // custom instance, a staged sibling) over the `Tel.Field` fallback chain.
+  // The generated record body binds it once per parse, so occurrence reads,
+  // repeatability dispatch and absence all consult one instance — exactly
+  // the derived engine's per-field instance. An inline method because
+  // `summonFrom` may only live in one; it expands where the generated
+  // parser is spliced.
+  inline def fieldInstance[fieldType]: fieldType is Tel.Parsing =
+    scala.compiletime.summonFrom:
+      case parsable: (`fieldType` is Tel.Parsable) => parsable
+      case _ => scala.compiletime.summonInline[fieldType is Tel.Field]
+
+  // ── Expansion-time environment ─────────────────────────────────────────
+
+  private def macroClassloader: ClassLoader =
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // A symbol defined in the compilation run in progress has no trustworthy
+  // classfile (none on a clean build; a stale one from the previous compile
+  // on an incremental build), so instance evaluation must refuse it and the
+  // caller degrade to a runtime seam.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+
+    val full =
+      dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
+
+  // ── Type transport into the staging context ────────────────────────────
+  // The outer macro's `Type` cannot cross into the inner compiler, so a type
+  // travels as a tree of `java.lang.Class`es and is rebuilt inside with
+  // `TypeRepr.typeConstructorOf`. This restricts instance evaluation to
+  // class-shaped types (plain classes and applications of them) — opaque
+  // and structural types degrade to a runtime seam.
+
+  private case class TypeShape(clazz: Class[?], arguments: List[TypeShape])
+
+  private val primitiveClasses: Map[String, Class[?]] =
+    Map
+      ( "scala.Int"     -> classOf[Int],
+        "scala.Long"    -> classOf[Long],
+        "scala.Double"  -> classOf[Double],
+        "scala.Float"   -> classOf[Float],
+        "scala.Boolean" -> classOf[Boolean],
+        "scala.Short"   -> classOf[Short],
+        "scala.Byte"    -> classOf[Byte],
+        "scala.Char"    -> classOf[Char],
+        "scala.Unit"    -> classOf[Unit] )
+
+  // The binary name of a class symbol: package segments joined with dots,
+  // enclosing type segments with dollars.
+  private def binaryName(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+
+    def build(symbol: Symbol): String =
+      val owner = symbol.owner
+
+      if owner.isPackageDef then
+        val prefix = owner.fullName
+        if prefix == "<empty>" then symbol.name else prefix+"."+symbol.name
+      else
+        val ownerName = build(if owner.isClassDef then owner else owner.owner)
+        ownerName+"$"+symbol.name
+
+    build(symbol)
+
+  private def shapeOf(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[TypeShape] =
+    import quotes.reflect.*
+
+    def classFor(tpe: TypeRepr): Option[Class[?]] =
+      tpe.classSymbol.flatMap: symbol =>
+        if definedInCurrentRun(symbol) then None
+        else primitiveClasses.get(symbol.fullName).orElse:
+          try Some(Class.forName(binaryName(symbol), false, macroClassloader).nn)
+          catch
+            case _: ReflectiveOperationException => None
+            case _: LinkageError                 => None
+
+    tpe.dealias match
+      case AppliedType(constructor, arguments) =>
+        for
+          clazz <- classFor(constructor)
+          shapes <- arguments.foldRight(Option(List.empty[TypeShape])): (argument, list) =>
+                      list.flatMap { tail => shapeOf(argument).map(_ :: tail) }
+        yield TypeShape(clazz, shapes)
+
+      case other =>
+        classFor(other).map(TypeShape(_, Nil))
+
+  // ── Instance evaluation: the staging summon ────────────────────────────
+  // One fresh compiler per summon, over the macro classloader with the
+  // current output directory excluded from its classpath. The summon is
+  // embedded in the compiled snippet (`summonInline`), so it resolves during
+  // the inner compiler's inlining phase, composing conditional instances —
+  // the whole instance graph arrives live in one run.
+  private def summonViaStaging[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[field]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val target =
+            r2.Refinement
+              ( r2.TypeRepr.of[Inlinable], "Self",
+                r2.TypeBounds(rebuild(shape), rebuild(shape)) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+
+        result match
+          case instance: Inlinable =>
+            report.info
+              (s"stratiform: staged summon for ${TypeRepr.of[field].show} took ${duration}ms")
+
+            Some(instance)
+
+          case _ =>
+            None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The resolution ladder ──────────────────────────────────────────────
+  // builtin → staged summon → structural collection/product → (caller's)
+  // runtime seam. The cache spans one entry expansion, so a type's staging
+  // summon runs at most once however often it recurs in the graph.
+
+  private type Cache = scm.HashMap[String, Option[Inlinable]]
+
+  private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    builtinFor(tpe).orElse:
+      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+
+  private def builtinFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Inlinable] =
+    import quotes.reflect.*
+
+    if tpe =:= TypeRepr.of[Int] then Some(Inlinable.int)
+    else if tpe =:= TypeRepr.of[Long] then Some(Inlinable.long)
+    else if tpe =:= TypeRepr.of[Boolean] then Some(Inlinable.boolean)
+    else if tpe =:= TypeRepr.of[Double] then Some(Inlinable.double)
+    else if tpe =:= TypeRepr.of[Text] then Some(Inlinable.text)
+    else if tpe =:= TypeRepr.of[String] then Some(Inlinable.string)
+    else None
+
+  private def structuralFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            resolve[element](cache).map: instance =>
+              Inlinable.IterableInlinable[element]
+                (instance.asInstanceOf[element is Inlinable])
+
+      case _ =>
+        None
+    else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
+    else None
+
+  private[stratiform] def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Boolean =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.exists: classSymbol =>
+      classSymbol.flags.is(Flags.Case)
+      && !classSymbol.owner.isTerm
+      && (tpe match { case AppliedType(_, _) => false case _ => true })
+      && classSymbol.primaryConstructor.paramSymss
+         . filterNot(_.exists(_.isTypeParam)).length == 1
+      && !hasRenames(classSymbol)
+
+  // `@name` renames resolve through inline machinery the structural
+  // generator does not replicate; annotated records stay on `staged`.
+  private def hasRenames(using Quotes)(classSymbol: quotes.reflect.Symbol): Boolean =
+    import quotes.reflect.*
+
+    val annotated =
+      classSymbol.primaryConstructor.paramSymss.flatten.filterNot(_.isTypeParam)
+        . flatMap(_.annotations)
+      ++ classSymbol.caseFields.flatMap(_.annotations)
+
+    annotated.exists { annotation => annotation.tpe <:< TypeRepr.of[adversaria.name[?]] }
+
+  // ── The collection generator ───────────────────────────────────────────
+  // A single entry read as a collection: one element — the runtime
+  // `Tel.Parsable.iterable`'s single-entry behavior. In field position the
+  // product generator never calls this: it gathers each occurrence of the
+  // keyword directly (see `fieldLoop`), exactly as the derived engine
+  // routes repeatable fields through `parseElement`.
+  private[stratiform] def iterableBody[collection: Type]
+    (reader: Expr[TelReader], indent: Expr[Int], element0: Inlinable)
+    (using Quotes)
+  :   Expr[collection] =
+
+    import quotes.reflect.*
+
+    TypeRepr.of[collection].dealias match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            val instance = element0.asInstanceOf[Inlinable { type Self = element }]
+
+            '{
+              def parseElement(): element = ${ instance.parse(reader, indent) }
+              val factory = infer[scala.collection.Factory[element, collection]]
+              val builder = factory.newBuilder
+              builder += parseElement()
+              builder.result()
+            }
+
+      case _ =>
+        report.errorAndAbort
+          ("stratiform: an inlinable collection requires an applied collection type")
+
+  // ── The product generator ──────────────────────────────────────────────
+  // Self-contained monomorphic entry parsing, mirroring the staged parser's
+  // semantics: typed local slots and seen flags, literal packed-word keyword
+  // dispatch (an opaque keyword resolves through the interned keyword text
+  // against literal strings; unknown keywords are skipped), first occurrence
+  // read per keyword with focus bookkeeping, declared defaults then absent
+  // semantics for missing fields, direct construction. A collection field
+  // gathers every occurrence of its keyword into a typed builder — the
+  // derived engine's repeatable semantics, with the element's generated
+  // code inlined at the occurrence site. A field with no `Inlinable` binds
+  // its runtime `Tel.Parsing` instance once per record and keeps the
+  // engine's dynamic repeatability dispatch.
+  private[stratiform] def productFields[product: Type]
+    (reader: Expr[TelReader], indent: Expr[Int])
+    (using Quotes)
+  :   Expr[product] =
+
+    productFields[product](reader, indent, scm.HashMap())
+
+  private[stratiform] def productFields[product: Type]
+    (reader: Expr[TelReader], indent: Expr[Int], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    '{
+      val foci = infer[Foci[Tel.Focus]]
+      val focused = foci.active
+      val tactic = infer[Tactic[TelError]]
+      ${ fieldLoop[product](reader, indent, 'foci, 'focused, 'tactic, cache) }
+    }
+
+  // How one field reads, established at expansion: a builtin leaf, a
+  // gathered collection (with its element's generator), any other resolved
+  // instance (a nested record, a custom leaf), or the runtime seam.
+  private enum Plan:
+    case Leaf(instance: Inlinable)
+    case Gather(element: Inlinable)
+    case Nested(instance: Inlinable)
+    case Seam
+
+  private def fieldLoop[product: Type]
+    ( reader:  Expr[TelReader],
+      indent:  Expr[Int],
+      foci:    Expr[Foci[Tel.Focus]],
+      focused: Expr[Boolean],
+      tactic:  Expr[Tactic[TelError]],
+      cache:   Cache )
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+
+    if !productSupported(tpe) then
+      report.errorAndAbort
+        (s"stratiform: ${tpe.show} is not an inlinable product (a non-generic, top-level or "+
+          "object-nested case class with a single parameter list and no `@name` renames); "+
+          "use `Tel.Parsable.staged` or `derived`")
+
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+    val wireNames: List[String] = fieldNames.map { name => Tel.camelToKebab(name).s }
+
+    val plans: List[Plan] = fieldTypes.map: fieldType =>
+      builtinFor(fieldType) match
+        case Some(leaf) =>
+          Plan.Leaf(leaf)
+
+        case None =>
+          fieldType.asType match
+            case '[fieldType] =>
+              resolve[fieldType](cache) match
+                case Some(iterable: Inlinable.IterableInlinable[?]) => Plan.Gather(iterable.element0)
+                case Some(instance)                                 => Plan.Nested(instance)
+                case None                                           => Plan.Seam
+
+    // Keywords compile to literal packed-word comparisons using the same
+    // camel→kebab mapping and packing as the staged parser; a wire keyword
+    // that cannot pack (longer than eight bytes) always arrives as
+    // `KeywordOpaque` and resolves through the literal text step, which
+    // matches all fields by string.
+    def packedKeyword(index: Int): Option[Long] =
+      val name = wireNames(index)
+      val length = name.length
+
+      val packs = length > 0 && length <= 8 &&
+        name.forall { char => char >= '!' && char <= '~' }
+
+      if !packs then None else
+        var word = 0L
+        var position = 0
+
+        while position < length do
+          word |= (name.charAt(position).toLong & 0xFF) << (position*8)
+          position += 1
+
+        Some(word)
+
+    val packedKeywords: List[Option[Long]] = List.range(0, arity).map(packedKeyword)
+
+    val owner = Symbol.spliceOwner
+    val unit = Literal(UnitConstant())
+
+    val slots = List.range(0, arity).map: index =>
+      Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+    val seens = List.range(0, arity).map: index =>
+      Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+    def zero(fieldType: TypeRepr): Term =
+      if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+      else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+      else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+      else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+      else fieldType.asType match
+        case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+    val slotDefs = List.range(0, arity).map: index =>
+      ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+    val seenDefs = List.range(0, arity).map: index =>
+      ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+    def keyText(index: Int): Expr[Text] = '{ ${Expr(wireNames(index))}.tt }
+
+    // ── Gathered collection fields: a typed builder per field, an element
+    // def emitted once (composition points become local defs — a fully
+    // flattened parser exceeds HotSpot's huge-method limit and runs
+    // interpreted), each occurrence appended with focus bookkeeping. ──
+
+    case class GatherState(builder: Symbol, element: Symbol, defs: List[Statement])
+
+    val gathers: List[Option[GatherState]] = List.range(0, arity).map: index =>
+      plans(index) match
+        case Plan.Gather(element0) =>
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              fieldTypes(index) match
+                case AppliedType(_, arguments) =>
+                  arguments.last.asType match
+                    case '[element] =>
+                      val instance = element0.asInstanceOf[Inlinable { type Self = element }]
+
+                      val builderSymbol =
+                        Symbol.newVal
+                          ( owner, "gather"+index,
+                            TypeRepr.of[scm.Builder[element, fieldType]],
+                            Flags.EmptyFlags, Symbol.noSymbol )
+
+                      val builderDef =
+                        ValDef
+                          ( builderSymbol,
+                            Some:
+                              '{
+                                infer[scala.collection.Factory[element, fieldType]].newBuilder
+                              }.asTerm )
+
+                      val elementSymbol =
+                        Symbol.newMethod
+                          ( owner, "parseElement"+index,
+                            MethodType(Nil)(_ => Nil, _ => TypeRepr.of[element]) )
+
+                      val elementRhs =
+                        instance.parse(reader, indent).asTerm.changeOwner(elementSymbol)
+
+                      val elementDef = DefDef(elementSymbol, _ => Some(elementRhs))
+
+                      Some(GatherState(builderSymbol, elementSymbol, List(builderDef, elementDef)))
+
+                case _ =>
+                  None
+
+        case _ =>
+          None
+
+    // ── Seam fields: the runtime instance, bound once per record, with the
+    // engine's dynamic repeatability dispatch and occurrence buffer. ──
+
+    case class SeamState(instance: Symbol, repeats: Symbol, buffer: Symbol, defs: List[Statement])
+
+    val bufferType = TypeRepr.of[scm.ListBuffer[Any] | Null]
+
+    val seams: List[Option[SeamState]] = List.range(0, arity).map: index =>
+      plans(index) match
+        case Plan.Seam =>
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              val instanceSymbol =
+                Symbol.newVal
+                  ( owner, "instance"+index, TypeRepr.of[fieldType is Tel.Parsing],
+                    Flags.EmptyFlags, Symbol.noSymbol )
+
+              val instanceDef =
+                ValDef
+                  ( instanceSymbol,
+                    Some('{ stagedInternal.fieldInstance[fieldType] }.asTerm) )
+
+              val instanceRef = Ref(instanceSymbol).asExprOf[fieldType is Tel.Parsing]
+
+              val repeatsSymbol =
+                Symbol.newVal
+                  ( owner, "repeats"+index, TypeRepr.of[Boolean],
+                    Flags.EmptyFlags, Symbol.noSymbol )
+
+              val repeatsDef =
+                ValDef(repeatsSymbol, Some('{ Tel.Parsable.repeats($instanceRef) }.asTerm))
+
+              val bufferSymbol =
+                Symbol.newVal(owner, "buffer"+index, bufferType, Flags.Mutable, Symbol.noSymbol)
+
+              val bufferDef = ValDef(bufferSymbol, Some('{ null }.asTerm))
+
+              Some:
+                SeamState
+                  ( instanceSymbol, repeatsSymbol, bufferSymbol,
+                    List(instanceDef, repeatsDef, bufferDef) )
+
+        case _ =>
+          None
+
+    // Nested records (and custom non-leaf instances): the body is emitted
+    // once as a local def and called from the dispatch arm, keeping each
+    // generated method JIT-compilable.
+    val nesteds: List[Option[(Symbol, Statement)]] = List.range(0, arity).map: index =>
+      plans(index) match
+        case Plan.Nested(instance0) =>
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+
+              val symbol =
+                Symbol.newMethod
+                  ( owner, "parseNested"+index,
+                    MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
+
+              val rhs = instance.parse(reader, indent).asTerm.changeOwner(symbol)
+              Some((symbol, DefDef(symbol, _ => Some(rhs))))
+
+        case _ =>
+          None
+
+    // ── Dispatch arms ──────────────────────────────────────────────────────
+
+    def firstWins(index: Int, read: Term): Term =
+      If
+        ( Ref(seens(index)),
+          '{ $reader.skipEntry($indent) }.asTerm,
+          Block
+            ( List
+                ( Assign(Ref(slots(index)), read),
+                  Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+              unit ) )
+
+    val arms: List[CaseDef] = List.range(0, arity).map: index =>
+      val rhs: Term = fieldTypes(index).asType match
+        case '[fieldType] =>
+          plans(index) match
+            case Plan.Leaf(instance0) =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+
+              firstWins
+                ( index,
+                  '{
+                    Tel.Parsable.focusing($foci, ${keyText(index)})
+                      (${ instance.parse(reader, indent) })
+                  }.asTerm )
+
+            case Plan.Nested(_) =>
+              val (symbol, _) = nesteds(index).get
+              val call = Apply(Ref(symbol), Nil).asExprOf[fieldType]
+
+              firstWins
+                ( index,
+                  '{ Tel.Parsable.focusing($foci, ${keyText(index)})($call) }.asTerm )
+
+            case Plan.Gather(_) =>
+              val gather = gathers(index).get
+
+              fieldTypes(index) match
+                case AppliedType(_, arguments) =>
+                  arguments.last.asType match
+                    case '[element] =>
+                      val builderRef =
+                        Ref(gather.builder).asExprOf[scm.Builder[element, fieldType]]
+
+                      val call = Apply(Ref(gather.element), Nil).asExprOf[element]
+
+                      '{
+                        $builderRef.addOne
+                          (Tel.Parsable.focusing($foci, ${keyText(index)})($call))
+                      }.asTerm
+
+                case _ =>
+                  report.errorAndAbort("stratiform: unreachable gather shape")
+
+            case Plan.Seam =>
+              val seam = seams(index).get
+              val instanceRef = Ref(seam.instance).asExprOf[fieldType is Tel.Parsing]
+              val bufferRef = Ref(seam.buffer).asExprOf[scm.ListBuffer[Any] | Null]
+
+              val ensure: Term =
+                If
+                  ( '{ $bufferRef == null }.asTerm,
+                    Assign(Ref(seam.buffer), '{ scm.ListBuffer.empty[Any] }.asTerm),
+                    unit )
+
+              val append: Term =
+                '{
+                  $bufferRef.asInstanceOf[scm.ListBuffer[Any]].addOne
+                    ( Tel.Parsable.focusing($foci, ${keyText(index)}):
+                        Tel.Parsable.parseElement($instanceRef, $reader, $indent) )
+                }.asTerm
+
+              val read: Term =
+                '{
+                  Tel.Parsable.focusing($foci, ${keyText(index)})
+                    ($instanceRef.parse($reader, $indent))
+                }.asTerm
+
+              If
+                ( Ref(seam.repeats),
+                  Block(List(ensure, append), unit),
+                  firstWins(index, read) )
+
+      CaseDef(Literal(IntConstant(index)), None, rhs)
+
+    val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipEntry($indent) }.asTerm)
+
+    // ── The keyword loop: packed-word dispatch with a literal text step for
+    // opaque keywords, mirroring the staged parser's single-step protocol. ──
+
+    val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+    val word = Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+    val found = Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+    val wordRef = Ref(word).asExprOf[Long]
+
+    def packedChain(index: Int): Term =
+      if index == arity then Literal(IntConstant(-1))
+      else packedKeywords(index) match
+        case None => packedChain(index + 1)
+
+        case Some(packed) =>
+          If
+            ( '{ $wordRef == ${Expr(packed)} }.asTerm,
+              Literal(IntConstant(index)),
+              packedChain(index + 1) )
+
+    val textStep: Term =
+      val name =
+        Symbol.newVal(owner, "name", TypeRepr.of[String], Flags.EmptyFlags, Symbol.noSymbol)
+
+      val nameRef = Ref(name).asExprOf[String]
+
+      def stringChain(index: Int): Term =
+        if index == arity then Literal(IntConstant(-1))
+        else
+          If
+            ( '{ $nameRef == ${Expr(wireNames(index))} }.asTerm,
+              Literal(IntConstant(index)),
+              stringChain(index + 1) )
+
+      Block
+        ( List(ValDef(name, Some('{ $reader.keywordText.s }.asTerm))),
+          stringChain(0) )
+
+    val resolveStep: Term =
+      If('{ $wordRef == TelReader.KeywordOpaque }.asTerm, textStep, packedChain(0))
+
+    val step: Term =
+      Block
+        ( List(ValDef(word, Some('{ $reader.keywordWord($indent) }.asTerm))),
+          If
+            ( '{ $wordRef == TelReader.KeywordEnd }.asTerm,
+              Assign(Ref(run), Literal(BooleanConstant(false))),
+              Block
+                ( List(ValDef(found, Some(resolveStep))),
+                  Match(Ref(found), arms :+ fallthrough) ) ) )
+
+    val loop: List[Statement] =
+      List(ValDef(run, Some(Literal(BooleanConstant(true)))), While(Ref(run), step))
+
+    // ── Fields whose keywords never arrived — and gathered fields, whose
+    // collection is always built from the occurrences (zero occurrences
+    // build the empty collection; a repeatable field never consults the
+    // declared default), exactly as the derived engine does. ──
+
+    val absents: List[Term] = List.range(0, arity).map: index =>
+      fieldTypes(index).asType match
+        case '[fieldType] =>
+          def resolveAbsent(onAbsent: Expr[fieldType]): Term =
+            Assign
+              ( Ref(slots(index)),
+                '{
+                  val declared = wisteria.internal.default[product, fieldType](${Expr(index)})
+
+                  if !declared.absent then declared.asInstanceOf[fieldType]
+                  else Tel.Parsable.focusing($foci, ${keyText(index)})($onAbsent)
+                }.asTerm )
+
+          def whenUnseen(onAbsent: Expr[fieldType]): Term =
+            If
+              ( '{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm,
+                resolveAbsent(onAbsent), unit )
+
+          plans(index) match
+            case Plan.Leaf(instance0) =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+              whenUnseen(instance.absent(tactic))
+
+            case Plan.Nested(instance0) =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+              whenUnseen(instance.absent(tactic))
+
+            case Plan.Gather(_) =>
+              val gather = gathers(index).get
+
+              fieldTypes(index) match
+                case AppliedType(_, arguments) =>
+                  arguments.last.asType match
+                    case '[element] =>
+                      val builderRef =
+                        Ref(gather.builder).asExprOf[scm.Builder[element, fieldType]]
+
+                      Assign(Ref(slots(index)), '{ $builderRef.result() }.asTerm)
+
+                case _ =>
+                  report.errorAndAbort("stratiform: unreachable gather shape")
+
+            case Plan.Seam =>
+              val seam = seams(index).get
+              val instanceRef = Ref(seam.instance).asExprOf[fieldType is Tel.Parsing]
+              val bufferRef = Ref(seam.buffer).asExprOf[scm.ListBuffer[Any] | Null]
+
+              val gatherFinish: Term =
+                Assign
+                  ( Ref(slots(index)),
+                    '{
+                      Tel.Parsable.focusing($foci, ${keyText(index)}):
+                        Tel.Parsable.gathered[fieldType]
+                          ( $instanceRef,
+                            $bufferRef match
+                              case null   => Nil
+                              case buffer => buffer.toList )
+                    }.asTerm )
+
+              If
+                ( Ref(seam.repeats),
+                  gatherFinish,
+                  whenUnseen('{ $instanceRef.absent()(using $tactic) }) )
+
+    val construct: Term =
+      Apply(Select(New(Inferred(tpe)), ctor), slots.map { slot => Ref(slot) })
+
+    val gatherDefs: List[Statement] = gathers.flatMap(_.toList).flatMap(_.defs)
+    val seamDefs: List[Statement] = seams.flatMap(_.toList).flatMap(_.defs)
+    val nestedDefs: List[Statement] = nesteds.flatMap(_.toList).map(_(1))
+
+    Block
+      ( slotDefs ::: seenDefs ::: gatherDefs ::: seamDefs ::: nestedDefs ::: loop ::: absents,
+        construct )
+    . asExprOf[product]
+
+  // ── The entry macro ────────────────────────────────────────────────────
+  def inlinableParsable[value: Type](using Quotes): Expr[value is Tel.Parsable] =
+    import quotes.reflect.*
+
+    val cache: Cache = scm.HashMap()
+
+    if !productSupported(TypeRepr.of[value].dealias) then
+      report.errorAndAbort
+        (s"stratiform: ${TypeRepr.of[value].show} is not an inlinable product (a non-generic, "+
+          "top-level or object-nested case class with a single parameter list and no `@name` "+
+          "renames); use `Tel.Parsable.staged` or `derived`")
+
+    '{
+      // Sealed per the codec-thunk pattern, like the staged instances: the
+      // generated body resolves its capabilities where it is spliced.
+      caps.unsafe.unsafeAssumePure:
+        new Tel.Parsable:
+          type Self = value
+          def shape(): Morphology = Morphology.Any
+
+          def parse(reader: TelReader, indent: Int): value =
+            reader.finishLine()
+            val indent1 = indent + 1
+            ${ productFields[value]('reader, 'indent1, cache) }
+
+          override def parse(reader: TelReader): value =
+            ${ productFields[value]('reader, '{0}, cache) }
+    }

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -1141,11 +1141,32 @@ object Xml extends Tag.Container
       override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): value =
         convert(text).or(raise(XmlError()) yet sentinel)
 
-  given intParsable: Int is Xml.Parsable = primitiveParsable(0): text =>
-    try Integer.parseInt(text.s) catch case _: NumberFormatException => Unset
+  // `Int`/`Long`/`Double`/`Boolean` read their value straight from the
+  // buffered content chars (`reader.int()`/`long()`/`double()`/`boolean()`),
+  // so a valid scalar never materializes the value `Text` that `text()`
+  // would — only exotic content does, through the reader's internal general
+  // fallback, which parses exactly as the primitives here would have.
+  given intParsable: Int is Xml.Parsable = new Xml.Parsable:
+    type Self = Int
+    def parse(reader: XmlReader^): Int = reader.int().or(reader.fault() yet 0)
 
-  given longParsable: Long is Xml.Parsable = primitiveParsable(0L): text =>
-    try jl.Long.parseLong(text.s) catch case _: NumberFormatException => Unset
+    override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): Int =
+      raise(XmlError()) yet 0
+
+    override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): Int =
+      try Integer.parseInt(text.s)
+      catch case _: NumberFormatException => raise(XmlError()) yet 0
+
+  given longParsable: Long is Xml.Parsable = new Xml.Parsable:
+    type Self = Long
+    def parse(reader: XmlReader^): Long = reader.long().or(reader.fault() yet 0L)
+
+    override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): Long =
+      raise(XmlError()) yet 0L
+
+    override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): Long =
+      try jl.Long.parseLong(text.s)
+      catch case _: NumberFormatException => raise(XmlError()) yet 0L
 
   given shortParsable: Short is Xml.Parsable = primitiveParsable(0.toShort): text =>
     try jl.Short.parseShort(text.s) catch case _: NumberFormatException => Unset
@@ -1153,17 +1174,32 @@ object Xml extends Tag.Container
   given byteParsable: Byte is Xml.Parsable = primitiveParsable(0.toByte): text =>
     try jl.Byte.parseByte(text.s) catch case _: NumberFormatException => Unset
 
-  given doubleParsable: Double is Xml.Parsable = primitiveParsable(0.0): text =>
-    try jl.Double.parseDouble(text.s) catch case _: NumberFormatException => Unset
+  given doubleParsable: Double is Xml.Parsable = new Xml.Parsable:
+    type Self = Double
+    def parse(reader: XmlReader^): Double = reader.double().or(reader.fault() yet 0.0)
+
+    override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): Double =
+      raise(XmlError()) yet 0.0
+
+    override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): Double =
+      try jl.Double.parseDouble(text.s)
+      catch case _: NumberFormatException => raise(XmlError()) yet 0.0
 
   given floatParsable: Float is Xml.Parsable = primitiveParsable(0.0f): text =>
     try jl.Float.parseFloat(text.s) catch case _: NumberFormatException => Unset
 
-  given booleanParsable: Boolean is Xml.Parsable = primitiveParsable(false): text =>
-    text.s match
-      case "true"  => true
-      case "false" => false
-      case _       => Unset
+  given booleanParsable: Boolean is Xml.Parsable = new Xml.Parsable:
+    type Self = Boolean
+    def parse(reader: XmlReader^): Boolean = reader.boolean().or(reader.fault() yet false)
+
+    override def absent()(using Tactic[XmlError], Foci[Xml.Focus]): Boolean =
+      raise(XmlError()) yet false
+
+    override def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): Boolean =
+      text.s match
+        case "true"  => true
+        case "false" => false
+        case _       => raise(XmlError()) yet false
 
   // Element-wise `Xml.Field` for collections, resolved during derivation:
   // the element's own parser comes from the fallback chain, so nested
@@ -1370,7 +1406,7 @@ object Xml extends Tag.Container
   =>  ( tactic: Tactic[ParseError], xmlTactic: Tactic[XmlError], foci: Foci[Xml.Focus] )
   =>  ( (Text is Readable to (value in Xml))^{parsable, tactic, xmlTactic} ) =
 
-    text => parseDirect(Iterator(text), parsable).asInstanceOf[value in Xml]
+    text => parseDirect(text, parsable).asInstanceOf[value in Xml]
 
   // Direct-parsing counterpart of `Xml2.aggregableIn`: drives an
   // `Xml.Parsable` instance over the input through an `XmlReader`, so no
@@ -1396,7 +1432,25 @@ object Xml extends Tag.Container
             foci:      Foci[Xml.Focus] )
   :   value =
 
-    val parser = XmlParser.fromIterator(input)
+    parseWith(XmlParser.fromIterator(input), parsable)
+
+  // Whole-`Text` form: a pre-filled single-chunk cursor, no iterator
+  // plumbing (the `readableParsed` entry).
+  private def parseDirect[value](input: Text, parsable: (value is Xml.Parsable)^)
+    ( using schema:    XmlSchema,
+            tactic:    Tactic[ParseError],
+            xmlTactic: Tactic[XmlError],
+            foci:      Foci[Xml.Focus] )
+  :   value =
+
+    parseWith(XmlParser.fromText(input), parsable)
+
+  private def parseWith[value](parser: XmlParser^, parsable: (value is Xml.Parsable)^)
+    ( using schema:    XmlSchema,
+            tactic:    Tactic[ParseError],
+            xmlTactic: Tactic[XmlError],
+            foci:      Foci[Xml.Focus] )
+  :   value =
 
     parser.directSession:
       parser.directRoot() match
@@ -1947,6 +2001,21 @@ object Xml extends Tag.Container
   // base class.
 
   private[xylophone] object XmlParser:
+    // Exact powers of ten for the Clinger double fast path: every entry is
+    // exactly representable, so `mantissa.toDouble / TenPow(scale)` is
+    // correctly rounded whenever the mantissa fits in 53 bits.
+    private[xylophone] val TenPow: Array[Double] =
+      Array(1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15)
+
+    // `true` and `false` packed LSB-first, for the boolean content fast path.
+    private[xylophone] val TrueWord: Long =
+      ('t'.toLong & 0xFF) | (('r'.toLong & 0xFF) << 8) | (('u'.toLong & 0xFF) << 16)
+        | (('e'.toLong & 0xFF) << 24)
+
+    private[xylophone] val FalseWord: Long =
+      ('f'.toLong & 0xFF) | (('a'.toLong & 0xFF) << 8) | (('l'.toLong & 0xFF) << 16)
+        | (('s'.toLong & 0xFF) << 24) | (('e'.toLong & 0xFF) << 32)
+
     // Use untracked lineation in the cursor: avoids a per-`advance` branch
     // (newline detection) and a per-`mark` write into the cursor's parallel
     // offsets array. Errors still carry an accurate absolute `offset` /
@@ -3494,6 +3563,168 @@ object Xml extends Tag.Container
               nodes += 1
 
         if nodes == 0 then t"" else if nodes == 1 then single else null
+
+    // ── Byte-parsed scalar content ─────────────────────────────────────────
+    // The current element's text content parsed straight from the buffered
+    // chars as a primitive, consumed together with its close tag, or `Unset`
+    // for missing, wrong-shaped or unparseable content — saving the value
+    // `Text` that `directText` would materialize only for the primitive to
+    // re-scan. The fast path accepts only content whose parse is provably
+    // identical to the `String`-parsing primitives'; anything else — an
+    // entity, an interior node, an exotic spelling, a value outside the
+    // exact range — rewinds to the content's start (the `readAttrValue`
+    // precedent) and takes the general `directText` path, so the two routes
+    // agree by construction.
+
+    private def directTextLongFallback()(using Tactic[ParseError]): Optional[Long] =
+      directText() match
+        case null       => Unset
+        case text: Text =>
+          try Optional(jl.Long.parseLong(text.s)) catch case _: NumberFormatException => Unset
+
+    private[xylophone] def directTextLong()(using Tactic[ParseError]): Optional[Long] =
+      if directEmpty then
+        directText()
+        Unset
+      else
+        val start = begin()
+        var value = 0L
+        var digits = 0
+        var neg = false
+        var bad = false
+        var c = ' '
+
+        while !bad && more && { c = peek; c != '<' } do
+          if c >= '0' && c <= '9' then
+            // Eighteen digits can never overflow; longer runs fall back.
+            if digits == 18 then bad = true else
+              value = value*10 + (c - '0')
+              digits += 1
+              advance()
+          else if c == '-' && digits == 0 && !neg then
+            neg = true
+            advance()
+          else bad = true
+
+        if !bad && more && digits > 0 then
+          advance()
+
+          if more && peek == '/' then
+            advance()
+            directClose()
+            Optional(if neg then -value else value)
+          else
+            reset(start)
+            directTextLongFallback()
+        else
+          reset(start)
+          directTextLongFallback()
+
+    private[xylophone] def directTextInt()(using Tactic[ParseError]): Optional[Int] =
+      val value = directTextLong()
+
+      if value.absent then Unset else
+        val long = value.vouch
+        if long >= Int.MinValue.toLong && long <= Int.MaxValue.toLong
+        then Optional(long.toInt)
+        else Unset
+
+    private def directTextDoubleFallback()(using Tactic[ParseError]): Optional[Double] =
+      directText() match
+        case null       => Unset
+        case text: Text =>
+          try Optional(jl.Double.parseDouble(text.s))
+          catch case _: NumberFormatException => Unset
+
+    private[xylophone] def directTextDouble()(using Tactic[ParseError]): Optional[Double] =
+      if directEmpty then
+        directText()
+        Unset
+      else
+        val start = begin()
+        var mantissa = 0L
+        var digits = 0
+        var decimals = -1
+        var neg = false
+        var bad = false
+        var c = ' '
+
+        while !bad && more && { c = peek; c != '<' } do
+          if c >= '0' && c <= '9' then
+            // Fifteen mantissa digits stay below 2^53, so `toDouble` is
+            // exact and the division below is correctly rounded — the
+            // Clinger fast path, bit-identical to `Double.parseDouble`.
+            if digits == 15 then bad = true else
+              mantissa = mantissa*10 + (c - '0')
+              digits += 1
+              if decimals >= 0 then decimals += 1
+              advance()
+          else if c == '.' && decimals < 0 then
+            decimals = 0
+            advance()
+          else if c == '-' && digits == 0 && decimals < 0 && !neg then
+            neg = true
+            advance()
+          else bad = true
+
+        if !bad && more && digits > 0 then
+          advance()
+
+          if more && peek == '/' then
+            advance()
+            directClose()
+            val scale = if decimals > 0 then decimals else 0
+            val magnitude = mantissa.toDouble/XmlParser.TenPow(scale)
+            Optional(if neg then -magnitude else magnitude)
+          else
+            reset(start)
+            directTextDoubleFallback()
+        else
+          reset(start)
+          directTextDoubleFallback()
+
+    private def directTextBooleanFallback()(using Tactic[ParseError]): Optional[Boolean] =
+      directText() match
+        case null       => Unset
+        case text: Text => text.s match
+          case "true"  => Optional(true)
+          case "false" => Optional(false)
+          case _       => Unset
+
+    private[xylophone] def directTextBoolean()(using Tactic[ParseError]): Optional[Boolean] =
+      if directEmpty then
+        directText()
+        Unset
+      else
+        val start = begin()
+        var word = 0L
+        var length = 0
+        var bad = false
+        var c = ' '
+
+        while !bad && more && { c = peek; c != '<' } do
+          if c >= 'a' && c <= 'z' && length < 5 then
+            word |= (c.toLong & 0xFF) << (length*8)
+            length += 1
+            advance()
+          else bad = true
+
+        val isTrue = length == 4 && word == XmlParser.TrueWord
+        val isFalse = length == 5 && word == XmlParser.FalseWord
+
+        if !bad && more && (isTrue || isFalse) then
+          advance()
+
+          if more && peek == '/' then
+            advance()
+            directClose()
+            Optional(isTrue)
+          else
+            reset(start)
+            directTextBooleanFallback()
+        else
+          reset(start)
+          directTextBooleanFallback()
 
     // Skips the current element's entire remaining subtree, consuming and
     // validating every close tag on the way, building nothing. Used for

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -472,17 +472,21 @@ object Xml extends Tag.Container
     inline def disjunction[derivation: SumReflection]
     :   derivation is Decodable in Xml =
 
+      // The label list and the `@name[Xml]` / bare `@name` variant-rename map
+      // (serialized element label back to the variant name) are
+      // per-derivation constants: built once here rather than on every
+      // decode call, whose profile they dominated (map building plus
+      // generic-equality lookups, per occurrence) — jacinta's map hoist.
+      val labels: List[Text] = variantLabels
+
+      val variantNames: Map[Text, Text] =
+        variantRelabelling[derivation, Xml].map: (variant, wire) => wire -> variant
+
       xml =>
         provide[Foci[Xml.Focus]]:
           provide[Tactic[XmlError]]:
             provide[Tactic[VariantError]]:
               val discriminable = infer[derivation is Discriminable in Xml]
-              val labels: List[Text]    = variantLabels
-
-              // `@name[Xml]` / bare `@name` variant renames: map the serialized
-              // element label back to the variant name before delegating.
-              val variantNames: Map[Text, Text] =
-                variantRelabelling[derivation, Xml].map: (variant, wire) => wire -> variant
 
               val resolved: Optional[Text] =
                 discriminable.discriminate(xml).let: wire =>

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -505,6 +505,35 @@ object Xml extends Tag.Container
                     case _ =>
                       abort(XmlError())
 
+  // A sum discriminated by an attribute on the value's element —
+  // `<payment type="Card">…</payment>`. This is the shape a sum nested
+  // inside a product needs: the product encoder relabels the variant
+  // element with the *field's* name, which destroys the label-based default
+  // discriminator, so the variant rides in an attribute instead. A named,
+  // recognisable class (like jacinta's `DiscriminantField`), so staged and
+  // inlined sum parsers can dispatch on the attribute straight off the open
+  // tag, without materializing the element.
+  final class DiscriminantAttribute[derivation](val attribute: Text) extends Discriminable:
+    type Self = derivation
+    type Form = xylophone.Xml
+
+    def discriminate(xml: xylophone.Xml): Optional[Text] = xml match
+      case Element(_, attributes, _)           => attributes.at(attribute)
+      case Fragment(Element(_, attributes, _)) => attributes.at(attribute)
+      case _                                   => Unset
+
+    def rewrite(kind: Text, xml: xylophone.Xml): xylophone.Xml = xml match
+      case Element(label, attributes, children) =>
+        Element(label, attributes.updated(attribute, kind), children)
+
+      case Fragment(Element(label, attributes, children)) =>
+        Element(label, attributes.updated(attribute, kind), children)
+
+      case other =>
+        other
+
+    def variant(xml: xylophone.Xml): xylophone.Xml = xml
+
   // Wisteria-based encoder, the mirror of `DecodableDerivation`. A product
   // encodes to an `Element` labelled with the type's short name (`typeName`);
   // each field becomes a child `Element` labelled with the field name via
@@ -1330,6 +1359,18 @@ object Xml extends Tag.Container
   =>  ( ((value in Xml) is Aggregable by Text)^{parsable, tactic, xmlTactic} ) =
 
     input => parseDirect(input.iterator, parsable).asInstanceOf[value in Xml]
+
+  // Whole-`Text` direct read: when the entire content is already in hand,
+  // parse it in place rather than wrapping it in a one-element stream —
+  // jacinta's `readableParsed` precedent. Concrete in `Text`, so it beats
+  // the composed pipeline by specificity.
+  given readableParsed: [value]
+  =>  ( parsable: (value is Xml.Parsable)^ )
+  =>  ( schema: XmlSchema )
+  =>  ( tactic: Tactic[ParseError], xmlTactic: Tactic[XmlError], foci: Foci[Xml.Focus] )
+  =>  ( (Text is Readable to (value in Xml))^{parsable, tactic, xmlTactic} ) =
+
+    text => parseDirect(Iterator(text), parsable).asInstanceOf[value in Xml]
 
   // Direct-parsing counterpart of `Xml2.aggregableIn`: drives an
   // `Xml.Parsable` instance over the input through an `XmlReader`, so no

--- a/lib/xylophone/src/core/xylophone.XmlReader.scala
+++ b/lib/xylophone/src/core/xylophone.XmlReader.scala
@@ -132,10 +132,22 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // The current element's text content, consumed together with its close
   // tag: `Unset` when the content is not exactly one text run (mirroring
   // `textOf`'s shape rules, under which CDATA is *not* text). Backs the
-  // primitive and text-codec parsers.
+  // text-codec parsers.
   update def text(): Optional[Text] =
     val text = parser.directText()(using parseTactic)
     if text == null then Unset else text.nn
+
+  // The current element's content parsed straight from the buffered chars
+  // as a primitive (consumed with its close tag), or `Unset` for missing,
+  // wrong-shaped or unparseable content — the byte-parsed counterparts of
+  // `text()`, saving the value `Text` it would otherwise materialize only
+  // for the primitive to re-scan. Values and failures agree with the
+  // `String`-parsing primitives exactly: exotic content falls back to the
+  // general path internally.
+  update def int(): Optional[Int] = parser.directTextInt()(using parseTactic)
+  update def long(): Optional[Long] = parser.directTextLong()(using parseTactic)
+  update def double(): Optional[Double] = parser.directTextDouble()(using parseTactic)
+  update def boolean(): Optional[Boolean] = parser.directTextBoolean()(using parseTactic)
 
   // Skips the current element's entire subtree, validating every close tag
   // on the way, building nothing — for unknown child elements and duplicate

--- a/lib/xylophone/src/core/xylophone.XmlReader.scala
+++ b/lib/xylophone/src/core/xylophone.XmlReader.scala
@@ -105,7 +105,14 @@ extends caps.ExclusiveCapability, caps.Stateful:
   // tag is consumed and validated. Character data, comments, CDATA sections
   // and processing instructions between child elements are consumed
   // transparently — the AST derivation looks only at `Element` children.
-  update def nextChild(): Optional[Text] =
+  //
+  // The hot forwarders are `inline` (enabled by the toolchain's
+  // inline-update receiver fix), so the derived engine's steps reach the
+  // parser without a call through the rim. Methods that appear inside
+  // xylophone's macro quotes stay non-inline: the spliced reader there is
+  // capture-erased, and an inline update method requires an exclusive
+  // receiver.
+  inline update def nextChild(): Optional[Text] =
     val name = parser.directNextChild()(using parseTactic)
     if name == null then Unset else name.nn
 
@@ -137,7 +144,7 @@ extends caps.ExclusiveCapability, caps.Stateful:
 
   // The fallback seam: materialize the current element as an `Xml` tree, for
   // field types that only carry a `Decodable in Xml`.
-  update def element(): Xml = parser.directElement()(using parseTactic)
+  inline update def element(): Xml = parser.directElement()(using parseTactic)
 
   // Raise an `XmlError` through the read-site tactic and continue — for leaf
   // instances that reject an element's content, preserving the AST

--- a/lib/xylophone/src/staged/xylophone.Inlinable.scala
+++ b/lib/xylophone/src/staged/xylophone.Inlinable.scala
@@ -1,0 +1,212 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The Expr-level counterpart of `Xml.Parsable`: a typeclass whose methods
+// are macro-time code generators, following jacinta's `Inlinable` exactly.
+// An instance receives an `Expr` of the reader (positioned with the current
+// element just opened) and returns an `Expr` of the decoded value, which
+// the deriving macro splices directly into its generated parser — so an
+// instance contributes *inlined* code, with no runtime dispatch, no
+// instance arrays and no adapter hops between composed parsers.
+//
+// Instances are ordinary runtime values: code generation is deferred to the
+// `parse` call, which receives the `Quotes` and the `Type` of `Self`, so
+// `derived` needs no macro of its own. At a `Inlinable.parsable[T]`
+// expansion, the instance behind each summoned given is obtained *live* by
+// running the implicit search inside an in-macro staging compiler (the
+// prescience mechanism), which composes conditional instances — a collection
+// of a custom element, for example — through ordinary given resolution. The
+// constraint this inherits: an instance (and its type) must be compiled in
+// an earlier run than the expansion; same-run instances degrade to a spliced
+// runtime call through `Xml.Field`.
+trait Inlinable extends Typeclass:
+  def parse(reader: Expr[XmlReader])(using Quotes, Type[Self]): Expr[Self]
+
+  // What a field of this type yields when no child element carries its
+  // name, mirroring the runtime instances: an abort unless overridden (the
+  // primitive instances raise and continue with a sentinel).
+  def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+    (using Quotes, Type[Self])
+  :   Expr[Self] =
+
+    '{ abort(XmlError())(using $tactic) }
+
+object Inlinable:
+  // Generates a monomorphic `Xml.Parsable` for a case class at compile
+  // time, like `Xml.Parsable.staged`, but composed through `Inlinable`
+  // instances: nested records, collection gathering and custom leaf parsers
+  // all inline into one flat parser.
+  inline def parsable[value]: value is Xml.Parsable =
+    ${ xylophone.stagedInternal.inlinableParsable[value] }
+
+  // The structural instance for a case class: reflects `Self` when invoked
+  // (no macro — `Type[Self]` arrives with the call).
+  def derived[product]: product is Inlinable = ProductInlinable[product]()
+
+  private[xylophone] final class ProductInlinable[product]() extends Inlinable:
+    type Self = product
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[product]): Expr[product] =
+      stagedInternal.productFields[product](reader)
+
+    // A missing (or wrong-shape) record: one raise at the current focus,
+    // then a user-supplied `Default` sentinel or a per-sub-field absent
+    // build — the derived engine's `absent()` exactly.
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[product])
+    :   Expr[product] =
+
+      stagedInternal.productAbsent[product](tactic, foci)
+
+  private[xylophone] final class IterableInlinable[element](val element0: element is Inlinable)
+  extends Inlinable:
+    type Self = Iterable[element]
+
+    // A single element read as a collection: one element — the runtime
+    // `Xml.Parsable.iterable`'s behavior when handed a lone element. In
+    // *field* position the deriving generator never calls this: it gathers
+    // each same-name occurrence through the element's own generator.
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      stagedInternal.iterableBody[Iterable[element]](reader, element0)
+
+    // A missing collection field is the empty collection on both paths.
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      stagedInternal.iterableAbsent[Iterable[element]](element0)
+
+  // ── Instances ──────────────────────────────────────────────────────────
+  // The leaf generators mirror the primitive `Xml.Parsable` instances (the
+  // staged parser's builtin arms) exactly, so direct, staged and inlined
+  // reads yield equal values and equal errors.
+
+  given int: (Int is Inlinable) = new Inlinable:
+    type Self = Int
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Int]): Expr[Int] =
+      '{ Xml.intParsable.parse($reader) }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Int])
+    :   Expr[Int] =
+
+      '{ Xml.Parsable.missing[Int](0)(using $tactic) }
+
+  given long: (Long is Inlinable) = new Inlinable:
+    type Self = Long
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Long]): Expr[Long] =
+      '{ Xml.longParsable.parse($reader) }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Long])
+    :   Expr[Long] =
+
+      '{ Xml.Parsable.missing[Long](0L)(using $tactic) }
+
+  given double: (Double is Inlinable) = new Inlinable:
+    type Self = Double
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Double]): Expr[Double] =
+      '{ Xml.doubleParsable.parse($reader) }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Double])
+    :   Expr[Double] =
+
+      '{ Xml.Parsable.missing[Double](0.0)(using $tactic) }
+
+  given float: (Float is Inlinable) = new Inlinable:
+    type Self = Float
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Float]): Expr[Float] =
+      '{ Xml.floatParsable.parse($reader) }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Float])
+    :   Expr[Float] =
+
+      '{ Xml.Parsable.missing[Float](0.0f)(using $tactic) }
+
+  given boolean: (Boolean is Inlinable) = new Inlinable:
+    type Self = Boolean
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Boolean]): Expr[Boolean] =
+      '{ Xml.booleanParsable.parse($reader) }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Boolean])
+    :   Expr[Boolean] =
+
+      '{ Xml.Parsable.missing[Boolean](false)(using $tactic) }
+
+  given text: (Text is Inlinable) = new Inlinable:
+    type Self = Text
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[Text]): Expr[Text] =
+      '{ $reader.text().or { $reader.fault(); t"" } }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[Text])
+    :   Expr[Text] =
+
+      '{ Xml.Parsable.missing[Text](t"")(using $tactic) }
+
+  given string: (String is Inlinable) = new Inlinable:
+    type Self = String
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[String]): Expr[String] =
+      '{ ($reader.text().or { $reader.fault(); t"" }).s }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[String])
+    :   Expr[String] =
+
+      '{ Xml.Parsable.missing[String]("")(using $tactic) }
+
+  given iterable: [collection <: Iterable, element]
+  =>  (element0: element is Inlinable)
+  =>  (collection[element] is Inlinable) =
+    IterableInlinable[element](element0).asInstanceOf[collection[element] is Inlinable]

--- a/lib/xylophone/src/staged/xylophone.Inlinable.scala
+++ b/lib/xylophone/src/staged/xylophone.Inlinable.scala
@@ -97,6 +97,26 @@ object Inlinable:
 
       stagedInternal.productAbsent[product](tactic, foci)
 
+  // The structural instance for a sealed sum whose variants are all
+  // inlinable case classes and whose `Discriminable in Xml` is an
+  // `Xml.DiscriminantAttribute` (established live, through the staging
+  // summon): the variant rides in an attribute of the open tag, so the
+  // generated code dispatches on it straight off the reader and parses the
+  // chosen variant's fields in place — no element AST, no `delegate`.
+  private[xylophone] final class SumInlinable[sum](val attribute: String) extends Inlinable:
+    type Self = sum
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[sum]): Expr[sum] =
+      stagedInternal.sumBody[sum](reader, attribute)
+
+    // A missing sum field: the AST disjunction over the `Absent` sentinel —
+    // no discriminator, so a raise-plus-`Default` or an abort.
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[sum])
+    :   Expr[sum] =
+
+      stagedInternal.sumAbsent[sum](tactic)
+
   private[xylophone] final class IterableInlinable[element](val element0: element is Inlinable)
   extends Inlinable:
     type Self = Iterable[element]

--- a/lib/xylophone/src/staged/xylophone.stagedInternal.scala
+++ b/lib/xylophone/src/staged/xylophone.stagedInternal.scala
@@ -1,0 +1,958 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package xylophone
+
+import scala.collection.mutable as scm
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The machinery behind `xylophone.Inlinable`: expansion-time instance
+// resolution (through an in-macro staging compiler), the structural
+// generators for products and collections, and the `Inlinable.parsable`
+// entry macro — jacinta's `stagedInternal`, transposed to XML's element
+// reading (read-site capabilities from the reader, two-word packed name
+// dispatch) and to the derived engine's gathering semantics for repeatable
+// fields.
+object stagedInternal:
+
+  // The runtime seam for a field type without an `Inlinable`: the field's
+  // `Xml.Parsing` instance, preferring a nominal `Parsable` in scope (a
+  // custom instance, a staged sibling) over the `Xml.Field` fallback chain.
+  // The generated record body binds it once per parse, so occurrence reads,
+  // repeatability dispatch and absence all consult one instance — exactly
+  // the derived engine's per-field instance. An inline method because
+  // `summonFrom` may only live in one; it expands where the generated
+  // parser is spliced.
+  inline def fieldInstance[fieldType]: fieldType is Xml.Parsing =
+    scala.compiletime.summonFrom:
+      case parsable: (`fieldType` is Xml.Parsable) => parsable
+      case _ => scala.compiletime.summonInline[fieldType is Xml.Field]
+
+  // ── Expansion-time environment ─────────────────────────────────────────
+
+  private def macroClassloader: ClassLoader =
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // A symbol defined in the compilation run in progress has no trustworthy
+  // classfile (none on a clean build; a stale one from the previous compile
+  // on an incremental build), so instance evaluation must refuse it and the
+  // caller degrade to a runtime seam.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+
+    val full =
+      dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
+
+  // ── Type transport into the staging context ────────────────────────────
+  // The outer macro's `Type` cannot cross into the inner compiler, so a type
+  // travels as a tree of `java.lang.Class`es and is rebuilt inside with
+  // `TypeRepr.typeConstructorOf`. This restricts instance evaluation to
+  // class-shaped types (plain classes and applications of them) — opaque
+  // and structural types degrade to a runtime seam.
+
+  private case class TypeShape(clazz: Class[?], arguments: List[TypeShape])
+
+  private val primitiveClasses: Map[String, Class[?]] =
+    Map
+      ( "scala.Int"     -> classOf[Int],
+        "scala.Long"    -> classOf[Long],
+        "scala.Double"  -> classOf[Double],
+        "scala.Float"   -> classOf[Float],
+        "scala.Boolean" -> classOf[Boolean],
+        "scala.Short"   -> classOf[Short],
+        "scala.Byte"    -> classOf[Byte],
+        "scala.Char"    -> classOf[Char],
+        "scala.Unit"    -> classOf[Unit] )
+
+  // The binary name of a class symbol: package segments joined with dots,
+  // enclosing type segments with dollars.
+  private def binaryName(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+
+    def build(symbol: Symbol): String =
+      val owner = symbol.owner
+
+      if owner.isPackageDef then
+        val prefix = owner.fullName
+        if prefix == "<empty>" then symbol.name else prefix+"."+symbol.name
+      else
+        val ownerName = build(if owner.isClassDef then owner else owner.owner)
+        ownerName+"$"+symbol.name
+
+    build(symbol)
+
+  private def shapeOf(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[TypeShape] =
+    import quotes.reflect.*
+
+    def classFor(tpe: TypeRepr): Option[Class[?]] =
+      tpe.classSymbol.flatMap: symbol =>
+        if definedInCurrentRun(symbol) then None
+        else primitiveClasses.get(symbol.fullName).orElse:
+          try Some(Class.forName(binaryName(symbol), false, macroClassloader).nn)
+          catch
+            case _: ReflectiveOperationException => None
+            case _: LinkageError                 => None
+
+    tpe.dealias match
+      case AppliedType(constructor, arguments) =>
+        for
+          clazz <- classFor(constructor)
+          shapes <- arguments.foldRight(Option(List.empty[TypeShape])): (argument, list) =>
+                      list.flatMap { tail => shapeOf(argument).map(_ :: tail) }
+        yield TypeShape(clazz, shapes)
+
+      case other =>
+        classFor(other).map(TypeShape(_, Nil))
+
+  // ── Instance evaluation: the staging summon ────────────────────────────
+  // One fresh compiler per summon, over the macro classloader with the
+  // current output directory excluded from its classpath. The summon is
+  // embedded in the compiled snippet (`summonInline`), so it resolves during
+  // the inner compiler's inlining phase, composing conditional instances —
+  // the whole instance graph arrives live in one run.
+  private def summonViaStaging[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[field]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val target =
+            r2.Refinement
+              ( r2.TypeRepr.of[Inlinable], "Self",
+                r2.TypeBounds(rebuild(shape), rebuild(shape)) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+
+        result match
+          case instance: Inlinable =>
+            report.info
+              (s"xylophone: staged summon for ${TypeRepr.of[field].show} took ${duration}ms")
+
+            Some(instance)
+
+          case _ =>
+            None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The resolution ladder ──────────────────────────────────────────────
+  // builtin → staged summon → structural collection/product → (caller's)
+  // runtime seam. The cache spans one entry expansion, so a type's staging
+  // summon runs at most once however often it recurs in the graph.
+
+  private type Cache = scm.HashMap[String, Option[Inlinable]]
+
+  private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    builtinFor(tpe).orElse:
+      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+
+  private def builtinFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Inlinable] =
+    import quotes.reflect.*
+
+    if tpe =:= TypeRepr.of[Int] then Some(Inlinable.int)
+    else if tpe =:= TypeRepr.of[Long] then Some(Inlinable.long)
+    else if tpe =:= TypeRepr.of[Double] then Some(Inlinable.double)
+    else if tpe =:= TypeRepr.of[Float] then Some(Inlinable.float)
+    else if tpe =:= TypeRepr.of[Boolean] then Some(Inlinable.boolean)
+    else if tpe =:= TypeRepr.of[Text] then Some(Inlinable.text)
+    else if tpe =:= TypeRepr.of[String] then Some(Inlinable.string)
+    else None
+
+  private def structuralFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            resolve[element](cache).map: instance =>
+              Inlinable.IterableInlinable[element]
+                (instance.asInstanceOf[element is Inlinable])
+
+      case _ =>
+        None
+    else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
+    else None
+
+  private[xylophone] def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Boolean =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.exists: classSymbol =>
+      classSymbol.flags.is(Flags.Case)
+      && !classSymbol.owner.isTerm
+      && (tpe match { case AppliedType(_, _) => false case _ => true })
+      && classSymbol.primaryConstructor.paramSymss
+         . filterNot(_.exists(_.isTypeParam)).length == 1
+      && !hasAnnotations(classSymbol)
+
+  // `@name` renames resolve through inline machinery the structural
+  // generator does not replicate, and `@attribute` fields fill from the
+  // open tag rather than a child element; annotated records stay on
+  // `staged`.
+  private def hasAnnotations(using Quotes)(classSymbol: quotes.reflect.Symbol): Boolean =
+    import quotes.reflect.*
+
+    val annotated =
+      classSymbol.primaryConstructor.paramSymss.flatten.filterNot(_.isTypeParam)
+        . flatMap(_.annotations)
+      ++ classSymbol.caseFields.flatMap(_.annotations)
+
+    annotated.exists: annotation =>
+      annotation.tpe <:< TypeRepr.of[adversaria.name[?]]
+      || annotation.tpe <:< TypeRepr.of[Xml.attribute]
+
+  // ── The collection generator ───────────────────────────────────────────
+  // A single element read as a collection: one element — the runtime
+  // `Xml.Parsable.iterable`'s single-element behavior. In field position the
+  // product generator never calls this: it gathers each same-name
+  // occurrence directly (see `fieldLoop`), exactly as the derived engine
+  // routes repeatable fields through `parseElement`.
+  private[xylophone] def iterableBody[collection: Type]
+    (reader: Expr[XmlReader], element0: Inlinable)
+    (using Quotes)
+  :   Expr[collection] =
+
+    import quotes.reflect.*
+
+    TypeRepr.of[collection].dealias match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            val instance = element0.asInstanceOf[Inlinable { type Self = element }]
+
+            '{
+              def parseElement(): element = ${ instance.parse(reader) }
+              val factory = infer[scala.collection.Factory[element, collection]]
+              val builder = factory.newBuilder
+              builder += parseElement()
+              builder.result()
+            }
+
+      case _ =>
+        report.errorAndAbort
+          ("xylophone: an inlinable collection requires an applied collection type")
+
+  private[xylophone] def iterableAbsent[collection: Type](element0: Inlinable)(using Quotes)
+  :   Expr[collection] =
+
+    import quotes.reflect.*
+
+    TypeRepr.of[collection].dealias match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            '{ infer[scala.collection.Factory[element, collection]].newBuilder.result() }
+
+      case _ =>
+        report.errorAndAbort
+          ("xylophone: an inlinable collection requires an applied collection type")
+
+  // ── The product generator ──────────────────────────────────────────────
+  // Self-contained monomorphic element parsing, mirroring the staged
+  // parser's semantics: typed local slots and seen flags, literal
+  // packed-word child-name dispatch (an opaque name resolves through the
+  // child's label against literal strings; unknown children are skipped),
+  // first occurrence read per name with focus bookkeeping, declared
+  // defaults then absent semantics for missing fields, direct construction.
+  // A collection field gathers every same-name occurrence into a typed
+  // builder — the derived engine's repeatable semantics, with the element's
+  // generated code inlined at the occurrence site. A field with no
+  // `Inlinable` binds its runtime `Xml.Parsing` instance once per record
+  // and keeps the engine's dynamic repeatability dispatch. Like the staged
+  // parser (and unlike jacinta's), the capabilities come from the reader at
+  // the read site.
+  private[xylophone] def productFields[product: Type](reader: Expr[XmlReader])(using Quotes)
+  :   Expr[product] =
+
+    productFields[product](reader, scm.HashMap())
+
+  private[xylophone] def productFields[product: Type]
+    (reader: Expr[XmlReader], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    '{
+      val foci = $reader.foci
+      val focused = foci.active
+      val tactic = $reader.errorTactic
+      ${ fieldLoop[product](reader, 'foci, 'focused, 'tactic, cache) }
+    }
+
+  // How one field reads, established at expansion: a builtin leaf, a
+  // gathered collection (with its element's generator), any other resolved
+  // instance (a nested record, a custom leaf), or the runtime seam.
+  private enum Plan:
+    case Leaf(instance: Inlinable)
+    case Gather(element: Inlinable)
+    case Nested(instance: Inlinable)
+    case Seam
+
+  private def plansFor[product: Type](cache: Cache)(using Quotes)
+  :   (List[quotes.reflect.TypeRepr], List[Plan]) =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+    val classSymbol = tpe.classSymbol.get
+    val fields = classSymbol.caseFields
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    val plans: List[Plan] = fieldTypes.map: fieldType =>
+      builtinFor(fieldType) match
+        case Some(leaf) =>
+          Plan.Leaf(leaf)
+
+        case None =>
+          fieldType.asType match
+            case '[fieldType] =>
+              resolve[fieldType](cache) match
+                case Some(iterable: Inlinable.IterableInlinable[?]) => Plan.Gather(iterable.element0)
+                case Some(instance)                                 => Plan.Nested(instance)
+                case None                                           => Plan.Seam
+
+    (fieldTypes, plans)
+
+  private def fieldLoop[product: Type]
+    ( reader:  Expr[XmlReader],
+      foci:    Expr[Foci[Xml.Focus]],
+      focused: Expr[Boolean],
+      tactic:  Expr[Tactic[XmlError]],
+      cache:   Cache )
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+
+    if !productSupported(tpe) then
+      report.errorAndAbort
+        (s"xylophone: ${tpe.show} is not an inlinable product (a non-generic, top-level or "+
+          "object-nested case class with a single parameter list and no `@name` or "+
+          "`@attribute` annotations); use `Xml.Parsable.staged` or `derived`")
+
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val (fieldTypes, plans) = plansFor[product](cache)
+
+    // Names compile to literal packed-word comparisons using the same
+    // two-word packing as the staged parser; a field name that cannot pack
+    // always arrives as `NameOpaque` and resolves through the literal text
+    // step, which matches all fields by string.
+    def packedName(index: Int): Option[(Long, Long)] =
+      val name = fieldNames(index)
+      val length = name.length
+
+      val packs = length > 0 && length <= 16 &&
+        name.forall { char => char >= '!' && char < 127 }
+
+      if !packs then None else
+        var low = 0L
+        var high = 0L
+        var position = 0
+
+        while position < length do
+          val byte = name.charAt(position).toLong & 0xFF
+          if position < 8 then low |= byte << (position*8)
+          else high |= byte << ((position - 8)*8)
+          position += 1
+
+        Some((low, high))
+
+    val packedNames: List[Option[(Long, Long)]] = List.range(0, arity).map(packedName)
+
+    val owner = Symbol.spliceOwner
+    val unit = Literal(UnitConstant())
+
+    val slots = List.range(0, arity).map: index =>
+      Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+    val seens = List.range(0, arity).map: index =>
+      Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+    def zero(fieldType: TypeRepr): Term =
+      if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+      else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+      else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+      else if fieldType =:= TypeRepr.of[Float] then Literal(FloatConstant(0.0f))
+      else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+      else fieldType.asType match
+        case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+    val slotDefs = List.range(0, arity).map: index =>
+      ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+    val seenDefs = List.range(0, arity).map: index =>
+      ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+    def keyText(index: Int): Expr[Text] = '{ ${Expr(fieldNames(index))}.tt }
+
+    // ── Gathered collection fields: a typed builder per field, an element
+    // def emitted once (composition points become local defs — a fully
+    // flattened parser exceeds HotSpot's huge-method limit and runs
+    // interpreted), each occurrence appended with focus bookkeeping. ──
+
+    case class GatherState(builder: Symbol, element: Symbol, defs: List[Statement])
+
+    val gathers: List[Option[GatherState]] = List.range(0, arity).map: index =>
+      plans(index) match
+        case Plan.Gather(element0) =>
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              fieldTypes(index) match
+                case AppliedType(_, arguments) =>
+                  arguments.last.asType match
+                    case '[element] =>
+                      val instance = element0.asInstanceOf[Inlinable { type Self = element }]
+
+                      val builderSymbol =
+                        Symbol.newVal
+                          ( owner, "gather"+index,
+                            TypeRepr.of[scm.Builder[element, fieldType]],
+                            Flags.EmptyFlags, Symbol.noSymbol )
+
+                      val builderDef =
+                        ValDef
+                          ( builderSymbol,
+                            Some:
+                              '{
+                                infer[scala.collection.Factory[element, fieldType]].newBuilder
+                              }.asTerm )
+
+                      val elementSymbol =
+                        Symbol.newMethod
+                          ( owner, "parseElement"+index,
+                            MethodType(Nil)(_ => Nil, _ => TypeRepr.of[element]) )
+
+                      val elementRhs =
+                        instance.parse(reader).asTerm.changeOwner(elementSymbol)
+
+                      val elementDef = DefDef(elementSymbol, _ => Some(elementRhs))
+
+                      Some(GatherState(builderSymbol, elementSymbol, List(builderDef, elementDef)))
+
+                case _ =>
+                  None
+
+        case _ =>
+          None
+
+    // ── Seam fields: the runtime instance, bound once per record, with the
+    // engine's dynamic repeatability dispatch and occurrence buffer. ──
+
+    case class SeamState(instance: Symbol, repeats: Symbol, buffer: Symbol, defs: List[Statement])
+
+    val bufferType = TypeRepr.of[scm.ListBuffer[Any] | Null]
+
+    val seams: List[Option[SeamState]] = List.range(0, arity).map: index =>
+      plans(index) match
+        case Plan.Seam =>
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              val instanceSymbol =
+                Symbol.newVal
+                  ( owner, "instance"+index, TypeRepr.of[fieldType is Xml.Parsing],
+                    Flags.EmptyFlags, Symbol.noSymbol )
+
+              val instanceDef =
+                ValDef
+                  ( instanceSymbol,
+                    Some('{ stagedInternal.fieldInstance[fieldType] }.asTerm) )
+
+              val instanceRef = Ref(instanceSymbol).asExprOf[fieldType is Xml.Parsing]
+
+              val repeatsSymbol =
+                Symbol.newVal
+                  ( owner, "repeats"+index, TypeRepr.of[Boolean],
+                    Flags.EmptyFlags, Symbol.noSymbol )
+
+              val repeatsDef =
+                ValDef(repeatsSymbol, Some('{ Xml.Parsable.repeats($instanceRef) }.asTerm))
+
+              val bufferSymbol =
+                Symbol.newVal(owner, "buffer"+index, bufferType, Flags.Mutable, Symbol.noSymbol)
+
+              val bufferDef = ValDef(bufferSymbol, Some('{ null }.asTerm))
+
+              Some:
+                SeamState
+                  ( instanceSymbol, repeatsSymbol, bufferSymbol,
+                    List(instanceDef, repeatsDef, bufferDef) )
+
+        case _ =>
+          None
+
+    // Nested records (and custom non-leaf instances): the body is emitted
+    // once as a local def and called from the dispatch arm, keeping each
+    // generated method JIT-compilable.
+    val nesteds: List[Option[(Symbol, Statement)]] = List.range(0, arity).map: index =>
+      plans(index) match
+        case Plan.Nested(instance0) =>
+          fieldTypes(index).asType match
+            case '[fieldType] =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+
+              val symbol =
+                Symbol.newMethod
+                  ( owner, "parseNested"+index,
+                    MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
+
+              val rhs = instance.parse(reader).asTerm.changeOwner(symbol)
+              Some((symbol, DefDef(symbol, _ => Some(rhs))))
+
+        case _ =>
+          None
+
+    // ── Dispatch arms ──────────────────────────────────────────────────────
+
+    def firstWins(index: Int, read: Term): Term =
+      If
+        ( Ref(seens(index)),
+          '{ $reader.skipElement() }.asTerm,
+          Block
+            ( List
+                ( Assign(Ref(slots(index)), read),
+                  Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+              unit ) )
+
+    val arms: List[CaseDef] = List.range(0, arity).map: index =>
+      val rhs: Term = fieldTypes(index).asType match
+        case '[fieldType] =>
+          plans(index) match
+            case Plan.Leaf(instance0) =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+
+              firstWins
+                ( index,
+                  '{
+                    Xml.Parsable.focusing($foci, ${keyText(index)})
+                      (${ instance.parse(reader) })
+                  }.asTerm )
+
+            case Plan.Nested(_) =>
+              val (symbol, _) = nesteds(index).get
+              val call = Apply(Ref(symbol), Nil).asExprOf[fieldType]
+
+              firstWins
+                ( index,
+                  '{ Xml.Parsable.focusing($foci, ${keyText(index)})($call) }.asTerm )
+
+            case Plan.Gather(_) =>
+              val gather = gathers(index).get
+
+              fieldTypes(index) match
+                case AppliedType(_, arguments) =>
+                  arguments.last.asType match
+                    case '[element] =>
+                      val builderRef =
+                        Ref(gather.builder).asExprOf[scm.Builder[element, fieldType]]
+
+                      val call = Apply(Ref(gather.element), Nil).asExprOf[element]
+
+                      '{
+                        $builderRef.addOne
+                          (Xml.Parsable.focusing($foci, ${keyText(index)})($call))
+                      }.asTerm
+
+                case _ =>
+                  report.errorAndAbort("xylophone: unreachable gather shape")
+
+            case Plan.Seam =>
+              val seam = seams(index).get
+              val instanceRef = Ref(seam.instance).asExprOf[fieldType is Xml.Parsing]
+              val bufferRef = Ref(seam.buffer).asExprOf[scm.ListBuffer[Any] | Null]
+
+              val ensure: Term =
+                If
+                  ( '{ $bufferRef == null }.asTerm,
+                    Assign(Ref(seam.buffer), '{ scm.ListBuffer.empty[Any] }.asTerm),
+                    unit )
+
+              val append: Term =
+                '{
+                  $bufferRef.asInstanceOf[scm.ListBuffer[Any]].addOne
+                    ( Xml.Parsable.focusing($foci, ${keyText(index)}):
+                        Xml.Parsable.parseElement($instanceRef, $reader) )
+                }.asTerm
+
+              val read: Term =
+                '{
+                  Xml.Parsable.focusing($foci, ${keyText(index)})
+                    ($instanceRef.parse($reader))
+                }.asTerm
+
+              If
+                ( Ref(seam.repeats),
+                  Block(List(ensure, append), unit),
+                  firstWins(index, read) )
+
+      CaseDef(Literal(IntConstant(index)), None, rhs)
+
+    val fallthrough = CaseDef(Wildcard(), None, '{ $reader.skipElement() }.asTerm)
+
+    // ── The child loop: packed two-word dispatch with a literal text step
+    // for opaque names, mirroring the staged parser's step protocol. ──
+
+    val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+    val word = Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+    val high = Symbol.newVal(owner, "high", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+    val found = Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+    val wordRef = Ref(word).asExprOf[Long]
+    val highRef = Ref(high).asExprOf[Long]
+
+    def packedChain(index: Int): Term =
+      if index == arity then Literal(IntConstant(-1))
+      else packedNames(index) match
+        case None => packedChain(index + 1)
+
+        case Some((low, highWord)) =>
+          If
+            ( '{ $wordRef == ${Expr(low)} && $highRef == ${Expr(highWord)} }.asTerm,
+              Literal(IntConstant(index)),
+              packedChain(index + 1) )
+
+    val textStep: Term =
+      val name =
+        Symbol.newVal(owner, "name", TypeRepr.of[String], Flags.EmptyFlags, Symbol.noSymbol)
+
+      val nameRef = Ref(name).asExprOf[String]
+
+      def stringChain(index: Int): Term =
+        if index == arity then Literal(IntConstant(-1))
+        else
+          If
+            ( '{ $nameRef == ${Expr(fieldNames(index))} }.asTerm,
+              Literal(IntConstant(index)),
+              stringChain(index + 1) )
+
+      Block
+        ( List(ValDef(name, Some('{ $reader.childLabel.s }.asTerm))),
+          stringChain(0) )
+
+    val resolveStep: Term =
+      If
+        ( '{ $wordRef == XmlReader.NameOpaque }.asTerm,
+          textStep,
+          Block
+            ( List(ValDef(high, Some('{ $reader.childWordHigh }.asTerm))),
+              packedChain(0) ) )
+
+    val step: Term =
+      Block
+        ( List(ValDef(word, Some('{ $reader.childWord() }.asTerm))),
+          If
+            ( '{ $wordRef == XmlReader.NameEnd }.asTerm,
+              Assign(Ref(run), Literal(BooleanConstant(false))),
+              Block
+                ( List(ValDef(found, Some(resolveStep))),
+                  Match(Ref(found), arms :+ fallthrough) ) ) )
+
+    val loop: List[Statement] =
+      List(ValDef(run, Some(Literal(BooleanConstant(true)))), While(Ref(run), step))
+
+    // ── Fields whose names never arrived — and gathered fields, whose
+    // collection is always built from the occurrences (zero occurrences
+    // build the empty collection; a repeatable field never consults the
+    // declared default), exactly as the derived engine does. ──
+
+    val absents: List[Term] = List.range(0, arity).map: index =>
+      fieldTypes(index).asType match
+        case '[fieldType] =>
+          def resolveAbsent(onAbsent: Expr[fieldType]): Term =
+            Assign
+              ( Ref(slots(index)),
+                '{
+                  val declared = wisteria.internal.default[product, fieldType](${Expr(index)})
+
+                  if !declared.absent then declared.asInstanceOf[fieldType]
+                  else Xml.Parsable.focusing($foci, ${keyText(index)})($onAbsent)
+                }.asTerm )
+
+          def whenUnseen(onAbsent: Expr[fieldType]): Term =
+            If
+              ( '{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm,
+                resolveAbsent(onAbsent), unit )
+
+          plans(index) match
+            case Plan.Leaf(instance0) =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+              whenUnseen(instance.absent(tactic, foci))
+
+            case Plan.Nested(instance0) =>
+              val instance = instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+              whenUnseen(instance.absent(tactic, foci))
+
+            case Plan.Gather(_) =>
+              val gather = gathers(index).get
+
+              fieldTypes(index) match
+                case AppliedType(_, arguments) =>
+                  arguments.last.asType match
+                    case '[element] =>
+                      val builderRef =
+                        Ref(gather.builder).asExprOf[scm.Builder[element, fieldType]]
+
+                      Assign(Ref(slots(index)), '{ $builderRef.result() }.asTerm)
+
+                case _ =>
+                  report.errorAndAbort("xylophone: unreachable gather shape")
+
+            case Plan.Seam =>
+              val seam = seams(index).get
+              val instanceRef = Ref(seam.instance).asExprOf[fieldType is Xml.Parsing]
+              val bufferRef = Ref(seam.buffer).asExprOf[scm.ListBuffer[Any] | Null]
+
+              val gatherFinish: Term =
+                Assign
+                  ( Ref(slots(index)),
+                    '{
+                      Xml.Parsable.focusing($foci, ${keyText(index)}):
+                        Xml.Parsable.gathered[fieldType]
+                          ( $instanceRef,
+                            $bufferRef match
+                              case null   => Nil
+                              case buffer => buffer.toList )
+                    }.asTerm )
+
+              If
+                ( Ref(seam.repeats),
+                  gatherFinish,
+                  whenUnseen('{ $instanceRef.absent()(using $tactic, $foci) }) )
+
+    val construct: Term =
+      Apply(Select(New(Inferred(tpe)), ctor), slots.map { slot => Ref(slot) })
+
+    val gatherDefs: List[Statement] = gathers.flatMap(_.toList).flatMap(_.defs)
+    val seamDefs: List[Statement] = seams.flatMap(_.toList).flatMap(_.defs)
+    val nestedDefs: List[Statement] = nesteds.flatMap(_.toList).map(_(1))
+
+    Block
+      ( slotDefs ::: seenDefs ::: gatherDefs ::: seamDefs ::: nestedDefs ::: loop ::: absents,
+        construct )
+    . asExprOf[product]
+
+  // ── The absent build ───────────────────────────────────────────────────
+  // A missing (or wrong-shape) record: one raise at the current focus, then
+  // a user-supplied `Default` sentinel or an absent build in which every
+  // sub-field takes its declared default or raises at its own focus —
+  // exactly the derived engine's `absent()`.
+  private[xylophone] def productAbsent[product: Type]
+    (tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+    (using Quotes)
+  :   Expr[product] =
+
+    productAbsent[product](tactic, foci, scm.HashMap())
+
+  private[xylophone] def productAbsent[product: Type]
+    (tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val (fieldTypes, plans) = plansFor[product](cache)
+
+    def build(): Expr[product] =
+      val arguments: List[Term] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val keyText: Expr[Text] = '{ ${Expr(fieldNames(index))}.tt }
+
+            def declared(onAbsent: Expr[fieldType]): Expr[fieldType] =
+              '{
+                val declared = wisteria.internal.default[product, fieldType](${Expr(index)})
+
+                if !declared.absent then declared.asInstanceOf[fieldType]
+                else Xml.Parsable.focusing($foci, $keyText)($onAbsent)
+              }
+
+            val argument: Expr[fieldType] = plans(index) match
+              case Plan.Leaf(instance0) =>
+                declared(instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+                  . absent(tactic, foci))
+
+              case Plan.Nested(instance0) =>
+                declared(instance0.asInstanceOf[Inlinable { type Self = fieldType }]
+                  . absent(tactic, foci))
+
+              case Plan.Gather(element0) =>
+                '{
+                  Xml.Parsable.focusing($foci, $keyText)
+                    (${ iterableAbsent[fieldType](element0) })
+                }
+
+              case Plan.Seam =>
+                '{
+                  val instance = stagedInternal.fieldInstance[fieldType]
+
+                  if Xml.Parsable.repeats(instance) then
+                    Xml.Parsable.focusing($foci, $keyText)
+                      (Xml.Parsable.gathered[fieldType](instance, Nil))
+                  else
+                    ${ declared('{ instance.absent()(using $tactic, $foci) }) }
+                }
+
+            argument.asTerm
+
+      Apply(Select(New(Inferred(tpe)), ctor), arguments).asExprOf[product]
+
+    // A user-supplied `Default[product]` collapses a missing nested value
+    // to a single error, exactly as the derived engine's `fallback` does.
+    Expr.summon[Default[product]] match
+      case Some(default) =>
+        '{
+          raise(XmlError())(using $tactic)
+          $default()
+        }
+
+      case None =>
+        '{
+          raise(XmlError())(using $tactic)
+          ${ build() }
+        }
+
+  // ── The entry macro ────────────────────────────────────────────────────
+  def inlinableParsable[value: Type](using Quotes): Expr[value is Xml.Parsable] =
+    import quotes.reflect.*
+
+    val cache: Cache = scm.HashMap()
+
+    if !productSupported(TypeRepr.of[value].dealias) then
+      report.errorAndAbort
+        (s"xylophone: ${TypeRepr.of[value].show} is not an inlinable product (a non-generic, "+
+          "top-level or object-nested case class with a single parameter list and no `@name` "+
+          "or `@attribute` annotations); use `Xml.Parsable.staged` or `derived`")
+
+    '{
+      // Sealed per the codec-thunk pattern, like the staged instances: the
+      // generated body resolves its capabilities at the read site, through
+      // the reader.
+      caps.unsafe.unsafeAssumePure:
+        new Xml.Parsable:
+          type Self = value
+
+          def parse(reader: XmlReader): value =
+            ${ productFields[value]('reader, cache) }
+
+          override def absent()(using tactic: Tactic[XmlError], foci: Foci[Xml.Focus]): value =
+            ${ productAbsent[value]('tactic, 'foci, cache) }
+    }

--- a/lib/xylophone/src/staged/xylophone.stagedInternal.scala
+++ b/lib/xylophone/src/staged/xylophone.stagedInternal.scala
@@ -280,7 +280,93 @@ object stagedInternal:
       case _ =>
         None
     else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
-    else None
+    else sumFor[field](cache)
+
+  // A sealed sum qualifies when every variant is itself an inlinable case
+  // class (resolved through the ladder, so custom variant instances
+  // compose) and its `Discriminable in Xml` — obtained live through the
+  // staging summon — is an `Xml.DiscriminantAttribute`, whose dispatch can
+  // be read straight off the open tag. Anything else — singleton variants,
+  // `@name` renames, an unresolvable variant, a label-based or custom
+  // discriminator — degrades to the runtime seam, preserving the derived
+  // semantics exactly.
+  private def sumFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    sumVariants(quotes.reflect.TypeRepr.of[field].dealias).flatMap: variants =>
+      val resolvable = variants.forall: (_, variantType) =>
+        variantType.asType match
+          case '[variantType] => resolve[variantType](cache).isDefined
+
+      if !resolvable then None
+      else discriminantAttribute[field].map { attribute => Inlinable.SumInlinable[field](attribute) }
+
+  // The variants of a stageable sealed sum: `(label, type)` per variant, or
+  // `None` when the shape is unsupported.
+  private def sumVariants(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[List[(String, quotes.reflect.TypeRepr)]] =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.flatMap: classSymbol =>
+      val applied = tpe match
+        case AppliedType(_, _) => true
+        case _                 => false
+
+      val children = classSymbol.children
+
+      val supported =
+        !applied
+        && classSymbol.flags.is(Flags.Sealed)
+        && children.nonEmpty
+        && children.forall: child =>
+             child.isClassDef && child.flags.is(Flags.Case) && !hasAnnotations(child)
+
+      if supported then Some(children.map { child => (child.name, child.typeRef) }) else None
+
+  // The sum's discriminator attribute, when its `Discriminable in Xml`
+  // resolves — inside the staging compiler, so the instance is live — to an
+  // `Xml.DiscriminantAttribute`.
+  private def discriminantAttribute[sum: Type](using Quotes): Option[String] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[sum]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val xml = r2.TypeRepr.of[Xml]
+
+          val target =
+            r2.Refinement
+              ( r2.Refinement
+                  ( r2.TypeRepr.of[wisteria.Discriminable], "Self",
+                    r2.TypeBounds(rebuild(shape), rebuild(shape)) ),
+                "Form",
+                r2.TypeBounds(xml, xml) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        result match
+          case attribute: Xml.DiscriminantAttribute[?] => Some(attribute.attribute.s)
+          case _                                       => None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
 
   private[xylophone] def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr)
   :   Boolean =
@@ -929,6 +1015,81 @@ object stagedInternal:
           raise(XmlError())(using $tactic)
           ${ build() }
         }
+
+  // ── The sum generator ──────────────────────────────────────────────────
+  // The variant rides in an attribute of the just-opened element — the
+  // `Xml.DiscriminantAttribute` shape — so dispatch reads it straight off
+  // the open tag and the chosen variant's fields parse as the element's
+  // children, in place. A missing or unrecognised discriminator skips the
+  // element and takes the AST disjunction's fallback: a raise-plus-`Default`
+  // when the user supplied one, an abort otherwise.
+  private[xylophone] def sumBody[sum: Type](reader: Expr[XmlReader], attribute: String)
+    (using Quotes)
+  :   Expr[sum] =
+
+    sumBody[sum](reader, attribute, scm.HashMap())
+
+  private def sumBody[sum: Type](reader: Expr[XmlReader], attribute: String, cache: Cache)
+    (using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    val variants = sumVariants(TypeRepr.of[sum].dealias).getOrElse:
+      report.errorAndAbort
+        (s"xylophone: ${TypeRepr.of[sum].show} is not an inlinable sum (a non-generic sealed "+
+          "type whose variants are all case classes without annotations)")
+
+    val arity = variants.length
+
+    def fallback(tactic: Expr[Tactic[XmlError]]): Expr[sum] =
+      Expr.summon[Default[sum]] match
+        case Some(default) =>
+          '{
+            $reader.skipElement()
+            raise(XmlError())(using $tactic)
+            $default()
+          }
+
+        case None =>
+          '{ abort(XmlError())(using $tactic) }
+
+    def dispatch(index: Int, wire: Expr[String], tactic: Expr[Tactic[XmlError]]): Expr[sum] =
+      if index == arity then fallback(tactic)
+      else variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"xylophone: no Inlinable for variant ${variants(index)(0)}")
+          . asInstanceOf[Inlinable { type Self = variantType }]
+
+          '{
+            if $wire == ${Expr(variants(index)(0))} then
+              def parseVariant(): variantType = ${ instance.parse(reader) }
+              parseVariant()
+            else ${ dispatch(index + 1, wire, tactic) }
+          }
+
+    '{
+      val tactic = $reader.errorTactic
+      val wire: String = Attributes.fetch($reader.attributes())(${Expr(attribute)}.tt).let(_.s).or("")
+      ${ dispatch(0, 'wire, 'tactic) }
+    }
+
+  // A missing sum field: no discriminator, so the AST disjunction's
+  // fallback — a raise-plus-`Default` or an abort.
+  private[xylophone] def sumAbsent[sum: Type](tactic: Expr[Tactic[XmlError]])(using Quotes)
+  :   Expr[sum] =
+
+    Expr.summon[Default[sum]] match
+      case Some(default) =>
+        '{
+          raise(XmlError())(using $tactic)
+          $default()
+        }
+
+      case None =>
+        '{ abort(XmlError())(using $tactic) }
 
   // ── The entry macro ────────────────────────────────────────────────────
   def inlinableParsable[value: Type](using Quotes): Expr[value is Xml.Parsable] =


### PR DESCRIPTION
TEL and XML join JSON in supporting fully inlined direct parsers, and both formats' tokenizers gain the treatment that made the JSON parser fast — making the inlined arms the fastest decoders for all three formats: TEL ~23µs and XML ~22µs on the ~10 KB cross-format corpus (previously 37µs/33µs staged), against Jsoniter's 7.7µs for JSON.

### Inlined TEL and XML parsers

`stratiform.Inlinable` and `xylophone.Inlinable` (new opt-in `staged` components) mirror jacinta's design: instances are ordinary values whose `parse` methods are compile-time code generators, resolved live at expansion and composed into one flat, monomorphic parser via `Inlinable.parsable[T]`:

```scala
given Orders is Tel.Parsable = stratiform.Inlinable.parsable[Orders]
given Orders is Xml.Parsable = xylophone.Inlinable.parsable[Orders]
```

Collection fields gather occurrences into typed builders inline; sealed sums parse in place too — TEL dispatching on the variant compound's packed keyword, XML on a discriminator attribute via the new nameable `Xml.DiscriminantAttribute` shape. Fields without an `Inlinable` degrade to a runtime seam that preserves the derived engines' semantics exactly: gathering, first-match-wins, defaults, absence behavior and error foci.

### Faster direct reading for every arm

Whole-input reads now parse in place instead of wrapping the input in a one-element stream; the TEL and XML sum decoders build their variant-label maps once per derivation instead of per decode; and XML scalar content (`Int`, `Long`, `Double`, `Boolean`) parses straight from the buffered chars — bit-identical to `parseDouble` on the Clinger fast path — with no value `Text` materialized.

### A fused TEL direct tokenizer

The TEL direct rim no longer rides the presentation-grade AST line parser: the packed keyword step reads one SWAR word (its stop-scan word *is* the packed form) and interns nothing — keyword text materializes lazily, only for opaque dispatches and errors; leaf values parse in place from the cursor buffer with no arena copy, rewinding to the general path for any line shape outside the provably-identical subset; and the direct rim uses plain `(using Tactic)` calls rather than per-call context closures. Between them, TEL direct decoding is roughly twice as fast as before across the direct, staged and inlined arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
