### PR TITLE
Route facsimile's I/O, hashing and crypto through Soundness APIs

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1292,10 +1292,10 @@ object exoskeleton extends Library:
       settings.cc(super.scalacOptions())
 
 object facsimile extends Library:
-  object core extends Component(aperture.core, galilei.core, turbulence.core, pneumatic.flate, zephyrine.core,
-      gastronomy.core, enigmatic.core,
+  object core extends Component(aperture.core, galilei.core, galilei.jvm, ambience.core, turbulence.core,
+      pneumatic.flate, zephyrine.core, gastronomy.core, enigmatic.core,
       hypotenuse.core, phoenicia.core, quantitative.units, iridescence.core, aviation.core):
-    override def scalaJs = false // random-access file reading (`java.nio`), `java.util.zip`, JCE
+    override def scalaJs = false // memory-mapped random-access reads (galilei.jvm `Ram`), JCE
     override def scalacOptions = Task:
       settings.cc(super.scalacOptions() ++ Seq("-Yno-predef", "-Yimports:java.lang,scala,proscenium"))
   object test extends Tests(core):

--- a/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
+++ b/lib/enigmatic/src/core/enigmatic.SymmetricKey.scala
@@ -42,6 +42,13 @@ object SymmetricKey:
   def generate[cipher <: Cipher & Symmetric]()(using cipher: cipher): SymmetricKey[cipher] =
     SymmetricKey(cipher.genKey())
 
+  // Adopt externally-supplied key material — for example a key produced by a key-
+  // derivation function — as a symmetric key, in contrast to `generate`'s fresh random
+  // key. The bytes must be a valid key length for the cipher; an invalid length surfaces
+  // when the key is used (as a `CryptoError` on decryption). Defining this `apply`
+  // suppresses the synthetic constructor proxy, so it is the sole `SymmetricKey(bytes)`.
+  def apply[cipher <: Cipher](bytes: Data): SymmetricKey[cipher] = new SymmetricKey(bytes)
+
 class SymmetricKey[cipher <: Cipher](private[enigmatic] val bytes: Data)
 extends PrivateKey[cipher](bytes):
   def verify[value: Encodable in Data](value: value, signature: Signature[cipher])

--- a/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
+++ b/lib/exoskeleton/src/rig/exoskeleton.Enclave.scala
@@ -99,11 +99,14 @@ extends Rig:
   type Transport = Json
 
   def stage(out: Path on Linux): Path on Linux =
-    val target = unsafely(out.peer(name))
+    // Children of the per-stage `out` directory (not `peer` siblings): each staged build's
+    // artifacts must stay in its own directory, or two builds of the same tool name — an
+    // upgrade test's v1 and v2 — would collide at the same path.
+    val target = unsafely(out / name)
 
     unsafely:
       val name2 = t"$name.jar"
-      val jarfile = out.peer(name2)
+      val jarfile = out / name2
       // `Fqcn.apply` rather than the `fqcn""` interpolator: the macro's synthesized tree
       // fails capture-variable unification when expanded in a capture-checked module.
       val executor: Fqcn = safely(Fqcn(t"superlunary.Executor2")).vouch

--- a/lib/facsimile/src/core/facsimile.ByteSource.scala
+++ b/lib/facsimile/src/core/facsimile.ByteSource.scala
@@ -32,12 +32,7 @@
                                                                                                   */
 package facsimile
 
-import java.nio as jn
-import java.nio.channels as jnc
-
 import anticipation.*
-import rudiments.*
-import vacuous.*
 
 // A random-access view of the bytes backing a PDF file, as zephyrine's shared `Expanse`. A
 // read past the end of the source yields fewer bytes than requested, never padding.
@@ -47,23 +42,13 @@ private[facsimile] class DataSource(data: Data) extends ByteSource:
   def size: Long = data.length.toLong
   def read(offset: Long, length: Int): Data = data.slice(offset.toInt, offset.toInt + length)
 
-// Positional reads against a channel held open for the lifetime of a `Pdf` scope. Unlike
-// Zeppelin's per-read reopening (whose entries must outlive any handle), a PDF is resolved
-// through many small reads which all happen strictly within the scope, so a held channel is
-// both safe and necessary for a consistent snapshot of the file.
-private[facsimile] class ChannelSource(channel: jnc.FileChannel) extends ByteSource:
-  def size: Long = channel.size
-
+// Positional reads against another `Expanse` — galilei's memory-mapped `Ram`, held open for
+// the lifetime of a `Pdf` scope. A PDF is resolved through many small reads which all happen
+// strictly within the scope, so the held mapping is both safe and a consistent snapshot of
+// the file. The size is pinned at construction: the underlying mapping may later grow (for
+// the incremental-update append), and the document's own view must not shift underneath it.
+private[facsimile] class ExpanseSource(expanse: zephyrine.Expanse, val size: Long)
+extends ByteSource:
   def read(offset: Long, length: Int): Data =
-    if length <= 0 then IArray.empty[Byte] else
-      val buffer = jn.ByteBuffer.allocate(length).nn
-      var position = offset
-      var eof = false
-
-      while buffer.hasRemaining && !eof do
-        val count = channel.read(buffer, position)
-        if count < 0 then eof = true else position += count
-
-      if buffer.hasRemaining
-      then buffer.array.nn.slice(0, buffer.position).immutable(using Unsafe)
-      else buffer.array.nn.immutable(using Unsafe)
+    if length <= 0 || offset >= size then IArray.empty[Byte]
+    else expanse.read(offset, length.min((size - offset).toInt))

--- a/lib/facsimile/src/core/facsimile.Filter.scala
+++ b/lib/facsimile/src/core/facsimile.Filter.scala
@@ -32,9 +32,6 @@
                                                                                                   */
 package facsimile
 
-import java.io as ji
-import java.util.zip as juz
-
 import anticipation.*
 import contingency.*
 import gossamer.*
@@ -182,26 +179,21 @@ private[facsimile] object Filter:
     . or(abort(PdfError(PdfError.Reason.CorruptStream(t"FlateDecode"))))
 
   private def inflate(data: Data, nowrap: Boolean): Optional[Data] =
-    val inflater = juz.Inflater(nowrap)
-    val out = ji.ByteArrayOutputStream()
-    val buffer = new Array[Byte](8192)
-    inflater.setInput(data.mutable(using Unsafe))
+    val builder = Array.newBuilder[Byte]
 
     try
-      // Stop on completion, or when no more output can be produced from the input that
-      // remains: a truncated stream yields what it decoded.
-      var stalled = false
+      val chunks =
+        if nowrap then LazyList(data).decompress[Deflate] else LazyList(data).decompress[Zlib]
 
-      while !inflater.finished && !stalled do
-        val count = inflater.inflate(buffer)
+      // Forcing the stream incrementally means a truncated (but valid-so-far) input keeps
+      // whatever it decoded before the bytes ran out, matching the eager inflater's
+      // partial-on-truncation behaviour; corrupt data throws from the backend.
+      chunks.each: chunk =>
+        builder.addAll(chunk.mutable(using Unsafe))
+    catch case _: IllegalStateException => ()
 
-        if count > 0 then out.write(buffer, 0, count)
-        else stalled = inflater.needsInput || inflater.needsDictionary
-
-      if out.size == 0 && data.length > 0 && !inflater.finished then Unset
-      else out.toByteArray.nn.immutable(using Unsafe)
-    catch case _: juz.DataFormatException => Unset
-    finally inflater.end()
+    val result = builder.result()
+    if result.length == 0 && data.length > 0 then Unset else result.immutable(using Unsafe)
 
   private def asciiHex(data: Data): Data raises PdfError =
     val bytes = Array.newBuilder[Byte]

--- a/lib/facsimile/src/core/facsimile.FontEmbedder.scala
+++ b/lib/facsimile/src/core/facsimile.FontEmbedder.scala
@@ -32,15 +32,17 @@
                                                                                                   */
 package facsimile
 
-import java.security as js
-
 import anticipation.*
 import contingency.*
+import gastronomy.*
 import gossamer.*
 import hypotenuse.*
 import phoenicia.*
 import rudiments.*
 import vacuous.*
+
+import gastronomy.crypto.permitDisallowedCrypto
+import gastronomy.providers.javaStdlibProvider
 
 // Embeds a TrueType (or OpenType) font program as a simple, single-byte PDF font with WinAnsi
 // encoding: the program becomes a `FontFile2` stream, referenced by a `FontDescriptor` built
@@ -136,8 +138,7 @@ private[facsimile] object FontEmbedder:
   // The conventional six-uppercase-letter subset tag, derived deterministically from the
   // name and subset text, so identical subsets embed identically.
   private def tag(name: Text, chars: Text): Text =
-    val md5 = js.MessageDigest.getInstance("MD5").nn
-    val digest = md5.digest(t"$name:$chars".s.getBytes("UTF-8")).nn
+    val digest = t"$name:$chars".digest[Md5].data
 
     val letters = (0 until 6).map: index =>
       ('A' + ((digest(index) & 0xff)%26)).toChar

--- a/lib/facsimile/src/core/facsimile.Guard.scala
+++ b/lib/facsimile/src/core/facsimile.Guard.scala
@@ -38,9 +38,13 @@ import javax.crypto.spec as jcs
 
 import anticipation.*
 import contingency.*
+import gastronomy.*
 import gossamer.*
 import rudiments.*
 import vacuous.*
+
+import gastronomy.crypto.permitDisallowedCrypto
+import gastronomy.providers.javaStdlibProvider
 
 // The standard security handler (ISO 32000-2 §7.6.4), revisions 2–6. The file key is derived
 // from the user password and the `/Encrypt` dictionary and validated against `/U` at open;
@@ -61,6 +65,16 @@ private[facsimile] object Guard:
       0x01, 0x08, 0x2e, 0x2e, 0x00, 0xb6, 0xd0, 0x68, 0x3e, 0x80, 0x2f, 0x0c, 0xa9, 0xfe,
       0x64, 0x53, 0x69, 0x7a )
     . map(_.toByte)
