### PR TITLE
Decrypt PDF documents, and add an opaque Password type to enigmatic

### DIFF
--- a/lib/enigmatic/src/core/enigmatic.Password.scala
+++ b/lib/enigmatic/src/core/enigmatic.Password.scala
@@ -30,23 +30,31 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package enigmatic
 
-// `Concession`, `Permit`, `ProcessingPermit` and the `crypto.permit…Crypto`
-// aggregates are re-exported by gastronomy (where they now live).
-export
-  enigmatic
-  . { Aes, Blowfish, BlockCipher, BlockCipherMode, BlockCipherPadding, Cbc, Cfb, Cipher,
-      CipherSession, Cleartext, cleartext, Crypto, CryptoError, Ctr, decrypt, Decryptor, Des,
-      Divulgence,
-      Dsa, Ecb, encrypt, Encryptor, Encryption, expose,
-      Hmac, hmac, InitializationVector, Iso10126, JavaStdlibCrypto, NoPadding, Ofb, Pem, PemError,
-      PemLabel, Password,
-      Permits, Pkcs7, PrivateKey, PublicKey, Rc2, Rsa, Signature, Signing,
-      Symmetric, SymmetricKey, TripleDes }
+import anticipation.*
+import gossamer.*
+import spectacular.*
 
-package blockCipherMode:
-  export enigmatic.blockCipherMode.{cbc, cfb, ctr, ofb}
+object Password:
+  def apply(cleartext: Text): Password = new Password(cleartext)
 
-package blockCipherPadding:
-  export enigmatic.blockCipherPadding.{iso10126, pkcs7}
+  // Never renders the secret: a `Password` is safe to log or embed in a message.
+  given showable: Password is Showable = _ => t"Password(•••)"
+
+// A password held opaquely: constructed from cleartext, but with no way to read that
+// cleartext back except through `expose`, which lends it — as a scoped `Cleartext`
+// capability — to a block, exactly as `PrivateKey.expose` lends a `Decryptor`. Capture
+// checking confines the capability to the block, so it (and any closure over it) cannot
+// escape; `result` is instantiated at the call site.
+class Password(private val cleartext: Text):
+  def expose[result](block: Cleartext^ ?=> result): result = block(using Cleartext(cleartext))
+
+// The scoped view of a password's cleartext, lent within `expose`. A stateless
+// `SharedCapability`, freely aliasable within the block but not beyond it.
+class Cleartext private[enigmatic] (private val secret: Text) extends caps.SharedCapability:
+  def text: Text = secret
+
+// The cleartext lent within an `expose` block, reached contextually: `cleartext.text` rather
+// than `summon[Cleartext].text`, following the same idiom as parasite's `monitor`.
+transparent inline def cleartext: Cleartext^ = infer[Cleartext^]

--- a/lib/enigmatic/src/test/enigmatic.CaptureTests.scala
+++ b/lib/enigmatic/src/test/enigmatic.CaptureTests.scala
@@ -112,3 +112,24 @@ object CaptureTests extends Suite(m"Capability confinement tests"):
         val ciphertext = key.expose:
           LazyList(t"Hello world".in[Data]).encrypt(InitializationVector.random)
     . assert(_ == Nil)
+
+    test(m"a password's cleartext is available within expose"):
+      Password(t"hunter2").expose(cleartext.text)
+    . assert(_ == t"hunter2")
+
+    test(m"the Cleartext capability cannot be returned from expose"):
+      demilitarize:
+        val password = Password(t"hunter2")
+        val stolen = password.expose(summon[Cleartext])
+      . map(_.message)
+    . assert(_.exists(_.contains("outlives its scope")))
+
+    test(m"a closure reading the cleartext later cannot escape expose"):
+      demilitarize:
+        val password = Password(t"hunter2")
+        val later = password.expose(() => cleartext.text)
+    . assert(_.nonEmpty)
+
+    test(m"a password never renders its secret"):
+      Password(t"hunter2").show
+    . assert(_ == t"Password(•••)")

