### PR TITLE
Make streamed HTTP handler bodies capture-honest

### DIFF
--- a/lib/scintillate/src/server/scintillate.HttpConnection.scala
+++ b/lib/scintillate/src/server/scintillate.HttpConnection.scala
@@ -52,6 +52,15 @@ import vacuous.*
 import zephyrine.*
 
 object HttpConnection:
+  // A named SAM rather than a curried function type: the response the server writes
+  // out may capture the live connection (a streamed body reading the request stream),
+  // and a function type cannot take a `^` parameter (the `Spring` precedent). The
+  // tactic is a using-parameter, not a curried context-function result — a value of
+  // curried dependent context-function type is not yet supported — so nothing escapes
+  // `apply`; `connection.respond(response)` resolves the ambient `StreamError` tactic.
+  trait Respond:
+    def apply(response: Http.Response^)(using Tactic[StreamError]): Unit
+
   // Explicit `using` evidence instead of `logs`/`raises` sugar: the `respond` closure built
   // in the body cannot cross the nested context-function results the sugar desugars to (the
   // stacked-raises convention; see rep/DECISIONS.md).
@@ -106,57 +115,58 @@ object HttpConnection:
     val port = Option(exchange.getRequestURI.nn.getPort).filter(_ > 0).getOrElse:
       exchange.getLocalAddress.nn.getPort
 
-    def respond(response: Http.Response): Unit raises StreamError =
-      var chunked = false
+    val respond: Respond^ = new Respond:
+      def apply(response: Http.Response^)(using Tactic[StreamError]): Unit =
+        var chunked = false
 
-      response.textHeaders.each:
-        case Http.Header(key, value) =>
-          if key.lower == t"transfer-encoding" && value.lower == t"chunked" then chunked = true
+        response.textHeaders.each:
+          case Http.Header(key, value) =>
+            if key.lower == t"transfer-encoding" && value.lower == t"chunked" then chunked = true
 
-          exchange.getResponseHeaders.nn.add(key.s, value.s)
+            exchange.getResponseHeaders.nn.add(key.s, value.s)
 
-      val length = if chunked then 0 else response.body match
-        case Http.Body.Empty        => -1
-        case Http.Body.Fixed(data)  => data.length
-        case Http.Body.Flowing(_)   => 0
+        val length = if chunked then 0 else response.body match
+          case Http.Body.Empty        => -1
+          case Http.Body.Fixed(data)  => data.length
+          case Http.Body.Flowing(_)   => 0
 
-      exchange.sendResponseHeaders(response.status.code, length)
-      val responseBody = exchange.getResponseBody.nn
+        exchange.sendResponseHeaders(response.status.code, length)
+        val responseBody = exchange.getResponseBody.nn
 
-      var count: Int = 0
+        var count: Int = 0
 
-      response.body match
-        case Http.Body.Fixed(data) =>
-          try
-            responseBody.write(data.mutable(using Unsafe))
-            count += data.length
-            responseBody.flush()
-          catch case _: ji.IOException => abort(StreamError(count.b))
+        response.body match
+          case Http.Body.Fixed(data) =>
+            try
+              responseBody.write(data.mutable(using Unsafe))
+              count += data.length
+              responseBody.flush()
+            catch case _: ji.IOException => abort(StreamError(count.b))
 
-        case Http.Body.Flowing(source) =>
-          val stream = source()
+          case Http.Body.Flowing(source) =>
+            val stream = source()
 
-          def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
-            case size: Int =>
-              try
-                val window = stream.window(using Unsafe).asInstanceOf[Array[Byte]]
-                responseBody.write(window, stream.start, size)
-                count += size
-                responseBody.flush()
-              catch case _: ji.IOException => abort(StreamError(count.b))
+            def recur(): Unit = stream.refill(Credit(Long.MaxValue)) match
+              case size: Int =>
+                try
+                  val window = stream.window(using Unsafe).asInstanceOf[Array[Byte]]
+                  responseBody.write(window, stream.start, size)
+                  count += size
+                  responseBody.flush()
+                catch case _: ji.IOException => abort(StreamError(count.b))
 
-              stream.skip(size)
-              recur()
+                stream.skip(size)
+                recur()
 
-            case _ => ()
+              case _ => ()
 
-          recur()
+            recur()
 
