### PR TITLE
Read the PDF document layer: pages, metadata and navigation

### DIFF
--- a/lib/facsimile/doc/basics.md
+++ b/lib/facsimile/doc/basics.md
@@ -47,3 +47,36 @@ pdfFile.open():
 
 Decoded `Data` and parsed `Cos` values are pure and may escape the `open` block; the `Pdf`
 itself, and anything which still resolves lazily through it, may not.
+
+### Pages
+
+The page tree is flattened into reading order, with the inheritable attributes — resources,
+boxes and rotation — applied along each path. Page geometry is expressed in typesafe
+lengths: a PDF point is exactly 1/72 inch, `quantitative`'s `Points` unit.
+
+```scala
+pdfFile.open():
+  val page = pdf.pages(0)
+  page.mediaBox.width   // Quantity[Points[1]]
+  page.rotation         // Page.Rotation.Quarter, for /Rotate 90
+  page.width            // rotation-aware display width
+  page.annotations      // typed Link, Note and Widget annotations
+```
+
+A `Page` still resolves through the document, so — like the `Pdf` — it cannot leave the
+`open` block; everything extracted from it can.
+
+### Document structure
+
+Metadata and navigation structures are fully materialized as pure values:
+
+```scala
+pdfFile.open():
+  pdf.info.title        // Optional[Text]
+  pdf.info.created      // Optional[PdfInfo.Timing]: a Timestamp and optional UTC offset
+  pdf.bookmarks         // the outline tree, with Destinations
+  pdf.destinations      // named destinations
+  pdf.attachments       // embedded files (read `data` inside the scope)
+  pdf.pageLabel(0.z)    // "i", "42", "A-7"...
+  pdf.xmp               // the raw XMP packet, if any
+```

--- a/lib/facsimile/doc/features.md
+++ b/lib/facsimile/doc/features.md
@@ -3,6 +3,9 @@
 - follows incremental-update chains, with the newest version of each object winning
 - loads objects lazily and on demand, including from compressed object streams
 - decodes FlateDecode, ASCIIHexDecode and RunLengthDecode filters, with PNG and TIFF predictors
+- flattens the page tree with attribute inheritance, and typed page boxes in `Quantity[Points[1]]`
+- reads document information (with PDF date parsing), bookmarks, named destinations and annotations
+- surfaces embedded files, page labels and the XMP metadata packet
 - capture checking confines the open file to its scope; extracted values are pure and portable
 - tolerates common real-world deviations: prepended junk, raw deflate streams, truncated data
 - no third-party dependencies

--- a/lib/facsimile/src/core/facsimile.Annotation.scala
+++ b/lib/facsimile/src/core/facsimile.Annotation.scala
@@ -30,7 +30,81 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import contingency.*
+import denominative.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+object Annotation:
+  extension (annotation: Annotation)
+    def rect: PdfRect = annotation match
+      case Link(rect, _, _, _)  => rect
+      case Note(rect, _, _, _)  => rect
+      case Widget(rect, _, _)   => rect
+      case Other(_, rect, _)    => rect
+
+    def dictionary: Map[Text, Cos] = annotation match
+      case Link(_, _, _, dictionary)  => dictionary
+      case Note(_, _, _, dictionary)  => dictionary
+      case Widget(_, _, dictionary)   => dictionary
+      case Other(_, _, dictionary)    => dictionary
+
+  private[facsimile] def read
+    ( value: Cos, pages: Map[Int, Ordinal], named: Text => Optional[Cos], scale: Double )
+    ( using pdf: Pdf )
+  :   Optional[Annotation] raises PdfError =
+
+    pdf.resolved(value) match
+      case Cos.Dictionary(entries) =>
+        PdfRect.read(entries.at(t"Rect").or(Cos.Nil), scale).let: rect =>
+          val action = pdf.resolved(entries.at(t"A").or(Cos.Nil))
+          val kind = action(t"S").let(_.name).or(t"")
+
+          entries.at(t"Subtype").let(pdf.resolved(_).name).or(t"") match
+            case t"Link" =>
+              val target = entries.at(t"Dest")
+                . or(if kind == t"GoTo" then action(t"D") else Unset)
+
+              val uri =
+                if kind == t"URI" then action(t"URI").let(pdf.resolved(_).text) else Unset
+
+              Link(rect, target.let(Destination.read(_, pages, named)), uri, entries)
+
+            case t"Text" =>
+              Note
+                ( rect,
+                  entries.at(t"Contents").let(pdf.resolved(_).text),
+                  entries.at(t"Open").let(pdf.resolved(_).truth).or(false),
+                  entries )
+
+            case t"Widget" =>
+              Widget(rect, entries.at(t"T").let(pdf.resolved(_).text), entries)
+
+            case subtype =>
+              Other(subtype, rect, entries)
+
+      case _ =>
+        Unset
+
+// A page annotation (ISO 32000-2 §12.5): links, sticky notes and form widgets as typed
+// cases, and the remaining twenty-odd subtypes as `Other`, always with the raw dictionary
+// as an escape hatch.
+enum Annotation:
+  case Link
+    ( rect:        PdfRect,
+      destination: Optional[Destination],
+      uri:         Optional[Text],
+      dictionary:  Map[Text, Cos] )
+
+  case Note
+    ( rect:       PdfRect,
+      contents:   Optional[Text],
+      open:       Boolean,
+      dictionary: Map[Text, Cos] )
+
+  case Widget(rect: PdfRect, fieldName: Optional[Text], dictionary: Map[Text, Cos])
+  case Other(subtype: Text, rect: PdfRect, dictionary: Map[Text, Cos])

--- a/lib/facsimile/src/core/facsimile.Bookmark.scala
+++ b/lib/facsimile/src/core/facsimile.Bookmark.scala
@@ -30,7 +30,14 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import vacuous.*
+
+// One entry of the document outline (ISO 32000-2 §12.3.3), fully materialized as a pure
+// tree: PDF's "outlines" are what every viewer presents as bookmarks.
+case class Bookmark
+  ( title:       Text,
+    destination: Optional[Destination],
+    children:    List[Bookmark] )

--- a/lib/facsimile/src/core/facsimile.Cos.scala
+++ b/lib/facsimile/src/core/facsimile.Cos.scala
@@ -32,11 +32,50 @@
                                                                                                   */
 package facsimile
 
