### PR TITLE
Recover damaged PDF files by scanning for objects

### DIFF
--- a/lib/facsimile/doc/basics.md
+++ b/lib/facsimile/doc/basics.md
@@ -65,6 +65,14 @@ re-materializable `Spring[Data]` instead: each application mints a fresh streami
 endpoint which reads and decodes incrementally, never holding the whole payload. The
 endpoint reads through the document, so it is likewise confined to the scope.
 
+### Damaged files
+
+Real-world PDFs are frequently damaged — a missing or corrupt cross-reference table,
+prepended junk shifting every recorded offset, a truncated tail. When the cross-reference
+machinery cannot be trusted, Facsimile falls back to scanning the whole file for objects and
+rebuilding the table, and it corrects individually shifted offsets as objects are resolved,
+so a document that any conformant reader would open still opens here.
+
 ### Pages
 
 The page tree is flattened into reading order, with the inheritable attributes — resources,

--- a/lib/facsimile/doc/features.md
+++ b/lib/facsimile/doc/features.md
@@ -14,4 +14,5 @@
 - capture checking confines the open file to its scope; extracted values are pure and portable
 - decrypts documents secured with the standard handler: RC4, AES-128 and AES-256 (R2–R6)
 - tolerates common real-world deviations: prepended junk, raw deflate streams, truncated data
+- recovers from a missing or corrupt cross-reference table by scanning the file for objects
 - no third-party dependencies

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -329,11 +329,10 @@ extends caps.ExclusiveCapability:
         val resolution = xref.entries.at(number) match
           case Xref.Entry.Direct(offset, expected) =>
             if expected != generation then Cos.Nil else
-              val parser = CosParser(CosLexer(new Scan(source, offset)))
-              val (foundNumber, foundGeneration, content) = parser.indirect()
-
-              if foundNumber != number || foundGeneration != generation
-              then abort(PdfError(PdfError.Reason.MissingObject(number, generation)))
+              // If the recorded offset does not hold this object — a corrupt or shifted
+              // cross-reference table — fall back to the offset found by a full-file scan.
+              val content = atOffset(number, generation, offset).or:
+                recoveredOffset(number).let(atOffset(number, generation, _)).or(Cos.Nil)
 
               // A top-level indirect stream: record its owner so its payload can be
               // decrypted with the right key.
@@ -356,6 +355,22 @@ extends caps.ExclusiveCapability:
         cache(number) = resolution
         resolution
       finally loading.remove(number)
+
+  // Parses the object at an offset, returning its content only if the header matches the
+  // number and generation asked for; a mismatch (a lie in the cross-reference table) is
+  // `Unset`, so the caller can try a recovered offset instead.
+  private def atOffset(number: Int, generation: Int, offset: Long): Optional[Cos] raises PdfError =
+    if offset < 0 || offset >= source.size then Unset else
+      safely(CosParser(CosLexer(new Scan(source, offset))).indirect()).let: (found, gen, content) =>
+        if found == number && gen == generation then content else Unset
+
+  // A cross-reference table rebuilt by scanning the whole file for objects, computed once and
+  // only when the recorded table is found to be lying.
+  private lazy val recovered: Xref = safely(Xref.rebuild(source)).or(Xref(Map(), Map()))
+
+  private def recoveredOffset(number: Int): Optional[Long] = recovered.entries.at(number).let:
+    case Xref.Entry.Direct(offset, _) => offset
+    case _                            => Unset
 
   def resolved(value: Cos): Cos raises PdfError = value match
     case ref: Cos.Ref => apply(ref)

--- a/lib/facsimile/src/core/facsimile.Xref.scala
+++ b/lib/facsimile/src/core/facsimile.Xref.scala
@@ -47,8 +47,14 @@ private[facsimile] object Xref:
   // Locates `startxref` near the end of the file and walks the chain of cross-reference
   // sections — classic tables and cross-reference streams — through `/Prev`, newest first.
   // Later (older) sections never override earlier entries, and the newest trailer's values
-  // take precedence. `load` is the single seam a damaged-file `rebuild` can replace later.
+  // take precedence. When the cross-reference machinery is missing or corrupt — as it
+  // frequently is in the wild — the whole file is scanned for objects instead (`rebuild`).
   def load(source: ByteSource): Xref raises PdfError =
