### PR TITLE
Inlined Expr-composed direct parsing for CBOR, Protobuf and BinTEL

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -960,7 +960,7 @@ object crossparse extends Library:
   // expansion.
   object model
       extends Component(jacinta.staged, stratiform.staged, xylophone.staged,
-                       breviloquence.staged, ypsiloid.core):
+                       breviloquence.staged, locomotion.staged, ypsiloid.core):
     override def scalaJs = false // depends on the staged components (compiler jars)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -1560,7 +1560,18 @@ object locomotion extends Library:
         gossamer.core, spectacular.core, panopticon.core, zephyrine.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
-  object test extends Tests(core):
+  // `Protobuf.Inlinable`, whose entry macro needs expansion-time instance
+  // evaluation (an in-macro staging compiler), kept out of `core` so
+  // locomotion users don't inherit the compiler jars unless they opt in.
+  object staged extends Component(core):
+    override def scalaJs = false // expansion-time instance evaluation via staging
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
+  object test extends Tests(core, staged):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions())
   object bench extends Benchmarks(core, quantitative.units):

--- a/build.mill
+++ b/build.mill
@@ -1927,6 +1927,17 @@ object stratiform extends Library:
   object records extends Component(core, polyvinyl.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
+  // `BintelInlinable`, whose entry macro needs expansion-time instance
+  // evaluation (an in-macro staging compiler), kept out of `binary` so
+  // BinTEL users don't inherit the compiler jars unless they opt in.
+  object binaryStaged extends Component(binary):
+    override def scalaJs = false // expansion-time instance evaluation via staging
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
   // The Expr-level `Inlinable` typeclass and its expansion-time instance
   // evaluation (an in-macro staging compiler), kept out of `core` so
   // stratiform users don't inherit the compiler jars unless they opt in.
@@ -1945,8 +1956,10 @@ object stratiform extends Library:
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
-  object test extends Tests(core, base256, binary, records, time, http, eucalyptus.core)
-  object bench extends Benchmarks(core, quantitative.units, hellenism.core, ambience.core)
+  object test extends Tests(core, base256, binary, binaryStaged, records, time, http,
+      eucalyptus.core)
+  object bench extends Benchmarks(core, base256, binary, binaryStaged, quantitative.units,
+      hellenism.core, ambience.core)
 
 object superlunary extends Library:
   object core

--- a/build.mill
+++ b/build.mill
@@ -959,8 +959,8 @@ object crossparse extends Library:
   // load them (and resolve the companion `Inlinable` givens) at the bench's
   // expansion.
   object model
-      extends Component(jacinta.staged, stratiform.staged, xylophone.staged,
-                       breviloquence.staged, locomotion.staged, ypsiloid.core):
+      extends Component(jacinta.staged, stratiform.staged, stratiform.binaryStaged,
+                       xylophone.staged, breviloquence.staged, locomotion.staged, ypsiloid.core):
     override def scalaJs = false // depends on the staged components (compiler jars)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
@@ -970,7 +970,13 @@ object crossparse extends Library:
       mvn"io.circe::circe-parser:0.14.13",
       mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:2.35.3",
       mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-circe:2.35.3",
-      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.35.3"
+      mvn"com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-macros:2.35.3",
+      // The per-format best-in-class baselines for the document matrix.
+      mvn"io.bullet::borer-core:1.16.1",
+      mvn"io.bullet::borer-derivation:1.16.1",
+      mvn"com.google.protobuf:protobuf-java:4.29.3",
+      mvn"com.fasterxml:aalto-xml:1.3.3",
+      mvn"org.snakeyaml:snakeyaml-engine:2.7"
     )
 
 object dendrology extends Library:

--- a/build.mill
+++ b/build.mill
@@ -1506,7 +1506,7 @@ object jacinta extends Library:
       mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
       mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
     )
-  object test extends Tests(time, http, schema, records, sedentary.core, diuretic.core,
+  object test extends Tests(time, http, schema, records, staged, sedentary.core, diuretic.core,
     galilei.jvm, octogenarian.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):
     def mvnDeps = Seq(
@@ -1956,7 +1956,7 @@ object stratiform extends Library:
     override def scalaJs = false // transitively JVM-only (networking/crypto/fs/process)
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
-  object test extends Tests(core, base256, binary, binaryStaged, records, time, http,
+  object test extends Tests(core, base256, binary, binaryStaged, records, staged, time, http,
       eucalyptus.core)
   object bench extends Benchmarks(core, base256, binary, binaryStaged, quantitative.units,
       hellenism.core, ambience.core)
@@ -2229,7 +2229,7 @@ object xylophone extends Library:
       mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
       mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
     )
-  object test extends Tests(core)
+  object test extends Tests(core, staged)
   object bench extends Benchmarks(core, quantitative.units, hellenism.core):
     def mvnDeps = Seq(mvn"org.scala-lang.modules::scala-xml:2.4.0")
 

--- a/build.mill
+++ b/build.mill
@@ -771,7 +771,18 @@ object breviloquence extends Library:
                        zephyrine.core):
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
-  object test extends Tests(core, sedentary.core, eucalyptus.core)
+  // `Cbor.Inlinable`, whose entry macro needs expansion-time instance
+  // evaluation (an in-macro staging compiler), kept out of `core` so
+  // breviloquence users don't inherit the compiler jars unless they opt in.
+  object staged extends Component(core):
+    override def scalaJs = false // expansion-time instance evaluation via staging
+    override def scalacOptions = Task:
+      super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")
+    def mvnDeps = Seq(
+      mvn"org.scala-lang:scala3-compiler_3:${scalaVersion()}",
+      mvn"org.scala-lang:scala3-staging_3:${scalaVersion()}"
+    )
+  object test extends Tests(core, staged, sedentary.core, eucalyptus.core)
   object bench extends Benchmarks(core, quantitative.units):
     def mvnDeps = Seq(
       mvn"com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.18.2",
@@ -947,7 +958,9 @@ object crossparse extends Library:
   // that each format's `Inlinable` expansion-time instance evaluation can
   // load them (and resolve the companion `Inlinable` givens) at the bench's
   // expansion.
-  object model extends Component(jacinta.staged, stratiform.staged, xylophone.staged, ypsiloid.core):
+  object model
+      extends Component(jacinta.staged, stratiform.staged, xylophone.staged,
+                       breviloquence.staged, ypsiloid.core):
     override def scalaJs = false // depends on the staged components (compiler jars)
     override def scalacOptions = Task:
       super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium")

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -87,6 +87,17 @@ trait Cbor2:
     case given Reflection[`value`] =>
       DecodableDerivation.derived
 
+  // The AST-materializing read path: parse the whole input into a `Cbor`,
+  // then decode. Lives at this priority so `object Cbor`'s direct-parsing
+  // `aggregableParsed` wins whenever the value has a `Cbor.Parsable`; when
+  // it does not, this resolves exactly as before. `source.read[Foo in Cbor]`
+  // is shorthand for `source.read[Cbor].as[Foo]`; the `Form` type-tag is
+  // added by an `asInstanceOf` cast — `value in Cbor` is just
+  // `value { type Form = Cbor }` so the cast is a no-op at runtime.
+  given aggregableIn: [value: Decodable in Cbor] => (tactic: Tactic[CborError])
+  =>  (((value in Cbor) is Aggregable by Data)^{tactic}) =
+    bytes => Cbor.ast(bytes.read[Cbor.Ast]).as[value].asInstanceOf[value in Cbor]
+
   inline given encodable: [value] => value is Encodable in Cbor = summonFrom:
     case given (`value` is Encodable in Text) => value => ast(Ast(value.encode.s))
     case given Reflection[`value`]            => EncodableDerivation.derived
@@ -558,14 +569,90 @@ object Cbor extends Cbor2, Dynamic:
       def genericize(value: Cbor): HttpStreams.Content =
         (t"application/cbor", HttpStreams.Body(Ast.encodable.encoded(Cbor.unseal(value))))
 
-  // `source.read[Foo in Cbor]` shorthand for
-  // `source.read[Cbor].as[Foo]`. Mirrors `jacinta`'s `aggregableDirect`
-  // for `value in Json`. The `Form` type-tag is added by an
-  // `asInstanceOf` cast — `value in Cbor` is just
-  // `value { type Form = Cbor }` so the cast is a no-op at runtime.
-  given aggregableIn: [value: Decodable in Cbor] => (tactic: Tactic[CborError])
-  =>  (((value in Cbor) is Aggregable by Data)^{tactic}) =
-    bytes => Cbor.ast(bytes.read[Cbor.Ast]).as[value].asInstanceOf[value in Cbor]
+  object Parsable:
+    def apply[value](parser: (reader: CborReader^) => value)
+    :   ((value is Cbor.Parsable)^{parser}) =
+
+      new Cbor.Parsable:
+        type Self = value
+        def parse(reader: CborReader^): value = parser(reader)
+
+    // The universal bridge from the AST world: parse one whole item into a
+    // `Cbor` and decode it. Field types with only a `Decodable in Cbor`
+    // keep working through this, and it is the user's one-line escape hatch
+    // when a custom decoder must beat a generated direct parser.
+    def fromDecodable[value](decodable: (value is Decodable in Cbor)^)
+    :   ((value is Cbor.Parsable)^{decodable}) =
+
+      new Cbor.Parsable:
+        type Self = value
+        def parse(reader: CborReader^): value = decodable.decoded(reader.value())
+
+        override def absent()(using Tactic[CborError]): value =
+          decodable.decoded(Cbor.ast(Ast(Unset)))
+
+    // A required field whose key was absent from the map. Public because
+    // generated parsers are spliced into user modules.
+    def missing[value]()(using Tactic[CborError]): value = abort(CborError(Reason.Absent))
+
+  // The direct-parsing counterpart of `Decodable in Cbor`: consumes data
+  // items straight off the input bytes through a `CborReader` instead of
+  // walking a materialized `Cbor.Ast`, so `read[value in Cbor]` can
+  // instantiate values without building the AST. `Parsable` is the opt-in
+  // surface: explicit instances and `Cbor.Inlinable.parsable`. It has no
+  // blanket fallback given, so no read changes behavior until a type opts
+  // in; field types without one bridge through `Parsable.fromDecodable`.
+  trait Parsable extends distillate.Parsable:
+    type Transport = Cbor
+    type Reader = CborReader
+
+    // What a field of this type yields when its key is absent from the map,
+    // mirroring the AST path's `decoded(Cbor(Ast(Unset)))`: an abort unless
+    // overridden.
+    def absent()(using Tactic[CborError]): Self = abort(CborError(Reason.Absent))
+
+  // Direct-parsing counterpart of the `aggregable`/`aggregableIn` path:
+  // drives a `Cbor.Parsable` instance over the input through a
+  // `CborReader`, so no AST is built for the items the instance reads
+  // directly. Trailing bytes are rejected exactly as `Parser.parse`.
+  private def parseDirect[value]
+    ( input: Data, parsable: (value is Cbor.Parsable)^ )
+    ( using tactic: Tactic[CborError] )
+  :   value =
+
+    val parser = Parser(input)
+    val result = parsable.parse(CborReader(parser, tactic))
+
+    if parser.offset < parser.data.length
+    then abort(CborError(Reason.Trailing(parser.offset.toLong)))
+
+    result
+
+  // Direct parsing: when the value knows how to consume CBOR items itself,
+  // the AST is never materialized. Declared here (not in `Cbor2`, where the
+  // `Decodable`-based `aggregableIn` lives) so it wins whenever a
+  // `Cbor.Parsable` exists, and is otherwise inapplicable — existing code
+  // resolves exactly as before. Sealed per the codec-thunk pattern: the
+  // instance retains the resolution-scoped parsable and tactic.
+  given aggregableParsed: [value]
+  =>  (parsable: (value is Cbor.Parsable)^)
+  =>  (tactic: Tactic[CborError])
+  =>  ((value in Cbor) is Aggregable by Data) =
+
+    caps.unsafe.unsafeAssumePure:
+      bytes => parseDirect(bytes.read[Data], parsable).asInstanceOf[value in Cbor]
+
+  // Whole-`Data` direct read: when the entire content is already in hand,
+  // parse it in place rather than wrapping it in a one-element stream.
+  // Concrete in `Data`, so it beats the composed pipeline by specificity.
+  // Sealed like `aggregableParsed` above.
+  given readableParsed: [value]
+  =>  (parsable: (value is Cbor.Parsable)^)
+  =>  (tactic: Tactic[CborError])
+  =>  (Data is Readable to (value in Cbor)) =
+
+    caps.unsafe.unsafeAssumePure:
+      data => parseDirect(data, parsable).asInstanceOf[value in Cbor]
 
   given unit: (tactic: Tactic[CborError])
   =>  ((Unit is Decodable in Cbor)^{tactic}) =
@@ -685,17 +772,22 @@ object Cbor extends Cbor2, Dynamic:
     val values: IArray[Any] = IArray.from(elements.map(_(1).root.asInstanceOf[Any]))
     Cbor(Ast.map(keys, values))
 
-  def discriminatedUnion[value](label: Text): value is Discriminable in Cbor = new Discriminable:
+  // The map-key-discriminated `Discriminable` shape, as a nameable class so
+  // that generated parsers (which dispatch on the discriminant
+  // monomorphically) can recognize the shape and extract the key at
+  // expansion time.
+  final class DiscriminantKey[derivation](val key: Text) extends Discriminable:
     type Form = Cbor
-    type Self = value
-
-    protected def key: String = label.s
+    type Self = derivation
 
     import dynamicCborAccess.enabled
 
-    def rewrite(kind: Text, cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key)(kind))
-    def discriminate(cbor: Cbor): Optional[Text] = safely(cbor.selectDynamic(key).as[Text])
-    def variant(cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key)(Unset))
+    def rewrite(kind: Text, cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key.s)(kind))
+    def discriminate(cbor: Cbor): Optional[Text] = safely(cbor.selectDynamic(key.s).as[Text])
+    def variant(cbor: Cbor): Cbor = unsafely(cbor.updateDynamic(key.s)(Unset))
+
+  def discriminatedUnion[value](label: Text): value is Discriminable in Cbor =
+    DiscriminantKey[value](label)
 
 
   private[breviloquence] object Parser:
@@ -733,7 +825,10 @@ object Cbor extends Cbor2, Dynamic:
 
       result
 
-  private[breviloquence] final class Parser(input: IArray[Byte]):
+  // The class is public — generated parsers, spliced into user modules,
+  // bind it once per record and read through its direct rim — but only
+  // breviloquence's read paths can construct one.
+  final class Parser private[breviloquence] (input: IArray[Byte]):
     import Parser.{Break, boxLong}
 
     // Cache the underlying primitive array so reads compile to BALOAD rather
@@ -1084,6 +1179,369 @@ object Cbor extends Cbor2, Dynamic:
             case _  => abort(CborError(Reason.BadSimpleValue(headOffset, info)))
 
         case _ => abort(CborError(Reason.Reserved(headOffset, head)))
+
+    // ── The direct rim ───────────────────────────────────────────────────
+    // Byte-level reads for direct parsing (`Cbor.Parsable`): each consumes
+    // one complete item, with fast paths for the dominant head shapes and a
+    // fallback through the general `value()` path on anything exotic (tags,
+    // mistyped items, absence), so values and failures agree with the AST
+    // accessors exactly.
+
+    def directLong()(using Tactic[CborError]): Long =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if head < 0x18 then
+        offset = pos + 1
+        head.toLong
+      else if head >= 0x20 && head < 0x38 then
+        offset = pos + 1
+        -1L - (head & 0x1F).toLong
+      else
+        val major = head >>> 5
+
+        if major == 0 then
+          offset = pos + 1
+          val length = readLength(head & 0x1F, pos.toLong)
+          if length < 0 then abort(CborError(Reason.Reserved(pos.toLong, head)))
+          length
+        else if major == 1 then
+          offset = pos + 1
+          val length = readLength(head & 0x1F, pos.toLong)
+          if length < 0 then abort(CborError(Reason.Reserved(pos.toLong, head)))
+          if length == Long.MinValue then abort(CborError(Reason.Overflow(pos.toLong)))
+          -1L - length
+        else
+          value().long
+
+    def directDouble()(using Tactic[CborError]): Double =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if head == 0xFB then
+        offset = pos + 1
+        java.lang.Double.longBitsToDouble(readUInt64())
+      else if head == 0xFA then
+        offset = pos + 1
+        java.lang.Float.intBitsToFloat(readUInt32().toInt).toDouble
+      else if head == 0xF9 then
+        offset = pos + 1
+        halfToDouble(readUInt16())
+      else
+        value().double
+
+    def directBoolean()(using Tactic[CborError]): Boolean =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if head == 0xF5 then
+        offset = pos + 1
+        true
+      else if head == 0xF4 then
+        offset = pos + 1
+        false
+      else
+        value().boolean
+
+    def directString()(using Tactic[CborError]): String =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if head >= 0x60 && head < 0x78 then
+        val length = head & 0x1F
+        val end = pos + 1 + length
+        if end > data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+        val str = new String(data, pos + 1, length, java.nio.charset.StandardCharsets.UTF_8)
+        offset = end
+        str
+      else if (head >>> 5) == 3 then
+        offset = pos + 1
+
+        if (head & 0x1F) == 31 then readIndefiniteTextString() else
+          val length = boundedLength(readLength(head & 0x1F, pos.toLong), pos.toLong)
+          val str = decodeUtf8(data, offset, length, pos.toLong)
+          offset += length
+          str
+      else
+        value().string
+
+    def directBytes()(using Tactic[CborError]): IArray[Byte] =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if head >= 0x40 && head < 0x58 then
+        val length = head & 0x1F
+        val end = pos + 1 + length
+        if end > data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+        val out = new Array[Byte](length)
+        System.arraycopy(data, pos + 1, out, 0, length)
+        offset = end
+        out.asInstanceOf[IArray[Byte]]
+      else if (head >>> 5) == 2 then
+        offset = pos + 1
+
+        if (head & 0x1F) == 31 then readIndefiniteByteString() else
+          val length = boundedLength(readLength(head & 0x1F, pos.toLong), pos.toLong)
+          readBytes(length)
+      else
+        value().byteString
+
+    // The undefined-item peek for optional wrappers: a wire `undefined`
+    // (0xF7) reads as an absent value, exactly as the AST path's `optional`.
+    def directIsUndefined: Boolean =
+      offset < data.length && (data(offset) & 0xFF) == 0xF7
+
+    def directUndefined(): Unit = offset += 1
+
+    // Opens a map, returning its entry count, or -1 for indefinite length.
+    // Any other item is consumed whole and reads as an empty map (every
+    // field absent), exactly as the AST record decoder's
+    // `if root.isMap then root.entries else 0`.
+    def directOpenMap()(using Tactic[CborError]): Int =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if (head >>> 5) == 5 then
+        offset = pos + 1
+        val info = head & 0x1F
+
+        if info == 31 then -1 else
+          val length = readLength(info, pos.toLong)
+          if length < 0 || length > Int.MaxValue then abort(CborError(Reason.Overflow(pos.toLong)))
+          length.toInt
+      else
+        directSkipValue()
+        0
+
+    // Opens an array, returning its element count, or -1 for indefinite
+    // length. Any other item classifies through the AST accessor, so the
+    // failure agrees with the AST collection decoder's `.array`.
+    def directOpenArray()(using Tactic[CborError]): Int =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if (head >>> 5) == 4 then
+        offset = pos + 1
+        val info = head & 0x1F
+
+        if info == 31 then -1 else
+          val length = readLength(info, pos.toLong)
+          if length < 0 || length > Int.MaxValue then abort(CborError(Reason.Overflow(pos.toLong)))
+          length.toInt
+      else
+        value().array
+        0
+
+    // Consumes a Break stop code if one is next — the end step of an
+    // indefinite-length map or array.
+    def directBreak()(using Tactic[CborError]): Boolean =
+      if offset >= data.length then abort(CborError(Reason.Truncated(offset.toLong)))
+
+      if (data(offset) & 0xFF) == Break then
+        offset += 1
+        true
+      else
+        false
+
+    // The next map key in packed form, for parsers that compare keys against
+    // literal constants (generated parsers compile field names to
+    // immediates): the packed low word of a definite-length, 1-16 byte,
+    // 7-bit-clean text key (its high word left in `directKeyHigh`), or
+    // `CborReader.KeyOpaque` without consuming anything — the caller then
+    // takes the `directKeyName` step, which consumes the key generally.
+    var directKeyHigh: Long = 0L
+
+    def directKeyWord(): Long =
+      val pos = offset
+      if pos >= data.length then return CborReader.KeyOpaque
+      val head = data(pos) & 0xFF
+
+      if head > 0x60 && head <= 0x70 then
+        val length = head & 0x1F
+        val end = pos + 1 + length
+        if end > data.length then return CborReader.KeyOpaque
+        var low = 0L
+        var high = 0L
+        var ascii = 0
+        var position = 0
+
+        while position < length do
+          val byte = data(pos + 1 + position).toLong & 0xFF
+          ascii |= byte.toInt
+
+          if position < 8 then low |= byte << (position*8)
+          else high |= byte << ((position - 8)*8)
+
+          position += 1
+
+        if (ascii & 0x80) != 0 then CborReader.KeyOpaque else
+          offset = end
+          directKeyHigh = high
+          low
+      else
+        CborReader.KeyOpaque
+
+    // The general key step: consumes the key and returns a text key's
+    // content, or `null` for a non-text key — whose entry the AST record
+    // decoder ignores, so the caller skips its value and continues.
+    def directKeyName()(using Tactic[CborError]): String | Null =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+
+      if (head >>> 5) == 3 then directString()
+      else
+        directSkipValue()
+        null
+
+    // Skips one complete item, building nothing — for unknown keys and
+    // non-map-shaped records. Rejects exactly the head shapes `value()`
+    // rejects, so a skipped malformed item fails as the AST path (which
+    // parses every entry) would.
+    def directSkipValue()(using Tactic[CborError]): Unit =
+      val pos = offset
+      if pos >= data.length then abort(CborError(Reason.Truncated(pos.toLong)))
+      val head = data(pos) & 0xFF
+      offset = pos + 1
+      val major = head >>> 5
+      val info = head & 0x1F
+
+      (major: @scala.annotation.switch) match
+        case 0 | 1 =>
+          if readLength(info, pos.toLong) < 0
+          then abort(CborError(Reason.Reserved(pos.toLong, head)))
+
+        case 2 | 3 =>
+          if info == 31 then
+            var done = false
+
+            while !done do
+              expect(1)
+              val chunkHead = data(offset) & 0xFF
+
+              if chunkHead == Break then
+                offset += 1
+                done = true
+              else
+                if (chunkHead >>> 5) != major
+                then abort(CborError(Reason.Reserved(offset.toLong, chunkHead)))
+
+                val chunkOffset = offset.toLong
+                offset += 1
+                val length = boundedLength(readLength(chunkHead & 0x1F, chunkOffset), chunkOffset)
+                offset += length
+          else
+            val length = boundedLength(readLength(info, pos.toLong), pos.toLong)
+            offset += length
+
+        case 4 =>
+          if info == 31 then
+            while !directBreak() do directSkipValue()
+          else
+            val length = readLength(info, pos.toLong)
+
+            if length < 0 || length > Int.MaxValue
+            then abort(CborError(Reason.Overflow(pos.toLong)))
+
+            var index = 0
+
+            while index < length.toInt do
+              directSkipValue()
+              index += 1
+
+        case 5 =>
+          if info == 31 then
+            while !directBreak() do
+              directSkipValue()
+              directSkipValue()
+          else
+            val length = readLength(info, pos.toLong)
+
+            if length < 0 || length > Int.MaxValue
+            then abort(CborError(Reason.Overflow(pos.toLong)))
+
+            var index = 0
+
+            while index < length.toInt do
+              directSkipValue()
+              directSkipValue()
+              index += 1
+
+        case 6 =>
+          if readLength(info, pos.toLong) < 0
+          then abort(CborError(Reason.Reserved(pos.toLong, head)))
+
+          directSkipValue()
+
+        case 7 =>
+          info match
+            case 20 | 21 | 22 | 23 => ()
+
+            case 25 =>
+              expect(2)
+              offset += 2
+
+            case 26 =>
+              expect(4)
+              offset += 4
+
+            case 27 =>
+              expect(8)
+              offset += 8
+
+            case 24 => abort(CborError(Reason.BadSimpleValue(pos.toLong, readUInt8())))
+            case 31 => abort(CborError(Reason.UnexpectedBreak(pos.toLong)))
+            case _  => abort(CborError(Reason.BadSimpleValue(pos.toLong, info)))
+
+        case _ => abort(CborError(Reason.Reserved(pos.toLong, head)))
+
+    // Scans the upcoming map for the given text key and returns its text
+    // value, leaving the parser where it started — the dispatch primitive
+    // for a sum's discriminant entry, which may appear anywhere in the map.
+    // `null` when the item is not a map, has no such key, or the key's
+    // value is not text — the caller raises `Absent`, mirroring the AST
+    // path's `discriminate(cbor).lest(...)`.
+    def directDiscriminant(key: String)(using Tactic[CborError])
+    :   String | Null =
+
+      val start = offset
+
+      try
+        val head = if offset < data.length then data(offset) & 0xFF else 0
+        if (head >>> 5) != 5 then return null
+        offset += 1
+        val info = head & 0x1F
+
+        var remaining =
+          if info == 31 then -1 else
+            val length = readLength(info, start.toLong)
+
+            if length < 0 || length > Int.MaxValue
+            then abort(CborError(Reason.Overflow(start.toLong)))
+
+            length.toInt
+
+        while remaining != 0 do
+          if remaining < 0 && directBreak() then return null
+          val name = directKeyName()
+
+          if name != null && name == key then
+            val valueHead = if offset < data.length then data(offset) & 0xFF else 0
+            return if (valueHead >>> 5) == 3 then directString() else null
+          else
+            directSkipValue()
+
+          remaining -= 1
+
+        null
+      finally offset = start
 
 
 class Cbor(private[breviloquence] val root: Cbor.Ast) extends Dynamic derives CanEqual:

--- a/lib/breviloquence/src/core/breviloquence.Cbor.scala
+++ b/lib/breviloquence/src/core/breviloquence.Cbor.scala
@@ -570,6 +570,19 @@ object Cbor extends Cbor2, Dynamic:
         (t"application/cbor", HttpStreams.Body(Ast.encodable.encoded(Cbor.unseal(value))))
 
   object Parsable:
+    // The base of generated parsers: generated code is capture-erased, so
+    // the body receives the reader as a neutral carrier, and the capability
+    // is asserted here at the rim — the audited point — like the reader's
+    // own accessors. (A generated override of `parse` itself would narrow
+    // the trait's `Reader^` parameter to a pure type, which capture
+    // checking rejects at the instantiation site.)
+    abstract class Direct[value] extends Cbor.Parsable:
+      type Self = value
+
+      protected def parseCarrier(reader: AnyRef): value
+
+      def parse(reader: CborReader^): value = parseCarrier(reader.asInstanceOf[AnyRef])
+
     def apply[value](parser: (reader: CborReader^) => value)
     :   ((value is Cbor.Parsable)^{parser}) =
 
@@ -594,6 +607,17 @@ object Cbor extends Cbor2, Dynamic:
     // A required field whose key was absent from the map. Public because
     // generated parsers are spliced into user modules.
     def missing[value]()(using Tactic[CborError]): value = abort(CborError(Reason.Absent))
+
+    // The call points for a nominal `Parsable` in a field position of a
+    // *generated* parser (a recursive record's own instance, or a
+    // hand-written one). Both travel as neutral carriers — generated code
+    // is capture-erased — and the capability is reasserted here, at the
+    // audited point, exactly as the reader's own rim accessors do.
+    def parseField[value](parsable: AnyRef, reader: AnyRef): value =
+      parsable.asInstanceOf[value is Cbor.Parsable].parse(reader.asInstanceOf[CborReader^])
+
+    def absentField[value](parsable: AnyRef)(using Tactic[CborError]): value =
+      parsable.asInstanceOf[value is Cbor.Parsable].absent()
 
   // The direct-parsing counterpart of `Decodable in Cbor`: consumes data
   // items straight off the input bytes through a `CborReader` instead of

--- a/lib/breviloquence/src/core/breviloquence.CborReader.scala
+++ b/lib/breviloquence/src/core/breviloquence.CborReader.scala
@@ -1,0 +1,133 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import anticipation.*
+import contingency.*
+import vacuous.*
+
+object CborReader:
+  // Sentinel of `keyWord()`; impossible as a packed key, whose bytes are all
+  // 7-bit ASCII.
+  inline final val KeyOpaque = -2L
+
+  // Only breviloquence's read path (`Cbor.parseDirect`) constructs readers,
+  // so the exclusivity of the wrapped parser and the resolution scope of the
+  // carried tactic are preserved by construction. The wrapped tactic travels
+  // as a neutral carrier (jacinta's `JsonReader` pattern): the field stays
+  // pure, and each accessor reasserts the type at the rim — the audited
+  // point.
+  private[breviloquence] def apply(parser: Cbor.Parser, tactic: Tactic[CborError])
+  :   CborReader^ =
+
+    new CborReader(parser, tactic.asInstanceOf[AnyRef])
+
+// The public, restricted rim of the CBOR parser, handed to `Cbor.Parsable`
+// instances so they can consume data items straight off the input without an
+// intermediate `Cbor.Ast`. Each method consumes exactly one item (or one
+// structural step). The reader carries its own `Tactic[CborError]` — CBOR's
+// single error type covers both malformed input and mistyped items — so
+// instance `parse` bodies need no error vocabulary: failures abort through
+// the read call's ambient tactic.
+//
+// An exclusive, stateful capability, like the parser it wraps: it is owned
+// by one `Cbor.Parsable.parse` call at a time, for the duration of that
+// call, and nothing of it may be retained afterwards.
+final class CborReader private (parser0: AnyRef, tactic0: AnyRef)
+extends caps.ExclusiveCapability, caps.Stateful:
+  private inline def parser: Cbor.Parser = parser0.asInstanceOf[Cbor.Parser]
+
+  // The sealed conduit for generated parsers: package-private, so the only
+  // path to the wrapped capabilities from outside breviloquence is through
+  // the accessor the compiler synthesizes for breviloquence's own
+  // macro-generated splices — hand-written code cannot name it. Generated
+  // code binds the parser once per record and reads through `Cbor.Parser`'s
+  // direct rim without this class's per-item forwarders.
+  private[breviloquence] def rawParser: AnyRef = parser0
+  private[breviloquence] def rawTactic: AnyRef = tactic0
+  private inline def tactic: Tactic[CborError] = tactic0.asInstanceOf[Tactic[CborError]]
+
+  // ── Scalars: one data item each. Values and failures agree with the
+  // `Cbor.Ast` accessors exactly, so direct and AST reads yield equal
+  // values — integers coerce to floats and vice versa, as `.long` and
+  // `.double` do. ──
+  inline update def long(): Long = parser.directLong()(using tactic)
+  inline update def int(): Int = parser.directLong()(using tactic).toInt
+  inline update def double(): Double = parser.directDouble()(using tactic)
+  inline update def boolean(): Boolean = parser.directBoolean()(using tactic)
+  update def text(): Text = parser.directString()(using tactic).tt
+  update def string(): String = parser.directString()(using tactic)
+  update def byteString(): IArray[Byte] = parser.directBytes()(using tactic)
+
+  // ── Undefined handling: `hasUndefined` peeks without consuming, for
+  // optional wrappers that map a wire `undefined` (0xF7) to an absent
+  // value, exactly as the AST path's `optional`. ──
+  update def hasUndefined: Boolean = parser.directIsUndefined
+  update def undefined(): Unit = parser.directUndefined()
+
+  // ── Structure. `openMap()` and `openArray()` yield the entry or element
+  // count, or -1 for an indefinite-length item, whose end is a Break stop
+  // code consumed by `breakEnd()`. A non-map item under `openMap()` reads
+  // as an empty map (the AST record decoder's semantics); a non-array item
+  // under `openArray()` fails as the AST `.array` accessor. ──
+  inline update def openMap(): Int = parser.directOpenMap()(using tactic)
+  inline update def openArray(): Int = parser.directOpenArray()(using tactic)
+  inline update def breakEnd(): Boolean = parser.directBreak()(using tactic)
+
+  // The next map key in packed form, for parsers that compare keys against
+  // literal constants (generated parsers compile field names to
+  // immediates): the packed low word of the key (its high word from
+  // `keyHigh`), or `KeyOpaque` when the key cannot be packed — the caller
+  // then takes the `keyName` step instead, which consumes it generally.
+  update def keyWord(): Long = parser.directKeyWord()
+
+  update def keyHigh: Long = parser.directKeyHigh
+
+  // The general key step: a text key's content, or `null` for a non-text
+  // key, whose entry is ignored — the caller skips its value.
+  update def keyName(): String | Null = parser.directKeyName()(using tactic)
+
+  // ── The fallback seam: parse one whole item into an AST (for field types
+  // that only have a `Decodable in Cbor`), or skip one whole item (for
+  // unknown keys). ──
+  update def value(): Cbor = Cbor.ast(parser.value()(using tactic))
+  inline update def skipValue(): Unit = parser.directSkipValue()(using tactic)
+
+  // Scans the upcoming map for the given key and returns its text value,
+  // leaving the reader where it started — the dispatch primitive for a
+  // sum's discriminant entry, which may appear anywhere in the map. `Unset`
+  // when the item has no such key or its value is not text.
+  update def discriminant(key: Text): Optional[Text] =
+    parser.directDiscriminant(key.s)(using tactic) match
+      case null        => Unset
+      case tag: String => tag.tt

--- a/lib/breviloquence/src/core/soundness_breviloquence_core.scala
+++ b/lib/breviloquence/src/core/soundness_breviloquence_core.scala
@@ -32,4 +32,4 @@
                                                                                                   */
 package soundness
 
-export breviloquence.{Cbor, Cbor2, cborConversion, DynamicCborEnabler, dynamicCborAccess}
+export breviloquence.{Cbor, Cbor2, CborReader, cborConversion, DynamicCborEnabler, dynamicCborAccess}

--- a/lib/breviloquence/src/staged/breviloquence.Inlinable.scala
+++ b/lib/breviloquence/src/staged/breviloquence.Inlinable.scala
@@ -1,0 +1,157 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+
+// The Expr-level counterpart of `Cbor.Parsable`: a typeclass whose methods
+// are macro-time code generators. An instance receives an `Expr` of the
+// reader and returns an `Expr` of the decoded value, which the deriving
+// macro splices directly into its generated parser — so an instance
+// contributes *inlined* code, with no runtime dispatch, no instance arrays
+// and no adapter hops between composed parsers.
+//
+// Instances are ordinary runtime values: code generation is deferred to the
+// `parse` call, which receives the `Quotes` and the `Type` of `Self`, so
+// `derived` needs no macro of its own. At a `Cbor.Inlinable.parsable[T]`
+// expansion, the instance behind each summoned given is obtained *live* by
+// running the implicit search inside an in-macro staging compiler (the
+// prescience mechanism), which composes conditional instances — a collection
+// of a custom element, for example — through ordinary given resolution. The
+// constraint this inherits: an instance (and its type) must be compiled in
+// an earlier run than the expansion; same-run instances degrade to a spliced
+// runtime call through the `Decodable in Cbor` bridge.
+trait Inlinable extends Typeclass:
+  def parse(reader: Expr[CborReader])(using Quotes, Type[Self]): Expr[Self]
+
+  // What a field of this type yields when its key is absent from the map,
+  // mirroring the runtime instances: an abort unless overridden.
+  def absent(tactic: Expr[Tactic[CborError]])(using Quotes, Type[Self]): Expr[Self] =
+    '{ Cbor.Parsable.missing[Self]()(using $tactic) }
+
+object Inlinable:
+  // Generates a monomorphic `Cbor.Parsable` for a case class or a
+  // key-discriminated sealed sum at compile time, composed through
+  // `Inlinable` instances: nested records, collection loops, variant
+  // dispatch and custom leaf parsers all inline into one flat parser.
+  inline def parsable[value]: value is Cbor.Parsable =
+    ${ breviloquence.stagedInternal.inlinableParsable[value] }
+
+  // The structural instance for a case class: reflects `Self` when invoked
+  // (no macro — `Type[Self]` arrives with the call).
+  def derived[product]: product is Inlinable = ProductInlinable[product]()
+
+  private[breviloquence] final class ProductInlinable[product]() extends Inlinable:
+    type Self = product
+
+    def parse(reader: Expr[CborReader])(using Quotes, Type[product]): Expr[product] =
+      stagedInternal.productBody[product](reader)
+
+  private[breviloquence] final class IterableInlinable[element](element0: element is Inlinable)
+  extends Inlinable:
+    type Self = Iterable[element]
+
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      stagedInternal.iterableBody[Iterable[element]](reader, element0)
+
+  // The structural instance for a sealed sum whose `Discriminable in Cbor`
+  // is the key-discriminated shape (`Cbor.DiscriminantKey`): the variant is
+  // chosen by a scan-ahead of the discriminant entry, then parsed from the
+  // start of the map as its product, with the discriminant entry skipped as
+  // an unknown key — exactly the AST disjunction's semantics.
+  private[breviloquence] final class SumInlinable[sum](key: String) extends Inlinable:
+    type Self = sum
+
+    def parse(reader: Expr[CborReader])(using Quotes, Type[sum]): Expr[sum] =
+      stagedInternal.sumBody[sum](reader, key)
+
+  // ── Instances ──────────────────────────────────────────────────────────
+  // The leaf generators mirror the AST accessors' coercions exactly; the
+  // conditional collection instance composes through given resolution when
+  // the graph is resolved inside the staging compiler.
+
+  given int: (Int is Inlinable) = new Inlinable:
+    type Self = Int
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Int]): Expr[Int] =
+      '{ $reader.int() }
+
+  given long: (Long is Inlinable) = new Inlinable:
+    type Self = Long
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Long]): Expr[Long] =
+      '{ $reader.long() }
+
+  given double: (Double is Inlinable) = new Inlinable:
+    type Self = Double
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Double]): Expr[Double] =
+      '{ $reader.double() }
+
+  given float: (Float is Inlinable) = new Inlinable:
+    type Self = Float
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Float]): Expr[Float] =
+      '{ $reader.double().toFloat }
+
+  given boolean: (Boolean is Inlinable) = new Inlinable:
+    type Self = Boolean
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Boolean]): Expr[Boolean] =
+      '{ $reader.boolean() }
+
+  given text: (Text is Inlinable) = new Inlinable:
+    type Self = Text
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Text]): Expr[Text] =
+      '{ $reader.text() }
+
+  given string: (String is Inlinable) = new Inlinable:
+    type Self = String
+    def parse(reader: Expr[CborReader])(using Quotes, Type[String]): Expr[String] =
+      '{ $reader.string() }
+
+  given byteString: (IArray[Byte] is Inlinable) = new Inlinable:
+    type Self = IArray[Byte]
+    def parse(reader: Expr[CborReader])(using Quotes, Type[IArray[Byte]]): Expr[IArray[Byte]] =
+      '{ $reader.byteString() }
+
+  given cbor: (Cbor is Inlinable) = new Inlinable:
+    type Self = Cbor
+    def parse(reader: Expr[CborReader])(using Quotes, Type[Cbor]): Expr[Cbor] =
+      '{ $reader.value() }
+
+  given iterable: [collection <: Iterable, element]
+  =>  (element0: element is Inlinable)
+  =>  (collection[element] is Inlinable) =
+    IterableInlinable[element](element0).asInstanceOf[collection[element] is Inlinable]

--- a/lib/breviloquence/src/staged/breviloquence.Inlinable.scala
+++ b/lib/breviloquence/src/staged/breviloquence.Inlinable.scala
@@ -75,6 +75,27 @@ object Inlinable:
   // (no macro — `Type[Self]` arrives with the call).
   def derived[product]: product is Inlinable = ProductInlinable[product]()
 
+  // The `derives`-clause carrier: a `Self`-typed typeclass cannot appear in
+  // a `derives` clause (it has no type parameters), so `case class Foo(...)
+  // derives Inlinable.ForCbor` synthesizes this parameterized subtrait —
+  // which *is* a `Foo is Inlinable` — into `Foo`'s companion, where the
+  // staging summon finds it. The resolution ladder unwraps the delegate so
+  // structural instances keep their generator identities.
+  final class ForCbor[value](delegate0: value is Inlinable) extends Inlinable:
+    type Self = value
+    private[breviloquence] def delegate: value is Inlinable = delegate0
+
+    def parse(reader: Expr[CborReader])(using Quotes, Type[value]): Expr[value] =
+      delegate0.parse(reader)
+
+    override def absent(tactic: Expr[Tactic[CborError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.absent(tactic)
+
+  object ForCbor:
+    def derived[value]: ForCbor[value] = ForCbor(Inlinable.derived[value])
+
   private[breviloquence] final class ProductInlinable[product]() extends Inlinable:
     type Self = product
 

--- a/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
+++ b/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
@@ -252,7 +252,13 @@ object stagedInternal:
   // type's staging summon runs at most once however often it recurs in the
   // graph.
 
-  private type Cache = scm.HashMap[String, Option[Inlinable]]
+  // The per-entry expansion cache: memoized staging summons, and the set of
+  // types whose generators are currently on the expansion stack — a
+  // recursive occurrence (`Tree` with `children: List[Tree]`) must degrade
+  // to the runtime seam rather than expand forever.
+  private final class Cache:
+    val instances: scm.HashMap[String, Option[Inlinable]] = scm.HashMap()
+    val active: scm.Set[String] = scm.Set()
 
   private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
     import quotes.reflect.*
@@ -260,7 +266,58 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      . orElse(structuralFor[field](cache))
+      . orElse(runtimeFor[field])
+
+  // The runtime tiers, resolved with a reflection-level implicit search at
+  // expansion time and called through neutral-carrier helpers (the erasing
+  // cast crosses the capability boundary, as wisteria's field-instance
+  // engine does): a nominal `Parsable` — the recursion tie, since a
+  // recursive record's own alias given (a lazy val) is found from inside
+  // its own definition — then the `Decodable` bridge. Neither
+  // `summonInline` nor a `using` parameter works here: inside the generated
+  // parser's inline context, the former fails to expand the blanket
+  // `summonFrom` given for recursively-derived instances, and honest
+  // capability-typed codecs fail to conform to the evidence query.
+  private def runtimeFor[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    def searched(target: TypeRepr): Option[Expr[Any]] =
+      Implicits.search(target) match
+        case success: ImplicitSearchSuccess => Some(success.tree.asExpr)
+        case _                              => None
+
+    searched(TypeRepr.of[field is Cbor.Parsable]).map(RuntimeInlinable[field](_)).orElse:
+      searched(TypeRepr.of[field is Decodable in Cbor]).map(DecodedInlinable[field](_))
+
+  private final class RuntimeInlinable[value](parsable: Expr[Any]) extends Inlinable:
+    type Self = value
+
+    def parse(reader: Expr[CborReader])(using Quotes, Type[value]): Expr[value] =
+      '{
+        Cbor.Parsable.parseField[value]
+          ($parsable.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef])
+      }
+
+    override def absent(tactic: Expr[Tactic[CborError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      '{ Cbor.Parsable.absentField[value]($parsable.asInstanceOf[AnyRef])(using $tactic) }
+
+  private final class DecodedInlinable[value](decodable: Expr[Any]) extends Inlinable:
+    type Self = value
+
+    def parse(reader: Expr[CborReader])(using Quotes, Type[value]): Expr[value] =
+      '{ $decodable.asInstanceOf[value is Decodable in Cbor].decoded($reader.value()) }
+
+    override def absent(tactic: Expr[Tactic[CborError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      '{
+        $decodable.asInstanceOf[value is Decodable in Cbor]
+        . decoded(Cbor.ast(Cbor.Ast(vacuous.Unset)))
+      }
 
   // Composition points become local defs rather than textual inlining: a
   // fully-flattened parser exceeds HotSpot's huge-method bytecode limit and
@@ -316,6 +373,9 @@ object stagedInternal:
 
       case _ =>
         None
+    // A recursive occurrence degrades to the runtime seam, whose
+    // derivation is lazy.
+    else if cache.active.contains(tpe.show) then None
     else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
     else sumFor[field](cache)
 
@@ -477,9 +537,19 @@ object stagedInternal:
   private[breviloquence] def productBody[product: Type](reader: Expr[CborReader])(using Quotes)
   :   Expr[product] =
 
-    productBody[product](reader, scm.HashMap())
+    productBody[product](reader, Cache())
 
   private def productBody[product: Type](reader: Expr[CborReader], cache: Cache)(using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[product].dealias.show
+
+    try productBody0[product](reader, cache)
+    finally cache.active -= TypeRepr.of[product].dealias.show
+
+  private def productBody0[product: Type](reader: Expr[CborReader], cache: Cache)(using Quotes)
   :   Expr[product] =
 
     import quotes.reflect.*
@@ -755,9 +825,20 @@ object stagedInternal:
     (using Quotes)
   :   Expr[sum] =
 
-    sumBody[sum](reader, key, scm.HashMap())
+    sumBody[sum](reader, key, Cache())
 
   private def sumBody[sum: Type](reader: Expr[CborReader], key: String, cache: Cache)
+    (using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[sum].dealias.show
+
+    try sumBody0[sum](reader, key, cache)
+    finally cache.active -= TypeRepr.of[sum].dealias.show
+
+  private def sumBody0[sum: Type](reader: Expr[CborReader], key: String, cache: Cache)
     (using Quotes)
   :   Expr[sum] =
 
@@ -805,12 +886,19 @@ object stagedInternal:
   def inlinableParsable[value: Type](using Quotes): Expr[value is Cbor.Parsable] =
     import quotes.reflect.*
 
-    val cache: Cache = scm.HashMap()
+    val cache: Cache = Cache()
 
     val root: Inlinable = resolve[value](cache).getOrElse:
       report.errorAndAbort
         (s"breviloquence: no Inlinable instance for ${TypeRepr.of[value].show}, and it is not "+
           "an inlinable product, collection or key-discriminated sum; use a `Decodable in Cbor`")
+
+    // A runtime-tier root would find the very given under definition — an
+    // infinite self-call — or add nothing over the instance it wraps.
+    if root.isInstanceOf[RuntimeInlinable[?]] || root.isInstanceOf[DecodedInlinable[?]] then
+      report.errorAndAbort
+        (s"breviloquence: ${TypeRepr.of[value].show} has no generator of its own; use its "+
+          "existing instance directly rather than `Inlinable.parsable`")
 
     val instance = root.asInstanceOf[Inlinable { type Self = value }]
 
@@ -818,7 +906,9 @@ object stagedInternal:
       // Sealed per the codec-thunk pattern: the generated body resolves its
       // capabilities where it is spliced.
       caps.unsafe.unsafeAssumePure:
-        new Cbor.Parsable:
-          type Self = value
-          def parse(reader: CborReader): value = ${ instance.parse('{reader}) }
+        new Cbor.Parsable.Direct[value]:
+          protected def parseCarrier(reader0: AnyRef): value =
+            // A capability class cannot be quoted into a pure hole, so
+            // every use casts from the neutral carrier afresh.
+            ${ instance.parse('{ reader0.asInstanceOf[CborReader] }) }
     }

--- a/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
+++ b/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
@@ -266,9 +266,16 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field].map(unwrap))
       . orElse(structuralFor[field](cache))
       . orElse(runtimeFor[field])
+
+  // A `derives`-clause carrier delegates to a structural instance; the
+  // ladder works with the delegate so generator identities stay
+  // recognizable.
+  private def unwrap(instance: Inlinable): Inlinable = instance match
+    case derived: Inlinable.ForCbor[?] => derived.delegate.asInstanceOf[Inlinable]
+    case other                         => other
 
   // The runtime tiers, resolved with a reflection-level implicit search at
   // expansion time and called through neutral-carrier helpers (the erasing

--- a/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
+++ b/lib/breviloquence/src/staged/breviloquence.stagedInternal.scala
@@ -1,0 +1,824 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package breviloquence
+
+import scala.collection.mutable as scm
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import prepositional.*
+import vacuous.*
+
+// The machinery behind `Cbor.Inlinable`: expansion-time instance resolution
+// (through an in-macro staging compiler), the structural generators for
+// products, collections and sums, and the `Inlinable.parsable` entry macro.
+object stagedInternal:
+
+  // The runtime seam for a field type without an `Inlinable`: a nominal
+  // `Parsable` (a custom instance) is called directly; anything else bridges
+  // through its `Decodable in Cbor`, materializing just that field's
+  // subtree. An inline method because `summonFrom` may only live in one; it
+  // expands where the generated parser is spliced.
+  inline def fieldSeam[fieldType](reader: CborReader): fieldType =
+    scala.compiletime.summonFrom:
+      case parsable: (`fieldType` is Cbor.Parsable) => parsable.parse(reader)
+
+      case _ =>
+        Cbor.Parsable
+        . fromDecodable(scala.compiletime.summonInline[fieldType is Decodable in Cbor])
+        . parse(reader)
+
+  // The seam's absent counterpart, preserving the AST path's semantics for
+  // a missing key: `decoded(Cbor(Ast(Unset)))` through the bridge.
+  inline def fieldSeamAbsent[fieldType](tactic: Tactic[CborError]): fieldType =
+    scala.compiletime.summonFrom:
+      case parsable: (`fieldType` is Cbor.Parsable) => parsable.absent()(using tactic)
+
+      case _ =>
+        Cbor.Parsable
+        . fromDecodable(scala.compiletime.summonInline[fieldType is Decodable in Cbor])
+        . absent()(using tactic)
+
+  // ── Expansion-time environment ─────────────────────────────────────────
+
+  private def macroClassloader: ClassLoader =
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // A symbol defined in the compilation run in progress has no trustworthy
+  // classfile (none on a clean build; a stale one from the previous compile
+  // on an incremental build), so instance evaluation must refuse it and the
+  // caller degrade to a runtime seam.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+
+    val full =
+      dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
+
+  // ── Type transport into the staging context ────────────────────────────
+  // The outer macro's `Type` cannot cross into the inner compiler, so a type
+  // travels as a tree of `java.lang.Class`es and is rebuilt inside with
+  // `TypeRepr.typeConstructorOf`. This restricts instance evaluation to
+  // class-shaped types (plain classes and applications of them) — opaque
+  // and structural types degrade to a runtime seam.
+
+  private case class TypeShape(clazz: Class[?], arguments: List[TypeShape])
+
+  private val primitiveClasses: Map[String, Class[?]] =
+    Map
+      ( "scala.Int"     -> classOf[Int],
+        "scala.Long"    -> classOf[Long],
+        "scala.Double"  -> classOf[Double],
+        "scala.Float"   -> classOf[Float],
+        "scala.Boolean" -> classOf[Boolean],
+        "scala.Short"   -> classOf[Short],
+        "scala.Byte"    -> classOf[Byte],
+        "scala.Char"    -> classOf[Char],
+        "scala.Unit"    -> classOf[Unit] )
+
+  // The binary name of a class symbol: package segments joined with dots,
+  // enclosing type segments with dollars.
+  private def binaryName(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+
+    def build(symbol: Symbol): String =
+      val owner = symbol.owner
+
+      if owner.isPackageDef then
+        val prefix = owner.fullName
+        if prefix == "<empty>" then symbol.name else prefix+"."+symbol.name
+      else
+        val ownerName = build(if owner.isClassDef then owner else owner.owner)
+        ownerName+"$"+symbol.name
+
+    build(symbol)
+
+  private def shapeOf(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[TypeShape] =
+    import quotes.reflect.*
+
+    def classFor(tpe: TypeRepr): Option[Class[?]] =
+      tpe.classSymbol.flatMap: symbol =>
+        if definedInCurrentRun(symbol) then None
+        else primitiveClasses.get(symbol.fullName).orElse:
+          try Some(Class.forName(binaryName(symbol), false, macroClassloader).nn)
+          catch
+            case _: ReflectiveOperationException => None
+            case _: LinkageError                 => None
+
+    tpe.dealias match
+      case AppliedType(constructor, arguments) =>
+        for
+          clazz <- classFor(constructor)
+          shapes <- arguments.foldRight(Option(List.empty[TypeShape])): (argument, list) =>
+                      list.flatMap { tail => shapeOf(argument).map(_ :: tail) }
+        yield TypeShape(clazz, shapes)
+
+      case other =>
+        classFor(other).map(TypeShape(_, Nil))
+
+  // ── Instance evaluation: the staging summon ────────────────────────────
+  // One fresh compiler per summon, over the macro classloader with the
+  // current output directory excluded from its classpath. The summon is
+  // embedded in the compiled snippet (`summonInline`), so it resolves during
+  // the inner compiler's inlining phase, composing conditional instances —
+  // the whole instance graph arrives live in one run.
+  private def summonViaStaging[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[field]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val target =
+            r2.Refinement
+              ( r2.TypeRepr.of[Inlinable], "Self",
+                r2.TypeBounds(rebuild(shape), rebuild(shape)) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+
+        result match
+          case instance: Inlinable =>
+            report.info
+              ( s"breviloquence: staged summon for ${TypeRepr.of[field].show} took "+
+                s"${duration}ms" )
+
+            Some(instance)
+
+          case _ =>
+            None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The resolution ladder ──────────────────────────────────────────────
+  // builtin → staged summon → structural collection/product/sum →
+  // (caller's) runtime seam. The cache spans one entry expansion, so a
+  // type's staging summon runs at most once however often it recurs in the
+  // graph.
+
+  private type Cache = scm.HashMap[String, Option[Inlinable]]
+
+  private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    builtinFor(tpe).orElse:
+      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+
+  // Composition points become local defs rather than textual inlining: a
+  // fully-flattened parser exceeds HotSpot's huge-method bytecode limit and
+  // runs interpreted. A local def keeps each generated method
+  // JIT-compilable while the call stays monomorphic and direct. Leaf
+  // generators stay inline.
+  private def nested[fieldType: Type]
+    (instance: Inlinable { type Self = fieldType }, reader: Expr[CborReader])
+    (using Quotes)
+  :   Expr[fieldType] =
+
+    instance match
+      case _: Inlinable.ProductInlinable[?] | _: Inlinable.IterableInlinable[?]
+         | _: Inlinable.SumInlinable[?] =>
+        '{
+          def parseNested(): fieldType = ${ instance.parse(reader) }
+          parseNested()
+        }
+
+      case _ =>
+        instance.parse(reader)
+
+  private def builtinFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Inlinable] =
+    import quotes.reflect.*
+
+    if tpe =:= TypeRepr.of[Int] then Some(Inlinable.int)
+    else if tpe =:= TypeRepr.of[Long] then Some(Inlinable.long)
+    else if tpe =:= TypeRepr.of[Double] then Some(Inlinable.double)
+    else if tpe =:= TypeRepr.of[Float] then Some(Inlinable.float)
+    else if tpe =:= TypeRepr.of[Boolean] then Some(Inlinable.boolean)
+    else if tpe =:= TypeRepr.of[Text] then Some(Inlinable.text)
+    else if tpe =:= TypeRepr.of[String] then Some(Inlinable.string)
+    else if tpe =:= TypeRepr.of[IArray[Byte]] then Some(Inlinable.byteString)
+    else if tpe =:= TypeRepr.of[Cbor] then Some(Inlinable.cbor)
+    else None
+
+  private def structuralFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    // A `Map` is an `Iterable` of pairs, but its wire form is a CBOR map,
+    // not an array — it stays on the seam (the AST `mapDecodable`).
+    val isMap = tpe.derivesFrom(Symbol.requiredClass("scala.collection.Map"))
+
+    if !isMap && tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            resolve[element](cache).map: instance =>
+              Inlinable.IterableInlinable[element]
+                (instance.asInstanceOf[element is Inlinable])
+
+      case _ =>
+        None
+    else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
+    else sumFor[field](cache)
+
+  // A sealed sum qualifies when every variant is itself an inlinable case
+  // class (resolved through the ladder, so custom variant instances
+  // compose) and its `Discriminable in Cbor` — obtained live through the
+  // staging summon — is a `Cbor.DiscriminantKey`, whose dispatch is a
+  // scan-ahead of one map entry. Anything else — singleton variants,
+  // `@name` renames, an unresolvable variant, a custom discriminator —
+  // degrades to the runtime seam, preserving the derived semantics exactly.
+  private def sumFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    sumVariants(quotes.reflect.TypeRepr.of[field].dealias).flatMap: variants =>
+      val resolvable = variants.forall: (_, variantType) =>
+        variantType.asType match
+          case '[variantType] => resolve[variantType](cache).isDefined
+
+      if !resolvable then None
+      else discriminantKeyFor[field].map { key => Inlinable.SumInlinable[field](key) }
+
+  // The variants of a stageable sealed sum: `(label, type)` per variant, or
+  // `None` when the shape is unsupported.
+  private def sumVariants(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[List[(String, quotes.reflect.TypeRepr)]] =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.flatMap: classSymbol =>
+      val applied = tpe match
+        case AppliedType(_, _) => true
+        case _                 => false
+
+      val children = classSymbol.children
+
+      val supported =
+        !applied
+        && classSymbol.flags.is(Flags.Sealed)
+        && children.nonEmpty
+        && children.forall: child =>
+             child.isClassDef && child.flags.is(Flags.Case) && !hasRenames(child)
+
+      if supported then Some(children.map { child => (child.name, child.typeRef) }) else None
+
+  // The sum's discriminant key, when its `Discriminable in Cbor` resolves —
+  // inside the staging compiler, so the instance is live — to a
+  // `Cbor.DiscriminantKey`.
+  private def discriminantKeyFor[sum: Type](using Quotes): Option[String] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[sum]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val cbor = r2.TypeRepr.of[Cbor]
+
+          val target =
+            r2.Refinement
+              ( r2.Refinement
+                  ( r2.TypeRepr.of[wisteria.Discriminable], "Self",
+                    r2.TypeBounds(rebuild(shape), rebuild(shape)) ),
+                "Form",
+                r2.TypeBounds(cbor, cbor) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        result match
+          case discriminant: Cbor.DiscriminantKey[?] => Some(discriminant.key.s)
+          case _                                     => None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  private def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr): Boolean =
+    import quotes.reflect.*
+
+    tpe.classSymbol.exists: classSymbol =>
+      classSymbol.flags.is(Flags.Case)
+      && !classSymbol.owner.isTerm
+      && (tpe match { case AppliedType(_, _) => false case _ => true })
+      && classSymbol.primaryConstructor.paramSymss
+         . filterNot(_.exists(_.isTypeParam)).length == 1
+      && !hasRenames(classSymbol)
+
+  // `@name` renames resolve through inline machinery the structural
+  // generator does not replicate; annotated records stay on the AST path.
+  private def hasRenames(using Quotes)(classSymbol: quotes.reflect.Symbol): Boolean =
+    import quotes.reflect.*
+
+    val annotated =
+      classSymbol.primaryConstructor.paramSymss.flatten.filterNot(_.isTypeParam)
+        . flatMap(_.annotations)
+      ++ classSymbol.caseFields.flatMap(_.annotations)
+
+    annotated.exists { annotation => annotation.tpe <:< TypeRepr.of[adversaria.name[?]] }
+
+  // ── The collection generator ───────────────────────────────────────────
+  // Mirrors the AST `collectionDecodable` exactly: a definite array is
+  // count-driven, an indefinite one Break-terminated — with the element's
+  // generated code inlined into the loop.
+  private[breviloquence] def iterableBody[collection: Type]
+    (reader: Expr[CborReader], element0: Inlinable)
+    (using Quotes)
+  :   Expr[collection] =
+
+    import quotes.reflect.*
+
+    TypeRepr.of[collection].dealias match
+      case AppliedType(_, arguments) =>
+        arguments.last.asType match
+          case '[element] =>
+            val instance = element0.asInstanceOf[Inlinable { type Self = element }]
+
+            '{
+              def parseElement(): element = ${ instance.parse(reader) }
+              val factory = infer[scala.collection.Factory[element, collection]]
+              val builder = factory.newBuilder
+              val tactic = infer[Tactic[CborError]]
+              val parser = $reader.rawParser.asInstanceOf[Cbor.Parser]
+              var remaining = parser.directOpenArray()(using tactic)
+              var run = remaining != 0
+
+              while run do
+                if remaining < 0 && parser.directBreak()(using tactic) then run = false
+                else
+                  builder += parseElement()
+                  remaining -= 1
+                  if remaining == 0 then run = false
+
+              builder.result()
+            }
+
+      case _ =>
+        report.errorAndAbort
+          ("breviloquence: an inlinable collection requires an applied collection type")
+
+  // ── The product generator ──────────────────────────────────────────────
+  // Self-contained monomorphic record parsing, mirroring the AST record
+  // decoder's semantics: typed local slots and seen flags, literal
+  // packed-word key dispatch (an opaque key resolves through the generally
+  // consumed name against literal strings; unknown keys and non-text-keyed
+  // entries are skipped), first occurrence read per key, declared defaults
+  // then absent semantics for missing fields, direct construction.
+  private[breviloquence] def productBody[product: Type](reader: Expr[CborReader])(using Quotes)
+  :   Expr[product] =
+
+    productBody[product](reader, scm.HashMap())
+
+  private def productBody[product: Type](reader: Expr[CborReader], cache: Cache)(using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+
+    if !productSupported(tpe) then
+      report.errorAndAbort
+        (s"breviloquence: ${tpe.show} is not an inlinable product (a non-generic, top-level "+
+          "or object-nested case class with a single parameter list and no `@name` renames); "+
+          "use a `Decodable in Cbor`")
+
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    // Field names pack exactly as `directKeyWord` packs wire keys: 1-16
+    // bytes, all 7-bit ASCII, little-endian into a low and high word.
+    def packedName(index: Int): Option[(Long, Long)] =
+      val name = fieldNames(index)
+      val length = name.length
+
+      val packs = length > 0 && length <= 16 &&
+        name.forall { char => char >= ' ' && char < 127 }
+
+      if !packs then None else
+        var low = 0L
+        var high = 0L
+        var position = 0
+
+        while position < length do
+          val byte = name.charAt(position).toLong & 0xFF
+          if position < 8 then low |= byte << (position*8)
+          else high |= byte << ((position - 8)*8)
+          position += 1
+
+        Some((low, high))
+
+    val packedNames: List[Option[(Long, Long)]] = List.range(0, arity).map(packedName)
+
+    def body
+      ( tactic: Expr[Tactic[CborError]],
+        parser: Expr[Cbor.Parser] )
+    :   Expr[product] =
+
+      val owner = Symbol.spliceOwner
+
+      val slots = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+      val seens = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      def zero(fieldType: TypeRepr): Term =
+        if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+        else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+        else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+        else if fieldType =:= TypeRepr.of[Float] then Literal(FloatConstant(0.0f))
+        else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+        else fieldType.asType match
+          case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+      val slotDefs = List.range(0, arity).map: index =>
+        ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+      val seenDefs = List.range(0, arity).map: index =>
+        ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val unit = Literal(UnitConstant())
+
+      // Builtins read straight off the parser bound once per record,
+      // skipping the CborReader rim entirely.
+      def builtinDirect(tpe: TypeRepr): Option[Expr[Any]] =
+        if tpe =:= TypeRepr.of[Int] then Some('{ $parser.directLong()(using $tactic).toInt })
+        else if tpe =:= TypeRepr.of[Long] then Some('{ $parser.directLong()(using $tactic) })
+        else if tpe =:= TypeRepr.of[Double] then
+          Some('{ $parser.directDouble()(using $tactic) })
+        else if tpe =:= TypeRepr.of[Float] then
+          Some('{ $parser.directDouble()(using $tactic).toFloat })
+        else if tpe =:= TypeRepr.of[Boolean] then
+          Some('{ $parser.directBoolean()(using $tactic) })
+        else if tpe =:= TypeRepr.of[Text] then
+          Some('{ $parser.directString()(using $tactic).tt })
+        else if tpe =:= TypeRepr.of[String] then
+          Some('{ $parser.directString()(using $tactic) })
+        else if tpe =:= TypeRepr.of[IArray[Byte]] then
+          Some('{ $parser.directBytes()(using $tactic) })
+        else if tpe =:= TypeRepr.of[Cbor] then
+          Some('{ Cbor.ast($parser.value()(using $tactic)) })
+        else None
+
+      // The absent expression per field, through the ladder.
+      def fieldAbsent(index: Int): Expr[Any] =
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            if builtinDirect(fieldTypes(index)).isDefined then
+              '{ Cbor.Parsable.missing[fieldType]()(using $tactic) }
+            else resolve[fieldType](cache) match
+              case Some(instance0) =>
+                instance0.asInstanceOf[Inlinable { type Self = fieldType }].absent(tactic)
+
+              case None =>
+                '{ stagedInternal.fieldSeamAbsent[fieldType]($tactic) }
+
+      // One local def per field, shaped for the JIT: non-builtin bodies are
+      // potentially large, so each is emitted once and *called* from its
+      // dispatch arm.
+      val readDefs = List.range(0, arity).map: index =>
+        Symbol.newMethod
+          ( owner, "readField"+index,
+            MethodType(Nil)(_ => Nil, _ => fieldTypes(index)) )
+
+      val readDefDefs: List[Statement] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val rhs: Expr[fieldType] =
+              builtinDirect(fieldTypes(index)) match
+                case Some(direct) =>
+                  direct.asExprOf[fieldType]
+
+                case None =>
+                  resolve[fieldType](cache) match
+                    case Some(instance0) =>
+                      nested[fieldType]
+                        ( instance0.asInstanceOf[Inlinable { type Self = fieldType }],
+                          reader )
+
+                    case None =>
+                      '{ stagedInternal.fieldSeam[fieldType]($reader) }
+
+            DefDef(readDefs(index), _ => Some(rhs.asTerm.changeOwner(readDefs(index))))
+
+      def arms: List[CaseDef] = List.range(0, arity).map: index =>
+        val readAndMark =
+          Block
+            ( List
+                ( Assign(Ref(slots(index)), Apply(Ref(readDefs(index)), Nil)),
+                  Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+              unit )
+
+        // First occurrence wins, as the AST path's immutable map builder: a
+        // repeat key's value is skipped.
+        val rhs =
+          If
+            ( '{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm,
+              readAndMark,
+              '{ $parser.directSkipValue()(using $tactic) }.asTerm )
+
+        CaseDef(Literal(IntConstant(index)), None, rhs)
+
+      def fallthrough =
+        CaseDef(Wildcard(), None, '{ $parser.directSkipValue()(using $tactic) }.asTerm)
+
+      val remaining =
+        Symbol.newVal(owner, "remaining", TypeRepr.of[Int], Flags.Mutable, Symbol.noSymbol)
+
+      val run = Symbol.newVal(owner, "run", TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+      val remainingRef = Ref(remaining).asExprOf[Int]
+      val runRef = Ref(run).asExprOf[Boolean]
+
+      def packedChainOver(wordRef: Expr[Long], highRef: Expr[Long])(index: Int): Term =
+        if index == arity then Literal(IntConstant(-1))
+        else packedNames(index) match
+          case None => packedChainOver(wordRef, highRef)(index + 1)
+
+          case Some((low, highWord)) =>
+            If
+              ( '{ $wordRef == ${Expr(low)} && $highRef == ${Expr(highWord)} }.asTerm,
+                Literal(IntConstant(index)),
+                packedChainOver(wordRef, highRef)(index + 1) )
+
+      def namedChain(name: Expr[String], index: Int): Expr[Int] =
+        if index == arity then Expr(-1)
+        else
+          '{
+            if ${Expr(fieldNames(index))} == $name then ${Expr(index)}
+            else ${ namedChain(name, index + 1) }
+          }
+
+      // One entry step: read the key (packed fast path, general otherwise),
+      // dispatch, then count the entry off. A non-text key arrives as a
+      // `null` name: its entry is ignored, exactly as the AST record
+      // decoder — the key is already consumed, and the unknown arm skips
+      // the value.
+      def step: Term =
+        val word =
+          Symbol.newVal(owner, "word", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+
+        val high =
+          Symbol.newVal(owner, "high", TypeRepr.of[Long], Flags.EmptyFlags, Symbol.noSymbol)
+
+        val found =
+          Symbol.newVal(owner, "found", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+
+        val wordRef = Ref(word).asExprOf[Long]
+        val highRef = Ref(high).asExprOf[Long]
+
+        val opaque: Expr[Int] =
+          '{
+            val name = $parser.directKeyName()(using $tactic)
+            if name == null then -1 else ${ namedChain('{name.nn}, 0) }
+          }
+
+        val resolveStep: Term =
+          If
+            ( '{ $wordRef == CborReader.KeyOpaque }.asTerm,
+              opaque.asTerm,
+              Block
+                ( List(ValDef(high, Some('{ $parser.directKeyHigh }.asTerm))),
+                  packedChainOver(wordRef, highRef)(0) ) )
+
+        val entry: Term =
+          Block
+            ( List
+                ( ValDef(word, Some('{ $parser.directKeyWord() }.asTerm)),
+                  Block
+                    ( List(ValDef(found, Some(resolveStep))),
+                      Match(Ref(found), arms ::: List(fallthrough)) ),
+                  Assign(Ref(remaining), '{ $remainingRef - 1 }.asTerm) ),
+              If
+                ( '{ $remainingRef == 0 }.asTerm,
+                  Assign(Ref(run), Literal(BooleanConstant(false))),
+                  unit ) )
+
+        If
+          ( '{ $remainingRef < 0 && $parser.directBreak()(using $tactic) }.asTerm,
+            Assign(Ref(run), Literal(BooleanConstant(false))),
+            entry )
+
+      val loop: List[Statement] =
+        readDefDefs :::
+          List
+            ( ValDef(remaining, Some('{ $parser.directOpenMap()(using $tactic) }.asTerm)),
+              ValDef(run, Some('{ $remainingRef != 0 }.asTerm)),
+              While(runRef.asTerm, step) )
+
+      val absents: List[Term] = List.range(0, arity).map: index =>
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val resolveAbsent: Term =
+              Assign
+                ( Ref(slots(index)),
+                  '{
+                    val declared =
+                      wisteria.internal.default[product, fieldType](${Expr(index)})
+
+                    if !declared.absent then declared.asInstanceOf[fieldType]
+                    else ${ fieldAbsent(index).asExprOf[fieldType] }
+                  }.asTerm )
+
+            If('{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm, resolveAbsent, unit)
+
+      val construct: Term =
+        Apply(Select(New(Inferred(tpe)), ctor), slots.map { slot => Ref(slot) })
+
+      Block(slotDefs ::: seenDefs ::: loop ::: absents, construct).asExprOf[product]
+
+    '{
+      val tactic = infer[Tactic[CborError]]
+      val parser = $reader.rawParser.asInstanceOf[Cbor.Parser]
+      ${ body('tactic, 'parser) }
+    }
+
+  // ── The sum generator ──────────────────────────────────────────────────
+  // The variant is chosen by a scan-ahead of the discriminant entry (the
+  // parser is left where it started), then parsed from the start of the
+  // map as its product — the discriminant entry skips as an unknown key —
+  // exactly the AST disjunction's `discriminate` + `delegate` semantics.
+  private[breviloquence] def sumBody[sum: Type](reader: Expr[CborReader], key: String)
+    (using Quotes)
+  :   Expr[sum] =
+
+    sumBody[sum](reader, key, scm.HashMap())
+
+  private def sumBody[sum: Type](reader: Expr[CborReader], key: String, cache: Cache)
+    (using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    val variants = sumVariants(TypeRepr.of[sum].dealias).getOrElse:
+      report.errorAndAbort
+        (s"breviloquence: ${TypeRepr.of[sum].show} is not an inlinable sum (a non-generic "+
+          "sealed type whose variants are all case classes without `@name` renames)")
+
+    val arity = variants.length
+
+    def dispatch(index: Int, tag: Expr[String]): Expr[sum] =
+      if index == arity then
+        '{
+          provide[Tactic[wisteria.VariantError]]:
+            abort(wisteria.VariantError[sum]($tag.tt))
+        }
+      else variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"breviloquence: no Inlinable for variant ${variants(index)(0)}")
+          . asInstanceOf[Inlinable { type Self = variantType }]
+
+          '{
+            if $tag == ${Expr(variants(index)(0))} then
+              def parseVariant(): variantType = ${ instance.parse(reader) }
+              parseVariant()
+            else ${ dispatch(index + 1, tag) }
+          }
+
+    '{
+      val tactic = infer[Tactic[CborError]]
+      val parser = $reader.rawParser.asInstanceOf[Cbor.Parser]
+      val tag = parser.directDiscriminant(${Expr(key)})(using tactic)
+
+      if tag == null then abort(CborError(CborError.Reason.Absent))(using tactic)
+      else
+        val tagValue: String = tag.nn
+        ${ dispatch(0, 'tagValue) }
+    }
+
+  // ── The entry macro ────────────────────────────────────────────────────
+  def inlinableParsable[value: Type](using Quotes): Expr[value is Cbor.Parsable] =
+    import quotes.reflect.*
+
+    val cache: Cache = scm.HashMap()
+
+    val root: Inlinable = resolve[value](cache).getOrElse:
+      report.errorAndAbort
+        (s"breviloquence: no Inlinable instance for ${TypeRepr.of[value].show}, and it is not "+
+          "an inlinable product, collection or key-discriminated sum; use a `Decodable in Cbor`")
+
+    val instance = root.asInstanceOf[Inlinable { type Self = value }]
+
+    '{
+      // Sealed per the codec-thunk pattern: the generated body resolves its
+      // capabilities where it is spliced.
+      caps.unsafe.unsafeAssumePure:
+        new Cbor.Parsable:
+          type Self = value
+          def parse(reader: CborReader): value = ${ instance.parse('{reader}) }
+    }

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -55,6 +55,15 @@ enum Shape derives CanEqual:
   case Circle(radius: Double)
   case Square(side: Double)
 
+// Model types for the direct-parsing (`Inlinable`) suite. Same-run types
+// stay on the structural ladder: the staging summon refuses them, which is
+// exactly the degradation the suite exercises.
+case class Defaulted(x: Int, y: Int = 7) derives CanEqual
+case class Wide(seventeenCharacter: Int, y: Int) derives CanEqual
+case class Blob(data: IArray[Byte])
+case class Nums(values: List[Int]) derives CanEqual
+case class Mixed(a: Double, b: Boolean, c: Text) derives CanEqual
+
 enum CStatus derives CanEqual:
   @name[Cbor](t"ok") case Active(since: Int)
   @name(t"gone")     case Removed(at: Int)
@@ -430,3 +439,103 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val bytes = Cbor.Ast.encodable.encoded(Cbor.unseal(OptPerson(t"Eve", Unset).in[Cbor]))
         Cbor.ast(Cbor.Ast.parse(bytes)).as[OptPerson]
       . assert(_ == OptPerson(t"Eve", Unset))
+
+    suite(m"Direct parsing (Inlinable)"):
+      given (Point is Cbor.Parsable) = Inlinable.parsable[Point]
+      given (Person is Cbor.Parsable) = Inlinable.parsable[Person]
+      given (Wrapper is Cbor.Parsable) = Inlinable.parsable[Wrapper]
+      given (Team is Cbor.Parsable) = Inlinable.parsable[Team]
+      given (OptPerson is Cbor.Parsable) = Inlinable.parsable[OptPerson]
+      given (Defaulted is Cbor.Parsable) = Inlinable.parsable[Defaulted]
+      given (Wide is Cbor.Parsable) = Inlinable.parsable[Wide]
+      given (Blob is Cbor.Parsable) = Inlinable.parsable[Blob]
+      given (Nums is Cbor.Parsable) = Inlinable.parsable[Nums]
+      given (Mixed is Cbor.Parsable) = Inlinable.parsable[Mixed]
+
+      def encoded[value: Encodable in Cbor](value: value): IArray[Byte] =
+        Cbor.Ast.encodable.encoded(Cbor.unseal(value.in[Cbor]))
+
+      test(m"a flat product reads directly from bytes"):
+        encoded(Point(3, 4)).read[Point in Cbor]
+      . assert(_ == Point(3, 4))
+
+      test(m"text and numeric scalars agree with the AST path"):
+        encoded(Mixed(2.5, true, t"hello")).read[Mixed in Cbor]
+      . assert(_ == Mixed(2.5, true, t"hello"))
+
+      test(m"a nested product inlines through its own generated parser"):
+        encoded(Team(Person(t"Ada", 36), 5)).read[Team in Cbor]
+      . assert(_ == Team(Person(t"Ada", 36), 5))
+
+      test(m"a collection field loops over a definite-length array"):
+        encoded(Wrapper(List(1, 2, 3), t"hi")).read[Wrapper in Cbor]
+      . assert(_ == Wrapper(List(1, 2, 3), t"hi"))
+
+      test(m"a byte-string field reads in place"):
+        encoded(Blob(hex("01020304"))).read[Blob in Cbor].data.to(List)
+      . assert(_ == List[Byte](1, 2, 3, 4))
+
+      test(m"an indefinite-length map parses to the same record"):
+        hex("bf 6178 03 6179 04 ff").read[Point in Cbor]
+      . assert(_ == Point(3, 4))
+
+      test(m"an indefinite-length array parses to the same collection"):
+        hex("a1 6676616c756573 9f 010203 ff").read[Nums in Cbor]
+      . assert(_ == Nums(List(1, 2, 3)))
+
+      test(m"an unknown key is skipped whole"):
+        hex("a3 617a 05 6178 03 6179 04").read[Point in Cbor]
+      . assert(_ == Point(3, 4))
+
+      test(m"the first occurrence of a repeated key wins"):
+        hex("a3 6178 03 6178 09 6179 04").read[Point in Cbor]
+      . assert(_ == Point(3, 4))
+
+      test(m"a non-text-keyed entry is ignored"):
+        hex("a3 05 05 6178 03 6179 04").read[Point in Cbor]
+      . assert(_ == Point(3, 4))
+
+      test(m"a float coerces into an integer field as the AST accessor"):
+        hex("a2 6178 fb3ff8000000000000 6179 02").read[Point in Cbor]
+      . assert(_ == Point(1, 2))
+
+      test(m"a key too long to pack resolves through the general step"):
+        encoded(Wide(9, 2)).read[Wide in Cbor]
+      . assert(_ == Wide(9, 2))
+
+      test(m"a missing required field aborts with Absent"):
+        capture[CborError](hex("a1 6178 03").read[Point in Cbor]).reason
+      . assert(_ == CborError.Reason.Absent)
+
+      test(m"a missing field with a declared default takes it"):
+        hex("a1 6178 03").read[Defaulted in Cbor]
+      . assert(_ == Defaulted(3, 7))
+
+      test(m"an Optional field bridges to Unset when absent"):
+        hex("a1 646e616d65 63457665").read[OptPerson in Cbor]
+      . assert(_ == OptPerson(t"Eve", Unset))
+
+      test(m"an Optional field bridges to Unset from a wire undefined"):
+        hex("a2 646e616d65 63457665 63616765 f7").read[OptPerson in Cbor]
+      . assert(_ == OptPerson(t"Eve", Unset))
+
+      test(m"an Optional field reads its value when present"):
+        encoded(OptPerson(t"Ada", 36)).read[OptPerson in Cbor]
+      . assert(_ == OptPerson(t"Ada", 36))
+
+      test(m"a non-map item reads as an empty record"):
+        capture[CborError](hex("07").read[Point in Cbor]).reason
+      . assert(_ == CborError.Reason.Absent)
+
+      test(m"trailing bytes are rejected as on the AST path"):
+        val bytes = encoded(Point(3, 4))
+        val padded = IArray.from(bytes.to(List) :+ 0.toByte)
+        capture[CborError](padded.read[Point in Cbor]).reason match
+          case CborError.Reason.Trailing(offset) => offset
+          case _                                 => -1L
+      . assert(_ == 7L)
+
+      test(m"the aggregable trigger routes a stream through the direct parser"):
+        val bytes = encoded(Person(t"Ada", 36))
+        LazyList(bytes).read[Person in Cbor]
+      . assert(_ == Person(t"Ada", 36))

--- a/lib/breviloquence/src/test/breviloquence_test.scala
+++ b/lib/breviloquence/src/test/breviloquence_test.scala
@@ -539,3 +539,9 @@ object Tests extends Suite(m"Breviloquence Tests"):
         val bytes = encoded(Person(t"Ada", 36))
         LazyList(bytes).read[Person in Cbor]
       . assert(_ == Person(t"Ada", 36))
+
+      test(m"a recursive type degrades its recursive field to the seam"):
+        given (Tree is Cbor.Parsable) = Inlinable.parsable[Tree]
+        val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+        encoded(tree).read[Tree in Cbor]
+      . assert(_ == Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil))))))

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -41,6 +41,7 @@ import fulminate.*
 import gossamer.*
 import hellenism.*, classloaders.threadContextClassloader
 import jacinta.*
+import locomotion.*
 import prepositional.*
 import probably.*
 import proscenium.*
@@ -151,6 +152,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
   lazy val jsonData: Data = jsonText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
   lazy val telData: Data = telText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
   lazy val cborData: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobufData: Data = corpus.in[Protobuf].encode
 
   // ── The decode arms ───────────────────────────────────────────────────────
   // Each format is measured two ways: through its materialized AST, and
@@ -180,6 +182,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     given inlinedXmlOrders: Orders is Xml.Parsable = xylophone.Inlinable.parsable[Orders]
     given inlinedCborOrders: Orders is Cbor.Parsable = breviloquence.Inlinable.parsable[Orders]
 
+    given inlinedProtobufOrders: Orders is Protobuf.Parsable =
+      locomotion.Inlinable.parsable[Orders]
+
   def decodeJsonInlined(): Orders =
     import inlined.inlinedOrders
     jsonData.read[Orders in Json]
@@ -196,10 +201,15 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     import inlined.inlinedCborOrders
     cborData.read[Orders in Cbor]
 
+  def decodeProtobufInlined(): Orders =
+    import inlined.inlinedProtobufOrders
+    protobufData.read[Orders in Protobuf]
+
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
   def decodeXmlAst(): Orders = xmlText.read[Xml].as[Orders]
   def decodeYamlAst(): Orders = yamlText.read[Yaml].as[Orders]
   def decodeCborAst(): Orders = cborData.read[Cbor].as[Orders]
+  def decodeProtobufAst(): Orders = protobufData.read[Protobuf].as[Orders]
 
   // ── Jsoniter arms ─────────────────────────────────────────────────────────
   // The external yardstick, decoding the same JSON corpus: direct with a
@@ -252,7 +262,8 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
   def run(): Unit =
     println(s"Corpus sizes (bytes): JSON=${jsonText.s.length} TEL=${telText.s.length} "
-        + s"XML=${xmlText.s.length} YAML=${yamlText.s.length} CBOR=${cborData.length}")
+        + s"XML=${xmlText.s.length} YAML=${yamlText.s.length} CBOR=${cborData.length} "
+        + s"Protobuf=${protobufData.length}")
 
     // The correctness gate: every arm must reproduce the original value
     // before anything is timed.
@@ -265,6 +276,8 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeYamlAst() == corpus, "YAML AST decode disagrees with the corpus")
     assert(decodeCborInlined() == corpus, "CBOR inlined decode disagrees with the corpus")
     assert(decodeCborAst() == corpus, "CBOR AST decode disagrees with the corpus")
+    assert(decodeProtobufInlined() == corpus, "Protobuf inlined decode disagrees with the corpus")
+    assert(decodeProtobufAst() == corpus, "Protobuf AST decode disagrees with the corpus")
 
     val jsoniterExpected = jsoniterMirror(corpus)
     assert(decodeJsoniterDirect() == jsoniterExpected, "Jsoniter direct decode disagrees")
@@ -301,6 +314,12 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
       bench(m"CBOR via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeCborAst() }
 
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeProtobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeProtobufAst() }
+
       // YAML decodes through the AST only: aliases require materialized
       // subtrees, so ypsiloid deliberately has no inlined path.
       bench(m"YAML via AST")(target = 1*Second):
@@ -321,6 +340,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       profile(m"CBOR inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeCborInlined() }
+
+      profile(m"Protobuf inlined")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeProtobufInlined() }
 
       profile(m"XML inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlInlined() }

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -279,6 +279,14 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeProtobufInlined() == corpus, "Protobuf inlined decode disagrees with the corpus")
     assert(decodeProtobufAst() == corpus, "Protobuf AST decode disagrees with the corpus")
 
+    matrixConfig.check()
+    matrixMenu.check()
+    matrixUsers.check()
+    matrixLogs.check()
+    matrixTransactions.check()
+    matrixInts.check()
+    matrixDecimals.check()
+
     val jsoniterExpected = jsoniterMirror(corpus)
     assert(decodeJsoniterDirect() == jsoniterExpected, "Jsoniter direct decode disagrees")
     assert(decodeJsoniterAst() == jsoniterExpected, "Jsoniter AST decode disagrees")
@@ -330,6 +338,21 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
       bench(m"Jsoniter via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeJsoniterAst() }
+
+
+    matrixConfig.suites(bench)
+
+    matrixMenu.suites(bench)
+
+    matrixUsers.suites(bench)
+
+    matrixLogs.suites(bench)
+
+    matrixTransactions.suites(bench)
+
+    matrixInts.suites(bench)
+
+    matrixDecimals.suites(bench)
 
     // Where the self-time actually goes in each inlined arm — a JFR hotspot
     // histogram per parser, coloured by package. Jsoniter direct is the

--- a/lib/crossparse/src/bench/crossparse.Benchmarks.scala
+++ b/lib/crossparse/src/bench/crossparse.Benchmarks.scala
@@ -34,6 +34,7 @@ package crossparse
 
 import ambience.*, environments.javaEnvironment, systems.javaSystem
 import anticipation.*
+import breviloquence.*
 import contingency.*, strategies.throwUnsafely
 import distillate.*
 import fulminate.*
@@ -149,6 +150,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
   lazy val jsonData: Data = jsonText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
   lazy val telData: Data = telText.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val cborData: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
 
   // ── The decode arms ───────────────────────────────────────────────────────
   // Each format is measured two ways: through its materialized AST, and
@@ -176,6 +178,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     given inlinedOrders: Orders is Json.Parsable = jacinta.Inlinable.parsable[Orders]
     given inlinedTelOrders: Orders is Tel.Parsable = stratiform.Inlinable.parsable[Orders]
     given inlinedXmlOrders: Orders is Xml.Parsable = xylophone.Inlinable.parsable[Orders]
+    given inlinedCborOrders: Orders is Cbor.Parsable = breviloquence.Inlinable.parsable[Orders]
 
   def decodeJsonInlined(): Orders =
     import inlined.inlinedOrders
@@ -189,9 +192,14 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     import inlined.inlinedXmlOrders
     xmlText.read[Orders in Xml]
 
+  def decodeCborInlined(): Orders =
+    import inlined.inlinedCborOrders
+    cborData.read[Orders in Cbor]
+
   def decodeTelAst(): Orders = telData.read[Tel].as[Orders]
   def decodeXmlAst(): Orders = xmlText.read[Xml].as[Orders]
   def decodeYamlAst(): Orders = yamlText.read[Yaml].as[Orders]
+  def decodeCborAst(): Orders = cborData.read[Cbor].as[Orders]
 
   // ── Jsoniter arms ─────────────────────────────────────────────────────────
   // The external yardstick, decoding the same JSON corpus: direct with a
@@ -244,7 +252,7 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
 
   def run(): Unit =
     println(s"Corpus sizes (bytes): JSON=${jsonText.s.length} TEL=${telText.s.length} "
-        + s"XML=${xmlText.s.length} YAML=${yamlText.s.length}")
+        + s"XML=${xmlText.s.length} YAML=${yamlText.s.length} CBOR=${cborData.length}")
 
     // The correctness gate: every arm must reproduce the original value
     // before anything is timed.
@@ -255,6 +263,8 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     assert(decodeXmlInlined() == corpus, "XML inlined decode disagrees with the corpus")
     assert(decodeXmlAst() == corpus, "XML AST decode disagrees with the corpus")
     assert(decodeYamlAst() == corpus, "YAML AST decode disagrees with the corpus")
+    assert(decodeCborInlined() == corpus, "CBOR inlined decode disagrees with the corpus")
+    assert(decodeCborAst() == corpus, "CBOR AST decode disagrees with the corpus")
 
     val jsoniterExpected = jsoniterMirror(corpus)
     assert(decodeJsoniterDirect() == jsoniterExpected, "Jsoniter direct decode disagrees")
@@ -285,6 +295,12 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
       bench(m"XML via AST")(target = 1*Second):
         '{ crossparse.Benchmarks.decodeXmlAst() }
 
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeCborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.Benchmarks.decodeCborAst() }
+
       // YAML decodes through the AST only: aliases require materialized
       // subtrees, so ypsiloid deliberately has no inlined path.
       bench(m"YAML via AST")(target = 1*Second):
@@ -302,6 +318,9 @@ object Benchmarks extends Suite(m"Cross-format direct-parsing benchmarks"):
     suite(m"Profile: inlined-parser hotspots"):
       profile(m"TEL inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeTelInlined() }
+
+      profile(m"CBOR inlined")(target = 5*Second):
+        '{ crossparse.Benchmarks.decodeCborInlined() }
 
       profile(m"XML inlined")(target = 5*Second):
         '{ crossparse.Benchmarks.decodeXmlInlined() }

--- a/lib/crossparse/src/bench/crossparse.matrix.scala
+++ b/lib/crossparse/src/bench/crossparse.matrix.scala
@@ -1,0 +1,1104 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package crossparse
+
+import ambience.*, systems.javaSystem
+import anticipation.*
+import breviloquence.*
+import contingency.*, strategies.throwUnsafely
+import distillate.*
+import fulminate.*
+import gossamer.*
+import jacinta.*
+import locomotion.*
+import prepositional.*
+import probably.*
+import proscenium.*
+import quantitative.*
+import rudiments.*
+import sedentary.*
+import spectacular.*
+import stratiform.*
+import superlunary.*
+import symbolism.*
+import temporaryDirectories.systemTemporaryDirectory
+import turbulence.*
+import vacuous.*
+import xylophone.*
+import ypsiloid.*
+
+import jacinta.formatting.compactJsonFormatting
+import ypsiloid.formatting.blockYamlFormatting
+import ypsiloid.showable
+
+// ── The document matrix ─────────────────────────────────────────────────
+// Typed translations of the jacinta benchmark corpus (see
+// `crossparse.model`), each serialized once through every format's own
+// encoder and decoded back two ways per format — through the materialized
+// AST and through the inlined parser (YAML AST-only) — so the comparison
+// spans document shapes: a nested config, a small fragment, flat record
+// tables, and numeric arrays. One object per document, so each classfile
+// stays within the JVM's method and constant-pool limits.
+
+object matrixConfig:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: Config = corpora.config()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: Config is Json.Parsable = jacinta.Inlinable.parsable[Config]
+  given inlinedTel: Config is Tel.Parsable = stratiform.Inlinable.parsable[Config]
+  given inlinedXml: Config is Xml.Parsable = xylophone.Inlinable.parsable[Config]
+  given inlinedCbor: Config is Cbor.Parsable = breviloquence.Inlinable.parsable[Config]
+
+  given inlinedProtobuf: Config is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[Config]
+
+  given inlinedBintel: Config is Bintel.Parsable = BintelInlinable.parsable[Config]
+
+  def jsonAst(): Config = json.read[Json].as[Config]
+  def jsonInlined(): Config = json.read[Config in Json]
+  def telAst(): Config = tel.read[Tel].as[Config]
+  def telInlined(): Config = tel.read[Config in Tel]
+  def xmlAst(): Config = xml.read[Xml].as[Config]
+  def xmlInlined(): Config = xml.read[Config in Xml]
+  def yamlAst(): Config = yaml.read[Yaml].as[Config]
+  def cborAst(): Config = cbor.read[Cbor].as[Config]
+  def cborInlined(): Config = cbor.read[Config in Cbor]
+  def protobufAst(): Config = protobuf.read[Protobuf].as[Config]
+  def protobufInlined(): Config = protobuf.read[Config in Protobuf]
+  def bintelAst(): Config = Bintel.read[Config](bintel)
+  def bintelInlined(): Config = Bintel.parse[Config](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MConfig =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MConfig]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.config)
+
+  def borerRival(): MConfig =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MConfig]
+      (using borerCodecs.config).value
+
+  def protobufJavaRival(): MConfig = protobufWalks.config(protobuf)
+  def aaltoRival(): MConfig = aaltoWalks.config(xml.s)
+  def snakeyamlRival(): MConfig = snakeyamlWalks.config(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "config: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "config: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "config: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "config: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "config: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "config: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "config: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "config: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "config: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "config: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "config: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "config: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "config: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.config(corpus)
+    assert(jsoniterRival() == mirror, "config: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "config: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "config: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "config: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "config: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the config corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixConfig.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixConfig.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixConfig.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixConfig.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixConfig.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixConfig.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixConfig.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixConfig.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixConfig.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixConfig.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixConfig.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixConfig.snakeyamlRival() }
+
+object matrixMenu:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: MenuDoc = corpora.menu()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: MenuDoc is Json.Parsable = jacinta.Inlinable.parsable[MenuDoc]
+  given inlinedTel: MenuDoc is Tel.Parsable = stratiform.Inlinable.parsable[MenuDoc]
+  given inlinedXml: MenuDoc is Xml.Parsable = xylophone.Inlinable.parsable[MenuDoc]
+  given inlinedCbor: MenuDoc is Cbor.Parsable = breviloquence.Inlinable.parsable[MenuDoc]
+
+  given inlinedProtobuf: MenuDoc is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[MenuDoc]
+
+  given inlinedBintel: MenuDoc is Bintel.Parsable = BintelInlinable.parsable[MenuDoc]
+
+  def jsonAst(): MenuDoc = json.read[Json].as[MenuDoc]
+  def jsonInlined(): MenuDoc = json.read[MenuDoc in Json]
+  def telAst(): MenuDoc = tel.read[Tel].as[MenuDoc]
+  def telInlined(): MenuDoc = tel.read[MenuDoc in Tel]
+  def xmlAst(): MenuDoc = xml.read[Xml].as[MenuDoc]
+  def xmlInlined(): MenuDoc = xml.read[MenuDoc in Xml]
+  def yamlAst(): MenuDoc = yaml.read[Yaml].as[MenuDoc]
+  def cborAst(): MenuDoc = cbor.read[Cbor].as[MenuDoc]
+  def cborInlined(): MenuDoc = cbor.read[MenuDoc in Cbor]
+  def protobufAst(): MenuDoc = protobuf.read[Protobuf].as[MenuDoc]
+  def protobufInlined(): MenuDoc = protobuf.read[MenuDoc in Protobuf]
+  def bintelAst(): MenuDoc = Bintel.read[MenuDoc](bintel)
+  def bintelInlined(): MenuDoc = Bintel.parse[MenuDoc](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MMenuDoc =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MMenuDoc]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.menu)
+
+  def borerRival(): MMenuDoc =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MMenuDoc]
+      (using borerCodecs.menu).value
+
+  def protobufJavaRival(): MMenuDoc = protobufWalks.menu(protobuf)
+  def aaltoRival(): MMenuDoc = aaltoWalks.menu(xml.s)
+  def snakeyamlRival(): MMenuDoc = snakeyamlWalks.menu(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "menu: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "menu: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "menu: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "menu: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "menu: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "menu: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "menu: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "menu: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "menu: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "menu: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "menu: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "menu: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "menu: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.menu(corpus)
+    assert(jsoniterRival() == mirror, "menu: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "menu: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "menu: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "menu: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "menu: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the menu corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixMenu.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixMenu.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixMenu.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixMenu.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixMenu.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixMenu.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixMenu.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixMenu.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixMenu.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixMenu.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixMenu.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixMenu.snakeyamlRival() }
+
+object matrixUsers:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: Users = corpora.users()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: Users is Json.Parsable = jacinta.Inlinable.parsable[Users]
+  given inlinedTel: Users is Tel.Parsable = stratiform.Inlinable.parsable[Users]
+  given inlinedXml: Users is Xml.Parsable = xylophone.Inlinable.parsable[Users]
+  given inlinedCbor: Users is Cbor.Parsable = breviloquence.Inlinable.parsable[Users]
+
+  given inlinedProtobuf: Users is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[Users]
+
+  given inlinedBintel: Users is Bintel.Parsable = BintelInlinable.parsable[Users]
+
+  def jsonAst(): Users = json.read[Json].as[Users]
+  def jsonInlined(): Users = json.read[Users in Json]
+  def telAst(): Users = tel.read[Tel].as[Users]
+  def telInlined(): Users = tel.read[Users in Tel]
+  def xmlAst(): Users = xml.read[Xml].as[Users]
+  def xmlInlined(): Users = xml.read[Users in Xml]
+  def yamlAst(): Users = yaml.read[Yaml].as[Users]
+  def cborAst(): Users = cbor.read[Cbor].as[Users]
+  def cborInlined(): Users = cbor.read[Users in Cbor]
+  def protobufAst(): Users = protobuf.read[Protobuf].as[Users]
+  def protobufInlined(): Users = protobuf.read[Users in Protobuf]
+  def bintelAst(): Users = Bintel.read[Users](bintel)
+  def bintelInlined(): Users = Bintel.parse[Users](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MUsers =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MUsers]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.users)
+
+  def borerRival(): MUsers =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MUsers]
+      (using borerCodecs.users).value
+
+  def protobufJavaRival(): MUsers = protobufWalks.users(protobuf)
+  def aaltoRival(): MUsers = aaltoWalks.users(xml.s)
+  def snakeyamlRival(): MUsers = snakeyamlWalks.users(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "users: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "users: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "users: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "users: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "users: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "users: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "users: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "users: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "users: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "users: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "users: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "users: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "users: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.users(corpus)
+    assert(jsoniterRival() == mirror, "users: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "users: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "users: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "users: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "users: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the users corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixUsers.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixUsers.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixUsers.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixUsers.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixUsers.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixUsers.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixUsers.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixUsers.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixUsers.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixUsers.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixUsers.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixUsers.snakeyamlRival() }
+
+object matrixLogs:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: Logs = corpora.logs()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: Logs is Json.Parsable = jacinta.Inlinable.parsable[Logs]
+  given inlinedTel: Logs is Tel.Parsable = stratiform.Inlinable.parsable[Logs]
+  given inlinedXml: Logs is Xml.Parsable = xylophone.Inlinable.parsable[Logs]
+  given inlinedCbor: Logs is Cbor.Parsable = breviloquence.Inlinable.parsable[Logs]
+
+  given inlinedProtobuf: Logs is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[Logs]
+
+  given inlinedBintel: Logs is Bintel.Parsable = BintelInlinable.parsable[Logs]
+
+  def jsonAst(): Logs = json.read[Json].as[Logs]
+  def jsonInlined(): Logs = json.read[Logs in Json]
+  def telAst(): Logs = tel.read[Tel].as[Logs]
+  def telInlined(): Logs = tel.read[Logs in Tel]
+  def xmlAst(): Logs = xml.read[Xml].as[Logs]
+  def xmlInlined(): Logs = xml.read[Logs in Xml]
+  def yamlAst(): Logs = yaml.read[Yaml].as[Logs]
+  def cborAst(): Logs = cbor.read[Cbor].as[Logs]
+  def cborInlined(): Logs = cbor.read[Logs in Cbor]
+  def protobufAst(): Logs = protobuf.read[Protobuf].as[Logs]
+  def protobufInlined(): Logs = protobuf.read[Logs in Protobuf]
+  def bintelAst(): Logs = Bintel.read[Logs](bintel)
+  def bintelInlined(): Logs = Bintel.parse[Logs](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MLogs =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MLogs]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.logs)
+
+  def borerRival(): MLogs =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MLogs]
+      (using borerCodecs.logs).value
+
+  def protobufJavaRival(): MLogs = protobufWalks.logs(protobuf)
+  def aaltoRival(): MLogs = aaltoWalks.logs(xml.s)
+  def snakeyamlRival(): MLogs = snakeyamlWalks.logs(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "logs: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "logs: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "logs: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "logs: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "logs: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "logs: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "logs: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "logs: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "logs: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "logs: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "logs: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "logs: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "logs: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.logs(corpus)
+    assert(jsoniterRival() == mirror, "logs: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "logs: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "logs: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "logs: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "logs: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the logs corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixLogs.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixLogs.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixLogs.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixLogs.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixLogs.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixLogs.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixLogs.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixLogs.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixLogs.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixLogs.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixLogs.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixLogs.snakeyamlRival() }
+
+object matrixTransactions:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: Transactions = corpora.transactions()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: Transactions is Json.Parsable = jacinta.Inlinable.parsable[Transactions]
+  given inlinedTel: Transactions is Tel.Parsable = stratiform.Inlinable.parsable[Transactions]
+  given inlinedXml: Transactions is Xml.Parsable = xylophone.Inlinable.parsable[Transactions]
+  given inlinedCbor: Transactions is Cbor.Parsable = breviloquence.Inlinable.parsable[Transactions]
+
+  given inlinedProtobuf: Transactions is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[Transactions]
+
+  given inlinedBintel: Transactions is Bintel.Parsable = BintelInlinable.parsable[Transactions]
+
+  def jsonAst(): Transactions = json.read[Json].as[Transactions]
+  def jsonInlined(): Transactions = json.read[Transactions in Json]
+  def telAst(): Transactions = tel.read[Tel].as[Transactions]
+  def telInlined(): Transactions = tel.read[Transactions in Tel]
+  def xmlAst(): Transactions = xml.read[Xml].as[Transactions]
+  def xmlInlined(): Transactions = xml.read[Transactions in Xml]
+  def yamlAst(): Transactions = yaml.read[Yaml].as[Transactions]
+  def cborAst(): Transactions = cbor.read[Cbor].as[Transactions]
+  def cborInlined(): Transactions = cbor.read[Transactions in Cbor]
+  def protobufAst(): Transactions = protobuf.read[Protobuf].as[Transactions]
+  def protobufInlined(): Transactions = protobuf.read[Transactions in Protobuf]
+  def bintelAst(): Transactions = Bintel.read[Transactions](bintel)
+  def bintelInlined(): Transactions = Bintel.parse[Transactions](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MTransactions =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MTransactions]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.transactions)
+
+  def borerRival(): MTransactions =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MTransactions]
+      (using borerCodecs.transactions).value
+
+  def protobufJavaRival(): MTransactions = protobufWalks.transactions(protobuf)
+  def aaltoRival(): MTransactions = aaltoWalks.transactions(xml.s)
+  def snakeyamlRival(): MTransactions = snakeyamlWalks.transactions(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "transactions: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "transactions: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "transactions: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "transactions: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "transactions: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "transactions: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "transactions: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "transactions: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "transactions: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "transactions: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "transactions: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "transactions: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "transactions: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.transactions(corpus)
+    assert(jsoniterRival() == mirror, "transactions: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "transactions: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "transactions: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "transactions: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "transactions: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the transactions corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixTransactions.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixTransactions.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixTransactions.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixTransactions.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixTransactions.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixTransactions.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixTransactions.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixTransactions.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixTransactions.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixTransactions.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixTransactions.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixTransactions.snakeyamlRival() }
+
+object matrixInts:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: Ints = corpora.ints()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: Ints is Json.Parsable = jacinta.Inlinable.parsable[Ints]
+  given inlinedTel: Ints is Tel.Parsable = stratiform.Inlinable.parsable[Ints]
+  given inlinedXml: Ints is Xml.Parsable = xylophone.Inlinable.parsable[Ints]
+  given inlinedCbor: Ints is Cbor.Parsable = breviloquence.Inlinable.parsable[Ints]
+
+  given inlinedProtobuf: Ints is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[Ints]
+
+  given inlinedBintel: Ints is Bintel.Parsable = BintelInlinable.parsable[Ints]
+
+  def jsonAst(): Ints = json.read[Json].as[Ints]
+  def jsonInlined(): Ints = json.read[Ints in Json]
+  def telAst(): Ints = tel.read[Tel].as[Ints]
+  def telInlined(): Ints = tel.read[Ints in Tel]
+  def xmlAst(): Ints = xml.read[Xml].as[Ints]
+  def xmlInlined(): Ints = xml.read[Ints in Xml]
+  def yamlAst(): Ints = yaml.read[Yaml].as[Ints]
+  def cborAst(): Ints = cbor.read[Cbor].as[Ints]
+  def cborInlined(): Ints = cbor.read[Ints in Cbor]
+  def protobufAst(): Ints = protobuf.read[Protobuf].as[Ints]
+  def protobufInlined(): Ints = protobuf.read[Ints in Protobuf]
+  def bintelAst(): Ints = Bintel.read[Ints](bintel)
+  def bintelInlined(): Ints = Bintel.parse[Ints](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MInts =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MInts]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.ints)
+
+  def borerRival(): MInts =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MInts]
+      (using borerCodecs.ints).value
+
+  def protobufJavaRival(): MInts = protobufWalks.ints(protobuf)
+  def aaltoRival(): MInts = aaltoWalks.ints(xml.s)
+  def snakeyamlRival(): MInts = snakeyamlWalks.ints(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "ints: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "ints: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "ints: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "ints: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "ints: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "ints: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "ints: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "ints: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "ints: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "ints: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "ints: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "ints: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "ints: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.ints(corpus)
+    assert(jsoniterRival() == mirror, "ints: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "ints: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "ints: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "ints: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "ints: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the ints corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixInts.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixInts.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixInts.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixInts.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixInts.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixInts.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixInts.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixInts.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixInts.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixInts.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixInts.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixInts.snakeyamlRival() }
+
+object matrixDecimals:
+  given schema: XmlSchema = XmlSchema.Freeform
+
+  val corpus: Decimals = corpora.decimals()
+
+  lazy val json: Data = corpus.in[Json].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val tel: Data = corpus.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+  lazy val xml: Text = corpus.in[Xml].show
+  lazy val yaml: Text = corpus.in[Yaml].show
+  lazy val cbor: Data = Cbor.Ast.encodable.encoded(Cbor.unseal(corpus.in[Cbor]))
+  lazy val protobuf: Data = corpus.in[Protobuf].encode
+  lazy val bintel: Data = corpus.bintel
+
+  given inlinedJson: Decimals is Json.Parsable = jacinta.Inlinable.parsable[Decimals]
+  given inlinedTel: Decimals is Tel.Parsable = stratiform.Inlinable.parsable[Decimals]
+  given inlinedXml: Decimals is Xml.Parsable = xylophone.Inlinable.parsable[Decimals]
+  given inlinedCbor: Decimals is Cbor.Parsable = breviloquence.Inlinable.parsable[Decimals]
+
+  given inlinedProtobuf: Decimals is Protobuf.Parsable =
+    locomotion.Inlinable.parsable[Decimals]
+
+  given inlinedBintel: Decimals is Bintel.Parsable = BintelInlinable.parsable[Decimals]
+
+  def jsonAst(): Decimals = json.read[Json].as[Decimals]
+  def jsonInlined(): Decimals = json.read[Decimals in Json]
+  def telAst(): Decimals = tel.read[Tel].as[Decimals]
+  def telInlined(): Decimals = tel.read[Decimals in Tel]
+  def xmlAst(): Decimals = xml.read[Xml].as[Decimals]
+  def xmlInlined(): Decimals = xml.read[Decimals in Xml]
+  def yamlAst(): Decimals = yaml.read[Yaml].as[Decimals]
+  def cborAst(): Decimals = cbor.read[Cbor].as[Decimals]
+  def cborInlined(): Decimals = cbor.read[Decimals in Cbor]
+  def protobufAst(): Decimals = protobuf.read[Protobuf].as[Decimals]
+  def protobufInlined(): Decimals = protobuf.read[Decimals in Protobuf]
+  def bintelAst(): Decimals = Bintel.read[Decimals](bintel)
+  def bintelInlined(): Decimals = Bintel.parse[Decimals](bintel)
+
+  // ── The third-party baselines ──
+  def jsoniterRival(): MDecimals =
+    com.github.plokhotnyuk.jsoniter_scala.core.readFromArray[MDecimals]
+      (json.mutable(using Unsafe))(using jsoniterCodecs.decimals)
+
+  def borerRival(): MDecimals =
+    io.bullet.borer.Cbor.decode(cbor.mutable(using Unsafe)).to[MDecimals]
+      (using borerCodecs.decimals).value
+
+  def protobufJavaRival(): MDecimals = protobufWalks.decimals(protobuf)
+  def aaltoRival(): MDecimals = aaltoWalks.decimals(xml.s)
+  def snakeyamlRival(): MDecimals = snakeyamlWalks.decimals(yaml.s)
+
+  // The correctness gate: every arm must reproduce the corpus before
+  // anything is timed.
+  def check(): Unit =
+    assert(jsonInlined() == corpus, "decimals: JSON inlined decode disagrees")
+    assert(jsonAst() == corpus, "decimals: JSON AST decode disagrees")
+    assert(telInlined() == corpus, "decimals: TEL inlined decode disagrees")
+    assert(telAst() == corpus, "decimals: TEL AST decode disagrees")
+    assert(xmlInlined() == corpus, "decimals: XML inlined decode disagrees")
+    assert(xmlAst() == corpus, "decimals: XML AST decode disagrees")
+    assert(yamlAst() == corpus, "decimals: YAML AST decode disagrees")
+    assert(cborInlined() == corpus, "decimals: CBOR inlined decode disagrees")
+    assert(cborAst() == corpus, "decimals: CBOR AST decode disagrees")
+    assert(protobufInlined() == corpus, "decimals: Protobuf inlined decode disagrees")
+    assert(protobufAst() == corpus, "decimals: Protobuf AST decode disagrees")
+    assert(bintelInlined() == corpus, "decimals: BinTEL inlined decode disagrees")
+    assert(bintelAst() == corpus, "decimals: BinTEL AST decode disagrees")
+
+    val mirror = mirrors.decimals(corpus)
+    assert(jsoniterRival() == mirror, "decimals: Jsoniter decode disagrees")
+    assert(borerRival() == mirror, "decimals: borer decode disagrees")
+    assert(protobufJavaRival() == mirror, "decimals: protobuf-java decode disagrees")
+    assert(aaltoRival() == mirror, "decimals: Aalto decode disagrees")
+    assert(snakeyamlRival() == mirror, "decimals: snakeyaml decode disagrees")
+
+  def suites[report](bench: Bench)
+    (using Runner[report], Inclusion[report, Benchmark], Testable)
+  :   Unit =
+
+    suite(m"Decode the decimals corpus to case classes"):
+      bench(m"JSON inlined")(target = 1*Second):
+        '{ crossparse.matrixDecimals.jsonInlined() }
+
+      bench(m"JSON via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.jsonAst() }
+
+      bench(m"Jsoniter (JSON)")(target = 1*Second):
+        '{ crossparse.matrixDecimals.jsoniterRival() }
+
+      bench(m"TEL inlined")(target = 1*Second):
+        '{ crossparse.matrixDecimals.telInlined() }
+
+      bench(m"TEL via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.telAst() }
+
+      bench(m"XML inlined")(target = 1*Second):
+        '{ crossparse.matrixDecimals.xmlInlined() }
+
+      bench(m"XML via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.xmlAst() }
+
+      bench(m"Aalto (XML)")(target = 1*Second):
+        '{ crossparse.matrixDecimals.aaltoRival() }
+
+      bench(m"CBOR inlined")(target = 1*Second):
+        '{ crossparse.matrixDecimals.cborInlined() }
+
+      bench(m"CBOR via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.cborAst() }
+
+      bench(m"borer (CBOR)")(target = 1*Second):
+        '{ crossparse.matrixDecimals.borerRival() }
+
+      bench(m"Protobuf inlined")(target = 1*Second):
+        '{ crossparse.matrixDecimals.protobufInlined() }
+
+      bench(m"Protobuf via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.protobufAst() }
+
+      bench(m"protobuf-java")(target = 1*Second):
+        '{ crossparse.matrixDecimals.protobufJavaRival() }
+
+      bench(m"BinTEL inlined")(target = 1*Second):
+        '{ crossparse.matrixDecimals.bintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.bintelAst() }
+
+      bench(m"YAML via AST")(target = 1*Second):
+        '{ crossparse.matrixDecimals.yamlAst() }
+
+      bench(m"SnakeYAML (YAML)")(target = 1*Second):
+        '{ crossparse.matrixDecimals.snakeyamlRival() }
+
+// The deterministic corpus builders, mirroring the jacinta benchmark
+// generators (adapted: text values avoid spaces and format-sensitive
+// leading characters, so every format round-trips values byte-stably).
+object corpora:
+  def config(): Config =
+    Config
+      ( WebApp
+          ( servlets = List
+              ( Servlet
+                  ( t"cofaxCDS", t"org.cofax.cds.CDSServlet",
+                    List
+                      ( Param(t"installationAt", t"Philadelphia-PA"),
+                        Param(t"adminEmail", t"ksm@pobox.com"),
+                        Param(t"poweredBy", t"Cofax"),
+                        Param(t"poweredByIcon", t"/images/cofax.gif"),
+                        Param(t"staticPath", t"/content/static"),
+                        Param(t"templateProcessorClass", t"org.cofax.WysiwygTemplate"),
+                        Param(t"templateLoaderClass", t"org.cofax.FilesTemplateLoader"),
+                        Param(t"templatePath", t"templates") ) ),
+                Servlet
+                  ( t"cofaxEmail", t"org.cofax.cds.EmailServlet",
+                    List
+                      ( Param(t"mailHost", t"mail1"),
+                        Param(t"mailHostOverride", t"mail2") ) ),
+                Servlet(t"cofaxAdmin", t"org.cofax.cds.AdminServlet", Nil),
+                Servlet(t"fileServlet", t"org.cofax.cds.FileServlet", Nil),
+                Servlet
+                  ( t"cofaxTools", t"org.cofax.cms.CofaxToolsServlet",
+                    List
+                      ( Param(t"templatePath", t"toolstemplates/"),
+                        Param(t"logLocation", t"/usr/local/tomcat/logs/CofaxTools.log"),
+                        Param(t"dataLog", t"1"),
+                        Param(t"removePageCache", t"/content/admin/remove?cache=pages&id="),
+                        Param(t"fileTransferFolder", t"/usr/local/tomcat/webapps/content"),
+                        Param(t"lookInContext", t"1"),
+                        Param(t"adminGroupID", t"4"),
+                        Param(t"betaServer", t"true") ) ) ),
+            mappings = List
+              ( Mapping(t"cofaxCDS", t"/"),
+                Mapping(t"cofaxEmail", t"/cofaxutil/aemail/*"),
+                Mapping(t"cofaxAdmin", t"/admin/*"),
+                Mapping(t"fileServlet", t"/static/*"),
+                Mapping(t"cofaxTools", t"/tools/*") ),
+            taglib = Taglib(t"cofax.tld", t"/WEB-INF/tlds/cofax.tld") ) )
+
+  def menu(): MenuDoc =
+    MenuDoc
+      ( Menu
+          ( t"file", t"File",
+            Popup
+              ( List
+                  ( MenuItem(t"New", t"CreateNewDoc()"),
+                    MenuItem(t"Open", t"OpenDoc()"),
+                    MenuItem(t"Close", t"CloseDoc()") ) ) ) )
+
+  def users(): Users =
+    Users:
+      List.tabulate(100): i =>
+        User
+          ( id       = i,
+            username = t"user$i",
+            email    = t"user$i@example.com",
+            active   = (i & 1) == 0,
+            role     = if i % 10 == 0 then t"admin" else t"user" )
+
+  def logs(): Logs =
+    val levels = List(t"info", t"debug", t"warn", t"error")
+    val services = List(t"auth", t"api", t"db", t"cache", t"worker")
+
+    Logs:
+      List.tabulate(500): i =>
+        LogEntry
+          ( timestamp = 1700000000L + i,
+            level     = levels(i & 3),
+            service   = services(i % 5),
+            requestId = t"req-$i",
+            userId    = 1000 + (i % 50),
+            message   = t"event-$i-processed" )
+
+  def transactions(): Transactions =
+    Transactions:
+      List.tabulate(50): i =>
+        Transaction
+          ( from             = t"0xabcdef$i",
+            to               = t"0x123456$i",
+            valueWei         = t"12345678901234567890${1000 + i}",
+            valueEth         = t"1234567890.12345678901${i % 10}",
+            gasPriceWei      = t"30000000000.0123456789${i % 10}",
+            gasUsed          = 21000 + i*100,
+            blockNumber      = 18500000L + i,
+            nonce            = i,
+            temperatureDelta = (i % 10 + 1).toDouble/4096.0 )
+
+  def ints(): Ints = Ints(List.tabulate(1000) { i => i*37 + 1 })
+
+  // Fraction digits stay within every format's number fast path (a
+  // ~13-significant-digit double exposes a jacinta AST compact-BCD
+  // mis-decode — reported separately).
+  def decimals(): Decimals =
+    Decimals:
+      List.tabulate(1000) { i => (i*7 + 1).toDouble + ((i*13 + 1) % 1000).toDouble/1000.0 }

--- a/lib/crossparse/src/bench/crossparse.rivals.scala
+++ b/lib/crossparse/src/bench/crossparse.rivals.scala
@@ -1,0 +1,809 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package crossparse
+
+import anticipation.*
+import contingency.*, strategies.throwUnsafely
+import proscenium.*
+import rudiments.*
+import vacuous.*
+
+// ── Third-party baselines for the document matrix ───────────────────────
+// The best-in-class library for each format decodes the same corpus bytes
+// to `String`-field mirror records: Jsoniter (JSON, macro-generated
+// codecs), borer (CBOR, derived map-based codecs), protobuf-java (a
+// hand-written `CodedInputStream` walk — the fastest possible use of the
+// reference library), Aalto (XML, a hand-written StAX pull walk), and
+// snakeyaml-engine (YAML, composed to native collections and mapped by
+// hand). TEL and BinTEL have no third-party implementations.
+
+case class MParam(key: String, value: String)
+case class MServlet(servletName: String, servletClass: String, params: List[MParam])
+case class MMapping(servletName: String, url: String)
+case class MTaglib(uri: String, location: String)
+case class MWebApp(servlets: List[MServlet], mappings: List[MMapping], taglib: MTaglib)
+case class MConfig(webApp: MWebApp)
+case class MMenuItem(value: String, onclick: String)
+case class MPopup(menuitems: List[MMenuItem])
+case class MMenu(id: String, value: String, popup: MPopup)
+case class MMenuDoc(menu: MMenu)
+case class MUser(id: Int, username: String, email: String, active: Boolean, role: String)
+case class MUsers(users: List[MUser])
+
+case class MLogEntry
+  ( timestamp: Long, level: String, service: String, requestId: String, userId: Int,
+    message: String )
+
+case class MLogs(logs: List[MLogEntry])
+
+case class MTransaction
+  ( from: String, to: String, valueWei: String, valueEth: String, gasPriceWei: String,
+    gasUsed: Int, blockNumber: Long, nonce: Int, temperatureDelta: Double )
+
+case class MTransactions(transactions: List[MTransaction])
+case class MInts(values: List[Int])
+case class MDecimals(values: List[Double])
+
+// The expected mirror of each corpus, for the correctness gates.
+object mirrors:
+  def config(value: Config): MConfig =
+    MConfig
+      ( MWebApp
+          ( value.webApp.servlets.map: servlet =>
+              MServlet
+                ( servlet.servletName.s, servlet.servletClass.s,
+                  servlet.params.map { param => MParam(param.key.s, param.value.s) } ),
+            value.webApp.mappings.map { mapping => MMapping(mapping.servletName.s, mapping.url.s) },
+            MTaglib(value.webApp.taglib.uri.s, value.webApp.taglib.location.s) ) )
+
+  def menu(value: MenuDoc): MMenuDoc =
+    MMenuDoc
+      ( MMenu
+          ( value.menu.id.s, value.menu.value.s,
+            MPopup
+              ( value.menu.popup.menuitems.map: item =>
+                  MMenuItem(item.value.s, item.onclick.s) ) ) )
+
+  def users(value: Users): MUsers =
+    MUsers
+      ( value.users.map: user =>
+          MUser(user.id, user.username.s, user.email.s, user.active, user.role.s) )
+
+  def logs(value: Logs): MLogs =
+    MLogs
+      ( value.logs.map: entry =>
+          MLogEntry
+            ( entry.timestamp, entry.level.s, entry.service.s, entry.requestId.s,
+              entry.userId, entry.message.s ) )
+
+  def transactions(value: Transactions): MTransactions =
+    MTransactions
+      ( value.transactions.map: transaction =>
+          MTransaction
+            ( transaction.from.s, transaction.to.s, transaction.valueWei.s,
+              transaction.valueEth.s, transaction.gasPriceWei.s, transaction.gasUsed,
+              transaction.blockNumber, transaction.nonce, transaction.temperatureDelta ) )
+
+  def ints(value: Ints): MInts = MInts(value.values)
+  def decimals(value: Decimals): MDecimals = MDecimals(value.values)
+
+// The Jsoniter codecs: one macro-generated codec per document root.
+object jsoniterCodecs:
+  import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+  import com.github.plokhotnyuk.jsoniter_scala.macros.JsonCodecMaker
+
+  val config: JsonValueCodec[MConfig] = JsonCodecMaker.make
+  val menu: JsonValueCodec[MMenuDoc] = JsonCodecMaker.make
+  val users: JsonValueCodec[MUsers] = JsonCodecMaker.make
+  val logs: JsonValueCodec[MLogs] = JsonCodecMaker.make
+  val transactions: JsonValueCodec[MTransactions] = JsonCodecMaker.make
+  val ints: JsonValueCodec[MInts] = JsonCodecMaker.make
+  val decimals: JsonValueCodec[MDecimals] = JsonCodecMaker.make
+
+// The borer decoders: map-based derived codecs, transitively.
+object borerCodecs:
+  import io.bullet.borer.Decoder
+  import io.bullet.borer.derivation.MapBasedCodecs.*
+
+  given Decoder[MParam] = deriveDecoder
+  given Decoder[MServlet] = deriveDecoder
+  given Decoder[MMapping] = deriveDecoder
+  given Decoder[MTaglib] = deriveDecoder
+  given Decoder[MWebApp] = deriveDecoder
+  val config: Decoder[MConfig] = deriveDecoder
+
+  given Decoder[MMenuItem] = deriveDecoder
+  given Decoder[MPopup] = deriveDecoder
+  given Decoder[MMenu] = deriveDecoder
+  val menu: Decoder[MMenuDoc] = deriveDecoder
+
+  given Decoder[MUser] = deriveDecoder
+  val users: Decoder[MUsers] = deriveDecoder
+
+  given Decoder[MLogEntry] = deriveDecoder
+  val logs: Decoder[MLogs] = deriveDecoder
+
+  given Decoder[MTransaction] = deriveDecoder
+  val transactions: Decoder[MTransactions] = deriveDecoder
+
+  val ints: Decoder[MInts] = deriveDecoder
+  val decimals: Decoder[MDecimals] = deriveDecoder
+
+// The protobuf-java walks: `CodedInputStream` reads over the exact wire
+// bytes locomotion emits (declaration-order field numbers; strings and
+// messages length-delimited; numeric repeats packed).
+object protobufWalks:
+  import com.google.protobuf.CodedInputStream
+
+  private def stream(data: Data): CodedInputStream =
+    CodedInputStream.newInstance(data.mutable(using Unsafe)).nn
+
+  private def walkParam(in: CodedInputStream): MParam =
+    var key = ""
+    var value = ""
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => key = in.readStringRequireUtf8.nn
+        case 2 => value = in.readStringRequireUtf8.nn
+        case _ => sys.error("unexpected field")
+
+    MParam(key, value)
+
+  private def delimited[element](in: CodedInputStream)(read: CodedInputStream => element)
+  :   element =
+
+    val length = in.readRawVarint32()
+    val limit = in.pushLimit(length)
+    val result = read(in)
+    in.popLimit(limit)
+    result
+
+  private def walkServlet(in: CodedInputStream): MServlet =
+    var name = ""
+    var servletClass = ""
+    val params = List.newBuilder[MParam]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => name = in.readStringRequireUtf8.nn
+        case 2 => servletClass = in.readStringRequireUtf8.nn
+        case 3 => params += delimited(in)(walkParam)
+        case _ => sys.error("unexpected field")
+
+    MServlet(name, servletClass, params.result())
+
+  private def walkMapping(in: CodedInputStream): MMapping =
+    var name = ""
+    var url = ""
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => name = in.readStringRequireUtf8.nn
+        case 2 => url = in.readStringRequireUtf8.nn
+        case _ => sys.error("unexpected field")
+
+    MMapping(name, url)
+
+  private def walkTaglib(in: CodedInputStream): MTaglib =
+    var uri = ""
+    var location = ""
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => uri = in.readStringRequireUtf8.nn
+        case 2 => location = in.readStringRequireUtf8.nn
+        case _ => sys.error("unexpected field")
+
+    MTaglib(uri, location)
+
+  private def walkWebApp(in: CodedInputStream): MWebApp =
+    val servlets = List.newBuilder[MServlet]
+    val mappings = List.newBuilder[MMapping]
+    var taglib = MTaglib("", "")
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => servlets += delimited(in)(walkServlet)
+        case 2 => mappings += delimited(in)(walkMapping)
+        case 3 => taglib = delimited(in)(walkTaglib)
+        case _ => sys.error("unexpected field")
+
+    MWebApp(servlets.result(), mappings.result(), taglib)
+
+  def config(data: Data): MConfig =
+    val in = stream(data)
+    var webApp = MWebApp(Nil, Nil, MTaglib("", ""))
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => webApp = delimited(in)(walkWebApp)
+        case _ => sys.error("unexpected field")
+
+    MConfig(webApp)
+
+  private def walkMenuItem(in: CodedInputStream): MMenuItem =
+    var value = ""
+    var onclick = ""
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => value = in.readStringRequireUtf8.nn
+        case 2 => onclick = in.readStringRequireUtf8.nn
+        case _ => sys.error("unexpected field")
+
+    MMenuItem(value, onclick)
+
+  private def walkPopup(in: CodedInputStream): MPopup =
+    val items = List.newBuilder[MMenuItem]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => items += delimited(in)(walkMenuItem)
+        case _ => sys.error("unexpected field")
+
+    MPopup(items.result())
+
+  private def walkMenu(in: CodedInputStream): MMenu =
+    var id = ""
+    var value = ""
+    var popup = MPopup(Nil)
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => id = in.readStringRequireUtf8.nn
+        case 2 => value = in.readStringRequireUtf8.nn
+        case 3 => popup = delimited(in)(walkPopup)
+        case _ => sys.error("unexpected field")
+
+    MMenu(id, value, popup)
+
+  def menu(data: Data): MMenuDoc =
+    val in = stream(data)
+    var menu = MMenu("", "", MPopup(Nil))
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => menu = delimited(in)(walkMenu)
+        case _ => sys.error("unexpected field")
+
+    MMenuDoc(menu)
+
+  private def walkUser(in: CodedInputStream): MUser =
+    var id = 0
+    var username = ""
+    var email = ""
+    var active = false
+    var role = ""
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => id = in.readInt32()
+        case 2 => username = in.readStringRequireUtf8.nn
+        case 3 => email = in.readStringRequireUtf8.nn
+        case 4 => active = in.readBool()
+        case 5 => role = in.readStringRequireUtf8.nn
+        case _ => sys.error("unexpected field")
+
+    MUser(id, username, email, active, role)
+
+  def users(data: Data): MUsers =
+    val in = stream(data)
+    val users = List.newBuilder[MUser]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => users += delimited(in)(walkUser)
+        case _ => sys.error("unexpected field")
+
+    MUsers(users.result())
+
+  private def walkLogEntry(in: CodedInputStream): MLogEntry =
+    var timestamp = 0L
+    var level = ""
+    var service = ""
+    var requestId = ""
+    var userId = 0
+    var message = ""
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => timestamp = in.readInt64()
+        case 2 => level = in.readStringRequireUtf8.nn
+        case 3 => service = in.readStringRequireUtf8.nn
+        case 4 => requestId = in.readStringRequireUtf8.nn
+        case 5 => userId = in.readInt32()
+        case 6 => message = in.readStringRequireUtf8.nn
+        case _ => sys.error("unexpected field")
+
+    MLogEntry(timestamp, level, service, requestId, userId, message)
+
+  def logs(data: Data): MLogs =
+    val in = stream(data)
+    val logs = List.newBuilder[MLogEntry]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => logs += delimited(in)(walkLogEntry)
+        case _ => sys.error("unexpected field")
+
+    MLogs(logs.result())
+
+  private def walkTransaction(in: CodedInputStream): MTransaction =
+    var from = ""
+    var to = ""
+    var valueWei = ""
+    var valueEth = ""
+    var gasPriceWei = ""
+    var gasUsed = 0
+    var blockNumber = 0L
+    var nonce = 0
+    var temperatureDelta = 0.0
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => from = in.readStringRequireUtf8.nn
+        case 2 => to = in.readStringRequireUtf8.nn
+        case 3 => valueWei = in.readStringRequireUtf8.nn
+        case 4 => valueEth = in.readStringRequireUtf8.nn
+        case 5 => gasPriceWei = in.readStringRequireUtf8.nn
+        case 6 => gasUsed = in.readInt32()
+        case 7 => blockNumber = in.readInt64()
+        case 8 => nonce = in.readInt32()
+        case 9 => temperatureDelta = in.readDouble()
+        case _ => sys.error("unexpected field")
+
+    MTransaction
+      ( from, to, valueWei, valueEth, gasPriceWei, gasUsed, blockNumber, nonce,
+        temperatureDelta )
+
+  def transactions(data: Data): MTransactions =
+    val in = stream(data)
+    val transactions = List.newBuilder[MTransaction]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 => transactions += delimited(in)(walkTransaction)
+        case _ => sys.error("unexpected field")
+
+    MTransactions(transactions.result())
+
+  def ints(data: Data): MInts =
+    val in = stream(data)
+    val values = List.newBuilder[Int]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 =>
+          val length = in.readRawVarint32()
+          val limit = in.pushLimit(length)
+          while in.getBytesUntilLimit > 0 do values += in.readInt32()
+          in.popLimit(limit)
+
+        case _ =>
+          sys.error("unexpected field")
+
+    MInts(values.result())
+
+  def decimals(data: Data): MDecimals =
+    val in = stream(data)
+    val values = List.newBuilder[Double]
+
+    while !in.isAtEnd do
+      in.readTag() >>> 3 match
+        case 1 =>
+          val length = in.readRawVarint32()
+          val limit = in.pushLimit(length)
+          while in.getBytesUntilLimit > 0 do values += in.readDouble()
+          in.popLimit(limit)
+
+        case _ =>
+          sys.error("unexpected field")
+
+    MDecimals(values.result())
+
+// The snakeyaml-engine mappers: the reference YAML implementation composes
+// to native collections, then each document maps by hand.
+object snakeyamlWalks:
+  import org.snakeyaml.engine.v2.api.{Load, LoadSettings}
+
+  private def load(text: String): AnyRef =
+    Load(LoadSettings.builder.nn.build.nn).loadFromString(text).nn.asInstanceOf[AnyRef]
+
+  private def mapping(node: AnyRef): java.util.Map[String, AnyRef] =
+    node.asInstanceOf[java.util.Map[String, AnyRef]]
+
+  private def sequence(node: AnyRef): List[AnyRef] =
+    val list = node.asInstanceOf[java.util.List[AnyRef]]
+    val builder = List.newBuilder[AnyRef]
+    val iterator = list.iterator.nn
+    while iterator.hasNext do builder += iterator.next.nn
+    builder.result()
+
+  private def string(node: AnyRef): String = node.asInstanceOf[String]
+  private def int(node: AnyRef): Int = node.asInstanceOf[Number].intValue
+  private def long(node: AnyRef): Long = node.asInstanceOf[Number].longValue
+  private def double(node: AnyRef): Double = node.asInstanceOf[Number].doubleValue
+  private def boolean(node: AnyRef): Boolean = node.asInstanceOf[java.lang.Boolean].booleanValue
+
+  private def field(node: java.util.Map[String, AnyRef], name: String): AnyRef =
+    node.get(name).nn
+
+  def config(text: String): MConfig =
+    val root = mapping(load(text))
+    val webApp = mapping(field(root, "webApp"))
+
+    MConfig
+      ( MWebApp
+          ( sequence(field(webApp, "servlets")).map: node =>
+              val servlet = mapping(node)
+
+              MServlet
+                ( string(field(servlet, "servletName")),
+                  string(field(servlet, "servletClass")),
+                  sequence(field(servlet, "params")).map: paramNode =>
+                    val param = mapping(paramNode)
+                    MParam(string(field(param, "key")), string(field(param, "value"))) ),
+            sequence(field(webApp, "mappings")).map: node =>
+              val mapped = mapping(node)
+              MMapping(string(field(mapped, "servletName")), string(field(mapped, "url"))),
+            {
+              val taglib = mapping(field(webApp, "taglib"))
+              MTaglib(string(field(taglib, "uri")), string(field(taglib, "location")))
+            } ) )
+
+  def menu(text: String): MMenuDoc =
+    val root = mapping(load(text))
+    val menu = mapping(field(root, "menu"))
+    val popup = mapping(field(menu, "popup"))
+
+    MMenuDoc
+      ( MMenu
+          ( string(field(menu, "id")), string(field(menu, "value")),
+            MPopup
+              ( sequence(field(popup, "menuitems")).map: node =>
+                  val item = mapping(node)
+                  MMenuItem(string(field(item, "value")), string(field(item, "onclick"))) ) ) )
+
+  def users(text: String): MUsers =
+    val root = mapping(load(text))
+
+    MUsers
+      ( sequence(field(root, "users")).map: node =>
+          val user = mapping(node)
+
+          MUser
+            ( int(field(user, "id")), string(field(user, "username")),
+              string(field(user, "email")), boolean(field(user, "active")),
+              string(field(user, "role")) ) )
+
+  def logs(text: String): MLogs =
+    val root = mapping(load(text))
+
+    MLogs
+      ( sequence(field(root, "logs")).map: node =>
+          val entry = mapping(node)
+
+          MLogEntry
+            ( long(field(entry, "timestamp")), string(field(entry, "level")),
+              string(field(entry, "service")), string(field(entry, "requestId")),
+              int(field(entry, "userId")), string(field(entry, "message")) ) )
+
+  def transactions(text: String): MTransactions =
+    val root = mapping(load(text))
+
+    MTransactions
+      ( sequence(field(root, "transactions")).map: node =>
+          val transaction = mapping(node)
+
+          MTransaction
+            ( string(field(transaction, "from")), string(field(transaction, "to")),
+              string(field(transaction, "valueWei")), string(field(transaction, "valueEth")),
+              string(field(transaction, "gasPriceWei")), int(field(transaction, "gasUsed")),
+              long(field(transaction, "blockNumber")), int(field(transaction, "nonce")),
+              double(field(transaction, "temperatureDelta")) ) )
+
+  def ints(text: String): MInts =
+    val root = mapping(load(text))
+    MInts(sequence(field(root, "values")).map(int))
+
+  def decimals(text: String): MDecimals =
+    val root = mapping(load(text))
+    MDecimals(sequence(field(root, "values")).map(double))
+
+// The Aalto walks: a hand-written StAX pull loop per document — the
+// fastest available use of the reference-quality XML parser. Xylophone's
+// encoding names the root element after the type and repeats field-named
+// elements for collections, so each record reader dispatches on local
+// names until its end tag.
+object aaltoWalks:
+  import javax.xml.stream.XMLStreamConstants.START_ELEMENT
+  import org.codehaus.stax2.XMLStreamReader2
+
+  private val factory = com.fasterxml.aalto.stax.InputFactoryImpl()
+
+  private def reader(text: String): XMLStreamReader2 =
+    factory.createXMLStreamReader(java.io.StringReader(text)).nn
+    . asInstanceOf[XMLStreamReader2]
+
+  private def text(in: XMLStreamReader2): String = in.getElementText.nn
+
+  private def walkParam(in: XMLStreamReader2): MParam =
+    var key = ""
+    var value = ""
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "key"   => key = text(in)
+        case "value" => value = text(in)
+        case other   => sys.error("unexpected element: "+other)
+
+    MParam(key, value)
+
+  private def walkServlet(in: XMLStreamReader2): MServlet =
+    var name = ""
+    var servletClass = ""
+    val params = List.newBuilder[MParam]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "servletName"  => name = text(in)
+        case "servletClass" => servletClass = text(in)
+        case "params"       => params += walkParam(in)
+        case other          => sys.error("unexpected element: "+other)
+
+    MServlet(name, servletClass, params.result())
+
+  private def walkMapping(in: XMLStreamReader2): MMapping =
+    var name = ""
+    var url = ""
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "servletName" => name = text(in)
+        case "url"         => url = text(in)
+        case other         => sys.error("unexpected element: "+other)
+
+    MMapping(name, url)
+
+  private def walkTaglib(in: XMLStreamReader2): MTaglib =
+    var uri = ""
+    var location = ""
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "uri"      => uri = text(in)
+        case "location" => location = text(in)
+        case other      => sys.error("unexpected element: "+other)
+
+    MTaglib(uri, location)
+
+  private def walkWebApp(in: XMLStreamReader2): MWebApp =
+    val servlets = List.newBuilder[MServlet]
+    val mappings = List.newBuilder[MMapping]
+    var taglib = MTaglib("", "")
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "servlets" => servlets += walkServlet(in)
+        case "mappings" => mappings += walkMapping(in)
+        case "taglib"   => taglib = walkTaglib(in)
+        case other      => sys.error("unexpected element: "+other)
+
+    MWebApp(servlets.result(), mappings.result(), taglib)
+
+  def config(input: String): MConfig =
+    val in = reader(input)
+    in.nextTag()
+    var webApp = MWebApp(Nil, Nil, MTaglib("", ""))
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "webApp" => webApp = walkWebApp(in)
+        case other    => sys.error("unexpected element: "+other)
+
+    MConfig(webApp)
+
+  private def walkMenuItem(in: XMLStreamReader2): MMenuItem =
+    var value = ""
+    var onclick = ""
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "value"   => value = text(in)
+        case "onclick" => onclick = text(in)
+        case other     => sys.error("unexpected element: "+other)
+
+    MMenuItem(value, onclick)
+
+  private def walkPopup(in: XMLStreamReader2): MPopup =
+    val items = List.newBuilder[MMenuItem]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "menuitems" => items += walkMenuItem(in)
+        case other       => sys.error("unexpected element: "+other)
+
+    MPopup(items.result())
+
+  private def walkMenu(in: XMLStreamReader2): MMenu =
+    var id = ""
+    var value = ""
+    var popup = MPopup(Nil)
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "id"    => id = text(in)
+        case "value" => value = text(in)
+        case "popup" => popup = walkPopup(in)
+        case other   => sys.error("unexpected element: "+other)
+
+    MMenu(id, value, popup)
+
+  def menu(input: String): MMenuDoc =
+    val in = reader(input)
+    in.nextTag()
+    var menu = MMenu("", "", MPopup(Nil))
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "menu" => menu = walkMenu(in)
+        case other  => sys.error("unexpected element: "+other)
+
+    MMenuDoc(menu)
+
+  private def walkUser(in: XMLStreamReader2): MUser =
+    var id = 0
+    var username = ""
+    var email = ""
+    var active = false
+    var role = ""
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "id"       => id = text(in).toInt
+        case "username" => username = text(in)
+        case "email"    => email = text(in)
+        case "active"   => active = text(in).toBoolean
+        case "role"     => role = text(in)
+        case other      => sys.error("unexpected element: "+other)
+
+    MUser(id, username, email, active, role)
+
+  def users(input: String): MUsers =
+    val in = reader(input)
+    in.nextTag()
+    val users = List.newBuilder[MUser]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "users" => users += walkUser(in)
+        case other   => sys.error("unexpected element: "+other)
+
+    MUsers(users.result())
+
+  private def walkLogEntry(in: XMLStreamReader2): MLogEntry =
+    var timestamp = 0L
+    var level = ""
+    var service = ""
+    var requestId = ""
+    var userId = 0
+    var message = ""
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "timestamp" => timestamp = text(in).toLong
+        case "level"     => level = text(in)
+        case "service"   => service = text(in)
+        case "requestId" => requestId = text(in)
+        case "userId"    => userId = text(in).toInt
+        case "message"   => message = text(in)
+        case other       => sys.error("unexpected element: "+other)
+
+    MLogEntry(timestamp, level, service, requestId, userId, message)
+
+  def logs(input: String): MLogs =
+    val in = reader(input)
+    in.nextTag()
+    val logs = List.newBuilder[MLogEntry]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "logs" => logs += walkLogEntry(in)
+        case other  => sys.error("unexpected element: "+other)
+
+    MLogs(logs.result())
+
+  private def walkTransaction(in: XMLStreamReader2): MTransaction =
+    var from = ""
+    var to = ""
+    var valueWei = ""
+    var valueEth = ""
+    var gasPriceWei = ""
+    var gasUsed = 0
+    var blockNumber = 0L
+    var nonce = 0
+    var temperatureDelta = 0.0
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "from"             => from = text(in)
+        case "to"               => to = text(in)
+        case "valueWei"         => valueWei = text(in)
+        case "valueEth"         => valueEth = text(in)
+        case "gasPriceWei"      => gasPriceWei = text(in)
+        case "gasUsed"          => gasUsed = text(in).toInt
+        case "blockNumber"      => blockNumber = text(in).toLong
+        case "nonce"            => nonce = text(in).toInt
+        case "temperatureDelta" => temperatureDelta = text(in).toDouble
+        case other              => sys.error("unexpected element: "+other)
+
+    MTransaction
+      ( from, to, valueWei, valueEth, gasPriceWei, gasUsed, blockNumber, nonce,
+        temperatureDelta )
+
+  def transactions(input: String): MTransactions =
+    val in = reader(input)
+    in.nextTag()
+    val transactions = List.newBuilder[MTransaction]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "transactions" => transactions += walkTransaction(in)
+        case other          => sys.error("unexpected element: "+other)
+
+    MTransactions(transactions.result())
+
+  def ints(input: String): MInts =
+    val in = reader(input)
+    in.nextTag()
+    val values = List.newBuilder[Int]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "values" => values += text(in).toInt
+        case other    => sys.error("unexpected element: "+other)
+
+    MInts(values.result())
+
+  def decimals(input: String): MDecimals =
+    val in = reader(input)
+    in.nextTag()
+    val values = List.newBuilder[Double]
+
+    while in.nextTag() == START_ELEMENT do
+      in.getLocalName match
+        case "values" => values += text(in).toDouble
+        case other    => sys.error("unexpected element: "+other)
+
+    MDecimals(values.result())

--- a/lib/crossparse/src/model/crossparse.model.scala
+++ b/lib/crossparse/src/model/crossparse.model.scala
@@ -33,6 +33,7 @@
 package crossparse
 
 import anticipation.*
+import breviloquence.*
 import contingency.*, strategies.throwUnsafely
 import gossamer.*
 import jacinta.*
@@ -65,6 +66,11 @@ object Payment:
   // dispatch on the attribute straight off the open tag.
   given xmlDiscriminable: Payment is Discriminable in Xml = Xml.DiscriminantAttribute(t"type")
 
+  // The CBOR corpus carries the same `type` discriminator as a map entry;
+  // the named `DiscriminantKey` shape lets the inlined CBOR parser dispatch
+  // on a scan-ahead of that entry.
+  given cborDiscriminable: Payment is Discriminable in Cbor = Cbor.DiscriminantKey(t"type")
+
 case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
 
 // The per-format `Inlinable` givens are qualified: each format's staged
@@ -74,6 +80,7 @@ object LineItem:
   given jsonInlinable: (LineItem is jacinta.Inlinable) = jacinta.Inlinable.derived
   given telInlinable: (LineItem is stratiform.Inlinable) = stratiform.Inlinable.derived
   given xmlInlinable: (LineItem is xylophone.Inlinable) = xylophone.Inlinable.derived
+  given cborInlinable: (LineItem is breviloquence.Inlinable) = breviloquence.Inlinable.derived
 
 case class Customer(id: Long, name: Text, email: Text, region: Text)
 
@@ -81,6 +88,7 @@ object Customer:
   given jsonInlinable: (Customer is jacinta.Inlinable) = jacinta.Inlinable.derived
   given telInlinable: (Customer is stratiform.Inlinable) = stratiform.Inlinable.derived
   given xmlInlinable: (Customer is xylophone.Inlinable) = xylophone.Inlinable.derived
+  given cborInlinable: (Customer is breviloquence.Inlinable) = breviloquence.Inlinable.derived
 
 case class Order
   ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
@@ -90,6 +98,7 @@ object Order:
   given jsonInlinable: (Order is jacinta.Inlinable) = jacinta.Inlinable.derived
   given telInlinable: (Order is stratiform.Inlinable) = stratiform.Inlinable.derived
   given xmlInlinable: (Order is xylophone.Inlinable) = xylophone.Inlinable.derived
+  given cborInlinable: (Order is breviloquence.Inlinable) = breviloquence.Inlinable.derived
 
 case class Orders(orders: List[Order])
 
@@ -104,3 +113,4 @@ object Orders:
   given jsonInlinable: (Orders is jacinta.Inlinable) = jacinta.Inlinable.derived
   given telInlinable: (Orders is stratiform.Inlinable) = stratiform.Inlinable.derived
   given xmlInlinable: (Orders is xylophone.Inlinable) = xylophone.Inlinable.derived
+  given cborInlinable: (Orders is breviloquence.Inlinable) = breviloquence.Inlinable.derived

--- a/lib/crossparse/src/model/crossparse.model.scala
+++ b/lib/crossparse/src/model/crossparse.model.scala
@@ -71,39 +71,27 @@ object Payment:
   // on a scan-ahead of that entry.
   given cborDiscriminable: Payment is Discriminable in Cbor = Cbor.DiscriminantKey(t"type")
 
+// The per-format `Inlinable` instances arrive through `derives` clauses:
+// each format's carrier (`Inlinable.ForJson`, `Inlinable.ForTel`, …) is the
+// `Self`-typed typeclass, synthesized into the companion, where the staging
+// summons resolve them live.
 case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
-
-// The per-format `Inlinable` givens are qualified: each format's staged
-// component declares its own `Inlinable`, and this module imports all three
-// packages.
-object LineItem:
-  given jsonInlinable: (LineItem is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (LineItem is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (LineItem is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (LineItem is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (LineItem is locomotion.Inlinable) = locomotion.Inlinable.derived
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf
 
 case class Customer(id: Long, name: Text, email: Text, region: Text)
-
-object Customer:
-  given jsonInlinable: (Customer is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (Customer is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (Customer is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (Customer is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (Customer is locomotion.Inlinable) = locomotion.Inlinable.derived
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf
 
 case class Order
   ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
     priority: Boolean, discount: Double )
-
-object Order:
-  given jsonInlinable: (Order is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (Order is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (Order is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (Order is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (Order is locomotion.Inlinable) = locomotion.Inlinable.derived
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf
 
 case class Orders(orders: List[Order])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf
 
 object Orders:
   // Direct parsing is opt-in per format; only the top type needs a nominal
@@ -113,8 +101,105 @@ object Orders:
   given telParsable: Orders is Tel.Parsable = Tel.Parsable.derived
   given xmlParsable: Orders is Xml.Parsable = Xml.Parsable.derived
 
-  given jsonInlinable: (Orders is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (Orders is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (Orders is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (Orders is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (Orders is locomotion.Inlinable) = locomotion.Inlinable.derived
+// ── The document matrix ─────────────────────────────────────────────────
+// Typed translations of the jacinta benchmark corpus (a servlet config, a
+// menu fragment, user records, log entries, blockchain transactions, and
+// two numeric arrays), adapted so every format can represent them: uniform
+// record shapes (heterogeneous parameter objects become key/value lists),
+// identifier-safe field names, no sums (BinTEL cannot decode a sum in field
+// position), and wrapper records for the bare arrays (Protobuf and BinTEL
+// need a message root). High-precision numerics travel as `Text`, since no
+// common typed representation exists across the formats.
+
+case class Param(key: Text, value: Text)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Servlet(servletName: Text, servletClass: Text, params: List[Param])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Mapping(servletName: Text, url: Text)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Taglib(uri: Text, location: Text)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class WebApp(servlets: List[Servlet], mappings: List[Mapping], taglib: Taglib)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Config(webApp: WebApp)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class MenuItem(value: Text, onclick: Text)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Popup(menuitems: List[MenuItem])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Menu(id: Text, value: Text, popup: Popup)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class MenuDoc(menu: Menu)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class User(id: Int, username: Text, email: Text, active: Boolean, role: Text)
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Users(users: List[User])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class LogEntry
+  ( timestamp: Long, level: Text, service: Text, requestId: Text, userId: Int, message: Text )
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Logs(logs: List[LogEntry])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Transaction
+  ( from: Text, to: Text, valueWei: Text, valueEth: Text, gasPriceWei: Text, gasUsed: Int,
+    blockNumber: Long, nonce: Int, temperatureDelta: Double )
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Transactions(transactions: List[Transaction])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Ints(values: List[Int])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel
+
+case class Decimals(values: List[Double])
+derives jacinta.Inlinable.ForJson, stratiform.Inlinable.ForTel, xylophone.Inlinable.ForXml,
+    breviloquence.Inlinable.ForCbor, locomotion.Inlinable.ForProtobuf,
+    BintelInlinable.ForBintel

--- a/lib/jacinta/src/core/jacinta.Json.scala
+++ b/lib/jacinta/src/core/jacinta.Json.scala
@@ -591,6 +591,32 @@ object Json extends Json2, Dynamic:
     def shape(): Morphology
 
   object Parsable:
+    // The base of generated parsers: generated code is capture-erased, so
+    // the body receives the reader as a neutral carrier, and the capability
+    // is asserted here at the rim — the audited point — like the reader's
+    // own accessors. (A generated override of `parse` itself would narrow
+    // the trait's `Reader^` parameter to a pure type, which capture
+    // checking rejects at the instantiation site.)
+    abstract class Direct[value] extends Json.Parsable:
+      type Self = value
+
+      def shape(): Morphology = Morphology.Any
+
+      protected def parseCarrier(reader: AnyRef): value
+
+      def parse(reader: JsonReader^): value = parseCarrier(reader.asInstanceOf[AnyRef])
+
+    // The call points for a nominal `Parsing` instance in a field position
+    // of a *generated* parser (a recursive record's own `Parsable`, a
+    // hand-written one, or the `Json.Field` fallback chain). Both travel as
+    // neutral carriers — generated code is capture-erased — and the
+    // capability is reasserted here, at the audited point.
+    def parseField[value](parsing: AnyRef, reader: AnyRef): value =
+      parsing.asInstanceOf[value is Json.Parsing].parse(reader.asInstanceOf[JsonReader^])
+
+    def absentField[value](parsing: AnyRef)(using Tactic[JsonError]): value =
+      parsing.asInstanceOf[value is Json.Parsing].absent()
+
     def apply[value](shape0: => Morphology)(parser: (reader: JsonReader^) => value)
     :   ((value is Json.Parsable)^{parser}) =
       // Same shape-thunk laundering as `Encodable.apply`; see the comment there.

--- a/lib/jacinta/src/staged/jacinta.Inlinable.scala
+++ b/lib/jacinta/src/staged/jacinta.Inlinable.scala
@@ -75,6 +75,27 @@ object Inlinable:
   // (no macro — `Type[Self]` arrives with the call).
   def derived[product]: product is Inlinable = ProductInlinable[product]()
 
+  // The `derives`-clause carrier: a `Self`-typed typeclass cannot appear in
+  // a `derives` clause (it has no type parameters), so `case class Foo(...)
+  // derives Inlinable.ForJson` synthesizes this parameterized subtrait —
+  // which *is* a `Foo is Inlinable` — into `Foo`'s companion, where the
+  // staging summon finds it. The resolution ladder unwraps the delegate so
+  // structural instances keep their generator identities.
+  final class ForJson[value](delegate0: value is Inlinable) extends Inlinable:
+    type Self = value
+    private[jacinta] def delegate: value is Inlinable = delegate0
+
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[value]): Expr[value] =
+      delegate0.parse(reader)
+
+    override def absent(tactic: Expr[Tactic[JsonError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.absent(tactic)
+
+  object ForJson:
+    def derived[value]: ForJson[value] = ForJson(Inlinable.derived[value])
+
   private[jacinta] final class ProductInlinable[product]() extends Inlinable:
     type Self = product
 

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -235,7 +235,13 @@ object stagedInternal:
   // runtime seam. The cache spans one entry expansion, so a type's staging
   // summon runs at most once however often it recurs in the graph.
 
-  private type Cache = scm.HashMap[String, Option[Inlinable]]
+  // The per-entry expansion cache: memoized staging summons, and the set of
+  // types whose generators are currently on the expansion stack — a
+  // recursive occurrence (`Tree` with `children: List[Tree]`) must degrade
+  // to the runtime seam rather than expand forever.
+  private final class Cache:
+    val instances: scm.HashMap[String, Option[Inlinable]] = scm.HashMap()
+    val active: scm.Set[String] = scm.Set()
 
   private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
     import quotes.reflect.*
@@ -243,7 +249,42 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      . orElse(structuralFor[field](cache))
+      . orElse(runtimeFor[field])
+
+  // The runtime tiers, resolved with a reflection-level implicit search at
+  // expansion time and called through neutral-carrier helpers (the erasing
+  // cast crosses the capability boundary, as wisteria's field-instance
+  // engine does): a nominal `Parsable` — the recursion tie, since a
+  // recursive record's own alias given (a lazy val) is found from inside
+  // its own definition — then the `Json.Field` fallback chain. Neither
+  // `summonInline` nor a `using` parameter works for these from inside the
+  // generated parser's inline context.
+  private def runtimeFor[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    def searched(target: TypeRepr): Option[Expr[Any]] =
+      Implicits.search(target) match
+        case success: ImplicitSearchSuccess => Some(success.tree.asExpr)
+        case _                              => None
+
+    searched(TypeRepr.of[field is Json.Parsable]).map(RuntimeInlinable[field](_)).orElse:
+      searched(TypeRepr.of[field is Json.Field]).map(RuntimeInlinable[field](_))
+
+  private final class RuntimeInlinable[value](parsing: Expr[Any]) extends Inlinable:
+    type Self = value
+
+    def parse(reader: Expr[JsonReader])(using Quotes, Type[value]): Expr[value] =
+      '{
+        Json.Parsable.parseField[value]
+          ($parsing.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef])
+      }
+
+    override def absent(tactic: Expr[Tactic[JsonError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      '{ Json.Parsable.absentField[value]($parsing.asInstanceOf[AnyRef])(using $tactic) }
 
   // Composition points become local defs rather than textual inlining: a
   // fully-flattened parser exceeds HotSpot's huge-method bytecode limit and
@@ -282,7 +323,12 @@ object stagedInternal:
 
     val tpe = TypeRepr.of[field].dealias
 
-    if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+    // A `Map` is an `Iterable` of pairs, but its wire form is a JSON
+    // object, not an array — it stays on the runtime seam
+    // (`Json.Parsable.dictionary` through the `Field` chain).
+    val isMap = tpe.derivesFrom(Symbol.requiredClass("scala.collection.Map"))
+
+    if !isMap && tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
       case AppliedType(_, arguments) =>
         arguments.last.asType match
           case '[element] =>
@@ -292,6 +338,9 @@ object stagedInternal:
 
       case _ =>
         None
+    // A recursive occurrence degrades to the runtime seam, whose
+    // derivation is lazy.
+    else if cache.active.contains(tpe.show) then None
     else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
     else None
 
@@ -376,9 +425,19 @@ object stagedInternal:
   private[jacinta] def productBody[product: Type](reader: Expr[JsonReader])(using Quotes)
   :   Expr[product] =
 
-    productBody[product](reader, scm.HashMap())
+    productBody[product](reader, Cache())
 
   private def productBody[product: Type](reader: Expr[JsonReader], cache: Cache)(using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[product].dealias.show
+
+    try productBody0[product](reader, cache)
+    finally cache.active -= TypeRepr.of[product].dealias.show
+
+  private def productBody0[product: Type](reader: Expr[JsonReader], cache: Cache)(using Quotes)
   :   Expr[product] =
 
     import quotes.reflect.*
@@ -684,12 +743,19 @@ object stagedInternal:
   def inlinableParsable[value: Type](using Quotes): Expr[value is Json.Parsable] =
     import quotes.reflect.*
 
-    val cache: Cache = scm.HashMap()
+    val cache: Cache = Cache()
 
     val root: Inlinable = resolve[value](cache).getOrElse:
       report.errorAndAbort
         (s"jacinta: no Inlinable instance for ${TypeRepr.of[value].show}, and it is not an "+
           "inlinable product; use `Json.Parsable.staged` or `derived`")
+
+    // A runtime-tier root would find the very given under definition — an
+    // infinite self-call — or add nothing over the instance it wraps.
+    if root.isInstanceOf[RuntimeInlinable[?]] then
+      report.errorAndAbort
+        (s"jacinta: ${TypeRepr.of[value].show} has no generator of its own; use "+
+          "`Json.Parsable.staged` or `derived` rather than `Inlinable.parsable`")
 
     val instance = root.asInstanceOf[Inlinable { type Self = value }]
 
@@ -697,8 +763,9 @@ object stagedInternal:
       // Sealed per the codec-thunk pattern, like the staged instances: the
       // generated body resolves its capabilities where it is spliced.
       caps.unsafe.unsafeAssumePure:
-        new Json.Parsable:
-          type Self = value
-          def shape(): Morphology = Morphology.Any
-          def parse(reader: JsonReader): value = ${ instance.parse('{reader}) }
+        new Json.Parsable.Direct[value]:
+          protected def parseCarrier(reader0: AnyRef): value =
+            // A capability class cannot be quoted into a pure hole, so
+            // every use casts from the neutral carrier afresh.
+            ${ instance.parse('{ reader0.asInstanceOf[JsonReader] }) }
     }

--- a/lib/jacinta/src/staged/jacinta.stagedInternal.scala
+++ b/lib/jacinta/src/staged/jacinta.stagedInternal.scala
@@ -249,9 +249,16 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field].map(unwrap))
       . orElse(structuralFor[field](cache))
       . orElse(runtimeFor[field])
+
+  // A `derives`-clause carrier delegates to a structural instance; the
+  // ladder works with the delegate so generator identities (product,
+  // collection) stay recognizable.
+  private def unwrap(instance: Inlinable): Inlinable = instance match
+    case derived: Inlinable.ForJson[?] => derived.delegate.asInstanceOf[Inlinable]
+    case other                         => other
 
   // The runtime tiers, resolved with a reflection-level implicit search at
   // expansion time and called through neutral-carrier helpers (the erasing

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -102,6 +102,7 @@ case class Crew(lead: Worker, members: List[Worker]) derives CanEqual
 // Recursion through a collection (#1429), direct recursion, recursion through a map, and a generic
 // product used over a recursive type (which must stay structurally derived, not mis-read as a codec).
 case class Tree(value: Text, children: List[Tree]) derives CanEqual
+case class Counts(counts: Map[Text, Int], tag: Text) derives CanEqual
 case class TreeOpt(value: Text, child: Optional[TreeOpt]) derives CanEqual
 case class Forest(trees: Map[Text, Tree]) derives CanEqual
 case class Boxed[value](value: value) derives CanEqual
@@ -773,6 +774,18 @@ object Tests extends Suite(m"Jacinta Tests"):
       . assert(_ == JsonPrimitive.Null)
 
     suite(m"Direct parsing tests"):
+      test(m"an inlined recursive type ties through its own nominal Parsable"):
+        given (Tree is Json.Parsable) = Inlinable.parsable[Tree]
+        val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+        tree.in[Json].show.read[Tree in Json]
+      . assert(_ == Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil))))))
+
+      test(m"an inlined Map field stays on the runtime seam"):
+        given (Counts is Json.Parsable) = Inlinable.parsable[Counts]
+        val counts = Counts(Map(t"a" -> 1, t"b" -> 2), t"tag")
+        counts.in[Json].show.read[Counts in Json]
+      . assert(_ == Counts(Map(t"a" -> 1, t"b" -> 2), t"tag"))
+
       test(m"Read an Int directly"):
         t"42".read[Int in Json]
       . assert(_ == 42)

--- a/lib/locomotion/src/core/locomotion.Protobuf.scala
+++ b/lib/locomotion/src/core/locomotion.Protobuf.scala
@@ -67,6 +67,16 @@ trait Protobuf2:
   inline given decodable: [value] => value is Decodable in Protobuf = summonFrom:
     case given Reflection[`value`] => DecodableDerivation.derived
 
+  // The AST-materializing read path: `bytes.read[Foo in Protobuf]` shorthand
+  // for `bytes.read[Protobuf].as[Foo]`. Lives at this priority so `object
+  // Protobuf`'s direct-parsing `aggregableParsed` wins whenever the value
+  // has a `Protobuf.Parsable`; when it does not, this resolves exactly as
+  // before. `value in Protobuf` is just `value { type Form = Protobuf }`,
+  // so the cast is a no-op at runtime.
+  given aggregableIn: [value: Decodable in Protobuf] => (tactic: Tactic[ProtobufError])
+  =>  (((value in Protobuf) is Aggregable by Data)^{tactic}) =
+    bytes => Protobuf.message(bytes.read[Data]).as[value].asInstanceOf[value in Protobuf]
+
   // Unpacked `repeated`: each element is emitted as a separate field (one tag per
   // value). This is the fallback for elements with no `Packable` instance — strings,
   // byte arrays and embedded messages. Numeric scalars are handled by the
@@ -103,7 +113,95 @@ trait Protobuf2:
 object Protobuf extends Protobuf2:
   // Wraps a complete message payload as a length-delimited wire value — the shape
   // the derivations decode. Used by the `Aggregable` instances backing `read`.
-  private def message(bytes: Data): Protobuf = Wire(WireType.Len, bytes)
+  private[locomotion] def message(bytes: Data): Protobuf = Wire(WireType.Len, bytes)
+
+  object Parsable:
+    // The base of generated parsers: generated code is capture-erased, so
+    // the body receives the reader as a neutral carrier, and the capability
+    // is asserted here at the rim — the audited point — like the reader's
+    // own accessors. (A generated override of `parse` itself would narrow
+    // the trait's `Reader^` parameter to a pure type, which capture
+    // checking rejects at the instantiation site.)
+    abstract class Direct[value] extends Protobuf.Parsable:
+      type Self = value
+
+      protected def parseCarrier(reader: AnyRef): value
+
+      def parse(reader: ProtobufReader^): value = parseCarrier(reader.asInstanceOf[AnyRef])
+
+    def apply[value](parser: (reader: ProtobufReader^) => value)
+    :   ((value is Protobuf.Parsable)^{parser}) =
+
+      new Protobuf.Parsable:
+        type Self = value
+        def parse(reader: ProtobufReader^): value = parser(reader)
+
+    // The call point for a nominal `Parsable` in a field position of a
+    // *generated* parser (a recursive message's own instance, or a
+    // hand-written one). Both travel as neutral carriers — generated code
+    // is capture-erased — and the capability is reasserted here, at the
+    // audited point, exactly as the reader's own rim accessors do.
+    def parseField[value](parsable: AnyRef, reader: AnyRef): value =
+      parsable.asInstanceOf[value is Protobuf.Parsable]
+      . parse(reader.asInstanceOf[ProtobufReader^])
+
+    // The universal bridge from the AST world: materialize the window as a
+    // message and decode it. Types with only a `Decodable in Protobuf` keep
+    // working through this, and it is the user's one-line escape hatch when
+    // a custom decoder must beat a generated direct parser.
+    def fromDecodable[value](decodable: (value is Decodable in Protobuf)^)
+    :   ((value is Protobuf.Parsable)^{decodable}) =
+
+      new Protobuf.Parsable:
+        type Self = value
+        def parse(reader: ProtobufReader^): value = decodable.decoded(reader.message())
+
+  // The direct-parsing counterpart of `Decodable in Protobuf`: consumes
+  // fields straight off the input bytes through a `ProtobufReader` instead
+  // of walking the materialized number-keyed map, so `read[value in
+  // Protobuf]` can instantiate values without buffering every field's wire
+  // value. `Parsable` is the opt-in surface: explicit instances and
+  // `Protobuf.Inlinable.parsable`. It has no blanket fallback given, so no
+  // read changes behavior until a type opts in.
+  trait Parsable extends distillate.Parsable:
+    type Transport = Protobuf
+    type Reader = ProtobufReader
+
+  // Direct-parsing counterpart of the `aggregable`/`aggregableIn` path:
+  // drives a `Protobuf.Parsable` instance over the input through a
+  // `ProtobufReader`, its window set to the whole message.
+  private def parseDirect[value]
+    ( input: Data, parsable: (value is Protobuf.Parsable)^ )
+    ( using tactic: Tactic[ProtobufError] )
+  :   value =
+
+    parsable.parse(ProtobufReader(ProtobufParser(input), tactic))
+
+  // Direct parsing: when the value knows how to consume wire fields itself,
+  // the field map is never materialized. Declared here (not in `Protobuf2`,
+  // where the `Decodable`-based `aggregableIn` lives) so it wins whenever a
+  // `Protobuf.Parsable` exists, and is otherwise inapplicable — existing
+  // code resolves exactly as before. Sealed per the codec-thunk pattern:
+  // the instance retains the resolution-scoped parsable and tactic.
+  given aggregableParsed: [value]
+  =>  (parsable: (value is Protobuf.Parsable)^)
+  =>  (tactic: Tactic[ProtobufError])
+  =>  ((value in Protobuf) is Aggregable by Data) =
+
+    caps.unsafe.unsafeAssumePure:
+      bytes => parseDirect(bytes.read[Data], parsable).asInstanceOf[value in Protobuf]
+
+  // Whole-`Data` direct read: when the entire content is already in hand,
+  // parse it in place rather than wrapping it in a one-element stream.
+  // Concrete in `Data`, so it beats the composed pipeline by specificity.
+  // Sealed like `aggregableParsed` above.
+  given readableParsed: [value]
+  =>  (parsable: (value is Protobuf.Parsable)^)
+  =>  (tactic: Tactic[ProtobufError])
+  =>  (Data is Readable to (value in Protobuf)) =
+
+    caps.unsafe.unsafeAssumePure:
+      data => parseDirect(data, parsable).asInstanceOf[value in Protobuf]
 
   given protobuf: Protobuf is Decodable in Protobuf = identity(_)
 
@@ -127,14 +225,6 @@ object Protobuf extends Protobuf2:
 
   // `bytes.read[Protobuf]` aggregates the byte stream and wraps it as a message.
   given aggregable: Protobuf is Aggregable by Data = bytes => message(bytes.read[Data])
-
-  // `bytes.read[Foo in Protobuf]` shorthand for `bytes.read[Protobuf].as[Foo]`,
-  // mirroring jacinta's `value in Json` and breviloquence's `value in Cbor`.
-  // `value in Protobuf` is just `value { type Form = Protobuf }`, so the
-  // cast is a no-op at runtime.
-  given aggregableIn: [value: Decodable in Protobuf] => (tactic: Tactic[ProtobufError])
-  =>  (((value in Protobuf) is Aggregable by Data)^{tactic}) =
-    bytes => message(bytes.read[Data]).as[value].asInstanceOf[value in Protobuf]
 
   // Number-keyed optic: Protobuf fields are addressed by number, not name, so an
   // `Ordinal` selects field `n` (`Prim` = field 1). Updating parses the message's

--- a/lib/locomotion/src/core/locomotion.ProtobufParser.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufParser.scala
@@ -124,6 +124,210 @@ class ProtobufParser(data: Data):
 
     accumulator.view.mapValues(_.to(List)).to(Map)
 
+  // ── The direct rim ─────────────────────────────────────────────────────
+  // Byte-level reads for direct parsing (`Protobuf.Parsable`), bounded by a
+  // *window* — a limit within the input marking the extent of the value
+  // being parsed, so nested messages parse in place instead of slicing a
+  // fresh parser over a copied payload. A `parse` call receives the reader
+  // with its window set to the value's payload and must consume to the
+  // window's end; `directEnterField`/`directLeaveField` bracket one field's
+  // wire value per its tag's wire code, exactly as `fields()` slices it.
+
+  private var boundary: Int = data.length
+
+  def directAtLimit: Boolean = pos >= boundary
+  def directMark: Int = pos
+  def directBoundary: Int = boundary
+
+  // The next field tag: `(number << 3) | code`. Only called below the
+  // window's limit.
+  def directTag()(using Tactic[ProtobufError]): Int = directVarint().toInt
+
+  // A limit-bounded `varint()`: identical semantics against the window
+  // rather than the whole input.
+  def directVarint()(using Tactic[ProtobufError]): Long =
+    val start = pos
+    var result = 0L
+    var shift = 0
+    var continue = true
+
+    while continue do
+      if pos >= boundary then abort(ProtobufError(Reason.Truncated(pos)))
+      if shift >= 70 then abort(ProtobufError(Reason.MalformedVarint(start)))
+      val byte = data(pos) & 0xff
+      pos += 1
+
+      if shift == 63 && (byte & 0x7f) > 1 then abort(ProtobufError(Reason.Overflow(start)))
+      if shift < 64 then result |= (byte.toLong & 0x7f) << shift
+      shift += 7
+      if (byte & 0x80) == 0 then continue = false
+
+    result
+
+  def directFixed32()(using Tactic[ProtobufError]): Int =
+    if pos + 4 > boundary then abort(ProtobufError(Reason.Truncated(pos)))
+    var result = 0
+    var i = 0
+
+    while i < 4 do
+      result |= (data(pos + i) & 0xff) << (i*8)
+      i += 1
+
+    pos += 4
+    result
+
+  def directFixed64()(using Tactic[ProtobufError]): Long =
+    if pos + 8 > boundary then abort(ProtobufError(Reason.Truncated(pos)))
+    var result = 0L
+    var i = 0
+
+    while i < 8 do
+      result |= (data(pos + i).toLong & 0xff) << (i*8)
+      i += 1
+
+    pos += 8
+    result
+
+  // Narrows the window to one field's wire value — the same extent
+  // `fields()` slices for the field's payload — returning the enclosing
+  // limit for `directLeaveField`. For a length-delimited field the length
+  // prefix is consumed; for a varint field the window covers the varint's
+  // own bytes, mirroring the `data.slice(start, pos)` payload.
+  def directEnterField(code: Int)(using Tactic[ProtobufError]): Int =
+    val saved = boundary
+
+    code match
+      case 0 =>
+        val start = pos
+        directVarint()
+        boundary = pos
+        pos = start
+
+      case 1 =>
+        if pos + 8 > boundary then abort(ProtobufError(Reason.Truncated(pos)))
+        boundary = pos + 8
+
+      case 2 =>
+        val length = directVarint().toInt
+
+        if length < 0 || pos + length > boundary
+        then abort(ProtobufError(Reason.Truncated(pos)))
+
+        boundary = pos + length
+
+      case 5 =>
+        if pos + 4 > boundary then abort(ProtobufError(Reason.Truncated(pos)))
+        boundary = pos + 4
+
+      case other =>
+        abort(ProtobufError(Reason.UnexpectedWireType(other, pos)))
+
+    saved
+
+  // Restores the enclosing window, consuming whatever of the field's value
+  // remains — a parse may legitimately read less than the payload, as the
+  // AST accessors ignore a payload's trailing bytes.
+  def directLeaveField(saved: Int): Unit =
+    pos = boundary
+    boundary = saved
+
+  def directSkipField(code: Int)(using Tactic[ProtobufError]): Unit =
+    directLeaveField(directEnterField(code))
+
+  // ── Scalar field reads, dispatching on the tag's wire code. The fast
+  // path reads the natural encoding in place; a mismatched code reads the
+  // field's payload window and interprets it exactly as the AST accessor
+  // interprets the recorded payload. ──
+
+  def directLong(code: Int)(using Tactic[ProtobufError]): Long =
+    if code == 0 then directVarint() else
+      val saved = directEnterField(code)
+      val result = directVarint()
+      directLeaveField(saved)
+      result
+
+  def directDouble(code: Int)(using Tactic[ProtobufError]): Double =
+    if code == 1 then java.lang.Double.longBitsToDouble(directFixed64()) else
+      val saved = directEnterField(code)
+      val result = java.lang.Double.longBitsToDouble(directFixed64())
+      directLeaveField(saved)
+      result
+
+  def directFloat(code: Int)(using Tactic[ProtobufError]): Float =
+    if code == 5 then java.lang.Float.intBitsToFloat(directFixed32()) else
+      val saved = directEnterField(code)
+      val result = java.lang.Float.intBitsToFloat(directFixed32())
+      directLeaveField(saved)
+      result
+
+  def directString(code: Int)(using Tactic[ProtobufError]): String =
+    val saved = directEnterField(code)
+
+    val result =
+      java.lang.String
+        ( data.asInstanceOf[Array[Byte]], pos, boundary - pos,
+          java.nio.charset.StandardCharsets.UTF_8 )
+
+    directLeaveField(saved)
+    result
+
+  def directData(code: Int)(using Tactic[ProtobufError]): Data =
+    val saved = directEnterField(code)
+    val result = data.slice(pos, boundary)
+    directLeaveField(saved)
+    result
+
+  // One field's wire value, materialized — the runtime seam for field types
+  // without an `Inlinable`, gathered per occurrence and decoded through the
+  // field's `Decodable in Protobuf` exactly as the AST path.
+  def directWire(code: Int)(using Tactic[ProtobufError]): Protobuf =
+    val wireType =
+      WireType.fromId(code).lest(ProtobufError(Reason.UnexpectedWireType(code, pos)))
+
+    val saved = directEnterField(code)
+    val result = Protobuf.Wire(wireType, data.slice(pos, boundary))
+    directLeaveField(saved)
+    result
+
+  // The whole window's content as text or bytes — the window-level reads
+  // behind the reader's leaf accessors, mirroring how the AST accessors
+  // interpret a field's recorded payload.
+  def directStringWindow(): String =
+    val result =
+      java.lang.String
+        ( data.asInstanceOf[Array[Byte]], pos, boundary - pos,
+          java.nio.charset.StandardCharsets.UTF_8 )
+
+    pos = boundary
+    result
+
+  def directDataWindow(): Data =
+    val result = data.slice(pos, boundary)
+    pos = boundary
+    result
+
+  // The remaining window as a length-delimited message — the whole-value
+  // seam for `Parsable.fromDecodable`.
+  def directMessage(): Protobuf =
+    val result = Protobuf.Wire(WireType.Len, data.slice(pos, boundary))
+    pos = boundary
+    result
+
+  // ── The sum window: a oneof's variant is chosen by a scan of the whole
+  // message (the lowest variant number present, its last occurrence), then
+  // parsed from its recorded extent. `directRewindTo` re-enters a scanned
+  // extent; the packed save restores both position and limit. ──
+
+  def directWindow(start: Int, end: Int): Long =
+    val saved = (pos.toLong << 32) | (boundary.toLong & 0xFFFFFFFFL)
+    pos = start
+    boundary = end
+    saved
+
+  def directRestore(saved: Long): Unit =
+    pos = (saved >>> 32).toInt
+    boundary = (saved & 0xFFFFFFFFL).toInt
+
   // Splits a packed `repeated` payload (a single length-delimited field holding
   // concatenated scalar values) into one wire value per element. `wireType` is the
   // element encoding, supplied by the element's `Packable` instance.

--- a/lib/locomotion/src/core/locomotion.ProtobufReader.scala
+++ b/lib/locomotion/src/core/locomotion.ProtobufReader.scala
@@ -30,91 +30,69 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package crossparse
+package locomotion
 
 import anticipation.*
-import breviloquence.*
-import contingency.*, strategies.throwUnsafely
-import gossamer.*
-import jacinta.*
-import prepositional.*
-import rudiments.*
-import stratiform.*
-import vacuous.*
-import wisteria.*
-import xylophone.*
+import contingency.*
 
-// The discriminator key the JSON derivations read at this module's
-// derivation sites.
-import jacinta.discriminables.jsonByKindDiscriminable
+object ProtobufReader:
+  // Only locomotion's read path (`Protobuf.parseDirect`) constructs readers,
+  // so the exclusivity of the wrapped parser and the resolution scope of the
+  // carried tactic are preserved by construction. The wrapped tactic travels
+  // as a neutral carrier (jacinta's `JsonReader` pattern): the field stays
+  // pure, and each accessor reasserts the type at the rim — the audited
+  // point.
+  private[locomotion] def apply(parser: ProtobufParser, tactic: Tactic[ProtobufError])
+  :   ProtobufReader^ =
 
-// The shared structure decoded by every format: varied primitive types, a
-// nested record, a sequence and a coproduct. Compiled one phase before the
-// benchmarks, so `Json.Inlinable`'s expansion-time instance evaluation can
-// load the types and resolve the companion `Inlinable` givens.
-enum Payment:
-  case Card(number: Text, expiry: Text, secure: Boolean)
-  case Transfer(iban: Text, reference: Long)
+    new ProtobufReader(parser, tactic.asInstanceOf[AnyRef])
 
-object Payment:
-  // An XML sum nested inside a product cannot use xylophone's label-based
-  // default `Discriminable`: the product encoder relabels the variant
-  // element with the *field's* name, which destroys the discriminator. The
-  // variant rides in a `type` attribute instead — `<payment type="Card">` —
-  // mirroring the discriminator key the JSON and YAML corpora carry. The
-  // named `DiscriminantAttribute` shape also lets the inlined XML parser
-  // dispatch on the attribute straight off the open tag.
-  given xmlDiscriminable: Payment is Discriminable in Xml = Xml.DiscriminantAttribute(t"type")
+// The public, restricted rim of the Protobuf wire parser, handed to
+// `Protobuf.Parsable` instances so they can consume fields straight off the
+// input without the intermediate number-keyed `Protobuf` map. A `parse` call
+// receives the reader with its *window* set to the value's payload (the
+// whole input at the top level; one field's wire value in a field position)
+// and must consume to the window's end. The reader carries its own
+// `Tactic[ProtobufError]`, so instance `parse` bodies need no error
+// vocabulary: malformed input aborts through the read call's ambient tactic.
+//
+// An exclusive, stateful capability, like the parser it wraps: it is owned
+// by one `Protobuf.Parsable.parse` call at a time, for the duration of that
+// call, and nothing of it may be retained afterwards.
+final class ProtobufReader private (parser0: AnyRef, tactic0: AnyRef)
+extends caps.ExclusiveCapability, caps.Stateful:
+  private inline def parser: ProtobufParser = parser0.asInstanceOf[ProtobufParser]
 
-  // The CBOR corpus carries the same `type` discriminator as a map entry;
-  // the named `DiscriminantKey` shape lets the inlined CBOR parser dispatch
-  // on a scan-ahead of that entry.
-  given cborDiscriminable: Payment is Discriminable in Cbor = Cbor.DiscriminantKey(t"type")
+  // The sealed conduit for generated parsers: package-private, so the only
+  // path to the wrapped capabilities from outside locomotion is through the
+  // accessor the compiler synthesizes for locomotion's own macro-generated
+  // splices — hand-written code cannot name it. Generated code binds the
+  // parser once per record and reads through `ProtobufParser`'s direct rim
+  // without this class's per-field forwarders.
+  private[locomotion] def rawParser: AnyRef = parser0
+  private[locomotion] def rawTactic: AnyRef = tactic0
+  private inline def tactic: Tactic[ProtobufError] = tactic0.asInstanceOf[Tactic[ProtobufError]]
 
-case class LineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
+  // ── The message steps: the next field's tag while the window has
+  // content, then per-field reads. `enterField` narrows the window to one
+  // field's wire value (returning the token `leaveField` restores). ──
+  update def more: Boolean = !parser.directAtLimit
+  update def tag(): Int = parser.directTag()(using tactic)
+  update def enterField(code: Int): Int = parser.directEnterField(code)(using tactic)
+  update def leaveField(saved: Int): Unit = parser.directLeaveField(saved)
+  update def skipField(code: Int): Unit = parser.directSkipField(code)(using tactic)
 
-// The per-format `Inlinable` givens are qualified: each format's staged
-// component declares its own `Inlinable`, and this module imports all three
-// packages.
-object LineItem:
-  given jsonInlinable: (LineItem is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (LineItem is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (LineItem is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (LineItem is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (LineItem is locomotion.Inlinable) = locomotion.Inlinable.derived
+  // ── Scalars, reading the window's content exactly as the AST accessors
+  // interpret a field's recorded payload — for hand-written instances that
+  // compose over one wire value. ──
+  update def varint(): Long = parser.directVarint()(using tactic)
+  update def fixed32(): Int = parser.directFixed32()(using tactic)
+  update def fixed64(): Long = parser.directFixed64()(using tactic)
+  update def text(): Text = Text(parser.directStringWindow())
+  update def data(): Data = parser.directDataWindow()
 
-case class Customer(id: Long, name: Text, email: Text, region: Text)
-
-object Customer:
-  given jsonInlinable: (Customer is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (Customer is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (Customer is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (Customer is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (Customer is locomotion.Inlinable) = locomotion.Inlinable.derived
-
-case class Order
-  ( reference: Text, customer: Customer, items: List[LineItem], payment: Payment,
-    priority: Boolean, discount: Double )
-
-object Order:
-  given jsonInlinable: (Order is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (Order is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (Order is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (Order is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (Order is locomotion.Inlinable) = locomotion.Inlinable.derived
-
-case class Orders(orders: List[Order])
-
-object Orders:
-  // Direct parsing is opt-in per format; only the top type needs a nominal
-  // instance — nested types resolve through each format's field fallback
-  // chain.
-  given jsonParsable: Orders is Json.Parsable = Json.Parsable.derived
-  given telParsable: Orders is Tel.Parsable = Tel.Parsable.derived
-  given xmlParsable: Orders is Xml.Parsable = Xml.Parsable.derived
-
-  given jsonInlinable: (Orders is jacinta.Inlinable) = jacinta.Inlinable.derived
-  given telInlinable: (Orders is stratiform.Inlinable) = stratiform.Inlinable.derived
-  given xmlInlinable: (Orders is xylophone.Inlinable) = xylophone.Inlinable.derived
-  given cborInlinable: (Orders is breviloquence.Inlinable) = breviloquence.Inlinable.derived
-  given protobufInlinable: (Orders is locomotion.Inlinable) = locomotion.Inlinable.derived
+  // ── The fallback seam: one field's wire value (for gathered occurrences
+  // decoded through a `Decodable in Protobuf`), or the remaining window as
+  // a message (for `Parsable.fromDecodable`). ──
+  update def wire(code: Int): Protobuf = parser.directWire(code)(using tactic)
+  update def message(): Protobuf = parser.directMessage()

--- a/lib/locomotion/src/staged/locomotion.Inlinable.scala
+++ b/lib/locomotion/src/staged/locomotion.Inlinable.scala
@@ -1,0 +1,161 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import prepositional.*
+
+// The Expr-level counterpart of `Protobuf.Parsable`: a typeclass whose
+// methods are macro-time code generators. An instance receives an `Expr` of
+// the reader — its window set to the value's payload — and returns an `Expr`
+// of the decoded value, which the deriving macro splices directly into its
+// generated parser — so an instance contributes *inlined* code, with no
+// runtime dispatch, no field maps and no adapter hops between composed
+// parsers.
+//
+// Instances are ordinary runtime values: code generation is deferred to the
+// `parse` call, which receives the `Quotes` and the `Type` of `Self`, so
+// `derived` needs no macro of its own. At a `Protobuf.Inlinable.parsable[T]`
+// expansion, the instance behind each summoned given is obtained *live* by
+// running the implicit search inside an in-macro staging compiler (the
+// prescience mechanism). The constraint this inherits: an instance (and its
+// type) must be compiled in an earlier run than the expansion; same-run
+// instances degrade to a spliced runtime call through the
+// `Decodable in Protobuf` seam.
+trait Inlinable extends Typeclass:
+  def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Self]): Expr[Self]
+
+  // What a field of this type yields when its number is absent from the
+  // message. Proto3 has no required fields: scalars default to zero values
+  // and messages to all-fields-absent records — the structural instances
+  // override accordingly; the default aborts, so a custom instance that
+  // does not override is loud rather than silently wrong.
+  def absent(tactic: Expr[Tactic[ProtobufError]])(using Quotes, Type[Self]): Expr[Self] =
+    '{ abort(ProtobufError(ProtobufError.Reason.MissingField(0)))(using $tactic) }
+
+object Inlinable:
+  // Generates a monomorphic `Protobuf.Parsable` for a case-class message or
+  // a sealed-sum oneof at compile time, composed through `Inlinable`
+  // instances: nested messages, repeated-field gathering, variant dispatch
+  // and custom leaf parsers all inline into one flat parser.
+  inline def parsable[value]: value is Protobuf.Parsable =
+    ${ locomotion.stagedInternal.inlinableParsable[value] }
+
+  // The structural instance for a case-class message: reflects `Self` when
+  // invoked (no macro — `Type[Self]` arrives with the call).
+  def derived[product]: product is Inlinable = ProductInlinable[product]()
+
+  private[locomotion] final class ProductInlinable[product]() extends Inlinable:
+    type Self = product
+
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[product]): Expr[product] =
+      stagedInternal.productBody[product](reader)
+
+    override def absent(tactic: Expr[Tactic[ProtobufError]])(using Quotes, Type[product])
+    :   Expr[product] =
+
+      stagedInternal.productAbsent[product](tactic)
+
+  // A marker in the resolution ladder: repeated fields gather across the
+  // whole message (occurrences may be scattered and packed), so collection
+  // parsing lives in the *product* generator, not here. The instance only
+  // carries the element for that generator; a collection cannot be parsed
+  // from a single field window.
+  private[locomotion] final class IterableInlinable[element](val element0: element is Inlinable)
+  extends Inlinable:
+    type Self = Iterable[element]
+
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      quotes.reflect.report.errorAndAbort
+        ("locomotion: a repeated field parses through its message's generated parser; a "+
+          "collection has no standalone wire form")
+
+  // The structural instance for a sealed-sum oneof: the variant is chosen
+  // by a scan of the message (the lowest variant number present, its last
+  // occurrence), then parsed from its recorded extent — exactly the AST
+  // disjunction's semantics.
+  private[locomotion] final class SumInlinable[sum]() extends Inlinable:
+    type Self = sum
+
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[sum]): Expr[sum] =
+      stagedInternal.sumBody[sum](reader)
+
+  // ── Instances ──────────────────────────────────────────────────────────
+  // The leaf generators read the reader's window exactly as the AST
+  // accessors interpret a field's recorded payload, for hand-written
+  // instances that compose over one wire value.
+
+  given int: (Int is Inlinable) = new Inlinable:
+    type Self = Int
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Int]): Expr[Int] =
+      '{ $reader.varint().toInt }
+
+  given long: (Long is Inlinable) = new Inlinable:
+    type Self = Long
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Long]): Expr[Long] =
+      '{ $reader.varint() }
+
+  given boolean: (Boolean is Inlinable) = new Inlinable:
+    type Self = Boolean
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Boolean]): Expr[Boolean] =
+      '{ $reader.varint() != 0L }
+
+  given double: (Double is Inlinable) = new Inlinable:
+    type Self = Double
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Double]): Expr[Double] =
+      '{ java.lang.Double.longBitsToDouble($reader.fixed64()) }
+
+  given float: (Float is Inlinable) = new Inlinable:
+    type Self = Float
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Float]): Expr[Float] =
+      '{ java.lang.Float.intBitsToFloat($reader.fixed32()) }
+
+  given text: (Text is Inlinable) = new Inlinable:
+    type Self = Text
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Text]): Expr[Text] =
+      '{ $reader.text() }
+
+  given data: (Data is Inlinable) = new Inlinable:
+    type Self = Data
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[Data]): Expr[Data] =
+      '{ $reader.data() }
+
+  given iterable: [collection <: Iterable, element]
+  =>  (element0: element is Inlinable)
+  =>  (collection[element] is Inlinable) =
+    IterableInlinable[element](element0).asInstanceOf[collection[element] is Inlinable]

--- a/lib/locomotion/src/staged/locomotion.Inlinable.scala
+++ b/lib/locomotion/src/staged/locomotion.Inlinable.scala
@@ -78,6 +78,27 @@ object Inlinable:
   // invoked (no macro — `Type[Self]` arrives with the call).
   def derived[product]: product is Inlinable = ProductInlinable[product]()
 
+  // The `derives`-clause carrier: a `Self`-typed typeclass cannot appear in
+  // a `derives` clause (it has no type parameters), so `case class Foo(...)
+  // derives Inlinable.ForProtobuf` synthesizes this parameterized subtrait —
+  // which *is* a `Foo is Inlinable` — into `Foo`'s companion, where the
+  // staging summon finds it. The resolution ladder unwraps the delegate so
+  // structural instances keep their generator identities.
+  final class ForProtobuf[value](delegate0: value is Inlinable) extends Inlinable:
+    type Self = value
+    private[locomotion] def delegate: value is Inlinable = delegate0
+
+    def parse(reader: Expr[ProtobufReader])(using Quotes, Type[value]): Expr[value] =
+      delegate0.parse(reader)
+
+    override def absent(tactic: Expr[Tactic[ProtobufError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.absent(tactic)
+
+  object ForProtobuf:
+    def derived[value]: ForProtobuf[value] = ForProtobuf(Inlinable.derived[value])
+
   private[locomotion] final class ProductInlinable[product]() extends Inlinable:
     type Self = product
 

--- a/lib/locomotion/src/staged/locomotion.stagedInternal.scala
+++ b/lib/locomotion/src/staged/locomotion.stagedInternal.scala
@@ -331,7 +331,7 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     if builtinKind(tpe).isDefined then None else
-      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field].map(unwrap))
       . orElse(structuralFor[field](cache))
 
   private def structuralFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
@@ -341,6 +341,13 @@ object stagedInternal:
 
     if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
     else sumFor[field](cache)
+
+  // A `derives`-clause carrier delegates to a structural instance; the
+  // ladder works with the delegate so generator identities stay
+  // recognizable.
+  private def unwrap(instance: Inlinable): Inlinable = instance match
+    case derived: Inlinable.ForProtobuf[?] => derived.delegate.asInstanceOf[Inlinable]
+    case other                         => other
 
   // An `Optional[inner]` field: `inner | Unset.type`. Handled by the
   // generator itself (an absent field reads as `Unset`; a present one as

--- a/lib/locomotion/src/staged/locomotion.stagedInternal.scala
+++ b/lib/locomotion/src/staged/locomotion.stagedInternal.scala
@@ -1,0 +1,1164 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package locomotion
+
+import scala.collection.mutable as scm
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import prepositional.*
+import vacuous.*
+
+// The machinery behind `Protobuf.Inlinable`: expansion-time instance
+// resolution (through an in-macro staging compiler), the structural
+// generators for messages, repeated fields and oneof sums, and the
+// `Inlinable.parsable` entry macro.
+object stagedInternal:
+
+  // The runtime seam for a field type without an `Inlinable`: its
+  // occurrences are gathered as wire values through the record loop and
+  // decoded once through the field's `Decodable in Protobuf`, exactly as
+  // the AST path decodes `Repeated(values)`. (A custom *nominal*
+  // `Protobuf.Parsable` is a whole-message parser; field positions route
+  // through `Decodable` — `Parsable.fromDecodable` bridges the other way.)
+  // The seam resolves its `Decodable` with a reflection-level implicit
+  // search at expansion time, crossing the capability boundary through a
+  // single erasing cast — the same maneuver as wisteria's field-instance
+  // engine: resolution readily finds honest capability-typed codecs, but
+  // their `^{tactic, …}` types do not conform to a bare (or even `^`-typed)
+  // evidence query from inside the generated parser's inline context, and a
+  // `summonInline` there additionally fails to expand the blanket
+  // `summonFrom` given for recursively-derived instances.
+  private def seamDecode[fieldType: Type](wire: Expr[Protobuf])(using Quotes)
+  :   Expr[fieldType] =
+
+    import quotes.reflect.*
+
+    Implicits.search(TypeRepr.of[fieldType is Decodable in Protobuf]).absolve match
+      case success: ImplicitSearchSuccess =>
+        success.tree.asExpr.absolve match
+          case '{ $found: any } =>
+            '{ $found.asInstanceOf[fieldType is Decodable in Protobuf].decoded($wire) }
+
+      case failure: ImplicitSearchFailure =>
+        report.errorAndAbort
+          (s"locomotion: no Decodable in Protobuf for ${TypeRepr.of[fieldType].show}: "+
+            failure.explanation)
+
+  // A nominal `Protobuf.Parsable` for a field type, resolved at expansion
+  // time — the recursion tie: a recursive message's own alias given (a lazy
+  // val) is found from inside its own definition, so nested occurrences
+  // parse through the very instance being generated. Also the composition
+  // point for hand-written `Parsable`s in field positions.
+  private def parsableFor[fieldType: Type](using Quotes): Option[Expr[Any]] =
+    import quotes.reflect.*
+
+    Implicits.search(TypeRepr.of[fieldType is Protobuf.Parsable]) match
+      case success: ImplicitSearchSuccess => Some(success.tree.asExpr)
+      case _                              => None
+
+  // ── Expansion-time environment ─────────────────────────────────────────
+
+  private def macroClassloader: ClassLoader =
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // A symbol defined in the compilation run in progress has no trustworthy
+  // classfile (none on a clean build; a stale one from the previous compile
+  // on an incremental build), so instance evaluation must refuse it and the
+  // caller degrade to a runtime seam.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+
+    val full =
+      dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
+
+  // ── Type transport into the staging context ────────────────────────────
+  // The outer macro's `Type` cannot cross into the inner compiler, so a type
+  // travels as a tree of `java.lang.Class`es and is rebuilt inside with
+  // `TypeRepr.typeConstructorOf`. This restricts instance evaluation to
+  // class-shaped types (plain classes and applications of them) — opaque
+  // and structural types degrade to a runtime seam.
+
+  private case class TypeShape(clazz: Class[?], arguments: List[TypeShape])
+
+  private val primitiveClasses: Map[String, Class[?]] =
+    Map
+      ( "scala.Int"     -> classOf[Int],
+        "scala.Long"    -> classOf[Long],
+        "scala.Double"  -> classOf[Double],
+        "scala.Float"   -> classOf[Float],
+        "scala.Boolean" -> classOf[Boolean],
+        "scala.Short"   -> classOf[Short],
+        "scala.Byte"    -> classOf[Byte],
+        "scala.Char"    -> classOf[Char],
+        "scala.Unit"    -> classOf[Unit] )
+
+  // The binary name of a class symbol: package segments joined with dots,
+  // enclosing type segments with dollars.
+  private def binaryName(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+
+    def build(symbol: Symbol): String =
+      val owner = symbol.owner
+
+      if owner.isPackageDef then
+        val prefix = owner.fullName
+        if prefix == "<empty>" then symbol.name else prefix+"."+symbol.name
+      else
+        val ownerName = build(if owner.isClassDef then owner else owner.owner)
+        ownerName+"$"+symbol.name
+
+    build(symbol)
+
+  private def shapeOf(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[TypeShape] =
+    import quotes.reflect.*
+
+    def classFor(tpe: TypeRepr): Option[Class[?]] =
+      tpe.classSymbol.flatMap: symbol =>
+        if definedInCurrentRun(symbol) then None
+        else primitiveClasses.get(symbol.fullName).orElse:
+          try Some(Class.forName(binaryName(symbol), false, macroClassloader).nn)
+          catch
+            case _: ReflectiveOperationException => None
+            case _: LinkageError                 => None
+
+    tpe.dealias match
+      case AppliedType(constructor, arguments) =>
+        for
+          clazz <- classFor(constructor)
+          shapes <- arguments.foldRight(Option(List.empty[TypeShape])): (argument, list) =>
+                      list.flatMap { tail => shapeOf(argument).map(_ :: tail) }
+        yield TypeShape(clazz, shapes)
+
+      case other =>
+        classFor(other).map(TypeShape(_, Nil))
+
+  // ── Instance evaluation: the staging summon ────────────────────────────
+  // One fresh compiler per summon, over the macro classloader with the
+  // current output directory excluded from its classpath. The summon is
+  // embedded in the compiled snippet (`summonInline`), so it resolves during
+  // the inner compiler's inlining phase, composing conditional instances —
+  // the whole instance graph arrives live in one run.
+  private def summonViaStaging[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[field]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val target =
+            r2.Refinement
+              ( r2.TypeRepr.of[Inlinable], "Self",
+                r2.TypeBounds(rebuild(shape), rebuild(shape)) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+
+        result match
+          case instance: Inlinable =>
+            report.info
+              ( s"locomotion: staged summon for ${TypeRepr.of[field].show} took "+
+                s"${duration}ms" )
+
+            Some(instance)
+
+          case _ =>
+            None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The resolution ladder and field plans ──────────────────────────────
+  // Every field of a message compiles to one of four plans: a builtin
+  // scalar `Leaf` (read in place, last occurrence wins); a `Nested`
+  // instance (a message, sum or custom leaf, parsed within its field
+  // window); a `Gather` (a repeated field, appending per occurrence —
+  // packed or not — into a builder); or the runtime `Seam` (occurrences
+  // gathered as wire values and decoded once through the field's
+  // `Decodable in Protobuf`).
+
+  // The per-entry expansion cache: memoized staging summons, and the set of
+  // types whose generators are currently on the expansion stack — a
+  // recursive occurrence (`Tree` with `children: List[Tree]`) must degrade
+  // to the runtime seam rather than expand forever.
+  private final class Cache:
+    val instances: scm.HashMap[String, Option[Inlinable]] = scm.HashMap()
+    val active: scm.Set[String] = scm.Set()
+
+  // Builtin scalar kinds; the natural wire code of each is `naturalCode`.
+  private inline val KInt = 0
+  private inline val KLong = 1
+  private inline val KBoolean = 2
+  private inline val KDouble = 3
+  private inline val KFloat = 4
+  private inline val KText = 5
+  private inline val KData = 6
+
+  private def naturalCode(kind: Int): Int = kind match
+    case KDouble => 1
+    case KFloat  => 5
+    case KText   => 2
+    case KData   => 2
+    case _       => 0
+
+  private def builtinKind(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Int] =
+    import quotes.reflect.*
+
+    if tpe =:= TypeRepr.of[Int] then Some(KInt)
+    else if tpe =:= TypeRepr.of[Long] then Some(KLong)
+    else if tpe =:= TypeRepr.of[Boolean] then Some(KBoolean)
+    else if tpe =:= TypeRepr.of[Double] then Some(KDouble)
+    else if tpe =:= TypeRepr.of[Float] then Some(KFloat)
+    else if tpe =:= TypeRepr.of[Text] then Some(KText)
+    else if tpe =:= TypeRepr.of[Data] then Some(KData)
+    else None
+
+  private enum Elem:
+    case Scalar(kind: Int)
+    case Chunk(kind: Int)
+    case Nested(instance: Inlinable, tpe: Any)
+    case Runtime(parsable: Any)
+    case Seam
+
+  private enum Plan:
+    case Leaf(kind: Int)
+    case Nested(instance: Inlinable)
+    case NestedRuntime(parsable: Any)
+    case OptionalLeaf(kind: Int)
+    case OptionalNested(instance: Inlinable, innerType: Any)
+    case Gather(element: Elem, elementType: Any)
+    case Seam
+
+  private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    if builtinKind(tpe).isDefined then None else
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      . orElse(structuralFor[field](cache))
+
+  private def structuralFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
+    else sumFor[field](cache)
+
+  // An `Optional[inner]` field: `inner | Unset.type`. Handled by the
+  // generator itself (an absent field reads as `Unset`; a present one as
+  // its inner value), so the seam's open implicit search — which cannot
+  // resolve the optional instance from inside a nested inline context — is
+  // never consulted.
+  private def optionalInner(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    val unset = TypeRepr.of[vacuous.Optional.Unset]
+
+    tpe.dealias match
+      case OrType(left, right) if right =:= unset => Some(left.dealias)
+      case OrType(left, right) if left =:= unset  => Some(right.dealias)
+      case _                                      => None
+
+  private def planFor(using Quotes)(tpe0: quotes.reflect.TypeRepr, cache: Cache): Plan =
+    import quotes.reflect.*
+
+    val tpe = tpe0.dealias
+
+    builtinKind(tpe) match
+      case Some(kind) =>
+        Plan.Leaf(kind)
+
+      case None if optionalInner(tpe).isDefined =>
+        val inner = optionalInner(tpe).get
+
+        builtinKind(inner) match
+          case Some(kind) =>
+            Plan.OptionalLeaf(kind)
+
+          case None =>
+            val innerIterable = inner <:< TypeRepr.of[Iterable[Any]]
+
+            if innerIterable then Plan.Seam else inner.asType match
+              case '[innerType] =>
+                resolve[innerType](cache) match
+                  case Some(instance)
+                      if !instance.isInstanceOf[Inlinable.IterableInlinable[?]]
+                      && !cache.active.contains(inner.show) =>
+                    Plan.OptionalNested(instance, inner)
+
+                  case _ =>
+                    Plan.Seam
+
+      case None =>
+        val isMap = tpe.derivesFrom(Symbol.requiredClass("scala.collection.Map"))
+
+        // A `Map` is an `Iterable` of pairs, but its wire form is a
+        // repeated entry message — it stays on the seam (`mapDecodable`).
+        if !isMap && tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+          case AppliedType(_, arguments) =>
+            val elementType = arguments.last.dealias
+
+            builtinKind(elementType) match
+              case Some(kind) if kind <= KFloat =>
+                Plan.Gather(Elem.Scalar(kind), elementType)
+
+              case Some(kind) =>
+                Plan.Gather(Elem.Chunk(kind), elementType)
+
+              case None =>
+                elementType.asType match
+                  case '[element] =>
+                    resolve[element](cache) match
+                      case Some(instance)
+                          if !instance.isInstanceOf[Inlinable.IterableInlinable[?]]
+                          && !cache.active.contains(elementType.show) =>
+                        Plan.Gather(Elem.Nested(instance, elementType), elementType)
+
+                      // A recursive element would expand forever, and other
+                      // shapes have no generator: each occurrence decodes
+                      // through the *element's* `Decodable`, exactly the AST
+                      // `listDecodable`'s per-occurrence semantics. (A
+                      // custom `Packable` element would diverge here; only
+                      // builtin scalars are packable today.)
+                      case _ =>
+                        parsableFor[element] match
+                          case Some(parsable) =>
+                            Plan.Gather(Elem.Runtime(parsable), elementType)
+
+                          case None =>
+                            Plan.Gather(Elem.Seam, elementType)
+
+          case _ =>
+            Plan.Seam
+        else tpe.asType match
+          case '[field] =>
+            resolve[field](cache) match
+              case Some(instance: Inlinable.IterableInlinable[?]) => Plan.Seam
+
+              case Some(instance) if !cache.active.contains(tpe.show) =>
+                Plan.Nested(instance)
+
+              // A recursive message field would expand forever, and an
+              // unresolvable one has no generator: a nominal `Parsable`
+              // (the recursion tie, or a hand-written instance) parses the
+              // field's window in place; otherwise the seam.
+              case _ =>
+                parsableFor[field] match
+                  case Some(parsable) => Plan.NestedRuntime(parsable)
+                  case None           => Plan.Seam
+
+  // A sealed sum qualifies when every variant is itself an inlinable case
+  // class (resolved through the ladder, so custom variant instances
+  // compose). Variants are numbered by declaration order, exactly as the
+  // derivations encode them. Anything else — singleton variants, generic
+  // sums, an unresolvable variant — degrades to the runtime seam,
+  // preserving the derived semantics exactly.
+  private def sumFor[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
+    sumVariants(quotes.reflect.TypeRepr.of[field].dealias).flatMap: variants =>
+      val resolvable = variants.forall: (_, variantType) =>
+        variantType.asType match
+          case '[variantType] => resolve[variantType](cache).isDefined
+
+      if resolvable then Some(Inlinable.SumInlinable[field]()) else None
+
+  // The variants of a stageable sealed sum: `(label, type)` per variant, or
+  // `None` when the shape is unsupported.
+  private def sumVariants(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[List[(String, quotes.reflect.TypeRepr)]] =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.flatMap: classSymbol =>
+      val applied = tpe match
+        case AppliedType(_, _) => true
+        case _                 => false
+
+      val children = classSymbol.children
+
+      val supported =
+        !applied
+        && classSymbol.flags.is(Flags.Sealed)
+        && children.nonEmpty
+        && children.forall { child => child.isClassDef && child.flags.is(Flags.Case) }
+
+      if supported then Some(children.map { child => (child.name, child.typeRef) }) else None
+
+  // The field numbers of a product's fields: an `@field(n)` annotation with
+  // a literal argument, or 1-based declaration order. `None` when any
+  // annotation cannot be read statically.
+  private def fieldNumbersOf(using Quotes)(classSymbol: quotes.reflect.Symbol)
+  :   Option[List[Int]] =
+
+    import quotes.reflect.*
+
+    val params = classSymbol.primaryConstructor.paramSymss.flatten.filterNot(_.isTypeParam)
+    val caseFields = classSymbol.caseFields
+
+    def annotationNumber(annotations: List[Term]): Option[Option[Int]] =
+      annotations.filter(_.tpe <:< TypeRepr.of[locomotion.field]) match
+        case Nil =>
+          Some(None)
+
+        case Apply(_, List(Literal(IntConstant(number)))) :: Nil =>
+          Some(Some(number))
+
+        case _ =>
+          None
+
+    val numbers = List.range(0, caseFields.length).map: index =>
+      val annotations =
+        caseFields(index).annotations ++ params.lift(index).map(_.annotations).getOrElse(Nil)
+
+      annotationNumber(annotations).map(_.getOrElse(index + 1))
+
+    if numbers.exists(_.isEmpty) then None else
+      val resolved = numbers.map(_.get)
+      if resolved.distinct.length == resolved.length then Some(resolved) else None
+
+  private def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr): Boolean =
+    import quotes.reflect.*
+
+    tpe.classSymbol.exists: classSymbol =>
+      classSymbol.flags.is(Flags.Case)
+      && !classSymbol.owner.isTerm
+      && (tpe match { case AppliedType(_, _) => false case _ => true })
+      && classSymbol.primaryConstructor.paramSymss
+         . filterNot(_.exists(_.isTypeParam)).length == 1
+      && fieldNumbersOf(classSymbol).isDefined
+
+  // ── The product generator ──────────────────────────────────────────────
+  // Self-contained monomorphic message parsing, mirroring the AST record
+  // decoder's semantics: typed local slots and seen flags, a literal
+  // field-number dispatch, last-occurrence-wins scalars, per-occurrence
+  // gathering (packed or unpacked) for repeated fields, declared defaults
+  // then proto3 absent semantics for missing fields, direct construction.
+  private[locomotion] def productBody[product: Type](reader: Expr[ProtobufReader])
+    (using Quotes)
+  :   Expr[product] =
+
+    productBody[product](reader, Cache())
+
+  private def productBody[product: Type](reader: Expr[ProtobufReader], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+    cache.active += tpe.show
+
+    try productBody0[product](reader, cache) finally cache.active -= tpe.show
+
+  private def productBody0[product: Type](reader: Expr[ProtobufReader], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+
+    if !productSupported(tpe) then
+      report.errorAndAbort
+        (s"locomotion: ${tpe.show} is not an inlinable message (a non-generic, top-level or "+
+          "object-nested case class with a single parameter list and distinct, statically "+
+          "readable field numbers); use a `Decodable in Protobuf`")
+
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+    val numbers: List[Int] = fieldNumbersOf(classSymbol).get
+    val plans: List[Plan] = fieldTypes.map(planFor(_, cache))
+
+    def body
+      ( tactic: Expr[Tactic[ProtobufError]],
+        parser: Expr[ProtobufParser] )
+    :   Expr[product] =
+
+      val owner = Symbol.spliceOwner
+
+      val slots = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+      val seens = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      def zero(fieldType: TypeRepr): Term =
+        if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+        else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+        else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+        else if fieldType =:= TypeRepr.of[Float] then Literal(FloatConstant(0.0f))
+        else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+        else fieldType.asType match
+          case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+      val slotDefs = List.range(0, arity).map: index =>
+        ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+      val seenDefs = List.range(0, arity).map: index =>
+        ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val unit = Literal(UnitConstant())
+
+      // The proto3 zero value of a builtin scalar — what an absent field
+      // decodes to on the AST path (`decoded(Protobuf.Absent)`).
+      def zeroValue(kind: Int): Expr[Any] = kind match
+        case KInt     => Expr(0)
+        case KLong    => Expr(0L)
+        case KBoolean => Expr(false)
+        case KDouble  => Expr(0.0)
+        case KFloat   => Expr(0.0f)
+        case KText    => '{ Text("") }
+        case KData    => '{ IArray.empty[Byte] }
+
+      // One scalar field read, dispatching on the tag's wire code — the
+      // parser handles the natural fast path and payload-window fallback.
+      def scalarRead(kind: Int, code: Expr[Int]): Expr[Any] = kind match
+        case KInt     => '{ $parser.directLong($code)(using $tactic).toInt }
+        case KLong    => '{ $parser.directLong($code)(using $tactic) }
+        case KBoolean => '{ $parser.directLong($code)(using $tactic) != 0L }
+        case KDouble  => '{ $parser.directDouble($code)(using $tactic) }
+        case KFloat   => '{ $parser.directFloat($code)(using $tactic) }
+        case KText    => '{ Text($parser.directString($code)(using $tactic)) }
+        case KData    => '{ $parser.directData($code)(using $tactic) }
+
+      // One packed element read, in place within the packed run's window.
+      def packedRead(kind: Int): Expr[Any] = kind match
+        case KInt     => '{ $parser.directVarint()(using $tactic).toInt }
+        case KLong    => '{ $parser.directVarint()(using $tactic) }
+        case KBoolean => '{ $parser.directVarint()(using $tactic) != 0L }
+        case KDouble  => '{ java.lang.Double.longBitsToDouble($parser.directFixed64()(using $tactic)) }
+        case KFloat   => '{ java.lang.Float.intBitsToFloat($parser.directFixed32()(using $tactic)) }
+
+      // Per-field gathering state: a typed builder for `Gather` fields, a
+      // wire-value buffer for `Seam` fields.
+      val builders: Map[Int, Symbol] =
+        List.range(0, arity).flatMap: index =>
+          plans(index) match
+            case Plan.Gather(_, elementType0) =>
+              val elementType = elementType0.asInstanceOf[TypeRepr]
+
+              val builderType =
+                TypeRepr.of[scm.Builder].appliedTo(List(elementType, fieldTypes(index)))
+
+              Some(index -> Symbol.newVal
+                (owner, "builder"+index, builderType, Flags.EmptyFlags, Symbol.noSymbol))
+
+            case _ =>
+              None
+        . toMap
+
+      val buffers: Map[Int, Symbol] =
+        List.range(0, arity).flatMap: index =>
+          plans(index) match
+            case Plan.Seam =>
+              Some(index -> Symbol.newVal
+                ( owner, "buffer"+index, TypeRepr.of[scm.ListBuffer[Protobuf]],
+                  Flags.EmptyFlags, Symbol.noSymbol ))
+
+            case _ =>
+              None
+        . toMap
+
+      val builderDefs: List[Statement] = List.range(0, arity).flatMap: index =>
+        plans(index) match
+          case Plan.Gather(_, elementType0) =>
+            val elementType = elementType0.asInstanceOf[TypeRepr]
+
+            (elementType.asType, fieldTypes(index).asType) match
+              case ('[element], '[fieldType]) =>
+                val rhs: Expr[Any] =
+                  '{ infer[scala.collection.Factory[element, fieldType]].newBuilder }
+
+                Some(ValDef(builders(index), Some(rhs.asTerm)))
+
+          case _ =>
+            None
+
+      val bufferDefs: List[Statement] = List.range(0, arity).flatMap: index =>
+        plans(index) match
+          case Plan.Seam =>
+            Some(ValDef(buffers(index), Some('{ scm.ListBuffer[Protobuf]() }.asTerm)))
+
+          case _ =>
+            None
+
+      // Per-field local defs, shaped for the JIT: each field's read (or
+      // per-occurrence append) is emitted once and *called* from its
+      // dispatch arm.
+      val readDefs: Map[Int, Symbol] =
+        List.range(0, arity).flatMap: index =>
+          plans(index) match
+            case Plan.Leaf(_) | Plan.Nested(_) | Plan.NestedRuntime(_) | Plan.OptionalLeaf(_)
+               | Plan.OptionalNested(_, _) =>
+              Some(index -> Symbol.newMethod
+                ( owner, "readField"+index,
+                  MethodType(List("code"))(_ => List(TypeRepr.of[Int]),
+                    _ => fieldTypes(index)) ))
+
+            case Plan.Gather(_, _) =>
+              Some(index -> Symbol.newMethod
+                ( owner, "readOccurrence"+index,
+                  MethodType(List("code"))(_ => List(TypeRepr.of[Int]),
+                    _ => TypeRepr.of[Unit]) ))
+
+            case Plan.Seam =>
+              None
+        . toMap
+
+      val readDefDefs: List[Statement] = List.range(0, arity).flatMap: index =>
+        readDefs.get(index).map: method =>
+          DefDef(method, params =>
+            val code = params.head.head.asInstanceOf[Term].asExprOf[Int]
+
+            val rhs: Expr[Any] = plans(index) match
+              case Plan.Leaf(kind) =>
+                scalarRead(kind, code)
+
+              case Plan.OptionalLeaf(kind) =>
+                scalarRead(kind, code)
+
+              case Plan.Nested(instance) =>
+                fieldTypes(index).asType match
+                  case '[fieldType] =>
+                    '{
+                      val saved = $parser.directEnterField($code)(using $tactic)
+
+                      val result: fieldType =
+                        ${ instance.asInstanceOf[Inlinable { type Self = fieldType }]
+                             . parse(reader) }
+
+                      $parser.directLeaveField(saved)
+                      result
+                    }
+
+              case Plan.NestedRuntime(parsable) =>
+                fieldTypes(index).asType match
+                  case '[fieldType] =>
+                    val instance = parsable.asInstanceOf[Expr[Any]]
+
+                    '{
+                      val saved = $parser.directEnterField($code)(using $tactic)
+
+                      val result: fieldType =
+                        Protobuf.Parsable.parseField[fieldType]
+                          ($instance.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef])
+
+                      $parser.directLeaveField(saved)
+                      result
+                    }
+
+              case Plan.OptionalNested(instance, innerType0) =>
+                innerType0.asInstanceOf[TypeRepr].asType match
+                  case '[innerType] =>
+                    '{
+                      val saved = $parser.directEnterField($code)(using $tactic)
+
+                      val result: innerType =
+                        ${ instance.asInstanceOf[Inlinable { type Self = innerType }]
+                             . parse(reader) }
+
+                      $parser.directLeaveField(saved)
+                      result
+                    }
+
+              case Plan.Gather(element, elementType0) =>
+                val elementType = elementType0.asInstanceOf[TypeRepr]
+
+                (elementType.asType, fieldTypes(index).asType) match
+                  case ('[element], '[fieldType]) =>
+                    val builder =
+                      Ref(builders(index)).asExprOf[scm.Builder[element, fieldType]]
+
+                    element match
+                      case Elem.Scalar(kind) =>
+                        val natural = naturalCode(kind)
+
+                        '{
+                          if $code == 2 && ${Expr(natural)} != 2 then
+                            val saved = $parser.directEnterField(2)(using $tactic)
+
+                            while !$parser.directAtLimit do
+                              $builder += ${ packedRead(kind).asExprOf[element] }
+
+                            $parser.directLeaveField(saved)
+                          else $builder += ${ scalarRead(kind, code).asExprOf[element] }
+                        }
+
+                      case Elem.Chunk(kind) =>
+                        '{ $builder += ${ scalarRead(kind, code).asExprOf[element] } }
+
+                      case Elem.Nested(instance0, _) =>
+                        val instance =
+                          instance0.asInstanceOf[Inlinable { type Self = element }]
+
+                        '{
+                          val saved = $parser.directEnterField($code)(using $tactic)
+                          val result: element = ${ instance.parse(reader) }
+                          $parser.directLeaveField(saved)
+                          $builder += result
+                        }
+
+                      case Elem.Runtime(parsable) =>
+                        val instance = parsable.asInstanceOf[Expr[Any]]
+
+                        '{
+                          val saved = $parser.directEnterField($code)(using $tactic)
+
+                          val result: element =
+                            Protobuf.Parsable.parseField[element]
+                              ($instance.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef])
+
+                          $parser.directLeaveField(saved)
+                          $builder += result
+                        }
+
+                      case Elem.Seam =>
+                        val occurrence =
+                          seamDecode[element]('{ $parser.directWire($code)(using $tactic) })
+
+                        '{ $builder += $occurrence }
+
+              case Plan.Seam =>
+                '{ () }
+
+            Some(rhs.asTerm.changeOwner(method)))
+
+      // The dispatch arms, one per field number. Scalars and nested values
+      // overwrite their slot (last occurrence wins, as the AST accessors'
+      // `single`); gathered fields append.
+      def arms(code: Expr[Int]): List[CaseDef] = List.range(0, arity).map: index =>
+        val body: Term = plans(index) match
+          case Plan.Leaf(_) | Plan.Nested(_) | Plan.NestedRuntime(_) | Plan.OptionalLeaf(_)
+             | Plan.OptionalNested(_, _) =>
+            Block
+              ( List
+                  ( Assign
+                      ( Ref(slots(index)),
+                        Apply(Ref(readDefs(index)), List(code.asTerm)) ),
+                    Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                unit )
+
+          case Plan.Gather(_, _) =>
+            Block
+              ( List
+                  ( Apply(Ref(readDefs(index)), List(code.asTerm)),
+                    Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                unit )
+
+          case Plan.Seam =>
+            val buffer = Ref(buffers(index)).asExprOf[scm.ListBuffer[Protobuf]]
+
+            Block
+              ( List
+                  ( '{ $buffer += $parser.directWire($code)(using $tactic) }.asTerm,
+                    Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                unit )
+
+        CaseDef(Literal(IntConstant(numbers(index))), None, body)
+
+      def fallthrough(code: Expr[Int]) =
+        CaseDef(Wildcard(), None, '{ $parser.directSkipField($code)(using $tactic) }.asTerm)
+
+      // The record loop: one tag per iteration, dispatching on the field
+      // number until the window is exhausted.
+      val step: Term =
+        val tag = Symbol.newVal(owner, "tag", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+        val code = Symbol.newVal(owner, "code", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+        val tagRef = Ref(tag).asExprOf[Int]
+        val codeRef = Ref(code).asExprOf[Int]
+
+        Block
+          ( List
+              ( ValDef(tag, Some('{ $parser.directTag()(using $tactic) }.asTerm)),
+                ValDef(code, Some('{ $tagRef & 7 }.asTerm)) ),
+            Match('{ $tagRef >>> 3 }.asTerm, arms(codeRef) ::: List(fallthrough(codeRef))) )
+
+      val loop: List[Statement] =
+        List(While('{ !$parser.directAtLimit }.asTerm, step))
+
+      // The declared-default-then-absent expression per field.
+      def defaultOr(index: Int, absent: Expr[Any]): Expr[Any] =
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            '{
+              val declared = wisteria.internal.default[product, fieldType](${Expr(index)})
+
+              if !declared.absent then declared.asInstanceOf[fieldType]
+              else ${ absent.asExprOf[fieldType] }
+            }
+
+      def planAbsent(index: Int, tactic: Expr[Tactic[ProtobufError]]): Expr[Any] =
+        plans(index) match
+          case Plan.Leaf(kind) =>
+            zeroValue(kind)
+
+          case Plan.OptionalLeaf(_) | Plan.OptionalNested(_, _) =>
+            '{ vacuous.Unset }
+
+          case Plan.Nested(instance) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                instance.asInstanceOf[Inlinable { type Self = fieldType }].absent(tactic)
+
+          // An absent runtime-parsed message reads as an empty message —
+          // `decoded(Absent)`'s all-fields-absent record.
+          case Plan.NestedRuntime(parsable) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                val instance = parsable.asInstanceOf[Expr[Any]]
+
+                '{
+                  val window = $parser.directWindow(0, 0)
+
+                  val result: fieldType =
+                    Protobuf.Parsable.parseField[fieldType]
+                      ($instance.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef])
+
+                  $parser.directRestore(window)
+                  result
+                }
+
+          case Plan.Gather(_, _) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                '{ ${ Ref(builders(index)).asExpr }
+                     . asInstanceOf[scm.Builder[?, fieldType]].result() }
+
+          case Plan.Seam =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                seamDecode[fieldType]('{ Protobuf.Absent })
+
+      // Finalize each slot: missing fields take their declared default or
+      // proto3 absent value; gathered fields collect their builder; seam
+      // fields decode their gathered occurrences exactly as the AST path
+      // decodes `Repeated(values)`.
+      val finalizers: List[Term] = List.range(0, arity).map: index =>
+        val seen = Ref(seens(index)).asExprOf[Boolean]
+
+        plans(index) match
+          case Plan.Leaf(_) | Plan.Nested(_) | Plan.NestedRuntime(_) | Plan.OptionalLeaf(_)
+             | Plan.OptionalNested(_, _) =>
+            If
+              ( '{ !$seen }.asTerm,
+                Assign
+                  ( Ref(slots(index)),
+                    defaultOr(index, planAbsent(index, tactic)).asTerm ),
+                unit )
+
+          case Plan.Gather(_, _) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                val collected =
+                  '{ ${ Ref(builders(index)).asExpr }
+                       . asInstanceOf[scm.Builder[?, fieldType]].result() }
+
+                Assign
+                  ( Ref(slots(index)),
+                    '{
+                      if $seen then $collected
+                      else ${ defaultOr(index, collected).asExprOf[fieldType] }
+                    }.asTerm )
+
+          case Plan.Seam =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                val buffer = Ref(buffers(index)).asExprOf[scm.ListBuffer[Protobuf]]
+
+                val absent: Expr[fieldType] =
+                  defaultOr(index, seamDecode[fieldType]('{ Protobuf.Absent }))
+                  . asExprOf[fieldType]
+
+                Assign
+                  ( Ref(slots(index)),
+                    '{
+                      if $seen then
+                        ${ seamDecode[fieldType]('{ Protobuf.Repeated($buffer.toList) }) }
+                      else $absent
+                    }.asTerm )
+
+      val construct: Term =
+        Apply(Select(New(Inferred(tpe)), ctor), slots.map { slot => Ref(slot) })
+
+      Block
+        ( slotDefs ::: seenDefs ::: builderDefs ::: bufferDefs ::: readDefDefs ::: loop
+            ::: finalizers,
+          construct )
+      . asExprOf[product]
+
+    '{
+      val tactic = infer[Tactic[ProtobufError]]
+      val parser = $reader.rawParser.asInstanceOf[ProtobufParser]
+      ${ body('tactic, 'parser) }
+    }
+
+  // A wholly-absent message — what `decoded(Protobuf.Absent)` produces on
+  // the AST path: every field takes its declared default or proto3 absent
+  // value.
+  private[locomotion] def productAbsent[product: Type]
+    (tactic: Expr[Tactic[ProtobufError]])
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val cache: Cache = Cache()
+    val tpe = TypeRepr.of[product].dealias
+    cache.active += tpe.show
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+    val plans: List[Plan] = fieldTypes.map(planFor(_, cache))
+
+    val values: List[Term] = List.range(0, arity).map: index =>
+      fieldTypes(index).asType match
+        case '[fieldType] =>
+          val absent: Expr[Any] = plans(index) match
+            case Plan.Leaf(kind) => kind match
+              case KInt     => Expr(0)
+              case KLong    => Expr(0L)
+              case KBoolean => Expr(false)
+              case KDouble  => Expr(0.0)
+              case KFloat   => Expr(0.0f)
+              case KText    => '{ Text("") }
+              case KData    => '{ IArray.empty[Byte] }
+
+            case Plan.Nested(instance) =>
+              instance.asInstanceOf[Inlinable { type Self = fieldType }].absent(tactic)
+
+            case Plan.OptionalLeaf(_) | Plan.OptionalNested(_, _) =>
+              '{ vacuous.Unset }
+
+            case Plan.Gather(_, elementType0) =>
+              val elementType = elementType0.asInstanceOf[TypeRepr]
+
+              elementType.asType match
+                case '[element] =>
+                  '{ infer[scala.collection.Factory[element, fieldType]].newBuilder.result() }
+
+            case Plan.Seam =>
+              seamDecode[fieldType]('{ Protobuf.Absent })
+
+          '{
+            val declared = wisteria.internal.default[product, fieldType](${Expr(index)})
+
+            if !declared.absent then declared.asInstanceOf[fieldType]
+            else ${ absent.asExprOf[fieldType] }
+          }.asTerm
+
+    Apply(Select(New(Inferred(tpe)), ctor), values).asExprOf[product]
+
+  // ── The sum generator ──────────────────────────────────────────────────
+  // A oneof: the whole window is scanned once — recording, for the lowest
+  // variant number present, the extent of its last occurrence — then the
+  // chosen occurrence is re-entered and parsed as its variant message,
+  // exactly the AST disjunction's `map.contains(index + 1)` scan and
+  // `Repeated(...)`'s last-occurrence payload.
+  private[locomotion] def sumBody[sum: Type](reader: Expr[ProtobufReader])(using Quotes)
+  :   Expr[sum] =
+
+    sumBody[sum](reader, Cache())
+
+  private def sumBody[sum: Type](reader: Expr[ProtobufReader], cache: Cache)(using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[sum].dealias.show
+
+    try sumBody0[sum](reader, cache)
+    finally cache.active -= TypeRepr.of[sum].dealias.show
+
+  private def sumBody0[sum: Type](reader: Expr[ProtobufReader], cache: Cache)(using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    val variants = sumVariants(TypeRepr.of[sum].dealias).getOrElse:
+      report.errorAndAbort
+        (s"locomotion: ${TypeRepr.of[sum].show} is not an inlinable oneof (a non-generic "+
+          "sealed type whose variants are all case classes)")
+
+    val arity = variants.length
+
+    def dispatch(index: Int, chosen: Expr[Int], tactic: Expr[Tactic[ProtobufError]])
+    :   Expr[sum] =
+
+      if index == arity then
+        '{ abort(ProtobufError(ProtobufError.Reason.MissingField(0)))(using $tactic) }
+      else variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"locomotion: no Inlinable for variant ${variants(index)(0)}")
+          . asInstanceOf[Inlinable { type Self = variantType }]
+
+          '{
+            if $chosen == ${Expr(index + 1)} then
+              def parseVariant(): variantType = ${ instance.parse(reader) }
+              parseVariant()
+            else ${ dispatch(index + 1, chosen, tactic) }
+          }
+
+    '{
+      val tactic = infer[Tactic[ProtobufError]]
+      val parser = $reader.rawParser.asInstanceOf[ProtobufParser]
+      var chosen = Int.MaxValue
+      var chosenStart = 0
+      var chosenEnd = 0
+
+      while !parser.directAtLimit do
+        val tag = parser.directTag()(using tactic)
+        val number = tag >>> 3
+        val saved = parser.directEnterField(tag & 7)(using tactic)
+
+        if number >= 1 && number <= ${Expr(arity)} && number <= chosen then
+          chosen = number
+          chosenStart = parser.directMark
+          chosenEnd = parser.directBoundary
+
+        parser.directLeaveField(saved)
+
+      if chosen == Int.MaxValue
+      then abort(ProtobufError(ProtobufError.Reason.MissingField(0)))(using tactic)
+      else
+        val outer = parser.directWindow(chosenStart, chosenEnd)
+        val result: sum = ${ dispatch(0, 'chosen, 'tactic) }
+        parser.directRestore(outer)
+        result
+    }
+
+  // ── The entry macro ────────────────────────────────────────────────────
+  def inlinableParsable[value: Type](using Quotes): Expr[value is Protobuf.Parsable] =
+    import quotes.reflect.*
+
+    val cache: Cache = Cache()
+
+    val root: Inlinable = resolve[value](cache).getOrElse:
+      report.errorAndAbort
+        (s"locomotion: no Inlinable instance for ${TypeRepr.of[value].show}, and it is not "+
+          "an inlinable message or oneof; use a `Decodable in Protobuf`")
+
+    if root.isInstanceOf[Inlinable.IterableInlinable[?]] then
+      report.errorAndAbort
+        (s"locomotion: ${TypeRepr.of[value].show} is a collection; a Protobuf message is the "+
+          "unit of direct parsing")
+
+    val instance = root.asInstanceOf[Inlinable { type Self = value }]
+
+    '{
+      // Sealed per the codec-thunk pattern: the generated body resolves its
+      // capabilities where it is spliced.
+      caps.unsafe.unsafeAssumePure:
+        new Protobuf.Parsable.Direct[value]:
+          protected def parseCarrier(reader0: AnyRef): value =
+            // The reader is never bound as a typed local: a capability
+            // class cannot be quoted into a pure hole, so every use casts
+            // from the neutral carrier afresh — the rim-reassertion
+            // pattern, at each use.
+            ${ instance.parse('{ reader0.asInstanceOf[ProtobufReader] }) }
+    }

--- a/lib/locomotion/src/test/locomotion_test.scala
+++ b/lib/locomotion/src/test/locomotion_test.scala
@@ -68,6 +68,8 @@ case class Counts(@field(1) counts: Map[Text, Int]) derives CanEqual
 
 // Recursion through a collection (#1429) and a generic product used over a recursive type.
 case class Tree(@field(1) value: Text, @field(2) children: List[Tree]) derives CanEqual
+
+case class Defaulted(@field(1) a: Int, @field(2) b: Int = 7) derives CanEqual
 case class Boxed[value](@field(1) value: value) derives CanEqual
 
 object Tests extends Suite(m"Locomotion Protobuf Tests"):
@@ -262,3 +264,101 @@ object Tests extends Suite(m"Locomotion Protobuf Tests"):
       test(m"an absent field number is a no-op"):
         wrapper.lens(_(Sen) = Point(7, 8)).as[Wrapper]
       . assert(_ == Wrapper(Point(3, 4), t"origin"))
+
+    suite(m"Direct parsing (Inlinable)"):
+      given (Point is Protobuf.Parsable) = Inlinable.parsable[Point]
+      given (Person is Protobuf.Parsable) = Inlinable.parsable[Person]
+      given (Wrapper is Protobuf.Parsable) = Inlinable.parsable[Wrapper]
+      given (Sparse is Protobuf.Parsable) = Inlinable.parsable[Sparse]
+      given (Tags is Protobuf.Parsable) = Inlinable.parsable[Tags]
+      given (Numbers is Protobuf.Parsable) = Inlinable.parsable[Numbers]
+      given (MaybeName is Protobuf.Parsable) = Inlinable.parsable[MaybeName]
+      given (Shape is Protobuf.Parsable) = Inlinable.parsable[Shape]
+      given (Typed is Protobuf.Parsable) = Inlinable.parsable[Typed]
+      given (Counts is Protobuf.Parsable) = Inlinable.parsable[Counts]
+      given (Tree is Protobuf.Parsable) = Inlinable.parsable[Tree]
+      given (Defaulted is Protobuf.Parsable) = Inlinable.parsable[Defaulted]
+
+      def encoded[value: Encodable in Protobuf](value: value): Data = value.in[Protobuf].encode
+
+      test(m"a flat message reads directly from bytes"):
+        encoded(Person(t"Alice", 30)).read[Person in Protobuf]
+      . assert(_ == Person(t"Alice", 30))
+
+      test(m"a nested message inlines through its own generated parser"):
+        encoded(Wrapper(Point(3, 4), t"origin")).read[Wrapper in Protobuf]
+      . assert(_ == Wrapper(Point(3, 4), t"origin"))
+
+      test(m"sparse @field numbers dispatch correctly"):
+        encoded(Sparse(9, t"x")).read[Sparse in Protobuf]
+      . assert(_ == Sparse(9, t"x"))
+
+      test(m"repeated strings gather in stream order"):
+        encoded(Tags(List(t"a", t"b", t"c"))).read[Tags in Protobuf]
+      . assert(_ == Tags(List(t"a", t"b", t"c")))
+
+      test(m"a packed repeated field reads its run in place"):
+        val packed = IArray[Byte](0x0a, 0x06, 0x03, 0x8e.toByte, 0x02, 0x9e.toByte, 0xa7.toByte, 0x05)
+        packed.read[Numbers in Protobuf]
+      . assert(_ == Numbers(List(3, 270, 86942)))
+
+      test(m"unpacked occurrences of a packable element still gather"):
+        // Two unpacked varint occurrences of field 1: 3 and 270.
+        val unpacked = IArray[Byte](0x08, 0x03, 0x08, 0x8e.toByte, 0x02)
+        unpacked.read[Numbers in Protobuf]
+      . assert(_ == Numbers(List(3, 270)))
+
+      test(m"the last occurrence of a scalar field wins"):
+        // x=1, x=9, y=2.
+        val bytes = IArray[Byte](0x08, 0x01, 0x08, 0x09, 0x10, 0x02)
+        bytes.read[Point in Protobuf]
+      . assert(_ == Point(9, 2))
+
+      test(m"an unknown field number is skipped whole"):
+        // Field 5 (varint 1), then x=3, y=4.
+        val bytes = IArray[Byte](0x28, 0x01, 0x08, 0x03, 0x10, 0x04)
+        bytes.read[Point in Protobuf]
+      . assert(_ == Point(3, 4))
+
+      test(m"a missing scalar field takes its proto3 zero"):
+        // Only x=3.
+        IArray[Byte](0x08, 0x03).read[Point in Protobuf]
+      . assert(_ == Point(3, 0))
+
+      test(m"a missing field with a declared default takes it"):
+        IArray[Byte](0x08, 0x03).read[Defaulted in Protobuf]
+      . assert(_ == Defaulted(3, 7))
+
+      test(m"an empty message reads as all-absent"):
+        IArray[Byte]().read[Point in Protobuf]
+      . assert(_ == Point(0, 0))
+
+      test(m"a set optional bridges through its Decodable"):
+        encoded(MaybeName(t"set")).read[MaybeName in Protobuf]
+      . assert(_ == MaybeName(t"set"))
+
+      test(m"an unset optional reads back to Unset"):
+        encoded(MaybeName(Unset)).read[MaybeName in Protobuf]
+      . assert(_ == MaybeName(Unset))
+
+      test(m"the Circle variant of a oneof round-trips"):
+        encoded(Shape.Circle(5): Shape).read[Shape in Protobuf]
+      . assert(_ == Shape.Circle(5))
+
+      test(m"the Rectangle variant of a oneof round-trips"):
+        encoded(Shape.Rectangle(3, 4): Shape).read[Shape in Protobuf]
+      . assert(_ == Shape.Rectangle(3, 4))
+
+      test(m"typed integers bridge through their Decodables"):
+        val typed = Typed(7.bits.u32, 8L.bits.u64, -3.bits.s32, -4L.bits.s64, 5.bits, 6L.bits)
+        encoded(typed).read[Typed in Protobuf]
+      . assert(_ == Typed(7.bits.u32, 8L.bits.u64, -3.bits.s32, -4L.bits.s64, 5.bits, 6L.bits))
+
+      test(m"a map field bridges through the entry-message Decodable"):
+        encoded(Counts(Map(t"a" -> 1, t"b" -> 2))).read[Counts in Protobuf]
+      . assert(_ == Counts(Map(t"a" -> 1, t"b" -> 2)))
+
+      test(m"a recursive type degrades its recursive field to the seam"):
+        val tree = Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil)))))
+        encoded(tree).read[Tree in Protobuf]
+      . assert(_ == Tree(t"root", List(Tree(t"a", Nil), Tree(t"b", List(Tree(t"c", Nil))))))

--- a/lib/stratiform/src/bench/stratiform.Benchmarks.scala
+++ b/lib/stratiform/src/bench/stratiform.Benchmarks.scala
@@ -61,6 +61,20 @@ import vacuous.*
 // effect of the §19.5 schema-driven recovery overhead can be read
 // directly off the table.
 
+// The BinTEL decode corpus: an order book mirroring the crossparse corpus's
+// shape, without its sum — a sum in field position derives to an
+// unresolvable schema Reference, which BinTEL's AST path cannot decode
+// either. Top-level, so the schema derivation and the generated parser see
+// ordinary class symbols.
+case class BLineItem(sku: Text, description: Text, quantity: Int, price: Double, taxed: Boolean)
+case class BCustomer(id: Long, name: Text, email: Text, region: Text)
+
+case class BOrder
+  ( reference: Text, customer: BCustomer, items: List[BLineItem], priority: Boolean,
+    discount: Double )
+
+case class BOrders(orders: List[BOrder])
+
 object Benchmarks extends Suite(m"Stratiform parser benchmarks"):
   sealed trait Information extends Dimension
   sealed trait Bytes[Power <: Nat] extends Units[Power, Information]
@@ -114,8 +128,49 @@ object Benchmarks extends Suite(m"Stratiform parser benchmarks"):
   lazy val example7Schema: Tels = loadSchema("example7.schema.tel")
   lazy val example8Schema: Tels = loadSchema("example8.schema.tel")
 
+  def lineItem(order: Int, item: Int): BLineItem =
+    BLineItem
+      ( sku         = t"SKU-$order-$item",
+        description = t"component-${(order*7 + item*3) % 20}-assembly",
+        quantity    = (order + item) % 9 + 1,
+        price       = ((order*13 + item*7) % 400).toDouble + 0.25*(item % 4),
+        taxed       = (order + item) % 2 == 0 )
+
+  def order(index: Int): BOrder =
+    val regions = List(t"north", t"south", t"east", t"west")
+
+    BOrder
+      ( reference = t"ORD-2026-${1000 + index}",
+        customer  = BCustomer
+          ( id     = 10000L + index,
+            name   = t"customer-$index",
+            email  = t"user$index@example.com",
+            region = regions(index % 4) ),
+        items     = List.tabulate(6)(lineItem(index, _)),
+        priority  = index % 3 == 0,
+        discount  = 0.25*(index % 3) )
+
+  lazy val bintelCorpus: BOrders = BOrders(List.tabulate(12)(order(_)))
+  lazy val bintelData: Data = bintelCorpus.bintel
+
+  given bintelParsable: (BOrders is Bintel.Parsable) = BintelInlinable.parsable[BOrders]
+
+  def decodeBintelAst(): BOrders = Bintel.read[BOrders](bintelData)
+  def decodeBintelInlined(): BOrders = Bintel.parse[BOrders](bintelData)
+
   def run(): Unit =
     val bench = Bench()
+
+    assert(decodeBintelInlined() == bintelCorpus, "BinTEL inlined decode disagrees")
+    assert(decodeBintelAst() == bintelCorpus, "BinTEL AST decode disagrees")
+
+    suite(m"Decode a BinTEL order corpus to case classes"):
+      bench(m"BinTEL inlined")
+        (target = 1*Second, warmups = 15, baseline = Baseline(compare = Min)):
+        '{ stratiform.Benchmarks.decodeBintelInlined() }
+
+      bench(m"BinTEL via AST")(target = 1*Second):
+        '{ stratiform.Benchmarks.decodeBintelAst() }
 
     suite(m"Example 1 — web-app servlet config"):
       val size = example1Bytes.length*Byte

--- a/lib/stratiform/src/binary/stratiform.Bintel.scala
+++ b/lib/stratiform/src/binary/stratiform.Bintel.scala
@@ -436,6 +436,43 @@ object Bintel:
     if compounds.nil then IArray.empty
     else IArray(Tel.Block(IArray.empty, Unset, compounds, 0))
 
+  object Parsable:
+    // The base of generated parsers: generated code is capture-erased, so
+    // the body receives the reader as a neutral carrier, and the capability
+    // is asserted here at the rim — the audited point — like the reader's
+    // own accessors. (A generated override of `parse` itself would narrow
+    // the trait's `BintelReader^` parameter to a pure type, which capture
+    // checking rejects at the instantiation site.)
+    abstract class Direct[value] extends Bintel.Parsable:
+      type Self = value
+
+      protected def parseCarrier(reader: AnyRef): value
+
+      def parse(reader: BintelReader^): value = parseCarrier(reader.asInstanceOf[AnyRef])
+
+  // The direct-parsing counterpart of `Bintel.read`: consumes elements
+  // straight off the body bytes through a `BintelReader`, so neither the
+  // `Tel.Element` tree, nor its `Tel` presentation, nor the text-format
+  // decode that follows is materialized. `Parsable` is the opt-in surface:
+  // `Bintel.Inlinable.parsable` generates instances whose keyword-index
+  // dispatch is compiled from the value's statically-derived schema.
+  // BinTEL has no per-subtree bridge back to the AST path, so shapes the
+  // generator does not support stay on `Bintel.read`.
+  trait Parsable extends prepositional.Typeclass:
+    def parse(reader: BintelReader^): Self
+
+  // Decode BinTEL body bytes directly to a typed value through the value's
+  // `Bintel.Parsable`. Trailing bytes are rejected exactly as `decode`.
+  def parse[value](data: Data)
+    ( using parsable: (value is Bintel.Parsable)^ )
+    ( using tactic: Tactic[BintelError] )
+  :   value =
+
+    val parser = BintelParser(data)
+    val result = parsable.parse(BintelReader(parser, tactic))
+    if parser.offset != data.length then abort(BintelError(BintelError.Reason.TrailingBytes))
+    result
+
   // Decode BinTEL body bytes to a typed value, deriving the schema from the value's type
   // — the inverse of `value.bintel`.
   def read[value: Tel.Decodable](data: Data)

--- a/lib/stratiform/src/binary/stratiform.BintelParser.scala
+++ b/lib/stratiform/src/binary/stratiform.BintelParser.scala
@@ -1,0 +1,103 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import contingency.*
+
+// Reads BinTEL body bytes for direct parsing (`Bintel.Parsable`): the
+// document structure is fully count-driven and self-delimiting, so the
+// parser is a bare offset over the input. Each method mirrors one step of
+// `Bintel.decode`'s recursive descent — the varint reads carry the same
+// `VarintError`/`UnexpectedEoi` mapping, and scalar payloads the same
+// truncation check — so failures agree with the AST decoder exactly.
+//
+// The class is public — generated parsers, spliced into user modules, bind
+// it once per read and step through its direct rim — but only stratiform's
+// read path can construct one.
+final class BintelParser private[stratiform] (input: Data):
+  private[stratiform] val data: Array[Byte] = input.asInstanceOf[Array[Byte]]
+  private[stratiform] var offset: Int = 0
+
+  def directVarint()(using Tactic[BintelError]): Long =
+    if offset >= data.length then abort(BintelError(BintelError.Reason.UnexpectedEoi))
+
+    var result = 0L
+    var shift = 0
+    var continue = true
+
+    while continue do
+      if offset >= data.length then abort(BintelError(BintelError.Reason.VarintError))
+      val byte = data(offset) & 0xff
+
+      if shift >= 64 || (shift == 63 && (byte & 0x7f) > 1)
+      then abort(BintelError(BintelError.Reason.VarintError))
+
+      offset += 1
+      result |= (byte.toLong & 0x7f) << shift
+      shift += 7
+      if (byte & 0x80) == 0 then continue = false
+
+    result
+
+  // A child count or keyword index, bounded to `Int`.
+  def directCount()(using Tactic[BintelError]): Int =
+    val value = directVarint()
+
+    if value < 0 || value > Int.MaxValue
+    then abort(BintelError(BintelError.Reason.VarintError))
+
+    value.toInt
+
+  // One scalar payload: `length` varint then UTF-8 bytes, exactly as
+  // `decodeElement`'s Scalar case reads it.
+  def directScalar()(using Tactic[BintelError]): String =
+    val length = directCount()
+
+    if offset + length > data.length
+    then abort(BintelError(BintelError.Reason.ValueTruncated))
+
+    val result = java.lang.String(data, offset, length, java.nio.charset.StandardCharsets.UTF_8)
+    offset += length
+    result
+
+  // Skips one scalar payload without materializing it.
+  def directSkipScalar()(using Tactic[BintelError]): Unit =
+    val length = directCount()
+
+    if offset + length > data.length
+    then abort(BintelError(BintelError.Reason.ValueTruncated))
+
+    offset += length
+
+  def directAtEnd: Boolean = offset >= data.length

--- a/lib/stratiform/src/binary/stratiform.BintelReader.scala
+++ b/lib/stratiform/src/binary/stratiform.BintelReader.scala
@@ -1,0 +1,89 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import anticipation.*
+import contingency.*
+import vacuous.*
+
+object BintelReader:
+  // Only stratiform's read path (`Bintel.parse`) constructs readers, so the
+  // exclusivity of the wrapped parser and the resolution scope of the
+  // carried tactic are preserved by construction. The wrapped tactic
+  // travels as a neutral carrier (jacinta's `JsonReader` pattern): the
+  // field stays pure, and each accessor reasserts the type at the rim —
+  // the audited point.
+  private[stratiform] def apply(parser: BintelParser, tactic: Tactic[BintelError])
+  :   BintelReader^ =
+
+    new BintelReader(parser, tactic.asInstanceOf[AnyRef])
+
+// The public, restricted rim of the BinTEL body parser, handed to
+// `Bintel.Parsable` instances so they can consume elements straight off the
+// input without the intermediate `Tel.Element` tree, its `Tel`
+// presentation, or the text-format decode that follows. The structure is
+// count-driven: a `parse` call is invoked positioned at a struct body (a
+// child count, then that many `keyword-index`-prefixed elements) and must
+// consume it in full. The reader carries its own `Tactic[BintelError]`, so
+// malformed input aborts through the read call's ambient tactic; *decode*
+// errors (mistyped or absent values) accrue through the read site's
+// `Tactic[TelError]` and `Foci`, exactly as the AST path's text-format
+// decode.
+//
+// An exclusive, stateful capability, like the parser it wraps: it is owned
+// by one `Bintel.Parsable.parse` call at a time, for the duration of that
+// call, and nothing of it may be retained afterwards.
+final class BintelReader private (parser0: AnyRef, tactic0: AnyRef)
+extends caps.ExclusiveCapability, caps.Stateful:
+  private inline def parser: BintelParser = parser0.asInstanceOf[BintelParser]
+
+  // The sealed conduit for generated parsers: package-private, so the only
+  // path to the wrapped capabilities from outside stratiform is through the
+  // accessor the compiler synthesizes for stratiform's own macro-generated
+  // splices — hand-written code cannot name it. Generated code binds the
+  // parser once per read and steps through `BintelParser`'s direct rim
+  // without this class's per-step forwarders.
+  private[stratiform] def rawParser: AnyRef = parser0
+  private[stratiform] def rawTactic: AnyRef = tactic0
+  private inline def tactic: Tactic[BintelError] = tactic0.asInstanceOf[Tactic[BintelError]]
+
+  // ── The struct-body steps: the child count, then per child a keyword
+  // index — the flat position of the member it fills, matching the
+  // members' declaration order — and the member-typed payload. ──
+  update def count(): Int = parser.directCount()(using tactic)
+  update def index(): Int = parser.directCount()(using tactic)
+
+  // ── One scalar payload, as text: BinTEL scalars are the TEL atom's
+  // UTF-8 bytes, so a leaf's value semantics are the text format's. ──
+  update def scalar(): Text = Text(parser.directScalar()(using tactic))
+  update def skipScalar(): Unit = parser.directSkipScalar()(using tactic)

--- a/lib/stratiform/src/binaryStaged/stratiform.BintelInlinable.scala
+++ b/lib/stratiform/src/binaryStaged/stratiform.BintelInlinable.scala
@@ -75,6 +75,28 @@ object BintelInlinable:
   // (no macro — `Type[Self]` arrives with the call).
   def derived[product]: product is BintelInlinable = ProductInlinable[product]()
 
+  // The `derives`-clause carrier: a `Self`-typed typeclass cannot appear in
+  // a `derives` clause (it has no type parameters), so `case class Foo(...)
+  // derives BintelInlinable.ForBintel` synthesizes this parameterized
+  // subtrait — which *is* a `Foo is BintelInlinable` — into `Foo`'s
+  // companion, where the staging summon finds it. The resolution ladder
+  // unwraps the delegate so structural instances keep their generator
+  // identities.
+  final class ForBintel[value](delegate0: value is BintelInlinable) extends BintelInlinable:
+    type Self = value
+    private[stratiform] def delegate: value is BintelInlinable = delegate0
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[value]): Expr[value] =
+      delegate0.parse(reader)
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.absent(tactic)
+
+  object ForBintel:
+    def derived[value]: ForBintel[value] = ForBintel(BintelInlinable.derived[value])
+
   private[stratiform] final class ProductInlinable[product]() extends BintelInlinable:
     type Self = product
 

--- a/lib/stratiform/src/binaryStaged/stratiform.BintelInlinable.scala
+++ b/lib/stratiform/src/binaryStaged/stratiform.BintelInlinable.scala
@@ -1,0 +1,212 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import prepositional.*
+
+// The Expr-level counterpart of `Bintel.Parsable`: a typeclass whose
+// methods are macro-time code generators, mirroring `stratiform.Inlinable`
+// (the text format's) for the binary encoding. An instance receives an
+// `Expr` of the reader — positioned at its value's payload — and returns an
+// `Expr` of the decoded value, spliced directly into the composed parser.
+//
+// BinTEL is schema-driven: the wire carries no keywords, only flat keyword
+// *indices* resolved against the schema derived from the value's type. The
+// derivation gives every case-class field exactly one flat slot, in
+// declaration order, so the generated dispatch is a positional table — the
+// index IS the field's position. Decoding a BinTEL document through the AST
+// path ends in the *text* format's `Tel.Decodable`, so a generated parser's
+// value semantics (leaf faults, absent handling, foci) mirror the text
+// format's `Inlinable` exactly.
+trait BintelInlinable extends Typeclass:
+  def parse(reader: Expr[BintelReader])(using Quotes, Type[Self]): Expr[Self]
+
+  // What a field of this type yields when its index is absent from the
+  // struct body, mirroring the text format's instances: an abort unless
+  // overridden.
+  def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Self]): Expr[Self] =
+    '{ abort(TelError(TelError.Reason.Absent))(using $tactic) }
+
+object BintelInlinable:
+  // Generates a monomorphic `Bintel.Parsable` for a case class or a sealed
+  // sum at compile time: nested records, repeated-field gathering, variant
+  // dispatch and leaf parsers all inline into one flat parser over the
+  // body bytes — no `Tel.Element` tree, no `Tel` presentation, no
+  // text-format decode.
+  inline def parsable[value]: value is Bintel.Parsable =
+    ${ stratiform.bintelInternal.inlinableParsable[value] }
+
+  // The structural instance for a case class: reflects `Self` when invoked
+  // (no macro — `Type[Self]` arrives with the call).
+  def derived[product]: product is BintelInlinable = ProductInlinable[product]()
+
+  private[stratiform] final class ProductInlinable[product]() extends BintelInlinable:
+    type Self = product
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[product]): Expr[product] =
+      bintelInternal.productBody[product](reader)
+
+  // A marker in the resolution ladder: a repeatable field's occurrences are
+  // gathered by its *struct's* generated parser (they repeat the field's
+  // keyword index), so collection parsing lives in the product generator.
+  private[stratiform] final class IterableInlinable[element]
+    (val element0: element is BintelInlinable)
+  extends BintelInlinable:
+    type Self = Iterable[element]
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[Iterable[element]])
+    :   Expr[Iterable[element]] =
+
+      quotes.reflect.report.errorAndAbort
+        ("stratiform: a repeatable field parses through its struct's generated parser; a "+
+          "collection has no standalone BinTEL form")
+
+  // The structural instance for a *top-level* sealed sum, whose schema root
+  // is a struct with one `SelectRef` member: one flat slot per variant, so
+  // the wire index chooses the variant directly. (A sum in *field*
+  // position derives to an unresolvable `Reference` on the AST path too,
+  // so nested sums are rejected during planning.)
+  private[stratiform] final class SumInlinable[sum]() extends BintelInlinable:
+    type Self = sum
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[sum]): Expr[sum] =
+      bintelInternal.sumBody[sum](reader)
+
+  // ── Instances ──────────────────────────────────────────────────────────
+  // The leaf generators mirror the text format's primitive semantics
+  // exactly — including the `Absent`/`NotScalar` fault split and sentinel
+  // values — since the AST path decodes the presented `Tel` through the
+  // very same text-format instances. A BinTEL scalar always carries text,
+  // so only the `NotScalar` arm of the fault split is reachable.
+
+  given int: (Int is BintelInlinable) = new BintelInlinable:
+    type Self = Int
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[Int]): Expr[Int] =
+      '{
+        val atom = $reader.scalar()
+
+        try atom.s.toInt catch case _: NumberFormatException =>
+          raise(TelError(TelError.Reason.NotScalar(atom, t"Int")))(using infer[Tactic[TelError]])
+          0
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Int]): Expr[Int] =
+      '{ Tel.Parsable.missing[Int](0)(using $tactic) }
+
+  given long: (Long is BintelInlinable) = new BintelInlinable:
+    type Self = Long
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[Long]): Expr[Long] =
+      '{
+        val atom = $reader.scalar()
+
+        try atom.s.toLong catch case _: NumberFormatException =>
+          raise(TelError(TelError.Reason.NotScalar(atom, t"Long")))(using infer[Tactic[TelError]])
+          0L
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Long]): Expr[Long] =
+      '{ Tel.Parsable.missing[Long](0L)(using $tactic) }
+
+  given boolean: (Boolean is BintelInlinable) = new BintelInlinable:
+    type Self = Boolean
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[Boolean]): Expr[Boolean] =
+      '{
+        val atom = $reader.scalar()
+
+        atom.s match
+          case "true"  => true
+          case "false" => false
+
+          case _ =>
+            raise(TelError(TelError.Reason.NotScalar(atom, t"Boolean")))
+              (using infer[Tactic[TelError]])
+
+            false
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Boolean])
+    :   Expr[Boolean] =
+
+      '{ Tel.Parsable.missing[Boolean](false)(using $tactic) }
+
+  given double: (Double is BintelInlinable) = new BintelInlinable:
+    type Self = Double
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[Double]): Expr[Double] =
+      '{
+        val atom = $reader.scalar()
+
+        try atom.s.toDouble catch case _: NumberFormatException =>
+          raise(TelError(TelError.Reason.NotScalar(atom, t"Double")))
+            (using infer[Tactic[TelError]])
+
+          0.0
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Double])
+    :   Expr[Double] =
+
+      '{ Tel.Parsable.missing[Double](0.0)(using $tactic) }
+
+  given text: (Text is BintelInlinable) = new BintelInlinable:
+    type Self = Text
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[Text]): Expr[Text] =
+      '{ $reader.scalar() }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[Text]): Expr[Text] =
+      '{ Tel.Parsable.missing[Text](t"")(using $tactic) }
+
+  given string: (String is BintelInlinable) = new BintelInlinable:
+    type Self = String
+
+    def parse(reader: Expr[BintelReader])(using Quotes, Type[String]): Expr[String] =
+      '{ $reader.scalar().s }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[String])
+    :   Expr[String] =
+
+      '{ Tel.Parsable.missing[String]("")(using $tactic) }
+
+  given iterable: [collection <: Iterable, element]
+  =>  (element0: element is BintelInlinable)
+  =>  (collection[element] is BintelInlinable) =
+    IterableInlinable[element](element0).asInstanceOf[collection[element] is BintelInlinable]

--- a/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
+++ b/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
@@ -1,0 +1,927 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package stratiform
+
+import scala.collection.mutable as scm
+import scala.quoted.*
+
+import anticipation.*
+import contingency.*
+import distillate.*
+import gossamer.*
+import prepositional.*
+import vacuous.*
+
+// The machinery behind `BintelInlinable`: expansion-time instance
+// resolution (through an in-macro staging compiler), the structural
+// generators for structs, repeatable fields and top-level sums, and the
+// `BintelInlinable.parsable` entry macro.
+//
+// BinTEL has no per-subtree bridge back to the AST path (`Bintel.decode` is
+// schema-driven top-down), so there is no runtime seam: a shape the
+// generator does not support is rejected at expansion with a message
+// directing to `Bintel.read`. The exceptions are custom *scalar* leaves,
+// which decode through their `Decodable in Text` — exactly the text
+// format's blanket case for the atom the wire carries.
+object bintelInternal:
+
+  // ── Expansion-time environment ─────────────────────────────────────────
+
+  private def macroClassloader: ClassLoader =
+    val contextual = Thread.currentThread.nn.getContextClassLoader
+    if contextual != null then contextual else getClass.getClassLoader.nn
+
+  private def currentOutputDirectory(using Quotes): Option[String] =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      given dotty.tools.dotc.core.Contexts.Context = ctx
+      import dotty.tools.dotc.config.Settings.Setting.value
+
+      Option(ctx.settings.outputDir.value.file).map(_.nn.getCanonicalPath.nn)
+    catch case _: Exception => None
+
+  // A symbol defined in the compilation run in progress has no trustworthy
+  // classfile (none on a clean build; a stale one from the previous compile
+  // on an incremental build), so instance evaluation must refuse it.
+  private def definedInCurrentRun(using Quotes)(symbol: quotes.reflect.Symbol): Boolean =
+    try
+      val ctx = quotes.asInstanceOf[scala.quoted.runtime.impl.QuotesImpl].ctx
+      val run = ctx.run
+
+      if run == null then false else
+        val sources = run.nn.units.map(_.source.file.path).toSet
+        val position = symbol.pos
+        position.exists { position => sources.contains(position.sourceFile.path) }
+    catch case _: Exception => false
+
+  private def innerClasspath(using Quotes): String =
+    val separator = java.io.File.pathSeparator.nn
+
+    val full =
+      dotty.tools.dotc.util.ClasspathFromClassloader(macroClassloader).nn
+
+    currentOutputDirectory match
+      case None =>
+        full
+
+      case Some(excluded) =>
+        val entries = full.split(separator).nn
+        val joined = StringBuilder()
+        var index = 0
+
+        while index < entries.length do
+          val entry = entries(index).nn
+
+          val retain =
+            try java.io.File(entry).getCanonicalPath != excluded
+            catch case _: java.io.IOException => true
+
+          if retain then
+            if joined.nonEmpty then joined.append(separator)
+            joined.append(entry)
+
+          index += 1
+
+        joined.toString
+
+  // ── Type transport into the staging context ────────────────────────────
+
+  private case class TypeShape(clazz: Class[?], arguments: List[TypeShape])
+
+  private val primitiveClasses: Map[String, Class[?]] =
+    Map
+      ( "scala.Int"     -> classOf[Int],
+        "scala.Long"    -> classOf[Long],
+        "scala.Double"  -> classOf[Double],
+        "scala.Float"   -> classOf[Float],
+        "scala.Boolean" -> classOf[Boolean],
+        "scala.Short"   -> classOf[Short],
+        "scala.Byte"    -> classOf[Byte],
+        "scala.Char"    -> classOf[Char],
+        "scala.Unit"    -> classOf[Unit] )
+
+  private def binaryName(using Quotes)(symbol: quotes.reflect.Symbol): String =
+    import quotes.reflect.*
+
+    def build(symbol: Symbol): String =
+      val owner = symbol.owner
+
+      if owner.isPackageDef then
+        val prefix = owner.fullName
+        if prefix == "<empty>" then symbol.name else prefix+"."+symbol.name
+      else
+        val ownerName = build(if owner.isClassDef then owner else owner.owner)
+        ownerName+"$"+symbol.name
+
+    build(symbol)
+
+  private def shapeOf(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[TypeShape] =
+    import quotes.reflect.*
+
+    def classFor(tpe: TypeRepr): Option[Class[?]] =
+      tpe.classSymbol.flatMap: symbol =>
+        if definedInCurrentRun(symbol) then None
+        else primitiveClasses.get(symbol.fullName).orElse:
+          try Some(Class.forName(binaryName(symbol), false, macroClassloader).nn)
+          catch
+            case _: ReflectiveOperationException => None
+            case _: LinkageError                 => None
+
+    tpe.dealias match
+      case AppliedType(constructor, arguments) =>
+        for
+          clazz <- classFor(constructor)
+          shapes <- arguments.foldRight(Option(List.empty[TypeShape])): (argument, list) =>
+                      list.flatMap { tail => shapeOf(argument).map(_ :: tail) }
+        yield TypeShape(clazz, shapes)
+
+      case other =>
+        classFor(other).map(TypeShape(_, Nil))
+
+  // ── Instance evaluation: the staging summon ────────────────────────────
+
+  private def summonViaStaging[field: Type](using Quotes): Option[BintelInlinable] =
+    import quotes.reflect.*
+    import scala.quoted.staging
+
+    shapeOf(TypeRepr.of[field]).flatMap: shape =>
+      try
+        given settings: staging.Compiler.Settings =
+          staging.Compiler.Settings.make
+            (None, List("-experimental", "-classpath", innerClasspath))
+
+        given staging.Compiler = staging.Compiler.make(macroClassloader)
+        val started = System.nanoTime
+
+        val result: Any = staging.run:
+          val quotes2 = summon[Quotes]
+          import quotes2.reflect as r2
+
+          def rebuild(shape: TypeShape): r2.TypeRepr =
+            val base = r2.TypeRepr.typeConstructorOf(shape.clazz)
+            if shape.arguments.isEmpty then base
+            else base.appliedTo(shape.arguments.map(rebuild))
+
+          val target =
+            r2.Refinement
+              ( r2.TypeRepr.of[BintelInlinable], "Self",
+                r2.TypeBounds(rebuild(shape), rebuild(shape)) )
+
+          target.asType match
+            case '[target] => '{ scala.compiletime.summonInline[target] }
+
+        val duration = (System.nanoTime - started)/1000000L
+
+        result match
+          case instance: BintelInlinable =>
+            report.info
+              ( s"stratiform: staged summon for ${TypeRepr.of[field].show} took "+
+                s"${duration}ms" )
+
+            Some(instance)
+
+          case _ =>
+            None
+      catch
+        case _: ReflectiveOperationException => None
+        case _: LinkageError                 => None
+        case _: AssertionError               => None
+        case _: Exception                    => None
+
+  // ── The resolution ladder and field plans ──────────────────────────────
+  // BinTEL derivation gives every case-class field one flat slot in
+  // declaration order, so a field's wire keyword index is its position.
+  // Every field compiles to one of: a builtin `Leaf`; a `Nested` struct; an
+  // optional wrapper of either; a `Gather` (a repeatable field, appending
+  // per occurrence); or a `SeamText` custom scalar (decoded through its
+  // `Decodable in Text`, the wire atom's text semantics). Anything else is
+  // rejected — the AST path is the fallback.
+
+  private final class Cache:
+    val instances: scm.HashMap[String, Option[BintelInlinable]] = scm.HashMap()
+    val active: scm.Set[String] = scm.Set()
+
+  private inline val KInt = 0
+  private inline val KLong = 1
+  private inline val KBoolean = 2
+  private inline val KDouble = 3
+  private inline val KText = 4
+  private inline val KString = 5
+
+  private def builtinKind(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Int] =
+    import quotes.reflect.*
+
+    if tpe =:= TypeRepr.of[Int] then Some(KInt)
+    else if tpe =:= TypeRepr.of[Long] then Some(KLong)
+    else if tpe =:= TypeRepr.of[Boolean] then Some(KBoolean)
+    else if tpe =:= TypeRepr.of[Double] then Some(KDouble)
+    else if tpe =:= TypeRepr.of[Text] then Some(KText)
+    else if tpe =:= TypeRepr.of[String] then Some(KString)
+    else None
+
+  private enum Elem:
+    case Scalar(kind: Int)
+    case Nested(instance: BintelInlinable, tpe: Any)
+    case SeamText(decoder: Any)
+
+  private enum Plan:
+    case Leaf(kind: Int)
+    case Nested(instance: BintelInlinable)
+    case OptionalLeaf(kind: Int)
+    case OptionalNested(instance: BintelInlinable, innerType: Any)
+    case Gather(element: Elem, elementType: Any)
+    case SeamText(decoder: Any)
+
+  private def resolve[field: Type](cache: Cache)(using Quotes): Option[BintelInlinable] =
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[field].dealias
+
+    if builtinKind(tpe).isDefined then None else
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      . orElse:
+          if productSupported(tpe) && !cache.active.contains(tpe.show)
+          then Some(BintelInlinable.ProductInlinable[field]())
+          else None
+
+  // A custom scalar leaf: its `Decodable in Text`, resolved at expansion
+  // time with a reflection-level search and an erasing cast across the
+  // capability boundary (the protobuf port's lesson: neither `summonInline`
+  // nor evidence parameters resolve capability-typed codecs from inside the
+  // generated parser's inline context).
+  private def textDecoder[fieldType: Type](using Quotes): Option[Expr[Any]] =
+    import quotes.reflect.*
+
+    Implicits.search(TypeRepr.of[fieldType is Decodable in Text]) match
+      case success: ImplicitSearchSuccess => Some(success.tree.asExpr)
+      case _                              => None
+
+  private def optionalInner(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[quotes.reflect.TypeRepr] =
+
+    import quotes.reflect.*
+
+    val unset = TypeRepr.of[vacuous.Optional.Unset]
+
+    tpe.dealias match
+      case OrType(left, right) if right =:= unset => Some(left.dealias)
+      case OrType(left, right) if left =:= unset  => Some(right.dealias)
+      case _                                      => None
+
+  private def planFor[product: Type](using Quotes)
+    (fieldName: String, tpe0: quotes.reflect.TypeRepr, cache: Cache)
+  :   Plan =
+
+    import quotes.reflect.*
+
+    val tpe = tpe0.dealias
+
+    def reject(shape: String): Nothing =
+      report.errorAndAbort
+        (s"stratiform: the field `$fieldName` of ${TypeRepr.of[product].show} is $shape, "+
+          "which the BinTEL parser generator does not support; use `Bintel.read`")
+
+    builtinKind(tpe) match
+      case Some(kind) =>
+        Plan.Leaf(kind)
+
+      case None if optionalInner(tpe).isDefined =>
+        val inner = optionalInner(tpe).get
+
+        builtinKind(inner) match
+          case Some(kind) =>
+            Plan.OptionalLeaf(kind)
+
+          case None =>
+            if inner <:< TypeRepr.of[Iterable[Any]] then reject("an optional collection")
+
+            inner.asType match
+              case '[innerType] =>
+                resolve[innerType](cache) match
+                  case Some(instance)
+                      if !instance.isInstanceOf[BintelInlinable.IterableInlinable[?]] =>
+                    Plan.OptionalNested(instance, inner)
+
+                  case _ =>
+                    textDecoder[innerType] match
+                      case Some(_) => reject("an optional custom scalar")
+                      case None    => reject("an optional of an unsupported type")
+
+      case None =>
+        val isMap = tpe.derivesFrom(Symbol.requiredClass("scala.collection.Map"))
+
+        if isMap then reject("a Map (a nested `entries` struct on the wire)")
+        else if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+          case AppliedType(_, arguments) =>
+            val elementType = arguments.last.dealias
+
+            builtinKind(elementType) match
+              case Some(kind) =>
+                Plan.Gather(Elem.Scalar(kind), elementType)
+
+              case None =>
+                elementType.asType match
+                  case '[element] =>
+                    resolve[element](cache) match
+                      case Some(instance)
+                          if !instance.isInstanceOf[BintelInlinable.IterableInlinable[?]] =>
+                        Plan.Gather(Elem.Nested(instance, elementType), elementType)
+
+                      case _ =>
+                        textDecoder[element] match
+                          case Some(decoder) =>
+                            Plan.Gather(Elem.SeamText(decoder), elementType)
+
+                          case None =>
+                            reject("a collection of an unsupported element")
+
+          case _ =>
+            reject("an unapplied collection type")
+        else if sumVariants(tpe).isDefined then
+          reject("a sum (nested sums derive to an unresolvable schema Reference)")
+        else tpe.asType match
+          case '[field] =>
+            resolve[field](cache) match
+              case Some(instance)
+                  if !instance.isInstanceOf[BintelInlinable.IterableInlinable[?]] =>
+                Plan.Nested(instance)
+
+              case _ =>
+                textDecoder[field] match
+                  case Some(decoder) => Plan.SeamText(decoder)
+
+                  case None =>
+                    if cache.active.contains(tpe.show) then reject("recursive")
+                    else reject("of an unsupported type")
+
+  private def sumVariants(using Quotes)(tpe: quotes.reflect.TypeRepr)
+  :   Option[List[(String, quotes.reflect.TypeRepr)]] =
+
+    import quotes.reflect.*
+
+    tpe.classSymbol.flatMap: classSymbol =>
+      val applied = tpe match
+        case AppliedType(_, _) => true
+        case _                 => false
+
+      val children = classSymbol.children
+
+      val supported =
+        !applied
+        && classSymbol.flags.is(Flags.Sealed)
+        && children.nonEmpty
+        && children.forall { child => child.isClassDef && child.flags.is(Flags.Case) }
+
+      if supported then Some(children.map { child => (child.name, child.typeRef) }) else None
+
+  private def productSupported(using Quotes)(tpe: quotes.reflect.TypeRepr): Boolean =
+    import quotes.reflect.*
+
+    tpe.classSymbol.exists: classSymbol =>
+      classSymbol.flags.is(Flags.Case)
+      && !classSymbol.owner.isTerm
+      && (tpe match { case AppliedType(_, _) => false case _ => true })
+      && classSymbol.primaryConstructor.paramSymss
+         . filterNot(_.exists(_.isTypeParam)).length == 1
+      && !hasRenames(classSymbol)
+
+  // `@name` renames change the wire *keyword*, which positional index
+  // dispatch never reads — but they mark intent the generator does not
+  // otherwise honor for foci paths; renamed records stay on `Bintel.read`.
+  private def hasRenames(using Quotes)(classSymbol: quotes.reflect.Symbol): Boolean =
+    import quotes.reflect.*
+
+    val annotated =
+      classSymbol.primaryConstructor.paramSymss.flatten.filterNot(_.isTypeParam)
+        . flatMap(_.annotations)
+      ++ classSymbol.caseFields.flatMap(_.annotations)
+
+    annotated.exists { annotation => annotation.tpe <:< TypeRepr.of[adversaria.name[?]] }
+
+  // ── The product generator ──────────────────────────────────────────────
+  // One struct body: the child count, then per child a keyword index — the
+  // field's declaration position — and the member-typed payload. First
+  // occurrence wins for non-repeatable fields (later occurrences are
+  // consumed and discarded, exactly as the AST decoder parses every child);
+  // repeatable fields gather every occurrence in stream order. Missing
+  // fields take their declared default, then the text format's absent
+  // semantics, with the same foci bookkeeping as the presented-`Tel`
+  // decode.
+  private[stratiform] def productBody[product: Type](reader: Expr[BintelReader])(using Quotes)
+  :   Expr[product] =
+
+    productBody[product](reader, Cache())
+
+  private def productBody[product: Type](reader: Expr[BintelReader], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+    cache.active += tpe.show
+
+    try productBody0[product](reader, cache) finally cache.active -= tpe.show
+
+  private def productBody0[product: Type](reader: Expr[BintelReader], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.*
+
+    val tpe = TypeRepr.of[product].dealias
+
+    if !productSupported(tpe) then
+      report.errorAndAbort
+        (s"stratiform: ${tpe.show} is not an inlinable BinTEL struct (a non-generic, "+
+          "top-level or object-nested case class with a single parameter list and no "+
+          "`@name` renames); use `Bintel.read`")
+
+    val classSymbol = tpe.classSymbol.get
+    val ctor = classSymbol.primaryConstructor
+    val fields = classSymbol.caseFields
+    val arity = fields.length
+    val fieldNames: List[String] = fields.map(_.name)
+    val fieldTypes: List[TypeRepr] = fields.map { field => tpe.memberType(field).dealias }
+
+    val plans: List[Plan] =
+      List.range(0, arity).map { i => planFor[product](fieldNames(i), fieldTypes(i), cache) }
+
+    // The wire keyword of each field, for foci paths — kebab-cased as the
+    // schema derivation names it.
+    val keywords: List[String] =
+      fieldNames.map { name => Tel.camelToKebab(name).s }
+
+    def body
+      ( tactic:  Expr[Tactic[TelError]],
+        foci:    Expr[Foci[Tel.Focus]],
+        focused: Expr[Boolean],
+        parser:  Expr[BintelParser],
+        btactic: Expr[Tactic[BintelError]] )
+    :   Expr[product] =
+
+      val owner = Symbol.spliceOwner
+
+      val slots = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "slot"+index, fieldTypes(index), Flags.Mutable, Symbol.noSymbol)
+
+      val seens = List.range(0, arity).map: index =>
+        Symbol.newVal(owner, "seen"+index, TypeRepr.of[Boolean], Flags.Mutable, Symbol.noSymbol)
+
+      def zero(fieldType: TypeRepr): Term =
+        if fieldType =:= TypeRepr.of[Int] then Literal(IntConstant(0))
+        else if fieldType =:= TypeRepr.of[Long] then Literal(LongConstant(0L))
+        else if fieldType =:= TypeRepr.of[Double] then Literal(DoubleConstant(0.0))
+        else if fieldType =:= TypeRepr.of[Boolean] then Literal(BooleanConstant(false))
+        else fieldType.asType match
+          case '[fieldType] => '{ null.asInstanceOf[fieldType] }.asTerm
+
+      val slotDefs = List.range(0, arity).map: index =>
+        ValDef(slots(index), Some(zero(fieldTypes(index))))
+
+      val seenDefs = List.range(0, arity).map: index =>
+        ValDef(seens(index), Some(Literal(BooleanConstant(false))))
+
+      val unit = Literal(UnitConstant())
+
+      // One scalar-payload read per builtin kind, with the text format's
+      // fault semantics.
+      def leafRead(kind: Int): Expr[Any] = kind match
+        case KInt =>
+          '{
+            val atom = Text($parser.directScalar()(using $btactic))
+
+            try atom.s.toInt catch case _: NumberFormatException =>
+              raise(TelError(TelError.Reason.NotScalar(atom, t"Int")))(using $tactic)
+              0
+          }
+
+        case KLong =>
+          '{
+            val atom = Text($parser.directScalar()(using $btactic))
+
+            try atom.s.toLong catch case _: NumberFormatException =>
+              raise(TelError(TelError.Reason.NotScalar(atom, t"Long")))(using $tactic)
+              0L
+          }
+
+        case KBoolean =>
+          '{
+            val atom = Text($parser.directScalar()(using $btactic))
+
+            atom.s match
+              case "true"  => true
+              case "false" => false
+
+              case _ =>
+                raise(TelError(TelError.Reason.NotScalar(atom, t"Boolean")))(using $tactic)
+                false
+          }
+
+        case KDouble =>
+          '{
+            val atom = Text($parser.directScalar()(using $btactic))
+
+            try atom.s.toDouble catch case _: NumberFormatException =>
+              raise(TelError(TelError.Reason.NotScalar(atom, t"Double")))(using $tactic)
+              0.0
+          }
+
+        case KText   => '{ Text($parser.directScalar()(using $btactic)) }
+        case KString => '{ $parser.directScalar()(using $btactic) }
+
+      def leafSentinel(kind: Int): Expr[Any] = kind match
+        case KInt     => Expr(0)
+        case KLong    => Expr(0L)
+        case KBoolean => Expr(false)
+        case KDouble  => Expr(0.0)
+        case KText    => '{ t"" }
+        case KString  => Expr("")
+
+      def seamRead(decoder: Any): Expr[Any] =
+        val found = decoder.asInstanceOf[Expr[Any]]
+        '{ $found.asInstanceOf[Any is Decodable in Text]
+             . decoded(Text($parser.directScalar()(using $btactic))) }
+
+      // Per-field gathering state for repeatable fields.
+      val builders: Map[Int, Symbol] =
+        List.range(0, arity).flatMap: index =>
+          plans(index) match
+            case Plan.Gather(_, elementType0) =>
+              val elementType = elementType0.asInstanceOf[TypeRepr]
+
+              val builderType =
+                TypeRepr.of[scm.Builder].appliedTo(List(elementType, fieldTypes(index)))
+
+              Some(index -> Symbol.newVal
+                (owner, "builder"+index, builderType, Flags.EmptyFlags, Symbol.noSymbol))
+
+            case _ =>
+              None
+        . toMap
+
+      val builderDefs: List[Statement] = List.range(0, arity).flatMap: index =>
+        plans(index) match
+          case Plan.Gather(_, elementType0) =>
+            val elementType = elementType0.asInstanceOf[TypeRepr]
+
+            (elementType.asType, fieldTypes(index).asType) match
+              case ('[element], '[fieldType]) =>
+                val rhs: Expr[Any] =
+                  '{ infer[scala.collection.Factory[element, fieldType]].newBuilder }
+
+                Some(ValDef(builders(index), Some(rhs.asTerm)))
+
+          case _ =>
+            None
+
+      // One local def per field, shaped for the JIT, wrapped in the same
+      // per-field foci bookkeeping as the presented-`Tel` decode.
+      val readDefs: List[Symbol] = List.range(0, arity).map: index =>
+        val resultType = plans(index) match
+          case Plan.Gather(_, _) => TypeRepr.of[Unit]
+          case _                 => fieldTypes(index)
+
+        Symbol.newMethod
+          (owner, "readField"+index, MethodType(Nil)(_ => Nil, _ => resultType))
+
+      val readDefDefs: List[Statement] = List.range(0, arity).map: index =>
+        val keyword: Expr[Text] = '{ ${Expr(keywords(index))}.tt }
+
+        def focusedOver[result: Type](raw: Expr[result]): Expr[result] =
+          '{
+            if $focused then Tel.Parsable.focusing($foci, $keyword)($raw)
+            else $raw
+          }
+
+        val rhs: Term = plans(index) match
+          case Plan.Leaf(kind) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                focusedOver[fieldType](leafRead(kind).asExprOf[fieldType]).asTerm
+
+          case Plan.OptionalLeaf(kind) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                focusedOver[fieldType](leafRead(kind).asExprOf[fieldType]).asTerm
+
+          case Plan.Nested(instance) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                val raw =
+                  instance.asInstanceOf[BintelInlinable { type Self = fieldType }]
+                  . parse(reader)
+
+                focusedOver[fieldType](raw).asTerm
+
+          case Plan.OptionalNested(instance, innerType0) =>
+            (innerType0.asInstanceOf[TypeRepr].asType, fieldTypes(index).asType) match
+              case ('[innerType], '[fieldType]) =>
+                val raw =
+                  instance.asInstanceOf[BintelInlinable { type Self = innerType }]
+                  . parse(reader)
+
+                focusedOver[fieldType]('{ $raw.asInstanceOf[fieldType] }).asTerm
+
+          case Plan.SeamText(decoder) =>
+            fieldTypes(index).asType match
+              case '[fieldType] =>
+                focusedOver[fieldType]
+                  ('{ ${seamRead(decoder)}.asInstanceOf[fieldType] }).asTerm
+
+          case Plan.Gather(element, elementType0) =>
+            val elementType = elementType0.asInstanceOf[TypeRepr]
+
+            (elementType.asType, fieldTypes(index).asType) match
+              case ('[element], '[fieldType]) =>
+                val builder =
+                  Ref(builders(index)).asExprOf[scm.Builder[element, fieldType]]
+
+                val occurrence: Expr[element] = element match
+                  case Elem.Scalar(kind) =>
+                    leafRead(kind).asExprOf[element]
+
+                  case Elem.Nested(instance0, _) =>
+                    instance0.asInstanceOf[BintelInlinable { type Self = element }]
+                    . parse(reader)
+
+                  case Elem.SeamText(decoder) =>
+                    '{ ${seamRead(decoder)}.asInstanceOf[element] }
+
+                '{ $builder += ${ focusedOver[element](occurrence) } }.asTerm
+
+        DefDef(readDefs(index), _ => Some(rhs.changeOwner(readDefs(index))))
+
+      def arms: List[CaseDef] = List.range(0, arity).map: index =>
+        val body: Term = plans(index) match
+          case Plan.Gather(_, _) =>
+            Apply(Ref(readDefs(index)), Nil)
+
+          case Plan.Leaf(_) =>
+            // A later occurrence of a scalar field is skipped structurally,
+            // as the AST decoder consumes it without a typed parse.
+            If
+              ( '{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm,
+                Block
+                  ( List
+                      ( Assign(Ref(slots(index)), Apply(Ref(readDefs(index)), Nil)),
+                        Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                    unit ),
+                '{ $parser.directSkipScalar()(using $btactic) }.asTerm )
+
+          case _ =>
+            // A later occurrence of any other field is consumed and
+            // discarded — the AST decoder parses every child regardless.
+            If
+              ( '{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm,
+                Block
+                  ( List
+                      ( Assign(Ref(slots(index)), Apply(Ref(readDefs(index)), Nil)),
+                        Assign(Ref(seens(index)), Literal(BooleanConstant(true))) ),
+                    unit ),
+                Block(List(Apply(Ref(readDefs(index)), Nil)), unit) )
+
+        CaseDef(Literal(IntConstant(index)), None, body)
+
+      def badIndex =
+        CaseDef
+          ( Wildcard(), None,
+            '{ abort(BintelError(BintelError.Reason.BadKeywordIndex))(using $btactic) }.asTerm )
+
+      val total = Symbol.newVal(owner, "total", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+      val i = Symbol.newVal(owner, "i", TypeRepr.of[Int], Flags.Mutable, Symbol.noSymbol)
+      val totalRef = Ref(total).asExprOf[Int]
+      val iRef = Ref(i).asExprOf[Int]
+
+      val step: Term =
+        val kidx = Symbol.newVal(owner, "kidx", TypeRepr.of[Int], Flags.EmptyFlags, Symbol.noSymbol)
+
+        Block
+          ( List
+              ( ValDef(kidx, Some('{ $parser.directCount()(using $btactic) }.asTerm)),
+                Match(Ref(kidx), arms ::: List(badIndex)) ),
+            Assign(Ref(i), '{ $iRef + 1 }.asTerm) )
+
+      val loop: List[Statement] =
+        List
+          ( ValDef(total, Some('{ $parser.directCount()(using $btactic) }.asTerm)),
+            ValDef(i, Some(Literal(IntConstant(0)))),
+            While('{ $iRef < $totalRef }.asTerm, step) )
+
+      // Missing fields: declared default, then the text format's absent
+      // semantics under the field's focus.
+      val absents: List[Term] = List.range(0, arity).map: index =>
+        val keyword: Expr[Text] = '{ ${Expr(keywords(index))}.tt }
+
+        fieldTypes(index).asType match
+          case '[fieldType] =>
+            val absentExpr: Expr[fieldType] = plans(index) match
+              case Plan.Leaf(kind) =>
+                val sentinel = leafSentinel(kind).asExprOf[fieldType]
+                '{ Tel.Parsable.missing[fieldType]($sentinel)(using $tactic) }
+
+              case Plan.OptionalLeaf(_) | Plan.OptionalNested(_, _) =>
+                '{ vacuous.Unset.asInstanceOf[fieldType] }
+
+              case Plan.Nested(instance) =>
+                instance.asInstanceOf[BintelInlinable { type Self = fieldType }]
+                . absent(tactic)
+
+              case Plan.SeamText(_) =>
+                '{ abort(TelError(TelError.Reason.Absent))(using $tactic) }
+
+              case Plan.Gather(_, _) =>
+                '{ ${ Ref(builders(index)).asExpr }
+                     . asInstanceOf[scm.Builder[?, fieldType]].result() }
+
+            val resolveAbsent: Term =
+              Assign
+                ( Ref(slots(index)),
+                  '{
+                    val declared =
+                      wisteria.internal.default[product, fieldType](${Expr(index)})
+
+                    if !declared.absent then declared.asInstanceOf[fieldType]
+                    else Tel.Parsable.focusing($foci, $keyword)($absentExpr)
+                  }.asTerm )
+
+            val whenSeen: Term = plans(index) match
+              case Plan.Gather(_, _) =>
+                Assign
+                  ( Ref(slots(index)),
+                    '{ ${ Ref(builders(index)).asExpr }
+                         . asInstanceOf[scm.Builder[?, fieldType]].result() }.asTerm )
+
+              case _ =>
+                unit
+
+            If('{ !${Ref(seens(index)).asExprOf[Boolean]} }.asTerm, resolveAbsent, whenSeen)
+
+      val construct: Term =
+        Apply(Select(New(Inferred(tpe)), ctor), slots.map { slot => Ref(slot) })
+
+      Block(slotDefs ::: seenDefs ::: builderDefs ::: readDefDefs ::: loop ::: absents, construct)
+      . asExprOf[product]
+
+    '{
+      val tactic = infer[Tactic[TelError]]
+      val foci = infer[Foci[Tel.Focus]]
+      val focused = foci.active
+      val parser = $reader.rawParser.asInstanceOf[BintelParser]
+      val btactic = $reader.rawTactic.asInstanceOf[Tactic[BintelError]]
+      ${ body('tactic, 'foci, 'focused, 'parser, 'btactic) }
+    }
+
+  // ── The sum generator ──────────────────────────────────────────────────
+  // A top-level sum's schema root is a struct with one `SelectRef` member:
+  // one flat slot per variant, in declaration order, so the first child's
+  // keyword index chooses the variant directly. Extra children are
+  // consumed and discarded, as the AST decoder parses every child.
+  private[stratiform] def sumBody[sum: Type](reader: Expr[BintelReader])(using Quotes)
+  :   Expr[sum] =
+
+    sumBody[sum](reader, Cache())
+
+  private def sumBody[sum: Type](reader: Expr[BintelReader], cache: Cache)(using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[sum].dealias.show
+
+    try sumBody0[sum](reader, cache)
+    finally cache.active -= TypeRepr.of[sum].dealias.show
+
+  private def sumBody0[sum: Type](reader: Expr[BintelReader], cache: Cache)(using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    val variants = sumVariants(TypeRepr.of[sum].dealias).getOrElse:
+      report.errorAndAbort
+        (s"stratiform: ${TypeRepr.of[sum].show} is not an inlinable BinTEL sum (a "+
+          "non-generic sealed type whose variants are all case classes); use `Bintel.read`")
+
+    val arity = variants.length
+
+    def variantInstance(index: Int): (Type[?], BintelInlinable) =
+      variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"stratiform: no BintelInlinable for variant ${variants(index)(0)}")
+
+          (Type.of[variantType], instance)
+
+    def dispatch(index: Int, kidx: Expr[Int], btactic: Expr[Tactic[BintelError]]): Expr[sum] =
+      if index == arity then
+        '{ abort(BintelError(BintelError.Reason.BadKeywordIndex))(using $btactic) }
+      else variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"stratiform: no BintelInlinable for variant ${variants(index)(0)}")
+          . asInstanceOf[BintelInlinable { type Self = variantType }]
+
+          '{
+            if $kidx == ${Expr(index)} then
+              def parseVariant(): variantType = ${ instance.parse(reader) }
+              parseVariant()
+            else ${ dispatch(index + 1, kidx, btactic) }
+          }
+
+    def discard(index: Int, kidx: Expr[Int], btactic: Expr[Tactic[BintelError]]): Expr[Unit] =
+      if index == arity then
+        '{ abort(BintelError(BintelError.Reason.BadKeywordIndex))(using $btactic) }
+      else variants(index)(1).asType match
+        case '[type variantType <: sum; variantType] =>
+          val instance = resolve[variantType](cache).getOrElse:
+            report.errorAndAbort
+              (s"stratiform: no BintelInlinable for variant ${variants(index)(0)}")
+          . asInstanceOf[BintelInlinable { type Self = variantType }]
+
+          '{
+            if $kidx == ${Expr(index)} then
+              def parseExtra(): variantType = ${ instance.parse(reader) }
+              parseExtra()
+              ()
+            else ${ discard(index + 1, kidx, btactic) }
+          }
+
+    '{
+      val tactic = infer[Tactic[TelError]]
+      val parser = $reader.rawParser.asInstanceOf[BintelParser]
+      val btactic = $reader.rawTactic.asInstanceOf[Tactic[BintelError]]
+      val total = parser.directCount()(using btactic)
+
+      if total == 0 then abort(TelError(TelError.Reason.Absent))(using tactic)
+      else
+        val kidx = parser.directCount()(using btactic)
+        val result: sum = ${ dispatch(0, 'kidx, 'btactic) }
+        var i = 1
+
+        while i < total do
+          val extra = parser.directCount()(using btactic)
+          ${ discard(0, 'extra, 'btactic) }
+          i += 1
+
+        result
+    }
+
+  // ── The entry macro ────────────────────────────────────────────────────
+  def inlinableParsable[value: Type](using Quotes): Expr[value is Bintel.Parsable] =
+    import quotes.reflect.*
+
+    val cache: Cache = Cache()
+    val tpe = TypeRepr.of[value].dealias
+
+    val instance: BintelInlinable { type Self = value } =
+      if productSupported(tpe) then BintelInlinable.ProductInlinable[value]()
+      else if sumVariants(tpe).isDefined then BintelInlinable.SumInlinable[value]()
+      else
+        summonViaStaging[value].getOrElse:
+          report.errorAndAbort
+            (s"stratiform: ${tpe.show} is not an inlinable BinTEL struct or sum; use "+
+              "`Bintel.read`")
+        . asInstanceOf[BintelInlinable { type Self = value }]
+
+    '{
+      // Sealed per the codec-thunk pattern: the generated body resolves its
+      // capabilities where it is spliced.
+      caps.unsafe.unsafeAssumePure:
+        new Bintel.Parsable.Direct[value]:
+          protected def parseCarrier(reader0: AnyRef): value =
+            // A capability class cannot be quoted into a pure hole, so
+            // every use casts from the neutral carrier afresh.
+            ${ instance.parse('{ reader0.asInstanceOf[BintelReader] }) }
+    }

--- a/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
+++ b/lib/stratiform/src/binaryStaged/stratiform.bintelInternal.scala
@@ -268,11 +268,21 @@ object bintelInternal:
     val tpe = TypeRepr.of[field].dealias
 
     if builtinKind(tpe).isDefined then None else
-      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field].map(unwrap))
       . orElse:
           if productSupported(tpe) && !cache.active.contains(tpe.show)
           then Some(BintelInlinable.ProductInlinable[field]())
           else None
+
+  // A `derives`-clause carrier delegates to a structural instance; the
+  // ladder works with the delegate so generator identities stay
+  // recognizable.
+  private def unwrap(instance: BintelInlinable): BintelInlinable = instance match
+    case derived: BintelInlinable.ForBintel[?] =>
+      derived.delegate.asInstanceOf[BintelInlinable]
+
+    case other =>
+      other
 
   // A custom scalar leaf: its `Decodable in Text`, resolved at expansion
   // time with a reflection-level search and an erasing cast across the

--- a/lib/stratiform/src/core/stratiform.Tel.scala
+++ b/lib/stratiform/src/core/stratiform.Tel.scala
@@ -172,6 +172,36 @@ object Tel extends Tel2:
     def absent()(using Tactic[TelError]): Self = abort(TelError(TelError.Reason.Absent))
 
   object Parsable:
+    // The base of generated parsers: generated code is capture-erased, so
+    // the bodies receive the reader as a neutral carrier, and the
+    // capability is asserted here at the rim — the audited point — like the
+    // reader's own accessors. (A generated override of `parse` itself would
+    // narrow the trait's `TelReader^` parameter to a pure type, which
+    // capture checking rejects at the instantiation site.)
+    abstract class Direct[value] extends Tel.Parsable:
+      type Self = value
+
+      def shape(): Morphology = Morphology.Any
+
+      protected def parseEntry(reader: AnyRef, indent: Int): value
+      protected def parseWhole(reader: AnyRef): value
+
+      def parse(reader: TelReader^, indent: Int): value =
+        parseEntry(reader.asInstanceOf[AnyRef], indent)
+
+      override def parse(reader: TelReader^): value = parseWhole(reader.asInstanceOf[AnyRef])
+
+    // The call points for a nominal `Parsing` instance in an entry position
+    // of a *generated* parser (a recursive record's own `Parsable`, a
+    // hand-written one, or the `Tel.Field` fallback chain). Both travel as
+    // neutral carriers — generated code is capture-erased — and the
+    // capability is reasserted here, at the audited point.
+    def parseField[value](parsing: AnyRef, reader: AnyRef, indent: Int): value =
+      parsing.asInstanceOf[value is Tel.Parsing].parse(reader.asInstanceOf[TelReader^], indent)
+
+    def absentField[value](parsing: AnyRef)(using Tactic[TelError]): value =
+      parsing.asInstanceOf[value is Tel.Parsing].absent()
+
     def apply[value](shape0: => Morphology)(parser: (reader: TelReader^) => value)
     :   ((value is Tel.Parsable)^{parser}) =
 

--- a/lib/stratiform/src/staged/stratiform.Inlinable.scala
+++ b/lib/stratiform/src/staged/stratiform.Inlinable.scala
@@ -80,6 +80,29 @@ object Inlinable:
   // (no macro — `Type[Self]` arrives with the call).
   def derived[product]: product is Inlinable = ProductInlinable[product]()
 
+  // The `derives`-clause carrier: a `Self`-typed typeclass cannot appear in
+  // a `derives` clause (it has no type parameters), so `case class Foo(...)
+  // derives Inlinable.ForTel` synthesizes this parameterized subtrait —
+  // which *is* a `Foo is Inlinable` — into `Foo`'s companion, where the
+  // staging summon finds it. The resolution ladder unwraps the delegate so
+  // structural instances keep their generator identities.
+  final class ForTel[value](delegate0: value is Inlinable) extends Inlinable:
+    type Self = value
+    private[stratiform] def delegate: value is Inlinable = delegate0
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.parse(reader, indent)
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.absent(tactic)
+
+  object ForTel:
+    def derived[value]: ForTel[value] = ForTel(Inlinable.derived[value])
+
   private[stratiform] final class ProductInlinable[product]() extends Inlinable:
     type Self = product
 

--- a/lib/stratiform/src/staged/stratiform.stagedInternal.scala
+++ b/lib/stratiform/src/staged/stratiform.stagedInternal.scala
@@ -256,9 +256,16 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field].map(unwrap))
       . orElse(structuralFor[field](cache))
       . orElse(runtimeFor[field])
+
+  // A `derives`-clause carrier delegates to a structural instance; the
+  // ladder works with the delegate so generator identities stay
+  // recognizable.
+  private def unwrap(instance: Inlinable): Inlinable = instance match
+    case derived: Inlinable.ForTel[?] => derived.delegate.asInstanceOf[Inlinable]
+    case other                         => other
 
   // The runtime tiers, resolved with a reflection-level implicit search at
   // expansion time and called through neutral-carrier helpers (the erasing

--- a/lib/stratiform/src/staged/stratiform.stagedInternal.scala
+++ b/lib/stratiform/src/staged/stratiform.stagedInternal.scala
@@ -242,7 +242,13 @@ object stagedInternal:
   // runtime seam. The cache spans one entry expansion, so a type's staging
   // summon runs at most once however often it recurs in the graph.
 
-  private type Cache = scm.HashMap[String, Option[Inlinable]]
+  // The per-entry expansion cache: memoized staging summons, and the set of
+  // types whose generators are currently on the expansion stack — a
+  // recursive occurrence (`Tree` with `children: List[Tree]`) must degrade
+  // to the runtime seam rather than expand forever.
+  private[stratiform] final class Cache:
+    val instances: scm.HashMap[String, Option[Inlinable]] = scm.HashMap()
+    val active: scm.Set[String] = scm.Set()
 
   private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
     import quotes.reflect.*
@@ -250,7 +256,44 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      . orElse(structuralFor[field](cache))
+      . orElse(runtimeFor[field])
+
+  // The runtime tiers, resolved with a reflection-level implicit search at
+  // expansion time and called through neutral-carrier helpers (the erasing
+  // cast crosses the capability boundary, as wisteria's field-instance
+  // engine does): a nominal `Parsable` — the recursion tie, since a
+  // recursive record's own alias given (a lazy val) is found from inside
+  // its own definition — then the `Tel.Field` fallback chain. Neither
+  // `summonInline` nor a `using` parameter works for these from inside the
+  // generated parser's inline context.
+  private def runtimeFor[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    def searched(target: TypeRepr): Option[Expr[Any]] =
+      Implicits.search(target) match
+        case success: ImplicitSearchSuccess => Some(success.tree.asExpr)
+        case _                              => None
+
+    searched(TypeRepr.of[field is Tel.Parsable]).map(RuntimeInlinable[field](_)).orElse:
+      searched(TypeRepr.of[field is Tel.Field]).map(RuntimeInlinable[field](_))
+
+  private[stratiform] final class RuntimeInlinable[value](parsing: Expr[Any]) extends Inlinable:
+    type Self = value
+
+    def parse(reader: Expr[TelReader], indent: Expr[Int])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      '{
+        Tel.Parsable.parseField[value]
+          ($parsing.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef], $indent)
+      }
+
+    override def absent(tactic: Expr[Tactic[TelError]])(using Quotes, Type[value])
+    :   Expr[value] =
+
+      '{ Tel.Parsable.absentField[value]($parsing.asInstanceOf[AnyRef])(using $tactic) }
 
   private def builtinFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Inlinable] =
     import quotes.reflect.*
@@ -268,7 +311,11 @@ object stagedInternal:
 
     val tpe = TypeRepr.of[field].dealias
 
-    if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+    // A `Map` is an `Iterable` of pairs, but its wire form is not a
+    // repeated field of tuples — it stays on the runtime seam.
+    val isMap = tpe.derivesFrom(Symbol.requiredClass("scala.collection.Map"))
+
+    if !isMap && tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
       case AppliedType(_, arguments) =>
         arguments.last.asType match
           case '[element] =>
@@ -278,6 +325,9 @@ object stagedInternal:
 
       case _ =>
         None
+    // A recursive occurrence degrades to the runtime seam, whose
+    // derivation is lazy.
+    else if cache.active.contains(tpe.show) then None
     else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
     else sumFor[field](cache)
 
@@ -409,9 +459,21 @@ object stagedInternal:
     (using Quotes)
   :   Expr[product] =
 
-    productFields[product](reader, indent, scm.HashMap())
+    productFields[product](reader, indent, Cache())
 
   private[stratiform] def productFields[product: Type]
+    (reader: Expr[TelReader], indent: Expr[Int], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.TypeRepr
+
+    cache.active += TypeRepr.of[product].dealias.show
+
+    try productFields0[product](reader, indent, cache)
+    finally cache.active -= TypeRepr.of[product].dealias.show
+
+  private def productFields0[product: Type]
     (reader: Expr[TelReader], indent: Expr[Int], cache: Cache)
     (using Quotes)
   :   Expr[product] =
@@ -855,9 +917,20 @@ object stagedInternal:
     (using Quotes)
   :   Expr[sum] =
 
-    sumBody[sum](reader, indent, scm.HashMap())
+    sumBody[sum](reader, indent, Cache())
 
   private def sumBody[sum: Type](reader: Expr[TelReader], indent: Expr[Int], cache: Cache)
+    (using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[sum].dealias.show
+
+    try sumBody0[sum](reader, indent, cache)
+    finally cache.active -= TypeRepr.of[sum].dealias.show
+
+  private def sumBody0[sum: Type](reader: Expr[TelReader], indent: Expr[Int], cache: Cache)
     (using Quotes)
   :   Expr[sum] =
 
@@ -931,7 +1004,7 @@ object stagedInternal:
   def inlinableParsable[value: Type](using Quotes): Expr[value is Tel.Parsable] =
     import quotes.reflect.*
 
-    val cache: Cache = scm.HashMap()
+    val cache: Cache = Cache()
 
     if !productSupported(TypeRepr.of[value].dealias) then
       report.errorAndAbort
@@ -943,15 +1016,14 @@ object stagedInternal:
       // Sealed per the codec-thunk pattern, like the staged instances: the
       // generated body resolves its capabilities where it is spliced.
       caps.unsafe.unsafeAssumePure:
-        new Tel.Parsable:
-          type Self = value
-          def shape(): Morphology = Morphology.Any
-
-          def parse(reader: TelReader, indent: Int): value =
-            reader.finishLine()
+        new Tel.Parsable.Direct[value]:
+          protected def parseEntry(reader0: AnyRef, indent: Int): value =
+            // A capability class cannot be quoted into a pure hole, so
+            // every use casts from the neutral carrier afresh.
+            reader0.asInstanceOf[TelReader].finishLine()
             val indent1 = indent + 1
-            ${ productFields[value]('reader, 'indent1, cache) }
+            ${ productFields[value]('{ reader0.asInstanceOf[TelReader] }, 'indent1, cache) }
 
-          override def parse(reader: TelReader): value =
-            ${ productFields[value]('reader, '{0}, cache) }
+          protected def parseWhole(reader0: AnyRef): value =
+            ${ productFields[value]('{ reader0.asInstanceOf[TelReader] }, '{0}, cache) }
     }

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -83,6 +83,14 @@ object Tests extends Suite(m"Stratiform Tests"):
   case class Worker(name: Text, rank: Int) derives CanEqual
   case class Crew(worker: Worker, size: Int) derives CanEqual
 
+  // Model types for the BinTEL direct-parsing suite: a scalar list, and a
+  // sum without singleton variants (which the generator does not support).
+  case class Readings(values: List[Int], label: Text) derives CanEqual
+
+  enum BShape derives CanEqual:
+    case BCircle(radius: Int)
+    case BRect(width: Int, height: Int)
+
   enum Shape2 derives CanEqual:
     case Circle(radius: Int)
     case Rectangle(width: Int, height: Int)
@@ -2177,3 +2185,107 @@ object Tests extends Suite(m"Stratiform Tests"):
     RecordsTests()
     VerifyTests()
     AccrualTests()
+
+    suite(m"BinTEL direct parsing (BintelInlinable)"):
+      given (Tests.Person is Bintel.Parsable) = BintelInlinable.parsable[Tests.Person]
+      given (Tests.Company is Bintel.Parsable) = BintelInlinable.parsable[Tests.Company]
+      given (Tests.Team is Bintel.Parsable) = BintelInlinable.parsable[Tests.Team]
+      given (Tests.OptField is Bintel.Parsable) = BintelInlinable.parsable[Tests.OptField]
+
+      given (Tests.WithDefault is Bintel.Parsable) =
+        BintelInlinable.parsable[Tests.WithDefault]
+
+      given (Tests.Readings is Bintel.Parsable) = BintelInlinable.parsable[Tests.Readings]
+      given (Tests.BShape is Bintel.Parsable) = BintelInlinable.parsable[Tests.BShape]
+
+      test(m"a flat struct reads directly from body bytes"):
+        Bintel.parse[Tests.Person](Tests.Person(t"Alice", 30).bintel)
+      . assert(_ == Tests.Person(t"Alice", 30))
+
+      test(m"the direct read agrees with Bintel.read"):
+        val bytes = Tests.Person(t"Iris", 44).bintel
+        Bintel.parse[Tests.Person](bytes) == Bintel.read[Tests.Person](bytes)
+      . assert(identity)
+
+      test(m"a nested struct inlines through its own generated parser"):
+        val company = Tests.Company(t"Acme", Tests.Person(t"Bob", 50))
+        Bintel.parse[Tests.Company](company.bintel)
+      . assert(_ == Tests.Company(t"Acme", Tests.Person(t"Bob", 50)))
+
+      test(m"a repeatable struct field gathers every occurrence in order"):
+        val team = Tests.Team(t"crew", List(Tests.Person(t"A", 1), Tests.Person(t"B", 2)))
+        Bintel.parse[Tests.Team](team.bintel)
+      . assert(_ == Tests.Team(t"crew", List(Tests.Person(t"A", 1), Tests.Person(t"B", 2))))
+
+      test(m"a repeatable scalar field gathers every occurrence in order"):
+        val readings = Tests.Readings(List(3, 1, 4, 1, 5), t"pi")
+        Bintel.parse[Tests.Readings](readings.bintel)
+      . assert(_ == Tests.Readings(List(3, 1, 4, 1, 5), t"pi"))
+
+      test(m"an empty repeatable field reads as empty"):
+        Bintel.parse[Tests.Readings](Tests.Readings(Nil, t"none").bintel)
+      . assert(_ == Tests.Readings(Nil, t"none"))
+
+      test(m"an Optional field reads its value when present"):
+        Bintel.parse[Tests.OptField](Tests.OptField(7, t"note").bintel)
+      . assert(_ == Tests.OptField(7, t"note"))
+
+      test(m"an unset Optional agrees with the AST path"):
+        // The BinTEL *encoder* writes an unset `Optional` as a present,
+        // empty scalar, which the AST path restores as empty text rather
+        // than `Unset` — the direct parser reproduces that behavior
+        // exactly. (The encoder-side round-trip is a separate question.)
+        val bytes = Tests.OptField(7, Unset).bintel
+        Bintel.parse[Tests.OptField](bytes) == Bintel.read[Tests.OptField](bytes)
+      . assert(identity)
+
+      test(m"a truly absent Optional field reads Unset"):
+        // A hand-built body: one child, index 0 ("x"), scalar "7" — the
+        // `note` field is genuinely absent.
+        val bytes = IArray[Byte](0x01, 0x00, 0x01, '7'.toByte)
+        Bintel.parse[Tests.OptField](bytes)
+      . assert(_ == Tests.OptField(7, Unset))
+
+      test(m"a missing field with a declared default takes it"):
+        // A hand-built body: one child, index 0 ("name"), scalar "Bob".
+        val bytes = IArray[Byte](0x01, 0x00, 0x03, 'B'.toByte, 'o'.toByte, 'b'.toByte)
+        Bintel.parse[Tests.WithDefault](bytes)
+      . assert(_ == Tests.WithDefault(t"Bob", 18))
+
+      test(m"a missing required field raises Absent with its sentinel"):
+        // One child, index 1 ("age"), scalar "9" — "name" is missing.
+        val bytes = IArray[Byte](0x01, 0x01, 0x01, '9'.toByte)
+        capture[TelError](Bintel.parse[Tests.Person](bytes)).reason
+      . assert(_ == TelError.Reason.Absent)
+
+      test(m"an unparseable scalar raises NotScalar"):
+        // Two children: name "x", then age "abc".
+        val bytes = IArray[Byte]
+          (0x02, 0x00, 0x01, 'x'.toByte, 0x01, 0x03, 'a'.toByte, 'b'.toByte, 'c'.toByte)
+
+        capture[TelError](Bintel.parse[Tests.Person](bytes)).reason match
+          case TelError.Reason.NotScalar(atom, expected) => (atom.s, expected.s)
+          case other                                     => (other.toString, "")
+      . assert(_ == ("abc", "Int"))
+
+      test(m"a sum's variant is chosen by its keyword index"):
+        val shape: Tests.BShape = Tests.BShape.BRect(3, 4)
+        Bintel.parse[Tests.BShape](shape.bintel)
+      . assert(_ == Tests.BShape.BRect(3, 4))
+
+      test(m"the other variant round-trips too"):
+        val shape: Tests.BShape = Tests.BShape.BCircle(9)
+        Bintel.parse[Tests.BShape](shape.bintel)
+      . assert(_ == Tests.BShape.BCircle(9))
+
+      test(m"an out-of-range keyword index aborts"):
+        // One child with index 9 in a two-field struct.
+        val bytes = IArray[Byte](0x01, 0x09, 0x01, 'x'.toByte)
+        capture[BintelError](Bintel.parse[Tests.Person](bytes)).reason
+      . assert(_ == BintelError.Reason.BadKeywordIndex)
+
+      test(m"trailing bytes are rejected"):
+        val good = Tests.Person(t"Alice", 30).bintel
+        val padded = IArray.from(good.to(List) :+ 0.toByte)
+        capture[BintelError](Bintel.parse[Tests.Person](padded)).reason
+      . assert(_ == BintelError.Reason.TrailingBytes)

--- a/lib/stratiform/src/test/stratiform_test.scala
+++ b/lib/stratiform/src/test/stratiform_test.scala
@@ -2289,3 +2289,11 @@ object Tests extends Suite(m"Stratiform Tests"):
         val padded = IArray.from(good.to(List) :+ 0.toByte)
         capture[BintelError](Bintel.parse[Tests.Person](padded)).reason
       . assert(_ == BintelError.Reason.TrailingBytes)
+
+    suite(m"TEL direct parsing recursion"):
+      test(m"an inlined recursive type ties through its own nominal Parsable"):
+        given (Tests.Tree is Tel.Parsable) = Inlinable.parsable[Tests.Tree]
+        val tree = Tests.Tree(t"root", List(Tests.Tree(t"a", Nil)))
+        val data: Data = tree.in[Tel].show.s.getBytes("UTF-8").nn.immutable(using Unsafe)
+        data.read[Tests.Tree in Tel]
+      . assert(_ == Tests.Tree(t"root", List(Tests.Tree(t"a", Nil))))

--- a/lib/xylophone/src/core/xylophone.Xml.scala
+++ b/lib/xylophone/src/core/xylophone.Xml.scala
@@ -668,6 +668,30 @@ object Xml extends Tag.Container
     def attribute(text: Text)(using Tactic[XmlError], Foci[Xml.Focus]): Self = absent()
 
   object Parsable:
+    // The base of generated parsers: generated code is capture-erased, so
+    // the body receives the reader as a neutral carrier, and the capability
+    // is asserted here at the rim — the audited point — like the reader's
+    // own accessors. (A generated override of `parse` itself would narrow
+    // the trait's `XmlReader^` parameter to a pure type, which capture
+    // checking rejects at the instantiation site.)
+    abstract class Direct[value] extends Xml.Parsable:
+      type Self = value
+
+      protected def parseCarrier(reader: AnyRef): value
+
+      def parse(reader: XmlReader^): value = parseCarrier(reader.asInstanceOf[AnyRef])
+
+    // The call points for a nominal `Parsing` instance in a field position
+    // of a *generated* parser (a recursive record's own `Parsable`, a
+    // hand-written one, or the `Xml.Field` fallback chain). Both travel as
+    // neutral carriers — generated code is capture-erased — and the
+    // capability is reasserted here, at the audited point.
+    def parseField[value](parsing: AnyRef, reader: AnyRef): value =
+      parsing.asInstanceOf[value is Xml.Parsing].parse(reader.asInstanceOf[XmlReader^])
+
+    def absentField[value](parsing: AnyRef)(using Tactic[XmlError], Foci[Xml.Focus]): value =
+      parsing.asInstanceOf[value is Xml.Parsing].absent()
+
     def apply[value](parser: (reader: XmlReader^) => value)
     :   ((value is Xml.Parsable)^{parser}) =
 

--- a/lib/xylophone/src/staged/xylophone.Inlinable.scala
+++ b/lib/xylophone/src/staged/xylophone.Inlinable.scala
@@ -82,6 +82,28 @@ object Inlinable:
   // (no macro — `Type[Self]` arrives with the call).
   def derived[product]: product is Inlinable = ProductInlinable[product]()
 
+  // The `derives`-clause carrier: a `Self`-typed typeclass cannot appear in
+  // a `derives` clause (it has no type parameters), so `case class Foo(...)
+  // derives Inlinable.ForXml` synthesizes this parameterized subtrait —
+  // which *is* a `Foo is Inlinable` — into `Foo`'s companion, where the
+  // staging summon finds it. The resolution ladder unwraps the delegate so
+  // structural instances keep their generator identities.
+  final class ForXml[value](delegate0: value is Inlinable) extends Inlinable:
+    type Self = value
+    private[xylophone] def delegate: value is Inlinable = delegate0
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[value]): Expr[value] =
+      delegate0.parse(reader)
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[value])
+    :   Expr[value] =
+
+      delegate0.absent(tactic, foci)
+
+  object ForXml:
+    def derived[value]: ForXml[value] = ForXml(Inlinable.derived[value])
+
   private[xylophone] final class ProductInlinable[product]() extends Inlinable:
     type Self = product
 

--- a/lib/xylophone/src/staged/xylophone.stagedInternal.scala
+++ b/lib/xylophone/src/staged/xylophone.stagedInternal.scala
@@ -256,9 +256,16 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field].map(unwrap))
       . orElse(structuralFor[field](cache))
       . orElse(runtimeFor[field])
+
+  // A `derives`-clause carrier delegates to a structural instance; the
+  // ladder works with the delegate so generator identities stay
+  // recognizable.
+  private def unwrap(instance: Inlinable): Inlinable = instance match
+    case derived: Inlinable.ForXml[?] => derived.delegate.asInstanceOf[Inlinable]
+    case other                         => other
 
   // The runtime tiers, resolved with a reflection-level implicit search at
   // expansion time and called through neutral-carrier helpers (the erasing

--- a/lib/xylophone/src/staged/xylophone.stagedInternal.scala
+++ b/lib/xylophone/src/staged/xylophone.stagedInternal.scala
@@ -242,7 +242,13 @@ object stagedInternal:
   // runtime seam. The cache spans one entry expansion, so a type's staging
   // summon runs at most once however often it recurs in the graph.
 
-  private type Cache = scm.HashMap[String, Option[Inlinable]]
+  // The per-entry expansion cache: memoized staging summons, and the set of
+  // types whose generators are currently on the expansion stack — a
+  // recursive occurrence (`Tree` with `children: List[Tree]`) must degrade
+  // to the runtime seam rather than expand forever.
+  private[xylophone] final class Cache:
+    val instances: scm.HashMap[String, Option[Inlinable]] = scm.HashMap()
+    val active: scm.Set[String] = scm.Set()
 
   private def resolve[field: Type](cache: Cache)(using Quotes): Option[Inlinable] =
     import quotes.reflect.*
@@ -250,7 +256,43 @@ object stagedInternal:
     val tpe = TypeRepr.of[field].dealias
 
     builtinFor(tpe).orElse:
-      cache.getOrElseUpdate(tpe.show, summonViaStaging[field]).orElse(structuralFor[field](cache))
+      cache.instances.getOrElseUpdate(tpe.show, summonViaStaging[field])
+      . orElse(structuralFor[field](cache))
+      . orElse(runtimeFor[field])
+
+  // The runtime tiers, resolved with a reflection-level implicit search at
+  // expansion time and called through neutral-carrier helpers (the erasing
+  // cast crosses the capability boundary, as wisteria's field-instance
+  // engine does): a nominal `Parsable` — the recursion tie, since a
+  // recursive record's own alias given (a lazy val) is found from inside
+  // its own definition — then the `Xml.Field` fallback chain. Neither
+  // `summonInline` nor a `using` parameter works for these from inside the
+  // generated parser's inline context.
+  private def runtimeFor[field: Type](using Quotes): Option[Inlinable] =
+    import quotes.reflect.*
+
+    def searched(target: TypeRepr): Option[Expr[Any]] =
+      Implicits.search(target) match
+        case success: ImplicitSearchSuccess => Some(success.tree.asExpr)
+        case _                              => None
+
+    searched(TypeRepr.of[field is Xml.Parsable]).map(RuntimeInlinable[field](_)).orElse:
+      searched(TypeRepr.of[field is Xml.Field]).map(RuntimeInlinable[field](_))
+
+  private[xylophone] final class RuntimeInlinable[value](parsing: Expr[Any]) extends Inlinable:
+    type Self = value
+
+    def parse(reader: Expr[XmlReader])(using Quotes, Type[value]): Expr[value] =
+      '{
+        Xml.Parsable.parseField[value]
+          ($parsing.asInstanceOf[AnyRef], $reader.asInstanceOf[AnyRef])
+      }
+
+    override def absent(tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]])
+      (using Quotes, Type[value])
+    :   Expr[value] =
+
+      '{ Xml.Parsable.absentField[value]($parsing.asInstanceOf[AnyRef])(using $tactic, $foci) }
 
   private def builtinFor(using Quotes)(tpe: quotes.reflect.TypeRepr): Option[Inlinable] =
     import quotes.reflect.*
@@ -269,7 +311,11 @@ object stagedInternal:
 
     val tpe = TypeRepr.of[field].dealias
 
-    if tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
+    // A `Map` is an `Iterable` of pairs, but its wire form is not repeated
+    // elements of tuples — it stays on the runtime seam.
+    val isMap = tpe.derivesFrom(Symbol.requiredClass("scala.collection.Map"))
+
+    if !isMap && tpe <:< TypeRepr.of[Iterable[Any]] then tpe match
       case AppliedType(_, arguments) =>
         arguments.last.asType match
           case '[element] =>
@@ -279,6 +325,9 @@ object stagedInternal:
 
       case _ =>
         None
+    // A recursive occurrence degrades to the runtime seam, whose
+    // derivation is lazy.
+    else if cache.active.contains(tpe.show) then None
     else if productSupported(tpe) then Some(Inlinable.ProductInlinable[field]())
     else sumFor[field](cache)
 
@@ -460,9 +509,21 @@ object stagedInternal:
   private[xylophone] def productFields[product: Type](reader: Expr[XmlReader])(using Quotes)
   :   Expr[product] =
 
-    productFields[product](reader, scm.HashMap())
+    productFields[product](reader, Cache())
 
   private[xylophone] def productFields[product: Type]
+    (reader: Expr[XmlReader], cache: Cache)
+    (using Quotes)
+  :   Expr[product] =
+
+    import quotes.reflect.TypeRepr
+
+    cache.active += TypeRepr.of[product].dealias.show
+
+    try productFields0[product](reader, cache)
+    finally cache.active -= TypeRepr.of[product].dealias.show
+
+  private def productFields0[product: Type]
     (reader: Expr[XmlReader], cache: Cache)
     (using Quotes)
   :   Expr[product] =
@@ -940,7 +1001,7 @@ object stagedInternal:
     (using Quotes)
   :   Expr[product] =
 
-    productAbsent[product](tactic, foci, scm.HashMap())
+    productAbsent[product](tactic, foci, Cache())
 
   private[xylophone] def productAbsent[product: Type]
     (tactic: Expr[Tactic[XmlError]], foci: Expr[Foci[Xml.Focus]], cache: Cache)
@@ -1027,9 +1088,20 @@ object stagedInternal:
     (using Quotes)
   :   Expr[sum] =
 
-    sumBody[sum](reader, attribute, scm.HashMap())
+    sumBody[sum](reader, attribute, Cache())
 
   private def sumBody[sum: Type](reader: Expr[XmlReader], attribute: String, cache: Cache)
+    (using Quotes)
+  :   Expr[sum] =
+
+    import quotes.reflect.*
+
+    cache.active += TypeRepr.of[sum].dealias.show
+
+    try sumBody0[sum](reader, attribute, cache)
+    finally cache.active -= TypeRepr.of[sum].dealias.show
+
+  private def sumBody0[sum: Type](reader: Expr[XmlReader], attribute: String, cache: Cache)
     (using Quotes)
   :   Expr[sum] =
 
@@ -1095,7 +1167,7 @@ object stagedInternal:
   def inlinableParsable[value: Type](using Quotes): Expr[value is Xml.Parsable] =
     import quotes.reflect.*
 
-    val cache: Cache = scm.HashMap()
+    val cache: Cache = Cache()
 
     if !productSupported(TypeRepr.of[value].dealias) then
       report.errorAndAbort
@@ -1108,11 +1180,11 @@ object stagedInternal:
       // generated body resolves its capabilities at the read site, through
       // the reader.
       caps.unsafe.unsafeAssumePure:
-        new Xml.Parsable:
-          type Self = value
-
-          def parse(reader: XmlReader): value =
-            ${ productFields[value]('reader, cache) }
+        new Xml.Parsable.Direct[value]:
+          protected def parseCarrier(reader0: AnyRef): value =
+            // A capability class cannot be quoted into a pure hole, so
+            // every use casts from the neutral carrier afresh.
+            ${ productFields[value]('{ reader0.asInstanceOf[XmlReader] }, cache) }
 
           override def absent()(using tactic: Tactic[XmlError], foci: Foci[Xml.Focus]): value =
             ${ productAbsent[value]('tactic, 'foci, cache) }

--- a/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
+++ b/lib/xylophone/src/test/xylophone.DirectParsingTests.scala
@@ -60,6 +60,7 @@ case class PReading(temp: PTemperature, station: Text) derives CanEqual
 // in document order — one with a leaf-element list, one with a nested-record
 // list.
 case class PPlaylist(name: Text, songs: List[Text]) derives CanEqual
+case class PTree(value: Text, children: List[PTree]) derives CanEqual
 case class PTeam(name: Text, members: List[PWorker]) derives CanEqual
 
 case class PIssues(items: List[(Text, XmlError)] = Nil)(using Diagnostics)
@@ -112,6 +113,7 @@ object DirectParsingTests extends Suite(m"Xylophone direct parsing tests"):
     given PReading is Xml.Parsable = Xml.Parsable.derived
     given PPlaylist is Xml.Parsable = Xml.Parsable.derived
     given PTeam is Xml.Parsable = Xml.Parsable.derived
+    given PTree is Xml.Parsable = Inlinable.parsable[PTree]
 
     // The acceptance criterion: the direct read must equal the AST-path
     // read (parse to an `Xml` tree, then decode), for the same input.
@@ -240,6 +242,12 @@ object DirectParsingTests extends Suite(m"Xylophone direct parsing tests"):
         capture[XmlError](t"<Triangle><foo>1</foo></Triangle>".read[PShape in Xml])
         true
       . assert(identity)
+
+    suite(m"Recursion"):
+      test(m"an inlined recursive type ties through its own nominal Parsable"):
+        val tree = PTree(t"root", List(PTree(t"a", Nil), PTree(t"b", List(PTree(t"c", Nil)))))
+        tree.in[Xml].show.read[PTree in Xml]
+      . assert(_ == PTree(t"root", List(PTree(t"a", Nil), PTree(t"b", List(PTree(t"c", Nil))))))
 
     suite(m"Collections"):
       test(m"Contiguous repeated elements gather in order, equally on both paths"):


### PR DESCRIPTION
The direct, tree-free parsing that JSON, TEL and XML already offered now extends to all three binary formats. CBOR, Protocol Buffers and BinTEL each acquire an `Inlinable` typeclass whose instances are macro-time code generators: at a call site they compose a single monomorphic decoder that reads records straight from the wire, skipping the intermediate syntax tree entirely, and every format's inlined instances can be requested with a single `derives` clause. Across a corpus of seven document shapes these inlined parsers are the fastest decoders available for their formats — CBOR outpaces borer on every document, XML beats a hand-written Aalto StAX walk on six of seven, and Protocol Buffers comes within a small factor of a hand-written protobuf-java reader — while the same pass hardens the existing JSON, TEL and XML generators so recursive types, `Map` fields and capture-checked call sites all work.

## Direct binary parsing

`Cbor`, `Protobuf` and `Bintel` now support the same direct, tree-free
parsing that `Json`, `Tel` and `Xml` already offered. Opt a type in with an
`Inlinable` instance and reads go straight from the bytes to your case
classes, with no intermediate syntax tree:

```scala
import breviloquence.*

case class Point(x: Int, y: Int)
given (Point is Cbor.Parsable) = breviloquence.Inlinable.parsable[Point]

val point = cborBytes.read[Point in Cbor]
```

Protocol Buffers works the same way:

```scala
import locomotion.*

case class Person(@field(1) name: Text, @field(2) age: Int)
given (Person is Protobuf.Parsable) = locomotion.Inlinable.parsable[Person]

val person = protobufBytes.read[Person in Protobuf]
```

and BinTEL through `Bintel.parse`:

```scala
import stratiform.*

given (Point is Bintel.Parsable) = BintelInlinable.parsable[Point]
val point = Bintel.parse[Point](bintelBytes)
```

The generated parsers reproduce the AST decoders' behaviour exactly — the
same field defaults, `Optional` handling, repeated-field gathering and error
semantics — while allocating nothing for the tree.

## `derives` for `Inlinable`

Every format's `Inlinable` can now be attached with a `derives` clause, so
one type can opt into several formats at once:

```scala
case class Order(reference: Text, total: Double)
derives breviloquence.Inlinable.ForCbor,
    locomotion.Inlinable.ForProtobuf,
    stratiform.BintelInlinable.ForBintel
```

## Hardening

The JSON, TEL and XML generators now also handle recursive types — which
tie through their own nominal `Parsable` given — `Map`-typed fields, and
capture-checked call sites.
