### PR TITLE
Materialize Sheet, stream DSV rows, and parse records directly

### DIFF
--- a/lib/caesura/src/core/caesura.Dsv.scala
+++ b/lib/caesura/src/core/caesura.Dsv.scala
@@ -47,6 +47,7 @@ import spectacular.*
 import turbulence.*
 import vacuous.*
 import wisteria.*
+import zephyrine.*
 
 trait Dsv2:
   // Generic fallback: any `Decodable in Text` (custom types, enums, `Uuid`, …)
@@ -57,6 +58,19 @@ trait Dsv2:
   given decoder: [decodable] => (decodable: (decodable is Decodable in Text)^)
   =>  ((decodable is Decodable in Dsv)^{decodable}) =
     value => decodable.decoded(value.data.head)
+
+  // `source.read[Foo in Dsv]` shorthand: decodes a single DSV record (the first
+  // row) into `Foo` through the row AST. Held below `aggregableParsed` in
+  // `object Dsv`, so a type with an explicit `Dsv.Parsable` takes the direct
+  // (AST-free) path instead. The `Form` type-tag is added by an `asInstanceOf`
+  // cast — `value in Dsv` is just `value { type Form = Dsv }`, so the cast is a
+  // no-op at runtime.
+  given aggregableIn: [value: Decodable in Dsv] => (format: DsvFormat)
+  =>  (tactic: Tactic[DsvError])
+  =>  (((value in Dsv) is Aggregable by Text)^{tactic}) =
+    text =>
+      summon[Sheet is Aggregable by Text].aggregate(text).rows.head.as[value]
+      . asInstanceOf[value in Dsv]
 
 object Dsv extends Dsv2:
   def apply(iterable: Iterable[Text]): Dsv =
@@ -153,20 +167,6 @@ object Dsv extends Dsv2:
 
     DecodableDerivation.derived[value]
 
-  // `source.read[Foo in Dsv]` shorthand for `source.read[Sheet].rows.head.as[Foo]`:
-  // decodes a single DSV record (the first row) into `Foo`, mirroring the other
-  // formats' `value in Format` aggregables. Multi-row sources should be read as a
-  // `Sheet` instead (`Sheet.as[Foo]` yields a `LazyList[Foo]`). The `Form` type-tag is
-  // added by an `asInstanceOf` cast — `value in Dsv` is just `value { type Form = Dsv }`
-  // so the cast is a no-op at runtime.
-  given aggregableIn: [value: Decodable in Dsv] => (format: DsvFormat)
-  =>  (tactic: Tactic[DsvError])
-  =>  (((value in Dsv) is Aggregable by Text)^{tactic}) =
-    text =>
-      summon[Sheet is Aggregable by Text].aggregate(text).rows.head.as[value]
-      . asInstanceOf[value in Dsv]
-
-
   inline given encodableDerivation: [value <: Product: ProductReflection]
   =>  value is Encodable in Dsv =
 
@@ -190,6 +190,145 @@ object Dsv extends Dsv2:
             append(format.quote)
 
     cells.join(format.delimiter.show)
