### PR TITLE
Fix JSON number corruption in boxed arrays and Optional[product] decoder derivation

### DIFF
--- a/lib/embarcadero/src/oci/embarcadero.ImageHandle.scala
+++ b/lib/embarcadero/src/oci/embarcadero.ImageHandle.scala
@@ -104,22 +104,9 @@ extends caps.ExclusiveCapability:
   def imageConfig(manifest: Oci.Manifest): ImageConfig raises OciError =
     val bytes = verified(manifest.config)
 
-    // Field-wise, not `as[ImageConfig]`: jacinta's derivation currently fails on an
-    // `Optional` *product* field (`config`) inside a derived product decoder, though
-    // each field type decodes directly.
     decode(manifest.config.digest):
       import strategies.throwUnsafely
-      import dynamicJsonAccess.enabled
-      val json = bytes.read[Json]
-
-      ImageConfig
-        ( architecture = json.architecture.as[Text],
-          os           = json.os.as[Text],
-          rootfs       = json.rootfs.as[RootFs],
-          config       = json.config.as[Optional[ContainerConfig]],
-          history      = json.history.as[Optional[List[History]]],
-          created      = json.created.as[Optional[Text]],
-          author       = json.author.as[Optional[Text]] )
+      bytes.read[Json].as[ImageConfig]
 
   // A layer's stored blob, verbatim: for OCI layers, the gzip-compressed tar.
   def compressed(descriptor: Descriptor): LazyList[Data] raises OciError =

--- a/lib/jacinta/src/core/jacinta.Json.Parser.scala
+++ b/lib/jacinta/src/core/jacinta.Json.Parser.scala
@@ -664,6 +664,17 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
 
   protected inline update def relinquishBcdLongBuffer(): Unit = bcdLongBufferId -= 1
 
+  // Decode a single-Long BCD value to its scalar `JsonNumber` form for storage
+  // in a boxed (`IArray[Any]`) array: a `Long` if it is an exact integer that
+  // fits, else a `Double`. A boxed array must never hold a raw packed BCD-Long —
+  // its bits are `sign | count | nibbles`, not the numeric value, so
+  // `Json.Ast.double`/`long` (which treat a bare `Long` node as numeric) would
+  // misread it (see #1576).
+  protected def decodeBcdLongToScalar(value: Long): Any =
+    val text = Bcd.bcdLongText(value)
+    try java.lang.Long.parseLong(text)
+    catch case _: NumberFormatException => java.lang.Double.parseDouble(text)
+
   protected update def getBcdIntBuffer(): ArrayBuffer[Int] =
     bcdIntBufferId += 1
 
@@ -797,7 +808,9 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
     // comparisons (`>= 32`, `!= "`, `!= \`) into a single load + compare.
     while more && StringScanContinue(peek & 0xFF) != 0 do advance()
 
-    if !more then errorAt(Issue.PrematureEnd, region)
+    // Span from the string token's opening quote (one byte before the
+    // content region) — see `tail`.
+    if !more then errorAt(Issue.PrematureEnd, Cursor.Mark(region.absolute - 1))
 
     if peek == Quote then slice(region).also(advance())
     else tail(region)
@@ -871,7 +884,9 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
 
     while more && StringScanContinue(peek & 0xFF) != 0 do advance()
 
-    if !more then errorAt(Issue.PrematureEnd, region)
+    // Span from the string token's opening quote (one byte before the
+    // content region) — see `tail`.
+    if !more then errorAt(Issue.PrematureEnd, Cursor.Mark(region.absolute - 1))
 
     if peek != Quote then tail(region)
     else
@@ -937,10 +952,15 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
     resetString()
     appendRegionToBuffer(start)
 
+    // `start` marks the string *content* (it doubles as the slice region), but
+    // error spans must cover the whole string token from its opening quote —
+    // one byte earlier. A synthesized mark is safe here: `errorAt` only reads
+    // its absolute position.
+    val token: Region = Cursor.Mark(start.absolute - 1)
     var continue = true
 
     while continue do
-      if !more then errorAt(Issue.PrematureEnd, start)
+      if !more then errorAt(Issue.PrematureEnd, token)
       val ch = peek
 
       ch match