+    // Any structural failure in the cross-reference machinery drops through to a full-file
+    // scan for objects.
+    safely(strict(source)).or(rebuild(source))
+
+  private def strict(source: ByteSource): Xref raises PdfError =
     def recur(offset: Long, entries: Map[Int, Entry], trailer: Map[Text, Cos], visited: Set[Long])
     :   Xref =
 
@@ -75,6 +81,143 @@ private[facsimile] object Xref:
         recur(previous, mergedEntries, mergedTrailer, visited + offset)
 
     recur(startxref(source), Map(), Map(), Set())
+
+  // Recovers a cross-reference table from a damaged file by scanning for `N G obj` markers,
+  // the latest offset of each object number winning (an incremental update's newer copy
+  // appears later in the file). Object streams found this way are expanded to their compressed
+  // members. The trailer is the last `trailer` dictionary if any, else synthesized by finding
+  // the catalog among the recovered objects.
+  private[facsimile] def rebuild(source: ByteSource): Xref raises PdfError =
+    var entries = Map[Int, Entry]()
+    val objectStreams = List.newBuilder[Int]
+    val size = source.size
+    val chunkSize = 65536
+    val overlap = 32 // long enough to hold "NNNNNN GGGGG obj" split across a chunk boundary
+    var base = 0L
+
+    while base < size do
+      val length = (size - base).min((chunkSize + overlap).toLong).toInt
+      val chunk = source.read(base, length)
+      val limit = if base + length >= size then chunk.length else chunk.length - overlap
+      var i = 0
+
+      while i < limit do
+        // A candidate object header is `<digits> <digits> obj` at a token boundary.
+        if matches(chunk, i, t"obj") && (i + 3 >= chunk.length || !CosLexer.regular(chunk(i + 3) & 0xff))
+           && (i == 0 || CosLexer.whitespace(chunk(i - 1) & 0xff))
+        then
+          objectHeader(chunk, i).let: (number, generation, start) =>
+            val offset = base + start
+            entries = entries.updated(number, Entry.Direct(offset, generation))
+
+        i += 1
+
+      base += (if limit == chunk.length then chunk.length else limit).toLong
+
+    // Expand object streams: each `/Type /ObjStm` object's members become compressed entries,
+    // unless a direct copy of that member was already recovered (a later direct object wins).
+    val direct = entries
+
+    direct.foreach: (container, entry) =>
+      entry match
+        case Entry.Direct(offset, _) =>
+          safely(CosParser(CosLexer(new Scan(source, offset))).indirect()).let: (_, _, content) =>
+            content match
+              case body @ Cos.Body(dictionary, _)
+              if dictionary.at(t"Type").let(_.name) == t"ObjStm" =>
+                objStmMembers(source, body).each: number =>
+                  if !direct.contains(number)
+                  then entries = entries.updated(number, Entry.Compressed(container, 0))
+
+              case _ =>
+                ()
+
+        case _ =>
+          ()
+
+    Xref(entries, recoverTrailer(source, entries))
+
+  // Parses `<num> <gen> obj` ending at `objAt`, returning the object number, generation, and
+  // the offset the `<num>` begins at — by scanning backwards over the two preceding integers.
+  private def objectHeader(chunk: Data, objAt: Int): Optional[(Int, Int, Int)] =
+    def digits(end: Int): Optional[(Int, Int)] = // (value, startIndex), scanning back from end
+      var i = end
+      while i > 0 && CosLexer.whitespace(chunk(i - 1) & 0xff) do i -= 1
+      val last = i
+      while i > 0 && { val b = chunk(i - 1) & 0xff; b >= '0' && b <= '9' } do i -= 1
+      if i == last then Unset else (parseInt(chunk, i, last), i)
+
+    digits(objAt).let: (generation, genStart) =>
+      digits(genStart).let: (number, numberStart) =>
+        (number, generation, numberStart)
+
+  private def parseInt(chunk: Data, start: Int, end: Int): Int =
+    var value = 0
+    var i = start
+    while i < end do
+      value = value*10 + (chunk(i) & 0xff) - '0'
+      i += 1
+    value
+
+  // The object numbers packed into an object stream, from the header table of its decoded
+  // payload; tolerant of any failure (a member simply stays unrecovered).
+  private def objStmMembers(source: ByteSource, body: Cos.Body): List[Int] =
+    safely:
+      val length = body.entries.at(t"Length").let(_.long)
+        . or(abort(PdfError(PdfError.Reason.MissingEntry(t"Length")))).toInt
+
+      val count = body.entries.at(t"N").let(_.long)
+        . or(abort(PdfError(PdfError.Reason.MissingEntry(t"N")))).toInt
+
+      val raw = source.read(body.start, length)
+      val chain = Filter.chain(body.entries.at(t"Filter"), body.entries.at(t"DecodeParms"))
+      val data = Filter.decode(raw, chain)
+      val lexer = CosLexer(Scan(data))
+
+      List.range(0, count).map: _ =>
+        (lexer.next(), lexer.next()) match
+          case (CosToken.Integral(number), CosToken.Integral(_)) => number.toInt
+          case _ => abort(PdfError(PdfError.Reason.CorruptStream(t"ObjStm")))
+
+    . or(List())
+
+  // A recovered trailer: the file's last `trailer` dictionary if one survives, otherwise
+  // synthesized around the catalog found among the recovered objects.
+  private def recoverTrailer(source: ByteSource, entries: Map[Int, Entry]): Map[Text, Cos] =
+    lastTrailer(source).or:
+      entries.view.flatMap: (number, entry) =>
+        entry match
+          case Entry.Direct(offset, generation) =>
+            safely(CosParser(CosLexer(new Scan(source, offset))).indirect()).let: (_, _, content) =>
+              content.dictionary.let(_.at(t"Type")).let(_.name) match
+                case t"Catalog" => List(number -> generation)
+                case _          => List()
+
+            . or(List())
+
+          case _ =>
+            List()
+
+      . headOption.map: (number, generation) =>
+          Map(t"Root" -> Cos.Ref(number, generation))
+
+      . getOrElse(Map())
+
+  // The last `trailer` dictionary in the file, if any (classic-xref files have one even when
+  // their cross-reference table is corrupt).
+  private def lastTrailer(source: ByteSource): Optional[Map[Text, Cos]] =
+    val windowSize = source.size.min(4096L).toInt
+    val window = source.read(source.size - windowSize, windowSize)
+    val marker = t"trailer"
+
+    var i = window.length - marker.length
+
+    while i >= 0 && !matches(window, i, marker) do i -= 1
+    if i < 0 then Unset else
+      safely:
+        val lexer = CosLexer(new Scan(source, source.size - windowSize + i))
+        lexer.next() // the `trailer` keyword
+        CosParser(lexer).value().dictionary.or(abort(PdfError(PdfError.Reason.Truncated)))
 
   private def startxref(source: ByteSource): Long raises PdfError =
     val windowSize = source.size.min(2048L).toInt