+
+  // Direct-read entries, gated on an explicit `Dsv.Parsable` (they sit above
+  // the AST-based `aggregableIn` in `Dsv2`, so opting in switches the path).
+  // `read[Foo in Dsv]` parses the first row; `read[List[Foo] in Dsv]` parses
+  // every row. Sealed per the codec-thunk pattern.
+  given aggregableParsed: [value] => (parsable: value is Dsv.Parsable)
+  =>  ( format: DsvFormat, tactic: Tactic[DsvError], buffering: Buffering )
+  =>  ((value in Dsv) is Aggregable by Text) =
+    caps.unsafe.unsafeAssumePure:
+      new Aggregable:
+        type Self = value in Dsv
+        type Operand = Text
+
+        def aggregate(text: LazyList[Text]): value in Dsv = accept(Stream(text.iterator))
+
+        override def accept(stream: (Stream[Text] over Credit)^): value in Dsv =
+          val reader =
+            Sheet.directReader(stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Text] over Credit)^])
+
+          if reader.nextRow() then parsable.parse(reader, 0).asInstanceOf[value in Dsv]
+          else tactic.abort(DsvError(format, DsvError.Reason.Absent))
+
+  given aggregableParsedList: [value] => (parsable: value is Dsv.Parsable)
+  =>  ( format: DsvFormat, tactic: Tactic[DsvError], buffering: Buffering )
+  =>  ((List[value] in Dsv) is Aggregable by Text) =
+    caps.unsafe.unsafeAssumePure:
+      new Aggregable:
+        type Self = List[value] in Dsv
+        type Operand = Text
+
+        def aggregate(text: LazyList[Text]): List[value] in Dsv = accept(Stream(text.iterator))
+
+        override def accept(stream: (Stream[Text] over Credit)^): List[value] in Dsv =
+          val reader =
+            Sheet.directReader(stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Text] over Credit)^])
+
+          val buffer = scala.collection.mutable.ListBuffer[value]()
+          while reader.nextRow() do buffer += parsable.parse(reader, 0)
+          buffer.to(List).asInstanceOf[List[value] in Dsv]
+
+  // ---- Direct (AST-free) parsing --------------------------------------------
+  //
+  // `Dsv.Parsable` reads a value straight off the `DsvReader` token reader:
+  // no per-row `Dsv`, no per-field slice of the cell array. `Parsable` is the
+  // OPT-IN surface (explicit instances and `derives Dsv.Parsable`; no blanket
+  // given), so `read[T in Dsv]` changes behavior only when a type opts in;
+  // `Field` is the operational sibling that always resolves (bridging any
+  // `Decodable in Text`), used in field position by the derivation. Neither
+  // subtypes the other.
+  trait Parsing extends distillate.Parsable:
+    type Transport = Dsv
+    type Reader = DsvReader
+
+    // Cells this value occupies in positional mode.
+    def width: Int = 1
+
+    // Read a value from the current row, starting at cell `offset`.
+    def parse(reader: DsvReader^, offset: Int): Self
+
+    def parse(reader: DsvReader^): Self = parse(reader, 0)
+
+  trait Parsable extends Parsing
+
+  object Parsable:
+    inline def derived[value <: Product: ProductReflection]: value is Dsv.Parsable =
+      val field = ParsableDerivation.derived[value]
+
+      new Parsable:
+        type Self = value
+        override def width: Int = field.width
+        def parse(reader: DsvReader^, offset: Int): value = field.parse(reader, offset)
+
+  trait Field extends Parsing
+
+  object Field:
+    // Rim call points for generated code: the derivation's lambda holds the
+    // reader as a neutral `AnyRef` carrier (a function type may not take a
+    // `^` parameter, and an inline lambda may not mint the capability); these
+    // named methods reassert it.
+    def parseField[value](field: value is Dsv.Field, carrier: AnyRef, offset: Int): value =
+      field.parse(carrier.asInstanceOf[DsvReader^], offset)
+
+    def fieldColumn(carrier: AnyRef, name: Text): Optional[Int] =
+      carrier.asInstanceOf[DsvReader].column(name)
+
+    // Bridge: any `Decodable in Text` reads a single cell. An absent cell (a
+    // short positional row, or a header column missing here) aborts through
+    // the reader's own tactic; `optional` below intercepts that for
+    // `Optional` fields. Sealed per the codec-thunk pattern.
+    given decodable: [value] => (decodable: (value is Decodable in Text)^)
+    =>  value is Dsv.Field =
+      caps.unsafe.unsafeAssumePure:
+        new Field:
+          type Self = value
+
+          def parse(reader: DsvReader^, offset: Int): value =
+            reader.cell(offset).lay(reader.absent()): cell =>
+              decodable.decoded(cell)
+
+    given optional: [inner <: value, value >: Unset.type: Mandatable to inner]
+    =>  ( field: => inner is Dsv.Field )
+    =>  value is Dsv.Field =
+      caps.unsafe.unsafeAssumePure:
+        new Field:
+          type Self = value
+          override def width: Int = field.width
+
+          def parse(reader: DsvReader^, offset: Int): value =
+            if reader.cell(offset).absent then Unset else field.parse(reader, offset)
+
+  object ParsableDerivation extends ProductDerivable[Dsv.Field]:
+    // The generated parse lambda takes the reader as a neutral `AnyRef`
+    // carrier (a function type may not take a `^` parameter); the capability
+    // is reasserted at the rim inside. Nothing of the reader is retained.
+    class DsvProductParser[derivation](width0: Int, lambda: (AnyRef, Int) => derivation)
+    extends Field:
+      type Self = derivation
+      override def width: Int = width0
+
+      def parse(reader: DsvReader^, offset: Int): derivation =
+        lambda(reader.asInstanceOf[AnyRef], offset)
+
+    inline def conjunction[derivation <: Product: ProductReflection]
+    :   (derivation is Dsv.Field)^ =
+
+      val spans: IArray[Int] = Spannable.derived[derivation].spans()
+      var total: Int = 0
+      spans.foreach { span => total += span }
+
+      DsvProductParser[derivation](total, (carrier, offset) =>
+        var count = offset
+
+        build[derivation]:
+          [field] => context =>
+            // Header mode locates the field by column name; positional mode
+            // reads the field's span starting at the running offset.
+            val at = Dsv.Field.fieldColumn(carrier, label).or(count)
+            count += spans(index)
+            Dsv.Field.parseField(contextual, carrier, at))
 
   object DecodableDerivation extends ProductDerivable[Decodable in Dsv]:
     // An impure (`=>`) lambda: a derived decoder legitimately captures the consumer's

