### PR TITLE
Complete TrueType parsing and add font subsetting to Phoenicia

### DIFF
--- a/lib/phoenicia/doc/basics.md
+++ b/lib/phoenicia/doc/basics.md
@@ -29,14 +29,49 @@ time, it may be necessary to provide an `Otf` factory as well.
 
 ### Operations on `Ttf`s
 
-The only useful operation currently implemented on `Ttf` instances is the
-`advanceWidth` method, which takes a `Char` value and returns its width as a
+The `glyph` method takes a `Char` and returns the font's glyph for it, chosen
+through the font's preferred character mapping (favouring full-Unicode `cmap`
+subtables over Basic Multilingual Plane and legacy mappings). A character the
+font does not map yields glyph `0`, the conventional missing-glyph.
+
+The `advanceWidth` method takes a `Char` value and returns its width as a
 number of font design units. This width is specifically its _advance width_,
 the amount of horizontal distance traveled to accommodate the glyph before the
 next glyph; typically a lower value for a narrow character like `l` than for a
-wide character like `w`.
+wide character like `w`. `leftSideBearing` is its counterpart on the leading
+side of the glyph.
 
-A related method, width, takes a `Text` value, and returns the sum of the
+A related method, `width`, takes a `Text` value, and returns the sum of the
 advance widths of its characters, when rendered at normal spacing. The result
 is specified in `ems`, with the type `Quantity[Ems[1]]`.
 
+The names by which the font describes itself are available through `fontName`
+(its PostScript name) and `familyName`, decoded from the naming table with a
+preference for Windows-English records.
+
+### Font tables
+
+The tables of the font are interpreted on demand, and are accessible through
+methods named after their tags: `head` (global metrics, including the glyph
+bounding box and `unitsPerEm`), `hhea` and `hmtx` (horizontal metrics), `maxp`
+(the glyph count), `post` (the italic angle, underline metrics and fixed-pitch
+flag), `os2` (weight, typographic metrics, cap height and x-height where
+present, and embedding rights) and `name` (localized naming records, keyed by
+`Ttf.NameId`). Glyph outlines are located through `loca` and read from `glyf`,
+including the components of composite glyphs. A table absent from the font
+raises a `FontError`.
+
+### Subsetting
+
+The `subset` method produces a new `Ttf` containing only the outlines needed
+to render a given set of characters — or a `Text` value — while every other
+table is carried over unchanged:
+```scala
+val smaller = font.subset(t"Hello, World!")
+```
+
+Glyphs keep their original numbers, so character mappings, metrics and
+references between glyphs remain valid; composite glyphs retain their
+components (their closure computed with `glyphClosure`), and unused glyphs are
+left with empty outlines. The result is a complete, valid font file —
+checksums included — suitable for embedding in a PDF or elsewhere.

--- a/lib/phoenicia/doc/features.md
+++ b/lib/phoenicia/doc/features.md
@@ -1,3 +1,7 @@
 - reads TrueType and OpenType font files
 - can read from any [Turbulence](https://github.com/propensive/turbulence/) source
 - access font metrics and calculate widths of individual glyphs or strings of text
+- chooses the best Unicode character mapping, supporting all common `cmap` formats
+- interprets the `head`, `hhea`, `hmtx`, `maxp`, `post`, `OS/2`, `name`, `loca` and `glyf` tables
+- decodes font names, including the PostScript and family names
+- subsets fonts to the glyphs a set of characters needs, producing complete, valid font files

--- a/lib/phoenicia/src/core/phoenicia.FontError.scala
+++ b/lib/phoenicia/src/core/phoenicia.FontError.scala
@@ -37,14 +37,16 @@ import fulminate.*
 
 object FontError:
   enum Reason(val number: Int) extends Clarification:
-    case MissingTable(tag: TableTag) extends Reason(1)
-    case UnknownFormat               extends Reason(2)
-    case MagicNumber                 extends Reason(3)
+    case MissingTable(tag: TableTag)  extends Reason(1)
+    case UnknownFormat(format: Int)   extends Reason(2)
+    case MagicNumber                  extends Reason(3)
+    case MissingEncoding              extends Reason(4)
 
   given communicable: Reason is Communicable =
-    case Reason.MissingTable(tag) => m"the table ${tag.text} was not found"
-    case Reason.UnknownFormat     => m"the table contains data in an unknown format"
-    case Reason.MagicNumber       => m"the font did not contain expected check data"
+    case Reason.MissingTable(tag)     => m"the table ${tag.text} was not found"
+    case Reason.UnknownFormat(format) => m"the table contains data in unknown format $format"
+    case Reason.MagicNumber           => m"the font did not contain expected check data"
+    case Reason.MissingEncoding       => m"the font contains no usable character encoding"
 
 case class FontError(reason: FontError.Reason)(using Diagnostics)
 extends Error(564, reason.number)(m"the font could not be read because $reason")

--- a/lib/phoenicia/src/core/phoenicia.Sfnt.scala
+++ b/lib/phoenicia/src/core/phoenicia.Sfnt.scala
@@ -1,0 +1,115 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package phoenicia
+
+import anticipation.*
+import gossamer.*
+import rudiments.*
+import vacuous.*
+
+// Serialises a table set as an sfnt font file: the header, a directory sorted by tag, and the
+// tables themselves, four-byte aligned and zero-padded, with per-table checksums computed and
+// head's checksum adjustment set so the whole file sums to the specified constant.
+private[phoenicia] object Sfnt:
+  def assemble(version: Data, tables: List[(Text, Data)]): Data =
+    def padded(length: Int): Int = (length + 3)/4*4
+
+    val sorted = tables.sortBy(_(0).s)
+    val count = sorted.length
+    val entrySelector = 31 - Integer.numberOfLeadingZeros(count)
+    val searchRange = (1 << entrySelector)*16
+    val tablesStart = 12 + count*16
+
+    val total = tablesStart + sorted.sumBy: entry =>
+      padded(entry(1).length)
+
+    val buffer = new Array[Byte](total)
+
+    def putU16(position: Int, value: Int): Unit =
+      buffer(position) = (value >> 8).toByte
+      buffer(position + 1) = value.toByte
+
+    def putU32(position: Int, value: Long): Unit =
+      buffer(position) = (value >> 24).toByte
+      buffer(position + 1) = (value >> 16).toByte
+      buffer(position + 2) = (value >> 8).toByte
+      buffer(position + 3) = value.toByte
+
+    // The sum of big-endian 32-bit words, over the length rounded up to a word boundary —
+    // safe because tables are zero-padded in place.
+    def checksum(start: Int, length: Int): Long =
+      var sum = 0L
+      var position = start
+      val end = start + padded(length)
+
+      while position < end do
+        val word =
+          ((buffer(position) & 0xffL) << 24) | ((buffer(position + 1) & 0xffL) << 16) |
+            ((buffer(position + 2) & 0xffL) << 8) | (buffer(position + 3) & 0xffL)
+
+        sum = (sum + word) & 0xffffffffL
+        position += 4
+
+      sum
+
+    (0 until 4).each: index =>
+      buffer(index) = version(index)
+
+    putU16(4, count)
+    putU16(6, searchRange)
+    putU16(8, entrySelector)
+    putU16(10, count*16 - searchRange)
+
+    var offset = tablesStart
+    var headOffset = -1
+
+    sorted.indices.each: index =>
+      val (tag, table) = sorted(index)
+      val directory = 12 + index*16
+      val tagBytes = tag.s.getBytes("US-ASCII").nn
+
+      (0 until 4).each: position =>
+        buffer(directory + position) = tagBytes(position)
+
+      System.arraycopy(table.mutable(using Unsafe), 0, buffer, offset, table.length)
+      putU32(directory + 4, checksum(offset, table.length))
+      putU32(directory + 8, offset.toLong)
+      putU32(directory + 12, table.length.toLong)
+      if tag == t"head" then headOffset = offset
+      offset += padded(table.length)
+
+    // The caller supplies head with its adjustment zeroed, so the directory checksum above
+    // is the spec's zero-adjusted one; the adjustment is then patched in afterwards.
+    if headOffset >= 0 then putU32(headOffset + 8, (0xb1b0afbaL - checksum(0, total)) & 0xffffffffL)
+
+    buffer.immutable(using Unsafe)

--- a/lib/phoenicia/src/core/phoenicia.Ttf.scala
+++ b/lib/phoenicia/src/core/phoenicia.Ttf.scala
@@ -65,17 +65,17 @@ case class Ttf(data: Data):
   lazy val entrySelector = B16(data, 8).u16.int
   lazy val rangeShift = B16(data, 10).u16.int
 
-  // FIXME: Don't just assume encoding 0
-  def glyph(char: Char): Glyph[ttf.type] raises FontError =
-    cmap.glyphEncodings(0).format.glyph(char)
+  // The glyph for a character in the font's preferred character mapping, or glyph 0 — the
+  // missing-glyph — for a character the font does not map.
+  def glyph(char: Char): Glyph[ttf.type] raises FontError = cmap.glyph(char)
 
-  def advanceWidth(char: Char): Int raises FontError = hmtx.metrics(glyph(char).id).advanceWidth
+  def advanceWidth(char: Char): Int raises FontError = hmtx.advanceWidth(glyph(char).id)
 
   def width(text: Text): Quantity[Ems[1]] raises FontError =
     text.chars.sumBy(advanceWidth).toDouble*Em/head.unitsPerEm.int.toDouble
 
   def leftSideBearing(char: Char): Int raises FontError =
-    hmtx.metrics(glyph(char).id).leftSideBearing
+    hmtx.leftSideBearing(glyph(char).id)
 
   lazy val tables: Map[TableTag, TableOffset] =
     (0 until numTables).flatMap: n =>
@@ -148,11 +148,20 @@ case class Ttf(data: Data):
       metricDataFormat:    S16,
       numberOfHMetrics:    U16 )
 
