### PR TITLE
Complete facsimile's filter set, with LZW in turbulence, and stream payloads

### DIFF
--- a/lib/facsimile/doc/basics.md
+++ b/lib/facsimile/doc/basics.md
@@ -48,6 +48,11 @@ pdfFile.open():
 Decoded `Data` and parsed `Cos` values are pure and may escape the `open` block; the `Pdf`
 itself, and anything which still resolves lazily through it, may not.
 
+For a large payload — an image or an embedded file — `pdf.spring(body)` yields a
+re-materializable `Spring[Data]` instead: each application mints a fresh streaming pull
+endpoint which reads and decodes incrementally, never holding the whole payload. The
+endpoint reads through the document, so it is likewise confined to the scope.
+
 ### Pages
 
 The page tree is flattened into reading order, with the inheritable attributes — resources,

--- a/lib/facsimile/doc/features.md
+++ b/lib/facsimile/doc/features.md
@@ -2,7 +2,9 @@
 - random access through classic cross-reference tables and cross-reference streams
 - follows incremental-update chains, with the newest version of each object winning
 - loads objects lazily and on demand, including from compressed object streams
-- decodes FlateDecode, ASCIIHexDecode and RunLengthDecode filters, with PNG and TIFF predictors
+- decodes Flate, LZW, ASCIIHex, ASCII85 and RunLength filters, with PNG and TIFF predictors
+- streams large payloads incrementally through the zephyrine kernel, never materializing them
+- reads hybrid-reference files, and recovers from wrong or missing stream lengths
 - flattens the page tree with attribute inheritance, and typed page boxes in `Quantity[Points[1]]`
 - reads document information (with PDF date parsing), bookmarks, named destinations and annotations
 - surfaces embedded files, page labels and the XMP metadata packet

--- a/lib/facsimile/src/core/facsimile.Ascii85.scala
+++ b/lib/facsimile/src/core/facsimile.Ascii85.scala
@@ -1,0 +1,90 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package facsimile
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// ASCII85Decode (ISO 32000-2 §7.4.3): groups of five characters from `!`–`u` encode four
+// bytes base-85; `z` abbreviates four zero bytes; a partial final group of n characters
+// yields n−1 bytes; `~>` ends the data.
+private[facsimile] object Ascii85:
+  def decode(data: Data): Data raises PdfError =
+    val bytes = Array.newBuilder[Byte]
+    val group = new Array[Int](5)
+    var members = 0
+    var done = false
+    var i = 0
+
+    def emit(count: Int): Unit =
+      var value = 0L
+      var j = 0
+
+      while j < 5 do
+        value = value*85 + (if j < count then group(j) else 84)
+        j += 1
+
+      var shift = 24
+
+      while shift > 32 - count*8 do
+        bytes += ((value >> shift) & 0xff).toByte
+        shift -= 8
+
+    while i < data.length && !done do
+      val byte = data(i) & 0xff
+      i += 1
+
+      if byte == '~' then
+        done = true
+      else if byte == 'z' && members == 0 then
+        bytes += 0
+        bytes += 0
+        bytes += 0
+        bytes += 0
+      else if byte >= '!' && byte <= 'u' then
+        group(members) = byte - '!'
+        members += 1
+
+        if members == 5 then
+          emit(5)
+          members = 0
+      else if !CosLexer.whitespace(byte) then
+        abort(PdfError(PdfError.Reason.CorruptStream(t"ASCII85Decode")))
+
+    if members == 1 then abort(PdfError(PdfError.Reason.CorruptStream(t"ASCII85Decode")))
+    if members > 1 then emit(members)
+
+    bytes.result().immutable(using Unsafe)

--- a/lib/facsimile/src/core/facsimile.Filter.scala
+++ b/lib/facsimile/src/core/facsimile.Filter.scala
@@ -39,20 +39,14 @@ import anticipation.*
 import contingency.*
 import gossamer.*
 import rudiments.*
+import turbulence.*
 import vacuous.*
+import zephyrine.*
 
 // Stream filters (ISO 32000-2 §7.4). Image codecs — DCT, JPX, CCITT, JBIG2 — are *terminal*:
 // decoding stops before them and the caller receives the still-encoded image bytes, which is
 // what any consumer of those formats wants anyway.
 private[facsimile] object Filter:
-  enum Id:
-    case Flate, AsciiHex, Ascii85, Lzw, RunLength, Crypt
-    case Dct, Jpx, Ccitt, Jbig2
-
-    def terminal: Boolean = this match
-      case Dct | Jpx | Ccitt | Jbig2 => true
-      case _                         => false
-
   object Id:
     // Both the full names and the inline-image abbreviations of ISO 32000-2 §8.9.7.
     def parse(name: Text): Optional[Id] = name.s match
@@ -67,6 +61,14 @@ private[facsimile] object Filter:
       case "CCITTFaxDecode" | "CCF"  => Ccitt
       case "JBIG2Decode"             => Jbig2
       case _                         => Unset
