### PR TITLE
Open directories as scoped filesystem roots with fresh-plane confinement

### DIFF
--- a/lib/galilei/src/core/galilei.AccessRegister.scala
+++ b/lib/galilei/src/core/galilei.AccessRegister.scala
@@ -30,32 +30,49 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package galilei
 
-export
-  galilei
-  . { accessed, append, BlockDevice, C, CharDevice, children, CopyAttributes, copyInto, copyTo,
-      Creatable, create, created, CreateNonexistentParents, D, delete,
-      DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, DirectoryHandle,
-      DirectoryOpenable, Dos, Drive, Entry,
-      entry, executable, exists, Explorable, Fifo, file, File, FileOpenable,
-      FilesystemAttribute, FilesystemBackend,
-      Handle, hardLinks, hardLinkTo, hidden, IoError, IoEvent, javaFile, javaPath, Linux, Local,
-      MacOs, modified, MoveAtomically, moveInto, moveTo, OpenFlag,
-      OverwritePreexisting, p, Platform, Posix, readable, size, Socket, Stat,
-      Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch, TraversalOrder, UnixEntry,
-      Volume, volume, Windows, WindowsEntry, wipe, writable, write }
+import anticipation.*
+import aperture.*
+import gossamer.*
 
-package interfaces.paths:
-  export
-    anticipation.interfaces.paths
-    . { pathOnLinux, pathOnLocal, pathOnMacOs, pathOnPosix, pathOnWindows }
+// The process-global register of open directory scopes, acquired when a directory is opened
+// and released when its scope ends. Conflicts are detected on the real (symlink-resolved)
+// path, over subtree overlap: any number of overlapping `Read` and `Write` opens may coexist,
+// but an `Exclusive` open conflicts with any other open of an overlapping subtree. No type
+// system can see that two independently-opened handles denote overlapping trees, so this is
+// checked at runtime, at the `open` call — the one place a conflict can be acted upon.
+//
+// This arbitrates only between scopes within one JVM: it says nothing about other processes
+// (OS advisory locks may complement it later), and file opens do not yet participate.
+object AccessRegister:
+  private case class Registration(real: Text, atoms: Set[Mode])
 
-package filesystemOptions:
-  export
-    galilei.filesystemOptions
-    . { copyAttributes, createNonexistentParents, deleteRecursively,
-        dereferenceSymlinks, moveAtomically, overwritePreexisting }
+  private var registrations: List[Registration] = Nil
 
-package filesystemTraversal:
-  export galilei.filesystemTraversal.{postOrderTraversal, preOrderTraversal}
+  // The filesystem root would defeat the `+ "/"` prefix test, so it is normalized to empty.
+  private def normalize(real: Text): Text = if real == t"/" then t"" else real
+
+  private def overlapping(left: Text, right: Text): Boolean =
+    left == right || left.starts(t"$right/") || right.starts(t"$left/")
+
+  def acquire(real: Text, atoms: Set[Mode]): Boolean = synchronized:
+    val real2 = normalize(real)
+
+    val conflict = registrations.exists: registration =>
+      overlapping(real2, registration.real)
+        && (atoms.contains(Exclusive) || registration.atoms.contains(Exclusive))
+
+    if conflict then false else
+      registrations ::= Registration(real2, atoms)
+      true
+
+  def release(real: Text, atoms: Set[Mode]): Unit = synchronized:
+    val real2 = normalize(real)
+
+    def remove(list: List[Registration]): List[Registration] = list match
+      case Nil                                                => Nil
+      case head :: tail if head == Registration(real2, atoms) => tail
+      case head :: tail                                       => head :: remove(tail)
+
+    registrations = remove(registrations)

--- a/lib/galilei/src/core/galilei.DirectoryHandle.scala
+++ b/lib/galilei/src/core/galilei.DirectoryHandle.scala
@@ -30,32 +30,81 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package galilei
 
-export
-  galilei
-  . { accessed, append, BlockDevice, C, CharDevice, children, CopyAttributes, copyInto, copyTo,
-      Creatable, create, created, CreateNonexistentParents, D, delete,
-      DeleteRecursively, DereferenceSymlinks, descendants, dir, Directory, DirectoryHandle,
-      DirectoryOpenable, Dos, Drive, Entry,
-      entry, executable, exists, Explorable, Fifo, file, File, FileOpenable,
-      FilesystemAttribute, FilesystemBackend,
-      Handle, hardLinks, hardLinkTo, hidden, IoError, IoEvent, javaFile, javaPath, Linux, Local,
-      MacOs, modified, MoveAtomically, moveInto, moveTo, OpenFlag,
-      OverwritePreexisting, p, Platform, Posix, readable, size, Socket, Stat,
-      Substantiable, Subtree, Symlink, symlinkInto, symlinkTo, touch, TraversalOrder, UnixEntry,
-      Volume, volume, Windows, WindowsEntry, wipe, writable, write }
+import anticipation.*
+import aperture.*
+import contingency.*
+import gossamer.*
+import spectacular.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import vacuous.*
 
