### PR TITLE
Encrypt and decrypt kernel streams through cipher ducts

### DIFF
--- a/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
+++ b/lib/enigmatic/src/core/enigmatic.BlockCipher.scala
@@ -34,7 +34,10 @@ package enigmatic
 
 import anticipation.*
 import gossamer.*
+import prepositional.*
+import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 // A block cipher's type-level *policy* (which mode and padding apply, whether an
 // IV is needed and how input length is checked) lives here; the byte-level
@@ -83,6 +86,38 @@ extends Cipher, Encryption, Symmetric:
 
     prefix #::: recur(stream, 0)
 
+  // Kernel-native streaming encryption: the same session-driven
+  // transformation as `encryptStream`, as a pipeline stage. The IV (if any)
+  // is the stage's first output, and the `NoPadding` alignment check runs at
+  // end-of-stream, exactly as in the whole-value and `LazyList` forms.
+  def encrypt
+    ( stream: (Stream[Data] over Credit)^, key: Data, vector: InitializationVector )
+    ( using Buffering )
+  :   (Stream[Data] over Credit)^ =
+
+    val blockSize = cipher.blockSize(transformation)
+    val iv: Optional[Data] = if mode.usesIv then vector(blockSize) else Unset
+    val session = cipher.stream(transformation, key, iv)
+    val finalise: Int => Unit = total => padding.verify(total, blockSize, mode.blockAligned)
+
+    stream.via(CipherDuct(session, iv, finalise)).asInstanceOf[(Stream[Data] over Credit)^]
+
+  // Kernel-native streaming decryption. The leading IV block (for modes that
+  // use one) is consumed off the stream before the session begins. NOTE: an
+  // AEAD mode (GCM) releases no plaintext until its tag verifies at
+  // end-of-stream — the provider buffers the whole message internally — so
+  // streaming decryption of AEAD input bounds no memory; it is offered for
+  // API uniformity only.
+  def decrypt(stream: (Stream[Data] over Credit)^, key: Data)(using Buffering)
+  :   (Stream[Data] over Credit)^ =
+
+    val ivSize = if mode.usesIv then cipher.blockSize(transformation) else 0
+
+    val start: Data => CipherSession = iv =>
+      cipher.decryptStream(transformation, key, if mode.usesIv then iv else Unset)
+
+    stream.via(DecipherDuct(start, ivSize)).asInstanceOf[(Stream[Data] over Credit)^]
+
   def decrypt(bytes: Data, key: Data): Data =
     val ivSize: Optional[Int] = if mode.usesIv then cipher.blockSize(transformation) else Unset
     cipher.decrypt(transformation, key, ivSize, bytes)
@@ -90,3 +125,124 @@ extends Cipher, Encryption, Symmetric:
   def genKey(): Data = cipher.generateKey(keySize)
 
   def privateToPublic(key: Data): Data = key