+
+  enum Id:
+    case Flate, AsciiHex, Ascii85, Lzw, RunLength, Crypt
+    case Dct, Jpx, Ccitt, Jbig2
+
+    def terminal: Boolean = this match
+      case Dct | Jpx | Ccitt | Jbig2 => true
+      case _                         => false
 
   // Normalizes a stream dictionary's `/Filter` (a name or an array of names) and
   // `/DecodeParms` (a dictionary, an array with nulls, or absent) into a decoding plan. Both
@@ -105,6 +107,38 @@ private[facsimile] object Filter:
       val id = Id.parse(name).or(abort(PdfError(PdfError.Reason.UnknownFilter(name))))
       (id, if index < parameters.length then parameters(index) else Map())
 
+  // A streaming plan is plain data — closures at most — because ducts, being scoped
+  // capabilities, may only be minted at the `via` call site (a lambda cannot return a fresh
+  // capability; a method can). `Pdf.spring` interprets these steps into a pipeline.
+  private[facsimile] enum Step:
+    case Inflate
+    case Unlzw(earlyChange: Boolean)
+    case Gather(transform: Data => Data)
+
+  // The streaming plan for a decoding chain, stopping before any terminal codec: Flate
+  // streams incrementally through turbulence's zlib duct (without the eager path's
+  // raw-deflate retry, which is impossible mid-stream); the textual filters gather their
+  // input and decode on flush, which is immaterial at their typical sizes.
+  def steps(chain: List[(Id, Map[Text, Cos])])(using tactic: Tactic[PdfError])
+  :   List[Step^{tactic}] =
+    chain.takeWhile(!_(0).terminal).flatMap: (id, parms) =>
+      val predicted = parms.at(t"Predictor").let(_.long).or(1L) > 1
+
+      id match
+        case Id.Flate =>
+          if predicted then List(Step.Inflate, Step.Gather(predict(_, parms)))
+          else List(Step.Inflate)
+
+        case Id.Lzw =>
+          if predicted then List(Step.Unlzw(earlyChange(parms)), Step.Gather(predict(_, parms)))
+          else List(Step.Unlzw(earlyChange(parms)))
+
+        case Id.Crypt =>
+          List()
+
+        case other =>
+          List(Step.Gather(stage(_, other, parms)))
+
   // Applies a resolved filter chain eagerly, stopping at the first terminal codec.
   def decode(data: Data, chain: List[(Id, Map[Text, Cos])]): Data raises PdfError =
     chain match
@@ -116,12 +150,20 @@ private[facsimile] object Filter:
 
   private def stage(data: Data, id: Id, parms: Map[Text, Cos]): Data raises PdfError = id match
     case Id.Flate     => predict(flate(data), parms)
+    case Id.Lzw       => predict(lzw(data, parms), parms)
+    case Id.Ascii85   => Ascii85.decode(data)
     case Id.AsciiHex  => asciiHex(data)
     case Id.RunLength => runLength(data)
     case Id.Crypt     => data // `Identity` until encryption arrives; `Guard` will slot in here
-    case Id.Lzw       => abort(PdfError(PdfError.Reason.UnknownFilter(t"LZWDecode")))
-    case Id.Ascii85   => abort(PdfError(PdfError.Reason.UnknownFilter(t"ASCII85Decode")))
     case _            => data
+
+  private def lzw(data: Data, parms: Map[Text, Cos]): Data raises PdfError =
+    try Lzw.decompress(LazyList(data), earlyChange(parms)).foldLeft(IArray.empty[Byte])(_ ++ _)
+    catch case _: IllegalStateException =>
+      abort(PdfError(PdfError.Reason.CorruptStream(t"LZWDecode")))
+
+  private def earlyChange(parms: Map[Text, Cos]): Boolean =
+    parms.at(t"EarlyChange").let(_.long).or(1L) == 1L
 
   private def predict(data: Data, parms: Map[Text, Cos]): Data raises PdfError =
     val predictor = parms.at(t"Predictor").let(_.long).or(1L).toInt

--- a/lib/facsimile/src/core/facsimile.Gathering.scala
+++ b/lib/facsimile/src/core/facsimile.Gathering.scala
@@ -1,0 +1,92 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package facsimile
+
+import anticipation.*
+import rudiments.*
+import vacuous.*
+import zephyrine.*
+
+// A pipeline stage that gathers its whole input and transforms it during flush: the
+// streaming fallback for the textual filters (ASCIIHex, ASCII85, RunLength, LZW,
+// predictors), whose payloads are small in practice. The genuinely large payloads — raw
+// ranges, terminal image codecs, Flate — never pass through it, streaming incrementally
+// through their own stages instead.
+private[facsimile] class Gathering(transform: Data => Data) extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private val gathered: scala.collection.mutable.ArrayBuffer[Byte] =
+    scala.collection.mutable.ArrayBuffer()
+
+  private var result: Optional[Data] = Unset
+  private var delivered: Int = 0
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  update def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    val bytes = source.asInstanceOf[Array[Byte]]
+    var i = 0
+
+    while i < sourceLength do
+      gathered += bytes(sourceOffset + i)
+      i += 1
+
+    Duct.Progress(sourceLength, 0)
+
+  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    val out = target.asInstanceOf[Array[Byte]]
+
+    val data = result.or:
+      val transformed = transform(gathered.toArray.immutable(using Unsafe))
+      result = transformed
+      transformed
+
+    val count = targetSpace.min(data.length - delivered)
+    var i = 0
+
+    while i < count do
+      out(targetOffset + i) = data(delivered + i)
+      i += 1
+
+    delivered += count
+    count

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -36,8 +36,10 @@ import anticipation.*
 import contingency.*
 import denominative.*
 import gossamer.*