+import java.nio.charset as jncs
+
 import anticipation.*
 import rudiments.*
 import vacuous.*
 
 object Cos:
+  // The code points at which PDFDocEncoding (ISO 32000-2 Annex D.7) differs from Latin-1:
+  // typographic accents at 0x18–0x1F and publishing characters at 0x80–0x9F, with the euro
+  // sign at 0xA0.
+  private val docEncodingLow: IArray[Char] = IArray
+    ( '˘', 'ˇ', 'ˆ', '˙', '˝', '˛', '˚', '˜' )
+
+  private val docEncodingHigh: IArray[Char] = IArray
+    ( '•', '†', '‡', '…', '—', '–', 'ƒ', '⁄',
+      '‹', '›', '−', '‰', '„', '“', '”', '‘',
+      '’', '‚', '™', 'ﬁ', 'ﬂ', 'Ł', 'Œ', 'Š',
+      'Ÿ', 'Ž', 'ı', 'ł', 'œ', 'š', 'ž', '�' )
+
+  // A text string (ISO 32000-2 §7.9.2.2): UTF-16BE or UTF-8 by byte-order mark, otherwise
+  // PDFDocEncoding.
+  private[facsimile] def decodeText(bytes: Data): Text =
+    if bytes.length >= 2 && (bytes(0) & 0xff) == 0xfe && (bytes(1) & 0xff) == 0xff
+    then String(bytes.drop(2).mutable(using Unsafe), jncs.StandardCharsets.UTF_16BE).nn.tt
+    else if bytes.length >= 3
+            && (bytes(0) & 0xff) == 0xef && (bytes(1) & 0xff) == 0xbb && (bytes(2) & 0xff) == 0xbf
+    then String(bytes.drop(3).mutable(using Unsafe), jncs.StandardCharsets.UTF_8).nn.tt
+    else
+      val chars = new Array[Char](bytes.length)
+      var i = 0
+
+      while i < bytes.length do
+        val byte = bytes(i) & 0xff
+
+        chars(i) =
+          if byte >= 0x18 && byte <= 0x1f then docEncodingLow(byte - 0x18)
+          else if byte >= 0x80 && byte <= 0x9f then docEncodingHigh(byte - 0x80)
+          else if byte == 0xa0 then '€'
+          else byte.toChar
+
+        i += 1
+
+      String(chars).tt
+
   extension (cos: Cos)
     def dictionary: Optional[Map[Text, Cos]] = cos match
       case Cos.Dictionary(entries) => entries
@@ -69,6 +108,11 @@ object Cos:
 
     def chars: Optional[Data] = cos match
       case Cos.Chars(bytes) => bytes
+      case _                => Unset
+
+    // The string's content as text, interpreting its byte-order mark or PDFDocEncoding.
+    def text: Optional[Text] = cos match
+      case Cos.Chars(bytes) => decodeText(bytes)
       case _                => Unset
 
     def elements: Optional[List[Cos]] = cos match

--- a/lib/facsimile/src/core/facsimile.Destination.scala
+++ b/lib/facsimile/src/core/facsimile.Destination.scala
@@ -30,7 +30,85 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import contingency.*
+import denominative.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+object Destination:
+  // As an extension rather than a base-class method, since every case declares a `page`
+  // field of its own, which could not otherwise share the name.
+  extension (destination: Destination)
+    def page: Ordinal = destination match
+      case Xyz(page, _, _, _)    => page
+      case Fit(page)             => page
+      case FitWidth(page, _)     => page
+      case FitHeight(page, _)    => page
+      case FitRect(page, _)      => page
+      case FitBox(page)          => page
+      case FitBoxWidth(page, _)  => page
+      case FitBoxHeight(page, _) => page
+
+  // An explicit destination array (ISO 32000-2 §12.3.2.3), a dictionary wrapping one at
+  // `/D`, or a name/string to look up among the document's named destinations. `named` is
+  // consulted at most once, so a self-referential name cannot loop.
+  private[facsimile] def read
+    ( value: Cos,
+      pages: Map[Int, Ordinal],
+      named: Text => Optional[Cos],
+      following: Boolean = false )
+    ( using pdf: Pdf )
+  :   Optional[Destination] raises PdfError =
+
+    pdf.resolved(value) match
+      case Cos.Sequence(target :: Cos.Name(kind) :: rest) =>
+        val page: Optional[Ordinal] = target match
+          case Cos.Ref(number, _)  => pages.at(number)
+          case Cos.Integral(index) => index.toInt.z
+          case _                   => Unset
+
+        def dimension(index: Int): Optional[Double] =
+          if index < rest.length then pdf.resolved(rest(index)).double else Unset
+
+        page.let: page =>
+          kind.s match
+            case "XYZ"   => Xyz(page, dimension(0), dimension(1), dimension(2))
+            case "Fit"   => Fit(page)
+            case "FitH"  => FitWidth(page, dimension(0))
+            case "FitV"  => FitHeight(page, dimension(0))
+            case "FitB"  => FitBox(page)
+            case "FitBH" => FitBoxWidth(page, dimension(0))
+            case "FitBV" => FitBoxHeight(page, dimension(0))
+
+            case "FitR" =>
+              PdfRect.read(Cos.Sequence(rest), 1.0).let(FitRect(page, _))
+
+            case _ =>
+              Unset
+
+      case dictionary: Cos.Dictionary =>
+        dictionary(t"D").let(read(_, pages, named, following))
+
+      case other =>
+        if following then Unset else
+          val key = other match
+            case Cos.Name(name) => name
+            case cos            => cos.text
+
+          key.let(named(_)).let(read(_, pages, named, following = true))
+
+// Where a link, bookmark or navigation action lands: a page — by position in the flattened
+// page sequence — and how the viewer should fit it.
+enum Destination:
+  case Xyz(page: Ordinal, left: Optional[Double], top: Optional[Double], zoom: Optional[Double])
+  case Fit(page: Ordinal)
+  case FitWidth(page: Ordinal, top: Optional[Double])
+  case FitHeight(page: Ordinal, left: Optional[Double])
+  case FitRect(page: Ordinal, rect: PdfRect)
+  case FitBox(page: Ordinal)
+  case FitBoxWidth(page: Ordinal, top: Optional[Double])
+  case FitBoxHeight(page: Ordinal, left: Optional[Double])