--- a/lib/facsimile/doc/basics.md
+++ b/lib/facsimile/doc/basics.md
@@ -16,6 +16,18 @@ pdfFile.open():
   pdf.trailer          // the trailer dictionary
 ```
 
+An encrypted document is decrypted transparently; pass the user password to `open`, or
+omit it for the common empty-password case:
+
+```scala
+pdfFile.open(t"the password"):
+  pdf.encrypted        // true
+  pdf.pages.head.text  // decrypted like any other
+```
+
+The standard security handler is supported at all revisions — RC4, AES-128 and AES-256 —
+with a wrong password rejected immediately, when `open` is called.
+
 ### The COS object model
 
 Every value in a PDF is a `Cos` object: `Cos.Integral`, `Cos.Real`, `Cos.Name`, `Cos.Chars`

--- a/lib/facsimile/doc/features.md
+++ b/lib/facsimile/doc/features.md
@@ -12,5 +12,6 @@
 - reads fonts — standard-14 metrics, encodings, ToUnicode maps, embedded programs as `Ttf`s
 - extracts positioned text runs and plain text through the full text machinery
 - capture checking confines the open file to its scope; extracted values are pure and portable
+- decrypts documents secured with the standard handler: RC4, AES-128 and AES-256 (R2–R6)
 - tolerates common real-world deviations: prepended junk, raw deflate streams, truncated data
 - no third-party dependencies

--- a/lib/facsimile/src/core/facsimile.Guard.scala
+++ b/lib/facsimile/src/core/facsimile.Guard.scala
@@ -1,0 +1,313 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package facsimile
+
+import java.security as js
+import javax.crypto as jc
+import javax.crypto.spec as jcs
+
+import anticipation.*
+import contingency.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// The standard security handler (ISO 32000-2 §7.6.4), revisions 2–6. The file key is derived
+// from the user password and the `/Encrypt` dictionary and validated against `/U` at open;
+// per-object keys are derived from it (with the object number and generation for revisions
+// ≤4, or used directly for revision 6). Cryptographic primitives come from the JDK directly:
+// the algorithm is a precise sequence of digest and block-cipher rounds that maps onto
+// `MessageDigest`/`Cipher` more faithfully than onto a higher-level wrapper. RC4 is local.
+private[facsimile] object Guard:
+  enum Method:
+    case Rc4
+    case Aes128
+    case Aes256
+    case Identity
+
+  // The 32-byte padding string prepended to short passwords (algorithm 2).
+  private val padding: Array[Byte] = Array
+    ( 0x28, 0xbf, 0x4e, 0x5e, 0x4e, 0x75, 0x8a, 0x41, 0x64, 0x00, 0x4e, 0x56, 0xff, 0xfa,
+      0x01, 0x08, 0x2e, 0x2e, 0x00, 0xb6, 0xd0, 0x68, 0x3e, 0x80, 0x2f, 0x0c, 0xa9, 0xfe,
+      0x64, 0x53, 0x69, 0x7a )
+    . map(_.toByte)
+
+  def apply(encrypt: Map[Text, Cos], id: Data, password: Text)(using pdf: Pdf)
+  :   Guard raises PdfError =
+
+    val filter = encrypt.at(t"Filter").let(pdf.resolved(_).name).or(t"")
+    if filter != t"Standard" then abort(PdfError(PdfError.Reason.UnsupportedEncryption(0)))
+
+    val version = encrypt.at(t"V").let(pdf.resolved(_).long).or(0L).toInt
+    val revision = encrypt.at(t"R").let(pdf.resolved(_).long).or(0L).toInt
+    val length = encrypt.at(t"Length").let(pdf.resolved(_).long).or(40L).toInt
+    val permissions = encrypt.at(t"P").let(pdf.resolved(_).long).or(0L).toInt
+    val owner = encrypt.at(t"O").let(pdf.resolved(_).chars).or(IArray.empty[Byte])
+    val user = encrypt.at(t"U").let(pdf.resolved(_).chars).or(IArray.empty[Byte])
+
+    val encryptMetadata =
+      encrypt.at(t"EncryptMetadata").let(pdf.resolved(_).truth).or(true)
+
+    // The stream and string crypt-filter methods: revisions ≤4 apply one method throughout;
+    // revision 4+ names filters in `/CF` selected by `/StmF` and `/StrF`.
+    val (streamMethod, stringMethod) =
+      if version >= 4 then
+        val filters = pdf.resolved(encrypt.at(t"CF").or(Cos.Nil)).dictionary.or(Map[Text, Cos]())
+
+        def method(selector: Text): Method =
+          encrypt.at(selector).let(pdf.resolved(_).name).or(t"Identity") match
+            case t"Identity" => Method.Identity
+            case name =>
+              val cfm = pdf.resolved(filters.at(name).or(Cos.Nil))(t"CFM").let(_.name).or(t"")
+              cfm match
+                case t"V2"    => Method.Rc4
+                case t"AESV2" => Method.Aes128
+                case t"AESV3" => Method.Aes256
+                case _        => Method.Identity
+
+        (method(t"StmF"), method(t"StrF"))
+      else (Method.Rc4, Method.Rc4)
+
+    if revision >= 5 then
+      // Revisions 5–6 (AES-256): the file key is unwrapped from `/UE` with a key derived
+      // from the password, and neither object number nor generation enters the per-object
+      // key.
+      val ue = encrypt.at(t"UE").let(pdf.resolved(_).chars).or(IArray.empty[Byte])
+
+      val fileKey = unwrap6(password, user, ue)
+        . or(abort(PdfError(PdfError.Reason.BadPassword)))
+
+      new Guard(fileKey, revision, Method.Aes256, Method.Aes256, encryptMetadata)
+    else
+      val keyBytes = if version <= 1 then 5 else length/8
+
+      val fileKey =
+        deriveKey(password, owner, permissions, id, keyBytes, revision, encryptMetadata)
+
+      if !validate(fileKey, user, id, revision, keyBytes)
+      then abort(PdfError(PdfError.Reason.BadPassword))
+
+      new Guard(fileKey, revision, streamMethod, stringMethod, encryptMetadata)
+
+  // Algorithm 2: the file encryption key for revisions 2–4.
+  private def deriveKey
+    ( password: Text, owner: Data, permissions: Int, id: Data, keyBytes: Int, revision: Int,
+      encryptMetadata: Boolean )
+  :   Data =
+
+    val md5 = js.MessageDigest.getInstance("MD5").nn
+    md5.update(padded(password))
+    md5.update(owner.mutable(using Unsafe), 0, 32.min(owner.length))
+
+    md5.update(Array((permissions & 0xff).toByte, ((permissions >> 8) & 0xff).toByte,
+        ((permissions >> 16) & 0xff).toByte, ((permissions >> 24) & 0xff).toByte))
+
+    md5.update(id.mutable(using Unsafe))
+
+    if revision >= 4 && !encryptMetadata then md5.update(Array(0xff.toByte, 0xff.toByte,
+        0xff.toByte, 0xff.toByte))
+
+    var hash = md5.digest().nn
+
+    // Revision 3+: 50 further MD5 rounds over the first `keyBytes` bytes.
+    if revision >= 3 then
+      var i = 0
+
+      while i < 50 do
+        val next = js.MessageDigest.getInstance("MD5").nn
+        next.update(hash, 0, keyBytes)
+        hash = next.digest().nn
+        i += 1
+
+    hash.take(keyBytes).immutable(using Unsafe)
+
+  // Algorithm 6: validate the user password by reconstructing `/U`.
+  private def validate(fileKey: Data, user: Data, id: Data, revision: Int, keyBytes: Int)
+  :   Boolean =
+
+    if revision == 2 then Rc4(fileKey, padding.immutable(using Unsafe)).to(List) == user.to(List)
+    else
+      val md5 = js.MessageDigest.getInstance("MD5").nn
+      md5.update(padding)
+      md5.update(id.mutable(using Unsafe))
+      var value = md5.digest().nn.immutable(using Unsafe)
+
+      value = Rc4(fileKey, value)
+
+      var i = 1
+
+      while i <= 19 do
+        val roundKey = fileKey.map(byte => (byte ^ i).toByte)
+        value = Rc4(roundKey, value)
+        i += 1
+
+      // Only the first 16 bytes are meaningful; the rest of `/U` is arbitrary padding.
+      value.take(16).to(List) == user.take(16).to(List)
+
+  // Algorithms 2.A/8 (revision 6): validate the user password against `/U`, then unwrap the
+  // file key from `/UE` with the intermediate key, using AES-256-CBC with a zero IV and no
+  // padding.
+  private def unwrap6(password: Text, user: Data, ue: Data): Optional[Data] =
+    if user.length < 48 || ue.length < 32 then Unset else
+      val passwordBytes = password.s.getBytes("UTF-8").nn
+      val salt = user.slice(32, 40)
+      val keySalt = user.slice(40, 48)
+
+      if hash6(passwordBytes, salt, IArray.empty[Byte]).to(List) != user.take(32).to(List)
+      then Unset
+      else
+        val intermediate = hash6(passwordBytes, keySalt, IArray.empty[Byte])
+
+        try
+          val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
+
+          cipher.init(jc.Cipher.DECRYPT_MODE,
+              jcs.SecretKeySpec(intermediate.mutable(using Unsafe), "AES"),
+              jcs.IvParameterSpec(new Array[Byte](16)))
+
+          cipher.doFinal(ue.take(32).mutable(using Unsafe)).nn.immutable(using Unsafe)
+        catch case _: Exception => Unset
+
+  // Revision-6 hash (algorithm 2.B): SHA-256 seeded, then rounds mixing SHA-256/384/512
+  // selected by the running hash, until the 64th-plus round whose last byte is ≤ round−32.
+  private def hash6(password: Array[Byte], salt: Data, extra: Data): Data =
+    val sha256 = js.MessageDigest.getInstance("SHA-256").nn
+    sha256.update(password)
+    sha256.update(salt.mutable(using Unsafe))
+    if extra.length > 0 then sha256.update(extra.mutable(using Unsafe))
+    var k = sha256.digest().nn.immutable(using Unsafe)
+
+    var round = 0
+    var done = false
+
+    while !done do
+      val block = Array.newBuilder[Byte]
+      var i = 0
+
+      while i < 64 do
+        block.addAll(password)
+        block.addAll(k.mutable(using Unsafe))
+        if extra.length > 0 then block.addAll(extra.mutable(using Unsafe))
+        i += 1
+
+      val input = block.result()
+      val key = k.take(16).mutable(using Unsafe)
+      val iv = k.slice(16, 32).mutable(using Unsafe)
+
+      val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
+      cipher.init(jc.Cipher.ENCRYPT_MODE, jcs.SecretKeySpec(key, "AES"), jcs.IvParameterSpec(iv))
+      val e = cipher.doFinal(input).nn
+
+      var sum = 0
+      i = 0
+      while i < 16 do
+        sum += e(i) & 0xff
+        i += 1
+
+      val algorithm = sum%3 match
+        case 0 => "SHA-256"
+        case 1 => "SHA-384"
+        case _ => "SHA-512"
+
+      k = js.MessageDigest.getInstance(algorithm).nn.digest(e).nn.immutable(using Unsafe)
+      round += 1
+
+      if round >= 64 && (e(e.length - 1) & 0xff) <= round - 32 then done = true
+
+    k.take(32)
+
+  private def padded(password: Text): Array[Byte] =
+    val bytes = password.s.getBytes("ISO-8859-1").nn
+    val out = new Array[Byte](32)
+    val count = 32.min(bytes.length)
+    System.arraycopy(bytes, 0, out, 0, count)
+    System.arraycopy(padding, 0, out, count, 32 - count)
+    out
+
+private[facsimile] class Guard
+  ( fileKey: Data, revision: Int, streamMethod: Guard.Method, stringMethod: Guard.Method,
+    val encryptMetadata: Boolean ):
+
+  import Guard.Method
+
+  // Algorithm 1: the per-object key. For revision 6 the file key is used directly.
+  private def objectKey(number: Int, generation: Int, aes: Boolean): Data =
+    if revision >= 5 then fileKey else
+      val md5 = js.MessageDigest.getInstance("MD5").nn
+      md5.update(fileKey.mutable(using Unsafe))
+
+      md5.update(Array((number & 0xff).toByte, ((number >> 8) & 0xff).toByte,
+          ((number >> 16) & 0xff).toByte, (generation & 0xff).toByte,
+          ((generation >> 8) & 0xff).toByte))
+
+      if aes then md5.update(Array[Byte](0x73, 0x41, 0x6c, 0x54)) // the "sAlT" constant
+      md5.digest().nn.take((fileKey.length + 5).min(16)).immutable(using Unsafe)
+
+  def string(bytes: Data, number: Int, generation: Int): Data =
+    decrypt(bytes, number, generation, stringMethod)
+
+  def stream(bytes: Data, number: Int, generation: Int, cryptFilter: Optional[Method]): Data =
+    decrypt(bytes, number, generation, cryptFilter.or(streamMethod))
+
+  private def decrypt(bytes: Data, number: Int, generation: Int, method: Method): Data =
+    method match
+      case Method.Identity =>
+        bytes
+
+      case Method.Rc4 =>
+        Rc4(objectKey(number, generation, false), bytes)
+
+      case Method.Aes128 =>
+        aesCbc(objectKey(number, generation, true), bytes)
+
+      case Method.Aes256 =>
+        aesCbc(fileKey, bytes)
+
+  // AESV2/V3 layout: a 16-byte initialization vector prefixes the ciphertext.
+  private def aesCbc(key: Data, bytes: Data): Data =
+    if bytes.length <= 16 then IArray.empty[Byte] else
+      val iv = bytes.slice(0, 16).mutable(using Unsafe)
+      val body = bytes.slice(16, bytes.length).mutable(using Unsafe)
+
+      try
+        val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
+
+        cipher.init(jc.Cipher.DECRYPT_MODE, jcs.SecretKeySpec(key.mutable(using Unsafe), "AES"),
+            jcs.IvParameterSpec(iv))
+
+        val decrypted = cipher.doFinal(body).nn
+        // Strip PKCS#7 padding.
+        val pad = if decrypted.length > 0 then decrypted(decrypted.length - 1) & 0xff else 0
+        val end = if pad >= 1 && pad <= 16 then decrypted.length - pad else decrypted.length
+        decrypted.take(end).immutable(using Unsafe)
+      catch case _: Exception => IArray.empty[Byte]

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -58,12 +58,20 @@ object Pdf:
     def data: Data raises PdfError =
       body.let(pdf.payload(_)).or(abort(PdfError(PdfError.Reason.MissingEntry(t"EF"))))
 
-  // Until the encryption milestone lands, an encrypted file is refused outright rather
-  // than misread: strings and streams would otherwise surface as ciphertext.
-  private[facsimile] def validate(pdf: Pdf^, password: Optional[Text]): Unit raises PdfError =
-    pdf.trailer.at(t"Encrypt").let: encrypt =>
-      val revision = pdf.resolved(encrypt)(t"V").let(_.long).or(0L).toInt
-      abort(PdfError(PdfError.Reason.UnsupportedEncryption(revision)))
+  // Builds the security handler, if the file is encrypted, and installs it on the document.
+  // The `/Encrypt` dictionary and the trailer `/ID` are read before the guard exists — and
+  // so are never themselves decrypted — and a wrong password fails here, at open, rather
+  // than at first string or stream access.
+  private[facsimile] def unlock(pdf: Pdf^, password: Optional[Text]): Unit raises PdfError =
+    pdf.trailer.at(t"Encrypt").let: encryptRef =>
+      val encrypt = pdf.resolved(encryptRef).dictionary
+        . or(abort(PdfError(PdfError.Reason.UnsupportedEncryption(0))))
+
+      val id = pdf.trailer.at(t"ID") match
+        case Cos.Sequence(first :: _) => first.chars.or(IArray.empty[Byte])
+        case _                        => IArray.empty[Byte]
+
+      pdf.guard = Guard(encrypt, id, password.or(t""))(using pdf)
 
   // The header comment is nominally at offset 0, but tolerated anywhere in the first 1KiB,
   // matching widespread reader behaviour for files with prepended junk.
@@ -107,7 +115,18 @@ extends caps.ExclusiveCapability:
   private val containers: scala.collection.mutable.HashMap[Int, ObjectStream] =
     scala.collection.mutable.HashMap()
 
+  // The stream at each recorded payload offset belongs to this indirect object, so its bytes
+  // can be decrypted with the right per-object key. Populated as `Direct` objects load.
+  private val streamOwners: scala.collection.mutable.HashMap[Long, (Int, Int)] =
+    scala.collection.mutable.HashMap()
+
+  // The security handler, installed by `Pdf.unlock` after the document exists (it must read
+  // the unencrypted `/Encrypt` dictionary through this same document first).
+  private[facsimile] var guard: Optional[Guard] = Unset
+
   def trailer: Map[Text, Cos] = xref.trailer
+
+  def encrypted: Boolean = trailer.contains(t"Encrypt")
 
   def catalog: Map[Text, Cos] raises PdfError =
     resolved(trailer.at(t"Root").or(Cos.Nil)).dictionary
@@ -313,7 +332,15 @@ extends caps.ExclusiveCapability:
               if foundNumber != number || foundGeneration != generation
               then abort(PdfError(PdfError.Reason.MissingObject(number, generation)))
 
-              content
+              // A top-level indirect stream: record its owner so its payload can be
+              // decrypted with the right key.
+              content match
+                case Cos.Body(_, start) => streamOwners(start) = (number, generation)
+                case _                  => ()
+
+              // Strings in a directly-stored object are encrypted individually; those inside
+              // an object stream travel in its already-decrypted payload, so are skipped.
+              guard.lay(content)(decryptStrings(content, number, generation, _))
 
           case Xref.Entry.Compressed(container, index) =>
             if generation != 0 then Cos.Nil else
@@ -330,6 +357,27 @@ extends caps.ExclusiveCapability:
   def resolved(value: Cos): Cos raises PdfError = value match
     case ref: Cos.Ref => apply(ref)
     case other        => other
+
+  // Rewrites every string in an object with its decrypted bytes. A stream body's own
+  // dictionary is decrypted, but its payload is left to `raw`; nothing is done for `Ref`s,
+  // which resolve to their own separately-decrypted objects.
+  private def decryptStrings(value: Cos, number: Int, generation: Int, guard: Guard): Cos =
+    value match
+      case Cos.Chars(bytes) =>
+        Cos.Chars(guard.string(bytes, number, generation))
+
+      case Cos.Sequence(elements) =>
+        Cos.Sequence(elements.map(decryptStrings(_, number, generation, guard)))
+
+      case Cos.Dictionary(entries) =>
+        Cos.Dictionary(entries.view.mapValues(decryptStrings(_, number, generation, guard)).toMap)
+
+      case Cos.Body(entries, start) =>
+        val decrypted = entries.view.mapValues(decryptStrings(_, number, generation, guard)).toMap
+        Cos.Body(decrypted, start)
+
+      case other =>
+        other
 
   // The decoded content of a stream, decrypted (in a later milestone) and passed through its
   // filter chain, which stops at terminal image codecs. `/Length` may be indirect; filters in
@@ -356,9 +404,14 @@ extends caps.ExclusiveCapability:
     val start = body.start
     val end = payloadEnd(body)
 
+    // An encrypted stream is decrypted whole before filtering (a cipher spans the payload),
+    // so it starts the pipeline as one materialized chunk; a plain stream reads in chunks.
+    val decrypted: Optional[Data] = if encryptedStream(body) then raw(body) else Unset
+
     new Spring[Data]:
       def apply(): (Stream[Data] over Credit)^ =
-        pipeline(steps, Stream(ranges(start, end)))
+        decrypted.lay(pipeline(steps, Stream(ranges(start, end)))): data =>
+          pipeline(steps, Stream(List(data).iterator))
 
   // Interprets a streaming plan, minting each duct at its `via` call site.
   private def pipeline(steps: List[Filter.Step^], consume stream: (Stream[Data] over Credit)^)
@@ -389,9 +442,49 @@ extends caps.ExclusiveCapability:
       position = if chunk.length == 0 then end else position + chunk.length
       chunk
 
-  // The undecoded payload: the range from the payload's start to its computed end.
+  // The raw payload, decrypted if the document is encrypted and this stream is not exempt.
   private[facsimile] def raw(body: Cos.Body): Data raises PdfError =
-    source.read(body.start, (payloadEnd(body) - body.start).toInt)
+    val bytes = source.read(body.start, (payloadEnd(body) - body.start).toInt)
+
+    if !encryptedStream(body) then bytes else
+      guard.lay(bytes): guard =>
+        streamOwners.at(body.start).lay(bytes): (number, generation) =>
+          guard.stream(bytes, number, generation, Unset)
+
+  // Whether a stream's raw bytes need decrypting: the document is encrypted and the stream is
+  // not exempt — cross-reference streams (never encrypted), metadata under `/EncryptMetadata
+  // false`, and streams marked with the `Identity` crypt filter.
+  private def encryptedStream(body: Cos.Body): Boolean raises PdfError = guard.lay(false): guard =>
+    val kind = body.entries.at(t"Type").let(_.name).or(t"")
+
+    val exempt =
+      kind == t"XRef"
+      || (kind == t"Metadata" && !guard.encryptMetadata)
+      || cryptMethod(body) == Guard.Method.Identity
+
+    !exempt && streamOwners.contains(body.start)
+
+  // A `/Crypt` filter in the stream's filter chain selects a crypt method by name; `Identity`
+  // (the default) means the stream is stored in the clear.
+  private def cryptMethod(body: Cos.Body): Optional[Guard.Method] raises PdfError =
+    val filters = deepResolved(body.entries.at(t"Filter").or(Cos.Nil))
+
+    val hasCrypt = filters match
+      case Cos.Name(t"Crypt")     => true
+      case Cos.Sequence(elements) => elements.exists(_.name == t"Crypt")
+      case _                      => false
+
+    if !hasCrypt then Unset else
+      val parms = deepResolved(body.entries.at(t"DecodeParms").or(Cos.Nil))
+
+      val name = parms match
+        case Cos.Dictionary(entries) => entries.at(t"Name").let(_.name)
+        case Cos.Sequence(elements)  =>
+          elements.flatMap(_.dictionary.let(_.at(t"Name")).let(_.name).lay(List())(List(_))).headOption
+            . getOrElse(Unset)
+        case _                       => Unset
+
+      if name == t"Identity" || name.absent then Guard.Method.Identity else Unset
 
   // The exclusive end of the payload: `/Length` bytes when the declared length checks out —
   // the `endstream` keyword must follow it — and otherwise, since wrong lengths abound in

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -35,6 +35,7 @@ package facsimile
 import anticipation.*
 import contingency.*
 import denominative.*