+
+  // MD5 (weak, hence the permit) and SHA-2 digests through gastronomy's cross-platform
+  // hashing. The PDF security algorithms hash the concatenation of their parts, which is
+  // exactly one `.digest` over the joined bytes.
+  private def md5(data: Data): Data = data.digest[Md5].data
+
+  private def sha(bits: Int, data: Data): Data = bits match
+    case 384 => data.digest[Sha2[384]].data
+    case 512 => data.digest[Sha2[512]].data
+    case _   => data.digest[Sha2[256]].data
 
   def apply(encrypt: Map[Text, Cos], id: Data, password: Text)(using pdf: Pdf)
   :   Guard raises PdfError =
@@ -125,31 +139,28 @@ private[facsimile] object Guard:
       encryptMetadata: Boolean )
   :   Data =
 
-    val md5 = js.MessageDigest.getInstance("MD5").nn
-    md5.update(padded(password))
-    md5.update(owner.mutable(using Unsafe), 0, 32.min(owner.length))
+    val permissionsBytes: Data = IArray((permissions & 0xff).toByte,
+        ((permissions >> 8) & 0xff).toByte, ((permissions >> 16) & 0xff).toByte,
+        ((permissions >> 24) & 0xff).toByte)
 
-    md5.update(Array((permissions & 0xff).toByte, ((permissions >> 8) & 0xff).toByte,
-        ((permissions >> 16) & 0xff).toByte, ((permissions >> 24) & 0xff).toByte))
+    val metadataBytes: Data =
+      if revision >= 4 && !encryptMetadata
+      then IArray(0xff.toByte, 0xff.toByte, 0xff.toByte, 0xff.toByte)
+      else IArray.empty[Byte]
 