--- a/lib/facsimile/src/core/facsimile.Page.scala
+++ b/lib/facsimile/src/core/facsimile.Page.scala
@@ -30,7 +30,89 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import contingency.*
+import denominative.*
+import gossamer.*
+import quantitative.*
+import rudiments.*
+import vacuous.*
+
+object Page:
+  enum Rotation:
+    case None, Quarter, Half, ThreeQuarters
+
+  // The inheritable page-tree attributes (ISO 32000-2 §7.7.3.4): a child's own entry always
+  // wins over anything accumulated from its ancestors.
+  private[facsimile] case class Inherited
+    ( resources: Optional[Cos] = Unset,
+      mediaBox:  Optional[Cos] = Unset,
+      cropBox:   Optional[Cos] = Unset,
+      rotate:    Optional[Cos] = Unset ):
+
+    def update(node: Map[Text, Cos]): Inherited =
+      Inherited
+        ( node.at(t"Resources").or(resources),
+          node.at(t"MediaBox").or(mediaBox),
+          node.at(t"CropBox").or(cropBox),
+          node.at(t"Rotate").or(rotate) )
+
+// A leaf of the page tree, with its inherited attributes applied. A `Page` resolves lazily
+// through the document, so it captures the `Pdf` and cannot outlive the `open` scope;
+// everything extracted from it — boxes, rotation, text — is pure and portable.
+class Page private[facsimile]
+  ( private[facsimile] val pdf: Pdf,
+    val index: Ordinal,
+    private[facsimile] val entries: Map[Text, Cos],
+    inherited: Page.Inherited ):
+
+  def dictionary: Map[Text, Cos] = entries
+
+  // 1 default user-space unit is `userUnit`/72 inch; `/UserUnit` is not inheritable.
+  def userUnit: Double raises PdfError =
+    entries.at(t"UserUnit").let(pdf.resolved(_).double).or(1.0)
+
+  def mediaBox: PdfRect raises PdfError =
+    box(entries.at(t"MediaBox").or(inherited.mediaBox))
+    . or(abort(PdfError(PdfError.Reason.MissingEntry(t"MediaBox"))))
+
+  def cropBox: PdfRect raises PdfError =
+    box(entries.at(t"CropBox").or(inherited.cropBox)).or(mediaBox)
+
+  // The bleed, trim and art boxes are not inheritable and default to the crop box.
+  def bleedBox: PdfRect raises PdfError = box(entries.at(t"BleedBox")).or(cropBox)
+  def trimBox: PdfRect raises PdfError = box(entries.at(t"TrimBox")).or(cropBox)
+  def artBox: PdfRect raises PdfError = box(entries.at(t"ArtBox")).or(cropBox)
+
+  def rotation: Page.Rotation raises PdfError =
+    val degrees = entries.at(t"Rotate").or(inherited.rotate).let(pdf.resolved(_).long).or(0L)
+
+    ((degrees%360 + 360)%360) match
+      case 90L  => Page.Rotation.Quarter
+      case 180L => Page.Rotation.Half
+      case 270L => Page.Rotation.ThreeQuarters
+      case _    => Page.Rotation.None
+
+  // The page's displayed size: the crop box, with its axes exchanged when the page is
+  // rotated a quarter-turn either way.
+  def width: Quantity[Points[1]] raises PdfError = rotation match
+    case Page.Rotation.Quarter | Page.Rotation.ThreeQuarters => cropBox.height
+    case _                                                   => cropBox.width
+
+  def height: Quantity[Points[1]] raises PdfError = rotation match
+    case Page.Rotation.Quarter | Page.Rotation.ThreeQuarters => cropBox.width
+    case _                                                   => cropBox.height
+
+  def annotations: List[Annotation] raises PdfError =
+    val pages = pdf.pageNumbers
+    val named = pdf.rawDestinations
+    val scale = userUnit
+
+    pdf.resolved(entries.at(t"Annots").or(Cos.Nil)).elements.lay(List()): items =>
+      items.flatMap: item =>
+        Annotation.read(item, pages, named.at(_), scale)(using pdf).lay(List())(List(_))
+
+  private def box(value: Optional[Cos]): Optional[PdfRect] raises PdfError =
+    value.let(PdfRect.read(_, userUnit)(using pdf))

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -34,12 +34,27 @@ package facsimile
 
 import anticipation.*
 import contingency.*
+import denominative.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
 
 object Pdf:
   case class Version(major: Int, minor: Int)
+
+  // An embedded file from the `/EmbeddedFiles` name tree. Its metadata is materialized, but
+  // `data` still reads through the document, so an `Attachment` is confined to the scope;
+  // call `data` inside and keep the result.
+  class Attachment private[facsimile]
+    ( pdf:             Pdf,
+      val name:        Text,
+      val filename:    Optional[Text],
+      val description: Optional[Text],
+      val mediaType:   Optional[Text],
+      body:            Optional[Cos.Body] ):
+
+    def data: Data raises PdfError =
+      body.let(pdf.payload(_)).or(abort(PdfError(PdfError.Reason.MissingEntry(t"EF"))))
 
   // Until the encryption milestone lands, an encrypted file is refused outright rather
   // than misread: strings and streams would otherwise surface as ciphertext.
@@ -63,10 +78,8 @@ object Pdf:
       var j = 0
       while j < marker.length && (window(i + j) & 0xff) == marker.s.charAt(j).toInt do j += 1
 
-      if j == marker.length
-         && digit(window(i + 5) & 0xff)
-         && (window(i + 6) & 0xff) == '.'
-         && digit(window(i + 7) & 0xff)
+      if j == marker.length && digit(window(i + 5) & 0xff) &&
+        (window(i + 6) & 0xff) == '.' && digit(window(i + 7) & 0xff)
       then found = Version((window(i + 5) & 0xff) - '0', (window(i + 7) & 0xff) - '0')
       else i += 1
 
@@ -93,6 +106,191 @@ extends caps.ExclusiveCapability:
     scala.collection.mutable.HashMap()
 
   def trailer: Map[Text, Cos] = xref.trailer