+import prepositional.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 object Pdf:
   case class Version(major: Int, minor: Int)
@@ -333,18 +335,114 @@ extends caps.ExclusiveCapability:
   // filter chain, which stops at terminal image codecs. `/Length` may be indirect; filters in
   // a general stream may be too, so the chain inputs are resolved through this document.
   def payload(body: Cos.Body): Data raises PdfError =
-    val length = resolved(body.entries.at(t"Length").or(Cos.Nil)).long
-      . or(abort(PdfError(PdfError.Reason.MissingEntry(t"Length")))).toInt
-
-    val raw = source.read(body.start, length)
-    if raw.length < length then abort(PdfError(PdfError.Reason.Truncated))
-
     val chain =
       Filter.chain
         ( body.entries.at(t"Filter").let(deepResolved(_)),
           body.entries.at(t"DecodeParms").let(deepResolved(_)) )
 
-    Filter.decode(raw, chain)
+    Filter.decode(raw(body), chain)
+
+  // A re-materializable streaming view of the decoded payload: each `apply()` mints a fresh
+  // pull endpoint reading the raw range in chunks and decoding through the filter chain, so
+  // a large image or embedded file is never materialized whole. The endpoint reads through
+  // this document, so — like everything that does — it cannot outlive the `open` scope.
+  def spring(body: Cos.Body)(using tactic: Tactic[PdfError]): Spring[Data]^{this, tactic} =
+    val chain =
+      Filter.chain
+        ( body.entries.at(t"Filter").let(deepResolved(_)),
+          body.entries.at(t"DecodeParms").let(deepResolved(_)) )
+
+    val steps = Filter.steps(chain)
+    val start = body.start
+    val end = payloadEnd(body)
+
+    new Spring[Data]:
+      def apply(): (Stream[Data] over Credit)^ =
+        pipeline(steps, Stream(ranges(start, end)))
+
+  // Interprets a streaming plan, minting each duct at its `via` call site.
+  private def pipeline(steps: List[Filter.Step^], consume stream: (Stream[Data] over Credit)^)
+  :   (Stream[Data] over Credit)^ =
+
+    steps match
+      case Filter.Step.Inflate :: rest =>
+        pipeline(rest, stream.via(turbulence.Zlib.compression.decompressor()))
+
+      case Filter.Step.Unlzw(earlyChange) :: rest =>
+        pipeline(rest, stream.via(turbulence.Lzw.decompressor(earlyChange)))
+
+      case Filter.Step.Gather(transform) :: rest =>
+        pipeline(rest, stream.via(Gathering(transform)))
+
+      case _ =>
+        stream
+
+  // Chunked positional reads over a raw range: the pull side of `spring`.
+  private def ranges(start: Long, end: Long): Iterator[Data]^{this} = new Iterator[Data]:
+    private var position: Long = start
+
+    def hasNext: Boolean = position < end
+
+    def next(): Data =
+      val length = (end - position).min(65536L).toInt
+      val chunk = source.read(position, length)
+      position = if chunk.length == 0 then end else position + chunk.length
+      chunk
+
+  // The undecoded payload: the range from the payload's start to its computed end.
+  private[facsimile] def raw(body: Cos.Body): Data raises PdfError =
+    source.read(body.start, (payloadEnd(body) - body.start).toInt)
+
+  // The exclusive end of the payload: `/Length` bytes when the declared length checks out —
+  // the `endstream` keyword must follow it — and otherwise, since wrong lengths abound in
+  // real files, the nearest `endstream`, less the end-of-line before it.
+  private def payloadEnd(body: Cos.Body): Long raises PdfError =
+    resolved(body.entries.at(t"Length").or(Cos.Nil)).long.let: length =>
+      if length >= 0 && body.start + length <= source.size
+         && endstreamFollows(body.start + length)
+      then body.start + length else Unset
+
+    . or:
+        val marker = t"endstream"
+        val chunkSize = 65536
+        var offset = body.start
+        var found: Optional[Long] = Unset
+
+        while found.absent && offset < source.size do
+          val chunk = source.read(offset, chunkSize + marker.length - 1)
+          var i = 0
+
+          while found.absent && i <= chunk.length - marker.length do
+            var j = 0
+            while j < marker.length && (chunk(i + j) & 0xff) == marker.s.charAt(j).toInt do j += 1
+            if j == marker.length then found = offset + i else i += 1
+
+          offset += chunkSize
+
+        found.let: position =>
+          // The end-of-line before `endstream` belongs to the syntax, not the payload.
+          val windowStart = (position - 2).max(body.start)
+          val window = source.read(windowStart, (position - windowStart).toInt)
+          val last = if window.length >= 1 then window(window.length - 1) & 0xff else -1
+          val prior = if window.length >= 2 then window(window.length - 2) & 0xff else -1
+
+          if prior == 0x0d && last == 0x0a then position - 2
+          else if last == 0x0a || last == 0x0d then position - 1
+          else position
+
+        . or(abort(PdfError(PdfError.Reason.Truncated)))
+
+  private def endstreamFollows(position: Long): Boolean =
+    val marker = t"endstream"
+    val window = source.read(position, 24)
+    var i = 0
+
+    while i < window.length && CosLexer.whitespace(window(i) & 0xff) do i += 1
+
+    if i + marker.length > window.length then false else
+      var j = 0
+      while j < marker.length && (window(i + j) & 0xff) == marker.s.charAt(j).toInt do j += 1
+      j == marker.length
 
   // Resolves a value and, one level down, the elements of an array or the values of a
   // dictionary: sufficient for `/Filter` and `/DecodeParms` shapes.