--- a/lib/caesura/src/core/caesura.DsvReader.scala
+++ b/lib/caesura/src/core/caesura.DsvReader.scala
@@ -1,0 +1,64 @@
+                                                                                                  /*
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃                                                                                                  ┃
+┃                                                   ╭───╮                                          ┃
+┃                                                   │   │                                          ┃
+┃                                                   │   │                                          ┃
+┃   ╭───────╮╭─────────╮╭───╮ ╭───╮╭───╮╌────╮╭────╌┤   │╭───╮╌────╮╭────────╮╭───────╮╭───────╮   ┃
+┃   │   ╭───╯│   ╭─╮   ││   │ │   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮   ││   ╭─╮  ││   ╭───╯│   ╭───╯   ┃
+┃   │   ╰───╮│   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╰─╯  ││   ╰───╮│   ╰───╮   ┃
+┃   ╰───╮   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   │ │   ││   ╭────╯╰───╮   │╰───╮   │   ┃
+┃   ╭───╯   ││   ╰─╯   ││   ╰─╯   ││   │ │   ││   ╰─╯   ││   │ │   ││   ╰────╮╭───╯   │╭───╯   │   ┃
+┃   ╰───────╯╰─────────╯╰────╌╰───╯╰───╯ ╰───╯╰────╌╰───╯╰───╯ ╰───╯╰────────╯╰───────╯╰───────╯   ┃
+┃                                                                                                  ┃
+┃    Soundness, version 0.63.0.                                                                    ┃
+┃    © Copyright 2021-25 Jon Pretty, Propensive OÜ.                                                ┃
+┃                                                                                                  ┃
+┃    The primary distribution site is:                                                             ┃
+┃                                                                                                  ┃
+┃        https://soundness.dev/                                                                    ┃
+┃                                                                                                  ┃
+┃    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file     ┃
+┃    except in compliance with the License. You may obtain a copy of the License at                ┃
+┃                                                                                                  ┃
+┃        https://www.apache.org/licenses/LICENSE-2.0                                               ┃
+┃                                                                                                  ┃
+┃    Unless required by applicable law or agreed to in writing,  software distributed under the    ┃
+┃    License is distributed on an "AS IS" BASIS,  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,    ┃
+┃    either express or implied. See the License for the specific language governing permissions    ┃
+┃    and limitations under the License.                                                            ┃
+┃                                                                                                  ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+                                                                                                  */
+package caesura
+
+import anticipation.*
+import contingency.*
+import vacuous.*
+
+// The DSV token-reader capability for direct (AST-free) parsing: one row at a
+// time, cells addressed in place within the parser's reusable row buffer — no
+// per-row `Dsv`, no per-field slice. The reader is exclusive and stateful; it
+// is owned by the caller for the duration of a parse and nothing of it may be
+// retained in the result.
+class DsvReader private[caesura]
+  ( consume parser: Sheet.Parser^,
+    private[caesura] val format: DsvFormat,
+    private[caesura] val tactic: Tactic[DsvError] )
+extends caps.ExclusiveCapability, caps.Stateful:
+  // The reader carries the format and error tactic, so `Parsable`/`Field`
+  // instances are construction-free (the jacinta `JsonReader` pattern).
+  update def absent(): Nothing = tactic.abort(DsvError(format, DsvError.Reason.Absent))
+
+  // Advance to the next data row (consuming the header row first, when the
+  // format has one), returning false at the end of the input.
+  update def nextRow(): Boolean = parser.advanceData()
+
+  def cells: Int = parser.cellCount
+
+  // The cell at `index` within the current row, or `Unset` when the row is
+  // shorter (a short positional row, or a header column missing here).
+  def cell(index: Int): Optional[Text] = parser.cellAt(index)
+
+  // The column index of a header name, or `Unset` in positional mode.
+  def column(name: Text): Optional[Int] = parser.columnIndex(name)

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -81,7 +81,8 @@ object Sheet:
   given tabular: Sheet is Tabular[Text]:
     type Element = Dsv
 
-    def rows(value: Sheet) = value.rows
+    def rows(value: Sheet): Seq[Dsv] =
+      scala.collection.immutable.ArraySeq.unsafeWrapArray(value.rows.mutable(using Unsafe))
 
     def table(dsv: Sheet): Scaffold[Dsv, Text] =
       val columns: List[Text] =
@@ -105,39 +106,74 @@ object Sheet:
         type Self = Sheet
         type Operand = Text
 
-        def aggregate(text: LazyList[Text]): Sheet = sheet(parse(Stream(text.iterator)))
+        def aggregate(text: LazyList[Text]): Sheet = sheet(parseRows(Stream(text.iterator)))
         override def accept(stream: (Stream[Text] over Credit)^): Sheet =
           // The non-consume `accept` crosses to the consuming parser as a
           // neutral reference; each accept delivers a single-use stream.
-          sheet(parse(stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Text] over Credit)^]))
+          sheet(parseRows(stream.asInstanceOf[AnyRef].asInstanceOf[(Stream[Text] over Credit)^]))
 
-        private def sheet(rows: LazyList[Dsv]): Sheet =
+        private def sheet(iterator: Iterator[Dsv]^): Sheet =
+          val rows = IArray.from(iterator)
           if format.header then Sheet(rows, format, rows.prim.let(_.header))
           else Sheet(rows, format)
 
-  given showable: DsvFormat => Sheet is Showable = _.rows.map(_.show).join(t"\n")
+  given showable: DsvFormat => Sheet is Showable = _.rows.to(List).map(_.show).join(t"\n")
   given streamable: DsvFormat => Sheet is Streamable by Text over Credit = sheet =>
     Stream(sheet.rows.iterator.map(_.show+t"\n"))
 
 
-  // Parse rows from a pull endpoint, one block-credit refill per chunk.
-  private def parse(consume stream: (Stream[Text] over Credit)^)
+  // Parse rows from a pull endpoint as a single-consumer iterator, one
+  // block-credit refill per chunk. Each call builds a fresh parser over the
+  // stream; the iterator owns both for its lifetime.
+  private[caesura] def parseRows(consume stream: (Stream[Text] over Credit)^)
     ( using format: DsvFormat, tactic: Tactic[DsvError], buffering: Buffering )
-  :   LazyList[Dsv] =
+  :   Iterator[Dsv]^ =
 
     val block = buffering.capacity(Substrate.Chars)
 
