### PR TITLE
Route Parasite suspension through a Strand/Supervisor seam, licensed by Monitor^

### DIFF
--- a/lib/embarcadero/src/containerd/embarcadero.Containerd.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.Containerd.scala
@@ -89,6 +89,7 @@ object Containerd:
 case class Containerd(channel: GrpcChannel^):
   // The daemon's version and build revision (`containerd.services.version.v1.Version`).
   def version()
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   VersionResponse =
 
@@ -97,6 +98,7 @@ case class Containerd(channel: GrpcChannel^):
   // The containers in the bound namespace (`containerd.services.containers.v1`),
   // optionally narrowed by containerd `filters`.
   def containers(filters: List[Text] = Nil)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   List[Container] =
 
@@ -108,6 +110,7 @@ case class Containerd(channel: GrpcChannel^):
   // Register a container, returning it as stored (`Containers.Create`). The container's
   // `spec` carries the OCI runtime spec as an `AnyMessage`.
   def createContainer(container: Container)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Container =
 
@@ -122,6 +125,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // A single container by id (`Containers.Get`).
   def container(id: Text)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Container =
 
@@ -132,6 +136,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Remove a container by id (`Containers.Delete`).
   def deleteContainer(id: Text)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Unit =
 
@@ -141,6 +146,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // The namespaces known to the daemon (`Namespaces.List`).
   def namespaces(filter: Text = t"")
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   List[Namespace] =
 
@@ -151,6 +157,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Create a namespace, returning it as stored (`Namespaces.Create`).
   def createNamespace(namespace: Namespace)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Namespace =
 
@@ -161,6 +168,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Remove a namespace by name (`Namespaces.Delete`).
   def deleteNamespace(name: Text)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Unit =
 
@@ -169,6 +177,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // The images in the bound namespace (`Images.List`), optionally filtered.
   def images(filters: List[Text] = Nil)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   List[ImageRecord] =
 
@@ -179,6 +188,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // A single image by reference (`Images.Get`).
   def image(name: Text)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   ImageRecord =
 
@@ -189,6 +199,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Remove an image by reference (`Images.Delete`).
   def deleteImage(name: Text, sync: Boolean = false)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Unit =
 
@@ -200,6 +211,7 @@ case class Containerd(channel: GrpcChannel^):
   // `rootfs` mounts, e.g. from an unpacked snapshot) and optional runtime `options`,
   // returning the container id and the new task's host pid.
   def createTask(containerId: Text, rootfs: List[Mount] = Nil, options: AnyMessage = AnyMessage())
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   CreateTaskResponse =
 
@@ -209,6 +221,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Start a created task (`Tasks.Start`), returning its host pid.
   def startTask(containerId: Text, execId: Text = t"")
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Int =
 
@@ -219,6 +232,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Send a signal to a task (`Tasks.Kill`); `all` targets every process in the container.
   def killTask(containerId: Text, signal: Int, execId: Text = t"", all: Boolean = false)
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Unit =
 
@@ -228,6 +242,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Wait for a task to exit (`Tasks.Wait`), returning its exit status and time.
   def waitTask(containerId: Text, execId: Text = t"")
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   WaitResponse =
 
@@ -236,6 +251,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Delete a task (`Tasks.Delete`), returning its final exit status.
   def deleteTask(containerId: Text, execId: Text = t"")
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   DeleteTaskResponse =
 
@@ -245,6 +261,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // The state of a single task (`Tasks.Get`).
   def task(containerId: Text, execId: Text = t"")
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   Workload =
 
@@ -253,6 +270,7 @@ case class Containerd(channel: GrpcChannel^):
 
   // Every task known to the daemon (`Tasks.List`), optionally filtered.
   def tasks(filter: Text = t"")
+  ( using Monitor^ )
   ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   List[Workload] =
 

--- a/lib/embarcadero/src/containerd/embarcadero.Workload.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.Workload.scala
@@ -43,7 +43,7 @@ import vacuous.*
 
 object Workload:
   // Anchored here so `container.open[Workload](...)` resolves with no import.
