### PR TITLE
Make HTTP receive-side bodies single-owner kernel streams

### DIFF
--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -41,6 +41,7 @@ import beneficence.*
 import contingency.*
 import distillate.*
 import gossamer.*
+import prepositional.*
 import rudiments.*
 import spectacular.*
 import symbolism.*
@@ -77,19 +78,17 @@ object HttpConnection:
 
     lazy val in = exchange.getRequestBody.nn
 
-    val buffer = new Array[Byte](65536)
-
-    def stream(): LazyList[Data] =
-      val length = in.read(buffer)
-      if length > 0 then buffer.slice(0, length).snapshot #:: stream() else LazyList.empty
-
     val request =
       Http.Request
         ( method      = method,
           version     = version,
           host        = host,
           target      = target,
-          body        = () => Stream(stream().iterator),
+          // Each mint reads on from the same live request stream — the
+          // single-owner discipline (explicit `memoize` for re-reads). A read
+          // failure throws, as the raw `InputStream` did before.
+          body        = () => unsafely(summon[ji.InputStream is Source by Data over Credit])
+                              . stream(in),
           textHeaders = headers )
 
     Log.fine(HttpServerEvent.Received(request))

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -94,7 +94,9 @@ extends RequestServable:
   // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or empty
   // when neither is given. The framed stream stops exactly at the body's end so
   // the cursor is left at the next pipelined request.
-  private def requestBody(cursor: Cursor[Data, ?], head: Http.Request.Head): LazyList[Data] =
+  private def requestBody(cursor: Cursor[Data, ?], head: Http.Request.Head)
+  :   Stream[Data] over Credit =
+
     val chunked: Boolean = head.headers.exists: header =>
       header.key.lower == t"transfer-encoding" && header.value.lower.contains(t"chunked")
 
@@ -104,7 +106,7 @@ extends RequestServable:
         . lay(Unset: Optional[Int]): text =>
             safely(Integer.parseInt(text.s.trim.nn))
 
-      length.lay(LazyList())(Http.Request.fixedBody(cursor, _))
+      length.lay(Http.emptyBody())(Http.Request.fixedBody(cursor, _))
 
   // RFC 7230 §6.3: HTTP/1.1 keeps connections alive unless `Connection: close`;
   // HTTP/1.0 closes unless `Connection: keep-alive`.
@@ -177,7 +179,16 @@ extends RequestServable:
           // Tell a waiting client it may send the body before we read it.
           if expectsContinue(head) then writeAll(out, continueResponse.stream)
 
-          val body = if upgrade then cursor.remainder else requestBody(cursor, head)
+          // The framed body, minted once and lent single-owner: the handler and
+          // the post-response drain share it, so the handler pulls what it
+          // reads and the drain consumes the rest. A second `body()` call
+          // RESUMES rather than replaying — explicit `memoize` replaces the
+          // former LazyList view's implicit caching.
+          val bodyStream: Stream[Data] over Credit =
+            if upgrade then streamOf(cursor) else requestBody(cursor, head)
+
+          // Neutral carrier: the spring re-lends the same single-owner stream.
+          val bodyRef: AnyRef = bodyStream.asInstanceOf[AnyRef]
 
           val request =
             Http.Request
@@ -186,7 +197,7 @@ extends RequestServable:
                 head.host,
                 head.target,
                 head.headers,
-                () => body.iterator.stream )
+                () => bodyRef.asInstanceOf[Stream[Data] over Credit] )
 
           var upgraded = false
           var keep = keepAlive(head)
@@ -223,12 +234,22 @@ extends RequestServable:
             // (memoised) blocks doesn't move the cursor, so the position delta
             // measures only what the drain itself reads.
             val drainStart = cursor.position.n0
+            val drain = bodyRef.asInstanceOf[Stream[Data] over Credit]
+            var intact = true
+            var draining = true
 
-            def drained(stream: LazyList[Data]): Boolean = stream match
-              case _ #:: tail => cursor.position.n0 - drainStart <= drainLimit && drained(tail)
-              case _          => true
+            while draining do drain.refill(Credit(drainLimit)) match
+              case count: Int =>
+                drain.skip(count)
 
-            drained(body)
+                if cursor.position.n0 - drainStart > drainLimit then
+                  intact = false
+                  draining = false
+
+              case _ =>
+                draining = false
+
+            intact
 
     // A stream error tearing down the connection is logged and ends it; any other
     // unexpected failure is left to propagate out of the per-connection daemon, where

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -433,91 +433,130 @@ object Http:
           head.headers,
           () => cursor.remainder.iterator.stream )
 