+
+// The session-driven cipher transformation as a `Duct`: input windows feed
+// `CipherSession.update`, whose output (of arbitrary size — a block cipher
+// may buffer or release several blocks) stages in `pending` and delivers as
+// the target window allows. `prefix` (the IV) delivers before any ciphertext;
+// `finalise` sees the total input length at end-of-stream, before the final
+// block is flushed.
+private[enigmatic] final class CipherDuct
+  ( session: CipherSession, prefix: Optional[Data], finalise: Int => Unit )
+extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private var pending: Data = prefix.or(Data())
+  private var offset: Int = 0
+  private var total: Int = 0
+  private var finished: Boolean = false
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  private update def deliver(target: Array[Byte], targetOffset: Int, targetSpace: Int): Int =
+    val count = targetSpace.min(pending.length - offset)
+
+    if count > 0 then
+      System.arraycopy(pending.mutable(using Unsafe), offset, target, targetOffset, count)
+      offset += count
+
+    count
+
+  update def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    val bytes = target.asInstanceOf[Array[Byte]]
+
+    if offset < pending.length then Duct.Progress(0, deliver(bytes, targetOffset, targetSpace))
+    else
+      val chunk = input.materialize(source, sourceOffset, sourceLength)
+      total += sourceLength
+      pending = session.update(chunk)
+      offset = 0
+      Duct.Progress(sourceLength, deliver(bytes, targetOffset, targetSpace))
+
+  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    val bytes = target.asInstanceOf[Array[Byte]]
+
+    if offset < pending.length then deliver(bytes, targetOffset, targetSpace)
+    else if !finished then
+      finished = true
+      finalise(total)
+      pending = session.finish()
+      offset = 0
+      deliver(bytes, targetOffset, targetSpace)
+    else 0
+
+// Streaming decryption's IV-prefix state machine (the `Inflation` header
+// precedent): the leading `ivSize` bytes accumulate before the session can
+// exist; thereafter this delegates to a `CipherDuct` around the started
+// session. A stream that ends before a whole IV arrives starts the session
+// with the truncated prefix, and the provider raises its own (accurate)
+// invalid-parameter error.
+private[enigmatic] final class DecipherDuct(start: Data => CipherSession, ivSize: Int)
+extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private val header: Array[Byte] = new Array[Byte](ivSize)
+  private var headerFilled: Int = 0
+
+  // Untracked, cast-erased: the inner duct is reached only through this
+  // stage's own exclusive methods.
+  @caps.unsafe.untrackedCaptures
+  private var inner: CipherDuct | Null = null
+
+  private update def begin(): CipherDuct =
+    CipherDuct(start(header.take(headerFilled).immutable(using Unsafe)), Unset, _ => ())
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  update def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    inner match
+      case duct: CipherDuct =>
+        // `Addressable` instances are unique per medium, so the two ducts'
+        // `Storage` paths coincide at erasure.
+        duct.step
+          ( source.asInstanceOf[duct.input.Storage],
+            sourceOffset,
+            sourceLength,
+            target.asInstanceOf[duct.output.Storage],
+            targetOffset,
+            targetSpace )
+
+      case null =>
+        val take = sourceLength.min(ivSize - headerFilled)
+        System.arraycopy(source.asInstanceOf[Array[Byte]], sourceOffset, header, headerFilled, take)
+        headerFilled += take
+        if headerFilled == ivSize then inner = begin().asInstanceOf[CipherDuct]
+        Duct.Progress(take, 0)
+
+  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    inner match
+      case duct: CipherDuct =>
+        duct.flush(target.asInstanceOf[duct.output.Storage], targetOffset, targetSpace)
+      case null             =>
+        inner = begin().asInstanceOf[CipherDuct]
+        flush(target, targetOffset, targetSpace)

--- a/lib/enigmatic/src/core/enigmatic.Crypto.scala
+++ b/lib/enigmatic/src/core/enigmatic.Crypto.scala
@@ -63,6 +63,11 @@ object Crypto:
     def generateKey(bits: Int): Data
     def stream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession
 
+    // The decryption counterpart of `stream`: the caller supplies the IV
+    // (already separated from the ciphertext, which frames it as the leading
+    // block when the mode uses one).
+    def decryptStream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession
+
   trait PublicKeyCipher:
     def encrypt(input: Data, publicKey: Data): Data
     def decrypt(input: Data, privateKey: Data): Data

--- a/lib/enigmatic/src/core/enigmatic.JavaStdlibCrypto.scala
+++ b/lib/enigmatic/src/core/enigmatic.JavaStdlibCrypto.scala
@@ -170,13 +170,25 @@ object JavaStdlibCrypto extends Crypto:
         cipher.doFinal(input.drop(size)).nn.immutable(using Unsafe)
 
     def stream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession =
+      session(transformation, key, iv, jc.Cipher.ENCRYPT_MODE)
+
+    def decryptStream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession =
+      session(transformation, key, iv, jc.Cipher.DECRYPT_MODE)
+
+    private def session(transformation: Text, key: Data, iv: Optional[Data], opmode: Int)
+    :   CipherSession =
+
       val cipher = jc.Cipher.getInstance(transformation.s).nn
 
-      iv.lay(cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key))): iv =>
-        cipher.init(jc.Cipher.ENCRYPT_MODE, makeKey(key), IvParameterSpec(iv.mutable(using Unsafe)))
+      iv.lay(cipher.init(opmode, makeKey(key))): iv =>
+        cipher.init(opmode, makeKey(key), IvParameterSpec(iv.mutable(using Unsafe)))
 
       new CipherSession:
         def update(chunk: Data): Data =
-          cipher.update(chunk.mutable(using Unsafe)).nn.immutable(using Unsafe)
+          // `Cipher.update` returns null when a block cipher has buffered the
+          // whole input pending a complete block.
+          cipher.update(chunk.mutable(using Unsafe)) match
+            case null              => Data()
+            case out: Array[Byte]  => out.immutable(using Unsafe)
 
         def finish(): Data = cipher.doFinal().nn.immutable(using Unsafe)