-  given openable: (containerd: Containerd^)
+  given openable: (containerd: Containerd^, monitor: Monitor^)
   =>  ( Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   =>  ( WorkloadOpenable^ ) =
     WorkloadOpenable()

--- a/lib/embarcadero/src/containerd/embarcadero.WorkloadHandle.scala
+++ b/lib/embarcadero/src/containerd/embarcadero.WorkloadHandle.scala
@@ -53,6 +53,7 @@ object WorkloadHandle:
   // fail under capture checking, while extensions resolve directly.
   extension (handle: (WorkloadHandle & Granting[Grant.Read])^)
     def state()
+    ( using Monitor^ )
     ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
     :   ProcessStatus =
 
@@ -61,6 +62,7 @@ object WorkloadHandle:
   extension (handle: (WorkloadHandle & Granting[WorkloadGrant.Run])^)
     // `await`, not `wait`: the latter would clash with `Object#wait`.
     def await()
+    ( using Monitor^ )
     ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
     :   WaitResponse =
 
@@ -68,6 +70,7 @@ object WorkloadHandle:
 
   extension (handle: (WorkloadHandle & Granting[WorkloadGrant.Signal])^)
     def kill(signal: Int, all: Boolean = false)
+    ( using Monitor^ )
     ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
     :   Unit =
 
@@ -87,6 +90,7 @@ extends caps.ExclusiveCapability
 // which then fails to conform to the declared refinement.
 class WorkloadOpenable
   ( using containerd:    Containerd^,
+          monitor:       Monitor^,
           grpcError:     Tactic[GrpcError],
           http2Error:    Tactic[Http2Error],
           asyncError:    Tactic[AsyncError],

--- a/lib/ethereal/src/core/ethereal.Client.scala
+++ b/lib/ethereal/src/core/ethereal.Client.scala
@@ -70,4 +70,4 @@ case class Client(pid: Pid) extends Topical:
 
   val socket: Promise[Connection] = Promise()
 
-  def close(): Unit = safely(socket.await(1.0*Second).close())
+  def close()(using Monitor^): Unit = safely(socket.await(1.0*Second).close())

--- a/lib/ethereal/src/core/ethereal_core.scala
+++ b/lib/ethereal/src/core/ethereal_core.scala
@@ -387,6 +387,11 @@ def cli[bus <: Matchable](using executive: Executive)
         val clientState = client(pid)
         clientState.socket.fulfill(connection)
 
+        // The stream crosses the capability-erasing `java.io.OutputStream` interface, so the
+        // monitor its first write suspends on cannot stay tracked; laundered to pure, sound
+        // because it is the daemon-lifetime connection monitor, which outlives the stream.
+        val monitor0: Monitor^{} = caps.unsafe.unsafeAssumePure(summon[Monitor])
+
         val lazyStderr: ji.OutputStream = new ji.OutputStream():
           private val stderrOut: juca.AtomicReference[ji.OutputStream | Null] =
             juca.AtomicReference(null)
@@ -396,7 +401,7 @@ def cli[bus <: Matchable](using executive: Executive)
 
             if s != null then s
             else
-              val newS = clientState.stderr.await()
+              val newS = clientState.stderr.await()(using monitor0)
               stderrOut.set(newS)
               newS
 

--- a/lib/exoskeleton/src/args/exoskeleton.Cli.scala
+++ b/lib/exoskeleton/src/args/exoskeleton.Cli.scala
@@ -56,7 +56,8 @@ object Cli:
 
   def done(): Unit = trigger.offer(())
   def log(input: Text): Unit = messages ::= input
-  def await(): List[Text] = safely(trigger.await(10.0*Second)) yet messages.reverse
+  def await()(using Monitor^): List[Text] =
+    safely(trigger.await(10.0*Second)) yet messages.reverse
 
 
   def arguments

--- a/lib/exoskeleton/src/completions/exoskeleton_completions.scala
+++ b/lib/exoskeleton/src/completions/exoskeleton_completions.scala
@@ -218,7 +218,8 @@ package executives:
 
             case t"await" =>
               Cli.prepare()
-              safely(Cli.await()).or(Nil).map(Out.println(_))
+              import parasite.threading.platformThreading
+              safely(parasite.supervise(Cli.await())).or(Nil).map(Out.println(_))
               Exit.Ok
 
             case t"install" =>

--- a/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
+++ b/lib/obligatory/src/grpc/obligatory.GrpcChannel.scala
@@ -101,7 +101,10 @@ class GrpcChannel
   // carries the status in the headers). Raise unless the status is `Ok`.
   // Declared with explicit tactics rather than stacked `raises`: see `bintelDocument`
   // in stratiform (capture checking cannot unify cross-level tactic captures, 3.10).
-  private def expectStatus(stream: Http2Stream)(using Tactic[GrpcError], Tactic[AsyncError]): Unit =
+  private def expectStatus(stream: Http2Stream)
+    ( using Monitor^, Tactic[GrpcError], Tactic[AsyncError] )
+  :   Unit =
+
     val fields = stream.trailers.await() ++ stream.headers.await()
     val codeText = fields.find(_.name == t"grpc-status").optional.let(_.value)
     val message = fields.find(_.name == t"grpc-message").optional.let(_.value).or(t"")
@@ -131,6 +134,7 @@ class GrpcChannel
   def unary[request, response]
     ( method: Grpc.Method, value: request, metadata: Grpc.Metadata = Grpc.Metadata() )
     ( using request is Encodable in Protobuf, response is Decodable in Protobuf )
+    ( using Monitor^ )
     ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   response =
 
@@ -154,6 +158,7 @@ class GrpcChannel
   def serverStreaming[request, response]
     ( method: Grpc.Method, value: request, metadata: Grpc.Metadata = Grpc.Metadata() )
     ( using request is Encodable in Protobuf, response is Decodable in Protobuf )
+    ( using Monitor^ )
     ( using Tactic[GrpcError], Tactic[Http2Error], Tactic[AsyncError], Tactic[ProtobufError] )
   :   LazyList[response] =
 

--- a/lib/obligatory/src/grpc/obligatory.grpcInternal.scala
+++ b/lib/obligatory/src/grpc/obligatory.grpcInternal.scala
@@ -96,6 +96,12 @@ object grpcInternal:
             Expr.summon[Tactic[error]].getOrElse:
               halt(m"a contextual ${TypeRepr.of[Tactic[error]].show} instance is required")
 
+          // Summoned at the expansion site, outside the quote: a `given Monitor` declared inside
+          // the quote would resolve to itself and recurse.
+          def monitorExpr: Expr[Monitor] = Expr.summon[Monitor] match
+            case Some(monitor) => monitor
+            case _             => halt(m"a contextual `Monitor` instance is required")
+
           def encoder[request: Type]: Expr[request is Encodable in Protobuf] =
             Expr.summon[request is Encodable in Protobuf].getOrElse:
               halt(m"no ${TypeRepr.of[request is Encodable in Protobuf].show} instance was found")
@@ -116,6 +122,7 @@ object grpcInternal:
 
                     Some:
                       ' {
+                          given Monitor = ${monitorExpr}
                           given Tactic[GrpcError] = ${tactic[GrpcError]}
                           given Tactic[Http2Error] = ${tactic[Http2Error]}
                           given Tactic[AsyncError] = ${tactic[AsyncError]}
@@ -132,6 +139,7 @@ object grpcInternal:
 
                     Some:
                       ' {
+                          given Monitor = ${monitorExpr}
                           given Tactic[GrpcError] = ${tactic[GrpcError]}
                           given Tactic[Http2Error] = ${tactic[Http2Error]}
                           given Tactic[AsyncError] = ${tactic[AsyncError]}

--- a/lib/obligatory/src/json/obligatory.internal.scala
+++ b/lib/obligatory/src/json/obligatory.internal.scala
@@ -251,7 +251,7 @@ object internal:
                           JsonRpc.notification($url, $methodName, json)
                             ( using $monitor, $probate, $online )
 
-                          . await()
+                          . await()(using $monitor)
 
                         . yet (())
                       }
@@ -268,7 +268,7 @@ object internal:
                                 val response =
                                   JsonRpc.request($url, $methodName, json)
                                     ( using $monitor, $probate, $online )
-                                  . await()
+                                  . await()(using $monitor)
 
                                 $decoder.decoded(response)
                             }