-    // LazyList exactly `length` bytes of body off `cursor`, in buffer-sized
-    // pieces, leaving it at the first byte after the body (the start of the next
-    // pipelined request on a kept-alive connection). Uses `advance` rather than
-    // `next`, so — like `parseHead` — it never reads past the body and so never
-    // blocks waiting for bytes that will not arrive until the client has our
-    // response.
-    def fixedBody(cursor: Cursor[Data, {}]^, length: Int): LazyList[Data] =
-      def recur(remaining: Int): LazyList[Data] =
-        if remaining <= 0 || cursor.finished then LazyList() else
-          val take = remaining.min(cursor.available)
+    // The endpoint form: the request parses straight off the connection's pull
+    // endpoint. The body spring lends the cursor's remainder as a SINGLE-OWNER
+    // stream: each mint resumes from wherever the previous reader stopped, and
+    // explicit `memoize` replaces the LazyList form's implicit caching.
+    def parse(consume input: (Stream[Data] over Credit)^)(using Tactic[HttpRequestError])
+    :   Request^ =
 
-          val chunk = cursor.hold:
-            val start = cursor.mark
-            var index = 0
+      val cursor = Cursor[Data](input)
+      val head = parseHead(cursor)
 
-            while index < take do
+      // Sealed like `Response.parse`: the cursor is single-owner and reachable
+      // only through the spring; a capturing `Spring` would cascade `^` through
+      // every `Request` value.
+      val spring: Spring[Data]^ = () => streamOf(cursor)
+
+      Request
+        ( head.method,
+          head.version,
+          head.host,
+          head.target,
+          head.headers,
+          caps.unsafe.unsafeAssumePure(spring) )
+
+    // Exactly `length` bytes of body, lent zero-copy off `cursor` (which stays
+    // open, positioned at the first byte after the body — the start of the next
+    // pipelined request on a kept-alive connection). It never reads past the
+    // body, so it never blocks waiting for bytes that will not arrive until the
+    // client has our response.
+    def fixedBody(cursor: Cursor[Data, {}]^, length: Int)
+    :   (Stream[Data] over Credit)^{cursor, caps.any} =
+
+      streamOf(cursor, length)
+
+    // Decode a `Transfer-Encoding: chunked` request body off `cursor`, lending
+    // each chunk's data zero-copy and leaving the cursor after the terminating
+    // `0`-chunk and trailers — i.e. at the next request. Lenient: a malformed
+    // length or a truncated stream simply ends the body. Consumes CRLFs with
+    // `advance` (not `next`), so it never reads past the body's final `\r\n`
+    // (see `parseHead`).
+    def chunkedBody(cursor: Cursor[Data, {}]^)
+    :   (Stream[Data] over Credit)^{cursor, caps.any} =
+
+      new Stream[Data]:
+        type Transport = Credit
+
+        // Bytes left in the current chunk's data; -1 before its size is read.
+        private var remaining: Int = -1
+        private var ended: Boolean = false
+
+        // Snapshot of the cursor's buffer, taken by `refill` (the `streamOf`
+        // discipline: only update methods access the exclusive cursor).
+        private var storage: AnyRef = ""
+        private var start0: Int = 0
+        private var limit0: Int = 0
+
+        protected def window0: AnyRef = storage
+        def start: Int = start0
+        def limit: Int = limit0
+
+        update def skip(count: Int): Unit =
+          remaining -= count
+          start0 += count
+          cursor.unsafeAdvanceBy(count)(using Unsafe)
+
+        private def hex(digit: Int): Int =
+          if digit >= '0' && digit <= '9' then digit - '0'
+          else if digit >= 'a' && digit <= 'f' then digit - 'a' + 10
+          else if digit >= 'A' && digit <= 'F' then digit - 'A' + 10
+          else -1
+
+        private update def consumeCrlf(): Unit =
+          if cursor.peek == '\r' then cursor.advance()
+          if cursor.peek == '\n' then cursor.advance()
+
+        private update def skipToCrlf(): Unit =
+          while !(cursor.peek == '\r') && !cursor.finished do cursor.advance()
+
+        private update def readSize(): Int =
+          var size = 0
+          var continue = true
+
+          while continue do
+            val value = hex(cursor.peek.asInt)
+
+            if value < 0 then continue = false else
+              size = size*16 + value
               cursor.advance()
-              index += 1
 