-    val load: () => Optional[Text] = () => stream.refill(Credit(block)) match
-      case count: Int =>
-        val window = stream.window(using Unsafe)
-        val text = stream.addressable.materialize(window, stream.start, count)
-        stream.skip(count)
-        text
+    // The load closure is built inline in the constructor call: a local
+    // binding of it would hide the stream from the subsequent statement (the
+    // statement rule). The resolution-scoped tactic is sealed at the rim (the
+    // codec-thunk pattern, as in `aggregable` above) so the fresh parser can
+    // cross into the consume position without referring to the parameter.
+    given sealedTactic: Tactic[DsvError] = caps.unsafe.unsafeAssumePure(tactic)
 
-      case _ =>
-        Unset
+    rowIterator:
+      new Parser(() => stream.refill(Credit(block)) match
+        case count: Int =>
+          val window = stream.window(using Unsafe)
+          val text = stream.addressable.materialize(window, stream.start, count)
+          stream.skip(count)
+          text
 
-    new Parser(load).stream
+        case _ =>
+          Unset)
+
+  // Constructed in a helper: a local binding of the fresh parser would hide it
+  // from the anonymous class (the statement rule); consume parameters carry
+  // explicit capture sets and hide nothing.
+  private def rowIterator(consume parser: Parser^): Iterator[Dsv]^ =
+    new Iterator[Dsv]:
+      // Untracked: a stdlib `Iterator` cannot extend `Stateful`; the fields
+      // are reached only through this iterator's own methods.
+      @caps.unsafe.untrackedCaptures
+      private var pending: Optional[Dsv] = Unset
+      @caps.unsafe.untrackedCaptures
+      private var finished: Boolean = false
+
+      def hasNext: Boolean =
+        if pending.present then true
+        else if finished then false
+        else
+          pending = parser.nextRow()
+          if pending.absent then finished = true
+          pending.present
+
+      def next(): Dsv =
+        if !hasNext then Iterator.empty.next()
+        val row = pending.or(Iterator.empty.next())
+        pending = Unset
+        row
 
 
   private class Parser(load: () => Optional[Text])
@@ -290,9 +326,10 @@ object Sheet:
       else
         Unset
 
-    update def stream: LazyList[Dsv] = next()
-
-    update private def next(): LazyList[Dsv] = parseRow() match
+    // The next data row, or `Unset` at the end of the input. When the format
+    // has a header, the first parsed row is consumed into `headings` so every
+    // data row carries the name→index map.
+    update def nextRow(): Optional[Dsv] = parseRow() match
       case row: Dsv =>
         if isHeader && headings.absent then
           val data = row.data
@@ -304,29 +341,35 @@ object Sheet:
             i += 1
 
           headings = mapBuilder.result()
-          next()
+          nextRow()
         else
-          row #:: next()
+          row
 
       case _ =>
-        LazyList()
+        Unset
 
+// A fully-instantiated sheet of DSV data: every row is in memory, replayable
+// and indexable. The streaming counterpart is `stream.rows`, an
+// `Iterator[Dsv]` over a live pull endpoint, which never builds a `Sheet`.
 case class Sheet