+
+  def catalog: Map[Text, Cos] raises PdfError =
+    resolved(trailer.at(t"Root").or(Cos.Nil)).dictionary
+    . or(abort(PdfError(PdfError.Reason.MissingEntry(t"Root"))))
+
+  // The page tree flattened into reading order, with the inheritable attributes accumulated
+  // along each path; the object number of each leaf is kept so that destinations can refer
+  // back to a page by reference.
+  private[facsimile] def pageEntries
+  :   Vector[(Optional[Int], Map[Text, Cos], Page.Inherited)] raises PdfError =
+
+    var visited = Set[Int]()
+
+    def recur(node: Cos, number: Optional[Int], inherited: Page.Inherited)
+    :   Vector[(Optional[Int], Map[Text, Cos], Page.Inherited)] =
+
+      node match
+        case Cos.Ref(reference, _) =>
+          if visited.contains(reference)
+          then abort(PdfError(PdfError.Reason.CircularPageTree))
+
+          visited += reference
+          recur(resolved(node), reference, inherited)
+
+        case Cos.Dictionary(entries) => entries.at(t"Type").let(_.name) match
+          case t"Pages" =>
+            val updated = inherited.update(entries)
+
+            resolved(entries.at(t"Kids").or(Cos.Nil)).elements.lay(Vector()): kids =>
+              kids.to(Vector).flatMap(recur(_, Unset, updated))
+
+          case _ =>
+            Vector((number, entries, inherited))
+
+        case _ =>
+          Vector()
+
+    recur(catalog.at(t"Pages").or(Cos.Nil), Unset, Page.Inherited())
+
+  def pages: Vector[Page^{this}] raises PdfError =
+    pageEntries.zipWithIndex.map: (entry, index) =>
+      Page(this, index.z, entry(1), entry(2))
+
+  // Leaf object numbers mapped to positions in the flattened page sequence, for resolving
+  // destinations that refer to pages by reference.
+  private[facsimile] def pageNumbers: Map[Int, Ordinal] raises PdfError =
+    pageEntries.zipWithIndex.flatMap: (entry, index) =>
+      entry(0).lay(List()): number =>
+        List(number -> index.z)
+
+    . to(Map)
+
+  // Named destinations from both homes: the old-style `/Dests` dictionary and the
+  // `/Names /Dests` name tree, still as raw COS values.
+  private[facsimile] def rawDestinations: Map[Text, Cos] raises PdfError =
+    val old = resolved(catalog.at(t"Dests").or(Cos.Nil)).dictionary.or(Map[Text, Cos]())
+
+    val tree = resolved(catalog.at(t"Names").or(Cos.Nil))(t"Dests")
+      . let(Trees.names(_)(using this).to(Map)).or(Map[Text, Cos]())
+
+    old ++ tree
+
+  def destinations: Map[Text, Destination] raises PdfError =
+    val pages = pageNumbers
+    val raw = rawDestinations
+
+    raw.to(List).flatMap: (name, value) =>
+      Destination.read(value, pages, raw.at(_))(using this)
+      . lay(List()): destination =>
+          List(name -> destination)
+
+    . to(Map)
+
+  def bookmarks: List[Bookmark] raises PdfError =
+    val pages = pageNumbers
+    val raw = rawDestinations
+    var visited = Set[Int]()
+
+    // `/Dest` directly, or the `/D` of a `/GoTo` action.
+    def target(entries: Map[Text, Cos]): Optional[Cos] raises PdfError =
+      entries.at(t"Dest").or:
+        val action = resolved(entries.at(t"A").or(Cos.Nil))
+
+        if action(t"S").let(_.name).or(t"") == t"GoTo" then action(t"D") else Unset
+
+    def item(value: Cos): List[Bookmark] raises PdfError = value match
+      case Cos.Ref(number, _) =>
+        if visited.contains(number) then List() else
+          visited += number
+          item(resolved(value))
+
+      case Cos.Dictionary(entries) =>
+        val title = entries.at(t"Title").let(resolved(_).text).or(t"")
+
+        val destination =
+          target(entries).let(Destination.read(_, pages, raw.at(_))(using this))
+
+        Bookmark(title, destination, chain(entries.at(t"First"))) ::
+          chain(entries.at(t"Next"))
+
+      case _ =>
+        List()
+
+    def chain(first: Optional[Cos]): List[Bookmark] raises PdfError =
+      first.lay(List())(item(_))
+
+    chain(resolved(catalog.at(t"Outlines").or(Cos.Nil))(t"First"))
+
+  def attachments: List[Pdf.Attachment^{this}] raises PdfError =
+    resolved(catalog.at(t"Names").or(Cos.Nil))(t"EmbeddedFiles").lay(List()): tree =>
+      Trees.names(tree)(using this).map: (name, value) =>
+        val spec = resolved(value).dictionary.or(Map[Text, Cos]())
+        val filename = spec.at(t"UF").or(spec.at(t"F")).let(resolved(_).text)
+        val description = spec.at(t"Desc").let(resolved(_).text)
+        val files = resolved(spec.at(t"EF").or(Cos.Nil))
+
+        val body: Optional[Cos.Body] =
+          resolved(files(t"UF").or(files(t"F")).or(Cos.Nil)) match
+            case body: Cos.Body => body
+            case _              => Unset
+
+        val mediaType = body.let(_.entries.at(t"Subtype")).let(_.name)
+        Pdf.Attachment(this, name, filename, description, mediaType, body)
+
+  // The label a viewer displays for a page (ISO 32000-2 §12.4.2): styled and prefixed by
+  // the `/PageLabels` number tree, or the plain one-based page number when absent.
+  def pageLabel(index: Ordinal): Text raises PdfError =
+    catalog.at(t"PageLabels").lay(index.n1.toString.tt): tree =>
+      val ranges = Trees.numbers(tree)(using this).filter(_(0) <= index.n0)
+
+      if ranges.isEmpty then index.n1.toString.tt else
+        val (start, value) = ranges.maxBy(_(0))
+        val entries = resolved(value).dictionary.or(Map[Text, Cos]())
+        val prefix = entries.at(t"P").let(resolved(_).text).or(t"")
+        val first = entries.at(t"St").let(resolved(_).long).or(1L)
+        val number = first + (index.n0 - start)
+
+        val formatted = entries.at(t"S").let(resolved(_).name).lay(t""):
+          case t"D" => number.toString.tt
+          case t"R" => roman(number)
+          case t"r" => roman(number).s.toLowerCase.nn.tt
+          case t"A" => alphabetic(number)
+          case t"a" => alphabetic(number).s.toLowerCase.nn.tt
+          case _    => t""
+
+        t"$prefix$formatted"
+
+  private def roman(number: Long): Text =
+    val numerals =
+      List
+        ( 1000L -> "M", 900L -> "CM", 500L -> "D", 400L -> "CD", 100L -> "C", 90L -> "XC",
+          50L -> "L", 40L -> "XL", 10L -> "X", 9L -> "IX", 5L -> "V", 4L -> "IV", 1L -> "I" )
+
+    def recur(remaining: Long, numerals: List[(Long, String)], result: String): String =
+      numerals match
+        case (value, numeral) :: rest =>
+          if remaining >= value then recur(remaining - value, numerals, result + numeral)
+          else recur(remaining, rest, result)
+
+        case _ =>
+          result
+
+    if number <= 0 then t"" else recur(number, numerals, "").tt
+
+  // A, B, ..., Z, AA, BB, ..., ZZ, AAA, ... — the same letter repeated, per the spec.
+  private def alphabetic(number: Long): Text =
+    if number <= 0 then t"" else
+      val letter = ('A' + ((number - 1)%26)).toChar.toString
+      letter.repeat((((number - 1)/26) + 1).toInt).nn.tt
+
+  // The document-level XMP packet, undecoded: XML parsing belongs downstream.
+  def xmp: Optional[Data] raises PdfError =
+    resolved(catalog.at(t"Metadata").or(Cos.Nil)) match
+      case body: Cos.Body => payload(body)
+      case _              => Unset
+
+  def info: PdfInfo raises PdfError =
+    val entries = resolved(trailer.at(t"Info").or(Cos.Nil)).dictionary.or(Map[Text, Cos]())
+    def field(key: Text): Optional[Text] = entries.at(key).let(resolved(_).text)
+
+    PdfInfo
+      ( field(t"Title"), field(t"Author"), field(t"Subject"), field(t"Keywords"),
+        field(t"Creator"), field(t"Producer"),
+        field(t"CreationDate").let(PdfInfo.parseDate(_)),
+        field(t"ModDate").let(PdfInfo.parseDate(_)) )
 
   def apply(ref: Cos.Ref): Cos raises PdfError = apply(ref.number, ref.generation)
 
