### PR TITLE
Cross-platform OCI image assembly

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1070,13 +1070,15 @@ object diuretic extends Library:
       settings.cc(super.scalacOptions())
 
 object embarcadero extends Library:
-  // Building and hashing OCI image contents is cross-platform now that `bitumen.core` and
-  // `gastronomy` are, but opening an image from disk (`ImageHandle`) still needs `bitumen.jvm`, so
-  // the module stays JVM-only until it too is split into an in-memory core and a filesystem backend.
+  // Assembling and reading OCI images in memory — building tar layers and hashing blobs — is
+  // cross-platform, so an image can be built in the browser or a Wasm guest. Only opening an image
+  // from a filesystem *path* needs `bitumen.jvm`; that lives in the JVM-only `oci-jvm` source set,
+  // which `jsSources` excludes (and `jsDeps` drops the non-JS `bitumen.jvm` dependency for JS).
   object oci
       extends Component(bitumen.core, bitumen.jvm, jacinta.core, gastronomy.core, monotonous.core,
         gesticulate.core, aperture.core, pneumatic.flate):
-    override def scalaJs = false
+    override def sources = Task.Sources(moduleDir, moduleDir / os.up / "oci-jvm")
+    override def jsSources = Task.Sources(moduleDir)
     override def scalacOptions = Task:
       settings.cc(settings.maxInlines(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"), "64"))
   object containerd extends Component(obligatory.grpc, cordillera.core, coaxial.core, locomotion.core, anticipation.time, aperture.core):

--- a/lib/embarcadero/src/oci-jvm/embarcadero.ImageOpenable.scala
+++ b/lib/embarcadero/src/oci-jvm/embarcadero.ImageOpenable.scala
@@ -30,7 +30,40 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package embarcadero
 
-export embarcadero.{ContainerConfig, Descriptor, History, Image, ImageConfig, ImageDataOpenable,
-    ImageHandle, Index, Layer, Oci, OciError, RootFs}
+import anticipation.*
+import aperture.*
+import bitumen.*
+import contingency.*
+import prepositional.*
+import turbulence.*
+import zephyrine.*
+
+// Opening a filesystem *path* as an OCI image, delegating the TAR bracket to bitumen's disk-backed
+// `TarOpenable`. Split from `embarcadero.oci`'s cross-platform sources because it needs
+// `bitumen.jvm`; the in-memory `data.open[Image]` (via `ImageDataOpenable`) stays in the core.
+class ImageOpenable[path: Abstractable across Paths to Text]
+  ( using Tactic[OciError], Tactic[TarError], Tactic[StreamError] )
+extends Openable:
+
+  type Self = path
+  type Form = Image
+  type Operand = Nothing
+  type Result = ImageHandle
+
+  def open[grants <: Grant, result]
+    ( value: path, mode: Mode granting grants, flags: List[Nothing] )
+    ( block: ((ImageHandle & Granting[grants])^) ?=> result )
+  :   result =
+
+    if mode.atoms.contains(Write) then abort(OciError(OciError.Reason.WriteUnsupported))
+
+    TarOpenable[path]().open(value, mode, Nil): tar ?=>
+      block(using new ImageHandle(tar.entries) with Granting[grants] {})
+
+// Re-exported through `soundness.*`, so `path.open[Image]` resolves on the JVM as before.
+given openable: [path: Abstractable across Paths to Text]
+=>  ( Tactic[OciError], Tactic[TarError], Tactic[StreamError] )
+=>  ( ImageOpenable[path]^ ) =
+  ImageOpenable[path]

--- a/lib/embarcadero/src/oci-jvm/soundness_embarcadero_oci_jvm.scala
+++ b/lib/embarcadero/src/oci-jvm/soundness_embarcadero_oci_jvm.scala
@@ -32,5 +32,4 @@
                                                                                                   */
 package soundness
 
-export embarcadero.{ContainerConfig, Descriptor, History, Image, ImageConfig, ImageDataOpenable,
-    ImageHandle, Index, Layer, Oci, OciError, RootFs}
+export embarcadero.{ImageOpenable, openable}

--- a/lib/embarcadero/src/oci/embarcadero.Image.scala
+++ b/lib/embarcadero/src/oci/embarcadero.Image.scala
@@ -48,12 +48,8 @@ import vacuous.*
 import wisteria.*
 
 object Image:
-  // Anchored here so `path.open[Image]()` and `data.open[Image]()` resolve with no import.
-  given openable: [path: Abstractable across Paths to Text]
-  =>  ( Tactic[OciError], Tactic[TarError], Tactic[StreamError] )
-  =>  ( ImageOpenable[path]^ ) =
-    ImageOpenable[path]
-
+  // Anchored here so `data.open[Image]()` resolves with no import. Opening a filesystem
+  // *path* as an image (`path.open[Image]`) lives in the JVM-only source set.
   given dataOpenable: (Tactic[OciError], Tactic[TarError], Tactic[StreamError])
   =>  ( ImageDataOpenable^ ) =
     ImageDataOpenable()

--- a/lib/embarcadero/src/oci/embarcadero.ImageHandle.scala
+++ b/lib/embarcadero/src/oci/embarcadero.ImageHandle.scala
@@ -171,29 +171,9 @@ extends caps.ExclusiveCapability:
 // The `oci-layout` marker document at the archive root.
 private[embarcadero] case class OciLayout(imageLayoutVersion: Text)
 
-// Named classes rather than anonymous given instances, for the reasons documented on
-// galilei's `FileOpenable`. Archives open read-only: a `Write` mode is refused with
-// `OciError.Reason.WriteUnsupported`. The TAR bracket is delegated to bitumen's
-// `TarOpenable`, which holds the file open for the scope's duration.
-class ImageOpenable[path: Abstractable across Paths to Text]
-  ( using Tactic[OciError], Tactic[TarError], Tactic[StreamError] )
-extends Openable:
-
-  type Self = path
-  type Form = Image
-  type Operand = Nothing
-  type Result = ImageHandle
-
-  def open[grants <: Grant, result]
-    ( value: path, mode: Mode granting grants, flags: List[Nothing] )
-    ( block: ((ImageHandle & Granting[grants])^) ?=> result )
-  :   result =
-
-    if mode.atoms.contains(Write) then abort(OciError(OciError.Reason.WriteUnsupported))
-
-    TarOpenable[path]().open(value, mode, Nil): tar ?=>
-      block(using new ImageHandle(tar.entries) with Granting[grants] {})
-
+// A named class rather than an anonymous given instance, for the reasons documented on
+// galilei's `FileOpenable`. Opening in-memory `Data` as an OCI image; opening a filesystem
+// *path* (`ImageOpenable`) lives in the JVM-only source set. Read-only for now.
 class ImageDataOpenable(using Tactic[OciError], Tactic[TarError], Tactic[StreamError])
 extends Openable:
 


### PR DESCRIPTION
Assembling and reading OCI container images now works on every platform, including Scala.js and WASM. Embarcadero's filesystem image-opening — reaching disk through Bitumen's `TarOpenable` — is split into a JVM-only source set, leaving the in-memory work (building tar layers, hashing blobs, reading an image from a byte array) cross-platform. Building a container image in the browser or a Wasm guest is now possible; opening one from a filesystem path still requires the JVM.

## New in this release

An OCI image can be assembled and inspected entirely in memory, on any platform:

```scala
import soundness.*, providers.javaStdlibProvider

val image: Image = Image(config, List(layer))
val bytes: Data = image.archive.gzip.read[Data]   // a tar.gz of the OCI layout

bytes.open[Image]: image ?=>            // read it back — in the browser too
  image.manifest.layers
```

Opening an image directly from a filesystem path (`path.open[Image]`) continues to require the JVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)