-            cursor.grab(start, cursor.mark)
+          skipToCrlf() // discard any chunk extension
+          consumeCrlf()
+          size
 
-          chunk #:: recur(remaining - take)
-
-      LazyList.defer(recur(length))
-
-    // Decode a `Transfer-Encoding: chunked` request body off `cursor`, yielding
-    // each chunk's data and leaving the cursor after the terminating `0`-chunk
-    // and trailers — i.e. at the next request. Lenient: a malformed length or a
-    // truncated stream simply ends the body. Consumes CRLFs with `advance` (not
-    // `next`), so it never reads past the body's final `\r\n` (see `parseHead`).
-    def chunkedBody(cursor: Cursor[Data, {}]^): LazyList[Data] =
-      def hex(digit: Int): Int =
-        if digit >= '0' && digit <= '9' then digit - '0'
-        else if digit >= 'a' && digit <= 'f' then digit - 'a' + 10
-        else if digit >= 'A' && digit <= 'F' then digit - 'A' + 10
-        else -1
-
-      def consumeCrlf(): Unit =
-        if cursor.peek == '\r' then cursor.advance()
-        if cursor.peek == '\n' then cursor.advance()
-
-      def skipToCrlf(): Unit = while !(cursor.peek == '\r') && !cursor.finished do cursor.advance()
-
-      def readSize(): Int =
-        var size = 0
-        var continue = true
-
-        while continue do
-          val value = hex(cursor.peek.asInt)
-
-          if value < 0 then continue = false else
-            size = size*16 + value
-            cursor.advance()
-
-        skipToCrlf() // discard any chunk extension
-        consumeCrlf()
-        size
-
-      def recur(): LazyList[Data] = LazyList.defer:
-        if cursor.finished then LazyList() else
-          val size = readSize()
-
-          if size <= 0 then
-            while !(cursor.peek == '\r') && !cursor.finished do // trailer header lines
-              skipToCrlf()
+        update def refill(demand: Credit): Optional[Int] =
+          if !ended then
+            // The previous chunk's data is fully consumed: its trailing CRLF,
+            // then the next chunk's size line.
+            if remaining == 0 then
               consumeCrlf()
+              remaining = -1
 
-            consumeCrlf() // final blank line
-            LazyList()
+            if remaining < 0 then
+              if cursor.finished then ended = true else
+                val size = readSize()
 
+                if size <= 0 then
+                  while !(cursor.peek == '\r') && !cursor.finished do // trailers
+                    skipToCrlf()
+                    consumeCrlf()
+
+                  consumeCrlf() // final blank line
+                  ended = true
+                else remaining = size
+
+          if ended then Unset
+          else if cursor.more then
+            storage = cursor.unsafeBuffer(using Unsafe).asInstanceOf[AnyRef]
+            start0 = cursor.unsafePos(using Unsafe)
+            val available = cursor.unsafeWriteEnd(using Unsafe) - start0
+            val readable = remaining.min(available)
+            limit0 = start0 + readable
+            readable
           else
-            val data = cursor.hold:
-              val start = cursor.mark
-              var index = 0
-
-              while index < size && !cursor.finished do
-                cursor.advance()
-                index += 1
-
-              cursor.grab(start, cursor.mark)
-
-            consumeCrlf()
-            data #:: recur()
-
-      recur()
+            ended = true
+            Unset
 
   enum Body:
     case Flowing(source: Spring[Data]^)
@@ -863,10 +902,12 @@ object Http:
           cursor.expect('\n')(expected('\n'))
           headers = Http.Header(header, value) :: headers
 
-      // Sealed: the cursor is single-owner and reachable only through its
-      // memoized `remainder`, so the spring is pure in effect; a capturing
-      // `Body` would cascade `^` through every `Response` value.
-      val spring: Spring[Data]^ = () => cursor.remainder.iterator.stream
+      // The body spring lends the cursor's remainder as a SINGLE-OWNER stream:
+      // each mint resumes where the previous reader stopped (explicit `memoize`
+      // replaces the former memoized-remainder replay). Sealed: the cursor is
+      // reachable only through the spring; a capturing `Body` would cascade
+      // `^` through every `Response` value.
+      val spring: Spring[Data]^ = () => streamOf(cursor)
       val body = Http.Body.Flowing(caps.unsafe.unsafeAssumePure(spring))
 
       Response(version, status, headers.reverse, body)
@@ -882,9 +923,11 @@ object Http:
       copy(textHeaders = Header(key2, label.encode(value)) :: textHeaders.filter(_.key != key2))
 
 