+import enigmatic.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
@@ -61,8 +62,9 @@ object Pdf:
   // Builds the security handler, if the file is encrypted, and installs it on the document.
   // The `/Encrypt` dictionary and the trailer `/ID` are read before the guard exists — and
   // so are never themselves decrypted — and a wrong password fails here, at open, rather
-  // than at first string or stream access.
-  private[facsimile] def unlock(pdf: Pdf^, password: Optional[Text]): Unit raises PdfError =
+  // than at first string or stream access. The password's cleartext is read only within
+  // `expose`, so it is confined to this call; the empty password covers unprotected files.
+  private[facsimile] def unlock(pdf: Pdf^, password: Optional[Password]): Unit raises PdfError =
     pdf.trailer.at(t"Encrypt").let: encryptRef =>
       val encrypt = pdf.resolved(encryptRef).dictionary
         . or(abort(PdfError(PdfError.Reason.UnsupportedEncryption(0))))
@@ -71,7 +73,8 @@ object Pdf:
         case Cos.Sequence(first :: _) => first.chars.or(IArray.empty[Byte])
         case _                        => IArray.empty[Byte]
 
-      pdf.guard = Guard(encrypt, id, password.or(t""))(using pdf)
+      pdf.guard = password.lay(Guard(encrypt, id, t"")(using pdf)): password =>
+        password.expose(Guard(encrypt, id, cleartext.text)(using pdf))
 
   // The header comment is nominally at offset 0, but tolerated anywhere in the first 1KiB,
   // matching widespread reader behaviour for files with prepended junk.