@@ -948,11 +968,11 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
           continue = false
 
         case Tab | Newline | Return =>
-          errorAt(Issue.InvalidWhitespace, start)
+          errorAt(Issue.InvalidWhitespace, token)
 
         case Backslash =>
           advance()
-          if !more then errorAt(Issue.PrematureEnd, start)
+          if !more then errorAt(Issue.PrematureEnd, token)
 
           (peek: @switch) match
             case Quote     => appendChar('"')
@@ -964,12 +984,12 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
             case LowerR    => appendChar('\r')
             case LowerT    => appendChar('\t')
             case LowerU    => appendChar(parseUnicode())
-            case bad       => errorAt(Issue.IncorrectEscape(bad.toChar), start)
+            case bad       => errorAt(Issue.IncorrectEscape(bad.toChar), token)
 
         case _ =>
           if ch == 0 && holes then appendChar(' ')
           else ((ch >> 5): @switch) match
-            case 0                 => errorAt(Issue.NotEscaped(ch.toChar), start)
+            case 0                 => errorAt(Issue.NotEscaped(ch.toChar), token)
             case 1 | 2 | 3 | 4 | 5 => appendChar(ch.toChar)
 
             case _ =>
@@ -1428,17 +1448,9 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
       val n = src.length
       var i = 0
 
-      // Decode each BCD-Long to its scalar JsonNumber form. Long if the
-      // value is an exact integer that fits Long, else Double.
+      // Decode each BCD-Long to its scalar JsonNumber form (see #1576).
       while i < n do
-        val v = src(i)
-        val text = Bcd.bcdLongText(v)
-
-        val ast: Any =
-          try java.lang.Long.parseLong(text)
-          catch case _: NumberFormatException => java.lang.Double.parseDouble(text)
-
-        dst += ast
+        dst += decodeBcdLongToScalar(src(i))
         i += 1
 
       relinquishBcdLongBuffer()
@@ -1499,13 +1511,15 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
                     longItems.nn += bcdLong
 
                   case _ =>
-                    // Boxed mode — surface the value as a JsonNumber.
-                    // For ≤7 nibbles, the small-BCD `Int` is the right
-                    // shape; otherwise the BCD-Long itself is fine.
+                    // Boxed mode — surface the value as a JsonNumber. For ≤7
+                    // nibbles the small-BCD `Int` is a self-describing
+                    // `JsonNumber` (accessors decode it via `bcdIntToDouble`);
+                    // a larger BCD-Long must be decoded to a scalar, never
+                    // stored raw (see #1576).
                     if nibbles <= Bcd.MaxBcdIntNibbles then
                       anyItems.nn += Bcd.packBcdIntFromLong(bcdLong)
                     else
-                      anyItems.nn += bcdLong
+                      anyItems.nn += decodeBcdLongToScalar(bcdLong)
 
             case _ =>
               if first then
@@ -1700,7 +1714,7 @@ final class Parser extends caps.ExclusiveCapability, caps.Stateful:
                     if nibbles <= Bcd.MaxBcdIntNibbles then
                       anyItems.nn += Bcd.packBcdIntFromLong(bcdLong)
                     else
-                      anyItems.nn += bcdLong
+                      anyItems.nn += decodeBcdLongToScalar(bcdLong)
 
             case _ =>
               if first then

--- a/lib/jacinta/src/test/jacinta.ParserTests.scala
+++ b/lib/jacinta/src/test/jacinta.ParserTests.scala
@@ -38,7 +38,9 @@ import interfaces.paths.pathOnLinux
 import strategies.throwUnsafely
 import logging.silentLogging
 import charEncoders.utf8Encoder
+import environments.javaEnvironment
 import gitCommands.environmentDefaultGitCommand
+import systems.javaSystem
 import workingDirectories.javaWorkingDirectory
 import internetAccess.online
 import errorDiagnostics.stackTracesDiagnostics
@@ -53,7 +55,15 @@ import filesystemBackends.virtualMachine
 object ParserTests extends Suite(m"Jacinta JSON parser tests"):
   def run(): Unit =
     val work: Path on Linux = workingDirectory
