### PR TITLE
Flicker-free TUI rendering through screen-diffed presents

### DIFF
--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -101,8 +101,12 @@ extends Interactivity[TerminalEvent], caps.ExclusiveCapability:
   def columns: Optional[Int] = metrics.columns
   def columns_=(value: Optional[Int]): Unit = metrics.columns = value
 
+  // The fallbacks when the size is not yet known (no `LINES`/`COLUMNS` in the
+  // environment and no size-probe reply yet): the classic 80×24. Conservative on
+  // purpose — drawing too few rows is benign, while assuming a taller terminal than
+  // real scatters absolutely-addressed output off-screen and into clamped garbage.
   def knownColumns: Int = columns.or(80)
-  def knownRows: Int = rows.or(80)
+  def knownRows: Int = rows.or(24)
 
   // `width` reads the live column count through the untracked `Metrics` holder (bound to a
   // block local, not read through `this`), so the termcap — and the stdio built on it —
@@ -162,17 +166,27 @@ extends Interactivity[TerminalEvent], caps.ExclusiveCapability:
 
     . protect:
         daemon:
-          keyboard0.asInstanceOf[Keyboard.Standard].process(chars).each:
-            case resize@TerminalInfo.WindowSize(rows2, columns2) =>
-              metrics0.rows = rows2
-              metrics0.columns = columns2
-              events0.put(resize)
+          // The teardown in `interactive` closes stdin under the pump; the blocked read
+          // then surfaces as an `IOException`, which is the normal end of the session's
+          // input, not a failure — so it must not escalate (a plain `Throwable` bypasses
+          // the containment, which traps only typed `Error`s, and would reach the
+          // uncaught handler and print a stack trace over the restored terminal). The
+          // spool is stopped however the pump ends — exception, stdin EOF or decode
+          // error — so the session consuming the events always sees the input end.
+          try
+            keyboard0.asInstanceOf[Keyboard.Standard].process(chars).each:
+              case resize@TerminalInfo.WindowSize(rows2, columns2) =>
+                metrics0.rows = rows2
+                metrics0.columns = columns2
+                events0.put(resize)
 
-            case bgColor@TerminalInfo.BgColor(red, green, blue) =>
-              metrics0.mode =
-                if Terminal.dark(red, green, blue) then Brightness.Dark else Brightness.Light
+              case bgColor@TerminalInfo.BgColor(red, green, blue) =>
+                metrics0.mode =
+                  if Terminal.dark(red, green, blue) then Brightness.Dark else Brightness.Light
 
-              events0.put(bgColor)
+                events0.put(bgColor)
 
-            case other =>
-              events0.put(other)
+              case other =>
+                events0.put(other)
+          catch case _: java.io.IOException => ()
+          finally events0.stop()

--- a/lib/profanity/src/core/profanity_core.scala
+++ b/lib/profanity/src/core/profanity_core.scala
@@ -63,6 +63,14 @@ def interactive[result](block: (terminal: Terminal) ?=> result)
         processBuilder.inheritIO()
         if processBuilder.start().nn.waitFor() != 0 then abort(TerminalError())
 
+        // Learn the real terminal size at session start: shells do not export
+        // `LINES`/`COLUMNS` by default, and without this probe the session would run
+        // on the 80×24 fallback until the first resize. Emitted only now, after raw
+        // mode is set, so the reply is neither echoed nor line-buffered; the keyboard
+        // pump parses it into a `WindowSize`, updating `knownRows`/`knownColumns`
+        // (and any driver re-tiles, exactly as for a resize).
+        terminal.stdio.out.print(Terminal.reportSize)
+
       block(using terminal)
 
     finally

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -129,6 +129,7 @@ class Form
 
     root match
       case inline: InlineRoot => inline.reframe(root.width, height)
+      case screen: ScreenRoot => screen.reframe()
       case _                  => ()
 
     frame.arrange(Rect(0, 0, root.width, height)).cells.to(IndexedSeq)
@@ -208,14 +209,17 @@ class Form
     wakePending = false
     lastRedraw = System.currentTimeMillis
 
-    // A resize may have moved the old block; invalidate it (a width-only resize
-    // counts too) so the next present clears it. Done here, once, however many
-    // resizes were coalesced.
+    // A resize may have moved the old block (and reflowed the fullscreen contents);
+    // invalidate it (a width-only resize counts too) so the next present redraws in
+    // full. Done here, once, however many resizes were coalesced. This is what
+    // guarantees a SIGWINCH always forces a complete redraw, never a diff against a
+    // stale snapshot.
     if resizePending then
       resizePending = false
 
       root match
         case inline: InlineRoot => inline.invalidate()