+  // The horizontal metrics: one (advance, bearing) pair per glyph up to `count`, after which
+  // the last advance repeats — a monospaced tail — and bearings continue in their own array.
   case class HmtxTable(offset: Int, count: Int):
     lazy val metrics: IArray[HMetrics] =
       IArray.from:
         (0 until count).map: index =>
           HMetrics(B16(data, offset + index*4).u16.int, B16(data, offset + index*4 + 2).s16.int)
+
+    def advanceWidth(glyphId: Int): Int =
+      metrics(if glyphId < count then glyphId else count - 1).advanceWidth
+
+    def leftSideBearing(glyphId: Int): Int =
+      if glyphId < count then metrics(glyphId).leftSideBearing
+      else B16(data, offset + count*4 + (glyphId - count)*2).s16.int
 
     case class HMetrics(advanceWidth: Int, leftSideBearing: Int)
 
@@ -167,46 +176,34 @@ case class Ttf(data: Data):
         formatMemo.or:
           val format = formatId match
             case 0 =>
-              val length = B16(data, offset + 2).u16.int
-              val language = B16(data, offset + 4).u16.int
-              Format0(length, language)
+              Format0(offset + 6)
 
             case 4 =>
-              val length = B16(data, offset + 2).u16.int
-              val language = B16(data, offset + 4).u16.int
               val segCount = B16(data, offset + 6).u16.int/2
-              val searchRange = B16(data, offset + 8).u16.int/2
-              val entrySelector = B16(data, offset + 10).u16.int
-              val rangeShift = B16(data, offset + 12).u16.int
               val endCodesStart = offset + 14
-              val startCodesStart = endCodesStart + segCount*2 + 2
-              val idDeltaStart = startCodesStart + segCount*2
-              val idRangeOffsetsStart = startCodesStart + segCount*2
+              val startCodesStart = endCodesStart + segCount*2 + 2 // a reserved pad intervenes
+              val idDeltasStart = startCodesStart + segCount*2
+              val idRangeOffsetsStart = idDeltasStart + segCount*2
 
               val segments = (0 until segCount).map: n =>
                 Segment
                   ( B16(data, startCodesStart + n*2).u16.int.toChar,
                     B16(data, endCodesStart + n*2).u16.int.toChar,
-                    B16(data, idDeltaStart).s16.int,
-                    B16(data, idRangeOffsetsStart).u16.int )
+                    B16(data, idDeltasStart + n*2).s16.int,
+                    B16(data, idRangeOffsetsStart + n*2).u16.int )
 
-              Format4
-                ( length,
-                  language,
-                  segCount,
-                  searchRange,
-                  entrySelector,
-                  rangeShift,
-                  IArray.from(segments) )
+              Format4(idRangeOffsetsStart, IArray.from(segments))
+
+            case 6 =>
+              val first = B16(data, offset + 6).u16.int
+              val count = B16(data, offset + 8).u16.int
+              Format6(first, count, offset + 10)
 
             case 12 =>
-              val length = B32(data, offset + 2).s32.int
-              val language = B32(data, offset + 6).s32.int
-              val nGroups = B32(data, offset + 10).s32.int
-              Format12(length, language, nGroups)
+              Format12(B32(data, offset + 12).s32.int, offset + 16)
 
             case other =>
-              abort(FontError(FontError.Reason.UnknownFormat))
+              abort(FontError(FontError.Reason.UnknownFormat(other)))
 
           format.also:
             formatMemo = format
@@ -216,28 +213,54 @@ case class Ttf(data: Data):
       sealed trait Format:
         def glyph(char: Char): Glyph[ttf.type]
 