--- a/lib/facsimile/src/core/facsimile.Xref.scala
+++ b/lib/facsimile/src/core/facsimile.Xref.scala
@@ -55,7 +55,19 @@ private[facsimile] object Xref:
       if visited.contains(offset) || offset < 0 || offset >= source.size
       then abort(PdfError(PdfError.Reason.MalformedXref(offset)))
 
-      val (sectionEntries, sectionTrailer) = section(source, offset)
+      val (classicEntries, sectionTrailer) = section(source, offset)
+
+      // A hybrid-reference file (ISO 32000-2 §7.5.8.4): the classic section points at a
+      // cross-reference stream carrying the entries — typically for objects in object
+      // streams — which legacy readers see as free. The table's live entries win, but its
+      // free markers yield to the stream's.
+      val sectionEntries = sectionTrailer.at(t"XRefStm").let(_.long).lay(classicEntries):
+        hybrid =>
+          val (hybridEntries, _) = stream(source, hybrid)
+
+          hybridEntries ++ classicEntries.filter: (number, entry) =>
+            entry != Entry.Free || !hybridEntries.contains(number)
+
       val mergedEntries = sectionEntries ++ entries
       val mergedTrailer = sectionTrailer ++ trailer
 
@@ -115,7 +127,7 @@ private[facsimile] object Xref:
       case CosToken.Integral(first) =>
         val count = lexer.next() match
           case CosToken.Integral(count) => count.toInt
-          case _ => abort(PdfError(PdfError.Reason.MalformedXref(offset)))
+          case _                        => abort(PdfError(PdfError.Reason.MalformedXref(offset)))
 
         for index <- 0 until count do
           val entry = (lexer.next(), lexer.next(), lexer.next()) match
@@ -136,7 +148,7 @@ private[facsimile] object Xref:
       case CosToken.Keyword(word) if word.s == "trailer" =>
         CosParser(lexer).value() match
           case Cos.Dictionary(trailer) => trailer
-          case _ => abort(PdfError(PdfError.Reason.MalformedXref(offset)))
+          case _                       => abort(PdfError(PdfError.Reason.MalformedXref(offset)))
 
       case _ =>
         abort(PdfError(PdfError.Reason.MalformedXref(offset)))
@@ -177,7 +189,7 @@ private[facsimile] object Xref:
             elements.map(_.long.or(abort(PdfError(PdfError.Reason.MalformedXref(offset)))))
             . grouped(2).to(List).map:
                 case List(first, count) => (first, count)
-                case _ => abort(PdfError(PdfError.Reason.MalformedXref(offset)))
+                case _                  => abort(PdfError(PdfError.Reason.MalformedXref(offset)))
 
         val rowLength = widths.sum
         var entries = Map[Int, Entry]()

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -258,8 +258,8 @@ object Tests extends Suite(m"Facsimile tests"):
       . assert(_ == List(1, 2, 3, 4, 5, 6))
 
       test(m"an unknown filter name is an error"):
-        capture[PdfError](Filter.decode(data(1), List((Filter.Id.Lzw, Map())))).reason
-      . assert(_ == PdfError.Reason.UnknownFilter(t"LZWDecode"))
+        capture[PdfError](Filter.chain(Cos.Name(t"BogusDecode"), Unset)).reason
+      . assert(_ == PdfError.Reason.UnknownFilter(t"BogusDecode"))
 
     suite(m"Whole documents"):
       test(m"the version comes from the header"):
@@ -413,6 +413,73 @@ object Tests extends Suite(m"Facsimile tests"):
         PdfFile(xrefStreamDocument()).open():
           textOf(pdf.resolved(pdf(1, 0)(t"Greeting").or(Cos.Nil)))
       . assert(_ == t"hi")