-package interfaces.paths:
-  export
-    anticipation.interfaces.paths
-    . { pathOnLinux, pathOnLocal, pathOnMacOs, pathOnPosix, pathOnWindows }
+import IoError.{Operation, Reason}
 
-package filesystemOptions:
-  export
-    galilei.filesystemOptions
-    . { copyAttributes, createNonexistentParents, deleteRecursively,
-        dereferenceSymlinks, moveAtomically, overwritePreexisting }
+// The scoped capability provided by opening a directory: `path.open[Directory](Read & Write)`.
+// Each handle's `Plane` is a fresh abstract type, so paths formed within one handle's scope
+// (`dir / "src" / "main.scala"`) are typed on that handle's plane alone: using them under
+// another handle, or letting them escape, is a compile error; and the plane's naming rules
+// (see `Subtree`) make `..` inexpressible, so every path denotes an entry within the opened
+// directory's subtree, by construction.
+trait DirectoryHandle extends caps.ExclusiveCapability:
+  type Plane <: Subtree
+  type Under <: Platform
 
-package filesystemTraversal:
-  export galilei.filesystemTraversal.{postOrderTraversal, preOrderTraversal}
+  val stem: Path on Under
+
+  // The atomic modes this handle was opened with, for runtime attenuation and access-register
+  // checks, which cannot see grants after erasure.
+  val atoms: Set[Mode]
+
+  def base: Path on Plane = Path[Plane, EmptyTuple.type, EmptyTuple](t"", Nil)
+
+  // A method rather than an extension: generic `/` extensions (e.g. symbolism's) are lexically
+  // visible at use sites and would be tried first, failing without falling through.
+  transparent inline infix def / (child: Any) = base / child
+
+  // Public: called from transparent-inline subtree operations, where a `private` member's
+  // inline-accessor bridge would fail capture checking.
+  def resolve(path: Path on Plane): Path on Under =
+    path.descent.reverse.foldLeft(stem): (parent, name) =>
+      parent.child(name)(using Unsafe)
+
+// A named class rather than an anonymous given instance, for the reasons documented on
+// `FileOpenable`. Opening verifies that the entry exists and is a directory, so a handle
+// always denotes a real directory at the moment it is granted.
+class DirectoryOpenable[filesystem <: Platform: Filesystem, path <: Path on filesystem]
+  ( using backend: FilesystemBackend on filesystem, ioError: Tactic[IoError] )
+extends Openable:
+
+  type Self = path
+  type Form = Directory
+  type Operand = Nothing
+  type Result = DirectoryHandle { type Under = filesystem }
+
+  def open[grants <: Grant, result]
+    ( value: path, mode: Mode granting grants, flags: List[Nothing] )
+    ( block: (((DirectoryHandle { type Under = filesystem }) & Granting[grants])^) ?=> result )
+  :   result =
+
+    if backend.stat(value, true).entry != Directory
+    then abort(IoError(value, Operation.Open, Reason.IsNotDirectory))
+
+    // The register works on real paths, so two routes to one directory (via symlinks, or via
+    // `.` and repeated separators) register as the same subtree.
+    val real: Text = value.javaPath.toRealPath().nn.toString.tt
+
+    if !AccessRegister.acquire(real, mode.atoms)
+    then abort(IoError(value, Operation.Open, Reason.Busy))
+
+    try
+      val handle =
+        new DirectoryHandle with Granting[grants]:
+          type Under = filesystem
+          val stem: Path on filesystem = value
+          val atoms: Set[Mode] = mode.atoms
+
+      block(using handle)
+    finally AccessRegister.release(real, mode.atoms)

--- a/lib/galilei/src/core/galilei.Platform.scala
+++ b/lib/galilei/src/core/galilei.Platform.scala
@@ -81,6 +81,15 @@ object Platform:
   =>  ( FileOpenable[filesystem, path]^ ) =
     FileOpenable[filesystem, path]
 