--- a/lib/facsimile/src/core/facsimile.PdfFile.scala
+++ b/lib/facsimile/src/core/facsimile.PdfFile.scala
@@ -38,6 +38,7 @@ import java.nio.file as jnf
 
 import anticipation.*
 import contingency.*
+import enigmatic.*
 import gossamer.*
 import prepositional.*
 import rudiments.*
@@ -61,10 +62,10 @@ class PdfFile private (origin: PdfFile.Origin):
 
   // Runs `block` with a contextual `Pdf` — reached through the package-level `pdf` accessor —
   // over a source held open exactly for the block's duration. The header, cross-reference
-  // chain and (once supported) encryption keys are read eagerly, so a malformed file fails
-  // here and not at first access. Capture checking confines the `Pdf`, and anything that
-  // still resolves through it, to the block.
-  def open[result](password: Optional[Text] = Unset)(block: Pdf ?=> result)
+  // chain and, for an encrypted document, the encryption keys are read eagerly, so a
+  // malformed file — or a wrong password — fails here and not at first access. Capture
+  // checking confines the `Pdf`, and anything that still resolves through it, to the block.
+  def open[result](password: Optional[Password] = Unset)(block: Pdf ?=> result)
   :   result raises PdfError =
 
     origin match
@@ -81,7 +82,7 @@ class PdfFile private (origin: PdfFile.Origin):
 
   // The capability must be minted where the block is applied: a `Pdf` returned from another
   // method is a distinct fresh capability which could not flow into the block's own.