-      case class Format0(length: Int, language: Int) extends Format:
-        def glyph(char: Char): Glyph[ttf.type] = ???
-
-      case class Format4
-        ( length:        Int,
-          language:      Int,
-          segCount:      Int,
-          searchRange:   Int,
-          entrySelector: Int,
-          rangeShift:    Int,
-          segments:      IArray[Segment] )
-      extends Format:
-
+      // A byte-indexed array of glyph ids, for the first 256 character codes only.
+      case class Format0(start: Int) extends Format:
         def glyph(char: Char): Glyph[ttf.type] =
-          val segment = segments(segments.indexWhere(_.start > char) - 1)
+          Glyph(ttf, if char < 256 then data(start + char) & 0xff else 0)
 
-          // FIXME: Understand why we need to add a `+1` here to fix an off-by-one error
-          Glyph(ttf, segment.rangeOffset/2 + (char - segment.start) + segment.rangeOffset +
-            segment.delta + 1)
+      // Segmented ranges over the Basic Multilingual Plane. Each segment maps by a delta, or
+      // — when its range offset is nonzero — indirects into the glyph-id array which follows
+      // the range offsets, addressed relative to the segment's own range-offset word.
+      case class Format4(idRangeOffsetsStart: Int, segments: IArray[Segment]) extends Format:
+        def glyph(char: Char): Glyph[ttf.type] =
+          val index = segments.indexWhere(char <= _.end)
 
-      case class Format12(length: Int, language: Int, nGroups: Int) extends Format:
-        def glyph(char: Char): Glyph[ttf.type] = ???
+          if index < 0 || char < segments(index).start then Glyph(ttf, 0) else
+            val segment = segments(index)
+
+            val id =
+              if segment.rangeOffset == 0 then char + segment.delta
+              else
+                val position =
+                  idRangeOffsetsStart + index*2 + segment.rangeOffset + (char - segment.start)*2
+
+                val indirect = B16(data, position).u16.int
+                if indirect == 0 then 0 else indirect + segment.delta
+
+            Glyph(ttf, id & 0xffff)
+
+      // A dense run of glyph ids for a contiguous range of character codes.
+      case class Format6(first: Int, count: Int, start: Int) extends Format:
+        def glyph(char: Char): Glyph[ttf.type] =
+          if char >= first && char < first + count
+          then Glyph(ttf, B16(data, start + (char - first)*2).u16.int)
+          else Glyph(ttf, 0)
+
+      // Groups of sequential character-to-glyph mappings, covering all of Unicode. Groups are
+      // ordered by start code, permitting binary search.
+      case class Format12(groupCount: Int, start: Int) extends Format:
+        def glyph(char: Char): Glyph[ttf.type] =
+          def search(low: Int, high: Int): Int =
+            if low > high then 0 else
+              val middle = (low + high)/2
+              val groupStart = B32(data, start + middle*12).s32.int
+              val groupEnd = B32(data, start + middle*12 + 4).s32.int
+
+              if char < groupStart then search(low, middle - 1)
+              else if char > groupEnd then search(middle + 1, high)
+              else B32(data, start + middle*12 + 8).s32.int + char - groupStart
+
+          Glyph(ttf, search(0, groupCount - 1))
 
     lazy val version = B16(data, offset).u16.int
     lazy val numTables = B16(data, offset + 2).u16.int
@@ -248,3 +271,21 @@ case class Ttf(data: Data):
       val subOffset = B32(data, offset + 8 + n*8).s32.int
 
       GlyphEncoding(platformId, encodingId, offset + subOffset)
+
+    // The preferred character mapping: full Unicode before the Basic Multilingual Plane,
+    // Unicode before Windows symbol and legacy Macintosh encodings.
+    lazy val best: Optional[GlyphEncoding] =
+      def rank(encoding: GlyphEncoding): Int = (encoding.platformId, encoding.encodingId) match
+        case (3, 10)         => 0
+        case (0, 4) | (0, 6) => 1
+        case (3, 1)          => 2
+        case (0, 3)          => 3
+        case (0, _)          => 4
+        case (3, 0)          => 5
+        case (1, 0)          => 6
+        case _               => 7
+
+      if glyphEncodings.isEmpty then Unset else glyphEncodings.minBy(rank)
+
+    def glyph(char: Char): Glyph[ttf.type] raises FontError =
+      best.lest(FontError(FontError.Reason.MissingEncoding)).format.glyph(char)

--- a/lib/phoenicia/src/core/phoenicia.Ttf.scala
+++ b/lib/phoenicia/src/core/phoenicia.Ttf.scala
@@ -150,6 +150,33 @@ case class Ttf(data: Data):
 
     . lest(FontError(FontError.Reason.MissingTable(TtfTag.Name)))
 
+  def loca: LocaTable raises FontError =
+    tables.at(TtfTag.Loca).let: ref =>
+      LocaTable(ref.offset, maxp.glyphCount, head.indexToLocFormat.int == 1)
+
+    . lest(FontError(FontError.Reason.MissingTable(TtfTag.Loca)))
+
+  def glyf: GlyfTable raises FontError =
+    tables.at(TtfTag.Glyf).let: ref =>
+      GlyfTable(ref.offset, loca)
+
+    . lest(FontError(FontError.Reason.MissingTable(TtfTag.Glyf)))
+
+  // The transitive closure of a set of glyphs under composite-glyph components: every glyph
+  // needed to render the given ones.
+  def glyphClosure(glyphIds: Set[Int]): Set[Int] raises FontError =
+    val table = glyf
+
+    def expand(pending: List[Int], seen: Set[Int]): Set[Int] = pending match
+      case Nil =>
+        seen
+
+      case head :: tail =>
+        val fresh = table(head).components.filter(!seen.contains(_))
+        expand(fresh ++ tail, seen ++ fresh)
+
+    expand(glyphIds.to(List), glyphIds)
+
   // The font's PostScript name, by which PDF and PostScript documents reference it.
   def fontName: Optional[Text] = safely(name(Ttf.NameId.PostScriptName))
 
@@ -212,6 +239,46 @@ case class Ttf(data: Data):
       else B16(data, offset + count*4 + (glyphId - count)*2).s16.int
 
     case class HMetrics(advanceWidth: Int, leftSideBearing: Int)
