### PR TITLE
Survive terminal reflow: inline blocks recover their position on resize

### DIFF
--- a/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Tmux.scala
@@ -51,6 +51,22 @@ object Tmux:
           case char: Char => sh"tmux send-keys -t ${tmux.id} '$char'".exec[Unit]()
           case _          => panic(m"unreachable case")
 
+  // Resize the tmux window, delivering a SIGWINCH (and tmux's own reflow) to the
+  // application in the pane. Sessions in this rig are created detached with explicit
+  // `-x`/`-y`, i.e. manually sized, which is exactly the case `resize-window`
+  // controls. Note `Tmux.width`/`height` record the CREATION size; after a resize,
+  // read the live size from tmux itself if it matters.
+  def resize(width: Int, height: Int)(using tmux: Tmux)(using WorkingDirectory)
+  :   Unit raises TmuxError =
+
+    import logging.silentLogging
+
+    mitigate:
+      case ExecError(_, _, _) => TmuxError(TmuxError.Reason.ExecFailed)
+
+    . protect:
+        sh"tmux resize-window -t ${tmux.id} -x $width -y $height".exec[Unit]()
+
   def screenshot()(using tmux: Tmux)(using WorkingDirectory): Screenshot raises TmuxError =
     import logging.silentLogging
 

--- a/lib/profanity/src/core/profanity.Keyboard.scala
+++ b/lib/profanity/src/core/profanity.Keyboard.scala
@@ -187,19 +187,34 @@ object Keyboard:
                     Keyboard.csiu(sequence.to(List)) #:: process(tail)
 
                   case 'R' #:: tail =>
+                    // A cursor-position report. The plain form (`\e[<row>;<col>R`) is
+                    // the reply to a DSR `\e[6n` and decodes to `WindowSize` here — the
+                    // pump reclassifies it as a `CursorPosition` when an anchor query is
+                    // outstanding (they are indistinguishable at this level). The
+                    // `?`-prefixed DECXCPR form (`\e[?<row>;<col>[;<page>]R`), which a
+                    // terminal may volunteer, is unambiguous and decodes directly.
+                    //
                     // Explicit decoding rather than the `As[Int]` extractor: in a nested
                     // pattern the extractor's evidence is summoned against a skolem-typed
                     // scrutinee, which fails to unify under capture checking.
-                    val fields: List[Text] = sequence.map(_.show).join.cut(';').to(List)
+                    val raw: Text = sequence.map(_.show).join
+                    val query: Boolean = raw.starts(t"?")
+                    val fields: List[Text] = (if query then raw.skip(1) else raw).cut(';').to(List)
 
-                    val size: Optional[TerminalInfo.WindowSize] = fields match
+                    val report: Optional[TerminalInfo] = fields match
                       case List(rows, cols) =>
-                        safely(TerminalInfo.WindowSize(rows.as[Int], cols.as[Int]))
+                        safely:
+                          if query then TerminalInfo.CursorPosition(rows.as[Int], cols.as[Int])
+                          else TerminalInfo.WindowSize(rows.as[Int], cols.as[Int])
+
+                      // DECXCPR at VT level 4 appends the page number.
+                      case List(rows, cols, _) if query =>
+                        safely(TerminalInfo.CursorPosition(rows.as[Int], cols.as[Int]))
 
                       case _ =>
                         Unset
 