-  private def read[result](source: ByteSource, password: Optional[Text])(block: Pdf ?=> result)
+  private def read[result](source: ByteSource, password: Optional[Password])(block: Pdf ?=> result)
   :   result raises PdfError =
 
     val version = Pdf.readVersion(source) // check the header before anything else is trusted

--- a/lib/facsimile/src/core/facsimile.Rc4.scala
+++ b/lib/facsimile/src/core/facsimile.Rc4.scala
@@ -32,59 +32,47 @@
                                                                                                   */
 package facsimile
 
-import java.io as ji
-import java.nio.channels as jnc
-import java.nio.file as jnf
-
 import anticipation.*
-import contingency.*
-import gossamer.*
-import prepositional.*
 import rudiments.*
 import vacuous.*
 
-object PdfFile:
-  def apply[path: Abstractable across Paths to Text](path: path): PdfFile =
-    new PdfFile(Origin.OnDisk(path.generic))
+// RC4, the stream cipher of the PDF standard security handler at revisions 2–4 (ISO
+// 32000-2 §7.6.3). Symmetric, so the same operation encrypts and decrypts. Implemented here
+// rather than pulled from the JDK, whose `ARCFOUR` provider is not guaranteed present and
+// which would need per-call `Cipher` machinery for what is a dozen lines of arithmetic.
+private[facsimile] object Rc4:
+  def apply(key: Data, data: Data): Data =
+    val state = new Array[Int](256)
+    var i = 0
 
-  def apply(data: Data): PdfFile = new PdfFile(Origin.InMemory(data))
+    while i < 256 do
+      state(i) = i
+      i += 1
 