@@ -369,8 +369,8 @@ object internal:
 
             . asTerm
           else result.asType.absolve match
-            case '[result] => Expr.summon[result is Json.Decodable] match
-              case Some(decoder) =>
+            case '[result] => (Expr.summon[result is Json.Decodable], Expr.summon[Monitor]) match
+              case (Some(decoder), Some(monitor)) =>
                 Some:
                   ' {
                       val json = Map(${Varargs(entries)}*).in[Json]
@@ -378,19 +378,22 @@ object internal:
                       unsafely:
                         val response =
                           JsonRpc.request($rpc, $methodName, json)
-                          . await()
+                          . await()(using $monitor)
 
                         $decoder.decoded(response)
                     }
 
                   . asTerm
 
-              case _ =>
+              case (None, _) =>
                 halt:
                   m"""
                     could not find a contextual ${TypeRepr.of[result is Decodable in Json].show}
                     instance for the return type of ${method.name}
                   """
+
+              case _ =>
+                halt(m"a contextual `Monitor` instance is required")
 
         case _ =>
           halt(69, m"the method ${method.name} must have exactly one parameter list")

--- a/lib/parasite/src/core/parasite.Daemon.scala
+++ b/lib/parasite/src/core/parasite.Daemon.scala
@@ -59,5 +59,5 @@ object Daemon:
 
 
 trait Daemon:
-  def attend(): Unit
+  def attend()(using Monitor^): Unit
   def cancel(): Unit

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -90,7 +90,7 @@ sealed trait Monitor extends Resultant, Findable, caps.ExclusiveCapability:
   def chain: Optional[Chain]
   def stack: Text
   def daemon: Boolean
-  def attend(): Unit = promise.attend()
+  def attend()(using Monitor^): Unit = promise.attend()
   def ready: Boolean = promise.ready
   def cancel(): Unit
   def supervisor: Supervisor
@@ -300,6 +300,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
   // guarantees everything a join would. (A trailing unbounded `strand.join()` would also defeat
   // the timed variants' deadline.)
   def join[abstractable: Abstractable across Durations to Long](duration: abstractable)
+    ( using Monitor^ )
   :   Result raises AsyncError =
 
     promise.attend(duration)
@@ -307,7 +308,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
     result()
 
 
-  def join(): Result raises AsyncError =
+  def join()(using Monitor^): Result raises AsyncError =
     promise.attend()
     result()
 
@@ -317,14 +318,14 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
   // `Tactic[error | AsyncError]`. `error` is reconstructed by an unchecked cast that is sound for
   // any failure raised through the body's `AsyncTactic` (the only typed-error path); a genuinely
   // unchecked throwable from the body flows through as the raw `join` would have rethrown it.
-  def deliver[error <: Hazard]()(using Tactic[error | AsyncError]^): Result =
+  def deliver[error <: Hazard]()(using Monitor^, Tactic[error | AsyncError]^): Result =
     promise.attend()
     fulfilment()
 
 
   def deliver[error <: Hazard, abstractable: Abstractable across Durations to Long]
     ( duration: abstractable )
-    ( using Tactic[error | AsyncError]^ )
+    ( using Monitor^, Tactic[error | AsyncError]^ )
   :   Result =
 
     promise.attend(duration)

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -107,6 +107,17 @@ sealed trait Monitor extends Resultant, Findable, caps.ExclusiveCapability:
 // be referenced anywhere; the supervision tree (capability-tracked `Monitor`s) is rooted locally
 // per `supervise` block by a `Root`. The *license* to suspend is `Monitor^`; the supervisor is
 // only the mechanism.
+//
+// The WASIp3 (Component Model async) mapping, for a future `parasite.wasi` backend:
+//   fork                 → allocate a run-queue entry (the strand) and enqueue it
+//   park                 → suspend the current task, returning WAIT on its waitable-set;
+//                          `Strand.unpark` → resolve its wakeup waitable / mark it runnable
+//   park(deadline)/sleep → join a `wasi:clocks/monotonic-clock` timer to the set
+//   interrupted          → the strand's cancellation flag, set by `Strand.interrupt`
+// On a stackless runtime, a direct-style `park` from arbitrary stack depth only becomes
+// implementable once the compiler can CPS-transform suspending code; until then such a backend
+// serves the monadic dialect (`Task.bind`/`map`, `Task.sleep`, `Promise#task`), whose
+// continuations are already reified.
 trait Supervisor:
   def name: Name[Async]
 

--- a/lib/parasite/src/core/parasite.Monitor.scala
+++ b/lib/parasite/src/core/parasite.Monitor.scala
@@ -96,12 +96,17 @@ sealed trait Monitor extends Resultant, Findable, caps.ExclusiveCapability:
   def supervisor: Supervisor
 
   def snooze[generic: Abstractable across Durations to Long](duration: generic): Unit =
-    jucl.LockSupport.parkNanos(duration.generic)
+    supervisor.sleep(duration.generic)
 