+
+    suite(m"Streaming payloads"):
+      def drain(stream: (Stream[Data] over Credit)^): Data =
+        val builder = Array.newBuilder[Byte]
+
+        def recur(): Unit = stream.refill(Credit(4096)) match
+          case count: Int =>
+            val window = unsafely(stream.window).asInstanceOf[Array[Byte]]
+            var i = 0
+
+            while i < count do
+              builder += window(stream.start + i)
+              i += 1
+
+            stream.skip(count)
+            recur()
+
+          case _ =>
+            ()
+
+        recur()
+        builder.result().immutable(using Unsafe)
+
+      def streamed(body: Data): Text =
+        PdfFile(document(catalog, body)).open():
+          pdf(2, 0) match
+            case body: Cos.Body =>
+              String(drain(pdf.spring(body)()).mutable(using Unsafe), "UTF-8").tt
+
+            case _ =>
+              t""
+
+      test(m"a raw payload streams in chunks"):
+        streamed(t"<< /Length 11 >>\nstream\nHello world\nendstream".in[Data])
+      . assert(_ == t"Hello world")
+
+      test(m"a Flate payload streams through the zlib duct"):
+        val payload = deflate(t"streamed and inflated".in[Data])
+
+        val body = t"<< /Length ${payload.length} /Filter /FlateDecode >>\nstream\n".in[Data]
+          ++ payload ++ t"\nendstream".in[Data]
+
+        streamed(body)
+      . assert(_ == t"streamed and inflated")
+
+      test(m"a gathered filter delivers through flush"):
+        streamed(t"<< /Length 11 /Filter /ASCIIHexDecode >>\nstream\n48656C6C6F>\nendstream"
+          . in[Data])
+      . assert(_ == t"Hello")
+
+      test(m"a spring re-materializes the same content"):
+        val payload = deflate(t"again and again".in[Data])
+
+        val body = t"<< /Length ${payload.length} /Filter /FlateDecode >>\nstream\n".in[Data]
+          ++ payload ++ t"\nendstream".in[Data]
+
+        PdfFile(document(catalog, body)).open():
+          pdf(2, 0) match
+            case body: Cos.Body =>
+              val spring = pdf.spring(body)
+              val first = String(drain(spring()).mutable(using Unsafe), "UTF-8").tt
+              val second = String(drain(spring()).mutable(using Unsafe), "UTF-8").tt
+              (first, second)
+
+            case _ =>
+              (t"", t"")
+      . assert(_ == (t"again and again", t"again and again"))
 
     // A two-page document: object 1 catalog, 2 page-tree root (A4 media box, inherited),
     // 3 a plain page, 4 a page with its own crop box and rotation.
@@ -648,6 +715,78 @@ object Tests extends Suite(m"Facsimile tests"):
         PdfFile(paged()).open():
           pdf.pageLabel(1.z)
       . assert(_ == t"2")
+
+      test(m"ASCII85Decode decodes a full group"):
+        String
+          ( Filter.decode(t"9jqo^~>".in[Data], List((Filter.Id.Ascii85, Map())))
+            . mutable(using Unsafe), "UTF-8" ).tt
+      . assert(_ == t"Man ")
+
+      test(m"ASCII85Decode decodes a partial final group"):
+        String
+          ( Filter.decode(t"9jqo~>".in[Data], List((Filter.Id.Ascii85, Map())))
+            . mutable(using Unsafe), "UTF-8" ).tt
+      . assert(_ == t"Man")
+
+      test(m"the z shorthand is four zero bytes"):
+        Filter.decode(t"z~>".in[Data], List((Filter.Id.Ascii85, Map()))).to(List).map(_.toInt)
+      . assert(_ == List(0, 0, 0, 0))
+
+      test(m"LZWDecode decodes the specification's example"):
+        val encoded = data(0x80, 0x0b, 0x60, 0x50, 0x22, 0x0c, 0x0c, 0x85, 0x01)
+        String
+          ( Filter.decode(encoded, List((Filter.Id.Lzw, Map()))).mutable(using Unsafe),
+            "UTF-8" ).tt
+      . assert(_ == t"-----A---B")
+
+      test(m"a wrong stream length falls back to the endstream keyword"):
+        val body = t"<< /Length 3 >>\nstream\nHello\nendstream".in[Data]
+
+        PdfFile(document(catalog, body)).open():
+          pdf(2, 0) match
+            case body: Cos.Body => String(pdf.payload(body).mutable(using Unsafe), "UTF-8").tt
+            case _              => t""
+      . assert(_ == t"Hello")
+
+      test(m"a missing stream length falls back to the endstream keyword"):
+        val body = t"<< /Kind /Bare >>\nstream\nHello\nendstream".in[Data]
+
+        PdfFile(document(catalog, body)).open():
+          pdf(2, 0) match
+            case body: Cos.Body => String(pdf.payload(body).mutable(using Unsafe), "UTF-8").tt
+            case _              => t""
+      . assert(_ == t"Hello")
+
+      test(m"a hybrid-reference file resolves its compressed objects"):
+        var out: Data = t"%PDF-1.5\n".in[Data]
+
+        val offset1 = out.length
+        out = out ++ t"1 0 obj\n<< /Type /Catalog /Value 4 0 R >>\nendobj\n".in[Data]
+
+        // An object stream holding just object 4, whose pair table is 4 bytes long.
+        val offset2 = out.length
+        out = out ++ t"2 0 obj\n<< /Type /ObjStm /N 1 /First 4 /Length 6 >>\nstream\n".in[Data]
+          ++ t"4 0\n99".in[Data] ++ t"\nendstream\nendobj\n".in[Data]
+
+        // The cross-reference stream covering only object 4, as compressed.
+        val offset3 = out.length
+        out = out
+          ++ t"3 0 obj\n<< /Type /XRef /Size 5 /W [1 2 1] /Index [4 1] /Length 4 >>\nstream\n"
+             . in[Data]
+          ++ data(2, 0, 2, 0) ++ t"\nendstream\nendobj\n".in[Data]
+
+        // The classic table marks object 4 free — the hybrid signature — and points at the
+        // cross-reference stream through /XRefStm.
+        val xrefOffset = out.length
+        out = out ++ t"xref\n0 5\n0000000000 65535 f \n".in[Data]
+          ++ t"${pad10(offset1)} 00000 n \n${pad10(offset2)} 00000 n \n".in[Data]
+          ++ t"${pad10(offset3)} 00000 n \n0000000000 00000 f \n".in[Data]
+          ++ t"trailer\n<< /Size 5 /Root 1 0 R /XRefStm $offset3 >>\n".in[Data]
+          ++ t"startxref\n$xrefOffset\n%%EOF".in[Data]
+
+        PdfFile(out).open():
+          pdf.resolved(pdf(1, 0)(t"Value").or(Cos.Nil))
+      . assert(_ == Cos.Integral(99))
 
       test(m"XMP metadata surfaces as raw bytes"):
         val doc = document