-                    size.lay(process(tail))(_ #:: process(tail))
+                    report.lay(process(tail))(_ #:: process(tail))
 
                   case 'O' #:: tail =>
                     TerminalInfo.LoseFocus #:: process(tail)

--- a/lib/profanity/src/core/profanity.Terminal.scala
+++ b/lib/profanity/src/core/profanity.Terminal.scala
@@ -49,6 +49,22 @@ object Terminal:
   // (in `terminalFeatures`) and by the `Winch` (resize) signal handler below.
   def reportSize: Text = t"\e7\e[4095C\e[4095B\e[6n\e8"
 
+  // The anchor query a resize sends BEFORE the size probe: a bare DSR, answered with
+  // the cursor's position — which, after a reflow, is where the terminal moved the
+  // cursor an inline renderer had parked on a known cell. It must precede
+  // `reportSize`, whose corner-jam moves the cursor (its DECSC/DECRC bracket cannot
+  // be trusted to survive a reflow), and both go out in one write. The two replies
+  // are byte-identical in form; the `Report` expectation queue tells them apart by
+  // arrival order.
+  def anchorQuery: Text = t"\e[6n"
+
+  // What the next cursor-position report answers: the resize trap queues an `Anchor`
+  // then a `Size` per WINCH; the pump pops one per report. An empty queue means the
+  // report answers a bare size probe (session start, `terminalSizeFeature`), which
+  // queues no expectations.
+  private[profanity] enum Report:
+    case Anchor, Size
+
   // In the companion (not the class) so the pure pump-daemon body can call it without
   // charging `Terminal.this`.
   private[profanity] def dark(red: Int, green: Int, blue: Int): Boolean =
@@ -62,6 +78,11 @@ object Terminal:
     var mode: Optional[Brightness] = Unset
     var rows: Optional[Int] = Unset
     var columns: Optional[Int] = Unset
+
+    // Outstanding cursor-position-report expectations: appended by the resize trap
+    // (signal thread), consumed by the pump daemon — hence a concurrent queue.
+    val reports: java.util.concurrent.ConcurrentLinkedQueue[Report] =
+      java.util.concurrent.ConcurrentLinkedQueue()
 
 // A `Terminal` is a *capability*: it holds the live raw-mode tty session — the `Monitor` and
 // `Probate` of its input-pump daemon, the event spool, and mutable size/brightness state —
@@ -142,10 +163,17 @@ extends Interactivity[TerminalEvent], caps.ExclusiveCapability:
   locally:
     val out0 = console.stdio.out
     val events0 = events
+    val reports0 = metrics.reports
 
     console.trap:
       case Signal.Winch =>
-        out0.print(Terminal.reportSize)
+        // The anchor query goes FIRST — the cursor still sits wherever the last
+        // present parked it, and the size probe's corner-jam would move it. The
+        // expectations are queued before the write, so a reply can never arrive to
+        // find them missing; appends preserve arrival-order pairing across a burst.
+        reports0.add(Terminal.Report.Anchor)
+        reports0.add(Terminal.Report.Size)
+        out0.print(t"${Terminal.anchorQuery}${Terminal.reportSize}")
         events0.put(Signal.Winch)
         SignalResponse.Accept
 
@@ -191,9 +219,25 @@ extends Interactivity[TerminalEvent], caps.ExclusiveCapability:
           try
             keyboard0.asInstanceOf[Keyboard.Standard].process(chars).each:
               case resize@TerminalInfo.WindowSize(rows2, columns2) =>
-                metrics0.rows = rows2
-                metrics0.columns = columns2
-                events0.put(resize)
+                // An anchor query and a size probe elicit byte-identical replies,
+                // which the decoder always parses as `WindowSize`; the expectation
+                // queue written by the resize trap tells them apart by arrival
+                // order. An anchor reply never touches the metrics — its
+                // coordinates are a cursor cell, not a terminal size.
+                if metrics0.reports.poll() == Terminal.Report.Anchor
+                then events0.put(TerminalInfo.CursorPosition(rows2, columns2))
+                else
+                  metrics0.rows = rows2
+                  metrics0.columns = columns2
+                  events0.put(resize)
+
+              case position@TerminalInfo.CursorPosition(_, _) =>
+                // The unambiguous `?`-form report, should a terminal volunteer it
+                // for a plain query: consume the outstanding anchor expectation so
+                // the size reply that follows stays correctly classified.
+                if metrics0.reports.peek() == Terminal.Report.Anchor
+                then metrics0.reports.poll()
+                events0.put(position)
 
               case bgColor@TerminalInfo.BgColor(red, green, blue) =>
                 metrics0.mode =

--- a/lib/profanity/src/core/profanity.TerminalEvent.scala
+++ b/lib/profanity/src/core/profanity.TerminalEvent.scala
@@ -49,6 +49,14 @@ enum TerminalInfo extends TerminalEvent:
   case GainFocus
   case Paste(text: Text)
 
+  // Where the terminal reported the cursor, in 1-based screen coordinates: the reply
+  // to the anchor query a resize sends before its size probe (classified by arrival
+  // order in the pump), or to a DECXCPR (`?`-prefixed) report, should a terminal
+  // volunteer one. A reflowing terminal keeps the cursor attached to the logical cell
+  // it was on, so after a resize this reveals where that cell landed — the datum an
+  // inline renderer needs to find its block again.
+  case CursorPosition(row: Int, column: Int)
+
   // A synthetic event an application can put onto the terminal's event spool to
   // wake the event loop and request a repaint — e.g. after a background task has
   // changed the layout.

--- a/lib/profanity/src/test/profanity_test.scala
+++ b/lib/profanity/src/test/profanity_test.scala
@@ -430,6 +430,42 @@ object Tests extends Suite(m"Profanity Tests"):
           case Keypress.CharKey('a') => true
           case _                     => false
 
+      // The plain cursor-position report is a size-probe reply; the pump reclassifies
+      // it as an anchor reply when the resize trap queued one.
+      test(m"a plain CPR decodes to a WindowSize"):
+        supervise:
+          Keyboard.Standard().process(LazyList('', '[', '1', '2', ';', '3', '4', 'R')).head
+      . assert:
+          case TerminalInfo.WindowSize(12, 34) => true
+          case _                               => false
+
+      // The `?`-prefixed DECXCPR form is unambiguous: it can only be a cursor position.
+      test(m"a DECXCPR reply decodes to a CursorPosition"):
+        supervise:
+          Keyboard.Standard()
+          . process(LazyList('', '[', '?', '1', '2', ';', '3', '4', 'R'))
+          . head
+      . assert:
+          case TerminalInfo.CursorPosition(12, 34) => true
+          case _                                   => false
+
+      // DECXCPR at VT level 4 appends the page number, which is ignored.
+      test(m"a three-field DECXCPR reply decodes, dropping the page"):
+        supervise:
+          Keyboard.Standard()
+          . process(LazyList('', '[', '?', '1', '2', ';', '3', '4', ';', '1', 'R'))
+          . head
+      . assert:
+          case TerminalInfo.CursorPosition(12, 34) => true
+          case _                                   => false
+
+      test(m"a malformed report is dropped and the stream continues"):
+        supervise:
+          Keyboard.Standard().process(LazyList('', '[', '?', ';', 'R', 'z')).head
+      . assert:
+          case Keypress.CharKey('z') => true
+          case _                     => false
+
       suite(m"Terminal features"):
         test(m"the kitty keyboard feature pushes the protocol on"):
           terminalFeatures.kittyKeyboardFeature.enable

--- a/lib/ultimatum/src/core/ultimatum.Form.scala
+++ b/lib/ultimatum/src/core/ultimatum.Form.scala
@@ -66,6 +66,15 @@ class Form
   private var wakePending: Boolean = false
   private var resizePending: Boolean = false
 
+  // The anchor reply (the parked cursor's position after the resize's reflow),
+  // stashed when it decodes and handed to the inline root at the resize repaint;
+  // dropped on every new WINCH so it can only describe the latest reflow.
+  private var anchor: Optional[(Int, Int)] = Unset
+
+  // Whether the resize repaint has already been deferred once to await a late
+  // anchor reply; a single grace keeps a reply-less terminal from stalling.
+  private var resizeGrace: Boolean = false
+
   // Bind every container to the wake function so a mutation requests a repaint.
   private def bind(node: Pane): Unit = node match
     case Pane.Branch(_, _, panes) =>
@@ -205,24 +214,43 @@ class Form
       scheduleWake(resizeDelay)
 
   private def flushDeferred(): Unit = deferred.let: changed =>
-    deferred = Unset
-    wakePending = false
-    lastRedraw = System.currentTimeMillis
+    // A resize repaint whose anchor reply hasn't decoded yet defers once more, a few
+    // milliseconds: the reply usually sits in the input buffer already, and waiting
+    // for it is the difference between recovering the block's position and falling
+    // back to a full clear. Gated on a real `debounce` (so a driver with a no-op
+    // `scheduleWake` can never stall) and used at most once per resize.
+    if resizePending && anchor.absent && debounce > 0 && !resizeGrace then
+      resizeGrace = true
+      wakePending = true
+      scheduleWake(40)
+    else
+      deferred = Unset
+      wakePending = false
+      lastRedraw = System.currentTimeMillis
 
-    // A resize may have moved the old block (and reflowed the fullscreen contents);
-    // invalidate it (a width-only resize counts too) so the next present redraws in
-    // full. Done here, once, however many resizes were coalesced. This is what
-    // guarantees a SIGWINCH always forces a complete redraw, never a diff against a
-    // stale snapshot.
-    if resizePending then
-      resizePending = false
+      // A resize may have moved the old block (and reflowed the fullscreen contents);
+      // invalidate it (a width-only resize counts too) so the next present redraws in
+      // full. Done here, once, however many resizes were coalesced. This is what
+      // guarantees a SIGWINCH always forces a complete redraw, never a diff against a
+      // stale snapshot. An inline root additionally receives the anchor, from which
+      // it can recover the reflowed block's position instead of wiping the screen.
+      if resizePending then
+        resizePending = false
+        resizeGrace = false
 
-      root match
-        case inline: InlineRoot => inline.invalidate()
-        case screen: ScreenRoot => screen.invalidate()
-        case _                  => ()
+        root match
+          case inline: InlineRoot =>
+            anchor.let((row, column) => inline.anchor(row, column))
+            anchor = Unset
+            inline.invalidate()
 
-    refresh(changed)
+          case screen: ScreenRoot =>
+            screen.invalidate()
+
+          case _ =>
+            ()
+
+      refresh(changed)
 
   def run(events: Iterator[TerminalEvent]): Unit =
     requestRefresh(Set())
@@ -240,10 +268,30 @@ class Form
       case Keypress.Escape | Keypress.Ctrl('C' | 'D') =>
         running = false
 
+      // The WINCH signal arrives synchronously from the trap, well before the anchor
+      // and size replies decode: drop any anchor from a previous resize (it cannot
+      // describe this reflow) and, when a real debounce window exists, mark the
+      // resize NOW — so a keypress landing mid-resize coalesces instead of
+      // presenting against stale geometry. Without a debounce (no wake scheduling),
+      // suppression could stall, so the resize is only marked by `WindowSize`.
+      case Signal.Winch =>
+        anchor = Unset
+        resizeGrace = false
+
+        if debounce > 0 then
+          resizePending = true
+          requestResizeRefresh()
+
+      // The anchor query's reply: where the terminal moved the parked cursor during
+      // the reflow. Stashed for the resize repaint; never widget input, never a
+      // repaint by itself.
+      case TerminalInfo.CursorPosition(row, column) =>
+        anchor = (row, column)
+
       // A resize re-tiles to the new size; reset the rects so the whole layout is
       // repainted against the live dimensions, and mark the resize so the next
-      // repaint clears the moved block (with a cursor query). The repaint is debounced
-      // until the drag pauses; typing is unaffected.
+      // repaint clears the moved block (using the anchor reply, when one arrived).
+      // The repaint is debounced until the drag pauses; typing is unaffected.
       case _: TerminalInfo.WindowSize =>
         rects = IndexedSeq()
         resizePending = true
@@ -264,7 +312,14 @@ class Form
       case event =>
         if focuses.nonEmpty then
           focuses(focusIndex).handle(event)
-          requestRefresh(Set(focusLeaf(focusIndex)))
+          val changed = Set(focusLeaf(focusIndex))
+
+          // During a pending resize the widget's state updates immediately, but its
+          // repaint coalesces into the debounced resize flush: presenting now would
+          // draw against stale geometry and move the parked cursor out from under
+          // the anchor recovery. (A wake is always scheduled while `resizePending`.)
+          if resizePending then deferred = deferred.lay(changed)(_ ++ changed)
+          else requestRefresh(changed)
 
     root match
       case inline: InlineRoot => inline.finish()

--- a/lib/ultimatum/src/core/ultimatum.GridSurface.scala
+++ b/lib/ultimatum/src/core/ultimatum.GridSurface.scala
@@ -62,9 +62,7 @@ extends Canvas:
   // tagged with the absolute top row and column count it was drawn at, so the next
   // present can emit only the cells that differ (an unchanged overprint is a no-op).
   // It models the TERMINAL, not the compose grid: `reshape` and `clear` leave it alone
-  // (they only blank what will be composed next), and only `invalidate` drops it —
-  // forcing the next present to redraw everything, e.g. after a resize has reflowed
-  // whatever was really on screen.
+  // (they only blank what will be composed next).
   protected var snapshot: Optional[Screen[StyleWord]] = Unset
   protected var snapshotTop: Int = 0
   protected var snapshotColumns: Int = 0
@@ -72,9 +70,12 @@ extends Canvas:
 
   // Mark the next present as a full repaint: the screen can no longer be assumed to
   // match the snapshot (typically after a WINCH, when the terminal has reflowed it).
+  // The snapshot itself is RETAINED: it no longer describes the screen for diffing
+  // (the `invalidated` flag alone gates that path), but it remains the exact record
+  // of what the last present drew — which the resize recovery needs, to predict how
+  // the terminal re-wrapped those very rows at the new width.
   def invalidate(): Unit =
     invalidated = true
-    snapshot = Unset
 
   // The caret (hardware cursor) target and visibility, recorded by a root's `cursor`/
   // `showCaret` and applied when the frame is presented; and where the last present
@@ -86,7 +87,7 @@ extends Canvas:
   protected var presentedCaretColumn: Int = -1
   protected var presentedCaretVisible: Boolean = false
 
-  private val metric: Grapheme is Measurable = summon[Grapheme is Measurable]
+  protected val metric: Grapheme is Measurable = summon[Grapheme is Measurable]
 
   def width: Int = gridWidth
   def height: Int = gridHeight
@@ -184,6 +185,31 @@ extends Canvas:
 
     content
 
+  // The number of leading cells of row `r` of `screen2` (clipped to `limit`) up to and
+  // including the last cell that is not a default-styled blank — the row's true
+  // content width. A wide-trailing sentinel (nil grapheme) is content, so a wide
+  // glyph is never half-trimmed off the end.
+  protected def contentWidth(screen2: Screen[StyleWord], r: Int, limit: Int): Int =
+    var end = limit.min(screen2.width)
+
+    while end > 0
+      && screen2.grapheme((end - 1).z, r.z).text == t" "
+      && screen2.style((end - 1).z, r.z).raw == StyleWord.Default.raw
+    do end -= 1
+
+    end
+
+  // The row for a FULL-ROW present, with trailing default-styled blanks trimmed: the
+  // presenter's `el(2)` has already cleared the tail, so the emitted frame renders
+  // identically — but the row becomes a hard logical line of exactly its content
+  // width, which no terminal re-wraps on resize if it fits the new width, and every
+  // terminal re-wraps identically if it doesn't. That determinism is what the resize
+  // recovery's reflow prediction relies on. Diff runs must NOT use this (damage may
+  // be "became blank") and neither may `FlowExtent` compositing (an extent must
+  // overwrite its whole rectangle).
+  protected def trimmedRowContent(r: Int, columns: Int): Teletype =
+    runContent(r, 0, contentWidth(screen, r, columns))
+
   // Record the grid as what is now really on screen, drawn at absolute row `top` and
   // clipped to `columns`. Called by a presenter after every present, on both the full
   // and the diffed path.
@@ -257,17 +283,22 @@ extends Canvas:
     val caretRow2 = (top + caretRow.min(h - 1)).max(1)
     val caretColumn2 = caretColumn.min(columns - 1).max(0) + 1
 
+    // The caret cell matters even when hidden: the cursor physically PARKS there
+    // (below), making it the known anchor a resize recovery locates after a reflow.
     val caretSame = caretVisible == presentedCaretVisible
-      && (!caretVisible || (caretRow2 == presentedCaretRow && caretColumn2 == presentedCaretColumn))
+      && caretRow2 == presentedCaretRow && caretColumn2 == presentedCaretColumn
 
     if runs > 0 || !caretSame then
       val frame = StringBuilder()
       frame.append(csi.dectcem(false).s)
       frame.append(body.toString)
 
-      if caretVisible then
-        frame.append(csi.cup(caretRow2, caretColumn2).s)
-        frame.append(csi.dectcem(true).s)
+      // Park the cursor at the caret cell unconditionally — a hidden cursor still
+      // has a position, and a reflowing terminal drags that position with the cell
+      // it is on, so a resize can ask where the block went. Only visibility is
+      // conditional.
+      frame.append(csi.cup(caretRow2, caretColumn2).s)
+      if caretVisible then frame.append(csi.dectcem(true).s)
 
       recordSnapshot(top, columns)
       presentedCaretRow = caretRow2

--- a/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
+++ b/lib/ultimatum/src/core/ultimatum.InlineRoot.scala
@@ -98,6 +98,17 @@ extends GridSurface(widthFn(), 0):
 
   private var started: Boolean = false
 
+  // Where the terminal reported the parked cursor cell after the last resize's reflow
+  // (1-based screen coordinates), stashed by the driver from the anchor query's reply
+  // and consumed by the next resized present — so a stale anchor can never inform a
+  // later resize it didn't measure.
+  private var anchorCell: Optional[(Int, Int)] = Unset
+
+  // Stash the anchor reply for the next resized present. A reflowing terminal keeps
+  // the cursor attached to the logical cell it was on, and every present parks the
+  // cursor at the caret cell, so this reveals where that known cell landed.
+  def anchor(row: Int, column: Int): Unit = anchorCell = (row, column)
+
   override def width: Int = widthFn()
 
   // Resize the grid to the measured block height, clamped to the live terminal
@@ -108,12 +119,11 @@ extends GridSurface(widthFn(), 0):
   // so a focused editor shows it and a focused menu keeps it hidden.
   def cursor(visible: Boolean): Unit = caretVisible = visible
 
-  // Mark the next present as a resize repaint. Under `TopAfterResize` the first resize
-  // also switches to top-anchoring; the other anchorings keep their fixed reference.
-  // The driver calls it on every `WindowSize` event (a width-only resize counts too).
-  override def invalidate(): Unit =
-    super.invalidate()
-    if anchoring == InlineAnchoring.TopAfterResize then topAnchored = true
+  // `invalidate()` (inherited) marks the next present as a resize repaint; the driver
+  // calls it on every `WindowSize` event (a width-only resize counts too). Under
+  // `TopAfterResize`, the switch to top-anchoring no longer happens there: the resized
+  // present first tries to recover the block's position from the anchor reply, and
+  // flips (latched) only when that recovery is unavailable or fails.
 
   // Forget everything recorded about what is on screen, so the NEXT frame renders as a
   // fresh first frame at the current cursor rather than relative to (or docked against)
@@ -128,6 +138,7 @@ extends GridSurface(widthFn(), 0):
     flowCursorRow = 0
     invalidated = false
     snapshot = Unset
+    anchorCell = Unset
     presentedCaretRow = -1
     presentedCaretColumn = -1
     presentedCaretVisible = false
@@ -171,7 +182,7 @@ extends GridSurface(widthFn(), 0):
     var r = 0
     while r < h do
       emit(csi.el(2))
-      val rendered = rowContent(r, columns).render(termcap)
+      val rendered = trimmedRowContent(r, columns).render(termcap)
       emit(rendered)
       if rendered.contains(t"\e") then emit(csi.sgr(0))
       emit(t"\r")
@@ -241,6 +252,29 @@ extends GridSurface(widthFn(), 0):
 
     emit(csi.dectcem(false))
 
+    // The anchor is consumed by whichever present follows the resize that measured
+    // it — used or not — so it can never inform a later resize.
+    val anchor0 = anchorCell
+    anchorCell = Unset
+
+    // Today's resize behaviour, for when no anchor could reconcile the reflow: under
+    // `TopAfterResize` the block gives up its dock — flip to top-anchoring (latched;
+    // a terminal that failed to answer once won't start) and clear the whole screen;
+    // otherwise clear a bottom band sized by the wrap heuristic.
+    def unrecoveredResize(): Int =
+      if anchoring == InlineAnchoring.TopAfterResize then
+        topAnchored = true
+        emit(csi.cup(1, 1))
+        emit(csi.ed(0))
+        1
+      else
+        val narrowed = presentedColumns > columns && columns > 0
+        val wrap = if narrowed then (presentedColumns + columns - 1)/columns else 1
+        val cleared = (presentedRows*wrap).max(h)
+        emit(csi.cup((rows - cleared + 1).max(1), 1))
+        emit(csi.ed(0))
+        (rows - h + 1).max(1)
+
     // The block's absolute top row, and the resize/grow clearing for each anchoring.
     val top =
       if topAnchored then
@@ -253,14 +287,19 @@ extends GridSurface(widthFn(), 0):
         1
       else
         if resized then
-          // Clear the block's rows at the bottom dock, sized for the terminal
-          // re-wrapping our previous, wider lines.
-          val narrowed = presentedColumns > columns && columns > 0
-          val wrap = if narrowed then (presentedColumns + columns - 1)/columns else 1
-          val cleared = (presentedRows*wrap).max(h)
-          emit(csi.cup((rows - cleared + 1).max(1), 1))
-          emit(csi.ed(0))
-          (rows - h + 1).max(1)
+          // Recover the old block's position from the anchor: the terminal kept the
+          // parked cursor attached to its cell through the reflow, so the residue's
+          // top row is computable from the reply and the retained snapshot. Clear
+          // exactly from there to the screen foot and re-dock — the block survives
+          // the resize without wiping the scrollback history above it. When the
+          // anchor is missing or cannot be reconciled, fall back to today's clears.
+          val recovered: Optional[Int] = anchor0.let: (anchorRow, anchorColumn) =>
+            residueTop(anchorRow, anchorColumn, columns, rows)
+
+          recovered.lay(unrecoveredResize()): clearTop =>
+            emit(csi.cup(clearTop, 1))
+            emit(csi.ed(0))
+            (rows - h + 1).max(1)
         else if h > presentedRows then
           // Grow beyond the previous height. `ScrollIntoScrollback` scrolls the screen
           // up so the extra rows are free at the bottom, pushing the content above into
@@ -300,7 +339,10 @@ extends GridSurface(widthFn(), 0):
 
     while r < h do
       emit(csi.el(2))
-      val rendered = rowContent(r, columns).render(termcap)
+      // Trailing default-styled blanks are trimmed (`el(2)` has cleared them): each
+      // row becomes a hard logical line of its content width, so a resize's reflow
+      // of these rows is predictable — the basis of the anchor recovery above.
+      val rendered = trimmedRowContent(r, columns).render(termcap)
       emit(rendered)
       // Reset only after a row that actually emitted SGR, so a plain row is byte-for-
       // byte as before and no colour bleeds into the next `el(2)`-cleared row.
@@ -332,11 +374,12 @@ extends GridSurface(widthFn(), 0):
     presentedRows = h
     presentedColumns = columns
 
-    // The caret is the hardware cursor, placed at an absolute cell and shown only when
-    // visible; otherwise the cursor is left hidden.
-    if caretVisible then
-      emit(csi.cup((top + caretRow.min(h - 1)).max(1), caretColumn.min(columns - 1).max(0) + 1))
-      emit(csi.dectcem(true))
+    // The caret is the hardware cursor, parked at its absolute cell UNCONDITIONALLY —
+    // a hidden cursor still has a position, and a reflowing terminal drags that
+    // position with the cell it is on, so the next resize can ask where the block
+    // went. Only visibility is conditional.
+    emit(csi.cup((top + caretRow.min(h - 1)).max(1), caretColumn.min(columns - 1).max(0) + 1))
+    if caretVisible then emit(csi.dectcem(true))
 
     // What was just drawn IS the screen now: record it (and the caret) so the next
     // geometry-stable present can diff against it.
@@ -344,6 +387,99 @@ extends GridSurface(widthFn(), 0):
     recordCaret(top, columns, h)
 
     Out.print(frame.toString.tt)
+
+  // Predict the topmost screen row the previous block's residue can occupy after a
+  // resize, from the observed anchor cell and the retained snapshot. Two models cover
+  // the real terminal population: a REFLOWING terminal (VTE, iTerm2, kitty, alacritty,
+  // tmux, Terminal.app, foot, wezterm) re-wraps each of the block's hard logical lines
+  // at the new width and keeps the cursor attached to its logical cell; a TRUNCATING
+  // terminal (xterm, st, urxvt, screen, mosh) clips lines in place and leaves the
+  // cursor's row alone. Each model predicts where the parked cursor should have landed
+  // — row offset AND column — so the observed column discriminates them: trust the
+  // model whose column matches; when both match take the safer (upper) minimum; when
+  // neither matches the terminal did something unmodellable, so return `Unset` and let
+  // the caller fall back to today's clears. The result is clamped to the screen.
+  private def residueTop(anchorRow: Int, anchorColumn: Int, newColumns: Int, rows: Int)
+  :   Optional[Int] =
+
+    snapshot.let: snap =>
+      val oldH = snap.height
+      val parkLocal = presentedCaretRow - snapshotTop     // the park cell, block-local
+      val parkColumn = presentedCaretColumn - 1           // 0-based
+
+      if parkLocal < 0 || parkLocal >= oldH || anchorRow < 1 || anchorRow > rows
+        || newColumns <= 0
+      then Unset
+      else
+        // Simulate the terminal re-wrapping snapshot row `r`'s content (trimmed, so
+        // exactly what was really printed) at width `w`: the number of physical
+        // sub-rows it occupies, and the sub-row and column on which cell `target`
+        // lands. A wide glyph that would straddle the margin is pushed whole to the
+        // next sub-row, as terminals do. A target beyond the content (the park sat in
+        // the `el(2)`-cleared tail) stays on the last sub-row at its clamped column —
+        // erased cells are not content and never wrap.
+        def wrapProfile(r: Int, w: Int, target: Int): (Int, Int, Int) =
+          val width0 = contentWidth(snap, r, snapshotColumns)
+          var c = 0
+          var col = 0
+          var sub = 0
+          var targetSub = -1
+          var targetColumn = 0
+
+          while c < width0 do
+            val grapheme = snap.grapheme(c.z, r.z)
+
+            if grapheme.text.nil then
+              // A wide-trailing sentinel: its lead already advanced past this cell.
+              if c == target then
+                targetSub = sub
+                targetColumn = (col - 1).max(0)
+            else
+              val cellWidth = metric.width(grapheme)
+              if cellWidth > 0 && col + cellWidth > w then
+                sub += 1
+                col = 0
+              if c == target then
+                targetSub = sub
+                targetColumn = col
+              col += cellWidth
+
+            c += 1
+
+          if targetSub < 0 then
+            targetSub = sub
+            targetColumn = target.min(w - 1).max(0)
+
+          (sub + 1, targetSub, targetColumn)
+
+        // Physical rows of block content above the park cell, per model, and the
+        // column each model predicts for the anchor reply.
+        var reflowAbove = 0
+        var r = 0
+
+        while r < parkLocal do
+          reflowAbove += wrapProfile(r, newColumns, -1)(0)
+          r += 1
+
+        val (_, parkSub, parkNewColumn) = wrapProfile(parkLocal, newColumns, parkColumn)
+        reflowAbove += parkSub
+
+        val truncateAbove = parkLocal
+        val reflowColumn = parkNewColumn + 1
+        val truncateColumn = parkColumn.min(newColumns - 1) + 1
+
+        val matchReflow = anchorColumn == reflowColumn
+        val matchTruncate = anchorColumn == truncateColumn
+
+        val clearTop: Optional[Int] =
+          if matchReflow && !matchTruncate then anchorRow - reflowAbove
+          else if matchTruncate && !matchReflow then anchorRow - truncateAbove
+          else if matchReflow && matchTruncate
+          then (anchorRow - reflowAbove).min(anchorRow - truncateAbove)
+          else Unset
+
+        clearTop.let: top =>
+          if top > rows then Unset else top.max(1)
 
   // On exit, drop the cursor onto a fresh line below the block and re-show it, so
   // subsequent output continues after the rendered block (like a submitted prompt).

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -565,6 +565,207 @@ object Tests extends Suite(m"Ultimatum Tests"):
 
     // The buffered fullscreen root: panels composite into its grid, and `flush`
     // presents each frame as one write, diffed against the previous present.
+    // A resize present recovers the block's position from the anchor reply (where the
+    // terminal moved the parked cursor during its reflow), clearing exactly from the
+    // residue's top instead of wiping the screen; an anchor that cannot be reconciled
+    // falls back to the historic behaviour.
+    suite(m"InlineRoot reflow recovery"):
+      def capturing(): (ji.ByteArrayOutputStream, Stdio) =
+        val bytes = ji.ByteArrayOutputStream()
+        (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basicTermcap))
+
+      test(m"a shrink with an anchor clears from the recovered row and re-docks"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 6
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(6, 2); root.move(Prim, Prim); root.put(t"abcdef\nhi"); root.flush()
+        bytes.reset()
+        w = 4
+        root.invalidate()
+        root.anchor(2, 1)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"abcd\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[2;1H\e[0J\e[3;1H\e[2Kabcd\r\n\e[2Khi\r\e[3;1H\e[?25h")
+
+      // The park sat past the wrap point of its own row ("abcdef" at width 4 wraps
+      // after "abcd"), so the two models predict different anchor columns: a reply in
+      // column 2 can only be the reflow model, whose sub-row offset is honoured.
+      test(m"the anchor column selects the reflow model"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 6
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(6, 2); root.move(Prim, Prim); root.put(t"abcdef\nhi")
+        root.showCaret(5.z, Prim)
+        root.flush()
+        bytes.reset()
+        w = 4
+        root.invalidate()
+        root.anchor(3, 2)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"abcd\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[2;1H\e[0J\e[3;1H\e[2Kabcd\r\n\e[2Khi\r\e[3;4H\e[?25h")
+
+      // A reply in column 4 (the old column, clamped) can only be the truncate model:
+      // the cursor's row did not move, so the residue still starts at the old top.
+      test(m"the anchor column selects the truncate model"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 6
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(6, 2); root.move(Prim, Prim); root.put(t"abcdef\nhi")
+        root.showCaret(5.z, Prim)
+        root.flush()
+        bytes.reset()
+        w = 4
+        root.invalidate()
+        root.anchor(3, 4)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"abcd\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[3;1H\e[0J\e[3;1H\e[2Kabcd\r\n\e[2Khi\r\e[3;4H\e[?25h")
+
+      // A reply matching neither model's column is unmodellable: fall back to the
+      // historic flip-and-clear.
+      test(m"an unmatchable anchor column falls back to the full clear"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 6
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(6, 2); root.move(Prim, Prim); root.put(t"abcdef\nhi")
+        root.showCaret(5.z, Prim)
+        root.flush()
+        bytes.reset()
+        w = 4
+        root.invalidate()
+        root.anchor(3, 3)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"abcd\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;1H\e[0J\e[1;1H\e[2Kabcd\r\n\e[2Khi\r\e[1;4H\e[?25h")
+
+      test(m"a width growth recovers with both models in agreement"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 4
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"ab\nhi"); root.flush()
+        bytes.reset()
+        w = 6
+        root.invalidate()
+        root.anchor(2, 1)
+        root.reframe(6, 2); root.move(Prim, Prim); root.put(t"ab\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[2;1H\e[0J\e[3;1H\e[2Kab\r\n\e[2Khi\r\e[3;1H\e[?25h")
+
+      // The anchor is consumed by the present that follows its resize: a later resize
+      // without a fresh reply cannot reuse it, and falls back.
+      test(m"a second resize without a fresh anchor falls back"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 6
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(6, 2); root.move(Prim, Prim); root.put(t"abcdef\nhi"); root.flush()
+        w = 4
+        root.invalidate()
+        root.anchor(2, 1)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"abcd\nhi"); root.flush()
+        bytes.reset()
+        w = 3
+        root.invalidate()
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[1;1H\e[0J\e[1;1H\e[2Kab\r\n\e[2Khi\r\e[1;1H\e[?25h")
+
+      // A wide glyph that would straddle the new margin is pushed whole to the next
+      // sub-row, so "ab中" at width 3 occupies two physical rows in the reflow model.
+      test(m"a wide glyph is counted whole in the reflow prediction"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 4
+        val root = new InlineRoot(() => w, () => 4)
+        root.reframe(4, 2); root.move(Prim, Prim); root.put(t"ab中\nhi")
+        root.showCaret(Prim, Sec)
+        root.flush()
+        bytes.reset()
+        w = 3
+        root.invalidate()
+        root.anchor(4, 1)
+        root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\nhi"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[2;1H\e[0J\e[3;1H\e[2Kab\r\n\e[2Khi\r\e[4;1H\e[?25h")
+
+      // Trailing default-styled blanks are trimmed from a full-row render (`el(2)`
+      // has already cleared them), but a wide glyph's trailing sentinel is content:
+      // the row trims to include the whole glyph.
+      test(m"a row ending in a wide glyph trims to include the whole glyph"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = InlineRoot(4, 4)
+        root.reframe(4, 1); root.move(Prim, Prim); root.put(t"a中"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_ == t"\e[?25l\e[9999B\r\n\e[4;1H\e[2Ka中\r\e[4;1H\e[?25h")
+
+      // A styled blank is not a default cell: `el(2)` cannot reproduce it, so it is
+      // never trimmed and its SGR is emitted.
+      test(m"a styled trailing blank is not trimmed"):
+        val bytes = ji.ByteArrayOutputStream()
+        given Stdio =
+          Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.xtermTrueColorTermcap)
+        val root = InlineRoot(4, 4)
+        root.reframe(4, 1); root.move(Prim, Prim); root.put(e"a$Bold( )"); root.flush()
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_.contains(t"\e[1m"))
+
+    // The driver-side plumbing: the anchor reply flows from the event stream to the
+    // inline root's resize recovery, and typing mid-resize never presents against
+    // stale geometry.
+    suite(m"Form resize plumbing"):
+      def capturing(): (ji.ByteArrayOutputStream, Stdio) =
+        val bytes = ji.ByteArrayOutputStream()
+        (bytes, Stdio(ji.PrintStream(bytes, true), null, null, termcapDefinitions.basicTermcap))
+
+      test(m"a resize with an anchor reply recovers the block position"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        var w = 6
+        val root = new InlineRoot(() => w, () => 4)
+
+        val events = new Iterator[TerminalEvent]:
+          private var remaining: List[() => TerminalEvent] = List(
+            () => Signal.Winch,
+            () => TerminalInfo.CursorPosition(2, 1),
+            () => { w = 4; TerminalInfo.WindowSize(4, 4) },
+            () => Keypress.Escape)
+
+          def hasNext = remaining.nonEmpty
+
+          def next() =
+            val head = remaining.head
+            remaining = remaining.tail
+            head()
+
+        Form(root, Mode.Inline, rank(panel()(Out.print(t"abcdef")))).run(events)
+        String(bytes.toByteArray.nn, "UTF-8").tt
+      . assert(_.contains(t"\e[2;1H\e[0J"))
+
+      // With a real debounce window, a keypress between the WINCH and the resize
+      // repaint updates the widget but presents nothing: the repaint coalesces into
+      // the (never-woken, here) deferred resize flush, so the initial frame's row
+      // draws are the only ones emitted.
+      test(m"typing during a pending resize does not present"):
+        val (bytes, stdio) = capturing()
+        given Stdio = stdio
+        val root = new InlineRoot(() => 6, () => 4)
+
+        val events = List[TerminalEvent](
+          Signal.Winch,
+          Keypress.CharKey('x'),
+          Keypress.Escape)
+
+        Form(root, Mode.Inline, rank(editor()), debounce = 50).run(events.iterator)
+        String(bytes.toByteArray.nn, "UTF-8").tt.cut(t"\e[2K").length - 1
+      . assert(_ == 1)
+
     suite(m"ScreenRoot present"):
       def capturing(): (ji.ByteArrayOutputStream, Stdio) =
         val bytes = ji.ByteArrayOutputStream()

--- a/lib/ultimatum/src/test/ultimatum_test.scala
+++ b/lib/ultimatum/src/test/ultimatum_test.scala
@@ -333,7 +333,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.put(t"hi")
         root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[9999B\r\n\n\e[3;1H\e[2Khi \r\n\e[2K   \r\e[3;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[9999B\r\n\n\e[3;1H\e[2Khi\r\n\e[2K\r\e[3;1H\e[?25h")
 
       test(m"a growing block scrolls one more row into the dock"):
         val (bytes, stdio) = capturing()
@@ -343,7 +343,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         bytes.reset()
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[9999B\r\n\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[9999B\r\n\e[3;1H\e[2Kab\r\n\e[2Kcd\r\e[3;1H\e[?25h")
 
       // The block bottom-docks: shrinking moves it down (row 4) and clears the row it
       // vacated above (row 3).
@@ -355,7 +355,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         bytes.reset()
         root.reframe(3, 1); root.move(Prim, Prim); root.put(t"ef"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[4;1H\e[2Kef \r\e[3;1H\e[2K\e[4;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[4;1H\e[2Kef\r\e[3;1H\e[2K\e[4;1H\e[?25h")
 
       test(m"the caret is placed at its absolute screen cell"):
         val (bytes, stdio) = capturing()
@@ -367,7 +367,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.showCaret(Sec, Sec)
         root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[9999B\r\n\n\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[4;2H\e[?25h")
+      . assert(_ == t"\e[?25l\e[9999B\r\n\n\e[3;1H\e[2Kab\r\n\e[2Kcd\r\e[4;2H\e[?25h")
 
       test(m"finish drops the cursor onto a fresh line below the block"):
         val (bytes, stdio) = capturing()
@@ -391,7 +391,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.invalidate()
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[1;1H\e[0J\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[1;1H\e[0J\e[1;1H\e[2Kab\r\n\e[2Kcd\r\e[1;1H\e[?25h")
 
       // With `bottomDocked`, a resize never switches to top-anchoring: the block stays
       // docked and its rows are cleared at the bottom (row 3), not the top-left corner.
@@ -405,7 +405,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         root.invalidate()
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[3;1H\e[0J\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[3;1H\e[0J\e[3;1H\e[2Kab\r\n\e[2Kcd\r\e[3;1H\e[?25h")
 
       // With `topAnchored`, the very first frame is pinned to rows 1..h (no bottom dock,
       // no scroll into scrollback).
@@ -416,7 +416,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         val root = InlineRoot(3, 4)
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[1;1H\e[2Kab\r\n\e[2Kcd\r\e[1;1H\e[?25h")
 
       // With `fullscreen`, the first present enters the alternate screen buffer.
       test(m"fullscreen enters the alternate screen on the first present"):
@@ -426,7 +426,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         val root = InlineRoot(3, 4)
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?1049h\e[?25l\e[1;1H\e[2Kab \r\n\e[2Kcd \r\e[1;1H\e[?25h")
+      . assert(_ == t"\e[?1049h\e[?25l\e[1;1H\e[2Kab\r\n\e[2Kcd\r\e[1;1H\e[?25h")
 
       // ...and leaves it again on finish, restoring the pre-session screen.
       test(m"fullscreen leaves the alternate screen on finish"):
@@ -451,7 +451,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         bytes.reset()
         root.reframe(3, 1); root.move(Prim, Prim); root.put(t"ef"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[3;1H\e[2Kef \r\n\e[2K\e[3;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[3;1H\e[2Kef\r\n\e[2K\e[3;1H\e[?25h")
 
       // With `clampToScreen`, a growing block grows upward in place; it never scrolls the
       // screen into scrollback (no `\e[9999B`).
@@ -464,7 +464,7 @@ object Tests extends Suite(m"Ultimatum Tests"):
         bytes.reset()
         root.reframe(3, 2); root.move(Prim, Prim); root.put(t"ab\ncd"); root.flush()
         String(bytes.toByteArray.nn, "UTF-8").tt
-      . assert(_ == t"\e[?25l\e[3;1H\e[2Kab \r\n\e[2Kcd \r\e[3;1H\e[?25h")
+      . assert(_ == t"\e[?25l\e[3;1H\e[2Kab\r\n\e[2Kcd\r\e[3;1H\e[?25h")
 
     // A geometry-stable re-present diffs against the snapshot of what the last present
     // drew, overprinting only the damaged cells; an identical frame emits nothing.


### PR DESCRIPTION
Inline TUIs now survive a terminal resize without wiping the screen: every present parks the hardware cursor on a known cell, a resize sends an anchor query whose reply reveals where the terminal's reflow moved that cell, and the block clears exactly its own residue and re-docks — leaving the shell history above it intact. Terminals whose behaviour cannot be reconciled fall back to exactly the previous full-clear behaviour, so this is a strict improvement.

## Reflow recovery for inline blocks

When a terminal narrows, reflowing emulators (VTE, iTerm2, kitty, alacritty, tmux, Terminal.app and others) re-wrap long lines — the shell history above an inline block *and* the block's own rows — so the block's on-screen position shifts and stale wrapped fragments remain. Previously the only safe response was to give up: the default `TopAfterResize` anchoring flipped to top-anchored and cleared the whole screen.

Now:
- Every inline present parks the cursor at the caret cell (visible or not), making it a trackable anchor.
- On SIGWINCH, the trap sends a cursor-position query before the size probe, in one write; the two byte-identical replies are told apart by arrival order.
- The resized present reconciles the reply against a snapshot of exactly what it last drew, under two models — *reflow* (cursor tracked to its logical cell; the block's hard lines re-wrap predictably) and *truncate* (xterm-style; nothing moves) — discriminated by the anchor column each model predicts. It then clears from the recovered residue top to the screen foot and re-docks, still bottom-anchored.
- Anything unreconcilable — no reply, an implausible position, an unmatched column — falls back byte-for-byte to the previous behaviour, and `TopAfterResize` then flips as before.

Full-row renders now trim trailing default-styled blanks (`el(2)` already clears them), so each row is a hard logical line of known width — the property that makes the reflow prediction identical across emulators, and incidentally shrinks every frame.

`TerminalInfo.CursorPosition` joins Profanity's event vocabulary (with `?`-prefixed DECXCPR replies parsed defensively), typing during a pending resize coalesces into the resize repaint instead of drawing against stale geometry, and `Tmux.resize` joins the test rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