+
+  // The glyph-location index: for each glyph, the extent of its data within glyf. In the
+  // short format, offsets are stored halved in sixteen bits.
+  case class LocaTable(offset: Int, glyphCount: Int, longFormat: Boolean):
+    lazy val offsets: IArray[Int] =
+      IArray.from:
+        (0 to glyphCount).map: index =>
+          if longFormat then B32(data, offset + index*4).s32.int
+          else B16(data, offset + index*2).u16.int*2
+
+  case class GlyfTable(offset: Int, loca: LocaTable):
+    def apply(glyphId: Int): GlyphRecord =
+      GlyphRecord(offset + loca.offsets(glyphId), loca.offsets(glyphId + 1) - loca.offsets(glyphId))
+
+    // One glyph's raw data. A glyph with no outline — a space — has zero extent; a composite
+    // glyph has a negative contour count and a list of component glyphs.
+    case class GlyphRecord(start: Int, length: Int):
+      def empty: Boolean = length == 0
+      def bytes: Data = data.slice(start, start + length)
+      def contourCount: Int = if empty then 0 else B16(data, start).s16.int
+      def composite: Boolean = !empty && contourCount < 0
+
+      lazy val components: List[Int] =
+        if !composite then Nil else
+          val builder = List.newBuilder[Int]
+          var position = start + 10
+          var more = true
+
+          while more do
+            val flags = B16(data, position).u16.int
+            builder += B16(data, position + 2).u16.int
+            position += (if (flags & 0x0001) != 0 then 8 else 6) // words or bytes for the args
+
+            if (flags & 0x0008) != 0 then position += 2      // a single scale
+            else if (flags & 0x0040) != 0 then position += 4 // separate x and y scales
+            else if (flags & 0x0080) != 0 then position += 8 // a 2×2 transformation
+
+            more = (flags & 0x0020) != 0
+
+          builder.result()
 
   // The maximum-profile table; only the glyph count is of interest here.
   case class MaxpTable(offset: Int):

--- a/lib/phoenicia/src/core/phoenicia.Ttf.scala
+++ b/lib/phoenicia/src/core/phoenicia.Ttf.scala
@@ -162,6 +162,64 @@ case class Ttf(data: Data):
 
     . lest(FontError(FontError.Reason.MissingTable(TtfTag.Glyf)))
 
+  // A new font containing only the outlines needed to render the given characters — plus any
+  // composite components they reference — with the original glyph numbering retained: unused
+  // glyphs keep empty outlines, so character mappings, metrics and glyph references remain
+  // valid. Every other table is carried over unchanged.
+  def subset(chars: Set[Char]): Ttf raises FontError =
+    val retained = glyphClosure(chars.map(glyph(_).id) + 0)
+    val glyphs = glyf
+    val count = maxp.glyphCount
+
+    val offsets = new Array[Int](count + 1)
+    val parts = List.newBuilder[Data]
+    var position = 0
+
+    (0 until count).each: id =>
+      offsets(id) = position
+
+      if retained.contains(id) then
+        val bytes = glyphs(id).bytes
+        parts += bytes
+        position += bytes.length
+
+    offsets(count) = position
+
+    val newGlyf = new Array[Byte](position)
+    var written = 0
+
+    parts.result().each: part =>
+      System.arraycopy(part.mutable(using Unsafe), 0, newGlyf, written, part.length)
+      written += part.length
+
+    // The rebuilt loca always uses the long format, so head's format field must agree.
+    val newLoca = new Array[Byte]((count + 1)*4)
+
+    (0 to count).each: id =>
+      newLoca(id*4) = (offsets(id) >> 24).toByte
+      newLoca(id*4 + 1) = (offsets(id) >> 16).toByte
+      newLoca(id*4 + 2) = (offsets(id) >> 8).toByte
+      newLoca(id*4 + 3) = offsets(id).toByte
+
+    val headRef = tables.at(TtfTag.Head).lest(FontError(FontError.Reason.MissingTable(TtfTag.Head)))
+    val newHead = data.slice(headRef.offset, headRef.offset + headRef.length).mutable(using Unsafe)
+    (8 to 11).each { index => newHead(index) = 0 } // adjustment is recomputed on assembly
+    newHead(50) = 0
+    newHead(51) = 1
+
+    val carried = tables.values.to(List).flatMap: ref =>
+      if ref.id == TtfTag.Glyf || ref.id == TtfTag.Loca || ref.id == TtfTag.Head then Nil
+      else List(ref.id.text -> data.slice(ref.offset, ref.offset + ref.length))
+
+    val entries =
+      (t"glyf", newGlyf.immutable(using Unsafe)) ::
+        (t"loca", newLoca.immutable(using Unsafe)) ::
+        (t"head", newHead.immutable(using Unsafe)) :: carried
+
+    Ttf(Sfnt.assemble(data.slice(0, 4), entries))
+
+  def subset(text: Text): Ttf raises FontError = subset(text.chars.to(Set))
+
   // The transitive closure of a set of glyphs under composite-glyph components: every glyph
   // needed to render the given ones.
   def glyphClosure(glyphIds: Set[Int]): Set[Int] raises FontError =

--- a/lib/phoenicia/src/core/phoenicia.Ttf.scala
+++ b/lib/phoenicia/src/core/phoenicia.Ttf.scala
@@ -55,6 +55,14 @@ object Ttf:
   enum EncodingId:
     case Unicode1, Unicode1_1, IsoIec10646, Unicode2Bmp, Unicode2Full, UnicodeVariation, UnicodeFull
 
+  // Naming-table name identifiers (OpenType §name); each case's ordinal is its name id.
+  enum NameId:
+    case Copyright, Family, Subfamily, UniqueId, FullName, Version, PostScriptName, Trademark,
+      Manufacturer, Designer, Description, VendorUrl, DesignerUrl, License, LicenseUrl, Reserved,
+      TypographicFamily, TypographicSubfamily, CompatibleFullName, SampleText, PostScriptCidName,
+      WwsFamily, WwsSubfamily, LightBackgroundPalette, DarkBackgroundPalette,
+      VariationsPostScriptNamePrefix
+
 case class Ttf(data: Data):
   ttf =>
 
@@ -118,6 +126,35 @@ case class Ttf(data: Data):
 
     . lest(FontError(FontError.Reason.MissingTable(TtfTag.Hmtx)))
 