+        case screen: ScreenRoot => screen.invalidate()
         case _                  => ()
 
     refresh(changed)

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -38,6 +38,7 @@ import escapade.*
 import gossamer.*
 import hieroglyph.*, textMetrics.wideCharacterWidthMetric
 import profanity.*
+import vacuous.*
 import yossarian.*
 
 // The shared styled-grapheme grid behind `FlowExtent` (a clipped sub-rectangle that
@@ -55,6 +56,24 @@ extends Canvas:
   protected var screen: Screen[StyleWord] = Screen(gridWidth, gridHeight, StyleWord.Default)
   protected var col: Int = 0
   protected var row: Int = 0
+
+  // The physical-screen model: a copy of the grid as the last present actually drew it,
+  // tagged with the absolute top row and column count it was drawn at, so the next
+  // present can emit only the cells that differ (an unchanged overprint is a no-op).
+  // It models the TERMINAL, not the compose grid: `reshape` and `clear` leave it alone
+  // (they only blank what will be composed next), and only `invalidate` drops it —
+  // forcing the next present to redraw everything, e.g. after a resize has reflowed
+  // whatever was really on screen.
+  protected var snapshot: Optional[Screen[StyleWord]] = Unset
+  protected var snapshotTop: Int = 0
+  protected var snapshotColumns: Int = 0
+  protected var invalidated: Boolean = false
+
+  // Mark the next present as a full repaint: the screen can no longer be assumed to
+  // match the snapshot (typically after a WINCH, when the terminal has reflowed it).
+  def invalidate(): Unit =
+    invalidated = true
+    snapshot = Unset
 
   private val metric: Grapheme is Measurable = summon[Grapheme is Measurable]
 
@@ -138,10 +157,14 @@ extends Canvas:
   // A styled `Teletype` of row `r`, up to `columns` cells (wide-trailing sentinels
   // skipped), so the row's colour can be composited onto a parent surface or rendered
   // to SGR by the inline presenter.
-  protected def rowContent(r: Int, columns: Int): Teletype =
+  protected def rowContent(r: Int, columns: Int): Teletype = runContent(r, 0, columns)
+
+  // A styled `Teletype` of the cells `[from, until)` of row `r` (wide-trailing
+  // sentinels skipped): a single damaged run of the row, ready to render to SGR.
+  protected def runContent(r: Int, from: Int, until: Int): Teletype =
     var content = Teletype.empty
-    val limit = columns.min(gridWidth)
-    var c = 0
+    val limit = until.min(gridWidth)
+    var c = from
 
     while c < limit do
       val grapheme = screen.grapheme(c.z, r.z).text
@@ -149,6 +172,65 @@ extends Canvas:
       c += 1
 
     content
+
+  // Record the grid as what is now really on screen, drawn at absolute row `top` and
+  // clipped to `columns`. Called by a presenter after every present, on both the full
+  // and the diffed path.
+  protected def recordSnapshot(top: Int, columns: Int): Unit =
+    snapshot = screen.copy()
+    snapshotTop = top
+    snapshotColumns = columns
+
+  // Whether the snapshot really describes the screen region about to be presented: the
+  // same absolute top, the same column clip and the same grid dimensions. Any geometry
+  // change means the diff would be against the wrong cells, so the caller must fall
+  // back to a full redraw.
+  protected def snapshotValid(top: Int, columns: Int, h: Int): Boolean =
+    snapshot.lay(false): snap =>
+      snapshotTop == top && snapshotColumns == columns
+        && snap.height == h && snap.width == gridWidth
+
+  // Whether the cell at `(c, r)` differs from the snapshot's. A cell is one grapheme
+  // with one style; links never reach the grid (`putCell` always writes `t""`), so the
+  // pair is the whole identity.
+  private def cellChanged(snap: Screen[StyleWord], c: Int, r: Int): Boolean =
+    screen.grapheme(c.z, r.z).text != snap.grapheme(c.z, r.z).text
+      || screen.style(c.z, r.z).raw != snap.style(c.z, r.z).raw
+
+  // Diff the grid (drawn at absolute rows `top..top + h - 1`, clipped to `columns`)
+  // against the snapshot, appending one absolutely-addressed run per contiguous patch
+  // of changed cells: `cup` to the patch, its cells as SGR, and a style reset after any
+  // run that emitted SGR (each run renders self-contained, like a full row today).
+  // Returns the number of runs, so a caller can skip the write when nothing changed.
+  // A wide glyph never straddles a run boundary: its trailing sentinel carries the
+  // leading cell's style, so the two cells always change (or not) together; backing a
+  // run up off a sentinel start is a defensive backstop.
+  protected def emitDiffRuns
+    ( frame: StringBuilder, top: Int, columns: Int, h: Int, termcap: Termcap )
+  :   Int =
+
+    val snap = snapshot.vouch
+    var runs = 0
+    var r = 0
+
+    while r < h do
+      var c = 0
+
+      while c < columns do
+        if cellChanged(snap, c, r) then
+          var start = c
+          if screen.grapheme(start.z, r.z).text.nil && start > 0 then start -= 1
+          while c < columns && cellChanged(snap, c, r) do c += 1
+          frame.append(csi.cup(top + r, start + 1).s)
+          val rendered = runContent(r, start, c).render(termcap)
+          frame.append(rendered.s)
+          if rendered.contains(t"\e") then frame.append(csi.sgr(0).s)
+          runs += 1
+        else c += 1
+
+      r += 1
+
+    runs
 
   // A `Teletype` of `text` in one uniform style (sparse single-run form).
   private def styledCell(text: Text, style: StyleWord): Teletype =

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -38,6 +38,7 @@ import escapade.*
 import gossamer.*
 import hieroglyph.*, textMetrics.wideCharacterWidthMetric
 import profanity.*