+  // The `Openable` instance for the `Directory` form: anchored here for the same reason as
+  // the `File` instance above. With both in scope, a bare `path.open(...)` is ambiguous, and
+  // the form must be stated: `path.open[File](...)` or `path.open[Directory](...)`.
+  given directoryOpenable: [filesystem <: Platform: Filesystem, path <: Path on filesystem]
+  =>  ( FilesystemBackend on filesystem,
+        Tactic[IoError] )
+  =>  ( DirectoryOpenable[filesystem, path]^ ) =
+    DirectoryOpenable[filesystem, path]
+
   // Opening `Eof(path)` opens the file's content for appending: the instance prepends the
   // `Append` flag and delegates to the file's own instance. Named capturing evidence and an
   // honest result: the instance retains `openable`, which a pure context bound cannot accept.

--- a/lib/galilei/src/core/galilei.Subtree.scala
+++ b/lib/galilei/src/core/galilei.Subtree.scala
@@ -1,0 +1,137 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package galilei
+
+import anticipation.*
+import aperture.*
+import contingency.*
+import nomenclature.*
+import prepositional.*
+import rudiments.*
+import serpentine.*
+import turbulence.*
+import vacuous.*
+import zephyrine.*
+
+// The common upper bound of every `DirectoryHandle`'s fresh plane. Serpentine givens defined
+// generically over `plane <: Subtree` supply the naming rules for paths on any handle's plane,
+// so `dir / "name"` validates its names at compile time: in particular, `.` and `..` are
+// inadmissible, making escape from an opened directory inexpressible rather than checked.
+//
+// Deliberately, a subtree plane has no `Filesystem` instance: galilei's absolute-path
+// operations (bounded by `[plane: Filesystem]`) therefore cannot apply to subtree paths, which
+// would resolve them against the working directory instead of the handle.
+trait Subtree
+
+object Subtree:
+  type Rules = MustNotContain["/"] & MustNotEqual["."] & MustNotEqual[".."] & MustNotEqual[""]
+
+  inline given nominative: [plane <: Subtree] => plane is Nominative under Rules = !!
+
+  // Operations on subtree paths are `transparent inline`, taking their handle as a direct
+  // `using` parameter selected by plane refinement: routing them through typeclass instances
+  // capturing the handle fails under capture checking (given resolution mints fresh roots the
+  // scoped capability cannot flow into). The names are chosen not to collide with lexically
+  // imported generic extensions (turbulence's `read`, vacuous's `present`, galilei's `exists`
+  // and `delete`), which would otherwise be tried first and fail without falling through.
+  extension [plane <: Subtree](path: Path on plane)
+    transparent inline def contents[result]
+      ( using handle: ((DirectoryHandle { type Plane = plane }) & Granting[Grant.Read])^ )
+      ( using filesystem: handle.Under is Filesystem )
+      ( using readable: (Data is Readable to result)^, tactic: Tactic[IoError] )
+    :   result =
+      readResolved[handle.Under, result](handle.resolve(path))
+
+    transparent inline def overwrite[content](content: content)
+      ( using handle: ((DirectoryHandle { type Plane = plane }) & Granting[Grant.Write])^ )
+      ( using filesystem: handle.Under is Filesystem )
+      ( using streamable: (content is Streamable by Data over Credit)^ )
+      ( using tactic: Tactic[IoError] )
+    :   Unit =
+      writeResolved(handle.resolve(path), content)
+
+    transparent inline def extant()
+      ( using handle: ((DirectoryHandle { type Plane = plane }) & Granting[Grant.Read])^ )
+      ( using filesystem: handle.Under is Filesystem )
+      ( using backend: FilesystemBackend on handle.Under )
+    :   Boolean =
+      existsResolved(handle.resolve(path))
+
+    transparent inline def entries
+      ( using handle: ((DirectoryHandle { type Plane = plane }) & Granting[Grant.Read])^ )
+      ( using filesystem: handle.Under is Filesystem )
+      ( using backend: FilesystemBackend on handle.Under, tactic: Tactic[IoError] )
+    :   LazyList[Path on plane] =
+      entriesResolved(handle.resolve(path)).map: child =>
+        path.child(child.name)(using Unsafe)
+
+    transparent inline def remove()
+      ( using handle: ((DirectoryHandle { type Plane = plane }) & Granting[Grant.Write])^ )
+      ( using filesystem: handle.Under is Filesystem )
+      ( using backend: FilesystemBackend on handle.Under, tactic: Tactic[IoError] )
+    :   Unit =
+      removeResolved(handle.resolve(path))
+
+  // Helpers are public: `private` helpers called from the transparent-inline operations above
+  // generate inline-accessor bridges whose fresh capability roots fail capture checking.
+  def readResolved[under <: Platform, result](path: Path on under)
+    ( using filesystem: under is Filesystem )
+    ( using readable: (Data is Readable to result)^, tactic: Tactic[IoError] )
+  :   result =
+    Platform.pathReadable[under, result].read(path)
+
+  def writeResolved[under, content](path: Path on under, content: content)
+    ( using filesystem: under is Filesystem )
+    ( using streamable: (content is Streamable by Data over Credit)^ )
+    ( using tactic: Tactic[IoError] )
+  :   Unit =
+    path.write(content)
+
+  def existsResolved[under](path: Path on under)
+    ( using filesystem: under is Filesystem )
+    ( using backend: FilesystemBackend on under )
+  :   Boolean =
+    path.exists()
+
+  def entriesResolved[under](path: Path on under)
+    ( using filesystem: under is Filesystem )
+    ( using backend: FilesystemBackend on under, tactic: Tactic[IoError] )
+  :   LazyList[Path on under] =
+    path.children
+
+  def removeResolved[under](path: Path on under)
+    ( using filesystem: under is Filesystem )
+    ( using backend: FilesystemBackend on under, tactic: Tactic[IoError] )
+  :   Unit =
+    import filesystemOptions.deleteRecursively.disabled
+    path.delete()