-  ( rows:    LazyList[Dsv],
+  ( rows:    IArray[Dsv],
     format:  Optional[DsvFormat]    = Unset,
     columns: Optional[IArray[Text]] = Unset ):
 
-  def as[value: Decodable in Dsv]: LazyList[value] raises DsvError tracks CellRef =
-    rows.map(_.as[value])
+  def as[value: Decodable in Dsv]: List[value] raises DsvError tracks CellRef =
+    rows.to(List).map(_.as[value])
 
   override def hashCode: Int =
-    (rows.hashCode*31 + format.hashCode)*31 + columns.lay(-1): array =>
-      ju.Arrays.hashCode(array.mutable(using Unsafe))
+    (ju.Arrays.hashCode(rows.mutable(using Unsafe).asInstanceOf[Array[Object | Null]])*31
+        + format.hashCode)*31
+    + columns.lay(-1): array =>
+        ju.Arrays.hashCode(array.mutable(using Unsafe))
 
   override def equals(that: Any): Boolean = that.asMatchable match
     case dsv: Sheet =>
-      dsv.rows == rows && dsv.format == format && columns.lay(dsv.columns == Unset): columns =>
-        dsv.columns.lay(false)(columns.sameElements(_))
+      dsv.rows.sameElements(rows) && dsv.format == format
+      && columns.lay(dsv.columns == Unset): columns =>
+           dsv.columns.lay(false)(columns.sameElements(_))
 
     case _ =>
       false

--- a/lib/caesura/src/core/caesura.Sheet.scala
+++ b/lib/caesura/src/core/caesura.Sheet.scala
@@ -152,6 +152,26 @@ object Sheet:
   // Constructed in a helper: a local binding of the fresh parser would hide it
   // from the anonymous class (the statement rule); consume parameters carry
   // explicit capture sets and hide nothing.
+  // A token reader for direct (AST-free) parsing, over a fresh parser: the
+  // `Dsv.Parsable` counterpart of `parseRows`. Same rim discipline as above.
+  private[caesura] def directReader(consume stream: (Stream[Text] over Credit)^)
+    ( using format: DsvFormat, tactic: Tactic[DsvError], buffering: Buffering )
+  :   DsvReader^ =
+
+    val block = buffering.capacity(Substrate.Chars)
+    given sealedTactic: Tactic[DsvError] = caps.unsafe.unsafeAssumePure(tactic)
+
+    DsvReader(format = format, tactic = caps.unsafe.unsafeAssumePure(tactic), parser =
+      new Parser(() => stream.refill(Credit(block)) match
+        case count: Int =>
+          val window = stream.window(using Unsafe)
+          val text = stream.addressable.materialize(window, stream.start, count)
+          stream.skip(count)
+          text
+
+        case _ =>
+          Unset))
+
   private def rowIterator(consume parser: Parser^): Iterator[Dsv]^ =
     new Iterator[Dsv]:
       // Untracked: a stdlib `Iterator` cannot extend `Stateful`; the fields
@@ -176,7 +196,7 @@ object Sheet:
         row
 
 
-  private class Parser(load: () => Optional[Text])
+  private[caesura] class Parser(load: () => Optional[Text])
     ( using format: DsvFormat, tactic: Tactic[DsvError] )
   extends caps.ExclusiveCapability, caps.Stateful:
     private var current: String = ""
@@ -217,19 +237,31 @@ object Sheet:
       cellsBuf += Text(builder.toString.nn)
       builder.setLength(0)
 
-    update private def emitRow(): Dsv =
+    // The completed row's cells remain in `cellsBuf` (reused across rows):
+    // the direct parser reads them in place; `materialize()` copies them out
+    // for the `Dsv` row path.
+    update private def endRow(): Unit =
+      rowOrdinal = rowOrdinal.next
+
+    private[caesura] def cellCount: Int = cellsBuf.length
+
+    private[caesura] def cellAt(index: Int): Optional[Text] =
+      if index >= 0 && index < cellsBuf.length then cellsBuf(index) else Unset
+
+    private[caesura] def columnIndex(name: Text): Optional[Int] =
+      headings.let(_.at(name))
+
+    private[caesura] def materialize(): Dsv =
       val n = cellsBuf.length
       val arr = new Array[Text](n)
       cellsBuf.copyToArray(arr)
-      cellsBuf.clear()
-      rowOrdinal = rowOrdinal.next
       Dsv(IArray.unsafeFromArray(arr), headings)
 
     // Scan ahead in Fresh state for the next delimiter, quote, or line-ending,
     // bulk-appending the run of regular characters in one operation, then
-    // dispatch on the trigger char. Returns Unset to continue parsing or a
-    // Dsv when a row has just been closed.
-    update private def scanFresh(): Optional[Dsv] =
+    // dispatch on the trigger char. Returns true when a row has just been
+    // closed (its cells left in `cellsBuf`).
+    update private def scanFresh(): Boolean =
       val str = current
       val len = currentLen
       val d = delim
@@ -246,7 +278,7 @@ object Sheet:
 
           if ch == d then
             closeCell()
-            return Unset
+            return false
           else if ch == q then
             if builder.length > 0 then
               val reason = DsvError.Reason.MisplacedQuote
@@ -259,18 +291,19 @@ object Sheet:
               raise(DsvError(format, reason, row, cell, position))
 
             state = State.Quoted
-            return Unset
+            return false
           else
-            if cellsBuf.nil && builder.length == 0 then return Unset
+            if cellsBuf.nil && builder.length == 0 then return false
             else
               closeCell()
-              return emitRow()
+              endRow()
+              return true
 
         p += 1
 
       if p > s then builder.append(str, s, p)
       pos = p
-      Unset
+      false
 
     // Scan ahead in Quoted state for the next quote, bulk-appending all other
     // characters (including delimiters and newlines) verbatim.
@@ -289,64 +322,68 @@ object Sheet:
       else
         pos = p
 
-    update private def handleDoubleQuoted(): Optional[Dsv] =
+    update private def handleDoubleQuoted(): Boolean =
       val ch = current.charAt(pos)
       pos += 1
 
       if ch == quoteChar then
         builder.append(quoteChar)
         state = State.Quoted
-        Unset
+        false
       else if ch == delim then
         closeCell()
         state = State.Fresh
-        Unset
+        false
       else if ch == '\n' || ch == '\r' then
         closeCell()
         state = State.Fresh
-        emitRow()
+        endRow()
+        true
       else
         builder.append(ch)
-        Unset
+        false
 
-    update private def parseRow(): Optional[Dsv] =
+    // Parse the next row into `cellsBuf`, returning false at the end of the
+    // input. The previous row's cells are discarded on entry.
+    private[caesura] update def advance(): Boolean =
+      cellsBuf.clear()
+
       while loadChunk() do
-        val emitted: Optional[Dsv] = state match
+        val complete: Boolean = state match
           case State.Fresh        => scanFresh()
-          case State.Quoted       => scanQuoted(); Unset
+          case State.Quoted       => scanQuoted(); false
           case State.DoubleQuoted => handleDoubleQuoted()
 
-        emitted match
-          case row: Dsv => return row
-          case _        => ()
+        if complete then return true
 
       if cellsBuf.nonEmpty || builder.length > 0 then
         closeCell()
-        emitRow()
+        endRow()
+        true
       else
-        Unset
+        false
 
-    // The next data row, or `Unset` at the end of the input. When the format
-    // has a header, the first parsed row is consumed into `headings` so every
-    // data row carries the name→index map.
-    update def nextRow(): Optional[Dsv] = parseRow() match
-      case row: Dsv =>
+    // Advance to the next DATA row: when the format has a header, the first
+    // parsed row is consumed into `headings` so data rows can be addressed by
+    // column name.
+    private[caesura] update def advanceData(): Boolean =
+      if advance() then
         if isHeader && headings.absent then
-          val data = row.data
           val mapBuilder = Map.newBuilder[Text, Int]
           var i = 0
 
-          while i < data.length do
-            mapBuilder += data(i) -> i
+          while i < cellsBuf.length do
+            mapBuilder += cellsBuf(i) -> i
             i += 1
 
           headings = mapBuilder.result()
-          nextRow()
-        else
-          row
+          advanceData()
+        else true
+      else false
 
-      case _ =>
-        Unset
+    // The next data row, or `Unset` at the end of the input.
+    update def nextRow(): Optional[Dsv] =
+      if advanceData() then materialize() else Unset
 
 // A fully-instantiated sheet of DSV data: every row is in memory, replayable
 // and indexable. The streaming counterpart is `stream.rows`, an

--- a/lib/caesura/src/core/caesura_core.scala
+++ b/lib/caesura/src/core/caesura_core.scala
@@ -70,6 +70,40 @@ extension (consume stream: (Stream[Text] over Credit)^)
   def rows(using DsvFormat, Tactic[DsvError], Buffering): Iterator[Dsv]^ =
     Sheet.parseRows(stream)
 
+extension (consume stream: (Stream[Text] over Credit)^)
+  // Each row parsed straight to `value` through its `Dsv.Parsable` — the
+  // streaming direct form: no `Dsv` row value is ever built.
+  def rowsOf[value](using parsable: value is Dsv.Parsable)
+    ( using DsvFormat, Tactic[DsvError], Buffering )
+  :   Iterator[value]^ =
+
+    parsedIterator(Sheet.directReader(stream), parsable)
+
+// Constructed in a helper: a local binding of the fresh reader would hide it
+// from the anonymous class (the statement rule).
+private def parsedIterator[value](consume reader: DsvReader^, parsable: value is Dsv.Parsable)
+:   Iterator[value]^ =
+
+  new Iterator[value]:
+    @caps.unsafe.untrackedCaptures
+    private var pending: Optional[value] = Unset
+    @caps.unsafe.untrackedCaptures
+    private var finished: Boolean = false
+
+    def hasNext: Boolean =
+      if pending.present then true
+      else if finished then false
+      else
+        pending = if reader.nextRow() then parsable.parse(reader, 0) else Unset
+        if pending.absent then finished = true
+        pending.present
+
+    def next(): value =
+      if !hasNext then Iterator.empty.next()
+      val row = pending.or(Iterator.empty.next())
+      pending = Unset
+      row
+
 // Panopticon optics for tabular data (no nesting, so they mirror the row/cell
 // structure rather than JSON's map/array). `cellLens` reads/writes a cell by column
 // name within a row; the `Sheet` opticals address the n-th row (`Ordinal`), every

--- a/lib/caesura/src/core/caesura_core.scala
+++ b/lib/caesura/src/core/caesura_core.scala
@@ -33,12 +33,14 @@
 package caesura
 
 import anticipation.*
+import contingency.*
 import denominative.*
 import gossamer.*
 import panopticon.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
+import zephyrine.*
 
 package dsvFormats:
   given csvFormat: DsvFormat = DsvFormat(false, ',', '"', '"')
@@ -58,7 +60,15 @@ package dsvRedesignations:
 extension [encodable: Encodable in Dsv](value: encodable) def dsv: Dsv = encodable.encode(value)
 
 extension [encodable: Encodable in Dsv](value: Seq[encodable])
-  def dsv: Sheet = Sheet(value.to(LazyList).map(encodable.encode(_)))
+  def dsv: Sheet = Sheet(IArray.from(value.map(encodable.encode(_))))
+
+extension (consume stream: (Stream[Text] over Credit)^)
+  // The rows of a character stream of DSV data, as a single-consumer
+  // iterator: the streaming counterpart of `read[Sheet]`, which materializes.
+  // Quoted cells may span chunk (and line) boundaries; the parser carries its
+  // state across refills.
+  def rows(using DsvFormat, Tactic[DsvError], Buffering): Iterator[Dsv]^ =
+    Sheet.parseRows(stream)
 
 // Panopticon optics for tabular data (no nesting, so they mirror the row/cell
 // structure rather than JSON's map/array). `cellLens` reads/writes a cell by column

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -57,6 +57,38 @@ object Tests extends Suite(m"Caesura tests"):
         t"name,age\nalpha,1\nbeta,2".source[Text].rows.map(_[Text](t"name").or(t"?")).to(List)
       . assert(_ == List(t"alpha", t"beta"))
 
+    suite(m"Direct parsing"):
+      import dsvFormats.csvFormat
+
+      test(m"read a single record directly"):
+        t"hello,world".read[DirectFoo in Dsv]
+      . assert(_ == DirectFoo(t"hello", t"world"))
+
+      test(m"read every row as a List directly"):
+        t"a,b\nc,d\ne,f".read[List[DirectFoo] in Dsv]
+      . assert(_ == List(DirectFoo(t"a", t"b"), DirectFoo(t"c", t"d"), DirectFoo(t"e", t"f")))
+
+      test(m"typed rows stream one value per row"):
+        t"x,1\ny,2".source[Text].rowsOf[DirectStat].map(_.count).to(List)
+      . assert(_ == List(1, 2))
+
+      test(m"direct read locates fields by heading"):
+        import dsvFormats.csvWithHeaderFormat
+        t"count,name\n3,alpha".read[DirectStat in Dsv]
+      . assert(_ == DirectStat(t"alpha", 3, Unset))
+
+      test(m"a short row parses a trailing Optional to Unset"):
+        t"z,9".read[DirectStat in Dsv]
+      . assert(_ == DirectStat(t"z", 9, Unset))
+
+      test(m"a present trailing Optional parses positionally"):
+        t"z,9,note".read[DirectStat in Dsv]
+      . assert(_ == DirectStat(t"z", 9, t"note"))
+
+      test(m"quoted cells with embedded newlines parse directly"):
+        t"\"1\n2\",x".read[DirectFoo in Dsv]
+      . assert(_ == DirectFoo(t"1\n2", t"x"))
+
     suite(m"Parsing tests"):
       import dsvFormats.csvFormat
 
@@ -353,6 +385,13 @@ object Tests extends Suite(m"Caesura tests"):
     AccrualTests()
 
 case class Foo(one: Text, two: Text)
+case class DirectFoo(one: Text, two: Text)
+object DirectFoo:
+  given parsable: DirectFoo is Dsv.Parsable = Dsv.Parsable.derived
+
+case class DirectStat(name: Text, count: Int, note: Optional[Text])
+object DirectStat:
+  given parsable: DirectStat is Dsv.Parsable = Dsv.Parsable.derived
 case class Bar(one: Double, foo1: Foo, four: Int, foo2: Foo)
 case class Quux(name: Text, greeting: Text)
 case class Greeting(word: Text, name: Optional[Text])

--- a/lib/caesura/src/test/caesura_test.scala
+++ b/lib/caesura/src/test/caesura_test.scala
@@ -41,6 +41,22 @@ given decimalizer: Decimalizer = Decimalizer(1)
 
 object Tests extends Suite(m"Caesura tests"):
   def run(): Unit =
+    suite(m"Streaming rows"):
+      import dsvFormats.csvFormat
+
+      test(m"rows of a stream as an iterator"):
+        t"a,b\nc,d\ne,f".source[Text].rows.to(List)
+      . assert(_ == List(Dsv(t"a", t"b"), Dsv(t"c", t"d"), Dsv(t"e", t"f")))
+
+      test(m"quoted newlines survive one-char chunks"):
+        t"\"1\n2\",x\ny,z".s.grouped(1).map(_.tt).stream.rows.to(List)
+      . assert(_ == List(Dsv(t"1\n2", t"x"), Dsv(t"y", t"z")))
+
+      test(m"header rows carry column names"):
+        import dsvFormats.csvWithHeaderFormat
+        t"name,age\nalpha,1\nbeta,2".source[Text].rows.map(_[Text](t"name").or(t"?")).to(List)
+      . assert(_ == List(t"alpha", t"beta"))
+
     suite(m"Parsing tests"):
       import dsvFormats.csvFormat
 
@@ -93,44 +109,44 @@ object Tests extends Suite(m"Caesura tests"):
       . assert(_ == DsvError(summon[DsvFormat], DsvError.Reason.MisplacedQuote, Prim.next.next, Sec, 12))
 
       test(m"multi-line CSV without trailing newline"):
-        t"""foo,bar\nbaz,quux""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
+        t"""foo,bar\nbaz,quux""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
 
       test(m"multi-line CSV with trailing newline"):
-        t"""foo,bar\nbaz,quux\n""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
+        t"""foo,bar\nbaz,quux\n""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
 
       test(m"multi-line CSV with CR and LF"):
-        t"""foo,bar\r\nbaz,quux\r\n""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
+        t"""foo,bar\r\nbaz,quux\r\n""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
 
       test(m"multi-line CSV with quoted newlines"):
-        t""""foo","bar"\n"baz","quux"\n""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
+        t""""foo","bar"\n"baz","quux"\n""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"foo", t"bar"), Dsv(t"baz", t"quux")))
 
       test(m"multi-line CSV with newlines and quotes in cells"):