-    md5.update(id.mutable(using Unsafe))
-
-    if revision >= 4 && !encryptMetadata then md5.update(Array(0xff.toByte, 0xff.toByte,
-        0xff.toByte, 0xff.toByte))
-
-    var hash = md5.digest().nn
+    var hash: Data =
+      md5(padded(password).immutable(using Unsafe) ++ owner.take(32.min(owner.length)) ++
+        permissionsBytes ++ id ++ metadataBytes)
 
     // Revision 3+: 50 further MD5 rounds over the first `keyBytes` bytes.
     if revision >= 3 then
       var i = 0
 
       while i < 50 do
-        val next = js.MessageDigest.getInstance("MD5").nn
-        next.update(hash, 0, keyBytes)
-        hash = next.digest().nn
+        hash = md5(hash.take(keyBytes))
         i += 1
 
-    hash.take(keyBytes).immutable(using Unsafe)
+    hash.take(keyBytes)
 
   // Algorithm 6: validate the user password by reconstructing `/U`.
   private def validate(fileKey: Data, user: Data, id: Data, revision: Int, keyBytes: Int)
@@ -157,10 +168,7 @@ private[facsimile] object Guard:
 
     if revision == 2 then Rc4(fileKey, padding.immutable(using Unsafe)).to(List) == user.to(List)
     else
-      val md5 = js.MessageDigest.getInstance("MD5").nn
-      md5.update(padding)
-      md5.update(id.mutable(using Unsafe))
-      var value = md5.digest().nn.immutable(using Unsafe)
+      var value: Data = md5(padding.immutable(using Unsafe) ++ id)
 
       value = Rc4(fileKey, value)
 
@@ -201,11 +209,7 @@ private[facsimile] object Guard:
   // Revision-6 hash (algorithm 2.B): SHA-256 seeded, then rounds mixing SHA-256/384/512
   // selected by the running hash, until the 64th-plus round whose last byte is ≤ round−32.
   private def hash6(password: Array[Byte], salt: Data, extra: Data): Data =
-    val sha256 = js.MessageDigest.getInstance("SHA-256").nn
-    sha256.update(password)
-    sha256.update(salt.mutable(using Unsafe))
-    if extra.length > 0 then sha256.update(extra.mutable(using Unsafe))
-    var k = sha256.digest().nn.immutable(using Unsafe)
+    var k: Data = sha(256, password.immutable(using Unsafe) ++ salt ++ extra)
 
     var round = 0
     var done = false
@@ -234,12 +238,12 @@ private[facsimile] object Guard:
         sum += e(i) & 0xff
         i += 1
 
-      val algorithm = sum%3 match
-        case 0 => "SHA-256"
-        case 1 => "SHA-384"
-        case _ => "SHA-512"
+      val bits = sum%3 match
+        case 0 => 256
+        case 1 => 384
+        case _ => 512
 
-      k = js.MessageDigest.getInstance(algorithm).nn.digest(e).nn.immutable(using Unsafe)
+      k = sha(bits, e.immutable(using Unsafe))
       round += 1
 
       if round >= 64 && (e(e.length - 1) & 0xff) <= round - 32 then done = true
@@ -263,15 +267,14 @@ private[facsimile] class Guard
   // Algorithm 1: the per-object key. For revision 6 the file key is used directly.
   private def objectKey(number: Int, generation: Int, aes: Boolean): Data =
     if revision >= 5 then fileKey else