--- a/lib/enigmatic/src/core/enigmatic_expose.scala
+++ b/lib/enigmatic/src/core/enigmatic_expose.scala
@@ -72,6 +72,33 @@ extension (stream: LazyList[Data])
 
     algorithm.encryptStream(stream, encryptor.bytes, iv)
 
+extension (stream: (zephyrine.Stream[Data] over zephyrine.Credit)^)
+  // Kernel-native streaming encryption: the pipeline-stage counterpart of the
+  // `LazyList` form above, with the same IV-prefix framing.
+  def encrypt[cipher <: BlockCipher](iv: InitializationVector)
+    ( using encryptor:  Encryptor[cipher],
+            algorithm:  cipher & Encryption,
+            buffering:  zephyrine.Buffering,
+            erased weakness: Permit[Weakness[cipher]],
+            erased authentication: Permit[Authentication[cipher]] )
+  :   (zephyrine.Stream[Data] over zephyrine.Credit)^ =
+
+    algorithm.encrypt(stream, encryptor.bytes, iv)
+
+  // Kernel-native streaming decryption of `iv ++ ciphertext` framing,
+  // yielding plaintext bytes as they become available. An AEAD mode releases
+  // nothing until its tag verifies at end-of-stream (the provider buffers the
+  // whole message), so this bounds memory only for non-AEAD modes.
+  def decrypt[cipher <: BlockCipher]
+    ( using decryptor:  Decryptor[cipher],
+            algorithm:  cipher & Encryption,
+            buffering:  zephyrine.Buffering,
+            erased weakness: ProcessingPermit[Weakness[cipher]],
+            erased authentication: ProcessingPermit[Authentication[cipher]] )
+  :   (zephyrine.Stream[Data] over zephyrine.Credit)^ =
+
+    algorithm.decrypt(stream, decryptor.bytes)
+
 extension (data: Data)
   def decrypt[decodable: Decodable in Data, cipher <: Cipher]
     ( using decryptor: Decryptor[cipher],

--- a/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
+++ b/lib/enigmatic/src/openssl/enigmatic.OpensslCrypto.scala
@@ -163,14 +163,24 @@ object OpensslCrypto extends Crypto:
         oneShot(encrypting = false, transformation, key, data.take(size), data.drop(size))
 
     def stream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession =
+      session(transformation, key, iv, encrypting = true)
+
+    def decryptStream(transformation: Text, key: Data, iv: Optional[Data]): CipherSession =
+      session(transformation, key, iv, encrypting = false)
+
+    private def session
+      ( transformation: Text, key: Data, iv: Optional[Data], encrypting: Boolean )
+    :   CipherSession =
+
       val arena = Arena.ofShared().nn
       val parts = transformation.cut(t"/")
       val context = newContext()
       val cipher0 = cipher(opensslCipher(parts(0), parts(1), key.length))(using arena)
       val keySegment = ForeignLibrary.segment(key)(using arena)
       val ivSegment = iv.lay(MemorySegment.NULL)(ForeignLibrary.segment(_)(using arena))
+      val direction = if encrypting then t"Encrypt" else t"Decrypt"
 
-      lib.handle(t"EVP_EncryptInit_ex").invokeWithArguments
+      lib.handle(t"EVP_${direction}Init_ex").invokeWithArguments
         ( context, cipher0, MemorySegment.NULL, keySegment, ivSegment )
 
       if parts(2) == t"NoPadding" then
@@ -184,7 +194,7 @@ object OpensslCrypto extends Crypto:
           val length = arena.allocate(int).nn
           val input = ForeignLibrary.segment(chunk)(using arena)
 
-          lib.handle(t"EVP_EncryptUpdate").invokeWithArguments
+          lib.handle(t"EVP_${direction}Update").invokeWithArguments
             ( context, output, length, input, Integer.valueOf(chunk.length) )
 
           ForeignLibrary.bytes(output, length.get(int, 0L))
@@ -192,7 +202,7 @@ object OpensslCrypto extends Crypto:
         def finish(): Data =
           val output = arena.allocate(block.toLong).nn
           val length = arena.allocate(int).nn
-          lib.handle(t"EVP_EncryptFinal_ex").invokeWithArguments(context, output, length)
+          lib.handle(t"EVP_${direction}Final_ex").invokeWithArguments(context, output, length)
           val result = ForeignLibrary.bytes(output, length.get(int, 0L))
           lib.handle(t"EVP_CIPHER_CTX_free").invokeWithArguments(context)
           arena.close()

--- a/lib/enigmatic/src/test/enigmatic_test.scala
+++ b/lib/enigmatic/src/test/enigmatic_test.scala
@@ -185,6 +185,51 @@ object Tests extends Suite(m"Gastronomy tests"):
         t"Hello world".encrypt(InitializationVector.random).decrypt.as[Text]
     . assert(_ == t"Hello world")
 
+    test(m"stream-encrypted data decrypts through the whole-value path"):
+      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import charEncoders.utf8Encoder
+      val key = SymmetricKey.generate[Aes[256]]()
+      key.expose:
+        t"Hello world".in[Data].stream.encrypt(InitializationVector.random).memoize
+        . decrypt.as[Text]
+    . assert(_ == t"Hello world")
+
+    test(m"whole-value-encrypted data decrypts through a stream"):
+      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import charEncoders.utf8Encoder
+      val key = SymmetricKey.generate[Aes[256]]()
+      key.expose:
+        t"Hello world".encrypt(InitializationVector.random).stream.decrypt.memoize.to(List)
+    . assert(_ == t"Hello world".in[Data].to(List))
+
+    test(m"one-byte-chunk streams roundtrip through stream encrypt and decrypt"):
+      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import charEncoders.utf8Encoder
+      val key = SymmetricKey.generate[Aes[256]]()
+      key.expose:
+        val plain = t"The quick brown fox jumps over the lazy dog".in[Data]
+        val encrypted = plain.grouped(1).iterator.stream.encrypt(InitializationVector.random)
+        encrypted.memoize.grouped(1).iterator.stream.decrypt.memoize.to(List)
+    . assert(_ == t"The quick brown fox jumps over the lazy dog".in[Data].to(List))
+
+    test(m"CTR/NoPadding streams roundtrip (stream-aligned check at end)"):
+      import charEncoders.utf8Encoder
+      val key = SymmetricKey.generate[Aes[128] over Ctr against NoPadding]()
+      key.expose:
+        t"Hello world".in[Data].stream.encrypt(InitializationVector.random).memoize
+        . stream.decrypt.memoize.to(List)
+    . assert(_ == t"Hello world".in[Data].to(List))
+
+    test(m"legacy LazyList encryption survives one-byte chunks"):
+      import blockCipherMode.cbc, blockCipherPadding.pkcs7
+      import charEncoders.utf8Encoder
+      val key = SymmetricKey.generate[Aes[256]]()
+      key.expose:
+        val plain = t"Hello world".in[Data]
+        val chunks = plain.grouped(1).map { chunk => chunk }.to(LazyList)
+        chunks.encrypt(InitializationVector.random).reduce(_ ++ _).decrypt.as[Text]
+    . assert(_ == t"Hello world")
+
     test(m"CBC encryption of the same plaintext differs run-to-run (random IV)"):
       val key = SymmetricKey.generate[Aes[256] over Cbc against Pkcs7]()
       key.expose:


### PR DESCRIPTION
Block ciphers now apply as streaming pipeline stages: data encrypts and decrypts window by window through the provider's cipher session, with the same `iv ++ ciphertext` framing as the whole-value forms — and a latent crash in small-chunk streaming encryption is fixed.

`stream.encrypt[cipher](iv)` transforms a byte stream through a cipher stage, emitting the IV as its first output and running the `NoPadding` alignment check at end-of-stream; the new `stream.decrypt[cipher]` consumes the leading IV block before starting a decryption session:

```scala
key.expose:
  file.stream.encrypt[Aes[256]](InitializationVector.random).pump(socket)
  response.stream.decrypt[Aes[256]]
```

Both extensions demand the same permits as their whole-value counterparts, and both framings interoperate: stream-encrypted data decrypts through the whole-value path and vice versa. Streaming decryption is a new capability, backed by a `decryptStream` addition to the `Crypto.SymmetricCipher` SPI, implemented for both the JCE and OpenSSL providers. An AEAD mode releases no plaintext until its tag verifies at end-of-stream — the provider buffers the whole message — so streaming decryption bounds memory only for non-AEAD modes.

Also fixed: `javax.crypto.Cipher.update` returns null when a block cipher buffers all its input pending a complete block, so streaming encryption of small chunks previously crashed with a `NullPointerException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)