+import turbulence.*
 import vacuous.*
 import yossarian.*
 
@@ -74,6 +75,16 @@ extends Canvas:
   def invalidate(): Unit =
     invalidated = true
     snapshot = Unset
+
+  // The caret (hardware cursor) target and visibility, recorded by a root's `cursor`/
+  // `showCaret` and applied when the frame is presented; and where the last present
+  // left them, so a diffed present whose caret hasn't moved can omit placing it.
+  protected var caretColumn: Int = 0
+  protected var caretRow: Int = 0
+  protected var caretVisible: Boolean = true
+  protected var presentedCaretRow: Int = -1
+  protected var presentedCaretColumn: Int = -1
+  protected var presentedCaretVisible: Boolean = false
 
   private val metric: Grapheme is Measurable = summon[Grapheme is Measurable]
 
@@ -231,6 +242,46 @@ extends Canvas:
       r += 1
 
     runs
+
+  // Present by overprinting only the damaged cells (the geometry is unchanged, so a
+  // cell equal to the snapshot's is already on screen), the grid's rows mapping to the
+  // absolute screen rows `top..top + h - 1`. When no cell and no caret changed,
+  // NOTHING is written — an identical frame is a true no-op. Otherwise the patches
+  // land in one single write with the cursor hidden, so it never flashes across the
+  // screen between runs (and nothing can interleave mid-frame).
+  protected def presentDiff(top: Int, columns: Int, h: Int)(using Stdio): Unit =
+    val termcap = summon[Stdio].termcap
+    val body = StringBuilder()
+    val runs = emitDiffRuns(body, top, columns, h, termcap)
+
+    val caretRow2 = (top + caretRow.min(h - 1)).max(1)
+    val caretColumn2 = caretColumn.min(columns - 1).max(0) + 1
+
+    val caretSame = caretVisible == presentedCaretVisible
+      && (!caretVisible || (caretRow2 == presentedCaretRow && caretColumn2 == presentedCaretColumn))
+
+    if runs > 0 || !caretSame then
+      val frame = StringBuilder()
+      frame.append(csi.dectcem(false).s)
+      frame.append(body.toString)
+
+      if caretVisible then
+        frame.append(csi.cup(caretRow2, caretColumn2).s)
+        frame.append(csi.dectcem(true).s)
+
+      recordSnapshot(top, columns)
+      presentedCaretRow = caretRow2
+      presentedCaretColumn = caretColumn2
+      presentedCaretVisible = caretVisible
+      Out.print(frame.toString.tt)
+
+  // Record the caret state the present just applied, alongside `recordSnapshot`, so
+  // the next diffed present can recognise an unmoved caret. Called on the full path
+  // (the diffed path records inline, only when it writes).
+  protected def recordCaret(top: Int, columns: Int, h: Int): Unit =
+    presentedCaretRow = (top + caretRow.min(h - 1)).max(1)
+    presentedCaretColumn = caretColumn.min(columns - 1).max(0) + 1
+    presentedCaretVisible = caretVisible
 
   // A `Teletype` of `text` in one uniform style (sparse single-run form).
   private def styledCell(text: Text, style: StyleWord): Teletype =

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -39,6 +39,7 @@ import gossamer.*
 import profanity.*
 import symbolism.*
 import turbulence.*
+import vacuous.*
 
 object InlineRoot:
   // The root for inline mode over a real terminal: width and the height clamp are
@@ -83,7 +84,12 @@ extends GridSurface(widthFn(), 0):
   private var presentedRows: Int = 0
   private var presentedColumns: Int = 0
   private var presentedTop: Int = 1
