### PR TITLE
Use hieroglyph and distillate for facsimile's text codecs and number parsing

### DIFF
--- a/lib/facsimile/src/core/facsimile.CharMap.scala
+++ b/lib/facsimile/src/core/facsimile.CharMap.scala
@@ -32,11 +32,10 @@
                                                                                                   */
 package facsimile
 
-import java.nio.charset as jncs
-
 import anticipation.*
 import contingency.*
 import gossamer.*
+import hieroglyph.*
 import rudiments.*
 import vacuous.*
 
@@ -63,7 +62,7 @@ private[facsimile] object CharMap:
       result
 
     def target(value: Cos): Optional[Text] = value.chars.let: bytes =>
-      String(bytes.mutable(using Unsafe), jncs.StandardCharsets.UTF_16BE).nn.tt
+      charDecoders.utf16BeDecoder.decoded(bytes)
 
     def increment(text: Text, by: Int): Text =
       if text.s.isEmpty then text

--- a/lib/facsimile/src/core/facsimile.ContentWriter.scala
+++ b/lib/facsimile/src/core/facsimile.ContentWriter.scala
@@ -34,6 +34,7 @@ package facsimile
 
 import anticipation.*
 import gossamer.*
+import hieroglyph.*
 import iridescence.*
 import rudiments.*
 import vacuous.*
@@ -54,7 +55,7 @@ private[facsimile] object ContentWriter:
   :   Unit =
 
     def out(text: Text): Unit =
-      val raw = text.s.getBytes("ISO-8859-1").nn
+      val raw = charEncoders.iso88591Encoder.encoded(text)
       var i = 0
       while i < raw.length do { builder += raw(i); i += 1 }
 

--- a/lib/facsimile/src/core/facsimile.Cos.scala
+++ b/lib/facsimile/src/core/facsimile.Cos.scala
@@ -32,9 +32,8 @@
                                                                                                   */
 package facsimile
 
-import java.nio.charset as jncs
-
 import anticipation.*
+import hieroglyph.*
 import rudiments.*
 import vacuous.*
 
@@ -64,21 +63,21 @@ object Cos:
 
       bytes.immutable(using Unsafe)
     else
-      val body = text.s.getBytes("UTF-16BE").nn
+      val body = charEncoders.utf16BeEncoder.encoded(text)
       val bytes = new Array[Byte](body.length + 2)
       bytes(0) = 0xfe.toByte
       bytes(1) = 0xff.toByte
-      System.arraycopy(body, 0, bytes, 2, body.length)
+      System.arraycopy(body.mutable(using Unsafe), 0, bytes, 2, body.length)
       bytes.immutable(using Unsafe)
 
   // A text string (ISO 32000-2 §7.9.2.2): UTF-16BE or UTF-8 by byte-order mark, otherwise
   // PDFDocEncoding.
   private[facsimile] def decodeText(bytes: Data): Text =
     if bytes.length >= 2 && (bytes(0) & 0xff) == 0xfe && (bytes(1) & 0xff) == 0xff
-    then String(bytes.drop(2).mutable(using Unsafe), jncs.StandardCharsets.UTF_16BE).nn.tt
+    then charDecoders.utf16BeDecoder.decoded(bytes.drop(2))
     else if bytes.length >= 3
             && (bytes(0) & 0xff) == 0xef && (bytes(1) & 0xff) == 0xbb && (bytes(2) & 0xff) == 0xbf
-    then String(bytes.drop(3).mutable(using Unsafe), jncs.StandardCharsets.UTF_8).nn.tt
+    then charDecoders.utf8Decoder.decoded(bytes.drop(3))
     else
       val chars = new Array[Char](bytes.length)
       var i = 0

--- a/lib/facsimile/src/core/facsimile.CosLexer.scala
+++ b/lib/facsimile/src/core/facsimile.CosLexer.scala
@@ -32,11 +32,11 @@
                                                                                                   */
 package facsimile
 