-      val md5 = js.MessageDigest.getInstance("MD5").nn
-      md5.update(fileKey.mutable(using Unsafe))
-
-      md5.update(Array((number & 0xff).toByte, ((number >> 8) & 0xff).toByte,
+      val numbering: Data = IArray((number & 0xff).toByte, ((number >> 8) & 0xff).toByte,
           ((number >> 16) & 0xff).toByte, (generation & 0xff).toByte,
-          ((generation >> 8) & 0xff).toByte))
+          ((generation >> 8) & 0xff).toByte)
 
-      if aes then md5.update(Array[Byte](0x73, 0x41, 0x6c, 0x54)) // the "sAlT" constant
-      md5.digest().nn.take((fileKey.length + 5).min(16)).immutable(using Unsafe)
+      // the "sAlT" constant
+      val salt: Data = if aes then IArray[Byte](0x73, 0x41, 0x6c, 0x54) else IArray.empty[Byte]
+
+      Guard.md5(fileKey ++ numbering ++ salt).take((fileKey.length + 5).min(16))
 
   def string(bytes: Data, number: Int, generation: Int): Data =
     decrypt(bytes, number, generation, stringMethod)

--- a/lib/facsimile/src/core/facsimile.Guard.scala
+++ b/lib/facsimile/src/core/facsimile.Guard.scala
@@ -32,14 +32,15 @@
                                                                                                   */
 package facsimile
 
-import java.security as js
 import javax.crypto as jc
 import javax.crypto.spec as jcs
 
 import anticipation.*
 import contingency.*
+import enigmatic.*
 import gastronomy.*
 import gossamer.*
+import prepositional.*
 import rudiments.*
 import vacuous.*
 
@@ -49,9 +50,9 @@ import gastronomy.providers.javaStdlibProvider
 // The standard security handler (ISO 32000-2 §7.6.4), revisions 2–6. The file key is derived
 // from the user password and the `/Encrypt` dictionary and validated against `/U` at open;
 // per-object keys are derived from it (with the object number and generation for revisions
-// ≤4, or used directly for revision 6). Cryptographic primitives come from the JDK directly:
-// the algorithm is a precise sequence of digest and block-cipher rounds that maps onto
-// `MessageDigest`/`Cipher` more faithfully than onto a higher-level wrapper. RC4 is local.
+// ≤4, or used directly for revision 6). Digests come from gastronomy and AES-CBC from
+// enigmatic; the algorithm is a precise sequence of digest and block-cipher rounds. RC4,
+// which those libraries do not offer, is local.
 private[facsimile] object Guard:
   enum Method:
     case Rc4
@@ -196,6 +197,10 @@ private[facsimile] object Guard:
       else
         val intermediate = hash6(passwordBytes, keySalt, IArray.empty[Byte])
 
+        // AES-256-CBC with a zero IV and no padding. This stays on the JDK cipher: enigmatic's
+        // `NoPadding` given captures a `Tactic[CryptoError]`, and the only available strategy
+        // (`throwUnsafely`) yields a root `{any}` capability that capture checking cannot
+        // confine here — unlike the `Pkcs7` object ciphers below. See the module notes.
         try
           val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
 
@@ -228,6 +233,8 @@ private[facsimile] object Guard:
       val key = k.take(16).mutable(using Unsafe)
       val iv = k.slice(16, 32).mutable(using Unsafe)
 
+      // AES-128-CBC with no padding on block-aligned input; on the JDK cipher for the same
+      // capture-checking reason as `unwrap6`.
       val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
       cipher.init(jc.Cipher.ENCRYPT_MODE, jcs.SecretKeySpec(key, "AES"), jcs.IvParameterSpec(iv))
       val e = cipher.doFinal(input).nn
@@ -291,10 +298,10 @@ private[facsimile] class Guard
         Rc4(objectKey(number, generation, false), bytes)
 
       case Method.Aes128 =>
-        aesCbc(objectKey(number, generation, true), bytes)
+        aesCbc[128](objectKey(number, generation, true), bytes)
 
       case Method.Aes256 =>
-        aesCbc(fileKey, bytes)
+        aesCbc[256](fileKey, bytes)
 
   // The inverse operations, for writing new or edited objects into an encrypted document's
   // incremental update. RC4 is symmetric, so it reuses `decrypt`; AES prepends a fresh
@@ -309,41 +316,22 @@ private[facsimile] class Guard
     method match
       case Method.Identity => bytes
       case Method.Rc4      => Rc4(objectKey(number, generation, false), bytes)
-      case Method.Aes128   => aesCbcEncrypt(objectKey(number, generation, true), bytes)
-      case Method.Aes256   => aesCbcEncrypt(fileKey, bytes)
+      case Method.Aes128   => aesCbcEncrypt[128](objectKey(number, generation, true), bytes)
+      case Method.Aes256   => aesCbcEncrypt[256](fileKey, bytes)
 
-  private def aesCbcEncrypt(key: Data, bytes: Data): Data =
-    val iv = new Array[Byte](16)
-    js.SecureRandom().nextBytes(iv)
+  // A fresh random IV is prepended and PKCS#7 padding applied — both handled by enigmatic's
+  // `Cbc against Pkcs7`, whose whole-value output is exactly `iv ++ ciphertext`.
+  private def aesCbcEncrypt[bits <: 128 | 256: ValueOf](key: Data, bytes: Data): Data =
+    val symmetricKey = SymmetricKey[Aes[bits] over Cbc against Pkcs7](key)
 