-        case Http.Body.Empty =>
-          try responseBody.flush()
-          catch case _: ji.IOException => abort(StreamError(count.b))
+          case Http.Body.Empty =>
+            try responseBody.flush()
+            catch case _: ji.IOException => abort(StreamError(count.b))
 
-      exchange.close()
+        exchange.close()
 
     new HttpConnection(request, false, port, respond)
 
@@ -168,11 +178,10 @@ class HttpConnection
   (     request: Http.Request^,
     val tls:     Boolean,
     val port:    Int,
-    // Layered response-first: the eta-expansion of a `respond(response)(using Tactic)` local
-    // into a tactic-first nested context function would need the inner arrow to capture the
-    // outer tactic (the dependent-capture restriction); this way the capturing arrow is
-    // outermost.
-    val respond: Http.Response => Tactic[StreamError] ?=> Unit )
+    // The sink that writes the response to (and closes) the client connection. Its
+    // `apply` takes `Http.Response^`: the handler's response may capture this very
+    // connection — a streamed body reading the live request stream.
+    val respond: HttpConnection.Respond^ )
 extends Http.Request
   ( request.method,
     request.version,

--- a/lib/scintillate/src/server/scintillate.HttpServer.scala
+++ b/lib/scintillate/src/server/scintillate.HttpServer.scala
@@ -47,7 +47,8 @@ import urticose.*
 
 case class HttpServer(port: Int, local: Boolean = true)(using errorPage: WebserverErrorPage)
 extends RequestServable:
-  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
+  def handle(handler: (connection: HttpConnection) ?=> Http.Response^{connection})
+    ( using Monitor, Probate )
     ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^ =
 

--- a/lib/scintillate/src/server/scintillate.RequestServable.scala
+++ b/lib/scintillate/src/server/scintillate.RequestServable.scala
@@ -39,6 +39,11 @@ import telekinesis.*
 import urticose.*
 
 trait RequestServable:
-  def handle(handle: HttpConnection ?=> Http.Response)(using Monitor, Probate)
+  // The handler's response may capture the connection it answers
+  // (`Http.Response^{connection}`): a streamed body — a chunked response, SSE,
+  // or an upgraded protocol's raw stream — legitimately reads the live request
+  // stream, and is written out by the server within the connection's lifetime.
+  def handle(handle: (connection: HttpConnection) ?=> Http.Response^{connection})
+    ( using Monitor, Probate )
     ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^

--- a/lib/scintillate/src/server/scintillate.SocketServer.scala
+++ b/lib/scintillate/src/server/scintillate.SocketServer.scala
@@ -53,8 +53,8 @@ import zephyrine.*
 // A raw-TCP HTTP/1.1 server backend, built on a `java.net.ServerSocket` rather
 // than `com.sun.net.httpserver`. Each accepted socket is handled on its own
 // Loom virtual thread (`daemon`). The handler API is identical to `HttpServer`'s
-// — a `HttpConnection ?=> Http.Response` — so the two backends are
-// interchangeable. The connection loop supports keep-alive and pipelining,
+// — a `(connection: HttpConnection) ?=> Http.Response^{connection}` — so the two
+// backends are interchangeable. The connection loop supports keep-alive and pipelining,
 // `Content-Length` and chunked request bodies, `100-continue`, request-size
 // limits, and `101` protocol upgrades. Supplying an `SSLContext` as `ssl` serves
 // over TLS instead of cleartext.
@@ -134,7 +134,7 @@ extends RequestServable:
     head.version == 1.1 && head.headers.exists: header =>
       header.key.lower == t"expect" && header.value.lower.contains(t"100-continue")
 
-  private def streaming(response: Http.Response): Boolean = response.body match
+  private def streaming(response: Http.Response^): Boolean = response.body match
     case Http.Body.Flowing(_) => true
     case _                    => false
 
@@ -152,7 +152,7 @@ extends RequestServable:
   // it is also the in-process entry point for tests and benchmarks, which feed a
   // `ByteArrayInputStream` of requests and capture the responses with no network
   // involvement. The caller owns the streams (closing, read timeouts).
-  def serveConnection(handler: HttpConnection ?=> Http.Response)
+  def serveConnection(handler: (connection: HttpConnection) ?=> Http.Response^{connection})
     ( in: ji.InputStream, out: ji.OutputStream )
     ( using (HttpServerEvent is Loggable)^ )
   :   Unit =
@@ -205,20 +205,21 @@ extends RequestServable:
           var upgraded = false
           var keep = keepAlive(head)
 
-          def respond(response: Http.Response): Unit raises StreamError =
-            if response.status == Http.SwitchingProtocols then
-              // Switch to the upgraded protocol: write the handshake headers, then
-              // pipe its raw stream until it ends. This blocks for the lifetime of
-              // the upgraded connection (e.g. a WebSocket session).
-              upgraded = true
-              writeAll(out, Http.Response.serialize(response))
-            else
-              // A streaming body to a pre-1.1 client can't be chunked, so it must
-              // be delimited by closing the connection.
-              if head.version != 1.1 && streaming(response) then keep = false
-              val response2 = if keep then response else response + closeHeader
-              val bytes = Http.Response.serialize(response2, head.method != Http.Head, head.version)
-              writeAll(out, bytes)
+          val respond: HttpConnection.Respond^ = new HttpConnection.Respond:
+            def apply(response: Http.Response^)(using Tactic[StreamError]): Unit =
+              if response.status == Http.SwitchingProtocols then
+                // Switch to the upgraded protocol: write the handshake headers, then
+                // pipe its raw stream until it ends. This blocks for the lifetime of
+                // the upgraded connection (e.g. a WebSocket session).
+                upgraded = true
+                writeAll(out, Http.Response.serialize(response))
+              else
+                // A streaming body to a pre-1.1 client can't be chunked, so it must
+                // be delimited by closing the connection.
+                if head.version != 1.1 && streaming(response) then keep = false
+                val response2 = if keep then response else response + closeHeader
+                val bytes = Http.Response.serialize(response2, head.method != Http.Head, head.version)
+                writeAll(out, bytes)
 
           val connection = new HttpConnection(request, ssl.present, port, respond)
           Log.fine(HttpServerEvent.Received(request))
@@ -269,7 +270,8 @@ extends RequestServable:
         var continue = true
         while continue && !cursor.finished do continue = serveRequest(cursor)
 
-  def handle(handler: HttpConnection ?=> Http.Response)(using Monitor, Probate)
+  def handle(handler: (connection: HttpConnection) ?=> Http.Response^{connection})
+    ( using Monitor, Probate )
     ( using (HttpServerEvent is Loggable)^, Tactic[ServerError] )
   :   Service^ =
 

--- a/lib/scintillate/src/server/scintillate_core.scala
+++ b/lib/scintillate/src/server/scintillate_core.scala
@@ -69,7 +69,8 @@ package httpServers:
     type Request = HttpConnection^
     type Response = Http.Response
 
-    def server(port: TcpPort of port)(lambda: Request ?=> Response): Server^ =
+    def server(port: TcpPort of port)(lambda: (request: Request) ?=> Response^{request})
+    :   Server^ =
       if native then SocketServer(port.number, local).handle(lambda)
       else HttpServer(port.number, local).handle(lambda)
 

--- a/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
+++ b/lib/scintillate/src/servlet/scintillate.JavaServlet.scala
@@ -96,41 +96,42 @@ open class JavaServlet(handle: HttpConnection => Http.Response) extends jsh.Http
             . stream(in.asInstanceOf[ji.InputStream]),
           textHeaders = headers )
 