@@ -141,18 +339,19 @@ extends caps.ExclusiveCapability:
     val raw = source.read(body.start, length)
     if raw.length < length then abort(PdfError(PdfError.Reason.Truncated))
 
-    val chain = Filter.chain
-      ( body.entries.at(t"Filter").let(deepResolved(_)),
-        body.entries.at(t"DecodeParms").let(deepResolved(_)) )
+    val chain =
+      Filter.chain
+        ( body.entries.at(t"Filter").let(deepResolved(_)),
+          body.entries.at(t"DecodeParms").let(deepResolved(_)) )
 
     Filter.decode(raw, chain)
 
   // Resolves a value and, one level down, the elements of an array or the values of a
   // dictionary: sufficient for `/Filter` and `/DecodeParms` shapes.
   private def deepResolved(value: Cos): Cos raises PdfError = resolved(value) match
-    case Cos.Sequence(elements) => Cos.Sequence(elements.map(resolved(_)))
+    case Cos.Sequence(elements)  => Cos.Sequence(elements.map(resolved(_)))
     case Cos.Dictionary(entries) => Cos.Dictionary(entries.view.mapValues(resolved(_)).toMap)
-    case other => other
+    case other                   => other
 
   private def containerStream(container: Int): ObjectStream raises PdfError =
     containers.at(container).or:

--- a/lib/facsimile/src/core/facsimile.PdfInfo.scala
+++ b/lib/facsimile/src/core/facsimile.PdfInfo.scala
@@ -30,7 +30,74 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import aviation.*
+import contingency.*
+import quantitative.*
+import vacuous.*
+
+object PdfInfo:
+  // A PDF date (ISO 32000-2 §7.9.4): local time with an *optional* UTC offset — absence
+  // means the relationship to UTC is unknown, so a zoneless `Timestamp` carries the moment
+  // and the offset rides alongside only when the file stated one.
+  case class Timing(timestamp: Timestamp, offset: Optional[Duration])
+
+  // `D:YYYYMMDDHHmmSS±HH'mm'`, everything after the year optional; a malformed date is
+  // `Unset`, never an error, since real files abound with slightly-wrong dates.
+  private[facsimile] def parseDate(value: Text): Optional[Timing] =
+    val content = if value.s.startsWith("D:") then value.s.substring(2).nn else value.s
+
+    def digits(start: Int, length: Int, minimum: Int, maximum: Int): Optional[Int] =
+      if start + length > content.length then Unset else
+        var i = start
+        var number = 0
+        var bad = false
+
+        while i < start + length do
+          val char = content.charAt(i)
+          if char < '0' || char > '9' then bad = true else number = number*10 + (char - '0')
+          i += 1
+
+        if bad || number < minimum || number > maximum then Unset else number
+
+    digits(0, 4, 0, 9999).let: year =>
+      val month = digits(4, 2, 1, 12).or(1)
+      val day = digits(6, 2, 1, 31).or(1)
+      val hour = digits(8, 2, 0, 23).or(0)
+      val minute = digits(10, 2, 0, 59).or(0)
+      val second = digits(12, 2, 0, 59).or(0)
+
+      val offset: Optional[Duration] =
+        if content.length > 14 then content.charAt(14) match
+          case 'Z' =>
+            Quantity[Seconds[1]](0.0)
+
+          case sign @ ('+' | '-') =>
+            digits(15, 2, 0, 23).let: hours =>
+              val minutes = digits(18, 2, 0, 59).or(0)
+              val seconds = (hours*3600 + minutes*60)*(if sign == '-' then -1 else 1)
+              Quantity[Seconds[1]](seconds.toDouble)
+
+          case _ =>
+            Unset
+        else Unset
+
+      import calendars.gregorianCalendar
+
+      safely(Timestamp(Date(Year(year), Month(month), Day(day)),
+          Clockface(Base24(hour), Base60(minute), Base60(second)))).let: timestamp =>
+        Timing(timestamp, offset)
+
+// The document-information dictionary, fully materialized: a pure value that outlives the
+// `open` scope.
+case class PdfInfo
+  ( title:    Optional[Text],
+    author:   Optional[Text],
+    subject:  Optional[Text],
+    keywords: Optional[Text],
+    creator:  Optional[Text],
+    producer: Optional[Text],
+    created:  Optional[PdfInfo.Timing],
+    modified: Optional[PdfInfo.Timing] )