-import java.nio.charset as jncs
-
 import anticipation.*
 import contingency.*
+import distillate.*
 import gossamer.*
+import hieroglyph.*
 import rudiments.*
 import vacuous.*
 
@@ -156,13 +156,13 @@ private[facsimile] class CosLexer(scan: Scan):
     val content = text.toString
 
     if content.indexOf('.') >= 0 || content.indexOf('e') >= 0 || content.indexOf('E') >= 0 then
-      try CosToken.Real(java.lang.Double.parseDouble(if content == "." then "0" else content))
-      catch case _: NumberFormatException =>
-        abort(PdfError(PdfError.Reason.Unparseable(start, t"a numeric object")))
+      val corrected: Text = if content == "." then t"0" else content.tt
+
+      safely(CosToken.Real(corrected.as[Double]))
+      . or(abort(PdfError(PdfError.Reason.Unparseable(start, t"a numeric object"))))
     else
-      try CosToken.Integral(java.lang.Long.parseLong(content))
-      catch case _: NumberFormatException =>
-        abort(PdfError(PdfError.Reason.Unparseable(start, t"a numeric object")))
+      safely(CosToken.Integral(content.tt.as[Long]))
+      . or(abort(PdfError(PdfError.Reason.Unparseable(start, t"a numeric object"))))
 
   private def name(): CosToken =
     val bytes = Array.newBuilder[Byte]
@@ -257,5 +257,4 @@ private[facsimile] class CosLexer(scan: Scan):
     if high >= 0 then bytes += (high << 4).toByte // an odd final digit implies a trailing zero
     CosToken.Chars(bytes.result().immutable(using Unsafe))
 
-  private def decode(bytes: Data): Text =
-    String(bytes.mutable(using Unsafe), jncs.StandardCharsets.UTF_8).nn.tt
+  private def decode(bytes: Data): Text = charDecoders.utf8Decoder.decoded(bytes)

--- a/lib/facsimile/src/core/facsimile.CosWriter.scala
+++ b/lib/facsimile/src/core/facsimile.CosWriter.scala
@@ -33,6 +33,7 @@
 package facsimile
 
 import anticipation.*
+import hieroglyph.*
 import rudiments.*
 import vacuous.*
 
@@ -105,7 +106,7 @@ private[facsimile] object CosWriter:
 
   private def name(builder: scala.collection.mutable.ArrayBuilder[Byte], text: Text): Unit =
     builder += '/'.toByte
-    val raw = text.s.getBytes("UTF-8").nn
+    val raw = charEncoders.utf8Encoder.encoded(text)
     var i = 0
 
     while i < raw.length do

--- a/lib/facsimile/src/core/facsimile.Guard.scala
+++ b/lib/facsimile/src/core/facsimile.Guard.scala
@@ -40,6 +40,7 @@ import contingency.*
 import enigmatic.*
 import gastronomy.*
 import gossamer.*
+import hieroglyph.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -188,7 +189,7 @@ private[facsimile] object Guard:
   // padding.
   private def unwrap6(password: Text, user: Data, ue: Data): Optional[Data] =
     if user.length < 48 || ue.length < 32 then Unset else
-      val passwordBytes = password.s.getBytes("UTF-8").nn
+      val passwordBytes = charEncoders.utf8Encoder.encoded(password).mutable(using Unsafe)
       val salt = user.slice(32, 40)
       val keySalt = user.slice(40, 48)
 
@@ -258,7 +259,7 @@ private[facsimile] object Guard:
     k.take(32)
 
   private def padded(password: Text): Array[Byte] =
-    val bytes = password.s.getBytes("ISO-8859-1").nn
+    val bytes = charEncoders.iso88591Encoder.encoded(password).mutable(using Unsafe)
     val out = new Array[Byte](32)
     val count = 32.min(bytes.length)
     System.arraycopy(bytes, 0, out, 0, count)

--- a/lib/facsimile/src/core/facsimile.Pdf.scala
+++ b/lib/facsimile/src/core/facsimile.Pdf.scala
@@ -37,6 +37,7 @@ import contingency.*
 import denominative.*
 import enigmatic.*
 import gossamer.*