--- a/lib/turbulence/src/jvm/turbulence.Lzw.scala
+++ b/lib/turbulence/src/jvm/turbulence.Lzw.scala
@@ -30,6 +30,65 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package turbulence
 
-export turbulence.{Deflate, Gzip, Lzw, Zlib, gzip, gunzip}
+import anticipation.*
+import rudiments.*
+import vacuous.*
+import zephyrine.*
+
+// LZW, the compression of TIFF and PDF streams, implemented natively (the JDK offers none)
+// and therefore available on every platform. `earlyChange` — both sides widening their
+// codes one table entry sooner — is the TIFF/PDF default, and what every known encoder
+// produces; the parameterized factories serve formats which state it explicitly.
+object Lzw:
+  def compressor(earlyChange: Boolean)(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit } =
+
+    LzwStage(LzwEncoder(earlyChange))
+
+  def decompressor(earlyChange: Boolean)(using Buffering): Duct[Data, Data] {
+    type Transport = Credit
+    type Upstream = Credit } =
+
+    LzwStage(LzwDecoder(earlyChange))
+
+  def compress(stream: LazyList[Data], earlyChange: Boolean = true): LazyList[Data] =
+    drive(LzwEncoder(earlyChange), stream)
+
+  def decompress(stream: LazyList[Data], earlyChange: Boolean = true): LazyList[Data] =
+    drive(LzwDecoder(earlyChange), stream)
+
+  given compression: Lzw is Compression:
+    def compressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      LzwStage(LzwEncoder(true))
+
+    def decompressor()(using Buffering): Duct[Data, Data] {
+      type Transport = Credit
+      type Upstream = Credit } =
+
+      LzwStage(LzwDecoder(true))
+
+    def compress(stream: LazyList[Data]): LazyList[Data] = Lzw.compress(stream)
+    def decompress(stream: LazyList[Data]): LazyList[Data] = Lzw.decompress(stream)
+
+  // Drives an engine over a lazy stream chunk by chunk, then collects its finished tail.
+  private def drive(engine: LzwEngine, stream: LazyList[Data]): LazyList[Data] =
+    def recur(stream: LazyList[Data]): LazyList[Data] = stream match
+      case head #:: tail =>
+        engine.accept(head.mutable(using Unsafe), 0, head.length)
+        val data = engine.gather()
+        if data.length > 0 then data #:: recur(tail) else recur(tail)
+
+      case _ =>
+        engine.finish()
+        val data = engine.gather()
+        if data.length > 0 then LazyList(data) else LazyList.empty
+
+    LazyList.defer(recur(stream))
+
+sealed trait Lzw extends Compressor