-        t""""f""oo","Hello\nWorld"\nbaz,"1\n2\n3\n"\n""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"f\"oo", t"Hello\nWorld"), Dsv(t"baz", t"1\n2\n3\n")))
+        t""""f""oo","Hello\nWorld"\nbaz,"1\n2\n3\n"\n""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"f\"oo", t"Hello\nWorld"), Dsv(t"baz", t"1\n2\n3\n")))
 
       test(m"multi-line CSV with quoted quotes adjacent to newlines"):
-        t""""f""oo","Hello\nWorld"\nbaz,"1""\n""2\n3\n"\n""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"f\"oo", t"Hello\nWorld"), Dsv(t"baz", t"1\"\n\"2\n3\n")))
+        t""""f""oo","Hello\nWorld"\nbaz,"1""\n""2\n3\n"\n""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"f\"oo", t"Hello\nWorld"), Dsv(t"baz", t"1\"\n\"2\n3\n")))
 
       test(m"CSV with quoted quotes adjacent to delimiters"):
-        t""""f""oo","${"\"\""}Hello\nWorld${t"\"\""}"\n""".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"f\"oo", t"\"Hello\nWorld\"")))
+        t""""f""oo","${"\"\""}Hello\nWorld${t"\"\""}"\n""".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"f\"oo", t"\"Hello\nWorld\"")))
 
 
     suite(m"Alternative formats"):
       test(m"Parse TSV data without header"):
         import dsvFormats.tsvFormat