-    val jsonSuite: Path on Linux = work/"tests"/"JSONTestSuite"
+    val localSuite: Path on Linux = work/"tests"/"JSONTestSuite"
+
+    // The corpus lives in `tests/` where present (established dev checkouts);
+    // otherwise in the per-machine `~/.cache/soundness` cache, which — like
+    // the proscala toolchain cache — survives the throwaway attest worktrees,
+    // so only the very first run on a machine needs network access.
+    val jsonSuite: Path on Linux =
+      if (localSuite/"test_parsing").exists() then localSuite
+      else Xdg.cacheHome[Path on Linux]/"soundness"/"JSONTestSuite"
 
     if !(jsonSuite/"test_parsing").exists() then
       Git.clone(url"https://github.com/nst/JSONTestSuite", jsonSuite).complete()
@@ -302,9 +312,13 @@ object ParserTests extends Suite(m"Jacinta JSON parser tests"):
     suite(m"Number-only arrays"):
       def parseRaw(text: Text): Any = Json.Ast.parse(IArray.from(text.s.getBytes("UTF-8").nn))
 
-      test(m"Pure integer array uses the unboxed Array[Double] form"):
+      test(m"Pure integer array uses the unboxed small-BCD Array[Int] form"):
         parseRaw(t"[1, 2, 3]").getClass.getName
-      . assert(_ == "[D")
+      . assert(_ == "[I")
+
+      test(m"Array with an 8-nibble number widens to the Array[Long] form"):
+        parseRaw(t"[12345678, 2]").getClass.getName
+      . assert(_ == "[J")
 
       test(m"Pure integer array decodes back to the original numbers"):
         t"[1, 2, 3]".read[Json].as[List[Int]]
@@ -313,42 +327,42 @@ object ParserTests extends Suite(m"Jacinta JSON parser tests"):
       test(m"Decimal-only array uses the unboxed form and round-trips"):
         given Json.Formatting = Json.Formatting(Unset, false)
         val raw = parseRaw(t"[1.5, 2.25, 3.125]")
-        raw.getClass.getName == "[D"
+        raw.getClass.getName == "[I"
         && raw.asInstanceOf[Json.Ast].show == t"[1.5,2.25,3.125]"
       . assert(identity)
 
       test(m"Exponent-bearing numbers stay in the unboxed form"):
         val raw = parseRaw(t"[1e2, 2.5e-3]")
         raw.getClass.getName
-      . assert(_ == "[D")
+      . assert(_ == "[I")
 
       test(m"Negative numbers stay in the unboxed form and round-trip"):
         t"[-1, -2, -3]".read[Json].as[List[Int]]
       . assert(_ == List(-1, -2, -3))
 
-      test(m"Empty array uses the parity-padded boxed form, not Array[Double]"):
+      test(m"Empty array uses the parity-padded boxed form, not a number array"):
         val raw = parseRaw(t"[]")
         raw.asInstanceOf[Json.Ast].isArray && !raw.asInstanceOf[Json.Ast].isNumberArray
       . assert(identity)
 
       test(m"Single-element number array uses the unboxed form"):
         parseRaw(t"[42]").getClass.getName
-      . assert(_ == "[D")
+      . assert(_ == "[I")
 
       test(m"Non-number after numbers triggers fallback to the boxed form"):
         val raw = parseRaw(t"""[1, 2, "three"]""")
         raw.asInstanceOf[Json.Ast].isArray && !raw.asInstanceOf[Json.Ast].isNumberArray
       . assert(identity)
 
-      test(m"Fallback array preserves the leading numbers as Long values"):
-        t"""[1, 2, "three"]""".read[Json].root.arrayElement(0).asMatchable
-      . assert:
-          case l: Long => l == 1L
-          case _       => false
+      test(m"Fallback array preserves the leading numbers' values"):
+        // The boxed node keeps the small-BCD `Int` form; its numeric value
+        // surfaces through the accessors.
+        t"""[1, 2, "three"]""".read[Json].root.arrayElement(0).long
+      . assert(_ == 1L)
 
       test(m"Bcd-overflow number triggers fallback to the boxed form"):
         // 16-digit value overflows the 15-nibble in-Long fast path and