-// The thread-forking strategy. DECOUPLED from `Monitor` (see capture-checking-capabilities notes):
-// the global strategy singletons (`PlatformSupervisor` etc.) are plain values, NOT capabilities, so
-// they can be referenced anywhere; the supervision tree (capability-tracked `Monitor`s) is rooted
-// locally per `supervise` block by a `Root`.
+// The execution strategy: forking and — since every way a strand can *suspend* must be routed
+// through it — parking, sleeping and cancellation-status too. This is the whole platform seam:
+// a backend for a different execution model (an event loop over WASIp3 waitable-sets, say) is a
+// `Supervisor` implementation, selected by a `Threading` given; nothing else in parasite touches
+// the platform. DECOUPLED from `Monitor` (see capture-checking-capabilities notes): the global
+// strategy singletons (`PlatformSupervisor` etc.) are plain values, NOT capabilities, so they can
+// be referenced anywhere; the supervision tree (capability-tracked `Monitor`s) is rooted locally
+// per `supervise` block by a `Root`. The *license* to suspend is `Monitor^`; the supervisor is
+// only the mechanism.
 trait Supervisor:
   def name: Name[Async]
 
@@ -109,7 +114,37 @@ trait Supervisor:
   // building strings, and `VirtualSupervisor` — the default — never evaluates it. (A thunk, not
   // a by-name parameter, because a by-name `Optional[Text]` crashes the capture checker's Setup
   // phase on the union type.)
-  def fork(name: () => Optional[Text])(block: => Unit): Thread
+  def fork(name: () => Optional[Text])(block: => Unit): Strand
+
+  // The identity of the calling strand, as a waiter which a later `Strand.unpark` can release.
+  def strand(): Strand
+
+  // Suspend the calling strand until it is unparked. Spurious wakeups are permitted — every
+  // caller re-checks its condition in a loop, exactly as `LockSupport.park` demands.
+  def park(blocker: AnyRef): Unit
+
+  // Suspend the calling strand until the deadline (`System.nanoTime` basis) or an unpark.
+  def park(blocker: AnyRef, deadline: Long): Unit
+
+  // Timed suspension with no blocker and no wakeup channel.
+  def sleep(nanoseconds: Long): Unit
+
+  // Check-and-clear the calling strand's cancellation-interrupt status.
+  def interrupted(): Boolean
+
+// The thread-backed implementation of the suspension primitives, shared by every JVM supervisor.
+// This also compiles (and no-ops harmlessly) on the Scala.js/Wasm javalib, which fakes `Thread`
+// and `LockSupport`; if the fork's javalib ever drops those fakes, split this out with the
+// `jsSources` arrangement used by `pneumatic.flate`.
+trait ThreadSupervisor extends Supervisor:
+  def strand(): Strand = Strand.Threaded(Thread.currentThread.nn)
+  def park(blocker: AnyRef): Unit = jucl.LockSupport.park(blocker)
+
+  def park(blocker: AnyRef, deadline: Long): Unit =
+    jucl.LockSupport.parkNanos(blocker, deadline - jl.System.nanoTime())
+
+  def sleep(nanoseconds: Long): Unit = jucl.LockSupport.parkNanos(nanoseconds)
+  def interrupted(): Boolean = Thread.interrupted()
 
 // The local root of a supervision tree, created by `supervise`. A `Monitor` (hence a capability),
 // but its lifetime is the `supervise` block, so it does not escape as a global capability.
@@ -124,13 +159,13 @@ class Root(val supervisor: Supervisor) extends Monitor:
   def cancel(): Unit = ()
   def shutdown(): Unit = workers.each(_.cancel())
 
-object VirtualSupervisor extends Supervisor:
+object VirtualSupervisor extends ThreadSupervisor:
   def name: Name[Async] = n"virtual"
 
-  def fork(name: () => Optional[Text])(block: => Unit): Thread =
-    Thread.ofVirtual().nn.start{ () => block }.nn
+  def fork(name: () => Optional[Text])(block: => Unit): Strand =
+    Strand.Threaded(Thread.ofVirtual().nn.start{ () => block }.nn)
 
-object AdaptiveSupervisor extends Supervisor:
+object AdaptiveSupervisor extends ThreadSupervisor:
   def name: Name[Async] = n"adaptive"
 
   // Virtual-thread support is a deterministic property of the JVM, so it is probed once with a
@@ -144,19 +179,20 @@ object AdaptiveSupervisor extends Supervisor:
       true
     catch case error: UnsupportedOperationException => false
 
-  def fork(name: () => Optional[Text])(block: => Unit): Thread =
+  def fork(name: () => Optional[Text])(block: => Unit): Strand =
     if virtual then VirtualSupervisor.fork(name)(block)
     else PlatformSupervisor.fork(name)(block)
 
-object PlatformSupervisor extends Supervisor:
+object PlatformSupervisor extends ThreadSupervisor:
   def name: Name[Async] = n"platform"
 
-  def fork(name: () => Optional[Text])(block: => Unit): Thread =
+  def fork(name: () => Optional[Text])(block: => Unit): Strand =
     val runnable: Runnable^ = () => block
 
-    new Thread(runnable).tap: thread =>
-      name().let(_.s).let(thread.setName(_))
-      thread.start()
+    Strand.Threaded:
+      new Thread(runnable).tap: thread =>
+        name().let(_.s).let(thread.setName(_))
+        thread.start()
 
 abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) extends Monitor:
   self: Worker^ =>
@@ -190,7 +226,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
 
   def relent(): Unit =
     relents += 1
-    if Thread.interrupted() then throw new InterruptedException()
+    if supervisor.interrupted() then throw new InterruptedException()
 
     state.get().nn match
       case Initializing    => ()