--- a/lib/facsimile/src/test/facsimile_test.scala
+++ b/lib/facsimile/src/test/facsimile_test.scala
@@ -362,14 +362,75 @@ object Tests extends Suite(m"Facsimile tests"):
         capture[PdfError](PdfFile(t"not a pdf at all".in[Data]).open()(pdf.version)).reason
       . assert(_ == PdfError.Reason.NotPdf)
 
-      test(m"a missing startxref is an error"):
-        capture[PdfError](PdfFile(t"%PDF-1.7\nnothing else".in[Data]).open()(pdf.version)).reason
-      . assert(_ == PdfError.Reason.MissingStartxref)
-
       test(m"a public-key security handler is unsupported"):
         val doc = documentWith(t"/Encrypt << /Filter /Adobe.PubSec /V 4 >>", catalog)
         capture[PdfError](PdfFile(doc).open()(pdf.version)).reason
       . assert(_ == PdfError.Reason.UnsupportedEncryption(0))
+
+    suite(m"Damaged-file recovery"):
+      // A minimal well-formed document whose objects can be found by scanning, used as the
+      // basis for various corruptions.
+      def recoverable: Data = document
+        ( t"<< /Type /Catalog /Pages 2 0 R /Note (kept) >>".in[Data],
+          t"<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 200 300] >>".in[Data],
+          t"<< /Type /Page /Parent 2 0 R >>".in[Data] )
+
+      test(m"a document with no startxref is recovered by scanning"):
+        // Truncate the cross-reference section and trailer entirely.
+        val text = String(recoverable.mutable(using Unsafe), "ISO-8859-1")
+        val truncated = text.substring(0, text.indexOf("xref")).nn.tt.in[Data]
+
+        PdfFile(truncated).open():
+          (pdf.pages.length, pdf.pages(0).mediaBox.width)
+      . assert(_ == (1, Quantity[Points[1]](200.0)))
+
+      test(m"the catalog is found when the trailer is gone"):
+        val text = String(recoverable.mutable(using Unsafe), "ISO-8859-1")
+        val truncated = text.substring(0, text.indexOf("xref")).nn.tt.in[Data]
+
+        PdfFile(truncated).open():
+          pdf.resolved(pdf.trailer.at(t"Root").or(Cos.Nil))(t"Note").let(_.text)
+      . assert(_ == t"kept")
+
+      test(m"a corrupt startxref offset falls back to scanning"):
+        val text = String(recoverable.mutable(using Unsafe), "ISO-8859-1")
+        val corrupt = text.replaceAll("startxref\\n\\d+", "startxref\n999999").nn.tt.in[Data]
+
+        PdfFile(corrupt).open():
+          pdf.pages.length
+      . assert(_ == 1)
+
+      test(m"shifted cross-reference offsets are recovered per object"):
+        // Prepend junk so every recorded offset is wrong by a fixed amount, but leave the
+        // xref table itself syntactically valid.
+        val shifted = t"% a comment prepended by some tool\n".in[Data] ++ recoverable
+
+        PdfFile(shifted).open():
+          pdf.pages(0).mediaBox.height
+      . assert(_ == Quantity[Points[1]](300.0))
+
+      test(m"garbage between objects does not prevent recovery"):
+        val text = String(recoverable.mutable(using Unsafe), "ISO-8859-1")
+        val messy = text.replace("endobj\n2 0 obj", "endobj\n%% junk %%\n2 0 obj").nn.tt.in[Data]
+        val truncated =
+          String(messy.mutable(using Unsafe), "ISO-8859-1").nn
+          . pipe { s => s.substring(0, s.indexOf("xref")).nn.tt.in[Data] }
+
+        PdfFile(truncated).open():
+          pdf.pages.length
+      . assert(_ == 1)
+
+      test(m"an incremental update's newer object wins during recovery"):
+        val full = String(recoverable.mutable(using Unsafe), "ISO-8859-1")
+        val base = full.substring(0, full.indexOf("xref")).nn
+
+        // Append a newer copy of object 1 with a changed note, then no valid xref.
+        val updated =
+          (base + "1 0 obj\n<< /Type /Catalog /Pages 2 0 R /Note (updated) >>\nendobj\n").tt
+
+        PdfFile(updated.in[Data]).open():
+          pdf.resolved(pdf.trailer.at(t"Root").or(Cos.Nil))(t"Note").let(_.text)
+      . assert(_ == t"updated")
 
     suite(m"Cross-reference streams and object streams"):
       def xrefStreamDocument(): Data =


### PR DESCRIPTION
Facsimile now recovers from damaged files, the failure mode real-world PDFs reach most often.
When the cross-reference machinery cannot be trusted — a missing or corrupt `startxref`, a
table that fails to parse, or one whose offsets have all been shifted by prepended data — the
whole file is scanned for `N G obj` markers and the cross-reference table is rebuilt, the
latest copy of each object winning. The trailer is recovered from a surviving `trailer`
dictionary, or synthesized around the catalog found among the recovered objects. Individually
shifted offsets are corrected as objects resolve, so a document any conformant reader would
open now opens here too, transparently and with no change to the API.

```scala
PdfFile(damaged).open():
  pdf.pages.head.text   // recovered by scanning, if the xref table is unusable
```

This completes the reading side of the module: the COS kernel, the document layer, the full
filter set with streaming, content-stream parsing, fonts and text extraction, encryption, and
now resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