-        // forces a Bcd fallback, which doesn't fit in Array[Double].
+        // forces a Bcd fallback, which doesn't fit the unboxed forms.
         val raw = parseRaw(t"[1, 1234567890123456]")
         raw.asInstanceOf[Json.Ast].isArray && !raw.asInstanceOf[Json.Ast].isNumberArray
       . assert(identity)
@@ -358,12 +372,18 @@ object ParserTests extends Suite(m"Jacinta JSON parser tests"):
         raw.asInstanceOf[Json.Ast].arrayElement(1).isBcd
       . assert(identity)
 
-      test(m"15-nibble integer (parser fast path) stays in the unboxed form"):
-        // 15 digits = 15 nibbles, fits in the in-Long fast path and in
-        // Double exactly (< 2^50).
+      test(m"15-nibble integer exceeds the 14-nibble BCD-Long cap and boxes"):
+        // 15 digits fit the parser's in-Long fast path but not the 14-nibble
+        // single-Long BCD packing, so the element materializes as a `Bcd`
+        // and the array falls back to the boxed form.
         val raw = parseRaw(t"[1, 123456789012345]")
+        raw.asInstanceOf[Json.Ast].isArray && !raw.asInstanceOf[Json.Ast].isNumberArray
+      . assert(identity)
+
+      test(m"14-nibble integer stays in the unboxed Array[Long] form"):
+        val raw = parseRaw(t"[1, 12345678901234]")
         raw.getClass.getName
-      . assert(_ == "[D")
+      . assert(_ == "[J")
 
       test(m"Non-number first element keeps the boxed buffer"):
         val raw = parseRaw(t"""["a", 1, 2]""")
@@ -395,6 +415,29 @@ object ParserTests extends Suite(m"Jacinta JSON parser tests"):
       test(m"Object equality is preserved"):
         t"""{"a": 1, "b": 2}""".read[Json] == t"""{"b": 2, "a": 1}""".read[Json]
       . assert(identity)
+
+      // #1576: a >7-nibble number that arrives *after* the array is already
+      // boxed (a leading non-number) must be decoded to its scalar value, not
+      // stored as a raw packed BCD-Long that `double`/`long` then misread.
+      test(m"Boxed fractional element decodes to its scalar Double"):
+        t"""["x", 1016.865234375]""".read[Json].root.arrayElement(1).double
+      . assert(_ == 1016.865234375)
+
+      test(m"Boxed multi-digit integer element decodes to its scalar Long"):
+        t"""["x", 12345678901234]""".read[Json].root.arrayElement(1).long
+      . assert(_ == 12345678901234L)
+
+      // The pre-boxed migration path (number buffered first, then boxed) was
+      // already correct — guard it against regressions.
+      test(m"Pre-boxed fractional element decodes to its scalar Double"):
+        t"""[1016.865234375, "x"]""".read[Json].root.arrayElement(0).double
+      . assert(_ == 1016.865234375)
+
+      // The purely-numeric (unboxed IArray[Long]) path was also already
+      // correct — guard it too.
+      test(m"Unboxed fractional array element decodes to its scalar Double"):
+        t"""[1016.865234375]""".read[Json].root.arrayElement(0).double
+      . assert(_ == 1016.865234375)
 
 
 

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -1683,3 +1683,4 @@ object Tests extends Suite(m"Jacinta Tests"):
     ValidationTests()
     PositionTests()
     VerifyTests()
+    ParserTests()

--- a/lib/jacinta/src/test/jacinta_test.scala
+++ b/lib/jacinta/src/test/jacinta_test.scala
@@ -53,6 +53,7 @@ case class Outer(inner: Inner)
 case class NamedOuter(name: Text, inner: Inner)
 case class OptFoo(x: Option[Int])
 case class OptionalFoo(x: Optional[Int])
+case class OptInner(inner: Optional[Inner] = Unset)
 case class Bar(a: Int, b: Text)
 case class BarOpt(a: Int, b: Optional[Text])
 case class WithDefault(name: Text, age: Int = 18) derives CanEqual
@@ -300,6 +301,14 @@ object Tests extends Suite(m"Jacinta Tests"):
 
       test(m"Extract an explicit null Optional as Unset"):
         t"""{"x": null}""".read[Json].as[OptionalFoo].x
