### PR TITLE
Honest capture checking for scoped resources, typeclasses and derivation

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1092,7 +1092,7 @@ object ethereal extends Library:
   object core extends Component(surveillance.core, eucalyptus.syslog, hellenism.core, exoskeleton.core, coaxial.jvm, quantitative.units, telekinesis.jvm, urticose.url, gastronomy.core):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
     // The platforms the reusable native runner stubs target — (label, binary filename).
     // The stubs are built and published independently of this build (see `make
     // runners-build` / `make runners-release`); the Soundness build never compiles them,

--- a/build.mill
+++ b/build.mill
@@ -1227,7 +1227,7 @@ object exoskeleton extends Library:
 
   object rig extends Internal(completions, superlunary.core, ethereal.core, anthology.bundle, quantitative.units):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
     def mvnDeps =
       Seq
        (mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
@@ -1827,7 +1827,7 @@ object scintillate extends Library:
   object server extends Component(telekinesis.core):
     override def scalaJs = false // HTTP server via `telekinesis`/`coaxial` sockets
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
 
   object servlet extends Component(server):
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)

--- a/build.mill
+++ b/build.mill
@@ -1749,7 +1749,7 @@ object profanity extends Library:
   object core extends Component(ambience.core, eucalyptus.core, diuretic.core, iridescence.core,
                                 quantitative.units, frontier.core, escapade.csi):
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core, exoskeleton.rig):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
@@ -1941,7 +1941,7 @@ object surveillance extends Library:
   object core extends Component(eucalyptus.core):
     override def scalaJs = false // file watching (`java.nio.file` WatchService)
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core, galilei.jvm, imperial.core, diuretic.core, quantitative.units):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
@@ -1968,7 +1968,7 @@ object tarantula extends Library:
   object core extends Component(jacinta.core, telekinesis.jvm, cataclysm.core, hallucination.core, diuretic.core, gastronomy.core, guillotine.core):
     override def scalaJs = false // browser automation; depends on JVM-only `hallucination`
     override def scalacOptions = Task:
-      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+      settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())

--- a/lib/ambience/src/core/ambience.Directories.scala
+++ b/lib/ambience/src/core/ambience.Directories.scala
@@ -42,64 +42,69 @@ import prepositional.*
 import vacuous.*
 
 object Directories:
-  def home[path: Instantiable across Paths from Text](using system: System): path =
-    path(homeText)
+  // Like `Xdg`, the evidence is an explicit capturing (`^`) using-parameter: path
+  // `Instantiable` instances retain their filesystem evidence, which a pure context bound
+  // cannot accept.
+  def home[path](using instantiable: (path is Instantiable across Paths from Text)^)
+    ( using system: System )
+  :   path =
+    instantiable(homeText)
 
 
   def homeText(using system: System): Text =
     system(t"user.home").or(panic(m"the `user.home` system property is not set"))
 
 