+  def maxp: MaxpTable raises FontError =
+    tables.at(TtfTag.Maxp).let: ref =>
+      MaxpTable(ref.offset)
+
+    . lest(FontError(FontError.Reason.MissingTable(TtfTag.Maxp)))
+
+  def post: PostTable raises FontError =
+    tables.at(TtfTag.Post).let: ref =>
+      PostTable(ref.offset)
+
+    . lest(FontError(FontError.Reason.MissingTable(TtfTag.Post)))
+
+  def os2: Os2Table raises FontError =
+    tables.at(OtfTag.Os2).let: ref =>
+      Os2Table(ref.offset)
+
+    . lest(FontError(FontError.Reason.MissingTable(OtfTag.Os2)))
+
+  def name: NameTable raises FontError =
+    tables.at(TtfTag.Name).let: ref =>
+      NameTable(ref.offset)
+
+    . lest(FontError(FontError.Reason.MissingTable(TtfTag.Name)))
+
+  // The font's PostScript name, by which PDF and PostScript documents reference it.
+  def fontName: Optional[Text] = safely(name(Ttf.NameId.PostScriptName))
+
+  def familyName: Optional[Text] = safely(name(Ttf.NameId.Family))
+
   case class HeadTable
     ( majorVersion:       U16,
       minorVersion:       U16,
@@ -126,7 +163,18 @@ case class Ttf(data: Data):
       checksumAdjustment: B32,
       magicNumber:        B32,
       flags:              B16,
-      unitsPerEm:         U16 )
+      unitsPerEm:         U16,
+      created:            S64,
+      modified:           S64,
+      xMin:               S16,
+      yMin:               S16,
+      xMax:               S16,
+      yMax:               S16,
+      macStyle:           B16,
+      lowestRecPpem:      U16,
+      fontDirectionHint:  S16,
+      indexToLocFormat:   S16,
+      glyphDataFormat:    S16 )
 
   case class HheaTable
     ( majorVersion:        U16,
@@ -164,6 +212,89 @@ case class Ttf(data: Data):
       else B16(data, offset + count*4 + (glyphId - count)*2).s16.int
 
     case class HMetrics(advanceWidth: Int, leftSideBearing: Int)
+
+  // The maximum-profile table; only the glyph count is of interest here.
+  case class MaxpTable(offset: Int):
+    lazy val glyphCount: Int = B16(data, offset + 4).u16.int
+
+  // PostScript-related metadata.
+  case class PostTable(offset: Int):
+    lazy val italicAngle: Double = B32(data, offset + 4).s32.int/65536.0
+    lazy val underlinePosition: Int = B16(data, offset + 8).s16.int
+    lazy val underlineThickness: Int = B16(data, offset + 10).s16.int
+    lazy val monospaced: Boolean = B32(data, offset + 12).s32.int != 0
+
+  // OS/2 and Windows metrics. Later versions of the table append fields; those which the
+  // font's version predates are absent.
+  case class Os2Table(offset: Int):
+    lazy val version: Int = B16(data, offset).u16.int
+    lazy val weightClass: Int = B16(data, offset + 4).u16.int
+    lazy val widthClass: Int = B16(data, offset + 6).u16.int
+    lazy val fsType: Int = B16(data, offset + 8).u16.int
+    lazy val familyClass: Int = B16(data, offset + 30).s16.int
+    lazy val selection: Int = B16(data, offset + 62).u16.int
+    lazy val typoAscender: Int = B16(data, offset + 68).s16.int
+    lazy val typoDescender: Int = B16(data, offset + 70).s16.int
+    lazy val typoLineGap: Int = B16(data, offset + 72).s16.int
+    lazy val winAscent: Int = B16(data, offset + 74).u16.int
+    lazy val winDescent: Int = B16(data, offset + 76).u16.int
+
+    lazy val xHeight: Optional[Int] =
+      if version >= 2 then B16(data, offset + 86).s16.int else Unset
+
+    lazy val capHeight: Optional[Int] =
+      if version >= 2 then B16(data, offset + 88).s16.int else Unset
+
+    // Installable embedding is 0; of the restriction bits, only bit 1 forbids embedding
+    // outright.
+    def embeddable: Boolean = (fsType & 0x000f) != 0x0002
+
+  // The naming table: localized, per-platform strings such as the font's family and
+  // PostScript names.
+  case class NameTable(offset: Int):
+    lazy val count: Int = B16(data, offset + 2).u16.int
+    private lazy val storageStart: Int = offset + B16(data, offset + 4).u16.int
+
+    case class Record
+      ( platformId: Int, encodingId: Int, languageId: Int, nameId: Int, length: Int, start: Int ):
+
+      def decode: Text =
+        val bytes = data.mutable(using Unsafe)
+
+        platformId match
+          case 0 | 3 =>
+            String(bytes, start, length, "UTF-16BE").tt
+
+          case _ =>
+            try String(bytes, start, length, "x-MacRoman").tt
+            catch case _: Exception => String(bytes, start, length, "ISO-8859-1").tt
+
+    lazy val records: IArray[Record] =
+      IArray.from:
+        (0 until count).map: n =>
+          val base = offset + 6 + n*12
+
+          Record
+            ( B16(data, base).u16.int,
+              B16(data, base + 2).u16.int,
+              B16(data, base + 4).u16.int,
+              B16(data, base + 6).u16.int,
+              B16(data, base + 8).u16.int,
+              storageStart + B16(data, base + 10).u16.int )
+
+    // The best record for a name: Windows US English first, then other Unicode records, then
+    // legacy Macintosh.
+    def apply(nameId: Ttf.NameId): Optional[Text] =
+      val candidates = records.filter(_.nameId == nameId.ordinal)
+
+      def rank(record: Record): Int = (record.platformId, record.encodingId) match
+        case (3, 1)  => if record.languageId == 0x409 then 0 else 1
+        case (3, 10) => 2
+        case (0, _)  => 3
+        case (1, 0)  => 4
+        case _       => 5
+
+      if candidates.isEmpty then Unset else candidates.minBy(rank).decode
 
   case class CmapTable(offset: Int):
     case class GlyphEncoding(platformId: Int, encodingId: Int, offset: Int):

--- a/lib/phoenicia/src/test/phoenicia_test.scala
+++ b/lib/phoenicia/src/test/phoenicia_test.scala
@@ -34,5 +34,145 @@ package phoenicia
 
 import soundness.*
 
+import strategies.throwUnsafely
+
 object Tests extends Suite(m"Phoenicia Tests"):
-  def run(): Unit = ()
+
+  // Big-endian byte assembly for hand-built font fixtures.
+  def u16(values: Int*): Data =
+    IArray.from(values.flatMap { value => Seq((value >> 8).toByte, value.toByte) })
+
+  def u32(values: Long*): Data =
+    IArray.from:
+      values.flatMap: value =>
+        Seq((value >> 24).toByte, (value >> 16).toByte, (value >> 8).toByte, value.toByte)
+
+  // Assembles tables into an sfnt container: the header, a table directory, then the tables
+  // themselves, four-byte aligned. Checksums are left zero: the parser does not verify them.
+  def sfnt(tables: (Text, Data)*): Ttf =
+    val count = tables.length
+    val entrySelector = 31 - Integer.numberOfLeadingZeros(count)
+    val searchRange = (1 << entrySelector)*16
+    val header = u32(0x00010000L) ++ u16(count, searchRange, entrySelector, count*16 - searchRange)
+
+    var offset = 12 + count*16
+    val directory = List.newBuilder[Data]
+    val body = List.newBuilder[Data]
+
+    tables.each: (tag, table) =>
+      val padding = if table.length%4 == 0 then 0 else 4 - table.length%4
+      val tagBytes = IArray.from(tag.s.getBytes("US-ASCII").nn)
+      directory += tagBytes ++ u32(0L, offset.toLong, table.length.toLong)
+      body += table ++ IArray.fill[Byte](padding)(0)
+      offset += table.length + padding
+
+    Ttf(header ++ directory.result().reduce(_ ++ _) ++ body.result().reduce(_ ++ _))
+
+  val headTable: Data =
+    u16(1, 0, 1, 0)              // versions and font revision
+    ++ u32(0L, 0x5f0f3cf5L)      // checksum adjustment and magic number
+    ++ u16(0, 1000)              // flags and unitsPerEm
+    ++ u32(0L, 0L, 0L, 0L)       // created and modified
+    ++ u16(-50, -200, 1000, 800) // glyph bounding box
+    ++ u16(0, 8)                 // macStyle and lowestRecPPEM
+    ++ u16(2, 0, 0)              // direction hint, indexToLocFormat and glyphDataFormat
+
+  val hheaTable: Data =
+    u16(1, 0)                    // version
+    ++ u16(800, -200, 90)        // ascender, descender and line gap
+    ++ u16(600)                  // maximum advance width
+    ++ u16(10, 10, 1000)         // minimum bearings and maximum extent
+    ++ u16(1, 0, 0)              // caret slope and offset
+    ++ u16(0, 0, 0, 0)           // reserved
+    ++ u16(0, 3)                 // metric data format and number of metrics
+
+  // Three full metric pairs, then a bearing-only entry for the monospaced tail.
+  val hmtxTable: Data = u16(600, 10, 500, 20, 400, 30) ++ u16(25)
+
+  // Three segments: A–C mapping by delta, a–c indirecting through the glyph id array in
+  // rotated order, and the terminal sentinel.
+  val format4Subtable: Data =
+    u16(4, 46, 0)                // format, length and language
+    ++ u16(6, 4, 1, 2)           // segment count and search hints
+    ++ u16(0x43, 0x63, 0xffff)   // end codes
+    ++ u16(0)                    // reserved pad
+    ++ u16(0x41, 0x61, 0xffff)   // start codes
+    ++ u16(-64, 0, 1)            // id deltas
+    ++ u16(0, 4, 0)              // id range offsets
+    ++ u16(2, 3, 1)              // glyph id array
+
+  val cmapFormat4: Data = u16(0, 1) ++ u16(3, 1) ++ u32(12L) ++ format4Subtable
+
+  val cmapFormat0: Data =
+    val glyphIds = Array.fill[Byte](256)(0)
+    glyphIds(0x41) = 7
+    u16(0, 1) ++ u16(1, 0) ++ u32(12L) ++ u16(0, 262, 0) ++ glyphIds.immutable(using Unsafe)
+
+  val cmapFormat6: Data =
+    u16(0, 1) ++ u16(1, 0) ++ u32(12L)
+    ++ u16(6, 16, 0)             // format, length and language
+    ++ u16(0x30, 3)              // first code and count
+    ++ u16(11, 12, 13)           // glyph ids
+
+  // A Windows BMP Format 4 subtable alongside a full-Unicode Format 12 subtable which maps
+  // the same character differently; the latter should be preferred.
+  val cmapPreferring12: Data =
+    u16(0, 2)
+    ++ u16(3, 1) ++ u32(20L)
+    ++ u16(3, 10) ++ u32(66L)
+    ++ format4Subtable
+    ++ u16(12, 0) ++ u32(28L, 0L, 1L) ++ u32(0x41L, 0x41L, 5L)
+
+  def font(cmap: Data = cmapFormat4): Ttf =
+    sfnt(t"cmap" -> cmap, t"head" -> headTable, t"hhea" -> hheaTable, t"hmtx" -> hmtxTable)
+
+  def run(): Unit =
+    suite(m"Character mapping"):
+      val ttf = font()
+
+      test(m"Format 4 delta segment maps letters"):
+        List('A', 'B', 'C').map(ttf.glyph(_).id)
+      . assert(_ == List(1, 2, 3))
+
+      test(m"Format 4 indirect segment maps through the glyph id array"):
+        List('a', 'b', 'c').map(ttf.glyph(_).id)
+      . assert(_ == List(2, 3, 1))
+
+      test(m"An unmapped character maps to the missing-glyph"):
+        ttf.glyph('z').id
+      . assert(_ == 0)
+
+      test(m"Format 0 maps byte codes"):
+        font(cmapFormat0).glyph('A').id
+      . assert(_ == 7)
+
+      test(m"Format 0 maps characters beyond bytes to the missing-glyph"):
+        font(cmapFormat0).glyph('β').id
+      . assert(_ == 0)
+
+      test(m"Format 6 maps a dense range and nothing else"):
+        List('0', '1', '2', '3').map(font(cmapFormat6).glyph(_).id)
+      . assert(_ == List(11, 12, 13, 0))
+
+      test(m"A full-Unicode subtable is preferred to the BMP"):
+        font(cmapPreferring12).glyph('A').id
+      . assert(_ == 5)
+
+    suite(m"Horizontal metrics"):
+      val ttf = font()
+
+      test(m"Advance widths follow the character mapping"):
+        List(ttf.advanceWidth('A'), ttf.advanceWidth('B'))
+      . assert(_ == List(500, 400))
+
+      test(m"A glyph beyond the metrics count repeats the last advance"):
+        ttf.advanceWidth('C')
+      . assert(_ == 400)
+
+      test(m"A glyph beyond the metrics count reads the bearing tail"):
+        ttf.leftSideBearing('C')
+      . assert(_ == 25)
+
+      test(m"Text width scales advances by the em size"):
+        ttf.width(t"AB")
+      . assert(_ == 0.9*Em)

--- a/lib/phoenicia/src/test/phoenicia_test.scala
+++ b/lib/phoenicia/src/test/phoenicia_test.scala
@@ -71,14 +71,16 @@ object Tests extends Suite(m"Phoenicia Tests"):
 
     Ttf(header ++ directory.result().reduce(_ ++ _) ++ body.result().reduce(_ ++ _))
 
-  val headTable: Data =
+  def headTableWith(indexToLocFormat: Int): Data =
     u16(1, 0, 1, 0)              // versions and font revision
     ++ u32(0L, 0x5f0f3cf5L)      // checksum adjustment and magic number
     ++ u16(0, 1000)              // flags and unitsPerEm
     ++ u32(0L, 0L, 0L, 0L)       // created and modified
     ++ u16(-50, -200, 1000, 800) // glyph bounding box
     ++ u16(0, 8)                 // macStyle and lowestRecPPEM
-    ++ u16(2, 0, 0)              // direction hint, indexToLocFormat and glyphDataFormat
+    ++ u16(2, indexToLocFormat, 0) // direction hint, indexToLocFormat and glyphDataFormat
+
+  val headTable: Data = headTableWith(0)
 
   val hheaTable: Data =
     u16(1, 0)                    // version
@@ -119,6 +121,20 @@ object Tests extends Suite(m"Phoenicia Tests"):
     ++ u16(1, 0, 0, 6, 7, 34)      // Macintosh PostScript name
     ++ utf16(t"Test Sans") ++ utf16(t"TestSans") ++ ascii(t"MacName")
 
+  // Glyphs 1 and 2 are simple single-contour glyphs; glyph 3 is a composite of both, its
+  // second component using byte-sized args and a single scale.
+  val glyph1: Data = u16(1, 0, 0, 500, 700, 1, 0)
+  val glyph2: Data = u16(1, 10, 20, 400, 600, 1, 0)
+
+  val glyph3: Data =
+    u16(-1, 0, 0, 500, 700)      // composite header
+    ++ u16(0x0021, 1, 0, 0)      // first component: word args, with more to come
+    ++ u16(0x0008, 2, 0, 0x4000) // second component: byte args and a scale of one
+
+  val locaTable: Data = u16(0, 0, 7, 14, 27)
+  val locaTableLong: Data = u32(0L, 0L, 14L, 28L, 54L)
+  val glyfTable: Data = glyph1 ++ glyph2 ++ glyph3
+
   // Three segments: A–C mapping by delta, a–c indirecting through the glyph id array in
   // rotated order, and the terminal sentinel.
   val format4Subtable: Data =
@@ -153,9 +169,12 @@ object Tests extends Suite(m"Phoenicia Tests"):
     ++ format4Subtable
     ++ u16(12, 0) ++ u32(28L, 0L, 1L) ++ u32(0x41L, 0x41L, 5L)
 
-  def font(cmap: Data = cmapFormat4): Ttf =
-    sfnt(t"cmap" -> cmap, t"head" -> headTable, t"hhea" -> hheaTable, t"hmtx" -> hmtxTable,
-        t"maxp" -> maxpTable, t"post" -> postTable, t"OS/2" -> os2Table, t"name" -> nameTable)
+  def font(cmap: Data = cmapFormat4, head: Data = headTable, extra: (Text, Data)*): Ttf =
+    val base = List(t"cmap" -> cmap, t"head" -> head, t"hhea" -> hheaTable,
+        t"hmtx" -> hmtxTable, t"maxp" -> maxpTable, t"post" -> postTable, t"OS/2" -> os2Table,
+        t"name" -> nameTable, t"loca" -> locaTable, t"glyf" -> glyfTable)
+
+    sfnt((base ++ extra)*)
 
   def run(): Unit =
     suite(m"Character mapping"):
@@ -246,3 +265,26 @@ object Tests extends Suite(m"Phoenicia Tests"):
       test(m"The family name is decoded from UTF-16"):
         ttf.familyName
       . assert(_ == t"Test Sans")
+
+    suite(m"Glyph outlines"):
+      val ttf = font()
+
+      test(m"A glyph without an outline has zero extent"):
+        ttf.glyf(0).empty
+      . assert(_ == true)
+
+      test(m"A simple glyph records its contour count"):
+        (ttf.glyf(1).contourCount, ttf.glyf(1).composite, ttf.glyf(1).bytes.length)
+      . assert(_ == (1, false, 14))
+
+      test(m"A composite glyph lists its components"):
+        ttf.glyf(3).components
+      . assert(_ == List(1, 2))
+
+      test(m"The glyph closure follows composite components"):
+        ttf.glyphClosure(Set(3))
+      . assert(_ == Set(1, 2, 3))
+
+      test(m"Long-format loca offsets are read unhalved"):
+        font(head = headTableWith(1), extra = t"loca" -> locaTableLong).glyf(3).bytes.length
+      . assert(_ == 26)

--- a/lib/phoenicia/src/test/phoenicia_test.scala
+++ b/lib/phoenicia/src/test/phoenicia_test.scala
@@ -288,3 +288,49 @@ object Tests extends Suite(m"Phoenicia Tests"):
       test(m"Long-format loca offsets are read unhalved"):
         font(head = headTableWith(1), extra = t"loca" -> locaTableLong).glyf(3).bytes.length
       . assert(_ == 26)
+
+    suite(m"Subsetting"):
+      val ttf = font()
+
+      test(m"A subset font reparses, keeping its glyph count"):
+        ttf.subset(Set('A')).maxp.glyphCount
+      . assert(_ == 4)
+
+      test(m"Retained glyphs keep their outlines byte-for-byte"):
+        ttf.subset(Set('A')).glyf(1).bytes.to(List)
+      . assert(_ == glyph1.to(List))
+
+      test(m"Unused glyphs lose their outlines"):
+        (ttf.subset(Set('A')).glyf(2).empty, ttf.subset(Set('A')).glyf(3).empty)
+      . assert(_ == (true, true))
+
+      test(m"Composite components are retained transitively"):
+        val subset = ttf.subset(Set('C'))
+        (subset.glyf(1).empty, subset.glyf(2).empty, subset.glyf(3).composite)
+      . assert(_ == (false, false, true))
+
+      test(m"Character mapping survives subsetting"):
+        ttf.subset(t"A").glyph('A').id
+      . assert(_ == 1)
+
+      test(m"Metrics and names are carried over"):
+        (ttf.subset(t"A").advanceWidth('A'), ttf.subset(t"A").fontName)
+      . assert(_ == (500, t"TestSans"))
+
+      test(m"The subset head switches to long loca offsets"):
+        ttf.subset(Set('A')).head.indexToLocFormat.int
+      . assert(_ == 1)
+
+      test(m"The whole file sums to the checksum constant"):
+        val bytes = ttf.subset(Set('A')).data
+        var sum = 0L
+
+        (0 until bytes.length by 4).each: index =>
+          val word =
+            ((bytes(index) & 0xffL) << 24) | ((bytes(index + 1) & 0xffL) << 16) |
+            ((bytes(index + 2) & 0xffL) << 8) | (bytes(index + 3) & 0xffL)
+
+          sum = (sum + word) & 0xffffffffL
+
+        sum
+      . assert(_ == 0xb1b0afbaL)

--- a/lib/phoenicia/src/test/phoenicia_test.scala
+++ b/lib/phoenicia/src/test/phoenicia_test.scala
@@ -47,6 +47,9 @@ object Tests extends Suite(m"Phoenicia Tests"):
       values.flatMap: value =>
         Seq((value >> 24).toByte, (value >> 16).toByte, (value >> 8).toByte, value.toByte)
 
+  def ascii(text: Text): Data = IArray.from(text.s.getBytes("US-ASCII").nn)
+  def utf16(text: Text): Data = IArray.from(text.s.getBytes("UTF-16BE").nn)
+
   // Assembles tables into an sfnt container: the header, a table directory, then the tables
   // themselves, four-byte aligned. Checksums are left zero: the parser does not verify them.
   def sfnt(tables: (Text, Data)*): Ttf =
@@ -89,6 +92,33 @@ object Tests extends Suite(m"Phoenicia Tests"):
   // Three full metric pairs, then a bearing-only entry for the monospaced tail.
   val hmtxTable: Data = u16(600, 10, 500, 20, 400, 30) ++ u16(25)
 
+  val maxpTable: Data = u32(0x00010000L) ++ u16(4)
+
+  val postTable: Data =
+    u32(0x00030000L, 0xfff48000L) // version 3.0 and an italic angle of -11.5
+    ++ u16(-100, 50)              // underline position and thickness
+    ++ u32(1L)                    // fixed pitch
+
+  val os2Table: Data =
+    u16(2, 500, 700, 5, 8)               // version through fsType (preview-and-print)
+    ++ u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0) // sub/superscript and strikeout metrics
+    ++ u16(0)                            // family class
+    ++ u16(0, 0, 0, 0, 0)                // panose
+    ++ u32(0L, 0L, 0L, 0L)               // unicode ranges
+    ++ ascii(t"TEST")                    // vendor id
+    ++ u16(0x40, 0x41, 0x7a)             // selection and first/last character index
+    ++ u16(750, -250, 100)               // typographic ascent, descent and line gap
+    ++ u16(820, 220)                     // Windows ascent and descent
+    ++ u32(0L, 0L)                       // code page ranges
+    ++ u16(530, 730, 0, 32, 0)           // x-height, cap height and character fields
+
+  val nameTable: Data =
+    u16(0, 3, 42)               // format, count and storage offset
+    ++ u16(3, 1, 0x409, 1, 18, 0)  // Windows family name
+    ++ u16(3, 1, 0x409, 6, 16, 18) // Windows PostScript name
+    ++ u16(1, 0, 0, 6, 7, 34)      // Macintosh PostScript name
+    ++ utf16(t"Test Sans") ++ utf16(t"TestSans") ++ ascii(t"MacName")
+
   // Three segments: A–C mapping by delta, a–c indirecting through the glyph id array in
   // rotated order, and the terminal sentinel.
   val format4Subtable: Data =