-        t"Hello\tWorld\n".read[Sheet].rows
-      . assert(_ == LazyList(Dsv(t"Hello", t"World")))
+        t"Hello\tWorld\n".read[Sheet].rows.to(List)
+      . assert(_ == List(Dsv(t"Hello", t"World")))
 
       test(m"Parse TSV data with header"):
         import dsvFormats.tsvWithHeaderFormat
         t"Greeting\tAddressee\nHello\tWorld\n".read[Sheet]
-      . assert(_ == Sheet(LazyList(Dsv(IArray(t"Hello", t"World"), Map(t"Greeting" -> 0, t"Addressee" -> 1))), dsvFormats.tsvWithHeaderFormat, IArray(t"Greeting", t"Addressee")))
+      . assert(_ == Sheet(IArray(Dsv(IArray(t"Hello", t"World"), Map(t"Greeting" -> 0, t"Addressee" -> 1))), dsvFormats.tsvWithHeaderFormat, IArray(t"Greeting", t"Addressee")))
 
 
 
@@ -190,38 +206,38 @@ object Tests extends Suite(m"Caesura tests"):
 
     test(m"convert simple row to string"):
       import dsvFormats.csvFormat
-      Sheet(LazyList(Dsv(t"hello", t"world"))).show
+      Sheet(IArray(Dsv(t"hello", t"world"))).show
     . assert(_ == t"""hello,world""")
 
     test(m"convert complex row to string"):
       import dsvFormats.csvFormat