-  private var invalidated: Boolean = false
+
+  // Where the last present left the hardware cursor, so a diffed present whose caret
+  // hasn't moved (and whose cells haven't changed) can emit nothing at all.
+  private var presentedCaretRow: Int = -1
+  private var presentedCaretColumn: Int = -1
+  private var presentedCaretVisible: Boolean = false
 
   // For `Inline` anchoring: the row offset (from the block's top) at which the cursor was
   // left after the last frame, so the next frame can rise back to the top relatively.
@@ -114,8 +120,8 @@ extends GridSurface(widthFn(), 0):
   // Mark the next present as a resize repaint. Under `TopAfterResize` the first resize
   // also switches to top-anchoring; the other anchorings keep their fixed reference.
   // The driver calls it on every `WindowSize` event (a width-only resize counts too).
-  def invalidate(): Unit =
-    invalidated = true
+  override def invalidate(): Unit =
+    super.invalidate()
     if anchoring == InlineAnchoring.TopAfterResize then topAnchored = true
 
   // Forget everything recorded about what is on screen, so the NEXT frame renders as a
@@ -130,6 +136,10 @@ extends GridSurface(widthFn(), 0):
     presentedTop = 1
     flowCursorRow = 0
     invalidated = false
+    snapshot = Unset
+    presentedCaretRow = -1
+    presentedCaretColumn = -1
+    presentedCaretVisible = false
 
   // Record the caret's block-local target; `flush` positions the hardware cursor at
   // the corresponding absolute screen cell.
@@ -148,6 +158,11 @@ extends GridSurface(widthFn(), 0):
     val columns = gridWidth.min(widthFn())
     val h       = height
     invalidated = false
+
+    // `Inline` anchoring addresses the screen RELATIVELY, so an absolute snapshot can
+    // never describe where its cells really landed; drop it to keep the invariant that
+    // a snapshot always refers to an absolutely-addressed present.
+    snapshot = Unset
 
     val frame = StringBuilder()
     def emit(text: Text): Unit = frame.append(text.s)
@@ -205,6 +220,51 @@ extends GridSurface(widthFn(), 0):
     val rows    = heightFn()
     val columns = gridWidth.min(widthFn())
     val h       = height
+
+    // When the geometry is exactly as last presented (same dock row, height and width,
+    // and not a resize), every grid cell maps to the same screen cell as the snapshot,
+    // so the present is a pure overprint and only the cells that changed need emitting.
+    // Any geometry change falls back to the full redraw, which also handles docking,
+    // growth, shrink-clearing and resize-clearing.
+    val dockTop = if topAnchored then 1 else (rows - h + 1).max(1)
+
+    if !invalidated && started && h == presentedRows && columns == presentedColumns
+      && dockTop == presentedTop && snapshotValid(dockTop, columns, h)
+    then flushDockedDiff(dockTop, columns, h)
+    else flushDockedFull(rows, columns, h)
+
+  // Present by overprinting only the damaged cells (the geometry is unchanged, so a
+  // cell equal to the snapshot's is already on screen). When no cell and no caret
+  // changed, NOTHING is written — an identical frame is a true no-op.
+  private def flushDockedDiff(top: Int, columns: Int, h: Int): Unit =
+    val termcap = summon[Stdio].termcap
+    val body = StringBuilder()
+    val runs = emitDiffRuns(body, top, columns, h, termcap)
+
+    val caretRow2 = (top + caretRow.min(h - 1)).max(1)
+    val caretColumn2 = caretColumn.min(columns - 1).max(0) + 1
+
+    val caretSame = caretVisible == presentedCaretVisible
+      && (!caretVisible || (caretRow2 == presentedCaretRow && caretColumn2 == presentedCaretColumn))
+
+    if runs > 0 || !caretSame then
+      // Still one single write (see `flushDockedFull` on why), hiding the cursor while
+      // the patches land so it never flashes across the screen between runs.
+      val frame = StringBuilder()
+      frame.append(csi.dectcem(false).s)
+      frame.append(body.toString)
+
+      if caretVisible then
+        frame.append(csi.cup(caretRow2, caretColumn2).s)
+        frame.append(csi.dectcem(true).s)
+
+      recordSnapshot(top, columns)
+      presentedCaretRow = caretRow2
+      presentedCaretColumn = caretColumn2
+      presentedCaretVisible = caretVisible
+      Out.print(frame.toString.tt)
+
+  private def flushDockedFull(rows: Int, columns: Int, h: Int): Unit =
     val resized = invalidated
     invalidated = false
 
@@ -317,6 +377,13 @@ extends GridSurface(widthFn(), 0):
     if caretVisible then
       emit(csi.cup((top + caretRow.min(h - 1)).max(1), caretColumn.min(columns - 1).max(0) + 1))
       emit(csi.dectcem(true))