-    def respond(response: Http.Response): Unit =
-      val servletResponse1 = servletResponse0.asInstanceOf[jsh.HttpServletResponse]
-      servletResponse1.setStatus(response.status.code)
+    val respond: HttpConnection.Respond^ = new HttpConnection.Respond:
+      def apply(response: Http.Response^)(using Tactic[StreamError]): Unit =
+        val servletResponse1 = servletResponse0.asInstanceOf[jsh.HttpServletResponse]
+        servletResponse1.setStatus(response.status.code)
 
-      response.textHeaders.each:
-        case Http.Header(key, value) =>
-          servletResponse1.addHeader(key.s, value.s)
+        response.textHeaders.each:
+          case Http.Header(key, value) =>
+            servletResponse1.addHeader(key.s, value.s)
 
-      val out = servletResponse1.getOutputStream.nn
+        val out = servletResponse1.getOutputStream.nn
 
-      response.body match
-        case Http.Body.Fixed(data) =>
-          servletResponse.addHeader("content-length", data.length.show.s)
-          out.write(data.mutable(using Unsafe))
+        response.body match
+          case Http.Body.Fixed(data) =>
+            servletResponse.addHeader("content-length", data.length.show.s)
+            out.write(data.mutable(using Unsafe))
 
-        case Http.Body.Empty =>
-          servletResponse.addHeader("content-length", "0")
+          case Http.Body.Empty =>
+            servletResponse.addHeader("content-length", "0")
 