-    def successBody: Optional[LazyList[Data]] =
+    // The successful response's body as a single-owner pull endpoint (explicit
+    // `memoize` replaces the former implicit whole-body caching).
+    def successBody: Optional[(Stream[Data] over Credit)^] =
       if status.category != Http.Status.Category.Successful then Unset
-      else LazyList(body.stream.memoize)
+      else body.stream
 
 
     def receive[body](using receivable: (body is Receivable)^): body =

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -445,8 +445,13 @@ object Http:
 
       // Sealed like `Response.parse`: the cursor is single-owner and reachable
       // only through the spring; a capturing `Spring` would cascade `^` through
-      // every `Request` value.
-      val spring: Spring[Data]^ = () => streamOf(cursor)
+      // every `Request` value. The neutral carrier keeps the spring's result
+      // from naming the non-local cursor (the `-scalajs` row enforces the
+      // hiding rule where the JVM row does not).
+      val cursorRef: AnyRef = cursor.asInstanceOf[AnyRef]
+
+      val spring: Spring[Data]^ =
+        () => streamOf(cursorRef.asInstanceOf[Cursor[Data, {}]^])
 
       Request
         ( head.method,
@@ -906,8 +911,11 @@ object Http:
       // each mint resumes where the previous reader stopped (explicit `memoize`
       // replaces the former memoized-remainder replay). Sealed: the cursor is
       // reachable only through the spring; a capturing `Body` would cascade
-      // `^` through every `Response` value.
-      val spring: Spring[Data]^ = () => streamOf(cursor)
+      // `^` through every `Response` value. Neutral carrier: see `Request.parse`.
+      val cursorRef: AnyRef = cursor.asInstanceOf[AnyRef]
+
+      val spring: Spring[Data]^ =
+        () => streamOf(cursorRef.asInstanceOf[Cursor[Data, {}]^])
       val body = Http.Body.Flowing(caps.unsafe.unsafeAssumePure(spring))
 
       Response(version, status, headers.reverse, body)

--- a/lib/telekinesis/src/core/telekinesis.Receivable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Receivable.scala
@@ -46,15 +46,18 @@ trait Receivable2:
   =>  ((content is Receivable)^{tactic}) =
 
     Receivable:
-      body => content(body.memoize.utf8)
+      body => content(body.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^].memoize.utf8)
 
 
 object Receivable extends Receivable2:
   // A named SAM rather than a function type: a function type may not take a
   // capability-typed (`^`) parameter (the `Spring` precedent), and SAM
-  // conversion keeps `Receivable(stream => ...)` call sites unchanged.
+  // conversion keeps `Receivable(stream => ...)` call sites unchanged. The
+  // parameter is NOT `consume` (a SAM-lambda cannot provide one, on the
+  // `-scalajs` row): consuming readers cross it through a neutral carrier,
+  // per the `accept` convention.
   trait Reader[result]:
-    def read(consume stream: (Stream[Data] over Credit)^): result
+    def read(stream: (Stream[Data] over Credit)^): result
 
   // The reader receives the response body as a single-owner pull endpoint;
   // whole-value consumers go through their `Aggregable`'s `accept`.
@@ -67,7 +70,7 @@ object Receivable extends Receivable2:
 
   given text: (tactic: Tactic[HttpError])
   =>  ((Text is Receivable)^{tactic}) =
-    Receivable(_.memoize.utf8)
+    Receivable(_.asInstanceOf[AnyRef].asInstanceOf[(Stream[Data] over Credit)^].memoize.utf8)
 
   given streamable: [stream] => (aggregable: (stream is Aggregable by Data)^)
   =>  (tactic: Tactic[HttpError])

--- a/lib/telekinesis/src/core/telekinesis.Receivable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Receivable.scala
@@ -38,6 +38,7 @@ import gossamer.*
 import prepositional.*
 import turbulence.*
 import vacuous.*
+import zephyrine.*
 
 trait Receivable2:
   given instantiable: [content: Instantiable across HttpRequests from Text]
@@ -45,23 +46,33 @@ trait Receivable2:
   =>  ((content is Receivable)^{tactic}) =
 
     Receivable:
-      body => content(body.read[Data].utf8)
+      body => content(body.memoize.utf8)
 
 
 object Receivable extends Receivable2:
-  def apply[result](lambda: (LazyList[Data] => result)^)(using tactic: Tactic[HttpError])
+  // A named SAM rather than a function type: a function type may not take a
+  // capability-typed (`^`) parameter (the `Spring` precedent), and SAM
+  // conversion keeps `Receivable(stream => ...)` call sites unchanged.
+  trait Reader[result]:
+    def read(consume stream: (Stream[Data] over Credit)^): result
+
+  // The reader receives the response body as a single-owner pull endpoint;
+  // whole-value consumers go through their `Aggregable`'s `accept`.
+  def apply[result](lambda: Reader[result]^)(using tactic: Tactic[HttpError])
   :   ((result is Receivable)^{lambda, tactic}) =
     response =>
-      response.successBody.let(lambda).lest(HttpError(response.status, response.textHeaders))
+      if response.status.category != Http.Status.Category.Successful
+      then abort(HttpError(response.status, response.textHeaders))
+      else lambda.read(response.body.stream)
 
   given text: (tactic: Tactic[HttpError])
   =>  ((Text is Receivable)^{tactic}) =
-    Receivable(_.read[Data].utf8)
+    Receivable(_.memoize.utf8)
 
   given streamable: [stream] => (aggregable: (stream is Aggregable by Data)^)
   =>  (tactic: Tactic[HttpError])
   =>  ((stream is Receivable)^{aggregable, tactic}) =
-    Receivable(aggregable.aggregate(_))
+    Receivable(aggregable.accept(_))
 
   given httpStatus: Http.Status is Receivable = _.status
 

--- a/lib/telekinesis/src/test/telekinesis_test.scala
+++ b/lib/telekinesis/src/test/telekinesis_test.scala
@@ -397,13 +397,13 @@ object Tests extends Suite(m"Telekinesis tests"):
       for blockSize <- blockSizes do
         test(m"fixedBody reads exactly N bytes at block size $blockSize"):
           val cursor = Cursor[Data](chunks(t"hello world", blockSize).iterator)
-          Http.Request.fixedBody(cursor, 5).read[Data].utf8
+          Http.Request.fixedBody(cursor, 5).memoize.utf8
 
         . assert(_ == t"hello")
 
         test(m"fixedBody leaves the cursor after the body at block size $blockSize"):
           val cursor = Cursor[Data](chunks(t"hello world", blockSize).iterator)
-          Http.Request.fixedBody(cursor, 5).each(_ => ())
+          Http.Request.fixedBody(cursor, 5).memoize
           cursor.remainder.read[Data].utf8
 
         . assert(_ == t" world")
@@ -411,14 +411,14 @@ object Tests extends Suite(m"Telekinesis tests"):
         test(m"chunkedBody decodes chunks at block size $blockSize"):
           val fixture = t"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
           val cursor = Cursor[Data](chunks(fixture, blockSize).iterator)
-          Http.Request.chunkedBody(cursor).read[Data].utf8
+          Http.Request.chunkedBody(cursor).memoize.utf8
 
         . assert(_ == t"hello world")
 
         test(m"chunkedBody leaves the cursor after the body at block size $blockSize"):
           val fixture = t"3\r\nabc\r\n0\r\n\r\nNEXT"
           val cursor = Cursor[Data](chunks(fixture, blockSize).iterator)
-          Http.Request.chunkedBody(cursor).each(_ => ())
+          Http.Request.chunkedBody(cursor).memoize
           cursor.remainder.read[Data].utf8
 
         . assert(_ == t"NEXT")


### PR DESCRIPTION
HTTP request and response bodies now flow as lent, single-owner pull endpoints instead of memoized `LazyList`s, so bodies of any size stream through bounded memory on both the server and client receive paths.

**Behavioural change:** a body may now be read *once*. Reading `request.body()` (or a response body) a second time resumes from wherever the previous reader stopped, rather than replaying from a hidden cache; a consumer that needs the content more than once memoizes explicitly:

```scala
val content: Data = request.body().memoize   // then reuse `content` freely
```

Everything built on the standard machinery is unaffected: form decoding (`request.query`), `Receivable` consumers, and the uniform `.read` API already consume bodies exactly once.

On the server, `Content-Length` bodies lend exactly their length off the connection cursor zero-copy, and chunked bodies decode through a stream whose refills run the chunk-size state machine — both leaving the connection positioned at the next pipelined request, with the post-response drain consuming whatever the handler didn't. On the client, `successBody` no longer materializes the whole body, and `Receivable` instances read through their `Aggregable`'s streaming `accept`. The servlet backend's 64KiB chunk pump is replaced by the `InputStream` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)