+
+    // What was just drawn IS the screen now: record it (and the caret) so the next
+    // geometry-stable present can diff against it.
+    recordSnapshot(top, columns)
+    presentedCaretRow = (top + caretRow.min(h - 1)).max(1)
+    presentedCaretColumn = caretColumn.min(columns - 1).max(0) + 1
+    presentedCaretVisible = caretVisible
 
     Out.print(frame.toString.tt)
 

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -85,12 +85,6 @@ extends GridSurface(widthFn(), 0):
   private var presentedColumns: Int = 0
   private var presentedTop: Int = 1
 
-  // Where the last present left the hardware cursor, so a diffed present whose caret
-  // hasn't moved (and whose cells haven't changed) can emit nothing at all.
-  private var presentedCaretRow: Int = -1
-  private var presentedCaretColumn: Int = -1
-  private var presentedCaretVisible: Boolean = false
-
   // For `Inline` anchoring: the row offset (from the block's top) at which the cursor was
   // left after the last frame, so the next frame can rise back to the top relatively.
   private var flowCursorRow: Int = 0
@@ -103,9 +97,6 @@ extends GridSurface(widthFn(), 0):
     case InlineAnchoring.Inline                                        => false
 
   private var started: Boolean = false
-  private var caretColumn: Int = 0
-  private var caretRow: Int = 0
-  private var caretVisible: Boolean = true
 
   override def width: Int = widthFn()
 
@@ -230,39 +221,8 @@ extends GridSurface(widthFn(), 0):
 
     if !invalidated && started && h == presentedRows && columns == presentedColumns
       && dockTop == presentedTop && snapshotValid(dockTop, columns, h)
-    then flushDockedDiff(dockTop, columns, h)
+    then presentDiff(dockTop, columns, h)
     else flushDockedFull(rows, columns, h)
-
-  // Present by overprinting only the damaged cells (the geometry is unchanged, so a
-  // cell equal to the snapshot's is already on screen). When no cell and no caret
-  // changed, NOTHING is written — an identical frame is a true no-op.
-  private def flushDockedDiff(top: Int, columns: Int, h: Int): Unit =
-    val termcap = summon[Stdio].termcap
-    val body = StringBuilder()
-    val runs = emitDiffRuns(body, top, columns, h, termcap)
-
-    val caretRow2 = (top + caretRow.min(h - 1)).max(1)
-    val caretColumn2 = caretColumn.min(columns - 1).max(0) + 1
-
-    val caretSame = caretVisible == presentedCaretVisible
-      && (!caretVisible || (caretRow2 == presentedCaretRow && caretColumn2 == presentedCaretColumn))
-
-    if runs > 0 || !caretSame then
-      // Still one single write (see `flushDockedFull` on why), hiding the cursor while
-      // the patches land so it never flashes across the screen between runs.
-      val frame = StringBuilder()
-      frame.append(csi.dectcem(false).s)
-      frame.append(body.toString)
-
-      if caretVisible then
-        frame.append(csi.cup(caretRow2, caretColumn2).s)
-        frame.append(csi.dectcem(true).s)
-
-      recordSnapshot(top, columns)
-      presentedCaretRow = caretRow2
-      presentedCaretColumn = caretColumn2
-      presentedCaretVisible = caretVisible
-      Out.print(frame.toString.tt)
 
   private def flushDockedFull(rows: Int, columns: Int, h: Int): Unit =
     val resized = invalidated
@@ -381,9 +341,7 @@ extends GridSurface(widthFn(), 0):
     // What was just drawn IS the screen now: record it (and the caret) so the next
     // geometry-stable present can diff against it.
     recordSnapshot(top, columns)
-    presentedCaretRow = (top + caretRow.min(h - 1)).max(1)
-    presentedCaretColumn = caretColumn.min(columns - 1).max(0) + 1
-    presentedCaretVisible = caretVisible
+    recordCaret(top, columns, h)
 
     Out.print(frame.toString.tt)
 

--- a/lib/ultimatum/src/core/ultimatum.ScreenRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.ScreenRoot.scala
@@ -30,9 +30,97 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package ultimatum
 