-  private enum Origin:
-    case OnDisk(filename: Text)
-    case InMemory(data: Data)
+    // Key-scheduling.
+    var j = 0
+    i = 0
 
-// An unopened PDF: a locator, analogous to `Zipfile`, holding either a path or in-memory
-// bytes. Nothing is read until `open` is called; a future write mode becomes a sibling scope
-// (`edit`) rather than a change to this one.
-class PdfFile private (origin: PdfFile.Origin):
-  import PdfFile.Origin
+    while i < 256 do
+      j = (j + state(i) + (key(i%key.length) & 0xff)) & 0xff
+      val swap = state(i)
+      state(i) = state(j)
+      state(j) = swap
+      i += 1
 
-  // Runs `block` with a contextual `Pdf` — reached through the package-level `pdf` accessor —
-  // over a source held open exactly for the block's duration. The header, cross-reference
-  // chain and (once supported) encryption keys are read eagerly, so a malformed file fails
-  // here and not at first access. Capture checking confines the `Pdf`, and anything that
-  // still resolves through it, to the block.
-  def open[result](password: Optional[Text] = Unset)(block: Pdf ?=> result)
-  :   result raises PdfError =
+    // Pseudo-random generation, XORed into the data.
+    val out = new Array[Byte](data.length)
+    var a = 0
+    var b = 0
+    var k = 0
 
-    origin match
-      case Origin.InMemory(data) =>
-        read(DataSource(data), password)(block)
+    while k < data.length do
+      a = (a + 1) & 0xff
+      b = (b + state(a)) & 0xff
+      val swap = state(a)
+      state(a) = state(b)
+      state(b) = swap
+      out(k) = (data(k) ^ state((state(a) + state(b)) & 0xff)).toByte
+      k += 1
 
-      case Origin.OnDisk(filename) =>
-        val channel =
-          try jnc.FileChannel.open(jnf.Path.of(filename.s), jnf.StandardOpenOption.READ).nn
-          catch case error: ji.IOException =>
-            abort(PdfError(PdfError.Reason.Io(error.getMessage.nn.tt)))
-
-        try read(ChannelSource(channel), password)(block) finally channel.close()
-
-  // The capability must be minted where the block is applied: a `Pdf` returned from another
-  // method is a distinct fresh capability which could not flow into the block's own.
-  private def read[result](source: ByteSource, password: Optional[Text])(block: Pdf ?=> result)
-  :   result raises PdfError =
-
-    val version = Pdf.readVersion(source) // check the header before anything else is trusted
-    val pdf = Pdf(source, Xref.load(source), version)
-    Pdf.unlock(pdf, password)
-    block(using pdf)
+    out.immutable(using Unsafe)

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -889,12 +889,12 @@ object Tests extends Suite(m"Facsimile tests"):
       . assert(_ == t"Secret")
 
       test(m"an AES-256 string decrypts with the right password"):
-        PdfFile(aes256Document(t"open sesame")).open(t"open sesame"):
+        PdfFile(aes256Document(t"open sesame")).open(Password(t"open sesame")):
           pdf.resolved(pdf(2, 0)(t"Secret").or(Cos.Nil)).text
       . assert(_ == t"Secret")
 
       test(m"an AES-256 stream decrypts"):
-        PdfFile(aes256Document(t"open sesame")).open(t"open sesame"):
+        PdfFile(aes256Document(t"open sesame")).open(Password(t"open sesame")):
           pdf(3, 0) match
             case body: Cos.Body => String(pdf.payload(body).mutable(using Unsafe), "UTF-8").tt
             case _              => t""
@@ -902,7 +902,7 @@ object Tests extends Suite(m"Facsimile tests"):
 
       test(m"a wrong password is rejected at open"):
         capture[PdfError]:
-          PdfFile(aes256Document(t"open sesame")).open(t"wrong")(pdf.version)
+          PdfFile(aes256Document(t"open sesame")).open(Password(t"wrong"))(pdf.version)
         . reason
       . assert(_ == PdfError.Reason.BadPassword)
 

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -39,7 +39,10 @@ import errorDiagnostics.stackTracesDiagnostics
 import strategies.throwUnsafely
 
 import _root_.java.io as ji
+import _root_.java.security as js
 import _root_.java.util.zip as juz
+import _root_.javax.crypto as jc
+import _root_.javax.crypto.spec as jcs
 
 object Tests extends Suite(m"Facsimile tests"):
   def run(): Unit =
@@ -363,10 +366,10 @@ object Tests extends Suite(m"Facsimile tests"):
         capture[PdfError](PdfFile(t"%PDF-1.7\nnothing else".in[Data]).open()(pdf.version)).reason
       . assert(_ == PdfError.Reason.MissingStartxref)
 
-      test(m"an encrypted document is refused for now"):
-        val doc = documentWith(t"/Encrypt << /V 4 >>", catalog)
+      test(m"a public-key security handler is unsupported"):
+        val doc = documentWith(t"/Encrypt << /Filter /Adobe.PubSec /V 4 >>", catalog)
         capture[PdfError](PdfFile(doc).open()(pdf.version)).reason
-      . assert(_ == PdfError.Reason.UnsupportedEncryption(4))
+      . assert(_ == PdfError.Reason.UnsupportedEncryption(0))
 
     suite(m"Cross-reference streams and object streams"):
       def xrefStreamDocument(): Data =
@@ -663,6 +666,245 @@ object Tests extends Suite(m"Facsimile tests"):
             case _ =>
               (t"", t"")
       . assert(_ == (t"again and again", t"again and again"))