@@ -201,9 +237,9 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
       case Cancelled       => throw new InterruptedException()
 
   override def snooze[generic: Abstractable across Durations to Long](duration: generic): Unit =
-    if Thread.interrupted() || state.get() == Cancelled then throw new InterruptedException()
-    jucl.LockSupport.parkNanos(duration.generic)
-    if Thread.interrupted() || state.get() == Cancelled then throw new InterruptedException()
+    if supervisor.interrupted() || state.get() == Cancelled then throw new InterruptedException()
+    supervisor.sleep(duration.generic)
+    if supervisor.interrupted() || state.get() == Cancelled then throw new InterruptedException()
 
 
   def map[result2](lambda: Result => result2)(using Monitor^, Probate^)
@@ -221,7 +257,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
   // An explicit CAS loop rather than `updateAndGet`, whose update function may be re-run under
   // contention: the cancellation effects must fire exactly once, and only *after* the `Cancelled`
   // state is visible, so that a joiner woken by `promise.cancel()` cannot observe a stale
-  // `Active` state. The final `thread.join()` happens whenever the state is `Cancelled`, even if
+  // `Active` state. The final `strand.join()` happens whenever the state is `Cancelled`, even if
   // another cancellation won the race.
   @tailrec
   final def cancel(): Unit =
@@ -231,10 +267,10 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
       case Initializing | Active(_) =>
         if !state.compareAndSet(current, Cancelled) then cancel() else
           promise.cancel()
-          thread.interrupt()
-          thread.join()
+          strand.interrupt()
+          strand.join()
 
-      case Cancelled => thread.join()
+      case Cancelled => strand.join()
       case _         => ()
 
   def result()(using cancel: Tactic[AsyncError]^): Result =
@@ -259,9 +295,9 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
   // `canThrowAny`), so the static error is only `AsyncError`. Used internally (`map`/`bind`/
   // `sequence`/`race`) where the body's error type is not tracked. Public callers go via the typed
   // `Task#await`, which routes through `deliver` instead.
-  // No `thread.join()`: the promise is settled in the worker thread's `finally` block, strictly
+  // No `strand.join()`: the promise is settled in the worker strand's `finally` block, strictly
   // after the state is terminal and probate cleanup has run, so `attend` returning already
-  // guarantees everything a join would. (A trailing unbounded `thread.join()` would also defeat
+  // guarantees everything a join would. (A trailing unbounded `strand.join()` would also defeat
   // the timed variants' deadline.)
   def join[abstractable: Abstractable across Durations to Long](duration: abstractable)
   :   Result raises AsyncError =
@@ -314,7 +350,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
           case Cancelled                   => abort(AsyncError(Reason.Cancelled))
           case _                           => abort(AsyncError(Reason.Incomplete))
 
-  private lazy val thread: Thread = parent.supervisor.fork(() => stack):
+  private lazy val strand: Strand = parent.supervisor.fork(() => stack):
     val started: Boolean = state.updateAndGet:
       case Initializing => Active(jl.System.currentTimeMillis)
       case other        => other
@@ -330,7 +366,7 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
 
     catch
       case error: InterruptedException =>
-        Thread.interrupted()
+        supervisor.interrupted()
 
         state.updateAndGet:
           case Initializing | Active(_) | Cancelled => Cancelled
@@ -381,4 +417,4 @@ abstract class Worker(frame: Codepoint, parent: Monitor^, probate: Probate^) ext
 
       escalation.let(throw _)
 
-  thread
+  strand

--- a/lib/parasite/src/core/parasite.Promise.scala
+++ b/lib/parasite/src/core/parasite.Promise.scala
@@ -36,11 +36,11 @@ import language.experimental.pureFunctions
 
 import java.lang as jl
 import java.util.concurrent.atomic as juca
-import java.util.concurrent.locks as jucl
 import java.util.function as juf
 
 import anticipation.*
 import contingency.*
+import digression.*
 import prepositional.*
 import rudiments.*
 import vacuous.*
@@ -49,12 +49,12 @@ import unsafeExceptions.canThrowAny
 
 object Promise:
   enum State[+value]:
-    case Incomplete(waiting: Set[Thread])
+    case Incomplete(waiting: Set[Strand])
     case Complete(value: value)
     case Cancelled
 
 // A plain class, not a case class: a zero-field case class would make every promise `==` every
-// other, and promises are meaningful only by identity (`LockSupport.park` blocks on `this`).
+// other, and promises are meaningful only by identity (`Supervisor.park` blocks on `this`).
 final class Promise[value]():
   import Promise.State, State.{Incomplete, Complete, Cancelled}
 
@@ -75,6 +75,10 @@ final class Promise[value]():
     case Complete(_) => true
     case _           => false
 
+  // The promise's completion, reified as a `Task`: the monadic form of `await`, composable with
+  // `bind`/`map` without suspending the calling strand.
+  def task(using Monitor^, Probate^, Codepoint): (Task[value] emits AsyncError)^ = async(await())
+
   // The transition is pure — `getAndUpdate` may re-run it under contention — so the waiters are
   // unparked exactly once afterwards, from the returned previous state. No wakeup can be lost:
   // once `Complete` is installed, `enqueue` adds no further waiters.
@@ -87,21 +91,21 @@ final class Promise[value]():
     state.getAndUpdate(completeIncomplete(supplied)).nn match
       case Cancelled           => raise(AsyncError(AsyncError.Reason.Cancelled))
       case Complete(_)         => raise(AsyncError(AsyncError.Reason.AlreadyComplete))
-      case Incomplete(waiting) => waiting.each(jucl.LockSupport.unpark)
+      case Incomplete(waiting) => waiting.each(_.unpark())
 
   def offer(supplied: => value): Unit =
     state.getAndUpdate(completeIncomplete(supplied)).nn match