--- a/lib/facsimile/src/core/facsimile.PdfRect.scala
+++ b/lib/facsimile/src/core/facsimile.PdfRect.scala
@@ -28,9 +28,40 @@
 ┃    either express or implied. See the License for the specific language governing permissions    ┃
 ┃    and limitations under the License.                                                            ┃
 ┃                                                                                                  ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import contingency.*
+import quantitative.*
+import symbolism.*
+import vacuous.*
+
+object PdfRect:
+  // A `/Rect`-shaped array: four numbers whose corners may be given in any order, normalized
+  // here to lower-left and upper-right (ISO 32000-2 §7.9.5). `scale` carries `/UserUnit`,
+  // converting user-space units to points.
+  private[facsimile] def read(cos: Cos, scale: Double)(using pdf: Pdf)
+  :   Optional[PdfRect] raises PdfError =
+
+    pdf.resolved(cos).elements.let: elements =>
+      if elements.length != 4 then Unset else
+        val values = elements.map(pdf.resolved(_).double.or(0.0)*scale)
+
+        PdfRect
+          ( Quantity[Points[1]](values(0).min(values(2))),
+            Quantity[Points[1]](values(1).min(values(3))),
+            Quantity[Points[1]](values(0).max(values(2))),
+            Quantity[Points[1]](values(1).max(values(3))) )
+
+// A rectangle in default user space, held as typesafe lengths: one PDF point is exactly
+// 1/72 inch, which is `quantitative`'s `Points` unit.
+case class PdfRect
+  ( left:   Quantity[Points[1]],
+    bottom: Quantity[Points[1]],
+    right:  Quantity[Points[1]],
+    top:    Quantity[Points[1]] ):
+
+  def width: Quantity[Points[1]] = right - left
+  def height: Quantity[Points[1]] = top - bottom

--- a/lib/facsimile/src/core/facsimile.Trees.scala
+++ b/lib/facsimile/src/core/facsimile.Trees.scala
@@ -30,7 +30,45 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package facsimile
 
-export facsimile.{Annotation, Bookmark, Cos, Destination, Page, Pdf, PdfError, PdfFile,
-    PdfInfo, PdfRect, pdf}
+import anticipation.*
+import contingency.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// Name trees and number trees (ISO 32000-2 §7.9.6–7.9.7): balanced trees of `/Kids` whose
+// leaves carry sorted `/Names` or `/Nums` pair arrays. Both flatten to their in-order pairs,
+// with reference cycles guarded.
+private[facsimile] object Trees:
+  def names(root: Cos)(using Pdf): List[(Text, Cos)] raises PdfError =
+    pairs(root, t"Names", Set()).flatMap: (key, value) =>
+      key.text.let(text => List((text, value))).or(List())
+
+  def numbers(root: Cos)(using Pdf): List[(Long, Cos)] raises PdfError =
+    pairs(root, t"Nums", Set()).flatMap: (key, value) =>
+      key.long.let(number => List((number, value))).or(List())
+
+  private def pairs(node: Cos, key: Text, visited: Set[Int])(using pdf: Pdf)
+  :   List[(Cos, Cos)] raises PdfError =
+
+    node match
+      case Cos.Ref(number, _) =>
+        if visited.contains(number) then List()
+        else pairs(pdf.resolved(node), key, visited + number)
+
+      case Cos.Dictionary(entries) =>
+        entries.at(t"Kids").let(pdf.resolved(_).elements).lay(leaf(entries, key)): kids =>
+          kids.flatMap(pairs(_, key, visited))
+
+      case _ =>
+        List()
+
+  private def leaf(entries: Map[Text, Cos], key: Text)(using pdf: Pdf)
+  :   List[(Cos, Cos)] raises PdfError =
+
+    pdf.resolved(entries.at(key).or(Cos.Nil)).elements.lay(List()): elements =>
+      elements.grouped(2).to(List).flatMap:
+        case List(key, value) => List((pdf.resolved(key), value))
+        case _                => List()

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -413,3 +413,248 @@ object Tests extends Suite(m"Facsimile tests"):
         PdfFile(xrefStreamDocument()).open():
           textOf(pdf.resolved(pdf(1, 0)(t"Greeting").or(Cos.Nil)))
       . assert(_ == t"hi")