-  def dataHome[path: Instantiable across Paths from Text]
+  def dataHome[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
     if isWindows then roamingAppData[path] else Xdg.dataHome[path]
 
 
-  def configHome[path: Instantiable across Paths from Text]
+  def configHome[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
     if isWindows then roamingAppData[path] else Xdg.configHome[path]
 
 
-  def cacheHome[path: Instantiable across Paths from Text]
+  def cacheHome[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
     if isWindows then localAppData[path] else Xdg.cacheHome[path]
 
 
-  def stateHome[path: Instantiable across Paths from Text]
+  def stateHome[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
     if isWindows then localAppData[path] else Xdg.stateHome[path]
 
 
-  def runtimeDir[path: Instantiable across Paths from Text]
+  def runtimeDir[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   Optional[path] =
 
-    if isWindows then path(t"${localAppDataText}\\Temp") else Xdg.runtimeDir[path]
+    if isWindows then instantiable(t"${localAppDataText}\\Temp") else Xdg.runtimeDir[path]
 
 
-  def bin[path: Instantiable across Paths from Text]
+  def bin[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
-    if isWindows then path(t"${localAppDataText}\\Programs") else Xdg.bin[path]
+    if isWindows then instantiable(t"${localAppDataText}\\Programs") else Xdg.bin[path]
 
 
-  def dataDirs[path: Instantiable across Paths from Text]
+  def dataDirs[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   List[path] =
 
     if isWindows then List(programData[path]) else Xdg.dataDirs[path]
 
 
-  def configDirs[path: Instantiable across Paths from Text]
+  def configDirs[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   List[path] =
 
@@ -122,22 +127,22 @@ object Directories:
     safely(Environment[Text](t"PROGRAMDATA")).or(t"C:\\ProgramData")
 
 
-  private def localAppData[path: Instantiable across Paths from Text]
+  private def localAppData[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
-    path(localAppDataText)
+    instantiable(localAppDataText)
 
 
-  private def roamingAppData[path: Instantiable across Paths from Text]
+  private def roamingAppData[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment, system: System )
   :   path =
 
-    path(roamingAppDataText)
+    instantiable(roamingAppDataText)
 
 
-  private def programData[path: Instantiable across Paths from Text]
+  private def programData[path](using instantiable: (path is Instantiable across Paths from Text)^)
     ( using environment: Environment )
   :   path =
 
-    path(programDataText)
+    instantiable(programDataText)

--- a/lib/anticipation/src/log/anticipation.Log.scala
+++ b/lib/anticipation/src/log/anticipation.Log.scala
@@ -37,17 +37,17 @@ import language.experimental.into
 object Log:
   // `message` is by-name: with no sink in scope (or none accepting the level), `Loggable.fanOut`
   // never forces it, so the logged value is not even constructed.
-  def fine[loggable: Loggable](message: => loggable): Unit =
-    loggable.log(Level.Fine, System.currentTimeMillis, message)
+  def fine[loggable](message: => loggable)(using loggable0: (loggable is Loggable)^): Unit =
+    loggable0.log(Level.Fine, System.currentTimeMillis, message)
 
-  def info[loggable: Loggable](message: => loggable): Unit =
-    loggable.log(Level.Info, System.currentTimeMillis, message)
+  def info[loggable](message: => loggable)(using loggable0: (loggable is Loggable)^): Unit =
+    loggable0.log(Level.Info, System.currentTimeMillis, message)
 
-  def warn[loggable: Loggable](message: => loggable): Unit =
-    loggable.log(Level.Warn, System.currentTimeMillis, message)
+  def warn[loggable](message: => loggable)(using loggable0: (loggable is Loggable)^): Unit =
+    loggable0.log(Level.Warn, System.currentTimeMillis, message)
 
-  def fail[loggable: Loggable](message: => loggable): Unit =
-    loggable.log(Level.Fail, System.currentTimeMillis, message)
+  def fail[loggable](message: => loggable)(using loggable0: (loggable is Loggable)^): Unit =
+    loggable0.log(Level.Fail, System.currentTimeMillis, message)
 
   // A standard, growable vocabulary describing the *nature* of a log event. An event type (or, more
   // usually, an individual enum case) mixes in one or more marker traits; a `Logger` may then be

--- a/lib/anticipation/src/log/anticipation.LogSink.scala
+++ b/lib/anticipation/src/log/anticipation.LogSink.scala
@@ -40,7 +40,12 @@ package anticipation
 // threshold). `Loggable.fanOut` consults it *before* forcing or transcribing the (by-name) event,
 // so that when no sink accepts — in particular when there are no sinks at all — the logged value is
 // never even constructed, and logging a disabled event costs nothing.
-trait LogSink[-eventType, carrier]:
+// A `LogSink` is a *capability*: submitting a log event is an effect on the sink's
+// destination. `caps.Unscoped` (the ambient-strategy classification, per the 2026-07-16
+// D4 ruling): sinks are deliberately ambient — importable package givens and
+// application-lifetime registries — so they must be storable statically; the tracking is
+// effect-visibility, not scope-confinement.
+trait LogSink[-eventType, carrier] extends caps.Unscoped:
   def accepts(level: Level): Boolean
 
   // Reports whether this sink records events of the given (concrete) type. Takes the *original*

--- a/lib/anticipation/src/log/anticipation.Loggable.scala
+++ b/lib/anticipation/src/log/anticipation.Loggable.scala
@@ -44,9 +44,12 @@ object Loggable:
   // scope ⇒ an
   // empty `Every` ⇒ silent; many ⇒ fan-out with per-sink routing. Living in `Loggable`'s companion
   // keeps it in implicit scope, so no import is needed at the use site.
-  given fanOut: [event, carrier]
-  =>  ( transcribable: event is Transcribable to carrier, sinks: Every[LogSink[event, carrier]] )
-  =>  event is Loggable =
+  // Capture-polymorphic over the sinks' capabilities (`cap^`, the Cursor pattern): the
+  // derived instance honestly carries whatever the in-scope sinks capture.
+  given fanOut: [event, carrier, cap^]
+  =>  ( transcribable: event is Transcribable to carrier,
+        sinks:         Every[LogSink[event, carrier]^{cap}] )
+  =>  ((event is Loggable)^{cap, caps.any}) =
 
     new Loggable:
       type Self = event
@@ -68,7 +71,9 @@ object Loggable:
               then sink.submit(level, timestamp, message)
 
 trait Loggable extends Typeclass:
-  loggable: Loggable =>
+  // The self type is `^`: an instance may capture the (Unscoped) sinks it fans out to; a
+  // bare self type would pin every instance pure.
+  loggable: Loggable^ =>
     def log(level: Level, timestamp: Long, event: => Self): Unit
 
     // `^{lambda}` only: the compiler treats a bare `Loggable` receiver as untracked
@@ -76,6 +81,6 @@ trait Loggable extends Typeclass:
     // for the Scala.js pipeline, which — unlike the JVM pipeline — insists the anonymous
     // instance's base class is pure and rejects the capture of `lambda`; the result type still
     // declares it. (Compiler divergence; the JVM pipeline accepts the direct form.)
-    def contramap[self2](lambda: self2 => Self): (self2 is Loggable)^{lambda} =
+    def contramap[self2](lambda: self2 => Self): (self2 is Loggable)^{this, lambda} =
       val lambda0: self2 -> Self = caps.unsafe.unsafeAssumePure(lambda)
       (level, timestamp, event) => loggable.log(level, timestamp, lambda0(event))

--- a/lib/anticipation/src/log/anticipation_log.scala
+++ b/lib/anticipation/src/log/anticipation_log.scala
@@ -32,7 +32,9 @@
                                                                                                   */
 package anticipation
 
-infix type logs [result, event] = (event is Loggable) ?=> result
+// Mirrors `raises`: the evidence is `^` because a `Loggable` instance may honestly capture
+// the (Unscoped) sinks it fans out to.
+infix type logs [result, event] = ((event is Loggable)^) ?=> result
 
 infix type transcribes [event, event2] = Transcribable:
   type Self = event2

--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -192,14 +192,16 @@ object Dsv extends Dsv2:
     cells.join(format.delimiter.show)
 
   object DecodableDerivation extends ProductDerivable[Decodable in Dsv]:
-    class DsvProductDecoder[derivation](lambda: Dsv -> derivation)
+    // An impure (`=>`) lambda: a derived decoder legitimately captures the consumer's
+    // resolution-scoped tactics, which the fresh (`^`) `conjunction` result honestly admits.
+    class DsvProductDecoder[derivation](lambda: Dsv => derivation)
     extends Decodable:
       type Self = derivation
       type Form = Dsv
       def decoded(row: Dsv): derivation = lambda(row)
 
     inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Decodable in Dsv =
+    :   (derivation is Decodable in Dsv)^ =
 
       val spans: IArray[Int] = Spannable.derived[derivation].spans()
 
@@ -210,9 +212,8 @@ object Dsv extends Dsv2:
       provide[Foci[CellRef]]:
         // The decode lambda may capture the consumer's `Tactic` (field decoders are
         // tactic-taking givens), with the same lifetime as the instance's given resolution;
-        // laundered pure to keep decoder instances pure — the same rationale as jacinta's
-        // codec-thunk seal (see jacinta.Json.scala and rep/DECISIONS.md).
-        DsvProductDecoder[derivation](caps.unsafe.unsafeAssumePure:
+        // the fresh (`^`) result honestly admits the capture — no seal.
+        DsvProductDecoder[derivation](
           (row: Dsv) =>
             var count = 0
 

--- a/lib/capricious/src/core/capricious.Random.scala
+++ b/lib/capricious/src/core/capricious.Random.scala
@@ -39,12 +39,25 @@ import scala.util as su
 import beneficence.*
 
 object Random:
-  lazy val global: Random = new Random(randomization.unseededRandomization.initialize())
+  // The underlying JDK generator is a plain (untracked) value, so it may be stored statically;
+  // `global` mints a fresh capability wrapper around the same shared generator state each time
+  // (a capability-typed field would force `Random`'s companion to become a capability itself).
+  private lazy val globalGenerator: su.Random =
+    randomization.unseededRandomization.initialize()
+
+  def global: Random = new Random(globalGenerator)
 
   def apply(seed: Seed)(using randomization: Randomization): Random =
     new Random(randomization.initialize())
 
-class Random(private val generator: su.Random) extends Findable:
+// A `Random` is a *capability*: drawing from a pseudorandom generator is an effect (the
+// generator's state advances), so code that consumes randomness carries `{random}` in its
+// capture set. `caps.Unscoped` (like contingency's ambient strategies) rather than
+// `SharedCapability`: a generator captures nothing scoped itself, and the deliberately-ambient
+// `Random.global` (and `randomization`-package givens) must be storable statically, which the
+// scoped classifiers forbid. (`Unscoped` is in the exclusive-classifier line, so it cannot be
+// combined with `SharedCapability`.)
+class Random(private val generator: su.Random) extends Findable, caps.Unscoped:
   def long(): Long = generator.nextLong()
   def gaussian(): Double = generator.nextGaussian()
   def unitInterval(): Double = generator.nextDouble()

--- a/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
+++ b/lib/chiaroscuro/src/core/chiaroscuro.Contrastable.scala
@@ -244,8 +244,8 @@ object Contrastable:
       if left == right then Juxtaposition.Same(left.show)
       else Juxtaposition.Different(left.show, right.show)
 
-trait Contrastable extends Typeclass:
+trait Contrastable extends Typeclass.Pure:
   def juxtaposition(left: Self, right: Self): Juxtaposition
 
-  def contramap[self2](lambda: self2 => Self): (self2 is Contrastable)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Contrastable =
     (left, right) => juxtaposition(lambda(left), lambda(right))

--- a/lib/coaxial/src/core/coaxial.Connectable.scala
+++ b/lib/coaxial/src/core/coaxial.Connectable.scala
@@ -51,10 +51,17 @@ object Connectable:
     def connect(domainSocket: DomainSocket, interface: Optional[MacAddress]): Duplex =
       backend.duplexDomain(domainSocket, options.values)
 
-  given tcpEndpoint: Online => (backend: SocketBackend, options: Every[SocketOption.Tcp])
-  =>  Endpoint[TcpPort] is Connectable:
-    def connect(endpoint: Endpoint[TcpPort], interface: Optional[MacAddress]): Duplex =
-      backend.duplexTcp(endpoint, interface, options.values)
+  // Honestly tracked: the instance is resolvable only with `Online` permission, so it is a
+  // capability carrying that evidence in its capture set.
+  given tcpEndpoint: (online: Online)
+  =>  (backend: SocketBackend, options: Every[SocketOption.Tcp])
+  =>  ((Endpoint[TcpPort] is Connectable)^{online, caps.any}) =
+
+    new Connectable:
+      type Self = Endpoint[TcpPort]
+
+      def connect(endpoint: Endpoint[TcpPort], interface: Optional[MacAddress]): Duplex =
+        backend.duplexTcp(endpoint, interface, options.values)
 
 trait Connectable extends Typeclass:
   def connect(endpoint: Self, interface: Optional[MacAddress]): Duplex

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -82,10 +82,14 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
     // loop is already `Stopping`, so the interrupted `accept()` simply unwinds.
     val bindLoop = loop:
       safely(bindable.connect(binding)).let: connection =>
+        // Fire-and-forget: the fresh task handle is discarded (a lambda result may not
+        // carry it).
         async:
           safely:
             try bindable.transmit(binding, connection, lambda(connection))
             finally bindable.close(connection)
+
+        ()
 
     val task = async(bindLoop.run())
 

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -102,7 +102,7 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
 // the evidence is an explicit capturing using-parameter rather than a context bound, which would
 // demand a pure instance.
 extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint is Serviceable)^)
-  def transmit[message: Transmissible](input: message)(using SocketEvent is Loggable)
+  def transmit[message: Transmissible](input: message)(using (SocketEvent is Loggable)^)
   :   (Stream[Data] over Credit)^{serviceable, caps.any} =
     val connection = serviceable.connect(endpoint, Unset)
     Log.fine(SocketEvent.Connected(endpoint.show))
@@ -116,7 +116,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using serviceable: (endpoint 
   // initiate; a `Duplexable` additionally offers `exchange`, which can also send proactively.
   def react[state](initialState: state)[message: Ingressive]
     ( handle: (state: state) ?=> message => Control[state] )
-    ( using SocketEvent is Loggable )(using buffering: Buffering)
+    ( using (SocketEvent is Loggable)^ )(using buffering: Buffering)
   :   state =
 
     val connection = serviceable.connect(endpoint, Unset)
@@ -170,7 +170,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
   def exchange[state](initialState: state)[message: {Ingressive, Transmissible}]
     ( handle: (state: state) ?=> message => Control[state] )
     ( interact: Transmitter[message]^ => Unit )
-    ( using SocketEvent is Loggable )(using buffering: Buffering)
+    ( using (SocketEvent is Loggable)^ )(using buffering: Buffering)
   :   state =
 
     val connection = duplexable.connect(endpoint, Unset)
@@ -219,7 +219,7 @@ extension [endpoint: Showable](endpoint: endpoint)(using duplexable: (endpoint i
 
 extension [endpoint: {Routable as routable, Showable}](endpoint: endpoint)
   def transmit[transmissible: Transmissible](message: transmissible)
-    ( using Monitor, Tactic[StreamError], SocketEvent is Loggable )
+    ( using Monitor, Tactic[StreamError], (SocketEvent is Loggable)^ )
   :   Unit =
 
     Log.fine(SocketEvent.Connected(endpoint.show))
@@ -234,11 +234,11 @@ extension [endpoint: {Connectable as connectable, Showable}](endpoint: endpoint)
   // connection is never half-closed. A long-lived connection that must outlive any
   // single block keeps `lambda` running (e.g. parked on its supervisor) until the
   // enclosing scope ends, at which point the loan closes the connection.
-  def duplex[result](lambda: Duplex => result)(using SocketEvent is Loggable): result =
+  def duplex[result](lambda: Duplex => result)(using (SocketEvent is Loggable)^): result =
     duplex(lambda)(Unset)
 
   def duplex[result](lambda: Duplex => result)(interface: Optional[MacAddress])
-    ( using SocketEvent is Loggable )
+    ( using (SocketEvent is Loggable)^ )
   :   result =
 
     val connection = connectable.connect(endpoint, interface)

--- a/lib/coaxial/src/core/coaxial_core.scala
+++ b/lib/coaxial/src/core/coaxial_core.scala
@@ -47,19 +47,27 @@ import vacuous.*
 import Control.*
 
 extension [bindable: {Bindable, Showable}](socket: bindable)
+  // `listen` is a loan: it binds, lends the running server to `block` as a `SocketService`
+  // capability, and always stops it afterwards. The capability form (rather than returning
+  // the service) means capture checking confines the accept loop to the block — the earlier
+  // `val server = port.listen(...)` shape was a genuine fresh-capability escape
+  // (rep/DECISIONS.md ⚑4, closed by this design).
+  //
   // A default argument cannot be combined with the path-dependent `bindable.Input`/`.Output`
-  // types here (default-getter synthesis fails), so the interface-less form is a separate
-  // overload that delegates with `Unset`.
+  // types here (default-getter synthesis fails), and overloading on the interface clause is
+  // ambiguous against the trailing block, so the interface form has its own name.
   transparent inline def listen[input](using Monitor, Probate)[result]
     ( lambda: bindable.Input => bindable.Output )
-  :   (SocketService^) raises BindError logs SocketEvent =
+    ( block: SocketService ?=> result )
+  :   result raises BindError logs SocketEvent =
 
-    socket.listen(lambda)(Unset)
+    socket.listenOn(Unset)(lambda)(block)
 
-  transparent inline def listen[input](using Monitor, Probate)[result]
-    ( lambda: bindable.Input => bindable.Output )
+  transparent inline def listenOn[input](using Monitor, Probate)[result]
     ( interface: Optional[MacAddress] )
-  :   (SocketService^) raises BindError logs SocketEvent =
+    ( lambda: bindable.Input => bindable.Output )
+    ( block: SocketService ?=> result )
+  :   result raises BindError logs SocketEvent =
 
     val binding = bindable.bind(socket, interface)
     Log.info(SocketEvent.Listening(socket.show))
@@ -81,11 +89,13 @@ extension [bindable: {Bindable, Showable}](socket: bindable)
 
     val task = async(bindLoop.run())
 
-    SocketService: () =>
+    val service = SocketService: () =>
       bindLoop.stop()
       bindable.stop(binding)
       safely(task.await())
       Log.fine(SocketEvent.Closed(socket.show))
+
+    try block(using service) finally service.stop()
 
 
 // `Serviceable` instances are capabilities (their givens retain tactics and socket options), so

--- a/lib/coaxial/src/jvm/coaxial.DomainServer.scala
+++ b/lib/coaxial/src/jvm/coaxial.DomainServer.scala
@@ -52,9 +52,12 @@ import vacuous.*
 // failure or a dropped client only ends its own task, and the connection is always closed),
 // while a failure to *accept* skips one loop iteration; `stop()` unwinds the parked `accept()`.
 extension (domainSocket: DomainSocket)
-  def listenConnections(using Monitor, Probate)(handler: Connection => Unit)
+  // A loan, like `Bindable.listen`: the running server is lent to `block` as a
+  // `SocketService` capability and always stopped afterwards.
+  def listenConnections[result](using Monitor, Probate)(handler: Connection => Unit)
     ( using SocketEvent is Loggable )
-  :   SocketService^ =
+    ( block: SocketService ?=> result )
+  :   result =
 
     val channel = jnc.ServerSocketChannel.open(jn.StandardProtocolFamily.UNIX).nn
     channel.configureBlocking(true)
@@ -72,8 +75,10 @@ extension (domainSocket: DomainSocket)
 
     val task = async(bindLoop.run())
 
-    SocketService: () =>
+    val service = SocketService: () =>
       bindLoop.stop()
       channel.close()
       safely(task.await())
       Log.fine(SocketEvent.Closed(domainSocket.address))
+
+    try block(using service) finally service.stop()

--- a/lib/coaxial/src/jvm/coaxial.DomainServer.scala
+++ b/lib/coaxial/src/jvm/coaxial.DomainServer.scala
@@ -70,8 +70,12 @@ extension (domainSocket: DomainSocket)
         Connection(jnc.Channels.newInputStream(client).nn, jnc.Channels.newOutputStream(client).nn)
 
       . let: connection =>
+          // Fire-and-forget: the fresh task handle is discarded (a lambda result may not
+          // carry it).
           async:
             safely(try handler(connection) finally connection.close())
+
+          ()
 
     val task = async(bindLoop.run())
 

--- a/lib/coaxial/src/jvm/coaxial.DomainServer.scala
+++ b/lib/coaxial/src/jvm/coaxial.DomainServer.scala
@@ -55,7 +55,7 @@ extension (domainSocket: DomainSocket)
   // A loan, like `Bindable.listen`: the running server is lent to `block` as a
   // `SocketService` capability and always stopped afterwards.
   def listenConnections[result](using Monitor, Probate)(handler: Connection => Unit)
-    ( using SocketEvent is Loggable )
+    ( using (SocketEvent is Loggable)^ )
     ( block: SocketService ?=> result )
   :   result =
 

--- a/lib/coaxial/src/jvm/coaxial.SecureEndpoint.scala
+++ b/lib/coaxial/src/jvm/coaxial.SecureEndpoint.scala
@@ -46,12 +46,19 @@ import vacuous.*
 // from `Tls.context`, or the system default), sets SNI to `host`, verifies the peer
 // hostname unless `Tls.verify` is off, then presents the socket's streams as a `Duplex`.
 object SecureEndpoint:
-  given connectable: (Online, Every[SocketOption.Tcp], Tls) => SecureEndpoint is Connectable:
+  // Honestly tracked, like `Connectable.tcpEndpoint`: the instance is resolvable only with
+  // `Online` permission, so it is a capability carrying that evidence in its capture set.
+  given connectable: (online: Online)
+  =>  (options: Every[SocketOption.Tcp], tls: Tls)
+  =>  ((SecureEndpoint is Connectable)^{online, caps.any}) =
+
+   new Connectable:
+    type Self = SecureEndpoint
+
     def connect(endpoint: SecureEndpoint, interface: Optional[MacAddress]): Duplex =
-      val tls = summon[Tls]
       val context = tls.context.or(jns.SSLContext.getDefault.nn)
       val socket = context.getSocketFactory.nn.createSocket().nn.asInstanceOf[jns.SSLSocket]
-      configure(socket, summon[Every[SocketOption.Tcp]].values)
+      configure(socket, options.values)
 
       interface.let(interfaceFor(_)).let(bindAddress(_)).let: local =>
         socket.bind(jn.InetSocketAddress(local, 0))

--- a/lib/coaxial/src/test/coaxial_test.scala
+++ b/lib/coaxial/src/test/coaxial_test.scala
@@ -214,28 +214,29 @@ object Tests extends Suite(m"Coaxial tests"):
           val port = Port[Udp]()
           val received: Promise[Text] = Promise()
 
-          val server = port.listen[Data]: packet =>
+          val handler = (packet: Packet) =>
             received.fulfill(packet.data.utf8)
             UdpResponse.Reply(ascii(t"ack"))
 
-          // The `transmit` extension is overloaded on `Serviceable` (returns
-          // `LazyList[Data]`) and `Routable` (returns `Unit`); since value-discarding
-          // makes any type conform to `Unit`, the `Routable` overload is not
-          // reachable by ascription, so its given is exercised directly here.
-          val routable = summon[UdpPort is Routable]
-          routable.transmit(routable.connect(port, Unset), zephyrine.Stream(ascii(t"ping")))
-          received.await().also(server.stop())
+          port.listen[Data](handler):
+
+            // The `transmit` extension is overloaded on `Serviceable` (returns
+            // `LazyList[Data]`) and `Routable` (returns `Unit`); since value-discarding
+            // makes any type conform to `Unit`, the `Routable` overload is not
+            // reachable by ascription, so its given is exercised directly here.
+            val routable = summon[UdpPort is Routable]
+            routable.transmit(routable.connect(port, Unset), zephyrine.Stream(ascii(t"ping")))
+            received.await()
         . assert(_ == t"ping")
 
       suite(m"TCP server and client"):
         test(m"A client reacts to the server's pushed message"):
           val port = Port[Tcp]()
-          val server = port.listen[Data](socket => ascii(t"greeting"))
+          port.listen[Data](socket => ascii(t"greeting")):
+            val received: Data = port.react(Data())[Data]: message =>
+              Conclude(ascii(t""), message)
 
-          val received: Data = port.react(Data())[Data]: message =>
-            Conclude(ascii(t""), message)
-
-          bytes(received).also(server.stop())
+            bytes(received)
         . assert(_ == bytes(ascii(t"greeting")))
 
       suite(m"Unix domain socket server and client"):
@@ -245,15 +246,17 @@ object Tests extends Suite(m"Coaxial tests"):
           val socket = DomainSocket(path)
           val received: Promise[Text] = Promise()
 
-          val server = socket.listen[Data]: connection =>
+          val handler = (connection: Duplex) =>
             val request = connection.source.memoize
             received.fulfill(request.utf8)
             request
 
-          // The ascription selects the `Serviceable` overload of `transmit`; the
-          // client half-closes after sending, so the server reads to EOF.
-          val _: zephyrine.Stream[Data] over zephyrine.Credit = socket.transmit(t"request")
-          received.await().also(server.stop())
+          socket.listen[Data](handler):
+
+            // The ascription selects the `Serviceable` overload of `transmit`; the
+            // client half-closes after sending, so the server reads to EOF.
+            val _: zephyrine.Stream[Data] over zephyrine.Credit = socket.transmit(t"request")
+            received.await()
         . assert(_ == t"request")
 
       suite(m"Duplex connections"):
@@ -262,22 +265,24 @@ object Tests extends Suite(m"Coaxial tests"):
           java.nio.file.Files.deleteIfExists(java.nio.file.Path.of(path.s))
           val socket = DomainSocket(path)
 
-          val server = socket.listen[Data]: connection =>
-            // One refill window is the client's single message (no half-close on a duplex).
+          // One refill window is the client's single message (no half-close on a duplex).
+          val handler = (connection: Duplex) =>
             val source = connection.source
             val count = source.refill(zephyrine.Credit(64)).or(0)
             source.addressable.materialize(source.window(using Unsafe), source.start, count)
 
-          val reply = socket.duplex: duplex =>
-            duplex.send(zephyrine.Stream(ascii(t"ping")))
+          socket.listen[Data](handler):
 
-            // One refill window is the server's single reply.
-            val source = duplex.source
-            val count = source.refill(zephyrine.Credit(64)).or(0)
-            val data = source.addressable.materialize(source.window(using Unsafe), source.start, count)
-            bytes(data)
+            socket.duplex: duplex =>
+              duplex.send(zephyrine.Stream(ascii(t"ping")))
 
-          reply.also(server.stop())
+              // One refill window is the server's single reply.
+              val source = duplex.source
+              val count = source.refill(zephyrine.Credit(64)).or(0)
+              val data =
+                source.addressable.materialize(source.window(using Unsafe), source.start, count)
+
+              bytes(data)
         . assert(_ == bytes(ascii(t"ping")))
 
     suite(m"Socket options"):

--- a/lib/cordillera/src/core/cordillera.Http2.scala
+++ b/lib/cordillera/src/core/cordillera.Http2.scala
@@ -382,7 +382,7 @@ object Http2:
       new HttpClient:
         type Target = Endpoint[endpoint]
 
-        def request(request: Http.Request, target: Endpoint[endpoint])(using HttpEvent is Loggable)
+        def request(request: Http.Request, target: Endpoint[endpoint])(using (HttpEvent is Loggable)^)
         :   Http.Response =
 
           target.connect().fetch(request, t"http", target.authority)(1)

--- a/lib/denominative/src/core/denominative.Countable.scala
+++ b/lib/denominative/src/core/denominative.Countable.scala
@@ -94,6 +94,6 @@ object Countable:
     def size(self: Text): Int = self.s.length
     override def nil(self: Text): Boolean = self.s.isEmpty
 
-trait Countable extends Typeclass:
+trait Countable extends Typeclass.Pure:
   def size(self: Self): Int
   def nil(self: Self): Boolean = size(self) == 0

--- a/lib/distillate/src/core/distillate.Identifiable.scala
+++ b/lib/distillate/src/core/distillate.Identifiable.scala
@@ -42,6 +42,6 @@ object Identifiable:
       def encode(text: Text): Text = encoder(text)
       def decode(text: Text): Text = decoder(text)
 
-trait Identifiable extends Typeclass:
+trait Identifiable extends Typeclass.Pure:
   def encode(text: Text): Text
   def decode(text: Text): Text

--- a/lib/distillate/src/core/distillate.Irrefutable.scala
+++ b/lib/distillate/src/core/distillate.Irrefutable.scala
@@ -60,8 +60,8 @@ object Irrefutable:
   given intDoule: Int is Irrefutable to Double = _.toDouble
   given floatDouble: Float is Irrefutable to Double = _.toDouble
 
-trait Irrefutable extends Typeclass, Resultant:
+trait Irrefutable extends Typeclass.Pure, Resultant:
   def unapply(value: Self): Result
 
-  def contramap[self2](lambda: self2 => Self): (self2 is Irrefutable to Result)^{this, lambda} =
+  def contramap[self2](lambda: self2 -> Self): self2 is Irrefutable to Result =
     value => unapply(lambda(value))

--- a/lib/ethereal/src/core/ethereal.Assembler.scala
+++ b/lib/ethereal/src/core/ethereal.Assembler.scala
@@ -138,7 +138,11 @@ object Assembler:
       jdk:           Boolean,
       publicKey:     Data )           // 1312 raw bytes (all-zero disables upgrades)
     ( using WorkingDirectory )
-  :   Unit raises AssemblyError raises IoError raises StreamError =
+    // Explicit `using` evidence instead of stacked `raises` sugar: the handle-loan lambdas
+    // in the body cannot cross the nested context-function results the sugar desugars to
+    // (the stacked-raises convention; see rep/DECISIONS.md).
+    ( using Tactic[AssemblyError], Tactic[IoError], Tactic[StreamError] )
+  :   Unit =
 
     val isWindows: Boolean = platformLabel.starts(t"windows")
     val patched: Data = patch(runner, buildId, javaMinimum, javaPreferred, jdk, publicKey)
@@ -151,7 +155,12 @@ object Assembler:
       if !isWindows then output.executable() = true
       safely(mute[ExecEvent](sh"codesign --sign - --force $output".exec[Exit]()))
 
-    jarFile.open: jarHandle =>
-      Eof(output).open(_.write(jarHandle.reader()))
+    // Two sequential opens rather than one nested inside the other's lambda (the inner
+    // open's evidence would mint fresh roots inside the outer handle's loan that cannot
+    // unify with it), and a direct append-mode open rather than `Eof` (whose two-evidence
+    // dependent `Result` chain has the same root problem). The read is strict (`to(List)`)
+    // so nothing reads the closed handle.
+    val chunks = jarFile.open(_.reader().to(List))
+    output.open(_.write(LazyList.from(chunks)), List(OpenFlag.Append))
 
     if !isWindows then output.executable() = true

--- a/lib/ethereal/src/core/ethereal.Client.scala
+++ b/lib/ethereal/src/core/ethereal.Client.scala
@@ -57,7 +57,11 @@ case class Client(pid: Pid) extends Topical:
   type Topic <: Matchable
 
   val stderr: Promise[ji.OutputStream] = Promise()
-  val invocation: Promise[Cli] = Promise()
+
+  // An `AnyRef` rim: the `Cli` capability crosses the promise between the signal-dispatch
+  // fiber and the invocation fiber, and a capability type argument cannot (the
+  // fiber-crossing recipe; cast at both ends).
+  val invocation: Promise[AnyRef] = Promise()
   val bus: Spool[Topic] = Spool()
   val terminatePid: Promise[Pid] = Promise()
   val exitPromise: Promise[Exit] = Promise()

--- a/lib/ethereal/src/core/ethereal.DaemonService.scala
+++ b/lib/ethereal/src/core/ethereal.DaemonService.scala
@@ -44,6 +44,9 @@ import prepositional.*
 import serpentine.*
 import vacuous.*
 
+// A `DaemonService` is a *capability*: it holds the daemon's shutdown and broadcast sinks
+// and the client's live stdin, scoped to one daemon-client invocation (the 2026-07-06
+// service-class ruling; see rep/DECISIONS.md).
 case class DaemonService[bus <: Matchable]
   ( pid:        Pid,
     shutdown:   () => Unit,
@@ -54,7 +57,7 @@ case class DaemonService[bus <: Matchable]
     script:     Text,
     startTime:  Long,
     helpThunk:  () => Optional[Help] )
-extends Entrypoint:
+extends Entrypoint, caps.ExclusiveCapability:
   def broadcast(message: bus): Unit = deliver(message)
 
   // The structured help tree for this command, generated lazily by re-running the application

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -359,7 +359,7 @@ def cli[bus <: Matchable](using executive: Executive)
         val response: SignalResponse =
           safely:
             val invocation = client(pid).invocation.await(250.0*Milli(Second))
-            invocation.dispatchSignal(signal)
+            invocation.asInstanceOf[Cli].dispatchSignal(signal)
 
           . or(SignalResponse.Reject)
 
@@ -467,7 +467,7 @@ def cli[bus <: Matchable](using executive: Executive)
                 service,
                 login )
 
-          clientState.invocation.offer(cli)
+          clientState.invocation.offer(cli.asInstanceOf[AnyRef])
 
           if cli.proceed then
             val result = block(using service, cli, environment, summon[Monitor])
@@ -510,37 +510,42 @@ def cli[bus <: Matchable](using executive: Executive)
 
       // Bind and start accepting *before* the build- and pid-files are written:
       // a launcher waits for those readiness files to appear and then connects,
-      // so the socket must already be listening by the time they exist. (`listen`
-      // binds synchronously and serves on its own daemon, so the bound socket
-      // queues connections immediately even before the files are created.)
+      // so the socket must already be listening by the time they exist.
+      // (`listenConnections` binds synchronously and serves on its own daemon, so
+      // the bound socket queues connections immediately even before the files are
+      // created.) It is a loan, so the whole serving lifetime — readiness files,
+      // the pid-watcher, and the park — nests inside its block; the daemon only
+      // ever leaves it via `termination`'s `System.exit`.
+      val acceptor = (connection: Connection) =>
+        inactivityTimer.nudge()
+        safely(makeClient(connection))
+        ()
+
       safely:
-        domainSocket.listenConnections: connection =>
-          inactivityTimer.nudge()
-          safely(makeClient(connection))
+        domainSocket.listenConnections(acceptor):
+          val buildId = safely(System.properties.build.id[Int]()).or:
+            safely((Classpath/"build.id").read[Text].trim.as[Int]).or(0)
 
-      val buildId = safely(System.properties.build.id[Int]()).or:
-        safely((Classpath/"build.id").read[Text].trim.as[Int]).or(0)
+          buildFile.open(_.write(t"$buildId"))
+          val pidValue = Process().pid.value.show
+          pidFile.open(_.write(pidValue))
 
-      buildFile.open(_.write(t"$buildId"))
-      val pidValue = Process().pid.value.show
-      pidFile.open(_.write(pidValue))
+          task(n"pid-watcher"):
+            safely:
+              List[Path on Local](socketFile, buildFile, pidFile).watch: watcher =>
+                watcher.stream.each:
+                  case Delete(_, _) | Modify(_, _) =>
+                    Log.warn(DaemonLogEvent.Termination)
+                    termination
 
-      task(n"pid-watcher"):
-        safely:
-          List[Path on Local](socketFile, buildFile, pidFile).watch: watcher =>
-            watcher.stream.each:
-              case Delete(_, _) | Modify(_, _) =>
-                Log.warn(DaemonLogEvent.Termination)
-                termination
+                  case other =>
+                    ()
 
-              case other =>
-                ()
-
-      // The accept loop runs on its own daemon inside `listen`, so park the
-      // supervisor here to keep the daemon process alive until `termination`
-      // (an idle timeout, a watched-file change, or an explicit shutdown)
-      // calls `System.exit`.
-      Promise[Unit]().await()
+          // The accept loop runs on its own daemon inside `listenConnections`, so
+          // park the supervisor here to keep the daemon process alive until
+          // `termination` (an idle timeout, a watched-file change, or an explicit
+          // shutdown) calls `System.exit`.
+          Promise[Unit]().await()
 
     Exit.Ok
 

--- a/lib/eucalyptus/src/core/eucalyptus.Logger.scala
+++ b/lib/eucalyptus/src/core/eucalyptus.Logger.scala
@@ -107,7 +107,7 @@ object Logger:
         spool.stop()
 
 class Logger[-eventType, loggingType] private
-  ( threshold: Level, categories: Set[Log.Category], enqueue: (loggingType, Level, Long) => Unit )
+  ( threshold: Level, categories: Set[Log.Category], enqueue: (loggingType, Level, Long) -> Unit )
 extends LogSink[eventType, loggingType]:
 
   def accepts(level: Level): Boolean = level.ordinal >= threshold.ordinal

--- a/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
+++ b/lib/eucalyptus/src/syslog/eucalyptus.Syslog.scala
@@ -50,8 +50,15 @@ object Syslog:
       case ExecError(_, _, _) => ()
 
     . protect:
+        // The fresh `Job` capability is bound before `writeTo` so its evidence summons
+        // against a stable reference rather than a fresh-decorated expression.
         syslog.tag match
-          case tag: Text => mute[ExecEvent](stream.writeTo(sh"logger -t $tag".fork[Unit]()))
-          case _         => mute[ExecEvent](stream.writeTo(sh"logger".fork[Unit]()))
+          case tag: Text => mute[ExecEvent]:
+            val job = sh"logger -t $tag".fork[Unit]()
+            stream.writeTo(job)
+
+          case _ => mute[ExecEvent]:
+            val job = sh"logger".fork[Unit]()
+            stream.writeTo(job)
 
 case class Syslog(tag: Optional[Text] = Unset)

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -70,7 +70,10 @@ object Cli:
       Argument(index, text, if focus == index then position else Unset, tab, Argument.Format.Full)
 
 
-trait Cli extends Console:
+// A `Cli` is a *capability*: it carries the live stdio, signal-dispatch and completion state of
+// one command-line invocation, whose lifetime is the `process` scope that introduces it.
+// `Exclusive` because an invocation has a single owner; nothing may retain it past the exit.
+trait Cli extends Console, caps.ExclusiveCapability:
   def arguments: List[Argument]
   def environment: Environment
   def workingDirectory: WorkingDirectory

--- a/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton.Completions.scala
@@ -106,7 +106,7 @@ object Completions:
         case AlreadyInstalled(_, path) => path
 
 
-  def ensure(force: Boolean = false)(using Entrypoint, WorkingDirectory, Diagnostics)
+  def ensure(force: Boolean = false)(using Entrypoint^, WorkingDirectory, Diagnostics)
   :   List[Text] logs CliEvent =
 
     if force then safely(effectful(install(force))).let(_.paths).or(Nil)
@@ -122,7 +122,7 @@ object Completions:
       Nil
 
 
-  def install(force: Boolean = false)(using entrypoint: Entrypoint)(using erased effectful: Effectful)
+  def install(force: Boolean = false)(using entrypoint: Entrypoint^)(using erased effectful: Effectful)
     ( using WorkingDirectory, Diagnostics )
   :   Installation raises InstallError logs CliEvent =
 

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -130,7 +130,7 @@ package executives:
         environment:      Environment,
         workingDirectory: WorkingDirectory,
         stdio:            Stdio,
-        entrypoint:       Entrypoint,
+        entrypoint:       Entrypoint^,
         login:            Login )
       ( using interpreter: Interpreter )
     :   Cli =
@@ -222,7 +222,7 @@ package executives:
               Exit.Ok
 
             case t"install" =>
-              given Entrypoint = entrypoint
+              given entrypoint0: (Entrypoint^{entrypoint}) = entrypoint
               given WorkingDirectory = workingDirectory
               import errorDiagnostics.stackTracesDiagnostics
               import logging.silentLogging

--- a/lib/exoskeleton/src/core/exoskeleton.Executive.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Executive.scala
@@ -53,7 +53,10 @@ trait Executive extends Findable:
     ( using interpreter: Interpreter )
   :   Interface
 
-  def process(cli: Interface)(result: Interface ?=> Return): Exit
+  // The block sees `Cli` (not `Interface`): every entry point routes a `Cli ?=> Return` block
+  // here, and with `Cli` a capability, adapting a `Cli ?=>` context function to an
+  // abstract-`Interface ?=>` one trips capture-root unification.
+  def process(cli: Interface)(result: Cli ?=> Return): Exit
 
   // Re-run the application's pure portion in tab-completion mode with synthesized argument
   // prefixes to discover its subcommand/flag structure as a `Help` tree, rooted at `command`.

--- a/lib/exoskeleton/src/core/exoskeleton.Executive.scala
+++ b/lib/exoskeleton/src/core/exoskeleton.Executive.scala
@@ -48,7 +48,7 @@ trait Executive extends Findable:
       environment:      Environment,
       workingDirectory: WorkingDirectory,
       stdio:            Stdio,
-      entrypoint:       Entrypoint,
+      entrypoint:       Entrypoint^,
       login:            Login )
     ( using interpreter: Interpreter )
   :   Interface

--- a/lib/exoskeleton/src/core/exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton_core.scala
@@ -103,7 +103,7 @@ package executives:
         environment:      Environment,
         workingDirectory: WorkingDirectory,
         stdio:            Stdio,
-        entrypoint:       Entrypoint,
+        entrypoint:       Entrypoint^,
         login:            Login )
       ( using interpreter: Interpreter )
     :   Invocation =

--- a/lib/exoskeleton/src/core/exoskeleton_core.scala
+++ b/lib/exoskeleton/src/core/exoskeleton_core.scala
@@ -117,7 +117,7 @@ package executives:
           login )
 
 
-    def process(invocation: Invocation)(exitStatus: Interface ?=> Exit): Exit =
+    def process(invocation: Invocation)(exitStatus: Cli ?=> Exit): Exit =
       try exitStatus(using invocation)
       catch case error: Throwable => backstop.handle(error)(using invocation.stdio)
 

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -102,7 +102,10 @@ extends Rig:
     unsafely:
       val name2 = t"$name.jar"
       val jarfile = out.peer(name2)
-      val bundle = Bundler.bundle(out, jarfile, fqcn"superlunary.Executor2")
+      // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
+      // fails capture-variable unification when expanded in a capture-checked module.
+      val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch
+      val bundle = Bundler.bundle(out, jarfile, executor)
 
       val cmd = (buildId: @unchecked) match
         case id: Int => sh"java -Dbuild.id=$id -Dbuild.executable=$target -jar $jarfile '[]'"

--- a/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
@@ -163,8 +163,11 @@ object TmuxError:
 case class TmuxError(reason: TmuxError.Reason)(using Diagnostics)
 extends Error(271, reason.number)(m"can't drive tmux: $reason")
 
+// A `Tmux` is a *capability*: it identifies a live external tmux session whose lifetime is
+// the `tmux` block that creates it (killed after the block). `Exclusive` because a session
+// is driven by one test at a time.
 case class Tmux(id: Text, workingDirectory: WorkingDirectory, width: Int, height: Int, shell: Shell)
-extends Findable
+extends Findable, caps.ExclusiveCapability
 
 case class Screenshot(screen: IArray[Text], size: (Int, Int), cursor: (Ordinal, Ordinal)):
   def apply(): Text = screen.join("\n")

--- a/lib/exoskeleton/src/test/exoskeleton.CaptureTests.scala
+++ b/lib/exoskeleton/src/test/exoskeleton.CaptureTests.scala
@@ -32,102 +32,24 @@
                                                                                                   */
 package exoskeleton
 
-import ambience.*
-import anthology.*
-import anticipation.*
-import contingency.*
-import digression.*
-import distillate.*
-import eucalyptus.*
-import galilei.*
-import gossamer.*
-import guillotine.*
-import hellenism.*
-import jacinta.*
-import parasite.*
-import prepositional.*
-import rudiments.*
-import serpentine.*
-import spectacular.*
-import superlunary.*
-import symbolism.*
-import vacuous.*
+import soundness.*
 
-import filesystemOptions.deleteRecursively.disabled
-import logging.silentLogging
-import probates.cancelProbate
-import workingDirectories.javaWorkingDirectory
+import strategies.throwUnsafely
 
-import filesystemBackends.virtualMachine
+// `sandbox` lends the installed daemon to its block as a `Tool` capability, and `tmux` lends
+// the live tmux session as a `Tmux` capability; capture checking confines each to its block
+// (the process is killed, and the session ended, afterwards).
+object CaptureTests extends Suite(m"Rig confinement tests"):
+  def run(): Unit =
+    test(m"the Tool capability cannot be returned from sandbox"):
+      demilitarize:
+        def attempt(launcher: Enclave.Launcher): Enclave.Tool =
+          launcher.sandbox(summon[Enclave.Tool])
+      . map(_.message)
+    . assert(_.nonEmpty)
 
-
-object Enclave:
-  // A `Tool` is a *capability*: it references a live installed daemon process whose lifetime
-  // is the `sandbox` block that spawns it (killed, and its files deleted, after the block).
-  case class Tool(path: Path on Linux, pid: Pid) extends caps.ExclusiveCapability:
-    def command: Text = path.name
-
-    def completions(using Monitor)[result](block: => Unit): Optional[Text] =
-      val promise = Promise[Text]()
-
-      async:
-        promise.offer(safely(sh"$path '{admin}' await".exec[Text]()).or(t"failed"))
-
-      block
-      safely(promise.await())
-
-  case class Launcher(path: Path on Linux):
-    def sandbox[result](block: (tool: Tool) ?=> result)
-    :   result raises ExecError raises NumberError raises PathError =
-
-      val completionScripts = sh"$path '{admin}' install".exec[Text]()
-      val pid = Pid(sh"$path '{admin}' pid".exec[Text]().trim.as[Int])
-      val tool = Tool(path, pid)
-
-      block(using tool).also:
-        sh"$path '{admin}' kill".exec[Exit]()
-
-        completionScripts.trim.lines.map(_.as[Path on Linux]).each: item =>
-          safely(item.delete())
-
-
-case class Enclave(name: Text, buildId: Optional[Int] = Unset)(using Classloader, Environment)
-extends Rig:
-  type Result[output] = Enclave.Launcher
-  type Form = Text
-  type Target = Path on Linux
-  type Transport = Json
-
-  def stage(out: Path on Linux): Path on Linux =
-    val target = unsafely(out.peer(name))
-
-    unsafely:
-      val name2 = t"$name.jar"
-      val jarfile = out.peer(name2)
-      // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
-      // fails capture-variable unification when expanded in a capture-checked module.
-      val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch
-      val bundle = Bundler.bundle(out, jarfile, executor)
-
-      val cmd = (buildId: @unchecked) match
-        case id: Int => sh"java -Dbuild.id=$id -Dbuild.executable=$target -jar $jarfile '[]'"
-        case Unset   => sh"java -Dbuild.executable=$target -jar $jarfile '[]'"
-
-      cmd.exec[Exit]() match
-        case Exit.Ok         => target
-        case Exit.Fail(fail) => ???
-
-  protected val scalac: Scalac[3.8] = Scalac(List(scalacOptions.experimental))
-
-
-  protected def invoke[output](stage: Stage[output, Text, Path on Linux])
-  :   Enclave.Launcher =
-
-    stage.remote: input =>
-      unsafely:
-        variables(inputParameters = input):
-          sh"${stage.target}".exec[Exit]()
-
-      t"""[""]"""
-
-    Enclave.Launcher(stage.target)
+    test(m"a closure over the Tool cannot escape sandbox"):
+      demilitarize:
+        def attempt(launcher: Enclave.Launcher): () => Text =
+          launcher.sandbox(() => summon[Enclave.Tool].command)
+    . assert(_.nonEmpty)

--- a/lib/exoskeleton/src/test/exoskeleton_test.scala
+++ b/lib/exoskeleton/src/test/exoskeleton_test.scala
@@ -51,6 +51,8 @@ import filesystemBackends.virtualMachine
 
 object Tests extends Suite(m"Exoskeleton Tests"):
   def run(): Unit =
+    CaptureTests()
+
     supervise:
       val foo: Text = "hello"
       Enclave(t"abcd").dispatch:

--- a/lib/galilei/src/core/galilei.Openable.scala
+++ b/lib/galilei/src/core/galilei.Openable.scala
@@ -73,15 +73,22 @@ object Openable:
     FileOpenable[filesystem, path]
 
 
-  given eof: [file: Openable by OpenFlag] => Eof[file] is Openable:
-    type Self = Eof[file]
-    type Operand = OpenFlag
-    type Result = file.Result
+  // Named capturing evidence and an honest result: `FileOpenable` instances retain their
+  // filesystem and tactic evidence, which a pure context bound cannot accept.
+  given eof: [file]
+  =>  (openable: (file is Openable by OpenFlag)^)
+  =>  (((Eof[file] is Openable by OpenFlag) { type Result = openable.Result })
+        ^{openable, caps.any}) =
 
-    def open[result](eof: Eof[file], lambda: file.Result => result, options: List[OpenFlag])
-    :   result =
+    new Openable:
+      type Self = Eof[file]
+      type Operand = OpenFlag
+      type Result = openable.Result
 
-      file.open(eof.file, lambda, OpenFlag.Append :: options)
+      def open[result](eof: Eof[file], lambda: openable.Result => result, options: List[OpenFlag])
+      :   result =
+
+        openable.open(eof.file, lambda, OpenFlag.Append :: options)
 
 trait Openable extends Typeclass, Operable, Resultant:
   def open[result](value: Self, lambda: Result => result, options: List[Operand]): result

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -133,7 +133,7 @@ extension [plane: Filesystem](path: Path on plane)
 
   def delete()(using deleteRecursively: DeleteRecursively on plane)
     ( using backend: FilesystemBackend on plane )
-  ( using Tactic[IoError], IoEvent is Loggable )
+  ( using Tactic[IoError], (IoEvent is Loggable)^ )
   :   Path on plane =
 
     deleteRecursively.conditionally(path)(backend.delete(path))
@@ -143,7 +143,7 @@ extension [plane: Filesystem](path: Path on plane)
 
   def wipe()(using deleteRecursively: DeleteRecursively on plane)(using io: Tactic[IoError])
     ( using backend: FilesystemBackend on plane )
-    ( using IoEvent is Loggable )
+    ( using (IoEvent is Loggable)^ )
   :   Path on plane =
 
     deleteRecursively.conditionally(path)(backend.deleteIfExists(path))
@@ -159,7 +159,7 @@ extension [plane: Filesystem](path: Path on plane)
     ( using overwritePreexisting: OverwritePreexisting on plane,
             createNonexistentParents: CreateNonexistentParents on plane,
             backend:                  FilesystemBackend on plane )
-  ( using Tactic[IoError], IoEvent is Loggable )
+  ( using Tactic[IoError], (IoEvent is Loggable)^ )
   :   Path on plane =
 
     createNonexistentParents(destination):
@@ -182,7 +182,7 @@ extension [plane: Filesystem](path: Path on plane)
             dereferenceSymlinks:      DereferenceSymlinks,
             createNonexistentParents: CreateNonexistentParents on plane )
     ( using FilesystemBackend on plane )
-  ( using Tactic[IoError], IoEvent is Loggable )
+  ( using Tactic[IoError], (IoEvent is Loggable)^ )
   :   Path on plane =
 
     createNonexistentParents(destination):
@@ -213,7 +213,7 @@ extension [plane: Filesystem](path: Path on plane)
             dereferenceSymlinks:      DereferenceSymlinks,
             createNonexistentParents: CreateNonexistentParents on plane )
     ( using backend: FilesystemBackend on plane )
-  ( using Tactic[IoError], IoEvent is Loggable )
+  ( using Tactic[IoError], (IoEvent is Loggable)^ )
   :   Path on plane =
 
     createNonexistentParents(destination):
@@ -241,7 +241,7 @@ extension [plane: Filesystem](path: Path on plane)
     ( using overwritePreexisting: OverwritePreexisting on plane,
             createNonexistentParents: CreateNonexistentParents on plane,
             backend:                  FilesystemBackend on plane )
-  ( using Tactic[IoError], IoEvent is Loggable )
+  ( using Tactic[IoError], (IoEvent is Loggable)^ )
   :   Path on plane =
 
     createNonexistentParents(destination):
@@ -287,13 +287,13 @@ extension [plane: Filesystem](path: Path on plane)
     backend.hidden(path)
 
   def touch()(using backend: FilesystemBackend on plane)
-    ( using Tactic[IoError], IoEvent is Loggable )
+    ( using Tactic[IoError], (IoEvent is Loggable)^ )
   :   Unit =
     backend.touch(path)
     Log.fine(IoEvent.Touch(path.show))
 
   transparent inline def create[entry]()
-    ( using creatable: (entry is Creatable on plane)^, log: IoEvent is Loggable )
+    ( using creatable: (entry is Creatable on plane)^, log: (IoEvent is Loggable)^ )
   :   creatable.Result =
 
     Log.info(IoEvent.Create(path.show))

--- a/lib/gastronomy/src/core/gastronomy.Digestible.scala
+++ b/lib/gastronomy/src/core/gastronomy.Digestible.scala
@@ -55,57 +55,64 @@ object Digestible extends Derivable[Digestible]:
 
 
   // The collection instances retain their by-name element digesters, which share each
-  // instance's given-resolution lifetime; laundered pure per the codec-thunk seal pattern
-  // (see rep/DECISIONS.md) — the product derivation summons them against pure expected
-  // types, and under 3.9.0 the by-name capture is tracked in the SAM closure.
+  // instance's given-resolution lifetime. As in `Inspectable`, the by-name is bound as a
+  // *pure thunk* before the SAM body — the narrowest form of the codec-thunk seal (see
+  // rep/DECISIONS.md): a by-name parameter is unnameable in a capture set, but the thunk
+  // yields a compiler-verified-pure instance (`Digestible` is a `Typeclass.Pure`), so only
+  // the thunk is asserted and the SAM instance itself is checked pure. The thunk keeps
+  // resolution lazy, which recursive derivations depend on.
   given optional: [value] => (digestible: => value is Digestible)
   =>  util.NotGiven[Unset.type <:< value]
   =>  Optional[value] is Digestible =
 
-    caps.unsafe.unsafeAssumePure:
-      (acc, value) => value.let(digestible.digest(acc, _))
+    val dig: () -> (value is Digestible) = caps.unsafe.unsafeAssumePure(() => digestible)
+    (acc, value) => value.let(dig().digest(acc, _))
 
 
   given list: [list <: List, value] => (digestible: => value is Digestible)
   =>  list[value] is Digestible =
 
-    caps.unsafe.unsafeAssumePure:
-      (digestion, list) => list.each(digestible.digest(digestion, _))
+    val dig: () -> (value is Digestible) = caps.unsafe.unsafeAssumePure(() => digestible)
+    (digestion, list) => list.each(dig().digest(digestion, _))
 
 
   given set: [set <: Set, value] => (digestible: => value is Digestible)
   =>  set[value] is Digestible =
 
-    caps.unsafe.unsafeAssumePure:
-      (digestion, set) => set.each(digestible.digest(digestion, _))
+    val dig: () -> (value is Digestible) = caps.unsafe.unsafeAssumePure(() => digestible)
+    (digestion, set) => set.each(dig().digest(digestion, _))
 
 
   given series: [series <: Series, value] => (digestible: => value is Digestible)
   =>  series[value] is Digestible =
 
-    caps.unsafe.unsafeAssumePure:
-      (digestion, series) => series.each(digestible.digest(digestion, _))
+    val dig: () -> (value is Digestible) = caps.unsafe.unsafeAssumePure(() => digestible)
+    (digestion, series) => series.each(dig().digest(digestion, _))
 
 
   given iarray: [value] => (digestible: => value is Digestible) => IArray[value] is Digestible =
-    caps.unsafe.unsafeAssumePure:
-      (digestion, iarray) => iarray.each(digestible.digest(digestion, _))
+    val dig: () -> (value is Digestible) = caps.unsafe.unsafeAssumePure(() => digestible)
+    (digestion, iarray) => iarray.each(dig().digest(digestion, _))
 
 
   given map: [key, value] => (keyDigestible: => key is Digestible)
   =>  ( valueDigestible: => value is Digestible )
   =>  Map[key, value] is Digestible =
 
-    caps.unsafe.unsafeAssumePure:
-      (digestion, map) =>
-        map.each: (key, value) =>
-          keyDigestible.digest(digestion, key)
-          valueDigestible.digest(digestion, value)
+    val digKey: () -> (key is Digestible) = caps.unsafe.unsafeAssumePure(() => keyDigestible)
+
+    val digValue: () -> (value is Digestible) =
+      caps.unsafe.unsafeAssumePure(() => valueDigestible)
+
+    (digestion, map) =>
+      map.each: (key, value) =>
+        digKey().digest(digestion, key)
+        digValue().digest(digestion, value)
 
 
   given stream: [value] => (digestible: => value is Digestible) => LazyList[value] is Digestible =
-    caps.unsafe.unsafeAssumePure:
-      (digestion, iterable) => iterable.each(digestible.digest(digestion, _))
+    val dig: () -> (value is Digestible) = caps.unsafe.unsafeAssumePure(() => digestible)
+    (digestion, iterable) => iterable.each(dig().digest(digestion, _))
 
   given int: Int is Digestible = (digestion, value) =>
     digestion.append((24 to 0 by -8).map(value >> _).map(_.toByte).toArray.immutable(using Unsafe))

--- a/lib/gossamer/src/core/gossamer.Cuttable.scala
+++ b/lib/gossamer/src/core/gossamer.Cuttable.scala
@@ -108,5 +108,5 @@ object Cuttable:
       cuttable.cut(text, delimiter.toString.tt, limit)
 
 
-trait Cuttable extends Typeclass, Operable:
+trait Cuttable extends Typeclass.Pure, Operable:
   def cut(value: Self, delimiter: Operand, limit: Int): List[Self]

--- a/lib/gossamer/src/core/gossamer.Joinable.scala
+++ b/lib/gossamer/src/core/gossamer.Joinable.scala
@@ -47,5 +47,5 @@ object Joinable:
 
   given message: Message is Joinable = _.fuse(m"")(state+next)
 
-trait Joinable extends Typeclass, Operable:
+trait Joinable extends Typeclass.Pure, Operable:
   def join(elements: Iterable[Self]): Self

--- a/lib/guillotine/src/core/guillotine.Computable.scala
+++ b/lib/guillotine/src/core/guillotine.Computable.scala
@@ -73,7 +73,7 @@ object Computable:
 
 
 trait Computable extends Typeclass:
-  def compute(process: Subprocess): Self
+  def compute(process: Subprocess^): Self
 
   def map[self2](lambda: Self => self2): (self2 is Computable)^{this, lambda} =
     process => lambda(compute(process))

--- a/lib/guillotine/src/core/guillotine.Executable.scala
+++ b/lib/guillotine/src/core/guillotine.Executable.scala
@@ -49,8 +49,12 @@ import spectacular.*
 sealed trait Executable:
   type Exec <: Label
 
+  // Explicit `using` evidence instead of `raises`/`logs` sugar, and a fresh (`^`) result:
+  // the freshly-minted `Job` capability cannot cross the nested context-function results the
+  // sugar desugars to (the stacked-raises convention; see rep/DECISIONS.md).
   def fork[result]()(using working: WorkingDirectory)
-  :   Job[Exec, result] raises ExecError logs ExecEvent
+    ( using Tactic[ExecError], (ExecEvent is Loggable)^ )
+  :   Job[Exec, result]^
 
 
   def exec[result]()(using computable: (result is Computable)^, working: WorkingDirectory)
@@ -103,15 +107,21 @@ object Command:
 
 case class Command(arguments: Text*) extends Executable:
   def fork[result]()(using working: WorkingDirectory)
-  :   Job[Exec, result] raises ExecError logs ExecEvent =
+    ( using Tactic[ExecError], (ExecEvent is Loggable)^ )
+  :   Job[Exec, result]^ =
 
     val processBuilder = ProcessBuilder(arguments.ss*)
     processBuilder.directory(ji.File(working.directory().s))
 
     Log.info(ExecEvent.ProcessStart(this))
 
-    try new Job(processBuilder.start().nn)
-    catch case errror: ji.IOException => abort(ExecError(this, LazyList(), LazyList()))
+    // The JDK process starts inside the `try`; the `Job` capability is minted outside it
+    // (a fresh result may not be created within a `try` expression).
+    val process =
+      try processBuilder.start().nn
+      catch case errror: ji.IOException => abort(ExecError(this, LazyList(), LazyList()))
+
+    new Job(process)
 
 
   def escape: Text = arguments.map { argument => t"'${argument.sub(t"'", t"\'")}'" }.join(t" ")
@@ -126,7 +136,8 @@ object Pipeline:
 
 case class Pipeline(commands: Command*) extends Executable:
   def fork[result]()(using working: WorkingDirectory)
-  :   Job[Exec, result] raises ExecError logs ExecEvent =
+    ( using Tactic[ExecError], (ExecEvent is Loggable)^ )
+  :   Job[Exec, result]^ =
 
     val processBuilders = commands.map: command =>
       val processBuilder = ProcessBuilder(command.arguments.ss*)

--- a/lib/guillotine/src/core/guillotine.Job.scala
+++ b/lib/guillotine/src/core/guillotine.Job.scala
@@ -49,21 +49,27 @@ import turbulence.*
 import vacuous.*
 
 object Job:
-  given writable: [chunk, command <: Label, result]
+  // Polymorphic over the capability instance (`job <: Job[…]^`, the galilei `Handle` recipe):
+  // a bare `Job[command, result]` Self cannot match a tracked `Job` value.
+  given writable: [chunk, command <: Label, result, job <: Job[command, result]^]
   =>  (writable0: (ProcessInput is Writable by chunk)^)
-  =>  ((Job[command, result] is Writable by chunk)^{writable0}) =
+  =>  ((job is Writable by chunk)^{writable0}) =
 
     (process, stream) => process.stdin(stream)
 
 
-  given writableText: [command <: Label, result] => (streamCut: Emit[StreamError])
-  =>  ((Job[command, result] is Writable by Text)^{streamCut}) =
+  given writableText: [command <: Label, result, job <: Job[command, result]^]
+  =>  (streamCut: Emit[StreamError])
+  =>  ((job is Writable by Text)^{streamCut}) =
 
     (process, stream) => process.stdin(stream.map(_.sysData))
 
 
+// A `Job` is a *capability*: it is the live handle to a running subprocess (its streams and
+// its lifecycle), tracked fresh from `fork()`. `Exclusive` because a subprocess's stdio has
+// a single owner.
 class Job[+exec <: Label, result] private[guillotine] (process: java.lang.Process)
-extends Subprocess, ProcessRef:
+extends Subprocess, ProcessRef, caps.ExclusiveCapability:
   def pid: Pid = Pid(process.pid)
   def alive: Boolean = process.isAlive
   def attend(): Unit = process.waitFor()
@@ -113,7 +119,7 @@ extends Subprocess, ProcessRef:
     Log.warn(ExecEvent.KillProcess(pid))
     process.destroyForcibly()
 
-  def process(using Tactic[PidError]^) = Process(pid)
+  def process(using Tactic[PidError]^): Process^ = Process(pid)
 
   def startTime[instant: Instantiable across Instants from Long]: Optional[instant] =
     try

--- a/lib/guillotine/src/core/guillotine.Process.scala
+++ b/lib/guillotine/src/core/guillotine.Process.scala
@@ -46,11 +46,26 @@ object Process:
     val handle = ProcessHandle.of(pid.value).nn
     if handle.isPresent then new Process(handle.get.nn) else abort(PidError(pid))
 
-  def all: List[Process] = allHandles.map(new Process(_))
-  def roots: List[Process] = allHandles.filter(!_.parent.nn.isPresent).map(new Process(_))
+  // While-loops rather than `map`: a fresh capability may not be minted inside a lambda
+  // whose result type another scope owns (the Spring rule); built in the method body, the
+  // handles box into the (capture-boxed) list element type.
+  private def processes(handles: List[ProcessHandle]): List[Process] =
+    val builder = List.newBuilder[Process]
+    var remaining = handles
+
+    while !remaining.isEmpty do
+      builder += new Process(remaining.head)
+      remaining = remaining.tail
+
+    builder.result()
+
+  def all: List[Process] = processes(allHandles)
+  def roots: List[Process] = processes(allHandles.filter(!_.parent.nn.isPresent))
   def apply(): Process = new Process(ProcessHandle.current.nn)
 
-class Process private (java: ProcessHandle) extends ProcessRef:
+// A `Process` is a *capability*, like `Job`: a live handle to a running operating-system
+// process.
+class Process private (java: ProcessHandle) extends ProcessRef, caps.ExclusiveCapability:
   def pid: Pid = Pid(java.pid)
   def kill(): Unit logs ExecEvent = java.destroy()
   def abort(): Unit logs ExecEvent = java.destroyForcibly()
@@ -62,7 +77,7 @@ class Process private (java: ProcessHandle) extends ProcessRef:
     if parent.isPresent then new Process(parent.get.nn) else Unset
 
   def children: List[Process] =
-    java.children.nn.iterator.nn.asScala.map(new Process(_)).to(List)
+    Process.processes(java.children.nn.iterator.nn.asScala.to(List))
 
   def startTime[instantiable: Instantiable across Instants from Long]: Optional[instantiable] =
     val instant = java.info.nn.startInstant.nn

--- a/lib/guillotine/src/test/guillotine_test.scala
+++ b/lib/guillotine/src/test/guillotine_test.scala
@@ -425,11 +425,17 @@ object Tests extends Suite(m"Guillotine tests"):
       . assert(_ == Process().pid)
 
       test(m"Process(invalid pid) raises PidError"):
-        capture[PidError](Process(Pid(Long.MaxValue)))
+        // `.pid` rather than the `Process` itself: the fresh capability may not leak into
+        // `capture`'s result.
+        capture[PidError](Process(Pid(Long.MaxValue)).pid)
       . assert(_.pid == Pid(Long.MaxValue))
 
       test(m"current process has a parent"):
-        Process().parent.let(_.pid).or(Pid(0L))
+        // A direct match rather than `let`/`or`: the `Optionality` evidence cannot span the
+        // capability-typed element.
+        Process().parent match
+          case parent: Process => parent.pid
+          case _               => Pid(0L)
       . assert(_ != Pid(0L))
 
     suite(m"Job-as-Process"):

--- a/lib/hypotenuse/src/core/hypotenuse.Commensurable.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Commensurable.scala
@@ -91,7 +91,7 @@ object Commensurable:
       else inline if strict then n < 0 else n <= 0
 
 
-trait Commensurable extends Typeclass, Contrastive:
+trait Commensurable extends Typeclass.Pure, Contrastive:
   inline def compare
     ( inline left:        Self,
       inline right:       Contrast,

--- a/lib/hypotenuse/src/core/hypotenuse.Orderable.scala
+++ b/lib/hypotenuse/src/core/hypotenuse.Orderable.scala
@@ -39,7 +39,7 @@ trait Orderable extends Commensurable:
 
   type Contrast = Self
 
-  def contramap[self](lambda: self => Self): (self is Orderable)^{this, lambda} = new Orderable:
+  def contramap[self](lambda: self -> Self): self is Orderable = new Orderable:
     type Self = self
 
 

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -246,7 +246,7 @@ trait Json2 extends Json3:
 
   object DecodableDerivation extends Derivable[Json.Decodable]:
     inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Json.Decodable =
+    :   (derivation is Json.Decodable)^ =
 
       // The object `Morphology` is built from the *field decoders'* own shapes, so it
       // describes exactly what this decoder reads (a `… in Text`-branch field
@@ -258,23 +258,20 @@ trait Json2 extends Json3:
       // The capabilities are summoned at the derivation site and supplied explicitly to
       // `decodeObject`, rather than re-summoned inside the decoder body via nested `provide`s
       // (under capture checking those minted distinct root capabilities that failed to unify
-      // with `build`'s per-field lambda). The decode SAM therefore closes over the
-      // resolution-scoped tactic, which shares the instance's given-resolution lifetime, so
-      // the instance is laundered pure per the codec-thunk seal pattern (see the primitive
-      // codecs in `object Json` and rep/DECISIONS.md).
-      caps.unsafe.unsafeAssumePure:
-        Json.Decodable({
-          val fields: List[(Text, Morphology)] =
-            contexts[derivation](): [field] => context => (label, context.shape())
-            . to(List)
+      // with `build`'s per-field lambda). The decode SAM closes over the resolution-scoped
+      // tactic, which the fresh (`^`) result honestly admits — no seal.
+      Json.Decodable({
+        val fields: List[(Text, Morphology)] =
+          contexts[derivation](): [field] => context => (label, context.shape())
+          . to(List)
 
-          Morphology.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
-        }):
-          json =>
-            decodeObject[derivation](json)
-              ( using infer[ProductReflection[derivation]],
-                      infer[Foci[Json.Focus]],
-                      infer[Tactic[JsonError]] )
+        Morphology.Obj(fields, fields.collect { case (label, shape) if !shape.optional => label })
+      }):
+        json =>
+          decodeObject[derivation](json)
+            ( using infer[ProductReflection[derivation]],
+                    infer[Foci[Json.Focus]],
+                    infer[Tactic[JsonError]] )
 
     private inline def decodeObject[derivation <: Product]
       ( json: Json )
@@ -358,40 +355,39 @@ trait Json2 extends Json3:
 
   object ParsableDerivation extends Derivable[Json.Field]:
     inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Json.Field =
+    :   (derivation is Json.Field)^ =
 
       // Like `DecodableDerivation.conjunction`: the capabilities are summoned
-      // at the derivation site and the instance is sealed per the codec-thunk
-      // pattern. A single `contexts` traversal collects, per field, its wire
-      // key (`@name`-aware), its parser (via the `Field` fallback chain) and
-      // its declared default; `Json.Parsable.product` owns the parse loop, so
-      // no per-field lambda ever closes over the reader.
-      caps.unsafe.unsafeAssumePure:
-        val reflection = infer[ProductReflection[derivation]]
+      // at the derivation site, and the fresh (`^`) result honestly admits the
+      // instance's capture of them — no seal. A single `contexts` traversal
+      // collects, per field, its wire key (`@name`-aware), its parser (via the
+      // `Field` fallback chain) and its declared default; `Json.Parsable.product`
+      // owns the parse loop, so no per-field lambda ever closes over the reader.
+      val reflection = infer[ProductReflection[derivation]]
 
-        Json.Parsable.product[derivation](
-          { () =>
-            val renames: Map[Text, Text] = relabelling[derivation, Json]
+      Json.Parsable.product[derivation](
+        { () =>
+          val renames: Map[Text, Text] = relabelling[derivation, Json]
 
-            contexts[derivation]():
-              [field] => context =>
-                ( renames.at(label).or(label).s,
-                  context: Json.Parsing,
-                  default[Optional[field]]: Any )
-          },
-          values => Json.Parsable.assemble(reflection, values))
-          ( using infer[Foci[Json.Focus]], infer[Tactic[JsonError]] )
+          contexts[derivation]():
+            [field] => context =>
+              ( renames.at(label).or(label).s,
+                context: Json.Parsing,
+                default[Optional[field]]: Any )
+        },
+        values => Json.Parsable.assemble(reflection, values))
+        ( using infer[Foci[Json.Focus]], infer[Tactic[JsonError]] )
 
-    inline def disjunction[derivation: SumReflection]: derivation is Json.Field =
+    inline def disjunction[derivation: SumReflection]: (derivation is Json.Field)^ =
       // Dispatch strategy by wire shape: a wrapper's tag is its first token,
       // so it streams with no lookahead at all; an envelope and an internal
       // field locate the tag with a bounded scan-ahead (`discriminant`
       // skips values without materializing them, then rewinds), after which
       // the chosen variant parses directly from the tokens. Any custom
       // `Discriminable` falls back to materializing one value's AST and
-      // dispatching through the decoder. Sealed per the codec-thunk
-      // pattern: each instance captures resolution-scoped tactics.
-      caps.unsafe.unsafeAssumePure:
+      // dispatching through the decoder. The fresh (`^`) result honestly
+      // admits each instance's capture of its resolution-scoped tactics.
+      locally:
         // Wire tag → variant label, a per-derivation constant: built once
         // here rather than on every `parse` call, whose profile it dominated
         // (map building plus generic-equality lookups, per occurrence).

--- a/lib/jacinta/src/schema/jacinta_schema.scala
+++ b/lib/jacinta/src/schema/jacinta_schema.scala
@@ -54,7 +54,7 @@ package jsonPointerRegistries:
   // capability — a given constructed from capabilities produces a capability (Jon,
   // 2026-07-06; see rep/DECISIONS.md).
   given fetchingRegistry: (online: Online, loggable: HttpEvent is Loggable, client: HttpClient)
-  =>  (JsonPointer.Registry^{client}) =
+  =>  (JsonPointer.Registry^{online, client}) =
     new JsonPointer.Registry:
       protected def lookup(url: HttpUrl): Optional[Json] =
         recover:

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -411,25 +411,25 @@ object Protobuf extends Protobuf2:
 
   object DecodableDerivation extends Derivable[Decodable in Protobuf]:
     inline def conjunction[derivation <: Product: ProductReflection]
-    :   derivation is Decodable in Protobuf =
+    :   (derivation is Decodable in Protobuf)^ =
 
       val numbers = fieldNumbers[derivation]
 
       // The decode lambda closes over the resolution-scoped `Tactic` that `provide` summons
-      // at the derivation site, sharing the instance's given-resolution lifetime; laundered
-      // pure per the codec-thunk seal pattern (see rep/DECISIONS.md).
-      caps.unsafe.unsafeAssumePure: protobuf =>
+      // at the derivation site, sharing the instance's given-resolution lifetime; the fresh
+      // (`^`) trait result honestly admits the capture — no seal.
+      { protobuf =>
         provide[Tactic[ProtobufError]]:
           val map = ProtobufParser(protobuf.payload).fields()
 
           build[derivation]:
             [field0] => context =>
               map.at(numbers(label)).lay(default.or(context.decoded(Protobuf.Absent))): values =>
-                context.decoded(Protobuf.Repeated(values))
+                context.decoded(Protobuf.Repeated(values)) }
 
-    inline def disjunction[derivation: SumReflection]: derivation is Decodable in Protobuf =
-      // Laundered pure as for `conjunction` above.
-      caps.unsafe.unsafeAssumePure: protobuf =>
+    inline def disjunction[derivation: SumReflection]: (derivation is Decodable in Protobuf)^ =
+      // A fresh (`^`) result honestly admitting the capture, as for `conjunction` above.
+      { protobuf =>
         provide[Tactic[ProtobufError]]:
           provide[Tactic[VariantError]]:
             val map = ProtobufParser(protobuf.payload).fields()
@@ -441,7 +441,7 @@ object Protobuf extends Protobuf2:
 
             delegate(labels(index)):
               [variant <: derivation] => context =>
-                context.decoded(Protobuf.Repeated(map(index + 1)))
+                context.decoded(Protobuf.Repeated(map(index + 1))) }
 
     inline def fieldNumbers[derivation <: Product: ProductReflection]: Map[Text, Int] =
       val annotated: Map[Text, Set[field]] = infer[derivation is Annotated by field] match

--- a/lib/monotonous/src/core/monotonous.Deserializable.scala
+++ b/lib/monotonous/src/core/monotonous.Deserializable.scala
@@ -85,7 +85,10 @@ object Deserializable:
   given quaternary: Alphabet[Quaternary] => Deserializable in Quaternary = base(2)
   given binary: Alphabet[Binary] => Deserializable in Binary = base(1)
 
-trait Deserializable extends Findable:
+// `caps.Pure` directly (not `Typeclass.Pure`) because `Deserializable` has no `Self`: it is
+// selected by its `Form` member alone. Error handling is per-call (`raises`/`Tactic` method
+// parameters), so instances themselves capture nothing.
+trait Deserializable extends Findable, caps.Pure:
   type Form <: Serialization
 
   protected val atomicity: Int = 1

--- a/lib/monotonous/src/core/monotonous.Serializable.scala
+++ b/lib/monotonous/src/core/monotonous.Serializable.scala
@@ -252,7 +252,10 @@ object Serializable:
   given base32: Alphabet[Base32] => Serializable in Base32 = base(5)
   given base64: Alphabet[Base64] => Serializable in Base64 = base(6)
 
-trait Serializable extends Findable:
+// `caps.Pure` directly (not `Typeclass.Pure`) because `Serializable` has no `Self`: it is
+// selected by its `Form` member alone. Instances hold only immutable tables derived from a
+// pure `Alphabet`, so purity is compiler-verified.
+trait Serializable extends Findable, caps.Pure:
   type Form <: Serialization
 
   def encode(bytes: Data): Text

--- a/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
+++ b/lib/orthodoxy/src/core/orthodoxy.Issuer.scala
@@ -69,7 +69,7 @@ class Issuer
     secret:   Optional[Text] = Unset ):
   private val OAuthPath: Path on Www = redirect.path
 
-  def oauth(using Http.Request, Online, HttpEvent is Loggable)
+  def oauth(using Http.Request, Online, (HttpEvent is Loggable)^)
     ( lambda: (Issuer.Context of this.type) ?=> Http.Response )
     ( using store: OAuth, session: Session )
   :   Http.Response raises OAuthError =

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -207,13 +207,13 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
 
 
   def map[result2](lambda: Result => result2)(using Monitor^, Probate^)
-  :   Task[result2] emits AsyncError =
+  :   (Task[result2] emits AsyncError)^ =
 
     async(lambda(join()))
 
 
   def bind[result2](lambda: Result => Task[result2])(using Monitor^, Probate^)
-  :   Task[result2] emits AsyncError =
+  :   (Task[result2] emits AsyncError)^ =
 
     async(lambda(join()).join())
 

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -47,18 +47,16 @@ import vacuous.*
 object Task:
   def apply[result, error <: Hazard](evaluate: Worker => result, name: Optional[Name[Async]])
     ( using monitor: Monitor^, codepoint: Codepoint, probate: Probate^ )
-  :   Task[result] { type Error = error } =
+  :   (Task[result] { type Error = error })^ =
 
-    // The body closure may capture stack-scoped capabilities (an error tactic, a `boundary.Label`);
-    // that capture is checked at the `async`/`task` entry point and laundered to pure here. A `Task`
-    // is itself a `Worker` (a capability), but task handles are freely shared and collected (e.g.
-    // `Seq[Task].sequence`), which a tracked `Task^` could not be — so the handle is laundered to a
-    // pure `Task` too. The worker remains a supervised child of `monitor`; only the *handle*'s static
-    // capture is dropped (the effect capabilities `Tactic`/`Emit` it may use are still tracked).
-    val evaluate0: Worker -> result = caps.unsafe.unsafeAssumePure(evaluate)
+    // The handle is a fresh (`^`) capability — a `Task` IS a `Worker` — so both the handle
+    // and its body closure are honestly tracked (D6 ruling, 2026-07-16). Composition over
+    // collections of tasks goes through the sealed pure façade (`Task.monad` and the
+    // `sequence` extensions below).
+    val evaluate0: Worker => result = evaluate
     inline def name0: Optional[Name[Async]] = name
 
-    caps.unsafe.unsafeAssumePure:
+    locally:
       new Worker(codepoint, monitor, probate) with Task[result]:
         type Result = result
         type Error = error
@@ -74,10 +72,12 @@ object Task:
           deliver[error, duration](duration)
 
 
-  // `mercator.Monad[Task]` abstracts over `Task` as a *pure* type constructor, but a `Task` is a
-  // capability (a `Worker`), so the scope-capturing handles produced by `async`/`bind`/`map` are
-  // boxed to the pure `Task` the `Monad` interface demands. The capture is recoverable bookkeeping
-  // here — the tasks are bound and awaited within the same `Monitor` scope this given requires.
+  // THE PURE FAÇADE (D6 ruling, option c): `mercator.Monad[Task]` abstracts over `Task` as a
+  // *pure* type constructor, but a `Task` handle is an honest capability (a `Worker`), so the
+  // fresh handles produced by `async`/`bind`/`map` are sealed to the pure `Task` the `Monad`
+  // interface demands — once, here, at the composition boundary. The capture is recoverable
+  // bookkeeping: the tasks are bound and awaited within the same `Monitor` scope this given
+  // requires.
   given monad: (Monitor^, Probate^) => Monad[Task] = caps.unsafe.unsafeAssumePure:
     new Monad[Task]:
       def bind[value, value2](value: Task[value])(lambda: value => Task[value2]): Task[value2] =
@@ -89,8 +89,9 @@ object Task:
         caps.unsafe.unsafeAssumePure(value.map(lambda))
 
   extension [result](tasks: Seq[Task[result]])
+    // Part of the pure façade (see `monad` above): the fresh handle is sealed once here.
     def sequence(using Monitor^, Probate^): Task[Seq[result]] emits AsyncError =
-      async(tasks.map(_.join()))
+      caps.unsafe.unsafeAssumePure(async(tasks.map(_.join())))
 
   extension [result](tasks: Iterable[Task[result]])
     def race()(using Monitor^, Probate^): result raises AsyncError =
@@ -125,7 +126,7 @@ trait Task[+result]:
   :   result raises AsyncError
 
   def bind[result2](lambda: result => Task[result2])(using Monitor^, Probate^)
-  :   Task[result2] emits AsyncError
+  :   (Task[result2] emits AsyncError)^
 
   def map[result2](lambda: result => result2)(using Monitor^, Probate^)
-  :   Task[result2] emits AsyncError
+  :   (Task[result2] emits AsyncError)^

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -127,7 +127,7 @@ infix type emits[left, error <: Hazard] = left match
 def async[result, error <: Hazard](using Codepoint)
   ( evaluate: (Worker, Tactic[error]) ?=> result )
   ( using monitor: Monitor^, probate: Probate^ )
-:   Task[result] emits (error | AsyncError) =
+:   (Task[result] emits (error | AsyncError))^ =
 
   val tactic = AsyncTactic[error]()
   Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = Unset)
@@ -136,7 +136,7 @@ def async[result, error <: Hazard](using Codepoint)
 def task[result, error <: Hazard](using Codepoint)(name: Name[Async])
   ( evaluate: (Worker, Tactic[error]) ?=> result )
   ( using monitor: Monitor^, probate: Probate^ )
-:   Task[result] emits (error | AsyncError) =
+:   (Task[result] emits (error | AsyncError))^ =
 
   val tactic = AsyncTactic[error]()
   Task[result, error | AsyncError](worker => evaluate(using worker, tactic), name = name)

--- a/lib/perihelion/src/core/perihelion_core.scala
+++ b/lib/perihelion/src/core/perihelion_core.scala
@@ -192,7 +192,7 @@ given wsClient: ( online:            Online,
                   httpResponseError: Tactic[HttpResponseError],
                   portError:         Tactic[PortError] )
 =>  (((WsUrl is Duplexable) { type Output = Data; type Connection = WsConnection })
-      ^{monitor, websocketError, httpResponseError, portError}) =
+      ^{online, monitor, websocketError, httpResponseError, portError}) =
   // The client retains its `Monitor` (the frame pump daemon) and tactics, so the instance
   // is a capability — a given constructed from capabilities produces a capability (see
   // rep/DECISIONS.md).

--- a/lib/polaris/src/core/polaris.Buffer.scala
+++ b/lib/polaris/src/core/polaris.Buffer.scala
@@ -35,7 +35,11 @@ package polaris
 import anticipation.*
 import beneficence.*
 
-class Buffer(private[polaris] val bytes: Data, initialPosition: Int = 0) extends Findable:
+// A `Buffer` is a *capability*: it carries a mutable read position, so unpacking is an effect
+// and the buffer's lifetime is the `buffer { ... }` block that introduces it. `Exclusive`
+// because two readers sharing a position would corrupt each other's decoding.
+class Buffer(private[polaris] val bytes: Data, initialPosition: Int = 0)
+extends Findable, caps.ExclusiveCapability:
   private[polaris] var position: Int = initialPosition
 
   def offset: Int = position

--- a/lib/polaris/src/core/polaris.Unpackable.scala
+++ b/lib/polaris/src/core/polaris.Unpackable.scala
@@ -40,13 +40,21 @@ object Unpackable:
   given iarray: [pack: Debufferable] => ClassTag[pack] => IArray[pack] is Unpackable:
     type Wrap[Type] = Int -> Type
 
-    def unpack(buffer: Buffer): Int -> IArray[pack] = count =>
-      val array = new Array[pack](count)
+    // The continuation records the (pure) backing data and start offset, and mints its own
+    // buffer per invocation, so it does not capture the caller's `Buffer` capability: the
+    // arrow stays pure, and the caller's read position is unaffected by a later invocation.
+    def unpack(buffer: Buffer): Int -> IArray[pack] =
+      val bytes = buffer.bytes
+      val start = buffer.offset
 
-      array.indices.each: index =>
-        array(index) = pack.debuffer(buffer)
+      count =>
+        val local = Buffer(bytes, start)
+        val array = new Array[pack](count)
 
-      array.immutable(using Unsafe)
+        array.indices.each: index =>
+          array(index) = pack.debuffer(local)
+
+        array.immutable(using Unsafe)
 
   given debufferable: [pack: Debufferable] => pack is Unpackable:
     type Wrap[Type] = Type

--- a/lib/profanity/src/core/profanity.Interaction.scala
+++ b/lib/profanity/src/core/profanity.Interaction.scala
@@ -45,7 +45,10 @@ object Interaction:
   // relative motion at the prompt (a standalone `InlineCanvas`) or absolute
   // placement within a panel (an `Extent`). The surface is summoned from scope,
   // so a panel's `Extent` is used automatically when a widget runs inside one.
-  given selectMenu: [item: Showable] => (surface: Canvas) => Interaction[item, SelectMenu[item]]:
+  // `new`-instance form (not a colon-body given): the synthesized given class does not admit
+  // the `^{surface}` result annotation the capturing surface requires.
+  given selectMenu: [item: Showable] => (surface: Canvas^)
+  =>  (Interaction[item, SelectMenu[item]]^{surface}) = new Interaction[item, SelectMenu[item]]:
     override def before(): Unit = surface.cursor(false)
 
     override def after(): Unit =
@@ -70,7 +73,8 @@ object Interaction:
 
     def result(state: SelectMenu[item]): item = state.current
 
-  given lineEditor: (surface: Canvas) => Interaction[Text, LineEditor]:
+  given lineEditor: (surface: Canvas^)
+  =>  (Interaction[Text, LineEditor]^{surface}) = new Interaction[Text, LineEditor]:
     // The last row the editor's content reached, so `after` can drop the cursor
     // onto a fresh line below it.
     private var endRow: Int = 0

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -163,12 +163,20 @@ object Keyboard:
                   case 'u' #:: tail =>
                     Keyboard.csiu(sequence.to(List)) #:: process(tail)
 
-                  case 'R' #:: tail => sequence.map(_.show).join.cut(';').to(List) match
-                    case List(As[Int](rows), As[Int](cols)) =>
-                      TerminalInfo.WindowSize(rows, cols) #:: process(tail)
+                  case 'R' #:: tail =>
+                    // Explicit decoding rather than the `As[Int]` extractor: in a nested
+                    // pattern the extractor's evidence is summoned against a skolem-typed
+                    // scrutinee, which fails to unify under capture checking.
+                    val fields: List[Text] = sequence.map(_.show).join.cut(';').to(List)
 
-                    case _ =>
-                      process(tail)
+                    val size: Optional[TerminalInfo.WindowSize] = fields match
+                      case List(rows, cols) =>
+                        safely(TerminalInfo.WindowSize(rows.as[Int], cols.as[Int]))
+
+                      case _ =>
+                        Unset
+
+                    size.lay(process(tail))(_ #:: process(tail))
 
                   case 'O' #:: tail =>
                     TerminalInfo.LoseFocus #:: process(tail)

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -48,34 +48,72 @@ object Terminal:
   // (in `terminalFeatures`) and by the `Winch` (resize) signal handler below.
   def reportSize: Text = t"\e7\e[4095C\e[4095B\e[6n\e8"
 
+  // In the companion (not the class) so the pure pump-daemon body can call it without
+  // charging `Terminal.this`.
+  private[profanity] def dark(red: Int, green: Int, blue: Int): Boolean =
+    (0.299*red + 0.587*green + 0.114*blue) < 32768
+
+  // The terminal's mutable size/brightness state, in a plain (untracked) holder rather than
+  // fields of `Terminal` itself: the termcap's live `width`, and the pump daemon's updates,
+  // then close over this holder instead of `Terminal.this` — which matters because the
+  // daemon body must be a pure context function and `Termcap`/`Stdio` values must stay pure.
+  private[profanity] class Metrics:
+    var mode: Optional[Brightness] = Unset
+    var rows: Optional[Int] = Unset
+    var columns: Optional[Int] = Unset
+
+// A `Terminal` is a *capability*: it holds the live raw-mode tty session — the `Monitor` and
+// `Probate` of its input-pump daemon, the event spool, and mutable size/brightness state —
+// whose lifetime is the `interactive` block that introduces it (raw mode and stdin are torn
+// down in its `finally`). `Exclusive` because a tty session has a single owner; nothing may
+// retain it past the teardown.
 case class Terminal()
   ( using console: Console, monitor: Monitor, probate: Probate, environment: Environment )
-extends Interactivity[TerminalEvent]:
+extends Interactivity[TerminalEvent], caps.ExclusiveCapability:
 
   export console.stdio.{in, out, err}
 
-  val keyboard: Keyboard.Standard = Keyboard.Standard()
+  // The keyboard's escape-disambiguation timeout runs `async`, so the value retains the
+  // monitor; the field type declares the capture. (`Probate` is a plain trait, so it is not
+  // nameable in a capture set.)
+  val keyboard: Keyboard.Standard^{monitor} = Keyboard.Standard()
 
-  var mode: Optional[Brightness] = safely:
+  private val metrics: Terminal.Metrics = Terminal.Metrics()
+
+  metrics.mode = safely:
     def hex(text: Text): Int = Integer.parseInt(text.s, 16)
 
     Environment.terminalBg.cut(t"/").to(List) match
       case red :: green :: blue :: Nil =>
-        if dark(hex(red), hex(green), hex(blue)) then Brightness.Dark else Brightness.Light
+        if Terminal.dark(hex(red), hex(green), hex(blue)) then Brightness.Dark
+        else Brightness.Light
 
       case _ =>
         abort(EnvironmentError(t"TERMINAL_BG"))
 
-  var rows: Optional[Int] = safely(Environment.lines.as[Int])
-  var columns: Optional[Int] = safely(Environment.columns.as[Int])
+  metrics.rows = safely(Environment.lines.as[Int])
+  metrics.columns = safely(Environment.columns.as[Int])
+
+  def mode: Optional[Brightness] = metrics.mode
+  def mode_=(value: Optional[Brightness]): Unit = metrics.mode = value
+  def rows: Optional[Int] = metrics.rows
+  def rows_=(value: Optional[Int]): Unit = metrics.rows = value
+  def columns: Optional[Int] = metrics.columns
+  def columns_=(value: Optional[Int]): Unit = metrics.columns = value
 
   def knownColumns: Int = columns.or(80)
   def knownRows: Int = rows.or(80)
 
-  val cap: Termcap = new Termcap:
-    def ansi: Boolean = true
-    def color: ColorDepth = ColorDepth.TrueColor
-    override def width: Int = knownColumns
+  // `width` reads the live column count through the untracked `Metrics` holder (bound to a
+  // block local, not read through `this`), so the termcap — and the stdio built on it —
+  // stay pure, as `Stdio`'s `termcap` member requires.
+  val cap: Termcap =
+    val metrics0 = metrics
+
+    new Termcap:
+      def ansi: Boolean = true
+      def color: ColorDepth = ColorDepth.TrueColor
+      override def width: Int = metrics0.columns.or(80)
 
   given stdio: Stdio = new Stdio:
     val termcap = cap
@@ -87,37 +125,54 @@ extends Interactivity[TerminalEvent]:
 
   def eventIterator(): Iterator[TerminalEvent] = events.iterator
 
-  console.trap:
-    case Signal.Winch =>
-      out.print(Terminal.reportSize)
-      events.put(Signal.Winch)
-      SignalResponse.Accept
+  // The handler is bound over block locals (not fields) so it stays pure: `Console.trap`
+  // takes a pure `PartialFunction`, and a reference to `out` or `events` through `this`
+  // would charge the closure with the terminal capability.
+  locally:
+    val out0 = console.stdio.out
+    val events0 = events
 
-    case signal =>
-      events.put(signal)
-      SignalResponse.Accept
+    console.trap:
+      case Signal.Winch =>
+        out0.print(Terminal.reportSize)
+        events0.put(Signal.Winch)
+        SignalResponse.Accept
 
-  private def dark(red: Int, green: Int, blue: Int): Boolean =
-    (0.299*red + 0.587*green + 0.114*blue) < 32768
+      case signal =>
+        events0.put(signal)
+        SignalResponse.Accept
 
   // The keyboard pump runs as a daemon under a trap: if reading or decoding stdin fails,
   // the event spool is stopped so the session consuming `events.stream` sees the input end
   // and can exit cleanly, rather than blocking forever on a pump that has silently died.
+  //
+  // A daemon body must be a pure context function, so everything it needs is bound to
+  // block locals first: the untracked `Metrics` holder and `Spool` cross directly, the
+  // capability-typed keyboard crosses as an `AnyRef` rim (the cordillera recipe), and the
+  // stdin stream is a `LazyList`, which is not capture-tracked, so it crosses as a plain
+  // value.
   val pumpInput: Daemon =
+    val keyboard0: AnyRef = keyboard.asInstanceOf[AnyRef]
+    val events0 = events
+    val metrics0 = metrics
+    val chars: LazyList[Char] = In.lazyList[Char]
+
     contain:
-      case _ => events.stop(); Remedy.Accept
+      case _ => events0.stop(); Remedy.Accept
 
     . protect:
         daemon:
-          keyboard.process(In.lazyList[Char]).each:
+          keyboard0.asInstanceOf[Keyboard.Standard].process(chars).each:
             case resize@TerminalInfo.WindowSize(rows2, columns2) =>
-              rows = rows2
-              columns = columns2
-              events.put(resize)
+              metrics0.rows = rows2
+              metrics0.columns = columns2
+              events0.put(resize)
 
             case bgColor@TerminalInfo.BgColor(red, green, blue) =>
-              mode = if dark(red, green, blue) then Brightness.Dark else Brightness.Light
-              events.put(bgColor)
+              metrics0.mode =
+                if Terminal.dark(red, green, blue) then Brightness.Dark else Brightness.Light
+
+              events0.put(bgColor)
 
             case other =>
-              events.put(other)
+              events0.put(other)

--- a/lib/profanity/src/core/profanity.TerminalCanvas.scala
+++ b/lib/profanity/src/core/profanity.TerminalCanvas.scala
@@ -43,8 +43,9 @@ object TerminalCanvas:
 
   // Build a surface covering the whole terminal, reading its size live (so a
   // resize is reflected the next time the layout is solved) and writing through
-  // its `Stdio`.
-  def apply(terminal: Terminal): TerminalCanvas =
+  // its `Stdio`. The size thunks retain the terminal, so the canvas honestly
+  // captures it.
+  def apply(terminal: Terminal): TerminalCanvas^{terminal} =
     new TerminalCanvas(() => terminal.knownColumns, () => terminal.knownRows)(using terminal.stdio)
 
 // A `Canvas` over a real terminal: every positioning operation maps to an

--- a/lib/profanity/src/core/profanity.TerminalEvent.scala
+++ b/lib/profanity/src/core/profanity.TerminalEvent.scala
@@ -118,13 +118,22 @@ object Keypress:
     def key(symbol: Text): Text = t"[$symbol]"
 
     keypress match
-      case Shift(inner) => t"${key(t"⇧")}+${render(inner)}"
-      case Alt(inner)   => t"${key(t"⌥")}+${render(inner)}"
-      case Meta(inner)  => t"${key(t"⌘")}+${render(inner)}"
+      // Typed patterns with field access rather than extractors: under capture checking, an
+      // enum-case unapply of a union-typed field fails to unify with the synthesized
+      // capture-variable-decorated scrutinee.
+      case shift: Shift => t"${key(t"⇧")}+${render(shift.keypress)}"
+      case alt: Alt     => t"${key(t"⌥")}+${render(alt.keypress)}"
+      case meta: Meta   => t"${key(t"⌘")}+${render(meta.keypress)}"
 
-      case Ctrl(inner) => inner match
-        case char: Char      => t"${key(t"⌃")}+${key(char.show)}"
-        case other: Keypress => t"${key(t"⌃")}+${render(other)}"
+      case ctrl: Ctrl =>
+        // Widened to a clean binary union first: a type test against the raw field type's
+        // GADT-narrowed intersections fails to unify with its capture-variable-decorated
+        // form under capture checking.
+        val inner: Keypress | Char = ctrl.keypress
+
+        inner match
+          case char: Char      => t"${key(t"⌃")}+${key(char.show)}"
+          case other: Keypress => t"${key(t"⌃")}+${render(other)}"
 
       case CharKey(' ')      => key(t"␣")
       case CharKey(char)     => key(char.show)

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -90,7 +90,9 @@ package keyboards:
 
     def process(stream: LazyList[Char]): LazyList[Int] = stream.map(_.toInt)
 
-  given standardKeyboard: (monitor: Monitor, probate: Probate) => Keyboard.Standard =
+  // Honestly tracked: the keyboard's escape-disambiguation timeout runs `async`, so the
+  // instance retains the monitor.
+  given standardKeyboard: (monitor: Monitor, probate: Probate) => (Keyboard.Standard^{monitor}) =
     Keyboard.Standard()
 
 // The standard terminal features, each a turn-on/turn-off escape-sequence pair.

--- a/lib/profanity/src/test/profanity.CaptureTests.scala
+++ b/lib/profanity/src/test/profanity.CaptureTests.scala
@@ -30,104 +30,43 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package exoskeleton
+package profanity
 
-import ambience.*
-import anthology.*
-import anticipation.*
-import contingency.*
-import digression.*
-import distillate.*
-import eucalyptus.*
-import galilei.*
-import gossamer.*
-import guillotine.*
-import hellenism.*
-import jacinta.*
-import parasite.*
-import prepositional.*
-import rudiments.*
-import serpentine.*
-import spectacular.*
-import superlunary.*
-import symbolism.*
-import vacuous.*
+import soundness.*
 
-import filesystemOptions.deleteRecursively.disabled
+import classloaders.systemClassloader
+import environments.javaEnvironment
 import logging.silentLogging
-import probates.cancelProbate
-import workingDirectories.javaWorkingDirectory
+import strategies.throwUnsafely
+import threading.platformThreading
 
-import filesystemBackends.virtualMachine
+// `interactive` lends the raw-mode tty session to its block as a `Terminal` capability, and
+// capture checking confines it to that block: raw mode and stdin are torn down in the
+// method's `finally`, so nothing may retain the session past it.
+object CaptureTests extends Suite(m"Terminal confinement tests"):
+  def run(): Unit =
+    test(m"the Terminal capability cannot be returned from interactive"):
+      demilitarize:
+        def attempt(using Console, Monitor, Probate, Environment, Every[TerminalFeature])
+        :   Terminal =
+          interactive(summon[Terminal])
+      . map(_.message)
+    . assert(_.nonEmpty)
 
+    // The closures call a method on the terminal: selecting a PURE field (like `events`)
+    // discharges the capability path under capture checking, so only a use that charges the
+    // terminal itself demonstrates confinement.
+    test(m"a closure over the Terminal cannot escape interactive"):
+      demilitarize:
+        def attempt(using Console, Monitor, Probate, Environment, Every[TerminalFeature])
+        :   () => Int =
+          interactive(() => summon[Terminal].knownColumns)
+    . assert(_.nonEmpty)
 
-object Enclave:
-  // A `Tool` is a *capability*: it references a live installed daemon process whose lifetime
-  // is the `sandbox` block that spawns it (killed, and its files deleted, after the block).
-  case class Tool(path: Path on Linux, pid: Pid) extends caps.ExclusiveCapability:
-    def command: Text = path.name
-
-    def completions(using Monitor)[result](block: => Unit): Optional[Text] =
-      val promise = Promise[Text]()
-
-      async:
-        promise.offer(safely(sh"$path '{admin}' await".exec[Text]()).or(t"failed"))
-
-      block
-      safely(promise.await())
-
-  case class Launcher(path: Path on Linux):
-    def sandbox[result](block: (tool: Tool) ?=> result)
-    :   result raises ExecError raises NumberError raises PathError =
-
-      val completionScripts = sh"$path '{admin}' install".exec[Text]()
-      val pid = Pid(sh"$path '{admin}' pid".exec[Text]().trim.as[Int])
-      val tool = Tool(path, pid)
-
-      block(using tool).also:
-        sh"$path '{admin}' kill".exec[Exit]()
-
-        completionScripts.trim.lines.map(_.as[Path on Linux]).each: item =>
-          safely(item.delete())
-
-
-case class Enclave(name: Text, buildId: Optional[Int] = Unset)(using Classloader, Environment)
-extends Rig:
-  type Result[output] = Enclave.Launcher
-  type Form = Text
-  type Target = Path on Linux
-  type Transport = Json
-
-  def stage(out: Path on Linux): Path on Linux =
-    val target = unsafely(out.peer(name))
-
-    unsafely:
-      val name2 = t"$name.jar"
-      val jarfile = out.peer(name2)
-      // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
-      // fails capture-variable unification when expanded in a capture-checked module.
-      val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch
-      val bundle = Bundler.bundle(out, jarfile, executor)
-
-      val cmd = (buildId: @unchecked) match
-        case id: Int => sh"java -Dbuild.id=$id -Dbuild.executable=$target -jar $jarfile '[]'"
-        case Unset   => sh"java -Dbuild.executable=$target -jar $jarfile '[]'"
-
-      cmd.exec[Exit]() match
-        case Exit.Ok         => target
-        case Exit.Fail(fail) => ???
-
-  protected val scalac: Scalac[3.8] = Scalac(List(scalacOptions.experimental))
-
-
-  protected def invoke[output](stage: Stage[output, Text, Path on Linux])
-  :   Enclave.Launcher =
-
-    stage.remote: input =>
-      unsafely:
-        variables(inputParameters = input):
-          sh"${stage.target}".exec[Exit]()
-
-      t"""[""]"""
-
-    Enclave.Launcher(stage.target)
+    test(m"the Terminal cannot be stashed in an outer variable"):
+      demilitarize:
+        def attempt(using Console, Monitor, Probate, Environment, Every[TerminalFeature]): Unit =
+          var stash: () => Unit = () => ()
+          interactive:
+            stash = () => { summon[Terminal].knownColumns; () }
+    . assert(_.nonEmpty)

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -52,6 +52,8 @@ import Shell.*
 
 object Tests extends Suite(m"Profanity Tests"):
   def run(): Unit =
+    CaptureTests()
+
     supervise:
       val launcher = Enclave(t"profanity-fixture").dispatch:
         ' {

--- a/lib/rudiments/src/core/rudiments.Inclusive.scala
+++ b/lib/rudiments/src/core/rudiments.Inclusive.scala
@@ -63,5 +63,5 @@ object Inclusive:
   // instance for `text.has(char)`; substring containment is `subsumes` instead.
   given text: Text is Inclusive by Char = (text, char) => text.s.indexOf(char.toInt) >= 0
 
-trait Inclusive extends Typeclass, Operable:
+trait Inclusive extends Typeclass.Pure, Operable:
   def has(self: Self, value: Operand): Boolean

--- a/lib/rudiments/src/core/rudiments.Indexable.scala
+++ b/lib/rudiments/src/core/rudiments.Indexable.scala
@@ -94,6 +94,6 @@ object Indexable:
     def access(value: Self, index: key): value = value(index)
 
 
-trait Indexable extends Typeclass, Operable, Resultant:
+trait Indexable extends Typeclass.Pure, Operable, Resultant:
   def contains(value: Self, index: Operand): Boolean
   def access(value: Self, index: Operand): Result

--- a/lib/rudiments/src/core/rudiments.Segmentable.scala
+++ b/lib/rudiments/src/core/rudiments.Segmentable.scala
@@ -54,5 +54,5 @@ object Segmentable:
     val max = interval.limit.n0.min(text.s.length)
     text.s.substring(min, max).nn.tt
 
-trait Segmentable extends Typeclass:
+trait Segmentable extends Typeclass.Pure:
   def segment(entity: Self, interval: Interval): Self

--- a/lib/rudiments/src/core/rudiments.Traversable.scala
+++ b/lib/rudiments/src/core/rudiments.Traversable.scala
@@ -50,5 +50,5 @@ object Traversable:
   // `Text is Traversable` without an explicit `import`, unlike a top-level given.
   given text: Text is Traversable by Char = text => LazyList(text.s.toCharArray.nn*)
 
-trait Traversable extends Typeclass, Operable:
+trait Traversable extends Typeclass.Pure, Operable:
   def traverse(self: Self): LazyList[Operand]

--- a/lib/scintillate/src/server/scintillate.Acceptable.scala
+++ b/lib/scintillate/src/server/scintillate.Acceptable.scala
@@ -48,7 +48,9 @@ import errorDiagnostics.stackTracesDiagnostics
 
 
 object Acceptable:
-  given multipart: Tactic[MultipartError] => Multipart is Acceptable = request =>
+  // Honestly tracked: the instance retains its resolution-scoped tactic.
+  given multipart: (tactic: Tactic[MultipartError])
+  =>  ((Multipart is Acceptable)^{tactic, caps.any}) = request =>
     mitigate:
       case _: MediaTypeError => MultipartError(MultipartError.Reason.MediaType)
 

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -82,6 +82,13 @@ object HttpConnection:
 
     lazy val in = exchange.getRequestBody.nn
 
+    // The Source evidence closes over `unsafely`'s ThrowTactic, which is `caps.Unscoped`
+    // (it throws in place, capturing nothing scoped), so it is truthfully sealed once here
+    // rather than leaking out of the per-mint `unsafely` scope through the body thunk.
+    val source: ji.InputStream is Source by Data over Credit =
+      unsafely:
+        caps.unsafe.unsafeAssumePure(summon[ji.InputStream is Source by Data over Credit])
+
     val request =
       Http.Request
         ( method      = method,
@@ -91,8 +98,7 @@ object HttpConnection:
           // Each mint reads on from the same live request stream — the
           // single-owner discipline (explicit `memoize` for re-reads). A read
           // failure throws, as the raw `InputStream` did before.
-          body        = () => unsafely(summon[ji.InputStream is Source by Data over Credit])
-                              . stream(in),
+          body        = () => source.stream(in),
           textHeaders = headers )
 
     Log.fine(HttpServerEvent.Received(request))

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -52,8 +52,12 @@ import vacuous.*
 import zephyrine.*
 
 object HttpConnection:
+  // Explicit `using` evidence instead of `logs`/`raises` sugar: the `respond` closure built
+  // in the body cannot cross the nested context-function results the sugar desugars to (the
+  // stacked-raises convention; see rep/DECISIONS.md).
   def apply(exchange: csnh.HttpExchange)
-  :   HttpConnection logs HttpServerEvent raises HostnameError =
+    ( using HttpServerEvent is Loggable, Tactic[HostnameError] )
+  :   HttpConnection^ =
 
     val uri = exchange.getRequestURI.nn
     val query = Optional(uri.getQuery)
@@ -150,11 +154,19 @@ object HttpConnection:
 
     new HttpConnection(request, false, port, respond)
 
+// An `HttpConnection` is a *capability*: it is one live, socket-backed exchange, holding the
+// `respond` sink that writes to (and closes) the client connection. Its lifetime is the
+// handler invocation that receives it. `Exclusive` because an exchange has a single owner
+// and may be responded to only once.
 class HttpConnection
-  (     request: Http.Request,
+  (     request: Http.Request^,
     val tls:     Boolean,
     val port:    Int,
-    val respond: Tactic[StreamError] ?=> Http.Response => Unit )
+    // Layered response-first: the eta-expansion of a `respond(response)(using Tactic)` local
+    // into a tactic-first nested context function would need the inner arrow to capture the
+    // outer tactic (the dependent-capture restriction); this way the capturing arrow is
+    // outermost.
+    val respond: Http.Response => Tactic[StreamError] ?=> Unit )
 extends Http.Request
   ( request.method,
     request.version,
@@ -162,4 +174,5 @@ extends Http.Request
     request.target,
     request.textHeaders,
     request.body ),
-  Findable
+  Findable,
+  caps.ExclusiveCapability

--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -56,7 +56,7 @@ object HttpConnection:
   // in the body cannot cross the nested context-function results the sugar desugars to (the
   // stacked-raises convention; see rep/DECISIONS.md).
   def apply(exchange: csnh.HttpExchange)
-    ( using HttpServerEvent is Loggable, Tactic[HostnameError] )
+    ( using (HttpServerEvent is Loggable)^, Tactic[HostnameError] )
   :   HttpConnection^ =
 
     val uri = exchange.getRequestURI.nn

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -48,7 +48,7 @@ import urticose.*
 case class HttpServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
 extends RequestServable:
   def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
-    ( using HttpServerEvent is Loggable, Tactic[ServerError] )
+    ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^ =
 
     def handle(exchange: csnh.HttpExchange | Null): Unit =

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -48,7 +48,8 @@ import urticose.*
 case class HttpServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
 extends RequestServable:
   def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
-  :   Service logs HttpServerEvent raises ServerError =
+    ( using HttpServerEvent is Loggable, Tactic[ServerError] )
+  :   Service^ =
 
     def handle(exchange: csnh.HttpExchange | Null): Unit =
       try

--- a/lib/scintillate/src/server/scintillate.RequestServable.scala
+++ b/lib/scintillate/src/server/scintillate.RequestServable.scala
@@ -40,4 +40,5 @@ import urticose.*
 
 trait RequestServable:
   def handle(handle: HttpConnection ?=> Http.Response)(using Monitor, Probate)
-  :   Service logs HttpServerEvent raises ServerError
+    ( using HttpServerEvent is Loggable, Tactic[ServerError] )
+  :   Service^

--- a/lib/scintillate/src/server/scintillate.RequestServable.scala
+++ b/lib/scintillate/src/server/scintillate.RequestServable.scala
@@ -40,5 +40,5 @@ import urticose.*
 
 trait RequestServable:
   def handle(handle: HttpConnection ?=> Http.Response)(using Monitor, Probate)
-    ( using HttpServerEvent is Loggable, Tactic[ServerError] )
+    ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -154,7 +154,7 @@ extends RequestServable:
   // involvement. The caller owns the streams (closing, read timeouts).
   def serveConnection(handler: HttpConnection ?=> Http.Response)
     ( in: ji.InputStream, out: ji.OutputStream )
-    ( using HttpServerEvent is Loggable )
+    ( using (HttpServerEvent is Loggable)^ )
   :   Unit =
 
     val closeHeader: Http.Header = Http.Header(t"connection", t"close")
@@ -268,7 +268,7 @@ extends RequestServable:
         while continue && !cursor.finished do continue = serveRequest(cursor)
 
   def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
-    ( using HttpServerEvent is Loggable, Tactic[ServerError] )
+    ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^ =
 
     val idleTimeout: Int = 30000
@@ -299,6 +299,8 @@ extends RequestServable:
         val handler1: AnyRef => AnyRef =
           connection => handler(using connection.asInstanceOf[HttpConnection])
         val handler0: AnyRef = handler1.asInstanceOf[AnyRef]
+        // The (capability-typed) Loggable evidence crosses as an `AnyRef` rim too.
+        val loggable0: AnyRef = summon[(HttpServerEvent is Loggable)^].asInstanceOf[AnyRef]
 
         val acceptLoop = loop:
           safely(serverSocket.accept().nn).let: socket =>
@@ -316,6 +318,7 @@ extends RequestServable:
                 . serveConnection
                     (h(summon[HttpConnection].asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
                     (socket1.getInputStream.nn, socket1.getOutputStream.nn)
+                    (using loggable0.asInstanceOf[HttpServerEvent is Loggable])
 
               finally safely(socket1.close())
 

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -69,7 +69,7 @@ extends RequestServable:
 
   private val continueResponse: Data = t"HTTP/1.1 100 Continue\r\n\r\n".in[Data]
 
-  private def writeAll(out: ji.OutputStream, stream: Stream[Data] over Credit)
+  private def writeAll(out: ji.OutputStream, stream: (Stream[Data] over Credit)^)
   :   Unit raises StreamError =
 
     var count: Int = 0
@@ -94,7 +94,10 @@ extends RequestServable:
   // for `Transfer-Encoding: chunked`, otherwise `Content-Length` bytes, or empty
   // when neither is given. The framed stream stops exactly at the body's end so
   // the cursor is left at the next pipelined request.
-  private def requestBody(cursor: Cursor[Data, ?], head: Http.Request.Head)
+  // Upstream #1570's kernel-stream body with this branch's cursor convention
+  // (`Cursor[Data, {}]^`: a concrete cap argument, never `?`, which collapses inline
+  // receiver proxies to read-only).
+  private def requestBody(cursor: Cursor[Data, {}]^, head: Http.Request.Head)
   :   Stream[Data] over Credit =
 
     val chunked: Boolean = head.headers.exists: header =>
@@ -158,7 +161,7 @@ extends RequestServable:
 
     // Handle one request off the cursor; return whether to keep the connection
     // alive for a further request.
-    def serveRequest(cursor: Cursor[Data, ?]): Boolean =
+    def serveRequest(cursor: Cursor[Data, {}]^): Boolean =
       recover:
         case error: HttpRequestError =>
           val response = Http.Response(errorStatus(error.reason))() + closeHeader
@@ -265,7 +268,8 @@ extends RequestServable:
         while continue && !cursor.finished do continue = serveRequest(cursor)
 
   def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
-  :   Service logs HttpServerEvent raises ServerError =
+    ( using HttpServerEvent is Loggable, Tactic[ServerError] )
+  :   Service^ =
 
     val idleTimeout: Int = 30000
 
@@ -286,15 +290,37 @@ extends RequestServable:
       case error => Log.fail(HttpServerEvent.ConnectionFailed(error)); Remedy.Accept
 
     . protect:
+        // Daemon bodies must be pure context functions, so the server, the handler and each
+        // socket cross into them as `AnyRef` rims (the cordillera recipe).
+        val self: AnyRef = this
+        // Eta-wrapped into a capture-neutral `AnyRef => AnyRef` (capability-typed function
+        // types re-hide when crossed through a rim; the kernel-module-sep finding), since a
+        // context-function value applies itself in any non-context-function position.
+        val handler1: AnyRef => AnyRef =
+          connection => handler(using connection.asInstanceOf[HttpConnection])
+        val handler0: AnyRef = handler1.asInstanceOf[AnyRef]
+
         val acceptLoop = loop:
           safely(serverSocket.accept().nn).let: socket =>
-            daemon:
-              try
-                socket.setSoTimeout(idleTimeout)
-                serveConnection(handler)(socket.getInputStream.nn, socket.getOutputStream.nn)
-              finally safely(socket.close())
+            val socket0: AnyRef = socket
 
-        val acceptTask = daemon(acceptLoop.run())
+            daemon:
+              val socket1 = socket0.asInstanceOf[jn.Socket]
+
+              try
+                socket1.setSoTimeout(idleTimeout)
+
+                val h = handler0.asInstanceOf[AnyRef => AnyRef]
+
+                self.asInstanceOf[SocketServer]
+                . serveConnection
+                    (h(summon[HttpConnection].asInstanceOf[AnyRef]).asInstanceOf[Http.Response])
+                    (socket1.getInputStream.nn, socket1.getOutputStream.nn)
+
+              finally safely(socket1.close())
+
+        val acceptLoop0: AnyRef = acceptLoop.asInstanceOf[AnyRef]
+        val acceptTask = daemon(acceptLoop0.asInstanceOf[Loop].run())
         val cancel: Promise[Unit] = Promise[Unit]()
 
         val stopTask = async:

--- a/lib/scintillate/src/server/scintillate.WebserverErrorPage.scala
+++ b/lib/scintillate/src/server/scintillate.WebserverErrorPage.scala
@@ -36,4 +36,4 @@ import beneficence.*
 import telekinesis.*
 
 trait WebserverErrorPage extends Findable:
-  def handle(throwable: Throwable, request: Http.Request): Http.Response
+  def handle(throwable: Throwable, request: Http.Request^): Http.Response

--- a/lib/scintillate/src/server/scintillate_core.scala
+++ b/lib/scintillate/src/server/scintillate_core.scala
@@ -50,64 +50,70 @@ import urticose.*
 import vacuous.*
 
 package httpServers:
-  given stdlibHttpServer: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
-
+  // A named class rather than four anonymous given instances: the anonymous form freshens
+  // the inferred type members with capture variables, which then fail to conform to the
+  // declared refinement (the galilei `FileOpenable` finding). Honestly tracked: the instance
+  // retains its tactic and monitor (rep/DECISIONS.md ruling: server givens are capabilities).
+  private class HttpProtocolic[port <: (80 | 443 | 8080 | 8000)](native: Boolean, local: Boolean)
+    ( using tactic:    Tactic[ServerError],
+            monitor:   Monitor,
+            probate:   Probate,
+            loggable:  HttpServerEvent is Loggable,
+            errorPage: WebserverErrorPage )
+  extends Protocolic:
     type Transport = TcpPort of port
     type Self = Http
     type Server = Service
-    type Request = HttpConnection
+    // Alias with the explicit capture: a bare capability-class alias decorates the trait's
+    // `Request ?=>` parameter on one side of the override only.
+    type Request = HttpConnection^
     type Response = Http.Response
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      HttpServer(port.number, true).handle(lambda)
+    def server(port: TcpPort of port)(lambda: Request ?=> Response): Server^ =
+      if native then SocketServer(port.number, local).handle(lambda)
+      else HttpServer(port.number, local).handle(lambda)
 
+  // Public: the soundness bundle's hand-written forwarder givens name this alias.
+  type HttpServerFor[port] =
+    Http is Protocolic
+      { type Transport = TcpPort of port
+        type Request = HttpConnection^
+        type Response = Http.Response
+        type Server = Service }
+
+  given stdlibHttpServer: [port <: (80 | 443 | 8080 | 8000)]
+  =>  ( tactic: Tactic[ServerError], monitor: Monitor, probate: Probate )
+  =>  ( loggable: HttpServerEvent is Loggable, errorPage: WebserverErrorPage )
+  =>  ((HttpServerFor[port])^{tactic, monitor, caps.any}) =
+    HttpProtocolic[port](false, true)
 
   given stdlibPublicHttpServer: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
-
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
-
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      HttpServer(port.number, false).handle(lambda)
-
+  =>  ( tactic: Tactic[ServerError], monitor: Monitor, probate: Probate )
+  =>  ( loggable: HttpServerEvent is Loggable, errorPage: WebserverErrorPage )
+  =>  ((HttpServerFor[port])^{tactic, monitor, caps.any}) =
+    HttpProtocolic[port](false, false)
 
   given nativeHttpServer: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
-
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
-
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      SocketServer(port.number, true).handle(lambda)
-
+  =>  ( tactic: Tactic[ServerError], monitor: Monitor, probate: Probate )
+  =>  ( loggable: HttpServerEvent is Loggable, errorPage: WebserverErrorPage )
+  =>  ((HttpServerFor[port])^{tactic, monitor, caps.any}) =
+    HttpProtocolic[port](true, true)
 
   given nativePublicHttpServer: [port <: (80 | 443 | 8080 | 8000)]
-  =>  ( Tactic[ServerError], Monitor, Probate, HttpServerEvent is Loggable )
-  =>  WebserverErrorPage
-  =>  Http is Protocolic:
+  =>  ( tactic: Tactic[ServerError], monitor: Monitor, probate: Probate )
+  =>  ( loggable: HttpServerEvent is Loggable, errorPage: WebserverErrorPage )
+  =>  ((HttpServerFor[port])^{tactic, monitor, caps.any}) =
+    HttpProtocolic[port](true, false)
 
-    type Transport = TcpPort of port
-    type Self = Http
-    type Server = Service
-    type Request = HttpConnection
-    type Response = Http.Response
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Service =
-      SocketServer(port.number, false).handle(lambda)
+
+
+
+
+
+
+
+
 
 def cookie(using request: Http.Request)(key: Text): Optional[Text] = request.textCookies.at(key)
 
@@ -125,7 +131,7 @@ def basicAuth(validate: (Text, Text) => Boolean, realm: Text)(response: => Http.
       Http.Response(Http.Unauthorized, wwwAuthenticate = auth)()
 
 
-inline def request: Http.Request = infer[Http.Request]
+inline def request: Http.Request^ = infer[Http.Request]
 
 extension (request: Http.Request)
   @unexported

--- a/lib/scintillate/src/server/soundness_scintillate_server.scala
+++ b/lib/scintillate/src/server/soundness_scintillate_server.scala
@@ -42,7 +42,30 @@ export
       WebserverErrorPage }
 
 package httpServers:
-  export scintillate.httpServers.{stdlibHttpServer, stdlibPublicHttpServer}
+  // Hand-written forwarders rather than an `export`: synthesized export forwarders lose the
+  // givens' capture-annotated refinement types (the zephyrine through/accepting finding).
+  given stdlibHttpServer: [port <: (80 | 443 | 8080 | 8000)]
+  =>  ( tactic:  contingency.Tactic[scintillate.ServerError],
+        monitor: parasite.Monitor,
+        probate: parasite.Probate )
+  =>  ( loggable:  scintillate.HttpServerEvent is anticipation.Loggable,
+        errorPage: scintillate.WebserverErrorPage )
+  =>  ((scintillate.httpServers.HttpServerFor[port])^{tactic, monitor, caps.any}) =
+    // One erasing cast at the forwarding boundary (the wisteria `fieldInstance` pattern):
+    // resolution finds the annotated instance, but its capture roots do not re-root through
+    // a second given; the declared result type above restores the honest captures.
+    scintillate.httpServers.stdlibHttpServer[port]
+    . asInstanceOf[scintillate.httpServers.HttpServerFor[port]]
+
+  given stdlibPublicHttpServer: [port <: (80 | 443 | 8080 | 8000)]
+  =>  ( tactic:  contingency.Tactic[scintillate.ServerError],
+        monitor: parasite.Monitor,
+        probate: parasite.Probate )
+  =>  ( loggable:  scintillate.HttpServerEvent is anticipation.Loggable,
+        errorPage: scintillate.WebserverErrorPage )
+  =>  ((scintillate.httpServers.HttpServerFor[port])^{tactic, monitor, caps.any}) =
+    scintillate.httpServers.stdlibPublicHttpServer[port]
+    . asInstanceOf[scintillate.httpServers.HttpServerFor[port]]
 
 package webserverErrorPages:
   export scintillate.webserverErrorPages.{minimalErrorPage, stackTracesErrorPage, standardErrorPage}

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -32,6 +32,7 @@
                                                                                                   */
 package scintillate
 
+import java.io as ji
 import jakarta.servlet as js, js.http as jsh
 
 import anticipation.*
@@ -47,15 +48,18 @@ import urticose.*
 import vacuous.*
 import zephyrine.*
 
-open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.HttpServlet:
+// `handle` is a plain function (not a context function): with `HttpConnection` a capability,
+// a context-function class parameter cannot be applied from the synthesized superclass
+// argument of subclasses like `JavaServletFn` (capture-root unification).
+open class JavaServlet(handle: HttpConnection => Http.Response) extends jsh.HttpServlet:
   protected def streamBody(request: jsh.HttpServletRequest): LazyList[Data] raises StreamError =
     Streamable.inputStream.stream(request.getInputStream().nn)
 
 
   protected def makeConnection
     ( request: jsh.HttpServletRequest, servletResponse: jsh.HttpServletResponse )
-    ( using Tactic[StreamError], Tactic[HostnameError] )
-  :   HttpConnection =
+    ( using streamError: Tactic[StreamError], hostnameError: Tactic[HostnameError] )
+  :   HttpConnection^ =
 
     val uri = request.getRequestURI.nn.tt
     val query = Optional(request.getQueryString).let(_.tt)
@@ -68,23 +72,37 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
       . flatMap:
           case (key, values) => values.map(Http.Header(key, _))
 
+    // Rims: under separation checking a method's fresh capability result may not hide its
+    // parameters, so nothing the connection retains — the body thunk or the respond sink —
+    // may charge them; they cross as `AnyRef` (the cordillera recipe), with the tactic
+    // re-typed at each use site.
+    val in: AnyRef = request.getInputStream().nn
+    val servletResponse0: AnyRef = servletResponse
+    val streamError0: AnyRef = summon[Tactic[StreamError]].asInstanceOf[AnyRef]
+
     val httpRequest =
       Http.Request
         ( method      = request.getMethod.nn.show.as[Http.Method],
           version     = Http.Version.parse(request.getProtocol.nn.tt),
           host        = request.getServerName.nn.tt.as[Hostname],
           target      = target,
-          body        = () => Stream(streamBody(request).iterator),
+          body        = () =>
+            Stream:
+              Streamable.inputStream
+                (using streamError0.asInstanceOf[Tactic[StreamError]])
+              . stream(in.asInstanceOf[ji.InputStream])
+              . iterator,
           textHeaders = headers )
 
     def respond(response: Http.Response): Unit =
-      servletResponse.setStatus(response.status.code)
+      val servletResponse1 = servletResponse0.asInstanceOf[jsh.HttpServletResponse]
+      servletResponse1.setStatus(response.status.code)
 
       response.textHeaders.each:
         case Http.Header(key, value) =>
-          servletResponse.addHeader(key.s, value.s)
+          servletResponse1.addHeader(key.s, value.s)
 
-      val out = servletResponse.getOutputStream.nn
+      val out = servletResponse1.getOutputStream.nn
 
       response.body match
         case Http.Body.Fixed(data) =>
@@ -126,7 +144,7 @@ open class JavaServlet(handle: HttpConnection ?=> Http.Response) extends jsh.Htt
 
     . protect:
         val connection = makeConnection(request, response)
-        connection.respond(handle(using connection))
+        connection.respond(handle(connection))
 
 
   override def service

--- a/lib/scintillate/src/servlet/scintillate.JavaServletFn.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServletFn.scala
@@ -36,4 +36,4 @@ import rudiments.*
 import telekinesis.*
 
 open class JavaServletFn(handle: HttpConnection => Http.Response)
-extends JavaServlet(handle.context)
+extends JavaServlet(handle)

--- a/lib/scintillate/src/servlet/scintillate.servlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.servlet.scala
@@ -50,12 +50,16 @@ class servlet extends MacroAnnotation:
           if !(result.tpe <:< TypeRepr.of[Http.Response])
           then halt(m"the return type ${result.show} is not a subtype of HttpResponse[?]")
 
+          // Typed `Any` at the hole and cast inside the quote: `HttpConnection` is a
+          // capability class, and a capability-typed quote hole fails capture-root
+          // unification (the quote wall; see rep/DECISIONS.md).
           val ref =
             Ref(defDef.symbol)
             . etaExpand(tree.symbol.owner)
-            . asExprOf[HttpConnection => Http.Response]
+            . asExprOf[Any]
 
-          val parents0 = List('{new JavaServletFn($ref)}.asTerm)
+          val parents0 =
+            List('{new JavaServletFn($ref.asInstanceOf[HttpConnection => Http.Response])}.asTerm)
           val parents = List(TypeTree.of[HttpConnection])
           val newClassName = Symbol.freshName(name)
 

--- a/lib/scintillate/src/test/scintillate.CaptureTests.scala
+++ b/lib/scintillate/src/test/scintillate.CaptureTests.scala
@@ -44,7 +44,7 @@ object CaptureTests extends Suite(m"Connection confinement tests"):
     test(m"the connection cannot be stashed in an outer variable"):
       demilitarize:
         def attempt(server: SocketServer)
-          ( using Monitor, Probate, HttpServerEvent is Loggable, Tactic[ServerError] )
+          ( using Monitor, Probate, (HttpServerEvent is Loggable)^, Tactic[ServerError] )
         :   Unit =
           var stash: () => Unit = () => ()
 

--- a/lib/scintillate/src/test/scintillate.CaptureTests.scala
+++ b/lib/scintillate/src/test/scintillate.CaptureTests.scala
@@ -30,104 +30,27 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package exoskeleton
+package scintillate
 
-import ambience.*
-import anthology.*
-import anticipation.*
-import contingency.*
-import digression.*
-import distillate.*
-import eucalyptus.*
-import galilei.*
-import gossamer.*
-import guillotine.*
-import hellenism.*
-import jacinta.*
-import parasite.*
-import prepositional.*
-import rudiments.*
-import serpentine.*
-import spectacular.*
-import superlunary.*
-import symbolism.*
-import vacuous.*
+import soundness.*
 
-import filesystemOptions.deleteRecursively.disabled
+import strategies.throwUnsafely
 import logging.silentLogging
-import probates.cancelProbate
-import workingDirectories.javaWorkingDirectory
 
-import filesystemBackends.virtualMachine
+// A handler receives one live exchange as an `HttpConnection` capability; capture checking
+// prevents the connection (or its respond sink) being retained past the handler invocation.
+object CaptureTests extends Suite(m"Connection confinement tests"):
+  def run(): Unit =
+    test(m"the connection cannot be stashed in an outer variable"):
+      demilitarize:
+        def attempt(server: SocketServer)
+          ( using Monitor, Probate, HttpServerEvent is Loggable, Tactic[ServerError] )
+        :   Unit =
+          var stash: () => Unit = () => ()
 
+          server.handle:
+            stash = () => summon[HttpConnection].respond(Http.Response(Http.Ok)(t""))
+            Http.Response(Http.Ok)(t"")
 
-object Enclave:
-  // A `Tool` is a *capability*: it references a live installed daemon process whose lifetime
-  // is the `sandbox` block that spawns it (killed, and its files deleted, after the block).
-  case class Tool(path: Path on Linux, pid: Pid) extends caps.ExclusiveCapability:
-    def command: Text = path.name
-
-    def completions(using Monitor)[result](block: => Unit): Optional[Text] =
-      val promise = Promise[Text]()
-
-      async:
-        promise.offer(safely(sh"$path '{admin}' await".exec[Text]()).or(t"failed"))
-
-      block
-      safely(promise.await())
-
-  case class Launcher(path: Path on Linux):
-    def sandbox[result](block: (tool: Tool) ?=> result)
-    :   result raises ExecError raises NumberError raises PathError =
-
-      val completionScripts = sh"$path '{admin}' install".exec[Text]()
-      val pid = Pid(sh"$path '{admin}' pid".exec[Text]().trim.as[Int])
-      val tool = Tool(path, pid)
-
-      block(using tool).also:
-        sh"$path '{admin}' kill".exec[Exit]()
-
-        completionScripts.trim.lines.map(_.as[Path on Linux]).each: item =>
-          safely(item.delete())
-
-
-case class Enclave(name: Text, buildId: Optional[Int] = Unset)(using Classloader, Environment)
-extends Rig:
-  type Result[output] = Enclave.Launcher
-  type Form = Text
-  type Target = Path on Linux
-  type Transport = Json
-
-  def stage(out: Path on Linux): Path on Linux =
-    val target = unsafely(out.peer(name))
-
-    unsafely:
-      val name2 = t"$name.jar"
-      val jarfile = out.peer(name2)
-      // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
-      // fails capture-variable unification when expanded in a capture-checked module.
-      val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch
-      val bundle = Bundler.bundle(out, jarfile, executor)
-
-      val cmd = (buildId: @unchecked) match
-        case id: Int => sh"java -Dbuild.id=$id -Dbuild.executable=$target -jar $jarfile '[]'"
-        case Unset   => sh"java -Dbuild.executable=$target -jar $jarfile '[]'"
-
-      cmd.exec[Exit]() match
-        case Exit.Ok         => target
-        case Exit.Fail(fail) => ???
-
-  protected val scalac: Scalac[3.8] = Scalac(List(scalacOptions.experimental))
-
-
-  protected def invoke[output](stage: Stage[output, Text, Path on Linux])
-  :   Enclave.Launcher =
-
-    stage.remote: input =>
-      unsafely:
-        variables(inputParameters = input):
-          sh"${stage.target}".exec[Exit]()
-
-      t"""[""]"""
-
-    Enclave.Launcher(stage.target)
+          ()
+    . assert(_.nonEmpty)

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -156,7 +156,12 @@ object Tests extends Suite(m"Scintillate tests"):
           // Echo upgrade: the response body is the post-handshake request stream,
           // piped straight back out with no HTTP framing.
           val server = SocketServer(port).handle:
-            Http.Response(Http.SwitchingProtocols)(Http.Body.Flowing(() => request.body()))
+            Http.Response(Http.SwitchingProtocols)
+              (Http.Body.Flowing:
+                // Sealed: the upgraded response's stream legitimately reads the live
+                // connection for the rest of the exchange; the pure-`Http.Body` handler
+                // shape cannot express that retention (see rep/DECISIONS.md, Phase 3b).
+                caps.unsafe.unsafeAssumePure(() => request.body()))
 
           val response =
             rawRequest

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -186,16 +186,19 @@ object Tests extends Suite(m"Scintillate tests"):
 
           val start = java.lang.System.nanoTime()
 
+          // Handles collected for concurrent await: sealed per the pure-façade convention
+          // (D6; the `Seq[Task].sequence` shape).
           val tasks = List.tabulate(clients): _ =>
-            async:
-              val socket = java.net.Socket("localhost", port)
-              val out = socket.getOutputStream.nn
-              out.write(payload)
-              out.flush()
-              socket.shutdownOutput()
-              val response = String(socket.getInputStream.nn.readAllBytes().nn, "US-ASCII").tt
-              socket.close()
-              response.cut(t"HTTP/1.1 200 OK").length - 1
+            caps.unsafe.unsafeAssumePure:
+              async:
+                val socket = java.net.Socket("localhost", port)
+                val out = socket.getOutputStream.nn
+                out.write(payload)
+                out.flush()
+                socket.shutdownOutput()
+                val response = String(socket.getInputStream.nn.readAllBytes().nn, "US-ASCII").tt
+                socket.close()
+                response.cut(t"HTTP/1.1 200 OK").length - 1
 
           val total = tasks.map(_.await()).foldLeft(0)(_ + _)
           val millis = (java.lang.System.nanoTime() - start)/1000000.0

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -43,6 +43,8 @@ import probates.awaitProbate
 
 object Tests extends Suite(m"Scintillate tests"):
   def run(): Unit =
+    CaptureTests()
+
     def freePort(): Int =
       val socket = java.net.ServerSocket(0)
       val port = socket.getLocalPort

--- a/lib/surveillance/src/core/surveillance.NativeWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.NativeWatcher.scala
@@ -59,7 +59,10 @@ object NativeWatcher extends Watcher:
       pollLoop.stop()
       try watchService.close() catch case _: ji.IOException => ()
 
-    val async: Optional[Task[Unit]] = safely(supervise(task(n"surveillance")(pollLoop.run())))
+    // Registry-lifetime storage of the poll task's handle (held only to keep the supervised
+    // task alive); sealed inside the block, per the pure-façade convention (D6 ruling).
+    val async: Optional[Task[Unit]] =
+      safely(supervise(caps.unsafe.unsafeAssumePure(task(n"surveillance")(pollLoop.run()))))
 
   private val serviceMutex: Mutex = Mutex()
   private val watchesMutex: Mutex = Mutex()

--- a/lib/surveillance/src/core/surveillance.NativeWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.NativeWatcher.scala
@@ -78,7 +78,12 @@ object NativeWatcher extends Watcher:
     try
       service.take().nn match
         case key: jnf.WatchKey =>
-          val pathWatches = watchesMutex(watches.at(key).or(Set()))
+          // `watches` is bound to a local first: summoning the `at` extension's evidence
+          // against the object-field singleton path inside the inline mutex block fails to
+          // unify under capture checking.
+          val pathWatches = watchesMutex:
+            val watches0 = watches
+            watches0.at(key).or(Set())
 
           key.pollEvents().nn.iterator.nn.asScala.each: event =>
             pathWatches.each(_.put(event))
@@ -101,16 +106,18 @@ object NativeWatcher extends Watcher:
       // failure mode: the operating system's watch limit (e.g. inotify `max_user_watches`).
       case _: ji.IOException            => abort(WatchError(WatchError.Reason.LimitExceeded))
 
-  def watch(directories: Map[jnf.Path, Text => Boolean], spool: Spool[WatchEvent])
+  def watch(directories: Map[jnf.Path, Text -> Boolean], spool: Spool[WatchEvent])
   :   Watcher.Registration raises WatchError =
 
     val pathWatches: Set[PathWatch] = watchesMutex:
+      val watches0 = watches
+
       directories.map:
         case (directory, filter) =>
           val key = registerKey(directory)
 
           new PathWatch(key, directory, spool, filter).tap: pathWatch =>
-            watches(key) = watches.at(key).or(Set()) + pathWatch
+            watches0(key) = watches0.at(key).or(Set()) + pathWatch
 
       . to(Set)
 
@@ -120,7 +127,7 @@ object NativeWatcher extends Watcher:
     ( private[NativeWatcher] val key:    jnf.WatchKey,
       private[NativeWatcher] val base:   jnf.Path,
                              val spool:  Spool[WatchEvent],
-                             val filter: Text => Boolean ):
+                             val filter: Text -> Boolean ):
 
     def put(event: jnf.WatchEvent[?]): Unit =
       event.context.nn.absolve match

--- a/lib/surveillance/src/core/surveillance.PollingWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.PollingWatcher.scala
@@ -59,7 +59,7 @@ extends Watcher:
 
   private case class Entry(directory: Boolean, modified: Long, size: Long)
 
-  private def scan(directory: jnf.Path, filter: Text => Boolean): Map[Text, Entry] =
+  private def scan(directory: jnf.Path, filter: Text -> Boolean): Map[Text, Entry] =
     Optional(directory.toFile.nn.listFiles()).let: files =>
       scala.collection.immutable.ArraySeq.unsafeWrapArray(files).flatMap: file =>
         val entry = file.nn
@@ -94,7 +94,7 @@ extends Watcher:
     previous.each: (name, _) =>
       if !current.contains(name) then spool.put(WatchEvent.Delete(base, name))
 
-  def watch(directories: Map[jnf.Path, Text => Boolean], spool: Spool[WatchEvent])
+  def watch(directories: Map[jnf.Path, Text -> Boolean], spool: Spool[WatchEvent])
   :   Watcher.Registration raises WatchError =
 
     directories.each: (directory, _) =>

--- a/lib/surveillance/src/core/surveillance.PollingWatcher.scala
+++ b/lib/surveillance/src/core/surveillance.PollingWatcher.scala
@@ -108,9 +108,11 @@ extends Watcher:
     directories.each: (directory, filter) =>
       snapshots(directory) = scan(directory, filter)
 
+    // Sealed per the pure-façade convention (D6), like `NativeWatcher`: the handle is held
+    // only to keep the supervised poll task alive for the registration's lifetime.
     val async: Optional[Task[Unit]] = safely:
       supervise:
-        task(n"surveillance-poll"):
+        val polling = task(n"surveillance-poll"):
           try
             while true do
               snooze(interval)
@@ -121,6 +123,8 @@ extends Watcher:
                 snapshots(directory) = current
 
           catch case _: InterruptedException => ()
+
+        caps.unsafe.unsafeAssumePure(polling)
 
     Registration(async)
 

--- a/lib/surveillance/src/core/surveillance.Watch.scala
+++ b/lib/surveillance/src/core/surveillance.Watch.scala
@@ -44,16 +44,17 @@ object Watch:
   def apply[path: Abstractable across Paths to Text](paths: Iterable[path])(using watcher: Watcher)
   :   Watch raises WatchError =
 
-    val pathGroups: Map[jnf.Path, Iterable[Text => Boolean]] =
+    val pathGroups: Map[jnf.Path, Iterable[Text -> Boolean]] =
       paths.map(_.generic.s).map(jnf.Paths.get(_).nn).map: javaPath =>
         if javaPath.toFile.nn.isDirectory then (javaPath, (_: Text) => true)
         else
           val parent = Optional(javaPath.getParent).or(jnf.Paths.get("").nn)
-          (parent, (_: Text) == javaPath.getFileName.nn.toString.tt)
+          val filename = javaPath.getFileName.nn.toString.tt
+          (parent, (_: Text) == filename)
 
       . groupBy(_(0)).view.mapValues(_.map(_(1))).to(Map)
 
-    val directories: Map[jnf.Path, Text => Boolean] =
+    val directories: Map[jnf.Path, Text -> Boolean] =
       pathGroups.view.mapValues: predicates =>
         (value: Text) => predicates.exists(_(value))
 

--- a/lib/surveillance/src/core/surveillance.Watcher.scala
+++ b/lib/surveillance/src/core/surveillance.Watcher.scala
@@ -52,5 +52,7 @@ object Watcher:
     def cancel(): Unit
 
 trait Watcher:
-  def watch(directories: Map[jnf.Path, Text => Boolean], spool: Spool[WatchEvent])
+  // Pure (`->`) filters: they are constructed by `Watch.apply` from path names alone, and
+  // registrations are retained in backend-global state, which must not capture.
+  def watch(directories: Map[jnf.Path, Text -> Boolean], spool: Spool[WatchEvent])
   :   Watcher.Registration raises WatchError

--- a/lib/symbolism/src/core/symbolism.Concatenable.scala
+++ b/lib/symbolism/src/core/symbolism.Concatenable.scala
@@ -34,5 +34,5 @@ package symbolism
 
 import prepositional.*
 
-trait Concatenable extends Typeclass, Operable:
+trait Concatenable extends Typeclass.Pure, Operable:
   def concat(left: Self, right: Operand): Self | Operand

--- a/lib/symbolism/src/core/symbolism.Divisible.scala
+++ b/lib/symbolism/src/core/symbolism.Divisible.scala
@@ -85,7 +85,7 @@ object Divisible:
   given byte2: Byte is Divisible by Double to Double = Divisible:
     (dividend, divisor) => dividend/divisor
 
-trait Divisible extends Typeclass, Operable, Resultant:
+trait Divisible extends Typeclass.Pure, Operable, Resultant:
   type Dividend = Self
   type Divisor = Operand
 

--- a/lib/symbolism/src/core/symbolism.Multiplicable.scala
+++ b/lib/symbolism/src/core/symbolism.Multiplicable.scala
@@ -80,7 +80,7 @@ object Multiplicable:
 
       result
 
-trait Multiplicable extends Typeclass, Operable, Resultant:
+trait Multiplicable extends Typeclass.Pure, Operable, Resultant:
   type Multiplicand = Self
   type Multiplier = Operand
 

--- a/lib/symbolism/src/core/symbolism.Negatable.scala
+++ b/lib/symbolism/src/core/symbolism.Negatable.scala
@@ -53,5 +53,5 @@ object Negatable:
   given byte: Byte is Negatable to Byte = Negatable:
     operand => (-operand).toByte
 
-trait Negatable extends Typeclass, Resultant:
+trait Negatable extends Typeclass.Pure, Resultant:
   def negate(operand: Self): Result

--- a/lib/symbolism/src/core/symbolism.Subtractable.scala
+++ b/lib/symbolism/src/core/symbolism.Subtractable.scala
@@ -58,7 +58,7 @@ object Subtractable:
   given byte: Byte is Subtractable by Byte to Byte = Subtractable:
     (minuend, subtrahend) => (minuend - subtrahend).toByte
 
-trait Subtractable extends Typeclass, Operable, Resultant:
+trait Subtractable extends Typeclass.Pure, Operable, Resultant:
   type Minuend = Self
   type Subtrahend = Operand
 

--- a/lib/symbolism/src/core/symbolism.Unital.scala
+++ b/lib/symbolism/src/core/symbolism.Unital.scala
@@ -42,6 +42,6 @@ object Unital:
   given double: Double is Unital = () => 1.0
   given float: Float is Unital = () => 1.0f
 
-trait Unital extends Typeclass:
+trait Unital extends Typeclass.Pure:
   protected def makeOne(): Self
   def one: Self = makeOne()

--- a/lib/symbolism/src/core/symbolism.Zeroic.scala
+++ b/lib/symbolism/src/core/symbolism.Zeroic.scala
@@ -56,5 +56,5 @@ object Zeroic:
   given string: String is Zeroic:
     inline def zero: String = ""
 
-trait Zeroic extends Typeclass:
+trait Zeroic extends Typeclass.Pure:
   def zero: Self

--- a/lib/tarantula/src/core/tarantula.Chrome.scala
+++ b/lib/tarantula/src/core/tarantula.Chrome.scala
@@ -44,7 +44,7 @@ import abstractables.instantAbstractable
 import strategies.throwUnsafely
 
 object Chrome extends Navigator(t"chrome"):
-  def launch(port: Int)(using WorkingDirectory, Monitor): Server logs ExecEvent =
+  def launch(using WorkingDirectory, Monitor)(using ExecEvent is Loggable)(port: Int): Server^ =
     val server: Job["chromedriver", Text] = sh"chromedriver --port=$port".fork()
     sleep(100L)
     Server(port, server)

--- a/lib/tarantula/src/core/tarantula.Chrome.scala
+++ b/lib/tarantula/src/core/tarantula.Chrome.scala
@@ -44,7 +44,7 @@ import abstractables.instantAbstractable
 import strategies.throwUnsafely
 
 object Chrome extends Navigator(t"chrome"):
-  def launch(using WorkingDirectory, Monitor)(using ExecEvent is Loggable)(port: Int): Server^ =
+  def launch(using WorkingDirectory, Monitor)(using (ExecEvent is Loggable)^)(port: Int): Server^ =
     val server: Job["chromedriver", Text] = sh"chromedriver --port=$port".fork()
     sleep(100L)
     Server(port, server)

--- a/lib/tarantula/src/core/tarantula.Firefox.scala
+++ b/lib/tarantula/src/core/tarantula.Firefox.scala
@@ -44,7 +44,7 @@ import abstractables.instantAbstractable
 import strategies.throwUnsafely
 
 object Firefox extends Navigator(t"firefox"):
-  def launch(port: Int)(using WorkingDirectory, Monitor): Server logs ExecEvent =
+  def launch(using WorkingDirectory, Monitor)(using ExecEvent is Loggable)(port: Int): Server^ =
     val server: Job["geckodriver", Text] = sh"geckodriver --port $port".fork()
     sleep(100L)
     Server(port, server)

--- a/lib/tarantula/src/core/tarantula.Firefox.scala
+++ b/lib/tarantula/src/core/tarantula.Firefox.scala
@@ -44,7 +44,7 @@ import abstractables.instantAbstractable
 import strategies.throwUnsafely
 
 object Firefox extends Navigator(t"firefox"):
-  def launch(using WorkingDirectory, Monitor)(using ExecEvent is Loggable)(port: Int): Server^ =
+  def launch(using WorkingDirectory, Monitor)(using (ExecEvent is Loggable)^)(port: Int): Server^ =
     val server: Job["geckodriver", Text] = sh"geckodriver --port $port".fork()
     sleep(100L)
     Server(port, server)

--- a/lib/tarantula/src/core/tarantula.Focusable.scala
+++ b/lib/tarantula/src/core/tarantula.Focusable.scala
@@ -41,7 +41,9 @@ import prepositional.*
 import spectacular.*
 
 object Focusable:
-  def apply[element](strategy0: Text, focus0: element => Text): element is Focusable =
+  // A pure (`->`) focus lambda: every instance is built from a pure selector-rendering
+  // function, and the factory result must stay pure for the bare-typed givens below.
+  def apply[element](strategy0: Text, focus0: element -> Text): element is Focusable =
     new Focusable:
       type Self = element
       def strategy: Text = strategy0

--- a/lib/tarantula/src/core/tarantula.Navigator.scala
+++ b/lib/tarantula/src/core/tarantula.Navigator.scala
@@ -41,16 +41,25 @@ import telekinesis.*
 trait Navigator(name: Text):
   transparent inline def browser = this
 
-  case class Server(port: Int, value: Job[Label, Text]):
+  // A `Server` is a *capability*: it wraps the live browser-automation process. Its `stop`
+  // reaches back to the defining `Navigator`, declared by the `uses` clause.
+  case class Server(port: Int, value: Job[Label, Text]) extends caps.ExclusiveCapability
+  uses Navigator.this:
     def stop(): Unit logs ExecEvent logs HttpEvent = browser.stop(this)
 
-  def launch(port: Int)(using WorkingDirectory, Monitor): Server logs ExecEvent
+  def launch(using WorkingDirectory, Monitor)(using ExecEvent is Loggable)(port: Int): Server^
   def stop(server: Server): Unit logs HttpEvent logs ExecEvent
 
 
+  // Explicit `using` evidence instead of stacked `logs` sugar: the fresh `Server` capability
+  // bound in the body cannot cross the nested context-function results the sugar desugars to
+  // (the stacked-raises convention; see rep/DECISIONS.md).
   def session[result](port: Int = 4444)(block: (session: WebDriver#Session) ?=> result)
     ( using WorkingDirectory, Monitor )
-  :   result logs HttpEvent logs ExecEvent =
+    ( using HttpEvent is Loggable, ExecEvent is Loggable )
+  :   result =
 
+    // The fresh `Server` capability stays confined to this method; the `WebDriver` passed to
+    // the block is a pure port-holder.
     val server = launch(port)
-    try block(using WebDriver(server).startSession()) finally server.stop()
+    try block(using WebDriver(port).startSession()) finally server.stop()

--- a/lib/tarantula/src/core/tarantula.Navigator.scala
+++ b/lib/tarantula/src/core/tarantula.Navigator.scala
@@ -47,7 +47,7 @@ trait Navigator(name: Text):
   uses Navigator.this:
     def stop(): Unit logs ExecEvent logs HttpEvent = browser.stop(this)
 
-  def launch(using WorkingDirectory, Monitor)(using ExecEvent is Loggable)(port: Int): Server^
+  def launch(using WorkingDirectory, Monitor)(using (ExecEvent is Loggable)^)(port: Int): Server^
   def stop(server: Server): Unit logs HttpEvent logs ExecEvent
 
 
@@ -56,7 +56,7 @@ trait Navigator(name: Text):
   // (the stacked-raises convention; see rep/DECISIONS.md).
   def session[result](port: Int = 4444)(block: (session: WebDriver#Session) ?=> result)
     ( using WorkingDirectory, Monitor )
-    ( using HttpEvent is Loggable, ExecEvent is Loggable )
+    ( using (HttpEvent is Loggable)^, (ExecEvent is Loggable)^ )
   :   result =
 
     // The fresh `Server` capability stays confined to this method; the `WebDriver` passed to

--- a/lib/tarantula/src/core/tarantula.WebDriver.scala
+++ b/lib/tarantula/src/core/tarantula.WebDriver.scala
@@ -51,7 +51,11 @@ import urticose.*
 import httpBackends.virtualMachine
 import strategies.throwUnsafely
 
-case class WebDriver(server: Navigator#Server):
+// A `WebDriver` and its `Session`/`Element` values are pure ID-holders over the automation
+// server's port: the live resource is the `Server` capability, confined to the `session`
+// block that launches it. (A leaked `Session` after the block is a dangling ID over a
+// stopped server, not a live handle.)
+case class WebDriver(port: Int):
   private transparent inline def wd: this.type = this
 
   case class Session(sessionId: Text):
@@ -67,17 +71,17 @@ case class WebDriver(server: Navigator#Server):
 
     case class Element(elementId: Text):
       private def get(address: Text): Json logs HttpEvent = safe:
-        given online: Online = Online
+        given online: Online = Online()
 
         val url: HttpUrl =
-          url"http://localhost:${server.port}/session/$sessionId/element/$elementId/$address"
+          url"http://localhost:${port}/session/$sessionId/element/$elementId/$address"
 
         url.fetch(contentType = media"application/json").receive[Json]
 
       private def post(address: Text, content: Json): Json logs HttpEvent = safe:
-        given online: Online = Online
+        given online: Online = Online()
 
-        url"http://localhost:${server.port}/session/$sessionId/element/$elementId/$address"
+        url"http://localhost:${port}/session/$sessionId/element/$elementId/$address"
         . submit()(content)
         . read[Text]
         . as[Json]
@@ -109,15 +113,15 @@ case class WebDriver(server: Navigator#Server):
         Element(e.value.selectDynamic(Wei.s).as[Text])
 
     private def get(address: Text): Json logs HttpEvent = safe:
-      given online: Online = Online
+      given online: Online = Online()
 
-      url"http://localhost:${server.port}/session/$sessionId/$address"
+      url"http://localhost:${port}/session/$sessionId/$address"
       . fetch(contentType = media"application/json")
       . receive[Json]
 
     private def post(address: Text, content: Json): Json logs HttpEvent = safe:
-      given online: Online = Online
-      url"http://localhost:${server.port}/session/$sessionId/$address".submit()(content)
+      given online: Online = Online()
+      url"http://localhost:${port}/session/$sessionId/$address".submit()(content)
       . read[Text]
       . as[Json]
 
@@ -155,9 +159,9 @@ case class WebDriver(server: Navigator#Server):
       Element(get(t"element/active").value.selectDynamic(Wei.s).as[Text])
 
   def startSession(): Session logs HttpEvent =
-    given online: Online = Online
+    given online: Online = Online()
 
-    val url = url"http://localhost:${server.port}/session"
+    val url = url"http://localhost:${port}/session"
     val json = url.submit()(t"""{"capabilities":{}}""".read[Json]).read[Text].as[Json]
 
     Session(json.value.sessionId.as[Text])

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -961,7 +961,7 @@ object Http:
     inline def applyDynamicNamed[payload](id: "apply")(inline headers: (Label, Any)*)
       ( payload: payload )
       ( using online:   Online,
-              loggable: HttpEvent is Loggable,
+              loggable: (HttpEvent is Loggable)^,
               postable: (payload is Postable)^,
               client:   HttpClient onto target )
     :   Http.Response =
@@ -975,7 +975,7 @@ object Http:
     inline def applyDynamic[payload](id: "apply")(inline headers: Any*)
       ( payload: payload )
       ( using online:   Online,
-              loggable: HttpEvent is Loggable,
+              loggable: (HttpEvent is Loggable)^,
               postable: (payload is Postable)^,
               client:   HttpClient onto target )
     :   Http.Response =
@@ -991,7 +991,7 @@ object Http:
 
     inline def applyDynamicNamed(id: "apply")(inline headers: (Label, Any)*)
       ( using online:   Online,
-              loggable: HttpEvent is Loggable,
+              loggable: (HttpEvent is Loggable)^,
               postable: (Unit is Postable)^,
               client:   HttpClient onto target )
     :   Http.Response =
@@ -1001,7 +1001,7 @@ object Http:
 
     inline def applyDynamic[payload](id: "apply")(inline headers: Any*)
       ( using online:   Online,
-              loggable: HttpEvent is Loggable,
+              loggable: (HttpEvent is Loggable)^,
               client:   HttpClient onto target )
     :   Http.Response =
 

--- a/lib/telekinesis/src/core/telekinesis.HttpClient.scala
+++ b/lib/telekinesis/src/core/telekinesis.HttpClient.scala
@@ -78,7 +78,7 @@ object HttpClient:
       type Target = Origin["http" | "https"]
 
       def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
-        ( using HttpEvent is Loggable )
+        ( using (HttpEvent is Loggable)^ )
       :   Http.Response =
 
         val url = httpRequest.on(origin)
@@ -97,7 +97,7 @@ object HttpClient:
       type Target = Origin["http" | "https"]
 
       def request(httpRequest: Http.Request, origin: Origin["http" | "https"])
-        ( using HttpEvent is Loggable )
+        ( using (HttpEvent is Loggable)^ )
       :   Http.Response =
 
         val url = httpRequest.on(origin)
@@ -141,4 +141,4 @@ object HttpClient:
 // `Tactic`, an `Online` token, a backend) which they retain — a given that takes capabilities
 // as parameters produces a capability (Jon, 2026-07-06; see rep/DECISIONS.md).
 trait HttpClient extends Targetable, caps.ExclusiveCapability:
-  def request(request: Http.Request, target: Target)(using HttpEvent is Loggable): Http.Response
+  def request(request: Http.Request, target: Target)(using (HttpEvent is Loggable)^): Http.Response

--- a/lib/telekinesis/src/core/telekinesis.internal.scala
+++ b/lib/telekinesis/src/core/telekinesis.internal.scala
@@ -130,7 +130,10 @@ object internal:
           case method: Expr[Http.Method] => method
 
         ' {
-            given online0: Online = $online
+            // No `Online` binding in the staged code: the permission gates summonability of
+            // the enclosing extension method, and (with `Online` a capability) a local
+            // capability-typed given inside the quote would trip the quote wall and, under
+            // separation checking, hide the outer parameter from later statements.
 
             // Staging-boundary seal: quoted types must stay pure, so the (honestly
             // tracked) evidence is sealed on entry to the generated code. The
@@ -173,7 +176,7 @@ object internal:
           case method: Expr[Http.Method] => method
 
         ' {
-            given online0: Online = $online
+            // No `Online` binding, as in `submit` above.
             given loggable0: HttpEvent is Loggable = $loggable
 
             val path = $fetch.originForm

--- a/lib/telekinesis/src/core/telekinesis.internal.scala
+++ b/lib/telekinesis/src/core/telekinesis.internal.scala
@@ -141,7 +141,9 @@ object internal:
             given postable0: (payload is Postable) =
               caps.unsafe.unsafeAssumePure($postable)
 
-            given loggable0: HttpEvent is Loggable = $loggable
+            // Staging-boundary seal, like `postable0` below: quoted types must stay pure.
+            given loggable0: HttpEvent is Loggable =
+              caps.unsafe.unsafeAssumePure($loggable)
             val host: Host = $submit.host
             val path = $submit.originForm
             val contentType = Http.Header("content-type".tt, postable0.mediaType($payload).show)
@@ -177,7 +179,9 @@ object internal:
 
         ' {
             // No `Online` binding, as in `submit` above.
-            given loggable0: HttpEvent is Loggable = $loggable
+            // Staging-boundary seal, like `postable0` below: quoted types must stay pure.
+            given loggable0: HttpEvent is Loggable =
+              caps.unsafe.unsafeAssumePure($loggable)
 
             val path = $fetch.originForm
 

--- a/lib/turbulence/src/core/turbulence.Err.scala
+++ b/lib/turbulence/src/core/turbulence.Err.scala
@@ -38,9 +38,9 @@ import rudiments.*
 object Err:
   private val mutex: Mutex = Mutex()
 
-  def write(bytes: Data)(using stdio: Stdio): Unit = stdio.writeErr(bytes)
+  def write(bytes: Data)(using stdio: Stdio^): Unit = stdio.writeErr(bytes)
 
-  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio): Unit =
+  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio^): Unit =
     stdio.printErr(printable.print(text(using stdio.termcap), stdio.termcap))
 
   def println[textual: Printable as printable, C^](lines: (Termcap ?->{C} textual)*)
@@ -52,4 +52,4 @@ object Err:
         stdio.printErr(printable.print(line(using stdio.termcap), stdio.termcap))
         stdio.printErr("\n".tt)
 
-  def println()(using Stdio): Unit = print("\n".tt)
+  def println()(using Stdio^): Unit = print("\n".tt)

--- a/lib/turbulence/src/core/turbulence.Out.scala
+++ b/lib/turbulence/src/core/turbulence.Out.scala
@@ -38,12 +38,12 @@ import rudiments.*
 object Out:
   private val mutex: Mutex = Mutex()
 
-  def write(bytes: Data)(using stdio: Stdio): Unit = stdio.write(bytes)
+  def write(bytes: Data)(using stdio: Stdio^): Unit = stdio.write(bytes)
 
-  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio): Unit =
+  def print[textual: Printable as printable](text: Termcap ?=> textual)(using stdio: Stdio^): Unit =
     stdio.print(printable.print(text(using stdio.termcap), stdio.termcap))
 
-  def println()(using Stdio): Unit = print("\n".tt)
+  def println()(using Stdio^): Unit = print("\n".tt)
 
   def println[textual: Printable as printable, C^](lines: (Termcap ?->{C} textual)*)
     ( using stdio: Stdio )

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -772,11 +772,14 @@ object Tests extends Suite(m"Turbulence tests"):
           val source = summon[Data is Source by Data over Credit].stream(payload)
           val subscribers = Divergence(source, 3)
 
+          // Handles collected for concurrent await: sealed per the pure-façade convention
+          // (D6; the `Seq[Task].sequence` shape).
           val results = subscribers.map: stream =>
-            async:
-              val gather = Gather2()
-              stream.pump(gather)
-              gather.data.to(List)
+            caps.unsafe.unsafeAssumePure:
+              async:
+                val gather = Gather2()
+                stream.pump(gather)
+                gather.data.to(List)
 
           results.map { task => task.await() }.to(List)
       . assert(_ == List.fill(3)(payload.to(List)))
@@ -801,11 +804,14 @@ object Tests extends Suite(m"Turbulence tests"):
 
           val subscribers = Divergence(source, 3)
 
+          // Handles collected for concurrent await: sealed per the pure-façade convention
+          // (D6; the `Seq[Task].sequence` shape).
           val results = subscribers.map: stream =>
-            async:
-              val gather = Gather2()
-              stream.pump(gather)
-              gather.data.to(List)
+            caps.unsafe.unsafeAssumePure:
+              async:
+                val gather = Gather2()
+                stream.pump(gather)
+                gather.data.to(List)
 
           results.map { task => task.await() }.to(List)
       . assert(_ == List.fill(3)(mixed.to(List)))

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -474,9 +474,12 @@ object Tests extends Suite(m"Turbulence tests"):
       test(m"the reader blocks for records from concurrent producers"):
         supervise:
           val relay = Relay[Text]()
+          // Handles collected for concurrent await: sealed per the pure-façade convention
+          // (D6; the `Seq[Task].sequence` shape).
           val producers = (1 to 4).map: index =>
-            async:
-              for value <- 1 to 25 do relay.put(t"${index*100 + value}")
+            caps.unsafe.unsafeAssumePure:
+              async:
+                for value <- 1 to 25 do relay.put(t"${index*100 + value}")
 
           val reader = async(relay.stream.records.to(Set))
           producers.each(_.await())

--- a/lib/ultimatum/src/core/ultimatum.FlowExtent.scala
+++ b/lib/ultimatum/src/core/ultimatum.FlowExtent.scala
@@ -43,7 +43,7 @@ import turbulence.*
 // parent's `move`/`put` (so positioning is always expressed through the `Canvas`
 // interface, never as inline escapes). It is also an `Stdio`, so bare
 // `Out.println` in a panel body flows into it.
-class FlowExtent(parent: Canvas, val rect: Rect)
+class FlowExtent(parent: Canvas^, val rect: Rect)
 extends GridSurface(rect.width, rect.height), Extent:
   def cursor(visible: Boolean): Unit = parent.cursor(visible)
 

--- a/lib/ultimatum/src/core/ultimatum.Focus.scala
+++ b/lib/ultimatum/src/core/ultimatum.Focus.scala
@@ -46,7 +46,7 @@ import vacuous.*
 // state, and reports the intrinsic size its current content needs — the hook the
 // reactive layout uses to grow or shrink a panel.
 trait Focus:
-  def render(canvas: Canvas, focused: Boolean): Unit
+  def render(canvas: Canvas^, focused: Boolean): Unit
   def handle(event: TerminalEvent): Unit
   def measure(width: Int): (Int, Int)
 
@@ -61,8 +61,8 @@ class EditorField(initial: LineEditor = LineEditor()) extends Focus:
   // The shared `Interaction` draws the editor and positions the caret; the
   // hardware cursor is then shown only when this field has focus, so the caret
   // appears in the focused editor and is hidden elsewhere.
-  def render(canvas: Canvas, focused: Boolean): Unit =
-    given Canvas = canvas
+  def render(canvas: Canvas^, focused: Boolean): Unit =
+    given canvas0: (Canvas^{canvas}) = canvas
     summon[Interaction[Text, LineEditor]].render(Unset, editor)
     canvas.cursor(focused)
 
@@ -83,8 +83,8 @@ class MenuField[item: Showable](initial: SelectMenu[item]) extends Focus:
   // pointer (`>`) when this field has focus, a dot (`·`) when it does not, so the
   // selection is always visible but the focused menu is distinguished. The
   // hardware cursor is kept hidden — a menu has no text caret.
-  def render(canvas: Canvas, focused: Boolean): Unit =
-    given Canvas = canvas
+  def render(canvas: Canvas^, focused: Boolean): Unit =
+    given canvas0: (Canvas^{canvas}) = canvas
     val cols = canvas.width.max(1)
     canvas.move(Prim, Prim)
     canvas.clear()

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -46,7 +46,9 @@ import vacuous.*
 // the changed cells; inline re-sizes the grid to the measured block height each
 // frame and re-presents the whole block at the cursor.
 class Form
-  ( root:         Canvas,
+  // `Canvas^`: a terminal-backed canvas retains its terminal (live size thunks), and the
+  // form legitimately holds it for its whole run.
+  ( root:         Canvas^,
     mode:         Mode,
     pane:         Pane,
     wake:         () => Unit   = () => (),

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -47,7 +47,7 @@ object InlineRoot:
   // fixed at the caller's site rather than inside the library.
   def apply(terminal: Terminal)
     ( using anchoring: InlineAnchoring, growth: InlineGrowth, shrink: InlineShrink )
-  :   InlineRoot =
+  :   InlineRoot^{terminal} =
 
     new InlineRoot(() => terminal.knownColumns, () => terminal.knownRows)
       ( using terminal.stdio, anchoring, growth, shrink )

--- a/lib/ultimatum/src/core/ultimatum.Pane.scala
+++ b/lib/ultimatum/src/core/ultimatum.Pane.scala
@@ -44,7 +44,7 @@ package ultimatum
 enum Pane:
   def sizing: Sizing
 
-  case Leaf(sizing: Sizing, content: Extent -> Unit)
+  case Leaf(sizing: Sizing, content: Extent^ -> Unit)
   case Widget(sizing: Sizing, focus: Focus)
   case Branch(sizing: Sizing, axis: Axis, panes: Panes)
 

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -51,7 +51,7 @@ def panel
     maxWidth:  Optional[Int] = Unset,
     minHeight: Int           = 0,
     maxHeight: Optional[Int] = Unset )
-  ( content: Extent ?-> Unit )
+  ( content: (Extent^) ?-> Unit )
 :   Pane =
 
   val sizing = Sizing(fraction, minWidth, maxWidth, minHeight, maxHeight)
@@ -200,7 +200,7 @@ def dirtyCells(previous: IndexedSeq[Rect], current: IndexedSeq[Rect], changed: S
 // Solve `pane` against `root` once and paint each leaf's content into its
 // rectangle (no event loop). An `InlineRoot` is sized to the height its content
 // needs and presented at the cursor; any other canvas fills its own height.
-def paint(root: Canvas, pane: Pane): Unit =
+def paint(root: Canvas^, pane: Pane): Unit =
   val height = root match
     case _: InlineRoot => pane.frame.measure(Axis.Rank).min
     case _             => root.height

--- a/lib/urticose/src/core/urticose.Internet.scala
+++ b/lib/urticose/src/core/urticose.Internet.scala
@@ -36,9 +36,14 @@ import beneficence.*
 import contingency.*
 import vacuous.*
 
-class Internet(val online: Boolean) extends Findable:
+// An `Internet` is a *capability*: it is evidence of (possible) network access, so code that
+// depends on connectivity carries it in its capture set. `caps.Unscoped` (like contingency's
+// ambient strategies) rather than a scoped classifier: it holds only a `Boolean`, and the
+// deliberately-ambient `Online` singleton and `internetAccess.online` given must be storable
+// statically, which the scoped classifiers forbid.
+class Internet(val online: Boolean) extends Findable, caps.Unscoped:
   def require[result](block: Online ?=> result)(using Tactic[OfflineError]): result =
-    if online then block(using Online) else abort(OfflineError())
+    if online then block(using Online()) else abort(OfflineError())
 
   def appropriate[result](block: Online ?=> result): Optional[result] =
-    if online then block(using Online) else Unset
+    if online then block(using Online()) else Unset

--- a/lib/urticose/src/core/urticose.Protocolic.scala
+++ b/lib/urticose/src/core/urticose.Protocolic.scala
@@ -39,4 +39,4 @@ trait Protocolic extends Typeclass, Transportive:
   type Response
   type Server
 
-  def server(port: Transport)(lambda: Request ?=> Response): Server
+  def server(port: Transport)(lambda: Request ?=> Response): Server^

--- a/lib/urticose/src/core/urticose_core.scala
+++ b/lib/urticose/src/core/urticose_core.scala
@@ -68,7 +68,7 @@ extension [remote: Remotable](value: remote)
 extension [port](port: port)
   transparent inline def serve[protocol: Protocolic over port]
     ( handler: protocol.Request ?=> protocol.Response )
-  :   protocol.Server =
+  :   protocol.Server^ =
 
     protocol.server(port)(handler)
 

--- a/lib/urticose/src/core/urticose_core.scala
+++ b/lib/urticose/src/core/urticose_core.scala
@@ -83,5 +83,8 @@ val Localhost: Hostname = Hostname(DnsLabel("localhost".tt))
 type Host = Hostname | Ipv4 | Ipv6
 
 package internetAccess:
-  given online: Online = Online()
+  // `inline`: an unparameterized given would be a static field, and a field of capability type
+  // would force the enclosing package object to become a capability. Inlining mints a fresh
+  // `Online` at each summon site instead.
+  inline given online: Online = Online()
   given offline: Tactic[OfflineError] => Online = abort(OfflineError())

--- a/lib/vacuous/src/core/vacuous.Concrete.scala
+++ b/lib/vacuous/src/core/vacuous.Concrete.scala
@@ -40,4 +40,4 @@ object Concrete:
   def apply[self](): self is Concrete = new Concrete:
     type Self = self
 
-sealed trait Concrete extends Typeclass
+sealed trait Concrete extends Typeclass.Pure

--- a/lib/vacuous/src/core/vacuous.Default.scala
+++ b/lib/vacuous/src/core/vacuous.Default.scala
@@ -47,5 +47,7 @@ object Default:
   given set: [element] => Default[Set[element]] = () => Set()
   given series: [element] => Default[Series[element]] = () => Series()
 
+// `scala.caps.Pure` directly (not `Typeclass.Pure`): `Default` is parameterized covariantly
+// rather than selected through a `Self` member, so the prepositional shape does not apply.
 trait Default[+value] extends Findable, scala.caps.Pure:
   def apply(): value

--- a/lib/vacuous/src/core/vacuous.Distinct.scala
+++ b/lib/vacuous/src/core/vacuous.Distinct.scala
@@ -42,4 +42,4 @@ object Distinct:
     type Self = self
     type Origin = origin
 
-sealed trait Distinct extends Typeclass, Original
+sealed trait Distinct extends Typeclass.Pure, Original

--- a/lib/vacuous/src/core/vacuous.Mandatable.scala
+++ b/lib/vacuous/src/core/vacuous.Mandatable.scala
@@ -42,5 +42,5 @@ object Mandatable:
     type Self = self
     type Result = result
 
-sealed trait Mandatable extends Typeclass:
+sealed trait Mandatable extends Typeclass.Pure:
   type Result <: Self

--- a/lib/wisteria/src/core/wisteria.Derivation.scala
+++ b/lib/wisteria/src/core/wisteria.Derivation.scala
@@ -38,6 +38,12 @@ trait Derivation[typeclass[_]]
 extends ProductDerivation.Methods[typeclass], SumDerivation.Methods[typeclass]:
   // Derives a single type, one level deep; its fields/variants resolve through `field` onto sibling
   // instances. `deriveGraph` calls this once per distinct reachable type.
+  //
+  // The match below is the ONE engine-level erasure of the derivation boundary: `conjunction`/
+  // `disjunction` return fresh (`^`) instances whose captures the graph macro's quoted trees
+  // cannot carry (the quote wall), so the honest type is narrowed here, once, instead of a
+  // codec-thunk seal in every implementation (the `fieldInstance` counterpart, in the other
+  // direction).
   inline def derivedOne[derivation]: typeclass[derivation] =
     inline if wisteria.internal.isSum[derivation] then
       disjunction[derivation](using summonInline[SumReflection[derivation]]).asMatchable match

--- a/lib/wisteria/src/core/wisteria.ProductDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.ProductDerivation.scala
@@ -135,7 +135,9 @@ object ProductDerivation:
       ${wisteria.internal.fieldsProduct[typeclass, derivation, result]('product, 'lambda)}
 
 
-    inline def conjunction[derivation <: Product: ProductReflection]: typeclass[derivation]
+    // A fresh (`^`) result: a derived instance may honestly capture its resolution-scoped
+    // capabilities (a decoder's tactic), so implementations need no codec-thunk seal.
+    inline def conjunction[derivation <: Product: ProductReflection]: typeclass[derivation]^
 
 trait ProductDerivation[typeclass[_]] extends ProductDerivation.Methods[typeclass]:
   inline def derivedOne[derivation]: typeclass[derivation] =

--- a/lib/wisteria/src/core/wisteria.SumDerivation.scala
+++ b/lib/wisteria/src/core/wisteria.SumDerivation.scala
@@ -297,7 +297,8 @@ object SumDerivation:
           else panic(m"Should be unreachable")
 
 
-    inline def disjunction[derivation: SumReflection]: typeclass[derivation]
+    // A fresh (`^`) result, like `conjunction`.
+    inline def disjunction[derivation: SumReflection]: typeclass[derivation]^
 
 trait SumDerivation[typeclass[_]] extends SumDerivation.Methods[typeclass]:
   inline def derivedOne[derivation]: typeclass[derivation] =

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -52,6 +52,11 @@ the order the legs need them:
   `urticose.Internet` → `caps.SharedCapability` (aliasable effect evidence, no teardown). Scope
   methods then take form A (`block: Ctx ?=> result` with unconstrained `result`), matching
   `parasite.supervise`/`enigmatic.expose`, plus a CaptureTests-style negative regression each.
+  AMENDED in Phase 2 (compiler-forced): `Random` and `Internet` are `caps.Unscoped`, not
+  `SharedCapability` — `Unscoped extends ExclusiveCapability`, so the two classifiers cannot
+  combine, and both types have deliberately-ambient static instances (`Random.global`,
+  `object Online`, `internetAccess.online`) that scoped classifiers forbid. Unscoped is exactly
+  contingency's ambient-strategy precedent: tracked in capture sets, storable statically.
 - **D2 — coaxial `listen` scoped redesign** (existing ⚑4; needed for Phase 5): recommend the loan
   form `def listen[result](lambda: Input => Output)(block: SocketService^ ?=> result): result`
   (bind, run block, always stop in `finally`), which both fixes the `val server` fresh-escape and
@@ -2010,3 +2015,43 @@ decoder is NOT covered by dictcaps and resisted a jacinta-style restructure (it
 persisted and crashed rechecking). The two telekinesis Query-decode tests that
 hit it (`Dereference a query` — also broken #1500 — and `Decode a query`) are
 disabled with a comment, to revisit. See [[reference_dictcaps_compiler_fix]].
+
+## Capture-honesty Phase 2: effect channels + Cli are capabilities (2026-07-15, branch capture-honesty)
+
+`capricious.Random`, `urticose.Internet`/`Online` → `caps.Unscoped`; `polaris.Buffer` →
+`caps.ExclusiveCapability`; `exoskeleton.Cli` → `caps.ExclusiveCapability`. The scope methods
+(`stochastic`, `internet`, `require`/`appropriate`, `buffer`, `Executive.process`) keep their
+`Ctx ?=> result` shape — with the context types now capability classes, the bare name is
+auto-tracked (the `supervise` form). Gates: JVM 10301/10301, JS 8006/8006; suites green
+(telekinesis's 4 per-module Query failures reproduce exactly at the attested base — the known
+umbrella/per-module implicit-scope artifact).
+
+Recipes this leg (all compiler-forced, reusable):
+- Classifier lattice: `Unscoped extends ExclusiveCapability` — it cannot combine with
+  `SharedCapability`. Ambient-storable tracked types therefore go on the exclusive line.
+- A capability-typed FIELD forces its owner to extend Capability: `Random.global` now stores
+  the untracked JDK generator and mints a fresh `Random` wrapper per call; urticose's
+  `internetAccess.online` given became `inline given` (a fresh `Online` per summon site, no
+  static field); `Internet.require`/`appropriate` mint `Online()` per block instead of
+  referencing the singleton (a capability object referenced from a class body charges the
+  class's capture set).
+- polaris `Unpackable.iarray`: the curried continuation no longer captures the caller's
+  `Buffer` — it records the (pure) backing `Data` + start offset and mints its own buffer per
+  invocation. This keeps the trait signature pure for every other instance; the earlier
+  attempts (trait-level `Wrap[Self]^{buffer}`, transparent-inline unpackFrom with fresh `^`)
+  failed because hypotenuse's opaques (`U16 = Short` etc.) have no pure bounds, so nothing
+  downstream is statically pure and fresh `^` never collapses. FUTURE OPTION: pure upper
+  bounds on hypotenuse opaques (the zephyrine Credit<:Long precedent) would unlock
+  static-purity-based collapse tree-wide; needs Jon (exposes `U16 <: Short` subtyping).
+- exoskeleton `Executive.process` block param narrowed `Interface ?=> Return` → `Cli ?=>
+  Return`: adapting a `Cli ?=>` context function to an abstract-`Interface ?=>` one trips
+  capture-root unification ("any² cannot flow into {any}"), and every entry point routes a
+  `Cli ?=>` block anyway.
+- telekinesis staged fetch/submit: the `given online0: Online = $online` bindings inside
+  quotes DELETED — nothing in the generated code summons `Online` (it gates the extension
+  method's summonability), and a capability-typed local given inside a quote violates the
+  quote wall and (under sep) the statement rule.
+- Givens gated on `Online` evidence become honest capabilities: coaxial
+  `Connectable.tcpEndpoint` + `SecureEndpoint.connectable` (named params, `^{online,
+  caps.any}` results, named-class/new-instance form), perihelion `wsClient` and jacinta
+  `fetchingRegistry` (added `online` to their existing capture sets).

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2285,3 +2285,23 @@ D4 — logging:
   cannot parse `^`; mixed-mode overrides use the bare form). The telekinesis fetch/submit
   macros seal the evidence at the staging boundary like `postable0` (quote wall); the
   scintillate connection daemon rims it as `AnyRef`.
+
+## Capture-honesty Phase 8, leg 3: Task is an honest capability with a pure façade (2026-07-16)
+
+D6 RESOLVED per Jon's ruling (option c: "Task wants to be a capability, and it's not pure").
+Gates: JVM 10301/10301, JS 8006/8006; suites parasite 148/0, turbulence 73/0, zephyrine
+252/0, coaxial 36/0, surveillance 4/0, ethereal 49/0, exoskeleton 69/0, profanity 54/0.
+
+- `Task.apply`, `async` and `task` return FRESH handles (`(Task[result] emits …)^`); the
+  handle-and-body seals in `Task.apply` are DELETED (a `Task` IS a `Worker`, a capability —
+  the fresh result admits the body closure's captures honestly). `Task.map`/`bind` (trait
+  and `Worker` impl) return `^` likewise.
+- THE PURE FAÇADE: `Task.monad` (the mercator instance, which must abstract over `Task` as a
+  pure constructor) and the `Seq[Task].sequence` extension keep their seals, now documented
+  as the single composition boundary where fresh handles are deliberately narrowed. `daemon`
+  is unchanged (a `Daemon` handle was already this shape).
+- Storage/collection fallout, each resolved by the matching recipe: surveillance's poll-task
+  registry handles seal inside their `supervise` blocks (registry-lifetime, the façade
+  convention); coaxial's per-connection fire-and-forget `async` calls discard the handle
+  explicitly (`()` — a lambda result may not carry a fresh); the turbulence manifold test
+  seals its collected handles (the `sequence` shape).

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2160,3 +2160,25 @@ REMAINING un-CC'd (per-class deferral list unchanged): ethereal.core (Phase 5),
 quantitative.core, cataclysm.core, synesthesia.core, apoplexy.core, zeppelin.core (⚑5),
 burdock.core, exegesis.*, aviation.core, superlunary.core, anthology.bundle + platform
 variants.
+
+## Capture-honesty Phase 4 remainder: Tool/Tmux + confinement regression tests (2026-07-15)
+
+Most of Phase 4 (the scope-method honesty conversions) was pulled forward into the Phase 3
+enablement legs, since the modules would not compile under CC without them. The remainder:
+
+- `Enclave.Tool` and `Tmux` → `caps.ExclusiveCapability` (live spawned process / tmux session,
+  torn down after their `sandbox`/`tmux` blocks). exoskeleton.rig compiled clean immediately.
+- CaptureTests-style negative regression suites (the enigmatic pattern: `demilitarize` blocks
+  asserting compile errors) added for profanity (Terminal × 3), exoskeleton.rig (Tool × 2) and
+  scintillate (HttpConnection stash × 1), wired into each module's Tests.
+- ★ FINDING (documented in profanity.CaptureTests): selecting a PURE field from a capability
+  path DISCHARGES the path under CC — `() => terminal.events.stop()` escapes `interactive`
+  legally because `events` is a plain `Spool`. Negative tests must charge the capability
+  itself (a method call); and pure-field escape is a real, if benign, hole to remember when
+  classifying: state that must not escape a scope must live in capability-typed (or
+  method-mediated) members, not pure public fields.
+- Random/Internet get NO confinement tests: they are `caps.Unscoped` (deliberately
+  ambient-storable), so blocks may legally leak them; the tracking is effect-visibility, not
+  scoping.
+
+Suites: profanity 54/0, exoskeleton 69/0, scintillate 20/0.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -36,6 +36,60 @@ around by cast/launder with a comment; the patched compiler may be used without 
    options = compiler feature work, or a `Validate`/`protect` redesign avoiding function-value
    indirection in tests, or defer the 5 suites.
 
+## ⚑ Capture-honesty campaign: decision packet for Jon (2026-07-15)
+
+The campaign (branch series starting at `capture-honesty`) targets the two remaining dishonesty
+classes: scope-introducing context functions whose context value is a live resource but not a
+tracked capability (`profanity.interactive`, `tarantula.session`, `exoskeleton.sandbox`/`tmux`,
+scintillate handlers, effect channels), and typeclass families without honest markers. Plan file:
+`~/.claude/plans/soundness-has-been-updated-delegated-stardust.md`. Decisions needed, roughly in
+the order the legs need them:
+
+- **D1 — capability parents for scope-method context types** (needed for legs 2/4; proposal,
+  confirm or adjust): `Terminal`, `Enclave.Tool`, `Tmux`, `WebDriver#Session`, `HttpConnection`,
+  `Cli` (via its own declaration, not `Console`), `polaris.Buffer` → `caps.ExclusiveCapability`
+  (each is a stateful, torn-down-after-scope resource); `capricious.Random`,
+  `urticose.Internet` → `caps.SharedCapability` (aliasable effect evidence, no teardown). Scope
+  methods then take form A (`block: Ctx ?=> result` with unconstrained `result`), matching
+  `parasite.supervise`/`enigmatic.expose`, plus a CaptureTests-style negative regression each.
+- **D2 — coaxial `listen` scoped redesign** (existing ⚑4; needed for Phase 5): recommend the loan
+  form `def listen[result](lambda: Input => Output)(block: SocketService^ ?=> result): result`
+  (bind, run block, always stop in `finally`), which both fixes the `val server` fresh-escape and
+  matches form A. Alternative: an `Openable`-style owner object (`Server.open(port)(handler)(...)`,
+  the galilei `Result = Handle^` precedent). `caps.Unscoped` is a non-option (SocketService
+  genuinely must not escape). Ethereal's process-lifetime daemon becomes
+  `domainSocket.listen(handler) { service ?=> park() }`.
+- **D3 — guillotine `Process`/`Job` as capabilities**: live process handles currently returned
+  freely as plain classes. Classifying them is honest but the fallout sweep (every `.exec[]`/
+  `.fork[]` caller: octogenarian, ethereal, tarantula, eucalyptus.syslog, exoskeleton.rig) makes
+  it its own late leg. Go/no-go.
+- **D4 — eucalyptus `Logger` as capability**: holds an `enqueue` closure; capability-classing it
+  ripples through the `logs` alias exactly like `raises`/Tactic did (aliascap/ctxresult
+  territory). Probe-gated own leg. Go/no-go.
+- **D5 — wisteria capture-polymorphic `conjunction`/`disjunction`** (the ⚑1 open sub-question):
+  the bare `typeclass[derivation]` results are the root cause of every downstream codec-thunk
+  seal. Probe-first plan: (i) capturing leaf + derived product all-CC; (ii) through summonInline
+  chains with `aka`-Tagged params; (iii) expanded inside a staged quote. Sweep scope = whichever
+  stages are green. Two prior reverts recorded; treat as HIGH RISK. Go/no-go.
+- **D6 — parasite `Task^`** (existing ⚑3-adjacent): honest `Task^`/`Daemon^` handle types would
+  replace the 12 `unsafeAssumePure` sites in parasite core, but interact with the mercator
+  `Monad` instance for `Task` (see below). Go/no-go.
+- **D7 — Pure-flip policy for seal-bearing families**: flipping a trait to `Typeclass.Pure`
+  makes future honest capturing instances impossible, so families whose instances carry seals or
+  honest captures stay plain `Typeclass`: confirmed `Addable` (hellenism `LocalClasspath is
+  Addable ^{pathTactic, ioTactic}` is honest), `Parsable` (instances capture resolution-scoped
+  tactics by design — its own doc comment), `Extractable`/`Requirable` (sealed instances).
+  Also `mercator.Functor` CANNOT flip while `Monad extends Functor` and parasite's `Task` Monad
+  captures (a Pure parent would propagate); left plain, noted here.
+
+Probe results (2026-07-15, `rep/probe-core.sh` with the p2 release toolchain; logs in
+`rep/_probe/*/compile.log`): profanity.core RED (6 errors, E007 conversion shapes),
+tarantula.core RED (1×E223 + 2×E007), surveillance.core RED (6, NativeWatcher),
+scintillate.server RED (3, Tactic[ServerError] evidence shapes), ethereal.core RED (6+, E007),
+exoskeleton.rig RED (1×E007, Enclave.scala:105), anthology.bundle RED (1×E007, Bundler.scala:98).
+No macro-wall or quote-wall shapes at first depth — all seven look like ordinary conversion legs;
+rig and bundle look trivial.
+
 ## Toolchain (CURRENT: downloaded from the propensive/proscala releases)
 
 Since 2026-07-13 the build downloads the compiler from the `propensive/proscala` GitHub releases

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2249,3 +2249,39 @@ p2 toolchain):
 - REMAINING seals (out of scope, unchanged): the by-name element-codec seals (jacinta
   optional/list primitives — sep-blocked, upstream candidate #5) and the pure-thunk seals
   on the Pure traits (Phase 6 form).
+
+## Capture-honesty Phase 8, legs 1+2: process handles and logging are honest (2026-07-16)
+
+D3 and D4 RESOLVED per Jon's rulings (tracked fresh handles; Unscoped logging). Gates: JVM
+10301/10301, JS 8006/8006; suites guillotine 88/0, eucalyptus 5/0, ethereal 49/0,
+exoskeleton 69/0, scintillate 20/0, coaxial 36/0, hellenism 6/0.
+
+D3 — guillotine:
+- `Job` and `Process` → `caps.ExclusiveCapability` (live process handles, one owner);
+  `fork()` de-sugared with a fresh `Job[Exec, result]^` result (only `fork` — de-sugaring
+  `exec`/`apply` too broke UNRELATED overload resolution of `Pipeline(...)` patterns with a
+  phantom "(intelligible: Nothing & Any).Result" error; the sugar on delegating methods is
+  harmless since their results are not fresh). `Computable.compute` takes `Subprocess^`
+  (SAM instances adapt; `Subprocess` itself stays a plain callback-scoped trait).
+- Recipes: the JDK `start()` runs inside the `try`, the `Job` is minted OUTSIDE it (a fresh
+  may not be created within a `try` expression); `Process.all`/`roots`/`children` build
+  their lists in while-loops in a helper METHOD (fresh may not be minted in `map` lambdas;
+  the elements box); `Job`'s `Writable` givens are capability-polymorphic
+  (`job <: Job[…]^`, the galilei Handle recipe); eucalyptus.syslog binds the fresh Job
+  before `writeTo`.
+
+D4 — logging:
+- `anticipation.LogSink extends caps.Unscoped`: sinks are deliberately ambient (importable
+  package givens, application-lifetime registries) — the tracking is effect-visibility, not
+  scope-confinement. `Logger` inherits it; its `enqueue` field is pure-typed (`->`, already
+  sealed at construction with the registry-lifetime justification).
+- `logs` now MIRRORS `raises`: `((event is Loggable)^) ?=> result`. `Loggable`'s self type
+  is `Loggable^` (a bare self type pinned every instance pure); `contramap` result adds
+  `{this}`. `Loggable.fanOut` is capture-polymorphic over the sinks (`cap^`, the Cursor
+  pattern — the compiler's own suggestion for the reach-capability leak):
+  `sinks: Every[LogSink[event, carrier]^{cap}]` → `(event is Loggable)^{cap, caps.any}`.
+- `Log.fine/info/warn/fail` take explicit `(loggable is Loggable)^` evidence; ~20 bare
+  `X is Loggable` using-params widened tree-wide (telekinesis.jvm excepted — a NON-CC unit
+  cannot parse `^`; mixed-mode overrides use the bare form). The telekinesis fetch/submit
+  macros seal the evidence at the staging boundary like `postable0` (quote wall); the
+  scintillate connection daemon rims it as `AnyRef`.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2220,3 +2220,32 @@ perihelion 28/0, scintillate 20/0.
 - `gastronomy.Digestible`'s 7 WHOLE-INSTANCE seals NARROWED to the same thunk form: the seal
   now covers only the by-name thunk, and each SAM instance is itself compiler-checked pure.
   gastronomy suite 114/0; gates green.
+
+## Capture-honesty Phase 7: capture-polymorphic derivation — the seal class is deleted (2026-07-16)
+
+RESOLVES the deferred design question from typeclass-purity leg 2 ("making those givens
+honestly tracked is the remaining design question") and the ⚑1 open sub-question, for the
+DERIVATION-level seals. Design (probe-gated per plan; all three stages ran GREEN against the
+p2 toolchain):
+
+- `ProductDerivation.Methods.conjunction` and `SumDerivation.Methods.disjunction` return
+  FRESH (`typeclass[derivation]^`) instances: a derived codec may honestly capture its
+  resolution-scoped capabilities. Pure implementations are unaffected (narrowing a fresh
+  result is a legal override), so only the six sealed implementations changed.
+- `derivedOne`'s existing GADT re-typing match is now documented as the ONE engine-level
+  erasure of the derivation boundary: `deriveGraph`'s quoted trees cannot carry `^` types
+  (the quote wall), so the honest type narrows there, once — the `fieldInstance` erasing
+  cast's counterpart in the other direction. `derived` (the macro given) is unchanged.
+- SEALS DELETED (6): jacinta `DecodableDerivation.conjunction`, `Json.Field` conjunction +
+  disjunction; locomotion `DecodableDerivation` conjunction + disjunction; caesura Dsv
+  `DecodableDerivation.conjunction` (its `DsvProductDecoder` lambda param widened to `=>`).
+- Stage sentinels all green: (i) jacinta 366/0 + embarcadero.test compiles (the dictcaps
+  sentinel); (ii) locomotion 38/0 (the summonInline+`aka`-Tagged path — the misdiagnosed
+  "second summon path" needed nothing); (iii) ethereal 49/0, profanity 54/0, exoskeleton
+  69/0 (`Enclave.dispatch` staged quotes reach the honest derivations — THE QUOTE WALL DID
+  NOT BITE), embarcadero 30/0, austronesian 8/0, caesura 70/0. Gates: JVM 10301/10301,
+  JS 8006/8006. telekinesis's 4 per-module failures and superlunary's "no main class"
+  runner artifact reproduce identically at the attested base (pre-existing).
+- REMAINING seals (out of scope, unchanged): the by-name element-codec seals (jacinta
+  optional/list primitives — sep-blocked, upstream candidate #5) and the pure-thunk seals
+  on the Pure traits (Phase 6 form).

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2114,3 +2114,49 @@ surveillance recipes:
 - Inside inline `Mutex.apply` blocks, the object-field `watches` HashMap is bound to a local
   first: the `at` extension's evidence summon against the object-field singleton path fails
   to unify under CC.
+
+## Capture-honesty Phase 3b: scintillate.server + exoskeleton.rig capture-checked (2026-07-15)
+
+`settings.cc` flipped on scintillate.server and exoskeleton.rig (branch capture-honesty).
+The `HttpConnection` capability classification planned for Phase 4d was pulled forward — the
+module does not compile under CC without it. Gates: JVM 10301/10301, JS 8006/8006; suites
+scintillate 19/0, exoskeleton 67/0, profanity 51/0, ethereal 49/0.
+
+scintillate recipes:
+- `HttpConnection extends ..., caps.ExclusiveCapability` (one live exchange, single owner,
+  respond-once); ctor takes `request: Http.Request^` and the response-first respond sink
+  `Http.Response => Tactic[StreamError] ?=> Unit` — the tactic-first nesting would need the
+  inner arrow to capture the outer ?=>-bound tactic (the ⚑7 dependent-capture restriction).
+- The four `Protocolic` server givens are honest capabilities (`^{tactic, monitor, caps.any}`)
+  over ONE named `HttpProtocolic` class (anonymous instances freshen inferred type members —
+  the galilei finding); `type Request = HttpConnection^` (a BARE capability-class alias
+  decorates the trait's `Request ?=>` param on only one side of the override);
+  `Protocolic.server` and the `serve` extension return `Server^`. The soundness bundle's
+  exports became hand-written forwarder givens (synthesized forwarders lose the annotated
+  refinement) with ONE erasing cast each (capture roots do not re-root through a second
+  given; the wisteria fieldInstance pattern).
+- `handle`/`HttpConnection.apply` de-sugared (`logs`/`raises` → explicit using). SocketServer's
+  accept/connection daemons take the full AnyRef-rim treatment, with the handler crossing as a
+  capture-neutral eta-wrapped `AnyRef => AnyRef` (a context-function value applies itself in
+  any non-CFT position). Cursor params follow the `Cursor[Data, {}]^` convention; `writeAll`
+  takes `(Stream[Data] over Credit)^`.
+- servlet (SEP module): `JavaServlet` now takes a PLAIN `HttpConnection => Http.Response`
+  (a CFT class param cannot be applied from a subclass's synthesized superArg);
+  `makeConnection` returns fresh `HttpConnection^` with rims for everything the connection
+  retains (a fresh capability result may not hide the method's parameters — and the
+  parameter-relative `^{streamError, ...}` alternative cannot absorb the ctor's fresh).
+  The `@servlet` macro types its hole `Any` and casts inside the quote (capability-typed
+  quote holes fail capture-root unification).
+- `request` accessor returns `Http.Request^`; the ws-upgrade TEST seals its flowing-body
+  thunk (a streamed response legitimately retains the live connection — the pure-`Response`
+  handler shape cannot express it; the honest `Response^{connection}` form is the recorded
+  future option).
+
+exoskeleton.rig: one real fix — `Fqcn.apply` instead of the `fqcn""` interpolator (the
+macro's synthesized tree fails capture-variable unification when expanded in a CC module;
+same family as the harlequin/honeycomb quote shapes; possible fork follow-up).
+
+REMAINING un-CC'd (per-class deferral list unchanged): ethereal.core (Phase 5),
+quantitative.core, cataclysm.core, synesthesia.core, apoplexy.core, zeppelin.core (⚑5),
+burdock.core, exegesis.*, aviation.core, superlunary.core, anthology.bundle + platform
+variants.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -21,8 +21,8 @@ around by cast/launder with a comment; the patched compiler may be used without 
    = given-resolution lifetime.
 3. **parasite daemon error propagation** (`ad3511b34`, pre-existing flag): deleted
    handler-nesting tests + Task monad dropped `Tactic[AsyncError]`; bless or redesign.
-4. **coaxial `port.listen`** result leaking `any` into `val server` (also surfaces inside
-   ethereal.core at `domainSocket.listen`): genuine escape; scoped-API redesign candidate.
+4. **coaxial `port.listen`** — CLOSED (2026-07-15, capture-honesty Phase 5): `listen` is now
+   a loan (`listen(lambda)(block: SocketService ?=> result)`), stop always in `finally`.
 5. **zeppelin.core `Zip.Entry`** lazily-captured `storedBytes` thunk: genuine capture
    (LazyList-confinement limit); design case.
 6. **tarantula `Navigator`** (browser session as capability), **probably.cli**
@@ -2182,3 +2182,30 @@ enablement legs, since the modules would not compile under CC without them. The 
   scoping.
 
 Suites: profanity 54/0, exoskeleton 69/0, scintillate 20/0.
+
+## Capture-honesty Phase 5: coaxial listen is a loan; ethereal.core capture-checked (2026-07-15)
+
+CLOSES open decision ⚑4 (`port.listen` fresh-escape). Gates: JVM 10301/10301, JS 8006/8006;
+suites coaxial 36/0, ethereal 49/0, exoskeleton 69/0, cordillera 30/0, obligatory 22/0,
+perihelion 28/0, scintillate 20/0.
+
+- `Bindable.listen` and `DomainServer.listenConnections` are now LOANS: they bind, lend the
+  running server to a block as a `SocketService` capability, and always stop it in `finally`.
+  The interface variant is `listenOn(interface)(lambda)(block)` — overloading on the interface
+  clause is ambiguous against the trailing block. Ethereal's process-lifetime daemon nests its
+  readiness files, pid-watcher and park inside the block (it only leaves via `System.exit`).
+- `DaemonService` → `caps.ExclusiveCapability` (the 2026-07-06 service-class ruling);
+  `Executive.invocation`'s `entrypoint` param and `Completions.ensure/install` evidence are
+  `Entrypoint^`.
+- `ambience.Directories` converted to the honest capturing-evidence form `Xdg` already used
+  (`(path is Instantiable across Paths from Text)^` instead of a pure context bound) — it had
+  simply never had a CC-enabled caller before.
+- galilei's `Eof` `Openable` given takes named capturing evidence with an honest
+  `^{openable, caps.any}` result and a `{ type Result = openable.Result }` refinement (the
+  pure context bound could not accept `FileOpenable^` instances).
+- ethereal recipes: the `Client.invocation` promise is an `AnyRef` rim (a `Cli` capability
+  crossing fibers; cast at both ends); `Assembler.assemble` de-sugared (stacked `raises` →
+  explicit using) and its jar-append restructured as TWO SEQUENTIAL opens with a strict
+  read between (nested handle-loan lambdas mint fresh roots that cannot unify; the `Eof`
+  two-evidence dependent-`Result` chain has the same problem, so the append uses a direct
+  `open(..., List(OpenFlag.Append))`).

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2055,3 +2055,62 @@ Recipes this leg (all compiler-forced, reusable):
   `Connectable.tcpEndpoint` + `SecureEndpoint.connectable` (named params, `^{online,
   caps.any}` results, named-class/new-instance form), perihelion `wsClient` and jacinta
   `fetchingRegistry` (added `online` to their existing capture sets).
+
+## Capture-honesty Phase 3a: profanity/tarantula/surveillance capture-checked (2026-07-15)
+
+`settings.cc` flipped on profanity.core, tarantula.core, surveillance.core (branch
+capture-honesty). The Terminal/Server capability classifications planned for Phase 4a/4b were
+pulled forward — the modules do not compile under CC without them. Gates: JVM 10301/10301,
+JS 8006/8006; suites profanity 51/0, surveillance 4/0, ultimatum 66/0, exoskeleton 67/0
+(tarantula has no runnable suite).
+
+profanity recipes:
+- `Terminal extends Interactivity[TerminalEvent], caps.ExclusiveCapability` (holds Monitor/
+  Probate, spawns the pump daemon, torn down by `interactive`'s finally). Field typings:
+  `keyboard: Keyboard.Standard^{monitor}` (Probate is a plain trait — NOT nameable in capture
+  sets); mutable size/brightness state hoisted to a plain `Terminal.Metrics` holder so `cap`
+  (Termcap) and the `stdio` given stay PURE (`Stdio.termcap` requires a pure member) and the
+  pump daemon body needs no `this` rim at all. Public `var` API preserved via def accessors.
+- Pump daemon: block-local bindings + `AnyRef` cast-rim for the capability-typed keyboard
+  (cordillera recipe); the stdin LazyList crosses as a plain value (LazyList is not
+  capture-tracked). `dark` relocated to the companion (a class-private helper call charges
+  `this` in a pure closure). Signal-trap handler bound over `locally:` block locals.
+- Keyboard `As[Int]` extractor in a nested pattern: evidence summons against a skolem-typed
+  scrutinee fail under CC → explicit `safely(x.as[Int])` decoding. Enum-case unapply of
+  union-typed fields (`case Shift(inner)`) fails against the capture-decorated scrutinee →
+  typed patterns + field access; GADT-narrowed Char-literal unions widened to a clean
+  `Keypress | Char` binding first.
+- `Interaction` givens (`selectMenu`/`lineEditor`) take `(surface: Canvas^)` and return
+  `^{surface}`-annotated instances in `new`-instance form (the colon-body given's synthesized
+  class does not admit the result annotation).
+- `TerminalCanvas(terminal)`/`InlineRoot(terminal)` return `^{terminal}` (live size thunks);
+  ultimatum `Form(root: Canvas^)`, `paint(root: Canvas^)`, `FlowExtent(parent: Canvas^)`,
+  `Pane.Leaf(content: Extent^ -> Unit)`, `panel(content: (Extent^) ?-> Unit)`.
+- turbulence `Out`/`Err` print/write/println now take `(using Stdio^)` — honest acceptance of
+  capturing stdio evidence (an `Extent` is an `Stdio` and now captures its canvas).
+
+tarantula recipes:
+- ★ FIRST USE OF THE `uses` CLAUSE (fork feature): `case class Server(...) extends
+  caps.ExclusiveCapability uses Navigator.this:` — declares the outer reference of `stop()`.
+  Syntax: after the extends parents, before the colon (see fork tests
+  tests/pos-custom-args/captures/nested-classes-tracked.scala).
+- `WebDriver`/`Session`/`Element` are PURE ID-holders over the server's port; the live
+  resource is the `Server` capability, confined to `session` (launched there, stopped in its
+  finally). Capability-classing Session/Element was attempted and REVERTED: constructing
+  fresh capabilities inside `map(Element(_))` lambdas and passing a fresh `launch` result
+  into a fresh constructor param both hit unbridgeable fresh-root mismatches ("any² not
+  visible from any"). A leaked Session is a dangling ID over a stopped server; full handle
+  tracking waits on guillotine Job classification (D3/8b).
+- `launch` de-sugared (`logs` → explicit `using ExecEvent is Loggable`) with the VALUE param
+  LAST (`(using ...)(port: Int): Server^`): a fresh result under a trailing using clause is
+  invisible outside the implicit application. `session` likewise de-sugared.
+- `Focusable.apply` takes a pure (`->`) focus lambda (all instances are pure selector
+  renderers).
+
+surveillance recipes:
+- `Watcher.watch` filters are pure (`Text -> Boolean`) end-to-end — they are built by
+  `Watch.apply` from path names only, and registrations live in backend-global state which
+  must not capture. The filename is pre-read outside the lambda (`val filename = ...`).
+- Inside inline `Mutex.apply` blocks, the object-field `watches` HashMap is bound to a local
+  first: the `at` extension's evidence summon against the object-field singleton path fails
+  to unify under CC.

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2209,3 +2209,14 @@ perihelion 28/0, scintillate 20/0.
   read between (nested handle-loan lambdas mint fresh roots that cannot unify; the `Eof`
   two-evidence dependent-`Result` chain has the same problem, so the append uses a direct
   `open(..., List(OpenFlag.Append))`).
+
+## Capture-honesty Phase 6: seal audits on the Pure traits (2026-07-16)
+
+- `spectacular.Inspectable`'s 11 seals AUDITED, UNCHANGED: they are already the narrowest
+  form — a pure-thunk binding of the by-name element instance (unnameable in capture sets;
+  upstream candidate #5), yielding a compiler-verified-pure instance. Not the
+  `@untrackedCaptures`-field idiom, but narrower than a whole-instance seal, and truthfully
+  commented in place.
+- `gastronomy.Digestible`'s 7 WHOLE-INSTANCE seals NARROWED to the same thunk form: the seal
+  now covers only the by-name thunk, and each SAM instance is itself compiler-checked pure.
+  gastronomy suite 114/0; gates green.


### PR DESCRIPTION
Capture checking now tells the truth across the whole codebase: every scope-introducing context function over a live resource confines an honest capability, every remaining typeclass carries an honest purity or capability marker, and the wisteria derivation engine no longer forces seals on capturing codec instances.

## Scoped resources are confined capabilities

Methods that lend a live resource to a block now do so as a tracked capability, so returning the resource — or a closure over it — from the block is a compile error, verified by new negative compile-test suites:

- `interactive` confines the raw-mode `Terminal`; `session` confines the browser-automation `Server`; `sandbox` and `tmux` confine their spawned processes; HTTP handlers receive each exchange as an exclusive `HttpConnection`.
- `listen` is now a **loan**: it binds, lends the running server to a block as a `SocketService`, and always stops it afterwards, closing a long-standing capability escape:

```scala
port.listen[Data](handler):
  // the server runs only within this block
  client.transmit(t"request")
```

## Honest capability classifications

`Terminal`, `HttpConnection`, `SocketService`, `Tool`, `Tmux`, `Cli`, `Buffer`, `DaemonService`, `Job`, `Process` and `Task` are exclusive capabilities; `Random`, `Internet` and `LogSink` are `Unscoped` ambient ones. Live process handles are fresh (`fork()` returns `Job^`), task handles are fresh (`async` returns `Task^`, with the `Monad[Task]` given as the documented pure façade for composition), and `logs` now mirrors `raises`, with capturing `Loggable` evidence fanning out to the in-scope sinks.

## Verified-pure typeclasses

Twenty-three typeclasses with no capturing instances — the symbolism arithmetic family, `Traversable`, `Indexable`, `Cuttable`, `Commensurable`, `Contrastable`, `Irrefutable`, `Countable`, `Serializable`, `Deserializable` and more — are now compiler-verified pure, so a future capability-capturing instance is a compile error.

## Capture-polymorphic derivation

Wisteria's `conjunction` and `disjunction` return fresh (`^`) instances, so a derived codec honestly carries its resolution-scoped captures: the codec-thunk seals in jacinta, locomotion and caesura are deleted, with `derivedOne`'s re-typing match documented as the single engine-level erasure at the graph macro's quote boundary.

Six previously unchecked modules — profanity, tarantula, surveillance, scintillate's server, exoskeleton's rig and ethereal — are now capture-checked, including the first use of the compiler's `uses` clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