--- a/lib/turbulence/src/jvm/turbulence.LzwEngine.scala
+++ b/lib/turbulence/src/jvm/turbulence.LzwEngine.scala
@@ -1,0 +1,258 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package turbulence
+
+import anticipation.*
+import rudiments.*
+import vacuous.*
+import zephyrine.*
+
+// LZW, as used by TIFF and PDF: MSB-first codes of 9 to 12 bits, code 256 clearing the
+// table and 257 ending the data. The algorithm lives in plain engine classes — the moral
+// equivalent of `juz.Deflater`, so the lazy `LazyList` drivers may close over them exactly
+// as `Zlib`'s do over a deflater — and the `Duct` stages are thin wrappers.
+//
+// With `earlyChange` — the TIFF/PDF default — both sides widen their codes one table entry
+// sooner. The decoder's table trails the encoder's by one entry, so the encoder widens (and
+// clears) at a `nextCode` threshold one higher than the decoder's table-length threshold,
+// which is what keeps the two in step.
+private[turbulence] trait LzwEngine:
+  protected val pending: scala.collection.mutable.ArrayBuffer[Byte] =
+    scala.collection.mutable.ArrayBuffer()
+
+  private var delivered: Int = 0
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit
+  def finish(): Unit
+
+  def deliver(target: Array[Byte], offset: Int, space: Int): Int =
+    var produced = 0
+
+    while delivered < pending.length && produced < space do
+      target(offset + produced) = pending(delivered)
+      delivered += 1
+      produced += 1
+
+    if delivered == pending.length then
+      pending.clear()
+      delivered = 0
+
+    produced
+
+  // Everything not yet delivered, drained in one immutable piece: the whole-value
+  // counterpart of `deliver`, and — being a method of an untracked engine with a pure
+  // result — safe to call from within a lazy stream's thunks.
+  def gather(): Data =
+    val result = new Array[Byte](pending.length - delivered)
+    var i = 0
+
+    while delivered < pending.length do
+      result(i) = pending(delivered)
+      i += 1
+      delivered += 1
+
+    pending.clear()
+    delivered = 0
+    result.immutable(using Unsafe)
+
+private[turbulence] class LzwEncoder(earlyChange: Boolean) extends LzwEngine:
+  private val codes: scala.collection.mutable.HashMap[(Int, Byte), Int] =
+    scala.collection.mutable.HashMap()
+
+  private var nextCode = 258
+  private var width = 9
+  private var prefix = -1
+  private var bits = 0L
+  private var bitCount = 0
+  private var begun = false
+  private var ended = false
+
+  private val early: Int = if earlyChange then 1 else 0
+
+  private def emit(code: Int): Unit =
+    bits = (bits << width) | code
+    bitCount += width
+
+    while bitCount >= 8 do
+      pending += ((bits >> (bitCount - 8)) & 0xff).toByte
+      bitCount -= 8
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit =
+    if !begun then
+      emit(256)
+      begun = true
+
+    var i = 0
+
+    while i < length do
+      val byte = bytes(offset + i)
+
+      if prefix < 0 then prefix = byte & 0xff else codes.at((prefix, byte)) match
+        case code: Int =>
+          prefix = code
+
+        case _ =>
+          emit(prefix)
+          codes((prefix, byte)) = nextCode
+          nextCode += 1
+
+          // The decoder's table trails by one entry, so its thresholds sit one lower.
+          if nextCode >= (1 << width) + 1 - early && width < 12 then width += 1
+
+          if nextCode >= 4096 - early then
+            emit(256)
+            codes.clear()
+            nextCode = 258
+            width = 9
+
+          prefix = byte & 0xff
+
+      i += 1
+
+  def finish(): Unit =
+    if !ended then
+      if !begun then
+        emit(256)
+        begun = true
+
+      if prefix >= 0 then
+        emit(prefix)
+        prefix = -1
+
+      emit(257)
+      if bitCount > 0 then emit(0) // pad the final code out to a byte boundary
+      bitCount = 0
+      ended = true
+
+private[turbulence] class LzwDecoder(earlyChange: Boolean) extends LzwEngine:
+  private val table: scala.collection.mutable.ArrayBuffer[Array[Byte]] =
+    scala.collection.mutable.ArrayBuffer()
+
+  private var width = 9
+  private var bits = 0L
+  private var bitCount = 0
+  private var finished = false
+
+  private var previous: Array[Byte] = new Array[Byte](0)
+
+  private val early: Int = if earlyChange then 1 else 0
+
+  reset()
+
+  private def reset(): Unit =
+    table.clear()
+    var byte = 0
+
+    while byte < 256 do
+      table += Array(byte.toByte)
+      byte += 1
+
+    table += new Array[Byte](0) // the clear code
+    table += new Array[Byte](0) // the end-of-data code
+    width = 9
+    previous = new Array[Byte](0)
+
+  private def interpret(): Unit =
+    val code = ((bits >> (bitCount - width)) & ((1L << width) - 1)).toInt
+    bitCount -= width
+
+    code match
+      case 256 =>
+        reset()
+
+      case 257 =>
+        finished = true
+
+      case code =>
+        val entry: Array[Byte] =
+          if code < table.length then table(code).nn
+          else if code == table.length && previous.length > 0 then previous :+ previous(0)
+          else throw IllegalStateException("the LZW data is corrupt")
+
+        var i = 0
+
+        while i < entry.length do
+          pending += entry(i)
+          i += 1
+
+        if previous.length > 0 then table += previous :+ entry(0)
+        previous = entry
+        if table.length >= (1 << width) - early && width < 12 then width += 1
+
+  def accept(bytes: Array[Byte], offset: Int, length: Int): Unit =
+    var consumed = 0
+
+    while consumed < length do
+      while bitCount <= 56 && consumed < length do
+        bits = (bits << 8) | (bytes(offset + consumed) & 0xff)
+        bitCount += 8
+        consumed += 1
+
+      while bitCount >= width && !finished do interpret()
+      if finished then consumed = length // trailing bytes after end-of-data are noise
+
+  def finish(): Unit = while bitCount >= width && !finished do interpret()
+
+// The `Duct` stages: thin wrappers presenting an engine to the streaming kernel. All output
+// is staged through the engine's retained `pending` buffer, drained into whatever target
+// space each step or flush offers.
+private[turbulence] class LzwStage(engine: LzwEngine) extends Duct[Data, Data]:
+  type Transport = Credit
+  type Upstream = Credit
+
+  private var finishing = false
+
+  def regulation: Credit is Regulation = summon[Credit is Regulation]
+  def translate(demand: Credit): Credit = demand
+
+  update def step
+    ( source: input.Storage,
+      sourceOffset: Int,
+      sourceLength: Int,
+      target: output.Storage,
+      targetOffset: Int,
+      targetSpace: Int )
+  :   Duct.Progress =
+
+    engine.accept(source.asInstanceOf[Array[Byte]], sourceOffset, sourceLength)
+
+    Duct.Progress
+      ( sourceLength,
+        engine.deliver(target.asInstanceOf[Array[Byte]], targetOffset, targetSpace) )
+
+  override update def flush(target: output.Storage, targetOffset: Int, targetSpace: Int): Int =
+    if !finishing then
+      engine.finish()
+      finishing = true
+
+    engine.deliver(target.asInstanceOf[Array[Byte]], targetOffset, targetSpace)