-      case Incomplete(waiting) => waiting.each(jucl.LockSupport.unpark)
+      case Incomplete(waiting) => waiting.each(_.unpark())
       case _                   => ()
 
-  private def enqueue(thread: Thread)(current: State[value] | Null): State[value] =
+  private def enqueue(strand: Strand)(current: State[value] | Null): State[value] =
     current.nn match
-      case Incomplete(waiting) => Incomplete(waiting + thread)
+      case Incomplete(waiting) => Incomplete(waiting + strand)
       case Complete(value)     => Complete(value)
       case _                   => Cancelled
 
-  def await(): value raises AsyncError =
-    if Thread.interrupted() then throw new InterruptedException()
+  def await()(using monitor: Monitor^): value raises AsyncError =
+    if monitor.supervisor.interrupted() then throw new InterruptedException()
 
     // A settled promise needs no CAS and no waiter-set allocation — the common case when joining
     // an already-finished task. The enqueue operator is allocated once per call, outside the
@@ -110,32 +114,34 @@ final class Promise[value]():
       case Complete(value) => value
       case Cancelled       => abort(AsyncError(AsyncError.Reason.Cancelled))
       case Incomplete(_)   =>
-        val enqueue0: juf.UnaryOperator[State[value]] = enqueue(Thread.currentThread.nn)(_)
+        val strand0: Strand = monitor.supervisor.strand()
+        val enqueue0: juf.UnaryOperator[State[value]] = enqueue(strand0)(_)
 
         @tailrec
         def recur(): value =
-          if Thread.interrupted() then throw new InterruptedException()
+          if monitor.supervisor.interrupted() then throw new InterruptedException()
 
           state.getAndUpdate(enqueue0).nn match
-            case Incomplete(_)   => jucl.LockSupport.park(this) yet recur()
+            case Incomplete(_)   => monitor.supervisor.park(this) yet recur()
             case Complete(value) => value
             case Cancelled       => abort(AsyncError(AsyncError.Reason.Cancelled))
 
         recur()
 
-  def attend(): Unit =
-    if Thread.interrupted() then throw new InterruptedException()
+  def attend()(using monitor: Monitor^): Unit =
+    if monitor.supervisor.interrupted() then throw new InterruptedException()
 
     if !ready then
-      val enqueue0: juf.UnaryOperator[State[value]] = enqueue(Thread.currentThread.nn)(_)
+      val strand0: Strand = monitor.supervisor.strand()
+      val enqueue0: juf.UnaryOperator[State[value]] = enqueue(strand0)(_)
 
       @tailrec
       def recur(): Unit =
-        if Thread.interrupted() then throw new InterruptedException()
+        if monitor.supervisor.interrupted() then throw new InterruptedException()
 
         state.getAndUpdate(enqueue0) match
           case Incomplete(_) =>
-            jucl.LockSupport.park(this)
+            monitor.supervisor.park(this)
             recur()
 
           case _ =>
@@ -148,29 +154,31 @@ final class Promise[value]():
     case current       => current.nn
 
   def cancel(): Unit = state.getAndUpdate(cancelIncomplete) match
-    case Incomplete(waiting) => waiting.each(jucl.LockSupport.unpark)
+    case Incomplete(waiting) => waiting.each(_.unpark())
     case _                   => ()
 
 
   def await[generic: Abstractable across Durations to Long](duration: generic)
+    ( using monitor: Monitor^ )
   :   value raises AsyncError =
 
-    if Thread.interrupted() then throw new InterruptedException()
+    if monitor.supervisor.interrupted() then throw new InterruptedException()
 
     state.get().nn match
       case Complete(value) => value
       case Cancelled       => abort(AsyncError(AsyncError.Reason.Cancelled))
       case Incomplete(_)   =>
         val deadline = jl.System.nanoTime() + duration.generic
-        val enqueue0: juf.UnaryOperator[State[value]] = enqueue(Thread.currentThread.nn)(_)
+        val strand0: Strand = monitor.supervisor.strand()
+        val enqueue0: juf.UnaryOperator[State[value]] = enqueue(strand0)(_)
 
         @tailrec
         def recur(): value =
-          if Thread.interrupted() then throw new InterruptedException()
+          if monitor.supervisor.interrupted() then throw new InterruptedException()
           else if deadline < jl.System.nanoTime then abort(AsyncError(AsyncError.Reason.Timeout))
           else state.getAndUpdate(enqueue0).nn match
             case Incomplete(_) =>
-              jucl.LockSupport.parkNanos(this, deadline - jl.System.nanoTime())
+              monitor.supervisor.park(this, deadline)
               recur()
 
             case Complete(value) =>
@@ -182,20 +190,24 @@ final class Promise[value]():
         recur()
 
 
-  def attend[generic: Abstractable across Durations to Long](duration: generic): Unit =
-    if Thread.interrupted() then throw new InterruptedException()
+  def attend[generic: Abstractable across Durations to Long](duration: generic)
+    ( using monitor: Monitor^ )
+  :   Unit =
+
+    if monitor.supervisor.interrupted() then throw new InterruptedException()
 
     if !ready then
       val deadline = jl.System.nanoTime() + duration.generic
-      val enqueue0: juf.UnaryOperator[State[value]] = enqueue(Thread.currentThread.nn)(_)
+      val strand0: Strand = monitor.supervisor.strand()
+      val enqueue0: juf.UnaryOperator[State[value]] = enqueue(strand0)(_)
 
       @tailrec
       def recur(): Unit =
-        if Thread.interrupted() then throw new InterruptedException()
+        if monitor.supervisor.interrupted() then throw new InterruptedException()
         else if deadline > jl.System.nanoTime
         then state.getAndUpdate(enqueue0).nn match
           case Incomplete(_) =>
-            jucl.LockSupport.parkNanos(this, deadline - jl.System.nanoTime())
+            monitor.supervisor.park(this, deadline)
             recur()
 
           case Cancelled =>