-      Sheet(LazyList(Dsv(t"0.1", t"two", t"three", t"4", t"five", t"six"))).show
+      Sheet(IArray(Dsv(t"0.1", t"two", t"three", t"4", t"five", t"six"))).show
     . assert(_ == t"""0.1,two,three,4,five,six""")
 
     test(m"convert row with escaped quote"):
       import dsvFormats.csvFormat
-      Sheet(LazyList(Dsv(t"hello\"world"))).show
+      Sheet(IArray(Dsv(t"hello\"world"))).show
     . assert(_ == t""""hello""world"""")
 
     test(m"convert row with delimiter in cell"):
       import dsvFormats.csvFormat
-      Sheet(LazyList(Dsv(t"hello, world", t"test"))).show
+      Sheet(IArray(Dsv(t"hello, world", t"test"))).show
     . assert(_ == t""""hello, world",test""")
 
     test(m"convert row with newline in cell"):
       import dsvFormats.csvFormat
-      Sheet(LazyList(Dsv(t"line1\nline2", t"test"))).show
+      Sheet(IArray(Dsv(t"line1\nline2", t"test"))).show
     . assert(_ == t""""line1\nline2",test""")
 
     test(m"convert row with carriage return in cell"):
       import dsvFormats.csvFormat
-      Sheet(LazyList(Dsv(t"line1\rline2", t"test"))).show
+      Sheet(IArray(Dsv(t"line1\rline2", t"test"))).show
     . assert(_ == t""""line1\rline2",test""")
 
     test(m"simple parse TSV"):
       import dsvFormats.tsvFormat
       t"hello\tworld".read[Sheet]
-    . assert(_ == Sheet(LazyList(Dsv(t"hello", t"world")), format = dsvFormats.tsvFormat))
+    . assert(_ == Sheet(IArray(Dsv(t"hello", t"world")), format = dsvFormats.tsvFormat))
 
     test(m"decode case class from TSV"):
       import dsvFormats.tsvFormat


### PR DESCRIPTION
CSV/DSV data gets an honest split between its two access patterns, and a direct-to-case-class parser in the style of the JSON, TEL and XML direct parsers. `Sheet` is now the fully-instantiated form — `rows: IArray[Dsv]`, replayable, indexable and cheap to compare — while streaming consumption goes through iterators that never build a `Sheet` at all.

## Streaming rows

```scala
stream.rows          // Iterator[Dsv]: one row at a time off a live stream
text.read[Sheet]     // the whole sheet, in memory
```

The streaming form uses the same chunk-spanning parser as `Sheet` (quoted cells may cross chunk and line boundaries), one fresh parser per stream.

## Direct parsing

`Dsv.Parsable` reads a value straight off the token reader: no per-row `Dsv`, no per-field slice of the cell array. It is opt-in per type; types without an instance keep the existing row-decoder path.

```scala
case class Stat(name: Text, count: Int, note: Optional[Text])
object Stat:
  given Stat is Dsv.Parsable = Dsv.Parsable.derived

text.read[Stat in Dsv]          // first record
text.read[List[Stat] in Dsv]    // every record
stream.rowsOf[Stat]             // Iterator[Stat], one value per row
```

Fields dispatch by header name when the format has a header row, positionally by span otherwise; `Optional` fields absorb short rows and missing columns; any `Decodable in Text` serves as a field type.

## Changed

`Sheet.rows` is `IArray[Dsv]` (previously `LazyList[Dsv]`), and `Sheet.as[T]` returns `List[T]`. Code that consumed `rows` lazily for streaming should use `stream.rows` or `stream.rowsOf[T]` instead.