@@ -124,7 +154,8 @@ object Tests extends Suite(m"Phoenicia Tests"):
     ++ u16(12, 0) ++ u32(28L, 0L, 1L) ++ u32(0x41L, 0x41L, 5L)
 
   def font(cmap: Data = cmapFormat4): Ttf =
-    sfnt(t"cmap" -> cmap, t"head" -> headTable, t"hhea" -> hheaTable, t"hmtx" -> hmtxTable)
+    sfnt(t"cmap" -> cmap, t"head" -> headTable, t"hhea" -> hheaTable, t"hmtx" -> hmtxTable,
+        t"maxp" -> maxpTable, t"post" -> postTable, t"OS/2" -> os2Table, t"name" -> nameTable)
 
   def run(): Unit =
     suite(m"Character mapping"):
@@ -176,3 +207,42 @@ object Tests extends Suite(m"Phoenicia Tests"):
       test(m"Text width scales advances by the em size"):
         ttf.width(t"AB")
       . assert(_ == 0.9*Em)
+
+    suite(m"Font tables"):
+      val ttf = font()
+
+      test(m"The head table records the glyph bounding box"):
+        (ttf.head.xMin.int, ttf.head.yMin.int, ttf.head.xMax.int, ttf.head.yMax.int)
+      . assert(_ == (-50, -200, 1000, 800))
+
+      test(m"The maximum profile records the glyph count"):
+        ttf.maxp.glyphCount
+      . assert(_ == 4)
+
+      test(m"The post table decodes the fixed-point italic angle"):
+        ttf.post.italicAngle
+      . assert(_ == -11.5)
+
+      test(m"The post table identifies a monospaced font"):
+        ttf.post.monospaced
+      . assert(_ == true)
+
+      test(m"OS/2 metrics are read at their versioned offsets"):
+        (ttf.os2.weightClass, ttf.os2.typoAscender, ttf.os2.typoDescender)
+      . assert(_ == (700, 750, -250))
+
+      test(m"Cap height and x-height are present from OS/2 version 2"):
+        (ttf.os2.capHeight, ttf.os2.xHeight)
+      . assert(_ == (730, 530))
+
+      test(m"Preview-and-print fonts count as embeddable"):
+        ttf.os2.embeddable
+      . assert(_ == true)
+
+      test(m"Windows names are preferred to Macintosh names"):
+        ttf.fontName
+      . assert(_ == t"TestSans")
+
+      test(m"The family name is decoded from UTF-16"):
+        ttf.familyName
+      . assert(_ == t"Test Sans")