-    val pad = 16 - bytes.length%16
-    val padded = new Array[Byte](bytes.length + pad)
-    System.arraycopy(bytes.mutable(using Unsafe), 0, padded, 0, bytes.length)
-    var i = bytes.length
-    while i < padded.length do { padded(i) = pad.toByte; i += 1 }
+    symmetricKey.expose:
+      bytes.encrypt[Aes[bits] over Cbc against Pkcs7](InitializationVector.random)
 
-    val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
-
-    cipher.init(jc.Cipher.ENCRYPT_MODE, jcs.SecretKeySpec(key.mutable(using Unsafe), "AES"),
-        jcs.IvParameterSpec(iv))
-
-    (iv.immutable(using Unsafe) ++ cipher.doFinal(padded).nn.immutable(using Unsafe))
-
-  // AESV2/V3 layout: a 16-byte initialization vector prefixes the ciphertext.
-  private def aesCbc(key: Data, bytes: Data): Data =
+  // AESV2/V3 layout: a 16-byte initialization vector prefixes the ciphertext, which enigmatic
+  // reads back off the front; `Pkcs7` strips the padding. Any failure yields empty bytes.
+  private def aesCbc[bits <: 128 | 256: ValueOf](key: Data, bytes: Data): Data =
     if bytes.length <= 16 then IArray.empty[Byte] else
-      val iv = bytes.slice(0, 16).mutable(using Unsafe)
-      val body = bytes.slice(16, bytes.length).mutable(using Unsafe)
+      val symmetricKey = SymmetricKey[Aes[bits] over Cbc against Pkcs7](key)
 
-      try
-        val cipher = jc.Cipher.getInstance("AES/CBC/NoPadding").nn
-
-        cipher.init(jc.Cipher.DECRYPT_MODE, jcs.SecretKeySpec(key.mutable(using Unsafe), "AES"),
-            jcs.IvParameterSpec(iv))
-
-        val decrypted = cipher.doFinal(body).nn
-        // Strip PKCS#7 padding.
-        val pad = if decrypted.length > 0 then decrypted(decrypted.length - 1) & 0xff else 0
-        val end = if pad >= 1 && pad <= 16 then decrypted.length - pad else decrypted.length
-        decrypted.take(end).immutable(using Unsafe)
-      catch case _: Exception => IArray.empty[Byte]
+      safely(symmetricKey.expose(bytes.decrypt[Data, Aes[bits] over Cbc against Pkcs7]))
+      . or(IArray.empty[Byte])

--- a/lib/facsimile/src/core/facsimile.PdfFile.scala
+++ b/lib/facsimile/src/core/facsimile.PdfFile.scala
@@ -32,20 +32,32 @@
                                                                                                   */
 package facsimile
 
-import java.io as ji
-import java.nio as jn
-import java.nio.channels as jnc
-import java.nio.file as jnf
-
+import ambience.*
 import anticipation.*
 import aperture.*
 import contingency.*
+import distillate.*
 import enigmatic.*
-import galilei.CreateFlag
+import eucalyptus.*
+import galilei.*
 import gossamer.*
+import nomenclature.*
 import prepositional.*
 import rudiments.*
+import serpentine.*
+import turbulence.*
 import vacuous.*
+
+import fulminate.errorDiagnostics.stackTracesDiagnostics
+import filesystemBackends.virtualMachine
+import filesystemOptions.createNonexistentParents.enabled
+import filesystemOptions.deleteRecursively.enabled
+import filesystemOptions.dereferenceSymlinks.enabled
+import filesystemOptions.moveAtomically.enabled
+import filesystemOptions.overwritePreexisting.enabled
+import logging.silentLogging
+import systems.javaSystem
+import workingDirectories.javaWorkingDirectory
 
 object PdfFile:
   def apply[path: Abstractable across Paths to Text](path: path): PdfFile =
@@ -63,27 +75,30 @@ object PdfFile:
     ( using Tactic[PdfError] )
   :   Unit =
 
-    val target = jnf.Path.of(filename.s).nn
+    mitigate:
+      case PathError(_, _)     => PdfError(PdfError.Reason.Io(t"the path is invalid"))
+      case NameError(_, _, _)  => PdfError(PdfError.Reason.Io(t"the path is invalid"))
+      case IoError(_, _, _, _) => PdfError(PdfError.Reason.Io(t"the file could not be written"))
 
-    if !flags.contains(CreateFlag.Replace) && jnf.Files.exists(target)
-    then abort(PdfError(PdfError.Reason.Io(t"the file already exists")))
+    . protect:
+        val target: Path on Local = workingDirectory[Path on Local].resolve(filename)
 
-    try
-      if flags.contains(CreateFlag.Parents) then
-        Optional(target.toAbsolutePath.nn.getParent).let(jnf.Files.createDirectories(_))
+        if !flags.contains(CreateFlag.Replace) && target.exists()
+        then abort(PdfError(PdfError.Reason.Io(t"the file already exists")))
 