-export ultimatum.{Rect, Extent, FlowExtent, InlineRoot, ScreenRoot, Axis, Sizing, Limits, Frame,
-    Placement, Pane, Panes, Mode, BorderStyle, panel, file, rank, border, layout, paint, Focus,
-    EditorField, MenuField, Form, dirtyCells, editor, menu, form, InlineAnchoring, InlineGrowth,
-    InlineShrink}
+import anticipation.*
+import denominative.*
+import escapade.*
+import gossamer.*
+import profanity.*
+import turbulence.*
+
+object ScreenRoot:
+  // Build a fullscreen root covering the whole terminal, reading its size live (so a
+  // resize is reflected the next time the layout is solved) and writing through its
+  // `Stdio`. The size thunks retain the terminal, so the root honestly captures it.
+  def apply(terminal: Terminal): ScreenRoot^{terminal} =
+    new ScreenRoot(() => terminal.knownColumns, () => terminal.knownRows)(using terminal.stdio)
+
+  def apply(width: Int, height: Int)(using Stdio): ScreenRoot =
+    new ScreenRoot(() => width, () => height)
+
+// The root `Canvas` for FULLSCREEN mode: panels composite into its character grid
+// (inherited from `GridSurface`), and `flush` presents by diffing the grid against
+// the snapshot of what the last present drew, overprinting only the damaged runs —
+// an unchanged cell is a no-op and an identical frame emits nothing at all. Every
+// present is ONE write, so partial frames never flash and the SIGWINCH size-probe
+// reply cannot interleave mid-frame. The first present, and any present after
+// `invalidate` (a resize, when the terminal has reflowed whatever was on screen),
+// redraws every row. It replaces the unbuffered `TerminalCanvas` as the fullscreen
+// root, whose immediate per-`put` writes re-emitted every cell a repaint touched.
+class ScreenRoot(widthFn: () => Int, heightFn: () => Int)(using stdio: Stdio)
+extends GridSurface(widthFn(), heightFn()):
+
+  // The live terminal size, for the layout solver; the grid is re-fitted to it by
+  // `reframe` before each solve, so the two only ever disagree mid-resize.
+  override def width: Int = widthFn()
+  override def height: Int = heightFn()
+
+  // Re-fit the grid to the live terminal size. A real change blanks the grid and
+  // invalidates the snapshot: the terminal has reflowed whatever was on screen, so
+  // the next present must redraw everything.
+  def reframe(): Unit =
+    if widthFn() != gridWidth || heightFn() != gridHeight then
+      reshape(widthFn(), heightFn())
+      invalidate()
+
+  // Cursor visibility is deferred like the caret: recorded now, applied by `flush`,
+  // so a focused editor shows it and a focused menu keeps it hidden.
+  def cursor(visible: Boolean): Unit = caretVisible = visible
+
+  // Record the caret's target cell; `flush` positions the hardware cursor there.
+  def showCaret(column: Ordinal, row2: Ordinal): Unit =
+    caretColumn = column.n0
+    caretRow = row2.n0
+
+  def flush(): Unit =
+    val columns = gridWidth
+    val h       = gridHeight
+
+    if !invalidated && snapshotValid(1, columns, h) then presentDiff(1, columns, h)
+    else
+      invalidated = false
+
+      val frame = StringBuilder()
+      def emit(text: Text): Unit = frame.append(text.s)
+      val termcap = stdio.termcap
+
+      emit(csi.dectcem(false))
+
+      // Draw every row at its absolute position (`cup` per row, never a newline, so
+      // the bottom row can never scroll the screen), cleared and reset like a docked
+      // inline row so no colour bleeds between rows.
+      var r = 0
+
+      while r < h do
+        emit(csi.cup(r + 1, 1))
+        emit(csi.el(2))
+        val rendered = rowContent(r, columns).render(termcap)
+        emit(rendered)
+        if rendered.contains(t"\e") then emit(csi.sgr(0))
+        r += 1
+
+      if caretVisible then
+        emit(csi.cup((1 + caretRow.min(h - 1)).max(1), caretColumn.min(columns - 1).max(0) + 1))
+        emit(csi.dectcem(true))
+
+      // What was just drawn IS the screen now: record it (and the caret) so the next
+      // present can diff against it.
+      recordSnapshot(1, columns)
+      recordCaret(1, columns, h)
+
+      Out.print(frame.toString.tt)
+
+  // On exit, re-show the hardware cursor; the alternate-screen wrapper around the
+  // session restores the previous screen contents.
+  def finish(): Unit = Out.print(csi.dectcem(true))

--- a/lib/ultimatum/src/core/ultimatum_core.scala
+++ b/lib/ultimatum/src/core/ultimatum_core.scala
@@ -166,11 +166,15 @@ def form(mode: Mode = Mode.Fullscreen)(pane: Pane)
   mode match
     case Mode.Fullscreen =>
       profanity.terminalFeatures.alternateScreenFeature:
-        val root = TerminalCanvas(terminal)
+        // A buffered root: panels composite into its in-memory grid and each present
+        // diffs against what is already on screen, so unchanged cells are never
+        // re-emitted (no flicker). `cursor(false)` is recorded now and applied by the
+        // first present; `finish` re-shows the cursor on the way out.
+        val root = ScreenRoot(terminal)
         root.cursor(false)
 
         try Form(root, mode, pane, wake).run(terminal.eventIterator())
-        finally root.cursor(true)
+        finally root.finish()
 
     case Mode.Inline =>
       // A deferred resize repaint is woken by posting a `Redraw` after the remaining