### PR DESCRIPTION
Phoenicia now interprets the full set of TrueType tables that font embedding requires — correct and complete character mapping, global and horizontal metrics, PostScript naming, OS/2 typographic metrics and embedding rights, and glyph outlines including composite components — and can subset a font to the glyphs a set of characters needs, serialising a complete, checksummed font file that independent font stacks accept.

Phoenicia's TrueType support has grown from a small slice of the format to everything needed to measure, name, inspect and embed fonts.

## Character mapping

Looking up a glyph by character now chooses the font's best `cmap` subtable by Unicode preference (full Unicode, then the Basic Multilingual Plane, then Windows symbol and legacy Macintosh mappings), and understands Formats 0, 4, 6 and 12 — including Format 4's indirection through the glyph-id array, which was previously mishandled. A character the font does not map yields glyph `0`, the conventional missing-glyph, and advance widths are now correct for fonts with a monospaced `hmtx` tail.

## Metric and naming tables

The `head` table is parsed in full — including the glyph bounding box and `indexToLocFormat` — alongside four newly-supported tables: `maxp` (glyph count), `post` (italic angle, underline metrics, fixed pitch), version-aware `OS/2` (weight, typographic ascent and descent, cap height and x-height where present, and embedding rights) and `name`, whose localized records decode from UTF-16BE or Macintosh encodings with Windows-English preference:

```scala
val font = Ttf(data)
font.fontName        // the PostScript name, e.g. ArialMT
font.familyName      // e.g. Arial
font.os2.capHeight   // e.g. 1467
font.post.italicAngle
```

## Glyph outlines and subsetting

Glyph outlines are located through `loca` (both formats) and read from `glyf`, including the component lists of composite glyphs, with `glyphClosure` computing the transitive closure of a glyph set under composition. On top of this, `subset` produces a new font containing only the outlines a set of characters needs:

```scala
val smaller = font.subset(t"Hello, World!")
```

Glyph numbering is retained — unused glyphs simply lose their outlines — so character mappings, metrics and inter-glyph references remain valid, and every other table is carried over unchanged. The result is a complete font file with correct per-table checksums and a recomputed `checkSumAdjustment`, verified by round-tripping through Phoenicia's own parser and accepted by CoreText.

🤖 Generated with [Claude Code](https://claude.com/claude-code)