+
+    // A two-page document: object 1 catalog, 2 page-tree root (A4 media box, inherited),
+    // 3 a plain page, 4 a page with its own crop box and rotation.
+    def paged(extraCatalog: Text = t"", page3: Text = t"", page4: Text = t""): Data =
+      document
+        ( t"<< /Type /Catalog /Pages 2 0 R $extraCatalog >>".in[Data],
+          t"<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 /MediaBox [0 0 595 842] >>".in[Data],
+          t"<< /Type /Page /Parent 2 0 R $page3 >>".in[Data],
+          t"<< /Type /Page /Parent 2 0 R /CropBox [10 10 300 400] /Rotate 90 $page4 >>"
+          . in[Data] )
+
+    suite(m"Pages"):
+      test(m"the page tree flattens in order"):
+        PdfFile(paged()).open():
+          pdf.pages.length
+      . assert(_ == 2)
+
+      test(m"the media box is inherited from the page-tree root"):
+        PdfFile(paged()).open():
+          pdf.pages(0).mediaBox.width
+      . assert(_ == Quantity[Points[1]](595.0))
+
+      test(m"the crop box defaults to the media box"):
+        PdfFile(paged()).open():
+          pdf.pages(0).cropBox.height
+      . assert(_ == Quantity[Points[1]](842.0))
+
+      test(m"a page's own crop box wins"):
+        PdfFile(paged()).open():
+          pdf.pages(1).cropBox.width
+      . assert(_ == Quantity[Points[1]](290.0))
+
+      test(m"the trim box defaults to the crop box"):
+        PdfFile(paged()).open():
+          pdf.pages(1).trimBox.height
+      . assert(_ == Quantity[Points[1]](390.0))
+
+      test(m"rotation is read from the page"):
+        PdfFile(paged()).open():
+          pdf.pages(1).rotation
+      . assert(_ == Page.Rotation.Quarter)
+
+      test(m"a quarter-turned page exchanges width and height"):
+        PdfFile(paged()).open():
+          pdf.pages(1).width
+      . assert(_ == Quantity[Points[1]](390.0))
+
+      test(m"an unrotated page keeps its axes"):
+        PdfFile(paged()).open():
+          pdf.pages(0).rotation
+      . assert(_ == Page.Rotation.None)
+
+      test(m"a UserUnit scales the boxes"):
+        PdfFile(paged(page3 = t"/UserUnit 2")).open():
+          pdf.pages(0).mediaBox.width
+      . assert(_ == Quantity[Points[1]](1190.0))
+
+      test(m"a cyclic page tree is an error"):
+        val doc = document
+          ( t"<< /Type /Catalog /Pages 2 0 R >>".in[Data],
+            t"<< /Type /Pages /Kids [2 0 R] /Count 1 >>".in[Data] )
+
+        capture[PdfError](PdfFile(doc).open()(pdf.pages.length)).reason
+      . assert(_ == PdfError.Reason.CircularPageTree)
+
+    suite(m"Document information"):
+      def informed(info: Text): Data =
+        val body = t"<< /Type /Catalog /Pages 3 0 R >>".in[Data]
+        val pages = t"<< /Type /Pages /Kids [] /Count 0 >>".in[Data]
+        documentWith(t"/Info 2 0 R", body, t"<< $info >>".in[Data], pages)
+
+      test(m"the title is read"):
+        PdfFile(informed(t"/Title (A Document)")).open():
+          pdf.info.title
+      . assert(_ == t"A Document")
+
+      test(m"a UTF-16BE string decodes by its byte-order mark"):
+        PdfFile(informed(t"/Author <FEFF00480069>")).open():
+          pdf.info.author
+      . assert(_ == t"Hi")
+
+      test(m"PDFDocEncoding maps its differences from Latin-1"):
+        PdfFile(informed(t"/Subject (caf\\351 \\200)")).open():
+          pdf.info.subject
+      . assert(_ == t"café •")
+
+      test(m"a creation date parses with its offset"):
+        PdfFile(informed(t"/CreationDate (D:20240102030405+01'30')")).open():
+          pdf.info.created.let(_.offset)
+      . assert(_ == Quantity[Seconds[1]](5400.0))
+
+      test(m"a date with no offset has an unknown zone"):
+        PdfFile(informed(t"/CreationDate (D:20240102030405)")).open():
+          pdf.info.created.let(_.offset)
+      . assert(_ == Unset)
+
+      test(m"a malformed date is unset, not an error"):
+        PdfFile(informed(t"/ModDate (yesterday)")).open():
+          pdf.info.modified
+      . assert(_ == Unset)
+
+      test(m"a truncated date defaults its later components"):
+        PdfFile(informed(t"/CreationDate (D:2024)")).open():
+          pdf.info.created.let(_.timestamp)
+      . assert: timestamp =>
+          import calendars.gregorianCalendar
+          timestamp == Timestamp(Date(Year(2024), Month(1), Day(1)),
+              Clockface(Base24(0), Base60(0), Base60(0)))
+
+      test(m"document information escapes the scope as a pure value"):
+        val info = PdfFile(informed(t"/Title (Kept)")).open()(pdf.info)
+        info.title
+      . assert(_ == t"Kept")
+
+    suite(m"Navigation"):
+      def navigable(catalogExtra: Text, objects: Data*): Data =
+        val standard = List
+          ( t"<< /Type /Catalog /Pages 2 0 R $catalogExtra >>".in[Data],
+            t"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 100 100] >>".in[Data],
+            t"<< /Type /Page /Parent 2 0 R >>".in[Data] )
+
+        document((standard ++ objects)*)
+
+      test(m"a named destination resolves through the name tree"):
+        val doc = navigable
+          ( t"/Names << /Dests << /Names [(intro) [3 0 R /XYZ 10 20 null]] >> >>" )
+
+        PdfFile(doc).open():
+          pdf.destinations.at(t"intro")
+      . assert(_ == Destination.Xyz(Prim, 10.0, 20.0, Unset))
+
+      test(m"an old-style /Dests dictionary also resolves"):
+        val doc = navigable(t"/Dests << /intro [3 0 R /FitH 30] >>")
+
+        PdfFile(doc).open():
+          pdf.destinations.at(t"intro")
+      . assert(_ == Destination.FitWidth(Prim, 30.0))
+
+      test(m"bookmarks form a tree with destinations"):
+        val doc = navigable
+          ( t"/Outlines 4 0 R",
+            t"<< /Type /Outlines /First 5 0 R >>".in[Data],
+            t"<< /Title (One) /Parent 4 0 R /Next 6 0 R /Dest [3 0 R /Fit] >>".in[Data],
+            t"<< /Title (Two) /Parent 4 0 R /First 7 0 R >>".in[Data],
+            t"<< /Title (Child) /Parent 6 0 R >>".in[Data] )
+
+        PdfFile(doc).open():
+          pdf.bookmarks.map(bookmark => (bookmark.title, bookmark.children.length))
+      . assert(_ == List((t"One", 0), (t"Two", 1)))
+
+      test(m"a bookmark destination lands on its page"):
+        val doc = navigable
+          ( t"/Outlines 4 0 R",
+            t"<< /Type /Outlines /First 5 0 R >>".in[Data],
+            t"<< /Title (One) /Parent 4 0 R /Dest [3 0 R /Fit] >>".in[Data] )
+
+        PdfFile(doc).open():
+          pdf.bookmarks.head.destination
+      . assert(_ == Destination.Fit(Prim))
+
+      test(m"a cyclic outline terminates"):
+        val doc = navigable
+          ( t"/Outlines 4 0 R",
+            t"<< /Type /Outlines /First 5 0 R >>".in[Data],
+            t"<< /Title (Loop) /Parent 4 0 R /Next 5 0 R >>".in[Data] )
+
+        PdfFile(doc).open():
+          pdf.bookmarks.length
+      . assert(_ == 1)
+
+    suite(m"Annotations, attachments and labels"):
+      test(m"a URI link annotation"):
+        val doc = document
+          ( t"<< /Type /Catalog /Pages 2 0 R >>".in[Data],
+            t"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 100 100] >>".in[Data],
+            t"<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".in[Data],
+            t"<< /Subtype /Link /Rect [0 0 10 20] /A << /S /URI /URI (https://x.com) >> >>"
+            . in[Data] )
+
+        PdfFile(doc).open():
+          pdf.pages(0).annotations.head match
+            case Annotation.Link(rect, _, uri, _) => (rect.height, uri)
+            case _                                => (Quantity[Points[1]](0.0), Unset)
+      . assert(_ == (Quantity[Points[1]](20.0), t"https://x.com"))
+
+      test(m"a note annotation carries its contents"):
+        val doc = document
+          ( t"<< /Type /Catalog /Pages 2 0 R >>".in[Data],
+            t"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 100 100] >>".in[Data],
+            t"<< /Type /Page /Parent 2 0 R /Annots [4 0 R] >>".in[Data],
+            t"<< /Subtype /Text /Rect [0 0 5 5] /Contents (Remember) /Open true >>".in[Data] )
+
+        PdfFile(doc).open():
+          pdf.pages(0).annotations.head match
+            case Annotation.Note(_, contents, open, _) => (contents, open)
+            case _                                     => (Unset, false)
+      . assert(_ == (t"Remember", true))
+
+      test(m"an attachment surfaces its metadata and content"):
+        val doc = document
+          ( t"<< /Type /Catalog /Pages 2 0 R /Names << /EmbeddedFiles << /Names [(notes.txt) 4 0 R] >> >> >>"
+            . in[Data],
+            t"<< /Type /Pages /Kids [] /Count 0 >>".in[Data],
+            t"<< /Type /Page >>".in[Data],
+            t"<< /Type /Filespec /F (notes.txt) /EF << /F 5 0 R >> >>".in[Data],
+            t"<< /Type /EmbeddedFile /Subtype /text#2Fplain /Length 5 >>\nstream\nhello\nendstream"
+            . in[Data] )
+
+        PdfFile(doc).open():
+          val attachment = pdf.attachments.head
+
+          ( attachment.name,
+            attachment.filename,
+            attachment.mediaType,
+            String(attachment.data.mutable(using Unsafe), "UTF-8").tt )
+      . assert(_ == (t"notes.txt", t"notes.txt", t"text/plain", t"hello"))
+
+      test(m"page labels follow the number-tree ranges"):
+        val doc = document
+          ( t"<< /Type /Catalog /Pages 2 0 R /PageLabels << /Nums [0 << /S /r >> 2 << /S /D /St 5 /P (A-) >>] >> >>"
+            . in[Data],
+            t"<< /Type /Pages /Kids [3 0 R 4 0 R 5 0 R] /Count 3 /MediaBox [0 0 9 9] >>"
+            . in[Data],
+            t"<< /Type /Page /Parent 2 0 R >>".in[Data],
+            t"<< /Type /Page /Parent 2 0 R >>".in[Data],
+            t"<< /Type /Page /Parent 2 0 R >>".in[Data] )
+
+        PdfFile(doc).open():
+          List(pdf.pageLabel(0.z), pdf.pageLabel(1.z), pdf.pageLabel(2.z))
+      . assert(_ == List(t"i", t"ii", t"A-5"))
+
+      test(m"a document without page labels numbers plainly"):
+        PdfFile(paged()).open():
+          pdf.pageLabel(1.z)
+      . assert(_ == t"2")
+
+      test(m"XMP metadata surfaces as raw bytes"):
+        val doc = document
+          ( t"<< /Type /Catalog /Pages 2 0 R /Metadata 3 0 R >>".in[Data],
+            t"<< /Type /Pages /Kids [] /Count 0 >>".in[Data],
+            t"<< /Type /Metadata /Subtype /XML /Length 5 >>\nstream\n<xmp/\nendstream".in[Data] )
+
+        PdfFile(doc).open():
+          pdf.xmp.let(bytes => String(bytes.mutable(using Unsafe), "UTF-8").tt)
+      . assert(_ == t"<xmp/")