--- a/lib/galilei/src/core/galilei_core.scala
+++ b/lib/galilei/src/core/galilei_core.scala
@@ -65,6 +65,9 @@ extension [target: Substantiable](value: target)
 // that gates read and write operations.
 transparent inline def file(using handle: galilei.Handle^): handle.type = handle
 
+// The contextual directory handle within an `open[Directory]` block.
+transparent inline def dir(using handle: galilei.DirectoryHandle^): handle.type = handle
+
 package filesystemTraversal:
   given preOrderTraversal: TraversalOrder = TraversalOrder.PreOrder
   given postOrderTraversal: TraversalOrder = TraversalOrder.PostOrder

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -84,3 +84,122 @@ object Tests extends Suite(m"Galilei tests"):
         unsafely:
           dest.open[File]()(file.stream.read[Data]).utf8
       . assert(_ == t"Hello world!")
+
+    suite(m"Opening directories"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.deleteRecursively.enabled
+
+      val dirLeaf: Text = Uuid().show
+      val root: Path on Linux = unsafely((% / "tmp" / dirLeaf).on[Linux])
+      unsafely(root.create[Directory]())
+
+      test(m"An opened directory can write and read back an entry"):
+        unsafely:
+          root.open[Directory](Read & Write): dir ?=>
+            val target = dir / "greeting.txt"
+            target.overwrite(t"Hello directory")
+            target.contents[Text]
+      . assert(_ == t"Hello directory")
+
+      test(m"An entry is extant after writing, and a missing one is not"):
+        unsafely:
+          root.open[Directory](): dir ?=>
+            ((dir / "greeting.txt").extant(), (dir / "missing.txt").extant())
+      . assert(_ == (true, false))
+
+      test(m"The entries of the directory root are listed"):
+        unsafely:
+          root.open[Directory](): dir ?=>
+            dir.base.entries.to(List).map(_.name)
+      . assert(_ == List(t"greeting.txt"))
+
+      test(m"A removed entry is no longer extant"):
+        unsafely:
+          root.open[Directory](Read & Write): dir ?=>
+            val doomed = dir / "doomed.txt"
+            doomed.overwrite(t"temporary")
+            doomed.remove()
+            doomed.extant()
+      . assert(_ == false)
+
+      test(m"Opening a non-directory raises IoError"):
+        import errorDiagnostics.emptyDiagnostics
+        unsafely:
+          val plainFile: Path on Linux = root / "plain.txt"
+          plainFile.write(t"not a directory")
+          capture[IoError](plainFile.open[Directory]() { () }).reason
+      . assert(_ == IoError.Reason.IsNotDirectory)
+
+      test(m"A write operation without the Write grant does not compile"):
+        demilitarize:
+          root.open[Directory](): dir ?=>
+            (dir / "nope.txt").overwrite(t"nope")
+        . map(_.message)
+      . assert(_.nonEmpty)
+
+      test(m"A dot-dot path element does not compile"):
+        demilitarize:
+          root.open[Directory](): dir ?=>
+            dir / ".."
+        . map(_.message)
+      . assert(_.nonEmpty)
+
+      test(m"A path from one directory cannot be written under another"):
+        demilitarize:
+          root.open[Directory](): first ?=>
+            root.open[Directory](Read & Write): second ?=>
+              (first / "stolen.txt").overwrite(t"nope")
+        . map(_.message)
+      . assert(_.nonEmpty)
+
+    suite(m"The access register"):
+      import filesystemOptions.createNonexistentParents.enabled
+      import filesystemOptions.overwritePreexisting.enabled
+      import filesystemOptions.deleteRecursively.enabled
+
+      val registerLeaf: Text = Uuid().show
+      val outer: Path on Linux = unsafely((% / "tmp" / registerLeaf).on[Linux])
+      val inner: Path on Linux = unsafely(outer / "nested")
+      val siblingLeaf: Text = t"$registerLeaf-sibling"
+      val sibling: Path on Linux = unsafely((% / "tmp" / siblingLeaf).on[Linux])
+      unsafely(inner.create[Directory]())
+      unsafely(sibling.create[Directory]())
+
+      test(m"Overlapping Read opens coexist"):
+        unsafely:
+          outer.open[Directory](): a ?=>
+            inner.open[Directory](): b ?=>
+              true
+      . assert(_ == true)
+
+      test(m"An Exclusive open conflicts with an overlapping open"):
+        import errorDiagnostics.emptyDiagnostics
+        unsafely:
+          capture[IoError]:
+            outer.open[Directory](): a ?=>
+              inner.open[Directory](Read & Exclusive) { () }
+          . reason
+      . assert(_ == IoError.Reason.Busy)
+
+      test(m"An open under an Exclusive open conflicts"):
+        import errorDiagnostics.emptyDiagnostics
+        unsafely:
+          capture[IoError]:
+            outer.open[Directory](Read & Exclusive): a ?=>
+              inner.open[Directory]() { () }
+          . reason
+      . assert(_ == IoError.Reason.Busy)
+
+      test(m"An Exclusive open of a sibling does not conflict"):
+        unsafely:
+          outer.open[Directory](Read & Exclusive): a ?=>
+            sibling.open[Directory](Read & Exclusive): b ?=>
+              true
+      . assert(_ == true)
+
+      test(m"An Exclusive scope is released when it ends"):
+        unsafely:
+          outer.open[Directory](Read & Exclusive) { () }
+          outer.open[Directory](Read & Exclusive) { true }
+      . assert(_ == true)


### PR DESCRIPTION
Opening a directory — `path.open[Directory](Read & Write)` — now provides a scoped handle whose paths live on a plane unique to that handle, making escape from the opened directory inexpressible rather than checked: the plane's naming rules reject `.` and `..` at compile time, so every path formed within the scope denotes an entry inside the opened subtree, and a path from one handle is a type error under any other. A process-global access register arbitrates overlapping opens at runtime.

> **Stacked on #1588** (aperture). Once that merges, this will be rebased onto `main` so the diff shows only the directory work.

## Release notes

- **Directories open as scoped filesystem roots:**
  ```scala
  root.open[Directory](Read & Write): dir ?=>
    val target = dir / "notes" / "hello.txt"
    target.overwrite(t"Hello directory")
    target.contents[Text]
  ```
  Each handle's plane is fresh, so `dir / ".."` does not compile, a path created under one handle cannot be used under another, and nothing derived from the handle can escape the block (capture checking). The contextual handle is also reachable as `dir`.
- **Subtree operations**, all gated by the open call's grants: `contents[T]` (whole-file read), `overwrite(content)`, `extant()`, `entries` (listing, as paths on the same plane), and `remove()`. Writing through a `Read`-opened directory is a compile error.
- **Subtree planes have no `Filesystem` instance**, deliberately: galilei's absolute-path operations cannot apply to subtree paths, which would otherwise resolve them against the working directory.
- **The access register**: opens are recorded against real (symlink-resolved) paths, and an `Exclusive` open conflicts with any overlapping open — in either direction, ancestor or descendant — raising `IoError` with `Reason.Busy` at the `open` call. Overlapping `Read` and `Write` opens coexist. The register is in-process only.
- Opening a non-directory as `Directory` raises `IoError` with `Reason.IsNotDirectory`.
- Deferred to follow-ups: attenuated sub-opens (`(dir / "sub").open[Directory]`), `open[File]` on subtree paths, and file-open participation in the register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