+
+    suite(m"Encryption"):
+      val padding: Array[Byte] = Array[Byte]
+        ( 0x28, 0xbf.toByte, 0x4e, 0x5e, 0x4e, 0x75, 0x8a.toByte, 0x41, 0x64, 0x00, 0x4e,
+          0x56, 0xff.toByte, 0xfa.toByte, 0x01, 0x08, 0x2e, 0x2e, 0x00, 0xb6.toByte,
+          0xd0.toByte, 0x68, 0x3e, 0x80.toByte, 0x2f, 0x0c, 0xa9.toByte, 0xfe.toByte,
+          0x64, 0x53, 0x69, 0x7a )
+
+      def hexOf(bytes: Array[Byte]): Text =
+        val builder = StringBuilder()
+        var i = 0
+        while i < bytes.length do
+          builder.append(f"${bytes(i) & 0xff}%02x")
+          i += 1
+        builder.toString.tt
+
+      def xor(bytes: Array[Byte], value: Int): Array[Byte] =
+        val out = new Array[Byte](bytes.length)
+        var i = 0
+        while i < bytes.length do
+          out(i) = (bytes(i) ^ value).toByte
+          i += 1
+        out
+
+      def md5(chunks: Array[Byte]*): Array[Byte] =
+        val digest = js.MessageDigest.getInstance("MD5").nn
+        chunks.foreach(digest.update(_))
+        digest.digest().nn
+
+      // A test-side implementation of the standard security handler's *encryption* — the
+      // inverse of the reader's `Guard`, and independently written — used to build encrypted
+      // fixtures with an empty user password.
+      def rc4(key: Array[Byte], data: Array[Byte]): Array[Byte] =
+        Rc4(key.immutable(using Unsafe), data.immutable(using Unsafe)).mutable(using Unsafe)
+
+      val id: Array[Byte] =
+        val bytes = new Array[Byte](16)
+        var i = 0
+        while i < 16 do
+          bytes(i) = i.toByte
+          i += 1
+        bytes
+
+      // Builds an RC4-encrypted document (revision 2 = 40-bit, revision 3 = 128-bit) of the
+      // catalog plus one string-bearing object and one stream object.
+      def rc4Document(revision: Int): Data =
+        val keyBytes = if revision == 2 then 5 else 16
+        val permissions = -44
+
+        val ownerKey =
+          var hash = md5(padding)
+          if revision >= 3 then for _ <- 0 until 50 do hash = md5(hash.take(keyBytes))
+          hash.take(keyBytes)
+
+        val ownerEntry =
+          var value = rc4(ownerKey, padding)
+          if revision >= 3 then for i <- 1 to 19 do value = rc4(xor(ownerKey, i), value)
+          value
+
+        val permBytes = Array((permissions & 0xff).toByte, ((permissions >> 8) & 0xff).toByte,
+            ((permissions >> 16) & 0xff).toByte, ((permissions >> 24) & 0xff).toByte)
+
+        val fileKey =
+          var hash = md5(padding, ownerEntry, permBytes, id)
+          if revision >= 3 then for _ <- 0 until 50 do hash = md5(hash.take(keyBytes))
+          hash.take(keyBytes)
+
+        val userEntry =
+          if revision == 2 then rc4(fileKey, padding)
+          else
+            var value = rc4(fileKey, md5(padding, id))
+            for i <- 1 to 19 do value = rc4(xor(fileKey, i), value)
+            value ++ new Array[Byte](16)
+
+        def objectKey(number: Int, generation: Int): Array[Byte] =
+          md5(fileKey, Array((number & 0xff).toByte, ((number >> 8) & 0xff).toByte,
+              ((number >> 16) & 0xff).toByte, (generation & 0xff).toByte,
+              ((generation >> 8) & 0xff).toByte)).take((keyBytes + 5).min(16))
+
+        def hex(bytes: Array[Byte]): Text = hexOf(bytes)
+
+        val version = if revision == 2 then 1 else 2
+        val secret = rc4(objectKey(2, 0), t"Secret".s.getBytes("ISO-8859-1").nn)
+        val streamPlain = t"encrypted stream".s.getBytes("ISO-8859-1").nn
+        val streamCipher = rc4(objectKey(3, 0), streamPlain)
+
+        val encrypt =
+          t"<< /Filter /Standard /V $version /R $revision /Length ${keyBytes*8} /P $permissions /O <${hex(ownerEntry)}> /U <${hex(userEntry)}> >>"
+
+        buildEncrypted
+          ( encrypt,
+            t"<< /Type /Catalog >>".in[Data],
+            t"<< /Secret <${hex(secret)}> >>".in[Data],
+            (t"<< /Length ${streamCipher.length} >>\nstream\n".in[Data]
+                ++ streamCipher.immutable(using Unsafe) ++ t"\nendstream".in[Data]) )
+
+      // Assembles a document with an `/Encrypt` entry (object N+1) and an `/ID`.
+      def buildEncrypted(encrypt: Text, bodies: Data*): Data =
+        var out: Data = t"%PDF-1.6\n".in[Data]
+        val offsets = List.newBuilder[Long]
+
+        bodies.zipWithIndex.each: (body, index) =>
+          offsets += out.length.toLong
+          out = out ++ t"${index + 1} 0 obj\n".in[Data] ++ body ++ t"\nendobj\n".in[Data]
+
+        val encryptNumber = bodies.length + 1
+        offsets += out.length.toLong
+        out = out ++ t"$encryptNumber 0 obj\n".in[Data] ++ encrypt.in[Data] ++ t"\nendobj\n".in[Data]
+
+        val idHex = hexOf(id)
+        val xrefOffset = out.length
+        out = out ++ t"xref\n0 ${encryptNumber + 1}\n0000000000 65535 f \n".in[Data]
+
+        offsets.result().each: offset =>
+          out = out ++ t"${pad10(offset)} 00000 n \n".in[Data]
+
+        out ++ t"trailer\n<< /Size ${encryptNumber + 1} /Root 1 0 R /Encrypt $encryptNumber 0 R /ID [<$idHex> <$idHex>] >>\nstartxref\n$xrefOffset\n%%EOF".in[Data]
+
+      // An AES-256 (revision 6) fixture, whose key derivation the reader must mirror exactly.
+      def aes256Document(password: Text): Data =
+        def hash6(pw: Array[Byte], salt: Array[Byte]): Array[Byte] =
+          var k: Array[Byte] = md5(pw, salt) // placeholder, replaced below
+          val sha256 = js.MessageDigest.getInstance("SHA-256").nn
+          sha256.update(pw)
+          sha256.update(salt)
+          k = sha256.digest().nn
+          var round = 0
+          var done = false
+
+          while !done do
+            val block = Array.newBuilder[Byte]
+            for _ <- 0 until 64 do
+              block.addAll(pw)
+              block.addAll(k)
+
+            val input = block.result()
+            val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
+            cipher.init(jc.Cipher.ENCRYPT_MODE, jcs.SecretKeySpec(k.take(16), "AES"),
+                jcs.IvParameterSpec(k.slice(16, 32)))
+            val e = cipher.doFinal(input).nn
+            var sum = 0
+            for i <- 0 until 16 do sum += e(i) & 0xff
+            val algo = sum%3 match
+              case 0 => "SHA-256"
+              case 1 => "SHA-384"
+              case _ => "SHA-512"
+            k = js.MessageDigest.getInstance(algo).nn.digest(e).nn
+            round += 1
+            if round >= 64 && (e(e.length - 1) & 0xff) <= round - 32 then done = true
+
+          k.take(32)
+
+        val pw = password.s.getBytes("UTF-8").nn
+        val random = js.SecureRandom()
+        val userSalt = new Array[Byte](8)
+        val userKeySalt = new Array[Byte](8)
+        random.nextBytes(userSalt)
+        random.nextBytes(userKeySalt)
+
+        val fileKey = new Array[Byte](32)
+        random.nextBytes(fileKey)
+
+        val userEntry = hash6(pw, userSalt) ++ userSalt ++ userKeySalt
+        val intermediate = hash6(pw, userKeySalt)
+
+        val wrap = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
+        wrap.init(jc.Cipher.ENCRYPT_MODE, jcs.SecretKeySpec(intermediate, "AES"),
+            jcs.IvParameterSpec(new Array[Byte](16)))
+        val ue = wrap.doFinal(fileKey).nn
+
+        def hex(bytes: Array[Byte]): Text = hexOf(bytes)
+
+        def encryptStream(number: Int, plain: Array[Byte]): Array[Byte] =
+          val iv = new Array[Byte](16)
+          random.nextBytes(iv)
+          val padLength = 16 - plain.length%16
+          val padded = plain ++ Array.fill(padLength)(padLength.toByte)
+          val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
+          cipher.init(jc.Cipher.ENCRYPT_MODE, jcs.SecretKeySpec(fileKey, "AES"),
+              jcs.IvParameterSpec(iv))
+          iv ++ cipher.doFinal(padded).nn
+
+        val secret = encryptStream(2, t"Secret".s.getBytes("UTF-8").nn)
+        val streamCipher = encryptStream(3, t"encrypted stream".s.getBytes("UTF-8").nn)
+
+        val ownerHex = hex(new Array[Byte](48))
+        val encrypt =
+          t"<< /Filter /Standard /V 5 /R 6 /Length 256 /P -44 /O <$ownerHex> /U <${hex(userEntry)}> /UE <${hex(ue)}> /CF << /StdCF << /CFM /AESV3 >> >> /StmF /StdCF /StrF /StdCF >>"
+
+        buildEncrypted
+          ( encrypt,
+            t"<< /Type /Catalog >>".in[Data],
+            (t"<< /Secret <${hex(secret)}> >>".in[Data]),
+            (t"<< /Length ${streamCipher.length} >>\nstream\n".in[Data]
+                ++ streamCipher.immutable(using Unsafe) ++ t"\nendstream".in[Data]) )
+
+      test(m"RC4 matches its known-answer vector"):
+        Rc4(t"Key".in[Data], t"Plaintext".in[Data]).to(List).map(b => f"${b & 0xff}%02X").mkString.tt
+      . assert(_ == t"BBF316E8D940AF0AD3")
+
+      test(m"an encrypted document reports it"):
+        PdfFile(rc4Document(3)).open():
+          pdf.encrypted
+      . assert(_ == true)
+
+      test(m"a revision-3 string decrypts with the empty password"):
+        PdfFile(rc4Document(3)).open():
+          pdf.resolved(pdf(2, 0)(t"Secret").or(Cos.Nil)).text
+      . assert(_ == t"Secret")
+
+      test(m"a revision-3 stream decrypts"):
+        PdfFile(rc4Document(3)).open():
+          pdf(3, 0) match
+            case body: Cos.Body => String(pdf.payload(body).mutable(using Unsafe), "UTF-8").tt
+            case _              => t""
+      . assert(_ == t"encrypted stream")
+
+      test(m"a revision-2 (40-bit) string decrypts"):
+        PdfFile(rc4Document(2)).open():
+          pdf.resolved(pdf(2, 0)(t"Secret").or(Cos.Nil)).text
+      . assert(_ == t"Secret")
+
+      test(m"an AES-256 string decrypts with the right password"):
+        PdfFile(aes256Document(t"open sesame")).open(t"open sesame"):
+          pdf.resolved(pdf(2, 0)(t"Secret").or(Cos.Nil)).text
+      . assert(_ == t"Secret")
+
+      test(m"an AES-256 stream decrypts"):
+        PdfFile(aes256Document(t"open sesame")).open(t"open sesame"):
+          pdf(3, 0) match
+            case body: Cos.Body => String(pdf.payload(body).mutable(using Unsafe), "UTF-8").tt
+            case _              => t""
+      . assert(_ == t"encrypted stream")
+
+      test(m"a wrong password is rejected at open"):
+        capture[PdfError]:
+          PdfFile(aes256Document(t"open sesame")).open(t"wrong")(pdf.version)
+        . reason
+      . assert(_ == PdfError.Reason.BadPassword)
 
     // A two-page document: object 1 catalog, 2 page-tree root (A4 media box, inherited),
     // 3 a plain page, 4 a page with its own crop box and rotation.