--- a/lib/turbulence/src/test/turbulence_test.scala
+++ b/lib/turbulence/src/test/turbulence_test.scala
@@ -511,6 +511,26 @@ object Tests extends Suite(m"Turbulence tests"):
       test(m"Roundtrip compress/decompress a long repetitive stream with Gzip"):
         longData.compress[Gzip].decompress[Gzip]
       . assert(_.flatten == longData.flatten)
+
+      test(m"Roundtrip compress/decompress a single block with LZW"):
+        LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).compress[Lzw].decompress[Lzw]
+      . assert(_.flatten == LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).flatten)
+
+      // Varied enough to push the code table through its 9-, 10- and 11-bit widths.
+      val variedData =
+        LazyList(IArray.from((0 until 20000).map { index => ((index*index + index/3)%251).toByte }))
+
+      test(m"Roundtrip compress/decompress across LZW width growth"):
+        variedData.compress[Lzw].decompress[Lzw]
+      . assert(_.flatten == variedData.flatten)
+
+      test(m"Roundtrip compress/decompress a long stream across LZW table clears"):
+        longData.compress[Lzw].decompress[Lzw]
+      . assert(_.flatten == longData.flatten)
+
+      test(m"LZW without early change also roundtrips"):
+        Lzw.decompress(Lzw.compress(variedData, earlyChange = false), earlyChange = false)
+      . assert(_.flatten == variedData.flatten)
       test(m"Compress a single block with Zlib"):
         LazyList(Data(1, 1, 2, 3, 5, 8, 13, 21, 34)).compress[Zlib].to(List).map(_.to(List))
       . assert(_ == List(List(120, -100, 98, 100, 100, 98, 102, -27, -32, 21, 85, 2, 0, 0, 0, -1, -1), List(3, 0, 0, -26, 0, 89)))


### PR DESCRIPTION
Facsimile now decodes every non-image PDF stream filter, and turbulence gains LZW as a
first-class compression format alongside Deflate, Gzip and Zlib — implemented natively,
since the JDK offers none, with a full encoder and decoder behind the `Compression`
typeclass (`stream.compress[Lzw]`, `stream.decompress[Lzw]`), and `earlyChange`
parameterized for the formats that state it. Facsimile's reader uses the decoder for
`LZWDecode` (honouring `/EarlyChange`), adds `ASCII85Decode`, reads hybrid-reference files
(`/XRefStm`), and recovers from wrong or missing stream `/Length` values by scanning for
the `endstream` keyword.

Large payloads no longer need materializing: `pdf.spring(body)` yields a re-materializable
`Spring[Data]`, each application of which mints a fresh streaming pull endpoint that reads
the raw range in chunks and decodes through the filter chain — Flate and LZW stream
incrementally through turbulence ducts; terminal image codecs pass through undecoded.

```scala
pdfFile.open():
  pdf(12, 0) match
    case body: Cos.Body =>
      val spring = pdf.spring(body)   // confined to the scope, like the Pdf
      spring().pump(intake)           // stream an image or embedded file, chunk by chunk
    case _ => ()
```

As with everything that reads through the document, a `Spring` and its endpoints cannot
outlive the `open` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