### PR DESCRIPTION
Facsimile gains its typed document layer: everything above the COS kernel that describes a
PDF's structure rather than its syntax. The page tree is flattened into reading order with
its inheritable attributes applied, and page geometry — media, crop, bleed, trim and art
boxes, with `/UserUnit` scaling and rotation-aware dimensions — is expressed in
`quantitative`'s point lengths (1 pt = 1/72 inch), the same units Cataclysm uses. Document
information, bookmarks, named destinations, annotations, embedded files, page labels and
XMP metadata are all read as fully-materialized pure values, while a `Page`, which still
resolves lazily through the document, is confined to the `open` scope by capture checking.

```scala
pdfFile.open():
  val page = pdf.pages(0)
  page.mediaBox.width      // Quantity[Points[1]]
  page.rotation            // Page.Rotation.Quarter, for /Rotate 90
  page.annotations         // typed Link, Note and Widget annotations

  pdf.info.title           // Optional[Text], decoded from UTF-16BE or PDFDocEncoding
  pdf.info.created         // Optional[PdfInfo.Timing]: a Timestamp plus optional UTC offset
  pdf.bookmarks            // the outline tree, with typed Destinations
  pdf.attachments          // embedded files; read `data` inside the scope
  pdf.pageLabel(0.z)       // "i", "42", "A-7"...
```

PDF dates (`D:YYYYMMDDHHmmSS±HH'mm'`) parse to aviation `Timestamp`s with the offset kept
separately, since its absence means the relationship to UTC is unknown; malformed dates are
`Unset` rather than errors. Destinations cover all eight fit modes and resolve through both
the old-style `/Dests` dictionary and the `/Names` tree. Values extracted inside the scope —
`PdfInfo`, `Bookmark`, `PdfRect`, decoded text — escape freely, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