-      val last = filename.s.split('/').nn.last.nn
-      val temporary = target.resolveSibling(t".$last.part".s).nn
+        if flags.contains(CreateFlag.Parents) then
+          target.parent.let: parent =>
+            if !parent.exists() then parent.create[Directory]()
 
-      try
-        jnf.Files.write(temporary, bytes.mutable(using Unsafe))
-        jnf.Files.move(temporary, target, jnf.StandardCopyOption.ATOMIC_MOVE,
-            jnf.StandardCopyOption.REPLACE_EXISTING)
-      catch case throwable: Throwable =>
-        try jnf.Files.deleteIfExists(temporary) catch case _: Exception => ()
-        throw throwable
-    catch case error: ji.IOException =>
-      abort(PdfError(PdfError.Reason.Io(error.getMessage.nn.tt)))
+        val part: Text = t".${target.name}.part"
+        val temporary = target.peer(part)
+
+        try
+          temporary.write(bytes)
+          temporary.moveTo(target)
+        catch case throwable: Throwable =>
+          safely(temporary.wipe())
+          throw throwable
 
   // A named class rather than an anonymous given instance, for the reasons documented on
   // galilei's `FileOpenable`. Documents open read-only: a future write mode is a staged
@@ -182,46 +197,56 @@ class PdfFile private (origin: PdfFile.Origin):
       case Origin.InMemory(data) =>
         // In-memory bytes have nowhere to be written back; opening them writably is refused.
         if writable then abort(PdfError(PdfError.Reason.WriteUnsupported))
-        read[grants, result](DataSource(data), password, Unset)(block)
+        val (outcome, _) = read[grants, result](DataSource(data), password, false)(block)
+        outcome
 
       case Origin.OnDisk(filename) =>
-        val options =
-          if writable
-          then List(jnf.StandardOpenOption.READ, jnf.StandardOpenOption.WRITE)
-          else List(jnf.StandardOpenOption.READ)
+        mitigate:
+          case PathError(_, _)     => PdfError(PdfError.Reason.Io(t"the path is invalid"))
+          case IoError(_, _, _, _) => PdfError(PdfError.Reason.Io(t"the file could not be opened"))
 
-        val channel =
-          try jnc.FileChannel.open(jnf.Path.of(filename.s), options*).nn
-          catch case error: ji.IOException =>
-            abort(PdfError(PdfError.Reason.Io(error.getMessage.nn.tt)))
+        . protect:
+            val path: Path on Local = workingDirectory[Path on Local].resolve(filename)
 
-        try read[grants, result](ChannelSource(channel), password, if writable then channel else Unset)(block)
-        finally channel.close()
+            if writable then
+              path.open[Ram](Read & Write): ram ?=>
+                // The source pins the file's size at open: the mapping grows for the
+                // incremental-update append below, and the document's view must not shift.
+                val source = ExpanseSource(ram.expanse, ram.size)
+                val (outcome, increment) = read[grants, result](source, password, true)(block)
+
+                increment.let: bytes =>
+                  ram.grow(source.size + bytes.length)
+                  ram(source.size) = bytes
+
+                outcome
+            else
+              path.open[Ram](): ram ?=>
+                val source = ExpanseSource(ram.expanse, ram.size)
+                val (outcome, _) = read[grants, result](source, password, false)(block)
+                outcome
 
   // The capability must be minted where the block is applied: a `Pdf` returned from another
   // method is a distinct fresh capability which could not flow into the block's own. The
   // `Granting` cast only refines the static type with the grants aperture has already vetted.
-  // When a write channel is supplied, the overlay accumulated during the block is serialised
-  // as an incremental update and appended to the file on the way out.
+  // When opened writably, the overlay accumulated during the block is serialised as an
+  // incremental update and returned for the caller to append to the file on the way out.
   private def read[grants <: Grant, result]
-    ( source: ByteSource, password: Optional[Password], sink: Optional[jnc.FileChannel] )
+    ( source: ByteSource, password: Optional[Password], writable: Boolean )
     ( block: ((Pdf & Granting[grants])^) ?=> result )
-  :   result raises PdfError =
+  :   (result, Optional[Data]) raises PdfError =
 
     val version = Pdf.readVersion(source) // check the header before anything else is trusted
     val pdf = Pdf(source, Xref.load(source), version)
     Pdf.unlock(pdf, password)
     val outcome = block(using pdf.asInstanceOf[Pdf & Granting[grants]])
 
-    sink.let: channel =>
-      if pdf.dirty then
+    val increment: Optional[Data] =
+      if writable && pdf.dirty then
         // An incremental update chains to the previous cross-reference section; a file whose
         // table was only recovered by scanning has none to chain to.
         if pdf.xref.startxref.absent then abort(PdfError(PdfError.Reason.WriteUnsupported))
+        PdfWriter.increment(pdf, source.size)
+      else Unset
 
-        val bytes = PdfWriter.increment(pdf, source.size)
-        val buffer = jn.ByteBuffer.wrap(bytes.mutable(using Unsafe)).nn
-        var position = source.size
-        while buffer.hasRemaining do position += channel.write(buffer, position)
-
-    outcome
+    (outcome, increment)