+import hieroglyph.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -64,7 +65,7 @@ object Pdf:
       t"xref\n0 3\n0000000000 65535 f \n${pad(offset1)} 00000 n \n${pad(offset2)} 00000 n \n"
 
     val trailer = t"trailer\n<< /Size 3 /Root 1 0 R >>\nstartxref\n$xrefOffset\n%%EOF"
-    val bytes = t"$body$table$trailer".s.getBytes("ISO-8859-1").nn.immutable(using Unsafe)
+    val bytes = charEncoders.iso88591Encoder.encoded(t"$body$table$trailer")
     val source = DataSource(bytes)
     Pdf(source, Xref.load(source), Version(1, 7))
 

--- a/lib/facsimile/src/core/facsimile.PdfWriter.scala
+++ b/lib/facsimile/src/core/facsimile.PdfWriter.scala
@@ -35,6 +35,7 @@ package facsimile
 import anticipation.*
 import contingency.*
 import gossamer.*
+import hieroglyph.*
 import rudiments.*
 import vacuous.*
 
@@ -54,7 +55,7 @@ private[facsimile] object PdfWriter:
       builder.addAll(data.mutable(using Unsafe))
       length += data.length
 
-    def ascii(text: Text): Unit = raw(text.s.getBytes("ISO-8859-1").nn.immutable(using Unsafe))
+    def ascii(text: Text): Unit = raw(charEncoders.iso88591Encoder.encoded(text))
 
     // A binary comment after the header marks the file as containing binary data.
     ascii(t"%PDF-1.7\n")
@@ -100,7 +101,7 @@ private[facsimile] object PdfWriter:
       builder.addAll(data.mutable(using Unsafe))
       length += data.length
 
-    def ascii(text: Text): Unit = raw(text.s.getBytes("ISO-8859-1").nn.immutable(using Unsafe))
+    def ascii(text: Text): Unit = raw(charEncoders.iso88591Encoder.encoded(text))
 
     // A leading end-of-line guards against the original file not ending in one.
     ascii(t"\n")

--- a/lib/facsimile/src/core/facsimile_core.scala
+++ b/lib/facsimile/src/core/facsimile_core.scala
@@ -35,3 +35,7 @@ package facsimile
 // The contextual document within a `PdfFile.open` block: `pdf.trailer` rather than
 // `summon[Pdf].trailer`, following parasite's `monitor`.
 transparent inline def pdf: Pdf^ = infer[Pdf^]
+
+// Malformed text decodes with U+FFFD substitution, matching the REPLACE behaviour of the
+// JDK's `String(bytes, charset)` constructor, which PDF string handling has always had.
+private[facsimile] given replacementSanitizer: hieroglyph.TextSanitizer = (_, _) => '\ufffd'


### PR DESCRIPTION
Facsimile's remaining charset conversions now go through hieroglyph's `charEncoders` and `charDecoders` — with malformed input substituting U+FFFD, exactly as before — and COS numeric tokens parse through distillate's typed decoders, removing every remaining `java.nio.charset` use from the library.

This completes the charset-and-parsing leg of facsimile's migration onto Soundness APIs:

- Text serialisation (ISO-8859-1 structure tokens, UTF-8 names, UTF-16BE text strings) uses hieroglyph's `charEncoders`, byte-for-byte identical to the previous `String.getBytes` calls.
- Text-string, CMap and name decoding uses hieroglyph's `charDecoders`, with a facsimile-internal `TextSanitizer` that substitutes `U+FFFD` for malformed input, preserving the established replacement behaviour of `String(bytes, charset)`.
- COS numeric tokens (`123`, `-4.5`, and the nonstandard-but-tolerated exponent forms) parse with distillate's `as[Long]`/`as[Double]`, whose grammar matches the previous `java.lang` parsers, surfacing failures as typed errors rather than caught exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