+      . assert(_ == Unset)
+
+      test(m"Decode a present Optional product field"):
+        t"""{"inner":{"n":42}}""".read[Json].as[OptInner].inner
+      . assert(_ == Inner(42))
+
+      test(m"Decode an absent Optional product field"):
+        t"""{}""".read[Json].as[OptInner].inner
       . assert(_ == Unset)
 
       test(m"Decode a top-level null to an Optional as Unset"):

--- a/lib/wisteria/src/core/wisteria.internal.scala
+++ b/lib/wisteria/src/core/wisteria.internal.scala
@@ -560,6 +560,25 @@ object internal:
                 case None =>
                   product.typeSymbol.caseFields.foreach: field =>
                     visit(product.memberType(field), false)
+          else tpe match
+            // An alias like `Optional[P]` dealiases to a union (`Unset | P`) with no type
+            // arguments, so the codec probes above cannot follow its elements, and a union is
+            // neither a sum nor a product. Visit each branch so a structural element inside a
+            // union field (`Optional`-of-product, #1600) still becomes a shared sibling: the
+            // element codec then resolves to the sibling's lazy val — never a fresh capturing
+            // expansion inside `optional`'s by-name slot, which capture checking rejects.
+            // Singleton members (`Unset`, `None.type`) are sentinels handled by the union-level
+            // codec itself: they can never need a sibling, and probing their resolvability
+            // expands capability givens at macro time, which perturbs capture-checking state.
+            case OrType(left, right) =>
+              def branch(part: TypeRepr): Unit =
+                if !(part.dealias <:< TypeRepr.of[scala.Singleton]) then visit(part, false)
+
+              branch(left)
+              branch(right)
+
+            case _ =>
+              ()
 
       val rootType = TypeRepr.of[derivation].dealias
       visit(rootType, isRoot = true)

--- a/src/test/soundness.Tests.scala
+++ b/src/test/soundness.Tests.scala
@@ -163,6 +163,5 @@ object Tests extends Suite(m"Soundness tests"):
 
 object FailingTests extends Suite(m"Failing tests"):
   def run(): Unit =
-    jacinta.ParserTests()
     telekinesis.Tests()
     // turbulence.Tests() - deadlock


### PR DESCRIPTION
Two serious Jacinta bugs in the materialized-AST decode path are fixed: #1576, where a JSON number of more than 7 significant digits arriving after an array had fallen back to the boxed (heterogeneous) representation was stored as a raw packed BCD-`Long` and silently misread as a wildly wrong value; and #1600, where deriving a JSON decoder for a product with an `Optional[P]` field (with `P` itself a product) failed to compile in capture-checked modules. Along the way, the Jacinta parser test suite — which had been parked in the `FailingTests` bucket and skipped by CI — was repaired and reinstated as part of `jacinta.Tests`. A further pre-existing capture-checking hole surfaced from behind #1600's error is tracked separately as #1604.

## Release notes

- JSON numbers in heterogeneous arrays now always decode to their correct values. Previously, a number with more than seven significant digits appearing in a mixed-type array (or after an array had otherwise fallen back to boxed storage) would silently decode to a garbled value:
  ```scala
  t"""["label", 1016.865234375]""".read[Json](1).as[Double]
  // was 1.0133348286654883E18 — now 1016.865234375
  ```
- A product containing an `Optional` field of another product now derives a JSON decoder, including in capture-checked modules:
  ```scala
  case class Inner(name: Text)
  case class Outer(inner: Optional[Inner] = Unset)
  json.as[Outer]   // previously failed to compile; now works
  ```
  Wisteria's derivation graph now follows union type members (such as `Optional[P]`, an alias of `Unset | P`), so a structural element inside a union field becomes a shared sibling instance, exactly as elements of collection codecs already did. `ImageHandle.imageConfig` in Embarcadero accordingly collapses back to a one-line `as[ImageConfig]`.
- Parse errors inside JSON strings (bad escapes, unterminated strings) once again report a span anchored at the string token's opening quote.
- The Jacinta parser test suite (including the JSONTestSuite conformance corpus) runs as part of the normal test procedure. The corpus is cached per-machine under `~/.cache/soundness/JSONTestSuite`, so CI builds in throwaway worktrees need no network access after the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)