@@ -207,6 +211,7 @@ def paint(root: Canvas^, pane: Pane): Unit =
 
   root match
     case inline: InlineRoot => inline.reframe(root.width, height)
+    case screen: ScreenRoot => screen.reframe()
     case _                  => ()
 
   val placement = pane.frame.arrange(Rect(0, 0, root.width, height))

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -466,6 +466,198 @@ object Tests extends Suite(m"Ultimatum Tests"):
         String(bytes.toByteArray.nn, "UTF-8").tt
       . assert(_ == t"\e[?25l\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
 
+    // A geometry-stable re-present diffs against the snapshot of what the last present
+    // drew, overprinting only the damaged cells; an identical frame emits nothing.
+    suite(m"InlineRoot diff present"):
+      def capturing(): (ji.ByteArrayOutputStream, Stdio) =
+        val bytes = ji.ByteArrayOutputStream()
+        (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basicTermcap))
+
+      // Present `first`, then re-present `second` at the same geometry and capture
+      // only the second frame's bytes.
+      def represent(width: Int, height: Int, first: Text, second: Text)
+        ( using Stdio, ji.ByteArrayOutputStream )
+      :   Text =
+
+        val root = InlineRoot(width, 4)
+        root.reframe(width, height); root.move(Prim, Prim); root.put(first); root.flush()
+        summon[ji.ByteArrayOutputStream].reset()
+        root.reframe(width, height); root.move(Prim, Prim); root.put(second); root.flush()
+        String(summon[ji.ByteArrayOutputStream].toByteArray.nn, "UTF-8").tt
+
+      test(m"an identical re-present emits nothing at all"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(3, 2, t"ab\ncd", t"ab\ncd")
+      . assert(_ == t"")
+
+      test(m"a single changed cell emits one absolutely-addressed grapheme"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(3, 2, t"ab\ncd", t"ab\ncD")
+      . assert(_ == t"\e[?25l\e[4;2HD\e[3;1H\e[?25h")
+
+      test(m"adjacent changed cells coalesce into one run"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(3, 2, t"ab\ncd", t"ab\nxy")
+      . assert(_ == t"\e[?25l\e[4;1Hxy\e[3;1H\e[?25h")
+
+      test(m"disjoint changed cells are addressed as separate runs"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(3, 1, t"abc", t"xbz")
+      . assert(_ == t"\e[?25l\e[4;1Hx\e[4;3Hz\e[4;1H\e[?25h")
+
+      // A wide (CJK) glyph occupies two cells (its trailing sentinel carries the same
+      // style), so damage always covers the whole glyph, in both directions.
+      test(m"a wide glyph replacing narrow cells re-emits both cells"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(3, 1, t"abc", t"a中")
+      . assert(_ == t"\e[?25l\e[4;2H中\e[4;1H\e[?25h")
+
+      test(m"narrow cells replacing a wide glyph re-emit both cells"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(3, 1, t"a中", t"abc")
+      . assert(_ == t"\e[?25l\e[4;2Hbc\e[4;1H\e[?25h")
+
+      test(m"an unchanged wide glyph beside a changed cell is not re-emitted"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        given ji.ByteArrayOutputStream = bytes
+        represent(4, 1, t"中ab", t"中ax")
+      . assert(_ == t"\e[?25l\e[4;4Hx\e[4;1H\e[?25h")
+
+      // A style-only change is damage too, and the run renders its SGR self-contained
+      // (ending with a reset, so nothing bleeds beyond the patch).
+      test(m"a style-only change re-emits the cell as SGR within the run"):
+        val bytes = ji.ByteArrayOutputStream()
+        given Stdio =
+          Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.xtermTrueColorTermcap)
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 1); root.move(Prim, Prim); root.put(t"ab"); root.flush()
+        bytes.reset()
+        root.reframe(3, 1); root.move(Prim, Prim); root.put(e"$Bold(a)b"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert: emitted =>
+          emitted.contains(t"\e[4;1H") && emitted.contains(t"\e[1m") && emitted.contains(t"\e[0m")
+            && !emitted.contains(t"\e[2K")
+
+      test(m"a caret-only move emits just the caret placement"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(3, 4)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
+        bytes.reset()
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd")
+        root.showCaret(Sec, Prim)
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[3;2H\e[?25h")
+
+    // The buffered fullscreen root: panels composite into its grid, and `flush`
+    // presents each frame as one write, diffed against the previous present.
+    suite(m"ScreenRoot present"):
+      def capturing(): (ji.ByteArrayOutputStream, Stdio) =
+        val bytes = ji.ByteArrayOutputStream()
+        (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basicTermcap))
+
+      test(m"move and put emit nothing until flush"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = ScreenRoot(3, 2)
+        root.move(Prim, Prim)
+        root.put(t"ab")
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"")
+
+      test(m"the first flush redraws every row absolutely"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = ScreenRoot(3, 2)
+        root.move(Prim, Prim)
+        root.put(t"ab")
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;1H\e[2Kab \e[2;1H\e[2K   \e[1;1H\e[?25h")
+
+      test(m"an identical re-flush emits nothing at all"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = ScreenRoot(3, 2)
+        root.move(Prim, Prim); root.put(t"ab"); root.flush()
+        bytes.reset()
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"")
+
+      test(m"a single changed cell is overprinted alone"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = ScreenRoot(3, 2)
+        root.move(Prim, Prim); root.put(t"ab"); root.flush()
+        bytes.reset()
+        root.move(Sec, Prim); root.put(t"X"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;2HX\e[1;1H\e[?25h")
+
+      // The SIGWINCH guarantee: `invalidate` (called by the form driver on every
+      // WindowSize event) forces the next flush to redraw everything, even when no
+      // cell changed.
+      test(m"invalidate forces the next flush to redraw in full"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = ScreenRoot(3, 2)
+        root.move(Prim, Prim); root.put(t"ab"); root.flush()
+        bytes.reset()
+        root.invalidate()
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;1H\e[2Kab \e[2;1H\e[2K   \e[1;1H\e[?25h")
+
+      test(m"clearing the grid blanks exactly the cells that had content"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = ScreenRoot(3, 2)
+        root.move(Prim, Prim); root.put(t"ab"); root.flush()
+        bytes.reset()
+        root.clear()
+        root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;1H  \e[1;1H\e[?25h")
+
+      // A WindowSize event re-tiles the layout against the live size: the form driver
+      // invalidates the root and `reframe` re-fits the grid, so the present after a
+      // resize is a full redraw of the re-solved layout.
+      test(m"a WindowSize event re-tiles and fully redraws"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var liveRows: Int = 4
+        val root = new ScreenRoot(() => 10, () => liveRows)
+
+        val resize = new Iterator[TerminalEvent]:
+          private var pending = true
+          def hasNext = pending
+
+          def next() =
+            pending = false
+            liveRows = 2
+            TerminalInfo.WindowSize(2, 10)
+
+        Form(root, Mode.Fullscreen, rank(panel()(Out.print(t"A")), panel()(Out.print(t"B"))))
+        . run(resize)
+
+        root.render
+      . assert(_ == t"A         \nB         ")
+
     suite(m"Dynamic panes"):
       def cell(): Pane = panel()(())
 


### PR DESCRIPTION
Ultimatum no longer flickers when redrawing a TUI: every present is now diffed against an in-memory model of what is already on the physical screen, so unchanged cells are never re-emitted, an identical frame writes nothing at all, and a keystroke that changes two cells costs about twenty bytes of output instead of a full-frame redraw. A terminal resize still forces a complete, guaranteed redraw. Terminal sessions also learn their real size at startup rather than waiting for the first resize, and no longer print a spurious stack trace on exit.

## Diff-based rendering in Ultimatum

`GridSurface` — the styled character grid behind Ultimatum's canvases — now records a snapshot of the cells each present actually drew. A geometry-stable present compares the freshly-composed grid against that snapshot and emits one absolutely-addressed run per contiguous patch of damaged cells, in a single write:

- **Inline mode** (`InlineRoot`): previously every row was cleared (`\e[2K`) and re-rendered on every frame. Now an unchanged frame emits nothing, and a typical keystroke emits only the cells it changed, plus the caret. Wide (CJK) glyphs are never split across a patch boundary, and styled runs render self-contained SGR so no colour bleeds beyond a patch.
- **Fullscreen mode**: a new buffered root, `ScreenRoot`, replaces the unbuffered `TerminalCanvas` in `form(Mode.Fullscreen)`. Panels composite into its in-memory grid and each frame is presented as one write, diffed against the previous present — where previously every `move`/`put` was written to the terminal immediately.

A resize (SIGWINCH) invalidates the snapshot, so the next present always redraws everything: the terminal may have reflowed what was on screen, and a diff against stale contents would corrupt the display. Removing a pane now erases exactly its vacated cells rather than clearing the whole screen.

```scala
form(Mode.Fullscreen): // presents now emit only damaged cells
  rank(editor(), editor())
```

## Terminal session robustness (Profanity)

- `interactive` now probes the terminal size immediately after entering raw mode, so a session whose environment lacks `LINES`/`COLUMNS` learns its true dimensions at startup instead of running on a fallback until the first resize. The row fallback is now the conservative 24 (previously 80, which scattered absolutely-addressed output off-screen on real terminals).
- Closing stdin at session teardown no longer prints an `IOException` stack trace over the restored terminal: the keyboard pump treats stdin closure as the normal end of input, and always stops the event spool however it ends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