-        case Http.Body.Flowing(source) =>
-          servletResponse.addHeader("transfer-encoding", "chunked")
-          val stream = source()
+          case Http.Body.Flowing(source) =>
+            servletResponse.addHeader("transfer-encoding", "chunked")
+            val stream = source()
 
-          // A while-loop rather than a recursive def: a def capturing the
-          // locally bound exclusive stream may not call itself.
-          var draining = true
+            // A while-loop rather than a recursive def: a def capturing the
+            // locally bound exclusive stream may not call itself.
+            var draining = true
 
-          while draining do stream.refill(Credit(Long.MaxValue)) match
-            case count: Int =>
-              out.write(stream.window(using Unsafe).asInstanceOf[Array[Byte]], stream.start, count)
-              out.flush()
-              stream.skip(count)
+            while draining do stream.refill(Credit(Long.MaxValue)) match
+              case count: Int =>
+                out.write(stream.window(using Unsafe).asInstanceOf[Array[Byte]], stream.start, count)
+                out.flush()
+                stream.skip(count)
 
-            case _ => draining = false
+              case _ => draining = false
 
-      out.close()
+        out.close()
 
     new HttpConnection(httpRequest, false, request.getServerPort, respond)
 

--- a/lib/scintillate/src/test/scintillate.CaptureTests.scala
+++ b/lib/scintillate/src/test/scintillate.CaptureTests.scala
@@ -54,3 +54,17 @@ object CaptureTests extends Suite(m"Connection confinement tests"):
 
           ()
     . assert(_.nonEmpty)
+
+    // A streamed response body may retain the connection it answers (`Http.Response^
+    // {connection}`) but nothing else scoped: a body reading a *foreign* capability
+    // would outlive the handler through a stream the server never framed.
+    test(m"a response body may not capture a foreign stream"):
+      demilitarize:
+        def attempt(server: SocketServer, foreign: (Stream[Data] over Credit)^)
+          ( using Monitor, Probate, (HttpServerEvent is Loggable)^, Tactic[ServerError] )
+        :   Unit =
+          server.handle:
+            Http.Response(Http.Ok)(Http.Body.Flowing(() => foreign))
+
+          ()
+    . assert(_.nonEmpty)

--- a/lib/scintillate/src/test/scintillate_test.scala
+++ b/lib/scintillate/src/test/scintillate_test.scala
@@ -158,12 +158,10 @@ object Tests extends Suite(m"Scintillate tests"):
           // Echo upgrade: the response body is the post-handshake request stream,
           // piped straight back out with no HTTP framing.
           val server = SocketServer(port).handle:
-            Http.Response(Http.SwitchingProtocols)
-              (Http.Body.Flowing:
-                // Sealed: the upgraded response's stream legitimately reads the live
-                // connection for the rest of the exchange; the pure-`Http.Body` handler
-                // shape cannot express that retention (see rep/DECISIONS.md, Phase 3b).
-                caps.unsafe.unsafeAssumePure(() => request.body()))
+            // The upgraded response's stream reads the live connection for the rest
+            // of the exchange; the handler result type `Http.Response^{connection}`
+            // expresses that retention honestly, so no seal is needed.
+            Http.Response(Http.SwitchingProtocols)(Http.Body.Flowing(() => request.body()))
 
           val response =
             rawRequest

--- a/lib/telekinesis/src/core/telekinesis.Cookie.scala
+++ b/lib/telekinesis/src/core/telekinesis.Cookie.scala
@@ -76,7 +76,11 @@ object Cookie:
     given addable: Http.Response is Addable by Cookie.Value to Http.Response =
       Addable: (response, cookie) =>
         val header = Http.Header(t"set-cookie", cookie.show)
-        response.status(header :: response.textHeaders, response.body)
+
+        // `response` is pure here, so its body is pure; the seal only discharges
+        // the field's capture-polymorphic declared type (see `Protoresponse`).
+        val body = caps.unsafe.unsafeAssumePure(response.body)
+        response.status(header :: response.textHeaders, body)
 
     given decodable: List[Cookie.Value] is Decodable in Text = value =>
       value.cut(t"; ").flatMap:

--- a/lib/telekinesis/src/core/telekinesis.Http.scala
+++ b/lib/telekinesis/src/core/telekinesis.Http.scala
@@ -219,7 +219,8 @@ object Http:
       case 4 => Http.Category.ClientError
       case 5 => Http.Category.ServerError
 
-    def apply(headers: List[Header], body: Body): Response = Response.response(this, headers, body)
+    def apply(headers: List[Header], body: Body^): Response^{body} =
+      Response.response(this, headers, body)
 
   export Status.*
 
@@ -660,7 +661,7 @@ object Http:
       ${telekinesis.internal.response('headers)}
 
     case class Protoresponse(status0: Optional[Status], headers: Seq[Header]):
-      def apply(body: Body = Body.Empty): Response =
+      def apply(body: Body^ = Body.Empty): Response^{body} =
         Response(1.1, status0.or(Ok), headers.to(List), body)
 
       def apply[servable: Servable](body: servable): Response =
@@ -670,7 +671,9 @@ object Http:
           ( 1.1,
             status0.or(response.status),
             headers.to(List) ++ response.textHeaders,
-            response.body )
+            // `serve` returns a pure `Response`, so its body is pure; the seal only
+            // discharges the field's capture-polymorphic declared type.
+            caps.unsafe.unsafeAssumePure(response.body) )
 
     given streamable: (tactic: Tactic[HttpError])
     =>  ((Response is Streamable by Data over Credit)^{tactic}) = response =>
@@ -680,7 +683,8 @@ object Http:
         case _ =>
           abort(HttpError(response.status, response.textHeaders))
 
-    private[Http] def response(status: Status, headers: List[Header], body: Body): Response =
+    private[Http] def response(status: Status, headers: List[Header], body: Body^)
+    :   Response^{body} =
       new Response(1.1, status, headers, body)
 
     // Serialise a response to HTTP/1.1 wire bytes: status line, headers (with an
@@ -689,7 +693,7 @@ object Http:
     // body. `includeBody` is `false` for responses to `HEAD` requests and for
     // `101` upgrades (where the caller pipes the post-handshake stream raw). The
     // inverse of `parse`.
-    def serialize(response: Response, includeBody: Boolean = true, version: Version = 1.1)
+    def serialize(response: Response^, includeBody: Boolean = true, version: Version = 1.1)
       ( using buffering: Buffering )
     :   (Stream[Data] over Credit)^ =
 
@@ -902,8 +906,9 @@ object Http:
       // The body spring lends the cursor's remainder as a SINGLE-OWNER stream:
       // each mint resumes where the previous reader stopped (explicit `memoize`
       // replaces the former memoized-remainder replay). Sealed: the cursor is
-      // reachable only through the spring; a capturing `Body` would cascade
-      // `^` through every `Response` value. Neutral carrier: see `Request.parse`.
+      // reachable only through the spring, and the client API keeps `Response`
+      // pure (the honest capturing form is reserved for server-side handler
+      // results). Neutral carrier: see `Request.parse`.
       val cursorRef: AnyRef = cursor.asInstanceOf[AnyRef]
 
       val spring: Spring[Data]^ =
@@ -912,15 +917,27 @@ object Http:
 
       Response(version, status, headers.reverse, body)
 
+  // The body is capture-polymorphic (`Body^`): a server-side streamed response
+  // legitimately retains the live connection it answers — the handler shape
+  // `(connection: HttpConnection) ?=> Http.Response^{connection}` — while every
+  // client-facing `Response` remains pure.
   into case class Response private
-    ( version: Version, status: Status, textHeaders: List[Header], body: Body )
+    ( version: Version, status: Status, textHeaders: List[Header], body: Body^ )
   extends Dynamic:
 
     def updateDynamic[label <: Label: Directive of topic, topic](name: label)(value: topic)
-    :   Response =
+    :   Response^{this} =
 
       val key2 = name.tt.uncamel.kebab.lower
-      copy(textHeaders = Header(key2, label.encode(value)) :: textHeaders.filter(_.key != key2))
+
+      // Explicit construction rather than `copy`: the synthesized `copy`'s
+      // capture-polymorphic `body` formal is fresh, so its `this.body` default
+      // would hide a capability the prefix also captures (separation).
+      new Response
+        ( version,
+          status,
+          Header(key2, label.encode(value)) :: textHeaders.filter(_.key != key2),
+          body )
 
 
     // The successful response's body as a single-owner pull endpoint (explicit
@@ -944,9 +961,11 @@ object Http:
 
 
     @targetName("add")
-    infix def + [value: Encodable in Http.Header](value: value): Response =
+    infix def + [value: Encodable in Http.Header](value: value): Response^{this} =
       val header: Http.Header = value.encode
-      copy(textHeaders = header :: textHeaders)
+
+      // Explicit construction rather than `copy`: see `updateDynamic`.
+      new Response(version, status, header :: textHeaders, body)
 
   case class Submit[target](originForm: Text, target: target, host: Host)
   extends Dynamic:

--- a/lib/telekinesis/src/core/telekinesis.Receivable.scala
+++ b/lib/telekinesis/src/core/telekinesis.Receivable.scala
@@ -80,5 +80,7 @@ object Receivable extends Receivable2:
   given httpStatus: Http.Status is Receivable = _.status
 
 trait Receivable extends Typeclass:
-  def read(response: Http.Response): Self
+  // Widened (`Response^`): a reader may consume a response whose streamed body
+  // retains the live connection it arrived on.
+  def read(response: Http.Response^): Self
   def map[self2](lambda: Self => self2): (self2 is Receivable)^{this, lambda} = response => lambda(read(response))

--- a/lib/urticose/src/core/urticose.Protocolic.scala
+++ b/lib/urticose/src/core/urticose.Protocolic.scala
@@ -35,8 +35,14 @@ package urticose
 import prepositional.*
 
 trait Protocolic extends Typeclass, Transportive:
-  type Request
+  // Capability-bounded so `request` is trackable in `server`'s dependent result capture:
+  // a protocol's request is a live connection.
+  type Request <: caps.Capability
   type Response
   type Server
 
-  def server(port: Transport)(lambda: Request ?=> Response): Server^
+  // The handler's result may capture the request it received (`Response^{request}`): a
+  // streamed response body legitimately retains the live connection it answers, and is
+  // consumed by the server within that connection's lifetime. Capturing anything *else*
+  // scoped is forbidden — the response outlives the handler's own frame.
+  def server(port: Transport)(lambda: (request: Request) ?=> Response^{request}): Server^

--- a/lib/urticose/src/core/urticose_core.scala
+++ b/lib/urticose/src/core/urticose_core.scala
@@ -67,7 +67,7 @@ extension [remote: Remotable](value: remote)
 
 extension [port](port: port)
   transparent inline def serve[protocol: Protocolic over port]
-    ( handler: protocol.Request ?=> protocol.Response )
+    ( handler: (request: protocol.Request) ?=> protocol.Response^{request} )
   :   protocol.Server^ =
 
     protocol.server(port)(handler)

--- a/rep/DECISIONS.md
+++ b/rep/DECISIONS.md
@@ -2147,10 +2147,8 @@ scintillate recipes:
   parameter-relative `^{streamError, ...}` alternative cannot absorb the ctor's fresh).
   The `@servlet` macro types its hole `Any` and casts inside the quote (capability-typed
   quote holes fail capture-root unification).
-- `request` accessor returns `Http.Request^`; the ws-upgrade TEST seals its flowing-body
-  thunk (a streamed response legitimately retains the live connection — the pure-`Response`
-  handler shape cannot express it; the honest `Response^{connection}` form is the recorded
-  future option).
+- `request` accessor returns `Http.Request^`. (The ws-upgrade seal was retired — see the
+  `Response^{connection}` leg below.)
 
 exoskeleton.rig: one real fix — `Fqcn.apply` instead of the `fqcn""` interpolator (the
 macro's synthesized tree fails capture-variable unification when expanded in a CC module;
@@ -2160,6 +2158,45 @@ REMAINING un-CC'd (per-class deferral list unchanged): ethereal.core (Phase 5),
 quantitative.core, cataclysm.core, synesthesia.core, apoplexy.core, zeppelin.core (⚑5),
 burdock.core, exegesis.*, aviation.core, superlunary.core, anthology.bundle + platform
 variants.
+
+## Capture-honesty follow-up: honest `Response^{connection}` for streamed bodies (2026-07-16)
+
+Retired the last scintillate seal (the ws-upgrade test's `unsafeAssumePure` flowing-body
+thunk) by making the handler result type capture-honest end-to-end. A streamed response
+body — a chunked response, SSE, or an upgraded protocol's raw stream — legitimately reads
+the live request stream for the rest of the exchange; the handler shape now expresses that.
+
+- Handler result type across the whole server API: `(connection: HttpConnection) ?=>
+  Http.Response^{connection}` (a **dependent context function** whose result captures its own
+  context parameter). Threaded through `RequestServable.handle`, `HttpServer.handle`,
+  `SocketServer.{handle, serveConnection}`, `scintillate_core`'s `HttpProtocolic.server`, and
+  `urticose`'s `Protocolic.server` + the `serve` extension.
+- `urticose.Protocolic#Request` gained a `<: caps.Capability` bound: an abstract type member
+  cannot appear in a dependent-result capture set unless it is known to be trackable (`cannot
+  be tracked since its capture set is empty` otherwise). `Any^` did NOT suffice — the fork
+  requires a `Capability` bound for the `{request}` capture to be admitted.
+- `Http.Response#body` widened to `Body^`; `Response` constructors/derivations
+  (`Status.apply`, `Protoresponse.apply`, `response`, `updateDynamic`, `+`) return
+  `Response^{body}` / `Response^{this}`. Two internal constructions that hand a **pure** body
+  to `copy` keep a one-line `unsafeAssumePure` (Cookie `addable`, `Protoresponse.apply` over a
+  `Servable`) — the seal only discharges the field's now capture-polymorphic declared type, it
+  hides nothing live. `updateDynamic`/`+` had to drop `copy` for explicit `new Response(...)`:
+  the synthesized `copy`'s fresh capture-polymorphic `body` formal separation-clashes with the
+  prefix's `this.body`.
+- `HttpConnection#respond` became a **named SAM** `HttpConnection.Respond` with
+  `def apply(response: Http.Response^)(using Tactic[StreamError]): Unit`, replacing the curried
+  `Http.Response => Tactic[StreamError] ?=> Unit` function field. Two reasons: a function type
+  cannot take a `^` parameter (the `Spring` precedent), and a **value** of curried dependent
+  context-function type — `(r: Http.Response^) => (Tactic ?=> Unit)^{r}` — is "not yet
+  supported" by the fork. The using-parameter form keeps the response consumed inside `apply`,
+  so nothing escapes; call sites (`connection.respond(response)`) are unchanged.
+- `Receivable.read` widened to `Http.Response^` (a reader may consume a response whose streamed
+  body retains its connection). Client-facing `Response.parse` stays pure (the client seal is
+  unchanged) — the honest capturing form is reserved for the server's handler result.
+- New negative CaptureTest: a handler returning `Http.Body.Flowing(() => foreign)` over a
+  **foreign** `(Stream[Data] over Credit)^` param must not compile — `Response^{connection}`
+  admits the connection only, not arbitrary scoped capabilities. The ws-upgrade positive test
+  (real streamed body reading `request.body()`) now compiles seal-free and passes.
 
 ## Capture-honesty Phase 4 remainder: Tool/Tmux + confinement regression tests (2026-07-15)
 


### PR DESCRIPTION
Server-side HTTP handlers may now return a response whose streamed body legitimately retains the connection it answers, so a chunked response, an SSE stream, or an upgraded protocol's raw bytes can read the live request stream for the rest of the exchange without an escape hatch. The handler type became a dependent context function, `(connection: HttpConnection) ?=> Http.Response^{connection}`, and capture checking now proves such a body may retain that connection and nothing else scoped — closing the last capture-checking seal in scintillate.

The scintillate server handler type is now capture-polymorphic in the connection:

```scala
// A WebSocket-style upgrade whose response body is the post-handshake
// request stream, piped straight back out — no seal required:
SocketServer(port).handle:
  Http.Response(Http.SwitchingProtocols)(Http.Body.Flowing(() => request.body()))
```

The response captures the connection it answers, and the compiler tracks that honestly. Attempting to smuggle a *different* live resource out through the response — a stream that outlives the handler — no longer compiles:

```scala
server.handle:
  // does not compile: `foreign` is not the connection this handler answers
  Http.Response(Http.Ok)(Http.Body.Flowing(() => foreign))
```

`Http.Response#body` is now `Body^` and the response constructors return `Http.Response^{…}` accordingly; client-facing `Http.Response` values built from pure bodies remain pure, so ordinary request/response code is unaffected. `HttpConnection#respond` is now a small named interface (`HttpConnection.Respond`) rather than a curried function, because a function type cannot take a capturing parameter — call sites (`connection.respond(response)`) are unchanged.