--- a/lib/galilei/src/jvm/galilei.Ram.scala
+++ b/lib/galilei/src/jvm/galilei.Ram.scala
@@ -61,8 +61,16 @@ enum RamFlag:
   case Size(bytes: Long)
 
 object Ram:
-  class RamHandle private[galilei] (buffer: jn.MappedByteBuffer, val size: Long)
+  class RamHandle private[galilei] (channel: jnc.FileChannel, readWrite: Boolean, initial: Long)
   extends caps.ExclusiveCapability:
+
+    private val mapMode: jnc.FileChannel.MapMode =
+      if readWrite then jnc.FileChannel.MapMode.READ_WRITE.nn else jnc.FileChannel.MapMode.READ_ONLY.nn
+
+    private var buffer: jn.MappedByteBuffer = channel.map(mapMode, 0, initial).nn
+    private var currentSize: Long = initial
+
+    def size: Long = currentSize
 
     // Public: called from the grant-gated transparent-inline operations below, where a
     // `private` member's inline-accessor bridge would fail capture checking.
@@ -74,6 +82,19 @@ object Ram:
     def writeTo(offset: Long, data: Data): Unit =
       buffer.put(offset.toInt, data.mutable(using Unsafe), 0, data.length)
 
+    // Extends the mapped file to `newSize` and remaps, so subsequent positional writes can
+    // address the grown region — the growth that a fixed up-front mapping otherwise forbids.
+    // Only reachable with the `Write` grant; a `newSize` no larger than the current size is a
+    // no-op, and (like the initial mapping) `newSize` must fit in `Int`.
+    def growTo(newSize: Long): Unit =
+      if newSize > currentSize then
+        buffer.force()
+        channel.write(jn.ByteBuffer.wrap(Array[Byte](0)).nn, newSize - 1)
+        buffer = channel.map(mapMode, 0, newSize).nn
+        currentSize = newSize
+
+    def flush(): Unit = buffer.force()
+
     // A shared positional view, for consumers written against zephyrine's `Expanse`.
     def expanse: Expanse = new Expanse:
       def size: Long = RamHandle.this.size
@@ -84,6 +105,7 @@ object Ram:
 
   extension (handle: RamHandle & Granting[Grant.Write])
     transparent inline def update(offset: Long, data: Data): Unit = handle.writeTo(offset, data)
+    transparent inline def grow(newSize: Long): Unit = handle.growTo(newSize)
 
   // A named class rather than an anonymous given instance, for the reasons documented on
   // `FileOpenable`. An `Exclusive` mode implies a writable channel, since OS exclusive locks
@@ -127,14 +149,10 @@ object Ram:
           if lock.isEmpty then abort(IoError(value, Operation.Open, Reason.Busy))
 
           try
-            val mapMode =
-              if mode.atoms.contains(Write) then jnc.FileChannel.MapMode.READ_WRITE
-              else jnc.FileChannel.MapMode.READ_ONLY
-
-            val buffer = channel.map(mapMode, 0, size).nn
-
-            try block(using new RamHandle(buffer, size) with Granting[grants] {})
-            finally if mode.atoms.contains(Write) then buffer.force()
+            val write = mode.atoms.contains(Write)
+            val handle = new RamHandle(channel, write, size) with Granting[grants] {}
+            try block(using handle)
+            finally if write then handle.flush()
           finally lock.foreach { held => if held != null then held.release() }
         finally channel.close()
 
@@ -187,10 +205,9 @@ object Ram:
             // Extend the new, empty file to its mapped size by writing its final byte.
             channel.write(jn.ByteBuffer.wrap(Array[Byte](0)).nn, size - 1)
 
-            val buffer = channel.map(jnc.FileChannel.MapMode.READ_WRITE, 0, size).nn
-
-            try block(using new RamHandle(buffer, size) with Granting[Grant.Read & Grant.Write] {})
-            finally buffer.force()
+            val handle = new RamHandle(channel, true, size) with Granting[Grant.Read & Grant.Write] {}
+            try block(using handle)
+            finally handle.flush()
           catch case throwable: Throwable =>
             try backend.deleteIfExists(value) catch case _: Exception => ()
             throw throwable

--- a/lib/galilei/src/test/galilei_test.scala
+++ b/lib/galilei/src/test/galilei_test.scala
@@ -297,6 +297,32 @@ object Tests extends Suite(m"Galilei tests"):
         . map(_.message)
       . assert(_.nonEmpty)
 
+      test(m"Growing a mapping extends the file for positional writes past the old end"):
+        val growLeaf: Text = Uuid().show
+        val growFile: Path on Linux = unsafely((% / "tmp" / growLeaf).on[Linux])
+        unsafely(growFile.write(t"0123456789"))
+        unsafely:
+          growFile.open[Ram](Read & Write): ram ?=>
+            ram.grow(13L)
+            ram(10L) = t"abc".in[Data]
+
+          growFile.read[Text]
+      . assert(_ == t"0123456789abc")
+
+      test(m"Growing does not shrink when passed a smaller size"):
+        unsafely:
+          ramFile.open[Ram](Read & Write): ram ?=>
+            ram.grow(4L)
+            ram.size
+      . assert(_ == 10L)
+
+      test(m"Growing without the Write grant does not compile"):
+        demilitarize:
+          ramFile.open[Ram](): ram ?=>
+            ram.grow(20L)
+        . map(_.message)
+      . assert(_.nonEmpty)
+
     suite(m"Creating mapped files"):
       import errorDiagnostics.emptyDiagnostics
 