### PR DESCRIPTION
Facsimile now reads encrypted documents, and enigmatic gains a `Password` type to carry the
secret safely. The standard security handler is supported at every revision — RC4 (40- and
128-bit), AES-128 and AES-256 — so `open` decrypts strings and streams transparently. The
file encryption key is derived from the password and validated against the `/U` entry when
the document is opened, so a wrong password fails there and then rather than surfacing as
garbled content; per-object keys then decrypt each string as its object loads, and each
stream ahead of its filter chain.

`Password`, alongside `PrivateKey`, holds cleartext that cannot be read back except through
`expose`, which lends it as a scoped `Cleartext` capability — capture checking confines it to
the block, so neither it nor a closure over it can escape — and it never renders its secret
when shown.

```scala
val pdfFile = PdfFile(path)

pdfFile.open(Password(t"the password")):   // omit for the common empty-password case
  pdf.encrypted                            // true
  pdf.pages.head.text                      // decrypted like any other
```

RC4 is implemented within facsimile; MD5, the SHA-2 hash chain of revision 6, and AES-CBC
come from the JDK. Cross-reference streams, metadata under `/EncryptMetadata false`, and
streams marked with the `Identity` crypt filter are left in the clear, as the specification
requires. Public-key security handlers remain unsupported and are reported as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