--- a/lib/parasite/src/core/parasite.Strand.scala
+++ b/lib/parasite/src/core/parasite.Strand.scala
@@ -30,28 +30,35 @@
 ┃                                                                                                  ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
                                                                                                   */
-package soundness
+package parasite
 
-export
-  parasite
-  . { AdaptiveSupervisor, async, Async, AsyncError, cancel, Chain, Probate, Daemon, daemon, delay,
-      Destruction, Fault, Fulfillment, hibernate, Hook, intercept,
-      Interceptable, Monitor, monitor, Observation, Os, Perseverance, PlatformSupervisor, Promise,
-      relent, retry, RetryError, Shutdown, sleep, snooze, Strand, supervise, Supervisor, Task, task,
-      Tenacity, Threading, Timeout, Transgression, contain, Containment, VirtualSupervisor, Worker,
-      AsyncTactic, Remedy, concurrent }
+import language.experimental.pureFunctions
 
-package threading:
-  export parasite.threading.{adaptiveThreading, platformThreading, virtualThreading}
+import java.util.concurrent.locks as jucl
 
-package probates:
-  export parasite.probates.{awaitProbate, cancelProbate, failProbate, panicProbate}
+import scala.compiletime.asMatchable
 
-package supervisors:
-  export parasite.supervisors.globalSupervisor
+object Strand:
+  // Equality delegates to the underlying thread: `Promise` stores waiters in a `Set[Strand]`, and
+  // two handles on the same thread must coincide there, however they were obtained.
+  final class Threaded(val thread: Thread) extends Strand:
+    def interrupt(): Unit = thread.interrupt()
+    def join(): Unit = thread.join()
+    def unpark(): Unit = jucl.LockSupport.unpark(thread)
 
-package retryTenacities:
-  export
-    parasite.retryTenacities
-    . { exponentialFiveTimesTenacity, exponentialForeverTenacity, exponentialTenTimesTenacity,
-        fixedNoDelayFiveTimesTenacity, fixedNoDelayForeverTenacity, fixedNoDelayTenTimesTenacity }
+    override def equals(that: Any): Boolean = that.asMatchable match
+      case that: Threaded => that.thread == thread
+      case _              => false
+
+    override def hashCode: Int = thread.hashCode
+
+// The abstract handle on a unit of execution forked by a `Supervisor`: the minimal surface that
+// supervision (`Worker.cancel`) and wakeup (`Promise`) require. On the JVM it wraps a `Thread`; an
+// event-loop supervisor (Wasm/WASIp3) would implement it over a run-queue entry. `unpark` lives
+// here rather than on `Supervisor` because the wake side of a `Promise` (`fulfill`/`offer`/
+// `cancel`) runs with no `Monitor` in scope, possibly on a foreign strand: a strand must be
+// self-wakeable.
+trait Strand:
+  def interrupt(): Unit   // request cancellation of the strand
+  def join(): Unit        // block until the strand has terminated
+  def unpark(): Unit      // release the strand from a `Supervisor.park`

--- a/lib/parasite/src/core/parasite.Task.scala
+++ b/lib/parasite/src/core/parasite.Task.scala
@@ -64,9 +64,10 @@ object Task:
         def daemon: Boolean = false
         def evaluate(worker: Worker): Result = evaluate0(worker)
 
-        def await(): result raises (error | AsyncError) = deliver[error]()
+        def await()(using Monitor^): result raises (error | AsyncError) = deliver[error]()
 
         def await[duration: Abstractable across Durations to Long](duration: duration)
+          ( using Monitor^ )
         :   result raises (error | AsyncError) =
 
           deliver[error, duration](duration)
@@ -87,6 +88,15 @@ object Task:
 
       def apply[value, value2](value: Task[value])(lambda: value => value2): Task[value2] =
         caps.unsafe.unsafeAssumePure(value.map(lambda))
+
+  // The monadic form of `snooze`: a task which completes after the duration, for composition
+  // with `bind`/`map` without suspending the calling strand.
+  def sleep[duration: Abstractable across Durations to Long](duration: duration)
+    ( using Monitor^, Probate^, Codepoint )
+  :   (Task[Unit] emits AsyncError)^ =
+
+    async(snooze(duration))
+
 
   extension [result](tasks: Seq[Task[result]])
     // Part of the pure façade (see `monad` above): the fresh handle is sealed once here.
@@ -111,18 +121,19 @@ trait Task[+result]:
   type Error <: Hazard
 
   def ready: Boolean
-  def attend(): Unit
+  def attend()(using Monitor^): Unit
   def cancel(): Unit
 
-  def await(): result raises (Error | AsyncError)
+  def await()(using Monitor^): result raises (Error | AsyncError)
 
-  def await[duration: Abstractable across Durations to Long](duration: duration)
+  def await[duration: Abstractable across Durations to Long](duration: duration)(using Monitor^)
   :   result raises (Error | AsyncError)
 
   // The raw join, for parasite-internal combinators that do not track the error type.
-  protected[parasite] def join(): result raises AsyncError
+  protected[parasite] def join()(using Monitor^): result raises AsyncError
 
   protected[parasite] def join[duration: Abstractable across Durations to Long](duration: duration)
+    ( using Monitor^ )
   :   result raises AsyncError
 
   def bind[result2](lambda: result => Task[result2])(using Monitor^, Probate^)

--- a/lib/parasite/src/core/parasite_core.scala
+++ b/lib/parasite/src/core/parasite_core.scala
@@ -56,7 +56,9 @@ package threading:
   given adaptiveThreading: Threading = () => AdaptiveSupervisor
 
 package probates:
-  given awaitProbate: Probate = _.delegate(_.attend())
+  // Cleanup runs on the completing worker's own strand, with no ambient `Monitor`: the dying
+  // worker itself licenses the suspension (a `Worker` IS a `Monitor`).
+  given awaitProbate: Probate = worker => worker.delegate(_.attend()(using worker))
   given cancelProbate: Probate = _.delegate(_.cancel())
 
   given panicProbate: Probate = _.delegate: child =>
@@ -68,6 +70,14 @@ package probates:
 
 package supervisors:
   given globalSupervisor: Supervisor = PlatformSupervisor
+
+// A process-lifetime monitor for blocking *outside* any `supervise` scope: it parks the calling
+// platform thread and supervises nothing. A deliberate, explicitly-imported escape hatch for
+// call sites (daemon lifecycles, process-lifetime waits) where no supervision scope can exist;
+// prefer `supervise` wherever the blocking region is already scoped. (An object, not a `package`,
+// because a top-level field of capability type must live in an object extending `Capability`.)
+object unsupervised extends caps.ExclusiveCapability:
+  given orphanMonitor: Monitor = Root(PlatformSupervisor)
 
 package retryTenacities:
   given exponentialForeverTenacity: Tenacity = Tenacity.exponential(10L, 1.2)

--- a/lib/parasite/src/core/soundness_parasite_core.scala
+++ b/lib/parasite/src/core/soundness_parasite_core.scala
@@ -50,6 +50,9 @@ package probates:
 package supervisors:
   export parasite.supervisors.globalSupervisor
 
+object unsupervised:
+  export parasite.unsupervised.orphanMonitor
+
 package retryTenacities:
   export
     parasite.retryTenacities

--- a/lib/sedentary/src/core/sedentary.Stress.scala
+++ b/lib/sedentary/src/core/sedentary.Stress.scala
@@ -121,8 +121,11 @@ extends Rig:
     val start: Int = concurrency0.or(1)
     // Whether the ambient `Threading` forks virtual threads, probed with a no-op fork so
     // adaptive and custom supervisors classify by what they actually do. The remote JVM runs
-    // the same `java`, so the probe's answer holds there.
-    val virtual2: Boolean = threading.supervisor().fork(() => Unset)(()).isVirtual
+    // the same `java`, so the probe's answer holds there. A non-thread-backed strand (an
+    // event-loop supervisor) classifies as not virtual.
+    val virtual2: Boolean = threading.supervisor().fork(() => Unset)(()) match
+      case strand: Strand.Threaded => strand.thread.isVirtual
+      case _                       => false
     val threshold0: Optional[Long] = threshold.let(_.generic)
     val compliance0: Optional[Int] = compliance
 

--- a/lib/synesthesia/src/core/synesthesia.Mcp.scala
+++ b/lib/synesthesia/src/core/synesthesia.Mcp.scala
@@ -850,7 +850,11 @@ object Mcp:
     def `prompts/get`(name: Text, arguments: Optional[Map[Text, Text]], _meta: Optional[Json])
     :   GetPrompt =
 
-      val messages = spec.invokePrompt(server, client, name, arguments.or(Map())).map:
+      // The RPC proxy's awaits are scoped to this call, so it runs under its own supervision.
+      import threading.platformThreading
+
+      val messages = unsafely(supervise:
+        spec.invokePrompt(server, client, name, arguments.or(Map()))).map:
         case Human(message) => PromptMessage(Role.User, TextContent(message))
         case Agent(message) => PromptMessage(Role.Assistant, TextContent(message))
 
@@ -876,7 +880,9 @@ object Mcp:
     def `resources/unsubscribe`(uri: Text, _meta: Optional[Json]): Unit = ???
 
     def `tools/call`(name: Text, arguments: Json, _meta: Optional[Json]): CallTool =
-      val result = spec.invokeTool(server, client, name, arguments)
+      // The RPC proxy's awaits are scoped to this call, so it runs under its own supervision.
+      import threading.platformThreading
+      val result = unsafely(supervise(spec.invokeTool(server, client, name, arguments)))
 
       import formatting.compactJsonFormatting
       CallTool(content = List(TextContent(result.show)), structuredContent = result)


### PR DESCRIPTION
Parasite's execution model was hard-wired to JVM threads: `Supervisor.fork` returned `java.lang.Thread`, and suspension (`LockSupport.park` in `Promise`, `parkNanos` in `snooze`) and cancellation (`Thread.interrupt`/`join`) were called directly. This change completes the platform seam so that a non-thread backend — such as an event loop over WASIp3 waitable-sets — can be supplied purely as a `Supervisor`, and makes awaiting an honestly-licensed effect, positioning `Monitor^` to become a `Suspend^` capability once compiler-supported CPS exists. The refactor is behaviour-neutral on the JVM.

### Release notes

- `Supervisor.fork` now returns a new abstract handle, `Strand` (`interrupt`/`join`/`unpark`), instead of `java.lang.Thread`, and `Supervisor` gains the suspension primitives `strand()`, `park`, `sleep` and `interrupted()`. Custom supervisors should extend `ThreadSupervisor` to retain thread-backed behaviour.
- Blocking methods — `Task#await`/`attend`, `Promise#await`/`attend`, `Monitor#attend` and `Daemon#attend` — now require a contextual `Monitor^`. Code inside `supervise` or `async` blocks compiles unchanged; code that blocks outside any supervision scope can wrap the region in `supervise`, or explicitly `import unsupervised.orphanMonitor` as a deliberate escape hatch:
  ```scala
  import unsupervised.orphanMonitor
  promise.await()   // parks the calling platform thread; supervises nothing
  ```
- New monadic waiting combinators, composable without suspending the calling strand:
  ```scala
  Task.sleep(1*Second).bind { _ => poll() }   // a task completing after a duration
  promise.task.map(render(_))                 // a promise's completion, as a Task
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)