--- a/lib/serpentine/src/core/serpentine.Path.scala
+++ b/lib/serpentine/src/core/serpentine.Path.scala
@@ -305,14 +305,16 @@ case class Path(root: Text, descent: Text*) extends Limited, Topical, Planar:
   transparent inline def peer(child: Any)(using child.type is Admissible on Plane)
   :   Path on Plane under Limit =
 
+    // A peer replaces the leaf, so the current leaf is dropped from the descent — mirroring
+    // `child.type *: tail` at the type level.
     inline caps.unsafe.unsafeErasedValue[Topic] match
       case _: (head *: tail) =>
         Path[Plane, Limit, child.type *: tail]
-          ( root, infer[child.type is Navigable on Plane].follow(child) +: descent )
+          ( root, infer[child.type is Navigable on Plane].follow(child) +: descent.drop(1) )
 
       case _ =>
         Path[Plane, Limit, Tuple]
-          ( root, infer[child.type is Navigable on Plane].follow(child) +: descent )
+          ( root, infer[child.type is Navigable on Plane].follow(child) +: descent.drop(1) )
 
 
   transparent inline def + (relative: Relative): Path =

--- a/lib/serpentine/src/test/serpentine_test.scala
+++ b/lib/serpentine/src/test/serpentine_test.scala
@@ -71,6 +71,20 @@ object Tests extends Suite(m"internal Benchmarks"):
 
       . assert(_ == Path(t"/", t"baz", t"foo"))
 
+      test(m"A peer replaces the leaf"):
+        val path: Path on Linux = (% / "foo" / "bar").on[Linux]
+        path.peer("baz")
+
+      . assert(_ == Path(t"/", t"baz", t"foo"))
+
+      test(m"A peer of a platformed path replaces the leaf"):
+        unsafely:
+          val path: Path on Linux = (% / "foo" / "bar").on[Linux]
+          val leaf: Text = t"baz"
+          path.peer(leaf)
+
+      . assert(_ == Path(t"/", t"baz", t"foo"))
+
       test(m"Construct a path with unknown label"):
         val dir: Text = t""
         val path = (% / dir / "baz")


### PR DESCRIPTION
Facsimile now performs its decompression, hashing, symmetric encryption and file access through Soundness libraries — pneumatic, gastronomy, enigmatic, serpentine and galilei — instead of calling `java.util.zip`, `java.security` and `java.nio` directly, taking it most of the way toward future JS/WASI support; along the way, galilei's memory-mapped `Ram` gains a `grow` operation, enigmatic gains a public factory for adopting externally-derived key material as a `SymmetricKey`, and a bug in serpentine's `Path.peer` — which returned a child rather than a sibling — is fixed.

Facsimile's low-level plumbing now goes through Soundness APIs:

- **FlateDecode** inflates through pneumatic (`data.decompress[Zlib]`, with a raw-`Deflate` retry for headerless streams in the wild), removing `java.util.zip`.
- **PDF security-handler digests** (MD5 key derivation, revision-6 SHA-256/384/512 rounds) and **font-subset tags** use gastronomy's cross-platform hashing; MD5's weakness is acknowledged explicitly with `import crypto.permitDisallowedCrypto`.
- **AES object encryption** (AESV2/V3, CBC with PKCS#7) goes through enigmatic, with IVs drawn from the provider's own randomness, removing `java.security.SecureRandom`.
- **File access** uses galilei: documents open through a memory-mapped `Ram` scope for positional reads, incremental updates append through the new `ram.grow(size)` followed by a positional write, and newly-created documents commit via a hidden temporary sibling moved atomically onto the target with `moveTo`. Text filenames — absolute or relative — resolve with `workingDirectory[Path on Local].resolve(...)`.

Two library improvements support this:

- **enigmatic**: `SymmetricKey(bytes)` adopts externally-derived key material (e.g. the output of a key-derivation function) as a symmetric key, alongside the existing random `SymmetricKey.generate()`:
  ```scala
  val key = SymmetricKey[Aes[256] over Cbc against Pkcs7](derivedBytes)
  ```
- **galilei**: a `Ram` handle can now grow, gated by the `Write` grant:
  ```scala
  path.open[Ram](Read & Write): ram ?=>
    ram.grow(ram.size + extra.length)
    ram(offset) = extra
  ```

Additionally, serpentine's `Path.peer` now correctly replaces the leaf: previously `(% / "foo" / "bar").peer("baz")` produced `/foo/bar/baz` rather than `/foo/baz`. Code that relied on the old `peer` behaviour should use `/`: exoskeleton's `Enclave` now stages its artifacts explicitly as children of the per-stage output directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
